### PR TITLE
fix(stripe): do not handle webhook for pro payment credit amount

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -334,6 +334,14 @@ async function handlePaymentIntentSucceeded(
 	// Convert amount from cents to dollars
 	const totalAmountInDollars = amount / 100;
 
+	// Check if this is a subscription payment (pro plan payments don't have baseAmount)
+	if (metadata?.plan === "pro") {
+		console.log(
+			`Payment intent ${paymentIntent.id} is for pro subscription, skipping credit processing`,
+		);
+		return; // Pro subscription payments are handled by invoice.payment_succeeded webhook
+	}
+
 	// Get the credit amount (base amount without fees) from metadata
 	const creditAmount = parseFloat(paymentIntent.metadata.baseAmount);
 	if (!creditAmount) {


### PR DESCRIPTION
Skip credit processing for pro subscription payments to prevent webhook errors.

The `handlePaymentIntentSucceeded` webhook was incorrectly attempting to process credit amounts for pro subscription payments, which do not have `baseAmount` metadata. Pro subscription payments are handled by the `invoice.payment_succeeded` webhook, so this change ensures they are correctly ignored by the credit processing logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-5da0d746-c543-4d35-a094-239794100882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5da0d746-c543-4d35-a094-239794100882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment processing by skipping credit processing for "pro" plan subscription payments, ensuring these are handled correctly and not processed twice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->