### PR TITLE
Remove redefined unifiedfinishreason type

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { UnifiedFinishReason } from "@llmgateway/db/schema";
 import { models, providers } from "@llmgateway/models";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
@@ -22,15 +23,7 @@ import { useApi } from "@/lib/fetch-client";
 
 import type { Log } from "@llmgateway/db";
 
-const UnifiedFinishReason = {
-	COMPLETED: "completed",
-	LENGTH_LIMIT: "length_limit",
-	CONTENT_FILTER: "content_filter",
-	GATEWAY_ERROR: "gateway_error",
-	UPSTREAM_ERROR: "upstream_error",
-	CANCELED: "canceled",
-	UNKNOWN: "unknown",
-} as const;
+// Use shared UnifiedFinishReason from @llmgateway/db
 
 interface RecentLogsProps {
 	initialData?:
@@ -262,7 +255,12 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 					</SelectTrigger>
 					<SelectContent>
 						<SelectItem value="all">All unified reasons</SelectItem>
-						{Object.entries(UnifiedFinishReason).map(([key, value]) => (
+						{(
+							Object.entries(UnifiedFinishReason as Record<string, string>) as [
+								string,
+								string,
+							][]
+						).map(([key, value]) => (
 							<SelectItem key={value} value={value}>
 								{key
 									.toLowerCase()

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -22,6 +22,7 @@
 		"paths": {
 			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"],
+			"@llmgateway/db/schema": ["../../packages/db/src/schema"],
 			"content-collections": ["./.content-collections/generated"]
 		}
 	},

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,11 @@
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
+		},
+		"./schema": {
+			"types": "./dist/schema.d.ts",
+			"import": "./dist/schema.js",
+			"require": "./dist/schema.cjs"
 		}
 	},
 	"main": "./dist/index.cjs",


### PR DESCRIPTION
Remove the duplicated `UnifiedFinishReason` constant in `recent-logs.tsx` and import it from `@llmgateway/db/schema` to use a shared type and prevent bundling server-side code into the UI.

Directly importing from `@llmgateway/db` caused server-side modules to be bundled into the UI. This PR addresses that by introducing a new `db/schema` subpath export for client-safe types and updating the UI's `tsconfig.json` accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ce18adb-6abf-4e2a-b97b-4d900a448bd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ce18adb-6abf-4e2a-b97b-4d900a448bd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

