### PR TITLE
fix(models): remove unsupported fields from Google tool parameters

### DIFF
--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -428,11 +428,19 @@ export async function prepareRequestBody(
 			if (tools && tools.length > 0) {
 				requestBody.tools = [
 					{
-						functionDeclarations: tools.map((tool: any) => ({
-							name: tool.function.name,
-							description: tool.function.description,
-							parameters: tool.function.parameters,
-						})),
+						functionDeclarations: tools.map((tool: any) => {
+							// Remove additionalProperties and $schema from parameters as Google doesn't accept them
+							const {
+								additionalProperties: _additionalProperties,
+								$schema: _$schema,
+								...cleanParameters
+							} = tool.function.parameters || {};
+							return {
+								name: tool.function.name,
+								description: tool.function.description,
+								parameters: cleanParameters,
+							};
+						}),
 					},
 				];
 			}


### PR DESCRIPTION
## Summary
- Fixes Google tool call errors by removing `additionalProperties` and `$schema` fields from function parameters
- Google's API doesn't accept these JSON Schema fields and returns a 400 error when they're present
- The fix destructures these fields out when transforming tools for Google providers (google-vertex and google-ai-studio)

## Problem
When using tool calls with Google models, the gateway was returning an error:
```
Invalid JSON payload received. Unknown name "additionalProperties" at 'tools[0].function_declarations[0].parameters': Cannot find field.
Invalid JSON payload received. Unknown name "$schema" at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

## Solution
Modified the tool transformation logic in `packages/models/src/provider-api.ts` to remove the unsupported fields before sending to Google's API.

## Test Plan
- [x] Build passes successfully
- [x] Code formatted with `pnpm format`
- [ ] Test tool calls with Google models to verify the fix works

🤖 Generated with [Claude Code](https://claude.ai/code)