### PR TITLE
fix(chat): update error messages for provider key issues

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -262,7 +262,7 @@ describe("test", () => {
 		expect(res.status).toBe(400);
 		const msg = await res.text();
 		expect(msg).toMatchInlineSnapshot(
-			`"No API key set for provider: inference.net. Please add a provider key in your settings."`,
+			`"No API key set for provider: inference.net. Please add a provider key in your settings or add credits and switch to credits or hybrid mode."`,
 		);
 	});
 
@@ -333,7 +333,7 @@ describe("test", () => {
 		expect(res.status).toBe(400);
 		const errorMessage = await res.text();
 		expect(errorMessage).toMatchInlineSnapshot(
-			`"No API key set for provider: openai. Please add a provider key in your settings."`,
+			`"No API key set for provider: openai. Please add a provider key in your settings or add credits and switch to credits or hybrid mode."`,
 		);
 	});
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -280,7 +280,7 @@ chat.openapi(completions, async (c) => {
 
 			if (availableModelProviders.length === 0) {
 				throw new HTTPException(400, {
-					message: `No API key set for provider: ${modelInfo.providers[0]}. Please add a provider key in your settings.`,
+					message: `No API key set for provider: ${modelInfo.providers[0]}. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.`,
 				});
 			}
 
@@ -333,7 +333,7 @@ chat.openapi(completions, async (c) => {
 
 		if (!providerKey) {
 			throw new HTTPException(400, {
-				message: `No API key set for provider: ${usedProvider}. Please add a provider key in your settings.`,
+				message: `No API key set for provider: ${usedProvider}. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.`,
 			});
 		}
 	} else if (project.mode === "credits") {


### PR DESCRIPTION
Improved error messages to guide users to add provider keys or switch to credits/hybrid mode when no API key is set for a provider. Updated related test snapshots.