### PR TITLE
feat(models): sort by publish date

### DIFF
--- a/apps/ui/src/components/models/all-models.tsx
+++ b/apps/ui/src/components/models/all-models.tsx
@@ -342,12 +342,15 @@ export function AllModels({ children }: { children: React.ReactNode }) {
 			return true;
 		});
 
-		// Apply sorting
-		if (!sortField) {
-			return filteredModels;
-		}
-
+		// Apply sorting - default to publishedAt descending (newest first)
 		return [...filteredModels].sort((a, b) => {
+			// Default sorting by publishedAt when no sort field selected
+			if (!sortField) {
+				const aDate = a.publishedAt?.getTime() ?? 0;
+				const bDate = b.publishedAt?.getTime() ?? 0;
+				return bDate - aDate; // Descending (newest first)
+			}
+
 			let aValue: any;
 			let bValue: any;
 


### PR DESCRIPTION
## Summary
- Default sorting for the models list now uses the publishedAt date when no sort field is selected, showing newest models first.
- Existing sorting behavior remains intact when a sort field is provided.

## Changes

### Core Functionality
- Update AllModels sorting logic to fall back to publishedAt (newest first) when sortField is not specified.
- Treat missing publishedAt as timestamp 0, ensuring older items appear after those with a date.

### Rationale
- Improves user experience by presenting the most recently published models upfront without requiring an explicit sort selection.

## Test plan
- [x] Open the models list with no sort field and verify the newest models appear first.
- [x] Apply an explicit sort field and verify sorting behavior matches existing implementation.
- [x] Verify models without publishedAt appear at the end (treated as oldest).


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/87f7bb68-438b-4e30-a3c9-ff6c331f9d3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Models now display sorted by publication date (newest first) by default when no custom sorting is selected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->