### PR TITLE
fix(api): remove obsolete paidModeEnabled

### DIFF
--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -21,7 +21,6 @@ const organizationSchema = z.object({
 	autoTopUpEnabled: z.boolean(),
 	autoTopUpThreshold: z.string().nullable(),
 	autoTopUpAmount: z.string().nullable(),
-	paidModeEnabled: z.boolean().optional(),
 });
 
 const projectSchema = z.object({
@@ -105,11 +104,7 @@ organization.openapi(getOrganizations, async (c) => {
 
 	const organizations = userOrganizations
 		.map((uo) => uo.organization!)
-		.filter((org) => org.status !== "deleted")
-		.map((org) => ({
-			...org,
-			paidModeEnabled: process.env.PAID_MODE === "true",
-		}));
+		.filter((org) => org.status !== "deleted");
 
 	return c.json({
 		organizations,

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -1166,7 +1166,6 @@ export interface paths {
 								autoTopUpEnabled: boolean;
 								autoTopUpThreshold: string | null;
 								autoTopUpAmount: string | null;
-								paidModeEnabled?: boolean;
 							}[];
 						};
 					};
@@ -1212,7 +1211,6 @@ export interface paths {
 								autoTopUpEnabled: boolean;
 								autoTopUpThreshold: string | null;
 								autoTopUpAmount: string | null;
-								paidModeEnabled?: boolean;
 							};
 						};
 					};
@@ -1380,7 +1378,6 @@ export interface paths {
 								autoTopUpEnabled: boolean;
 								autoTopUpThreshold: string | null;
 								autoTopUpAmount: string | null;
-								paidModeEnabled?: boolean;
 							};
 						};
 					};


### PR DESCRIPTION
## Summary
- remove `paidModeEnabled` from organization schema
- regenerate API types

## Testing
- `pnpm format`
- `pnpm build` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ECONNREFUSED)*
- `pnpm test:e2e` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68507e67af9083248dd9a178ad2ad7b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the paidModeEnabled property from organization-related responses and API types. Organizations data now no longer includes this field in the user interface or API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->