### PR TITLE
fix(models): filter out unstable and experimental providers

### DIFF
--- a/packages/models/src/get-cheapest-from-available-providers.ts
+++ b/packages/models/src/get-cheapest-from-available-providers.ts
@@ -11,10 +11,33 @@ export function getCheapestFromAvailableProviders<
 		return null;
 	}
 
-	let cheapestProvider = availableModelProviders[0];
+	// Filter out unstable and experimental providers
+	const stableProviders = availableModelProviders.filter((provider) => {
+		const providerInfo = modelWithPricing.providers.find(
+			(p) => p.providerId === provider.providerId,
+		);
+		const providerStability =
+			providerInfo && "stability" in providerInfo
+				? (providerInfo as ProviderModelMapping).stability
+				: undefined;
+		const modelStability =
+			"stability" in modelWithPricing
+				? (modelWithPricing as { stability?: string }).stability
+				: undefined;
+		const effectiveStability = providerStability ?? modelStability;
+		return (
+			effectiveStability !== "unstable" && effectiveStability !== "experimental"
+		);
+	});
+
+	if (stableProviders.length === 0) {
+		return null;
+	}
+
+	let cheapestProvider = stableProviders[0];
 	let lowestPrice = Number.MAX_VALUE;
 
-	for (const provider of availableModelProviders) {
+	for (const provider of stableProviders) {
 		const providerInfo = modelWithPricing.providers.find(
 			(p) => p.providerId === provider.providerId,
 		);

--- a/packages/models/src/get-cheapest-model-for-provider.ts
+++ b/packages/models/src/get-cheapest-model-for-provider.ts
@@ -14,13 +14,28 @@ export function getCheapestModelForProvider(
 		.filter((model) => !model.deprecatedAt || new Date() <= model.deprecatedAt)
 		.map((model) => ({
 			model: model.id,
+			modelStability:
+				"stability" in model
+					? (model.stability as string | undefined)
+					: undefined,
 			provider: model.providers.find((p) => p.providerId === provider)!,
 		}))
 		.filter(
 			({ provider: providerInfo }) =>
 				providerInfo.inputPrice !== undefined &&
 				providerInfo.outputPrice !== undefined,
-		);
+		)
+		.filter(({ provider: providerInfo, modelStability }) => {
+			const providerStability =
+				"stability" in providerInfo
+					? (providerInfo.stability as string | undefined)
+					: undefined;
+			const effectiveStability = providerStability ?? modelStability;
+			return (
+				effectiveStability !== "unstable" &&
+				effectiveStability !== "experimental"
+			);
+		});
 
 	if (availableModels.length === 0) {
 		return null;


### PR DESCRIPTION
Refined model queries to exclude providers and models with stability marked as "unstable" or "experimental." Ensures only stable options are considered when determining the cheapest provider or model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stability-aware selection: automatically filters out unstable or experimental providers and models.
  * Smarter cost optimization: picks the lowest-cost stable provider using input/output pricing and applicable discounts.
  * More predictable behavior: returns no selection when only unstable/experimental options are available.
  * Improved reliability in model-provider matching by prioritizing stable options without changing any public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->