### PR TITLE
feat: add Turbo build cache mount to unified.dockerfile

### DIFF
--- a/infra/unified.dockerfile
+++ b/infra/unified.dockerfile
@@ -34,7 +34,7 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 
 # Build all apps
-RUN pnpm build
+RUN --mount=type=cache,target=/app/.turbo pnpm build
 
 # Runtime stage with all services
 FROM alpine:3.19 AS runtime


### PR DESCRIPTION
**The Issue**

Following the successful implementation of Turbo build cache optimization in `split.dockerfile` (merged in previous PR), the `unified.dockerfile` was still missing the same performance optimization.

**What this PR changes**

Updates the build step in `unified.dockerfile` to use Docker BuildKit's cache mount for /app/.turbo:
`RUN --mount=type=cache,target=/app/.turbo pnpm build`

**Why I implemented this**

This completes the Turbo cache optimization across all Docker build contexts in the project. Using BuildKit cache mounts is the modern, recommended way to handle build caching with Turborepo in Docker.

This approach:

          - Automatically creates the cache directory as needed
          - Speeds up repeated builds by persisting cache between builds
          - Provides consistent performance across both deployment methods
