### PR TITLE
fix(gateway): enrich streaming tool call deltas with id

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -331,6 +331,17 @@ export const toolCallModels = testModels
 	// Exclude novita/minimax-m2.1 due to model variability in tool calling
 	.filter((m) => m.model !== "novita/minimax-m2.1");
 
+export const streamingToolCallModels = toolCallModels.filter((m) =>
+	m.providers.some((p: ProviderModelMapping) => {
+		// Check model-level streaming first, then fall back to provider-level
+		if (p.streaming !== undefined) {
+			return p.streaming;
+		}
+		const provider = providers.find((pr) => pr.id === p.providerId);
+		return provider?.streaming;
+	}),
+);
+
 export const imageModels = testModels.filter((m) => {
 	const model = models.find((mo) => m.originalModel === mo.id);
 	return (model as ModelDefinition).output?.includes("image");

--- a/apps/gateway/src/chat-toolcalls.e2e.ts
+++ b/apps/gateway/src/chat-toolcalls.e2e.ts
@@ -9,9 +9,11 @@ import {
 	getConcurrentTestOptions,
 	getTestOptions,
 	logMode,
+	streamingToolCallModels,
 	toolCallModels,
 	validateLogByRequestId,
 } from "@/chat-helpers.e2e.js";
+import { readAll } from "@/test-utils/test-helpers.js";
 
 describe("e2e", getConcurrentTestOptions(), () => {
 	beforeAll(beforeAllHook);
@@ -126,6 +128,134 @@ describe("e2e", getConcurrentTestOptions(), () => {
 			expect(json.usage.prompt_tokens).toBeGreaterThan(0);
 			expect(json.usage.completion_tokens).toBeGreaterThan(0);
 			expect(json.usage.total_tokens).toBeGreaterThan(0);
+		},
+	);
+
+	test.each(streamingToolCallModels)(
+		"streaming tool calls $model",
+		getTestOptions(),
+		async ({ model }) => {
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: model,
+					stream: true,
+					messages: [
+						{
+							role: "system",
+							content:
+								"You are a weather assistant that can get weather information for cities.",
+						},
+						{
+							role: "user",
+							content: "What's the weather like in San Francisco?",
+						},
+					],
+					tools: [
+						{
+							type: "function",
+							function: {
+								name: "get_weather",
+								description: "Get the current weather for a given city",
+								parameters: {
+									type: "object",
+									properties: {
+										city: {
+											type: "string",
+											description: "The city name to get weather for",
+										},
+										unit: {
+											type: "string",
+											enum: ["celsius", "fahrenheit"],
+											description: "Temperature unit",
+											default: "fahrenheit",
+										},
+									},
+									required: ["city"],
+								},
+							},
+						},
+					],
+					tool_choice: "auto",
+				}),
+			});
+
+			if (res.status !== 200) {
+				console.log("response:", await res.text());
+				throw new Error(`Request failed with status ${res.status}`);
+			}
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			if (logMode) {
+				console.log(
+					"streaming tool calls response:",
+					JSON.stringify(streamResult, null, 2),
+				);
+			}
+
+			expect(streamResult.hasValidSSE).toBe(true);
+			expect(streamResult.eventCount).toBeGreaterThan(0);
+
+			// Verify that all streaming responses are transformed to OpenAI format
+			expect(streamResult.hasOpenAIFormat).toBe(true);
+
+			// Find chunks with tool calls
+			const toolCallChunks = streamResult.chunks.filter(
+				(chunk) => chunk.choices?.[0]?.delta?.tool_calls,
+			);
+
+			// Should have at least one tool call chunk
+			expect(toolCallChunks.length).toBeGreaterThan(0);
+
+			// The first chunk with tool_calls should have id, type, and function.name
+			const firstToolCallChunk = toolCallChunks[0];
+			const firstToolCall = firstToolCallChunk.choices[0].delta.tool_calls[0];
+			expect(firstToolCall).toHaveProperty("id");
+			expect(firstToolCall).toHaveProperty("type", "function");
+			expect(firstToolCall).toHaveProperty("function");
+			expect(firstToolCall.function).toHaveProperty("name", "get_weather");
+
+			// All tool_call delta chunks should have an index for matching
+			// For Anthropic, we enrich all chunks with id/type/name
+			// For OpenAI, only the first chunk has these fields, subsequent ones use index for matching
+			for (const chunk of toolCallChunks) {
+				const toolCall = chunk.choices[0].delta.tool_calls[0];
+				// All chunks should have an index
+				expect(toolCall).toHaveProperty("index");
+				expect(typeof toolCall.index).toBe("number");
+				// All chunks should have a function object with arguments
+				expect(toolCall).toHaveProperty("function");
+			}
+
+			// Accumulate arguments from all chunks
+			let fullArguments = "";
+			for (const chunk of toolCallChunks) {
+				const args = chunk.choices[0].delta.tool_calls[0].function.arguments;
+				if (args) {
+					fullArguments += args;
+				}
+			}
+
+			// Parse and validate the accumulated arguments
+			if (fullArguments) {
+				const args = JSON.parse(fullArguments);
+				expect(args).toHaveProperty("city");
+				expect(typeof args.city).toBe("string");
+				expect(args.city.toLowerCase()).toContain("san francisco");
+			}
+
+			// Validate logs
+			const log = await validateLogByRequestId(requestId);
+			expect(log.streamed).toBe(true);
 		},
 	);
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3343,6 +3343,54 @@ chat.openapi(completions, async (c) => {
 								}
 							}
 
