### PR TITLE
fix: update Anthropic model names and updates

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -156,7 +156,7 @@ export const anthropicModels = [
 		],
 	},
 	{
-		id: "claude-opus-4-1",
+		id: "claude-opus-4-1-20250805",
 		name: "Claude Opus 4.1",
 		family: "anthropic",
 		deprecatedAt: undefined,
@@ -164,7 +164,7 @@ export const anthropicModels = [
 		providers: [
 			{
 				providerId: "anthropic",
-				modelName: "claude-opus-4-1",
+				modelName: "claude-opus-4-1-20250805",
 				inputPrice: 15.0 / 1e6,
 				outputPrice: 75.0 / 1e6,
 				cachedInputPrice: 1.5 / 1e6,
@@ -174,6 +174,28 @@ export const anthropicModels = [
 				streaming: true,
 				vision: true,
 				reasoning: true,
+				tools: true,
+			},
+		],
+	},
+	{
+		id: "claude-3-5-sonnet-20240620",
+		name: "Claude 3.5 Sonnet (Old)",
+		family: "anthropic",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "anthropic",
+				modelName: "claude-3-5-sonnet-20240620",
+				inputPrice: 3.0 / 1e6,
+				outputPrice: 15.0 / 1e6,
+				cachedInputPrice: 0.3 / 1e6,
+				requestPrice: 0,
+				contextSize: 200000,
+				maxOutput: 8192,
+				streaming: true,
+				vision: true,
 				tools: true,
 			},
 		],


### PR DESCRIPTION
## Summary
- Corrects the model name for "Claude Opus 4.1" to "claude-opus-4-1-20250805" for accurate pricing and identification
- Adds a new model entry for "Claude 3.5 Sonnet (Old)" with updated pricing and capabilities

## Changes

### Model Updates
- Renamed model ID and provider modelName from "claude-opus-4-1" to "claude-opus-4-1-20250805" to reflect the correct version
- Added new model configuration for "claude-3-5-sonnet-20240620" with:
  - Input and output pricing
  - Context size of 200,000
  - Max output tokens of 8192
  - Streaming, vision, and tools support enabled

## Test plan
- Verify that the updated model names are correctly recognized and priced in the system
- Confirm the new "Claude 3.5 Sonnet (Old)" model is available and its properties are correctly applied
- Run existing tests to ensure no regressions in model handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a84fd5cd-321d-45a3-bc68-b688656e5bb0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a selectable model: Claude 3.5 Sonnet (Old), with support for streaming, vision, and tool use.
* **Chores**
  * Updated Claude Opus 4.1 to the latest dated variant to reflect current availability while preserving capabilities (reasoning, vision, streaming, tools).
  * Synchronized model metadata (context window, output limits, and pricing) to align with the provider’s latest terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->