### PR TITLE
fix(auto-routing): filter providers

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -960,27 +960,20 @@ chat.openapi(completions, async (c) => {
 					return false;
 				}
 
-				// If reasoning_effort is specified, only include providers that support reasoning
-				if (reasoning_effort !== undefined) {
-					// Also check for tool support if tools are specified
-					if (tools !== undefined || tool_choice !== undefined) {
-						return (
-							contextSizeMet &&
-							(provider as ProviderModelMapping).reasoning === true &&
-							(provider as ProviderModelMapping).tools === true
-						);
-					}
-					return (
-						contextSizeMet &&
-						(provider as ProviderModelMapping).reasoning === true
-					);
+				// Check reasoning capability if reasoning_effort is specified
+				if (
+					reasoning_effort !== undefined &&
+					(provider as ProviderModelMapping).reasoning !== true
+				) {
+					return false;
 				}
 
-				// If tools or tool_choice is specified, only include providers that support tools
-				if (tools !== undefined || tool_choice !== undefined) {
-					return (
-						contextSizeMet && (provider as ProviderModelMapping).tools === true
-					);
+				// Check tool capability if tools or tool_choice is specified
+				if (
+					(tools !== undefined || tool_choice !== undefined) &&
+					(provider as ProviderModelMapping).tools !== true
+				) {
+					return false;
 				}
 
 				return contextSizeMet;


### PR DESCRIPTION
When tools or tool_choice parameters are specified, the auto-routing provider selection now properly filters out providers that don't support tools, mirroring the existing reasoning_effort filtering logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider selection now validates reasoning capability separately from context-size checks, preventing incorrect exclusions.
  * Added explicit gating for tool usage so only providers that support tools are considered when tools or tool-choice are requested.
  * Maintains existing context-size gating while making reasoning and tool checks early and independent for more reliable filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->