### PR TITLE
fix(chat): standardize tool call handling in responses

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2220,10 +2220,17 @@ chat.openapi(completions, async (c) => {
 								case "google-ai-studio":
 									if (data.candidates?.[0]?.finishReason) {
 										const googleFinishReason = data.candidates[0].finishReason;
+										// Check if there are function calls in this response
+										const hasFunctionCalls =
+											data.candidates?.[0]?.content?.parts?.some(
+												(part: any) => part.functionCall,
+											);
 										// Map Google finish reasons to OpenAI format
 										finishReason =
 											googleFinishReason === "STOP"
-												? "stop"
+												? hasFunctionCalls
+													? "tool_calls"
+													: "stop"
 												: googleFinishReason === "MAX_TOKENS"
 													? "length"
 													: googleFinishReason === "SAFETY"

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -84,11 +84,33 @@ export function parseProviderResponse(
 				}),
 			);
 
+			// Extract tool calls from Google format - reuse the same parts array
+			toolResults =
+				parts
+					.filter((part: any) => part.functionCall)
+					.map((part: any, index: number) => ({
+						id: `${part.functionCall.name}_${json.candidates?.[0]?.index ?? 0}_${index}`, // Google doesn't provide ID, so generate one
+						type: "function",
+						function: {
+							name: part.functionCall.name,
+							arguments: JSON.stringify(part.functionCall.args || {}),
+						},
+					})) || null;
+			if (toolResults && toolResults.length === 0) {
+				toolResults = null;
+			}
+
 			const googleFinishReason = json.candidates?.[0]?.finishReason;
+			// Check if there are function calls in this response
+			const hasFunctionCalls = json.candidates?.[0]?.content?.parts?.some(
+				(part: any) => part.functionCall,
+			);
 			// Map Google finish reasons to OpenAI format
 			finishReason = googleFinishReason
 				? googleFinishReason === "STOP"
-					? "stop"
+					? hasFunctionCalls
+						? "tool_calls"
+						: "stop"
 					: googleFinishReason === "MAX_TOKENS"
 						? "length"
 						: googleFinishReason === "SAFETY"
@@ -122,22 +144,6 @@ export function parseProviderResponse(
 			if (promptTokens !== null) {
 				totalTokens =
 					promptTokens + (completionTokens || 0) + (reasoningTokens || 0);
-			}
-
-			// Extract tool calls from Google format - reuse the same parts array
-			toolResults =
-				parts
-					.filter((part: any) => part.functionCall)
-					.map((part: any, index: number) => ({
-						id: `${part.functionCall.name}_${json.candidates?.[0]?.index ?? 0}_${index}`, // Google doesn't provide ID, so generate one
-						type: "function",
-						function: {
-							name: part.functionCall.name,
-							arguments: JSON.stringify(part.functionCall.args || {}),
-						},
-					})) || null;
-			if (toolResults && toolResults.length === 0) {
-				toolResults = null;
 			}
 			break;
 		}

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -43,16 +43,7 @@ export function transformResponseToOpenai(
 							...(toolResults && { tool_calls: toolResults }),
 							...(images && images.length > 0 && { images }),
 						},
-						finish_reason:
-							finishReason === "STOP"
-								? toolResults && toolResults.length > 0
-									? "tool_calls"
-									: "stop"
-								: finishReason === "MAX_TOKENS"
-									? "length"
-									: finishReason === "SAFETY"
-										? "content_filter"
-										: "stop",
+						finish_reason: finishReason || "stop",
 					},
 				],
 				usage: {


### PR DESCRIPTION
Ensure consistent processing of tool calls in Google provider responses. Standardize finish reason mapping, detect function calls for tool call generation, and update transformation logic to align with other providers. Simplified finish reason fallback to "stop" when undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Surfaced tool calls in Google AI Studio responses, enabling tools to be executed from those replies.
* Bug Fixes
  * Corrected finish reason handling for Google AI Studio, distinguishing tool-related stops.
  * Improved token usage reporting with more accurate prompt, completion, and reasoning counts.
* Refactor
  * Simplified finish reason passthrough for Google AI Studio when transforming to OpenAI format.
* Chores
  * Consolidated Google-specific parsing logic for cleaner, more reliable behavior without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->