### PR TITLE
fix(api): use typed body parsing in API routes

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -20,7 +20,7 @@ const chatCompletionSchema = z.object({
 
 chat.post("/completion", async (c) => {
 	try {
-		const body = await c.req.json();
+		const body = c.req.valid("json");
 		const { messages, model, stream, apiKey } =
 			chatCompletionSchema.parse(body);
 

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -1,4 +1,4 @@
-import { OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 
@@ -18,11 +18,29 @@ const chatCompletionSchema = z.object({
 	apiKey: z.string().optional(), // Optional user API key
 });
 
-chat.post("/completion", async (c) => {
+const completionRoute = createRoute({
+	method: "post",
+	path: "/completion",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: chatCompletionSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: "Chat completion response",
+		},
+	},
+});
+
+chat.openapi(completionRoute, async (c) => {
 	try {
 		const body = c.req.valid("json");
-		const { messages, model, stream, apiKey } =
-			chatCompletionSchema.parse(body);
+		const { messages, model, stream, apiKey } = body;
 
 		// Require user to provide their own API key
 		if (!apiKey) {

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -77,7 +77,7 @@ keysApi.openapi(create, async (c) => {
 		});
 	}
 
-	const { description, projectId } = await c.req.json();
+	const { description, projectId } = c.req.valid("json");
 
 	// Get the user's organizations
 	const userOrgs = await db.query.userOrganization.findMany({
@@ -396,7 +396,7 @@ keysApi.openapi(updateStatus, async (c) => {
 	}
 
 	const { id } = c.req.param();
-	const { status } = await c.req.json();
+	const { status } = c.req.valid("json");
 
 	// Get the user's projects
 	const userOrgs = await db.query.userOrganization.findMany({

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -5,6 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import type { ServerTypes } from "../vars";
+import type { ProviderId } from "@llmgateway/models";
 
 export const keysProvider = new OpenAPIHono<ServerTypes>();
 
@@ -151,8 +152,12 @@ keysProvider.openapi(create, async (c) => {
 	try {
 		const isTestEnv =
 			process.env.NODE_ENV === "test" && process.env.E2E_TEST !== "true";
+		// Validate that provider is one of the allowed provider IDs
+		if (!providers.some((p) => p.id === provider) && provider !== "custom") {
+			throw new Error(`Invalid provider: ${provider}`);
+		}
 		validationResult = await validateProviderKey(
-			provider as any,
+			provider as ProviderId,
 			userToken,
 			baseUrl,
 			isTestEnv,

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -84,7 +84,7 @@ keysProvider.openapi(create, async (c) => {
 		token: userToken,
 		baseUrl,
 		organizationId,
-	} = await c.req.json();
+	} = c.req.valid("json");
 
 	// Verify the user has access to this organization
 	const userOrgs = await db.query.userOrganization.findMany({
@@ -437,7 +437,7 @@ keysProvider.openapi(updateStatus, async (c) => {
 	}
 
 	const { id } = c.req.param();
-	const { status } = await c.req.json();
+	const { status } = c.req.valid("json");
 
 	// Get the user's projects
 	const userOrgs = await db.query.userOrganization.findMany({

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -152,7 +152,7 @@ keysProvider.openapi(create, async (c) => {
 		const isTestEnv =
 			process.env.NODE_ENV === "test" && process.env.E2E_TEST !== "true";
 		validationResult = await validateProviderKey(
-			provider,
+			provider as any,
 			userToken,
 			baseUrl,
 			isTestEnv,

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -294,7 +294,7 @@ organization.openapi(updateOrganization, async (c) => {
 		autoTopUpEnabled,
 		autoTopUpThreshold,
 		autoTopUpAmount,
-	} = await c.req.json();
+	} = c.req.valid("json");
 
 	const userOrganization = await db.query.userOrganization.findFirst({
 		where: {

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -93,7 +93,7 @@ projects.openapi(updateProject, async (c) => {
 	}
 
 	const { id } = c.req.param();
-	const { cachingEnabled, cacheDurationSeconds, mode } = await c.req.json();
+	const { cachingEnabled, cacheDurationSeconds, mode } = c.req.valid("json");
 
 	const userOrgs = await db.query.userOrganization.findMany({
 		where: {
@@ -205,7 +205,7 @@ projects.openapi(createProject, async (c) => {
 		});
 	}
 
-	const body = await c.req.json();
+	const body = c.req.valid("json");
 	const {
 		name,
 		organizationId,

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -43,7 +43,7 @@ const createProSubscription = createRoute({
 
 subscriptions.openapi(createProSubscription, async (c) => {
 	const user = c.get("user");
-	const { billingCycle } = await c.req.json();
+	const { billingCycle } = c.req.valid("json");
 
 	if (!user) {
 		throw new HTTPException(401, {

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -169,7 +169,7 @@ user.openapi(updateUser, async (c) => {
 		});
 	}
 
-	const updateData = await c.req.json();
+	const updateData = c.req.valid("json");
 
 	const userRecord = await db.query.user.findFirst({
 		where: {
@@ -256,7 +256,7 @@ user.openapi(updatePassword, async (c) => {
 		});
 	}
 
-	const { currentPassword, newPassword } = await c.req.json();
+	const { currentPassword, newPassword } = c.req.valid("json");
 
 	const cookieHeader = c.req.raw.headers.get("cookie");
 	const sessionToken = cookieHeader

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -1767,6 +1767,53 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	"/chat/completion": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: {
+				content: {
+					"application/json": {
+						messages: {
+							/** @enum {string} */
+							role: "user" | "assistant" | "system";
+							content: string;
+						}[];
+						model: string;
+						/** @default false */
+						stream?: boolean;
+						apiKey?: string;
+					};
+				};
+			};
+			responses: {
+				/** @description Chat completion response */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content?: never;
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	"/chats": {
 		parameters: {
 			query?: never;


### PR DESCRIPTION
## Summary
- enforce typed request body parsing with `c.req.valid("json")` across API routes

## Testing
- `pnpm format`
- `pnpm generate` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: ECONNREFUSED)*
- `pnpm test:e2e` *(fails: ECONNREFUSED)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685190cd027483248b3e0be058015dee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved request body processing across multiple API endpoints by adopting a validation-based method, enhancing data consistency and schema validation without altering functionality.
- **New Features**
	- Added a new chat completion API endpoint supporting structured message inputs and streaming options for enhanced AI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->