### PR TITLE
fix(auth): temporarily disable session cookie cache

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -70,10 +70,6 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
 		},
 	},
 	session: {
-		cookieCache: {
-			enabled: true,
-			maxAge: 5 * 60,
-		},
 		expiresIn: 60 * 60 * 24 * 30, // 30 days
 		updateAge: 60 * 60 * 24, // 1 day (every 1 day the session expiration is updated)
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated session management settings to remove cookie caching. Sessions now expire after 30 days, with updates every 1 day. No visible changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->