### PR TITLE
fix(logs): handle canceled logs with unified finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -78,10 +78,14 @@ export type LogData = InferInsertModel<typeof log>;
 
 export async function insertLog(logData: LogInsertData): Promise<unknown> {
 	if (logData.unifiedFinishReason === undefined) {
-		logData.unifiedFinishReason = getUnifiedFinishReason(
-			logData.finishReason,
-			logData.usedProvider,
-		);
+		if (logData.canceled) {
+			logData.unifiedFinishReason = UnifiedFinishReason.CANCELED;
+		} else {
+			logData.unifiedFinishReason = getUnifiedFinishReason(
+				logData.finishReason,
+				logData.usedProvider,
+			);
+		}
 	}
 	await publishToQueue(LOG_QUEUE, logData);
 	return 1; // Return 1 to match test expectations


### PR DESCRIPTION
Applied logic to set `unifiedFinishReason` to `CANCELED` for logs where the `canceled` property is true. Ensures accurate representation of log statuses.