### PR TITLE
feat(ci): add auto-merge GitHub Action

### DIFF
--- a/.github/workflows/auto-merge-label.yml
+++ b/.github/workflows/auto-merge-label.yml
@@ -1,0 +1,45 @@
+name: Auto Merge on Label
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: contains(github.event.label.name, 'auto-merge')
+    permissions:
+      pull-requests: write
+      contents: write
+      checks: read
+    steps:
+      - name: Wait for checks to complete
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: wait-for-checks
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: e2e
+          ref: ${{ github.event.pull_request.head.sha }}
+          timeoutSeconds: 1800 # 30 minutes
+          intervalSeconds: 30
+
+      - name: Auto merge if e2e check passes
+        if: steps.wait-for-checks.outputs.conclusion == 'success'
+        uses: pascalgn/merge-action@v0.15.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          merge_method: squash
+          merge_commit_title: ${{ github.event.pull_request.title }}
+          merge_commit_message: ${{ github.event.pull_request.body }}
+
+      - name: Comment on failure
+        if: steps.wait-for-checks.outputs.conclusion != 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ Auto-merge failed: e2e check did not pass (status: ${{ steps.wait-for-checks.outputs.conclusion }}). Please ensure e2e tests are passing before using the auto-merge label.'
+            })


### PR DESCRIPTION
## Summary
- Introduces a new GitHub Actions workflow to automatically merge pull requests labeled with `auto-merge` after successful end-to-end (e2e) tests
- Automates the merge process using squash merge method
- Adds failure notification comment if e2e checks do not pass within the timeout period

## Changes

### GitHub Actions Workflow
- Created `.github/workflows/auto-merge-label.yml` workflow triggered on PR label events
- Workflow waits for the `e2e` check to complete with a 30-minute timeout
- If the `e2e` check passes, the PR is automatically merged using the squash method
- If the `e2e` check fails or times out, a comment is posted on the PR notifying about the failure and advising to ensure tests pass before using the label

## Test plan
- [ ] Label a PR with `auto-merge` and verify the workflow waits for e2e checks
- [ ] Confirm PR is auto-merged on successful e2e check
- [ ] Confirm failure comment is posted if e2e check fails or times out
- [ ] Validate permissions and token usage for merge and commenting actions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1585d120-6672-40e8-8298-51001bede11e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced an automated PR merge workflow triggered by applying the “auto-merge” label. The system waits for end-to-end tests to complete and, on success, performs a squash merge using the PR title and description.
  - If checks fail or don’t complete, it posts a comment explaining that auto-merge didn’t proceed and advises ensuring E2E tests pass before using the label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->