### PR TITLE
fix(chat): enforce correct object type for streaming

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -806,9 +806,10 @@ function transformStreamingChunkToOpenAIFormat(
 					usage: data.usage || null,
 				};
 			} else {
-				// Even if the response has the correct format, ensure role is set in delta
+				// Even if the response has the correct format, ensure role is set in delta and object is correct for streaming
 				transformedData = {
 					...data,
+					object: "chat.completion.chunk", // Force correct object type for streaming
 					choices:
 						data.choices?.map((choice: any) => ({
 							...choice,


### PR DESCRIPTION
Ensured `object` field is set to "chat.completion.chunk" in transformed data. This guarantees correct format for streaming responses and prevents potential inconsistencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of streaming chat responses by ensuring the response type is always correctly set for all providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->