### PR TITLE
fix(chat): handle abort errors during stream reading

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1701,7 +1701,11 @@ chat.openapi(completions, async (c) => {
 					}
 				}
 			} catch (error) {
-				console.error("Error reading stream:", error);
+				if (error instanceof Error && error.name === "AbortError") {
+					canceled = true;
+				} else {
+					console.error("Error reading stream:", error);
+				}
 			} finally {
 				// Clean up the event listeners
 				c.req.raw.signal.removeEventListener("abort", onAbort);


### PR DESCRIPTION
Added specific handling for `AbortError` in stream reading logic to prevent unnecessary error logging and ensure proper cleanup.