### PR TITLE
fix(models): refactor temperature handling for GPT-5

### DIFF
--- a/packages/models/src/prepare-request-body.ts
+++ b/packages/models/src/prepare-request-body.ts
@@ -77,14 +77,14 @@ export async function prepareRequestBody(
 		requestBody.tool_choice = tool_choice;
 	}
 
+	// Override temperature to 1 for GPT-5 models (they only support temperature = 1)
+	if (usedModel.startsWith("gpt-5")) {
+		// eslint-disable-next-line no-param-reassign
+		temperature = 1;
+	}
+
 	switch (usedProvider) {
 		case "openai": {
-			// Override temperature to 1 for GPT-5 models (they only support temperature = 1)
-			let effectiveTemperature = temperature;
-			if (usedModel.startsWith("gpt-5")) {
-				effectiveTemperature = 1;
-			}
-
 			// Check if messages contain existing tool calls or tool results
 			// If so, use Chat Completions API instead of Responses API
 			const hasExistingToolCalls = messages.some(
@@ -131,8 +131,8 @@ export async function prepareRequestBody(
 				}
 
 				// Add optional parameters if they are provided
-				if (effectiveTemperature !== undefined) {
-					responsesBody.temperature = effectiveTemperature;
+				if (temperature !== undefined) {
+					responsesBody.temperature = temperature;
 				}
 				if (max_tokens !== undefined) {
 					responsesBody.max_output_tokens = max_tokens;
@@ -151,8 +151,8 @@ export async function prepareRequestBody(
 				}
 
 				// Add optional parameters if they are provided
-				if (effectiveTemperature !== undefined) {
-					requestBody.temperature = effectiveTemperature;
+				if (temperature !== undefined) {
+					requestBody.temperature = temperature;
 				}
 				if (max_tokens !== undefined) {
 					// GPT-5 models use max_completion_tokens instead of max_tokens


### PR DESCRIPTION
Simplified logic to enforce temperature = 1 for GPT-5 models. Replaced `effectiveTemperature` variable with direct assignment to `temperature`. Updated conditions to reflect this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models whose IDs start with “gpt-5” now default to temperature 1, improving determinism out of the box for these models.
  * Temperature is applied consistently across OpenAI Responses and Chat Completions, reducing unexpected differences between endpoints. This makes behavior more predictable.
  * No breaking changes to public APIs or configuration; existing setups continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->