### PR TITLE
feat(playground): auto-select model

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -63,31 +63,13 @@ export default function ChatPageClient({
 	);
 	const [availableModels] = useState<ComboboxModel[]>(mapped);
 
-	// Sort models by publishedAt (or releasedAt fallback) to match model selector ordering
-	const sortedModels = useMemo(() => {
-		return [...models].sort((a, b) => {
-			const dateA = a.publishedAt
-				? new Date(a.publishedAt).getTime()
-				: a.releasedAt
-					? new Date(a.releasedAt).getTime()
-					: 0;
-			const dateB = b.publishedAt
-				? new Date(b.publishedAt).getTime()
-				: b.releasedAt
-					? new Date(b.releasedAt).getTime()
-					: 0;
-			return dateB - dateA;
-		});
-	}, [models]);
-
 	const getInitialModel = () => {
 		const modelFromUrl = searchParams.get("model");
 		if (modelFromUrl) {
 			return modelFromUrl;
 		}
-		// Use the first model from sorted list as default
-		const firstModel = sortedModels[0];
-		return firstModel?.id || "auto";
+		// Default to "auto" model which auto-selects the best provider
+		return "auto";
 	};
 
 	const [selectedModel, setSelectedModel] = useState(getInitialModel());


### PR DESCRIPTION
## Summary
- Auto-selects the 'auto' model by default in the playground chat page.
- Removes the model sorting logic; relies on the auto provider selection instead.

## Changes

### Core Functionality
- Removed the sorting of available models by publishedAt/releasedAt, and now default model is "auto" when no URL parameter is provided.
- getInitialModel() now returns "auto" by default (unless a model is specified in the URL query).
- Initialization of selectedModel now uses getInitialModel() without depending on a sorted list.

### Code Cleanup
- Removed the unused sortedModels useMemo block and related logic.

## Rationale
- The 'auto' model already selects the best provider. Defaulting to it simplifies UX and aligns with intended behavior, while still honoring ?model=... overrides.

## Test plan
- [x] Load playground without a model param and verify the selected model is "auto".
- [x] Load playground with ?model=customModel and verify the selected model matches the URL parameter.
- [x] Ensure the application remains stable if the models list changes and no sorting is applied.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5e52bd2b-4acc-4ef6-b7b9-0c898b4aa48b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved default model selection behavior in the chat interface. When no model is explicitly chosen, the system now defaults to "auto" mode, providing more intuitive behavior. Direct URL-based model selections continue to work without any changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->