### PR TITLE
feat(moonshot): add Kimi K2 model

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -76,4 +76,25 @@ export const moonshotModels = [
 			},
 		],
 	},
+	{
+		id: "kimi-k2-thinking",
+		name: "Kimi K2 Thinking",
+		family: "moonshot",
+		providers: [
+			{
+				providerId: "moonshot",
+				modelName: "kimi-k2-thinking",
+				inputPrice: 0.6 / 1e6,
+				outputPrice: 2.5 / 1e6,
+				cachedInputPrice: 0.15 / 1e6,
+				requestPrice: 0,
+				contextSize: 262144,
+				maxOutput: 262144,
+				streaming: true,
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary
- Adds Kimi K2 Thinking to the Moonshot model registry
- Defines provider settings, pricing, and capabilities for the model (streaming, tools, JSON output)

## Changes
### Moonshot Model Registry
- Added a new entry:
  - id: "kimi-k2-thinking"
  - name: "Kimi K2 Thinking"
  - family: "moonshot"
  - providers:
    - providerId: "moonshot"
      modelName: "kimi-k2-thinking"
      inputPrice: 0.6 / 1e6
      outputPrice: 2.5 / 1e6
      cachedInputPrice: 0.15 / 1e6
      requestPrice: 0
      contextSize: 262144
      maxOutput: 262144
      streaming: true
      vision: false
      tools: true
      jsonOutput: true

## Rationale
- Expands the Moonshot model lineup by adding Kimi K2 Thinking with a full provider configuration, enabling usage alongside existing Moonshot models.

## Test plan
- [x] Type-check/build passes with the new model entry
- [x] Moonshot model registry includes the entry for "kimi-k2-thinking"
- [x] Pricing and capability fields align with other Moonshot models

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e1441030-23fa-4ab5-bbd6-b66d7cc26191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kimi K2 Thinking model now available with streaming support, tool integration for function calling, and JSON output formatting. Handles complex reasoning tasks with extended context support and optimized pricing for cached inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->