### PR TITLE
feat(models): add new Qwen model, remove Llama model

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2,6 +2,29 @@ import type { ModelDefinition } from "@llmgateway/models";
 
 export const alibabaModels = [
 	{
+		id: "qwen3-next-80b-a3b-thinking-free",
+		name: "Qwen3 Next 80B A3B Thinking (Free)",
+		family: "meta",
+		free: true,
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				test: "only",
+				providerId: "cloudrift",
+				modelName: "Qwen/Qwen3-Next-80B-A3B-Thinking",
+				inputPrice: 0.0 / 1e6,
+				outputPrice: 0.0 / 1e6,
+				requestPrice: 0,
+				contextSize: 16380,
+				maxOutput: undefined,
+				streaming: true,
+				vision: false,
+				tools: false,
+			},
+		],
+	},
+	{
 		id: "qwen-max",
 		name: "Qwen Max",
 		family: "alibaba",

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -47,28 +47,6 @@ export const metaModels = [
 		],
 	},
 	{
-		id: "llama-3.1-70b-instruct-free",
-		name: "Meta Llama 3.1 70B Instruct FP8 (Free)",
-		family: "meta",
-		free: true,
-		deprecatedAt: undefined,
-		deactivatedAt: undefined,
-		providers: [
-			{
-				providerId: "cloudrift",
-				modelName: "meta-llama/Meta-Llama-3.1-70B-Instruct-FP8",
-				inputPrice: 0.0 / 1e6,
-				outputPrice: 0.0 / 1e6,
-				requestPrice: 0,
-				contextSize: 16380,
-				maxOutput: undefined,
-				streaming: true,
-				vision: false,
-				tools: false,
-			},
-		],
-	},
-	{
 		id: "llama-3.2-11b-instruct",
 		name: "Llama 3.2 11B Instruct",
 		family: "meta",


### PR DESCRIPTION
Added "Qwen3 Next 80B A3B Thinking" model to Alibaba with all associated configuration. Removed deprecated "Llama 3.1 70B Instruct FP8" model from Meta. Maintains provider and pricing information adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Qwen3 Next 80B Thinking (Free) under Alibaba. Supports streaming responses with ~16k context. No usage cost.

* Removals
  * Removed Meta Llama 3.1 70B Instruct (Free) from the catalog.

* Changes
  * Model list refreshed to reflect availability updates; existing paid models unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->