### PR TITLE
Skip E2E tests for Dependabot PRs in GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,7 +80,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: e2e-shards
-    if: always()
+    if: always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Modifies the GitHub Actions workflow to skip end-to-end (E2E) tests for pull requests created by Dependabot
- Ensures E2E tests only run for PRs originating from the main repository and not from Dependabot's forked branches

## Changes

### CI Workflow
- Updated `.github/workflows/e2e.yml`:
  - Changed the condition for the `e2e` job to run only if the actor is not `dependabot[bot]` and the PR head repository matches the main repository
  - This prevents unnecessary E2E test runs on Dependabot automated dependency update PRs

## Test plan
- Verified that E2E tests do not run for Dependabot PRs
- Confirmed E2E tests still run for regular PRs from the main repository
- Checked GitHub Actions logs to ensure the conditional logic behaves as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4150d18a-1564-4e43-93ec-ba66f13416aa