### PR TITLE
Remove redefined unifiedfinishreason type

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { UnifiedFinishReason } from "@llmgateway/db";
 import { models, providers } from "@llmgateway/models";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
@@ -22,15 +23,6 @@ import { useApi } from "@/lib/fetch-client";
 
 import type { Log } from "@llmgateway/db";
 
-const UnifiedFinishReason = {
-	COMPLETED: "completed",
-	LENGTH_LIMIT: "length_limit",
-	CONTENT_FILTER: "content_filter",
-	GATEWAY_ERROR: "gateway_error",
-	UPSTREAM_ERROR: "upstream_error",
-	CANCELED: "canceled",
-	UNKNOWN: "unknown",
-} as const;
 const FINISH_REASONS = ["stop", "length", "error", "content_filter"];
 
 interface RecentLogsProps {


### PR DESCRIPTION
Remove redefined `UnifiedFinishReason` const in `recent-logs.tsx` and import it from `@llmgateway/db` to eliminate duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0cc88c6-a245-49cb-94f5-8ced0504c24e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0cc88c6-a245-49cb-94f5-8ced0504c24e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

