### PR TITLE
feat(worker): add logging

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -45,6 +45,12 @@ const schema = z.object({
 	api_key_id: z.string(),
 	project_mode: z.enum(["api-keys", "credits", "hybrid"]),
 	used_mode: z.enum(["api-keys", "credits"]),
+	duration: z.number(),
+	requested_model: z.string(),
+	requested_provider: z.string().nullable(),
+	used_model: z.string(),
+	used_provider: z.string(),
+	response_size: z.number(),
 });
 
 export async function acquireLock(key: string): Promise<boolean> {
@@ -297,6 +303,12 @@ async function batchProcessLogs(): Promise<void> {
 					api_key_id: log.apiKeyId,
 					project_mode: tables.project.mode,
 					used_mode: log.usedMode,
+					duration: log.duration,
+					requested_model: log.requestedModel,
+					requested_provider: log.requestedProvider,
+					used_model: log.usedModel,
+					used_provider: log.usedProvider,
+					response_size: log.responseSize,
 				})
 				.from(log)
 				.leftJoin(tables.project, eq(tables.project.id, log.projectId))
@@ -333,6 +345,12 @@ async function batchProcessLogs(): Promise<void> {
 					apiKeyId: row.api_key_id,
 					projectMode: row.project_mode,
 					usedMode: row.used_mode,
+					duration: row.duration,
+					requestedModel: row.requested_model,
+					requestedProvider: row.requested_provider,
+					usedModel: row.used_model,
+					usedProvider: row.used_provider,
+					responseSize: row.response_size,
 				});
 
 				if (row.cost && row.cost > 0 && !row.cached) {


### PR DESCRIPTION
## Summary
- Enhances logging in the worker service by adding new fields to capture detailed request and response metadata
- Tracks duration, requested and used model/provider, and response size for each log entry

## Changes

### Worker Logging Enhancements
- Extended the log schema to include:
  - `duration`: time taken for the request
  - `requested_model`: model initially requested
  - `requested_provider`: provider initially requested (nullable)
  - `used_model`: model actually used
  - `used_provider`: provider actually used
  - `response_size`: size of the response
- Updated batch processing of logs to include these new fields when inserting and reading logs

## Test plan
- [ ] Verify logs contain the new fields with correct values
- [ ] Confirm no regressions in existing log processing
- [ ] Test with various request scenarios to ensure accurate capture of model/provider and duration data

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e36739a8-1f68-4807-b3e3-e94a27c06e4b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced usage logs with additional fields: duration, requested model/provider, used model/provider, and response size. These details are now included in per-log entries and batch outputs, improving observability and analytics.

- Chores
  - Internal logging pipeline updated to propagate the new fields end-to-end without changing existing cost calculations or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->