### PR TITLE
fix(chat): handle finish_reason for tool_use

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -657,7 +657,9 @@ function transformToOpenAIFormat(
 						finish_reason:
 							finishReason === "end_turn"
 								? "stop"
-								: finishReason?.toLowerCase() || "stop",
+								: finishReason === "tool_use"
+									? "tool_calls"
+									: finishReason?.toLowerCase() || "stop",
 					},
 				],
 				usage: {


### PR DESCRIPTION
Add specific handling for the "tool_use" finish reason by mapping it to "tool_calls". This ensures accurate categorization of special finish reasons in chat responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of finish reasons in chat responses, providing more accurate status mapping for certain cases when using the Anthropic provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->