### PR TITLE
feat(gateway): map content filter types

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -60,6 +60,12 @@ describe("getUnifiedFinishReason", () => {
 		expect(
 			getUnifiedFinishReason("IMAGE_PROHIBITED_CONTENT", "google-ai-studio"),
 		).toBe(UnifiedFinishReason.CONTENT_FILTER);
+		expect(getUnifiedFinishReason("IMAGE_RECITATION", "google-ai-studio")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+		expect(getUnifiedFinishReason("IMAGE_OTHER", "google-ai-studio")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
 		expect(getUnifiedFinishReason("NO_IMAGE", "google-ai-studio")).toBe(
 			UnifiedFinishReason.CONTENT_FILTER,
 		);

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -62,6 +62,7 @@ export function getUnifiedFinishReason(
 				finishReason === "LANGUAGE" ||
 				finishReason === "IMAGE_SAFETY" ||
 				finishReason === "IMAGE_PROHIBITED_CONTENT" ||
+				finishReason === "IMAGE_RECITATION" ||
 				finishReason === "IMAGE_OTHER" ||
 				finishReason === "NO_IMAGE"
 			) {


### PR DESCRIPTION
## Summary
- Extend content filter handling in gateway finish reason to include IMAGE_RECITATION and IMAGE_OTHER.
- Update tests to cover new mappings.

## Changes

### Gateway Logs
- Update getUnifiedFinishReason to treat IMAGE_RECITATION and IMAGE_OTHER as content-filter finish reasons (mapping to UnifiedFinishReason.CONTENT_FILTER).

### Tests

- Extend logs.spec.ts with new test cases:
  - getUnifiedFinishReason("IMAGE_RECITATION", "google-ai-studio") => UnifiedFinishReason.CONTENT_FILTER
  - getUnifiedFinishReason("IMAGE_OTHER", "google-ai-studio") => UnifiedFinishReason.CONTENT_FILTER

## Files touched
- apps/gateway/src/lib/logs.ts
- apps/gateway/src/lib/logs.spec.ts

## Test plan
- [x] Run unit tests locally
- [x] Verify new mappings for IMAGE_RECITATION and IMAGE_OTHER
- [x] Ensure no regressions for existing finish reason mappings

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/26e3b6bf-98a2-44a0-b57e-84e6aa8145cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced content filter detection for Google AI Studio and Vertex AI providers to properly classify additional image-related response types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->