### PR TITLE
fix(playground): centralize API base URL in env file

### DIFF
--- a/apps/ui/src/components/Chat.tsx
+++ b/apps/ui/src/components/Chat.tsx
@@ -8,6 +8,7 @@ import { Card } from "@/lib/components/card";
 import { Input } from "@/lib/components/input";
 import { ScrollArea } from "@/lib/components/scroll-area";
 import { toast } from "@/lib/components/use-toast";
+import { API_URL } from "@/lib/env";
 
 interface Message {
 	role: "user" | "assistant";
@@ -37,7 +38,8 @@ export function Chat() {
 		setIsLoading(true);
 
 		try {
-			const response = await fetch("/api/chat/completion", {
+			const response = await fetch(API_URL + "/chat/completion", {
+				credentials: "include",
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/apps/ui/src/hooks/useChats.ts
+++ b/apps/ui/src/hooks/useChats.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@/lib/components/use-toast";
+import { API_URL } from "@/lib/env";
 
 export interface Chat {
 	id: string;
@@ -20,11 +21,9 @@ export interface ChatMessage {
 	createdAt: string;
 }
 
-const API_BASE = "/api";
-
 // Helper function for authenticated fetch
 async function authFetch(url: string, options: RequestInit = {}) {
-	const response = await fetch(`${API_BASE}${url}`, {
+	const response = await fetch(`${API_URL}${url}`, {
 		...options,
 		headers: {
 			"Content-Type": "application/json",

--- a/apps/ui/src/routes/playground.tsx
+++ b/apps/ui/src/routes/playground.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/hooks/useChats";
 import { useUser } from "@/hooks/useUser";
 import { SidebarProvider } from "@/lib/components/sidebar";
+import { API_URL } from "@/lib/env";
 import { $api } from "@/lib/fetch-client";
 
 export interface Message {
@@ -167,7 +168,8 @@ function RouteComponent() {
 			});
 
 			const supportsStreaming = getModelStreamingSupport(selectedModel);
-			const response = await fetch("/api/chat/completion", {
+			const response = await fetch(API_URL + "/chat/completion", {
+				credentials: "include",
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({


### PR DESCRIPTION
Replaced hardcoded API paths with `API_URL` from the environment variable across components and hooks. This change improves maintainability and simplifies API endpoint management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated API requests to use a centralized environment variable for the base URL.
  - Ensured API requests include credentials for improved authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->