### PR TITLE
feat(health-checks): return 503 on failure

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -112,6 +112,30 @@ const root = createRoute({
 			},
 			description: "Health check response.",
 		},
+		503: {
+			content: {
+				"application/json": {
+					schema: z
+						.object({
+							message: z.string(),
+							version: z.string(),
+							health: z.object({
+								status: z.string(),
+								database: z.object({
+									connected: z.boolean(),
+									error: z.string().optional(),
+								}),
+								redis: z.object({
+									connected: z.boolean(),
+									error: z.string().optional(),
+								}),
+							}),
+						})
+						.openapi({}),
+				},
+			},
+			description: "Service unavailable - Redis or database connection failed.",
+		},
 	},
 });
 
@@ -146,11 +170,16 @@ app.openapi(root, async (c) => {
 		);
 	}
 
-	return c.json({
-		message: "OK",
-		version: process.env.APP_VERSION || "v0.0.0-unknown",
-		health,
-	});
+	const statusCode = health.status === "error" ? 503 : 200;
+
+	return c.json(
+		{
+			message: "OK",
+			version: process.env.APP_VERSION || "v0.0.0-unknown",
+			health,
+		},
+		statusCode,
+	);
 });
 
 app.route("/stripe", stripeRoutes);

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -43,6 +43,29 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Service unavailable - Redis or database connection failed. */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            version: string;
+                            health: {
+                                status: string;
+                                database: {
+                                    connected: boolean;
+                                    error?: string;
+                                };
+                                redis: {
+                                    connected: boolean;
+                                    error?: string;
+                                };
+                            };
+                        };
+                    };
+                };
             };
         };
         put?: never;


### PR DESCRIPTION
## Summary
- Enhances health check endpoints in both API and Gateway apps
- Returns HTTP 503 Service Unavailable status when Redis or database connection fails
- Adds detailed 503 response schema describing connection status and errors

## Changes

### API and Gateway Health Checks
- Added 503 response schema to OpenAPI definitions with detailed health status
- Modified health check handlers to return 503 status code if health status is "error"
- Response includes message, app version, and health details for Redis and database connections

## Test plan
- [ ] Verify health check returns 200 with healthy Redis and database
- [ ] Simulate Redis or database failure and confirm health check returns 503
- [ ] Validate response schema matches OpenAPI specification for 503 responses
- [ ] Confirm version and message fields are present in all health check responses

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c07bf8b5-9614-40b1-a46c-7c324e134cd6