### PR TITLE
feat(ui): show filtered counts for models/providers

### DIFF
--- a/apps/ui/src/components/models/all-models.tsx
+++ b/apps/ui/src/components/models/all-models.tsx
@@ -162,6 +162,10 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 		[router, searchParams],
 	);
 
+	// Calculate total counts
+	const totalModelCount = models.length;
+	const totalProviderCount = providers.length;
+
 	const modelsWithProviders: ModelWithProviders[] = useMemo(() => {
 		const baseModels = (models as readonly ModelDefinition[]).map((model) => ({
 			...model,
@@ -372,6 +376,16 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 			return 0;
 		});
 	}, [searchQuery, filters, sortField, sortDirection]);
+
+	// Calculate unique filtered providers
+	const filteredProviderCount = useMemo(() => {
+		const uniqueProviders = new Set(
+			modelsWithProviders.flatMap((model) =>
+				model.providerDetails.map((p) => p.provider.providerId),
+			),
+		);
+		return uniqueProviders.size;
+	}, [modelsWithProviders]);
 
 	const handleSort = (field: SortField) => {
 		if (sortField === field) {
@@ -1480,16 +1494,20 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 								<Card>
 									<CardContent className="p-4">
 										<div className="text-2xl font-bold">
-											{modelsWithProviders.length}
+											{hasActiveFilters
+												? `${modelsWithProviders.length}/${totalModelCount}`
+												: modelsWithProviders.length}
 										</div>
-										<div className="text-sm text-muted-foreground">
-											Total Models
-										</div>
+										<div className="text-sm text-muted-foreground">Models</div>
 									</CardContent>
 								</Card>
 								<Card>
 									<CardContent className="p-4">
-										<div className="text-2xl font-bold">{providers.length}</div>
+										<div className="text-2xl font-bold">
+											{hasActiveFilters
+												? `${filteredProviderCount}/${totalProviderCount}`
+												: totalProviderCount}
+										</div>
 										<div className="text-sm text-muted-foreground">
 											Providers
 										</div>


### PR DESCRIPTION
## Summary
- Improve filter feedback by showing current visible vs total counts for models and providers. When filters are active, counts show visible/total; otherwise display totals only.

## Changes
- Compute and store totalModelCount and totalProviderCount
- Compute filteredProviderCount as unique provider IDs across filtered models
- Update UI cards in AllModels:
  - Models card now shows either visibleModelCount or visibleModelCount/totalModelCount, followed by "Models"
  - Providers card shows either visibleProviderCount or visibleProviderCount/totalProviderCount, followed by "Providers"
- Keep sort/filter logic unchanged

## Rationale
- Provides clearer context for users about how many items match their filters vs overall.

## Testing
- Without filters: both cards show total counts
- With filters: counts reflect visible items and total values
- Check provider count accounts for unique providers across models
- Ensure UI formatting remains consistent

## Files touched
- apps/ui/src/components/models/all-models.tsx


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ec3ccb13-2d72-491c-885f-9c29f3bed6de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Enhanced filtering feedback: Model and Provider cards now display filtered/total count indicators when filters are applied
- Shows matching results alongside total available options (e.g., "5/100 Models", "3/15 Providers")  
- Count display reverts to single totals when no active filters are present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->