### PR TITLE
refactor(logging): log fetch failures as warnings

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2331,7 +2331,7 @@ chat.openapi(completions, async (c) => {
 				} else if (error instanceof Error) {
 					// Handle fetch errors (timeout, connection failures, etc.)
 					const errorMessage = error.message;
-					logger.error("Fetch error", {
+					logger.warn("Fetch error", {
 						error: errorMessage,
 						usedProvider,
 						requestedProvider,
@@ -3768,7 +3768,7 @@ chat.openapi(completions, async (c) => {
 	// Handle fetch errors (timeout, connection failures, etc.)
 	if (fetchError) {
 		const errorMessage = fetchError.message;
-		logger.error("Fetch error", {
+		logger.warn("Fetch error", {
 			error: errorMessage,
 			usedProvider,
 			requestedProvider,


### PR DESCRIPTION
## Summary
- Downgrades log level for fetch-related failures from error to warning in chat fetch paths.
- Preserves error details and contextual fields (error, usedProvider, requestedProvider) while avoiding noisy error logs for recoverable failures.

## Changes
### Logging
- Replaced logger.error("Fetch error", ...) with logger.warn("Fetch error", ...) in two fetch error handling sites:
  - Inside chat.openapi error handling (error instanceof Error)
  - In the outer fetch error handling block

### Code references
- File: apps/gateway/src/chat/chat.ts

### Rationale
- Treats transient fetch failures as warnings rather than errors to reduce noise and align with retryable scenarios.

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Verify that fetch failure logs appear at warning level with the same payload
- [x] Manual test: simulate timeout/connection errors and confirm log level is warning

**Branch:** terragon/log-fetch-failure-as-warning-dvgqup

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1688ead4-4816-497c-9929-3709934a94e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging levels for chat fetch error handling to improve log clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->