### PR TITLE
fix(gateway): map google image other finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -62,6 +62,7 @@ export function getUnifiedFinishReason(
 				finishReason === "LANGUAGE" ||
 				finishReason === "IMAGE_SAFETY" ||
 				finishReason === "IMAGE_PROHIBITED_CONTENT" ||
+				finishReason === "IMAGE_OTHER" ||
 				finishReason === "NO_IMAGE"
 			) {
 				return UnifiedFinishReason.CONTENT_FILTER;


### PR DESCRIPTION
## Summary
Add IMAGE_OTHER to the list of Google finish reasons that map to the content filter unified reason.

## Test plan
- Unit tests passed (315 passed, 2 skipped)
- Build completed successfully

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image generation completion responses from Google provider to properly categorize content filter-related finish reasons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->