### PR TITLE
feat(logs): add support for google-ai-studio finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -39,6 +39,7 @@ export function getUnifiedFinishReason(
 			}
 			break;
 		case "google-vertex":
+		case "google-ai-studio":
 			if (finishReason === "STOP") {
 				return UnifiedFinishReason.COMPLETED;
 			}


### PR DESCRIPTION
Extended `getUnifiedFinishReason` to handle the "google-ai-studio" provider, ensuring proper mapping for `STOP` finish reasons.