### PR TITLE
fix(MagicTweet): remove unused prop

### DIFF
--- a/apps/ui/src/lib/components/tweet-card.tsx
+++ b/apps/ui/src/lib/components/tweet-card.tsx
@@ -232,7 +232,6 @@ export const TweetMedia = ({ tweet }: { tweet: EnrichedTweet }) => {
 
 export const MagicTweet = ({
 	tweet,
-	components,
 	className,
 	...props
 }: {


### PR DESCRIPTION
## Summary
- Removes unused prop 'components' from MagicTweet to satisfy lint rules
- No runtime changes; UI behavior remains unchanged

## Changes
### Code
- In `apps/ui/src/lib/components/tweet-card.tsx`, remove the unused `components` prop from the `MagicTweet` destructuring

### Lint / TypeScript
- Run `pnpm lint` and fix warnings; this change resolves the unused prop warning without introducing new issues

## Test plan
- [x] Run `pnpm lint` locally to verify no unused-variable/prop warnings remain
- [x] Build and run UI to ensure no regressions
- [x] Manually verify that `MagicTweet` rendering remains unaffected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5b25622f-4295-4445-b37c-828ab4904484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified the tweet display component by removing an unused customization prop, resulting in a cleaner API with no change to visuals or behavior.
  - Existing pages and timelines render exactly as before.
  - Any custom integrations that referenced the removed prop should be updated, but standard usage is unaffected.
  - No configuration or migration is required for default setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->