### PR TITLE
feat(infra): update local Docker Compose configs

### DIFF
--- a/infra/bunnyshell.yaml
+++ b/infra/bunnyshell.yaml
@@ -89,18 +89,17 @@ components:
         dockerfile: infra/split.dockerfile
         target: gateway
       environment:
-        ANTHROPIC_API_KEY: ""
-        DATABASE_URL: "postgres://postgres:llmgateway_dev_password@postgres:5432/llmgateway"
-        GOOGLE_AI_STUDIO_API_KEY: ""
-        INFERENCE_NET_API_KEY: ""
         NODE_ENV: production
-        OPENAI_API_KEY: ""
         PORT: "80"
+        DATABASE_URL: "postgres://postgres:llmgateway_dev_password@postgres:5432/llmgateway"
         REDIS_HOST: redis
         REDIS_PASSWORD: redis_dev_password
         REDIS_PORT: "6379"
-        TOGETHER_AI_API_KEY: ""
-        VERTEX_API_KEY: ""
+        # LLM Provider API Keys
+        OPENAI_API_KEY: ""
+        GOOGLE_AI_STUDIO_API_KEY: ""
+        INFERENCE_NET_API_KEY: ""
+        ANTHROPIC_API_KEY: ""
       healthcheck:
         test:
           - CMD

--- a/infra/docker-compose.split.local.yml
+++ b/infra/docker-compose.split.local.yml
@@ -1,6 +1,153 @@
 name: llmgateway-prod
 
 services:
