### PR TITLE
feat(ci): update workflow for release-based image builds

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -27,6 +27,11 @@ jobs:
             SHORT_SHA=$(git rev-parse --short HEAD)
             echo "IMAGE_TAG=v0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
           else
+            # Validate that the tag only contains allowed characters
+            if [[ ! "${{ github.event.release.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.]+)*$ ]]; then
+              echo "Invalid tag name for Docker: ${{ github.event.release.tag_name }}"
+              exit 1
+            fi
             echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,9 +1,8 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,18 +31,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get short SHA
-        id: get_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
       - name: Build and push split
         uses: docker/build-push-action@v6
         with:
           context: .
           file: infra/split.dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
           tags: |
-            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ steps.get_sha.outputs.short_sha }}
+            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ github.event.release.tag_name }}
             ghcr.io/${{ github.repository }}-${{ matrix.app }}:latest
           target: ${{ matrix.app }}
           cache-from: type=gha,scope=${{ matrix.app }}
@@ -76,19 +71,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get short SHA
-        id: get_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
       - name: Build and push unified
         uses: docker/build-push-action@v6
         with:
           context: .
           file: infra/unified.dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}-unified:${{ steps.get_sha.outputs.short_sha }}
+            ghcr.io/${{ github.repository }}-unified:${{ github.event.release.tag_name }}
             ghcr.io/${{ github.repository }}-unified:latest
           cache-from: type=gha,scope=unified
           cache-to: type=gha,mode=max,scope=unified

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -12,14 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  push-split:
+  setup:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        app: [api, gateway, ui, docs]
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      image_tag: ${{ steps.set-tag.outputs.IMAGE_TAG }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,6 +29,19 @@ jobs:
           else
             echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
+
+  push-split:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [api, gateway, ui, docs]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,7 +60,7 @@ jobs:
           file: infra/split.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ steps.set-tag.outputs.IMAGE_TAG }}
+            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ needs.setup.outputs.image_tag }}
             ghcr.io/${{ github.repository }}-${{ matrix.app }}:latest
           target: ${{ matrix.app }}
           cache-from: type=gha,scope=${{ matrix.app }}
@@ -66,6 +75,7 @@ jobs:
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}
 
   push-unified:
+    needs: setup
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -73,16 +83,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set image tag
-        id: set-tag
-        run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            SHORT_SHA=$(git rev-parse --short HEAD)
-            echo "IMAGE_TAG=v0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
-          else
-            echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -102,7 +102,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}-unified:${{ steps.set-tag.outputs.IMAGE_TAG }}
+            ghcr.io/${{ github.repository }}-unified:${{ needs.setup.outputs.image_tag }}
             ghcr.io/${{ github.repository }}-unified:latest
           cache-from: type=gha,scope=unified
           cache-to: type=gha,mode=max,scope=unified

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -37,6 +37,7 @@ jobs:
 
   push-split:
     needs: setup
+    if: needs.setup.result == 'success'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,6 +72,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.app }}
           cache-to: type=gha,mode=max,scope=${{ matrix.app }}
           build-args: |
+            APP_VERSION=${{ needs.setup.outputs.image_tag }}
             VITE_API_URL=${{ secrets.API_URL }}
             VITE_DOCS_URL=${{ secrets.DOCS_URL }}
             VITE_CRISP_ID=${{ secrets.CRISP_ID }}
@@ -81,6 +83,7 @@ jobs:
 
   push-unified:
     needs: setup
+    if: needs.setup.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -111,3 +114,5 @@ jobs:
             ghcr.io/${{ github.repository }}-unified:latest
           cache-from: type=gha,scope=unified
           cache-to: type=gha,mode=max,scope=unified
+          build-args: |
+            APP_VERSION=${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -28,7 +28,7 @@ jobs:
             echo "IMAGE_TAG=v0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
           else
             # Validate that the tag only contains allowed characters
-            if [[ ! "${{ github.event.release.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.]+)*$ ]]; then
+            if [[ ! "${{ github.event.release.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_-]+)*$ ]]; then
               echo "Invalid tag name for Docker: ${{ github.event.release.tag_name }}"
               exit 1
             fi

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -3,6 +3,9 @@ name: ci
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +24,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set image tag
+        id: set-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "IMAGE_TAG=v0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          else
+            echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -38,7 +51,7 @@ jobs:
           file: infra/split.dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ github.event.release.tag_name }}
+            ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ steps.set-tag.outputs.IMAGE_TAG }}
             ghcr.io/${{ github.repository }}-${{ matrix.app }}:latest
           target: ${{ matrix.app }}
           cache-from: type=gha,scope=${{ matrix.app }}
@@ -61,6 +74,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set image tag
+        id: set-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo "IMAGE_TAG=v0.0.0-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          else
+            echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -79,7 +102,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}-unified:${{ github.event.release.tag_name }}
+            ghcr.io/${{ github.repository }}-unified:${{ steps.set-tag.outputs.IMAGE_TAG }}
             ghcr.io/${{ github.repository }}-unified:latest
           cache-from: type=gha,scope=unified
           cache-to: type=gha,mode=max,scope=unified


### PR DESCRIPTION
Replace branch-based triggers with release events. Use release tags for Docker image versions and streamline build steps by removing short SHA retrieval.