### PR TITLE
feat: add image compression workflow

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -14,7 +14,9 @@ jobs:
   compress:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -1,0 +1,23 @@
+name: Compress Images
+
+on:
+  pull_request:
+    paths:
+      - "**/*.jpg"
+      - "**/*.jpeg"
+      - "**/*.png"
+      - "**/*.webp"
+      - "**/*.avif"
+  workflow_dispatch:
+
+jobs:
+  compress:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    permissions: write-all
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Compress PR images
+        uses: calibreapp/image-actions@main

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Compress PR images
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@1.4.1


### PR DESCRIPTION
## Summary
- Introduces a new GitHub Actions workflow to automatically compress images in pull requests
- Targets common image formats: JPG, JPEG, PNG, WEBP, and AVIF
- Runs on pull request events and can be triggered manually via workflow dispatch

## Changes

### GitHub Workflow
- Added `.github/workflows/calibreapp-image-actions.yml` to:
  - Trigger on pull requests affecting image files
  - Use `calibreapp/image-actions` action to compress images
  - Run on `ubuntu-latest` with write permissions
  - Checkout repository before compression step

## Test plan
- [ ] Open a pull request with image file changes and verify the workflow triggers
- [ ] Confirm images are compressed successfully by the action
- [ ] Manually trigger the workflow via GitHub UI to ensure dispatch works

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dd528ae4-0e51-4b2d-9dfb-d7975f892ad2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Image-compression workflow updated for more consistent, reliable optimization of new or updated images (JPG, JPEG, PNG, WEBP, AVIF) in pull requests.
  * Maintains automatic runs on PRs and supports manual triggers for flexibility.
  * Reduces variability in asset optimization, helping keep images consistently smaller and page loads faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->