### PR TITLE
Add RouteWay provider with llama-3.3-70b model support

### DIFF
--- a/apps/gateway/src/lib/provider.ts
+++ b/apps/gateway/src/lib/provider.ts
@@ -19,6 +19,7 @@ export const providerEnvVarMap: Record<Provider, string> = {
 	alibaba: "ALIBABA_API_KEY",
 	nebius: "NEBIUS_API_KEY",
 	zai: "Z_AI_API_KEY",
+	routeway: "ROUTEWAY_API_KEY",
 	custom: "UNUSED",
 };
 

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -66,6 +66,18 @@ export const metaModels = [
 				vision: false,
 				tools: false,
 			},
+			{
+				providerId: "routeway",
+				modelName: "llama-3.3-70b-instruct:free",
+				inputPrice: 0.0 / 1e6,
+				outputPrice: 0.0 / 1e6,
+				requestPrice: 0,
+				contextSize: 128000,
+				maxOutput: undefined,
+				streaming: true,
+				vision: false,
+				tools: false,
+			},
 		],
 	},
 	{

--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -528,6 +528,7 @@ export async function prepareRequestBody(
 		case "alibaba":
 		case "nebius":
 		case "zai":
+		case "routeway":
 		case "custom": {
 			if (stream) {
 				requestBody.stream_options = {
@@ -826,6 +827,9 @@ export function getProviderEndpoint(
 			case "zai":
 				url = "https://api.z.ai";
 				break;
+			case "routeway":
+				url = "https://api.routeway.ai";
+				break;
 			case "custom":
 				if (!baseUrl) {
 					throw new Error(`Custom provider requires a baseUrl`);
@@ -898,6 +902,7 @@ export function getProviderEndpoint(
 		case "moonshot":
 		case "alibaba":
 		case "nebius":
+		case "routeway":
 		case "custom":
 		default:
 			return `${url}/v1/chat/completions`;

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -223,6 +223,17 @@ export const providers = [
 		announcement: null,
 	},
 	{
+		id: "routeway",
+		name: "RouteWay",
+		description: "RouteWay's OpenAI-compatible large language models",
+		streaming: true,
+		cancellation: true,
+		jsonOutput: true,
+		color: "#4f46e5",
+		website: "https://api.routeway.ai",
+		announcement: null,
+	},
+	{
 		id: "custom",
 		name: "Custom",
 		description: "Custom OpenAI-compatible provider with configurable base URL",


### PR DESCRIPTION
## Summary
- Adds support for the RouteWay provider to the LLM Gateway
- Integrates the llama-3.3-70b-instruct:free model from RouteWay
- Configures environment variable, API endpoint, and provider metadata

## Changes

### Provider Integration
- Added `routeway` to the provider environment variable map (`ROUTEWAY_API_KEY`)
- Registered RouteWay provider in the providers list with metadata including streaming, cancellation, and JSON output support

### Model Support
- Added llama-3.3-70b-instruct:free model under RouteWay in metaModels with pricing, context size, and streaming capabilities

### API Handling
- Extended `prepareRequestBody` to handle RouteWay provider streaming options
- Added RouteWay API base URL (`https://api.routeway.ai`) in `getProviderEndpoint`
- Included RouteWay in the default chat completions endpoint path handling

## Test plan
- Verify environment variable recognition for RouteWay
- Test API requests and streaming responses with the RouteWay provider
- Confirm model metadata is correctly loaded and used
- Validate endpoint URL resolution for RouteWay
- Ensure no regressions for existing providers

This PR enables usage of RouteWay's OpenAI-compatible large language models, expanding the gateway's provider ecosystem.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/54ebe9ac-2cb1-42d5-a0a7-08cb7c96135e