### PR TITLE
feat(ui): add shared UpgradeToProDialog component

### DIFF
--- a/apps/ui/src/components/billing/plan-management.tsx
+++ b/apps/ui/src/components/billing/plan-management.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 
+import { UpgradeToProDialog } from "@/components/shared/upgrade-to-pro-dialog";
 import { useDefaultOrganization } from "@/hooks/useOrganization";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
@@ -12,22 +12,12 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/lib/components/dialog";
 import { useToast } from "@/lib/components/use-toast";
 import { $api } from "@/lib/fetch-client";
 
 export function PlanManagement() {
 	const { data: organization } = useDefaultOrganization();
 	const { toast } = useToast();
-	const [upgradeDialogOpen, setUpgradeDialogOpen] = useState(false);
 	const queryClient = useQueryClient();
 
 	const { data: subscriptionStatus } = $api.useQuery(
@@ -194,14 +184,9 @@ export function PlanManagement() {
 			</CardContent>
 			<CardFooter className="flex justify-between">
 				{!isProPlan ? (
-					<Dialog open={upgradeDialogOpen} onOpenChange={setUpgradeDialogOpen}>
-						<DialogTrigger asChild>
-							<Button>Upgrade to Pro</Button>
-						</DialogTrigger>
-						<DialogContent>
-							<UpgradeDialog onSuccess={() => setUpgradeDialogOpen(false)} />
-						</DialogContent>
-					</Dialog>
+					<UpgradeToProDialog>
+						<Button>Upgrade to Pro</Button>
+					</UpgradeToProDialog>
 				) : (
 					<div className="flex gap-2">
 						{!subscriptionStatus?.subscriptionCancelled && (
@@ -233,83 +218,5 @@ export function PlanManagement() {
 				)}
 			</CardFooter>
 		</Card>
-	);
-}
-
-function UpgradeDialog({ onSuccess }: { onSuccess: () => void }) {
-	const { toast } = useToast();
-	const [loading, setLoading] = useState(false);
-
-	const createSubscriptionMutation = $api.useMutation(
-		"post",
-		"/subscriptions/create-pro-subscription",
-	);
-
-	const handleUpgrade = async () => {
-		setLoading(true);
-
-		try {
-			const { checkoutUrl } = await createSubscriptionMutation.mutateAsync({});
-
-			// Redirect to Stripe Checkout
-			window.location.href = checkoutUrl;
-		} catch (error) {
-			toast({
-				title: "Upgrade Failed",
-				description: `Failed to create checkout session. Please try again. Error: ${error}`,
-				variant: "destructive",
-			});
-			setLoading(false);
-		}
-	};
-
-	return (
-		<>
-			<DialogHeader>
-				<DialogTitle>Upgrade to Pro</DialogTitle>
-				<DialogDescription>
-					Unlock provider keys and get full access to all features for
-					$50/month.
-				</DialogDescription>
-			</DialogHeader>
-			<div className="py-4">
-				<div className="border rounded-lg p-4 space-y-3">
-					<h4 className="font-medium">What you'll get:</h4>
-					<ul className="space-y-2 text-sm">
-						<li className="flex items-center gap-2">
-							<div className="w-2 h-2 rounded-full bg-green-500" />
-							Use your own OpenAI, Anthropic, and other provider API keys
-						</li>
-						<li className="flex items-center gap-2">
-							<div className="w-2 h-2 rounded-full bg-green-500" />
-							Hybrid mode: fallback to credits when needed
-						</li>
-						<li className="flex items-center gap-2">
-							<div className="w-2 h-2 rounded-full bg-green-500" />
-							No surcharges or fees for API keys or credits usage
-						</li>
-						<li className="flex items-center gap-2">
-							<div className="w-2 h-2 rounded-full bg-green-500" />
-							All existing features (credits, analytics, etc.)
-						</li>
-					</ul>
-				</div>
-			</div>
-			<DialogFooter>
-				<div className="flex flex-col gap-2 items-end">
-					<Button
-						onClick={handleUpgrade}
-						disabled={loading || createSubscriptionMutation.isPending}
-					>
-						{loading || createSubscriptionMutation.isPending
-							? "Redirecting to checkout..."
-							: "Upgrade for $50/month now"}
-					</Button>
-					<div className="text-sm text-muted-foreground">
-						<p>You'll be redirected to Stripe Checkout to complete payment.</p>
-					</div>
-				</div>
-			</DialogFooter>
-		</>
 	);
 }

--- a/apps/ui/src/components/landing/pricing-plans.tsx
+++ b/apps/ui/src/components/landing/pricing-plans.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { Check, Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 
+import { UpgradeToProDialog } from "@/components/shared/upgrade-to-pro-dialog";
 import { useUser } from "@/hooks/useUser";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
@@ -398,30 +399,49 @@ export function PricingPlans() {
 									</ul>
 								</CardContent>
 								<CardFooter>
-									<Button
-										className={`w-full ${plan.popular ? "bg-primary hover:bg-primary/90" : ""}`}
-										variant={plan.popular ? "default" : "outline"}
-										disabled={plan.disabled || isLoading}
-										onClick={() => {
-											if (
-												plan.name === "Pro" &&
-												subscriptionStatus?.plan === "pro"
-											) {
-												if (subscriptionStatus.subscriptionCancelled) {
-													handleResumeSubscription();
+									{plan.name === "Pro" &&
+									subscriptionStatus?.plan !== "pro" &&
+									user ? (
+										<UpgradeToProDialog
+											onSuccess={() => fetchSubscriptionStatus()}
+										>
+											<Button
+												className={`w-full ${plan.popular ? "bg-primary hover:bg-primary/90" : ""}`}
+												variant={plan.popular ? "default" : "outline"}
+												disabled={plan.disabled || isLoading}
+											>
+												{isLoading && (
+													<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+												)}
+												{plan.cta}
+											</Button>
+										</UpgradeToProDialog>
+									) : (
+										<Button
+											className={`w-full ${plan.popular ? "bg-primary hover:bg-primary/90" : ""}`}
+											variant={plan.popular ? "default" : "outline"}
+											disabled={plan.disabled || isLoading}
+											onClick={() => {
+												if (
+													plan.name === "Pro" &&
+													subscriptionStatus?.plan === "pro"
+												) {
+													if (subscriptionStatus.subscriptionCancelled) {
+														handleResumeSubscription();
+													} else {
+														handleCancelSubscription();
+													}
 												} else {
-													handleCancelSubscription();
+													handlePlanSelection(plan.name);
 												}
-											} else {
-												handlePlanSelection(plan.name);
-											}
-										}}
-									>
-										{isLoading && (
-											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-										)}
-										{plan.cta}
-									</Button>
+											}}
+										>
+											{isLoading && (
+												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+											)}
+											{plan.cta}
+										</Button>
+									)}
 								</CardFooter>
 							</Card>
 						);

--- a/apps/ui/src/components/shared/upgrade-to-pro-dialog.tsx
+++ b/apps/ui/src/components/shared/upgrade-to-pro-dialog.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+
+import { Button } from "@/lib/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/lib/components/dialog";
+import { useToast } from "@/lib/components/use-toast";
+import { $api } from "@/lib/fetch-client";
+
+interface UpgradeToProDialogProps {
+	children: React.ReactNode;
+	onSuccess?: () => void;
+}
+
+export function UpgradeToProDialog({
+	children,
+	onSuccess,
+}: UpgradeToProDialogProps) {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>{children}</DialogTrigger>
+			<DialogContent>
+				<UpgradeDialogContent
+					onSuccess={() => {
+						setOpen(false);
+						onSuccess?.();
+					}}
+				/>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function UpgradeDialogContent({ onSuccess }: { onSuccess: () => void }) {
+	const { toast } = useToast();
+	const [loading, setLoading] = useState(false);
+
+	const createSubscriptionMutation = $api.useMutation(
+		"post",
+		"/subscriptions/create-pro-subscription",
+	);
+
+	const handleUpgrade = async () => {
+		setLoading(true);
+
+		try {
+			const { checkoutUrl } = await createSubscriptionMutation.mutateAsync({});
+
+			// Redirect to Stripe Checkout
+			window.location.href = checkoutUrl;
+		} catch (error) {
+			toast({
+				title: "Upgrade Failed",
+				description: `Failed to create checkout session. Please try again. Error: ${error}`,
+				variant: "destructive",
+			});
+			setLoading(false);
+		}
+	};
+
+	return (
+		<>
+			<DialogHeader>
+				<DialogTitle>Upgrade to Pro</DialogTitle>
+				<DialogDescription>
+					Unlock provider keys and get full access to all features for
+					$50/month.
+				</DialogDescription>
+			</DialogHeader>
+			<div className="py-4">
+				<div className="border rounded-lg p-4 space-y-3">
+					<h4 className="font-medium">What you'll get:</h4>
+					<ul className="space-y-2 text-sm">
+						<li className="flex items-center gap-2">
+							<div className="w-2 h-2 rounded-full bg-green-500" />
+							Use your own OpenAI, Anthropic, and other provider API keys
+						</li>
+						<li className="flex items-center gap-2">
+							<div className="w-2 h-2 rounded-full bg-green-500" />
+							Hybrid mode: fallback to credits when needed
+						</li>
+						<li className="flex items-center gap-2">
+							<div className="w-2 h-2 rounded-full bg-green-500" />
+							No surcharges or fees for API keys or credits usage
+						</li>
+						<li className="flex items-center gap-2">
+							<div className="w-2 h-2 rounded-full bg-green-500" />
+							All existing features (credits, analytics, etc.)
+						</li>
+					</ul>
+				</div>
+			</div>
+			<DialogFooter>
+				<div className="flex flex-col gap-2 items-end">
+					<Button
+						onClick={handleUpgrade}
+						disabled={loading || createSubscriptionMutation.isPending}
+					>
+						{loading || createSubscriptionMutation.isPending
+							? "Redirecting to checkout..."
+							: "Upgrade for $50/month now"}
+					</Button>
+					<div className="text-sm text-muted-foreground">
+						<p>You'll be redirected to Stripe Checkout to complete payment.</p>
+					</div>
+				</div>
+			</DialogFooter>
+		</>
+	);
+}


### PR DESCRIPTION
Refactored and centralized Pro upgrade dialog into a reusable shared component. Replaced individual dialog instances across PlanManagement and pricing plans with the new component for better code reuse and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new upgrade dialog for the Pro plan, providing a streamlined and consistent upgrade experience across the app.
  - Users are now redirected to Stripe Checkout for payment when upgrading to Pro, with clear feedback and error handling.

- **Refactor**
  - Simplified upgrade logic in plan management and pricing plans by using the new shared upgrade dialog component, resulting in a more consistent and maintainable user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->