### PR TITLE
feat(models): display context size in UI for models

### DIFF
--- a/apps/ui/src/components/models/models-list.tsx
+++ b/apps/ui/src/components/models/models-list.tsx
@@ -4,6 +4,7 @@ import { models } from "@openllm/models";
 
 import { Badge } from "@/lib/components/badge";
 import { Card } from "@/lib/components/card";
+import { formatContextSize } from "@/lib/utils";
 
 import type { ModelDefinition } from "@openllm/models";
 
@@ -23,6 +24,9 @@ export function ModelsList() {
 						{model.providers.map((provider) => (
 							<div key={provider.providerId} className="mt-2">
 								<div className="font-medium">{provider.providerId}:</div>
+								{provider.contextSize && (
+									<div>Context: {formatContextSize(provider.contextSize)}</div>
+								)}
 								{provider.inputPrice !== undefined && (
 									<div>
 										Input: ${(provider.inputPrice * 1e6).toFixed(2)} / M tokens

--- a/apps/ui/src/lib/utils.ts
+++ b/apps/ui/src/lib/utils.ts
@@ -4,3 +4,21 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
+
+/**
+ * Formats a context size number into a human-readable string with k/M suffixes
+ * @param contextSize - The context size in tokens
+ * @returns Formatted string (e.g., "128k", "1M", "—")
+ */
+export function formatContextSize(contextSize?: number): string {
+	if (!contextSize) {
+		return "—";
+	}
+	if (contextSize >= 1000000) {
+		return `${(contextSize / 1000000).toFixed(contextSize % 1000000 === 0 ? 0 : 1)}M`;
+	}
+	if (contextSize >= 1000) {
+		return `${(contextSize / 1000).toFixed(contextSize % 1000 === 0 ? 0 : 1)}k`;
+	}
+	return contextSize.toString();
+}

--- a/apps/ui/src/routes/models.tsx
+++ b/apps/ui/src/routes/models.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/components/card";
 import { DOCS_URL } from "@/lib/env";
 import Logo from "@/lib/icons/Logo";
+import { formatContextSize } from "@/lib/utils";
 
 const providerLogoComponents: Partial<
 	Record<ProviderId, React.FC<React.SVGProps<SVGSVGElement>> | null>
@@ -43,6 +44,7 @@ interface ProviderModel {
 	providerName: string;
 	inputPrice?: number;
 	outputPrice?: number;
+	contextSize?: number;
 }
 
 const getProviderIcon = (providerId: ProviderId) => {
@@ -87,6 +89,7 @@ const groupedProviders = modelDefinitions.reduce<
 			providerName: provider.name,
 			inputPrice: map.inputPrice,
 			outputPrice: map.outputPrice,
+			contextSize: map.contextSize,
 		});
 	});
 	return acc;
@@ -155,6 +158,11 @@ function ProvidersPage() {
 													</CardDescription>
 												</CardHeader>
 												<CardContent className="mt-auto space-y-2">
+													{model.contextSize && (
+														<p className="text-xs text-muted-foreground">
+															Context: {formatContextSize(model.contextSize)}
+														</p>
+													)}
 													{(model.inputPrice !== undefined ||
 														model.outputPrice !== undefined) && (
 														<p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Added UI display for `contextSize` property in model cards and the models list. Introduced `formatContextSize` utility for better readability of large context values. Ensures easier visibility of maximum token context window size in the interface.