### PR TITLE
fix: reset auth dialog form state when switching between login/signup…

### DIFF
--- a/apps/ui/src/components/playground/auth-dialog.tsx
+++ b/apps/ui/src/components/playground/auth-dialog.tsx
@@ -201,7 +201,7 @@ export function AuthDialog({ open }: AuthDialogProps) {
 				</DialogHeader>
 
 				{mode === "login" ? (
-					<Form {...loginForm}>
+					<Form {...loginForm} key="login-form">
 						<form
 							onSubmit={loginForm.handleSubmit(handleLogin)}
 							className="space-y-4"
@@ -214,6 +214,7 @@ export function AuthDialog({ open }: AuthDialogProps) {
 										<FormLabel>Email</FormLabel>
 										<FormControl>
 											<Input
+												key="login-email"
 												placeholder="name@example.com"
 												type="email"
 												autoComplete="username webauthn"
@@ -232,6 +233,7 @@ export function AuthDialog({ open }: AuthDialogProps) {
 										<FormLabel>Password</FormLabel>
 										<FormControl>
 											<Input
+												key="login-password"
 												placeholder="••••••••"
 												type="password"
 												autoComplete="current-password webauthn"
@@ -255,7 +257,7 @@ export function AuthDialog({ open }: AuthDialogProps) {
 						</form>
 					</Form>
 				) : (
-					<Form {...signupForm}>
+					<Form {...signupForm} key="signup-form">
 						<form
 							onSubmit={signupForm.handleSubmit(handleSignup)}
 							className="space-y-4"
@@ -267,7 +269,11 @@ export function AuthDialog({ open }: AuthDialogProps) {
 									<FormItem>
 										<FormLabel>Name</FormLabel>
 										<FormControl>
-											<Input placeholder="John Doe" {...field} />
+											<Input
+												key="signup-name"
+												placeholder="John Doe"
+												{...field}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -281,6 +287,7 @@ export function AuthDialog({ open }: AuthDialogProps) {
 										<FormLabel>Email</FormLabel>
 										<FormControl>
 											<Input
+												key="signup-email"
 												placeholder="name@example.com"
 												type="email"
 												{...field}
@@ -298,6 +305,7 @@ export function AuthDialog({ open }: AuthDialogProps) {
 										<FormLabel>Password</FormLabel>
 										<FormControl>
 											<Input
+												key="signup-password"
 												placeholder="••••••••"
 												type="password"
 												{...field}


### PR DESCRIPTION
### The Issue

When users navigate to the playground and click "Sign in to LLM Gateway", they can enter their email and password in the login form. However, when they click "Don't have an account? Create one" to switch to the signup mode, the "Create your account" dialog shows the email and password from the login form as plain text (not hidden) and makes these fields non-editable.

This creates a poor user experience where:

        -   The name field shows the email address instead of being empty
        -   The password field displays the password in plain text instead of being masked
        -   Both fields are not editable, preventing users from entering their actual signup information
        
I have attached a video demonstrating this issue.


https://github.com/user-attachments/assets/13da07c0-f97a-4363-a493-24550ce4b11a


### What this PR changes

1. Resets form state when switching between login and signup modes in the auth dialog
2. Clears all form values when transitioning from login to signup
3. Ensures the name field is empty and editable in signup mode
4. Ensures the password field is empty and properly masked in signup mode
5. Maintains proper form validation and user experience


### Why I fixed the form state reset

After investigating the auth dialog component, I discovered that the form state wasn't being properly reset when switching between authentication modes. The login form values were being carried over to the signup form, causing the fields to display incorrect data and become non-editable. The fix ensures each form mode starts with clean, editable fields as expected by users.