### PR TITLE
feat(dashboard): add Pro plan check for sidebar CTA

### DIFF
--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -229,7 +229,7 @@ export function DashboardSidebar() {
 			</SidebarContent>
 
 			<SidebarFooter className="border-t">
-				{showCreditCTA && organization?.plan !== "pro" && (
+				{showCreditCTA && organization && organization.plan !== "pro" && (
 					<div className="flex relative flex-col items-start space-y-4 rounded-lg bg-primary/5 p-4 dark:bg-primary/10">
 						<button
 							aria-label="Dismiss"


### PR DESCRIPTION
Updated the dashboard sidebar to conditionally display the credit CTA based on the user's organization plan. Replaced the credit CTA message to promote the Pro plan. Added integration with the `useDefaultOrganization` hook for plan details.

NOTE: we need to link to billing page before this can be merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the sidebar footer to display an "Upgrade to Pro" call-to-action for organizations not on the Pro plan.
- **Style**
  - Revised CTA text and subtext in the sidebar footer for improved clarity.
  - Replaced the previous top-up button with a streamlined upgrade button linking to billing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->