### PR TITLE
fix: include reasoning tokens

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1977,7 +1977,9 @@ chat.openapi(completions, async (c) => {
 
 							if (finalTotalTokens === null) {
 								finalTotalTokens =
-									(finalPromptTokens || 0) + (finalCompletionTokens || 0);
+									(finalPromptTokens || 0) +
+									(finalCompletionTokens || 0) +
+									(reasoningTokens || 0);
 							}
 
 							// Send final usage chunk before [DONE] if we have any usage data
@@ -2001,10 +2003,13 @@ chat.openapi(completions, async (c) => {
 									usage: {
 										prompt_tokens: Math.max(1, finalPromptTokens || 1),
 										completion_tokens: finalCompletionTokens || 0,
-										total_tokens: Math.max(
-											1,
-											finalTotalTokens || Math.max(1, finalPromptTokens || 1),
-										),
+										total_tokens: (() => {
+											const fallbackTotal =
+												(finalPromptTokens || 0) +
+												(finalCompletionTokens || 0) +
+												(reasoningTokens || 0);
+											return Math.max(1, finalTotalTokens ?? fallbackTotal);
+										})(),
 									},
 								};
 

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -54,10 +54,13 @@ export function transformResponseToOpenai(
 				usage: {
 					prompt_tokens: Math.max(1, promptTokens || 1),
 					completion_tokens: completionTokens || 0,
-					total_tokens: Math.max(
-						1,
-						totalTokens || Math.max(1, promptTokens || 1),
-					),
+					total_tokens: (() => {
+						const fallbackTotal =
+							(promptTokens || 0) +
+							(completionTokens || 0) +
+							(reasoningTokens || 0);
+						return Math.max(1, totalTokens ?? fallbackTotal);
+					})(),
 					...(reasoningTokens !== null && {
 						reasoning_tokens: reasoningTokens,
 					}),
@@ -105,10 +108,13 @@ export function transformResponseToOpenai(
 				usage: {
 					prompt_tokens: Math.max(1, promptTokens || 1),
 					completion_tokens: completionTokens || 0,
-					total_tokens: Math.max(
-						1,
-						totalTokens || Math.max(1, promptTokens || 1),
-					),
+					total_tokens: (() => {
+						const fallbackTotal =
+							(promptTokens || 0) +
+							(completionTokens || 0) +
+							(reasoningTokens || 0);
+						return Math.max(1, totalTokens ?? fallbackTotal);
+					})(),
 					...(reasoningTokens !== null && {
 						reasoning_tokens: reasoningTokens,
 					}),
@@ -153,10 +159,13 @@ export function transformResponseToOpenai(
 					usage: {
 						prompt_tokens: Math.max(1, promptTokens || 1),
 						completion_tokens: completionTokens || 0,
-						total_tokens: Math.max(
-							1,
-							totalTokens || Math.max(1, promptTokens || 1),
-						),
+						total_tokens: (() => {
+							const fallbackTotal =
+								(promptTokens || 0) +
+								(completionTokens || 0) +
+								(reasoningTokens || 0);
+							return Math.max(1, totalTokens ?? fallbackTotal);
+						})(),
 						...(reasoningTokens !== null && {
 							reasoning_tokens: reasoningTokens,
 						}),
@@ -217,10 +226,13 @@ export function transformResponseToOpenai(
 					usage: {
 						prompt_tokens: Math.max(1, promptTokens || 1),
 						completion_tokens: completionTokens || 0,
-						total_tokens: Math.max(
-							1,
-							totalTokens || Math.max(1, promptTokens || 1),
-						),
+						total_tokens: (() => {
+							const fallbackTotal =
+								(promptTokens || 0) +
+								(completionTokens || 0) +
+								(reasoningTokens || 0);
+							return Math.max(1, totalTokens ?? fallbackTotal);
+						})(),
 						...(reasoningTokens !== null && {
 							reasoning_tokens: reasoningTokens,
 						}),


### PR DESCRIPTION
## Summary
- Corrects the total tokens calculation by including `reasoningTokens` in the sum
- Applies this fix in both the main chat processing and the response transformation to OpenAI format

## Changes

### Token Calculation Fix
- Updated `finalTotalTokens` calculation in `chat.ts` to add `reasoningTokens` alongside prompt and completion tokens
- Modified total tokens fallback logic in `transform-response-to-openai.ts` to include `reasoningTokens` when computing total tokens
- Ensured `total_tokens` always reflects the sum of prompt, completion, and reasoning tokens, with a minimum of 1

## Test plan
- [ ] Verify that total tokens reported in chat completions include reasoning tokens
- [ ] Confirm that transformed OpenAI responses correctly sum all token types
- [ ] Check that no regressions occur in token usage reporting

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/17a10b36-857a-4ccd-9e75-78eb566cd5a3