### PR TITLE
fix: preserve reasoning content by mapping to thought instead of text

### DIFF
--- a/apps/gateway/src/chat/tools/extract-reasoning.ts
+++ b/apps/gateway/src/chat/tools/extract-reasoning.ts
@@ -20,7 +20,7 @@ export function extractReasoning(data: any, provider: Provider): string {
 		case "google-ai-studio": {
 			const parts = data.candidates?.[0]?.content?.parts || [];
 			const reasoningParts = parts.filter((part: any) => part.thought);
-			return reasoningParts.map((part: any) => part.text).join("") || "";
+			return reasoningParts.map((part: any) => part.thought).join("") || "";
 		}
 		default: // OpenAI format
 			return (


### PR DESCRIPTION
## Summary
- Fixes the extraction of reasoning content for the Google AI Studio provider
- Corrects the mapping from `text` to `thought` to preserve the actual reasoning content

## Changes

### Core Functionality
- Updated `extractReasoning` function in `extract-reasoning.ts`
- Changed the mapping of reasoning parts from `part.text` to `part.thought` for Google AI Studio provider

## Test plan
- Verify that reasoning content is correctly extracted and preserved for Google AI Studio responses
- Ensure no regressions occur for other providers, especially the default OpenAI format

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6372edf4-617c-4123-8bc8-417a96141499