### PR TITLE
fix(ui): hide retention message on cancel

### DIFF
--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -126,6 +126,7 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 							{!log.content &&
 								log.unifiedFinishReason !== "tool_calls" &&
 								!log.hasError &&
+								!log.canceled &&
 								!retentionEnabled && (
 									<TooltipProvider>
 										<Tooltip>


### PR DESCRIPTION
## Summary
- Fixes incorrect retention message being shown for cancelled requests in the UI
- Ensures retention messages render only for non-cancelled, non-error, and non-tool_call paths as intended

## Changes
### UI
- Add check for log.canceled to the retention message rendering condition in `apps/ui/src/components/dashboard/log-card.tsx` so the retention banner does not appear when a log is cancelled

### Rationale
- Previously, the retention message could appear on cancelled requests, causing confusing or misleading UI behavior. This change prevents that scenario by excluding cancelled logs from showing the retention message

## Test plan
- [x] Verify retention message is not displayed for a log marked as canceled
- [x] Verify retention message is displayed for non-cancelled logs when other conditions are met
- [x] Confirm no regressions in other log rendering paths (tool_calls, errors, etc.)

## Notes
- No backend changes; this is a UI-only fix to align messaging with actual log states

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0a9ae0ba-0a2d-493d-a54e-cc5c893fe19b