### PR TITLE
feat(log-card): improve cache label

### DIFF
--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -162,7 +162,13 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 						</div>
 						<div className="flex items-center gap-1">
 							<Zap className="h-3.5 w-3.5" />
-							<span>{log.cached ? "Cached" : "Not cached"}</span>
+							<span>
+								{log.cached
+									? "Fully cached"
+									: log.cachedTokens && Number(log.cachedTokens) > 0
+										? "Partially cached"
+										: "Not cached"}
+							</span>
 						</div>
 						<div className="flex items-center gap-1">
 							<Clock className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- Refines cache status display in the log card to differentiate fully cached, partially cached, and not cached states.

## Changes
### UI
- Updated log-card.tsx to render more granular cache status:
  - Show "Fully cached" when `log.cached` is true
  - Show "Partially cached" when `log.cached` is falsey but `log.cachedTokens > 0`
  - Show "Not cached" otherwise

### Notes
- No backend changes; purely UI label logic update.

## Files touched
- apps/ui/src/components/dashboard/log-card.tsx

## Test plan
- [x] Verify UI shows "Fully cached" for logs with `log.cached = true`
- [x] Verify UI shows "Partially cached" for logs with `log.cachedTokens > 0` and `log.cached` is false
- [x] Verify UI shows "Not cached" for logs that don’t meet the above conditions
- [x] Ensure icons/spacing remain consistent with existing design

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2469b2e9-4079-4c27-8504-3e35f719b5c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cache status display in log cards to show three distinct states: "Fully cached," "Partially cached," and "Not cached" for improved visibility into caching performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->