### PR TITLE
fix(tests): filter TEST_MODELS by provider correctly

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -179,6 +179,14 @@ export const testModels = filteredModels
 				continue;
 			}
 
+			// Filter by TEST_MODELS if specified
+			if (specifiedModels) {
+				const providerModelId = `${provider.providerId}/${model.id}`;
+				if (!specifiedModels.includes(providerModelId)) {
+					continue;
+				}
+			}
+
 			// Skip unstable providers if not in full mode, unless they have test: "only" or are in TEST_MODELS
 			if (provider.stability === "unstable" && !fullMode) {
 				// Allow if provider has test: "only"
@@ -226,6 +234,14 @@ export const providerModels = filteredModels
 			// Skip providers marked with test: "skip"
 			if (provider.test === "skip") {
 				continue;
+			}
+
+			// Filter by TEST_MODELS if specified
+			if (specifiedModels) {
+				const providerModelId = `${provider.providerId}/${model.id}`;
+				if (!specifiedModels.includes(providerModelId)) {
+					continue;
+				}
 			}
 
 			// Skip unstable providers if not in full mode, unless they have test: "only" or are in TEST_MODELS


### PR DESCRIPTION
## Summary
Fixed TEST_MODELS environment variable to properly filter tests by the specified provider/model combination instead of running all provider mappings for a model.

## Problem
When TEST_MODELS was set with format `provider/model-id` (e.g., `openai/gpt-4o-mini`), the code would include the model but still test ALL provider mappings for that model (e.g., OpenAI, Azure, Vertex AI, etc.) instead of just the specified provider.

## Solution
Added early provider filtering in both `testModels` and `providerModels` generation to skip providers that don't match the TEST_MODELS specification before other checks are performed.

## Test plan
- [x] Set `TEST_MODELS=openai/gpt-4o-mini` and verify only OpenAI provider is tested
- [x] Run `pnpm format` to ensure code follows style guide
- [ ] Run targeted e2e tests to verify filtering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Enhanced end-to-end test filtering to run only selected provider/model combinations via an environment setting. When not specified, tests run as before. This works alongside existing selection and skip rules, enabling faster, more targeted runs in CI and local development while leaving product behavior unchanged for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->