### PR TITLE
feat(models): add llama-4-maverick-17b support

### DIFF
--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -483,6 +483,19 @@ export let models = [
 		],
 	},
 	{
+		model: "llama-4-maverick-17b-128e-instruct",
+		providers: [
+			{
+				providerId: "cloudrift",
+				modelName: "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+				inputPrice: 0.1 / 1e6,
+				outputPrice: 0.35 / 1e6,
+				contextSize: 1_050_000,
+				streaming: true,
+			},
+		],
+	},
+	{
 		model: "mistral-large-latest",
 		providers: [
 			{


### PR DESCRIPTION
Introduced new model `llama-4-maverick-17b-128e-instruct` with cloudrift provider support. Added pricing, context size, and streaming capabilities for enhanced model usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the "llama-4-maverick-17b-128e-instruct" model, including streaming capabilities and updated pricing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->