### PR TITLE
fix(playground): prevent duplicate API key calls

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -206,8 +206,14 @@ export default function ChatPageClient({
 
 	// After login, ensure a playground key cookie exists via backend
 	useEffect(() => {
+		// Reset ref when user logs out or project is unset
+		if (!isAuthenticated || !selectedProject) {
+			ensuredProjectRef.current = null;
+			return;
+		}
+
 		const ensureKey = async () => {
-			if (!isAuthenticated || !selectedOrganization || !selectedProject) {
+			if (!selectedOrganization) {
 				return;
 			}
 			// Skip if we've already ensured the key for this project


### PR DESCRIPTION
Added ref to track ensured projects and prevent redundant calls to /api/ensure-playground-key endpoint that were causing excessive backend requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced redundant key validation calls when switching projects, improving playground responsiveness and load times.
  * Validation now resets when you sign out or deselect a project.
  * Validation requires an organization to be selected before proceeding, preventing unnecessary requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->