### PR TITLE
fix(gateway): handle Responses API streaming tool calls

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -593,7 +593,58 @@ export function transformStreamingToOpenai(
 						};
 						break;
 
-					case "response.output_item.added":
+					case "response.output_item.added": {
+						// Check if this is a function_call item
+						const item = data.item;
+						if (item?.type === "function_call") {
+							// First chunk for function call - emit id, type, name
+							transformedData = {
+								id: data.response?.id || `chatcmpl-${Date.now()}`,
+								object: "chat.completion.chunk",
+								created:
+									data.response?.created_at || Math.floor(Date.now() / 1000),
+								model: data.response?.model || usedModel,
+								choices: [
+									{
+										index: 0,
+										delta: {
+											tool_calls: [
+												{
+													index: data.output_index || 0,
+													id: item.call_id || `call_${Date.now()}`,
+													type: "function",
+													function: {
+														name: item.name || "",
+														arguments: "",
+													},
+												},
+											],
+											role: "assistant",
+										},
+										finish_reason: null,
+									},
+								],
+								usage: null,
+							};
+						} else {
+							transformedData = {
+								id: data.response?.id || `chatcmpl-${Date.now()}`,
+								object: "chat.completion.chunk",
+								created:
+									data.response?.created_at || Math.floor(Date.now() / 1000),
+								model: data.response?.model || usedModel,
+								choices: [
+									{
+										index: 0,
+										delta: { role: "assistant" },
+										finish_reason: null,
+									},
+								],
+								usage: null,
+							};
+						}
+						break;
+					}
 					case "response.output_item.done":
 					case "response.web_search_call.in_progress":
 					case "response.web_search_call.searching":
@@ -653,6 +704,55 @@ export function transformStreamingToOpenai(
 										role: "assistant",
 										content: data.delta || data.part?.text || "",
 									},
+									finish_reason: null,
+								},
+							],
+							usage: null,
+						};
+						break;
+
+					case "response.function_call_arguments.delta":
+						// Streaming function call arguments from Responses API
+						transformedData = {
+							id: data.response?.id || `chatcmpl-${Date.now()}`,
+							object: "chat.completion.chunk",
+							created:
+								data.response?.created_at || Math.floor(Date.now() / 1000),
+							model: data.response?.model || usedModel,
+							choices: [
+								{
+									index: 0,
+									delta: {
+										tool_calls: [
+											{
+												index: data.output_index || 0,
+												function: {
+													arguments: data.delta || "",
+												},
+											},
+										],
+										role: "assistant",
+									},
+									finish_reason: null,
+								},
+							],
+							usage: null,
+						};
+						break;
+
+					case "response.function_call_arguments.done":
+						// Function call arguments complete - just emit empty delta
+						// (id/type/name already sent in output_item.added, args sent in deltas)
+						transformedData = {
+							id: data.response?.id || `chatcmpl-${Date.now()}`,
+							object: "chat.completion.chunk",
+							created:
+								data.response?.created_at || Math.floor(Date.now() / 1000),
+							model: data.response?.model || usedModel,
+							choices: [
+								{
+									index: 0,
+									delta: { role: "assistant" },
 									finish_reason: null,
 								},
 							],


### PR DESCRIPTION
## Summary
- Add support for OpenAI Responses API streaming function call events
- Handle `response.output_item.added` for function_call items (first chunk with id/type/name)
- Handle `response.function_call_arguments.delta` for streaming arguments
- Handle `response.function_call_arguments.done` for completion

This fixes streaming tool calls for gpt-5 and other models using the Responses API.

## Test plan
- [x] Run `TEST_MODELS=openai/gpt-5-mini pnpm test:e2e` - streaming tool calls now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)