### PR TITLE
fix(model): exclude experimental stability in gateway filters

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -66,7 +66,8 @@ export const filteredModels = models
 	.filter((model) => {
 		// Check only model-level stability, not provider-level
 		const modelStability = (model as ModelDefinition).stability;
-		const isUnstable = modelStability === "unstable";
+		const isUnstable =
+			modelStability === "unstable" || modelStability === "experimental";
 
 		if (!isUnstable) {
 			return true;


### PR DESCRIPTION
## Summary
- Extend the model stability filter to also exclude experimental models, ensuring only stable models are used by the gateway.

## Changes
- apps/gateway/src/chat-helpers.e2e.ts
  - Treat stability === "experimental" as unstable by updating the isUnstable check
  - Existing behavior for stability === "unstable" remains unchanged
  - Models with stability not equal to unstable/experimental continue to be included

## Testing
- Run existing end-to-end tests to verify stable models are still included while experimental models are excluded
- Validate that filteredModels contains only models with stability other than unstable or experimental

## Notes
- No changes to provider-level stability logic; this update focuses on model-level filtering only

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/810159be-adcc-4070-b4ff-f6790f004e5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated model stability classification to treat "experimental" and "unstable" models consistently within the filtering system. This affects which models are available based on your configuration settings in non-full mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->