### PR TITLE
revert(fix/activity): remove unused finish reason filter

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -31,6 +31,7 @@ const UnifiedFinishReason = {
 	CANCELED: "canceled",
 	UNKNOWN: "unknown",
 } as const;
+const FINISH_REASONS = ["stop", "length", "error", "content_filter"];
 
 interface RecentLogsProps {
 	initialData?:
@@ -53,6 +54,9 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 
 	// Initialize state from URL parameters
 	const [dateRange, setDateRange] = useState<DateRange | undefined>();
+	const [finishReason, setFinishReason] = useState<string | undefined>(
+		searchParams.get("finishReason") || undefined,
+	);
 	const [unifiedFinishReason, setUnifiedFinishReason] = useState<
 		string | undefined
 	>(searchParams.get("unifiedFinishReason") || undefined);
@@ -144,6 +148,9 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 	if (dateRange?.end) {
 		queryParams.endDate = dateRange.end.toISOString();
 	}
+	if (finishReason && finishReason !== "all") {
+		queryParams.finishReason = finishReason;
+	}
 	if (unifiedFinishReason && unifiedFinishReason !== "all") {
 		queryParams.unifiedFinishReason = unifiedFinishReason;
 	}
@@ -165,6 +172,7 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 
 	const shouldUseInitialData =
 		!dateRange && // No date range selected (date range is not in URL initially)
+		finishReason === (searchParams.get("finishReason") || undefined) &&
 		unifiedFinishReason ===
 			(searchParams.get("unifiedFinishReason") || undefined) &&
 		provider === (searchParams.get("provider") || undefined) &&
@@ -251,6 +259,23 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 				<DateRangeSelect onChange={handleDateRangeChange} />
 
 				<Select
+					onValueChange={handleFilterChange("finishReason", setFinishReason)}
+					value={finishReason || "all"}
+				>
+					<SelectTrigger className="w-[180px]">
+						<SelectValue placeholder="Filter by reason" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">All reasons</SelectItem>
+						{FINISH_REASONS.map((reason) => (
+							<SelectItem key={reason} value={reason}>
+								{reason}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+
+				<Select
 					onValueChange={handleFilterChange(
 						"unifiedFinishReason",
 						setUnifiedFinishReason,
@@ -308,7 +333,7 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 				</Select>
 
 				<Input
-					placeholder="Custom header key"
+					placeholder="Custom header key (e.g., uid)"
 					value={customHeaderKey}
 					onChange={(e) => {
 						isFilteringRef.current = true;
@@ -323,7 +348,7 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 				/>
 
 				<Input
-					placeholder="Custom header value"
+					placeholder="Custom header value (e.g., 12345)"
 					value={customHeaderValue}
 					onChange={(e) => {
 						isFilteringRef.current = true;


### PR DESCRIPTION
This reverts commit b15bb28698d5db9311b330d0e6b0d1daf2cc45d9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Finish Reason filter (stop, length, error, content filter) to Recent Logs with an “All reasons” option.
  * Filter selection syncs with the URL and is applied to data queries; initial results align with the chosen reason.
  * Updated header input placeholders with example values for clearer filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->