### PR TITLE
fix(models): update deprecation dates for grok-2 models

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -93,8 +93,8 @@ export const xaiModels = [
 		id: "grok-2-1212",
 		name: "Grok-2 (1212)",
 		family: "xai",
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deprecatedAt: new Date("2025-08-08"),
+		deactivatedAt: new Date("2025-09-15"),
 		providers: [
 			{
 				providerId: "xai",
@@ -115,8 +115,8 @@ export const xaiModels = [
 		id: "grok-2-vision-1212",
 		name: "Grok-2 Vision (1212)",
 		family: "xai",
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deprecatedAt: new Date("2025-08-08"),
+		deactivatedAt: new Date("2025-09-15"),
 		providers: [
 			{
 				providerId: "xai",


### PR DESCRIPTION
Update `deprecatedAt` and `deactivatedAt` fields for "Grok-2" and "Grok-2 Vision" models with defined future dates for consistency and clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deprecation and deactivation dates for the "grok-2-1212" and "grok-2-vision-1212" models. These models are now scheduled to be deprecated on August 8, 2025, and deactivated on September 15, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->