### PR TITLE
feat(models): transform anthropic messages for vision

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -865,7 +865,9 @@ describe("e2e", () => {
 				expect(json.usage.completion_tokens).toBeGreaterThan(0);
 				expect(json.usage.total_tokens).toBeGreaterThan(0);
 				expect(json.usage.total_tokens).toEqual(
-					json.usage.prompt_tokens + json.usage.completion_tokens,
+					json.usage.prompt_tokens +
+						json.usage.completion_tokens +
+						(json.usage.reasoning_tokens || 0),
 				);
 			},
 		);


### PR DESCRIPTION
Introduced `transformGoogleMessages` and `transformAnthropicMessages` to handle image URLs by converting them to base64 format. Updated `prepareRequestBody` for Google and Anthropic providers to utilize these transformations. Enhanced fallback handling for unsupported content types and improved performance with parallel processing of image data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved image handling for Google and Anthropic models: image URLs are now inlined as base64 data for more reliable processing.
  - Normalized message roles and content structure for Google and Anthropic integrations.

- Bug Fixes
  - Prevented empty text blocks that could cause provider errors.
  - Clearer, sanitized error messages when image processing fails; graceful fallbacks for Anthropic.

- Tests
  - Updated token accounting assertions to include optional reasoning tokens in totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->