### PR TITLE
feat(ui): add JSON Output filter and chip

### DIFF
--- a/apps/ui/src/components/models/all-models.tsx
+++ b/apps/ui/src/components/models/all-models.tsx
@@ -22,6 +22,7 @@ import {
 	ExternalLink,
 	Percent,
 	Scale,
+	Braces,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -128,6 +129,7 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 			vision: searchParams.get("vision") === "true",
 			tools: searchParams.get("tools") === "true",
 			reasoning: searchParams.get("reasoning") === "true",
+			jsonOutput: searchParams.get("jsonOutput") === "true",
 			imageGeneration: searchParams.get("imageGeneration") === "true",
 			free: searchParams.get("free") === "true",
 			discounted: searchParams.get("discounted") === "true",
@@ -217,6 +219,9 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 				filters.capabilities.reasoning &&
 				!model.providerDetails.some((p) => p.provider.reasoning)
 			) {
+				return false;
+			}
+			if (filters.capabilities.jsonOutput && !model.jsonOutput) {
 				return false;
 			}
 			if (
@@ -496,6 +501,13 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 				color: "text-orange-500",
 			});
 		}
+		if (model?.jsonOutput) {
+			capabilities.push({
+				icon: Braces,
+				label: "JSON Output",
+				color: "text-cyan-500",
+			});
+		}
 		if (model?.output?.includes("image")) {
 			capabilities.push({
 				icon: ImagePlus,
@@ -514,6 +526,7 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 				vision: false,
 				tools: false,
 				reasoning: false,
+				jsonOutput: false,
 				imageGeneration: false,
 				free: false,
 				discounted: false,
@@ -532,6 +545,7 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 			vision: undefined,
 			tools: undefined,
 			reasoning: undefined,
+			jsonOutput: undefined,
 			free: undefined,
 			discounted: undefined,
 			provider: undefined,
@@ -591,6 +605,12 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 									label: "Reasoning",
 									icon: MessageSquare,
 									color: "text-orange-500",
+								},
+								{
+									key: "jsonOutput",
+									label: "JSON Output",
+									icon: Braces,
+									color: "text-cyan-500",
 								},
 								{
 									key: "imageGeneration",


### PR DESCRIPTION
## Summary
- Adds JSON Output capability flag and UI tag for model cards
- Integrates JSON Output as a filter controlled by URL param jsonOutput
- Filters and displays only models that support JSON Output when the filter is enabled
- Uses a Braces icon to represent JSON Output on model capability chips

## Changes

### Core Functionality
- Read jsonOutput from URL search params and map to filters.jsonOutput
- When filters.capabilities.jsonOutput is true, filter out models that do not expose jsonOutput
- Add model.jsonOutput-based capability to model cards so the JSON Output chip appears where applicable

### UI / Components
- Import Braces icon from lucide-react
- Display a "JSON Output" capability chip on models that have jsonOutput, colored cyan
- Initialize jsonOutput in filters to false by default and include it in reset/state management

### Files
- apps/ui/src/components/models/all-models.tsx

## Test plan
- [x] Open the models page with jsonOutput=true query param and verify only models supporting JSON Output are shown
- [x] Confirm a JSON Output chip appears on model cards that support it
- [x] Toggle or apply the jsonOutput filter and ensure non-supporting models are hidden when enabled
- [x] Ensure existing capabilities and UI behavior remain unaffected


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1f3ba1a6-7e04-46e6-b0fb-268f964e58d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON Output as a new filterable capability to help identify all models that support JSON-formatted responses.
  * JSON Output capability indicators now display throughout model views in both table and grid display formats.
  * Users can easily filter and discover models based on JSON Output support from the updated filters panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->