### PR TITLE
feat: add canonical metadata to UI and docs

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -29,6 +29,9 @@ export const metadata: Metadata = {
 	icons: {
 		icon: "/favicon/favicon.ico?v=2",
 	},
+	alternates: {
+		canonical: "./",
+	},
 };
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -29,6 +29,9 @@ export const metadata: Metadata = {
 	icons: {
 		icon: "/favicon/favicon.ico?v=2",
 	},
+	alternates: {
+		canonical: "./",
+	},
 	openGraph: {
 		title: "LLM Gateway",
 		description:


### PR DESCRIPTION
Set canonical URL via metadata alternates to the current path without query string. This ensures search engines recognize the primary version of each page.

## Changes
- Added `alternates.canonical: "./"` to UI root layout
- Added `alternates.canonical: "./"` to docs root layout

Both layouts now properly export canonical metadata that resolves relative to the current URL without query parameters.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added canonical URL metadata to optimize search engine indexing for documentation and UI applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->