### PR TITLE
chore(env): update Node.js and pnpm versions in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.10.0
-pnpm 10.8.0
+nodejs 24.5.0
+pnpm 10.14.0

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
 	},
 	"dangerouslyDisablePackageManagerCheck": true,
 	"globalDependencies": [
+		".tool-versions",
 		".npmrc",
 		"package.json",
 		"pnpm-lock.yaml",


### PR DESCRIPTION
Updated Node.js to version 24.5.0 and pnpm to version 10.14.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js and pnpm versions in the tool configuration.
  * Improved build tracking by including tool version changes as global dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->