### PR TITLE
Implement token-based auto routing

### DIFF
--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -2,13 +2,22 @@ import { type Model, type ModelDefinition, models } from "@llmgateway/models";
 import { encode, encodeChat } from "gpt-tokenizer";
 
 // Define ChatMessage type to match what gpt-tokenizer expects
-interface ChatMessage {
+export interface ChatMessage {
 	role: "user" | "system" | "assistant" | undefined;
 	content: string;
 	name?: string;
 }
 
-const DEFAULT_TOKENIZER_MODEL = "gpt-4";
+export const DEFAULT_TOKENIZER_MODEL = "gpt-4";
+
+export function countMessageTokens(messages: ChatMessage[]): number {
+	try {
+		return encodeChat(messages, DEFAULT_TOKENIZER_MODEL).length;
+	} catch (error) {
+		console.error(`Failed to encode chat messages: ${error}`);
+		return 0;
+	}
+}
 
 /**
  * Calculate costs based on model, provider, and token counts


### PR DESCRIPTION
## Summary
- export tokenizer helpers from costs
- compute message tokens during `auto` routing
- skip models with insufficient context, deprecated, or deactivated

## Testing
- `pnpm build` *(fails: ENETUNREACH)*
- `pnpm test:unit` *(fails: relation missing)*
- `pnpm test:e2e` *(fails: relation missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c86d742d48324a607e74bd4d5777f