### PR TITLE
chore(models): deactivate Claude 3.5

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -103,7 +103,7 @@ export const anthropicModels = [
 		name: "Claude 3.5 Sonnet (2024-10-22)",
 		family: "anthropic",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-10-22T00:00:00Z"),
 		providers: [
 			{
 				providerId: "anthropic",


### PR DESCRIPTION
## Summary
- Sets a deactivation date for the Claude 3.5 Sonnet (2024-10-22) model
- Marks the model as deactivated starting from 2025-10-22

## Changes

### Model Configuration
- Updated `anthropicModels` array in `anthropic.ts`
- Changed `deactivatedAt` from `undefined` to `new Date("2025-10-22T00:00:00Z")` for Claude 3.5 Sonnet model

## Test plan
- Verify that the model's `deactivatedAt` field is correctly set to the specified date
- Confirm no other model configurations were affected by this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c3b84bfd-ab4f-4d5d-afa1-c40c835a3612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated model lifecycle status: Claude 3.5 Sonnet (2024-10-22) now has a scheduled deactivation date (2025-10-22).
  - After the deactivation date, the model will no longer be available for selection or new runs.
  - Users should transition workflows to a supported alternative before the cutoff to avoid interruptions.
  - No other models are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->