### PR TITLE
feat(api): enhance reasoning content checks

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -628,10 +628,10 @@ describe("e2e", () => {
 			) as ProviderModelMapping;
 			const useResponsesApi = process.env.USE_RESPONSES_API === "true";
 			const isOpenAI = reasoningProvider?.providerId === "openai";
-			// When using the Responses API, only enforce reasoning_content checks for OpenAI.
+			// only enforce reasoning_content checks for where reasoningOutput is not "omit" and for openai, only if the responses api is used
 			if (
 				reasoningProvider?.reasoningOutput !== "omit" &&
-				(!useResponsesApi || isOpenAI)
+				(!isOpenAI || useResponsesApi)
 			) {
 				expect(json.choices[0].message).toHaveProperty("reasoning_content");
 			}
@@ -746,7 +746,7 @@ describe("e2e", () => {
 			// When using the Responses API, only enforce reasoning_content checks for OpenAI.
 			if (
 				reasoningProvider?.reasoningOutput !== "omit" &&
-				(!useResponsesApi || isOpenAI)
+				(!isOpenAI || useResponsesApi)
 			) {
 				const reasoningChunks = streamResult.chunks.filter(
 					(chunk: any) =>

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -625,9 +625,16 @@ describe("e2e", () => {
 			// check for reasoning response - only if the provider expects reasoning output
 			const reasoningProvider = providers?.find(
 				(p: ProviderModelMapping) => p.reasoning === true,
-			);
+			) as ProviderModelMapping;
 			if (
-				(reasoningProvider as ProviderModelMapping)?.reasoningOutput !== "omit"
+				reasoningProvider?.reasoningOutput !== "omit" &&
+				!(
+					// only enforce reasoning content checks for openai on the responses API
+					(
+						process.env.USE_RESPONSES_API === "true" &&
+						reasoningProvider?.providerId === "openai"
+					)
+				)
 			) {
 				expect(json.choices[0].message).toHaveProperty("reasoning_content");
 			}
@@ -736,9 +743,16 @@ describe("e2e", () => {
 			// Verify reasoning content is present in unified reasoning_content field - only if the provider expects reasoning output
 			const reasoningProvider = providers?.find(
 				(p: ProviderModelMapping) => p.reasoning === true,
-			);
+			) as ProviderModelMapping;
 			if (
-				(reasoningProvider as ProviderModelMapping)?.reasoningOutput !== "omit"
+				reasoningProvider?.reasoningOutput !== "omit" &&
+				!(
+					// only enforce reasoning content checks for openai on the responses API
+					(
+						process.env.USE_RESPONSES_API === "true" &&
+						reasoningProvider?.providerId === "openai"
+					)
+				)
 			) {
 				const reasoningChunks = streamResult.chunks.filter(
 					(chunk: any) =>

--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -626,15 +626,12 @@ describe("e2e", () => {
 			const reasoningProvider = providers?.find(
 				(p: ProviderModelMapping) => p.reasoning === true,
 			) as ProviderModelMapping;
+			const useResponsesApi = process.env.USE_RESPONSES_API === "true";
+			const isOpenAI = reasoningProvider?.providerId === "openai";
+			// When using the Responses API, only enforce reasoning_content checks for OpenAI.
 			if (
 				reasoningProvider?.reasoningOutput !== "omit" &&
-				!(
-					// only enforce reasoning content checks for openai on the responses API
-					(
-						process.env.USE_RESPONSES_API === "true" &&
-						reasoningProvider?.providerId === "openai"
-					)
-				)
+				(!useResponsesApi || isOpenAI)
 			) {
 				expect(json.choices[0].message).toHaveProperty("reasoning_content");
 			}
@@ -744,15 +741,12 @@ describe("e2e", () => {
 			const reasoningProvider = providers?.find(
 				(p: ProviderModelMapping) => p.reasoning === true,
 			) as ProviderModelMapping;
+			const useResponsesApi = process.env.USE_RESPONSES_API === "true";
+			const isOpenAI = reasoningProvider?.providerId === "openai";
+			// When using the Responses API, only enforce reasoning_content checks for OpenAI.
 			if (
 				reasoningProvider?.reasoningOutput !== "omit" &&
-				!(
-					// only enforce reasoning content checks for openai on the responses API
-					(
-						process.env.USE_RESPONSES_API === "true" &&
-						reasoningProvider?.providerId === "openai"
-					)
-				)
+				(!useResponsesApi || isOpenAI)
 			) {
 				const reasoningChunks = streamResult.chunks.filter(
 					(chunk: any) =>


### PR DESCRIPTION
Conditionally enforce reasoning content validation for OpenAI responses when `USE_RESPONSES_API` is enabled. Prevent unnecessary checks for other providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end reasoning tests to better handle provider-specific behavior.
  * Applies the same gating to streaming and non-streaming checks so reasoning content is only asserted when appropriate for the provider and configuration.
  * Skips reasoning content assertions for OpenAI when the Responses API is not enabled; other providers retain prior behavior.
  * No changes to public APIs or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->