### PR TITLE
feat(infra): use turbo build in split dockerfile

### DIFF
--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -59,7 +59,7 @@ COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=api... install --frozen-lockfile
 COPY . .
-RUN --mount=type=cache,target=/app/.turbo pnpm --filter=api... build
+RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=api
 
 # Builder for Gateway
 # syntax=docker/dockerfile:1-labs
@@ -69,7 +69,7 @@ COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=gateway... install --frozen-lockfile
 COPY . .
-RUN --mount=type=cache,target=/app/.turbo pnpm --filter=gateway... build
+RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=gateway
 
 # Builder for UI
 # syntax=docker/dockerfile:1-labs
@@ -79,7 +79,7 @@ COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=ui... install --frozen-lockfile
 COPY . .
-RUN --mount=type=cache,target=/app/.turbo pnpm --filter=ui... build
+RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=ui
 
 # Builder for Playground
 # syntax=docker/dockerfile:1-labs
@@ -89,7 +89,7 @@ COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=playground... install --frozen-lockfile
 COPY . .
-RUN --mount=type=cache,target=/app/.turbo pnpm --filter=playground... build
+RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=playground
 
 # Builder for Worker
 # syntax=docker/dockerfile:1-labs
@@ -99,7 +99,7 @@ COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=worker... install --frozen-lockfile
 COPY . .
-RUN --mount=type=cache,target=/app/.turbo pnpm --filter=worker... build
+RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=worker
 
 # Builder for Docs
 # syntax=docker/dockerfile:1-labs
@@ -109,7 +109,7 @@ COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=docs... install --frozen-lockfile
 COPY . .
-RUN --mount=type=cache,target=/app/.turbo pnpm --filter=docs... build
+RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=docs
 
 FROM debian:12-slim AS runtime
 


### PR DESCRIPTION
## Summary
- Replace `pnpm --filter=<app>... build` commands with `turbo build --filter=<app>` in split dockerfile
- Leverages Turbo's build orchestration and caching capabilities for better performance
- Maintains same functionality while using the monorepo's preferred build tool

## Test plan
- [ ] Verify docker build still works for all services
- [ ] Test that turbo caching is properly utilized during builds
- [ ] Confirm all apps build successfully with new commands

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the build process across all services to align with project scripts, improving consistency and reproducibility.
  * Streamlined build command invocation to reduce variance between components and simplify maintenance.
  * Retained existing caching and workflows; no runtime or functional changes expected.
  * Improves reliability of production images and local builds without impacting user-facing behavior.
  * No user-visible changes; features and performance remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->