### PR TITLE
chore(config): add support for custom distDir in dev mode

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -9,6 +9,7 @@
 # test & build
 /coverage
 /.next/
+/.next-dev/
 /.next-prod/
 /out/
 /build

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -4,6 +4,7 @@ const withMDX = createMDX();
 
 /** @type {import("next").NextConfig} */
 const config = {
+	distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
 	reactStrictMode: true,
 	productionBrowserSourceMaps: true,
 	eslint: {

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -27,7 +27,8 @@
 		"**/*.tsx",
 		".next/types/**/*.ts",
 		"next-env.d.ts",
-		"out/types/**/*.ts"
+		"out/types/**/*.ts",
+		".next-dev/types/**/*.ts"
 	],
 	"exclude": ["node_modules"]
 }

--- a/apps/ui/.gitignore
+++ b/apps/ui/.gitignore
@@ -15,6 +15,7 @@
 
 # next.js
 /.next/
+/.next-dev/
 /out/
 
 # production

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -3,6 +3,7 @@ import { withContentCollections } from "@content-collections/next";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+	distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
 	productionBrowserSourceMaps: true,
 	eslint: {
 		ignoreDuringBuilds: true,

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -26,11 +26,12 @@
 		}
 	},
 	"include": [
-		"next-env.d.ts",
 		"**/*.ts",
 		"**/*.tsx",
+		"./.content-collections/generated/index.d.ts",
 		".next/types/**/*.ts",
-		"./.content-collections/generated/index.d.ts"
+		"next-env.d.ts",
+		".next-dev/types/**/*.ts"
 	],
 	"exclude": ["node_modules"]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,6 +110,7 @@ export default [
 		ignores: [
 			"**/.tanstack/",
 			"**/.next/",
+			"**/.next-dev/",
 			"**/.source/",
 			"**/.output/",
 			"**/.conductor/",

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,7 @@
 			"outputs": [
 				"dist/**",
 				".next/**",
+				".next-dev/**",
 				".vercel/**",
 				".output/**",
 				".vinxi/**",


### PR DESCRIPTION
Added logic to conditionally set `distDir` to `.next-dev` for development environments, enhancing separation of dev and prod builds. Updated `.gitignore`, ESLint ignores, and `tsconfig.json` includes accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized development build output directory to “.next-dev” for docs and UI apps.
  * Updated ignore rules to exclude “.next-dev” in project and app-level .gitignore files.
  * Added “.next-dev” to ESLint ignore patterns.
  * Extended Turbo build outputs to include “.next-dev/**”.
  * Updated TypeScript configs to include “.next-dev” type outputs and generated content types.
  * Reordered TypeScript include entries without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->