### PR TITLE
Add rate limiting for free models in chat API

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -49,6 +49,7 @@ import {
 	getProviderEnvVar,
 	hasProviderEnvironmentToken,
 } from "../lib/provider";
+import { checkFreeModelRateLimit } from "../lib/rate-limit";
 
 import type { ServerTypes } from "../vars";
 
@@ -2663,6 +2664,30 @@ chat.openapi(completions, async (c) => {
 						"Email verification required to use free models. Please verify your email address.",
 				});
 			}
+
+			// Check rate limits for free models
+			const rateLimitResult = await checkFreeModelRateLimit(
+				project.organizationId,
+				requestedModel,
+				modelInfo as ModelDefinition,
+			);
+			if (!rateLimitResult.allowed) {
+				const retryAfter = rateLimitResult.retryAfter?.toString() || "60";
+				const limit = parseFloat(organization.credits || "0") > 0 ? "20" : "1";
+				const resetTime = (
+					Math.floor(Date.now() / 1000) + (rateLimitResult.retryAfter || 60)
+				).toString();
+
+				c.header("Retry-After", retryAfter);
+				c.header("X-RateLimit-Limit", limit);
+				c.header("X-RateLimit-Remaining", "0");
+				c.header("X-RateLimit-Reset", resetTime);
+
+				throw new HTTPException(429, {
+					message:
+						"Rate limit exceeded for free models. Please try again later.",
+				});
+			}
 		}
 
 		usedToken = getProviderTokenFromEnv(usedProvider);
@@ -2729,6 +2754,31 @@ chat.openapi(completions, async (c) => {
 					throw new HTTPException(403, {
 						message:
 							"Email verification required to use free models. Please verify your email address.",
+					});
+				}
+
+				// Check rate limits for free models
+				const rateLimitResult = await checkFreeModelRateLimit(
+					project.organizationId,
+					requestedModel,
+					modelInfo as ModelDefinition,
+				);
+				if (!rateLimitResult.allowed) {
+					const retryAfter = rateLimitResult.retryAfter?.toString() || "60";
+					const limit =
+						parseFloat(organization.credits || "0") > 0 ? "20" : "1";
+					const resetTime = (
+						Math.floor(Date.now() / 1000) + (rateLimitResult.retryAfter || 60)
+					).toString();
+
+					c.header("Retry-After", retryAfter);
+					c.header("X-RateLimit-Limit", limit);
+					c.header("X-RateLimit-Remaining", "0");
+					c.header("X-RateLimit-Reset", resetTime);
+
+					throw new HTTPException(429, {
+						message:
+							"Rate limit exceeded for free models. Please try again later.",
 					});
 				}
 			}

