### PR TITLE
feat(models): add support for grok-4-0709 model

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -116,4 +116,24 @@ export const xaiModels = [
 		],
 		jsonOutput: true,
 	},
+	{
+		model: "grok-4-0709",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-4-0709",
+				inputPrice: 3.0 / 1e6,
+				outputPrice: 15.0 / 1e6,
+				requestPrice: 0,
+				imageInputPrice: undefined,
+				contextSize: 128000,
+				maxOutput: undefined,
+				streaming: true,
+				vision: false,
+			},
+		],
+		jsonOutput: true,
+	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
Added a new entry in the model definitions for the grok-4-0709 model, including its pricing details, context size, and streaming capability.