### PR TITLE
fix(onboarding): trigger onboarding redirect when incomplete

### DIFF
--- a/apps/ui/src/hooks/useUser.ts
+++ b/apps/ui/src/hooks/useUser.ts
@@ -57,7 +57,7 @@ export function useUser(options?: UseUserOptions) {
 
 		// Redirect to onboarding if user hasn't completed it
 		if (!data.user.onboardingCompleted) {
-			navigate({ to: "/onboarding" });
+			navigate({ to: "/onboarding", replace: true });
 		}
 	}, [data?.user, isLoading, navigate, routerState.location.pathname]);
 

--- a/apps/ui/src/hooks/useUser.ts
+++ b/apps/ui/src/hooks/useUser.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
 
@@ -24,6 +24,7 @@ export interface UseUserOptions {
 export function useUser(options?: UseUserOptions) {
 	const posthog = usePostHog();
 	const navigate = useNavigate();
+	const routerState = useRouterState();
 	const api = useApi();
 
 	const { data, isLoading, error } = api.useQuery("get", "/user/me", {
@@ -38,6 +39,29 @@ export function useUser(options?: UseUserOptions) {
 		});
 	}
 
+	// Check for onboarding completion for all authenticated users
+	useEffect(() => {
+		if (!data?.user || isLoading) {
+			return;
+		}
+
+		const currentPath = routerState.location.pathname;
+		const isAuthPage = ["/login", "/signup", "/onboarding"].includes(
+			currentPath,
+		);
+
+		// Don't redirect if already on auth pages
+		if (isAuthPage) {
+			return;
+		}
+
+		// Redirect to onboarding if user hasn't completed it
+		if (!data.user.onboardingCompleted) {
+			navigate({ to: "/onboarding" });
+		}
+	}, [data?.user, isLoading, navigate, routerState.location.pathname]);
+
+	// Handle existing redirect logic
 	useEffect(() => {
 		if (!options?.redirectTo || !options?.redirectWhen) {
 			return;


### PR DESCRIPTION
Implement automatic onboarding redirect for incomplete users in `useUser` to ensure all authenticated users complete the process.

Previously, onboarding checks were opt-in. This change makes the check universal for authenticated users, automatically redirecting them to `/onboarding` if incomplete, while excluding auth pages to prevent redirect loops.