### PR TITLE
feat(cache): add streaming cache support for chat responses

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -25,13 +25,16 @@ import { streamSSE } from "hono/streaming";
 import {
 	checkCustomProviderExists,
 	generateCacheKey,
+	generateStreamingCacheKey,
 	getCache,
 	getCustomProviderKey,
 	getOrganization,
 	getProject,
 	getProviderKey,
+	getStreamingCache,
 	isCachingEnabled,
 	setCache,
+	setStreamingCache,
 } from "../lib/cache";
 import { calculateCosts } from "../lib/costs";
 import { insertLog } from "../lib/logs";
@@ -1636,9 +1639,10 @@ chat.openapi(completions, async (c) => {
 		await isCachingEnabled(project.id);
 
 	let cacheKey: string | null = null;
-	if (cachingEnabled && !stream) {
-		// Don't cache streaming responses
-		cacheKey = generateCacheKey({
+	let streamingCacheKey: string | null = null;
+
+	if (cachingEnabled) {
+		const cachePayload = {
 			model: usedModel,
 			messages,
 			temperature,
@@ -1647,56 +1651,177 @@ chat.openapi(completions, async (c) => {
 			frequency_penalty,
 			presence_penalty,
 			response_format,
-		});
+		};
 
-		const cachedResponse = cacheKey ? await getCache(cacheKey) : null;
-		if (cachedResponse) {
-			// Log the cached request
-			const duration = 0; // No processing time needed
-			const baseLogEntry = createLogEntry(
-				requestId,
-				project,
-				apiKey,
-				providerKey?.id,
-				usedModel,
-				usedProvider,
-				requestedModel,
-				requestedProvider,
-				messages,
-				temperature,
-				max_tokens,
-				top_p,
-				frequency_penalty,
-				presence_penalty,
-			);
+		if (stream) {
+			streamingCacheKey = generateStreamingCacheKey(cachePayload);
+			const cachedStreamingResponse =
+				await getStreamingCache(streamingCacheKey);
+			if (cachedStreamingResponse?.metadata.completed) {
+				// Extract final content and metadata from cached chunks
+				let fullContent = "";
+				let fullReasoningContent = "";
+				let promptTokens = null;
+				let completionTokens = null;
+				let totalTokens = null;
+				let reasoningTokens = null;
+				let cachedTokens = null;
+				let fullToolCalls: any = null;
 
-			await insertLog({
-				...baseLogEntry,
-				duration,
-				responseSize: JSON.stringify(cachedResponse).length,
-				content: cachedResponse.choices?.[0]?.message?.content || null,
-				reasoningContent:
-					cachedResponse.choices?.[0]?.message?.reasoning_content || null,
-				finishReason: cachedResponse.choices?.[0]?.finish_reason || null,
-				promptTokens: cachedResponse.usage?.prompt_tokens || null,
-				completionTokens: cachedResponse.usage?.completion_tokens || null,
-				totalTokens: cachedResponse.usage?.total_tokens || null,
-				reasoningTokens: cachedResponse.usage?.reasoning_tokens || null,
-				cachedTokens: null,
-				hasError: false,
-				streamed: false,
-				canceled: false,
-				errorDetails: null,
-				inputCost: 0,
-				outputCost: 0,
-				cachedInputCost: 0,
-				requestCost: 0,
-				cost: 0,
-				estimatedCost: false,
-				cached: true,
-			});
+				for (const chunk of cachedStreamingResponse.chunks) {
+					try {
+						const chunkData = JSON.parse(chunk.data);
 
-			return c.json(cachedResponse);
+						// Extract content from chunk
+						if (chunkData.choices?.[0]?.delta?.content) {
+							fullContent += chunkData.choices[0].delta.content;
+						}
+
+						// Extract reasoning content from chunk
+						if (chunkData.choices?.[0]?.delta?.reasoning_content) {
+							fullReasoningContent +=
+								chunkData.choices[0].delta.reasoning_content;
+						}
+
+						// Extract tool calls (final format, not delta)
+						if (chunkData.choices?.[0]?.delta?.tool_calls && !fullToolCalls) {
+							fullToolCalls = chunkData.choices[0].delta.tool_calls;
+						}
+
+						// Extract usage information (usually in the last chunks)
+						if (chunkData.usage) {
+							if (chunkData.usage.prompt_tokens) {
+								promptTokens = chunkData.usage.prompt_tokens;
+							}
+							if (chunkData.usage.completion_tokens) {
+								completionTokens = chunkData.usage.completion_tokens;
+							}
+							if (chunkData.usage.total_tokens) {
+								totalTokens = chunkData.usage.total_tokens;
+							}
+							if (chunkData.usage.reasoning_tokens) {
+								reasoningTokens = chunkData.usage.reasoning_tokens;
+							}
+							if (chunkData.usage.prompt_tokens_details?.cached_tokens) {
+								cachedTokens =
+									chunkData.usage.prompt_tokens_details.cached_tokens;
+							}
+						}
+					} catch (e) {
+						// Skip malformed chunks
+						console.warn("Failed to parse cached chunk:", e);
+					}
+				}
+
+				// Log the cached streaming request with reconstructed content
+				const baseLogEntry = createLogEntry(
+					requestId,
+					project,
+					apiKey,
+					providerKey?.id,
+					usedModel,
+					usedProvider,
+					requestedModel,
+					requestedProvider,
+					messages,
+					temperature,
+					max_tokens,
+					top_p,
+					frequency_penalty,
+					presence_penalty,
+				);
+
+				await insertLog({
+					...baseLogEntry,
+					duration: 0, // No processing time for cached response
+					responseSize: JSON.stringify(cachedStreamingResponse).length,
+					content: fullContent || null,
+					reasoningContent: fullReasoningContent || null,
+					toolCalls: fullToolCalls,
+					finishReason: cachedStreamingResponse.metadata.finishReason,
+					promptTokens: promptTokens?.toString() || null,
+					completionTokens: completionTokens?.toString() || null,
+					totalTokens: totalTokens?.toString() || null,
+					reasoningTokens: reasoningTokens?.toString() || null,
+					cachedTokens: cachedTokens?.toString() || null,
+					hasError: false,
+					streamed: true,
+					canceled: false,
+					errorDetails: null,
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					cost: 0,
+					estimatedCost: false,
+					cached: true,
+				});
+
+				// Return cached streaming response by replaying chunks
+				return streamSSE(c, async (stream) => {
+					for (const chunk of cachedStreamingResponse.chunks) {
+						await new Promise<void>((resolve) => {
+							setTimeout(() => resolve(), 20); // Small delay between chunks
+						});
+						await stream.writeSSE({
+							data: chunk.data,
+							id: String(chunk.eventId),
+							event: chunk.event,
+						});
+					}
+				});
+			}
+		} else {
+			cacheKey = generateCacheKey(cachePayload);
+			const cachedResponse = cacheKey ? await getCache(cacheKey) : null;
+			if (cachedResponse) {
+				// Log the cached request
+				const duration = 0; // No processing time needed
+				const baseLogEntry = createLogEntry(
+					requestId,
+					project,
+					apiKey,
+					providerKey?.id,
+					usedModel,
+					usedProvider,
+					requestedModel,
+					requestedProvider,
+					messages,
+					temperature,
+					max_tokens,
+					top_p,
+					frequency_penalty,
+					presence_penalty,
+				);
+
+				await insertLog({
+					...baseLogEntry,
+					duration,
+					responseSize: JSON.stringify(cachedResponse).length,
+					content: cachedResponse.choices?.[0]?.message?.content || null,
+					reasoningContent:
+						cachedResponse.choices?.[0]?.message?.reasoning_content || null,
+					finishReason: cachedResponse.choices?.[0]?.finish_reason || null,
+					promptTokens: cachedResponse.usage?.prompt_tokens || null,
+					completionTokens: cachedResponse.usage?.completion_tokens || null,
+					totalTokens: cachedResponse.usage?.total_tokens || null,
+					reasoningTokens: cachedResponse.usage?.reasoning_tokens || null,
+					cachedTokens: null,
+					hasError: false,
+					streamed: false,
+					canceled: false,
+					errorDetails: null,
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					cost: 0,
+					estimatedCost: false,
+					cached: true,
+				});
+
+				return c.json(cachedResponse);
+			}
 		}
 	}
 
@@ -1756,6 +1881,34 @@ chat.openapi(completions, async (c) => {
 		return streamSSE(c, async (stream) => {
 			let eventId = 0;
 			let canceled = false;
+
+			// Streaming cache variables
+			const streamingChunks: Array<{
+				data: string;
+				eventId: number;
+				event?: string;
+				timestamp: number;
+			}> = [];
+			const streamStartTime = Date.now();
+
+			// Helper function to write SSE and capture for cache
+			const writeSSEAndCache = async (sseData: {
+				data: string;
+				event?: string;
+				id?: string;
+			}) => {
+				await stream.writeSSE(sseData);
+
+				// Capture for streaming cache if enabled
+				if (cachingEnabled && streamingCacheKey) {
+					streamingChunks.push({
+						data: sseData.data,
+						eventId: sseData.id ? parseInt(sseData.id, 10) : eventId,
+						event: sseData.event,
+						timestamp: Date.now() - streamStartTime,
+					});
+				}
+			};
 
 			// Set up cancellation handling
 			const controller = new AbortController();
@@ -1826,14 +1979,14 @@ chat.openapi(completions, async (c) => {
 					});
 
 					// Send a cancellation event to the client
-					await stream.writeSSE({
+					await writeSSEAndCache({
 						event: "canceled",
 						data: JSON.stringify({
 							message: "Request canceled by client",
 						}),
 						id: String(eventId++),
 					});
-					await stream.writeSSE({
+					await writeSSEAndCache({
 						event: "done",
 						data: "[DONE]",
 						id: String(eventId++),
@@ -1850,7 +2003,7 @@ chat.openapi(completions, async (c) => {
 					`Provider error - Status: ${res.status}, Text: ${errorResponseText}`,
 				);
 
-				await stream.writeSSE({
+				await writeSSEAndCache({
 					event: "error",
 					data: JSON.stringify({
 						error: {
@@ -1863,7 +2016,7 @@ chat.openapi(completions, async (c) => {
 					}),
 					id: String(eventId++),
 				});
-				await stream.writeSSE({
+				await writeSSEAndCache({
 					event: "done",
 					data: "[DONE]",
 					id: String(eventId++),
@@ -1916,7 +2069,7 @@ chat.openapi(completions, async (c) => {
 			}
 
 			if (!res.body) {
-				await stream.writeSSE({
+				await writeSSEAndCache({
 					event: "error",
 					data: JSON.stringify({
 						error: {
@@ -1928,7 +2081,7 @@ chat.openapi(completions, async (c) => {
 					}),
 					id: String(eventId++),
 				});
-				await stream.writeSSE({
+				await writeSSEAndCache({
 					event: "done",
 					data: "[DONE]",
 					id: String(eventId++),
@@ -2025,7 +2178,7 @@ chat.openapi(completions, async (c) => {
 									data,
 								);
 
-								await stream.writeSSE({
+								await writeSSEAndCache({
 									data: JSON.stringify(transformedData),
 									id: String(eventId++),
 								});
@@ -2077,7 +2230,7 @@ chat.openapi(completions, async (c) => {
 
 									// Send final chunk when we get a finish reason
 									if (finishReason) {
-										await stream.writeSSE({
+										await writeSSEAndCache({
 											event: "done",
 											data: "[DONE]",
 											id: String(eventId++),
@@ -2194,13 +2347,13 @@ chat.openapi(completions, async (c) => {
 											},
 										};
 
-										await stream.writeSSE({
+										await writeSSEAndCache({
 											data: JSON.stringify(finalUsageChunk),
 											id: String(eventId++),
 										});
 									}
 
-									await stream.writeSSE({
+									await writeSSEAndCache({
 										event: "done",
 										data: "[DONE]",
 										id: String(eventId++),
@@ -2240,7 +2393,7 @@ chat.openapi(completions, async (c) => {
 											}
 										}
 
-										await stream.writeSSE({
+										await writeSSEAndCache({
 											data: JSON.stringify(transformedData),
 											id: String(eventId++),
 										});
@@ -2508,13 +2661,13 @@ chat.openapi(completions, async (c) => {
 							},
 						};
 
-						await stream.writeSSE({
+						await writeSSEAndCache({
 							data: JSON.stringify(finalUsageChunk),
 							id: String(eventId++),
 						});
 
 						// Send final [DONE] if we haven't already
-						await stream.writeSSE({
+						await writeSSEAndCache({
 							event: "done",
 							data: "[DONE]",
 							id: String(eventId++),
@@ -2578,6 +2731,30 @@ chat.openapi(completions, async (c) => {
 					estimatedCost: costs.estimatedCost,
 					cached: false,
 				});
+
+				// Save streaming cache if enabled and not canceled
+				if (cachingEnabled && streamingCacheKey && !canceled && finishReason) {
+					try {
+						const streamingCacheData = {
+							chunks: streamingChunks,
+							metadata: {
+								model: usedModel,
+								provider: usedProvider,
+								finishReason: finishReason,
+								totalChunks: streamingChunks.length,
+								duration: duration,
+								completed: true,
+							},
+						};
+						await setStreamingCache(
+							streamingCacheKey,
+							streamingCacheData,
+							cacheDuration,
+						);
+					} catch (error) {
+						console.error("Error saving streaming cache:", error);
+					}
+				}
 			}
 		});
 	}

--- a/apps/gateway/src/lib/cache.ts
+++ b/apps/gateway/src/lib/cache.ts
@@ -250,3 +250,61 @@ export async function checkCustomProviderExists(
 		throw error;
 	}
 }
+
+// Streaming cache data structure
+interface StreamingCacheChunk {
+	data: string;
+	eventId: number;
+	event?: string;
+	timestamp: number;
+}
+
+interface StreamingCacheData {
+	chunks: StreamingCacheChunk[];
+	metadata: {
+		model: string;
+		provider: string;
+		finishReason: string | null;
+		totalChunks: number;
+		duration: number;
+		completed: boolean;
+	};
+}
+
+export function generateStreamingCacheKey(
+	payload: Record<string, any>,
+): string {
+	return `stream:${generateCacheKey(payload)}`;
+}
+
+export async function setStreamingCache(
+	key: string,
+	data: StreamingCacheData,
+	expirationSeconds: number,
+): Promise<void> {
+	if (process.env.NODE_ENV === "test") {
+		// temp disable caching in test mode
+		return;
+	}
+
+	try {
+		await redisClient.set(key, JSON.stringify(data), "EX", expirationSeconds);
+	} catch (error) {
+		console.error("Error setting streaming cache:", error);
+	}
+}
+
+export async function getStreamingCache(
+	key: string,
+): Promise<StreamingCacheData | null> {
+	try {
+		const cachedValue = await redisClient.get(key);
+		if (!cachedValue) {
+			return null;
+		}
+		return JSON.parse(cachedValue);
+	} catch (error) {
+		console.error("Error getting streaming cache:", error);
+		return null;
+	}
+}


### PR DESCRIPTION
Integrated caching support for streaming chat responses. Added utility functions `setStreamingCache`, `getStreamingCache`, and `generateStreamingCacheKey`. Enhanced chat logic to handle streaming response caching, including replaying cached chunks and saving streamed data. Improved logging with reconstructed content from cached data.