### PR TITLE
Handle invalid cached chunk json

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1887,6 +1887,11 @@ chat.openapi(completions, async (c) => {
 
 				for (const chunk of cachedStreamingResponse.chunks) {
 					try {
+						// Skip "[DONE]" markers as they are not JSON
+						if (chunk.data === "[DONE]") {
+							continue;
+						}
+
 						const chunkData = JSON.parse(chunk.data);
 
 						// Extract content from chunk


### PR DESCRIPTION
Add a check to skip `[DONE]` markers when parsing cached streaming chunks to prevent `SyntaxError`.

The `[DONE]` string is a stream termination marker, not a JSON object, and was causing parsing failures when retrieved from cache.

---
<a href="https://cursor.com/background-agent?bcId=bc-f04c68ff-9a75-42ba-832c-f1689f95ff5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f04c68ff-9a75-42ba-832c-f1689f95ff5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

