### PR TITLE
feat(models): add OpenAI o1-mini model support with system role handling

### DIFF
--- a/packages/models/src/models.spec.ts
+++ b/packages/models/src/models.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { models } from "./models";
+import { prepareRequestBody } from "./provider-api";
 
 describe("Models", () => {
 	it("should not have duplicate model IDs", () => {
@@ -16,5 +17,117 @@ describe("Models", () => {
 			);
 			throw new Error(`Duplicate model IDs found: ${duplicates.join(", ")}`);
 		}
+	});
+
+	it("should include o1-mini model", () => {
+		const o1MiniModel = models.find((model) => model.id === "o1-mini");
+		expect(o1MiniModel).toBeDefined();
+		expect(o1MiniModel?.supportsSystemRole).toBe(false);
+		expect(o1MiniModel?.family).toBe("openai");
+	});
+});
+
+describe("System Role Handling", () => {
+	it("should transform system messages to user messages for o1-mini", async () => {
+		const messages = [
+			{ role: "system", content: "You are a helpful assistant." },
+			{ role: "user", content: "Hello" },
+		];
+
+		const requestBody = await prepareRequestBody(
+			"openai",
+			"o1-mini",
+			messages,
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			undefined, // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		);
+
+		expect(requestBody.input).toHaveLength(2);
+		expect(requestBody.input[0].role).toBe("user");
+		expect(requestBody.input[0].content).toBe(
+			"System: You are a helpful assistant.",
+		);
+		expect(requestBody.input[1].role).toBe("user");
+		expect(requestBody.input[1].content).toBe("Hello");
+	});
+
+	it("should preserve system messages for models that support them", async () => {
+		const messages = [
+			{ role: "system", content: "You are a helpful assistant." },
+			{ role: "user", content: "Hello" },
+		];
+
+		const requestBody = await prepareRequestBody(
+			"openai",
+			"gpt-4o-mini",
+			messages,
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			undefined, // reasoning_effort
+			false, // supportsReasoning
+			false, // isProd
+		);
+
+		expect(requestBody.messages).toHaveLength(2);
+		expect(requestBody.messages[0].role).toBe("system");
+		expect(requestBody.messages[0].content).toBe(
+			"You are a helpful assistant.",
+		);
+		expect(requestBody.messages[1].role).toBe("user");
+		expect(requestBody.messages[1].content).toBe("Hello");
+	});
+
+	it("should handle array content in system messages", async () => {
+		const messages = [
+			{
+				role: "system",
+				content: [
+					{ type: "text", text: "You are a helpful" },
+					{ type: "text", text: "assistant." },
+				],
+			},
+			{ role: "user", content: "Hello" },
+		];
+
+		const requestBody = await prepareRequestBody(
+			"openai",
+			"o1-mini",
+			messages,
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			undefined, // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		);
+
+		expect(requestBody.input).toHaveLength(2);
+		expect(requestBody.input[0].role).toBe("user");
+		expect(requestBody.input[0].content).toBe(
+			"System: You are a helpful assistant.",
+		);
 	});
 });

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -127,6 +127,10 @@ export interface ModelDefinition {
 	 * Output formats supported by the model (defaults to ['text'] if not specified)
 	 */
 	output?: ("text" | "image")[];
+	/**
+	 * Whether this model supports system role messages (defaults to true if not specified)
+	 */
+	supportsSystemRole?: boolean;
 }
 
 export const models = [

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -170,24 +170,30 @@ export const openaiModels = [
 		],
 		jsonOutput: true,
 	},
-	// TODO this model does not support the system role in the messages array (jeez openai)
-	// {
-	// 	model: "o1-mini",
-	// 	deprecatedAt: undefined,
-	// 	deactivatedAt: undefined,
-	// 	providers: [
-	// 		{
-	// 			providerId: "openai",
-	// 			modelName: "o1-mini",
-	// 			inputPrice: 1.1 / 1e6,
-	// 			outputPrice: 4.4 / 1e6, requestPrice: 0,
-	// 			contextSize: 128000, maxOutput: undefined,
-	// 			streaming: true,
-	// 			reasoning: true,
-	// 		},
-	// 	],
-	// 	jsonOutput: true,
-	// },
+	{
+		id: "o1-mini",
+		name: "o1 Mini",
+		family: "openai",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "openai",
+				modelName: "o1-mini",
+				inputPrice: 1.1 / 1e6,
+				outputPrice: 4.4 / 1e6,
+				requestPrice: 0,
+				contextSize: 128000,
+				maxOutput: undefined,
+				streaming: false,
+				vision: false,
+				tools: false,
+				reasoning: true,
+			},
+		],
+		jsonOutput: true,
+		supportsSystemRole: false,
+	},
 	{
 		id: "gpt-4.1-mini",
 		name: "GPT-4.1 Mini",

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -186,6 +186,31 @@ async function transformGoogleMessages(messages: any[], isProd = false) {
 }
 
 /**
+ * Transforms messages for models that don't support system roles by converting system messages to user messages
+ */
+function transformMessagesForNoSystemRole(messages: any[]): any[] {
+	return messages.map((message, index) => {
+		if (message.role === "system") {
+			const systemContent =
+				typeof message.content === "string"
+					? message.content
+					: Array.isArray(message.content)
+						? message.content
+								.map((part) => (part.type === "text" ? part.text : part))
+								.join(" ")
+						: String(message.content);
+
+			return {
+				...message,
+				role: "user",
+				content: `System: ${systemContent}`,
+			};
+		}
+		return message;
+	});
+}
+
+/**
  * Transforms Anthropic messages to handle image URLs by converting them to base64
  */
 async function transformAnthropicMessages(messages: any[], isProd = false) {
@@ -350,9 +375,19 @@ export async function prepareRequestBody(
 	supportsReasoning?: boolean,
 	isProd = false,
 ) {
+	// Check if the model supports system role
+	const modelDef = models.find((m) => m.id === usedModel);
+	const supportsSystemRole = modelDef?.supportsSystemRole !== false;
+
+	// Transform messages if model doesn't support system role
+	let processedMessages = messages;
+	if (!supportsSystemRole) {
+		processedMessages = transformMessagesForNoSystemRole(messages);
+	}
+
 	const requestBody: any = {
 		model: usedModel,
-		messages,
+		messages: processedMessages,
 		stream: stream,
 	};
 
@@ -371,7 +406,7 @@ export async function prepareRequestBody(
 				// Transform to responses API format (now supports tools as well)
 				const responsesBody: any = {
 					model: usedModel,
-					input: messages,
+					input: processedMessages,
 					reasoning: {
 						effort: reasoning_effort || "medium",
 						summary: "detailed",
@@ -509,7 +544,7 @@ export async function prepareRequestBody(
 			const minMaxTokens = Math.max(1024, thinkingBudget + 1000);
 			requestBody.max_tokens = max_tokens ?? minMaxTokens;
 			requestBody.messages = await transformAnthropicMessages(
-				messages.map((m) => ({
+				processedMessages.map((m) => ({
 					...m, // Preserve original properties for transformation
 					role:
 						m.role === "assistant"
@@ -587,7 +622,10 @@ export async function prepareRequestBody(
 			delete requestBody.messages; // Not used in body for Google providers
 			delete requestBody.tool_choice; // Google doesn't support tool_choice parameter
 
-			requestBody.contents = await transformGoogleMessages(messages, isProd);
+			requestBody.contents = await transformGoogleMessages(
+				processedMessages,
+				isProd,
+			);
 
 			// Transform tools from OpenAI format to Google format
 			if (tools && tools.length > 0) {


### PR DESCRIPTION
## Summary
- Enable support for OpenAI's o1-mini model by implementing proper system role handling
- Add supportsSystemRole flag to ModelDefinition interface for model capability indication
- Transform system messages to user messages with "System: " prefix for incompatible models
- Maintain full compatibility with existing models that support system roles

## Key Changes
- Added o1-mini model definition in `packages/models/src/models/openai.ts` with `supportsSystemRole: false`
- Implemented `transformMessagesForNoSystemRole()` function to convert system messages to user messages
- Updated `prepareRequestBody()` to automatically handle system role transformation based on model capabilities
- Added comprehensive unit tests covering system role transformation scenarios
- Supports both string and array content types in system messages

## Test Plan
- ✅ All existing unit tests pass
- ✅ New unit tests verify system role transformation for o1-mini
- ✅ Unit tests verify system role preservation for compatible models
- ✅ Unit tests cover array content handling in system messages
- 🔄 E2E tests will run automatically to verify model functionality in real scenarios

## Technical Details
The implementation detects when a model doesn't support system roles (via `supportsSystemRole: false`) and automatically transforms system messages by:
1. Converting the role from "system" to "user"  
2. Prepending the content with "System: " to preserve the semantic meaning
3. Handling both string and array content formats correctly

This approach ensures backwards compatibility while enabling o1-mini usage without breaking existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)