### PR TITLE
feat(models): add free Nvidia Nemotron Nano 9B V2 model

### DIFF
--- a/packages/models/src/models/routeway.ts
+++ b/packages/models/src/models/routeway.ts
@@ -185,4 +185,28 @@ export const routewayModels = [
 		],
 		jsonOutput: true,
 	},
+	{
+		id: "nemotron-nano-9b-v2",
+		name: "Nemotron Nano 9B V2",
+		family: "nvidia",
+		free: true,
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				test: "only",
+				providerId: "routeway",
+				modelName: "nemotron-nano-9b-v2:free",
+				inputPrice: 0.0 / 1e6,
+				outputPrice: 0.0 / 1e6,
+				requestPrice: 0,
+				contextSize: 128_000,
+				maxOutput: undefined,
+				streaming: true,
+				vision: false,
+				tools: false,
+			},
+		],
+		jsonOutput: true,
+	},
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/routeway.ts
+++ b/packages/models/src/models/routeway.ts
@@ -194,7 +194,6 @@ export const routewayModels = [
 		deactivatedAt: undefined,
 		providers: [
 			{
-				test: "only",
 				providerId: "routeway",
 				modelName: "nemotron-nano-9b-v2:free",
 				inputPrice: 0.0 / 1e6,


### PR DESCRIPTION
Added a new model "Nemotron Nano 9B V2" to the routeway. Includes metadata such as pricing, context size, capabilities (streaming, vision, and tools), and provider details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Nemotron Nano 9B V2 model on the free tier.
  * Supports streaming responses and structured JSON output.
  * Provides a 128k context window for longer prompts.
  * Does not support vision or tool integrations.

* **Chores**
  * Appended the new model to the catalog without modifying existing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->