### PR TITLE
feat(e2e): skip unstable models

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -401,6 +401,7 @@ export const googleModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				stability: "unstable",
 			},
 		],
 		jsonOutput: true,


### PR DESCRIPTION
## Summary
- Enhances end-to-end test filtering to exclude unstable models and providers when not in full mode
- Allows inclusion of unstable models/providers if marked with `test: "only"` or explicitly specified in `TEST_MODELS`
- Adds `stability: "unstable"` flag to a Google model to support this filtering logic

## Changes

### Filtering Logic
- Updated model filtering to:
  - Exclude unstable models unless in full mode
  - Include unstable models if any provider has `test: "only"`
  - Include unstable models if listed in `TEST_MODELS`
- Updated provider filtering in test setup to:
  - Skip unstable providers unless in full mode
  - Include unstable providers if marked `test: "only"` or specified in `TEST_MODELS`

### Model Metadata
- Added `stability: "unstable"` to a Google model in `packages/models/src/models/google.ts`

## Test plan
- Verified that unstable models/providers are skipped in non-full mode
- Verified that unstable models/providers with `test: "only"` or in `TEST_MODELS` are included
- Confirmed full mode includes all models regardless of stability
- Ran existing e2e tests to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ab8ac205-7911-48ca-82ac-2987855562f8