### PR TITLE
fix(auth): update default URLs to localhost for dev environment

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -4,8 +4,8 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { createAuthMiddleware } from "better-auth/api";
 import { passkey } from "better-auth/plugins/passkey";
 
-const uiUrl = process.env.UI_URL || "https://dev.llmgateway.io";
-const originUrls = process.env.ORIGIN_URL || "https://dev.llmgateway.io";
+const uiUrl = process.env.UI_URL || "http://localhost:3002";
+const originUrls = process.env.ORIGIN_URL || "http://localhost:3002";
 
 export const auth: ReturnType<typeof betterAuth> = betterAuth({
 	advanced: {


### PR DESCRIPTION
Updated `UI_URL` and `ORIGIN_URL` defaults to `http://localhost:3002` to improve local development experience.