### PR TITLE
fix(google): use global by default

### DIFF
--- a/packages/models/src/get-provider-endpoint.ts
+++ b/packages/models/src/get-provider-endpoint.ts
@@ -156,12 +156,14 @@ export function getProviderEndpoint(
 			const endpoint = stream ? "streamGenerateContent" : "generateContent";
 			const model = modelName || "gemini-2.5-flash-lite";
 
-			// Special handling for some models which require project ID and location
+			// Special handling for some models which require a non-global location
 			let baseEndpoint: string;
 			if (
-				modelName === "gemini-2.5-flash-preview-09-2025" ||
-				modelName === "gemini-2.5-flash-lite-preview-09-2025"
+				model === "gemini-2.0-flash-lite" ||
+				model === "gemini-2.5-flash-lite"
 			) {
+				baseEndpoint = `${url}/v1/publishers/google/models/${model}:${endpoint}`;
+			} else {
 				const projectId = process.env.LLM_GOOGLE_CLOUD_PROJECT;
 				const region = process.env.LLM_GOOGLE_VERTEX_REGION || "global";
 
@@ -172,9 +174,6 @@ export function getProviderEndpoint(
 				}
 
 				baseEndpoint = `${url}/v1/projects/${projectId}/locations/${region}/publishers/google/models/${model}:${endpoint}`;
-			} else {
-				// Standard endpoint for other models
-				baseEndpoint = `${url}/v1/publishers/google/models/${model}:${endpoint}`;
 			}
 
 			const queryParams = [];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated endpoint routing for Google Vertex to better handle specific Gemini model variants.
  * Certain Gemini "lite" variants now use publisher-style endpoints, while other models route via project/location endpoints.
  * Removed the previous generic publisher routing for non-lite models to ensure correct regional handling and requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->