### PR TITLE
chore(email): ignore keemail.me

### DIFF
--- a/apps/api/src/utils/email-validation.spec.ts
+++ b/apps/api/src/utils/email-validation.spec.ts
@@ -42,6 +42,12 @@ describe("validateEmail", () => {
 			expect(result.valid).toBe(false);
 			expect(result.reason).toBe("blacklisted_domain");
 		});
+
+		it("should reject emails from keemail.me", () => {
+			const result = validateEmail("user@keemail.me");
+			expect(result.valid).toBe(false);
+			expect(result.reason).toBe("blacklisted_domain");
+		});
 	});
 
 	describe("disposable email validation", () => {

--- a/apps/api/src/utils/email-validation.ts
+++ b/apps/api/src/utils/email-validation.ts
@@ -6,7 +6,7 @@ export interface EmailValidationResult {
 	message?: string;
 }
 
-const BLACKLISTED_DOMAINS = ["duck.com", "duckduckgo.com"];
+const BLACKLISTED_DOMAINS = ["duck.com", "duckduckgo.com", "keemail.me"];
 
 export function validateEmail(email: string): EmailValidationResult {
 	const emailLower = email.toLowerCase();


### PR DESCRIPTION
## Summary
- Adds keemail.me to the signup blacklist to prevent accounts from this domain.
- Updates unit tests to cover keemail.me rejection.

## Changes

### Core Functionality
- Extend BLACKLISTED_DOMAINS in apps/api/src/utils/email-validation.ts to include keemail.me

### Tests
- Update apps/api/src/utils/email-validation.spec.ts with test asserting that user@keemail.me is rejected with reason "blacklisted_domain".

## Test plan
- Run unit tests for email validation
- [x] Validate user@keemail.me is rejected with "blacklisted_domain"
- [x] Ensure existing blacklisted domains still reject: duck.com, duckduckgo.com

## Notes
- No changes to public API; behavior is strictly updated to reject additional disallowed domain during signup verification.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/12e933ac-4b92-4c06-a569-d904ccffa06b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added "keemail.me" to the email validation blacklist to prevent registrations from this domain.

* **Tests**
  * Expanded test coverage for blacklisted domain validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->