### PR TITLE
feat(models): add support for free models

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -13,6 +13,7 @@ import {
 	getProviderEndpoint,
 	getProviderHeaders,
 	type Model,
+	type ModelDefinition,
 	models,
 	prepareRequestBody,
 	type Provider,
@@ -1533,7 +1534,7 @@ chat.openapi(completions, async (c) => {
 	}
 
 	if (response_format?.type === "json_object") {
-		if (!(modelInfo as any).jsonOutput) {
+		if (!(modelInfo as ModelDefinition).jsonOutput) {
 			throw new HTTPException(400, {
 				message: `Model ${requestedModel} does not support JSON output mode`,
 			});
@@ -1894,7 +1895,7 @@ chat.openapi(completions, async (c) => {
 			});
 		}
 
-		if (organization.credits <= 0) {
+		if (organization.credits <= 0 && !(modelInfo as ModelDefinition).free) {
 			throw new HTTPException(402, {
 				message: "Organization has insufficient credits",
 			});
@@ -1945,7 +1946,7 @@ chat.openapi(completions, async (c) => {
 				});
 			}
 
-			if (organization.credits <= 0) {
+			if (organization.credits <= 0 && !(modelInfo as ModelDefinition).free) {
 				throw new HTTPException(402, {
 					message:
 						"No API key set for provider and organization has insufficient credits",

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -57,6 +57,7 @@ const modelSchema = z.object({
 	per_request_limits: z.record(z.string()).optional(),
 	supported_parameters: z.array(z.string()).optional(),
 	json_output: z.boolean(),
+	free: z.boolean().optional(),
 	deprecated_at: z.string().optional(),
 	deactivated_at: z.string().optional(),
 });
@@ -168,6 +169,7 @@ modelsApi.openapi(listModels, async (c) => {
 				supported_parameters: getSupportedParametersFromModel(model),
 				// Add model-level capabilities
 				json_output: model.jsonOutput || false,
+				free: model.free || false,
 				deprecated_at: model.deprecatedAt?.toISOString(),
 				deactivated_at: model.deactivatedAt?.toISOString(),
 			};

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -100,7 +100,11 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 						<div className="flex items-center gap-1">
 							<Coins className="h-3.5 w-3.5" />
 							<span>
-								{log.cost ? `$${log.cost.toFixed(6)}` : log.cached ? "$0" : "?"}
+								{log.cost
+									? `$${log.cost.toFixed(6)}`
+									: log.cached
+										? "$0"
+										: "$0"}
 							</span>
 						</div>
 						{log.source && (
@@ -224,19 +228,19 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 							<div className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm">
 								<div className="text-muted-foreground">Input Cost</div>
 								<div>
-									{log.inputCost ? `$${log.inputCost.toFixed(6)}` : "?"}
+									{log.inputCost ? `$${log.inputCost.toFixed(6)}` : "$0"}
 								</div>
 								<div className="text-muted-foreground">Output Cost</div>
 								<div>
-									{log.outputCost ? `$${log.outputCost.toFixed(6)}` : "?"}
+									{log.outputCost ? `$${log.outputCost.toFixed(6)}` : "$0"}
 								</div>
 								<div className="text-muted-foreground">Request Cost</div>
 								<div>
-									{log.requestCost ? `$${log.requestCost.toFixed(6)}` : "0"}
+									{log.requestCost ? `$${log.requestCost.toFixed(6)}` : "$0"}
 								</div>
 								<div className="text-muted-foreground">Total Cost</div>
 								<div className="font-medium">
-									{log.cost ? `$${log.cost.toFixed(6)}` : "?"}
+									{log.cost ? `$${log.cost.toFixed(6)}` : "$0"}
 								</div>
 							</div>
 						</div>

--- a/apps/ui/src/components/models/all-models.tsx
+++ b/apps/ui/src/components/models/all-models.tsx
@@ -5,6 +5,7 @@ import {
 	Check,
 	Copy,
 	Eye,
+	Gift,
 	MessageSquare,
 	Wrench,
 	Zap,
@@ -82,6 +83,7 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 			vision: false,
 			tools: false,
 			reasoning: false,
+			free: false,
 		},
 		inputPrice: {
 			min: "",
@@ -151,6 +153,9 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 				filters.capabilities.reasoning &&
 				!model.providerDetails.some((p) => p.provider.reasoning)
 			) {
+				return false;
+			}
+			if (filters.capabilities.free && !model.free) {
 				return false;
 			}
 
@@ -362,6 +367,7 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 				vision: false,
 				tools: false,
 				reasoning: false,
+				free: false,
 			},
 			inputPrice: { min: "", max: "" },
 			outputPrice: { min: "", max: "" },
@@ -415,6 +421,12 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 									label: "Reasoning",
 									icon: MessageSquare,
 									color: "text-orange-500",
+								},
+								{
+									key: "free",
+									label: "Free",
+									icon: Gift,
+									color: "text-emerald-500",
 								},
 							].map(({ key, label, icon: Icon, color }) => (
 								<div key={key} className="flex items-center space-x-2">
@@ -604,8 +616,17 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 						<TableRow key={model.id}>
 							<TableCell className="font-medium">
 								<div className="space-y-1">
-									<div className="font-semibold text-sm">
+									<div className="font-semibold text-sm flex items-center gap-2">
 										{model.name || model.id}
+										{model.free && (
+											<Badge
+												variant="secondary"
+												className="text-xs bg-emerald-100 text-emerald-700 border-emerald-200"
+											>
+												<Gift className="h-3 w-3 mr-1" />
+												Free
+											</Badge>
+										)}
 									</div>
 									<div className="text-xs text-muted-foreground">
 										Family:{" "}
@@ -762,8 +783,17 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 					<CardHeader>
 						<div className="flex items-start justify-between gap-2">
 							<div className="flex-1 min-w-0">
-								<CardTitle className="text-base leading-tight">
+								<CardTitle className="text-base leading-tight flex items-center gap-2 flex-wrap">
 									{model.name || model.id}
+									{model.free && (
+										<Badge
+											variant="secondary"
+											className="text-xs bg-emerald-100 text-emerald-700 border-emerald-200"
+										>
+											<Gift className="h-3 w-3 mr-1" />
+											Free
+										</Badge>
+									)}
 								</CardTitle>
 								<CardDescription className="text-sm mt-1">
 									<Badge variant="outline" className="text-xs">
@@ -1002,7 +1032,7 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 								{renderFilters()}
 							</div>
 
-							<div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
 								<Card>
 									<CardContent className="p-4">
 										<div className="text-2xl font-bold">
@@ -1046,6 +1076,19 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 										</div>
 										<div className="text-sm text-muted-foreground">
 											Tool-enabled{hasActiveFilters ? " (filtered)" : ""}
+										</div>
+									</CardContent>
+								</Card>
+								<Card>
+									<CardContent className="p-4">
+										<div className="text-2xl font-bold">
+											{
+												modelsWithProviders.filter((m) => (m as any).free)
+													.length
+											}
+										</div>
+										<div className="text-sm text-muted-foreground">
+											Free Models{hasActiveFilters ? " (filtered)" : ""}
 										</div>
 									</CardContent>
 								</Card>

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -98,6 +98,10 @@ export interface ModelDefinition {
 	 */
 	jsonOutput?: boolean;
 	/**
+	 * Whether this model is free to use
+	 */
+	free?: boolean;
+	/**
 	 * Date when the model will be deprecated (still usable but filtered from selection algorithms)
 	 */
 	deprecatedAt?: Date;

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -47,6 +47,28 @@ export const metaModels = [
 		],
 	},
 	{
+		id: "llama-3.1-70b-instruct-free",
+		name: "Meta Llama 3.1 70B Instruct FP8 (Free)",
+		family: "meta",
+		free: true,
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "cloudrift",
+				modelName: "meta-llama/Meta-Llama-3.1-70B-Instruct-FP8",
+				inputPrice: 0.0 / 1e6,
+				outputPrice: 0.0 / 1e6,
+				requestPrice: 0,
+				contextSize: 16380,
+				maxOutput: undefined,
+				streaming: true,
+				vision: false,
+				tools: false,
+			},
+		],
+	},
+	{
 		id: "llama-3.2-11b-instruct",
 		name: "Llama 3.2 11B Instruct",
 		family: "meta",


### PR DESCRIPTION
Added a `free` property to model metadata and updated cost display logic in the dashboard to handle free models. Modified gateway logic to bypass credit checks for free models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Free” models: badge in lists, Free filter, and Free Models counter in summaries.
  * Models API now exposes a free attribute for discovery.
  * Added a new free model: Meta Llama 3.1 70B Instruct (FP8).
  * Free models are exempt from credit checks.

* **Bug Fixes**
  * Cost displays now consistently default to “$0” when values are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->