### PR TITLE
feat(e2e): add TEST_MODELS env var for selective model testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,14 @@ Always run `pnpm format` before committing code. Run `pnpm generate` if API rout
 - `pnpm test:unit` - Run unit tests (\*.spec.ts files)
 - `pnpm test:e2e` - Run end-to-end tests (\*.e2e.ts files)
 
+#### E2E Test Options
+
+- `TEST_MODELS` - Run tests only for specific models (comma-separated list of `provider/model-id` pairs)
+  Example: `TEST_MODELS="openai/gpt-4o-mini,anthropic/claude-3-5-sonnet-20241022" pnpm test:e2e`
+  This is useful for quick testing as the full e2e suite can take too long with all models.
+- `FULL_MODE` - Include free models in tests (default: only paid models)
+- `LOG_MODE` - Enable detailed logging of responses
+
 ### Database Operations
 
 - `pnpm push-dev` - Push schema changes to development database

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -25,6 +25,16 @@ console.log("running with test options:", getTestOptions());
 const fullMode = process.env.FULL_MODE;
 const logMode = process.env.LOG_MODE;
 
+// Parse TEST_MODELS environment variable
+const testModelsEnv = process.env.TEST_MODELS;
+const specifiedModels = testModelsEnv
+	? testModelsEnv.split(",").map((m) => m.trim())
+	: null;
+
+if (specifiedModels) {
+	console.log(`TEST_MODELS specified: ${specifiedModels.join(", ")}`);
+}
+
 // Filter models based on test skip/only property
 const hasOnlyModels = models.some((model) =>
 	model.providers.some(
@@ -95,6 +105,13 @@ const testModels = filteredModels
 		}
 
 		return testCases;
+	})
+	.filter((testCase) => {
+		// Filter by TEST_MODELS if specified
+		if (!specifiedModels) {
+			return true;
+		}
+		return specifiedModels.includes(testCase.model);
 	});
 
 const providerModels = filteredModels
@@ -129,6 +146,13 @@ const providerModels = filteredModels
 		}
 
 		return testCases;
+	})
+	.filter((testCase) => {
+		// Filter by TEST_MODELS if specified
+		if (!specifiedModels) {
+			return true;
+		}
+		return specifiedModels.includes(testCase.model);
 	});
 
 // Log the number of test models after filtering


### PR DESCRIPTION
## Summary
- Added `TEST_MODELS` environment variable to filter e2e tests by specific models
- Significantly reduces test execution time when testing specific models
- Updated CLAUDE.md documentation with the new feature

## Changes
1. **Modified `apps/gateway/src/api.e2e.ts`**:
   - Added parsing of `TEST_MODELS` environment variable
   - Added filtering logic to test only specified models when `TEST_MODELS` is provided
   - Models are specified in `provider/model-id` format

2. **Updated `CLAUDE.md` documentation**:
   - Added documentation for the new `TEST_MODELS` environment variable
   - Included example usage
   - Documented other existing e2e test options (`FULL_MODE`, `LOG_MODE`)

## Usage
```bash
# Test specific models only
TEST_MODELS="openai/gpt-4o-mini,anthropic/claude-3-5-sonnet-20241022" pnpm test:e2e

# Test all models (default behavior)
pnpm test:e2e
```

## Benefits
- ✅ Significantly reduces test execution time for targeted testing
- ✅ Maintains backward compatibility - existing tests work unchanged
- ✅ Easy to use comma-separated list format
- ✅ Clear console output showing which models are being tested

## Test plan
- [x] Tested with single model: `TEST_MODELS="openai/gpt-4o-mini"`
- [x] Tested with multiple models: `TEST_MODELS="openai/gpt-4o-mini,anthropic/claude-3-5-sonnet-20241022"`
- [x] Tested without TEST_MODELS (default behavior - tests all 108 models)
- [x] Verified console output correctly shows filtered model count

🤖 Generated with [Claude Code](https://claude.ai/code)