### PR TITLE
fix: update aws bedrock region prefix to global

### DIFF
--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -69,7 +69,7 @@ export function CreateProviderKeyDialog({
 	const [token, setToken] = useState("");
 	const [awsBedrockRegionPrefix, setAwsBedrockRegionPrefix] = useState<
 		"us." | "global." | "eu."
-	>("us.");
+	>("global.");
 	const [azureResource, setAzureResource] = useState("");
 	const [azureApiVersion, setAzureApiVersion] = useState("2024-10-21");
 	const [azureDeploymentType, setAzureDeploymentType] = useState<
@@ -260,7 +260,7 @@ export function CreateProviderKeyDialog({
 			setBaseUrl("");
 			setCustomName("");
 			setToken("");
-			setAwsBedrockRegionPrefix("us.");
+			setAwsBedrockRegionPrefix("global.");
 			setAzureResource("");
 			setAzureApiVersion("2024-10-21");
 			setAzureDeploymentType("ai-foundry");

--- a/packages/models/src/get-provider-endpoint.ts
+++ b/packages/models/src/get-provider-endpoint.ts
@@ -220,8 +220,8 @@ export function getProviderEndpoint(
 		case "aws-bedrock": {
 			const prefix =
 				providerKeyOptions?.aws_bedrock_region_prefix ||
-				getProviderEnvValue("aws-bedrock", "region", configIndex, "us.") ||
-				"us.";
+				getProviderEnvValue("aws-bedrock", "region", configIndex, "global.") ||
+				"global.";
 
 			const endpoint = stream ? "converse-stream" : "converse";
 			return `${url}/model/${prefix}${modelName}/${endpoint}`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Configuration Updates**
- Updated the AWS Bedrock provider's default region configuration. The region prefix now defaults to "global." instead of "us." when setting up AWS Bedrock connections. This change improves endpoint routing and compatibility across all supported regions when no specific region is explicitly configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->