### PR TITLE
fix(telemetry): make telemetry opt-in with docker default

### DIFF
--- a/apps/api/src/lib/beacon.ts
+++ b/apps/api/src/lib/beacon.ts
@@ -34,9 +34,6 @@ async function sendBeacon(data: BeaconData): Promise<void> {
 export async function sendInstallationBeacon(): Promise<void> {
 	// Check if telemetry is active via environment variable
 	if (process.env.TELEMETRY_ACTIVE !== "true") {
-		console.log(
-			"Telemetry disabled - TELEMETRY_ACTIVE environment variable not set to 'true'",
-		);
 		return;
 	}
 

--- a/apps/api/src/lib/beacon.ts
+++ b/apps/api/src/lib/beacon.ts
@@ -32,10 +32,10 @@ async function sendBeacon(data: BeaconData): Promise<void> {
  * Retrieves installation data and sends beacon on startup
  */
 export async function sendInstallationBeacon(): Promise<void> {
-	// Check if telemetry is disabled via environment variable
-	if (process.env.DISABLE_TELEMETRY === "true") {
+	// Check if telemetry is active via environment variable
+	if (process.env.TELEMETRY_ACTIVE !== "true") {
 		console.log(
-			"Telemetry disabled via DISABLE_TELEMETRY environment variable",
+			"Telemetry disabled - TELEMETRY_ACTIVE environment variable not set to 'true'",
 		);
 		return;
 	}
@@ -44,7 +44,7 @@ export async function sendInstallationBeacon(): Promise<void> {
 		"Sending installation beacon (for anonymous tracking of self-hosted installs.",
 	);
 	console.log(
-		"To disable, set DISABLE_TRACKING=true in your environment variables.",
+		"To disable, set TELEMETRY_ACTIVE=false in your environment variables.",
 	);
 
 	try {

--- a/apps/api/src/routes/beacon.spec.ts
+++ b/apps/api/src/routes/beacon.spec.ts
@@ -11,39 +11,6 @@ vi.mock("../posthog", () => ({
 }));
 
 describe("beacon endpoint", () => {
-	it("should not send data to PostHog when telemetry is disabled", async () => {
-		// Set TELEMETRY_ACTIVE to false
-		const originalValue = process.env.TELEMETRY_ACTIVE;
-		process.env.TELEMETRY_ACTIVE = "false";
-
-		const beaconData = {
-			uuid: "123e4567-e89b-12d3-a456-426614174000",
-			type: "self-host",
-			timestamp: "2024-01-01T00:00:00.000Z",
-		};
-
-		const response = await app.request("/beacon", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify(beaconData),
-		});
-
-		expect(response.status).toBe(200);
-		const responseData = await response.json();
-		expect(responseData).toEqual({
-			success: true,
-			message: "Beacon received (telemetry disabled)",
-		});
-
-		// Verify PostHog was NOT called when telemetry is disabled
-		expect(posthog.capture).not.toHaveBeenCalled();
-
-		// Restore original value
-		process.env.TELEMETRY_ACTIVE = originalValue;
-	});
-
 	it("should accept valid beacon data", async () => {
 		const beaconData = {
 			uuid: "123e4567-e89b-12d3-a456-426614174000",

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -115,7 +115,7 @@ beacon.openapi(beaconRoute, async (c) => {
 	const cloudProvider = c.req.header("CF-Ray")
 		? "cloudflare"
 		: c.req.header("X-Google-Cloud-Region") ||
-			c.req.header("X-Cloud-Trace-Context")
+			  c.req.header("X-Cloud-Trace-Context")
 			? "gcp"
 			: "unknown";
 

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -98,8 +98,8 @@ function extractRegionInfo(c: any): { country?: string; region?: string } {
 beacon.openapi(beaconRoute, async (c) => {
 	const beaconData = c.req.valid("json");
 
-	// Check if telemetry is disabled via environment variable
-	if (process.env.DISABLE_TELEMETRY === "true") {
+	// Check if telemetry is active via environment variable
+	if (process.env.TELEMETRY_ACTIVE !== "true") {
 		console.log("Telemetry disabled - beacon data discarded");
 		return c.json({
 			success: true,
@@ -115,7 +115,7 @@ beacon.openapi(beaconRoute, async (c) => {
 	const cloudProvider = c.req.header("CF-Ray")
 		? "cloudflare"
 		: c.req.header("X-Google-Cloud-Region") ||
-			  c.req.header("X-Cloud-Trace-Context")
+			c.req.header("X-Cloud-Trace-Context")
 			? "gcp"
 			: "unknown";
 

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -98,15 +98,6 @@ function extractRegionInfo(c: any): { country?: string; region?: string } {
 beacon.openapi(beaconRoute, async (c) => {
 	const beaconData = c.req.valid("json");
 
-	// Check if telemetry is active via environment variable
-	if (process.env.TELEMETRY_ACTIVE !== "true") {
-		console.log("Telemetry disabled - beacon data discarded");
-		return c.json({
-			success: true,
-			message: "Beacon received (telemetry disabled)",
-		});
-	}
-
 	// Extract IP and region information
 	const clientIP = extractClientIP(c);
 	const regionInfo = extractRegionInfo(c);

--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -79,6 +79,7 @@ COPY --from=builder /app/packages/db/migrations ./migrations
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
+ENV TELEMETRY_ACTIVE=true
 CMD ["pnpm", "start"]
 
 FROM runtime AS gateway

--- a/infra/unified.dockerfile
+++ b/infra/unified.dockerfile
@@ -123,6 +123,7 @@ ENV POSTGRES_DB=llmgateway
 ENV DATABASE_URL=postgres://postgres:llmgateway@localhost:5432/llmgateway
 ENV REDIS_HOST=localhost
 ENV REDIS_PORT=6379
+ENV TELEMETRY_ACTIVE=true
 
 ENV RUN_MIGRATIONS=true
 


### PR DESCRIPTION
Migrate telemetry control from `DISABLE_TELEMETRY` to `TELEMETRY_ACTIVE` to switch to an opt-in model while maintaining default enablement for Docker deployments.