### PR TITLE
fix(chat): use estimateTokens helper for chat token calculation

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -165,13 +165,8 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 
 			// If candidatesTokenCount is missing, estimate it from the content
 			if (completionTokens === null && content) {
-				try {
-					completionTokens = encode(content).length;
-				} catch (error) {
-					// Fallback to simple estimation if encoding fails
-					console.error(`Failed to encode completion text: ${error}`);
-					completionTokens = Math.max(1, Math.round(content.length / 4));
-				}
+				const estimation = estimateTokens(usedProvider, [], content, null, null);
+				completionTokens = estimation.calculatedCompletionTokens;
 			}
 
 			// Calculate totalTokens if not provided but we have prompt and completion tokens
@@ -358,15 +353,8 @@ function extractTokenUsage(
 
 				// If candidatesTokenCount is missing and we have content, estimate it
 				if (completionTokens === null && fullContent) {
-					try {
-						completionTokens = encode(fullContent).length;
-					} catch (error) {
-						// Fallback to simple estimation if encoding fails
-						console.error(
-							`Failed to encode completion text in streaming: ${error}`,
-						);
-						completionTokens = Math.max(1, Math.round(fullContent.length / 4));
-					}
+					const estimation = estimateTokens(provider, [], fullContent, null, null);
+					completionTokens = estimation.calculatedCompletionTokens;
 				}
 			}
 			break;
@@ -2096,12 +2084,8 @@ chat.openapi(completions, async (c) => {
 
 								// Estimate missing tokens if needed using helper function
 								if (finalPromptTokens === null) {
-									finalPromptTokens = Math.round(
-										messages.reduce(
-											(acc, m) => acc + (m.content?.length || 0),
-											0,
-										) / 4,
-									);
+									const estimation = estimateTokens(usedProvider, messages, null, null, null);
+									finalPromptTokens = estimation.calculatedPromptTokens;
 								}
 
 								if (finalCompletionTokens === null) {
@@ -2178,12 +2162,8 @@ chat.openapi(completions, async (c) => {
 										usage.prompt_tokens === undefined
 									) {
 										// Estimate prompt tokens if not provided
-										const estimatedPromptTokens = Math.round(
-											messages.reduce(
-												(acc, m) => acc + (m.content?.length || 0),
-												0,
-											) / 4,
-										);
+										const estimation = estimateTokens(usedProvider, messages, null, null, null);
+										const estimatedPromptTokens = estimation.calculatedPromptTokens;
 										transformedData.usage = {
 											prompt_tokens: estimatedPromptTokens,
 											completion_tokens: usage.output_tokens,
@@ -2293,12 +2273,8 @@ chat.openapi(completions, async (c) => {
 								// Estimate tokens if not provided and we have a finish reason
 								if (finishReason && (!promptTokens || !completionTokens)) {
 									if (!promptTokens) {
-										promptTokens = Math.round(
-											messages.reduce(
-												(acc, m) => acc + (m.content?.length || 0),
-												0,
-											) / 4,
-										);
+										const estimation = estimateTokens(usedProvider, messages, null, null, null);
+										promptTokens = estimation.calculatedPromptTokens;
 									}
 
 									if (!completionTokens) {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -165,7 +165,13 @@ function parseProviderResponse(usedProvider: Provider, json: any) {
 
 			// If candidatesTokenCount is missing, estimate it from the content
 			if (completionTokens === null && content) {
-				const estimation = estimateTokens(usedProvider, [], content, null, null);
+				const estimation = estimateTokens(
+					usedProvider,
+					[],
+					content,
+					null,
+					null,
+				);
 				completionTokens = estimation.calculatedCompletionTokens;
 			}
 
@@ -353,7 +359,13 @@ function extractTokenUsage(
 
 				// If candidatesTokenCount is missing and we have content, estimate it
 				if (completionTokens === null && fullContent) {
-					const estimation = estimateTokens(provider, [], fullContent, null, null);
+					const estimation = estimateTokens(
+						provider,
+						[],
+						fullContent,
+						null,
+						null,
+					);
 					completionTokens = estimation.calculatedCompletionTokens;
 				}
 			}
@@ -2084,7 +2096,13 @@ chat.openapi(completions, async (c) => {
 
 								// Estimate missing tokens if needed using helper function
 								if (finalPromptTokens === null) {
-									const estimation = estimateTokens(usedProvider, messages, null, null, null);
+									const estimation = estimateTokens(
+										usedProvider,
+										messages,
+										null,
+										null,
+										null,
+									);
 									finalPromptTokens = estimation.calculatedPromptTokens;
 								}
 
@@ -2162,8 +2180,15 @@ chat.openapi(completions, async (c) => {
 										usage.prompt_tokens === undefined
 									) {
 										// Estimate prompt tokens if not provided
-										const estimation = estimateTokens(usedProvider, messages, null, null, null);
-										const estimatedPromptTokens = estimation.calculatedPromptTokens;
+										const estimation = estimateTokens(
+											usedProvider,
+											messages,
+											null,
+											null,
+											null,
+										);
+										const estimatedPromptTokens =
+											estimation.calculatedPromptTokens;
 										transformedData.usage = {
 											prompt_tokens: estimatedPromptTokens,
 											completion_tokens: usage.output_tokens,
@@ -2273,7 +2298,13 @@ chat.openapi(completions, async (c) => {
 								// Estimate tokens if not provided and we have a finish reason
 								if (finishReason && (!promptTokens || !completionTokens)) {
 									if (!promptTokens) {
-										const estimation = estimateTokens(usedProvider, messages, null, null, null);
+										const estimation = estimateTokens(
+											usedProvider,
+											messages,
+											null,
+											null,
+											null,
+										);
 										promptTokens = estimation.calculatedPromptTokens;
 									}
 


### PR DESCRIPTION
Replace manual token calculations with the `estimateTokens` helper function for consistent and accurate estimation.

Previously, some token estimations relied on a simple division by 4, which is less accurate and inconsistent with other parts of the codebase. This PR leverages the existing `estimateTokens` function, which uses proper tokenization and a more robust fallback strategy, ensuring a unified and more precise approach to token counting across the application.

---

[Open in Web](https://cursor.com/agents?id=bc-4bacdae3-19e8-4fc4-a58a-aef2e5e1a8e2) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4bacdae3-19e8-4fc4-a58a-aef2e5e1a8e2) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency and accuracy of token usage estimates across chat providers by centralizing token estimation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->