+							// For Anthropic streaming tool calls, enrich delta chunks with id/type/name
+							// from the initial content_block_start event. This ensures OpenAI SDK compatibility.
+							if (usedProvider === "anthropic") {
+								const toolCalls =
+									transformedData.choices?.[0]?.delta?.tool_calls;
+								if (toolCalls && toolCalls.length > 0) {
+									// First, extract tool calls to update our tracking
+									const rawToolCalls = extractToolCalls(data, usedProvider);
+									if (rawToolCalls && rawToolCalls.length > 0) {
+										if (!streamingToolCalls) {
+											streamingToolCalls = [];
+										}
+										for (const newCall of rawToolCalls) {
+											// For content_block_start events (have id), add to tracking
+											if (newCall.id) {
+												const contentBlockIndex: number =
+													typeof data.index === "number"
+														? data.index
+														: streamingToolCalls.length;
+												// Store at the content block index position
+												streamingToolCalls[contentBlockIndex] = {
+													...newCall,
+													_contentBlockIndex: contentBlockIndex,
+												};
+											}
+											// For content_block_delta events, enrich with stored id/type/name
+											else if (newCall._contentBlockIndex !== undefined) {
+												const existingCall =
+													streamingToolCalls[newCall._contentBlockIndex];
+												if (existingCall) {
+													// Enrich the transformed data with id, type, and function.name
+													for (const tc of toolCalls) {
+														if (tc.index === newCall._contentBlockIndex) {
+															tc.id = existingCall.id;
+															tc.type = "function";
+															if (!tc.function) {
+																tc.function = {};
+															}
+															tc.function.name = existingCall.function.name;
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+
 							await writeSSEAndCache({
 								data: JSON.stringify(transformedData),
 								id: String(eventId++),
@@ -3497,8 +3545,9 @@ chat.openapi(completions, async (c) => {
 											streamingToolCalls[newCall._contentBlockIndex];
 									} else {
 										// For other providers and Anthropic content_block_start, match by ID
+										// Note: Array may have sparse entries due to index-based assignment, so check for null/undefined
 										existingCall = streamingToolCalls.find(
-											(call) => call.id === newCall.id,
+											(call) => call && call.id === newCall.id,
 										);
 									}
 


### PR DESCRIPTION
## Summary
- Fixed Anthropic streaming tool calls missing `id`, `type`, and `function.name` in delta chunks
- Added tracking of tool call metadata from `content_block_start` events
- Enriched subsequent `content_block_delta` chunks with stored metadata before sending to client
- Added e2e test for streaming tool calls

## Test plan
- [x] Build passes
- [x] Streaming tool calls test passes for Anthropic (`claude-3-5-haiku-20241022`)
- [x] Streaming tool calls test passes for OpenAI (`gpt-4o-mini`)
- [x] Non-streaming tool calls still work for both providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming tool call support for multiple models with enhanced Anthropic compatibility.

* **Tests**
  * Added end-to-end tests for streaming tool call functionality across supported models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->