### PR TITLE
fix: spacing in YAML comment

### DIFF
--- a/.github/workflows/auto-merge-label.yml
+++ b/.github/workflows/auto-merge-label.yml
@@ -23,4 +23,4 @@ jobs:
           MERGE_REQUIRED_APPROVALS: "0"
           MERGE_DELETE_BRANCH: "true"
           MERGE_READY_STATE: "ready_for_review,clean"
-          LOG: "TRACE"  # or "DEBUG"
+          LOG: "TRACE" # or "DEBUG"


### PR DESCRIPTION
## Summary
- Corrects spacing in a comment within the `.github/workflows/auto-merge-label.yml` file

## Changes

### Workflow Configuration
- Adjusted spacing after `#` in the `LOG` comment from `# or "DEBUG"` to `# or "DEBUG"` (removed trailing space)

## Test plan
- Verified YAML syntax remains valid
- Confirmed no functional changes to the workflow behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ceca8ed2-4454-42d4-bc6c-e9be9b33ceb7