### PR TITLE
fix(models): add OpenAPI examples to listModels query params

### DIFF
--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -80,12 +80,14 @@ const listModels = createRoute({
 				.string()
 				.optional()
 				.transform((val) => val === "true")
-				.describe("Include deactivated models in the response"),
+				.describe("Include deactivated models in the response")
+				.openapi({ example: "false" }),
 			exclude_deprecated: z
 				.string()
 				.optional()
 				.transform((val) => val === "true")
-				.describe("Exclude deprecated models from the response"),
+				.describe("Exclude deprecated models from the response")
+				.openapi({ example: "false" }),
 		}),
 	},
 	responses: {


### PR DESCRIPTION
## Summary
- Enhances the OpenAPI documentation for the `listModels` route
- Adds example values for `include_deactivated` and `exclude_deprecated` query parameters

## Changes

### API Documentation
- Updated `include_deactivated` parameter to include an OpenAPI example value of `"false"`
- Updated `exclude_deprecated` parameter to include an OpenAPI example value of `"false"`

## Test plan
- Verified that the OpenAPI schema now includes example values for these parameters
- Ensured no changes to runtime behavior or API responses

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d1809233-143a-4cdb-a89b-ac49bffd821b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation for the models list endpoint by adding example values (“false”) to the include_deactivated and exclude_deprecated query parameters in OpenAPI.
  * Clarifies expected/default usage for clients while keeping current behavior unchanged (parameters remain optional and default to false).
  * Improves discoverability and consistency in generated docs and client SDKs without modifying runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->