### PR TITLE
feat(models): add o3 and o3-mini model configurations

### DIFF
--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -152,6 +152,32 @@ export let models = [
 		jsonOutput: true,
 	},
 	{
+		model: "o3",
+		providers: [
+			{
+				providerId: "openai",
+				modelName: "o3",
+				inputPrice: 2 / 1e6,
+				outputPrice: 8 / 1e6,
+				contextSize: 200000,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
+		model: "o3-mini",
+		providers: [
+			{
+				providerId: "openai",
+				modelName: "o3-mini",
+				inputPrice: 1.1 / 1e6,
+				outputPrice: 4.4 / 1e6,
+				contextSize: 200000,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
 		model: "claude-3-7-sonnet-20250219",
 		providers: [
 			{

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -151,19 +151,20 @@ export let models = [
 		],
 		jsonOutput: true,
 	},
-	{
-		model: "o3",
-		providers: [
-			{
-				providerId: "openai",
-				modelName: "o3",
-				inputPrice: 2 / 1e6,
-				outputPrice: 8 / 1e6,
-				contextSize: 200000,
-			},
-		],
-		jsonOutput: true,
-	},
+	// TODO configure streaming: false for this once we can configure it on a model level
+	// {
+	// 	model: "o3",
+	// 	providers: [
+	// 		{
+	// 			providerId: "openai",
+	// 			modelName: "o3",
+	// 			inputPrice: 2 / 1e6,
+	// 			outputPrice: 8 / 1e6,
+	// 			contextSize: 200000,
+	// 		},
+	// 	],
+	// 	jsonOutput: true,
+	// },
 	{
 		model: "o3-mini",
 		providers: [


### PR DESCRIPTION
Added configurations for "o3" and "o3-mini" models with respective pricing and context size details. These models are supported by OpenAI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "o3-mini" model, including pricing details and JSON output capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->