### PR TITLE
fix(models): mark some models as unstable

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -21,6 +21,7 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "nebius",
+				stability: "unstable" as const,
 				modelName: "deepseek-ai/DeepSeek-V3",
 				inputPrice: 0.5 / 1e6,
 				outputPrice: 1.5 / 1e6,

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -212,6 +212,7 @@ export const metaModels = [
 		providers: [
 			{
 				providerId: "together.ai",
+				stability: "unstable" as const,
 				modelName: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
 				inputPrice: 0.18 / 1e6,
 				outputPrice: 0.59 / 1e6,

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -270,6 +270,7 @@ export const openaiModels = [
 		family: "openai",
 		providers: [
 			{
+				stability: "unstable" as const,
 				providerId: "openai",
 				modelName: "o1-mini",
 				inputPrice: 1.1 / 1e6,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added stability status to model configurations, marking DeepSeek V3 (Nebius), Meta Llama Scout models (Together.ai and AWS Bedrock), and OpenAI o1-mini as unstable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->