### PR TITLE
feat(infra): use turbo prune for optimized service deployment

### DIFF
--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -100,56 +100,60 @@ ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION
 
 FROM runtime AS api
-WORKDIR /app/temp
-COPY --from=builder /app/apps ./apps
-COPY --from=builder /app/packages ./packages
-COPY --from=builder /app/.npmrc /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
-RUN pnpm --filter=api --prod deploy ../dist/api
-RUN rm -rf /app/temp
-WORKDIR /app/dist/api
+WORKDIR /app
+# Use turbo prune to create a pruned subset for the api app
+RUN --mount=from=builder,source=/app,target=/source \
+    cd /source && \
+    pnpm turbo prune api --docker && \
+    cp -r out/json/* /app/ && \
+    pnpm install --prod --frozen-lockfile && \
+    cp -r out/full/* /app/
 # copy migrations files for API service to run migrations at runtime
 COPY --from=builder /app/packages/db/migrations ./migrations
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
 ENV TELEMETRY_ACTIVE=true
-CMD ["pnpm", "start"]
+CMD ["pnpm", "start", "--filter=api"]
 
 FROM runtime AS gateway
-WORKDIR /app/temp
-COPY --from=builder /app/apps ./apps
-COPY --from=builder /app/packages ./packages
-COPY --from=builder /app/.npmrc /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
-RUN pnpm --filter=gateway --prod deploy ../dist/gateway
-RUN rm -rf /app/temp
-WORKDIR /app/dist/gateway
+WORKDIR /app
+# Use turbo prune to create a pruned subset for the gateway app
+RUN --mount=from=builder,source=/app,target=/source \
+    cd /source && \
+    pnpm turbo prune gateway --docker && \
+    cp -r out/json/* /app/ && \
+    pnpm install --prod --frozen-lockfile && \
+    cp -r out/full/* /app/
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["pnpm", "start"]
+CMD ["pnpm", "start", "--filter=gateway"]
 
 FROM runtime AS ui
-WORKDIR /app/temp
-COPY --from=builder /app/apps ./apps
-COPY --from=builder /app/packages ./packages
-COPY --from=builder /app/.npmrc /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
-RUN pnpm --filter=ui --prod deploy ../dist/ui
-RUN rm -rf /app/temp
-WORKDIR /app/dist/ui
+WORKDIR /app
+# Use turbo prune to create a pruned subset for the ui app
+RUN --mount=from=builder,source=/app,target=/source \
+    cd /source && \
+    pnpm turbo prune ui --docker && \
+    cp -r out/json/* /app/ && \
+    pnpm install --prod --frozen-lockfile && \
+    cp -r out/full/* /app/
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["pnpm", "start"]
+CMD ["pnpm", "start", "--filter=ui"]
 
 FROM runtime AS docs
-WORKDIR /app/temp
-COPY --from=builder /app/apps ./apps
-COPY --from=builder /app/packages ./packages
-COPY --from=builder /app/.npmrc /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
-RUN pnpm --filter=docs --prod deploy ../dist/docs
-RUN rm -rf /app/temp
-WORKDIR /app/dist/docs
+WORKDIR /app
+# Use turbo prune to create a pruned subset for the docs app
+RUN --mount=from=builder,source=/app,target=/source \
+    cd /source && \
+    pnpm turbo prune docs --docker && \
+    cp -r out/json/* /app/ && \
+    pnpm install --prod --frozen-lockfile && \
+    cp -r out/full/* /app/
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["pnpm", "start"]
+CMD ["pnpm", "start", "--filter=docs"]

--- a/infra/unified.dockerfile
+++ b/infra/unified.dockerfile
@@ -97,11 +97,35 @@ RUN --mount=type=cache,target=/app/.turbo pnpm build
 RUN mkdir -p /app/services /var/log/supervisor /run/postgresql /var/lib/postgresql/data && \
     chown -R postgres:postgres /var/lib/postgresql
 
-# Deploy all services with a single command
-RUN pnpm --filter=api --prod deploy /app/services/api && \
-    pnpm --filter=gateway --prod deploy /app/services/gateway && \
-    pnpm --filter=ui --prod deploy /app/services/ui && \
-    pnpm --filter=docs --prod deploy /app/services/docs
+# Deploy all services using turbo prune
+RUN mkdir -p /tmp/prune && \
+    pnpm turbo prune api --docker --out-dir=/tmp/prune/api && \
+    pnpm turbo prune gateway --docker --out-dir=/tmp/prune/gateway && \
+    pnpm turbo prune ui --docker --out-dir=/tmp/prune/ui && \
+    pnpm turbo prune docs --docker --out-dir=/tmp/prune/docs && \
+    \
+    # Deploy API
+    cp -r /tmp/prune/api/json/* /app/services/api/ && \
+    cd /app/services/api && pnpm install --prod --frozen-lockfile && \
+    cp -r /tmp/prune/api/full/* /app/services/api/ && \
+    \
+    # Deploy Gateway
+    cp -r /tmp/prune/gateway/json/* /app/services/gateway/ && \
+    cd /app/services/gateway && pnpm install --prod --frozen-lockfile && \
+    cp -r /tmp/prune/gateway/full/* /app/services/gateway/ && \
+    \
+    # Deploy UI
+    cp -r /tmp/prune/ui/json/* /app/services/ui/ && \
+    cd /app/services/ui && pnpm install --prod --frozen-lockfile && \
+    cp -r /tmp/prune/ui/full/* /app/services/ui/ && \
+    \
+    # Deploy Docs
+    cp -r /tmp/prune/docs/json/* /app/services/docs/ && \
+    cd /app/services/docs && pnpm install --prod --frozen-lockfile && \
+    cp -r /tmp/prune/docs/full/* /app/services/docs/ && \
+    \
+    # Cleanup
+    rm -rf /tmp/prune
 
 # Copy migrations files to API service
 COPY packages/db/migrations /app/services/api/migrations


### PR DESCRIPTION
Replaced direct service deployment with `pnpm turbo prune` to enhance Docker image builds. This enables creating minimized subsets for each service, reducing build size and improving performance.