### PR TITLE
fix: include provider in cache key for uniqueness

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1326,6 +1326,7 @@ chat.openapi(completions, async (c) => {
 
 	if (cachingEnabled) {
 		const cachePayload = {
+			provider: usedProvider,
 			model: usedModel,
 			messages,
 			temperature,


### PR DESCRIPTION
## Summary
- Fixes cache key uniqueness by including the `provider` field in the cache payload

## Changes

### Core Functionality
- Added `provider: usedProvider` to the cache payload in `apps/gateway/src/chat/chat.ts` to ensure cache keys are unique across different providers

## Test plan
- [ ] Verify caching behavior with multiple providers
- [ ] Confirm cache hits and misses are accurate when provider changes
- [ ] Run existing tests to ensure no regressions in chat functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c20ebd4e-8179-41c6-818c-3cbaa6ab4976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Chat responses now reliably reflect the selected AI provider by isolating cached results per provider.
  - Prevents cross-provider mix-ups and stale answers after switching providers, improving conversation accuracy.
  - Reduces unexpected tone/format differences caused by reused responses from a different provider.
  - Delivers more consistent behavior and trustworthiness without changing existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->