### PR TITLE
fix(chat): correct env variable names for API keys

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -47,10 +47,10 @@ function getProviderTokenFromEnv(usedProvider: Provider): string | undefined {
 			token = process.env.GOOGLE_AI_STUDIO_API_KEY;
 			break;
 		case "inference.net":
-			token = process.env.INFERENCE_API_KEY;
+			token = process.env.INFERENCE_NET_API_KEY;
 			break;
 		case "kluster.ai":
-			token = process.env.KLUSTER_API_KEY;
+			token = process.env.KLUSTER_AI_API_KEY;
 			break;
 		default:
 			throw new HTTPException(400, {


### PR DESCRIPTION
Updated environment variable names for consistency with the expected service names to avoid misconfiguration errors.