### PR TITLE
Add kimi-k2-instruct via groq provider

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -9,6 +9,18 @@ export const moonshotModels = [
 		deactivatedAt: undefined,
 		providers: [
 			{
+				providerId: "groq",
+				modelName: "moonshotai/kimi-k2-instruct",
+				inputPrice: 1.0 / 1e6,
+				outputPrice: 9.0 / 1e6,
+				requestPrice: 0,
+				contextSize: 131072,
+				maxOutput: 16384,
+				streaming: true,
+				vision: false,
+				tools: true,
+			},
+			{
 				providerId: "novita",
 				modelName: "moonshotai/kimi-k2-instruct",
 				inputPrice: 0.57 / 1e6,


### PR DESCRIPTION
Add `moonshotai/kimi-k2-instruct` model via Groq provider to expand available options for the kimi-k2 model.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c80f98f-6730-43bd-a9ff-4022e1986d85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c80f98f-6730-43bd-a9ff-4022e1986d85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

