### PR TITLE
fix(billing): correct Stripe fee calculation

### DIFF
--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -236,7 +236,7 @@ function AmountStep({
 									<span>${feeData.baseAmount.toFixed(2)}</span>
 								</div>
 								<div className="flex justify-between">
-									<span>Stripe fees ($0.35 + 2.9%)</span>
+									<span>Stripe fees ($0.30 + 2.9%)</span>
 									<span>${feeData.stripeFee.toFixed(2)}</span>
 								</div>
 								{feeData.internationalFee > 0 && (
@@ -624,7 +624,7 @@ function ConfirmPaymentStep({
 								<span>${feeData.baseAmount.toFixed(2)}</span>
 							</div>
 							<div className="flex justify-between">
-								<span>Stripe fees ($0.35 + 2.9%)</span>
+								<span>Stripe fees ($0.30 + 2.9%)</span>
 								<span>${feeData.stripeFee.toFixed(2)}</span>
 							</div>
 							{feeData.internationalFee > 0 && (

--- a/apps/ui/src/components/billing/auto-topup-settings.tsx
+++ b/apps/ui/src/components/billing/auto-topup-settings.tsx
@@ -212,7 +212,7 @@ function AutoTopUpSettings() {
 									<span>${feeData.baseAmount.toFixed(2)}</span>
 								</div>
 								<div className="flex justify-between">
-									<span>Stripe fees ($0.35 + 2.9%)</span>
+									<span>Stripe fees ($0.30 + 2.9%)</span>
 									<span>${feeData.stripeFee.toFixed(2)}</span>
 								</div>
 								{feeData.internationalFee > 0 && (

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -227,7 +227,7 @@ function AmountStep({
 									<span>${feeData.baseAmount.toFixed(2)}</span>
 								</div>
 								<div className="flex justify-between">
-									<span>Stripe fees ($0.35 + 2.9%)</span>
+									<span>Stripe fees ($0.30 + 2.9%)</span>
 									<span>${feeData.stripeFee.toFixed(2)}</span>
 								</div>
 								{feeData.internationalFee > 0 && (
@@ -627,7 +627,7 @@ function ConfirmPaymentStep({
 								<span>${feeData.baseAmount.toFixed(2)}</span>
 							</div>
 							<div className="flex justify-between">
-								<span>Stripe fees ($0.35 + 2.9%)</span>
+								<span>Stripe fees ($0.30 + 2.9%)</span>
 								<span>${feeData.stripeFee.toFixed(2)}</span>
 							</div>
 							{feeData.internationalFee > 0 && (


### PR DESCRIPTION
- Fixed Stripe fixed fee from $0.35 to correct $0.30
- Updated fee calculation to reverse-calculate from desired net amount to properly account for percentage fees on total
- This ensures users receive exact credit amount they pay for
- Updated all UI labels to reflect $0.30 + 2.9% fee structure

Previously, fees were calculated on base amount, causing discrepancy with actual Stripe charges. Now correctly calculates total charge needed to net desired amount after all percentage-based fees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Pricing Updates**
  * Stripe base fee reduced from $0.35 to $0.30 across credit top-up flows and auto-topup displays.

* **Calculation Updates**
  * Fee computation updated so displayed totals and breakdowns account for the revised base fee and aggregated percentage-based fees, including international and plan-related adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->