### PR TITLE
fix(chat): remove unused "event" property in writeSSE calls

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1432,7 +1432,6 @@ chat.openapi(completions, async (c) => {
 									};
 
 									await stream.writeSSE({
-										event: "chunk",
 										data: JSON.stringify(finalUsageChunk),
 										id: String(eventId++),
 									});
@@ -1478,7 +1477,6 @@ chat.openapi(completions, async (c) => {
 									}
 
 									await stream.writeSSE({
-										event: "chunk",
 										data: JSON.stringify(transformedData),
 										id: String(eventId++),
 									});
@@ -1677,7 +1675,6 @@ chat.openapi(completions, async (c) => {
 						};
 
 						await stream.writeSSE({
-							event: "chunk",
 							data: JSON.stringify(finalUsageChunk),
 							id: String(eventId++),
 						});


### PR DESCRIPTION
Eliminated redundant "event: chunk" property in multiple writeSSE calls within the chat module to simplify data payloads and improve readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated streaming responses to remove the "event": "chunk" field from Server-Sent Events (SSE) messages. This change does not affect the structure of the data or overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->