### PR TITLE
feat(models): modularize and extend Perplexity models

### DIFF
--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -1,3 +1,5 @@
+import { perplexityModels } from "./models/perplexity";
+
 import type { providers } from "./providers";
 
 export type Provider = (typeof providers)[number]["id"];
@@ -54,7 +56,7 @@ export interface ModelDefinition {
 	deactivatedAt?: Date;
 }
 
-export let models = [
+export const models = [
 	{
 		model: "custom", // custom provider which expects base URL to be set
 		deprecatedAt: undefined,
@@ -996,21 +998,5 @@ export let models = [
 		],
 		jsonOutput: true,
 	},
-	{
-		model: "sonar-pro",
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
-		providers: [
-			{
-				providerId: "perplexity",
-				modelName: "sonar-pro",
-				inputPrice: 1.0 / 1e6,
-				outputPrice: 1.0 / 1e6,
-				contextSize: 127072,
-				streaming: false,
-				vision: false,
-			},
-		],
-		jsonOutput: false,
-	},
+	...perplexityModels,
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/perplexity.ts
+++ b/packages/models/src/models/perplexity.ts
@@ -1,0 +1,21 @@
+import type { ModelDefinition } from "@llmgateway/models";
+
+export const perplexityModels = [
+	{
+		model: "sonar-pro",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "perplexity",
+				modelName: "sonar-pro",
+				inputPrice: 1.0 / 1e6,
+				outputPrice: 1.0 / 1e6,
+				contextSize: 127072,
+				streaming: false,
+				vision: false,
+			},
+		],
+		jsonOutput: false,
+	},
+] as const satisfies ModelDefinition[];


### PR DESCRIPTION
Stacked PRs:
 * #434
 * __->__#433


--- --- ---

### feat(models): modularize and extend Perplexity models


Extract Perplexity-related models into a separate module for improved modularity and maintainability.
Reuse `perplexityModels` in the main model definitions to streamline integration.