### PR TITLE
fix(model-pricing): parse discount variable

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -50,7 +50,9 @@ export const anthropicModels = [
 				inputPrice: 0.8 / 1e6,
 				outputPrice: 4.0 / 1e6,
 				cachedInputPrice: 0.08 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 200000,
 				maxOutput: 8192,
@@ -87,7 +89,9 @@ export const anthropicModels = [
 				inputPrice: 3.0 / 1e6,
 				outputPrice: 15.0 / 1e6,
 				cachedInputPrice: 0.3 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 200000,
 				maxOutput: 8192,
@@ -170,7 +174,9 @@ export const anthropicModels = [
 				inputPrice: 3.0 / 1e6,
 				outputPrice: 15.0 / 1e6,
 				cachedInputPrice: 0.3 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 200000,
 				maxOutput: undefined,
@@ -210,7 +216,9 @@ export const anthropicModels = [
 				inputPrice: 15.0 / 1e6,
 				outputPrice: 75.0 / 1e6,
 				cachedInputPrice: 1.5 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 200000,
 				maxOutput: undefined,
@@ -251,7 +259,9 @@ export const anthropicModels = [
 				inputPrice: 15.0 / 1e6,
 				outputPrice: 75.0 / 1e6,
 				cachedInputPrice: 1.5 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 200000,
 				maxOutput: 32000,

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -59,7 +59,9 @@ export const deepseekModels = [
 				modelName: "deepseek-reasoner",
 				inputPrice: 0.55 / 1e6,
 				outputPrice: 2.19 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 64000,
 				maxOutput: undefined,
@@ -167,7 +169,9 @@ export const deepseekModels = [
 				inputPrice: 0.56 / 1e6,
 				outputPrice: 1.68 / 1e6,
 				cachedInputPrice: 0.07 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 128000,
 				maxOutput: undefined,

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -25,7 +25,9 @@ export const googleModels = [
 				modelName: "gemini-2.5-pro",
 				inputPrice: 1.25 / 1e6,
 				outputPrice: 10.0 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 1000000,
 				maxOutput: undefined,
@@ -147,7 +149,9 @@ export const googleModels = [
 				inputPrice: 0.3 / 1e6,
 				outputPrice: 2.5 / 1e6,
 				cachedInputPrice: 0.075 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 1000000,
 				maxOutput: undefined,
@@ -183,7 +187,9 @@ export const googleModels = [
 				inputPrice: 0.1 / 1e6,
 				outputPrice: 0.4 / 1e6,
 				cachedInputPrice: 0.025 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 1000000,
 				maxOutput: undefined,

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -370,7 +370,9 @@ export const openaiModels = [
 				inputPrice: 1.25 / 1e6,
 				outputPrice: 10.0 / 1e6,
 				cachedInputPrice: 0.125 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 400000,
 				maxOutput: 128000,
@@ -428,7 +430,9 @@ export const openaiModels = [
 				inputPrice: 0.25 / 1e6,
 				outputPrice: 2 / 1e6,
 				cachedInputPrice: 0.025 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 400000,
 				maxOutput: 128000,
@@ -486,7 +490,9 @@ export const openaiModels = [
 				inputPrice: 0.05 / 1e6,
 				outputPrice: 0.4 / 1e6,
 				cachedInputPrice: 0.005 / 1e6,
-				discount: parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT || "1"),
+				discount: process.env.ROUTEWAY_PAID_DISCOUNT
+					? parseFloat(process.env.ROUTEWAY_PAID_DISCOUNT)
+					: undefined,
 				requestPrice: 0,
 				contextSize: 400000,
 				maxOutput: 128000,


### PR DESCRIPTION
## Summary
- Updates the parsing of the `ROUTEWAY_PAID_DISCOUNT` environment variable across multiple model pricing configurations
- Changes discount parsing to return `undefined` if the environment variable is not set, instead of defaulting to 1
- Applies this fix to Anthropics, Deepseek, Google, and OpenAI model pricing definitions

## Changes

### Model Pricing Updates
- Modified discount field in `anthropic.ts`, `deepseek.ts`, `google.ts`, and `openai.ts` to:
  - Check if `ROUTEWAY_PAID_DISCOUNT` is set
  - Parse it as a float if present
  - Otherwise, set discount to `undefined` instead of defaulting to 1

This change ensures that the discount is only applied when explicitly configured, preventing unintended default discounts.

## Test plan
- Verified that discount values are correctly parsed when `ROUTEWAY_PAID_DISCOUNT` is set
- Verified that discount is `undefined` when the environment variable is not set
- Confirmed no impact on other pricing fields or model configurations

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f0900898-f9b7-415c-bed1-4b41a58aa28e