### PR TITLE
fix: centralize provider env util

### DIFF
--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -47,8 +47,9 @@ describe("e2e tests for provider keys", () => {
 	test.each(testProviders)(
 		"POST /keys/provider with $name key",
 		async ({ providerId }) => {
-			const envVar = getProviderEnvVar(providerId);
-			if (!envVar) {
+			const envVarName = getProviderEnvVar(providerId);
+			const envVarValue = envVarName ? process.env[envVarName] : undefined;
+			if (!envVarValue) {
 				console.log(`Skipping ${providerId} test - no API key provided`);
 				return;
 			}
@@ -61,7 +62,7 @@ describe("e2e tests for provider keys", () => {
 				},
 				body: JSON.stringify({
 					provider: providerId,
-					token: envVar,
+					token: envVarValue,
 					organizationId: "test-org-id",
 				}),
 			});
@@ -71,7 +72,7 @@ describe("e2e tests for provider keys", () => {
 			expect(res.status).toBe(200);
 			expect(json).toHaveProperty("providerKey");
 			expect(json.providerKey.provider).toBe(providerId);
-			expect(json.providerKey.token).toBe(envVar);
+			expect(json.providerKey.token).toBe(envVarValue);
 
 			const providerKey = await db.query.providerKey.findFirst({
 				where: {
@@ -85,7 +86,7 @@ describe("e2e tests for provider keys", () => {
 			});
 			expect(providerKey).not.toBeNull();
 			expect(providerKey?.provider).toBe(providerId);
-			expect(providerKey?.token).toBe(envVar);
+			expect(providerKey?.token).toBe(envVarValue);
 		},
 	);
 

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -109,10 +109,11 @@ describe("e2e tests with real provider keys", () => {
 		});
 
 		for (const provider of providers) {
-			const envVar = getProviderEnvVar(provider.id);
-			if (envVar) {
-				await createProviderKey(provider.id, envVar, "api-keys");
-				await createProviderKey(provider.id, envVar, "credits");
+			const envVarName = getProviderEnvVar(provider.id);
+			const envVarValue = envVarName ? process.env[envVarName] : undefined;
+			if (envVarValue) {
+				await createProviderKey(provider.id, envVarValue, "api-keys");
+				await createProviderKey(provider.id, envVarValue, "credits");
 			}
 		}
 	});
@@ -351,8 +352,9 @@ describe("e2e tests with real provider keys", () => {
 	);
 
 	test("JSON output mode error for unsupported model", async () => {
-		const envVar = getProviderEnvVar("anthropic");
-		if (!envVar) {
+		const envVarName = getProviderEnvVar("anthropic");
+		const envVarValue = envVarName ? process.env[envVarName] : undefined;
+		if (!envVarValue) {
 			console.log(
 				"Skipping JSON output error test - no Anthropic API key provided",
 			);
@@ -390,8 +392,9 @@ describe("e2e tests with real provider keys", () => {
 	test("/v1/chat/completions with llmgateway/auto in credits mode", async () => {
 		// require all provider keys to be set
 		for (const provider of providers) {
-			const envVar = getProviderEnvVar(provider.id);
-			if (!envVar) {
+			const envVarName = getProviderEnvVar(provider.id);
+			const envVarValue = envVarName ? process.env[envVarName] : undefined;
+			if (!envVarValue) {
 				console.log(
 					`Skipping llmgateway/auto in credits mode test - no API key provided for ${provider.id}`,
 				);
@@ -485,8 +488,9 @@ describe("e2e tests with real provider keys", () => {
 	});
 
 	test.skip("/v1/chat/completions with bare 'custom' model", async () => {
-		const envVar = getProviderEnvVar("openai");
-		if (!envVar) {
+		const envVarName = getProviderEnvVar("openai");
+		const envVarValue = envVarName ? process.env[envVarName] : undefined;
+		if (!envVarValue) {
 			console.log("Skipping custom model test - no OpenAI API key provided");
 			return;
 		}
@@ -504,7 +508,7 @@ describe("e2e tests with real provider keys", () => {
 		await db.insert(tables.providerKey).values({
 			id: "provider-key-custom",
 			provider: "llmgateway",
-			token: envVar,
+			token: envVarValue,
 			baseUrl: "https://api.openai.com", // Use real OpenAI endpoint for testing
 			status: "active",
 			organizationId: "org-id",

--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -1,0 +1,26 @@
+import type { Provider } from "@llmgateway/models";
+
+export const providerEnvVarMap: Record<Provider, string> = {
+	openai: "OPENAI_API_KEY",
+	anthropic: "ANTHROPIC_API_KEY",
+	"google-vertex": "VERTEX_API_KEY",
+	"google-ai-studio": "GOOGLE_AI_STUDIO_API_KEY",
+	"inference.net": "INFERENCE_NET_API_KEY",
+	"kluster.ai": "KLUSTER_AI_API_KEY",
+	"together.ai": "TOGETHER_AI_API_KEY",
+	cloudrift: "CLOUD_RIFT_API_KEY",
+	mistral: "MISTRAL_API_KEY",
+};
+
+export function getProviderEnvVar(
+	provider: Provider | string,
+): string | undefined {
+	return providerEnvVarMap[provider as Provider];
+}
+
+export function hasProviderEnvironmentToken(
+	provider: Provider | string,
+): boolean {
+	const envVar = getProviderEnvVar(provider);
+	return envVar ? Boolean(process.env[envVar]) : false;
+}

--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -1,6 +1,7 @@
 import type { Provider } from "@llmgateway/models";
 
 export const providerEnvVarMap: Record<Provider, string> = {
+	llmgateway: "LLMGATEWAY_API_KEY",
 	openai: "OPENAI_API_KEY",
 	anthropic: "ANTHROPIC_API_KEY",
 	"google-vertex": "VERTEX_API_KEY",

--- a/apps/gateway/src/test-utils/test-helpers.ts
+++ b/apps/gateway/src/test-utils/test-helpers.ts
@@ -3,6 +3,8 @@ import { db } from "@llmgateway/db";
 import redisClient from "../lib/redis";
 import { processLogQueue } from "../worker";
 
+export { getProviderEnvVar } from "../lib/provider";
+
 export async function clearCache() {
 	await redisClient.flushdb();
 }
@@ -44,19 +46,4 @@ export async function waitForLogs(
 	console.warn(message);
 
 	throw new Error(message);
-}
-
-export function getProviderEnvVar(provider: string): string | undefined {
-	const envMap: Record<string, string> = {
-		openai: "OPENAI_API_KEY",
-		anthropic: "ANTHROPIC_API_KEY",
-		"google-vertex": "VERTEX_API_KEY",
-		"google-ai-studio": "GOOGLE_AI_STUDIO_API_KEY",
-		"inference.net": "INFERENCE_NET_API_KEY",
-		"kluster.ai": "KLUSTER_AI_API_KEY",
-		"together.ai": "TOGETHER_AI_API_KEY",
-		cloudrift: "CLOUD_RIFT_API_KEY",
-		mistral: "MISTRAL_API_KEY",
-	};
-	return process.env[envMap[provider]];
 }


### PR DESCRIPTION
## Summary
- extract provider environment helpers into `provider.ts`
- reuse the helpers across gateway code and tests

## Testing
- `pnpm test:unit` *(fails: relation "user" does not exist)*
- `pnpm test:e2e` *(fails: relation "provider_key" does not exist)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685c889952e48324947181b3c5e1f83a