### PR TITLE
fix(ui): reuse provider dropdown in onboarding

### DIFF
--- a/apps/ui/src/components/onboarding/provider-key-step.tsx
+++ b/apps/ui/src/components/onboarding/provider-key-step.tsx
@@ -15,6 +15,7 @@ import {
 	CardTitle,
 } from "../../lib/components/card";
 import { Step } from "../../lib/components/stepper";
+import { ProviderSelect } from "../provider-keys/provider-select";
 import { UpgradeToProDialog } from "@/components/shared/upgrade-to-pro-dialog";
 import { useDefaultOrganization } from "@/hooks/useOrganization";
 import {
@@ -26,13 +27,6 @@ import {
 	FormMessage,
 } from "@/lib/components/form";
 import { Input } from "@/lib/components/input";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/lib/components/select";
 import { toast } from "@/lib/components/use-toast";
 import { $api } from "@/lib/fetch-client";
 
@@ -138,23 +132,14 @@ export function ProviderKeyStep() {
 										render={({ field }) => (
 											<FormItem>
 												<FormLabel>Provider</FormLabel>
-												<Select
-													onValueChange={field.onChange}
-													defaultValue={field.value}
-												>
-													<FormControl>
-														<SelectTrigger>
-															<SelectValue placeholder="Select a provider" />
-														</SelectTrigger>
-													</FormControl>
-													<SelectContent>
-														{providers.map((provider) => (
-															<SelectItem key={provider.id} value={provider.id}>
-																{provider.name}
-															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
+												<FormControl>
+													<ProviderSelect
+														onValueChange={field.onChange}
+														value={field.value}
+														providers={providers}
+														placeholder="Select a provider"
+													/>
+												</FormControl>
 												<FormMessage />
 											</FormItem>
 										)}

--- a/apps/ui/src/components/onboarding/provider-key-step.tsx
+++ b/apps/ui/src/components/onboarding/provider-key-step.tsx
@@ -136,7 +136,9 @@ export function ProviderKeyStep() {
 													<ProviderSelect
 														onValueChange={field.onChange}
 														value={field.value}
-														providers={providers}
+														providers={providers.filter(
+															(p) => p.id !== "llmgateway",
+														)}
 														placeholder="Select a provider"
 													/>
 												</FormControl>

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -1,18 +1,9 @@
-import { providers, type ProviderId } from "@llmgateway/models";
+import { providers } from "@llmgateway/models";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePostHog } from "posthog-js/react";
 import React, { useState } from "react";
 
-import anthropicLogo from "@/assets/models/anthropic.svg?react";
-import CloudRiftLogo from "@/assets/models/cloudrift.svg?react";
-import GoogleStudioAiLogo from "@/assets/models/google-studio-ai.svg?react";
-import GoogleVertexLogo from "@/assets/models/google-vertex-ai.svg?react";
-import InferenceLogo from "@/assets/models/inference-net.svg?react";
-import KlusterLogo from "@/assets/models/kluster-ai.svg?react";
-import LLMGatewayLogo from "@/assets/models/llmgateway.svg?react";
-import MistralLogo from "@/assets/models/mistral.svg?react";
-import OpenAiLogo from "@/assets/models/openai.svg?react";
-import TogetherAiLogo from "@/assets/models/together-ai.svg?react";
+import { ProviderSelect } from "./provider-select";
 import { useDefaultOrganization } from "@/hooks/useOrganization";
 import { Alert, AlertDescription } from "@/lib/components/alert";
 import { Badge } from "@/lib/components/badge";
@@ -28,30 +19,8 @@ import {
 } from "@/lib/components/dialog";
 import { Input } from "@/lib/components/input";
 import { Label } from "@/lib/components/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/lib/components/select";
 import { toast } from "@/lib/components/use-toast";
 import { $api } from "@/lib/fetch-client";
-
-const providerLogoComponents: Partial<
-	Record<ProviderId, React.FC<React.SVGProps<SVGSVGElement>> | null>
-> = {
-	llmgateway: LLMGatewayLogo,
-	openai: OpenAiLogo,
-	anthropic: anthropicLogo,
-	"google-vertex": GoogleVertexLogo,
-	"inference.net": InferenceLogo,
-	"kluster.ai": KlusterLogo,
-	"together.ai": TogetherAiLogo,
-	"google-ai-studio": GoogleStudioAiLogo,
-	cloudrift: CloudRiftLogo,
-	mistral: MistralLogo,
-};
 
 export function CreateProviderKeyDialog({
 	children,
@@ -209,37 +178,12 @@ export function CreateProviderKeyDialog({
 				<form onSubmit={handleSubmit} className="space-y-4 py-4">
 					<div className="space-y-2">
 						<Label htmlFor="provider">Provider</Label>
-						<Select
+						<ProviderSelect
 							onValueChange={setSelectedProvider}
 							value={selectedProvider}
-						>
-							<SelectTrigger className="w-full">
-								<SelectValue placeholder="Select provider..." />
-							</SelectTrigger>
-							<SelectContent>
-								{isLoading ? (
-									<SelectItem value="loading" disabled>
-										Loading providers...
-									</SelectItem>
-								) : availableProviders.length > 0 ? (
-									availableProviders.map((provider) => {
-										const Logo = providerLogoComponents[provider.id];
-										return (
-											<SelectItem key={provider.id} value={provider.id}>
-												<div className="flex items-center gap-2">
-													{Logo && <Logo className="h-4 w-4 text-white" />}
-													<span>{provider.name}</span>
-												</div>
-											</SelectItem>
-										);
-									})
-								) : (
-									<SelectItem value="none" disabled>
-										All providers already have keys
-									</SelectItem>
-								)}
-							</SelectContent>
-						</Select>
+							providers={availableProviders}
+							loading={isLoading}
+						/>
 					</div>
 
 					<div className="space-y-2">

--- a/apps/ui/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-list.tsx
@@ -3,12 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { KeyIcon, MoreHorizontal, PlusIcon } from "lucide-react";
 
 import { CreateProviderKeyDialog } from "./create-provider-key-dialog";
-import AnthropicLogo from "@/assets/models/anthropic.svg?react";
-import GoogleVertexLogo from "@/assets/models/google-vertex-ai.svg?react";
-import InferenceLogo from "@/assets/models/inference-net.svg?react";
-import KlusterLogo from "@/assets/models/kluster-ai.svg?react";
-import LLMGatewayLogo from "@/assets/models/llmgateway.svg?react";
-import OpenAILogo from "@/assets/models/openai.svg?react";
+import { providerLogoComponents } from "@/components/provider-keys/provider-logo";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -41,17 +36,6 @@ import {
 import { toast } from "@/lib/components/use-toast";
 import { $api } from "@/lib/fetch-client";
 
-export const providerLogoComponents: Partial<
-	Record<ProviderId, React.FC<React.SVGProps<SVGSVGElement>>>
-> = {
-	llmgateway: LLMGatewayLogo,
-	openai: OpenAILogo,
-	anthropic: AnthropicLogo,
-	"google-vertex": GoogleVertexLogo,
-	"inference.net": InferenceLogo,
-	"kluster.ai": KlusterLogo,
-};
-
 export function ProviderKeysList() {
 	const queryClient = useQueryClient();
 
@@ -70,7 +54,7 @@ export function ProviderKeysList() {
 				onSuccess: () => {
 					toast({ title: "Deleted", description: "Provider key removed" });
 
-					queryClient.invalidateQueries({ queryKey });
+					void queryClient.invalidateQueries({ queryKey });
 				},
 				onError: () =>
 					toast({

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -1,0 +1,28 @@
+import anthropicLogo from "@/assets/models/anthropic.svg?react";
+import CloudRiftLogo from "@/assets/models/cloudrift.svg?react";
+import GoogleStudioAiLogo from "@/assets/models/google-studio-ai.svg?react";
+import GoogleVertexLogo from "@/assets/models/google-vertex-ai.svg?react";
+import InferenceLogo from "@/assets/models/inference-net.svg?react";
+import KlusterLogo from "@/assets/models/kluster-ai.svg?react";
+import LLMGatewayLogo from "@/assets/models/llmgateway.svg?react";
+import MistralLogo from "@/assets/models/mistral.svg?react";
+import OpenAiLogo from "@/assets/models/openai.svg?react";
+import TogetherAiLogo from "@/assets/models/together-ai.svg?react";
+
+import type { ProviderId } from "@llmgateway/models";
+import type React from "react";
+
+export const providerLogoComponents: Partial<
+	Record<ProviderId, React.FC<React.SVGProps<SVGSVGElement>> | null>
+> = {
+	llmgateway: LLMGatewayLogo,
+	openai: OpenAiLogo,
+	anthropic: anthropicLogo,
+	"google-vertex": GoogleVertexLogo,
+	"inference.net": InferenceLogo,
+	"kluster.ai": KlusterLogo,
+	"together.ai": TogetherAiLogo,
+	"google-ai-studio": GoogleStudioAiLogo,
+	cloudrift: CloudRiftLogo,
+	mistral: MistralLogo,
+};

--- a/apps/ui/src/components/provider-keys/provider-select.tsx
+++ b/apps/ui/src/components/provider-keys/provider-select.tsx
@@ -1,0 +1,64 @@
+import { providerLogoComponents } from "./provider-keys-list";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/lib/components/select";
+
+import type { ProviderId } from "@llmgateway/models";
+
+interface Provider {
+	id: string;
+	name: string;
+}
+
+interface ProviderSelectProps {
+	value?: string;
+	onValueChange?: (value: string) => void;
+	providers: Provider[];
+	loading?: boolean;
+	placeholder?: string;
+	emptyMessage?: string;
+}
+
+export function ProviderSelect({
+	value,
+	onValueChange,
+	providers,
+	loading = false,
+	placeholder = "Select provider...",
+	emptyMessage = "All providers already have keys",
+}: ProviderSelectProps) {
+	return (
+		<Select onValueChange={onValueChange} value={value}>
+			<SelectTrigger className="w-full">
+				<SelectValue placeholder={placeholder} />
+			</SelectTrigger>
+			<SelectContent>
+				{loading ? (
+					<SelectItem value="loading" disabled>
+						Loading providers...
+					</SelectItem>
+				) : providers.length > 0 ? (
+					providers.map((provider) => {
+						const Logo = providerLogoComponents[provider.id as ProviderId];
+						return (
+							<SelectItem key={provider.id} value={provider.id}>
+								<div className="flex items-center gap-2">
+									{Logo && <Logo className="h-4 w-4 text-white" />}
+									<span>{provider.name}</span>
+								</div>
+							</SelectItem>
+						);
+					})
+				) : (
+					<SelectItem value="none" disabled>
+						{emptyMessage}
+					</SelectItem>
+				)}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/apps/ui/src/components/provider-keys/provider-select.tsx
+++ b/apps/ui/src/components/provider-keys/provider-select.tsx
@@ -1,4 +1,4 @@
-import { providerLogoComponents } from "./provider-keys-list";
+import { providerLogoComponents } from "@/components/provider-keys/provider-logo";
 import {
 	Select,
 	SelectContent,


### PR DESCRIPTION
## Summary
- extract `ProviderSelect` component for provider dropdown
- reuse ProviderSelect in provider key onboarding step
- adopt ProviderSelect in provider key dialog

## Testing
- `docker compose up -d` *(fails: Cannot connect to the Docker daemon)*
- `pnpm format`
- `pnpm build` *(fails: ENETUNREACH trying to connect during ui build)*
- `pnpm test` *(fails: Redis connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684f6eeac8ac8324a6b0b491ebcca9ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified provider selection dropdown for a more consistent experience when choosing providers.
  - Added provider logos to the selection dropdown for clearer identification.

- **Refactor**
  - Simplified and standardized the provider selection interface across onboarding and provider key creation screens.
  - Consolidated provider logo management for streamlined UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->