### PR TITLE
chore(ui): import collections dynamically for all pages

### DIFF
--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable import/order */
-import { allBlogs } from "content-collections";
-
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Image from "next/image";
@@ -12,12 +9,15 @@ import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
 import type { Blog } from "content-collections";
+import type { Metadata } from "next";
 
 interface BlogEntryPageProps {
 	params: Promise<{ slug: string }>;
 }
 
 export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
+	const { allBlogs } = await import("content-collections");
+
 	const { slug } = await params;
 
 	const entry = allBlogs.find((entry: Blog) => entry.slug === slug);
@@ -86,12 +86,18 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 }
 
 export async function generateStaticParams() {
+	const { allBlogs } = await import("content-collections");
+
 	return allBlogs.map((entry: Blog) => ({
 		slug: entry.slug,
 	}));
 }
 
-export async function generateMetadata({ params }: BlogEntryPageProps) {
+export async function generateMetadata({
+	params,
+}: BlogEntryPageProps): Promise<Metadata> {
+	const { allBlogs } = await import("content-collections");
+
 	const { slug } = await params;
 
 	const entry = allBlogs.find((entry: Blog) => entry.slug === slug);

--- a/apps/ui/src/app/blog/category/[category]/page.tsx
+++ b/apps/ui/src/app/blog/category/[category]/page.tsx
@@ -1,8 +1,6 @@
 import { BlogList } from "@/components/blog/list";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
-import { allBlogs } from "content-collections";
-
 interface BlogItem {
 	id: string;
 	slug: string;
@@ -27,7 +25,9 @@ export default async function BlogCategoryPage({ params }: CategoryPageProps) {
 	const { category } = await params;
 	const slug = decodeURIComponent(category);
 
-	const filtered = (allBlogs as any[])
+	const { allBlogs } = await import("content-collections");
+
+	const filtered = allBlogs
 		.filter((entry: any) => !entry?.draft)
 		.filter((entry: any) =>
 			(entry.categories || []).some((c: string) => slugify(c) === slug),
@@ -51,8 +51,11 @@ export default async function BlogCategoryPage({ params }: CategoryPageProps) {
 }
 
 export async function generateStaticParams() {
+	const { allBlogs } = await import("content-collections");
 	const slugs = new Set<string>();
-	for (const post of allBlogs as any[]) {
+	for (const post of allBlogs) {
+		// TODO
+		// @ts-ignore
 		(post.categories || []).forEach((c: string) => slugs.add(slugify(c)));
 	}
 	return Array.from(slugs).map((category) => ({ category }));

--- a/apps/ui/src/app/blog/page.tsx
+++ b/apps/ui/src/app/blog/page.tsx
@@ -1,8 +1,6 @@
 import { BlogList } from "@/components/blog/list";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
-import { allBlogs } from "content-collections";
-
 interface BlogItem {
 	id: string;
 	slug: string;
@@ -12,6 +10,8 @@ interface BlogItem {
 }
 
 export default async function BlogPage() {
+	const { allBlogs } = await import("content-collections");
+
 	const sortedEntries = allBlogs
 		.sort(
 			(a: any, b: any) =>

--- a/apps/ui/src/app/changelog/[slug]/page.tsx
+++ b/apps/ui/src/app/changelog/[slug]/page.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable import/order */
-import { allChangelogs } from "content-collections";
-
 import { ArrowLeftIcon } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Image from "next/image";
@@ -12,6 +9,7 @@ import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
 import type { Changelog } from "content-collections";
+import type { Metadata } from "next";
 
 interface ChangelogEntryPageProps {
 	params: Promise<{ slug: string }>;
@@ -20,6 +18,8 @@ interface ChangelogEntryPageProps {
 export default async function ChangelogEntryPage({
 	params,
 }: ChangelogEntryPageProps) {
+	const { allChangelogs } = await import("content-collections");
+
 	const { slug } = await params;
 
 	const entry = allChangelogs.find((entry: Changelog) => entry.slug === slug);
@@ -89,12 +89,18 @@ export default async function ChangelogEntryPage({
 }
 
 export async function generateStaticParams() {
+	const { allChangelogs } = await import("content-collections");
+
 	return allChangelogs.map((entry) => ({
 		slug: entry.slug,
 	}));
 }
 
-export async function generateMetadata({ params }: ChangelogEntryPageProps) {
+export async function generateMetadata({
+	params,
+}: ChangelogEntryPageProps): Promise<Metadata> {
+	const { allChangelogs } = await import("content-collections");
+
 	const { slug } = await params;
 
 	const entry = allChangelogs.find((entry: Changelog) => entry.slug === slug);

--- a/apps/ui/src/app/changelog/page.tsx
+++ b/apps/ui/src/app/changelog/page.tsx
@@ -1,11 +1,11 @@
-/* eslint-disable import/order */
-import { allChangelogs } from "content-collections";
 import { ChangelogComponent } from "@/components/changelog";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
 import type { Changelog } from "content-collections";
 
 export default async function ChangelogPage() {
+	const { allChangelogs } = await import("content-collections");
+
 	const sortedEntries = allChangelogs
 		.sort(
 			(a: Changelog, b: Changelog) =>


### PR DESCRIPTION
Replaced static imports of `content-collections` with dynamic imports across blog and changelog pages to improve loading efficiency and resolve unused imports.