### PR TITLE
test(api): add assertion for token usage consistency

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -452,6 +452,9 @@ describe("e2e tests with real provider keys", () => {
 				expect(json.usage.prompt_tokens).toBeGreaterThan(0);
 				expect(json.usage.completion_tokens).toBeGreaterThan(0);
 				expect(json.usage.total_tokens).toBeGreaterThan(0);
+				expect(json.usage.total_tokens).toEqual(
+					json.usage.prompt_tokens + json.usage.completion_tokens,
+				);
 			},
 		);
 	}

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -136,9 +136,10 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 			promptTokens = json.usageMetadata?.promptTokenCount || null;
 			completionTokens = json.usageMetadata?.candidatesTokenCount || null;
 			// Calculate total consistently like Anthropic
-			totalTokens = promptTokens && completionTokens
-				? promptTokens + completionTokens
-				: json.usageMetadata?.totalTokenCount || null;
+			totalTokens =
+				promptTokens && completionTokens
+					? promptTokens + completionTokens
+					: json.usageMetadata?.totalTokenCount || null;
 			break;
 		case "inference.net":
 		case "kluster.ai":
@@ -150,9 +151,10 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 			promptTokens = json.usage?.prompt_tokens || null;
 			completionTokens = json.usage?.completion_tokens || null;
 			// Calculate total consistently like Anthropic
-			totalTokens = promptTokens && completionTokens
-				? promptTokens + completionTokens
-				: json.usage?.total_tokens || null;
+			totalTokens =
+				promptTokens && completionTokens
+					? promptTokens + completionTokens
+					: json.usage?.total_tokens || null;
 			break;
 		case "mistral":
 			content = json.choices?.[0]?.message?.content || null;

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -135,9 +135,8 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 			finishReason = json.candidates?.[0]?.finishReason || null;
 			promptTokens = json.usageMetadata?.promptTokenCount || null;
 			completionTokens = json.usageMetadata?.candidatesTokenCount || null;
-			// Calculate total consistently like Anthropic
 			totalTokens =
-				promptTokens && completionTokens
+				promptTokens !== null && completionTokens !== null
 					? promptTokens + completionTokens
 					: json.usageMetadata?.totalTokenCount || null;
 			break;
@@ -150,9 +149,8 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 			finishReason = json.choices?.[0]?.finish_reason || null;
 			promptTokens = json.usage?.prompt_tokens || null;
 			completionTokens = json.usage?.completion_tokens || null;
-			// Calculate total consistently like Anthropic
 			totalTokens =
-				promptTokens && completionTokens
+				promptTokens !== null && completionTokens !== null
 					? promptTokens + completionTokens
 					: json.usage?.total_tokens || null;
 			break;

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -135,7 +135,10 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 			finishReason = json.candidates?.[0]?.finishReason || null;
 			promptTokens = json.usageMetadata?.promptTokenCount || null;
 			completionTokens = json.usageMetadata?.candidatesTokenCount || null;
-			totalTokens = json.usageMetadata?.totalTokenCount || null;
+			// Calculate total consistently like Anthropic
+			totalTokens = promptTokens && completionTokens
+				? promptTokens + completionTokens
+				: json.usageMetadata?.totalTokenCount || null;
 			break;
 		case "inference.net":
 		case "kluster.ai":
@@ -146,7 +149,10 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 			finishReason = json.choices?.[0]?.finish_reason || null;
 			promptTokens = json.usage?.prompt_tokens || null;
 			completionTokens = json.usage?.completion_tokens || null;
-			totalTokens = json.usage?.total_tokens || null;
+			// Calculate total consistently like Anthropic
+			totalTokens = promptTokens && completionTokens
+				? promptTokens + completionTokens
+				: json.usage?.total_tokens || null;
 			break;
 		case "mistral":
 			content = json.choices?.[0]?.message?.content || null;


### PR DESCRIPTION
Ensure `total_tokens` equals the sum of `prompt_tokens` and `completion_tokens` in API usage tests.