### PR TITLE
feat: add API key filter to usage pages and statistics button

### DIFF
--- a/apps/admin/src/lib/api/v1.d.ts
+++ b/apps/admin/src/lib/api/v1.d.ts
@@ -751,6 +751,7 @@ export interface paths {
                 query: {
                     days: string;
                     projectId?: string;
+                    apiKeyId?: string;
                 };
                 header?: never;
                 path?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -751,6 +751,7 @@ export interface paths {
                 query: {
                     days: string;
                     projectId?: string;
+                    apiKeyId?: string;
                 };
                 header?: never;
                 path?: never;

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/model-usage/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/model-usage/page.tsx
@@ -1,7 +1,4 @@
-import Link from "next/link";
-
-import { ActivityChart } from "@/components/dashboard/activity-chart";
-import { Button } from "@/lib/components/button";
+import { ModelUsageClient } from "@/components/usage/model-usage-client";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { ActivitT } from "@/types/activity";
@@ -15,73 +12,33 @@ export default async function ModelUsagePage({
 	params: Promise<{ orgId: string; projectId: string }>;
 	searchParams?: Promise<{
 		days?: string;
-		startDate?: string;
-		endDate?: string;
-		finishReason?: string;
-		unifiedFinishReason?: string;
-		provider?: string;
-		model?: string;
-		limit?: string;
+		apiKeyId?: string;
 	}>;
 }) {
 	const { projectId, orgId } = await params;
 	const searchParamsData = await searchParams;
 	const daysParam = searchParamsData?.days;
+	const apiKeyId = searchParamsData?.apiKeyId;
 
 	const days = daysParam === "30" ? 30 : 7;
 
-	// Server-side data fetching for activity data
-	const initialActivityData = await fetchServerData<ActivitT>(
-		"GET",
-		"/activity",
-		{
-			params: {
-				query: {
-					days: String(days),
-					projectId,
+	// Server-side data fetching for activity data (only if no apiKeyId filter)
+	const initialActivityData = apiKeyId
+		? null
+		: await fetchServerData<ActivitT>("GET", "/activity", {
+				params: {
+					query: {
+						days: String(days),
+						projectId,
+					},
 				},
-			},
-		},
-	);
-
-	if (!initialActivityData) {
-		return <div>No data found</div>;
-	}
+			});
 
 	return (
-		<div className="flex flex-col">
-			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
-				<div className="flex items-center justify-between space-y-2">
-					<h2 className="text-3xl font-bold tracking-tight">Usage by model</h2>
-					<div className="flex items-center space-x-2">
-						<Button
-							variant={days === 7 ? "default" : "outline"}
-							size="sm"
-							asChild
-						>
-							<Link
-								href={`/dashboard/${orgId}/${projectId}/model-usage?days=7`}
-							>
-								7 Days
-							</Link>
-						</Button>
-						<Button
-							variant={days === 30 ? "default" : "outline"}
-							size="sm"
-							asChild
-						>
-							<Link
-								href={`/dashboard/${orgId}/${projectId}/model-usage?days=30`}
-							>
-								30 Days
-							</Link>
-						</Button>
-					</div>
-				</div>
-				<div className="space-y-4">
-					<ActivityChart initialData={initialActivityData} />
-				</div>
-			</div>
-		</div>
+		<ModelUsageClient
+			initialActivityData={initialActivityData || undefined}
+			orgId={orgId}
+			projectId={projectId}
+		/>
 	);
 }

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import {
+	BarChart3Icon,
 	EditIcon,
 	KeyIcon,
 	MoreHorizontal,
@@ -91,6 +92,9 @@ export function ApiKeysList({
 
 	const getIamRulesUrl = (keyId: string) =>
 		`/dashboard/${orgId}/${projectId}/api-keys/${keyId}/iam` as Route;
+
+	const getStatisticsUrl = (keyId: string) =>
+		`/dashboard/${orgId}/${projectId}/usage?apiKeyId=${keyId}` as Route;
 
 	// All hooks must be called before any conditional returns
 	const { data, isLoading, error } = api.useQuery(
@@ -611,6 +615,12 @@ export function ApiKeysList({
 										<DropdownMenuContent align="end">
 											<DropdownMenuLabel>Actions</DropdownMenuLabel>
 											<DropdownMenuItem asChild>
+												<Link href={getStatisticsUrl(key.id)}>
+													<BarChart3Icon className="mr-2 h-4 w-4" />
+													View Statistics
+												</Link>
+											</DropdownMenuItem>
+											<DropdownMenuItem asChild>
 												<Link href={getIamRulesUrl(key.id)}>
 													<Shield className="mr-2 h-4 w-4" />
 													Manage IAM Rules
@@ -694,6 +704,12 @@ export function ApiKeysList({
 								</DropdownMenuTrigger>
 								<DropdownMenuContent align="end">
 									<DropdownMenuLabel>Actions</DropdownMenuLabel>
+									<DropdownMenuItem asChild>
+										<Link href={getStatisticsUrl(key.id)}>
+											<BarChart3Icon className="mr-2 h-4 w-4" />
+											View Statistics
+										</Link>
+									</DropdownMenuItem>
 									<DropdownMenuItem asChild>
 										<Link href={getIamRulesUrl(key.id)}>
 											<Shield className="mr-2 h-4 w-4" />

--- a/apps/ui/src/components/dashboard/activity-chart.tsx
+++ b/apps/ui/src/components/dashboard/activity-chart.tsx
@@ -177,9 +177,10 @@ const CustomTooltip = ({
 
 interface ActivityChartProps {
 	initialData?: ActivitT;
+	apiKeyId?: string;
 }
 
-export function ActivityChart({ initialData }: ActivityChartProps) {
+export function ActivityChart({ initialData, apiKeyId }: ActivityChartProps) {
 	const searchParams = useSearchParams();
 	const [breakdownField, setBreakdownField] = useState<
 		"requests" | "cost" | "tokens"
@@ -200,6 +201,7 @@ export function ActivityChart({ initialData }: ActivityChartProps) {
 				query: {
 					days: String(days),
 					...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
+					...(apiKeyId ? { apiKeyId } : {}),
 				},
 			},
 		},

--- a/apps/ui/src/components/usage/cache-rate-chart.tsx
+++ b/apps/ui/src/components/usage/cache-rate-chart.tsx
@@ -20,6 +20,7 @@ import type { TooltipProps } from "recharts";
 interface CacheRateChartProps {
 	initialData?: ActivitT;
 	projectId: string | undefined;
+	apiKeyId?: string;
 }
 
 const CustomTooltip = ({
@@ -51,6 +52,7 @@ const CustomTooltip = ({
 export function CacheRateChart({
 	initialData,
 	projectId,
+	apiKeyId,
 }: CacheRateChartProps) {
 	const searchParams = useSearchParams();
 	const { selectedProject } = useDashboardState();
@@ -68,6 +70,7 @@ export function CacheRateChart({
 				query: {
 					days: String(days),
 					...(projectId ? { projectId: projectId } : {}),
+					...(apiKeyId ? { apiKeyId } : {}),
 				},
 			},
 		},

--- a/apps/ui/src/components/usage/cost-breakdown-chart.tsx
+++ b/apps/ui/src/components/usage/cost-breakdown-chart.tsx
@@ -13,6 +13,8 @@ import type { TooltipProps } from "recharts";
 
 interface CostBreakdownChartProps {
 	initialData?: ActivitT;
+	projectId?: string;
+	apiKeyId?: string;
 }
 
 const CustomTooltip = ({
@@ -39,7 +41,11 @@ const CustomTooltip = ({
 	return null;
 };
 
-export function CostBreakdownChart({ initialData }: CostBreakdownChartProps) {
+export function CostBreakdownChart({
+	initialData,
+	projectId,
+	apiKeyId,
+}: CostBreakdownChartProps) {
 	const searchParams = useSearchParams();
 	const { selectedProject } = useDashboardNavigation();
 	const [showAllSegments, setShowAllSegments] = useState(false);
@@ -47,6 +53,9 @@ export function CostBreakdownChart({ initialData }: CostBreakdownChartProps) {
 	// Get days from URL parameter
 	const daysParam = searchParams.get("days");
 	const days = daysParam === "30" ? 30 : 7;
+
+	// Use provided projectId or fall back to selectedProject
+	const effectiveProjectId = projectId || selectedProject?.id;
 
 	const api = useApi();
 	const { data, isLoading, error } = api.useQuery(
@@ -56,17 +65,18 @@ export function CostBreakdownChart({ initialData }: CostBreakdownChartProps) {
 			params: {
 				query: {
 					days: String(days),
-					...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
+					...(effectiveProjectId ? { projectId: effectiveProjectId } : {}),
+					...(apiKeyId ? { apiKeyId } : {}),
 				},
 			},
 		},
 		{
-			enabled: !!selectedProject?.id,
+			enabled: !!effectiveProjectId,
 			initialData,
 		},
 	);
 
-	if (!selectedProject?.id) {
+	if (!effectiveProjectId) {
 		return (
 			<div className="flex h-[350px] items-center justify-center">
 				<p className="text-muted-foreground">

--- a/apps/ui/src/components/usage/error-rate-chart.tsx
+++ b/apps/ui/src/components/usage/error-rate-chart.tsx
@@ -20,6 +20,7 @@ import type { TooltipProps } from "recharts";
 interface ErrorRateChartProps {
 	initialData?: ActivitT;
 	projectId: string | undefined;
+	apiKeyId?: string;
 }
 
 const CustomTooltip = ({
@@ -51,6 +52,7 @@ const CustomTooltip = ({
 export function ErrorRateChart({
 	initialData,
 	projectId,
+	apiKeyId,
 }: ErrorRateChartProps) {
 	const searchParams = useSearchParams();
 	const { selectedProject } = useDashboardState();
@@ -68,6 +70,7 @@ export function ErrorRateChart({
 				query: {
 					days: String(days),
 					...(projectId ? { projectId: projectId } : {}),
+					...(apiKeyId ? { apiKeyId } : {}),
 				},
 			},
 		},

--- a/apps/ui/src/components/usage/model-usage-client.tsx
+++ b/apps/ui/src/components/usage/model-usage-client.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { ActivityChart } from "@/components/dashboard/activity-chart";
+import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { Button } from "@/lib/components/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/lib/components/select";
+import { useApi } from "@/lib/fetch-client";
+
+import type { ActivitT } from "@/types/activity";
+
+interface ModelUsageClientProps {
+	initialActivityData?: ActivitT;
+	orgId: string;
+	projectId: string;
+}
+
+export function ModelUsageClient({
+	initialActivityData,
+	orgId,
+	projectId,
+}: ModelUsageClientProps) {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+	const { buildUrl } = useDashboardNavigation();
+	const api = useApi();
+
+	// Fetch API keys for the project
+	const { data: apiKeysData } = api.useQuery(
+		"get",
+		"/keys/api",
+		{
+			params: {
+				query: {
+					projectId: projectId || "",
+				},
+			},
+		},
+		{
+			enabled: !!projectId,
+		},
+	);
+
+	const apiKeys =
+		apiKeysData?.apiKeys.filter((key) => key.status !== "deleted") || [];
+
+	// Get days from URL parameter
+	const daysParam = searchParams.get("days");
+	const days = daysParam === "30" ? 30 : 7;
+
+	// Get apiKeyId from URL
+	const apiKeyId = searchParams.get("apiKeyId") || undefined;
+
+	// Function to update apiKeyId in URL
+	const updateApiKeyIdInUrl = (newApiKeyId: string | undefined) => {
+		const params = new URLSearchParams(searchParams);
+		if (newApiKeyId) {
+			params.set("apiKeyId", newApiKeyId);
+		} else {
+			params.delete("apiKeyId");
+		}
+		router.push(`${buildUrl("model-usage")}?${params.toString()}`);
+	};
+
+	return (
+		<div className="flex flex-col">
+			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
+				<div className="flex items-center justify-between space-y-2">
+					<h2 className="text-3xl font-bold tracking-tight">Usage by model</h2>
+					<div className="flex items-center space-x-2">
+						<Select
+							value={apiKeyId || "all"}
+							onValueChange={(value) =>
+								updateApiKeyIdInUrl(value === "all" ? undefined : value)
+							}
+						>
+							<SelectTrigger size="sm" className="w-[180px]">
+								<SelectValue placeholder="All API Keys" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All API Keys</SelectItem>
+								{apiKeys.map((key) => (
+									<SelectItem key={key.id} value={key.id}>
+										{key.description}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Button
+							variant={days === 7 ? "default" : "outline"}
+							size="sm"
+							asChild
+						>
+							<Link
+								href={`/dashboard/${orgId}/${projectId}/model-usage?days=7${apiKeyId ? `&apiKeyId=${apiKeyId}` : ""}`}
+							>
+								7 Days
+							</Link>
+						</Button>
+						<Button
+							variant={days === 30 ? "default" : "outline"}
+							size="sm"
+							asChild
+						>
+							<Link
+								href={`/dashboard/${orgId}/${projectId}/model-usage?days=30${apiKeyId ? `&apiKeyId=${apiKeyId}` : ""}`}
+							>
+								30 Days
+							</Link>
+						</Button>
+					</div>
+				</div>
+				<div className="space-y-4">
+					<ActivityChart
+						initialData={apiKeyId ? undefined : initialActivityData}
+						apiKeyId={apiKeyId}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/components/usage/model-usage-table.tsx
+++ b/apps/ui/src/components/usage/model-usage-table.tsx
@@ -24,11 +24,13 @@ type SortDirection = "asc" | "desc";
 interface ModelUsageTableProps {
 	initialData?: ActivitT;
 	projectId: string | undefined;
+	apiKeyId?: string;
 }
 
 export function ModelUsageTable({
 	initialData,
 	projectId,
+	apiKeyId,
 }: ModelUsageTableProps) {
 	const searchParams = useSearchParams();
 	const [sortColumn, setSortColumn] = useState<SortColumn>("totalTokens");
@@ -48,6 +50,7 @@ export function ModelUsageTable({
 				query: {
 					days: String(days),
 					...(projectId ? { projectId: projectId } : {}),
+					...(apiKeyId ? { apiKeyId } : {}),
 				},
 			},
 		},

--- a/apps/ui/src/components/usage/usage-chart.tsx
+++ b/apps/ui/src/components/usage/usage-chart.tsx
@@ -20,6 +20,7 @@ import type { TooltipProps } from "recharts";
 interface UsageChartProps {
 	initialData?: ActivitT;
 	projectId: string | undefined;
+	apiKeyId?: string;
 }
 
 const CustomTooltip = ({
@@ -45,7 +46,11 @@ const CustomTooltip = ({
 	return null;
 };
 
-export function UsageChart({ initialData, projectId }: UsageChartProps) {
+export function UsageChart({
+	initialData,
+	projectId,
+	apiKeyId,
+}: UsageChartProps) {
 	const searchParams = useSearchParams();
 	const { selectedProject } = useDashboardState();
 
@@ -62,6 +67,7 @@ export function UsageChart({ initialData, projectId }: UsageChartProps) {
 				query: {
 					days: String(days),
 					...(projectId ? { projectId: projectId } : {}),
+					...(apiKeyId ? { apiKeyId } : {}),
 				},
 			},
 		},

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -751,6 +751,7 @@ export interface paths {
                 query: {
                     days: string;
                     projectId?: string;
+                    apiKeyId?: string;
                 };
                 header?: never;
                 path?: never;


### PR DESCRIPTION


https://github.com/user-attachments/assets/35cf4a8f-978f-4680-9b41-a6e8b98bccfb



## Summary
- Add optional API key filtering to model usage and usage & metrics pages
- Users can view usage statistics for a specific API key via query string
- Add "View Statistics" action button to API keys page for quick access

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] All UI components render correctly
- [x] API endpoint accepts and filters by apiKeyId parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to filter usage and activity statistics by individual API keys.
  * Introduced "View Statistics" action on API key entries for quick access to per-key usage data.
  * API key selection dropdown now available in usage analytics to switch between all keys or specific ones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->