### PR TITLE
fix(models): mark routeway free models unstable

### DIFF
--- a/packages/models/src/models/routeway.ts
+++ b/packages/models/src/models/routeway.ts
@@ -11,6 +11,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "deepseek-r1t2-chimera:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -34,6 +35,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "glm-4.5-air:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -57,6 +59,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "kimi-dev-72b:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -80,6 +83,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "mistral-small-3:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -103,6 +107,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "gpt-oss-20b:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -126,6 +131,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "gpt-4.1:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -149,6 +155,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "llama-3.3-70b-instruct:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -172,6 +179,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "llama-4-scout:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -195,6 +203,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "llama-4-maverick:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,
@@ -218,6 +227,7 @@ export const routewayModels = [
 		providers: [
 			{
 				providerId: "routeway",
+				stability: "unstable" as const,
 				modelName: "nemotron-nano-9b-v2:free",
 				inputPrice: 0.0 / 1e6,
 				outputPrice: 0.0 / 1e6,


### PR DESCRIPTION
## Summary
- Mark all routeway free-model entries as unstable by adding stability: "unstable" to each provider block.

## Changes
### Core Functionality
- Added stability: "unstable" as const to routeway provider entries for the following free models:
  - deepseek-r1t2-chimera:free
  - glm-4.5-air:free
  - kimi-dev-72b:free
  - mistral-small-3:free
  - gpt-oss-20b:free
  - gpt-4.1:free
  - llama-3.3-70b-instruct:free
  - llama-4-scout:free
  - llama-4-maverick:free
  - nemotron-nano-9b-v2:free

### Data Model
- Ensured type consistency with stability field using as const for all affected entries.

## Files touched
- packages/models/src/models/routeway.ts

## Test plan
- [x] Build and type-check the repository
- [x] Verify stability: "unstable" is present for all listed free-model entries
- [x] Run existing unit tests (if applicable) and ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d4c9e193-ea6f-4b2a-91bb-f245d5b45776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stability status information to providers, indicating their current operational state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->