### PR TITLE
refactor(ui): remove unused responsive sidebar logic

### DIFF
--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -96,12 +96,6 @@ export function DashboardSidebar() {
 	};
 
 	useEffect(() => {
-		if (window.matchMedia("(max-width: 640px)").matches) {
-			toggleSidebar();
-		}
-	}, [toggleSidebar]);
-
-	useEffect(() => {
 		if (isSettingsActive() && !settingsExpanded) {
 			setSettingsExpanded(true);
 		}


### PR DESCRIPTION
Eliminated unnecessary `useEffect` for toggling the sidebar on smaller screens. Simplifies the component logic without affecting functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the automatic sidebar toggle for small screens (640px or less). The sidebar will no longer auto-toggle based on viewport width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->