### PR TITLE
ci(workflows): exclude Dependabot from e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,6 @@ jobs:
   e2e:
     uses: ./.github/workflows/run.yml
     secrets: inherit
+    if: ${{ github.actor != 'dependabot[bot]' }}
     with:
       cmd: pnpm run setup && pnpm test:e2e


### PR DESCRIPTION
Added a condition to skip e2e tests for Dependabot commits.