### PR TITLE
Remove unnecessary eslint-disable comments for import order

### DIFF
--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 import { allBlogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";

--- a/apps/ui/src/app/changelog/[slug]/page.tsx
+++ b/apps/ui/src/app/changelog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 import { allChangelogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";


### PR DESCRIPTION
## Summary
- Removed redundant `// eslint-disable-next-line import/order` comments from blog and changelog page components
- Cleans up code by allowing ESLint to enforce import order rules

## Changes

### Code Cleanup
- Deleted eslint-disable comments in:
  - `apps/ui/src/app/blog/[slug]/page.tsx`
  - `apps/ui/src/app/changelog/[slug]/page.tsx`

## Test plan
- [x] Verify that the application builds without ESLint import order errors
- [x] Confirm that blog and changelog pages render correctly without import order disabling
- [x] Run lint checks to ensure import order is enforced properly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4006524e-b981-411a-a5a1-5ae48c3c7788