### PR TITLE
fix(api): adjust free model filtering in e2e tests

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -59,7 +59,7 @@ const filteredModels = models
 	.filter((model) => !["custom", "auto"].includes(model.id))
 	// Filter out deactivated models
 	.filter((model) => !model.deactivatedAt || new Date() <= model.deactivatedAt)
-	// Filter out free models if not in full mode, unless they have test: "only"
+	// Filter out free models if not in full mode, unless they have test: "only" or are in TEST_MODELS
 	.filter((model) => {
 		const isFreeModel = (model as ModelDefinition).free;
 		if (!isFreeModel) {
@@ -69,10 +69,30 @@ const filteredModels = models
 			return true;
 		} // In full mode, all models are included
 
-		// For free models in non-full mode, only include if any provider has test: "only"
-		return model.providers.some(
-			(provider: ProviderModelMapping) => provider.test === "only",
-		);
+		// For free models in non-full mode, include if:
+		// 1. Any provider has test: "only"
+		if (
+			model.providers.some(
+				(provider: ProviderModelMapping) => provider.test === "only",
+			)
+		) {
+			return true;
+		}
+
+		// 2. Model is specified in TEST_MODELS
+		if (specifiedModels) {
+			const modelInTestModels = model.providers.some(
+				(provider: ProviderModelMapping) => {
+					const providerModelId = `${provider.providerId}/${model.id}`;
+					return specifiedModels.includes(providerModelId);
+				},
+			);
+			if (modelInTestModels) {
+				return true;
+			}
+		}
+
+		return false; // Otherwise, exclude free models in non-full mode
 	})
 	// Filter by TEST_MODELS if specified
 	.filter((model) => {

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -59,8 +59,21 @@ const filteredModels = models
 	.filter((model) => !["custom", "auto"].includes(model.id))
 	// Filter out deactivated models
 	.filter((model) => !model.deactivatedAt || new Date() <= model.deactivatedAt)
-	// Filter out free models if not in full mode
-	.filter((model) => fullMode || !(model as ModelDefinition).free)
+	// Filter out free models if not in full mode, unless they have test: "only"
+	.filter((model) => {
+		const isFreeModel = (model as ModelDefinition).free;
+		if (!isFreeModel) {
+			return true;
+		} // Non-free models are always included
+		if (fullMode) {
+			return true;
+		} // In full mode, all models are included
+
+		// For free models in non-full mode, only include if any provider has test: "only"
+		return model.providers.some(
+			(provider: ProviderModelMapping) => provider.test === "only",
+		);
+	})
 	// Filter by TEST_MODELS if specified
 	.filter((model) => {
 		if (!specifiedModels) {


### PR DESCRIPTION
## Summary
- Adjusts the filtering logic for free models in the end-to-end test setup
- Ensures free models are included in non-full mode only if any provider has `test: "only"` flag

## Changes

### Filtering Logic
- Modified the model filtering in `api.e2e.ts` to:
  - Always include non-free models
  - Include all models in full mode
  - For free models in non-full mode, include only if any provider has `test: "only"` flag

## Test plan
- [x] Verify that free models without `test: "only"` are excluded in non-full mode
- [x] Verify that free models with `test: "only"` are included in non-full mode
- [x] Confirm no impact on full mode filtering
- [x] Run existing e2e tests to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/eb9ed4f7-4779-407f-b854-d8b2312f41ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined automated test model selection to correctly handle free and non-free models across full and non-full modes and provider test flags.
  * Improves test accuracy and coverage, leading to more reliable CI outcomes and reduced false positives/negatives.
  * No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->