### PR TITLE
feat(payments): handle Stripe card declines

### DIFF
--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2802,6 +2802,17 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Payment failed due to card decline */
+                402: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
             };
         };
         delete?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2802,6 +2802,17 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Payment failed due to card decline */
+                402: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
             };
         };
         delete?: never;


### PR DESCRIPTION
## Summary
- Adds robust handling for Stripe card declines during top-ups with saved payment methods. Returns HTTP 402 with a clear, user-friendly message, without affecting successful payments.
- Keeps existing success flow intact and only augments error handling for card declines.

## Changes
### API
- File: apps/api/src/routes/payments.ts
  - Wrap Stripe paymentIntent creation in a try/catch block.
  - On StripeCardError, inspect decline_code and code to craft a user-facing message. Handles common decline scenarios such as:
    - insufficient_funds
    - fraudulent
    - lost_card / stolen_card
    - expired_card
    - incorrect_cvc
    - processing_error
    - card_not_supported
  - Throw HTTPException(402, { message: string }) with the constructed message.
  - Preserves the existing success path; non-decline Stripe errors are rethrown as before.
  - Explicitly keep 200 responses for successful flows.

### OpenAPI / API Docs
- File: payments.openapi (within topUpWithSavedMethod route)
  - Add 402 response to the route documenting: { message: string } with description "Payment failed due to card decline".
  - Aligns runtime behavior with API contract shown to clients.

### Type Definitions
- Files: apps/playground/src/lib/api/v1.d.ts and apps/ui/src/lib/api/v1.d.ts
  - Extend paths.topUpWithSavedMethod 402 response to include:
    - content: { "application/json": { message: string } }
  - Ensures TypeScript consumers and UI tooling are aware of the new error shape.

## Rationale
- Card declines are a common, user-facing error that should be surfaced clearly to clients.
- Returning 402 with a meaningful message enables apps to present actionable guidance to users (e.g., try another card, update card, contact bank).
- Centralizing error mapping keeps the payment flow robust and maintainable.

## Testing / Validation
- Manual tests:
  - Trigger top-up with a saved method that causes a Stripe card decline with various decline codes to verify the user-friendly messages are returned and 402 status is set.
  - Trigger a successful payment to ensure the 200 response and { success: true } payload remain unaffected.
- Automated tests:
  - If present, extend tests to simulate StripeCardError paths and assert 402 + { message } body.

## Potential Impact
- No breaking changes for successful payments.
- Clients should adjust to handle HTTP 402 with a JSON error payload instead of general 4xx without a message.

## Documentation Notes
- The 402 error description now explicitly notes a card decline.
- Client implementations can map this to user-facing UI prompts (e.g., retry with different card).


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bc53a148-c39e-445a-bf0c-4ff5d2d7fad2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed card payments during top-up, now providing users with friendly messages explaining specific decline reasons such as insufficient funds, fraud detection, and expired cards.
  * Enhanced payment success responses with explicit confirmation status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->