### PR TITLE
feat(models): add deactivation filter for some models

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -42,8 +42,13 @@ if (hasOnlyModels) {
 	);
 }
 
-const testModels = models
+const filteredModels = models
+	// Filter out auto/custom models
 	.filter((model) => !["custom", "auto"].includes(model.model))
+	// Filter out deactivated models
+	.filter((model) => !model.deactivatedAt || new Date() <= model.deactivatedAt);
+
+const testModels = filteredModels
 	// If any model has test: "only", only include those models
 	.filter((model) => {
 		if (hasOnlyModels) {
@@ -88,8 +93,7 @@ const testModels = models
 		return testCases;
 	});
 
-const providerModels = models
-	.filter((model) => !["custom", "auto"].includes(model.model))
+const providerModels = filteredModels
 	// If any model has test: "only", only include those models
 	.filter((model) => {
 		if (hasOnlyModels) {

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -58,7 +58,7 @@ export const googleModels = [
 	{
 		model: "gemini-2.5-flash-preview-04-17",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-07-22"),
 		providers: [
 			{
 				providerId: "google-ai-studio",
@@ -112,7 +112,7 @@ export const googleModels = [
 	{
 		model: "gemini-2.5-flash-preview-04-17-thinking",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-07-22"),
 		providers: [
 			{
 				providerId: "google-ai-studio",


### PR DESCRIPTION
Added support to filter out deactivated models based on their `deactivatedAt` property. Updated relevant logic in gateway e2e tests to utilize the new filter. Adjusted deactivation dates for specific Google models.