### PR TITLE
feat(header): add x-ignore-issues header for custom headers

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -719,4 +719,60 @@ describe("test", () => {
 			/Custom headers \(X-LLMGateway-\*\) require a Pro plan/i,
 		);
 	});
+
+	test("x-ignore-issues header allows custom headers without Pro plan", async () => {
+		// Ensure org is on free plan
+		await db
+			.update(tables.organization)
+			.set({ plan: "free" })
+			.where(eq(tables.organization.id, "org-id"));
+
+		// Create API key and provider key so request can route
+		await db.insert(tables.apiKey).values({
+			id: "token-id-ignore",
+			token: "token-with-ignore",
+			projectId: "project-id",
+			description: "Test API Key with ignore header",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-ignore",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+		});
+
+		// Simulate hosted/paid mode
+		process.env.HOSTED = "true";
+		process.env.PAID_MODE = "true";
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer token-with-ignore`,
+				"X-LLMGateway-uid": "abc123",
+				"x-ignore-issues": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o-mini",
+				messages: [
+					{
+						role: "user",
+						content: "Hello!",
+					},
+				],
+			}),
+		});
+
+		// Should succeed (200) instead of failing with 402
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json).toHaveProperty("choices.[0].message.content");
+
+		// Wait for the worker to process the log and check that custom headers were NOT stored
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].customHeaders).toEqual({});
+	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -137,9 +137,18 @@ function validateAndNormalizeSource(
 /**
  * Extracts X-LLMGateway-* headers from the request context
  * Returns a key-value object where keys are the suffix after x-llmgateway- and values are header values
+ * If x-ignore-issues: true is present, custom headers are filtered out to prevent errors
  */
 function extractCustomHeaders(c: any): Record<string, string> {
 	const customHeaders: Record<string, string> = {};
+
+	// Check if x-ignore-issues header is set to true
+	const ignoreIssues = c.req.header("x-ignore-issues") === "true";
+
+	// If ignoring issues, don't extract custom headers to avoid errors
+	if (ignoreIssues) {
+		return customHeaders;
+	}
 
 	// Get all headers from the raw request
 	const headers = c.req.raw.headers;


### PR DESCRIPTION
## Summary
- Introduces support for the `x-ignore-issues` header to allow custom headers without requiring a Pro plan
- Prevents errors by filtering out custom headers when `x-ignore-issues: true` is present
- Enables free plan users to use custom headers in hosted/paid mode without receiving 402 errors

## Changes

### API Behavior
- Added a test case in `api.spec.ts` to verify that requests with `x-ignore-issues: true` succeed even on the free plan
- Ensured that custom headers are not stored in logs when `x-ignore-issues` is used

### Header Extraction Logic
- Updated `extractCustomHeaders` function in `chat.ts` to skip extracting custom headers if `x-ignore-issues: true` is detected

## Test plan
- [x] Run existing and new tests in `api.spec.ts` to confirm the new header behavior
- [x] Verify that requests with `x-ignore-issues` succeed with status 200 on free plans
- [x] Confirm that custom headers are filtered out and not logged when ignoring issues


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b58eabfd-530b-41d5-8006-93c537013bb8