### PR TITLE
fix(ui): remove temporary TypeScript build error ignore in next.config.ts

### DIFF
--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -6,10 +6,6 @@ const nextConfig: NextConfig = {
 	eslint: {
 		ignoreDuringBuilds: true,
 	},
-	typescript: {
-		// TODO TEMP!!!!!
-		ignoreBuildErrors: true,
-	},
 	// experimental: {
 	// 	typedRoutes: true,
 	// 	clientSegmentCache: true,


### PR DESCRIPTION
## Summary
- Removes the temporary `ignoreBuildErrors` flag from the TypeScript configuration in `next.config.ts`.
- Ensures TypeScript build errors are no longer ignored during the UI app build process.

## Changes

### Configuration
- **next.config.ts**: Deleted the `typescript.ignoreBuildErrors` setting which was previously set to `true` as a temporary workaround.

## Test plan
- [ ] Verify that TypeScript build errors are now reported during the UI app build.
- [ ] Confirm that the build fails if there are TypeScript errors, ensuring type safety.
- [ ] Run existing UI tests to ensure no regressions.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a7ffc4a8-57eb-4229-8af0-52b3403373ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to stop bypassing TypeScript build errors. Builds will now fail on type errors, aligning behavior with standard TypeScript enforcement.
  * No changes to application features, UI, or performance are expected for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->