### PR TITLE
feat(models): add image pricing

### DIFF
--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -196,6 +196,36 @@ export default async function ModelPage({ params }: PageProps) {
 								})()}{" "}
 								output tokens
 							</div>
+							{modelProviders.some((p) => p.imageOutputPrice) && (
+								<div>
+									Starting at{" "}
+									{(() => {
+										const imageOutputPrices = modelProviders
+											.filter((p) => p.imageOutputPrice)
+											.map((p) => ({
+												price:
+													p.imageOutputPrice! *
+													1e6 *
+													(p.discount ? 1 - p.discount : 1),
+												originalPrice: p.imageOutputPrice! * 1e6,
+												discount: p.discount,
+											}));
+										if (imageOutputPrices.length === 0) {
+											return "Free";
+										}
+										const minPrice = Math.min(
+											...imageOutputPrices.map((p) => p.price),
+										);
+										const minPriceItem = imageOutputPrices.find(
+											(p) => p.price === minPrice,
+										);
+										return minPriceItem?.discount
+											? `$${minPrice.toFixed(2)}/M (${(minPriceItem.discount * 100).toFixed(0)}% off)`
+											: `$${minPrice.toFixed(2)}/M`;
+									})()}{" "}
+									image output tokens
+								</div>
+							)}
 						</div>
 
 						{/* Capabilities (using same icons as /models) */}

--- a/apps/ui/src/components/models/model-card.tsx
+++ b/apps/ui/src/components/models/model-card.tsx
@@ -329,6 +329,39 @@ export function ModelCard({
 													)}
 												</div>
 											</div>
+											{provider.imageOutputPrice !== undefined && (
+												<div className="space-y-1">
+													<div className="text-xs text-muted-foreground">
+														Image Out
+													</div>
+													<div className="font-semibold text-foreground text-sm">
+														{typeof formatPrice(
+															provider.imageOutputPrice,
+															provider.discount,
+														) === "string" ? (
+															<>
+																{formatPrice(
+																	provider.imageOutputPrice,
+																	provider.discount,
+																)}
+																<span className="text-muted-foreground text-xs ml-1">
+																	/M
+																</span>
+															</>
+														) : (
+															<span className="inline-flex items-baseline gap-1">
+																{formatPrice(
+																	provider.imageOutputPrice,
+																	provider.discount,
+																)}
+																<span className="text-muted-foreground text-xs">
+																	/M
+																</span>
+															</span>
+														)}
+													</div>
+												</div>
+											)}
 										</div>
 									</div>
 

--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -259,6 +259,37 @@ export function ModelProviderCard({
 							</div>
 						</div>
 					</div>
+					{provider.imageOutputPrice !== undefined && (
+						<div className="grid grid-cols-3 gap-3 mt-3">
+							<div className="col-span-3">
+								<div className="text-muted-foreground text-xs mb-1">
+									Image Output
+								</div>
+								<div className="font-mono">
+									<div className="space-y-1">
+										<div className="flex items-center gap-2">
+											{provider.discount ? (
+												<>
+													<span className="line-through text-muted-foreground text-xs">
+														{formatPrice(provider.imageOutputPrice)}
+													</span>
+													<span className="text-green-600 font-semibold">
+														{formatPrice(
+															provider.imageOutputPrice *
+																(1 - provider.discount),
+														)}
+													</span>
+												</>
+											) : (
+												formatPrice(provider.imageOutputPrice)
+											)}
+										</div>
+										<span className="text-muted-foreground text-xs">/M</span>
+									</div>
+								</div>
+							</div>
+						</div>
+					)}
 					{provider.discount && (
 						<div className="mt-2">
 							<Badge

--- a/apps/ui/src/components/models/models-list.tsx
+++ b/apps/ui/src/components/models/models-list.tsx
@@ -176,6 +176,12 @@ export function ModelsList() {
 									{provider.imageInputPrice !== undefined && (
 										<div>Image: ${provider.imageInputPrice} / input</div>
 									)}
+									{provider.imageOutputPrice !== undefined && (
+										<div>
+											Image Output: ${provider.imageOutputPrice * 1e6} / M
+											tokens
+										</div>
+									)}
 									{provider.requestPrice !== undefined && (
 										<div>
 											Request: ${provider.requestPrice * 1000} / 1K requests


### PR DESCRIPTION
Add imageOutputPrice display to model list, model card, provider card, and detail page for models like
gemini-3-pro-image-preview that have separate image output token pricing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image output pricing is now displayed across model details, provider cards, and model listings. Users can view per-token pricing for image generation outputs, including applicable discounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->