### PR TITLE
Add e2e test for auto model with reasoning_effort returning reasoning_content

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -1865,6 +1865,76 @@ describe("e2e", () => {
 		const log = await validateLogs();
 		expect(log.streamed).toBe(false);
 	});
+
+	test("auto model with reasoning_effort returns reasoning_content", async () => {
+		// Set up credits mode which is required for auto model routing
+		await db
+			.update(tables.organization)
+			.set({ credits: "1000" })
+			.where(eq(tables.organization.id, "org-id"));
+
+		await db
+			.update(tables.project)
+			.set({ mode: "credits" })
+			.where(eq(tables.project.id, "project-id"));
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "auto",
+				messages: [
+					{
+						role: "user",
+						content: "What is 3 + 5? Think step by step.",
+					},
+				],
+				reasoning_effort: "medium",
+			}),
+		});
+
+		const json = await res.json();
+		if (logMode) {
+			console.log("auto reasoning response:", JSON.stringify(json, null, 2));
+		}
+
+		expect(res.status).toBe(200);
+		validateResponse(json);
+
+		const log = await validateLogs();
+		expect(log.streamed).toBe(false);
+
+		// Verify basic response structure
+		expect(json).toHaveProperty("usage");
+		expect(json.usage).toHaveProperty("prompt_tokens");
+		expect(json.usage).toHaveProperty("completion_tokens");
+		expect(json.usage).toHaveProperty("total_tokens");
+		expect(typeof json.usage.prompt_tokens).toBe("number");
+		expect(typeof json.usage.completion_tokens).toBe("number");
+		expect(typeof json.usage.total_tokens).toBe("number");
+		expect(json.usage.prompt_tokens).toBeGreaterThan(0);
+		expect(json.usage.completion_tokens).toBeGreaterThan(0);
+		expect(json.usage.total_tokens).toBeGreaterThan(0);
+
+		// Check for reasoning tokens if available
+		if (json.usage.reasoning_tokens !== undefined) {
+			expect(typeof json.usage.reasoning_tokens).toBe("number");
+			expect(json.usage.reasoning_tokens).toBeGreaterThanOrEqual(0);
+		}
+
+		// Verify that auto model routed to a reasoning-capable model
+		expect(log.requestedModel).toBe("auto");
+		expect(log.usedProvider).toBeTruthy();
+		expect(log.usedModel).toBeTruthy();
+
+		// Most importantly: verify reasoning_content is returned
+		expect(json.choices[0].message).toHaveProperty("reasoning_content");
+		expect(typeof json.choices[0].message.reasoning_content).toBe("string");
+		expect(json.choices[0].message.reasoning_content.length).toBeGreaterThan(0);
+	});
 });
 
 async function readAll(stream: ReadableStream<Uint8Array> | null): Promise<{


### PR DESCRIPTION
## Summary
- Adds an end-to-end test for the auto model with `reasoning_effort` parameter
- Verifies that the response includes `reasoning_content` when using the auto model
- Ensures proper setup of organization credits and project mode for auto model routing
- Validates response structure including usage tokens and reasoning tokens
- Confirms that the auto model routes to a reasoning-capable model and returns expected logs

## Changes

### Test Enhancements
- Added a new test case in `api.e2e.ts`:
  - Sets organization credits and project mode to `credits` to enable auto model routing
  - Sends a chat completion request with `model: "auto"` and `reasoning_effort: "medium"`
  - Checks HTTP status and validates the response JSON structure
  - Confirms presence and type of `reasoning_content` in the response message
  - Validates usage tokens including optional reasoning tokens
  - Verifies logs to ensure correct model routing and provider usage

## Test plan
- [x] Run the new e2e test to verify that the auto model returns reasoning content
- [x] Confirm that all assertions on response structure and logs pass successfully
- [x] Ensure no regressions in existing e2e tests

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e80df600-c79e-412c-876d-2fbc3f1b91e2