### PR TITLE
fix(keys): mask tokens with variable lengths

### DIFF
--- a/apps/api/src/lib/maskToken.spec.ts
+++ b/apps/api/src/lib/maskToken.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { maskToken } from "./maskToken";
+
+describe("maskToken", () => {
+	it("masks all characters after the visible ones", () => {
+		const masked = maskToken("12345678901234567890", 12);
+		expect(masked).toBe("123456789012••••••••");
+	});
+
+	it("handles tokens shorter than visible length", () => {
+		const masked = maskToken("12345", 10);
+		expect(masked).toBe("12345");
+	});
+});

--- a/apps/api/src/lib/maskToken.ts
+++ b/apps/api/src/lib/maskToken.ts
@@ -1,3 +1,4 @@
 export function maskToken(token: string, visibleChars = 12): string {
-	return `${token.substring(0, visibleChars)}${"\u2022".repeat(11)}`;
+	const maskedLength = Math.max(token.length - visibleChars, 0);
+	return `${token.substring(0, visibleChars)}${"\u2022".repeat(maskedLength)}`;
 }


### PR DESCRIPTION
## Summary
- handle variable lengths in `maskToken`
- add unit tests for `maskToken`

## Testing
- `pnpm test:unit` *(fails: relation `api_key` does not exist)*
- `pnpm test:e2e` *(fails: relation `provider_key` does not exist)*
- `pnpm build` *(fails: api#build)*

------
https://chatgpt.com/codex/tasks/task_e_685c873ed9288324a1bec3d7351cd55e