### PR TITLE
Fix TypeError in token encoding by extracting text from message content

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -54,7 +54,11 @@ import { getProviderEnv } from "./tools/get-provider-env.js";
 import { parseProviderResponse } from "./tools/parse-provider-response.js";
 import { transformResponseToOpenai } from "./tools/transform-response-to-openai.js";
 import { transformStreamingToOpenai } from "./tools/transform-streaming-to-openai.js";
-import { type ChatMessage, DEFAULT_TOKENIZER_MODEL } from "./tools/types.js";
+import {
+	type ChatMessage,
+	DEFAULT_TOKENIZER_MODEL,
+	extractTextFromMessageContent,
+} from "./tools/types.js";
 import { validateFreeModelUsage } from "./tools/validate-free-model-usage.js";
 
 import type { ServerTypes } from "@/vars.js";
@@ -716,10 +720,7 @@ chat.openapi(completions, async (c) => {
 			try {
 				const chatMessages: ChatMessage[] = messages.map((m) => ({
 					role: m.role as "user" | "assistant" | "system" | undefined,
-					content:
-						typeof m.content === "string"
-							? m.content
-							: JSON.stringify(m.content),
+					content: extractTextFromMessageContent(m.content),
 					name: m.name,
 				}));
 				requiredContextSize = encodeChat(
@@ -2530,7 +2531,7 @@ chat.openapi(completions, async (c) => {
 							// Convert messages to the format expected by gpt-tokenizer
 							const chatMessages: any[] = messages.map((m) => ({
 								role: m.role as "user" | "assistant" | "system" | undefined,
-								content: m.content || "",
+								content: extractTextFromMessageContent(m.content) || "",
 								name: m.name,
 							}));
 							calculatedPromptTokens = encodeChat(

--- a/apps/gateway/src/chat/tools/calculate-prompt-tokens.ts
+++ b/apps/gateway/src/chat/tools/calculate-prompt-tokens.ts
@@ -1,6 +1,10 @@
 import { encodeChat } from "gpt-tokenizer";
 
-import { type ChatMessage, DEFAULT_TOKENIZER_MODEL } from "./types.js";
+import {
+	type ChatMessage,
+	DEFAULT_TOKENIZER_MODEL,
+	extractTextFromMessageContent,
+} from "./types.js";
 
 /**
  * Transforms streaming chunk to OpenAI format for non-OpenAI providers
@@ -10,8 +14,7 @@ export function calculatePromptTokensFromMessages(messages: any[]): number {
 	try {
 		const chatMessages: ChatMessage[] = messages.map((m: any) => ({
 			role: m.role,
-			content:
-				typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+			content: extractTextFromMessageContent(m.content),
 			name: m.name,
 		}));
 		return encodeChat(chatMessages, DEFAULT_TOKENIZER_MODEL).length;

--- a/apps/gateway/src/chat/tools/estimate-tokens.ts
+++ b/apps/gateway/src/chat/tools/estimate-tokens.ts
@@ -2,7 +2,11 @@ import { encode, encodeChat } from "gpt-tokenizer";
 
 import { logger } from "@llmgateway/logger";
 
-import { type ChatMessage, DEFAULT_TOKENIZER_MODEL } from "./types.js";
+import {
+	type ChatMessage,
+	DEFAULT_TOKENIZER_MODEL,
+	extractTextFromMessageContent,
+} from "./types.js";
 
 import type { Provider } from "@llmgateway/models";
 
@@ -27,10 +31,7 @@ export function estimateTokens(
 				// Convert messages to the format expected by gpt-tokenizer
 				const chatMessages: ChatMessage[] = messages.map((m) => ({
 					role: m.role,
-					content:
-						typeof m.content === "string"
-							? m.content
-							: JSON.stringify(m.content),
+					content: extractTextFromMessageContent(m.content),
 					name: m.name,
 				}));
 				calculatedPromptTokens = encodeChat(

--- a/apps/gateway/src/chat/tools/types.ts
+++ b/apps/gateway/src/chat/tools/types.ts
@@ -7,6 +7,26 @@ export interface ChatMessage {
 	name?: string;
 }
 
+/**
+ * Extracts text content from a message content field, handling both string and array formats
+ * This function is necessary because BaseMessage.content can be string | MessageContent[]
+ * but gpt-tokenizer expects only strings
+ */
+export function extractTextFromMessageContent(content: string | any[]): string {
+	if (typeof content === "string") {
+		return content;
+	}
+
+	if (Array.isArray(content)) {
+		return content
+			.filter((part: any) => part.type === "text")
+			.map((part: any) => part.text || "")
+			.join(" ");
+	}
+
+	return "";
+}
+
 // Define OpenAI-compatible image object type
 export interface ImageObject {
 	type: "image_url";


### PR DESCRIPTION
## Summary
- Resolves TypeError caused by non-string message content during token encoding
- Introduces `extractTextFromMessageContent` utility to handle string and array content types
- Updates chat message processing to use this utility for consistent string content

## Changes

### Core Functionality
- Added `extractTextFromMessageContent` function in `types.ts` to extract plain text from message content that can be a string or an array
- Replaced direct content usage with `extractTextFromMessageContent` in:
  - `chat.ts` (message mapping for encoding and token calculation)
  - `calculate-prompt-tokens.ts` (prompt token calculation)
  - `estimate-tokens.ts` (token estimation)

### Bug Fix
- Prevents `TypeError` by ensuring all message contents passed to `gpt-tokenizer` are strings

## Test plan
- [x] Verify no TypeError occurs when message content is an array
- [x] Confirm token counts are correctly calculated for various message content formats
- [x] Test chat completions and streaming with mixed content types
- [x] Ensure backward compatibility with string-only message content

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/113d7469-8d36-49e1-850f-d5e9c39e6e77