### PR TITLE
fix: use Geist Mono font

### DIFF
--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -15,7 +15,7 @@ const inter = Inter({
 });
 
 const geistMono = Geist_Mono({
-	variable: "--font-mono",
+	variable: "--font-geist-mono",
 	subsets: ["latin"],
 });
 


### PR DESCRIPTION
## Summary
- Fix code snippet font to render in monospace by using Geist Mono font variable.

## Changes

### Core Functionality
- Updated Geist Mono font configuration in layout.tsx to use the Geist Mono CSS variable.
- Replaced variable: "--font-mono" with "--font-geist-mono" to ensure code blocks render monospace.

### Files Changed
- apps/playground/src/app/layout.tsx

## Test plan
- [x] Build the playground app locally
- [x] Verify code blocks and inline code render in monospace in the Playground
- [x] Ensure no visual regressions in non-code text fonts

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/39064b5f-0f3f-4197-9f75-0b81b544d76e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated font variable naming in the application layout configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->