### PR TITLE
fix(worker): cleanup user-agent field in log retention

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -405,6 +405,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 						rawResponse: null,
 						upstreamRequest: null,
 						upstreamResponse: null,
+						userAgent: null,
 						dataRetentionCleanedUp: true,
 					})
 					.where(inArray(log.id, idsToClean));
@@ -477,6 +478,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 						rawResponse: null,
 						upstreamRequest: null,
 						upstreamResponse: null,
+						userAgent: null,
 						dataRetentionCleanedUp: true,
 					})
 					.where(inArray(log.id, idsToClean));


### PR DESCRIPTION
## Summary

Include userAgent in the data retention cleanup process for both free and pro plan organizations. The userAgent field is now cleared along with other sensitive data during the automated log cleanup.

## Test plan

- Verify that the build and tests pass
- Check that the cleanup process clears userAgent for both free and pro plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)