### PR TITLE
Add verified emails to Brevo CRM after email verification

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -106,6 +106,14 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
 	emailVerification: {
 		sendOnSignUp: true,
 		autoSignInAfterVerification: true,
+		afterEmailVerification: async (user: {
+			id: string;
+			email: string;
+			name?: string | null;
+		}) => {
+			// Add verified email to Brevo CRM
+			await createBrevoContact(user.email, user.name || undefined);
+		},
 		sendVerificationEmail: async ({ user, token }) => {
 			const url = `${apiUrl}/auth/verify-email?token=${token}&callbackURL=${uiUrl}/dashboard?emailVerified=true`;
 			if (!smtpHost || !smtpUser || !smtpPass) {
@@ -181,19 +189,6 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
 						organizationId: organization.id,
 						mode: "hybrid",
 					});
-				}
-			}
-
-			// Check if this is an email verification event
-			if (ctx.path.startsWith("/verify-email")) {
-				const newSession = ctx.context.newSession;
-
-				// If we have a new session with a user, create Brevo contact
-				if (newSession?.user) {
-					await createBrevoContact(
-						newSession.user.email,
-						newSession.user.name || undefined,
-					);
 				}
 			}
 		}),


### PR DESCRIPTION
## Summary
- Integrates Brevo CRM contact creation after user email verification
- Removes redundant Brevo contact creation on email verification endpoint

## Changes

### Authentication
- Added `afterEmailVerification` hook to send verified user email and name to Brevo CRM
- Removed previous logic that created Brevo contact during email verification endpoint handling to avoid duplication

## Test plan
- [ ] Verify that after a user verifies their email, their contact is created in Brevo CRM
- [ ] Confirm no duplicate contacts are created on email verification endpoint
- [ ] Ensure email verification flow and auto sign-in continue to work as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/117285a1-4eff-4c5c-afb1-005feaf91dea