### PR TITLE
feat(Next.js): migrate to standalone output

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,6 +5,7 @@ const withMDX = createMDX();
 /** @type {import("next").NextConfig} */
 const config = {
 	distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
+	output: "standalone",
 	reactStrictMode: true,
 	productionBrowserSourceMaps: true,
 	eslint: {

--- a/apps/playground/next.config.ts
+++ b/apps/playground/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
 	distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
+	output: "standalone",
 	reactStrictMode: true,
 	productionBrowserSourceMaps: true,
 	eslint: {

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -4,6 +4,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
 	distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
+	output: "standalone",
 	productionBrowserSourceMaps: true,
 	eslint: {
 		ignoreDuringBuilds: true,

--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -152,7 +152,8 @@ WORKDIR /app/dist/ui
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["./node_modules/.bin/next", "start"]
+ENV HOSTNAME=0.0.0.0
+CMD ["node", ".next/standalone/apps/ui/server.js"]
 
 FROM runtime AS playground
 WORKDIR /app/temp
@@ -165,7 +166,8 @@ WORKDIR /app/dist/playground
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["./node_modules/.bin/next", "start"]
+ENV HOSTNAME=0.0.0.0
+CMD ["node", ".next/standalone/apps/playground/server.js"]
 
 FROM runtime AS worker
 WORKDIR /app/temp
@@ -189,4 +191,5 @@ WORKDIR /app/dist/docs
 EXPOSE 80
 ENV PORT=80
 ENV NODE_ENV=production
-CMD ["./node_modules/.bin/next", "start", "-H", "0.0.0.0"]
+ENV HOSTNAME=0.0.0.0
+CMD ["node", ".next/standalone/apps/docs/server.js"]

--- a/infra/supervisord.conf
+++ b/infra/supervisord.conf
@@ -27,7 +27,7 @@ stdout_logfile_maxbytes=0
 
 
 [program:ui]
-command=/app/services/ui/node_modules/next/dist/bin/next start
+command=/usr/local/bin/node .next/standalone/apps/ui/server.js
 directory=/app/services/ui
 user=root
 autostart=true
@@ -36,10 +36,10 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-environment=PORT=3002,NODE_ENV=production
+environment=PORT=3002,NODE_ENV=production,HOSTNAME=0.0.0.0
 
 [program:playground]
-command=/app/services/playground/node_modules/next/dist/bin/next start
+command=/usr/local/bin/node .next/standalone/apps/playground/server.js
 directory=/app/services/playground
 user=root
 autostart=true
@@ -48,10 +48,10 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-environment=PORT=3003,NODE_ENV=production
+environment=PORT=3003,NODE_ENV=production,HOSTNAME=0.0.0.0
 
 [program:docs]
-command=/app/services/docs/node_modules/next/dist/bin/next start -H 0.0.0.0
+command=/usr/local/bin/node .next/standalone/apps/docs/server.js
 directory=/app/services/docs
 user=root
 autostart=true
@@ -60,7 +60,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-environment=PORT=3005,NODE_ENV=production
+environment=PORT=3005,NODE_ENV=production,HOSTNAME=0.0.0.0
 
 
 [program:api]


### PR DESCRIPTION
## Summary
- Migrates Next.js applications (`docs`, `playground`, `ui`) to use the `standalone` output mode
- Updates Dockerfiles to run standalone server.js instead of `next start`
- Modifies supervisord configuration to launch standalone server.js with proper environment variables

## Changes

### Next.js Configuration
- Added `output: "standalone"` to `next.config` files in `apps/docs`, `apps/playground`, and `apps/ui`

### Dockerfile Updates
- Changed CMD commands in `infra/split.dockerfile` to run standalone server.js for each app
- Set `HOSTNAME=0.0.0.0` environment variable for proper network binding

### Supervisord Configuration
- Updated commands to run standalone server.js instead of `next start`
- Added `HOSTNAME=0.0.0.0` to environment variables for all programs (`ui`, `playground`, `docs`)

## Test plan
- [x] Build and run Docker containers for all apps
- [x] Verify apps start correctly using standalone server.js
- [x] Confirm apps are accessible on expected ports
- [x] Check logs for any errors related to startup or environment variables

This migration improves deployment by leveraging Next.js standalone output, simplifying runtime dependencies and container size.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c30ce626-3772-4244-8cb6-ca38e61aca85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Switched all apps to standalone server builds, reducing runtime dependencies and simplifying deployments.
  - Improved startup performance and consistency by running Node directly against standalone outputs.
  - Unified host binding to 0.0.0.0 for all apps to ensure reliable access in containerized environments.
  - Enabled automatic process restarts for app services to enhance resilience and uptime.
  - Updated container and supervisor configurations to align with the new build output, resulting in leaner images and more predictable runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->