### PR TITLE
fix(admin): replace root redirect with sign-in page

### DIFF
--- a/.github/test-split-docker.sh
+++ b/.github/test-split-docker.sh
@@ -19,7 +19,7 @@ APP_ENDPOINTS["gateway"]="http://localhost:4001"
 APP_ENDPOINTS["ui"]="http://localhost:3002"
 APP_ENDPOINTS["playground"]="http://localhost:3003"
 APP_ENDPOINTS["docs"]="http://localhost:3005"
-APP_ENDPOINTS["admin"]="http://localhost:3006/login"
+APP_ENDPOINTS["admin"]="http://localhost:3006"
 
 # Health check routes for each app (optional)
 declare -A HEALTH_ROUTES

--- a/.github/test-unified-docker.sh
+++ b/.github/test-unified-docker.sh
@@ -23,7 +23,7 @@ APP_ENDPOINTS["gateway"]="http://localhost:4001"
 APP_ENDPOINTS["ui"]="http://localhost:3002"
 APP_ENDPOINTS["playground"]="http://localhost:3003"
 APP_ENDPOINTS["docs"]="http://localhost:3005"
-APP_ENDPOINTS["admin"]="http://localhost:3006/login"
+APP_ENDPOINTS["admin"]="http://localhost:3006"
 
 # Health check routes for each app (optional)
 declare -A HEALTH_ROUTES

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -13,8 +13,9 @@ interface MeResponse {
 export async function middleware(req: NextRequest) {
 	const { pathname } = req.nextUrl;
 
-	// Allow auth and static routes without admin check
+	// Allow auth, static routes, and root path without admin check
 	if (
+		pathname === "/" ||
 		pathname.startsWith("/login") ||
 		pathname.startsWith("/signup") ||
 		pathname.startsWith("/_next") ||

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { ArrowUpRight, CircleDollarSign, Coins, Users } from "lucide-react";
+import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
 import { getAdminDashboardMetrics } from "@/lib/admin-metrics";
 import { cn } from "@/lib/utils";
 
@@ -58,8 +60,32 @@ function MetricCard({
 	);
 }
 
+function SignInPrompt() {
+	return (
+		<div className="flex min-h-screen items-center justify-center px-4">
+			<div className="w-full max-w-md text-center">
+				<div className="mb-8">
+					<h1 className="text-3xl font-semibold tracking-tight">
+						Admin Dashboard
+					</h1>
+					<p className="mt-2 text-sm text-muted-foreground">
+						Sign in to access the admin dashboard
+					</p>
+				</div>
+				<Button asChild size="lg" className="w-full">
+					<Link href="/login">Sign In</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}
+
 export default async function Page() {
 	const metrics = await getAdminDashboardMetrics();
+
+	if (!metrics) {
+		return <SignInPrompt />;
+	}
 
 	return (
 		<div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 md:px-8">

--- a/apps/admin/src/lib/admin-metrics.ts
+++ b/apps/admin/src/lib/admin-metrics.ts
@@ -1,5 +1,3 @@
-import { redirect } from "next/navigation";
-
 import { fetchServerData } from "./server-api";
 
 export interface AdminDashboardMetrics {
@@ -11,15 +9,11 @@ export interface AdminDashboardMetrics {
 	payingCustomers: number;
 }
 
-export async function getAdminDashboardMetrics(): Promise<AdminDashboardMetrics> {
+export async function getAdminDashboardMetrics(): Promise<AdminDashboardMetrics | null> {
 	const data = await fetchServerData<AdminDashboardMetrics>(
 		"GET",
 		"/admin/metrics",
 	);
-
-	if (!data) {
-		redirect("/login");
-	}
 
 	return data;
 }


### PR DESCRIPTION
## Summary

Previously, the admin dashboard root path (/) would redirect to /login when the user was not authenticated. This caused issues with routing and navigation. This PR fixes the issue by showing a sign-in page at the root instead of redirecting.

## Changes

- Updated middleware to allow root path without auth check
- Modified admin root page to show sign-in prompt when not authenticated
- Removed redirect logic from `getAdminDashboardMetrics`
- Updated test scripts to check root endpoint instead of `/login`

## Test Plan

- [ ] Verify admin dashboard root loads without redirect
- [ ] Verify sign-in prompt is shown when not authenticated
- [ ] Verify dashboard metrics are shown when authenticated
- [ ] Verify test scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now displays a sign-in prompt for unauthenticated users instead of redirecting automatically.

* **Chores**
  * Updated admin application endpoints and authentication route handling for improved access control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->