### PR TITLE
feat(logs): map OTHER to UNKNOWN

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -63,6 +63,9 @@ describe("getUnifiedFinishReason", () => {
 		expect(getUnifiedFinishReason("NO_IMAGE", "google-ai-studio")).toBe(
 			UnifiedFinishReason.CONTENT_FILTER,
 		);
+		expect(getUnifiedFinishReason("OTHER", "google-ai-studio")).toBe(
+			UnifiedFinishReason.UNKNOWN,
+		);
 	});
 
 	it("handles special cases", () => {

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -67,6 +67,9 @@ export function getUnifiedFinishReason(
 			) {
 				return UnifiedFinishReason.CONTENT_FILTER;
 			}
+			if (finishReason === "OTHER") {
+				return UnifiedFinishReason.UNKNOWN;
+			}
 			break;
 		default: // OpenAI format (also used by inference.net and other providers)
 			if (finishReason === "stop") {


### PR DESCRIPTION
## Summary
- Adds mapping for finishReason "OTHER" to `UnifiedFinishReason.UNKNOWN` in the unified finish reason logic.
- Ensures non-standard finish reasons are categorized as unknown for safer filtering.

## Changes
### Core Logic
- Update `getUnifiedFinishReason` in `apps/gateway/src/lib/logs.ts` to return `UnifiedFinishReason.UNKNOWN` when `finishReason` is "OTHER" (in addition to existing handling for content filter scenarios).
- This hook now covers more edge cases and aligns with the new test coverage.

### Tests
- Extend `logs.spec.ts` to cover the new edge case:
  - When `finishReason` is "OTHER" for provider "google-ai-studio", the function should return `UnifiedFinishReason.UNKNOWN`.

## Rationale
- Provides consistent and safe mapping for non-standard finish reasons, improving downstream log categorization and analytics.

## Test plan
- Run unit tests:
  - Verify `getUnifiedFinishReason("OTHER", "google-ai-studio")` yields `UnifiedFinishReason.UNKNOWN`.
  - Ensure existing tests for other finish reasons remain unaffected.

## Notes
- No breaking changes introduced; this is an additive enhancement to finish reason handling.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/55e97d7e-4f72-4978-be42-96f307c503fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected response types from Google AI Studio and Google Vertex providers by mapping them to a standard fallback state, ensuring more robust error handling.

* **Tests**
  * Added test coverage for edge-case response type handling from Google AI Studio provider.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->