### PR TITLE
Fix logs filter handling

### DIFF
--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -149,6 +149,10 @@ logs.openapi(get, async (c) => {
 
 	// Get query parameters
 	const query = c.req.valid("query");
+
+	const sanitize = (value: string | undefined) =>
+		value === "all" ? undefined : value;
+
 	const {
 		apiKeyId,
 		providerKeyId,
@@ -163,7 +167,19 @@ logs.openapi(get, async (c) => {
 		cursor,
 		orderBy = "createdAt_desc",
 		limit: queryLimit,
-	} = query;
+	} = {
+		...query,
+		apiKeyId: sanitize(query.apiKeyId),
+		providerKeyId: sanitize(query.providerKeyId),
+		projectId: sanitize(query.projectId),
+		orgId: sanitize(query.orgId),
+		startDate: sanitize(query.startDate),
+		endDate: sanitize(query.endDate),
+		finishReason: sanitize(query.finishReason),
+		unifiedFinishReason: sanitize(query.unifiedFinishReason),
+		provider: sanitize(query.provider),
+		model: sanitize(query.model),
+	};
 
 	// Set default limit if not provided or enforce max limit
 	const limit = queryLimit ? Math.min(queryLimit, 100) : 50;


### PR DESCRIPTION
## Summary
- ignore query filters with value `all` in logs route

## Testing
- `pnpm format`
- `pnpm generate` *(fails: ENETUNREACH)*
- `pnpm build` *(fails: ENETUNREACH)*
- `pnpm test:unit` *(fails: relation does not exist)*
- `pnpm test:e2e` *(fails: relation does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68574be474bc832497b02f6982a19af0