### PR TITLE
fix(env): update env variable mappings for consistency

### DIFF
--- a/apps/ui/src/lib/env.ts
+++ b/apps/ui/src/lib/env.ts
@@ -1,6 +1,6 @@
 export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:4002";
 export const GITHUB_URL =
-	import.meta.env.GITHUB_URL || "https://github.com/theopenco/llmgateway";
+	import.meta.env.VITE_GITHUB_URL || "https://github.com/theopenco/llmgateway";
 export const DOCS_URL =
 	import.meta.env.VITE_DOCS_URL || "http://localhost:3005";
 export const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY;

--- a/turbo.json
+++ b/turbo.json
@@ -28,14 +28,10 @@
 				"openapi.json"
 			],
 			"env": [
-				"ORIGIN_URL",
-				"UI_URL",
-				"API_URL",
 				"VITE_POSTHOG_KEY",
 				"VITE_POSTHOG_HOST",
 				"NEXT_PUBLIC_POSTHOG_KEY",
 				"NEXT_PUBLIC_POSTHOG_HOST",
-				"GITHUB_URL",
 				"VITE_API_URL",
 				"VITE_DOCS_URL",
 				"VITE_CRISP_ID"


### PR DESCRIPTION
Replace `GITHUB_URL` with `VITE_GITHUB_URL` for alignment with other VITE-prefixed environment variables. Remove unused variables from turbo.json to streamline configuration.