### PR TITLE
fix(providers): add support for ZAI payloads

### DIFF
--- a/packages/models/src/provider-api.ts
+++ b/packages/models/src/provider-api.ts
@@ -524,6 +524,40 @@ export async function prepareRequestBody(
 			}
 			break;
 		}
+		case "zai": {
+			if (stream) {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+			if (response_format) {
+				requestBody.response_format = response_format;
+			}
+
+			// Add optional parameters if they are provided
+			if (temperature !== undefined) {
+				requestBody.temperature = temperature;
+			}
+			if (max_tokens !== undefined) {
+				requestBody.max_tokens = max_tokens;
+			}
+			if (top_p !== undefined) {
+				requestBody.top_p = top_p;
+			}
+			if (frequency_penalty !== undefined) {
+				requestBody.frequency_penalty = frequency_penalty;
+			}
+			if (presence_penalty !== undefined) {
+				requestBody.presence_penalty = presence_penalty;
+			}
+			// ZAI/GLM models use 'thinking' parameter for reasoning instead of 'reasoning_effort'
+			if (supportsReasoning) {
+				requestBody.thinking = {
+					type: "enabled",
+				};
+			}
+			break;
+		}
 		case "xai":
 		case "groq":
 		case "deepseek":
@@ -532,7 +566,6 @@ export async function prepareRequestBody(
 		case "moonshot":
 		case "alibaba":
 		case "nebius":
-		case "zai":
 		case "routeway":
 		case "custom": {
 			if (stream) {


### PR DESCRIPTION
Adds configuration and parameters specific to the ZAI reasoning models, including support for optional parameters (e.g., `temperature`, `max_tokens`) and a new `thinking` field to enable reasoning. Removes "zai" from the fallback provider case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced support for ZAI/GLM models with dedicated handling for improved reliability.
  - Streaming responses now include usage metrics.
  - Supports response formatting when specified.
  - Honors optional parameters: temperature, max tokens, top_p, frequency and presence penalties.
  - Enables reasoning via “thinking” for compatible models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->