### PR TITLE
fix(chat): remove unused Anthropic token estimation logic

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1537,29 +1537,6 @@ chat.openapi(completions, async (c) => {
 										data,
 									);
 
-									// For Anthropic, if we have partial usage data, complete it
-									if (usedProvider === "anthropic" && transformedData.usage) {
-										const usage = transformedData.usage;
-										if (
-											usage.output_tokens !== undefined &&
-											usage.prompt_tokens === undefined
-										) {
-											// Estimate prompt tokens if not provided
-											const estimatedPromptTokens = Math.round(
-												messages.reduce(
-													(acc, m) => acc + (m.content?.length || 0),
-													0,
-												) / 4,
-											);
-											transformedData.usage = {
-												prompt_tokens: estimatedPromptTokens,
-												completion_tokens: usage.output_tokens,
-												total_tokens:
-													estimatedPromptTokens + usage.output_tokens,
-											};
-										}
-									}
-
 									await stream.writeSSE({
 										data: JSON.stringify(transformedData),
 										id: String(eventId++),


### PR DESCRIPTION
Removed outdated logic for estimating prompt tokens when usage data is incomplete for the Anthropic provider. This simplifies and cleans up the chat token handling code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed estimation of prompt tokens from streaming responses for the Anthropic provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->