### PR TITLE
Optimize acquireLock for unique constraint errors

### DIFF
--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -35,8 +35,16 @@ async function acquireLock(key: string): Promise<boolean> {
 		});
 
 		return true;
-	} catch (_error) {
-		return false;
+	} catch (error) {
+		// If the insert failed due to a unique constraint violation, another process holds the lock
+		if (
+			typeof (error as any)?.code === "string" &&
+			(error as any).code === "23505"
+		) {
+			return false;
+		}
+		// Re-throw unexpected errors so they can be handled upstream
+		throw error;
 	}
 }
 


### PR DESCRIPTION
Refactor `acquireLock` to differentiate between unique constraint violations and other database errors, preventing the masking of unexpected issues.

The previous `acquireLock` implementation caught all errors and returned `false`, implying the lock was already held. This change ensures that only a unique constraint violation (Postgres error code 23505), which indicates the lock is indeed held by another process, results in `false`. All other database errors are now re-thrown, allowing for proper error handling upstream and preventing silent failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d706813-d5b7-43ff-bcc0-5fee61cfb0a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d706813-d5b7-43ff-bcc0-5fee61cfb0a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

