### PR TITLE
feat: add discount savings visualization on dashboard

### DIFF
--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -762,6 +762,7 @@ export interface paths {
                                 errorRate: number;
                                 cacheCount: number;
                                 cacheRate: number;
+                                discountSavings: number;
                                 modelBreakdown: {
                                     id: string;
                                     provider: string;

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -11,6 +11,7 @@ import {
 	CircleDollarSign,
 	BarChart3,
 	ChartColumnBig,
+	TrendingDown,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -28,6 +29,13 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/lib/components/select";
 import { Tabs, TabsList, TabsTrigger } from "@/lib/components/tabs";
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
@@ -46,6 +54,12 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 	// Get days from URL params, fallback to initialDays, then to 7
 	const daysParam = searchParams.get("days");
 	const days = (daysParam === "30" ? 30 : 7) as 7 | 30;
+
+	// Get metric type from URL params, default to "costs"
+	const metricParam = searchParams.get("metric");
+	const metric = (metricParam === "requests" ? "requests" : "costs") as
+		| "costs"
+		| "requests";
 
 	// If no days param exists, add it to the URL immediately
 	useEffect(() => {
@@ -86,6 +100,13 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		router.push(`${buildUrl()}?${params.toString()}`);
 	};
 
+	// Function to update URL with new metric parameter
+	const updateMetricInUrl = (newMetric: "costs" | "requests") => {
+		const params = new URLSearchParams(searchParams.toString());
+		params.set("metric", newMetric);
+		router.push(`${buildUrl()}?${params.toString()}`);
+	};
+
 	const activityData = data?.activity || [];
 
 	const totalRequests =
@@ -102,6 +123,8 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 			(sum, day) => sum + (day.cost - day.inputCost - day.outputCost),
 			0,
 		) || 0;
+	const totalSavings =
+		activityData.reduce((sum, day) => sum + day.discountSavings, 0) || 0;
 
 	const formatTokens = (tokens: number) => {
 		if (tokens >= 1_000_000) {
@@ -220,7 +243,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 					)}
 
 					<div
-						className={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-4", {
+						className={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-5", {
 							"pointer-events-none opacity-20": shouldShowGetStartedState,
 						})}
 					>
@@ -338,6 +361,31 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 								)}
 							</CardContent>
 						</Card>
+						<Card>
+							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+								<CardTitle className="text-sm font-medium">
+									Total Savings
+								</CardTitle>
+								<TrendingDown className="text-muted-foreground h-4 w-4" />
+							</CardHeader>
+							<CardContent>
+								{isLoading ? (
+									<>
+										<div className="text-2xl font-bold">Loading...</div>
+										<p className="text-muted-foreground text-xs">–</p>
+									</>
+								) : (
+									<>
+										<div className="text-2xl font-bold text-green-600">
+											${totalSavings.toFixed(4)}
+										</div>
+										<p className="text-muted-foreground text-xs">
+											From discounts in last {days} days
+										</p>
+									</>
+								)}
+							</CardContent>
+						</Card>
 					</div>
 					<div
 						className={cn("grid gap-4 md:grid-cols-2 lg:grid-cols-7", {
@@ -346,21 +394,35 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 					>
 						<Card className="col-span-4">
 							<CardHeader>
-								<CardTitle>Usage Overview</CardTitle>
-								<CardDescription>
-									Total Requests
-									{selectedProject && (
-										<span className="block mt-1 text-sm">
-											Filtered by project: {selectedProject.name}
-										</span>
-									)}
-								</CardDescription>
+								<div className="flex items-start justify-between">
+									<div className="flex-1">
+										<CardTitle>Usage Overview</CardTitle>
+										<CardDescription>
+											{metric === "costs" ? "Total Costs" : "Total Requests"}
+											{selectedProject && (
+												<span className="block mt-1 text-sm">
+													Filtered by project: {selectedProject.name}
+												</span>
+											)}
+										</CardDescription>
+									</div>
+									<Select value={metric} onValueChange={updateMetricInUrl}>
+										<SelectTrigger className="w-[140px]">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="costs">Costs</SelectItem>
+											<SelectItem value="requests">Requests</SelectItem>
+										</SelectContent>
+									</Select>
+								</div>
 							</CardHeader>
 							<CardContent className="pl-2">
 								<Overview
 									data={activityData}
 									isLoading={isLoading}
 									days={days}
+									metric={metric}
 								/>
 							</CardContent>
 						</Card>

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -762,6 +762,7 @@ export interface paths {
                                 errorRate: number;
                                 cacheCount: number;
                                 cacheRate: number;
+                                discountSavings: number;
                                 modelBreakdown: {
                                     id: string;
                                     provider: string;

--- a/apps/ui/src/types/activity.ts
+++ b/apps/ui/src/types/activity.ts
@@ -23,6 +23,7 @@ export interface DailyActivity {
 	errorRate: number;
 	cacheCount: number;
 	cacheRate: number;
+	discountSavings: number;
 	modelBreakdown: ActivityModelUsage[];
 }
 
@@ -46,6 +47,7 @@ export type ActivitT =
 				errorRate: number;
 				cacheCount: number;
 				cacheRate: number;
+				discountSavings: number;
 				modelBreakdown: ActivityModelUsage[];
 			}[];
 	  }


### PR DESCRIPTION
## Summary

Added discount savings visualization on the dashboard with the following features:

- New "Total Savings" card displays aggregated discounts from the last 7/30 days using a TrendingDown icon
- Added metric selector dropdown to the Usage Overview chart to toggle between "Costs" (default) and "Total Requests"
- When costs are selected, the chart displays stacked bars showing both costs and savings (highlighted in green)
- Fixed discount calculations using the correct formula: `cost * discount / (1 - discount)` to convert discount multipliers to actual dollar amounts
- Updated activity API to include `discountSavings` field in all aggregated data

This refactored implementation reuses existing activity data for optimal performance instead of adding new organization-level calculations.

## Test plan

- Verify the "Total Savings" card appears on the dashboard and displays correct values
- Test the metric dropdown switches between "Costs" and "Total Requests" views
- When "Costs" is selected, verify stacked bars show both costs and savings
- Verify the discount values match expected savings (discount multiplier to dollar conversion)
- Check that switching between 7-day and 30-day periods updates both cards and chart correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)