### PR TITLE
fix(activity): remove redundant finish reason filter

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -31,7 +31,6 @@ const UnifiedFinishReason = {
 	CANCELED: "canceled",
 	UNKNOWN: "unknown",
 } as const;
-const FINISH_REASONS = ["stop", "length", "error", "content_filter"];
 
 interface RecentLogsProps {
 	initialData?:
@@ -54,9 +53,6 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 
 	// Initialize state from URL parameters
 	const [dateRange, setDateRange] = useState<DateRange | undefined>();
-	const [finishReason, setFinishReason] = useState<string | undefined>(
-		searchParams.get("finishReason") || undefined,
-	);
 	const [unifiedFinishReason, setUnifiedFinishReason] = useState<
 		string | undefined
 	>(searchParams.get("unifiedFinishReason") || undefined);
@@ -148,9 +144,6 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 	if (dateRange?.end) {
 		queryParams.endDate = dateRange.end.toISOString();
 	}
-	if (finishReason && finishReason !== "all") {
-		queryParams.finishReason = finishReason;
-	}
 	if (unifiedFinishReason && unifiedFinishReason !== "all") {
 		queryParams.unifiedFinishReason = unifiedFinishReason;
 	}
@@ -172,7 +165,6 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 
 	const shouldUseInitialData =
 		!dateRange && // No date range selected (date range is not in URL initially)
-		finishReason === (searchParams.get("finishReason") || undefined) &&
 		unifiedFinishReason ===
 			(searchParams.get("unifiedFinishReason") || undefined) &&
 		provider === (searchParams.get("provider") || undefined) &&
@@ -257,23 +249,6 @@ export function RecentLogs({ initialData, projectId }: RecentLogsProps) {
 		>
 			<div className="flex flex-wrap gap-2 mb-4 sticky top-0 bg-background z-10 py-2">
 				<DateRangeSelect onChange={handleDateRangeChange} />
-
-				<Select
-					onValueChange={handleFilterChange("finishReason", setFinishReason)}
-					value={finishReason || "all"}
-				>
-					<SelectTrigger className="w-[180px]">
-						<SelectValue placeholder="Filter by reason" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="all">All reasons</SelectItem>
-						{FINISH_REASONS.map((reason) => (
-							<SelectItem key={reason} value={reason}>
-								{reason}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
 
 				<Select
 					onValueChange={handleFilterChange(


### PR DESCRIPTION
Deleted unused `FINISH_REASONS` constant and removed associated filter UI elements from RecentLogs. Simplified query parameters and state initialization logic accordingly.