### PR TITLE
feat(model-details): add JSON schema

### DIFF
--- a/apps/ui/src/components/models/model-detail-card.tsx
+++ b/apps/ui/src/components/models/model-detail-card.tsx
@@ -7,6 +7,7 @@ import {
 	MessageSquare,
 	ImagePlus,
 	Braces,
+	FileJson2,
 	Gift,
 } from "lucide-react";
 
@@ -104,6 +105,13 @@ export function ModelDetailCard({ model }: ModelDetailCardProps) {
 				icon: Braces,
 				label: "JSON Output",
 				color: "text-cyan-500",
+			});
+		}
+		if (provider.jsonOutputSchema) {
+			capabilities.push({
+				icon: FileJson2,
+				label: "JSON Schema",
+				color: "text-teal-500",
 			});
 		}
 		const hasImageGen = Array.isArray(modelData?.output)


### PR DESCRIPTION
## Summary
- Adds JSON Schema capability to model details when a provider exposes a JSON output schema

## Changes
### UI
- Update ModelDetailCard to import FileJson2 from lucide-react and render a new capability pill when provider.jsonOutputSchema is truthy
- Pill includes label "JSON Schema" and teal color to visually distinguish it

### Data model
- Reads provider.jsonOutputSchema to determine whether to show the JSON Schema capability (no backend changes)

### Accessibility & UX
- Improves discoverability of JSON schema output in model detail view with an explicit icon and label

## Test plan
- [x] When provider.jsonOutputSchema is present, the UI displays a "JSON Schema" pill with FileJson2 icon and teal color
- [x] When provider.jsonOutputSchema is absent, the JSON Schema pill is not shown
- [x] UI layout remains consistent with existing capability pills


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/356b6112-0579-41f7-973c-7e0e83c0d71b