### PR TITLE
feat(worker): add shutdown logic

### DIFF
--- a/packages/cache/src/redis.ts
+++ b/packages/cache/src/redis.ts
@@ -51,3 +51,16 @@ export async function consumeFromQueue(
 		throw error;
 	}
 }
+
+export async function closeRedisClient(): Promise<void> {
+	try {
+		await redisClient.disconnect();
+		logger.info("Redis client disconnected");
+	} catch (error) {
+		logger.error(
+			"Error disconnecting Redis client",
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		throw error;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds graceful shutdown logic to close Redis client and database connections in the worker
- Ensures all connections are properly closed during worker stop to prevent resource leaks
- Logs success or errors during connection closure without interrupting shutdown flow

## Changes

### Worker Shutdown Enhancements
- Imported and used `closeRedisClient` from cache package
- Imported and used `closeDatabase` and `closeCachedDatabase` from db package
- Updated `stopWorker` function to close Redis client and database connections concurrently
- Added logging for successful connection closures and error handling

### Redis Client Updates
- Added `closeRedisClient` function in cache package to disconnect Redis client
- Included error handling and logging in `closeRedisClient` to capture disconnect issues

## Test plan
- [x] Verify worker stops gracefully without hanging
- [x] Confirm Redis client disconnects properly on worker shutdown
- [x] Check database connections close without errors
- [x] Review logs for successful connection closure messages
- [x] Simulate errors during disconnect to ensure they are logged but do not prevent shutdown

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e0825be8-c1a5-4f28-a1e0-10f8df5e02d0