### PR TITLE
fix(ui): routing score display

### DIFF
--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -236,12 +236,12 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 																	{score.score.toFixed(2)}
 																	{score.uptime !== undefined && (
 																		<span className="ml-2">
-																			↑{(score.uptime * 100).toFixed(0)}%
+																			↑{score.uptime?.toFixed(0)}%
 																		</span>
 																	)}
 																	{score.latency !== undefined && (
 																		<span className="ml-2">
-																			{score.latency.toFixed(0)}ms
+																			{score.latency?.toFixed(0)}ms
 																		</span>
 																	)}
 																</span>


### PR DESCRIPTION
Uptime was already a percentage (0-100) but was being multiplied by 100 again, causing 10000% display.