### PR TITLE
Set maxOutput to 16000 for GLM-4-5v model in zaiModels

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -38,7 +38,7 @@ export const zaiModels = [
 				outputPrice: 1.8 / 1e6,
 				requestPrice: 0,
 				contextSize: 128000,
-				maxOutput: undefined,
+				maxOutput: 16000,
 				streaming: true,
 				reasoning: true,
 				reasoningOutput: "omit",


### PR DESCRIPTION
## Summary
- Sets the `maxOutput` property to 16000 for the GLM-4-5v model in the `zaiModels` array
- Enables limiting the maximum output tokens for this model

## Changes

### Model Configuration
- Updated `packages/models/src/models/zai.ts` to assign `maxOutput: 16000` instead of `undefined` for the GLM-4-5v model

## Test plan
- Verify that the GLM-4-5v model respects the new `maxOutput` limit during generation
- Confirm no regressions in streaming or reasoning features for this model

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/837a0fba-7890-4d5d-8214-78963c5b2a5a