### PR TITLE
feat(e2e): refine model filtering and test options

### DIFF
--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -1,14 +1,32 @@
 import { db, tables } from "@llmgateway/db";
-import { providers } from "@llmgateway/models";
+import {
+	models,
+	type ProviderModelMapping,
+	providers,
+} from "@llmgateway/models";
 import "dotenv/config";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	type TestOptions,
+} from "vitest";
 
 import { app } from "..";
 import { getProviderEnvVar } from "../../../gateway/src/test-utils/test-helpers";
 import { createTestUser, deleteAll } from "../testing";
 
-function getTestOptions() {
-	return process.env.CI ? { retry: 3 } : {};
+function getTestOptions(): TestOptions {
+	const hasTestOnly = models.some((model) =>
+		model.providers.some(
+			(provider: ProviderModelMapping) => provider.test === "only",
+		),
+	);
+	return process.env.CI
+		? { retry: 3 }
+		: { skip: hasTestOnly || !!process.env.TEST_MODELS };
 }
 
 describe("e2e tests for provider keys", getTestOptions(), () => {

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -60,7 +60,18 @@ const filteredModels = models
 	// Filter out deactivated models
 	.filter((model) => !model.deactivatedAt || new Date() <= model.deactivatedAt)
 	// Filter out free models if not in full mode
-	.filter((model) => fullMode || !(model as ModelDefinition).free);
+	.filter((model) => fullMode || !(model as ModelDefinition).free)
+	// Filter by TEST_MODELS if specified
+	.filter((model) => {
+		if (!specifiedModels) {
+			return true;
+		}
+		// Check if any provider/model combination from this model matches TEST_MODELS
+		return model.providers.some((provider: ProviderModelMapping) => {
+			const providerModelId = `${provider.providerId}/${model.id}`;
+			return specifiedModels.includes(providerModelId);
+		});
+	});
 
 const testModels = filteredModels
 	// If any model has test: "only", only include those models
@@ -105,13 +116,6 @@ const testModels = filteredModels
 		}
 
 		return testCases;
-	})
-	.filter((testCase) => {
-		// Filter by TEST_MODELS if specified
-		if (!specifiedModels) {
-			return true;
-		}
-		return specifiedModels.includes(testCase.model);
 	});
 
 const providerModels = filteredModels
@@ -146,13 +150,6 @@ const providerModels = filteredModels
 		}
 
 		return testCases;
-	})
-	.filter((testCase) => {
-		// Filter by TEST_MODELS if specified
-		if (!specifiedModels) {
-			return true;
-		}
-		return specifiedModels.includes(testCase.model);
 	});
 
 // Log the number of test models after filtering


### PR DESCRIPTION
Enhanced model filtering logic in e2e tests by integrating `TEST_MODELS` variable directly into the primary filter chain. Removed redundant filtering steps, improving code clarity and efficiency. Updated `getTestOptions` to account for models with the test-only flag or `TEST_MODELS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - E2E model selection now respects TEST_MODELS at the provider/model level, simplifying targeted runs.
  - Removed per-test-case filtering; selection occurs once at the model level for consistency.
  - In CI, failing tests automatically retry up to 3 times.
  - Locally, suites may be skipped when only “test-only” specs are present or when TEST_MODELS is set.
  - Overall, more predictable and transparent test gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->