### PR TITLE
feat(api): include user emails in metadata

### DIFF
--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -91,6 +91,7 @@ payments.openapi(createPaymentIntent, async (c) => {
 				organizationId,
 				baseAmount: amount.toString(),
 				totalFees: feeBreakdown.totalFees.toString(),
+				userEmail: user.email,
 			},
 		});
 
@@ -539,6 +540,7 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 				organizationId: userOrganization.organization.id,
 				baseAmount: amount.toString(),
 				totalFees: feeBreakdown.totalFees.toString(),
+				userEmail: user.email,
 			},
 		});
 

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -107,6 +107,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 				organizationId: organization.id,
 				plan: "pro",
 				billingCycle,
+				userEmail: user.email,
 			},
 			subscription_data: {
 				trial_period_days: 7,
@@ -114,6 +115,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 					organizationId: organization.id,
 					plan: "pro",
 					billingCycle,
+					userEmail: user.email,
 				},
 			},
 		});

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -123,6 +123,18 @@ async function processAutoTopUp(): Promise<void> {
 
 				const topUpAmount = Number(org.autoTopUpAmount || "10");
 
+				// Get the first user associated with this organization for email metadata
+				const orgUser = await db.query.userOrganization.findFirst({
+					where: {
+						organizationId: {
+							eq: org.id,
+						},
+					},
+					with: {
+						user: true,
+					},
+				});
+
 				const stripePaymentMethod = await stripe.paymentMethods.retrieve(
 					defaultPaymentMethod.stripePaymentMethodId,
 				);
@@ -170,6 +182,7 @@ async function processAutoTopUp(): Promise<void> {
 							transactionId: pendingTransaction.id,
 							baseAmount: feeBreakdown.baseAmount.toString(),
 							totalFees: feeBreakdown.totalFees.toString(),
+							...(orgUser?.user?.email && { userEmail: orgUser.user.email }),
 						},
 					});
 


### PR DESCRIPTION
Add user email metadata in payment transactions and subscriptions for better traceability. Update worker processes to query and include user emails associated with organizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User email addresses are now included in the metadata for Stripe payment intents and subscription checkout sessions, providing enhanced payment information visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->