### PR TITLE
feat(models): add Bedrock Llama models

### DIFF
--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -11,8 +11,8 @@ export const metaModels = [
 			{
 				providerId: "aws-bedrock",
 				modelName: "meta.llama3-1-8b-instruct-v1:0",
-				inputPrice: 2.2 / 1e6,
-				outputPrice: 6.6 / 1e6,
+				inputPrice: 0.22 / 1e6,
+				outputPrice: 0.22 / 1e6,
 				requestPrice: 0,
 				contextSize: 128000,
 				maxOutput: 2048,
@@ -68,8 +68,8 @@ export const metaModels = [
 			{
 				providerId: "aws-bedrock",
 				modelName: "meta.llama3-1-70b-instruct-v1:0",
-				inputPrice: 10.6 / 1e6,
-				outputPrice: 31.8 / 1e6,
+				inputPrice: 0.72 / 1e6,
+				outputPrice: 0.72 / 1e6,
 				requestPrice: 0,
 				contextSize: 128000,
 				maxOutput: 2048,


### PR DESCRIPTION
## Summary

- Add AWS Bedrock provider support for Meta Llama 3, 3.1, 3.2, 3.3, and 4 models
- Update Llama 4 Scout and Maverick models with correct vision support
- Add 9 new Bedrock Llama model variants with accurate pricing

### New Models Added

- Llama 3 8B Instruct (`meta.llama3-8b-instruct-v1:0`)
- Llama 3 70B Instruct (`meta.llama3-70b-instruct-v1:0`)
- Llama 3.1 8B Instruct (`meta.llama3-1-8b-instruct-v1:0`)
- Llama 3.1 70B Instruct (`meta.llama3-1-70b-instruct-v1:0`)
- Llama 3.2 1B Instruct (`meta.llama3-2-1b-instruct-v1:0`)
- Llama 3.2 3B Instruct (`meta.llama3-2-3b-instruct-v1:0`)
- Llama 3.2 11B Instruct (`meta.llama3-2-11b-instruct-v1:0`) - with vision
- Llama 3.2 90B Instruct (`meta.llama3-2-90b-instruct-v1:0`) - with vision
- Llama 3.3 70B Instruct (`meta.llama3-3-70b-instruct-v1:0`)

### Updated Models

- Llama 4 Scout 17B: enabled vision support
- Llama 4 Maverick 17B: updated pricing and enabled vision support

## Test plan

- [x] Run `aws bedrock list-foundation-models --region us-east-1` to verify models
- [x] Format code with `pnpm format`
- [ ] Build project to verify no TypeScript errors
- [ ] Test Bedrock Llama models in playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Llama 3.1 70B Instruct and expanded AWS Bedrock provider coverage for select Llama models.
  * Enabled vision capability on several 3.x/4.x variants and increased context size, max output and streaming support where applicable.

* **Chores**
  * Updated per-model pricing and provider-specific settings to reflect new provider coverage and capability changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->