### PR TITLE
feat(logs): add client_error handling for JSON validation

### DIFF
--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -25,6 +25,9 @@ export function getUnifiedFinishReason(
 	if (finishReason === "upstream_error") {
 		return UnifiedFinishReason.UPSTREAM_ERROR;
 	}
+	if (finishReason === "client_error") {
+		return UnifiedFinishReason.CLIENT_ERROR;
+	}
 
 	switch (provider) {
 		case "anthropic":


### PR DESCRIPTION
Improve error handling by introducing `UnifiedFinishReason.CLIENT_ERROR` for JSON validation issues. Update logs and finish reason to classify specific client-side errors. Add tests to validate `client_error` scenarios, ensuring appropriate responses for malformed requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for JSON output mode by providing clearer error messages when required keywords are missing from requests.
  * Enhanced transparency by returning original provider error responses for specific client errors.

* **Tests**
  * Added an end-to-end test to verify correct error response and logging when required "json" keyword is absent in messages.

* **Refactor**
  * Refined error classification to distinguish client errors from gateway errors, improving log accuracy and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->