### PR TITLE
refactor(worker): use regular DB client consistently

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 
 import { consumeFromQueue, LOG_QUEUE } from "@llmgateway/cache";
 import {
-	cdb as db,
+	db,
+	cdb,
 	log,
 	organization,
 	eq,
@@ -107,7 +108,7 @@ async function processAutoTopUp(): Promise<void> {
 	}
 
 	try {
-		const orgsNeedingTopUp = await db.query.organization.findMany({
+		const orgsNeedingTopUp = await cdb.query.organization.findMany({
 			where: {
 				autoTopUpEnabled: {
 					eq: true,
@@ -125,7 +126,7 @@ async function processAutoTopUp(): Promise<void> {
 		for (const org of filteredOrgs) {
 			try {
 				// Check if there's a recent pending or failed auto top-up transaction
-				const recentTransaction = await db.query.transaction.findFirst({
+				const recentTransaction = await cdb.query.transaction.findFirst({
 					where: {
 						organizationId: {
 							eq: org.id,
@@ -160,7 +161,7 @@ async function processAutoTopUp(): Promise<void> {
 					}
 				}
 
-				const defaultPaymentMethod = await db.query.paymentMethod.findFirst({
+				const defaultPaymentMethod = await cdb.query.paymentMethod.findFirst({
 					where: {
 						organizationId: {
 							eq: org.id,
@@ -181,7 +182,7 @@ async function processAutoTopUp(): Promise<void> {
 				const topUpAmount = Number(org.autoTopUpAmount || "10");
 
 				// Get the first user associated with this organization for email metadata
-				const orgUser = await db.query.userOrganization.findFirst({
+				const orgUser = await cdb.query.userOrganization.findFirst({
 					where: {
 						organizationId: {
 							eq: org.id,
@@ -206,7 +207,7 @@ async function processAutoTopUp(): Promise<void> {
 				});
 
 				// Insert pending transaction before creating payment intent
-				const pendingTransaction = await db
+				const pendingTransaction = await cdb
 					.insert(tables.transaction)
 					.values({
 						organizationId: org.id,
@@ -244,7 +245,7 @@ async function processAutoTopUp(): Promise<void> {
 					});
 
 					// Update transaction with Stripe payment intent ID
-					await db
+					await cdb
 						.update(tables.transaction)
 						.set({
 							stripePaymentIntentId: paymentIntent.id,
@@ -282,7 +283,7 @@ async function processAutoTopUp(): Promise<void> {
 							: new Error(String(stripeError)),
 					);
 					// Mark transaction as failed
-					await db
+					await cdb
 						.update(tables.transaction)
 						.set({
 							status: "failed",
@@ -309,7 +310,7 @@ export async function batchProcessLogs(): Promise<void> {
 	}
 
 	try {
-		await db.transaction(async (tx) => {
+		await cdb.transaction(async (tx) => {
 			// Get unprocessed logs with row-level locking to prevent concurrent processing
 			const rows = await tx
 				.select({
@@ -453,7 +454,7 @@ export async function processLogQueue(): Promise<void> {
 			| Omit<LogInsertData, "messages" | "content">
 		)[] = await Promise.all(
 			logData.map(async (data) => {
-				const organization = await db.query.organization.findFirst({
+				const organization = await cdb.query.organization.findFirst({
 					where: {
 						id: {
 							eq: data.organizationId,
@@ -476,7 +477,7 @@ export async function processLogQueue(): Promise<void> {
 
 		// Insert logs without processing credits or API key usage - they will be processed in batches
 		// Type assertion is safe here as both LogInsertData and its subset are compatible with the log insert schema
-		await db.insert(log).values(processedLogData as LogInsertData[]);
+		await cdb.insert(log).values(processedLogData as LogInsertData[]);
 	} catch (error) {
 		logger.error(
 			"Error processing log message",

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import { consumeFromQueue, LOG_QUEUE } from "@llmgateway/cache";
 import {
 	db,
-	cdb,
 	log,
 	organization,
 	eq,
@@ -108,7 +107,7 @@ async function processAutoTopUp(): Promise<void> {
 	}
 
 	try {
-		const orgsNeedingTopUp = await cdb.query.organization.findMany({
+		const orgsNeedingTopUp = await db.query.organization.findMany({
 			where: {
 				autoTopUpEnabled: {
 					eq: true,
@@ -126,7 +125,7 @@ async function processAutoTopUp(): Promise<void> {
 		for (const org of filteredOrgs) {
 			try {
 				// Check if there's a recent pending or failed auto top-up transaction
-				const recentTransaction = await cdb.query.transaction.findFirst({
+				const recentTransaction = await db.query.transaction.findFirst({
 					where: {
 						organizationId: {
 							eq: org.id,
@@ -161,7 +160,7 @@ async function processAutoTopUp(): Promise<void> {
 					}
 				}
 
-				const defaultPaymentMethod = await cdb.query.paymentMethod.findFirst({
+				const defaultPaymentMethod = await db.query.paymentMethod.findFirst({
 					where: {
 						organizationId: {
 							eq: org.id,
@@ -182,7 +181,7 @@ async function processAutoTopUp(): Promise<void> {
 				const topUpAmount = Number(org.autoTopUpAmount || "10");
 
 				// Get the first user associated with this organization for email metadata
-				const orgUser = await cdb.query.userOrganization.findFirst({
+				const orgUser = await db.query.userOrganization.findFirst({
 					where: {
 						organizationId: {
 							eq: org.id,
@@ -207,7 +206,7 @@ async function processAutoTopUp(): Promise<void> {
 				});
 
 				// Insert pending transaction before creating payment intent
-				const pendingTransaction = await cdb
+				const pendingTransaction = await db
 					.insert(tables.transaction)
 					.values({
 						organizationId: org.id,
@@ -245,7 +244,7 @@ async function processAutoTopUp(): Promise<void> {
 					});
 
 					// Update transaction with Stripe payment intent ID
-					await cdb
+					await db
 						.update(tables.transaction)
 						.set({
 							stripePaymentIntentId: paymentIntent.id,
@@ -283,7 +282,7 @@ async function processAutoTopUp(): Promise<void> {
 							: new Error(String(stripeError)),
 					);
 					// Mark transaction as failed
-					await cdb
+					await db
 						.update(tables.transaction)
 						.set({
 							status: "failed",
@@ -310,7 +309,7 @@ export async function batchProcessLogs(): Promise<void> {
 	}
 
 	try {
-		await cdb.transaction(async (tx) => {
+		await db.transaction(async (tx) => {
 			// Get unprocessed logs with row-level locking to prevent concurrent processing
 			const rows = await tx
 				.select({
@@ -454,7 +453,7 @@ export async function processLogQueue(): Promise<void> {
 			| Omit<LogInsertData, "messages" | "content">
 		)[] = await Promise.all(
 			logData.map(async (data) => {
-				const organization = await cdb.query.organization.findFirst({
+				const organization = await db.query.organization.findFirst({
 					where: {
 						id: {
 							eq: data.organizationId,
@@ -477,7 +476,7 @@ export async function processLogQueue(): Promise<void> {
 
 		// Insert logs without processing credits or API key usage - they will be processed in batches
 		// Type assertion is safe here as both LogInsertData and its subset are compatible with the log insert schema
-		await cdb.insert(log).values(processedLogData as LogInsertData[]);
+		await db.insert(log).values(processedLogData as LogInsertData[]);
 	} catch (error) {
 		logger.error(
 			"Error processing log message",


### PR DESCRIPTION
## Summary
- Switches from using the custom `cdb` client to the regular `db` client for operations involving the lock table and related transactions in the worker app
- Ensures consistent database client usage for transactional and locking queries
- Corrects import to use `db` instead of aliasing `cdb` as `db` for clarity and consistency

## Changes

### Worker App (`apps/worker/src/worker.ts`)
- Replaced `cdb` alias with direct `db` import for queries related to organizations, transactions, payment methods, and user organizations in the auto top-up process
- Updated transaction handling and log processing to use `db` client for consistency
- Adjusted imports to directly use `db` client

## Test plan
- [ ] Verify auto top-up process completes successfully with the updated DB client
- [ ] Confirm no deadlocks or concurrency issues occur during log processing
- [ ] Run existing unit and integration tests to ensure no regressions in DB operations

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5962617d-f9b7-4ddb-bc4a-eae75217edc0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal import naming and module organization. No changes to behavior, public APIs, or error handling; no user-facing impact or action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->