### PR TITLE
hotfix: fix redirection for models documentation

### DIFF
--- a/apps/ui/src/routes/models.tsx
+++ b/apps/ui/src/routes/models.tsx
@@ -183,7 +183,7 @@ function ProvidersPage() {
 
 					<footer className="mt-16 text-center">
 						<a
-							href={`${DOCS_URL}/v1/models`}
+							href={`${DOCS_URL}v1/models`}
 							target="_blank"
 							className="inline-flex items-center gap-2 text-sm text-muted-foreground"
 						>


### PR DESCRIPTION
https://github.com/user-attachments/assets/1cdc7373-f9df-4a79-ab60-5294f8d72149

Hello @steebchen @smakosh this is a small quick fix for this redirection i guess you guys forget and added `/` for the `DOCS_URL` this is a small hotfix for this