### PR TITLE
fix(api/models): expose reasoning parameter in models api

### DIFF
--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -204,7 +204,9 @@ function getSupportedParametersFromModel(model: ModelDefinition): string[] {
 			const params = [...supportedParameters];
 			// If any provider supports reasoning, expose the reasoning parameter
 			if (model.providers.some((p: any) => p?.reasoning)) {
-				if (!params.includes("reasoning")) params.push("reasoning");
+				if (!params.includes("reasoning")) {
+					params.push("reasoning");
+				}
 			}
 			return params;
 		}

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -40,6 +40,7 @@ const modelSchema = z.object({
 			vision: z.boolean(),
 			cancellation: z.boolean(),
 			tools: z.boolean(),
+			reasoning: z.boolean(),
 		}),
 	),
 	pricing: z.object({
@@ -145,6 +146,7 @@ modelsApi.openapi(listModels, async (c) => {
 						vision: provider.vision || false,
 						cancellation: providerDef?.cancellation || false,
 						tools: provider.tools || false,
+						reasoning: provider.reasoning || false,
 					};
 				}),
 				pricing: {
@@ -193,16 +195,25 @@ function getSupportedParametersFromModel(model: ModelDefinition): string[] {
 		"tool_choice",
 	];
 
-	// Look for supported parameters in any provider mapping for this model
+	// Start with explicit supported parameters if any provider defines them
 	for (const provider of model.providers) {
 		const supportedParameters = (provider as any)?.supportedParameters as
 			| string[]
 			| undefined;
 		if (supportedParameters && supportedParameters.length > 0) {
-			return supportedParameters;
+			const params = [...supportedParameters];
+			// If any provider supports reasoning, expose the reasoning parameter
+			if (model.providers.some((p: any) => p?.reasoning)) {
+				if (!params.includes("reasoning")) params.push("reasoning");
+			}
+			return params;
 		}
 	}
 
 	// If no provider has explicit supported parameters, return defaults
-	return defaultCommonParams;
+	const params = [...defaultCommonParams];
+	if (model.providers.some((p: any) => p?.reasoning)) {
+		params.push("reasoning");
+	}
+	return params;
 }


### PR DESCRIPTION
Expose the `reasoning` capability in the `/v1/models` API response to indicate provider support.

---
<a href="https://cursor.com/background-agent?bcId=bc-8033790a-e64c-4f70-bf50-efca36ac5826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8033790a-e64c-4f70-bf50-efca36ac5826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

