### PR TITLE
fix(model-list): show discounts in tiered pricing on provider cards

### DIFF
--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -322,10 +322,29 @@ export function ModelProviderCard({
 												? `>${(provider.pricingTiers![index - 1]?.upToTokens || 0) / 1000}K tokens`
 												: `≤${tier.upToTokens / 1000}K tokens`}
 										</span>
-										<span className="font-mono">
-											{formatPrice(tier.inputPrice)} in /{" "}
-											{formatPrice(tier.outputPrice)} out
-										</span>
+										{provider.discount ? (
+											<span className="font-mono">
+												<span className="line-through text-muted-foreground">
+													{formatPrice(tier.inputPrice)} in /{" "}
+													{formatPrice(tier.outputPrice)} out
+												</span>
+												<span className="text-green-600 font-semibold ml-2">
+													{formatPrice(
+														tier.inputPrice * (1 - provider.discount),
+													)}{" "}
+													in /{" "}
+													{formatPrice(
+														tier.outputPrice * (1 - provider.discount),
+													)}{" "}
+													out
+												</span>
+											</span>
+										) : (
+											<span className="font-mono">
+												{formatPrice(tier.inputPrice)} in /{" "}
+												{formatPrice(tier.outputPrice)} out
+											</span>
+										)}
 									</div>
 								))}
 							</div>


### PR DESCRIPTION
## Summary
- Displays discount information for tiered pricing on the provider card.

## Changes

### UI
- In `ModelProviderCard`, when `provider.discount` is present, render a struck-through original price and show discounted price in green for both input and output costs.
- If no discount is available, pricing remains unchanged and shown normally.

### Logic
- Discounted prices are calculated as `price * (1 - provider.discount)` for both input and output values.

### File Changes
- `apps/ui/src/components/models/model-provider-card.tsx`

## Test plan
- [x] With discount: verify original prices are struck through and discounted prices appear in green for both input and output.
- [x] Without discount: verify prices render as before with no strike-through or discount display.
- [x] Ensure the tier up-to tokens label remains correct and unaffected by discount logic.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/cf7700d8-afc8-45ae-a884-01b4b0b3adcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing tiers now display discounts when available. Original prices appear struck through, with the discounted amount highlighted in green and bold formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->