### PR TITLE
fix(gateway): handle AWS Bedrock streaming tool calls

### DIFF
--- a/apps/gateway/src/chat/tools/extract-tool-calls.ts
+++ b/apps/gateway/src/chat/tools/extract-tool-calls.ts
@@ -28,14 +28,13 @@ export function extractToolCalls(data: any, provider: Provider): any[] | null {
 			// Tool arguments come as content_block_delta - these don't have a direct ID,
 			// so we return null and let the streaming logic handle the accumulation
 			// by finding the matching tool call by content block index
+			// Per OpenAI spec, subsequent chunks omit id/type/name - only index and arguments
 			if (data.type === "content_block_delta" && data.delta?.partial_json) {
 				// Return a partial tool call with the index to help with matching
 				return [
 					{
 						_contentBlockIndex: data.index, // Use this for matching
-						type: "function",
 						function: {
-							name: "",
 							arguments: data.delta.partial_json,
 						},
 					},
@@ -103,6 +102,7 @@ export function extractToolCalls(data: any, provider: Provider): any[] | null {
 				];
 			}
 			// contentBlockDelta has the partial JSON arguments
+			// Per OpenAI spec, subsequent chunks omit id/type/name - only index and arguments
 			if (eventType === "contentBlockDelta" && data.delta?.toolUse) {
 				const args =
 					typeof data.delta.toolUse.input === "string"
@@ -111,9 +111,7 @@ export function extractToolCalls(data: any, provider: Provider): any[] | null {
 				return [
 					{
 						_contentBlockIndex: data.contentBlockIndex ?? 0,
-						type: "function",
 						function: {
-							name: "",
 							arguments: args,
 						},
 					},

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -811,6 +811,7 @@ export function transformStreamingToOpenai(
 				};
 			} else if (eventType === "contentBlockDelta" && data.delta?.toolUse) {
 				// Tool use delta event contains partial JSON arguments
+				// Per OpenAI spec, subsequent chunks omit id/type/name - only index and arguments
 				const toolUse = data.delta.toolUse;
 				// toolUse.input is a string (partial JSON), not an object
 				const args =
@@ -829,7 +830,6 @@ export function transformStreamingToOpenai(
 								tool_calls: [
 									{
 										index: data.contentBlockIndex || 0,
-										type: "function",
 										function: {
 											arguments: args,
 										},


### PR DESCRIPTION
## Summary
- Add `contentBlockStart` event handling for `tool_use` to capture the tool id and name in the first streaming chunk
- Fix `contentBlockDelta` to properly stream partial JSON arguments without double-escaping (input is already a string)
- Add `aws-bedrock` case to `extractToolCalls` for proper tool call enrichment

## Test plan
- [x] Run `LOG_MODE=true TEST_MODELS=aws-bedrock/claude-sonnet-4-5-20250929 pnpm test:e2e` - all tests pass including streaming tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock support for tool calling in chat, allowing models to invoke functions.
  * Initial tool invocations now emit an empty-arguments placeholder; subsequent streaming deltas supply incremental or JSON-formatted arguments.
  * Preserved existing behavior for other providers (Anthropic/OpenAI) so current integrations remain compatible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->