### PR TITLE
ci(workflows): update setup step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/run.yml
     secrets: inherit
     with:
-      cmd: docker compose up -d && pnpm build && bash .github/start.sh
+      cmd: pnpm run setup && pnpm build && bash .github/start.sh
 
   test:
     uses: ./.github/workflows/run.yml


### PR DESCRIPTION
Replace `docker compose up -d` with `pnpm run setup` for improved setup consistency and alignment with the build process.