### PR TITLE
feat(docs): add script to generate LLM content

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,6 +11,7 @@
 		"build": "pnpm generate && tsc && next build",
 		"dev": "next dev --turbo --port 3005",
 		"gen-docs": "node scripts/generate-docs.mjs",
+		"gen-llms": "tsx scripts/generate-llms.ts",
 		"generate": "fumadocs-mdx && pnpm gen-docs",
 		"postinstall": "fumadocs-mdx || true",
 		"start": "next start -H 0.0.0.0"

--- a/apps/docs/scripts/generate-llms.ts
+++ b/apps/docs/scripts/generate-llms.ts
@@ -1,9 +1,11 @@
+import { writeFileSync } from "fs";
 import { remarkInclude } from "fumadocs-mdx/config";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkMdx from "remark-mdx";
 
-import type { source } from "@/lib/source";
+import { source } from "@/lib/source";
+
 import type { InferPageType } from "fumadocs-core/source";
 
 const processor = remark().use(remarkMdx).use(remarkInclude).use(remarkGfm);
@@ -21,3 +23,16 @@ ${page.data.description}
 
 ${processed.value}`;
 }
+
+export async function writeLLMText() {
+	const llms = source.generateParams().map((page) => getLLMText(page));
+	const text = await Promise.all(llms);
+	writeFileSync("public/llms.txt", text.join("\n\n"));
+	console.log("✅ llms.txt has been generated");
+	process.exit(0);
+}
+
+void writeLLMText().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
Introduced `gen-llms` script for generating `llms.txt` with LLM
page content. Script processes markdown using plugins and writes
output to `public/llms.txt` for documentation purposes.