### PR TITLE
feat(docs): add VITE_DOCS_URL support for dynamic metadataBase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ REDIS_PORT=6379
 GATEWAY_PORT=4001
 API_PORT=4002
 UI_PORT=3002
+DOCS_PORT=3005
 
 # =============================================================================
 # AUTHENTICATION & SECURITY

--- a/apps/docs/app/(home)/[[...slug]]/page.tsx
+++ b/apps/docs/app/(home)/[[...slug]]/page.tsx
@@ -26,7 +26,9 @@ export async function generateMetadata({
 	const image = ["/docs-og", ...slug, "image.png"].join("/");
 
 	return {
-		metadataBase: new URL("https://docs.llmgateway.io"),
+		metadataBase: new URL(
+			process.env.VITE_DOCS_URL || "https://docs.llmgateway.io",
+		),
 		title: page.data.title,
 		description: page.data.description,
 		openGraph: {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -170,6 +170,34 @@ services:
     networks:
       - llmgateway-network
 
+  # Docs Service (Static files served via Nginx)
+  docs:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: docs
+      args:
+        VITE_DOCS_URL: ${VITE_DOCS_URL:-http://localhost:3005}
+    container_name: llmgateway-docs
+    restart: unless-stopped
+    ports:
+      - "${DOCS_PORT:-3005}:80"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+
 volumes:
   postgres_data:
     driver: local


### PR DESCRIPTION
Enabled dynamic `metadataBase` configuration using `VITE_DOCS_URL` in `page.tsx`. Updated `.env.example` and `docker-compose.prod.yml` to include `DOCS_PORT` configuration for hosting documentation in self-hosted setups.