### PR TITLE
fix(chat): handle user agent fallback for source validation

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -441,12 +441,16 @@ anthropic.openapi(messages, async (c) => {
 		openaiRequest.tools = openaiTools;
 	}
 
+	// Get user-agent for forwarding
+	const userAgent = c.req.header("User-Agent") || "";
+
 	// Make internal request to the existing chat completions endpoint using app.request()
 	const response = await app.request("/v1/chat/completions", {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
 			Authorization: c.req.header("Authorization") || "",
+			"User-Agent": userAgent,
 			"x-request-id": c.req.header("x-request-id") || "",
 			"x-source": c.req.header("x-source") || "",
 			"x-debug": c.req.header("x-debug") || "",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -384,10 +384,18 @@ chat.openapi(completions, async (c) => {
 	} = validationResult.data;
 
 	// Extract and validate source from x-source header with HTTP-Referer fallback
-	const source = validateSource(
+	let source = validateSource(
 		c.req.header("x-source"),
 		c.req.header("HTTP-Referer"),
 	);
+
+	// Match specific user agents and set source if x-source header is not specified
+	if (!source) {
+		const userAgent = c.req.header("User-Agent") || "";
+		if (/^claude-cli\/.+/.test(userAgent)) {
+			source = "claude.ai";
+		}
+	}
 
 	// Check if debug mode is enabled via x-debug header
 	const debugMode =


### PR DESCRIPTION
Add logic to set the source based on specific user agents when the x-source header is not specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forwards client User-Agent and HTTP-Referer headers to downstream chat completions, improving compatibility and context-aware behavior.
  * Automatically detects requests from claude-cli via User-Agent and assigns source as “claude.ai” when unspecified, enhancing attribution and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->