### PR TITLE
feat(gateway): add batch credit deduction processing

### DIFF
--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -261,7 +261,7 @@ async function processBatchCreditDeductions(): Promise<void> {
 		await db.transaction(async (tx) => {
 			// Get unprocessed logs with row-level locking to prevent concurrent processing
 			const unprocessedLogs = await tx.execute(sql`
-				SELECT l.id, l.organization_id, l.project_id, l.cost, l.cached, p.mode as project_mode
+				SELECT l.id, l.organization_id, l.project_id, l.cost, l.cached, l.api_key_id, p.mode as project_mode
 				FROM log l
 				LEFT JOIN project p ON l.project_id = p.id
 				WHERE l.processed_at IS NULL 
@@ -275,11 +275,12 @@ async function processBatchCreditDeductions(): Promise<void> {
 			}
 
 			console.log(
-				`Processing ${unprocessedLogs.rows.length} logs for credit deduction`,
+				`Processing ${unprocessedLogs.rows.length} logs for credit deduction and API key usage`,
 			);
 
-			// Group logs by organization and project to calculate total costs
+			// Group logs by organization and api key to calculate total costs
 			const orgCosts = new Map<string, number>();
+			const apiKeyCosts = new Map<string, number>();
 			const logIds: string[] = [];
 
 			for (const row of unprocessedLogs.rows) {
@@ -289,21 +290,26 @@ async function processBatchCreditDeductions(): Promise<void> {
 					projectId: row[2] as string,
 					cost: row[3] as string | null,
 					cached: row[4] as boolean | null,
-					projectMode: row[5] as string | null,
+					apiKeyId: row[5] as string,
+					projectMode: row[6] as string | null,
 				};
 
-				// Only deduct credits for non-cached logs with cost and non-api-key projects
-				if (
-					logData.cost &&
-					Number(logData.cost) > 0 &&
-					!logData.cached &&
-					logData.projectMode !== "api-keys"
-				) {
-					const currentCost = orgCosts.get(logData.organizationId) || 0;
-					orgCosts.set(
-						logData.organizationId,
-						currentCost + Number(logData.cost),
+				if (logData.cost && Number(logData.cost) > 0 && !logData.cached) {
+					// Always update API key usage for non-cached logs with cost
+					const currentApiKeyCost = apiKeyCosts.get(logData.apiKeyId) || 0;
+					apiKeyCosts.set(
+						logData.apiKeyId,
+						currentApiKeyCost + Number(logData.cost),
 					);
+
+					// Only deduct organization credits for non-api-key projects
+					if (logData.projectMode !== "api-keys") {
+						const currentOrgCost = orgCosts.get(logData.organizationId) || 0;
+						orgCosts.set(
+							logData.organizationId,
+							currentOrgCost + Number(logData.cost),
+						);
+					}
 				}
 
 				logIds.push(logData.id);
@@ -322,6 +328,20 @@ async function processBatchCreditDeductions(): Promise<void> {
 					console.log(
 						`Deducted ${totalCost} credits from organization ${orgId}`,
 					);
+				}
+			}
+
+			// Batch update API key usage within the same transaction
+			for (const [apiKeyId, totalCost] of apiKeyCosts.entries()) {
+				if (totalCost > 0) {
+					await tx
+						.update(apiKey)
+						.set({
+							usage: sql`${apiKey.usage} + ${totalCost}`,
+						})
+						.where(eq(apiKey.id, apiKeyId));
+
+					console.log(`Added ${totalCost} usage to API key ${apiKeyId}`);
 				}
 			}
 
@@ -369,22 +389,8 @@ export async function processLogQueue(): Promise<void> {
 			}),
 		);
 
-		// Insert logs without processing credits - they will be processed in batches
+		// Insert logs without processing credits or API key usage - they will be processed in batches
 		await db.insert(log).values(processedLogData as any);
-
-		// Update API key usage immediately (not batched to avoid complex aggregation)
-		for (const data of logData) {
-			if (!data.cost || data.cached) {
-				continue;
-			}
-
-			await db
-				.update(apiKey)
-				.set({
-					usage: sql`${apiKey.usage} + ${data.cost}`,
-				})
-				.where(eq(apiKey.id, data.apiKeyId));
-		}
 	} catch (error) {
 		console.error("Error processing log message:", error);
 	}

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -258,75 +258,83 @@ async function processBatchCreditDeductions(): Promise<void> {
 	}
 
 	try {
-		// Get unprocessed logs in batches
-		const unprocessedLogs = await db.query.log.findMany({
-			where: {
-				processedAt: {
-					isNull: true,
-				},
-			},
-			limit: BATCH_SIZE,
-			columns: {
-				id: true,
-				organizationId: true,
-				projectId: true,
-				cost: true,
-				cached: true,
-			},
+		await db.transaction(async (tx) => {
+			// Get unprocessed logs with row-level locking to prevent concurrent processing
+			const unprocessedLogs = await tx.execute(sql`
+				SELECT id, organization_id, project_id, cost, cached
+				FROM log 
+				WHERE processed_at IS NULL 
+				ORDER BY created_at ASC
+				LIMIT ${BATCH_SIZE}
+				FOR UPDATE SKIP LOCKED
+			`);
+
+			if (unprocessedLogs.rows.length === 0) {
+				return;
+			}
+
+			console.log(
+				`Processing ${unprocessedLogs.rows.length} logs for credit deduction`,
+			);
+
+			// Group logs by organization and project to calculate total costs
+			const orgCosts = new Map<string, number>();
+			const logIds: string[] = [];
+
+			for (const row of unprocessedLogs.rows) {
+				const logData = {
+					id: row[0] as string,
+					organizationId: row[1] as string,
+					projectId: row[2] as string,
+					cost: row[3] as string | null,
+					cached: row[4] as boolean | null,
+				};
+
+				const project = await getProject(logData.projectId);
+
+				// Only deduct credits for non-cached logs with cost and non-api-key projects
+				if (
+					logData.cost &&
+					Number(logData.cost) > 0 &&
+					!logData.cached &&
+					project?.mode !== "api-keys"
+				) {
+					const currentCost = orgCosts.get(logData.organizationId) || 0;
+					orgCosts.set(
+						logData.organizationId,
+						currentCost + Number(logData.cost),
+					);
+				}
+
+				logIds.push(logData.id);
+			}
+
+			// Batch update organization credits within the same transaction
+			for (const [orgId, totalCost] of orgCosts.entries()) {
+				if (totalCost > 0) {
+					await tx
+						.update(organization)
+						.set({
+							credits: sql`${organization.credits} - ${totalCost}`,
+						})
+						.where(eq(organization.id, orgId));
+
+					console.log(
+						`Deducted ${totalCost} credits from organization ${orgId}`,
+					);
+				}
+			}
+
+			// Mark all logs as processed within the same transaction
+			await tx
+				.update(log)
+				.set({
+					processedAt: new Date(),
+				})
+				.where(inArray(log.id, logIds));
+
+			console.log(`Marked ${logIds.length} logs as processed`);
 		});
-
-		if (unprocessedLogs.length === 0) {
-			return;
-		}
-
-		console.log(
-			`Processing ${unprocessedLogs.length} logs for credit deduction`,
-		);
-
-		// Group logs by organization and project to calculate total costs
-		const orgCosts = new Map<string, number>();
-		const logIds: string[] = [];
-
-		for (const log of unprocessedLogs) {
-			const project = await getProject(log.projectId);
-
-			// Only deduct credits for non-cached logs with cost and non-api-key projects
-			if (
-				log.cost &&
-				Number(log.cost) > 0 &&
-				!log.cached &&
-				project?.mode !== "api-keys"
-			) {
-				const currentCost = orgCosts.get(log.organizationId) || 0;
-				orgCosts.set(log.organizationId, currentCost + Number(log.cost));
-			}
-
-			logIds.push(log.id);
-		}
-
-		// Batch update organization credits
-		for (const [orgId, totalCost] of orgCosts.entries()) {
-			if (totalCost > 0) {
-				await db
-					.update(organization)
-					.set({
-						credits: sql`${organization.credits} - ${totalCost}`,
-					})
-					.where(eq(organization.id, orgId));
-
-				console.log(`Deducted ${totalCost} credits from organization ${orgId}`);
-			}
-		}
-
-		// Mark all logs as processed
-		await db
-			.update(log)
-			.set({
-				processedAt: new Date(),
-			})
-			.where(inArray(log.id, logIds));
-
-		console.log(`Marked ${logIds.length} logs as processed`);
 	} catch (error) {
 		console.error("Error processing batch credit deductions:", error);
 	} finally {

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -11,7 +11,7 @@ import {
 	inArray,
 } from "@llmgateway/db";
 
-import { getProject, getOrganization } from "./lib/cache";
+import { getOrganization } from "./lib/cache";
 import { consumeFromQueue, LOG_QUEUE } from "./lib/redis";
 import { calculateFees } from "../../api/src/lib/fee-calculator";
 import { stripe } from "../../api/src/routes/payments";
@@ -261,10 +261,11 @@ async function processBatchCreditDeductions(): Promise<void> {
 		await db.transaction(async (tx) => {
 			// Get unprocessed logs with row-level locking to prevent concurrent processing
 			const unprocessedLogs = await tx.execute(sql`
-				SELECT id, organization_id, project_id, cost, cached
-				FROM log 
-				WHERE processed_at IS NULL 
-				ORDER BY created_at ASC
+				SELECT l.id, l.organization_id, l.project_id, l.cost, l.cached, p.mode as project_mode
+				FROM log l
+				LEFT JOIN project p ON l.project_id = p.id
+				WHERE l.processed_at IS NULL 
+				ORDER BY l.created_at ASC
 				LIMIT ${BATCH_SIZE}
 				FOR UPDATE SKIP LOCKED
 			`);
@@ -288,16 +289,15 @@ async function processBatchCreditDeductions(): Promise<void> {
 					projectId: row[2] as string,
 					cost: row[3] as string | null,
 					cached: row[4] as boolean | null,
+					projectMode: row[5] as string | null,
 				};
-
-				const project = await getProject(logData.projectId);
 
 				// Only deduct credits for non-cached logs with cost and non-api-key projects
 				if (
 					logData.cost &&
 					Number(logData.cost) > 0 &&
 					!logData.cached &&
-					project?.mode !== "api-keys"
+					logData.projectMode !== "api-keys"
 				) {
 					const currentCost = orgCosts.get(logData.organizationId) || 0;
 					orgCosts.set(

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -8,6 +8,7 @@ import {
 	lt,
 	tables,
 	apiKey,
+	inArray,
 } from "@llmgateway/db";
 
 import { getProject, getOrganization } from "./lib/cache";
@@ -18,7 +19,13 @@ import { stripe } from "../../api/src/routes/payments";
 import type { LogInsertData } from "./lib/logs";
 
 const AUTO_TOPUP_LOCK_KEY = "auto_topup_check";
+const CREDIT_PROCESSING_LOCK_KEY = "credit_processing";
 const LOCK_DURATION_MINUTES = 10;
+
+// Configuration for batch processing
+const BATCH_SIZE = Number(process.env.CREDIT_BATCH_SIZE) || 100;
+const BATCH_PROCESSING_INTERVAL_SECONDS =
+	Number(process.env.CREDIT_BATCH_INTERVAL) || 30;
 
 async function acquireLock(key: string): Promise<boolean> {
 	const lockExpiry = new Date(Date.now() - LOCK_DURATION_MINUTES * 60 * 1000);
@@ -244,6 +251,89 @@ async function processAutoTopUp(): Promise<void> {
 	}
 }
 
+async function processBatchCreditDeductions(): Promise<void> {
+	const lockAcquired = await acquireLock(CREDIT_PROCESSING_LOCK_KEY);
+	if (!lockAcquired) {
+		return;
+	}
+
+	try {
+		// Get unprocessed logs in batches
+		const unprocessedLogs = await db.query.log.findMany({
+			where: {
+				processedAt: {
+					isNull: true,
+				},
+			},
+			limit: BATCH_SIZE,
+			columns: {
+				id: true,
+				organizationId: true,
+				projectId: true,
+				cost: true,
+				cached: true,
+			},
+		});
+
+		if (unprocessedLogs.length === 0) {
+			return;
+		}
+
+		console.log(
+			`Processing ${unprocessedLogs.length} logs for credit deduction`,
+		);
+
+		// Group logs by organization and project to calculate total costs
+		const orgCosts = new Map<string, number>();
+		const logIds: string[] = [];
+
+		for (const log of unprocessedLogs) {
+			const project = await getProject(log.projectId);
+
+			// Only deduct credits for non-cached logs with cost and non-api-key projects
+			if (
+				log.cost &&
+				Number(log.cost) > 0 &&
+				!log.cached &&
+				project?.mode !== "api-keys"
+			) {
+				const currentCost = orgCosts.get(log.organizationId) || 0;
+				orgCosts.set(log.organizationId, currentCost + Number(log.cost));
+			}
+
+			logIds.push(log.id);
+		}
+
+		// Batch update organization credits
+		for (const [orgId, totalCost] of orgCosts.entries()) {
+			if (totalCost > 0) {
+				await db
+					.update(organization)
+					.set({
+						credits: sql`${organization.credits} - ${totalCost}`,
+					})
+					.where(eq(organization.id, orgId));
+
+				console.log(`Deducted ${totalCost} credits from organization ${orgId}`);
+			}
+		}
+
+		// Mark all logs as processed
+		await db
+			.update(log)
+			.set({
+				processedAt: new Date(),
+			})
+			.where(inArray(log.id, logIds));
+
+		console.log(`Marked ${logIds.length} logs as processed`);
+	} catch (error) {
+		console.error("Error processing batch credit deductions:", error);
+	} finally {
+		await releaseLock(CREDIT_PROCESSING_LOCK_KEY);
+	}
+}
+
 export async function processLogQueue(): Promise<void> {
 	const message = await consumeFromQueue(LOG_QUEUE);
 
@@ -271,25 +361,15 @@ export async function processLogQueue(): Promise<void> {
 			}),
 		);
 
+		// Insert logs without processing credits - they will be processed in batches
 		await db.insert(log).values(processedLogData as any);
 
+		// Update API key usage immediately (not batched to avoid complex aggregation)
 		for (const data of logData) {
 			if (!data.cost || data.cached) {
 				continue;
 			}
 
-			const project = await getProject(data.projectId);
-
-			if (project?.mode !== "api-keys") {
-				await db
-					.update(organization)
-					.set({
-						credits: sql`${organization.credits} - ${data.cost}`,
-					})
-					.where(eq(organization.id, data.organizationId));
-			}
-
-			// update key usage
 			await db
 				.update(apiKey)
 				.set({
@@ -316,6 +396,7 @@ export async function startWorker() {
 	console.log("Starting log queue worker...");
 	const count = process.env.NODE_ENV === "production" ? 120 : 5;
 	let autoTopUpCounter = 0;
+	let creditProcessingCounter = 0;
 
 	// eslint-disable-next-line no-unmodified-loop-condition
 	while (!shouldStop) {
@@ -326,6 +407,12 @@ export async function startWorker() {
 			if (autoTopUpCounter >= count) {
 				await processAutoTopUp();
 				autoTopUpCounter = 0;
+			}
+
+			creditProcessingCounter++;
+			if (creditProcessingCounter >= BATCH_PROCESSING_INTERVAL_SECONDS) {
+				await processBatchCreditDeductions();
+				creditProcessingCounter = 0;
 			}
 
 			if (!shouldStop) {

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -251,7 +251,7 @@ async function processAutoTopUp(): Promise<void> {
 	}
 }
 
-async function processBatchCreditDeductions(): Promise<void> {
+async function batchProcessLogs(): Promise<void> {
 	const lockAcquired = await acquireLock(CREDIT_PROCESSING_LOCK_KEY);
 	if (!lockAcquired) {
 		return;
@@ -264,7 +264,7 @@ async function processBatchCreditDeductions(): Promise<void> {
 				SELECT l.id, l.organization_id, l.project_id, l.cost, l.cached, l.api_key_id, p.mode as project_mode
 				FROM log l
 				LEFT JOIN project p ON l.project_id = p.id
-				WHERE l.processed_at IS NULL 
+				WHERE l.processed_at IS NULL
 				ORDER BY l.created_at ASC
 				LIMIT ${BATCH_SIZE}
 				FOR UPDATE SKIP LOCKED
@@ -425,7 +425,7 @@ export async function startWorker() {
 
 			creditProcessingCounter++;
 			if (creditProcessingCounter >= BATCH_PROCESSING_INTERVAL_SECONDS) {
-				await processBatchCreditDeductions();
+				await batchProcessLogs();
 				creditProcessingCounter = 0;
 			}
 

--- a/apps/gateway/src/worker.ts
+++ b/apps/gateway/src/worker.ts
@@ -10,6 +10,7 @@ import {
 	apiKey,
 	inArray,
 } from "@llmgateway/db";
+import z from "zod";
 
 import { getOrganization } from "./lib/cache";
 import { consumeFromQueue, LOG_QUEUE } from "./lib/redis";
@@ -25,7 +26,17 @@ const LOCK_DURATION_MINUTES = 10;
 // Configuration for batch processing
 const BATCH_SIZE = Number(process.env.CREDIT_BATCH_SIZE) || 100;
 const BATCH_PROCESSING_INTERVAL_SECONDS =
-	Number(process.env.CREDIT_BATCH_INTERVAL) || 30;
+	Number(process.env.CREDIT_BATCH_INTERVAL) || 5;
+
+const schema = z.object({
+	id: z.string(),
+	organization_id: z.string(),
+	project_id: z.string(),
+	cost: z.number().nullable(),
+	cached: z.boolean(),
+	api_key_id: z.string(),
+	project_mode: z.string(),
+});
 
 async function acquireLock(key: string): Promise<boolean> {
 	const lockExpiry = new Date(Date.now() - LOCK_DURATION_MINUTES * 60 * 1000);
@@ -267,7 +278,7 @@ async function batchProcessLogs(): Promise<void> {
 				WHERE l.processed_at IS NULL
 				ORDER BY l.created_at ASC
 				LIMIT ${BATCH_SIZE}
-				FOR UPDATE SKIP LOCKED
+				FOR UPDATE OF l SKIP LOCKED
 			`);
 
 			if (unprocessedLogs.rows.length === 0) {
@@ -283,36 +294,21 @@ async function batchProcessLogs(): Promise<void> {
 			const apiKeyCosts = new Map<string, number>();
 			const logIds: string[] = [];
 
-			for (const row of unprocessedLogs.rows) {
-				const logData = {
-					id: row[0] as string,
-					organizationId: row[1] as string,
-					projectId: row[2] as string,
-					cost: row[3] as string | null,
-					cached: row[4] as boolean | null,
-					apiKeyId: row[5] as string,
-					projectMode: row[6] as string | null,
-				};
-
-				if (logData.cost && Number(logData.cost) > 0 && !logData.cached) {
+			for (const raw of unprocessedLogs.rows) {
+				const row = schema.parse(raw);
+				if (row.cost && row.cost > 0 && !row.cached) {
 					// Always update API key usage for non-cached logs with cost
-					const currentApiKeyCost = apiKeyCosts.get(logData.apiKeyId) || 0;
-					apiKeyCosts.set(
-						logData.apiKeyId,
-						currentApiKeyCost + Number(logData.cost),
-					);
+					const currentApiKeyCost = apiKeyCosts.get(row.api_key_id) || 0;
+					apiKeyCosts.set(row.api_key_id, currentApiKeyCost + row.cost);
 
 					// Only deduct organization credits for non-api-key projects
-					if (logData.projectMode !== "api-keys") {
-						const currentOrgCost = orgCosts.get(logData.organizationId) || 0;
-						orgCosts.set(
-							logData.organizationId,
-							currentOrgCost + Number(logData.cost),
-						);
+					if (row.project_mode !== "api-keys") {
+						const currentOrgCost = orgCosts.get(row.organization_id) || 0;
+						orgCosts.set(row.organization_id, currentOrgCost + row.cost);
 					}
 				}
 
-				logIds.push(logData.id);
+				logIds.push(row.id);
 			}
 
 			// Batch update organization credits within the same transaction

--- a/packages/db/migrations/1754922211_lowly_absorbing_man.sql
+++ b/packages/db/migrations/1754922211_lowly_absorbing_man.sql
@@ -1,4 +1,4 @@
 ALTER TABLE "log" ADD COLUMN "processed_at" timestamp;
 
 -- Set all existing logs as processed since they would have been processed by the old system
-UPDATE "log" SET "processed_at" = NOW() WHERE "processed_at" IS NULL;
+UPDATE "log" SET "processed_at" = "created_at" WHERE "processed_at" IS NULL;

--- a/packages/db/migrations/1754922211_lowly_absorbing_man.sql
+++ b/packages/db/migrations/1754922211_lowly_absorbing_man.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "log" ADD COLUMN "processed_at" timestamp;
+
+-- Set all existing logs as processed since they would have been processed by the old system
+UPDATE "log" SET "processed_at" = NOW() WHERE "processed_at" IS NULL;

--- a/packages/db/migrations/meta/1754922211_snapshot.json
+++ b/packages/db/migrations/meta/1754922211_snapshot.json
@@ -1,0 +1,1753 @@
+{
+  "id": "f8448b96-3c35-404e-a7a4-727f4b4c3ab3",
+  "prevId": "2df460fa-291f-48a2-bf14-41b15817ad58",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_key_project_id_project_id_fk": {
+          "name": "api_key_project_id_project_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_token_unique": {
+          "name": "api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_user_id_user_id_fk": {
+          "name": "chat_user_id_user_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation": {
+      "name": "installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installation_uuid_unique": {
+          "name": "installation_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lock": {
+      "name": "lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lock_key_unique": {
+          "name": "lock_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log": {
+      "name": "log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_provider": {
+          "name": "requested_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_model": {
+          "name": "used_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_provider": {
+          "name": "used_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_content": {
+          "name": "reasoning_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_results": {
+          "name": "tool_results",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unified_finish_reason": {
+          "name": "unified_finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_cost": {
+          "name": "input_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_cost": {
+          "name": "output_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_input_cost": {
+          "name": "cached_input_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_cost": {
+          "name": "request_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "streamed": {
+          "name": "streamed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_mode": {
+          "name": "used_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_organization_id_organization_id_fk": {
+          "name": "log_organization_id_organization_id_fk",
+          "tableFrom": "log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "log_project_id_project_id_fk": {
+          "name": "log_project_id_project_id_fk",
+          "tableFrom": "log",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "log_api_key_id_api_key_id_fk": {
+          "name": "log_api_key_id_api_key_id_fk",
+          "tableFrom": "log",
+          "tableTo": "api_key",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits": {
+          "name": "credits",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_top_up_threshold": {
+          "name": "auto_top_up_threshold",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "auto_top_up_amount": {
+          "name": "auto_top_up_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_cancelled": {
+          "name": "subscription_cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_start_date": {
+          "name": "trial_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_end_date": {
+          "name": "trial_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trial_active": {
+          "name": "is_trial_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_level": {
+          "name": "retention_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'retain'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_stripeCustomerId_unique": {
+          "name": "organization_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "organization_stripeSubscriptionId_unique": {
+          "name": "organization_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_action": {
+      "name": "organization_action",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_action_organization_id_organization_id_fk": {
+          "name": "organization_action_organization_id_organization_id_fk",
+          "tableFrom": "organization_action",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_method_organization_id_organization_id_fk": {
+          "name": "payment_method_organization_id_organization_id_fk",
+          "tableFrom": "payment_method",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caching_enabled": {
+          "name": "caching_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_duration_seconds": {
+          "name": "cache_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hybrid'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_organization_id_organization_id_fk": {
+          "name": "provider_key_organization_id_organization_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_key_organizationId_name_unique": {
+          "name": "provider_key_organizationId_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction": {
+      "name": "transaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_amount": {
+          "name": "credit_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_organization_id_organization_id_fk": {
+          "name": "transaction_organization_id_organization_id_fk",
+          "tableFrom": "transaction",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization": {
+      "name": "user_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organization_user_id_user_id_fk": {
+          "name": "user_organization_user_id_user_id_fk",
+          "tableFrom": "user_organization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_organization_organization_id_organization_id_fk": {
+          "name": "user_organization_organization_id_organization_id_fk",
+          "tableFrom": "user_organization",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1754525073775,
       "tag": "1754525073_demonic_human_fly",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1754922211699,
+      "tag": "1754922211_lowly_absorbing_man",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -300,6 +300,7 @@ export const log = pgTable("log", {
 	}).notNull(),
 	source: text(),
 	customHeaders: json().$type<{ [key: string]: string }>(),
+	processedAt: timestamp(),
 });
 
 export const passkey = pgTable("passkey", {


### PR DESCRIPTION
Introduced batch processing for credit deductions to improve efficiency. Added `processedAt` to
logs schema and implemented a new worker that handles unprocessed logs in defined intervals.Introduced batch processing for credit deductions to improve efficiency. Added `processedAt` to
logs schema and implemented a new worker that handles unprocessed logs in defined intervals.