### PR TITLE
fix(chat): handle non-string JSON errors

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -148,7 +148,11 @@ chat.openapi(completionRoute, async (c) => {
 					error: responseData.error,
 					responseData,
 				});
-				throw new Error(responseData.error);
+				const errorMessage =
+					typeof responseData.error === "string"
+						? responseData.error
+						: responseData.error?.message || JSON.stringify(responseData.error);
+				throw new Error(errorMessage);
 			}
 
 			// Validate response structure


### PR DESCRIPTION
## Summary
- Improves error handling in the chat API route when the error response is not a string
- Converts complex error objects to a readable string message before throwing

## Changes

### API Route Update
- Modified error handling logic in `apps/api/src/routes/chat.ts`
- Checks if `responseData.error` is a string; if not, attempts to extract `message` property or stringify the error object
- Throws a new `Error` with the processed error message for better clarity and debugging

## Test plan
- [ ] Trigger chat API errors with string error messages and verify correct error thrown
- [ ] Trigger chat API errors with object error messages and verify error message is properly stringified
- [ ] Confirm no regressions in chat completion error handling flow

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b874042a-8d93-45b8-95d1-206358fa3b0e