### PR TITLE
feat(ui): add throughput metric

### DIFF
--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -333,6 +333,12 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 							<div className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm">
 								<div className="text-muted-foreground">Duration</div>
 								<div>{formatDuration(log.duration ?? 0)}</div>
+								<div className="text-muted-foreground">Throughput</div>
+								<div>
+									{log.duration && log.totalTokens
+										? `${(Number(log.totalTokens) / (log.duration / 1000)).toFixed(1)}t/s`
+										: "-"}
+								</div>
 								{log.timeToFirstToken && (
 									<>
 										<div className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- Adds a new Throughput metric to the LogCard, displaying tokens per second (t/s) alongside duration in response logs.

## Changes

### UI
- **LogCard**: Added a new "Throughput" row in the metric grid. When both duration and totalTokens are available, it shows the computed throughput as `X.Xt/s`; otherwise it shows `-`.

### Implementation Details
- Reuses existing duration formatting.
- Computes throughput as: `(Number(log.totalTokens) / (log.duration / 1000)).toFixed(1)`

### Files touched
- apps/ui/src/components/dashboard/log-card.tsx

## Test plan
- [x] Log entries with duration and totalTokens display throughput correctly (e.g., 123.4t/s)
- [x] Missing duration or totalTokens shows "-"
- [x] Other log metrics unaffected

## Notes
- No API changes; purely UI enhancement.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e820c4f3-f9d1-4041-b451-b197fafaafa1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Throughput metric to the dashboard log card, displaying tokens per second in both expanded and collapsed views when duration and token data are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->