### PR TITLE
feat(playground): redirect to original URL after signin

### DIFF
--- a/apps/playground/src/app/login/page.tsx
+++ b/apps/playground/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, KeySquare } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -31,12 +31,24 @@ const formSchema = z.object({
 		.min(8, { message: "Password must be at least 8 characters" }),
 });
 
+function getSafeRedirectUrl(url: string | null): string {
+	if (!url) {
+		return "/";
+	}
+	if (url.startsWith("/") && !url.startsWith("//")) {
+		return url;
+	}
+	return "/";
+}
+
 export default function Login() {
 	const queryClient = useQueryClient();
 	const router = useRouter();
+	const searchParams = useSearchParams();
 	const posthog = usePostHog();
 	const [isLoading, setIsLoading] = useState(false);
 	const { signIn } = useAuth();
+	const returnUrl = getSafeRedirectUrl(searchParams.get("returnUrl"));
 
 	useUser({
 		redirectTo: "/",
@@ -81,7 +93,7 @@ export default function Login() {
 						email: values.email,
 					});
 					toast.success("Login successful");
-					router.push("/");
+					router.push(returnUrl);
 				},
 				onError: (ctx) => {
 					toast.error(ctx.error.message || "An unknown error occurred", {
@@ -121,7 +133,7 @@ export default function Login() {
 			}
 			posthog.capture("user_logged_in", { method: "passkey" });
 			toast.success("Login successful");
-			router.push("/");
+			router.push(returnUrl);
 		} catch (error: unknown) {
 			toast.error(
 				(error as Error)?.message || "Failed to sign in with passkey",

--- a/apps/playground/src/components/playground/auth-dialog.tsx
+++ b/apps/playground/src/components/playground/auth-dialog.tsx
@@ -4,10 +4,23 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 
-export function AuthDialog({ open }: { open: boolean }) {
+interface AuthDialogProps {
+	open: boolean;
+	returnUrl?: string;
+}
+
+export function AuthDialog({ open, returnUrl }: AuthDialogProps) {
 	if (!open) {
 		return null;
 	}
+
+	const loginUrl = returnUrl
+		? `/login?returnUrl=${encodeURIComponent(returnUrl)}`
+		: "/login";
+	const signupUrl = returnUrl
+		? `/signup?returnUrl=${encodeURIComponent(returnUrl)}`
+		: "/signup";
+
 	return (
 		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
 			<div className="w-[420px] rounded-md border bg-background p-4 shadow-md">
@@ -17,10 +30,10 @@ export function AuthDialog({ open }: { open: boolean }) {
 				</p>
 				<div className="flex items-center justify-end gap-2">
 					<Button size="sm" asChild>
-						<Link href="/login">Sign in</Link>
+						<Link href={loginUrl}>Sign in</Link>
 					</Button>
 					<Button size="sm" variant="outline" asChild>
-						<Link href="/signup">Create account</Link>
+						<Link href={signupUrl}>Create account</Link>
 					</Button>
 				</div>
 			</div>

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState, useRef } from "react";
 
 // Removed API key manager for playground; we rely on server-set cookie
@@ -43,6 +43,7 @@ export default function ChatPageClient({
 }: ChatPageClientProps) {
 	const { user, isLoading: isUserLoading } = useUser();
 	const router = useRouter();
+	const pathname = usePathname();
 	const searchParams = useSearchParams();
 
 	const mapped = useMemo(
@@ -200,6 +201,11 @@ export default function ChatPageClient({
 
 	const isAuthenticated = !isUserLoading && !!user;
 	const showAuthDialog = !isAuthenticated && !isUserLoading && !user;
+
+	const returnUrl = useMemo(() => {
+		const search = searchParams.toString();
+		return search ? `${pathname}?${search}` : pathname;
+	}, [pathname, searchParams]);
 
 	// Track which project has had its key ensured to prevent duplicate calls
 	const ensuredProjectRef = useRef<string | null>(null);
@@ -431,7 +437,7 @@ export default function ChatPageClient({
 					</div>
 				</div>
 			</div>
-			<AuthDialog open={showAuthDialog} />
+			<AuthDialog open={showAuthDialog} returnUrl={returnUrl} />
 		</SidebarProvider>
 	);
 }

--- a/apps/playground/src/components/playground/group-chat-client.tsx
+++ b/apps/playground/src/components/playground/group-chat-client.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react";
 import { X } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState, useRef } from "react";
 
 import { ThemeToggle } from "@/components/landing/theme-toggle";
@@ -46,6 +46,7 @@ export default function GroupChatClient({
 }: GroupChatClientProps) {
 	const { user, isLoading: isUserLoading } = useUser();
 	const router = useRouter();
+	const pathname = usePathname();
 	const searchParams = useSearchParams();
 
 	const mapped = useMemo(
@@ -74,6 +75,11 @@ export default function GroupChatClient({
 
 	const isAuthenticated = !isUserLoading && !!user;
 	const showAuthDialog = !isAuthenticated && !isUserLoading && !user;
+
+	const returnUrl = useMemo(() => {
+		const search = searchParams.toString();
+		return search ? `${pathname}?${search}` : pathname;
+	}, [pathname, searchParams]);
 
 	const ensuredProjectRef = useRef<string | null>(null);
 
@@ -503,7 +509,7 @@ export default function GroupChatClient({
 					</div>
 				</div>
 			</div>
-			<AuthDialog open={showAuthDialog} />
+			<AuthDialog open={showAuthDialog} returnUrl={returnUrl} />
 		</SidebarProvider>
 	);
 }


### PR DESCRIPTION
When users are prompted to sign in while viewing a specific page (e.g., /group or /?model=...), they are now redirected back to that page after successful authentication. Includes URL validation to prevent open redirect vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Login now redirects users back to their original page after authentication completes, rather than always redirecting to the home page. Applies to both email/password and passkey login methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->