### PR TITLE
test: fix test options argument for Vitest 3

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -161,6 +161,7 @@ describe("e2e tests with real provider keys", () => {
 
 	test.each(testModels)(
 		"/v1/chat/completions with $model",
+		getTestOptions(),
 		async ({ model }) => {
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -196,11 +197,11 @@ describe("e2e tests with real provider keys", () => {
 			// expect(log.outputCost).not.toBeNull();
 			// expect(log.cost).not.toBeNull();
 		},
-		getTestOptions(),
 	);
 
 	test.each(streamingModels)(
 		"/v1/chat/completions streaming with $model",
+		getTestOptions(),
 		async ({ model }) => {
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -291,7 +292,6 @@ describe("e2e tests with real provider keys", () => {
 			// expect(log.cost).not.toBeNull();
 			// expect(log.cost).toBeGreaterThanOrEqual(0);
 		},
-		getTestOptions(),
 	);
 
 	test.each(
@@ -301,6 +301,7 @@ describe("e2e tests with real provider keys", () => {
 		}),
 	)(
 		"/v1/chat/completions with JSON output mode for $model",
+		getTestOptions(),
 		async ({ model }) => {
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -336,7 +337,6 @@ describe("e2e tests with real provider keys", () => {
 			const parsedContent = JSON.parse(content);
 			expect(parsedContent).toHaveProperty("message");
 		},
-		getTestOptions(),
 	);
 
 	test("JSON output mode error for unsupported model", async () => {


### PR DESCRIPTION
## Summary
- move options to second arg in gateway e2e tests to avoid deprecation

## Testing
- `pnpm format`
- `pnpm test:prepare`
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: AssertionError: expected 400 to be 200)*
- `pnpm build` *(fails: gateway build ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68521fb041148324bd7e08e3436a75f9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Standardized the use of test options across all end-to-end API tests for improved consistency and reliability in different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->