### PR TITLE
fix(version): expose APP_VERSION env var in docker images

### DIFF
--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -60,6 +60,8 @@ RUN apk add --no-cache tini && \
     cp /sbin/tini /tini
 
 FROM base AS runtime
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
 COPY --from=init /tini /tini
 ENTRYPOINT ["/tini", "--"]
 COPY --from=builder /bin/pnpm /bin/pnpm
@@ -94,6 +96,8 @@ CMD ["pnpm", "start"]
 
 # Base static image with Nginx
 FROM nginx:alpine AS static-base
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
 
 # Copy Nginx configuration
 COPY infra/nginx-static.conf /etc/nginx/nginx.conf

--- a/infra/unified.dockerfile
+++ b/infra/unified.dockerfile
@@ -45,6 +45,8 @@ RUN pnpm build
 
 # Runtime stage with all services
 FROM alpine:3.19 AS runtime
+ARG APP_VERSION
+ENV APP_VERSION=$APP_VERSION
 
 # Install required packages
 RUN apk add --no-cache \


### PR DESCRIPTION
## Summary
- expose `APP_VERSION` build arg as runtime env var in both Dockerfiles

## Testing
- `pnpm prepare-codex`
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: 115 failing tests)*
- `pnpm build` *(fails: gateway build out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_6863174ff47483249b0f378a166c8ba6