### PR TITLE
feat(load-balancer): include 429 errors

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -1,7 +1,8 @@
 /**
  * Determines the appropriate finish reason based on HTTP status code and error message
  * 5xx status codes indicate upstream provider errors
- * 4xx status codes indicate client/gateway errors
+ * 429 status codes indicate upstream rate limiting (treated as upstream error)
+ * Other 4xx status codes indicate client/gateway errors
  * Special client errors (like JSON format validation) are classified as client_error
  */
 export function getFinishReasonFromError(
@@ -9,6 +10,11 @@ export function getFinishReasonFromError(
 	errorText?: string,
 ): string {
 	if (statusCode >= 500) {
+		return "upstream_error";
+	}
+
+	// 429 is a rate limit from the upstream provider, not a client error
+	if (statusCode === 429) {
 		return "upstream_error";
 	}
 


### PR DESCRIPTION
## Summary
- Treat HTTP 429 upstream rate limits as upstream errors for load balancer scoring
- Preserve existing handling for 5xx (upstream_error) and other 4xx (client/gateway errors)

## Changes
### Core Functionality
- Update getFinishReasonFromError to classify statusCode === 429 as upstream_error
- Retain existing 5xx => upstream_error and non-429 4xx => client_error handling

### Documentation
- Update function comment to reflect 429 behavior

### Tests
- [ ] Add unit tests for 429 classification (upstream_error)
- [ ] Ensure existing tests for 5xx and other 4xx pass

## Rationale
- Upstream rate limiting should influence load balancer scoring as an upstream issue, not a client error

## Compatibility / Migration
- No breaking changes; only error classification used by scoring logic

## How to test
- Unit tests for 429 resulting in finish_reason 'upstream_error'
- Validate behavior for 5xx and typical 4xx cases

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4b55751d-45c4-41c1-9eb9-8ca37592f24e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for rate-limited requests to properly classify and report upstream errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->