### PR TITLE
fix(gateway): support JSON schema for Responses API

### DIFF
--- a/packages/models/src/prepare-request-body.ts
+++ b/packages/models/src/prepare-request-body.ts
@@ -369,6 +369,30 @@ export async function prepareRequestBody(
 					responsesBody.max_output_tokens = max_tokens;
 				}
 
+				// Handle response_format for Responses API - transform to text.format
+				if (response_format) {
+					if (
+						response_format.type === "json_schema" &&
+						response_format.json_schema
+					) {
+						responsesBody.text = {
+							format: {
+								type: "json_schema",
+								name: response_format.json_schema.name,
+								schema: response_format.json_schema.schema as Record<
+									string,
+									unknown
+								>,
+								strict: response_format.json_schema.strict,
+							},
+						};
+					} else if (response_format.type === "json_object") {
+						responsesBody.text = {
+							format: { type: "json_object" },
+						};
+					}
+				}
+
 				return responsesBody;
 			} else {
 				// Use regular chat completions format

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -221,6 +221,17 @@ export interface OpenAIResponsesRequestBody {
 	stream?: boolean;
 	temperature?: number;
 	max_output_tokens?: number;
+	text?: {
+		format:
+			| { type: "text" }
+			| { type: "json_object" }
+			| {
+					type: "json_schema";
+					name: string;
+					schema: Record<string, unknown>;
+					strict?: boolean;
+			  };
+	};
 }
 
 export interface AnthropicSystemContent {


### PR DESCRIPTION
## Summary
- Added `text.format` support to `OpenAIResponsesRequestBody` type for structured outputs
- Transform `response_format` to `text.format` for models using the Responses API (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.1, gpt-5.2, etc.)
- Supports both `json_schema` and `json_object` response formats

## Test plan
- [x] Tested with `httpyac json-schema.http` - all Responses API models now return properly structured JSON output
- [x] Verified gpt-5, gpt-5-mini, gpt-5.1 models now work with JSON schema output

🤖 Generated with [Claude Code](https://claude.com/claude-code)