### PR TITLE
fix(api): allow promotion codes in Stripe

### DIFF
--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -100,6 +100,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 					quantity: 1,
 				},
 			],
+			allow_promotion_codes: true,
 			success_url: `${process.env.UI_URL || "http://localhost:3002"}/dashboard/settings/billing?success=true`,
 			cancel_url: `${process.env.UI_URL || "http://localhost:3002"}/dashboard/settings/billing?canceled=true`,
 			metadata: {


### PR DESCRIPTION
## Summary
- allow using promotion codes in Stripe Checkout by setting `allow_promotion_codes`

## Testing
- `pnpm prepare-codex` *(fails: source command not found)*
- `pnpm test:unit` *(fails: relation "user" does not exist)*
- `pnpm test:e2e` *(fails: numerous database table errors)*
- `pnpm build` *(fails: network unreachable during build)*
- `pnpm generate` *(fails: network unreachable during generate)*

------
https://chatgpt.com/codex/tasks/task_e_686303ac5a0883248402782d0c9fbcee