### PR TITLE
fix(gateway): log initial requested model ID

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -406,6 +406,9 @@ chat.openapi(completions, async (c) => {
 	// Extract custom X-LLMGateway-* headers
 	const customHeaders = extractCustomHeaders(c);
 
+	// Store the original llmgateway model ID for logging purposes
+	const initialRequestedModel = modelInput;
+
 	let requestedModel: Model = modelInput as Model;
 	let requestedProvider: Provider | undefined;
 	let customProviderName: string | undefined;
@@ -1413,7 +1416,7 @@ chat.openapi(completions, async (c) => {
 					usedModelFormatted,
 					usedModelMapping,
 					usedProvider,
-					requestedModel,
+					initialRequestedModel,
 					requestedProvider,
 					messages,
 					temperature,
@@ -1504,7 +1507,7 @@ chat.openapi(completions, async (c) => {
 					usedModelFormatted,
 					usedModelMapping,
 					usedProvider,
-					requestedModel,
+					initialRequestedModel,
 					requestedProvider,
 					messages,
 					temperature,
@@ -1723,7 +1726,7 @@ chat.openapi(completions, async (c) => {
 						usedModelFormatted,
 						usedModelMapping,
 						usedProvider,
-						requestedModel,
+						initialRequestedModel,
 						requestedProvider,
 						messages,
 						temperature,
@@ -1849,7 +1852,7 @@ chat.openapi(completions, async (c) => {
 					usedModelFormatted,
 					usedModelMapping,
 					usedProvider,
-					requestedModel,
+					initialRequestedModel,
 					requestedProvider,
 					messages,
 					temperature,
@@ -2696,7 +2699,7 @@ chat.openapi(completions, async (c) => {
 					usedModelFormatted,
 					usedModelMapping,
 					usedProvider,
-					requestedModel,
+					initialRequestedModel,
 					requestedProvider,
 					messages,
 					temperature,
@@ -2844,7 +2847,7 @@ chat.openapi(completions, async (c) => {
 			usedModelFormatted,
 			usedModelMapping,
 			usedProvider,
-			requestedModel,
+			initialRequestedModel,
 			requestedProvider,
 			messages,
 			temperature,
@@ -2927,7 +2930,7 @@ chat.openapi(completions, async (c) => {
 			usedModelFormatted,
 			usedModelMapping,
 			usedProvider,
-			requestedModel,
+			initialRequestedModel,
 			requestedProvider,
 			messages,
 			temperature,
@@ -3015,7 +3018,7 @@ chat.openapi(completions, async (c) => {
 					code: finishReason,
 					requestedProvider,
 					usedProvider,
-					requestedModel,
+					requestedModel: initialRequestedModel,
 					usedModel,
 					responseText: errorResponseText,
 				},
@@ -3105,7 +3108,7 @@ chat.openapi(completions, async (c) => {
 		usedModelFormatted,
 		usedModelMapping,
 		usedProvider,
-		requestedModel,
+		initialRequestedModel,
 		requestedProvider,
 		messages,
 		temperature,


### PR DESCRIPTION
## Summary

Fixes logging to use the original llmgateway model ID instead of the provider-specific rewritten model name.

### Changes

- Added `initialRequestedModel` variable to preserve the original user-provided model ID
- Updated all `createLogEntry()` calls (8 locations) to use `initialRequestedModel` instead of `requestedModel`
- Updated error response to include the initial requested model ID for consistency

### Problem

Previously, when a user requested a model like "gpt-4o-mini" or "openai/gpt-4o-mini", the code would rewrite `requestedModel` to the provider-specific model name (e.g., the actual model name used by the provider API). This rewritten value was then saved to the log table, making it difficult to track what the user originally requested.

### Solution

Now the original llmgateway model ID from user input is preserved in `initialRequestedModel` and used for all logging purposes, while `requestedModel` can still be used for provider-specific API calls.

### Test plan

- [x] Code formatted with `pnpm format`
- [ ] Manual testing to verify logs contain correct model IDs
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Response metadata now consistently reflects the originally requested model, eliminating mismatches after routing or normalization.
- Chores
  - Enhanced logging to preserve the originally requested model throughout request handling, improving auditability and traceability.
  - Standardized log entries and response details for clearer diagnostics and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->