### PR TITLE
fix(chat): override temperature to 1 for GPT-5 models

### DIFF
--- a/packages/models/src/models.spec.ts
+++ b/packages/models/src/models.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { models } from "./models";
+import { prepareRequestBody } from "./provider-api";
 
 describe("Models", () => {
 	it("should not have duplicate model IDs", () => {
@@ -16,5 +17,143 @@ describe("Models", () => {
 			);
 			throw new Error(`Duplicate model IDs found: ${duplicates.join(", ")}`);
 		}
+	});
+});
+
+describe("prepareRequestBody", () => {
+	const messages = [{ role: "user", content: "Hello" }];
+
+	describe("OpenAI provider", () => {
+		it("should override temperature to 1 for gpt-5 models", async () => {
+			const body = await prepareRequestBody(
+				"openai",
+				"gpt-5",
+				messages,
+				false, // stream
+				0.7, // temperature - should be overridden to 1
+				undefined, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				undefined, // reasoning_effort
+				false, // supportsReasoning
+				false, // isProd
+			);
+
+			expect(body.temperature).toBe(1);
+		});
+
+		it("should override temperature to 1 for gpt-5-mini models", async () => {
+			const body = await prepareRequestBody(
+				"openai",
+				"gpt-5-mini",
+				messages,
+				false, // stream
+				0.3, // temperature - should be overridden to 1
+				undefined, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				undefined, // reasoning_effort
+				false, // supportsReasoning
+				false, // isProd
+			);
+
+			expect(body.temperature).toBe(1);
+		});
+
+		it("should override temperature to 1 for gpt-5-nano models", async () => {
+			const body = await prepareRequestBody(
+				"openai",
+				"gpt-5-nano",
+				messages,
+				false, // stream
+				0.9, // temperature - should be overridden to 1
+				undefined, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				undefined, // reasoning_effort
+				false, // supportsReasoning
+				false, // isProd
+			);
+
+			expect(body.temperature).toBe(1);
+		});
+
+		it("should override temperature to 1 for gpt-5-chat-latest models", async () => {
+			const body = await prepareRequestBody(
+				"openai",
+				"gpt-5-chat-latest",
+				messages,
+				false, // stream
+				0.5, // temperature - should be overridden to 1
+				undefined, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				undefined, // reasoning_effort
+				false, // supportsReasoning
+				false, // isProd
+			);
+
+			expect(body.temperature).toBe(1);
+		});
+
+		it("should not override temperature for non-gpt-5 models", async () => {
+			const body = await prepareRequestBody(
+				"openai",
+				"gpt-4o-mini",
+				messages,
+				false, // stream
+				0.7, // temperature - should remain as-is
+				undefined, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				undefined, // reasoning_effort
+				false, // supportsReasoning
+				false, // isProd
+			);
+
+			expect(body.temperature).toBe(0.7);
+		});
+
+		it("should override temperature to 1 for gpt-5 models with reasoning enabled", async () => {
+			const body = await prepareRequestBody(
+				"openai",
+				"gpt-5",
+				messages,
+				false, // stream
+				0.8, // temperature - should be overridden to 1
+				undefined, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				"medium", // reasoning_effort
+				true, // supportsReasoning
+				false, // isProd
+			);
+
+			expect(body.temperature).toBe(1);
+		});
 	});
 });

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -367,6 +367,12 @@ export async function prepareRequestBody(
 
 	switch (usedProvider) {
 		case "openai": {
+			// Override temperature to 1 for GPT-5 models (they only support temperature = 1)
+			let effectiveTemperature = temperature;
+			if (usedModel.startsWith("gpt-5")) {
+				effectiveTemperature = 1;
+			}
+
 			if (supportsReasoning) {
 				// Transform to responses API format (now supports tools as well)
 				const responsesBody: any = {
@@ -403,8 +409,8 @@ export async function prepareRequestBody(
 				}
 
 				// Add optional parameters if they are provided
-				if (temperature !== undefined) {
-					responsesBody.temperature = temperature;
+				if (effectiveTemperature !== undefined) {
+					responsesBody.temperature = effectiveTemperature;
 				}
 				if (max_tokens !== undefined) {
 					responsesBody.max_completion_tokens = max_tokens;
@@ -423,8 +429,8 @@ export async function prepareRequestBody(
 				}
 
 				// Add optional parameters if they are provided
-				if (temperature !== undefined) {
-					requestBody.temperature = temperature;
+				if (effectiveTemperature !== undefined) {
+					requestBody.temperature = effectiveTemperature;
 				}
 				if (max_tokens !== undefined) {
 					requestBody.max_tokens = max_tokens;


### PR DESCRIPTION
## Summary
- Overrides the temperature parameter to 1 for all GPT-5 models in the OpenAI provider.
- Ensures GPT-5 models only use temperature = 1 as they do not support other values.
- Adds comprehensive tests to verify temperature override behavior for various GPT-5 model variants.

## Changes

### Core Functionality
- Modified `prepareRequestBody` in `provider-api.ts` to set temperature to 1 when the model starts with "gpt-5".
- Updated temperature assignment logic to use the overridden temperature value.

### Tests
- Added extensive tests in `models.spec.ts` for `prepareRequestBody`:
  - Confirm temperature is overridden to 1 for `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, and `gpt-5-chat-latest` models.
  - Confirm temperature is not overridden for non-GPT-5 models.
  - Confirm override works even when reasoning is enabled.

## Test plan
- [x] Run unit tests to verify temperature override for all GPT-5 model variants.
- [x] Verify no override occurs for other models.
- [x] Confirm no regressions in request body preparation for OpenAI provider.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ec4150fa-3794-4845-a3b1-329e57444340