### PR TITLE
fix(models): deprecate grok-3 fast and mini fast models

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -49,8 +49,8 @@ export const xaiModels = [
 		id: "grok-3-fast",
 		name: "Grok-3 Fast",
 		family: "xai",
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deprecatedAt: new Date("2025-08-08"),
+		deactivatedAt: new Date("2025-09-15"),
 		providers: [
 			{
 				providerId: "xai",
@@ -71,8 +71,8 @@ export const xaiModels = [
 		id: "grok-3-mini-fast",
 		name: "Grok-3 Mini Fast",
 		family: "xai",
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deprecatedAt: new Date("2025-08-08"),
+		deactivatedAt: new Date("2025-09-15"),
 		providers: [
 			{
 				providerId: "xai",


### PR DESCRIPTION
Deprecate `grok-3-fast` and `grok-3-mini-fast` models by setting their `deprecatedAt` and `deactivatedAt` values to match `grok-2`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f81f102-bf57-4d43-a745-ee6b1a77231f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f81f102-bf57-4d43-a745-ee6b1a77231f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deprecation and deactivation dates for the "grok-3-fast" and "grok-3-mini-fast" models. These models are now scheduled for deprecation on August 8, 2025, and deactivation on September 15, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->