### PR TITLE
chore(models): update deactivation date

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -27,7 +27,7 @@ export const googleModels = [
 		name: "Gemini 2.5 Pro Preview (05-06)",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-07-15"),
 		providers: [
 			{
 				providerId: "google-ai-studio",
@@ -48,7 +48,7 @@ export const googleModels = [
 		name: "Gemini 2.5 Pro Preview (06-05)",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-07-15"),
 		providers: [
 			{
 				providerId: "google-ai-studio",
@@ -69,7 +69,7 @@ export const googleModels = [
 		name: "Gemini 2.5 Flash Preview (04-17)",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: new Date("2025-07-22"),
+		deactivatedAt: new Date("2025-07-15"),
 		providers: [
 			{
 				providerId: "google-ai-studio",
@@ -90,7 +90,7 @@ export const googleModels = [
 		name: "Gemini 2.5 Flash Preview (05-20)",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-07-15"),
 		providers: [
 			{
 				providerId: "google-ai-studio",


### PR DESCRIPTION
## Summary
- Updates the `deactivatedAt` field for Gemini 2.5 preview models in the Google family
- Sets the deactivation date to July 15, 2025 for all relevant Gemini 2.5 preview variants

## Changes

### Model Updates
- **Gemini 2.5 Pro Preview (05-06)**: `deactivatedAt` changed from `undefined` to `2025-07-15`
- **Gemini 2.5 Pro Preview (06-05)**: `deactivatedAt` changed from `undefined` to `2025-07-15`
- **Gemini 2.5 Flash Preview (04-17)**: `deactivatedAt` changed from `2025-07-22` to `2025-07-15`
- **Gemini 2.5 Flash Preview (05-20)**: `deactivatedAt` changed from `undefined` to `2025-07-15`

## Test plan
- [x] Verify that the `deactivatedAt` dates are correctly set in the model definitions
- [x] Confirm no unintended changes to other model properties
- [x] Ensure that the new deactivation date aligns with product lifecycle expectations

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b6062349-f98b-44c4-98c3-0df4f8f0bdd9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated deactivation date to July 15, 2025 for the following Google Gemini preview models:
    - gemini-2.5-pro-preview-05-06
    - gemini-2.5-pro-preview-06-05
    - gemini-2.5-flash-preview-05-20
    - gemini-2.5-flash-preview-04-17-thinking (moved earlier from July 22, 2025)
  - Impact: These models will stop being available after July 15, 2025. Please plan to migrate to supported alternatives before this date to avoid service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->