### PR TITLE
fix(gateway): include upstream response text in streaming errors

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3505,7 +3505,7 @@ chat.openapi(completions, async (c) => {
 				} else {
 					console.error("Error reading stream:", error);
 
-					// Forward the error to the client
+					// Forward the error to the client with the buffered content that caused the error
 					try {
 						await stream.writeSSE({
 							event: "error",
@@ -3515,6 +3515,8 @@ chat.openapi(completions, async (c) => {
 									type: "gateway_error",
 									param: null,
 									code: "streaming_error",
+									// Include the buffer content that caused the parsing error
+									responseText: buffer.substring(0, 5000), // Limit to 5000 chars to avoid too large error messages
 								},
 							}),
 							id: String(eventId++),


### PR DESCRIPTION
## Summary
- Fixed missing upstream response text in streaming error responses
- Added `responseText` field to error objects when streaming fails
- Limited response text to 5000 characters to prevent oversized error messages

## Problem
When streaming encounters errors (e.g., malformed JSON from providers or network issues), the error response sent to the client only contained a generic error message like `"Error from provider: 400 Bad Request"`, without the actual upstream response that caused the error. This made debugging difficult as users couldn't see what the provider actually returned.

## Solution
Enhanced the streaming error handler to include the buffer content (limited to 5000 chars) in the error response. This provides crucial debugging information while keeping error messages at a reasonable size.

### Before
```json
{
  "error": {
    "message": "Error from provider: 400 Bad Request",
    "type": "gateway_error",
    "param": null,
    "code": "gateway_error"
  }
}
```

### After
```json
{
  "error": {
    "message": "Streaming error: [error details]",
    "type": "gateway_error",
    "param": null,
    "code": "streaming_error",
    "responseText": "[actual upstream response that caused the error]"
  }
}
```

## Test plan
- [x] Tested with simulated malformed JSON responses
- [x] Verified error response includes upstream text
- [x] Confirmed response text is limited to 5000 chars
- [x] Code formatted with `pnpm format`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming errors now return more informative messages, including a preview of the problematic response content (up to 5,000 characters) to help diagnose issues.
  * Consistent error reporting across all streaming error paths, ensuring the same detailed context is provided whenever a parsing error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->