### PR TITLE
fix(provider-keys): handle provider key server error

### DIFF
--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -173,9 +173,12 @@ keysProvider.openapi(create, async (c) => {
 	}
 
 	if (!validationResult.valid) {
-		if (validationResult.statusCode && validationResult.statusCode >= 500) {
+		if (validationResult.statusCode && (validationResult.statusCode >= 500 || validationResult.statusCode === 429)) {
+			const errorMessage = validationResult.statusCode === 429 
+				? "Rate limit exceeded during validation - please try again later" 
+				: validationResult.error || "Upstream server error";
 			throw new HTTPException(500, {
-				message: validationResult.error || "Upstream server error",
+				message: errorMessage,
 			});
 		}
 		throw new HTTPException(400, {

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -172,17 +172,16 @@ keysProvider.openapi(create, async (c) => {
 		});
 	}
 
+	if (validationResult.error) {
+		const errorMessage = validationResult.error || "Upstream server error";
+		throw new HTTPException(500, {
+			message: `Error from provider: ${errorMessage}. Please try again later or contact support.`,
+		});
+	}
+
 	if (!validationResult.valid) {
-		if (validationResult.statusCode && (validationResult.statusCode >= 500 || validationResult.statusCode === 429)) {
-			const errorMessage = validationResult.statusCode === 429 
-				? "Rate limit exceeded during validation - please try again later" 
-				: validationResult.error || "Upstream server error";
-			throw new HTTPException(500, {
-				message: errorMessage,
-			});
-		}
 		throw new HTTPException(400, {
-			message: `Invalid API key: ${validationResult.error || "Unknown error"}`,
+			message: `Invalid API key. Please make sure the key is correct.`,
 		});
 	}
 

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -175,7 +175,7 @@ keysProvider.openapi(create, async (c) => {
 	if (validationResult.error) {
 		const errorMessage = validationResult.error || "Upstream server error";
 		throw new HTTPException(500, {
-			message: `Error from provider: ${errorMessage}. Please try again later or contact support.`,
+			message: `Error from provider: ${errorMessage} and status code ${validationResult.statusCode}. Please try again later or contact support.`,
 		});
 	}
 

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -173,6 +173,11 @@ keysProvider.openapi(create, async (c) => {
 	}
 
 	if (!validationResult.valid) {
+		if (validationResult.statusCode && validationResult.statusCode >= 500) {
+			throw new HTTPException(500, {
+				message: validationResult.error || "Upstream server error",
+			});
+		}
 		throw new HTTPException(400, {
 			message: `Invalid API key: ${validationResult.error || "Unknown error"}`,
 		});

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -348,7 +348,7 @@ export async function validateProviderKey(
 	token: string,
 	baseUrl?: string,
 	skipValidation = false,
-): Promise<{ valid: boolean; error?: string }> {
+): Promise<{ valid: boolean; error?: string; statusCode?: number }> {
 	// Skip validation if requested (e.g. in test environment)
 	if (skipValidation) {
 		return { valid: true };
@@ -401,16 +401,6 @@ export async function validateProviderKey(
 		});
 
 		if (!response.ok) {
-			if (response.status >= 500) {
-				throw new Error(
-					`Server error: ${response.status} ${response.statusText}`,
-				);
-			}
-
-			if (response.status === 401) {
-				return { valid: false, error: "invalid api key" };
-			}
-
 			const errorText = await response.text();
 			let errorMessage = `Error from provider: ${response.status} ${response.statusText}`;
 
@@ -423,7 +413,15 @@ export async function validateProviderKey(
 				}
 			} catch (_err) {}
 
-			return { valid: false, error: errorMessage };
+			if (response.status === 401) {
+				return {
+					valid: false,
+					error: "invalid api key",
+					statusCode: response.status,
+				};
+			}
+
+			return { valid: false, error: errorMessage, statusCode: response.status };
 		}
 
 		return { valid: true };

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -416,7 +416,6 @@ export async function validateProviderKey(
 			if (response.status === 401) {
 				return {
 					valid: false,
-					error: "invalid api key",
 					statusCode: response.status,
 				};
 			}


### PR DESCRIPTION
## Summary
- return validation status code when checking provider API keys
- bubble up 5xx validation errors in provider key route

## Testing
- `pnpm generate` *(fails: ENETUNREACH)*
- `pnpm test:unit` *(fails: relation does not exist)*
- `pnpm test:e2e`
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68595bf583848324b233f64c2a7932ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during provider key validation by clearly distinguishing client-side errors from server-side issues for more precise feedback.
- **New Features**
	- Enhanced error messages for provider key validation failures, offering more detailed guidance based on error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->