### PR TITLE
feat(models): add minimal reasoning effort

### DIFF
--- a/apps/gateway/src/chat/tools/create-log-entry.ts
+++ b/apps/gateway/src/chat/tools/create-log-entry.ts
@@ -22,7 +22,7 @@ export function createLogEntry(
 	top_p: number | undefined,
 	frequency_penalty: number | undefined,
 	presence_penalty: number | undefined,
-	reasoningEffort: "low" | "medium" | "high" | undefined,
+	reasoningEffort: "minimal" | "low" | "medium" | "high" | undefined,
 	tools: OpenAIToolInput[] | undefined,
 	toolChoice: any | undefined,
 	source: string | undefined,

--- a/packages/models/src/prepare-request-body.ts
+++ b/packages/models/src/prepare-request-body.ts
@@ -48,7 +48,7 @@ export async function prepareRequestBody(
 	response_format: OpenAIRequestBody["response_format"],
 	tools?: OpenAIToolInput[],
 	tool_choice?: ToolChoiceType,
-	reasoning_effort?: "low" | "medium" | "high",
+	reasoning_effort?: "minimal" | "low" | "medium" | "high",
 	supportsReasoning?: boolean,
 	isProd = false,
 ): Promise<ProviderRequestBody> {

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -183,14 +183,14 @@ export interface OpenAIRequestBody extends BaseRequestBody {
 	stream_options?: {
 		include_usage: boolean;
 	};
-	reasoning_effort?: "low" | "medium" | "high";
+	reasoning_effort?: "minimal" | "low" | "medium" | "high";
 }
 
 export interface OpenAIResponsesRequestBody {
 	model: string;
 	input: OpenAIMessage[];
 	reasoning: {
-		effort: "low" | "medium" | "high";
+		effort: "minimal" | "low" | "medium" | "high";
 		summary: "detailed";
 	};
 	tools?: Array<{
@@ -285,7 +285,7 @@ export type RequestBodyPreparer = (
 	response_format?: OpenAIRequestBody["response_format"],
 	tools?: OpenAITool[],
 	tool_choice?: ToolChoiceType,
-	reasoning_effort?: "low" | "medium" | "high",
+	reasoning_effort?: "minimal" | "low" | "medium" | "high",
 	supportsReasoning?: boolean,
 	isProd?: boolean,
 ) => Promise<ProviderRequestBody>;


### PR DESCRIPTION
## Summary
- Introduces a new reasoning effort level: "minimal" alongside existing levels "low", "medium", and "high"
- Automatically sets the reasoning effort to "minimal" or "low" for auto-routing when the model supports reasoning

## Changes

### Core Logic
- Extended reasoning effort enum to include "minimal"
- In `chat.ts`, added logic to auto-set reasoning effort to:
  - "minimal" for models starting with "gpt-5*"
  - "low" for other models supporting reasoning
- Updated type definitions and request body preparation to support the new "minimal" level

### Logging
- Updated log entry creation to accept the new reasoning effort level

## Test plan
- Verify that requests with auto-routing and reasoning-supporting models default to the correct reasoning effort
- Confirm that the new "minimal" level is accepted and propagated through request preparation and logging
- Ensure no regressions in existing reasoning effort handling for "low", "medium", and "high" levels

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/afe9a50b-9745-46c2-905b-b4312f0c722c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “minimal” option for reasoning effort in chat/completions.
  * When using auto model routing and no reasoning effort is set, the system now assigns a default based on the selected model’s reasoning support (GPT‑5 family → minimal; others → low).
  * Explicit reasoning_effort settings are preserved, ensuring backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->