### PR TITLE
feat(providers): add support for custom OpenAI-compatible providers

### DIFF
--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -137,8 +137,8 @@ keysProvider.openapi(create, async (c) => {
 
 	// Check if custom provider is allowed (only for pro plan or self-hosted mode)
 	if (provider === "custom") {
-		const isHosted = true; // process.env.HOSTED === "true";
-		const isPaidMode = true; //  process.env.PAID_MODE === "true";
+		const isHosted = process.env.HOSTED === "true";
+		const isPaidMode = process.env.PAID_MODE === "true";
 		const isProPlan = organization?.plan === "pro";
 
 		// Custom providers are allowed if:

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -135,6 +135,23 @@ keysProvider.openapi(create, async (c) => {
 		});
 	}
 
+	// Check if custom provider is allowed (only for pro plan or self-hosted mode)
+	if (provider === "custom") {
+		const isHosted = true; // process.env.HOSTED === "true";
+		const isPaidMode = true; //  process.env.PAID_MODE === "true";
+		const isProPlan = organization?.plan === "pro";
+
+		// Custom providers are allowed if:
+		// 1. Self-hosted mode (HOSTED !== "true")
+		// 2. Pro plan in hosted mode
+		if (isHosted && isPaidMode && !isProPlan) {
+			throw new HTTPException(403, {
+				message:
+					"Custom providers are only available on the Pro plan. Please upgrade to use custom OpenAI-compatible providers.",
+			});
+		}
+	}
+
 	// Check if a provider key already exists for this provider and organization
 	const existingKey = await db.query.providerKey.findFirst({
 		where: {

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -19,6 +19,7 @@ const providerKeySchema = z.object({
 	updatedAt: z.date(),
 	token: z.string(),
 	provider: z.string(),
+	name: z.string().nullable(),
 	baseUrl: z.string().nullable(),
 	status: z.enum(["active", "inactive", "deleted"]).nullable(),
 	organizationId: z.string(),
@@ -33,6 +34,10 @@ const createProviderKeySchema = z.object({
 				"Invalid provider. Must be one of the supported providers or 'custom'.",
 		}),
 	token: z.string().min(1, "API key is required"),
+	name: z
+		.string()
+		.regex(/^[a-z]+$/, "Name must contain only lowercase letters a-z")
+		.optional(),
 	baseUrl: z.string().url().optional(),
 	organizationId: z.string().min(1, "Organization ID is required"),
 });
@@ -85,6 +90,7 @@ keysProvider.openapi(create, async (c) => {
 	const {
 		provider,
 		token: userToken,
+		name,
 		baseUrl,
 		organizationId,
 	} = c.req.valid("json");
@@ -158,12 +164,18 @@ keysProvider.openapi(create, async (c) => {
 		if (!providers.some((p) => p.id === provider) && provider !== "custom") {
 			throw new Error(`Invalid provider: ${provider}`);
 		}
-		validationResult = await validateProviderKey(
-			provider as ProviderId,
-			userToken,
-			baseUrl,
-			isTestEnv,
-		);
+
+		// Skip validation for custom providers as they don't have predefined models
+		if (provider === "custom") {
+			validationResult = { valid: true };
+		} else {
+			validationResult = await validateProviderKey(
+				provider as ProviderId,
+				userToken,
+				baseUrl,
+				isTestEnv,
+			);
+		}
 	} catch (error) {
 		throw new HTTPException(500, {
 			message:
@@ -193,6 +205,7 @@ keysProvider.openapi(create, async (c) => {
 			token: userToken,
 			organizationId,
 			provider,
+			name,
 			baseUrl,
 		})
 		.returning();

--- a/apps/docs/content/custom-providers.mdx
+++ b/apps/docs/content/custom-providers.mdx
@@ -1,0 +1,79 @@
+---
+title: Custom Providers
+description: Learn how to integrate custom OpenAI-compatible providers with LLMGateway for enhanced flexibility and control.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+# Custom Providers
+
+LLMGateway supports integrating custom OpenAI-compatible providers, allowing you to use any API that follows the OpenAI chat completions format. This feature is perfect for:
+
+- Private or self-hosted LLM deployments
+- Specialized AI providers not natively supported
+- Internal AI services within your organization
+- Testing against different model endpoints
+
+<Callout type="info">
+	Custom providers must be OpenAI-compatible, supporting the
+	`/v1/chat/completions` endpoint format.
+</Callout>
+
+## Quick Setup
+
+### 1. Add a Custom Provider Key
+
+Navigate to your organization's provider settings and add a custom provider via the UI.
+Provide a lowercase name, OpenAI-compatible base URL, and API token for the custom provider.
+
+### 2. Make Requests
+
+Once configured, make requests using the format `{customName}/{modelName}`:
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mycompany/custom-gpt-4",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello from my custom provider!"
+      }
+    ]
+  }'
+```
+
+## Configuration Requirements
+
+### Custom Provider Name
+
+- **Format**: Lowercase letters only (`a-z`)
+- **Examples**: `mycompany`, `internal`, `testing`
+- **Invalid**: `MyCompany`, `my-company`, `my_company`, `123test`
+
+<Callout type="warn">
+	The custom provider name must match the regex pattern `/^[a-z]+$/` exactly.
+</Callout>
+
+### Base URL
+
+- Must be a valid HTTPS URL
+- Should point to your provider's base endpoint
+- LLMGateway will append `/v1/chat/completions` automatically
+- **Example**: `https://api.example.com` → `https://api.example.com/v1/chat/completions`
+
+### API Token
+
+- Provider-specific authentication token
+- Used in the `Authorization: Bearer {token}` header
+
+<Callout type="info">
+	Unlike built-in providers, custom provider models don't require
+	pre-validation, giving you complete flexibility.
+</Callout>
+
+## Supported Features
+
+Custom providers inherit full LLMGateway functionality.

--- a/apps/docs/content/custom-providers.mdx
+++ b/apps/docs/content/custom-providers.mdx
@@ -70,8 +70,8 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 - Used in the `Authorization: Bearer {token}` header
 
 <Callout type="info">
-	Unlike built-in providers, custom provider models don't require
-	pre-validation, giving you complete flexibility.
+	Unlike built-in providers, custom provider models are not validated, giving
+	you complete flexibility.
 </Callout>
 
 ## Supported Features

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -142,7 +142,7 @@ const reasoningModels = testModels.filter((m) =>
 	m.providers.some((p: any) => p.reasoning === true),
 );
 
-describe("e2e tests with real provider keys", () => {
+describe("e2e", () => {
 	beforeEach(async () => {
 		await clearCache();
 
@@ -252,7 +252,7 @@ describe("e2e tests with real provider keys", () => {
 	}
 
 	test.each(testModels)(
-		"/v1/chat/completions with $model",
+		"completions $model",
 		getTestOptions(),
 		async ({ model }) => {
 			const res = await app.request("/v1/chat/completions", {
@@ -403,7 +403,7 @@ describe("e2e tests with real provider keys", () => {
 	);
 
 	test.each(reasoningModels)(
-		"/v1/chat/completions with reasoning for $model",
+		"reasoning $model",
 		getTestOptions(),
 		async ({ model }) => {
 			const res = await app.request("/v1/chat/completions", {
@@ -464,51 +464,47 @@ describe("e2e tests with real provider keys", () => {
 			const modelDef = models.find((def) => def.model === m.model);
 			return (modelDef as any)?.jsonOutput === true;
 		}),
-	)(
-		"/v1/chat/completions with JSON output mode for $model",
-		getTestOptions(),
-		async ({ model }) => {
-			const res = await app.request("/v1/chat/completions", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer real-token`,
-				},
-				body: JSON.stringify({
-					model: model,
-					messages: [
-						{
-							role: "system",
-							content:
-								"You are a helpful assistant. Always respond with valid JSON.",
-						},
-						{
-							role: "user",
-							content: 'Return a JSON object with "message": "Hello World"',
-						},
-					],
-					response_format: { type: "json_object" },
-				}),
-			});
+	)("JSON output $model", getTestOptions(), async ({ model }) => {
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: model,
+				messages: [
+					{
+						role: "system",
+						content:
+							"You are a helpful assistant. Always respond with valid JSON.",
+					},
+					{
+						role: "user",
+						content: 'Return a JSON object with "message": "Hello World"',
+					},
+				],
+				response_format: { type: "json_object" },
+			}),
+		});
 
-			const json = await res.json();
-			if (fullMode) {
-				console.log("json", JSON.stringify(json, null, 2));
-			}
-			expect(res.status).toBe(200);
-			expect(json).toHaveProperty("choices.[0].message.content");
+		const json = await res.json();
+		if (fullMode) {
+			console.log("json", JSON.stringify(json, null, 2));
+		}
+		expect(res.status).toBe(200);
+		expect(json).toHaveProperty("choices.[0].message.content");
 
-			const content = json.choices[0].message.content;
-			expect(() => JSON.parse(content)).not.toThrow();
+		const content = json.choices[0].message.content;
+		expect(() => JSON.parse(content)).not.toThrow();
 
-			const parsedContent = JSON.parse(content);
-			expect(parsedContent).toHaveProperty("message");
-		},
-	);
+		const parsedContent = JSON.parse(content);
+		expect(parsedContent).toHaveProperty("message");
+	});
 
 	if (fullMode) {
 		test.each(providerModels)(
-			"/v1/chat/completions with complex content array for $model",
+			"complex $model",
 			getTestOptions(),
 			async ({ model, provider }) => {
 				const res = await app.request("/v1/chat/completions", {
@@ -614,7 +610,7 @@ describe("e2e tests with real provider keys", () => {
 		await db.delete(tables.providerKey);
 	});
 
-	test("/v1/chat/completions with llmgateway/auto in credits mode", async () => {
+	test("completions with llmgateway/auto in credits mode", async () => {
 		// require all provider keys to be set
 		for (const provider of providers) {
 			const envVarName = getProviderEnvVar(provider.id);
@@ -673,7 +669,7 @@ describe("e2e tests with real provider keys", () => {
 		expect(logs[0].usedModel).toBeTruthy();
 	});
 
-	test("/v1/chat/completions with bare 'auto' model and credits", async () => {
+	test("completions with bare 'auto' model and credits", async () => {
 		await db
 			.update(tables.organization)
 			.set({ credits: "1000" })

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -23,6 +23,7 @@ import { HTTPException } from "hono/http-exception";
 import { streamSSE } from "hono/streaming";
 
 import {
+	checkCustomProviderExists,
 	generateCacheKey,
 	getCache,
 	getCustomProviderKey,
@@ -924,17 +925,10 @@ chat.openapi(completions, async (c) => {
 		// Check if the provider exists
 		const knownProvider = providers.find((p) => p.id === providerCandidate);
 		if (!knownProvider) {
-			// Check if this might be a custom provider name
-			// Custom provider names can only contain lowercase a-z characters
-			if (/^[a-z]+$/.test(providerCandidate)) {
-				// This looks like a custom provider name
-				customProviderName = providerCandidate;
-				requestedProvider = "custom";
-			} else {
-				throw new HTTPException(400, {
-					message: `Requested provider ${providerCandidate} not supported. If you requested a model on a specific provider, make sure to prefix the model name with the provider name. e.g. inference.net/llama-3.3-70b-instruct`,
-				});
-			}
+			// This might be a custom provider name - we'll validate against the database later
+			// For now, assume it's a potential custom provider
+			customProviderName = providerCandidate;
+			requestedProvider = "custom";
 		} else {
 			requestedProvider = providerCandidate as Provider;
 		}
@@ -1132,6 +1126,19 @@ chat.openapi(completions, async (c) => {
 		throw new HTTPException(500, {
 			message: "Could not find project",
 		});
+	}
+
+	// Validate the custom provider against the database if one was requested
+	if (requestedProvider === "custom" && customProviderName) {
+		const customProviderExists = await checkCustomProviderExists(
+			project.organizationId,
+			customProviderName,
+		);
+		if (!customProviderExists) {
+			throw new HTTPException(400, {
+				message: `Provider '${customProviderName}' not found.`,
+			});
+		}
 	}
 
 	// Apply routing logic after apiKey and project are available

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -25,6 +25,7 @@ import { streamSSE } from "hono/streaming";
 import {
 	generateCacheKey,
 	getCache,
+	getCustomProviderKey,
 	getOrganization,
 	getProject,
 	getProviderKey,
@@ -910,6 +911,7 @@ chat.openapi(completions, async (c) => {
 
 	let requestedModel: Model = modelInput as Model;
 	let requestedProvider: Provider | undefined;
+	let customProviderName: string | undefined;
 
 	// check if there is an exact model match
 	if (modelInput === "auto" || modelInput === "custom") {
@@ -920,48 +922,63 @@ chat.openapi(completions, async (c) => {
 		const providerCandidate = split[0];
 
 		// Check if the provider exists
-		if (!providers.find((p) => p.id === providerCandidate)) {
-			throw new HTTPException(400, {
-				message: `Requested provider ${providerCandidate} not supported. If you requested a model on a specific provider, make sure to prefix the model name with the provider name. e.g. inference.net/llama-3.3-70b-instruct`,
-			});
+		const knownProvider = providers.find((p) => p.id === providerCandidate);
+		if (!knownProvider) {
+			// Check if this might be a custom provider name
+			// Custom provider names can only contain lowercase a-z characters
+			if (/^[a-z]+$/.test(providerCandidate)) {
+				// This looks like a custom provider name
+				customProviderName = providerCandidate;
+				requestedProvider = "custom";
+			} else {
+				throw new HTTPException(400, {
+					message: `Requested provider ${providerCandidate} not supported. If you requested a model on a specific provider, make sure to prefix the model name with the provider name. e.g. inference.net/llama-3.3-70b-instruct`,
+				});
+			}
+		} else {
+			requestedProvider = providerCandidate as Provider;
 		}
-
-		requestedProvider = providerCandidate as Provider;
 		// Handle model names with multiple slashes (e.g. together.ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo)
 		const modelName = split.slice(1).join("/");
 
-		// First try to find by base model name
-		let modelDef = models.find((m) => m.model === modelName);
-
-		if (!modelDef) {
-			modelDef = models.find((m) =>
-				m.providers.some(
-					(p) =>
-						p.modelName === modelName && p.providerId === requestedProvider,
-				),
-			);
-		}
-
-		if (!modelDef) {
-			throw new HTTPException(400, {
-				message: `Requested model ${modelName} not supported`,
-			});
-		}
-
-		if (!modelDef.providers.some((p) => p.providerId === requestedProvider)) {
-			throw new HTTPException(400, {
-				message: `Provider ${requestedProvider} does not support model ${modelName}`,
-			});
-		}
-
-		// Use the provider-specific model name if available
-		const providerMapping = modelDef.providers.find(
-			(p) => p.providerId === requestedProvider,
-		);
-		if (providerMapping) {
-			requestedModel = providerMapping.modelName as Model;
-		} else {
+		// For custom providers, we don't need to validate the model name
+		// since they can use any OpenAI-compatible model name
+		if (requestedProvider === "custom") {
 			requestedModel = modelName as Model;
+		} else {
+			// First try to find by base model name
+			let modelDef = models.find((m) => m.model === modelName);
+
+			if (!modelDef) {
+				modelDef = models.find((m) =>
+					m.providers.some(
+						(p) =>
+							p.modelName === modelName && p.providerId === requestedProvider,
+					),
+				);
+			}
+
+			if (!modelDef) {
+				throw new HTTPException(400, {
+					message: `Requested model ${modelName} not supported`,
+				});
+			}
+
+			if (!modelDef.providers.some((p) => p.providerId === requestedProvider)) {
+				throw new HTTPException(400, {
+					message: `Provider ${requestedProvider} does not support model ${modelName}`,
+				});
+			}
+
+			// Use the provider-specific model name if available
+			const providerMapping = modelDef.providers.find(
+				(p) => p.providerId === requestedProvider,
+			);
+			if (providerMapping) {
+				requestedModel = providerMapping.modelName as Model;
+			} else {
+				requestedModel = modelName as Model;
+			}
 		}
 	} else if (models.find((m) => m.model === modelInput)) {
 		requestedModel = modelInput as Model;
@@ -982,20 +999,48 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	if (requestedProvider && !providers.find((p) => p.id === requestedProvider)) {
+	if (
+		requestedProvider &&
+		requestedProvider !== "custom" &&
+		!providers.find((p) => p.id === requestedProvider)
+	) {
 		throw new HTTPException(400, {
 			message: `Requested provider ${requestedProvider} not supported`,
 		});
 	}
 
-	const modelInfo =
-		models.find((m) => m.model === requestedModel) ||
-		models.find((m) => m.providers.find((p) => p.modelName === requestedModel));
+	let modelInfo;
 
-	if (!modelInfo) {
-		throw new HTTPException(400, {
-			message: `Unsupported model: ${requestedModel}`,
-		});
+	if (requestedProvider === "custom") {
+		// For custom providers, we create a mock model info that treats it as an OpenAI model
+		modelInfo = {
+			model: requestedModel,
+			providers: [
+				{
+					providerId: "custom" as const,
+					modelName: requestedModel,
+					inputPrice: 0,
+					outputPrice: 0,
+					contextSize: 8192,
+					maxOutput: 4096,
+					streaming: true,
+					vision: false,
+				},
+			],
+			jsonOutput: true,
+		};
+	} else {
+		modelInfo =
+			models.find((m) => m.model === requestedModel) ||
+			models.find((m) =>
+				m.providers.find((p) => p.modelName === requestedModel),
+			);
+
+		if (!modelInfo) {
+			throw new HTTPException(400, {
+				message: `Unsupported model: ${requestedModel}`,
+			});
+		}
 	}
 
 	// Check if model is deactivated
@@ -1238,11 +1283,30 @@ chat.openapi(completions, async (c) => {
 
 	// Update baseModelName to match the final usedModel after routing
 	// Find the model definition that corresponds to the final usedModel
-	const finalModelInfo = models.find(
-		(m) =>
-			m.model === usedModel ||
-			m.providers.some((p) => p.modelName === usedModel),
-	);
+	let finalModelInfo;
+	if (usedProvider === "custom") {
+		finalModelInfo = {
+			model: usedModel,
+			providers: [
+				{
+					providerId: "custom" as const,
+					modelName: usedModel,
+					inputPrice: 0,
+					outputPrice: 0,
+					contextSize: 8192,
+					maxOutput: 4096,
+					streaming: true,
+					vision: false,
+				},
+			],
+		};
+	} else {
+		finalModelInfo = models.find(
+			(m) =>
+				m.model === usedModel ||
+				m.providers.some((p) => p.modelName === usedModel),
+		);
+	}
 
 	const baseModelName = finalModelInfo?.model || usedModel;
 
@@ -1255,11 +1319,22 @@ chat.openapi(completions, async (c) => {
 
 	if (project.mode === "api-keys") {
 		// Get the provider key from the database using cached helper function
-		providerKey = await getProviderKey(project.organizationId, usedProvider);
+		if (usedProvider === "custom" && customProviderName) {
+			providerKey = await getCustomProviderKey(
+				project.organizationId,
+				customProviderName,
+			);
+		} else {
+			providerKey = await getProviderKey(project.organizationId, usedProvider);
+		}
 
 		if (!providerKey) {
+			const providerDisplayName =
+				usedProvider === "custom" && customProviderName
+					? customProviderName
+					: usedProvider;
 			throw new HTTPException(400, {
-				message: `No API key set for provider: ${usedProvider}. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.`,
+				message: `No API key set for provider: ${providerDisplayName}. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.`,
 			});
 		}
 
@@ -1283,7 +1358,14 @@ chat.openapi(completions, async (c) => {
 		usedToken = getProviderTokenFromEnv(usedProvider);
 	} else if (project.mode === "hybrid") {
 		// First try to get the provider key from the database
-		providerKey = await getProviderKey(project.organizationId, usedProvider);
+		if (usedProvider === "custom" && customProviderName) {
+			providerKey = await getCustomProviderKey(
+				project.organizationId,
+				customProviderName,
+			);
+		} else {
+			providerKey = await getProviderKey(project.organizationId, usedProvider);
+		}
 
 		if (providerKey) {
 			usedToken = providerKey.token;
@@ -1438,7 +1520,7 @@ chat.openapi(completions, async (c) => {
 
 	// Check if streaming is requested and if the model/provider combination supports it
 	if (stream) {
-		if (!getModelStreamingSupport(baseModelName, usedProvider)) {
+		if (getModelStreamingSupport(baseModelName, usedProvider) === false) {
 			throw new HTTPException(400, {
 				message: `Model ${usedModel} with provider ${usedProvider} does not support streaming`,
 			});

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1317,6 +1317,13 @@ chat.openapi(completions, async (c) => {
 	let providerKey: InferSelectModel<typeof tables.providerKey> | undefined;
 	let usedToken: string | undefined;
 
+	if (project.mode === "credits" && usedProvider === "custom") {
+		throw new HTTPException(400, {
+			message:
+				"Custom providers are not supported in credits mode. Please change your project settings to API keys or hybrid mode.",
+		});
+	}
+
 	if (project.mode === "api-keys") {
 		// Get the provider key from the database using cached helper function
 		if (usedProvider === "custom" && customProviderName) {

--- a/apps/gateway/src/lib/cache.ts
+++ b/apps/gateway/src/lib/cache.ts
@@ -211,3 +211,42 @@ export async function getCustomProviderKey(
 		throw error;
 	}
 }
+
+export async function checkCustomProviderExists(
+	organizationId: string,
+	providerCandidate: string,
+): Promise<boolean> {
+	try {
+		const existsCacheKey = `custom_provider_exists:${organizationId}:${providerCandidate}`;
+		const cachedResult = await getCache(existsCacheKey);
+
+		if (cachedResult !== null) {
+			return cachedResult;
+		}
+
+		const providerKey = await db.query.providerKey.findFirst({
+			where: {
+				status: {
+					eq: "active",
+				},
+				organizationId: {
+					eq: organizationId,
+				},
+				provider: {
+					eq: "custom",
+				},
+				name: {
+					eq: providerCandidate,
+				},
+			},
+		});
+
+		const exists = !!providerKey;
+		await setCache(existsCacheKey, exists, 60);
+
+		return exists;
+	} catch (error) {
+		console.error("Error checking if custom provider exists:", error);
+		throw error;
+	}
+}

--- a/apps/gateway/src/lib/cache.ts
+++ b/apps/gateway/src/lib/cache.ts
@@ -171,3 +171,43 @@ export async function getProviderKey(
 		throw error;
 	}
 }
+
+export async function getCustomProviderKey(
+	organizationId: string,
+	customName: string,
+): Promise<InferSelectModel<typeof tables.providerKey> | undefined> {
+	try {
+		const providerKeyCacheKey = `custom_provider_key:${organizationId}:${customName}`;
+		const cachedProviderKey = await getCache(providerKeyCacheKey);
+
+		if (cachedProviderKey) {
+			return cachedProviderKey;
+		}
+
+		const providerKey = await db.query.providerKey.findFirst({
+			where: {
+				status: {
+					eq: "active",
+				},
+				organizationId: {
+					eq: organizationId,
+				},
+				provider: {
+					eq: "custom",
+				},
+				name: {
+					eq: customName,
+				},
+			},
+		});
+
+		if (providerKey) {
+			await setCache(providerKeyCacheKey, providerKey, 60);
+		}
+
+		return providerKey;
+	} catch (error) {
+		console.error("Error fetching custom provider key:", error);
+		throw error;
+	}
+}

--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -17,6 +17,7 @@ export const providerEnvVarMap: Record<Provider, string> = {
 	groq: "GROQ_API_KEY",
 	deepseek: "DEEPSEEK_API_KEY",
 	perplexity: "PERPLEXITY_API_KEY",
+	custom: "UNUSED",
 };
 
 export function getProviderEnvVar(

--- a/apps/next/.content-collections/generated/index.d.ts
+++ b/apps/next/.content-collections/generated/index.d.ts
@@ -1,0 +1,7 @@
+import configuration from "../../content-collections.ts";
+import { GetTypeByName } from "@content-collections/core";
+
+export type Changelog = GetTypeByName<typeof configuration, "changelog">;
+export declare const allChangelogs: Array<Changelog>;
+
+export {};

--- a/apps/next/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/next/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -78,6 +78,11 @@ export function CreateProviderKeyDialog({
 			return false;
 		}
 
+		// Filter out custom provider for non-Pro users in hosted mode
+		if (provider.id === "custom" && config.hosted && !isProPlan) {
+			return false;
+		}
+
 		// If a provider is preselected, always include it even if it has a key
 		if (preselectedProvider && provider.id === preselectedProvider) {
 			return true;
@@ -105,6 +110,17 @@ export function CreateProviderKeyDialog({
 				title: "Upgrade Required",
 				description:
 					"Provider keys are only available on the Pro plan. Please upgrade to use your own API keys.",
+				variant: "destructive",
+			});
+			return;
+		}
+
+		// Additional check for custom providers specifically
+		if (selectedProvider === "custom" && config.hosted && !isProPlan) {
+			toast({
+				title: "Upgrade Required",
+				description:
+					"Custom providers are only available on the Pro plan. Please upgrade to use custom OpenAI-compatible providers.",
 				variant: "destructive",
 			});
 			return;
@@ -230,19 +246,28 @@ export function CreateProviderKeyDialog({
 					</DialogDescription>
 				</DialogHeader>
 				{config.hosted && !isProPlan && (
-					<Alert>
-						<AlertDescription className="flex items-center justify-between gap-2">
-							<span>Provider keys are only available on the Pro plan.</span>
-							<div className="flex items-center gap-2">
-								<Badge variant="outline">Pro Only</Badge>
-								<UpgradeToProDialog>
-									<Button size="sm" variant="outline">
-										Upgrade
-									</Button>
-								</UpgradeToProDialog>
-							</div>
-						</AlertDescription>
-					</Alert>
+					<div className="space-y-3">
+						<Alert>
+							<AlertDescription className="flex items-center justify-between gap-2">
+								<span>Provider keys are only available on the Pro plan.</span>
+								<div className="flex items-center gap-2">
+									<Badge variant="outline">Pro Only</Badge>
+									<UpgradeToProDialog>
+										<Button size="sm" variant="outline">
+											Upgrade
+										</Button>
+									</UpgradeToProDialog>
+								</div>
+							</AlertDescription>
+						</Alert>
+						<Alert>
+							<AlertDescription>
+								<span className="font-medium">Custom Providers:</span> Custom
+								OpenAI-compatible providers are also restricted to Pro plan
+								users for advanced integration capabilities.
+							</AlertDescription>
+						</Alert>
+					</div>
 				)}
 				<form onSubmit={handleSubmit} className="space-y-4 py-4">
 					<div className="space-y-2">

--- a/apps/next/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/next/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -35,6 +35,7 @@ interface CreateProviderKeyDialogProps {
 		createdAt: string;
 		updatedAt: string;
 		provider: string;
+		name: string | null;
 		baseUrl: string | null;
 		status: "active" | "inactive" | "deleted" | null;
 		organizationId: string;
@@ -55,6 +56,7 @@ export function CreateProviderKeyDialog({
 		preselectedProvider || "",
 	);
 	const [baseUrl, setBaseUrl] = useState("");
+	const [customName, setCustomName] = useState("");
 	const [token, setToken] = useState("");
 	const [isValidating, setIsValidating] = useState(false);
 
@@ -128,9 +130,29 @@ export function CreateProviderKeyDialog({
 			return;
 		}
 
+		if (selectedProvider === "custom" && (!baseUrl || !customName)) {
+			toast({
+				title: "Error",
+				description:
+					"Base URL and custom name are required for custom provider",
+				variant: "destructive",
+			});
+			return;
+		}
+
+		if (selectedProvider === "custom" && !/^[a-z]+$/.test(customName)) {
+			toast({
+				title: "Error",
+				description: "Custom name must contain only lowercase letters a-z",
+				variant: "destructive",
+			});
+			return;
+		}
+
 		const payload: {
 			provider: string;
 			token: string;
+			name?: string;
 			baseUrl?: string;
 			organizationId: string;
 		} = {
@@ -140,6 +162,9 @@ export function CreateProviderKeyDialog({
 		};
 		if (baseUrl) {
 			payload.baseUrl = baseUrl;
+		}
+		if (selectedProvider === "custom" && customName) {
+			payload.name = customName;
 		}
 
 		setIsValidating(true);
@@ -180,6 +205,7 @@ export function CreateProviderKeyDialog({
 		setTimeout(() => {
 			setSelectedProvider(preselectedProvider || "");
 			setBaseUrl("");
+			setCustomName("");
 			setToken("");
 		}, 300);
 	};
@@ -254,6 +280,37 @@ export function CreateProviderKeyDialog({
 								required
 							/>
 						</div>
+					)}
+
+					{selectedProvider === "custom" && (
+						<>
+							<div className="space-y-2">
+								<Label htmlFor="custom-name">Custom Provider Name</Label>
+								<Input
+									id="custom-name"
+									type="text"
+									placeholder="my-provider"
+									value={customName}
+									onChange={(e) => setCustomName(e.target.value.toLowerCase())}
+									pattern="[a-z]+"
+									required
+								/>
+								<p className="text-sm text-muted-foreground">
+									Used in model names like: {customName || "my-provider"}/gpt-4o
+								</p>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="custom-base-url">Base URL</Label>
+								<Input
+									id="custom-base-url"
+									type="url"
+									placeholder="https://api.example.com"
+									value={baseUrl}
+									onChange={(e) => setBaseUrl(e.target.value)}
+									required
+								/>
+							</div>
+						</>
 					)}
 
 					<DialogFooter>

--- a/apps/next/src/components/provider-keys/provider-keys-client.tsx
+++ b/apps/next/src/components/provider-keys/provider-keys-client.tsx
@@ -21,6 +21,7 @@ interface ProviderKeysClientProps {
 			createdAt: string;
 			updatedAt: string;
 			provider: string;
+			name: string | null;
 			baseUrl: string | null;
 			status: "active" | "inactive" | "deleted" | null;
 			organizationId: string;

--- a/apps/next/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/next/src/components/provider-keys/provider-keys-list.tsx
@@ -40,6 +40,7 @@ interface ProviderKeysListProps {
 			createdAt: string;
 			updatedAt: string;
 			provider: string;
+			name: string | null;
 			baseUrl: string | null;
 			status: "active" | "inactive" | "deleted" | null;
 			organizationId: string;
@@ -177,7 +178,19 @@ export function ProviderKeysList({
 									)}
 								</div>
 								<div className="flex flex-col">
-									<span className="font-medium">{provider.name}</span>
+									<div className="flex items-center gap-2">
+										<span className="font-medium">{provider.name}</span>
+										{hasKey && existingKey.name && (
+											<Badge variant="outline" className="text-xs">
+												{existingKey.name}
+											</Badge>
+										)}
+										{hasKey && existingKey.baseUrl && (
+											<Badge variant="outline" className="text-xs">
+												{existingKey.baseUrl}
+											</Badge>
+										)}
+									</div>
 									{hasKey && (
 										<div className="flex items-center gap-2 mt-1">
 											<Badge

--- a/apps/next/src/lib/api/v1.d.ts
+++ b/apps/next/src/lib/api/v1.d.ts
@@ -861,6 +861,7 @@ export interface paths {
 								createdAt: string;
 								updatedAt: string;
 								provider: string;
+								name: string | null;
 								baseUrl: string | null;
 								/** @enum {string|null} */
 								status: "active" | "inactive" | "deleted" | null;
@@ -885,6 +886,7 @@ export interface paths {
 					"application/json": {
 						provider: string;
 						token: string;
+						name?: string;
 						/** Format: uri */
 						baseUrl?: string;
 						organizationId: string;
@@ -904,6 +906,7 @@ export interface paths {
 								createdAt: string;
 								updatedAt: string;
 								provider: string;
+								name: string | null;
 								baseUrl: string | null;
 								/** @enum {string|null} */
 								status: "active" | "inactive" | "deleted" | null;
@@ -1010,6 +1013,7 @@ export interface paths {
 								createdAt: string;
 								updatedAt: string;
 								provider: string;
+								name: string | null;
 								baseUrl: string | null;
 								/** @enum {string|null} */
 								status: "active" | "inactive" | "deleted" | null;

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -71,6 +71,11 @@ export function CreateProviderKeyDialog({
 			return false;
 		}
 
+		// Filter out custom provider for non-Pro users in hosted mode
+		if (provider.id === "custom" && config.hosted && !isProPlan) {
+			return false;
+		}
+
 		// If a provider is preselected, always include it even if it has a key
 		if (preselectedProvider && provider.id === preselectedProvider) {
 			return true;
@@ -98,6 +103,17 @@ export function CreateProviderKeyDialog({
 				title: "Upgrade Required",
 				description:
 					"Provider keys are only available on the Pro plan. Please upgrade to use your own API keys.",
+				variant: "destructive",
+			});
+			return;
+		}
+
+		// Additional check for custom providers specifically
+		if (selectedProvider === "custom" && config.hosted && !isProPlan) {
+			toast({
+				title: "Upgrade Required",
+				description:
+					"Custom providers are only available on the Pro plan. Please upgrade to use custom OpenAI-compatible providers.",
 				variant: "destructive",
 			});
 			return;
@@ -221,19 +237,28 @@ export function CreateProviderKeyDialog({
 					</DialogDescription>
 				</DialogHeader>
 				{config.hosted && !isProPlan && (
-					<Alert>
-						<AlertDescription className="flex items-center justify-between gap-2">
-							<span>Provider keys are only available on the Pro plan.</span>
-							<div className="flex items-center gap-2">
-								<Badge variant="outline">Pro Only</Badge>
-								<UpgradeToProDialog>
-									<Button size="sm" variant="outline">
-										Upgrade
-									</Button>
-								</UpgradeToProDialog>
-							</div>
-						</AlertDescription>
-					</Alert>
+					<div className="space-y-3">
+						<Alert>
+							<AlertDescription className="flex items-center justify-between gap-2">
+								<span>Provider keys are only available on the Pro plan.</span>
+								<div className="flex items-center gap-2">
+									<Badge variant="outline">Pro Only</Badge>
+									<UpgradeToProDialog>
+										<Button size="sm" variant="outline">
+											Upgrade
+										</Button>
+									</UpgradeToProDialog>
+								</div>
+							</AlertDescription>
+						</Alert>
+						<Alert>
+							<AlertDescription>
+								<span className="font-medium">Custom Providers:</span> Custom
+								OpenAI-compatible providers are also restricted to Pro plan
+								users for advanced integration capabilities.
+							</AlertDescription>
+						</Alert>
+					</div>
 				)}
 				<form onSubmit={handleSubmit} className="space-y-4 py-4">
 					<div className="space-y-2">

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -43,6 +43,7 @@ export function CreateProviderKeyDialog({
 		preselectedProvider || "",
 	);
 	const [baseUrl, setBaseUrl] = useState("");
+	const [customName, setCustomName] = useState("");
 	const [token, setToken] = useState("");
 	const [isValidating, setIsValidating] = useState(false);
 
@@ -122,9 +123,29 @@ export function CreateProviderKeyDialog({
 			return;
 		}
 
+		if (selectedProvider === "custom" && (!baseUrl || !customName)) {
+			toast({
+				title: "Error",
+				description:
+					"Base URL and custom name are required for custom provider",
+				variant: "destructive",
+			});
+			return;
+		}
+
+		if (selectedProvider === "custom" && !/^[a-z]+$/.test(customName)) {
+			toast({
+				title: "Error",
+				description: "Custom name must contain only lowercase letters a-z",
+				variant: "destructive",
+			});
+			return;
+		}
+
 		const payload: {
 			provider: string;
 			token: string;
+			name?: string;
 			baseUrl?: string;
 			organizationId: string;
 		} = {
@@ -134,6 +155,9 @@ export function CreateProviderKeyDialog({
 		};
 		if (baseUrl) {
 			payload.baseUrl = baseUrl;
+		}
+		if (selectedProvider === "custom" && customName) {
+			payload.name = customName;
 		}
 
 		setIsValidating(true);
@@ -172,6 +196,7 @@ export function CreateProviderKeyDialog({
 		setTimeout(() => {
 			setSelectedProvider(preselectedProvider || "");
 			setBaseUrl("");
+			setCustomName("");
 			setToken("");
 		}, 300);
 	};
@@ -246,6 +271,37 @@ export function CreateProviderKeyDialog({
 								required
 							/>
 						</div>
+					)}
+
+					{selectedProvider === "custom" && (
+						<>
+							<div className="space-y-2">
+								<Label htmlFor="custom-name">Custom Provider Name</Label>
+								<Input
+									id="custom-name"
+									type="text"
+									placeholder="my-provider"
+									value={customName}
+									onChange={(e) => setCustomName(e.target.value.toLowerCase())}
+									pattern="[a-z]+"
+									required
+								/>
+								<p className="text-sm text-muted-foreground">
+									Used in model names like: {customName || "my-provider"}/gpt-4o
+								</p>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="custom-base-url">Base URL</Label>
+								<Input
+									id="custom-base-url"
+									type="url"
+									placeholder="https://api.example.com"
+									value={baseUrl}
+									onChange={(e) => setBaseUrl(e.target.value)}
+									required
+								/>
+							</div>
+						</>
 					)}
 
 					<DialogFooter>

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 import anthropicLogo from "@/assets/models/anthropic.svg?react";
 import CloudRiftLogo from "@/assets/models/cloudrift.svg?react";
 import DeepSeekLogo from "@/assets/models/deepseek.svg?react";
@@ -16,7 +18,17 @@ import TogetherAiLogo from "@/assets/models/together-ai.svg?react";
 import XaiLogo from "@/assets/models/xai.svg?react";
 
 import type { ProviderId } from "@llmgateway/models";
-import type React from "react";
+
+// Custom provider logo component
+const CustomProviderLogo: React.FC<React.SVGProps<SVGSVGElement>> = (props) => {
+	return React.createElement(
+		"svg",
+		{ viewBox: "0 0 24 24", fill: "currentColor", ...props },
+		React.createElement("path", {
+			d: "M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+		}),
+	);
+};
 
 export const providerLogoComponents: Partial<
 	Record<ProviderId, React.FC<React.SVGProps<SVGSVGElement>> | null>
@@ -37,4 +49,5 @@ export const providerLogoComponents: Partial<
 	perplexity: PerplexityLogo,
 	moonshot: MoonshotLogo,
 	novita: NovitaLogo,
+	custom: CustomProviderLogo,
 };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -861,6 +861,7 @@ export interface paths {
 								createdAt: string;
 								updatedAt: string;
 								provider: string;
+								name: string | null;
 								baseUrl: string | null;
 								/** @enum {string|null} */
 								status: "active" | "inactive" | "deleted" | null;
@@ -885,6 +886,7 @@ export interface paths {
 					"application/json": {
 						provider: string;
 						token: string;
+						name?: string;
 						/** Format: uri */
 						baseUrl?: string;
 						organizationId: string;
@@ -904,6 +906,7 @@ export interface paths {
 								createdAt: string;
 								updatedAt: string;
 								provider: string;
+								name: string | null;
 								baseUrl: string | null;
 								/** @enum {string|null} */
 								status: "active" | "inactive" | "deleted" | null;
@@ -1010,6 +1013,7 @@ export interface paths {
 								createdAt: string;
 								updatedAt: string;
 								provider: string;
+								name: string | null;
 								baseUrl: string | null;
 								/** @enum {string|null} */
 								status: "active" | "inactive" | "deleted" | null;

--- a/packages/db/migrations/1752885977_sleepy_prism.sql
+++ b/packages/db/migrations/1752885977_sleepy_prism.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider_key" ADD COLUMN "name" text;

--- a/packages/db/migrations/1753215645_organic_black_tarantula.sql
+++ b/packages/db/migrations/1753215645_organic_black_tarantula.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider_key" ADD CONSTRAINT "provider_key_organizationId_name_unique" UNIQUE("organization_id","name");

--- a/packages/db/migrations/meta/1752885977_snapshot.json
+++ b/packages/db/migrations/meta/1752885977_snapshot.json
@@ -1,0 +1,1689 @@
+{
+  "id": "3b7727f1-6d77-481a-874e-1d5cc1dda6d6",
+  "prevId": "133ec4c8-3212-4798-a700-c7bea4815d6f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_project_id_project_id_fk": {
+          "name": "api_key_project_id_project_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_token_unique": {
+          "name": "api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_user_id_user_id_fk": {
+          "name": "chat_user_id_user_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation": {
+      "name": "installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installation_uuid_unique": {
+          "name": "installation_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lock": {
+      "name": "lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lock_key_unique": {
+          "name": "lock_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log": {
+      "name": "log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_provider": {
+          "name": "requested_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_model": {
+          "name": "used_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_provider": {
+          "name": "used_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unified_finish_reason": {
+          "name": "unified_finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_input_cost": {
+          "name": "cached_input_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_cost": {
+          "name": "request_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_mode": {
+          "name": "used_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_organization_id_organization_id_fk": {
+          "name": "log_organization_id_organization_id_fk",
+          "tableFrom": "log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "log_project_id_project_id_fk": {
+          "name": "log_project_id_project_id_fk",
+          "tableFrom": "log",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "log_api_key_id_api_key_id_fk": {
+          "name": "log_api_key_id_api_key_id_fk",
+          "tableFrom": "log",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_top_up_threshold": {
+          "name": "auto_top_up_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "auto_top_up_amount": {
+          "name": "auto_top_up_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_cancelled": {
+          "name": "subscription_cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_start_date": {
+          "name": "trial_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end_date": {
+          "name": "trial_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trial_active": {
+          "name": "is_trial_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_level": {
+          "name": "retention_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'retain'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_stripeCustomerId_unique": {
+          "name": "organization_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "organization_stripeSubscriptionId_unique": {
+          "name": "organization_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_action": {
+      "name": "organization_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_action_organization_id_organization_id_fk": {
+          "name": "organization_action_organization_id_organization_id_fk",
+          "tableFrom": "organization_action",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_method_organization_id_organization_id_fk": {
+          "name": "payment_method_organization_id_organization_id_fk",
+          "tableFrom": "payment_method",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caching_enabled": {
+          "name": "caching_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_duration_seconds": {
+          "name": "cache_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credits'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_organization_id_organization_id_fk": {
+          "name": "provider_key_organization_id_organization_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_organization_id_organization_id_fk": {
+          "name": "transaction_organization_id_organization_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization": {
+      "name": "user_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organization_user_id_user_id_fk": {
+          "name": "user_organization_user_id_user_id_fk",
+          "tableFrom": "user_organization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_organization_organization_id_organization_id_fk": {
+          "name": "user_organization_organization_id_organization_id_fk",
+          "tableFrom": "user_organization",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/1753215645_snapshot.json
+++ b/packages/db/migrations/meta/1753215645_snapshot.json
@@ -1,0 +1,1698 @@
+{
+  "id": "516d40a0-e7c0-4a34-8bed-78798f386c31",
+  "prevId": "3b7727f1-6d77-481a-874e-1d5cc1dda6d6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_project_id_project_id_fk": {
+          "name": "api_key_project_id_project_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_token_unique": {
+          "name": "api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_user_id_user_id_fk": {
+          "name": "chat_user_id_user_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation": {
+      "name": "installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installation_uuid_unique": {
+          "name": "installation_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lock": {
+      "name": "lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lock_key_unique": {
+          "name": "lock_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log": {
+      "name": "log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_provider": {
+          "name": "requested_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_model": {
+          "name": "used_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_provider": {
+          "name": "used_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unified_finish_reason": {
+          "name": "unified_finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_input_cost": {
+          "name": "cached_input_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_cost": {
+          "name": "request_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_mode": {
+          "name": "used_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_organization_id_organization_id_fk": {
+          "name": "log_organization_id_organization_id_fk",
+          "tableFrom": "log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "log_project_id_project_id_fk": {
+          "name": "log_project_id_project_id_fk",
+          "tableFrom": "log",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "log_api_key_id_api_key_id_fk": {
+          "name": "log_api_key_id_api_key_id_fk",
+          "tableFrom": "log",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_top_up_threshold": {
+          "name": "auto_top_up_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "auto_top_up_amount": {
+          "name": "auto_top_up_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_cancelled": {
+          "name": "subscription_cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_start_date": {
+          "name": "trial_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end_date": {
+          "name": "trial_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trial_active": {
+          "name": "is_trial_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_level": {
+          "name": "retention_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'retain'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_stripeCustomerId_unique": {
+          "name": "organization_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "organization_stripeSubscriptionId_unique": {
+          "name": "organization_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_action": {
+      "name": "organization_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_action_organization_id_organization_id_fk": {
+          "name": "organization_action_organization_id_organization_id_fk",
+          "tableFrom": "organization_action",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_method_organization_id_organization_id_fk": {
+          "name": "payment_method_organization_id_organization_id_fk",
+          "tableFrom": "payment_method",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caching_enabled": {
+          "name": "caching_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_duration_seconds": {
+          "name": "cache_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credits'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_organization_id_organization_id_fk": {
+          "name": "provider_key_organization_id_organization_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_key_organizationId_name_unique": {
+          "name": "provider_key_organizationId_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_organization_id_organization_id_fk": {
+          "name": "transaction_organization_id_organization_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization": {
+      "name": "user_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organization_user_id_user_id_fk": {
+          "name": "user_organization_user_id_user_id_fk",
+          "tableFrom": "user_organization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_organization_organization_id_organization_id_fk": {
+          "name": "user_organization_organization_id_organization_id_fk",
+          "tableFrom": "user_organization",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1752885977695,
       "tag": "1752885977_sleepy_prism",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1753215645665,
+      "tag": "1753215645_organic_black_tarantula",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1752244118434,
       "tag": "1752244118_sharp_captain_flint",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1752885977695,
+      "tag": "1752885977_sleepy_prism",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,7 @@ import {
 	real,
 	text,
 	timestamp,
+	unique,
 } from "drizzle-orm/pg-core";
 import { customAlphabet } from "nanoid";
 
@@ -232,7 +233,7 @@ export const providerKey = pgTable(
 			.notNull()
 			.references(() => organization.id, { onDelete: "cascade" }),
 	},
-	(table) => [],
+	(table) => [unique().on(table.organizationId, table.name)],
 );
 
 export const log = pgTable("log", {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -223,6 +223,7 @@ export const providerKey = pgTable(
 			.$onUpdate(() => new Date()),
 		token: text().notNull(),
 		provider: text().notNull(),
+		name: text(), // Optional name for custom providers (lowercase a-z only)
 		baseUrl: text(), // Optional base URL for custom providers
 		status: text({
 			enum: ["active", "inactive", "deleted"],

--- a/packages/models/src/helpers.ts
+++ b/packages/models/src/helpers.ts
@@ -7,10 +7,10 @@ import { providers } from "./providers";
 export function getModelStreamingSupport(
 	modelName: string,
 	providerId?: string,
-): boolean {
+): boolean | null {
 	const modelInfo = models.find((m) => m.model === modelName);
 	if (!modelInfo) {
-		return false;
+		return null;
 	}
 
 	// If no specific provider is requested, check if any provider for this model supports streaming

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -27,6 +27,7 @@ export function getProviderHeaders(
 		case "perplexity":
 		case "novita":
 		case "moonshot":
+		case "custom":
 		default:
 			return {
 				Authorization: `Bearer ${token}`,
@@ -87,7 +88,8 @@ export function prepareRequestBody(
 		case "deepseek":
 		case "perplexity":
 		case "novita":
-		case "moonshot": {
+		case "moonshot":
+		case "custom": {
 			if (stream) {
 				requestBody.stream_options = {
 					include_usage: true,
@@ -305,6 +307,12 @@ export function getProviderEndpoint(
 			case "moonshot":
 				url = "https://api.moonshot.ai";
 				break;
+			case "custom":
+				if (!baseUrl) {
+					throw new Error(`Custom provider requires a baseUrl`);
+				}
+				url = baseUrl;
+				break;
 			default:
 				throw new Error(`Provider ${provider} requires a baseUrl`);
 		}
@@ -337,6 +345,7 @@ export function getProviderEndpoint(
 		case "groq":
 		case "deepseek":
 		case "moonshot":
+		case "custom":
 		default:
 			return `${url}/v1/chat/completions`;
 	}
@@ -420,6 +429,11 @@ export async function validateProviderKey(
 ): Promise<{ valid: boolean; error?: string; statusCode?: number }> {
 	// Skip validation if requested (e.g. in test environment)
 	if (skipValidation) {
+		return { valid: true };
+	}
+
+	// Skip validation for custom providers since they don't have predefined models
+	if (provider === "custom") {
 		return { valid: true };
 	}
 

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -11,7 +11,7 @@ export interface ProviderDefinition {
 	// Color used for UI representation (hex code)
 	color?: string;
 	// Website URL
-	website?: string;
+	website?: string | null;
 	// Announcement text
 	announcement?: string | null;
 }
@@ -194,6 +194,17 @@ export const providers = [
 		jsonOutput: false,
 		color: "#20B2AA",
 		website: "https://perplexity.ai",
+		announcement: null,
+	},
+	{
+		id: "custom",
+		name: "Custom",
+		description: "Custom OpenAI-compatible provider with configurable base URL",
+		streaming: true,
+		cancellation: true,
+		jsonOutput: true,
+		color: "#6b7280",
+		website: null,
 		announcement: null,
 	},
 ] as const satisfies ProviderDefinition[];


### PR DESCRIPTION
Introduced "custom" provider type with configurable name and base URL. Updated schema, UI, API, and caching logic to handle custom providers. Ensured validation and model compatibility checks accommodate custom providers.