### PR TITLE
feat(anthropic): add Claude Haiku 4.5 model

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -287,6 +287,28 @@ export const anthropicModels = [
 		],
 	},
 	{
+		id: "claude-haiku-4-5",
+		name: "Claude Haiku 4.5",
+		family: "anthropic",
+		deprecatedAt: undefined,
+		deactivatedAt: undefined,
+		providers: [
+			{
+				providerId: "anthropic",
+				modelName: "claude-haiku-4-5",
+				inputPrice: 1.0 / 1e6,
+				outputPrice: 5.0 / 1e6,
+				cachedInputPrice: 0.1 / 1e6,
+				requestPrice: 0,
+				contextSize: 200000,
+				maxOutput: 8192,
+				streaming: true,
+				vision: false,
+				tools: true,
+			},
+		],
+	},
+	{
 		id: "claude-opus-4-20250514",
 		name: "Claude Opus 4 (2025-05-14)",
 		family: "anthropic",


### PR DESCRIPTION
## Summary
- Adds Claude Haiku 4.5 model to Anthropic integration in anthropic.ts
- Mirrors existing Haiku models with pricing, context, and capabilities (streaming, tools)

## Changes
### Model Configuration
- Adds a new entry to the anthropicModels array:
  - id: "claude-haiku-4-5"
  - name: "Claude Haiku 4.5"
  - family: "anthropic"
  - deprecatedAt: undefined
  - deactivatedAt: undefined
  - providers: [
    - providerId: "anthropic"
    - modelName: "claude-haiku-4-5"
    - inputPrice: 1.0 / 1e6
    - outputPrice: 5.0 / 1e6
    - cachedInputPrice: 0.1 / 1e6
    - requestPrice: 0
    - contextSize: 200000
    - maxOutput: 8192
    - streaming: true
    - vision: false
    - tools: true
  ]

### Compatibility
- Non-breaking addition; extends available Claude Haiku variants

### Testing
- [x] Verify the new model appears in the anthropic models list
- [x] Validate key fields (pricing, contextSize, maxOutput, streaming, tools)
- [x] Ensure existing Claude Haiku models are unaffected

## Test plan
- [x] Fetch models list to confirm claude-haiku-4-5 is present
- [x] Check pricing and capabilities for the new model
- [x] Smoke test with a request using claude-haiku-4-5 if environment allows

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c77f8acd-5eb0-418e-a073-d4dfc99fd6d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Haiku 4.5 model.
  * Offers a 200K-token context window and up to 8,192 tokens per response.
  * Supports streaming and tool use; vision is not supported.
  * Pricing: input $0.001 per 1K tokens, output $0.005 per 1K tokens, cached input $0.0001 per 1K tokens, no per-request fee.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->