### PR TITLE
Refactor imports to use alias '@/' and update tsconfig paths

### DIFF
--- a/apps/api/src/auth/handler.ts
+++ b/apps/api/src/auth/handler.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 
 import { apiAuth } from "./config";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 // Create a Hono app for auth routes
 export const authHandler = new OpenAPIHono<ServerTypes>();

--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("activity endpoint", () => {
 	let token: string;

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { db } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const activity = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/beacon.spec.ts
+++ b/apps/api/src/routes/beacon.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { posthog } from "@/posthog";
+
 import { app } from "..";
-import { posthog } from "../posthog";
 
 // Mock PostHog
-vi.mock("../posthog", () => ({
+vi.mock("@/posthog", () => ({
 	posthog: {
 		capture: vi.fn(),
 	},

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -1,11 +1,11 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
+import { posthog } from "@/posthog";
+
 import { logger } from "@llmgateway/logger";
 
-import { posthog } from "../posthog";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const beacon = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { logger } from "@llmgateway/logger";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 const chat = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/chats.ts
+++ b/apps/api/src/routes/chats.ts
@@ -1,11 +1,11 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 
+import { hasActiveApiKey } from "@/lib/hasActiveApiKey";
+
 import { db, tables, desc, eq, count, and } from "@llmgateway/db";
 
-import { hasActiveApiKey } from "../lib/hasActiveApiKey";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 const chats = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,5 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 
+import { apiAuth as auth } from "@/auth/config";
+
 import { activity } from "./activity";
 import { chat } from "./chat";
 import { chats } from "./chats";
@@ -11,9 +13,8 @@ import { payments } from "./payments";
 import projects from "./projects";
 import { subscriptions } from "./subscriptions";
 import { user } from "./user";
-import { apiAuth as auth } from "../auth/config";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const routes = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, beforeEach, describe, afterEach } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("keys route", () => {
 	let token: string;

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -2,11 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "@/lib/maskToken";
+
 import { eq, db, shortid, tables } from "@llmgateway/db";
 
-import { maskToken } from "../lib/maskToken";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const keysApi = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -8,6 +8,8 @@ import {
 	type TestOptions,
 } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 import {
 	models,
@@ -17,7 +19,6 @@ import {
 
 import { app } from "..";
 import { getProviderEnvVar } from "../../../gateway/src/test-utils/test-helpers";
-import { createTestUser, deleteAll } from "../testing";
 
 function getTestOptions(): TestOptions {
 	const hasTestOnly = models.some((model) =>

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, beforeEach, describe, afterEach } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("provider keys route", () => {
 	let token: string;

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -2,12 +2,12 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "@/lib/maskToken";
+
 import { db, eq, tables } from "@llmgateway/db";
 import { providers, validateProviderKey } from "@llmgateway/models";
 
-import { maskToken } from "../lib/maskToken";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 import type { ProviderId } from "@llmgateway/models";
 
 export const keysProvider = new OpenAPIHono<ServerTypes>();

--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
+import { createTestUser, deleteAll } from "@/testing";
+
 import { db, tables } from "@llmgateway/db";
 
 import { app } from "..";
-import { createTestUser, deleteAll } from "../testing";
 
 describe("logs route", () => {
 	let token: string;

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -22,7 +22,7 @@ import {
 	tools,
 } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const logs = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { db, eq, tables } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const organization = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -3,12 +3,12 @@ import { HTTPException } from "hono/http-exception";
 import Stripe from "stripe";
 import { z } from "zod";
 
+import { ensureStripeCustomer } from "@/stripe";
+
 import { db, eq, tables } from "@llmgateway/db";
 import { calculateFees } from "@llmgateway/shared";
 
-import { ensureStripeCustomer } from "../stripe";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const stripe = new Stripe(
 	process.env.STRIPE_SECRET_KEY || "sk_test_123",

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { db, eq, tables } from "@llmgateway/db";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const projects = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -2,13 +2,14 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { ensureStripeCustomer } from "@/stripe";
+
 import { db } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
-import { ensureStripeCustomer } from "../stripe";
 import { stripe } from "./payments";
 
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const subscriptions = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -2,11 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { apiAuth as auth } from "@/auth/config";
+
 import { db, eq, tables } from "@llmgateway/db";
 
-import { apiAuth as auth } from "../auth/config";
-
-import type { ServerTypes } from "../vars";
+import type { ServerTypes } from "@/vars";
 
 export const user = new OpenAPIHono<ServerTypes>();
 

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/instrumentation/tsconfig.json
+++ b/packages/instrumentation/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { logger, createLogger } from ".";
+import { logger, createLogger } from "@/index";
 
 describe("LLMGateway Logger", () => {
 	beforeEach(() => {

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"paths": {
+			"@/*": ["./src/*"],
 			"@llmgateway/*": ["../../packages/*/src"]
 		}
 	},


### PR DESCRIPTION
## Summary
- Refactor import statements across multiple files to use the alias `@/` instead of relative paths
- Update `tsconfig.json` files in apps and packages to include path mapping for `@/*` to `./src/*`

## Changes

### Import Refactoring
- Changed imports in API routes, auth handler, tests, and other modules to use `@/` alias for cleaner and more maintainable code
- Updated imports for modules like `vars`, `posthog`, `lib` utilities, `auth/config`, and others to use the new alias

### TypeScript Configuration
- Added path alias `@/*` in `tsconfig.json` files for `apps/api`, `apps/worker`, and multiple packages (`cache`, `db`, `instrumentation`, `logger`, `models`, `shared`)
- This enables consistent and simplified import paths throughout the repository

## Test plan
- Verified that all tests pass after import path changes
- Ensured no runtime import errors occur due to path aliasing
- Confirmed that the project builds successfully with updated `tsconfig` settings

This refactor improves code readability and maintainability by standardizing import paths across the project.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ca0308e5-0754-40ba-abb6-380964936df3