### PR TITLE
feat(google): add deactivation dates and vision support

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -243,7 +243,7 @@ export const googleModels = [
 		name: "Gemini 1.5 Pro",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-09-20"),
 		providers: [
 			{
 				providerId: "google-ai-studio",
@@ -254,7 +254,7 @@ export const googleModels = [
 				contextSize: 1000000,
 				maxOutput: undefined,
 				streaming: true,
-				vision: false,
+				vision: true,
 				tools: true,
 			},
 		],
@@ -264,7 +264,7 @@ export const googleModels = [
 		name: "Gemini 1.5 Flash",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-09-20"),
 		providers: [
 			{
 				providerId: "google-ai-studio",
@@ -275,7 +275,7 @@ export const googleModels = [
 				contextSize: 1000000,
 				maxOutput: undefined,
 				streaming: true,
-				vision: false,
+				vision: true,
 				tools: true,
 			},
 		],
@@ -285,7 +285,7 @@ export const googleModels = [
 		name: "Gemini 1.5 Flash 8B",
 		family: "google",
 		deprecatedAt: undefined,
-		deactivatedAt: undefined,
+		deactivatedAt: new Date("2025-09-20"),
 		providers: [
 			{
 				providerId: "google-ai-studio",

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -13,7 +13,7 @@ NC='\033[0m' # No Color
 REGISTRY="ghcr.io"
 REPOSITORY_BASE="theopenco/llmgateway"
 PLATFORMS=("linux/amd64" "linux/arm64")
-SPLIT_APPS=("api" "gateway" "ui" "docs")
+SPLIT_APPS=("api" "gateway" "playground" "ui" "docs")
 
 # Function to print colored output
 print_status() {
@@ -215,7 +215,7 @@ wait_for_builds() {
         fi
         rm -f "/tmp/build_result_unified"
     fi
-    
+
 
     # Return failure if any builds failed
     if [[ ${#failed_builds[@]} -gt 0 ]]; then


### PR DESCRIPTION
Updated deactivation dates for Gemini 1.5 models and enabled vision support for "Gemini 1.5 Pro" in Google models. Expanded build script to include the "playground" application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled vision capabilities for Gemini 1.5 Pro, Gemini 1.5 Flash, and Gemini 1.5 Flash 8B, allowing image-based inputs where supported.

- Chores
  - Scheduled deactivation for Gemini 1.5 Pro, Gemini 1.5 Flash, and Gemini 1.5 Flash 8B effective 2025-09-20; plan transitions accordingly.
  - Updated build process to include Playground in split-image builds, improving parallelization and deployment consistency across apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->