### PR TITLE
Handle 'all' filter value in activity route

### DIFF
--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -72,7 +72,14 @@ activity.openapi(getActivity, async (c) => {
 	}
 
 	// Get the days parameter from the query
-	const { days, projectId } = c.req.valid("query");
+	const query = c.req.valid("query");
+	for (const key of Object.keys(query)) {
+		if ((query as Record<string, unknown>)[key] === "all") {
+			(query as Record<string, unknown>)[key] = undefined;
+		}
+	}
+
+	const { days, projectId } = query;
 
 	// Calculate the date range
 	const endDate = new Date();


### PR DESCRIPTION
## Summary
- sanitize query params in `activity` route so values equal to `all` are ignored

## Testing
- `pnpm generate` *(fails: ENETUNREACH)*
- `pnpm test:unit` *(fails: relation does not exist)*
- `pnpm test:e2e` *(fails: relation does not exist)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6857468b20b083249fee7b49331a3635