### PR TITLE
fix(models): enable vision and json output for llmgateway

### DIFF
--- a/packages/models/src/models/llmgateway.ts
+++ b/packages/models/src/models/llmgateway.ts
@@ -16,9 +16,10 @@ export const llmgatewayModels = [
 				requestPrice: undefined,
 				contextSize: undefined,
 				streaming: true,
-				vision: false,
+				vision: true,
 			},
 		],
+		jsonOutput: true,
 	},
 	{
 		id: "auto", // native automatic routing
@@ -35,8 +36,9 @@ export const llmgatewayModels = [
 				requestPrice: undefined,
 				contextSize: undefined,
 				streaming: true,
-				vision: false,
+				vision: true,
 			},
 		],
+		jsonOutput: true,
 	},
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -123,7 +123,7 @@ export const xaiModels = [
 				contextSize: 32768,
 				maxOutput: undefined,
 				streaming: true,
-				vision: false,
+				vision: true,
 			},
 		],
 		jsonOutput: true,

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -24,6 +24,7 @@ export const providers = [
 			"LLMGateway is a framework for building and deploying large language models.",
 		streaming: true,
 		cancellation: true,
+		jsonOutput: true,
 		color: "#6366f1",
 		website: "https://llmgateway.io",
 		announcement: null,


### PR DESCRIPTION
Enable vision and JSON output for llmgateway models and provider, and fix a vision model configuration bug.

The llmgateway models and provider were not configured to support vision and JSON output, despite the underlying schema allowing it. This PR updates the configurations to enable these features, ensuring llmgateway's capabilities align with modern AI workloads. Additionally, a bug in the XAI `grok-2-vision-1212` model, where `vision` was incorrectly set to `false`, has been fixed.

---

[Open in Web](https://cursor.com/agents?id=bc-5e3043b9-aab8-463e-b715-0772b7c0029f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5e3043b9-aab8-463e-b715-0772b7c0029f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled vision capabilities for select models, allowing them to process visual inputs.
  * Added support for JSON output mode for specific models and the LLM Gateway provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->