### PR TITLE
feat(auth): add x-api-key fallback

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -450,6 +450,7 @@ anthropic.openapi(messages, async (c) => {
 		headers: {
 			"Content-Type": "application/json",
 			Authorization: c.req.header("Authorization") || "",
+			"x-api-key": c.req.header("x-api-key") || "",
 			"User-Agent": userAgent,
 			"x-request-id": c.req.header("x-request-id") || "",
 			"x-source": c.req.header("x-source") || "",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -917,24 +917,25 @@ chat.openapi(completions, async (c) => {
 	let routingMetadata: RoutingMetadata | undefined;
 
 	const auth = c.req.header("Authorization");
-	if (!auth) {
-		throw new HTTPException(401, {
-			message:
-				"Unauthorized: No Authorization header provided. Expected 'Bearer your-api-token'",
-		});
+	const xApiKey = c.req.header("x-api-key");
+
+	let token: string | undefined;
+
+	if (auth) {
+		const split = auth.split("Bearer ");
+		if (split.length === 2 && split[1]) {
+			token = split[1];
+		}
 	}
 
-	const split = auth.split("Bearer ");
-	if (split.length !== 2) {
-		throw new HTTPException(401, {
-			message:
-				"Unauthorized: Invalid Authorization header format. Expected 'Bearer your-api-token'",
-		});
+	if (!token && xApiKey) {
+		token = xApiKey;
 	}
-	const token = split[1];
+
 	if (!token) {
 		throw new HTTPException(401, {
-			message: "Unauthorized: No token provided",
+			message:
+				"Unauthorized: No API key provided. Expected 'Authorization: Bearer your-api-token' header or 'x-api-key: your-api-token' header",
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Adds support for x-api-key as a fallback authentication header in the gateway.

## Changes
### Gateway: Anthropic
- Forwarded x-api-key header downstream by adding the header to outgoing requests:
  - "x-api-key": c.req.header("x-api-key") || ""

### Gateway: Chat
- Updated authentication flow to accept either:
  - Authorization: Bearer <token>
  - x-api-key: <token>
- Behavior:
  - If Authorization Bearer token is present, use that as the token.
  - If not, but x-api-key is provided, use that as the token.
  - If neither is provided, return 401 with a descriptive error indicating both header options.
- New error message when missing both headers:
  - "Unauthorized: No API key provided. Expected 'Authorization: Bearer your-api-token' header or 'x-api-key: your-api-token' header"

## Rationale
- Improves compatibility with clients that supply API keys via x-api-key, without breaking existing Authorization-based flows.

## Test plan
- [x] Bearer token authentication continues to work as before
- [x] x-api-key authentication works when provided
- [x] Missing both headers results in 401 with a descriptive error message
- [x] No changes to downstream behavior when using the existing Authorization flow

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f44b0afa-bc8b-49e6-8f59-6bae28cf6ab0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now supports x-api-key header as an alternative to the Authorization header.
  * Updated error messages to reference both available authentication methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->