### PR TITLE
fix(logger): disable in production

### DIFF
--- a/packages/instrumentation/src/logger.ts
+++ b/packages/instrumentation/src/logger.ts
@@ -7,17 +7,16 @@ export interface HonoRequestLoggerOptions {
 }
 
 export function createHonoRequestLogger(options: HonoRequestLoggerOptions) {
+	if (process.env.NODE_ENV === "production") {
+		return async (c: any, next: any) => await next();
+	}
+
 	return honoLogger((message: string, ...args: any) => {
-		logger.info(
-			message,
-			process.env.NODE_ENV === "production"
-				? {
-						kind: "request",
-						service: options.service,
-						source: "hono-logger",
-						args,
-					}
-				: undefined,
-		);
+		logger.info(message, {
+			kind: "request",
+			service: options.service,
+			source: "hono-logger",
+			args,
+		});
 	});
 }


### PR DESCRIPTION
## Background
The Hono request logger was unnecessarily running in production environments, adding overhead without providing value. This change aims to disable it only for production.

## Changes
- Modified `packages/instrumentation/src/logger.ts` in `createHonoRequestLogger`.
- Added a check for `process.env.NODE_ENV === "production"`.
- If in production, the function now returns a no-op middleware that simply calls `next()`.
- The full `honoLogger` middleware is only applied when not in production.

## Testing
- [ ] Verify Hono logger logs are NOT present in production environments.
- [ ] Confirm Hono logger logs ARE present in development environments.
