### PR TITLE
feat(api-keys): enforce plan limits

### DIFF
--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -121,6 +121,7 @@ export function ApiKeysList({
 	const allKeys = data?.apiKeys.filter((key) => key.status !== "deleted") || [];
 	const activeKeys = allKeys.filter((key) => key.status === "active");
 	const inactiveKeys = allKeys.filter((key) => key.status === "inactive");
+	const planLimits = data?.planLimits;
 
 	const filteredKeys = (() => {
 		switch (statusFilter) {
@@ -328,10 +329,23 @@ export function ApiKeysList({
 					<KeyIcon className="h-10 w-10 text-gray-500" />
 				</div>
 				<p className="text-gray-400 mb-6">No API keys have been created yet.</p>
-				<CreateApiKeyDialog selectedProject={selectedProject}>
+				<CreateApiKeyDialog
+					selectedProject={selectedProject}
+					disabled={
+						planLimits ? planLimits.currentCount >= planLimits.maxKeys : false
+					}
+					disabledMessage={
+						planLimits
+							? `${planLimits.plan === "pro" ? "Pro" : "Free"} plan allows maximum ${planLimits.maxKeys} API keys per project`
+							: undefined
+					}
+				>
 					<Button
 						type="button"
-						className="cursor-pointer flex items-center gap-2 bg-white text-black px-4 py-2 rounded-md hover:bg-gray-200"
+						disabled={
+							planLimits ? planLimits.currentCount >= planLimits.maxKeys : false
+						}
+						className="cursor-pointer flex items-center gap-2 bg-white text-black px-4 py-2 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
 					>
 						<PlusIcon className="h-5 w-5" />
 						Create API Key
@@ -384,6 +398,34 @@ export function ApiKeysList({
 					</TabsList>
 				</Tabs>
 			</div>
+
+			{/* Plan Limits Display */}
+			{planLimits && (
+				<div className="mb-4 rounded-lg border bg-muted/30 p-4">
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-4">
+							<div className="text-sm text-muted-foreground">
+								<span className="font-medium">API Keys:</span>{" "}
+								{planLimits.currentCount} of {planLimits.maxKeys} used
+							</div>
+							<div className="text-sm text-muted-foreground">
+								<span className="font-medium">Plan:</span>{" "}
+								{planLimits.plan === "pro" ? "Pro" : "Free"}
+							</div>
+						</div>
+						{planLimits.currentCount >= planLimits.maxKeys && (
+							<div className="text-xs text-amber-600 font-medium">
+								Limit reached
+							</div>
+						)}
+					</div>
+					{planLimits.plan === "free" && planLimits.currentCount >= 3 && (
+						<div className="mt-2 text-xs text-muted-foreground">
+							💡 Upgrade to Pro plan to create up to 20 API keys per project
+						</div>
+					)}
+				</div>
+			)}
 
 			{/* Inactive Keys Summary Bar */}
 			{statusFilter === "active" && inactiveKeys.length > 0 && (

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -704,7 +704,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description List of API keys. */
+                /** @description List of API keys with plan limits. */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -740,6 +740,12 @@ export interface paths {
                                 }[];
                                 maskedToken: string;
                             }[];
+                            planLimits?: {
+                                currentCount: number;
+                                maxKeys: number;
+                                /** @enum {string} */
+                                plan: "free" | "pro";
+                            };
                         };
                     };
                 };


### PR DESCRIPTION
## Summary
- Enforces API key creation limits per project based on the organization's subscription plan (Free or Pro).
- Free plan allows up to 5 API keys per project.
- Pro plan allows up to 20 API keys per project.
- Disables API key creation UI when the limit is reached and shows appropriate messages.
- Adds backend validation to prevent exceeding API key limits.
- Displays current usage and plan information in the API keys list UI.

## Changes

### Backend
- Added logic in the API key creation route to check the organization's plan and existing API keys count.
- Throws HTTP 400 error if the API key limit is reached for the project.
- Updated API key listing endpoint to include plan limits info (current count, max keys, plan type).
- Added tests to verify API key creation limits enforcement for Free and Pro plans.

### Frontend
- Updated API keys client to fetch and use plan limits data.
- Disabled the "Create API Key" button and dialog when the limit is reached, with tooltip explaining the limit.
- Displayed plan limits summary in the API keys list component, including usage count and upgrade suggestion for Free plan users.

## Test plan
- Verified API key creation fails with proper error when exceeding limits on Free and Pro plans.
- Verified UI disables creation controls and shows correct messages when limits are reached.
- Verified plan limits info is correctly displayed in the API keys list.
- Ran existing and new tests to ensure no regressions.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3d9da819-3999-4fa4-97e8-f347a6b8d51b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced per-project API key limits by plan (Free: 5, Pro: 20); attempts beyond the limit return an error.
  * List API now includes planLimits (current count, max keys, plan) when a project is selected.
  * UI displays plan usage and limits, shows “limit reached,” and suggests upgrading on Free; Create API Key is disabled with a tooltip when at the limit.
  * Create API Key dialog supports a disabled state and clearer error messages.

* **Tests**
  * Added tests for plan-based API key creation limits for Free and Pro plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->