### PR TITLE
feat(models): add support for xAI provider and models

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -98,6 +98,7 @@ function hasProviderEnvironmentToken(provider: Provider): boolean {
 		"kluster.ai": "KLUSTER_AI_API_KEY",
 		"together.ai": "TOGETHER_AI_API_KEY",
 		cloudrift: "CLOUD_RIFT_API_KEY",
+		xai: "X_AI_API_KEY",
 		mistral: "MISTRAL_API_KEY",
 	} as const;
 
@@ -140,6 +141,9 @@ function getProviderTokenFromEnv(usedProvider: Provider): string | undefined {
 			break;
 		case "mistral":
 			token = process.env.MISTRAL_API_KEY;
+			break;
+		case "xai":
+			token = process.env.X_AI_API_KEY;
 			break;
 		default:
 			throw new HTTPException(400, {

--- a/apps/gateway/src/test-utils/test-helpers.ts
+++ b/apps/gateway/src/test-utils/test-helpers.ts
@@ -57,6 +57,7 @@ export function getProviderEnvVar(provider: string): string | undefined {
 		"together.ai": "TOGETHER_AI_API_KEY",
 		cloudrift: "CLOUD_RIFT_API_KEY",
 		mistral: "MISTRAL_API_KEY",
+		xai: "X_AI_API_KEY",
 	};
 	return process.env[envMap[provider]];
 }

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -601,4 +601,101 @@ export let models = [
 		],
 		jsonOutput: false,
 	},
+	{
+		model: "grok-3",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-3",
+				inputPrice: 3.0 / 1e6,
+				outputPrice: 15.0 / 1e6,
+				contextSize: 131072,
+				streaming: true,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
+		model: "grok-3-mini",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-3-mini",
+				inputPrice: 0.3 / 1e6,
+				outputPrice: 0.5 / 1e6,
+				contextSize: 131072,
+				streaming: true,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
+		model: "grok-3-fast",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-3-fast",
+				inputPrice: 5.0 / 1e6,
+				outputPrice: 25.0 / 1e6,
+				contextSize: 131072,
+				streaming: true,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
+		model: "grok-3-mini-fast",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-3-mini-fast",
+				inputPrice: 0.6 / 1e6,
+				outputPrice: 4.0 / 1e6,
+				contextSize: 131072,
+				streaming: true,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
+		model: "grok-2-1212",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-2-1212",
+				inputPrice: 2.0 / 1e6,
+				outputPrice: 10.0 / 1e6,
+				contextSize: 131072,
+				streaming: true,
+			},
+		],
+		jsonOutput: true,
+	},
+	{
+		model: "grok-2-vision-1212",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-2-vision-1212",
+				inputPrice: 2.0 / 1e6,
+				outputPrice: 10.0 / 1e6,
+				imageInputPrice: 2.0 / 1e6,
+				contextSize: 32768,
+				streaming: true,
+			},
+		],
+		jsonOutput: true,
+	},
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -21,6 +21,7 @@ export function getProviderHeaders(
 		case "kluster.ai":
 		case "openai":
 		case "inference.net":
+		case "xai":
 		default:
 			return {
 				Authorization: `Bearer ${token}`,
@@ -61,7 +62,8 @@ export function prepareRequestBody(
 	}
 
 	switch (usedProvider) {
-		case "openai": {
+		case "openai":
+		case "xai": {
 			if (stream) {
 				requestBody.stream_options = {
 					include_usage: true,
@@ -245,6 +247,9 @@ export function getProviderEndpoint(
 			case "mistral":
 				url = "https://api.mistral.ai";
 				break;
+			case "xai":
+				url = "https://api.x.ai";
+				break;
 			default:
 				throw new Error(`Provider ${provider} requires a baseUrl`);
 		}
@@ -269,6 +274,7 @@ export function getProviderEndpoint(
 		case "openai":
 		case "llmgateway":
 		case "cloudrift":
+		case "xai":
 		default:
 			return `${url}/v1/chat/completions`;
 	}

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -128,6 +128,17 @@ export const providers = [
 		website: "https://mistral.ai",
 		announcement: null,
 	},
+	{
+		id: "xai",
+		name: "xAI",
+		description: "xAI's Grok large language models",
+		streaming: true,
+		cancellation: true,
+		jsonOutput: true,
+		color: "#000000",
+		website: "https://x.ai",
+		announcement: null,
+	},
 ] as const satisfies ProviderDefinition[];
 
 export type ProviderId = (typeof providers)[number]["id"];


### PR DESCRIPTION
Extend provider and model definitions to include xAI's Grok models. Add `xai` support for provider configurations, API keys, and endpoints. Update provider credentials logic to incorporate xAI-specific tokens.