### PR TITLE
chore(ci): trigger e2e on pull requests instead of push

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,6 @@
 name: e2e
 on:
-  push:
+  pull_request:
     paths:
       - "apps/gateway/**"
       - "packages/models/**"


### PR DESCRIPTION
Updated the e2e workflow to run on pull_request events for specific paths, ensuring tests align with changes made in PRs.