+  # Gateway Service
+  gateway:
+    build:
+      context: ..
+      dockerfile: infra/split.dockerfile
+      target: gateway
+    container_name: llmgateway-gateway
+    restart: unless-stopped
+    ports:
+      - "${GATEWAY_PORT:-4001}:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - NODE_ENV=production
+      - PORT=80
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
+      # LLM Provider API Keys
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY}
+
+  # API Service
+  api:
+    build:
+      context: ..
+      dockerfile: infra/split.dockerfile
+      target: api
+    container_name: llmgateway-api
+    restart: unless-stopped
+    ports:
+      - "${API_PORT:-4002}:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - NODE_ENV=production
+      - RUN_MIGRATIONS=true
+      - PORT=80
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
+      - UI_URL=${UI_URL:-http://localhost:3002}
+      - API_URL=${API_URL:-http://localhost:4002}
+      - ORIGIN_URL=${ORIGIN_URL:-http://localhost:3002}
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-localhost}
+      - PASSKEY_RP_ID=${PASSKEY_RP_ID:-localhost}
+      - PASSKEY_RP_NAME=${PASSKEY_RP_NAME:-LLMGateway}
+      - POSTHOG_KEY=${POSTHOG_KEY}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+
+  # UI Service
+  ui:
+    build:
+      context: ..
+      dockerfile: infra/split.dockerfile
+      target: ui
+    container_name: llmgateway-ui
+    restart: unless-stopped
+    ports:
+      - "${UI_PORT:-3002}:80"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - API_URL=${API_URL:-http://api:80}
+      - DOCS_URL=${DOCS_URL:-http://docs:80}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+      - POSTHOG_KEY=${POSTHOG_KEY}
+
+  # Docs Service
+  docs:
+    build:
+      context: ..
+      dockerfile: infra/split.dockerfile
+      target: docs
+    container_name: llmgateway-docs
+    restart: unless-stopped
+    ports:
+      - "${DOCS_PORT:-3005}:80"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
+      - POSTHOG_KEY=${POSTHOG_KEY}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+
   # PostgreSQL Database
   postgres:
     platform: linux/amd64
@@ -49,156 +196,6 @@ services:
       retries: 5
     networks:
       - llmgateway-network
-
-  # Gateway Service
-  gateway:
-    build:
-      context: ..
-      dockerfile: infra/split.dockerfile
-      target: gateway
-    container_name: llmgateway-gateway
-    restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - PORT=80
-      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
-      # LLM Provider API Keys
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - VERTEX_API_KEY=${VERTEX_API_KEY}
-      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY}
-      - INFERENCE_NET_API_KEY=${INFERENCE_NET_API_KEY}
-      - TOGETHER_AI_API_KEY=${TOGETHER_AI_API_KEY}
-    ports:
-      - "${GATEWAY_PORT:-4001}:80"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-
-  # API Service
-  api:
-    build:
-      context: ..
-      dockerfile: infra/split.dockerfile
-      target: api
-    container_name: llmgateway-api
-    restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - RUN_MIGRATIONS=true
-      - PORT=80
-      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
-      - UI_URL=${UI_URL:-http://localhost:3002}
-      - API_URL=${API_URL:-http://localhost:4002}
-      - ORIGIN_URL=${ORIGIN_URL:-http://localhost:3002}
-      - PASSKEY_RP_ID=${PASSKEY_RP_ID:-localhost}
-      - PASSKEY_RP_NAME=${PASSKEY_RP_NAME:-LLMGateway}
-      - POSTHOG_KEY=${POSTHOG_KEY}
-      - POSTHOG_HOST=${POSTHOG_HOST}
-      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
-      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
-    ports:
-      - "${API_PORT:-4002}:80"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-
-  # UI Service
-  ui:
-    build:
-      context: ..
-      dockerfile: infra/split.dockerfile
-      target: ui
-    container_name: llmgateway-ui
-    restart: unless-stopped
-    ports:
-      - "${UI_PORT:-3002}:80"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-    environment:
-      - DOCS_URL=${DOCS_URL:-http://docs:80}
-      - API_URL=${API_URL:-http://api:80}
-      - POSTHOG_HOST=${POSTHOG_HOST}
-      - POSTHOG_KEY=${POSTHOG_KEY}
-      - API=${API:-http://api:80}
-
-  # Docs Service
-  docs:
-    build:
-      context: ..
-      dockerfile: infra/split.dockerfile
-      target: docs
-    container_name: llmgateway-docs
-    restart: unless-stopped
-    ports:
-      - "${DOCS_PORT:-3005}:80"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-    environment:
-      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
-      - POSTHOG_KEY=${POSTHOG_KEY}
-      - POSTHOG_HOST=${POSTHOG_HOST}
 
 volumes:
   postgres_data:

--- a/infra/docker-compose.split.yml
+++ b/infra/docker-compose.split.yml
@@ -1,6 +1,141 @@
 name: llmgateway-prod
 
 services:
+  # Gateway Service
+  gateway:
+    image: ghcr.io/theopenco/llmgateway-gateway:latest
+    container_name: llmgateway-gateway
+    restart: unless-stopped
+    ports:
+      - "${GATEWAY_PORT:-4001}:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - NODE_ENV=production
+      - PORT=80
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
+      # LLM Provider API Keys
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY}
+
+  # API Service
+  api:
+    image: ghcr.io/theopenco/llmgateway-api:latest
+    container_name: llmgateway-api
+    restart: unless-stopped
+    ports:
+      - "${API_PORT:-4002}:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - NODE_ENV=production
+      - RUN_MIGRATIONS=true
+      - PORT=80
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
+      - UI_URL=${UI_URL:-http://localhost:3002}
+      - API_URL=${API_URL:-http://localhost:4002}
+      - ORIGIN_URL=${ORIGIN_URL:-http://localhost:3002}
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-localhost}
+      - PASSKEY_RP_ID=${PASSKEY_RP_ID:-localhost}
+      - PASSKEY_RP_NAME=${PASSKEY_RP_NAME:-LLMGateway}
+      - POSTHOG_KEY=${POSTHOG_KEY}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
+
+  # UI Service (Static files served via Nginx)
+  ui:
+    image: ghcr.io/theopenco/llmgateway-ui:latest
+    container_name: llmgateway-ui
+    restart: unless-stopped
+    ports:
+      - "${UI_PORT:-3002}:80"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - API_URL=${API_URL:-http://localhost:4002}
+      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+      - POSTHOG_KEY=${POSTHOG_KEY}
+
+  # Docs Service
+  docs:
+    image: ghcr.io/theopenco/llmgateway-docs:latest
+    container_name: llmgateway-docs
+    restart: unless-stopped
+    ports:
+      - "${DOCS_PORT:-3005}:80"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - llmgateway-network
+    environment:
+      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
+      - POSTHOG_KEY=${POSTHOG_KEY}
+      - POSTHOG_HOST=${POSTHOG_HOST}
+
   # PostgreSQL Database
   postgres:
     platform: linux/amd64
@@ -49,144 +184,6 @@ services:
       retries: 5
     networks:
       - llmgateway-network
-
-  # Gateway Service
-  gateway:
-    image: ghcr.io/theopenco/llmgateway-gateway:latest
-    container_name: llmgateway-gateway
-    restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - PORT=80
-      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
-      # LLM Provider API Keys
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - VERTEX_API_KEY=${VERTEX_API_KEY}
-      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY}
-      - INFERENCE_NET_API_KEY=${INFERENCE_NET_API_KEY}
-      - TOGETHER_AI_API_KEY=${TOGETHER_AI_API_KEY}
-    ports:
-      - "${GATEWAY_PORT:-4001}:80"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-
-  # API Service
-  api:
-    image: ghcr.io/theopenco/llmgateway-api:latest
-    container_name: llmgateway-api
-    restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - RUN_MIGRATIONS=true
-      - PORT=80
-      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-llmgateway_dev_password}@postgres:5432/${POSTGRES_DB:-llmgateway}
-      - UI_URL=${UI_URL:-http://localhost:3002}
-      - API_URL=${API_URL:-http://localhost:4002}
-      - ORIGIN_URL=${ORIGIN_URL:-http://localhost:3002}
-      - PASSKEY_RP_ID=${PASSKEY_RP_ID:-localhost}
-      - PASSKEY_RP_NAME=${PASSKEY_RP_NAME:-LLMGateway}
-      - POSTHOG_KEY=${POSTHOG_KEY}
-      - POSTHOG_HOST=${POSTHOG_HOST}
-      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
-      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
-    ports:
-      - "${API_PORT:-4002}:80"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-
-  # UI Service (Static files served via Nginx)
-  ui:
-    image: ghcr.io/theopenco/llmgateway-ui:latest
-    container_name: llmgateway-ui
-    restart: unless-stopped
-    ports:
-      - "${UI_PORT:-3002}:80"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-    environment:
-      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
-      - API_URL=${API_URL:-http://localhost:4002}
-      - POSTHOG_HOST=${POSTHOG_HOST}
-      - POSTHOG_KEY=${POSTHOG_KEY}
-      - API=${API:-http://localhost:4002}
-
-  # Docs Service
-  docs:
-    image: ghcr.io/theopenco/llmgateway-docs:latest
-    container_name: llmgateway-docs
-    restart: unless-stopped
-    ports:
-      - "${DOCS_PORT:-3005}:80"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--no-verbose",
-          "--tries=1",
-          "--spider",
-          "http://localhost:80/",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - llmgateway-network
-    environment:
-      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
-      - POSTHOG_KEY=${POSTHOG_KEY}
-      - POSTHOG_HOST=${POSTHOG_HOST}
 
 volumes:
   postgres_data:

--- a/infra/docker-compose.unified.local.yml
+++ b/infra/docker-compose.unified.local.yml
@@ -22,19 +22,12 @@ services:
       - UI_URL=${UI_URL:-http://localhost:3002}
       - API_URL=${API_URL:-http://localhost:4002}
       - ORIGIN_URL=${ORIGIN_URL:-http://localhost:3002}
+      - DOCS_URL=${DOCS_URL:-http://localhost:3005}
 
       # Authentication
       - PASSKEY_RP_ID=${PASSKEY_RP_ID:-localhost}
       - PASSKEY_RP_NAME=${PASSKEY_RP_NAME:-LLMGateway}
       - AUTH_SECRET=${AUTH_SECRET:-your-secret-key}
-
-      # LLM Provider API Keys (add the ones you need)
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-      - VERTEX_API_KEY=${VERTEX_API_KEY:-}
-      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY:-}
-      - INFERENCE_NET_API_KEY=${INFERENCE_NET_API_KEY:-}
-      - TOGETHER_AI_API_KEY=${TOGETHER_AI_API_KEY:-}
 
       # Analytics (optional)
       - POSTHOG_KEY=${POSTHOG_KEY:-}
@@ -51,6 +44,11 @@ services:
       - REDIS_HOST=localhost
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+
+      # LLM Provider API Keys (add the ones you need)
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY:-}
 
 volumes:
   llmgateway_postgres:

--- a/infra/docker-compose.unified.yml
+++ b/infra/docker-compose.unified.yml
@@ -20,19 +20,12 @@ services:
       - UI_URL=${UI_URL:-http://localhost:3002}
       - API_URL=${API_URL:-http://localhost:4002}
       - ORIGIN_URL=${ORIGIN_URL:-http://localhost:3002}
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-localhost}
 
       # Authentication
       - PASSKEY_RP_ID=${PASSKEY_RP_ID:-localhost}
       - PASSKEY_RP_NAME=${PASSKEY_RP_NAME:-LLMGateway}
       - AUTH_SECRET=${AUTH_SECRET:-your-secret-key}
-
-      # LLM Provider API Keys (add the ones you need)
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-      - VERTEX_API_KEY=${VERTEX_API_KEY:-}
-      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY:-}
-      - INFERENCE_NET_API_KEY=${INFERENCE_NET_API_KEY:-}
-      - TOGETHER_AI_API_KEY=${TOGETHER_AI_API_KEY:-}
 
       # Analytics (optional)
       - POSTHOG_KEY=${POSTHOG_KEY:-}
@@ -43,6 +36,11 @@ services:
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET:-}
       - STRIPE_PRO_MONTHLY_PRICE_ID=${STRIPE_PRO_MONTHLY_PRICE_ID:-}
       - STRIPE_PRO_YEARLY_PRICE_ID=${STRIPE_PRO_YEARLY_PRICE_ID:-}
+
+      # LLM Provider API Keys (add the ones you need)
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GOOGLE_AI_STUDIO_API_KEY=${GOOGLE_AI_STUDIO_API_KEY:-}
 
 volumes:
   llmgateway_postgres:


### PR DESCRIPTION
Add `DOCS_URL` and `COOKIE_DOMAIN` environment variables to local Docker Compose configurations. Rearrange and document service definitions to improve readability and maintain consistency across split and unified setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now supports a configurable DOCS_URL.
  * Unified deployments include COOKIE_DOMAIN for cookie handling.

* **Chores**
  * Reorganized compose setup: postgres and redis declared with health checks and persistent volumes; redis_data added.
  * Environment wiring expanded for gateway, API, and UI for production readiness (DB/Redis, migrations flag, telemetry, payments, and LLM provider keys).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->