### PR TITLE
fix(models): transform tool parameters for Anthropic

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -657,7 +657,9 @@ function transformToOpenAIFormat(
 						finish_reason:
 							finishReason === "end_turn"
 								? "stop"
-								: finishReason?.toLowerCase() || "stop",
+								: finishReason === "tool_use"
+									? "tool_calls"
+									: finishReason?.toLowerCase() || "stop",
 					},
 				],
 				usage: {


### PR DESCRIPTION
Refactored the requestBody to handle tool and tool_choice parameters conversion from OpenAI to Anthropic format. Added logic to define "anthropic-beta" header and remove generic tool_choice for compatibility. Simplified tool mapping and parameter transformation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with Anthropic provider by supporting tool usage and proper formatting of tool-related parameters.
  * Added support for a new Anthropic beta feature via updated request headers.

* **Bug Fixes**
  * Enhanced mapping of finish reasons for Anthropic responses to ensure accurate representation in OpenAI-compatible outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->