### PR TITLE
fix: prevent TypeError on encode by stringifying inputs

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2444,11 +2444,9 @@ chat.openapi(completions, async (c) => {
 
 					if (!completionTokens && fullContent) {
 						try {
-							const contentToEncode =
-								typeof fullContent === "string"
-									? fullContent
-									: JSON.stringify(fullContent ?? "");
-							calculatedCompletionTokens = encode(contentToEncode).length;
+							calculatedCompletionTokens = encode(
+								JSON.stringify(fullContent),
+							).length;
 						} catch (error) {
 							// Fallback to simple estimation if encoding fails
 							logger.error(

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2442,13 +2442,13 @@ chat.openapi(completions, async (c) => {
 						}
 					}
 
-					if (
-						!completionTokens &&
-						fullContent &&
-						typeof fullContent === "string"
-					) {
+					if (!completionTokens && fullContent) {
 						try {
-							calculatedCompletionTokens = encode(fullContent).length;
+							const contentToEncode =
+								typeof fullContent === "string"
+									? fullContent
+									: JSON.stringify(fullContent ?? "");
+							calculatedCompletionTokens = encode(contentToEncode).length;
 						} catch (error) {
 							// Fallback to simple estimation if encoding fails
 							logger.error(

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2442,7 +2442,11 @@ chat.openapi(completions, async (c) => {
 						}
 					}
 
-					if (!completionTokens && fullContent) {
+					if (
+						!completionTokens &&
+						fullContent &&
+						typeof fullContent === "string"
+					) {
 						try {
 							calculatedCompletionTokens = encode(fullContent).length;
 						} catch (error) {

--- a/apps/gateway/src/chat/tools/estimate-tokens.ts
+++ b/apps/gateway/src/chat/tools/estimate-tokens.ts
@@ -49,9 +49,11 @@ export function estimateTokens(
 		}
 
 		// Estimate completion tokens using encode for better accuracy
-		if (!completionTokens && content && typeof content === "string") {
+		if (!completionTokens && content) {
 			try {
-				calculatedCompletionTokens = encode(content).length;
+				const contentToEncode =
+					typeof content === "string" ? content : JSON.stringify(content ?? "");
+				calculatedCompletionTokens = encode(contentToEncode).length;
 			} catch (error) {
 				// Fallback to simple estimation if encoding fails
 				logger.error(

--- a/apps/gateway/src/chat/tools/estimate-tokens.ts
+++ b/apps/gateway/src/chat/tools/estimate-tokens.ts
@@ -49,7 +49,7 @@ export function estimateTokens(
 		}
 
 		// Estimate completion tokens using encode for better accuracy
-		if (!completionTokens && content) {
+		if (!completionTokens && content && typeof content === "string") {
 			try {
 				calculatedCompletionTokens = encode(content).length;
 			} catch (error) {

--- a/apps/gateway/src/chat/tools/estimate-tokens.ts
+++ b/apps/gateway/src/chat/tools/estimate-tokens.ts
@@ -51,9 +51,7 @@ export function estimateTokens(
 		// Estimate completion tokens using encode for better accuracy
 		if (!completionTokens && content) {
 			try {
-				const contentToEncode =
-					typeof content === "string" ? content : JSON.stringify(content ?? "");
-				calculatedCompletionTokens = encode(contentToEncode).length;
+				calculatedCompletionTokens = encode(JSON.stringify(content)).length;
 			} catch (error) {
 				// Fallback to simple estimation if encoding fails
 				logger.error(

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -77,11 +77,9 @@ export function calculateCosts(
 			} else if (fullOutput.prompt) {
 				// For text prompt
 				try {
-					const promptToEncode =
-						typeof fullOutput.prompt === "string"
-							? fullOutput.prompt
-							: JSON.stringify(fullOutput.prompt ?? "");
-					calculatedPromptTokens = encode(promptToEncode).length;
+					calculatedPromptTokens = encode(
+						JSON.stringify(fullOutput.prompt),
+					).length;
 				} catch (error) {
 					// If encoding fails, leave as null
 					logger.error(`Failed to encode prompt text: ${error}`);
@@ -92,11 +90,9 @@ export function calculateCosts(
 		// Calculate completion tokens
 		if (!completionTokens && fullOutput && fullOutput.completion) {
 			try {
-				const completionToEncode =
-					typeof fullOutput.completion === "string"
-						? fullOutput.completion
-						: JSON.stringify(fullOutput.completion ?? "");
-				calculatedCompletionTokens = encode(completionToEncode).length;
+				calculatedCompletionTokens = encode(
+					JSON.stringify(fullOutput.completion),
+				).length;
 			} catch (error) {
 				// If encoding fails, leave as null
 				logger.error(`Failed to encode completion text: ${error}`);

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -74,10 +74,14 @@ export function calculateCosts(
 					// If encoding fails, leave as null
 					logger.error(`Failed to encode chat messages in costs: ${error}`);
 				}
-			} else if (fullOutput.prompt && typeof fullOutput.prompt === "string") {
+			} else if (fullOutput.prompt) {
 				// For text prompt
 				try {
-					calculatedPromptTokens = encode(fullOutput.prompt).length;
+					const promptToEncode =
+						typeof fullOutput.prompt === "string"
+							? fullOutput.prompt
+							: JSON.stringify(fullOutput.prompt ?? "");
+					calculatedPromptTokens = encode(promptToEncode).length;
 				} catch (error) {
 					// If encoding fails, leave as null
 					logger.error(`Failed to encode prompt text: ${error}`);
@@ -86,14 +90,13 @@ export function calculateCosts(
 		}
 
 		// Calculate completion tokens
-		if (
-			!completionTokens &&
-			fullOutput &&
-			fullOutput.completion &&
-			typeof fullOutput.completion === "string"
-		) {
+		if (!completionTokens && fullOutput && fullOutput.completion) {
 			try {
-				calculatedCompletionTokens = encode(fullOutput.completion).length;
+				const completionToEncode =
+					typeof fullOutput.completion === "string"
+						? fullOutput.completion
+						: JSON.stringify(fullOutput.completion ?? "");
+				calculatedCompletionTokens = encode(completionToEncode).length;
 			} catch (error) {
 				// If encoding fails, leave as null
 				logger.error(`Failed to encode completion text: ${error}`);

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -74,7 +74,7 @@ export function calculateCosts(
 					// If encoding fails, leave as null
 					logger.error(`Failed to encode chat messages in costs: ${error}`);
 				}
-			} else if (fullOutput.prompt) {
+			} else if (fullOutput.prompt && typeof fullOutput.prompt === "string") {
 				// For text prompt
 				try {
 					calculatedPromptTokens = encode(fullOutput.prompt).length;
@@ -86,7 +86,12 @@ export function calculateCosts(
 		}
 
 		// Calculate completion tokens
-		if (!completionTokens && fullOutput && fullOutput.completion) {
+		if (
+			!completionTokens &&
+			fullOutput &&
+			fullOutput.completion &&
+			typeof fullOutput.completion === "string"
+		) {
 			try {
 				calculatedCompletionTokens = encode(fullOutput.completion).length;
 			} catch (error) {


### PR DESCRIPTION
## Summary
- Fixes TypeError by stringifying values before calling `encode` function
- Updates encoding logic in chat.ts, estimate-tokens.ts, and costs.ts to use `JSON.stringify` on inputs

## Changes

### Core Fixes
- **chat.ts**: Changed to `encode(JSON.stringify(fullContent))` to handle non-string inputs
- **estimate-tokens.ts**: Changed to `encode(JSON.stringify(content))` for token estimation
- **costs.ts**: Changed to `encode(JSON.stringify(fullOutput.prompt))` and `encode(JSON.stringify(fullOutput.completion))` to handle non-string values

## Test plan
- [x] Verify no TypeError occurs when non-string values are passed
- [x] Confirm token estimation works correctly for string inputs
- [x] Run existing tests to ensure no regressions in token calculation logic

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5890f12f-997b-4d95-ae72-3a167fe4fc40