### PR TITLE
docs(agents): clean up old tanstack references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 
 ### apps/ui
 
-This is a tanstack router project. Always use navigate() for navigation. Never use window.location.
+This is a Next.js App Router project. Use next/link for links and next/navigation's router.push/replace or redirect() for programmatic navigation. Never use window.location.
 
 ### apps/docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Always run `pnpm format` before committing code. Run `pnpm generate` if API rout
 
 - **Gateway** (`apps/gateway`) - LLM request routing and provider management (Hono + Zod + OpenAPI)
 - **API** (`apps/api`) - Backend API for user management, billing, analytics (Hono + Zod + OpenAPI)
-- **UI** (`apps/ui`) - Frontend dashboard (React + TanStack Router + Vite)
+- **UI** (`apps/ui`) - Frontend dashboard (Next.js App Router)
 - **Docs** (`apps/docs`) - Documentation site (Next.js + Fumadocs)
 
 ### Shared Packages
@@ -68,11 +68,11 @@ Always run `pnpm format` before committing code. Run `pnpm generate` if API rout
 
 ### Frontend
 
-- **Framework**: React with TanStack Router
+- **Framework**: Next.js App Router (React Server Components)
 - **State Management**: TanStack Query
 - **UI Components**: Radix UI with Tailwind CSS
-- **Build Tool**: Vite
-- **Navigation**: Use `navigate()` for programmatic navigation
+- **Build Tool**: Next.js (Turbopack during dev; Node/Edge runtime)
+- **Navigation**: Use `next/link` for links and `next/navigation`'s router for programmatic navigation
 
 ### Development Tools
 


### PR DESCRIPTION
Cleanup old TanStack Start references in markdown files as `apps/ui` now uses Next.js.

---
<a href="https://cursor.com/background-agent?bcId=bc-d04e5279-3e77-4c9c-9e7e-2c2a7377aceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d04e5279-3e77-4c9c-9e7e-2c2a7377aceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UI docs to reflect Next.js App Router (React Server Components) instead of TanStack Router.
  * Revised navigation guidance to use next/link for links and next/navigation (router.push/replace or redirect) for programmatic navigation.
  * Reaffirmed that window.location remains disallowed for navigation.
  * Updated frontend stack and build tooling descriptions to Next.js with Turbopack during development and Node/Edge runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->