### PR TITLE
refactor(openapi): centralize configuration for OpenAPI docs

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,22 @@ import { stripeRoutes } from "./stripe";
 
 import type { ServerTypes } from "./vars";
 
+export const config = {
+	servers: [
+		{
+			url:
+				process.env.NODE_ENV === "production"
+					? process.env.UI_URL + "/api"
+					: "http://localhost:3002/api",
+		},
+	],
+	openapi: "3.0.0",
+	info: {
+		version: "1.0.0",
+		title: "My API",
+	},
+};
+
 export const app = new OpenAPIHono<ServerTypes>();
 
 app.use(
@@ -105,21 +121,7 @@ app.openapi(root, async (c) => {
 
 app.route("/stripe", stripeRoutes);
 
-app.doc("/json", {
-	servers: [
-		{
-			url:
-				process.env.NODE_ENV === "production"
-					? process.env.UI_URL + "/api"
-					: "http://localhost:3002/api",
-		},
-	],
-	openapi: "3.0.0",
-	info: {
-		version: "1.0.0",
-		title: "My API",
-	},
-});
+app.doc("/json", config);
 
 app.get("/docs", swaggerUI({ url: "./json" }));
 

--- a/apps/api/src/scripts/generate-openapi.ts
+++ b/apps/api/src/scripts/generate-openapi.ts
@@ -1,19 +1,16 @@
 import { writeFileSync } from "fs";
 
-import { app } from "..";
+import { app, config } from "..";
 
 async function generateOpenAPI() {
-	const spec = app.getOpenAPIDocument({
-		openapi: "3.0.0",
-		info: {
-			version: "1.0.0",
-			title: "API Service",
-		},
-	});
+	const spec = app.getOpenAPIDocument(config);
 
 	writeFileSync("openapi.json", JSON.stringify(spec, null, 2));
 	console.log("✅ openapi.json has been generated");
 	process.exit(0);
 }
 
-generateOpenAPI();
+void generateOpenAPI().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -11,6 +11,26 @@ import { models } from "./models";
 
 import type { ServerTypes } from "./vars";
 
+export const config = {
+	servers: [
+		{
+			url:
+				process.env.NODE_ENV === "production"
+					? process.env.UI_URL || "http://localhost:4001"
+					: "http://localhost:4001",
+		},
+	],
+	openapi: "3.0.0",
+	info: {
+		version: "1.0.0",
+		title: "My API",
+	},
+	externalDocs: {
+		url: "https://docs.llmgateway.io",
+		description: "LLMGateway Documentation",
+	},
+};
+
 export const app = new OpenAPIHono<ServerTypes>();
 
 // Middleware to check for application/json content type on POST requests
@@ -124,12 +144,6 @@ v1.route("/models", models);
 
 app.route("/v1", v1);
 
-app.doc("/json", {
-	openapi: "3.0.0",
-	info: {
-		version: "1.0.0",
-		title: "My API",
-	},
-});
+app.doc("/json", config);
 
 app.get("/docs", swaggerUI({ url: "/json" }));

--- a/apps/gateway/src/scripts/generate-openapi.ts
+++ b/apps/gateway/src/scripts/generate-openapi.ts
@@ -1,19 +1,16 @@
 import { writeFileSync } from "fs";
 
-import { app } from "..";
+import { app, config } from "..";
 
 async function generateOpenAPI() {
-	const spec = app.getOpenAPIDocument({
-		openapi: "3.0.0",
-		info: {
-			version: "1.0.0",
-			title: "My API",
-		},
-	});
+	const spec = app.getOpenAPIDocument(config);
 
 	writeFileSync("openapi.json", JSON.stringify(spec, null, 2));
 	console.log("✅ openapi.json has been generated");
 	process.exit(0);
 }
 
-generateOpenAPI();
+void generateOpenAPI().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
Extracted shared OpenAPI configuration into a centralized `config` object for reuse across app and script files. Simplified `generateOpenAPI` scripts and updated app doc registration to use the new config.