### PR TITLE
feat(api): track payments in organization_action table

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -241,3 +241,18 @@ export const paymentMethod = pgTable("payment_method", {
 	type: text().notNull(), // "card", "sepa_debit", etc.
 	isDefault: boolean().notNull().default(false),
 });
+
+export const organizationAction = pgTable("organization_action", {
+	id: text().primaryKey().$defaultFn(shortid),
+	createdAt: timestamp().notNull().defaultNow(),
+	updatedAt: timestamp()
+		.notNull()
+		.defaultNow()
+		.$onUpdate(() => new Date()),
+	organizationId: text().notNull(),
+	type: text({
+		enum: ["credit", "debit"],
+	}).notNull(),
+	amount: decimal().notNull(),
+	description: text(),
+});


### PR DESCRIPTION
Added organization_action table schema and logic to insert payment details for credits received via Stripe. Enhanced Stripe webhook logging with structured event details.