### PR TITLE
fix(activity-log): display tool calls

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -28,6 +28,7 @@ const UnifiedFinishReason = {
 	COMPLETED: "completed",
 	LENGTH_LIMIT: "length_limit",
 	CONTENT_FILTER: "content_filter",
+	TOOL_CALLS: "tool_calls",
 	GATEWAY_ERROR: "gateway_error",
 	UPSTREAM_ERROR: "upstream_error",
 	CANCELED: "canceled",

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -54,7 +54,10 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 		StatusIcon = AlertCircle;
 		color = "text-red-500";
 		bgColor = "bg-red-100";
-	} else if (log.unifiedFinishReason !== "completed") {
+	} else if (
+		log.unifiedFinishReason !== "completed" &&
+		log.unifiedFinishReason !== "tool_calls"
+	) {
 		StatusIcon = AlertCircle;
 		color = "text-yellow-500";
 		bgColor = "bg-yellow-100";
@@ -71,7 +74,16 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 				<div className="flex-1 space-y-1 min-w-0">
 					<div className="flex items-start justify-between gap-4">
 						<p className="font-medium break-words max-w-none line-clamp-2">
-							{log.content || <i className="italic">–</i>}
+							{log.content ||
+								(log.unifiedFinishReason === "tool_calls" && log.toolResults ? (
+									Array.isArray(log.toolResults) ? (
+										`Tool calls: ${log.toolResults.map((tr) => tr.function?.name || "unknown").join(", ")}`
+									) : (
+										"Tool calls executed"
+									)
+								) : (
+									<i className="italic">–</i>
+								))}
 						</p>
 						<Badge
 							variant={log.hasError ? "destructive" : "default"}


### PR DESCRIPTION
## Summary
- Adds support for displaying tool call activities in the activity log and dashboard log card
- Ensures tool call finish reason is recognized and rendered properly
- Improves clarity by showing tool call function names or a generic message when tool results exist

## Changes

### Activity Log Component
- Added `TOOL_CALLS` to `UnifiedFinishReason` enum in `recent-logs.tsx` to represent tool call finish reason

### Dashboard Log Card Component
- Updated `LogCard` to treat `tool_calls` as a distinct finish reason that does not show warning styling
- Enhanced log content rendering to display tool call function names if available, or a fallback message "Tool calls executed"
- Maintains existing styling and error handling for other finish reasons

## Test plan
- [x] Verify that logs with `unifiedFinishReason` set to `tool_calls` display the tool call names or fallback message
- [x] Confirm that tool call logs do not show warning colors or icons
- [x] Check that other log types render as before without regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/48676a5f-7c45-4631-abbc-15ee5585c3af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new “Tool calls” finish reason to the activity filters and API queries.
  - Enhanced log cards to display a concise summary of executed tool calls when message content is absent.

- Bug Fixes
  - Adjusted status coloring so logs ending due to tool calls are no longer flagged with a warning state.

- Chores
  - Minor UI logic updates to better handle tool-call results without changing other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->