### PR TITLE
fix(beacon): include version in beacon payload

### DIFF
--- a/apps/api/src/lib/beacon.ts
+++ b/apps/api/src/lib/beacon.ts
@@ -5,6 +5,7 @@ interface BeaconData {
 	uuid: string;
 	type: string;
 	timestamp: string;
+	version: string;
 }
 
 /**
@@ -71,6 +72,7 @@ export async function sendInstallationBeacon(): Promise<void> {
 			uuid: installation.uuid,
 			type: installation.type,
 			timestamp: new Date().toISOString(),
+			version: process.env.APP_VERSION || "v0.0.0-unknown",
 		});
 
 		console.log("Installation beacon sent successfully");

--- a/apps/api/src/routes/beacon.spec.ts
+++ b/apps/api/src/routes/beacon.spec.ts
@@ -16,6 +16,7 @@ describe("beacon endpoint", () => {
 			uuid: "123e4567-e89b-12d3-a456-426614174000",
 			type: "self-host",
 			timestamp: "2024-01-01T00:00:00.000Z",
+			version: "v0.0.0-unknown",
 		};
 
 		const response = await app.request("/beacon", {
@@ -45,7 +46,6 @@ describe("beacon endpoint", () => {
 				client_ip: null, // No IP headers provided
 				country: undefined,
 				region: undefined,
-				cloud_provider: "unknown",
 			},
 		});
 	});
@@ -55,6 +55,7 @@ describe("beacon endpoint", () => {
 			uuid: "123e4567-e89b-12d3-a456-426614174000",
 			type: "self-host",
 			timestamp: "2024-01-01T00:00:00.000Z",
+			version: "v0.0.0-unknown",
 		};
 
 		const response = await app.request("/beacon", {
@@ -83,7 +84,6 @@ describe("beacon endpoint", () => {
 				client_ip: "203.0.113.42",
 				country: "US",
 				region: "California",
-				cloud_provider: "cloudflare",
 			},
 		});
 	});
@@ -93,6 +93,7 @@ describe("beacon endpoint", () => {
 			uuid: "123e4567-e89b-12d3-a456-426614174000",
 			type: "self-host",
 			timestamp: "2024-01-01T00:00:00.000Z",
+			version: "v0.0.0-unknown",
 		};
 
 		const response = await app.request("/beacon", {
@@ -120,7 +121,6 @@ describe("beacon endpoint", () => {
 				client_ip: "198.51.100.25", // First IP from X-Forwarded-For
 				country: undefined, // GCP doesn't provide country in standard headers
 				region: "us-central1",
-				cloud_provider: "gcp",
 			},
 		});
 	});
@@ -130,6 +130,7 @@ describe("beacon endpoint", () => {
 			uuid: "123e4567-e89b-12d3-a456-426614174000",
 			type: "self-host",
 			timestamp: "2024-01-01T00:00:00.000Z",
+			version: "v0.0.0-unknown",
 		};
 
 		const response = await app.request("/beacon", {
@@ -155,7 +156,6 @@ describe("beacon endpoint", () => {
 				client_ip: "192.0.2.123",
 				country: undefined,
 				region: undefined,
-				cloud_provider: "unknown",
 			},
 		});
 	});
@@ -165,6 +165,7 @@ describe("beacon endpoint", () => {
 			uuid: "invalid-uuid",
 			type: "self-host",
 			timestamp: "2024-01-01T00:00:00.000Z",
+			version: "v0.0.0-unknown",
 		};
 
 		const response = await app.request("/beacon", {

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -11,6 +11,7 @@ const beaconDataSchema = z.object({
 	uuid: z.string().uuid("Must be a valid UUID"),
 	type: z.string().min(1, "Type is required"),
 	timestamp: z.string().datetime("Must be a valid ISO datetime"),
+	version: z.string().min(1, "Version is required"),
 });
 
 const beaconRoute = createRoute({
@@ -118,11 +119,10 @@ beacon.openapi(beaconRoute, async (c) => {
 			installation: beaconData.type,
 			timestamp: beaconData.timestamp,
 			source: "self_hosted_api",
-			version: process.env.APP_VERSION || "v0.0.0-unknown",
+			version: beaconData.version,
 			client_ip: clientIP,
 			country: regionInfo.country,
 			region: regionInfo.region,
-			cloud_provider: cloudProvider,
 		},
 	});
 

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -110,6 +110,7 @@ export interface paths {
 						type: string;
 						/** Format: date-time */
 						timestamp: string;
+						version: string;
 					};
 				};
 			};


### PR DESCRIPTION
Added validation and inclusion of the `version` field in the beacon schema and payload to ensure accurate version tracking. Removed `cloud_provider` as it is no longer required for the payload.