### PR TITLE
fix(chat): ensure delta includes role property

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -246,6 +246,7 @@ describe("e2e tests with real provider keys", () => {
 				expect(chunk.choices).toHaveLength(1);
 				expect(chunk.choices[0]).toHaveProperty("index", 0);
 				expect(chunk.choices[0]).toHaveProperty("delta");
+				expect(chunk.choices[0]).toHaveProperty("delta.role", "assistant");
 				expect(chunk.choices[0].delta).toHaveProperty("content");
 				expect(typeof chunk.choices[0].delta.content).toBe("string");
 			}


### PR DESCRIPTION
Set the `role` property to "assistant" in all occurrences of `delta` to align with the OpenAI format. Updated tests to validate the inclusion of the `role` property and ensure compliance across providers. Enhanced error messages for unsupported providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming chat responses to always include the assistant role in each message chunk, ensuring better compatibility with OpenAI's expected format.

- **Tests**
  - Enhanced end-to-end tests to verify the presence of the assistant role in streaming chat responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->