### PR TITLE
feat(gateway): add json_schema response format

### DIFF
--- a/apps/gateway/src/chat-json.e2e.ts
+++ b/apps/gateway/src/chat-json.e2e.ts
@@ -77,10 +77,11 @@ describe("e2e", getConcurrentTestOptions(), () => {
 			if ((modelDef as ModelDefinition)?.jsonOutput !== true) {
 				return false;
 			}
-			// Check if any provider for this model supports jsonOutputSchema
+			// Check if any provider for this model supports jsonOutputSchema and is not explicitly disabled
 			return modelDef?.providers.some(
 				(provider) =>
-					(provider as ProviderModelMapping).jsonOutputSchema === true,
+					(provider as ProviderModelMapping).jsonOutputSchema === true &&
+					!(provider as ProviderModelMapping).disableJsonOutputSchema,
 			);
 		}),
 	)("JSON schema output $model", getTestOptions(), async ({ model }) => {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -571,7 +571,8 @@ chat.openapi(completions, async (c) => {
 			if (requestedModel !== "auto" && requestedModel !== "custom") {
 				const supportsJsonSchema = modelInfo.providers.some(
 					(provider) =>
-						(provider as ProviderModelMapping).jsonOutputSchema === true,
+						(provider as ProviderModelMapping).jsonOutputSchema === true &&
+						!(provider as ProviderModelMapping).disableJsonOutputSchema,
 				);
 
 				if (!supportsJsonSchema) {

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -90,6 +90,11 @@ export interface ProviderModelMapping {
 	 */
 	jsonOutputSchema?: boolean;
 	/**
+	 * Explicitly disable JSON schema output mode for this specific provider mapping
+	 * (overrides jsonOutputSchema at the provider level)
+	 */
+	disableJsonOutputSchema?: boolean;
+	/**
 	 * List of supported API parameters for this model/provider combination
 	 */
 	supportedParameters?: string[];

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -102,6 +102,7 @@ export const openaiModels = [
 				vision: false,
 				tools: true,
 				jsonOutputSchema: true,
+				disableJsonOutputSchema: true,
 			},
 		],
 		jsonOutput: true,


### PR DESCRIPTION
## Summary
Add support for OpenAI's `json_schema` response format type, which allows structured JSON output with schema validation.

## Changes
- Updated Zod schema to accept `json_schema` type with nested schema configuration
- Added separate E2E test for JSON schema validation
- Schema is passed through to OpenAI-compatible providers

## Test Plan
- [x] E2E tests passing with `TEST_MODELS=openai/gpt-5-nano`
- [x] Both `json_object` and `json_schema` formats tested
- [x] Code formatted with `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a structured JSON Schema response format alongside text and JSON-object responses, with optional schema metadata and strict validation.
  * Provider/model metadata updated to indicate JSON Schema support; specific models can opt out.

* **Tests**
  * End-to-end tests added to request JSON Schema responses, verify success, parse the returned JSON, and assert required fields and types.

* **Bug Fixes**
  * Requests using JSON Schema now return a clear validation error if the selected provider/model doesn't support it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->