### PR TITLE
refactor(paths): update imports to use base aliases

### DIFF
--- a/apps/api/src/auth/handler.ts
+++ b/apps/api/src/auth/handler.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 
 import { apiAuth } from "./config";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 // Create a Hono app for auth routes
 export const authHandler = new OpenAPIHono<ServerTypes>();

--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("activity endpoint", () => {
 	let token: string;

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { db } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const activity = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/beacon.spec.ts
+++ b/apps/api/src/routes/beacon.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { posthog } from "@/posthog";
+
 import { app } from "..";
-import { posthog } from "../posthog";
 
 // Mock PostHog
-vi.mock("../posthog", () => ({
+vi.mock("@/posthog", () => ({
 	posthog: {
 		capture: vi.fn(),
 	},

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -1,11 +1,11 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
+import { posthog } from "@/posthog";
+
 import { logger } from "@llmgateway/logger";
 
-import { posthog } from "../posthog";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const beacon = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { logger } from "@llmgateway/logger";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 const chat = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/chats.ts
+++ b/apps/api/src/routes/chats.ts
@@ -1,11 +1,11 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 
+import { hasActiveApiKey } from "@/lib/hasActiveApiKey";
+
 import { db, tables, desc, eq, count, and } from "@llmgateway/db";
 
-import { hasActiveApiKey } from "../lib/hasActiveApiKey";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 const chats = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,5 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 
+import { apiAuth as auth } from "@/auth/config";
+
 import { activity } from "./activity";
 import { chat } from "./chat";
 import { chats } from "./chats";
@@ -11,9 +13,8 @@ import { payments } from "./payments";
 import projects from "./projects";
 import { subscriptions } from "./subscriptions";
 import { user } from "./user";
-import { apiAuth as auth } from "../auth/config";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const routes = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, beforeEach, describe, afterEach } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("keys route", () => {
 	let token: string;

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -2,11 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "@/lib/maskToken";
+
 import { eq, db, shortid, tables } from "@llmgateway/db";
 
-import { maskToken } from "../lib/maskToken";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const keysApi = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -8,6 +8,8 @@ import {
 	type TestOptions,
 } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 import {
 	models,
@@ -17,7 +19,6 @@ import {
 
 import { app } from "..";
 import { getProviderEnvVar } from "../../../gateway/src/test-utils/test-helpers";
-import { createTestUser, deleteAll } from "../testing";
 
 function getTestOptions(): TestOptions {
 	const hasTestOnly = models.some((model) =>

--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -18,6 +18,7 @@ import {
 } from "@llmgateway/models";
 
 import { app } from "..";
+// eslint-disable-next-line no-relative-import-paths/no-relative-import-paths
 import { getProviderEnvVar } from "../../../gateway/src/test-utils/test-helpers";
 
 function getTestOptions(): TestOptions {

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, beforeEach, describe, afterEach } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("provider keys route", () => {
 	let token: string;

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -2,12 +2,12 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "@/lib/maskToken";
+
 import { db, eq, tables } from "@llmgateway/db";
 import { providers, validateProviderKey } from "@llmgateway/models";
 
-import { maskToken } from "../lib/maskToken";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 import type { ProviderId } from "@llmgateway/models";
 
 export const keysProvider = new OpenAPIHono<ServerTypes>();

--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("logs route", () => {
 	let token: string;

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -22,7 +22,7 @@ import {
 	tools,
 } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const logs = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { db, eq, tables } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const organization = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -3,12 +3,12 @@ import { HTTPException } from "hono/http-exception";
 import Stripe from "stripe";
 import { z } from "zod";
 
+import { ensureStripeCustomer } from "@/stripe";
+
 import { db, eq, tables } from "@llmgateway/db";
 import { calculateFees } from "@llmgateway/shared";
 
-import { ensureStripeCustomer } from "../stripe";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const stripe = new Stripe(
 	process.env.STRIPE_SECRET_KEY || "sk_test_123",

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { db, eq, tables } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const projects = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -2,13 +2,14 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { ensureStripeCustomer } from "@/stripe";
+
 import { db } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
-import { ensureStripeCustomer } from "../stripe";
 import { stripe } from "./payments";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const subscriptions = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -2,11 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { apiAuth as auth } from "@/auth/config";
+
 import { db, eq, tables } from "@llmgateway/db";
 
-import { apiAuth as auth } from "../auth/config";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const user = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/testing.ts
+++ b/apps/api/src/testing.ts
@@ -1,6 +1,7 @@
 import { db, tables } from "@llmgateway/db";
 
 import { app } from ".";
+// eslint-disable-next-line no-relative-import-paths/no-relative-import-paths
 import { clearCache } from "../../gateway/src/test-utils/test-helpers";
 
 import type { OpenAPIHono } from "@hono/zod-openapi";

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/apps/docs/components/ai/page-actions.tsx
+++ b/apps/docs/components/ai/page-actions.tsx
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import { cn } from "../../lib/cn";
+import { cn } from "@/lib/cn";
 
 const cache = new Map<string, string>();
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3,6 +3,12 @@ import { encode, encodeChat } from "gpt-tokenizer";
 import { HTTPException } from "hono/http-exception";
 import { streamSSE } from "hono/streaming";
 
+import { calculateCosts } from "@/lib/costs";
+import { throwIamException, validateModelAccess } from "@/lib/iam";
+import { insertLog } from "@/lib/logs";
+import { getProviderEnvVar, hasProviderEnvironmentToken } from "@/lib/provider";
+import { checkFreeModelRateLimit } from "@/lib/rate-limit";
+
 import {
 	checkCustomProviderExists,
 	generateCacheKey,
@@ -44,16 +50,7 @@ import {
 	providers,
 } from "@llmgateway/models";
 
-import { calculateCosts } from "../lib/costs";
-import { throwIamException, validateModelAccess } from "../lib/iam";
-import { insertLog } from "../lib/logs";
-import {
-	getProviderEnvVar,
-	hasProviderEnvironmentToken,
-} from "../lib/provider";
-import { checkFreeModelRateLimit } from "../lib/rate-limit";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 import type { Context } from "hono";
 
 // Helper function to validate free model usage

--- a/apps/gateway/src/chat/index.ts
+++ b/apps/gateway/src/chat/index.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 
 import { chat } from "./chat";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const exposed = new OpenAPIHono<ServerTypes>();
 

--- a/apps/gateway/src/lib/prompt-tokens.spec.ts
+++ b/apps/gateway/src/lib/prompt-tokens.spec.ts
@@ -4,7 +4,7 @@ import {
 	estimateTokens,
 	calculatePromptTokensFromMessages,
 	estimateTokensFromContent,
-} from "../chat/chat";
+} from "@/chat/chat";
 
 describe("Prompt token calculation", () => {
 	describe("estimateTokensFromContent", () => {

--- a/apps/gateway/src/models/index.ts
+++ b/apps/gateway/src/models/index.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 
 import { modelsApi } from "./models";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const models = new OpenAPIHono<ServerTypes>();
 

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -9,7 +9,7 @@ import {
 	type ModelDefinition,
 } from "@llmgateway/models";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const modelsApi = new OpenAPIHono<ServerTypes>();
 

--- a/apps/gateway/src/test-utils/test-helpers.ts
+++ b/apps/gateway/src/test-utils/test-helpers.ts
@@ -1,6 +1,7 @@
 import { redisClient } from "@llmgateway/cache";
 import { db } from "@llmgateway/db";
 
+// eslint-disable-next-line no-relative-import-paths/no-relative-import-paths
 import { processLogQueue } from "../../../worker/src/worker";
 
 export { getProviderEnvVar } from "../lib/provider";

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { allBlogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Image from "next/image";
@@ -8,6 +7,8 @@ import { notFound } from "next/navigation";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
+
+import { allBlogs } from "content-collections";
 
 import type { Blog } from "content-collections";
 

--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { allBlogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Image from "next/image";
@@ -7,8 +8,6 @@ import { notFound } from "next/navigation";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
-
-import { allBlogs } from "content-collections";
 
 import type { Blog } from "content-collections";
 

--- a/apps/ui/src/app/changelog/[slug]/page.tsx
+++ b/apps/ui/src/app/changelog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { allChangelogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Image from "next/image";
@@ -7,8 +8,6 @@ import { notFound } from "next/navigation";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
-
-import { allChangelogs } from "content-collections";
 
 import type { Changelog } from "content-collections";
 

--- a/apps/ui/src/app/changelog/[slug]/page.tsx
+++ b/apps/ui/src/app/changelog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { allChangelogs } from "content-collections";
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Image from "next/image";
@@ -8,6 +7,8 @@ import { notFound } from "next/navigation";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
+
+import { allChangelogs } from "content-collections";
 
 import type { Changelog } from "content-collections";
 

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
+import { LogCard } from "@/components/dashboard/log-card";
 import {
 	type DateRange,
 	DateRangeSelect,
@@ -19,8 +20,6 @@ import {
 import { useApi } from "@/lib/fetch-client";
 
 import { models, providers } from "@llmgateway/models";
-
-import { LogCard } from "../dashboard/log-card";
 
 import type { Log } from "@llmgateway/db";
 

--- a/apps/ui/src/components/compare/hero-compare.tsx
+++ b/apps/ui/src/components/compare/hero-compare.tsx
@@ -4,9 +4,8 @@ import React from "react";
 
 import { AnimatedGroup } from "@/components/landing/animated-group";
 import { Navbar } from "@/components/landing/navbar";
+import { AuthLink } from "@/components/shared/auth-link";
 import { Button } from "@/lib/components/button";
-
-import { AuthLink } from "../shared/auth-link";
 
 const transitionVariants = {
 	item: {

--- a/apps/ui/src/components/landing/comparison.tsx
+++ b/apps/ui/src/components/landing/comparison.tsx
@@ -2,10 +2,9 @@
 import { Check, X } from "lucide-react";
 import Link from "next/link";
 
+import { AuthLink } from "@/components/shared/auth-link";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
-
-import { AuthLink } from "../shared/auth-link";
 
 const comparisonData = [
 	{

--- a/apps/ui/src/components/landing/cta.tsx
+++ b/apps/ui/src/components/landing/cta.tsx
@@ -1,8 +1,7 @@
 "use client";
+import { AuthLink } from "@/components/shared/auth-link";
 import { Button } from "@/lib/components/button";
 import { useAppConfig } from "@/lib/config";
-
-import { AuthLink } from "../shared/auth-link";
 
 export default function CallToAction() {
 	const config = useAppConfig();

--- a/apps/ui/src/components/landing/hero.tsx
+++ b/apps/ui/src/components/landing/hero.tsx
@@ -7,6 +7,11 @@ import { useTheme } from "next-themes";
 import { Highlight, themes } from "prism-react-renderer";
 import { useEffect, useState } from "react";
 
+import {
+	providerLogoUrls,
+	getProviderLogoDarkModeClasses,
+} from "@/components/provider-keys/provider-logo";
+import { AuthLink } from "@/components/shared/auth-link";
 import { Button } from "@/lib/components/button";
 import { toast } from "@/lib/components/use-toast";
 import { useAppConfig } from "@/lib/config";
@@ -14,11 +19,6 @@ import { cn } from "@/lib/utils";
 
 import { AnimatedGroup } from "./animated-group";
 import { Navbar } from "./navbar";
-import {
-	providerLogoUrls,
-	getProviderLogoDarkModeClasses,
-} from "../provider-keys/provider-logo";
-import { AuthLink } from "../shared/auth-link";
 
 import type { ProviderId } from "@llmgateway/models";
 import type { Language, Token } from "prism-react-renderer";

--- a/apps/ui/src/components/onboarding/provider-key-step.tsx
+++ b/apps/ui/src/components/onboarding/provider-key-step.tsx
@@ -5,8 +5,17 @@ import * as React from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { ProviderSelect } from "@/components/provider-keys/provider-select";
 import { UpgradeToProDialog } from "@/components/shared/upgrade-to-pro-dialog";
 import { useDefaultOrganization } from "@/hooks/useOrganization";
+import { Button } from "@/lib/components/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/lib/components/card";
 import {
 	Form,
 	FormControl,
@@ -16,22 +25,12 @@ import {
 	FormMessage,
 } from "@/lib/components/form";
 import { Input } from "@/lib/components/input";
+import { Step } from "@/lib/components/stepper";
 import { toast } from "@/lib/components/use-toast";
 import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
 
 import { providers } from "@llmgateway/models";
-
-import { Button } from "../../lib/components/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "../../lib/components/card";
-import { Step } from "../../lib/components/stepper";
-import { ProviderSelect } from "../provider-keys/provider-select";
 
 const formSchema = z.object({
 	provider: z.string().min(1, "Provider is required"),

--- a/apps/ui/src/components/onboarding/welcome-step.tsx
+++ b/apps/ui/src/components/onboarding/welcome-step.tsx
@@ -1,15 +1,15 @@
 import { Rocket } from "lucide-react";
 import * as React from "react";
 
-import { useAuth } from "../../lib/auth-client";
+import { useAuth } from "@/lib/auth-client";
 import {
 	Card,
 	CardContent,
 	CardDescription,
 	CardHeader,
 	CardTitle,
-} from "../../lib/components/card";
-import { Step } from "../../lib/components/stepper";
+} from "@/lib/components/card";
+import { Step } from "@/lib/components/stepper";
 
 export function WelcomeStep() {
 	const { useSession } = useAuth();

--- a/apps/ui/src/components/playground/sidebar.tsx
+++ b/apps/ui/src/components/playground/sidebar.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 
+import { ModeToggle } from "@/components/mode-toggle";
 import {
 	useChats,
 	useDeleteChat,
@@ -44,8 +45,6 @@ import {
 } from "@/lib/components/sidebar";
 import { toast } from "@/lib/components/use-toast";
 import Logo from "@/lib/icons/Logo";
-
-import { ModeToggle } from "../mode-toggle";
 
 interface ChatSidebarProps {
 	currentChatId?: string;

--- a/apps/ui/src/components/providers/hero.tsx
+++ b/apps/ui/src/components/providers/hero.tsx
@@ -1,4 +1,5 @@
 import { providerLogoUrls } from "@/components/provider-keys/provider-logo";
+import { AuthLink } from "@/components/shared/auth-link";
 import { Button } from "@/lib/components/button";
 import Logo from "@/lib/icons/Logo";
 
@@ -6,8 +7,6 @@ import {
 	providers as providerDefinitions,
 	type ProviderId,
 } from "@llmgateway/models";
-
-import { AuthLink } from "../shared/auth-link";
 
 interface HeroProps {
 	providerId: ProviderId;

--- a/apps/ui/src/lib/components/stepper.tsx
+++ b/apps/ui/src/lib/components/stepper.tsx
@@ -1,7 +1,8 @@
 import { Check } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "../utils";
+import { cn } from "@/lib/utils";
+
 import { Button } from "./button";
 import { Progress } from "./progress";
 

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,15 @@
 import lint from "@steebchen/lint-next";
 import importPlugin from "eslint-plugin-import";
+import noRelativeImportPathsPlugin from "eslint-plugin-no-relative-import-paths";
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
 	...lint,
 	{
+		ignores: ["**/tsup.config.ts"],
 		plugins: {
 			import: importPlugin,
+			"no-relative-import-paths": noRelativeImportPathsPlugin,
 		},
 		settings: {
 			"import/resolver": {
@@ -79,6 +82,13 @@ export default [
 					pathGroupsExcludedImportTypes: ["builtin", "type"],
 				},
 			],
+			"no-relative-import-paths/no-relative-import-paths": [
+				"error",
+				{
+					allowSameFolder: true,
+					prefix: "@",
+				},
+			],
 		},
 	},
 	{
@@ -96,12 +106,6 @@ export default [
 			"no-console": "off",
 		},
 	},
-	// {
-	// 	files: ["**/*.{ts,tsx}"],
-	// 	rules: {
-	// 		"import/no-relative-parent-imports": "error",
-	// 	},
-	// },
 	{
 		ignores: [
 			"**/.tanstack/",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"eslint": "^9.34.0",
 		"eslint-import-resolver-typescript": "4.4.4",
 		"eslint-plugin-import": "2.32.0",
+		"eslint-plugin-no-relative-import-paths": "1.6.1",
 		"husky": "^9.1.7",
 		"lint-staged": "16.0.0",
 		"nodemon": "3.1.10",

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/instrumentation/tsconfig.json
+++ b/packages/instrumentation/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { logger, createLogger } from ".";
+import { logger, createLogger } from "@/index";
 
 describe("LLMGateway Logger", () => {
 	beforeEach(() => {

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.5.1))
+      eslint-plugin-no-relative-import-paths:
+        specifier: 1.6.1
+        version: 1.6.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -5569,6 +5572,9 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-no-relative-import-paths@1.6.1:
+    resolution: {integrity: sha512-YZNeOnsOrJcwhFw0X29MXjIzu2P/f5X2BZDPWw1R3VUYBRFxNIh77lyoL/XrMU9ewZNQPcEvAgL/cBOT1P330A==}
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -14133,6 +14139,8 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-no-relative-import-paths@1.6.1: {}
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.28.0(jiti@2.5.1)):
     dependencies:


### PR DESCRIPTION
Simplifies import paths across the gateway app by using base alias `@` for direct references. Updates `tsconfig.json` to include alias configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enforced model access controls with clearer error responses.
  - Cost accounting and richer request/response logging surface cost and token usage.
  - Free-tier rate limiting added; responses include rate-limit headers and return 429 when exceeded.

- Changes
  - All API routes now require authentication; unauthenticated requests receive 401 Unauthorized.

- Chores
  - Standardized absolute import paths and added TypeScript path aliases.
  - Introduced a lint rule to prevent disallowed relative imports.

- Tests
  - Updated tests to use the new import paths; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->