### PR TITLE
feat(model-detail): add back button on provider and model pages

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -98,11 +98,11 @@ export default async function ModelProviderPage({ params }: PageProps) {
 				<div className="container mx-auto px-4 py-8">
 					<div className="mb-6">
 						<Link
-							href="/models"
+							href={`/models/${encodeURIComponent(decodedName)}`}
 							className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
 						>
 							<ArrowLeft className="mr-2 h-4 w-4" />
-							Back to all models
+							Back to {modelDef.name}
 						</Link>
 					</div>
 					<div className="mb-8">

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -1,5 +1,6 @@
 import {
 	AlertTriangle,
+	ArrowLeft,
 	Play,
 	Zap,
 	Eye,
@@ -8,6 +9,7 @@ import {
 	ImagePlus,
 	Braces,
 } from "lucide-react";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import Footer from "@/components/landing/footer";
@@ -89,6 +91,15 @@ export default async function ModelPage({ params }: PageProps) {
 			<Navbar />
 			<div className="min-h-screen bg-background pt-24 md:pt-32 pb-16">
 				<div className="container mx-auto px-4 py-8">
+					<div className="mb-6">
+						<Link
+							href="/models"
+							className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+						>
+							<ArrowLeft className="mr-2 h-4 w-4" />
+							Back to all models
+						</Link>
+					</div>
 					<div className="mb-8">
 						<div className="flex items-center gap-3 mb-2 flex-wrap">
 							<h1 className="text-3xl md:text-4xl font-bold tracking-tight">


### PR DESCRIPTION
## Summary
- Adds back navigation on both the provider detail page and the model page:
  - Back to the model page from the provider detail.
  - Back to all models from the model page.

## Changes

### UI / Components
- Import `ArrowLeft` from `lucide-react` and `Link` from `next/link`.
- On the provider detail page, render a back link with text like "Back to {modelName}" above the page content, pointing to `/models/{encodeURIComponent(decodedName)}`.
- On the model page, render a back link with text "Back to all models" pointing to `/models`.
- Styling matches existing theme: inline-flex, text-sm/text-muted-foreground, hover state, with a left-arrow icon.

### Navigation
- Improves user flow by providing quick return paths to models catalog and a specific model page.

## Test plan
- [x] Open a provider detail page and verify the back link appears at the top.
- [x] Click the back link and ensure navigation to the corresponding model page.
- [x] Open the model page and verify the back to all models link appears at the top.
- [x] Click the back link and ensure navigation to `/models`.
- [x] Ensure styling aligns with existing UI (text color, hover, icon size).

📎 **Task**: https://www.terragonlabs.com/task/5b7c5403-8d0d-486d-b07a-90321af3db9c