### PR TITLE
fix(infra): replace Redis build with package installation

### DIFF
--- a/infra/supervisord.conf
+++ b/infra/supervisord.conf
@@ -16,7 +16,7 @@ stdout_logfile_maxbytes=0
 environment=PGDATA="/var/lib/postgresql/data"
 
 [program:redis]
-command=/usr/local/bin/redis-server --protected-mode no --bind 0.0.0.0 --port 6379 --appendonly no --save "" --dir /var/lib/redis
+command=/usr/bin/redis-server --protected-mode no --bind 0.0.0.0 --port 6379 --appendonly no --save "" --dir /var/lib/redis
 user=redis
 autostart=true
 autorestart=true

--- a/infra/unified.dockerfile
+++ b/infra/unified.dockerfile
@@ -24,14 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-17 \
     postgresql-contrib-17 \
     postgresql-client-17 \
-    && wget https://download.redis.io/redis-stable.tar.gz \
-    && tar -xzf redis-stable.tar.gz \
-    && cd redis-stable \
-    && make \
-    && make install \
-    && cd .. \
-    && rm -rf redis-stable redis-stable.tar.gz \
-    && adduser --system --group --no-create-home redis \
+    redis-server \
     && apt-get remove -y build-essential wget gnupg lsb-release \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Replaced manual Redis build process in Dockerfile with `redis-server` package installation to simplify setup and improve build efficiency. Removed unnecessary build dependencies.