### PR TITLE
refactor(ui): centralize destructive toast styles

### DIFF
--- a/apps/ui/src/components/onboarding/provider-key-step.tsx
+++ b/apps/ui/src/components/onboarding/provider-key-step.tsx
@@ -94,7 +94,6 @@ export function ProviderKeyStep() {
 				description:
 					error?.message || "Failed to add provider key. Please try again.",
 				variant: "destructive",
-				className: "text-white",
 			});
 		} finally {
 			setIsLoading(false);

--- a/apps/ui/src/components/passkeys/add-passkey.ts
+++ b/apps/ui/src/components/passkeys/add-passkey.ts
@@ -11,8 +11,6 @@ export async function addPasskey() {
 			toast({
 				title: "Error adding passkey",
 				description: result.error.message || "Please try again",
-				variant: "destructive",
-				className: "text-white",
 			});
 			return;
 		}
@@ -26,7 +24,6 @@ export async function addPasskey() {
 			title: "Error adding passkey",
 			description: "An unexpected error occurred",
 			variant: "destructive",
-			className: "text-white",
 		});
 	}
 }

--- a/apps/ui/src/components/passkeys/passkey-list.tsx
+++ b/apps/ui/src/components/passkeys/passkey-list.tsx
@@ -41,7 +41,6 @@ export function PasskeyList() {
 			toast({
 				title: "Error deleting passkey",
 				variant: "destructive",
-				className: "text-white",
 			});
 		},
 	});

--- a/apps/ui/src/components/playground/auth-dialog.tsx
+++ b/apps/ui/src/components/playground/auth-dialog.tsx
@@ -95,7 +95,6 @@ export function AuthDialog({ open }: AuthDialogProps) {
 					toast({
 						title: ctx.error.message || "An unknown error occurred",
 						variant: "destructive",
-						className: "text-white",
 					});
 				},
 			},
@@ -105,7 +104,6 @@ export function AuthDialog({ open }: AuthDialogProps) {
 			toast({
 				title: error.message || "An unknown error occurred",
 				variant: "destructive",
-				className: "text-white",
 			});
 		}
 
@@ -140,7 +138,6 @@ export function AuthDialog({ open }: AuthDialogProps) {
 					toast({
 						title: ctx.error.message || "Failed to sign up",
 						variant: "destructive",
-						className: "text-white",
 					});
 				},
 			},
@@ -150,7 +147,6 @@ export function AuthDialog({ open }: AuthDialogProps) {
 			toast({
 				title: error.message || "Failed to sign up",
 				variant: "destructive",
-				className: "text-white",
 			});
 		}
 
@@ -165,7 +161,6 @@ export function AuthDialog({ open }: AuthDialogProps) {
 				toast({
 					title: res.error.message || "Failed to sign in with passkey",
 					variant: "destructive",
-					className: "text-white",
 				});
 				return;
 			}
@@ -177,7 +172,6 @@ export function AuthDialog({ open }: AuthDialogProps) {
 			toast({
 				title: error?.message || "Failed to sign in with passkey",
 				variant: "destructive",
-				className: "text-white",
 			});
 		} finally {
 			setIsLoading(false);

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -97,7 +97,6 @@ export function CreateProviderKeyDialog({
 				description:
 					"Provider keys are only available on the Pro plan. Please upgrade to use your own API keys.",
 				variant: "destructive",
-				className: "text-white",
 			});
 			return;
 		}
@@ -109,7 +108,6 @@ export function CreateProviderKeyDialog({
 					? "Please select a provider"
 					: "Please enter the provider API key",
 				variant: "destructive",
-				className: "text-white",
 			});
 			return;
 		}
@@ -119,7 +117,6 @@ export function CreateProviderKeyDialog({
 				title: "Error",
 				description: "Base URL is required for LLM Gateway provider",
 				variant: "destructive",
-				className: "text-white",
 			});
 			return;
 		}
@@ -143,7 +140,6 @@ export function CreateProviderKeyDialog({
 				title: "Error",
 				description: "No organization found. Please try refreshing the page.",
 				variant: "destructive",
-				className: "text-white",
 			});
 			return;
 		}
@@ -173,7 +169,6 @@ export function CreateProviderKeyDialog({
 						title: "Error",
 						description: error?.message ?? "Failed to create key",
 						variant: "destructive",
-						className: "text-white",
 					});
 				},
 			},

--- a/apps/ui/src/lib/components/toaster.tsx
+++ b/apps/ui/src/lib/components/toaster.tsx
@@ -15,7 +15,11 @@ export function Toaster() {
 		<ToastProvider>
 			{toasts.map(({ id, title, description, action, ...props }) => {
 				return (
-					<Toast key={id} {...props}>
+					<Toast
+						key={id}
+						{...props}
+						className={props.variant === "destructive" ? "text-white" : ""}
+					>
 						<div className="grid gap-1">
 							{title && <ToastTitle>{title}</ToastTitle>}
 							{description && (

--- a/apps/ui/src/routes/login.tsx
+++ b/apps/ui/src/routes/login.tsx
@@ -83,7 +83,6 @@ function RouteComponent() {
 					toast({
 						title: ctx.error.message || "An unknown error occurred",
 						variant: "destructive",
-						className: "text-white",
 					});
 				},
 			},
@@ -93,7 +92,6 @@ function RouteComponent() {
 			toast({
 				title: error.message || "An unknown error occurred",
 				variant: "destructive",
-				className: "text-white",
 			});
 		}
 
@@ -108,7 +106,6 @@ function RouteComponent() {
 				toast({
 					title: res.error.message || "Failed to sign in with passkey",
 					variant: "destructive",
-					className: "text-white",
 				});
 				return;
 			}
@@ -119,7 +116,6 @@ function RouteComponent() {
 			toast({
 				title: error?.message || "Failed to sign in with passkey",
 				variant: "destructive",
-				className: "text-white",
 			});
 		} finally {
 			setIsLoading(false);

--- a/apps/ui/src/routes/signup.tsx
+++ b/apps/ui/src/routes/signup.tsx
@@ -80,7 +80,6 @@ function RouteComponent() {
 					toast({
 						title: ctx.error.message || "Failed to sign up",
 						variant: "destructive",
-						className: "text-white",
 					});
 				},
 			},
@@ -90,7 +89,6 @@ function RouteComponent() {
 			toast({
 				title: error.message || "Failed to sign up",
 				variant: "destructive",
-				className: "text-white",
 			});
 		}
 


### PR DESCRIPTION
Moved `className` logic for destructive toasts into `Toast` component, reducing duplication across multiple files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated error toast notifications throughout the app to use consistent styling for destructive messages. The "text-white" class is now applied automatically to destructive toasts, ensuring a uniform appearance for error notifications.
- **Bug Fixes**
  - Improved visual consistency of error toasts by centralizing their styling, removing redundant styling from individual toast calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->