### PR TITLE
feat(models): add new 2.5 pro preview 06-05 gemini model

### DIFF
--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -311,6 +311,18 @@ export let models = [
 		],
 	},
 	{
+		model: "gemini-2.5-pro-preview-06-05",
+		providers: [
+			{
+				providerId: "google-ai-studio",
+				modelName: "gemini-2.5-pro-preview-06-05",
+				inputPrice: 1.25 / 1e6,
+				outputPrice: 10.0 / 1e6,
+				contextSize: 1000000,
+			},
+		],
+	},
+	{
 		model: "gemini-2.5-flash-preview-04-17",
 		providers: [
 			{


### PR DESCRIPTION
Added `gemini-2.5-pro-preview-06-05` to `models.ts` with pricing, provider details, and context size for compatibility with latest offerings.