### PR TITLE
feat: add grok-code-fast-1 model from xAI

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -157,4 +157,26 @@ export const xaiModels = [
 		],
 		jsonOutput: true,
 	},
+	{
+		id: "grok-code-fast-1",
+		name: "Grok Code Fast 1",
+		family: "xai",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-code-fast-1",
+				inputPrice: 0.2 / 1e6,
+				outputPrice: 1.5 / 1e6,
+				requestPrice: 0,
+				contextSize: 256000,
+				maxOutput: 10000,
+				streaming: true,
+				vision: false,
+				tools: true,
+			},
+		],
+		jsonOutput: true,
+	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
- Add new model with 256K context and 10K max output
- Pricing: /usr/bin/bash.20/M input tokens, .50/M output tokens
- Supports streaming, tools, and JSON output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new model option: Grok Code Fast 1, optimized for rapid code-oriented tasks.
  * Supports streaming responses, tool usage, and structured JSON output.
  * Offers a large context window and high maximum output, enabling longer inputs and more comprehensive results.
  * Available alongside existing Grok models; no changes required to use existing models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->