### PR TITLE
perf: remove OR conditions from cleanup query

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -357,6 +357,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 			const batchResult = await db.transaction(async (tx) => {
 				// Find IDs of records to clean up (with LIMIT for batching)
 				// Use JOIN instead of subquery for better performance with large tables
+				// dataRetentionCleanedUp=false implies there's data to clean, no need for OR conditions
 				const recordsToClean = await tx
 					.select({ id: log.id })
 					.from(log)
@@ -366,7 +367,6 @@ export async function cleanupExpiredLogData(): Promise<void> {
 							eq(organization.plan, "free"),
 							lt(log.createdAt, freePlanCutoff),
 							eq(log.dataRetentionCleanedUp, false),
-							sql`(${log.messages} IS NOT NULL OR ${log.content} IS NOT NULL OR ${log.reasoningContent} IS NOT NULL OR ${log.tools} IS NOT NULL OR ${log.toolChoice} IS NOT NULL OR ${log.toolResults} IS NOT NULL OR ${log.customHeaders} IS NOT NULL OR ${log.rawRequest} IS NOT NULL OR ${log.rawResponse} IS NOT NULL OR ${log.upstreamRequest} IS NOT NULL OR ${log.upstreamResponse} IS NOT NULL)`,
 						),
 					)
 					.limit(CLEANUP_BATCH_SIZE)
@@ -425,6 +425,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 			const batchResult = await db.transaction(async (tx) => {
 				// Find IDs of records to clean up (with LIMIT for batching)
 				// Use JOIN instead of subquery for better performance with large tables
+				// dataRetentionCleanedUp=false implies there's data to clean, no need for OR conditions
 				const recordsToClean = await tx
 					.select({ id: log.id })
 					.from(log)
@@ -434,7 +435,6 @@ export async function cleanupExpiredLogData(): Promise<void> {
 							eq(organization.plan, "pro"),
 							lt(log.createdAt, proPlanCutoff),
 							eq(log.dataRetentionCleanedUp, false),
-							sql`(${log.messages} IS NOT NULL OR ${log.content} IS NOT NULL OR ${log.reasoningContent} IS NOT NULL OR ${log.tools} IS NOT NULL OR ${log.toolChoice} IS NOT NULL OR ${log.toolResults} IS NOT NULL OR ${log.customHeaders} IS NOT NULL OR ${log.rawRequest} IS NOT NULL OR ${log.rawResponse} IS NOT NULL OR ${log.upstreamRequest} IS NOT NULL OR ${log.upstreamResponse} IS NOT NULL)`,
 						),
 					)
 					.limit(CLEANUP_BATCH_SIZE)


### PR DESCRIPTION
## Summary

The `dataRetentionCleanedUp=false` flag already indicates data needs to be cleaned, so the complex OR conditions checking for non-null fields are redundant and prevent index usage.

This allows the partial index to be used effectively, avoiding sequential scans.

## Test plan

- Deploy and monitor cleanup query performance
- Expected: Query time should drop from ~8.9s to milliseconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cleanup logic for expired log data to reduce unnecessary database queries while maintaining existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->