### PR TITLE
fix(gateway): map google image safety finish reasons

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -51,6 +51,18 @@ describe("getUnifiedFinishReason", () => {
 		expect(getUnifiedFinishReason("SPII", "google-ai-studio")).toBe(
 			UnifiedFinishReason.CONTENT_FILTER,
 		);
+		expect(getUnifiedFinishReason("LANGUAGE", "google-ai-studio")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+		expect(getUnifiedFinishReason("IMAGE_SAFETY", "google-ai-studio")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+		expect(
+			getUnifiedFinishReason("IMAGE_PROHIBITED_CONTENT", "google-ai-studio"),
+		).toBe(UnifiedFinishReason.CONTENT_FILTER);
+		expect(getUnifiedFinishReason("NO_IMAGE", "google-ai-studio")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
 	});
 
 	it("handles special cases", () => {

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -58,7 +58,11 @@ export function getUnifiedFinishReason(
 				finishReason === "PROHIBITED_CONTENT" ||
 				finishReason === "RECITATION" ||
 				finishReason === "BLOCKLIST" ||
-				finishReason === "SPII"
+				finishReason === "SPII" ||
+				finishReason === "LANGUAGE" ||
+				finishReason === "IMAGE_SAFETY" ||
+				finishReason === "IMAGE_PROHIBITED_CONTENT" ||
+				finishReason === "NO_IMAGE"
 			) {
 				return UnifiedFinishReason.CONTENT_FILTER;
 			}


### PR DESCRIPTION
## Summary

This PR fixes the handling of Google's image-related finish reasons by properly classifying them as content filters in the unified finish reason system. Previously, finish reasons like `IMAGE_SAFETY` would be logged as "Unknown finish reason encountered" errors.

## Changes

- Added `IMAGE_SAFETY`, `IMAGE_PROHIBITED_CONTENT`, `LANGUAGE`, and `NO_IMAGE` to the content filter mapping for google-ai-studio and google-vertex providers
- Added corresponding unit tests for the new finish reason mappings

## Testing

All unit tests pass, including the new tests for the added finish reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of content filter detection for Google AI responses by expanding finish reason classification to recognize additional response types including language restrictions, image safety, prohibited content, and missing images

* **Tests**
  * Extended test coverage to ensure Google AI finish reasons are properly classified for content filtering scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->