### PR TITLE
Enhance CI Docker Workflow with Feature Branch Trigger and Conditional Builds

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
       - hotfix
+      - 'feature/**'
+    paths:
+      - '**/*.dockerfile'
+      - '.github/workflows/images.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,7 +42,7 @@ jobs:
 
   push-split:
     needs: setup
-    if: needs.setup.result == 'success'
+    if: needs.setup.result == 'success' && (github.ref == 'refs/heads/main' || github.event_name == 'release')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -77,7 +81,7 @@ jobs:
 
   push-unified:
     needs: setup
-    if: needs.setup.result == 'success'
+    if: needs.setup.result == 'success' && (github.ref == 'refs/heads/main' || github.event_name == 'release')
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -106,6 +110,55 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}-unified:${{ needs.setup.outputs.image_tag }}
             ghcr.io/${{ github.repository }}-unified:latest
+          cache-from: type=gha,scope=unified
+          cache-to: type=gha,mode=max,scope=unified
+          build-args: |
+            APP_VERSION=${{ needs.setup.outputs.image_tag }}
+
+  build-split:
+    needs: setup
+    if: needs.setup.result == 'success' && github.ref != 'refs/heads/main' && github.event_name != 'release'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [api, gateway, ui, docs]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build split (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/split.dockerfile
+          push: false
+          target: ${{ matrix.app }}
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}
+          build-args: |
+            APP_VERSION=${{ needs.setup.outputs.image_tag }}
+
+  build-unified:
+    needs: setup
+    if: needs.setup.result == 'success' && github.ref != 'refs/heads/main' && github.event_name != 'release'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build unified (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/unified.dockerfile
+          push: false
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=unified
           cache-to: type=gha,mode=max,scope=unified
           build-args: |


### PR DESCRIPTION
## Summary
- Extends the GitHub Actions workflow to trigger on feature branches matching `feature/**`
- Adds path filters to trigger workflow only on Dockerfile changes and workflow file updates
- Implements conditional Docker image push only on `main` branch or release events
- Introduces separate build jobs for feature branches that build Docker images without pushing

## Changes

### Workflow Trigger
- Added `feature/**` branch pattern to trigger the workflow
- Added path filters for `**/*.dockerfile` and `.github/workflows/images.yml` to limit workflow runs

### Conditional Push Logic
- Modified `push-split` and `push-unified` jobs to push images only if on `main` branch or during release events

### New Build Jobs for Feature Branches
- Added `build-split` job:
  - Runs on Ubuntu latest
  - Builds split Docker images for `api`, `gateway`, `ui`, and `docs` targets
  - Does not push images
  - Uses caching scoped per app
- Added `build-unified` job:
  - Runs on Ubuntu 24.04 ARM
  - Builds unified Docker image for multiple platforms
  - Does not push images
  - Uses caching scoped to unified build

## Test plan
- [ ] Verify workflow triggers on feature branches with Dockerfile or workflow changes
- [ ] Confirm Docker images are pushed only on `main` branch or release events
- [ ] Validate that feature branch builds complete successfully without pushing images
- [ ] Check caching behavior for build jobs to optimize build times

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f887e6a2-7cbb-4916-8413-dd17a54bf1d0