### PR TITLE
Add usedModelMapping field to log and update chat logging

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -231,6 +231,7 @@ function createLogEntry(
 	apiKey: ApiKey,
 	providerKeyId: string | undefined,
 	usedModel: string,
+	usedModelMapping: string | undefined,
 	usedProvider: string,
 	requestedModel: string,
 	requestedProvider: string | undefined,
@@ -258,6 +259,7 @@ function createLogEntry(
 		apiKeyId: apiKey.id,
 		usedMode: providerKeyId ? "api-keys" : "credits",
 		usedModel,
+		usedModelMapping,
 		usedProvider,
 		requestedModel,
 		requestedProvider,
@@ -2624,6 +2626,10 @@ chat.openapi(completions, async (c) => {
 
 	const baseModelName = finalModelInfo?.id || usedModel;
 
+	// Create the model mapping values according to new schema
+	const usedModelMapping = usedModel; // Store the original provider model name
+	const usedModelFormatted = `${usedProvider}/${baseModelName}`; // Store in LLMGateway format
+
 	let url: string | undefined;
 
 	// Get the provider key for the selected provider based on project mode
@@ -2916,7 +2922,8 @@ chat.openapi(completions, async (c) => {
 					project,
 					apiKey,
 					providerKey?.id,
-					usedModel,
+					usedModelFormatted,
+					usedModelMapping,
 					usedProvider,
 					requestedModel,
 					requestedProvider,
@@ -3003,7 +3010,8 @@ chat.openapi(completions, async (c) => {
 					project,
 					apiKey,
 					providerKey?.id,
-					usedModel,
+					usedModelFormatted,
+					usedModelMapping,
 					usedProvider,
 					requestedModel,
 					requestedProvider,
@@ -3214,7 +3222,8 @@ chat.openapi(completions, async (c) => {
 						project,
 						apiKey,
 						providerKey?.id,
-						usedModel,
+						usedModelFormatted,
+						usedModelMapping,
 						usedProvider,
 						requestedModel,
 						requestedProvider,
@@ -3336,7 +3345,8 @@ chat.openapi(completions, async (c) => {
 					project,
 					apiKey,
 					providerKey?.id,
-					usedModel,
+					usedModelFormatted,
+					usedModelMapping,
 					usedProvider,
 					requestedModel,
 					requestedProvider,
@@ -4135,7 +4145,8 @@ chat.openapi(completions, async (c) => {
 					project,
 					apiKey,
 					providerKey?.id,
-					usedModel,
+					usedModelFormatted,
+					usedModelMapping,
 					usedProvider,
 					requestedModel,
 					requestedProvider,
@@ -4279,7 +4290,8 @@ chat.openapi(completions, async (c) => {
 			project,
 			apiKey,
 			providerKey?.id,
-			usedModel,
+			usedModelFormatted,
+			usedModelMapping,
 			usedProvider,
 			requestedModel,
 			requestedProvider,
@@ -4355,7 +4367,8 @@ chat.openapi(completions, async (c) => {
 			project,
 			apiKey,
 			providerKey?.id,
-			usedModel,
+			usedModelFormatted,
+			usedModelMapping,
 			usedProvider,
 			requestedModel,
 			requestedProvider,
@@ -4528,7 +4541,8 @@ chat.openapi(completions, async (c) => {
 		project,
 		apiKey,
 		providerKey?.id,
-		usedModel,
+		usedModelFormatted,
+		usedModelMapping,
 		usedProvider,
 		requestedModel,
 		requestedProvider,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -262,6 +262,7 @@ export const log = pgTable("log", {
 	requestedModel: text().notNull(),
 	requestedProvider: text(),
 	usedModel: text().notNull(),
+	usedModelMapping: text(),
 	usedProvider: text().notNull(),
 	responseSize: integer().notNull(),
 	content: text(),


### PR DESCRIPTION
## Summary
- Introduces a new `usedModelMapping` field in the log schema to capture the original provider model name
- Updates chat logging to include both the formatted model name (`usedModelFormatted`) and the original model mapping (`usedModelMapping`)
- Enhances traceability of model usage by storing both LLMGateway format and original provider model names

## Changes

### Database Schema
- Added `usedModelMapping` as an optional text field in the `log` table schema

### Chat Application
- Modified `createLogEntry` function to accept and store `usedModelMapping`
- Updated multiple chat logging calls to pass both `usedModelFormatted` (LLMGateway format) and `usedModelMapping` (original provider model name)
- Defined `usedModelMapping` as the original provider model name and `usedModelFormatted` as a combination of `usedProvider` and base model name

## Test plan
- Verify logs contain both `usedModelFormatted` and `usedModelMapping` fields with correct values
- Test chat completions to ensure logging works without errors
- Confirm database schema migration applies successfully and preserves existing data

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1bd45e34-dd4b-4c83-9057-aa96f8191a87