### PR TITLE
refactor(infra): update commands to use `next` and `node` binaries

### DIFF
--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -106,7 +106,7 @@ EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
 ENV TELEMETRY_ACTIVE=true
-CMD ["pnpm", "start"]
+CMD ["node", "--enable-source-maps", "dist/serve.js"]
 
 FROM runtime AS gateway
 WORKDIR /app/temp
@@ -119,7 +119,7 @@ WORKDIR /app/dist/gateway
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["pnpm", "start"]
+CMD ["node", "--enable-source-maps", "dist/serve.js"]
 
 FROM runtime AS ui
 WORKDIR /app/temp
@@ -132,7 +132,7 @@ WORKDIR /app/dist/ui
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["pnpm", "start"]
+CMD ["./node_modules/.bin/next", "start"]
 
 FROM runtime AS docs
 WORKDIR /app/temp
@@ -145,4 +145,4 @@ WORKDIR /app/dist/docs
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["pnpm", "start"]
+CMD ["./node_modules/.bin/next", "start", "-H", "0.0.0.0"]

--- a/infra/supervisord.conf
+++ b/infra/supervisord.conf
@@ -27,7 +27,7 @@ stdout_logfile_maxbytes=0
 
 
 [program:ui]
-command=/usr/local/bin/pnpm start
+command=./node_modules/.bin/next start
 directory=/app/services/ui
 user=root
 autostart=true
@@ -39,7 +39,7 @@ stdout_logfile_maxbytes=0
 environment=PORT=3002,NODE_ENV=production
 
 [program:docs]
-command=/usr/local/bin/pnpm start
+command=./node_modules/.bin/next start -H 0.0.0.0
 directory=/app/services/docs
 user=root
 autostart=true
@@ -52,7 +52,7 @@ environment=PORT=3005,NODE_ENV=production
 
 
 [program:api]
-command=/usr/local/bin/pnpm start
+command=/usr/local/bin/node --enable-source-maps dist/serve.js
 directory=/app/services/api
 user=root
 autostart=true
@@ -64,7 +64,7 @@ stdout_logfile_maxbytes=0
 environment=PORT=4002,NODE_ENV=production
 
 [program:gateway]
-command=node dist/serve.js
+command=/usr/local/bin/node --enable-source-maps dist/serve.js
 directory=/app/services/gateway
 user=root
 autostart=true


### PR DESCRIPTION
Replaces `pnpm start` with explicit `next` and `node` commands in supervisord configuration and Dockerfiles to align with project runtime requirements.