### PR TITLE
Remove unused paidModeEnabled flag

### DIFF
--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -21,7 +21,6 @@ const organizationSchema = z.object({
 	autoTopUpEnabled: z.boolean(),
 	autoTopUpThreshold: z.string().nullable(),
 	autoTopUpAmount: z.string().nullable(),
-	paidModeEnabled: z.boolean().optional(),
 });
 
 const projectSchema = z.object({
@@ -105,11 +104,7 @@ organization.openapi(getOrganizations, async (c) => {
 
 	const organizations = userOrganizations
 		.map((uo) => uo.organization!)
-		.filter((org) => org.status !== "deleted")
-		.map((org) => ({
-			...org,
-			paidModeEnabled: process.env.PAID_MODE === "true",
-		}));
+		.filter((org) => org.status !== "deleted");
 
 	return c.json({
 		organizations,


### PR DESCRIPTION
## Summary
- remove `paidModeEnabled` from organization routes

## Testing
- `pnpm generate` *(fails: ENETUNREACH registry.npmjs.org)*
- `pnpm format`
- `pnpm test` *(fails: database connection refused)*
- `pnpm test:e2e` *(fails: database connection refused)*
- `pnpm build` *(fails: ENETUNREACH registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685082fdcba0832484304d783144968a