### PR TITLE
Update pricing for Gemini 1.5 Pro model in Google provider

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -181,8 +181,8 @@ export const googleModels = [
 			{
 				providerId: "google-ai-studio",
 				modelName: "gemini-1.5-pro",
-				inputPrice: 0.0375 / 1e6,
-				outputPrice: 0.15 / 1e6,
+				inputPrice: 2.50 / 1e6,
+				outputPrice: 10.00 / 1e6,
 				requestPrice: 0,
 				contextSize: 1000000,
 				maxOutput: undefined,


### PR DESCRIPTION
## Summary
- Updated the input and output pricing for the `gemini-1.5-pro` model under the Google AI Studio provider
- Increased input price from $0.0375 to $2.50 per million tokens
- Increased output price from $0.15 to $10.00 per million tokens

## Changes

### Pricing Update
- Modified `inputPrice` from `0.0375 / 1e6` to `2.50 / 1e6`
- Modified `outputPrice` from `0.15 / 1e6` to `10.00 / 1e6`
- No other changes to model configuration or parameters

## Test plan
- Verified that the new pricing values are correctly reflected in the model configuration
- Confirmed no impact on other models or providers
- Ensured no runtime errors occur due to pricing update

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7a9d3566-80af-4ed0-a9a1-f38120226691