### PR TITLE
Enhance LogCard to Display Used Model Mapping in Logs

### DIFF
--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -83,7 +83,16 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 					<div className="flex flex-wrap items-center gap-x-4 gap-y-1 pt-1 text-sm text-muted-foreground">
 						<div className="flex items-center gap-1">
 							<Package className="h-3.5 w-3.5" />
-							<span>{log.usedModel}</span>
+							<span>
+								{log.usedModel}
+								{log.usedModelMapping &&
+									log.usedModelMapping !== log.usedModel && (
+										<span className="text-muted-foreground">
+											{" "}
+											({log.usedModelMapping})
+										</span>
+									)}
+							</span>
 						</div>
 						<div className="flex items-center gap-1">
 							<Zap className="h-3.5 w-3.5" />
@@ -145,6 +154,15 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 								<div>{log.requestedModel}</div>
 								<div className="text-muted-foreground">Used Model</div>
 								<div>{log.usedModel}</div>
+								{log.usedModelMapping &&
+									log.usedModelMapping !== log.usedModel && (
+										<>
+											<div className="text-muted-foreground">
+												Used Model Mapping
+											</div>
+											<div>{log.usedModelMapping}</div>
+										</>
+									)}
 								<div className="text-muted-foreground">Provider</div>
 								<div>{log.usedProvider}</div>
 							</div>


### PR DESCRIPTION
## Summary
- Enhances the LogCard component in the dashboard UI to display the used model mapping alongside the used model in logs
- Adds conditional rendering to show the used model mapping only when it differs from the used model

## Changes

### UI Components
- **LogCard Component**:
  - Updated the model display section to include `usedModelMapping` next to `usedModel` with muted styling when they differ
  - Added a new section in the detailed log view to show "Used Model Mapping" with its value if applicable

## Test plan
- [x] Verify that logs with different `usedModel` and `usedModelMapping` show both values correctly
- [x] Confirm that logs with identical `usedModel` and `usedModelMapping` only show the used model once
- [x] Check UI layout and styling for the new mapping display
- [x] Ensure no regressions in other log details display

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ad6afbf4-bbce-44e8-83a7-2b9627455873