### PR TITLE
Fix handling of Google tool finish reason in parseProviderResponse

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -115,7 +115,9 @@ export function parseProviderResponse(
 						? "length"
 						: googleFinishReason === "SAFETY"
 							? "content_filter"
-							: "stop" // Safe fallback for unknown reasons
+							: googleFinishReason === "tool_calls"
+								? "tool_calls" // Handle when Google returns tool_calls directly
+								: "stop" // Safe fallback for unknown reasons
 				: null;
 			promptTokens = json.usageMetadata?.promptTokenCount || null;
 			completionTokens = json.usageMetadata?.candidatesTokenCount || null;


### PR DESCRIPTION
## Summary
- Correctly handle the "tool_calls" finish reason returned by Google in the parseProviderResponse function
- Add explicit check for "tool_calls" to avoid misclassification as "stop"

## Changes

### Core Functionality
- Updated `parseProviderResponse` in `parse-provider-response.ts` to:
  - Check if `googleFinishReason` is "tool_calls" and return "tool_calls" as the finish reason
  - Retain existing handling for "length", "SAFETY" (mapped to "content_filter"), and fallback to "stop" for unknown reasons

## Test plan
- Verify that responses with finish reason "tool_calls" are correctly identified and handled
- Ensure no regressions in handling other finish reasons
- Confirm that fallback to "stop" remains intact for unknown reasons

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0405a65a-261f-45fb-a54d-5774436bfb02