### PR TITLE
feat(gateway): allow slashes in x-source header validation

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -107,7 +107,7 @@ function getFinishReasonForError(
 /**
  * Validates and normalizes the x-source header
  * Strips http(s):// and www. if present
- * Validates allowed characters: a-zA-Z0-9, -, .
+ * Validates allowed characters: a-zA-Z0-9, -, ., /
  */
 function validateAndNormalizeSource(
 	source: string | undefined,
@@ -122,12 +122,12 @@ function validateAndNormalizeSource(
 	// Strip www. if present
 	normalized = normalized.replace(/^www\./, "");
 
-	// Validate allowed characters: a-zA-Z0-9, -, .
-	const allowedPattern = /^[a-zA-Z0-9.-]+$/;
+	// Validate allowed characters: a-zA-Z0-9, -, ., /
+	const allowedPattern = /^[a-zA-Z0-9./-]+$/;
 	if (!allowedPattern.test(normalized)) {
 		throw new HTTPException(400, {
 			message:
-				"Invalid x-source header: only alphanumeric characters, hyphens, and dots are allowed",
+				"Invalid x-source header: only alphanumeric characters, hyphens, dots, and slashes are allowed",
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Updated the validation logic for the `x-source` header to allow slashes (`/`) in addition to alphanumeric characters, hyphens, and dots.
- This change enables more flexible source identifiers that may include path-like structures.

## Changes

### Core Functionality
- Modified the `validateAndNormalizeSource` function in `apps/gateway/src/chat/chat.ts`:
  - Expanded the allowed character set in the regex pattern from `a-zA-Z0-9.-` to `a-zA-Z0-9./-`.
  - Updated the error message to reflect the inclusion of slashes as valid characters.

## Test plan
- [ ] Verify that `x-source` headers containing slashes pass validation.
- [ ] Confirm that headers with invalid characters still trigger the appropriate error.
- [ ] Ensure existing functionality for stripping `http(s)://` and `www.` prefixes remains intact.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/796f3d89-d43d-4494-bf6a-e854c4a53621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed request header validation to accept forward slashes in the source header, preventing unnecessary rejections of valid requests.
  * Improved the related validation error message for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->