### PR TITLE
feat(models): add reasoning and thinkingBudget support

### DIFF
--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -18,7 +18,7 @@ import {
 	readAll,
 } from "./test-utils/test-helpers.js";
 
-describe("e2e individual tests", getTestOptions(), () => {
+describe("e2e individual tests", () => {
 	// Helper to create unique test data for each test to avoid conflicts
 	async function createTestData(testId: string) {
 		const userId = `user-${testId}`;
@@ -100,7 +100,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"JSON output mode error for unsupported model",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const envVarName = getProviderEnvVar("anthropic");
 			const envVarValue = envVarName ? process.env[envVarName] : undefined;
@@ -140,7 +140,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"JSON output mode error when 'json' not mentioned in messages",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const envVarName = getProviderEnvVar("openai");
 			const envVarValue = envVarName ? process.env[envVarName] : undefined;
@@ -197,7 +197,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"completions with llmgateway/auto in credits mode",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			// require all provider keys to be set
 			for (const provider of providers) {
@@ -264,7 +264,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"completions with bare 'auto' model and credits",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const { orgId, projectId, token } = await createTestData("bare-auto");
 
@@ -377,7 +377,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"Prompt tokens are never zero even when provider returns 0",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const { token } = await createTestData("zero-tokens");
 
@@ -428,7 +428,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"Prompt tokens are calculated for streaming when provider returns 0",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const { token } = await createTestData("zero-tokens-streaming");
 
@@ -468,7 +468,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"GPT-5-nano responses API parameter handling",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const envVarName = getProviderEnvVar("openai");
 			const envVarValue = envVarName ? process.env[envVarName] : undefined;
@@ -530,7 +530,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"Auto-routing sets reasoning_effort to minimal for gpt-5 models",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const envVarName = getProviderEnvVar("openai");
 			const envVarValue = envVarName ? process.env[envVarName] : undefined;
@@ -613,7 +613,7 @@ describe("e2e individual tests", getTestOptions(), () => {
 
 	test(
 		"Success when requesting multi-provider model without prefix",
-		getTestOptions(),
+		getTestOptions({ completions: false }),
 		async () => {
 			const multiProviderModel = models.find((m) => m.providers.length > 1);
 			if (!multiProviderModel) {

--- a/apps/gateway/src/chat/tools/types.ts
+++ b/apps/gateway/src/chat/tools/types.ts
@@ -30,6 +30,7 @@ export interface ToolCall {
 export interface StreamingDelta {
 	role?: "assistant";
 	content?: string;
+	reasoning_content?: string;
 	images?: ImageObject[];
 	tool_calls?: ToolCall[];
 }

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -19,6 +19,7 @@ export const googleModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
+				reasoning: true,
 			},
 			{
 				providerId: "routeway-discount",
@@ -32,6 +33,7 @@ export const googleModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
+				reasoning: true,
 			},
 		],
 	},
@@ -162,6 +164,7 @@ export const googleModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
+				reasoning: true,
 			},
 			{
 				providerId: "routeway-discount",
@@ -176,6 +179,7 @@ export const googleModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
+				reasoning: true,
 			},
 		],
 	},

--- a/packages/models/src/prepare-request-body.spec.ts
+++ b/packages/models/src/prepare-request-body.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+
+import { prepareRequestBody } from "./prepare-request-body.js";
+
+describe("prepareRequestBody - Google AI Studio", () => {
+	test("should set thinkingBudget when reasoning_effort is provided", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.5-pro",
+			[{ role: "user", content: "What is 2+2?" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"medium", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.generationConfig).toBeDefined();
+		expect(requestBody.generationConfig.thinkingConfig).toBeDefined();
+		expect(requestBody.generationConfig.thinkingConfig.includeThoughts).toBe(
+			true,
+		);
+		expect(requestBody.generationConfig.thinkingConfig.thinkingBudget).toBe(
+			8192,
+		);
+	});
+
+	test("should map reasoning_effort values correctly", async () => {
+		const effortMapping = [
+			{ effort: "minimal", expected: 512 },
+			{ effort: "low", expected: 2048 },
+			{ effort: "medium", expected: 8192 },
+			{ effort: "high", expected: 24576 },
+		];
+
+		for (const { effort, expected } of effortMapping) {
+			const requestBody = (await prepareRequestBody(
+				"google-ai-studio",
+				"gemini-2.5-pro",
+				[{ role: "user", content: "test" }],
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				effort as "minimal" | "low" | "medium" | "high",
+				true,
+				false,
+			)) as any;
+
+			expect(requestBody.generationConfig.thinkingConfig.thinkingBudget).toBe(
+				expected,
+			);
+		}
+	});
+
+	test("should not set thinkingBudget when reasoning_effort is not provided", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.5-pro",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined, // reasoning_effort not provided
+			true, // supportsReasoning
+			false,
+		)) as any;
+
+		expect(requestBody.generationConfig.thinkingConfig.includeThoughts).toBe(
+			true,
+		);
+		expect(
+			requestBody.generationConfig.thinkingConfig.thinkingBudget,
+		).toBeUndefined();
+	});
+
+	test("should not set thinkingConfig when supportsReasoning is false", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-1.5-pro",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"medium",
+			false, // supportsReasoning is false
+			false,
+		)) as any;
+
+		expect(requestBody.generationConfig.thinkingConfig).toBeUndefined();
+	});
+});

--- a/packages/models/src/prepare-request-body.ts
+++ b/packages/models/src/prepare-request-body.ts
@@ -492,6 +492,25 @@ export async function prepareRequestBody(
 				requestBody.generationConfig.thinkingConfig = {
 					includeThoughts: true,
 				};
+
+				// Map reasoning_effort to thinking_budget
+				if (reasoning_effort !== undefined) {
+					const getThinkingBudget = (effort: string) => {
+						switch (effort) {
+							case "minimal":
+								return 512; // Minimum supported by most models
+							case "low":
+								return 2048;
+							case "high":
+								return 24576; // Maximum for Flash models
+							case "medium":
+							default:
+								return 8192; // Balanced default
+						}
+					};
+					requestBody.generationConfig.thinkingConfig.thinkingBudget =
+						getThinkingBudget(reasoning_effort);
+				}
 			}
 
 			break;


### PR DESCRIPTION
Introduced `reasoning` property in model configurations and mapped it to the `thinkingBudget` value in request payloads. Enhanced streaming to handle reasoning-specific content. Updated tests for reasoning effort configurations.