### PR TITLE
feat(logs): add routing metadata

### DIFF
--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -75,6 +75,25 @@ const logSchema = z.object({
 	mode: z.enum(["api-keys", "credits", "hybrid"]),
 	usedMode: z.enum(["api-keys", "credits"]),
 	source: z.string().nullable(),
+	routingMetadata: z
+		.object({
+			availableProviders: z.array(z.string()).optional(),
+			selectedProvider: z.string().optional(),
+			selectionReason: z.string().optional(),
+			providerScores: z
+				.array(
+					z.object({
+						providerId: z.string(),
+						score: z.number(),
+						uptime: z.number().optional(),
+						latency: z.number().optional(),
+						price: z.number().optional(),
+					}),
+				)
+				.optional(),
+		})
+		.nullable()
+		.optional(),
 });
 
 const querySchema = z.object({

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -601,6 +601,18 @@ export interface paths {
                                 /** @enum {string} */
                                 usedMode: "api-keys" | "credits";
                                 source: string | null;
+                                routingMetadata?: {
+                                    availableProviders?: string[];
+                                    selectedProvider?: string;
+                                    selectionReason?: string;
+                                    providerScores?: {
+                                        providerId: string;
+                                        score: number;
+                                        uptime?: number;
+                                        latency?: number;
+                                        price?: number;
+                                    }[];
+                                } | null;
                             }[];
                             /** @description Pagination metadata */
                             pagination: {

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -192,6 +192,67 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 								<div className="text-muted-foreground">Provider</div>
 								<div>{log.usedProvider}</div>
 							</div>
+							{log.routingMetadata && (
+								<div className="mt-3">
+									<h5 className="text-xs font-medium text-muted-foreground mb-2">
+										Routing Info
+									</h5>
+									<div className="rounded-md border border-dashed p-2 text-xs space-y-1.5 bg-muted/30">
+										{log.routingMetadata.selectionReason && (
+											<div className="flex justify-between">
+												<span className="text-muted-foreground">Selection</span>
+												<span className="font-mono">
+													{log.routingMetadata.selectionReason}
+												</span>
+											</div>
+										)}
+										{log.routingMetadata.availableProviders &&
+											log.routingMetadata.availableProviders.length > 0 && (
+												<div className="flex justify-between">
+													<span className="text-muted-foreground">
+														Available
+													</span>
+													<span className="font-mono">
+														{log.routingMetadata.availableProviders.join(", ")}
+													</span>
+												</div>
+											)}
+										{log.routingMetadata.providerScores &&
+											log.routingMetadata.providerScores.length > 0 && (
+												<div className="pt-1 border-t border-dashed">
+													<div className="text-muted-foreground mb-1">
+														Scores
+													</div>
+													<div className="space-y-1">
+														{log.routingMetadata.providerScores.map((score) => (
+															<div
+																key={score.providerId}
+																className="flex justify-between items-center"
+															>
+																<span className="font-mono">
+																	{score.providerId}
+																</span>
+																<span className="text-muted-foreground">
+																	{score.score.toFixed(2)}
+																	{score.uptime !== undefined && (
+																		<span className="ml-2">
+																			↑{(score.uptime * 100).toFixed(0)}%
+																		</span>
+																	)}
+																	{score.latency !== undefined && (
+																		<span className="ml-2">
+																			{score.latency.toFixed(0)}ms
+																		</span>
+																	)}
+																</span>
+															</div>
+														))}
+													</div>
+												</div>
+											)}
+									</div>
+								</div>
+							)}
 						</div>
 						<div className="space-y-2">
 							<h4 className="text-sm font-medium">Response Metrics</h4>

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -601,6 +601,18 @@ export interface paths {
                                 /** @enum {string} */
                                 usedMode: "api-keys" | "credits";
                                 source: string | null;
+                                routingMetadata?: {
+                                    availableProviders?: string[];
+                                    selectedProvider?: string;
+                                    selectionReason?: string;
+                                    providerScores?: {
+                                        providerId: string;
+                                        score: number;
+                                        uptime?: number;
+                                        latency?: number;
+                                        price?: number;
+                                    }[];
+                                } | null;
                             }[];
                             /** @description Pagination metadata */
                             pagination: {


### PR DESCRIPTION
Add routingMetadata to logs API schema and display routing info (selection reason, available providers, provider scores) in the log card expanded details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logs now display routing information including selection reason, available providers, and per-provider performance metrics (scores, uptime, and latency).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->