### PR TITLE
fix(auto-route): remove duplicate model

### DIFF
--- a/apps/playground/src/components/model-selector.tsx
+++ b/apps/playground/src/components/model-selector.tsx
@@ -183,6 +183,11 @@ export function ModelSelector({
 				searchText: rootSearchText,
 			});
 
+			// Skip provider entries for auto model - it should only appear as root
+			if (m.id === "auto") {
+				continue;
+			}
+
 			for (const mp of m.providers) {
 				const isDeactivated =
 					mp.deactivatedAt && new Date(mp.deactivatedAt) <= now;


### PR DESCRIPTION
Skip creating provider entries for the "auto" model since it should only appear once as a root model, not duplicated as a provider entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the Model Selector to display the "auto" model as a single root entry instead of duplicating it across multiple provider variations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->