### PR TITLE
feat(models): conditionally enable responses API

### DIFF
--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -443,8 +443,9 @@ export async function prepareRequestBody(
 				(p) => p.providerId === "openai",
 			);
 			const supportsResponsesApi =
+				process.env.USE_RESPONSES_API === "true" &&
 				(providerMapping as ProviderModelMapping)?.supportsResponsesApi !==
-				false;
+					false;
 
 			if (supportsReasoning && supportsResponsesApi && !hasExistingToolCalls) {
 				// Transform to responses API format (only when no existing tool calls)
@@ -871,7 +872,12 @@ export function getProviderEndpoint(
 		case "openai":
 			// Use responses endpoint for reasoning models that support responses API
 			// but not when there are existing tool calls in the conversation
-			if (supportsReasoning && model && !hasExistingToolCalls) {
+			if (
+				supportsReasoning &&
+				model &&
+				!hasExistingToolCalls &&
+				process.env.USE_RESPONSES_API === "true"
+			) {
 				const modelDef = models.find((m) => m.id === model);
 				const providerMapping = modelDef?.providers.find(
 					(p) => p.providerId === "openai",


### PR DESCRIPTION
Adds an environment check (`USE_RESPONSES_API`) to conditionally enable the responses API for OpenAI's reasoning models. Includes placeholder for potential integration despite current disabled functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in configuration for OpenAI Responses API
* **Chores**
  * Introduced environment-based configuration for API routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->