### PR TITLE
feat(canopywave): add reasoning flags and params to payload

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -189,6 +189,7 @@ export const deepseekModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
+				reasoning: true,
 			},
 		],
 		jsonOutput: false,

--- a/packages/models/src/prepare-request-body.ts
+++ b/packages/models/src/prepare-request-body.ts
@@ -304,6 +304,41 @@ export async function prepareRequestBody(
 			}
 			break;
 		}
+		case "canopywave": {
+			if (stream) {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+			if (response_format) {
+				requestBody.response_format = response_format;
+			}
+
+			// Add optional parameters if they are provided
+			if (temperature !== undefined) {
+				requestBody.temperature = temperature;
+			}
+			if (max_tokens !== undefined) {
+				requestBody.max_tokens = max_tokens;
+			}
+			if (top_p !== undefined) {
+				requestBody.top_p = top_p;
+			}
+			if (frequency_penalty !== undefined) {
+				requestBody.frequency_penalty = frequency_penalty;
+			}
+			if (presence_penalty !== undefined) {
+				requestBody.presence_penalty = presence_penalty;
+			}
+			// CanopyWave uses custom reasoning flags instead of reasoning_effort
+			if (reasoning_effort !== undefined) {
+				requestBody.chat_template_kwargs = {
+					thinking: true,
+				};
+				requestBody.separate_reasoning = true;
+			}
+			break;
+		}
 		case "xai":
 		case "groq":
 		case "deepseek":


### PR DESCRIPTION
## Summary
- Implement reasoning flags for CanopyWave payloads
- Enable optional reasoning flow and controls for CanopyWave requests
- Extend CanopyWave model support to include reasoning in streaming contexts

## Changes

### Models
- Enable reasoning in CanopyWave/DeepSeek model entries: added `reasoning: true` in the relevant DeepSeek model configuration.

### Request payload building
- In prepare-request-body.ts for CanopyWave:
  - If `stream` is true, set `requestBody.stream_options.include_usage = true`.
  - If `response_format` is provided, pass it through to `requestBody.response_format`.
  - Forward optional generation controls if provided:
    - `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`
  - Reasoning flags mapping for CanopyWave:
    - When `reasoning_effort` is provided, set
      - `requestBody.chat_template_kwargs = { thinking: true }`
      - `requestBody.separate_reasoning = true`
  - This implements CanopyWave-specific reasoning flags, aligning with the new behavior while preserving existing paths.

## Tests plan
- [x] With CanopyWave and streaming, `stream_options.include_usage` is present in the payload
- [x] `response_format` is applied when provided
- [x] Optional params (`temperature`, `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`) are correctly passed through when provided
- [x] Providing `reasoning_effort` results in `chat_template_kwargs: { thinking: true }` and `separate_reasoning: true` in the payload
- [x] Non-CanopyWave paths remain unaffected

## Notes
- This change introduces CanopyWave-specific reasoning behavior while keeping backward compatibility with existing models.
- Branch: terragon/add-reasoning-flags-canopywave-jevrod

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8d3f224f-26fc-4292-a3a5-eeba3f0e1c5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning capability support for DeepSeek V3.1 via the canopywave provider
  * Introduced reasoning_effort parameter for controlling model reasoning behavior
  * Extended model configuration options including temperature, max_tokens, top_p, frequency_penalty, presence_penalty, streaming, and response format support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->