### PR TITLE
ci: skip image build jobs if no relevant file changes in PR

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -8,21 +8,36 @@ on:
       - main
       - hotfix
   pull_request:
-    paths:
-      - "**/package.json"
-      - "**/tsconfig.json"
-      - "**/tsup.ts"
-      - "pnpm-lock.yaml"
-      - "infra/**.dockerfile"
-      - ".github/workflows/images.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images-changed: ${{ steps.changes.outputs.images }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check for relevant file changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            images:
+              - '**/package.json'
+              - '**/tsconfig.json'
+              - '**/tsup.ts'
+              - 'pnpm-lock.yaml'
+              - 'infra/**.dockerfile'
+              - '.github/workflows/images.yml'
+
   setup:
     runs-on: ubuntu-latest
+    needs: check-changes
     if: github.event_name != 'pull_request'
     outputs:
       image_tag: ${{ steps.set-tag.outputs.IMAGE_TAG }}
@@ -278,7 +293,8 @@ jobs:
 
   # PR-specific jobs that only build without pushing
   test-build-split:
-    if: github.event_name == 'pull_request'
+    needs: check-changes
+    if: github.event_name == 'pull_request' && needs.check-changes.outputs.images-changed == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -307,7 +323,8 @@ jobs:
             APP_VERSION=pr-test
 
   test-build-unified:
-    if: github.event_name == 'pull_request'
+    needs: check-changes
+    if: github.event_name == 'pull_request' && needs.check-changes.outputs.images-changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -329,3 +346,23 @@ jobs:
           cache-to: type=gha,mode=max,scope=unified-linux-amd64
           build-args: |
             APP_VERSION=pr-test
+
+  # Skip jobs for PR when files haven't changed - ensures jobs show as skipped
+  test-build-split-skip:
+    needs: check-changes
+    if: github.event_name == 'pull_request' && needs.check-changes.outputs.images-changed != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [api, gateway, ui, docs]
+    steps:
+      - name: Skip - no relevant file changes
+        run: echo "Skipping test-build-split for ${{ matrix.app }} - no relevant file changes detected"
+
+  test-build-unified-skip:
+    needs: check-changes
+    if: github.event_name == 'pull_request' && needs.check-changes.outputs.images-changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip - no relevant file changes
+        run: echo "Skipping test-build-unified - no relevant file changes detected"


### PR DESCRIPTION
## Summary
- Adds a pre-check job in the GitHub Actions workflow to detect changes in image-related files
- Skips image build jobs (`test-build-split` and `test-build-unified`) for pull requests if no relevant files have changed
- Adds explicit skip jobs to show skipped status in the workflow UI for better visibility

## Changes

### Workflow Updates
- Introduced `check-changes` job to filter PR file changes against image-related paths
- Modified `test-build-split` and `test-build-unified` jobs to run only if relevant files changed
- Added `test-build-split-skip` and `test-build-unified-skip` jobs to run and explicitly skip when no relevant changes detected
- Removed path filters from the `pull_request` trigger to allow the new filtering logic

## Benefits
- Reduces unnecessary CI runs and resource usage for PRs without image-related changes
- Improves feedback clarity by showing skipped jobs instead of silently not running them

## Test plan
- Verified that PRs with changes in image-related files trigger the build jobs
- Verified that PRs without changes in those files skip the build jobs and show skip messages
- Confirmed workflow concurrency and cancellation behavior remains intact

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/96141344-1a1b-4b9b-868c-f05080ad7e15