### PR TITLE
style: use Inter font across UI docs playground

### DIFF
--- a/apps/playground/src/app/globals.css
+++ b/apps/playground/src/app/globals.css
@@ -6,8 +6,6 @@
 @theme inline {
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
-	--font-sans: var(--font-geist-sans);
-	--font-mono: var(--font-geist-mono);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
 
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
@@ -8,13 +8,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-const geistSans = Geist({
-	variable: "--font-geist-sans",
-	subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-	variable: "--font-geist-mono",
+const inter = Inter({
 	subsets: ["latin"],
 });
 
@@ -46,10 +40,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
 	return (
-		<html lang="en" suppressHydrationWarning>
-			<body
-				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-			>
+		<html lang="en" className={inter.className} suppressHydrationWarning>
+			<body className="antialiased">
 				<Providers config={config}>{children}</Providers>
 			</body>
 		</html>

--- a/apps/ui/src/app/globals.css
+++ b/apps/ui/src/app/globals.css
@@ -7,16 +7,6 @@
 
 body {
 	@apply m-0;
-	font-family:
-		-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-		"Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-code {
-	font-family:
-		source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 :root {

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
 
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
@@ -8,13 +8,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-const geistSans = Geist({
-	variable: "--font-geist-sans",
-	subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-	variable: "--font-geist-mono",
+const inter = Inter({
 	subsets: ["latin"],
 });
 
@@ -49,10 +43,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
 	return (
-		<html lang="en" suppressHydrationWarning>
-			<body
-				className={`${geistSans.variable} ${geistMono.variable} min-h-screen antialiased`}
-			>
+		<html lang="en" className={inter.className} suppressHydrationWarning>
+			<body className="min-h-screen antialiased">
 				<Providers config={config}>{children}</Providers>
 			</body>
 		</html>


### PR DESCRIPTION
## Summary
- Replaces Geist Sans/Mono with Inter font across Playground and UI docs
- Removes Geist font variables and font-family fallbacks
- Updates Next.js root layouts to apply Inter via next/font
- Drops explicit code font stack; code blocks will use the browser's default monospace

## Changes

### Core Functionality
- Import Inter font from next/font/google in both playground and ui layout files
- Apply Inter font className to the HTML element and retain antialiased body

### Styling
- Remove Geist font variable declarations from playground globals.css
- Remove body and code font-family fallbacks from ui globals.css
- Ensure typography is consistently rendered with Inter across pages

### UI/UX
- Typography updates provide a consistent look and feel without layout changes

### Files touched
- apps/playground/src/app/globals.css
- apps/playground/src/app/layout.tsx
- apps/ui/src/app/globals.css
- apps/ui/src/app/layout.tsx

## Test plan
- [x] Load playground and UI docs pages to verify Inter font is applied
- [x] Confirm code blocks render with default browser monospace
- [x] Check for layout shifts or font loading flashes
- [x] Ensure text rendering remains legible and consistent across pages

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e8a16fcb-a80f-488c-b1f1-eae236d3a611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the default typography across the platform from Geist to Inter font for improved visual consistency.
  * Removed custom font variable declarations from theme definitions and simplified font application logic.
  * Streamlined font configuration to use a unified approach across all components for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->