### PR TITLE
feat(models): add new Perplexity models with updated specs

### DIFF
--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -1,3 +1,5 @@
+import { perplexityModels } from "./models/perplexity";
+
 import type { providers } from "./providers";
 
 export type Provider = (typeof providers)[number]["id"];
@@ -54,7 +56,7 @@ export interface ModelDefinition {
 	deactivatedAt?: Date;
 }
 
-export let models = [
+export const models = [
 	{
 		model: "custom", // custom provider which expects base URL to be set
 		deprecatedAt: undefined,
@@ -996,21 +998,5 @@ export let models = [
 		],
 		jsonOutput: true,
 	},
-	{
-		model: "sonar-pro",
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
-		providers: [
-			{
-				providerId: "perplexity",
-				modelName: "sonar-pro",
-				inputPrice: 1.0 / 1e6,
-				outputPrice: 1.0 / 1e6,
-				contextSize: 127072,
-				streaming: false,
-				vision: false,
-			},
-		],
-		jsonOutput: false,
-	},
+	...perplexityModels,
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/perplexity.ts
+++ b/packages/models/src/models/perplexity.ts
@@ -2,6 +2,24 @@ import type { ModelDefinition } from "@llmgateway/models";
 
 export const perplexityModels = [
 	{
+		model: "sonar-reasoning-pro",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "perplexity",
+				modelName: "sonar-reasoning-pro",
+				inputPrice: 0.000003,
+				outputPrice: 0.00001,
+				imageInputPrice: 0,
+				contextSize: 128000,
+				streaming: false,
+				vision: false,
+			},
+		],
+		jsonOutput: false,
+	},
+	{
 		model: "sonar-pro",
 		deprecatedAt: undefined,
 		deactivatedAt: undefined,
@@ -9,9 +27,28 @@ export const perplexityModels = [
 			{
 				providerId: "perplexity",
 				modelName: "sonar-pro",
-				inputPrice: 1.0 / 1e6,
-				outputPrice: 1.0 / 1e6,
-				contextSize: 127072,
+				inputPrice: 0.000003,
+				outputPrice: 0.000015,
+				imageInputPrice: 0,
+				contextSize: 200000,
+				streaming: false,
+				vision: false,
+			},
+		],
+		jsonOutput: false,
+	},
+	{
+		model: "sonar",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "perplexity",
+				modelName: "sonar",
+				inputPrice: 0.000001,
+				outputPrice: 0.000001,
+				imageInputPrice: 0,
+				contextSize: 130000,
 				streaming: false,
 				vision: false,
 			},

--- a/packages/models/src/models/perplexity.ts
+++ b/packages/models/src/models/perplexity.ts
@@ -1,0 +1,21 @@
+import type { ModelDefinition } from "@llmgateway/models";
+
+export const perplexityModels = [
+	{
+		model: "sonar-pro",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "perplexity",
+				modelName: "sonar-pro",
+				inputPrice: 1.0 / 1e6,
+				outputPrice: 1.0 / 1e6,
+				contextSize: 127072,
+				streaming: false,
+				vision: false,
+			},
+		],
+		jsonOutput: false,
+	},
+] as const satisfies ModelDefinition[];


### PR DESCRIPTION
Stacked PRs:
 * __->__#434
 * #433


--- --- ---

### feat(models): add new Perplexity models with updated specs


Added `sonar-reasoning-pro` and `sonar` models to `perplexityModels`.
Updated `sonar-pro` model's pricing and context size for accuracy.
Extended provider definitions to include `imageInputPrice`.