### PR TITLE
chore: remove path filters

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -8,9 +8,6 @@ on:
       - main
       - hotfix
   pull_request:
-    paths:
-      - "infra/**.dockerfile"
-      - ".github/workflows/images.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Removed path filters from the pull_request trigger in the GitHub Actions workflow `images.yml`.
- This change allows the workflow to run on all pull requests regardless of the files changed.

## Changes

### CI/CD Workflow
- **images.yml**: Deleted the `paths` filter under the `pull_request` event to enable the workflow to trigger on any PR, not just those modifying Dockerfiles or the workflow file itself.

## Test plan
- [ ] Open a pull request modifying files outside the previously filtered paths and verify the `images.yml` workflow triggers.
- [ ] Confirm the workflow still triggers on PRs modifying Dockerfiles or the workflow file.
- [ ] Ensure no unintended workflow runs occur on unrelated PRs.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/253bbfa0-562b-4939-98cc-dea0432affbf