### PR TITLE
feat(chat): add support for tools and tool_choice

### DIFF
--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -42,12 +42,23 @@ export function prepareRequestBody(
 	frequency_penalty: number | undefined,
 	presence_penalty: number | undefined,
 	response_format: any,
+	tools?: any[],
+	tool_choice?: string | { type: string; function: { name: string } },
 ) {
 	const requestBody: any = {
 		model: usedModel,
 		messages,
 		stream: stream,
 	};
+
+	// Add tools and tool_choice if provided
+	if (tools && tools.length > 0) {
+		requestBody.tools = tools;
+	}
+
+	if (tool_choice) {
+		requestBody.tool_choice = tool_choice;
+	}
 
 	switch (usedProvider) {
 		case "openai": {


### PR DESCRIPTION
Enhanced chat API to accept `tools` and `tool_choice` parameters. Modified content handling to support `tool_calls` in OpenAI responses. Updated validation schema to include new fields for tools and tool choice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tool calls in the chat completion API, enabling richer message content types and function call metadata.
  - Expanded chat message and response formats to handle text, images, and tool invocation details.
  - Users can now specify tools and tool choices when interacting with the chat API.

- **Bug Fixes**
  - Improved handling of messages containing tool calls to ensure correct content parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->