### PR TITLE
feat(chat): restrict auto chat to JSON providers

### DIFF
--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -652,4 +652,65 @@ describe("e2e individual tests", () => {
 			expect(log.streamed).toBe(false);
 		},
 	);
+
+	test(
+		"Auto-routing filters models by JSON output support",
+		getTestOptions({ completions: false }),
+		async () => {
+			const { orgId, projectId, token } = await createTestData("auto-json");
+
+			await db
+				.update(tables.organization)
+				.set({ credits: "1000" })
+				.where(eq(tables.organization.id, orgId));
+
+			await db
+				.update(tables.project)
+				.set({ mode: "credits" })
+				.where(eq(tables.project.id, projectId));
+
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					Authorization: `Bearer ${token}`,
+				},
+				body: JSON.stringify({
+					model: "auto",
+					messages: [
+						{
+							role: "user",
+							content: "Respond with JSON containing a greeting message",
+						},
+					],
+					response_format: { type: "json_object" },
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			validateResponse(json);
+
+			const log = await validateLogByRequestId(requestId);
+			expect(log.requestedModel).toBe("auto");
+			expect(log.usedProvider).toBeTruthy();
+			expect(log.usedModel).toBeTruthy();
+
+			// Verify that the selected model supports JSON output
+			const usedModelDef = models.find((m) => m.id === log.usedModelMapping);
+			expect(usedModelDef).toBeDefined();
+
+			const usedProviderMapping = usedModelDef?.providers.find(
+				(p) => (p as any).providerId === log.usedProvider,
+			);
+			expect(usedProviderMapping).toBeDefined();
+			expect((usedProviderMapping as any).jsonOutput).toBe(true);
+
+			// Verify the content is valid JSON
+			const content = json.choices[0].message.content;
+			expect(() => JSON.parse(content)).not.toThrow();
+		},
+	);
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -909,6 +909,16 @@ chat.openapi(completions, async (c) => {
 				const modelContextSize = provider.contextSize ?? 8192;
 				const contextSizeMet = modelContextSize >= requiredContextSize;
 
+				// If JSON output is requested, only include providers that support it
+				if (
+					response_format?.type === "json_object" ||
+					response_format?.type === "json_schema"
+				) {
+					if ((provider as ProviderModelMapping).jsonOutput !== true) {
+						return false;
+					}
+				}
+
 				// If no_reasoning is true, exclude reasoning models
 				if (
 					no_reasoning &&


### PR DESCRIPTION
## Summary
- Ensure JSON output requests (json_object / json_schema) in auto mode only route to providers that support JSON output.
- Adds an e2e test to validate provider filtering and JSON content validity for auto-selected models.

## Changes
### Backend
- Update chat provider selection to filter providers when response_format.type is json_object or json_schema. Only include providers with jsonOutput === true.
- This ensures auto model selection can return valid JSON content when JSON output is requested.

### Tests
- Added e2e test: "Auto-routing filters models by JSON output support" to verify:
  - Auto model routing respects JSON output capability
  - The chosen model and provider mappings indicate JSON output support
  - The response content is valid JSON

### Files
- apps/gateway/src/chat/chat.ts
- apps/gateway/src/api-individual.e2e.ts

## Why
- To guarantee that when clients request JSON-formatted output, auto selection does not pick models/providers that cannot produce JSON, preventing invalid responses and improving reliability.

## Test Plan
- [x] Run gateway e2e tests
- [x] Validate that JSON output is produced and parsable when json_object/json_schema is requested

## Notes
- No public API changes beyond filtering logic; behavior is scoped to output format handling.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/05b4037b-ac47-47d0-8182-d99fbe717b01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-routing now filters model candidates to only include providers supporting JSON output when response_format type is set to json_object or json_schema.

* **Tests**
  * Added end-to-end test coverage for auto-routing with JSON output filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->