### PR TITLE
chore(docker): use BuildKit cache mount for Turborepo instead of manual .turbo creation

### DIFF
--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM node:20.10-alpine AS base
 
 # Build stage
@@ -33,19 +34,8 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY .. .
 
-# Create Turbo cache directories before building (todo temp figure out a better solution)
-RUN mkdir -p /app/packages/db/.turbo \
-    /app/packages/auth/.turbo \
-    /app/packages/models/.turbo \
-    /app/apps/api/.turbo \
-    /app/apps/gateway/.turbo \
-    /app/apps/ui/.turbo \
-    /app/apps/docs/.turbo \
-    /app/apps/next/.turbo \
-    /app/.turbo
-
 # Build all apps
-RUN pnpm build
+RUN --mount=type=cache,target=/app/.turbo pnpm build
 
 
 FROM base AS init


### PR DESCRIPTION
### The Issue

The Dockerfile was manually creating .turbo cache directories in every app and package to prevent potential build errors with Turborepo. This was a temporary workaround, as noted by the comment:

`> “todo temp figure out a better solution”`

Manually creating these folders is unnecessary, adds boilerplate, and doesn’t provide any build cache benefits.


### What this PR changes

- Removes the manual mkdir commands for .turbo folders in the Dockerfile.

- Updates the build step to use Docker BuildKit’s cache mount for /app/.turbo:
           ` RUN --mount=type=cache,target=/app/.turbo pnpm build`
           
- Adds the BuildKit syntax directive at the top of the Dockerfile.


### Why I fixed this

Using BuildKit cache mounts is the modern, recommended way to handle build caching with Turborepo in Docker.

This approach:

- Automatically creates the cache directory as needed.
- Speeds up repeated builds by persisting cache between builds (on the same machine/runner).
- Keeps the Dockerfile cleaner and easier to maintain.