### PR TITLE
feat(gateway): update API server URL configuration

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -14,7 +14,10 @@ import type { ServerTypes } from "./vars";
 export const config = {
 	servers: [
 		{
-			url: process.env.API_URL || "http://localhost:4001",
+			url: "https://api.llmgateway.io",
+		},
+		{
+			url: "http://localhost:4001",
 		},
 	],
 	openapi: "3.0.0",


### PR DESCRIPTION
Replaced the default API server URL with "https://api.llmgateway.io" while retaining a fallback server option for local development.