### PR TITLE
feat(auto-model): add reasoning support

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2419,26 +2419,6 @@ chat.openapi(completions, async (c) => {
 		// Only consider hardcoded models for auto selection
 		let allowedAutoModels = ["gpt-5-nano", "gpt-4.1-nano"];
 
-		// If reasoning_effort is specified, expand to include reasoning-capable models
-		if (reasoning_effort !== undefined) {
-			allowedAutoModels = [
-				...allowedAutoModels,
-				"qwen3-30b-a3b-thinking-2507",
-				"qwen3-max",
-				"claude-3-7-sonnet-20250219",
-				"claude-opus-4-1",
-				"o1",
-				"gpt-oss-120b",
-				"gpt-oss-20b",
-				"gpt-5",
-				"gpt-5-mini",
-				"gpt-5-nano",
-				"glm-4.5",
-				"glm-4.5v",
-				"glm-4.5-x",
-			];
-		}
-
 		// If free_models_only is true, expand to include free models
 		if (free_models_only) {
 			allowedAutoModels = [...allowedAutoModels, "kimi-k2-free"];

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2212,7 +2212,12 @@ chat.openapi(completions, async (c) => {
 	}
 
 	// Check if reasoning_effort is specified but model doesn't support reasoning
-	if (reasoning_effort !== undefined) {
+	// Skip this check for "auto" and "custom" models as they will be resolved dynamically
+	if (
+		reasoning_effort !== undefined &&
+		requestedModel !== "auto" &&
+		requestedModel !== "custom"
+	) {
 		// Check if any provider for this model supports reasoning
 		const supportsReasoning = modelInfo.providers.some(
 			(provider) => (provider as ProviderModelMapping).reasoning === true,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2419,6 +2419,26 @@ chat.openapi(completions, async (c) => {
 		// Only consider hardcoded models for auto selection
 		let allowedAutoModels = ["gpt-5-nano", "gpt-4.1-nano"];
 
+		// If reasoning_effort is specified, expand to include reasoning-capable models
+		if (reasoning_effort !== undefined) {
+			allowedAutoModels = [
+				...allowedAutoModels,
+				"qwen3-30b-a3b-thinking-2507",
+				"qwen3-max",
+				"claude-3-7-sonnet-20250219",
+				"claude-opus-4-1",
+				"o1",
+				"gpt-oss-120b",
+				"gpt-oss-20b",
+				"gpt-5",
+				"gpt-5-mini",
+				"gpt-5-nano",
+				"glm-4.5",
+				"glm-4.5v",
+				"glm-4.5-x",
+			];
+		}
+
 		// If free_models_only is true, expand to include free models
 		if (free_models_only) {
 			allowedAutoModels = [...allowedAutoModels, "kimi-k2-free"];
@@ -2448,11 +2468,21 @@ chat.openapi(completions, async (c) => {
 				availableProviders.includes(provider.providerId),
 			);
 
-			// Filter by context size requirement
+			// Filter by context size requirement and reasoning capability if needed
 			const suitableProviders = availableModelProviders.filter((provider) => {
 				// Use the provider's context size, defaulting to a reasonable value if not specified
 				const modelContextSize = provider.contextSize ?? 8192;
-				return modelContextSize >= requiredContextSize;
+				const contextSizeMet = modelContextSize >= requiredContextSize;
+
+				// If reasoning_effort is specified, only include providers that support reasoning
+				if (reasoning_effort !== undefined) {
+					return (
+						contextSizeMet &&
+						(provider as ProviderModelMapping).reasoning === true
+					);
+				}
+
+				return contextSizeMet;
 			});
 
 			if (suitableProviders.length > 0) {


### PR DESCRIPTION
## Summary
- Adds support for reasoning capability in automatic model selection
- Expands allowed auto models to include reasoning-capable models when `reasoning_effort` is specified
- Filters model providers by reasoning capability in addition to context size

## Changes

### Core Functionality
- Extended the list of allowed auto models to include reasoning-capable models if `reasoning_effort` is provided
- Updated filtering logic to ensure only providers supporting reasoning are considered when `reasoning_effort` is specified

## Test plan
- Verify that models capable of reasoning are included in auto selection when `reasoning_effort` is set
- Confirm that providers without reasoning capability are excluded when `reasoning_effort` is specified
- Ensure existing behavior remains unchanged when `reasoning_effort` is not provided
- Test with various context size requirements to validate filtering logic

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2be69044-f5c3-4659-8752-af969fc9c0e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-routing now prefers reasoning-capable providers when a reasoning level is requested; otherwise only context-size is considered.
  * Explicit model requests validate reasoning support and return a clear 400 error if unsupported.
  * Auto/custom model selections accept reasoning preferences without upfront validation, enabling dynamic provider resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->