### PR TITLE
feat(models): add aliases field for alternative model search terms

### DIFF
--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -14,6 +14,7 @@ export const modelsApi = new OpenAPIHono<ServerTypes>();
 const modelSchema = z.object({
 	id: z.string(),
 	name: z.string(),
+	aliases: z.array(z.string()).optional(),
 	created: z.number(),
 	description: z.string().optional(),
 	family: z.string(),
@@ -158,6 +159,7 @@ modelsApi.openapi(listModels, async (c) => {
 			return {
 				id: model.id,
 				name: model.name || model.id,
+				aliases: model.aliases,
 				created: Math.floor(Date.now() / 1000), // Current timestamp in seconds
 				description: `${model.id} provided by ${model.providers.map((p) => p.providerId).join(", ")}`,
 				family: model.family,

--- a/apps/ui/src/components/models/all-models.tsx
+++ b/apps/ui/src/components/models/all-models.tsx
@@ -163,8 +163,11 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 				const matchesFamily = normalizeString(model.family).includes(
 					normalizedQuery,
 				);
+				const matchesAlias = model.aliases?.some((alias) =>
+					normalizeString(alias).includes(normalizedQuery),
+				);
 
-				if (!matchesName && !matchesId && !matchesFamily) {
+				if (!matchesName && !matchesId && !matchesFamily && !matchesAlias) {
 					return false;
 				}
 			}

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -96,6 +96,10 @@ export interface ModelDefinition {
 	 */
 	name?: string;
 	/**
+	 * Alternative names or search terms for the model
+	 */
+	aliases?: string[];
+	/**
 	 * Model family (e.g., 'openai', 'deepseek', 'anthropic')
 	 */
 	family: string;

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -130,6 +130,7 @@ export const googleModels = [
 	{
 		id: "gemini-2.5-flash-image-preview",
 		name: "Gemini 2.5 Flash Image Preview",
+		aliases: ["nano banana"],
 		family: "google",
 		deprecatedAt: undefined,
 		deactivatedAt: undefined,


### PR DESCRIPTION
## Summary
This PR adds an aliases field to the model system, allowing models to have alternative names or search terms that users can use to find them more easily.

## Changes
- ✨ Add optional `aliases` field to ModelDefinition interface
- 🔍 Update models page search functionality to include aliases in search query
- 🏷️ Add 'nano banana' alias to gemini-2.5-flash-image-preview model
- 🔌 Include aliases in /v1/models API endpoint response

## Implementation Details
### Model Definition
Added an optional `aliases?: string[]` field to the `ModelDefinition` interface in `packages/models/src/models.ts`

### Search Functionality
Updated the search filter in `apps/ui/src/components/models/all-models.tsx` to check if any aliases match the search query. The search now checks:
- Model name
- Model ID
- Model family
- Model aliases (new)

### API Response
Modified the /v1/models endpoint to include the aliases field in the response, making them available to API consumers.

## Example Usage
Users can now search for "nano banana" to find the gemini-2.5-flash-image-preview model, demonstrating how aliases can provide fun or memorable alternative search terms.

## Testing
- ✅ Code builds successfully
- ✅ Linting and formatting passed
- ✅ Search functionality works with aliases

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Models can now include aliases (alternative names) that appear in model listings and are returned by the models API.
  - Search in the All Models view matches aliases in addition to name, ID, and family for better discoverability.
  - Added an alias for the Google model “gemini-2.5-flash-image-preview” (“nano banana”).
  - Aliases are optional and gracefully handled when not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->