### PR TITLE
feat(docs): add edge runtime to routes

### DIFF
--- a/apps/docs/app/(home)/layout.tsx
+++ b/apps/docs/app/(home)/layout.tsx
@@ -7,6 +7,8 @@ import { source } from "@/lib/source";
 import type { DocsLayoutProps } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
 
+export const runtime = "edge";
+
 const docsOptions: DocsLayoutProps = {
 	...baseOptions,
 	tree: source.pageTree,

--- a/apps/docs/app/api/proxy/route.ts
+++ b/apps/docs/app/api/proxy/route.ts
@@ -1,5 +1,7 @@
 import { openapi } from "@/lib/source";
 
+export const runtime = "edge";
+
 export const { GET, HEAD, PUT, POST, PATCH, DELETE } = openapi.createProxy({
 	allowedOrigins: [
 		"https://docs.llmgateway.io",

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -2,4 +2,6 @@ import { createFromSource } from "fumadocs-core/search/server";
 
 import { source } from "@/lib/source";
 
+export const runtime = "edge";
+
 export const { GET } = createFromSource(source);

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -19,6 +19,7 @@ const mono = Geist_Mono({
 	variable: "--font-mono",
 });
 
+export const runtime = "edge";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -2,6 +2,7 @@ import { source } from "@/lib/source";
 
 import { getLLMText } from "./get-llm-text";
 
+export const runtime = "edge";
 export const revalidate = false;
 
 export async function GET() {


### PR DESCRIPTION
## Summary
- Add `export const runtime = "edge"` to compatible Next.js routes in the docs package
- Applied to layouts and API routes that don't use `generateStaticParams()`
- Routes with `generateStaticParams()` were not modified as edge runtime is incompatible with static generation

## Test plan
- [x] Run `pnpm format` - passed
- [x] Run `pnpm build --filter docs` - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application performance through infrastructure optimization across documentation services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->