### PR TITLE
feat(api): add unsupported message

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -20,6 +20,7 @@ import { anthropic } from "./anthropic/anthropic.js";
 import { chat } from "./chat/chat.js";
 import { tracingMiddleware } from "./middleware/tracing.js";
 import { models } from "./models/route.js";
+import { responses } from "./responses/responses.js";
 
 import type { ServerTypes } from "./vars.js";
 
@@ -228,6 +229,7 @@ const v1 = new OpenAPIHono<ServerTypes>();
 v1.route("/chat", chat);
 v1.route("/models", models);
 v1.route("/messages", anthropic);
+v1.route("/responses", responses);
 
 app.route("/v1", v1);
 

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+
+import type { ServerTypes } from "@/vars.js";
+
+export const responses = new Hono<ServerTypes>();
+
+const errorMessage =
+	"The Responses API is currently not supported. Please use the /v1/chat/completions API route instead.";
+
+responses.post("/", (c) => {
+	return c.text(errorMessage, 404);
+});
+
+responses.get("/:response_id", (c) => {
+	return c.text(errorMessage, 404);
+});


### PR DESCRIPTION
Return a helpful error message indicating that the Responses API is not supported and users should use /v1/chat/completions instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/responses` endpoint to the API gateway. The endpoint currently returns an error message directing users to use `/v1/chat/completions` instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->