### PR TITLE
feat(header): add x-ignore-issues support

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -719,4 +719,60 @@ describe("test", () => {
 			/Custom headers \(X-LLMGateway-\*\) require a Pro plan/i,
 		);
 	});
+
+	test("Custom headers are ignored when x-ignore-issues is true", async () => {
+		// Downgrade org to free
+		await db
+			.update(tables.organization)
+			.set({ plan: "free" })
+			.where(eq(tables.organization.id, "org-id"));
+
+		// Create API key and provider key so request can route
+		await db.insert(tables.apiKey).values({
+			id: "token-id-ignore",
+			token: "token-with-ignore",
+			projectId: "project-id",
+			description: "Test API Key with ignore issues",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-ignore",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+		});
+
+		// Simulate hosted/paid mode
+		process.env.HOSTED = "true";
+		process.env.PAID_MODE = "true";
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer token-with-ignore`,
+				"X-LLMGateway-uid": "abc123",
+				"x-ignore-issues": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o-mini",
+				messages: [
+					{
+						role: "user",
+						content: "Hello!",
+					},
+				],
+			}),
+		});
+
+		// Should succeed instead of returning 402
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json).toHaveProperty("choices.[0].message.content");
+
+		// Wait for the worker to process the log and check that custom headers were NOT stored
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].customHeaders).toBeNull();
+	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -137,9 +137,16 @@ function validateAndNormalizeSource(
 /**
  * Extracts X-LLMGateway-* headers from the request context
  * Returns a key-value object where keys are the suffix after x-llmgateway- and values are header values
+ * If x-ignore-issues header is set to "true", custom headers are ignored and empty object is returned
  */
 function extractCustomHeaders(c: any): Record<string, string> {
 	const customHeaders: Record<string, string> = {};
+
+	// Check if issues should be ignored
+	const ignoreIssues = c.req.header("x-ignore-issues") === "true";
+	if (ignoreIssues) {
+		return customHeaders; // Return empty object to avoid Pro plan requirement
+	}
 
 	// Get all headers from the raw request
 	const headers = c.req.raw.headers;


### PR DESCRIPTION
## Summary
- Introduces support for the `x-ignore-issues` header to allow ignoring custom header validation issues
- When `x-ignore-issues` is set to "true", custom `X-LLMGateway-*` headers are ignored and not stored
- Enables requests to succeed without requiring a Pro plan even if custom headers are present

## Changes

### Core Functionality
- Modified `extractCustomHeaders` to return an empty object if `x-ignore-issues` header is "true", bypassing Pro plan restrictions

### API Tests
- Added a new test case in `api.spec.ts` to verify that requests with `x-ignore-issues: true` succeed without 402 errors
- Test simulates a free plan organization and ensures custom headers are not stored in logs when ignored

## Test plan
- [x] Run existing and new tests to confirm that requests with `x-ignore-issues: true` bypass custom header checks
- [x] Verify that requests without the header or with it set to false still enforce Pro plan requirements
- [x] Confirm logs do not contain custom headers when `x-ignore-issues` is true

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/31fed814-fda3-4854-8100-8eb5d724fac6