### PR TITLE
feat(ui): reorganize Self-Host plan in pricing list

### DIFF
--- a/apps/ui/src/components/landing/pricing-plans.tsx
+++ b/apps/ui/src/components/landing/pricing-plans.tsx
@@ -215,6 +215,25 @@ export function PricingPlans() {
 
 	const plans = [
 		{
+			name: "Self-Host",
+			description: "Host on your own infrastructure",
+			price: {
+				monthly: "Free",
+				annual: "Free",
+			},
+			features: [
+				"100% free forever",
+				"Full control over your data",
+				"Host on your infrastructure",
+				"No usage limits",
+				"Community support",
+				"Regular updates",
+			],
+			cta: "View Documentation",
+			popular: false,
+			disabled: false,
+		},
+		{
 			name: "Free",
 			description: "Perfect for trying out the platform",
 			price: {
@@ -271,25 +290,6 @@ export function PricingPlans() {
 				"24/7 premium support",
 			],
 			cta: "Contact Sales",
-			popular: false,
-			disabled: false,
-		},
-		{
-			name: "Self-Host",
-			description: "Host on your own infrastructure",
-			price: {
-				monthly: "Free",
-				annual: "Free",
-			},
-			features: [
-				"100% free forever",
-				"Full control over your data",
-				"Host on your infrastructure",
-				"No usage limits",
-				"Community support",
-				"Regular updates",
-			],
-			cta: "View Documentation",
 			popular: false,
 			disabled: false,
 		},


### PR DESCRIPTION
Moved the Self-Host plan to the top of the pricing plans array for better visibility and emphasis.

<img width="1683" alt="image" src="https://github.com/user-attachments/assets/08e0f92f-05dc-4011-a0ee-598a6e5484f1" />
