### PR TITLE
feat(ci): add pull request workflows for test builds

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
       - hotfix
+  pull_request:
+    paths:
+      - "infra/**.dockerfile"
+      - ".github/workflows/images.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +19,7 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     outputs:
       image_tag: ${{ steps.set-tag.outputs.IMAGE_TAG }}
     steps:
@@ -38,7 +43,7 @@ jobs:
 
   build-split:
     needs: setup
-    if: needs.setup.result == 'success'
+    if: needs.setup.result == 'success' && github.event_name != 'pull_request'
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -110,7 +115,7 @@ jobs:
     needs:
       - setup
       - build-split
-    if: needs.setup.result == 'success'
+    if: needs.setup.result == 'success' && github.event_name != 'pull_request'
     strategy:
       matrix:
         app: [api, gateway, ui, docs]
@@ -156,7 +161,7 @@ jobs:
 
   build-unified:
     needs: setup
-    if: needs.setup.result == 'success'
+    if: needs.setup.result == 'success' && github.event_name != 'pull_request'
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -226,7 +231,7 @@ jobs:
     needs:
       - setup
       - build-unified
-    if: needs.setup.result == 'success'
+    if: needs.setup.result == 'success' && github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write
@@ -266,3 +271,57 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ github.repository }}-unified:${{ needs.setup.outputs.image_tag }}
+
+  # PR-specific jobs that only build without pushing
+  test-build-split:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [api, gateway, ui, docs]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test build split dockerfile
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/split.dockerfile
+          platforms: linux/amd64
+          target: ${{ matrix.app }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.app }}-linux-amd64
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}-linux-amd64
+          build-args: |
+            APP_VERSION=pr-test
+
+  test-build-unified:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test build unified dockerfile
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/unified.dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=unified-linux-amd64
+          cache-to: type=gha,mode=max,scope=unified-linux-amd64
+          build-args: |
+            APP_VERSION=pr-test


### PR DESCRIPTION
Introduced separate jobs to test Docker builds for split and unified workflows on pull requests without pushing images. Updated conditions in existing jobs to exclude pull_request events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to run validation builds on pull requests without publishing images.
  * Added gating to prevent release workflows from triggering on PRs, reducing risk of unintended publishes.
  * Improved caching to speed up PR build verification.
  * Separated PR validation from main-branch release builds for clearer pipelines.
  * Delivers faster, safer feedback on changes before merge without affecting production artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->