### PR TITLE
fix(models): transform tool parameters for Google API

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -617,7 +617,9 @@ function transformToOpenAIFormat(
 						},
 						finish_reason:
 							finishReason === "STOP"
-								? "stop"
+								? toolResults && toolResults.length > 0
+									? "tool_calls"
+									: "stop"
 								: finishReason?.toLowerCase() || "stop",
 					},
 				],
@@ -929,6 +931,10 @@ function transformStreamingChunkToOpenAIFormat(
 				};
 			} else if (data.candidates?.[0]?.finishReason) {
 				const finishReason = data.candidates[0].finishReason;
+				// Check if there are function calls in this response
+				const hasFunctionCalls = data.candidates?.[0]?.content?.parts?.some(
+					(part: any) => part.functionCall,
+				);
 				transformedData = {
 					id: data.responseId || `chatcmpl-${Date.now()}`,
 					object: "chat.completion.chunk",
@@ -942,7 +948,9 @@ function transformStreamingChunkToOpenAIFormat(
 							},
 							finish_reason:
 								finishReason === "STOP"
-									? "stop"
+									? hasFunctionCalls
+										? "tool_calls"
+										: "stop"
 									: finishReason?.toLowerCase() || "stop",
 						},
 					],

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -158,6 +158,7 @@ export function prepareRequestBody(
 			delete requestBody.model; // Not used in body
 			delete requestBody.stream; // Stream is handled via URL parameter
 			delete requestBody.messages; // Not used in body for Google providers
+			delete requestBody.tool_choice; // Google doesn't support tool_choice parameter
 
 			requestBody.contents = messages.map((m) => ({
 				role: m.role === "assistant" ? "model" : "user", // get rid of system role
@@ -176,6 +177,19 @@ export function prepareRequestBody(
 							},
 						],
 			}));
+
+			// Transform tools from OpenAI format to Google format
+			if (tools && tools.length > 0) {
+				requestBody.tools = [
+					{
+						functionDeclarations: tools.map((tool: any) => ({
+							name: tool.function.name,
+							description: tool.function.description,
+							parameters: tool.function.parameters,
+						})),
+					},
+				];
+			}
 
 			requestBody.generationConfig = {};
 


### PR DESCRIPTION
Added conversion logic to map tools and tool_choice parameters from OpenAI format to Google's expected format. Removed unsupported tool_choice parameter to ensure compatibility.