### PR TITLE
test(gateway): update auto-routing reasoning_effort test

### DIFF
--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -584,14 +584,17 @@ describe("e2e individual tests", () => {
 			const log = await validateLogByRequestId(requestId);
 			expect(log.requestedModel).toBe("auto");
 
-			// Auto-routing should select a reasoning model
-			// If gpt-5* is selected, reasoning_effort should be "minimal"
-			// For other reasoning models, reasoning_effort should be "low"
+			// Verify a reasoning model was selected
 			const usedModel = log.usedModelMapping;
-			expect(usedModel).toBeTruthy();
+			expect(usedModel).toBeDefined();
 
-			// The key test is that a reasoning model was selected and the request completed successfully
-			// This validates that the auto-routing + reasoning_effort logic works without errors
+			// Verify reasoningEffort is set and has the correct value based on model
+			expect(log.reasoningEffort).toBeDefined();
+			if (usedModel?.startsWith("gpt-5")) {
+				expect(log.reasoningEffort).toEqual("minimal");
+			} else {
+				expect(log.reasoningEffort).toEqual("low");
+			}
 
 			// Verify the response has valid usage information
 			expect(json.usage).toBeDefined();


### PR DESCRIPTION
## Background
The existing test for auto-routing was too specific, assuming only `gpt-5-nano` would be selected with `reasoning_effort` set to "minimal". This prevented the test from passing when other reasoning models (which should use "low" effort) were selected.

## Changes
- Renamed test `Auto-routing sets reasoning_effort to minimal for gpt-5 models` to `Auto-routing sets reasoning_effort appropriately` in `apps/gateway/src/api-individual.e2e.ts`.
- Removed assertions that checked for a specific `usedModelMapping` (`gpt-5-nano`).
- Updated assertions to verify that *a* reasoning model is selected and the request completes successfully.
- Modified comments to reflect that the test now covers scenarios where `reasoning_effort` could be "minimal" (for gpt-5*) or "low" (for other reasoning models).

## Testing
- [ ] Run `e2e individual tests` to verify the updated auto-routing logic.
- [ ] Ensure requests complete successfully with various models routed by `auto`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated auto-routing test assertions for reasoning model selection to be more flexible
  * Refined expectations for reasoning effort configuration across different model types
  * Adjusted token usage verification to accommodate varying effort levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->