### PR TITLE
fix(drizzle): disable pluralization

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -491,6 +491,7 @@ export const apiAuth: ReturnType<typeof betterAuth> = instrumentBetterAuth(
 		secret: process.env.AUTH_SECRET || "your-secret-key",
 		database: drizzleAdapter(db, {
 			provider: "pg",
+			usePlural: false,
 			schema: {
 				user: tables.user,
 				session: tables.session,


### PR DESCRIPTION
## Summary
- Fixes a transaction support warning in Drizzle by configuring the drizzleAdapter to not pluralize table names.

## Changes

### Core Functionality
- In `apps/api/src/auth/config.ts`, added `usePlural: false` under the drizzleAdapter provider options.

### Backwards Compatibility
- Keeps existing table/schema mappings (user, session, etc.) while disabling pluralization to align with Drizzle expectations.

## Test plan
- [x] Run API locally and start auth flow; ensure no transaction warnings in logs
- [x] Verify authentication works with PostgreSQL
- [x] Confirm table mappings (user, session) still function
- [x] Run unit/integration tests if present (no tests updated)

## Notes
- No schema changes or migrations required.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1583cea1-25fa-47e9-902b-2cfa2a4b6365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration to adjust database table naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->