### PR TITLE
fix(apikey): unify token masking logic

### DIFF
--- a/apps/api/src/lib/maskToken.ts
+++ b/apps/api/src/lib/maskToken.ts
@@ -1,0 +1,3 @@
+export function maskToken(token: string, visibleChars = 12): string {
+	return `${token.substring(0, visibleChars)}${"\u2022".repeat(11)}`;
+}

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -3,6 +3,8 @@ import { eq, db, shortid, tables } from "@llmgateway/db";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "../lib/maskToken";
+
 import type { ServerTypes } from "../vars";
 
 export const keysApi = new OpenAPIHono<ServerTypes>();
@@ -221,7 +223,7 @@ keysApi.openapi(list, async (c) => {
 	return c.json({
 		apiKeys: apiKeys.map((key) => ({
 			...key,
-			maskedToken: `${key.token.substring(0, 12)}•••••••••••`,
+			maskedToken: maskToken(key.token),
 			token: undefined,
 		})),
 	});
@@ -454,7 +456,7 @@ keysApi.openapi(updateStatus, async (c) => {
 		message: `API key status updated to ${status}`,
 		apiKey: {
 			...updatedApiKey,
-			maskedToken: `${updatedApiKey.token.substring(0, 12)}•••••••••••`,
+			maskedToken: maskToken(updatedApiKey.token),
 			token: undefined,
 		},
 	});

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -4,6 +4,8 @@ import { providers, validateProviderKey } from "@llmgateway/models";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "../lib/maskToken";
+
 import type { ServerTypes } from "../vars";
 import type { ProviderId } from "@llmgateway/models";
 
@@ -267,7 +269,7 @@ keysProvider.openapi(list, async (c) => {
 	return c.json({
 		providerKeys: providerKeys.map((key) => ({
 			...key,
-			maskedToken: `${key.token.substring(0, 12)}•••••••••••`,
+			maskedToken: maskToken(key.token),
 			token: undefined,
 		})),
 	});
@@ -496,7 +498,7 @@ keysProvider.openapi(updateStatus, async (c) => {
 		message: `Provider key status updated to ${status}`,
 		providerKey: {
 			...updatedProviderKey,
-			maskedToken: `${updatedProviderKey.token.substring(0, 12)}•••••••••••`,
+			maskedToken: maskToken(updatedProviderKey.token),
 			token: undefined,
 		},
 	});


### PR DESCRIPTION
## Summary
- expose reusable `maskToken` helper for consistent API key obfuscation
- refactor key routes to use the shared masking helper

## Testing
- `pnpm generate` *(fails: connect ENETUNREACH)*
- `pnpm build` *(fails: connect ENETUNREACH)*
- `pnpm test:unit` *(fails: relation "user" does not exist)*
- `pnpm test:e2e` *(fails: relation "api_key" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6852e564ce448324b6b4bf430f02cba5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved consistency in how sensitive tokens are masked in API responses by centralizing masking logic.
- **Bug Fixes**
	- Enhanced reliability of token masking to ensure sensitive information is consistently obscured in key-related API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->