--- a/apps/gateway/src/lib/rate-limit.spec.ts
+++ b/apps/gateway/src/lib/rate-limit.spec.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { checkFreeModelRateLimit, isFreeModel } from "./rate-limit";
+
+// Mock dependencies
+vi.mock("./cache", () => ({
+	getOrganization: vi.fn(),
+}));
+
+vi.mock("./redis", () => ({
+	default: {
+		zremrangebyscore: vi.fn(),
+		zcard: vi.fn(),
+		zrange: vi.fn(),
+		zadd: vi.fn(),
+		expire: vi.fn(),
+	},
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+const mockRedis = await import("./redis");
+const mockCache = await import("./cache");
+const redis = mockRedis.default;
+
+describe("Rate Limiting", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("isFreeModel", () => {
+		it("should return true for free models", () => {
+			const freeModel = { free: true };
+			expect(isFreeModel(freeModel)).toBe(true);
+		});
+
+		it("should return false for non-free models", () => {
+			const paidModel = { free: false };
+			expect(isFreeModel(paidModel)).toBe(false);
+		});
+
+		it("should return false for models without free property", () => {
+			const model = {};
+			expect(isFreeModel(model)).toBe(false);
+		});
+	});
+
+	describe("checkFreeModelRateLimit", () => {
+		const organizationId = "test-org-id";
+		const model = "test-model";
+
+		it("should allow non-free models without rate limiting", async () => {
+			const modelDefinition = { free: false };
+
+			const result = await checkFreeModelRateLimit(
+				organizationId,
+				model,
+				modelDefinition,
+			);
+
+			expect(result.allowed).toBe(true);
+			expect(result.retryAfter).toBeUndefined();
+		});
+
+		it("should apply base rate limits for orgs with 0 credits", async () => {
+			const modelDefinition = { free: true };
+
+			vi.mocked(mockCache.getOrganization).mockResolvedValue({
+				credits: "0",
+			});
+
+			vi.mocked(redis.zcard).mockResolvedValue(0);
+
+			const result = await checkFreeModelRateLimit(
+				organizationId,
+				model,
+				modelDefinition,
+			);
+
+			expect(result.allowed).toBe(true);
+			expect(redis.zremrangebyscore).toHaveBeenCalled();
+			expect(redis.zadd).toHaveBeenCalled();
+			expect(redis.expire).toHaveBeenCalled();
+		});
+
+		it("should apply elevated rate limits for orgs with credits > 0", async () => {
+			const modelDefinition = { free: true };
+
+			vi.mocked(mockCache.getOrganization).mockResolvedValue({
+				credits: "10.50",
+			});
+
+			vi.mocked(redis.zcard).mockResolvedValue(5); // Under elevated limit (20)
+
+			const result = await checkFreeModelRateLimit(
+				organizationId,
+				model,
+				modelDefinition,
+			);
+
+			expect(result.allowed).toBe(true);
+		});
+
+		it("should block requests when base rate limit is exceeded", async () => {
+			const modelDefinition = { free: true };
+
+			vi.mocked(mockCache.getOrganization).mockResolvedValue({
+				credits: "0",
+			});
+
+			vi.mocked(redis.zcard).mockResolvedValue(1); // At limit (1)
+			const futureTimestamp = Date.now() + 30000; // 30 seconds in future
+			vi.mocked(redis.zrange).mockResolvedValue([
+				"123",
+				futureTimestamp.toString(),
+			]);
+
+			const result = await checkFreeModelRateLimit(
+				organizationId,
+				model,
+				modelDefinition,
+			);
+
+			expect(result.allowed).toBe(false);
+			expect(result.retryAfter).toBeGreaterThan(0);
+		});
+
+		it("should block requests when elevated rate limit is exceeded", async () => {
+			const modelDefinition = { free: true };
+
+			vi.mocked(mockCache.getOrganization).mockResolvedValue({
+				credits: "10.50",
+			});
+
+			vi.mocked(redis.zcard).mockResolvedValue(20); // At elevated limit (20)
+			const futureTimestamp = Date.now() + 30000; // 30 seconds in future
+			vi.mocked(redis.zrange).mockResolvedValue([
+				"123",
+				futureTimestamp.toString(),
+			]);
+
+			const result = await checkFreeModelRateLimit(
+				organizationId,
+				model,
+				modelDefinition,
+			);
+
+			expect(result.allowed).toBe(false);
+			expect(result.retryAfter).toBeGreaterThan(0);
+		});
+
+		it("should allow requests on Redis errors", async () => {
+			const modelDefinition = { free: true };
+
+			vi.mocked(mockCache.getOrganization).mockResolvedValue({
+				credits: "0",
+			});
+			vi.mocked(redis.zremrangebyscore).mockRejectedValue(
+				new Error("Redis error"),
+			);
+
+			const result = await checkFreeModelRateLimit(
+				organizationId,
+				model,
+				modelDefinition,
+			);
+
+			expect(result.allowed).toBe(true);
+		});
+	});
+});

--- a/apps/gateway/src/lib/rate-limit.ts
+++ b/apps/gateway/src/lib/rate-limit.ts
@@ -1,0 +1,123 @@
+import { logger } from "@llmgateway/logger";
+
+import { getOrganization } from "./cache";
+import redisClient from "./redis";
+
+/**
+ * Rate limiting configuration for free models
+ */
+const FREE_MODEL_RATE_LIMITS = {
+	// 1 request per minute for orgs with 0 credits
+	BASE_LIMIT: 1,
+	BASE_WINDOW: 60, // seconds
+
+	// 20 requests per minute for orgs with > 0 credits
+	ELEVATED_LIMIT: 20,
+	ELEVATED_WINDOW: 60, // seconds
+};
+
+/**
+ * Check if a model is free based on model definition
+ */
+export function isFreeModel(modelDefinition: any): boolean {
+	return modelDefinition?.free === true;
+}
+
+/**
+ * Generate Redis key for rate limiting
+ */
+function getRateLimitKey(organizationId: string, model: string): string {
+	return `rate_limit:free_model:${organizationId}:${model}`;
+}
+
+/**
+ * Check if organization has elevated rate limits (credits > 0)
+ */
+async function hasElevatedLimits(organizationId: string): Promise<boolean> {
+	try {
+		const org = await getOrganization(organizationId);
+		return org && parseFloat(org.credits || "0") > 0;
+	} catch (error) {
+		logger.error(
+			"Error checking organization credits for rate limiting:",
+			error as Error,
+		);
+		// Default to base limits on error
+		return false;
+	}
+}
+
+/**
+ * Check rate limit for free models
+ * Returns true if request is allowed, false if rate limited
+ */
+export async function checkFreeModelRateLimit(
+	organizationId: string,
+	model: string,
+	modelDefinition: any,
+): Promise<{ allowed: boolean; retryAfter?: number }> {
+	// Only apply rate limiting to free models
+	if (!isFreeModel(modelDefinition)) {
+		return { allowed: true };
+	}
+
+	try {
+		const hasElevated = await hasElevatedLimits(organizationId);
+		const limit = hasElevated
+			? FREE_MODEL_RATE_LIMITS.ELEVATED_LIMIT
+			: FREE_MODEL_RATE_LIMITS.BASE_LIMIT;
+		const window = hasElevated
+			? FREE_MODEL_RATE_LIMITS.ELEVATED_WINDOW
+			: FREE_MODEL_RATE_LIMITS.BASE_WINDOW;
+
+		const key = getRateLimitKey(organizationId, model);
+
+		// Use sliding window approach with Redis
+		const now = Date.now();
+		const windowStart = now - window * 1000;
+
+		// Remove old entries and count current requests in window
+		await redisClient.zremrangebyscore(key, "-inf", windowStart);
+		const currentCount = await redisClient.zcard(key);
+
+		if (currentCount >= limit) {
+			// Rate limited - calculate retry after
+			const oldestEntry = await redisClient.zrange(key, 0, 0, "WITHSCORES");
+			const retryAfter =
+				oldestEntry.length > 1
+					? Math.ceil(
+							(parseInt(oldestEntry[1], 10) + window * 1000 - now) / 1000,
+						)
+					: window;
+
+			logger.info(`Rate limit exceeded for free model`, {
+				organizationId,
+				model,
+				currentCount,
+				limit,
+				hasElevated,
+				retryAfter,
+			});
+
+			return { allowed: false, retryAfter };
+		}
+
+		// Add current request to sliding window
+		await redisClient.zadd(key, now, now.toString());
+		await redisClient.expire(key, window * 2); // Set expiry to 2x window for cleanup
+
+		logger.debug(`Free model rate limit check passed`, {
+			organizationId,
+			model,
+			currentCount: currentCount + 1,
+			limit,
+			hasElevated,
+		});
+
+		return { allowed: true };
+	} catch (error) {
+		logger.error("Error checking free model rate limit:", error as Error);
+		// Allow request on error to avoid blocking users due to Redis issues
+		return { allowed: true };
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces rate limiting for free models in the chat API to prevent abuse
- Applies different rate limits based on organization credits:
  - Base limit: 1 request per minute for orgs with 0 credits
  - Elevated limit: 20 requests per minute for orgs with credits > 0
- Returns appropriate HTTP 429 responses with rate limit headers when limits are exceeded

## Changes

### Rate Limiting Logic
- Added `rate-limit.ts` with functions to check if a model is free and enforce rate limits using Redis sorted sets
- Sliding window rate limiting approach implemented for accurate request counting
- Handles Redis errors gracefully by allowing requests to avoid blocking users

### Chat API Integration
- Integrated `checkFreeModelRateLimit` in chat request handlers to enforce limits on free models
- Sends `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers on rate limit exceedance
- Throws HTTP 429 error with a clear message when rate limit is exceeded

### Testing
- Added comprehensive unit tests in `rate-limit.spec.ts` covering:
  - Free vs non-free model detection
  - Rate limiting behavior for orgs with and without credits
  - Correct blocking and retry-after calculation
  - Handling of Redis errors

## Test plan
- [x] Verified rate limiting triggers correctly for free models
- [x] Confirmed elevated limits apply for organizations with credits
- [x] Tested HTTP 429 responses and headers on limit exceedance
- [x] Ran unit tests to cover all new rate limiting logic
- [x] Ensured no impact on non-free model requests

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e8a2fc74-4e60-4d12-8d40-32b73bae19a9