### PR TITLE
refactor(tests): rename timeout option

### DIFF
--- a/apps/gateway/src/api.e2e.ts
+++ b/apps/gateway/src/api.e2e.ts
@@ -1,5 +1,12 @@
 import "dotenv/config";
-import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	type TestOptions,
+} from "vitest";
 
 import { db, tables } from "@llmgateway/db";
 import {
@@ -23,8 +30,8 @@ function generateTestRequestId(): string {
 }
 
 // Helper function to get test options with retry for CI environment
-function getTestOptions() {
-	return process.env.CI ? { retry: 3, testTimeout: 120000 } : {};
+function getTestOptions(): TestOptions {
+	return process.env.CI ? { retry: 3, timeout: 120000 } : {};
 }
 
 console.log("running with test options:", getTestOptions());

--- a/apps/gateway/src/log-queue.e2e.ts
+++ b/apps/gateway/src/log-queue.e2e.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, type TestOptions } from "vitest";
 
 import { db, tables } from "@llmgateway/db";
 
@@ -11,8 +11,8 @@ import {
 } from "./test-utils/test-helpers";
 
 // Helper function to get test options with retry for CI environment
-function getTestOptions() {
-	return process.env.CI ? { retry: 3, testTimeout: 120000 } : {};
+function getTestOptions(): TestOptions {
+	return process.env.CI ? { retry: 3, timeout: 120000 } : {};
 }
 
 describe("Log Queue Processing E2E", () => {


### PR DESCRIPTION
## Summary
- Added explicit typing for `getTestOptions` function returning `TestOptions` from Vitest
- Renamed `testTimeout` option to `timeout` in test options for consistency
- Applied changes to both `api.e2e.ts` and `log-queue.e2e.ts` test files

## Changes

### Test Configuration
- Imported `type TestOptions` from Vitest to type the `getTestOptions` function
- Updated `getTestOptions` to return `TestOptions` type
- Changed test option key from `testTimeout` to `timeout` to match Vitest's expected option name

### Files Updated
- `apps/gateway/src/api.e2e.ts`
- `apps/gateway/src/log-queue.e2e.ts`

## Test plan
- Verified that tests run with retry and timeout options correctly applied in CI environment
- Ensured no regressions in test execution behavior after renaming option
- Confirmed type safety improvements with explicit typing of test options function

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d79fd35c-148e-4daf-8122-e78a8aa0c441