### PR TITLE
Remove unnecessary eslint-disable comments for import order

### DIFF
--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 import { allBlogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";

--- a/apps/ui/src/app/changelog/[slug]/page.tsx
+++ b/apps/ui/src/app/changelog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 import { allChangelogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";


### PR DESCRIPTION
## Summary
- Removed redundant `// eslint-disable-next-line import/order` comments from blog and changelog page components
- Cleans up code by relying on proper import order without disabling lint rules

## Changes

### Code Cleanup
- Deleted eslint-disable comments in:
  - `apps/ui/src/app/blog/[slug]/page.tsx`
  - `apps/ui/src/app/changelog/[slug]/page.tsx`

## Test plan
- [x] Verify no lint errors related to import order in blog and changelog pages
- [x] Confirm pages render correctly without import order disable comments

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/29cb8f4c-f6e9-4de8-9072-db8315e163e2