### PR TITLE
refactor(shared): consolidate http clients

### DIFF
--- a/apps/api/src/lib/http-client.ts
+++ b/apps/api/src/lib/http-client.ts
@@ -1,79 +1,8 @@
-import { trace, propagation, context, SpanKind } from "@opentelemetry/api";
+import { createHttpClient } from "@llmgateway/shared";
 
-export interface HttpClientOptions {
-	method?: string;
-	headers?: Record<string, string>;
-	body?: string | object;
-	timeout?: number;
-}
+export const httpClient = createHttpClient({
+	tracerName: "llmgateway-api",
+	clientName: "api-http-client",
+});
 
-export async function httpClient(
-	url: string,
-	options: HttpClientOptions = {},
-): Promise<Response> {
-	const { method = "GET", headers = {}, body, timeout = 30000 } = options;
-
-	// Start the client span first
-	const tracer = trace.getTracer("llmgateway-api");
-	const span = tracer.startSpan(`HTTP ${method} ${new URL(url).pathname}`, {
-		kind: SpanKind.CLIENT,
-		attributes: {
-			"http.method": method,
-			"http.url": url,
-			"http.client": "api-http-client",
-		},
-	});
-
-	// Create context with the client span and inject trace context into headers
-	const spanContext = trace.setSpan(context.active(), span);
-	const traceHeaders: Record<string, string> = {};
-	propagation.inject(spanContext, traceHeaders);
-
-	const fetchHeaders = {
-		"Content-Type": "application/json",
-		...headers,
-		...traceHeaders,
-	};
-
-	const fetchOptions: RequestInit = {
-		method,
-		headers: fetchHeaders,
-		signal: AbortSignal.timeout(timeout),
-	};
-
-	if (body) {
-		fetchOptions.body = typeof body === "string" ? body : JSON.stringify(body);
-	}
-
-	try {
-		// Execute the fetch within the span context
-		const response = await context.with(spanContext, () =>
-			fetch(url, fetchOptions),
-		);
-
-		span.setAttributes({
-			"http.status_code": response.status,
-			"http.response.size": response.headers.get("content-length") || "",
-		});
-
-		if (!response.ok) {
-			span.setStatus({
-				code: response.status >= 500 ? 2 : 1, // ERROR : OK
-				message: `HTTP ${response.status}`,
-			});
-		}
-
-		return response;
-	} catch (error) {
-		span.recordException(
-			error instanceof Error ? error : new Error(String(error)),
-		);
-		span.setStatus({
-			code: 2, // ERROR
-			message: error instanceof Error ? error.message : String(error),
-		});
-		throw error;
-	} finally {
-		span.end();
-	}
-}
+export type { HttpClientOptions } from "@llmgateway/shared";

--- a/apps/gateway/src/lib/http-client.ts
+++ b/apps/gateway/src/lib/http-client.ts
@@ -1,79 +1,8 @@
-import { trace, propagation, context, SpanKind } from "@opentelemetry/api";
+import { createHttpClient } from "@llmgateway/shared";
 
-export interface HttpClientOptions {
-	method?: string;
-	headers?: Record<string, string>;
-	body?: string | object;
-	timeout?: number;
-}
+export const httpClient = createHttpClient({
+	tracerName: "llmgateway-gateway",
+	clientName: "gateway-http-client",
+});
 
-export async function httpClient(
-	url: string,
-	options: HttpClientOptions = {},
-): Promise<Response> {
-	const { method = "GET", headers = {}, body, timeout = 30000 } = options;
-
-	// Start the client span first
-	const tracer = trace.getTracer("llmgateway-gateway");
-	const span = tracer.startSpan(`HTTP ${method} ${new URL(url).pathname}`, {
-		kind: SpanKind.CLIENT,
-		attributes: {
-			"http.method": method,
-			"http.url": url,
-			"http.client": "gateway-http-client",
-		},
-	});
-
-	// Create context with the client span and inject trace context into headers
-	const spanContext = trace.setSpan(context.active(), span);
-	const traceHeaders: Record<string, string> = {};
-	propagation.inject(spanContext, traceHeaders);
-
-	const fetchHeaders = {
-		"Content-Type": "application/json",
-		...headers,
-		...traceHeaders,
-	};
-
-	const fetchOptions: RequestInit = {
-		method,
-		headers: fetchHeaders,
-		signal: AbortSignal.timeout(timeout),
-	};
-
-	if (body) {
-		fetchOptions.body = typeof body === "string" ? body : JSON.stringify(body);
-	}
-
-	try {
-		// Execute the fetch within the span context
-		const response = await context.with(spanContext, () =>
-			fetch(url, fetchOptions),
-		);
-
-		span.setAttributes({
-			"http.status_code": response.status,
-			"http.response.size": response.headers.get("content-length") || "",
-		});
-
-		if (!response.ok) {
-			span.setStatus({
-				code: response.status >= 500 ? 2 : 1, // ERROR : OK
-				message: `HTTP ${response.status}`,
-			});
-		}
-
-		return response;
-	} catch (error) {
-		span.recordException(
-			error instanceof Error ? error : new Error(String(error)),
-		);
-		span.setStatus({
-			code: 2, // ERROR
-			message: error instanceof Error ? error.message : String(error),
-		});
-		throw error;
-	} finally {
-		span.end();
-	}
-}
+export type { HttpClientOptions } from "@llmgateway/shared";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {
 		"@llmgateway/models": "workspace:*",
+		"@opentelemetry/api": "1.9.0",
 		"@radix-ui/react-avatar": "1.1.11",
 		"@radix-ui/react-checkbox": "^1.3.3",
 		"@radix-ui/react-collapsible": "1.1.12",

--- a/packages/shared/src/http-client.ts
+++ b/packages/shared/src/http-client.ts
@@ -1,0 +1,87 @@
+import { trace, propagation, context, SpanKind } from "@opentelemetry/api";
+
+export interface HttpClientOptions {
+	method?: string;
+	headers?: Record<string, string>;
+	body?: string | object;
+	timeout?: number;
+}
+
+export interface HttpClientConfig {
+	tracerName: string;
+	clientName: string;
+}
+
+export function createHttpClient(config: HttpClientConfig) {
+	return async function httpClient(
+		url: string,
+		options: HttpClientOptions = {},
+	): Promise<Response> {
+		const { method = "GET", headers = {}, body, timeout = 30000 } = options;
+
+		// Start the client span first
+		const tracer = trace.getTracer(config.tracerName);
+		const span = tracer.startSpan(`HTTP ${method} ${new URL(url).pathname}`, {
+			kind: SpanKind.CLIENT,
+			attributes: {
+				"http.method": method,
+				"http.url": url,
+				"http.client": config.clientName,
+			},
+		});
+
+		// Create context with the client span and inject trace context into headers
+		const spanContext = trace.setSpan(context.active(), span);
+		const traceHeaders: Record<string, string> = {};
+		propagation.inject(spanContext, traceHeaders);
+
+		const fetchHeaders = {
+			"Content-Type": "application/json",
+			...headers,
+			...traceHeaders,
+		};
+
+		const fetchOptions: RequestInit = {
+			method,
+			headers: fetchHeaders,
+			signal: AbortSignal.timeout(timeout),
+		};
+
+		if (body) {
+			fetchOptions.body =
+				typeof body === "string" ? body : JSON.stringify(body);
+		}
+
+		try {
+			// Execute the fetch within the span context
+			const response = await context.with(spanContext, () =>
+				fetch(url, fetchOptions),
+			);
+
+			span.setAttributes({
+				"http.status_code": response.status,
+				"http.response.size": response.headers.get("content-length") || "",
+			});
+
+			if (!response.ok) {
+				span.setStatus({
+					code: response.status >= 500 ? 2 : 1, // ERROR : OK
+					message: `HTTP ${response.status}`,
+				});
+			}
+
+			return response;
+		} catch (error) {
+			span.recordException(
+				error instanceof Error ? error : new Error(String(error)),
+			);
+			span.setStatus({
+				code: 2, // ERROR
+				message: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
+		} finally {
+			span.end();
+		}
+	};
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,6 +12,12 @@ export {
 	type HealthResponse,
 } from "./health-check.js";
 
+export {
+	createHttpClient,
+	type HttpClientOptions,
+	type HttpClientConfig,
+} from "./http-client.js";
+
 export { ModelSelector, ProviderIcons } from "./components/index.js";
 
 export { useIsMobile } from "./hooks/use-mobile.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,7 +242,7 @@ importers:
         version: 9.38.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       openapi-typescript:
         specifier: 7.10.1
         version: 7.10.1(typescript@5.9.3)
@@ -695,7 +695,7 @@ importers:
         version: 9.38.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       openapi-typescript:
         specifier: 7.10.1
         version: 7.10.1(typescript@5.9.3)
@@ -716,10 +716,10 @@ importers:
     dependencies:
       '@content-collections/core':
         specifier: 0.11.1
-        version: 0.11.1(typescript@5.9.2)
+        version: 0.11.1(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.9
-        version: 0.2.9(@content-collections/core@0.11.1(typescript@5.9.2))(next@16.1.1(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 0.2.9(@content-collections/core@0.11.1(typescript@5.9.3))(next@16.1.1(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.3))
@@ -921,7 +921,7 @@ importers:
         version: 10.4.21(postcss@8.5.6)
       openapi-typescript:
         specifier: 7.10.1
-        version: 7.10.1(typescript@5.9.2)
+        version: 7.10.1(typescript@5.9.3)
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -1065,6 +1065,9 @@ importers:
       '@llmgateway/models':
         specifier: workspace:*
         version: link:../models
+      '@opentelemetry/api':
+        specifier: 1.9.0
+        version: 1.9.0
       '@radix-ui/react-avatar':
         specifier: 1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -10601,7 +10604,7 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.6.0
 
-  '@content-collections/core@0.11.1(typescript@5.9.2)':
+  '@content-collections/core@0.11.1(typescript@5.9.3)':
     dependencies:
       '@standard-schema/spec': 1.0.0
       camelcase: 8.0.0
@@ -10613,18 +10616,18 @@ snapshots:
       pluralize: 8.0.0
       serialize-javascript: 6.0.2
       tinyglobby: 0.2.15
-      typescript: 5.9.2
+      typescript: 5.9.3
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@content-collections/integrations@0.3.0(@content-collections/core@0.11.1(typescript@5.9.2))':
+  '@content-collections/integrations@0.3.0(@content-collections/core@0.11.1(typescript@5.9.3))':
     dependencies:
-      '@content-collections/core': 0.11.1(typescript@5.9.2)
+      '@content-collections/core': 0.11.1(typescript@5.9.3)
 
-  '@content-collections/next@0.2.9(@content-collections/core@0.11.1(typescript@5.9.2))(next@16.1.1(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@content-collections/next@0.2.9(@content-collections/core@0.11.1(typescript@5.9.3))(next@16.1.1(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
-      '@content-collections/core': 0.11.1(typescript@5.9.2)
-      '@content-collections/integrations': 0.3.0(@content-collections/core@0.11.1(typescript@5.9.2))
+      '@content-collections/core': 0.11.1(typescript@5.9.3)
+      '@content-collections/integrations': 0.3.0(@content-collections/core@0.11.1(typescript@5.9.3))
       next: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   '@drizzle-team/brocli@0.10.2': {}
@@ -15336,7 +15339,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@2.6.1))
@@ -15386,21 +15389,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.38.0(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -15431,14 +15419,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15475,7 +15463,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.34.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -17856,16 +17844,6 @@ snapshots:
   openapi-types@12.1.3: {}
 
   openapi-typescript-helpers@0.0.15: {}
-
-  openapi-typescript@7.10.1(typescript@5.9.2):
-    dependencies:
-      '@redocly/openapi-core': 1.34.5(supports-color@10.2.2)
-      ansi-colors: 4.1.3
-      change-case: 5.4.4
-      parse-json: 8.3.0
-      supports-color: 10.2.2
-      typescript: 5.9.2
-      yargs-parser: 21.1.1
 
   openapi-typescript@7.10.1(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
Consolidates duplicate HTTP client implementations by introducing a shared, instrumented HTTP client in the shared package and updating API and Gateway apps to use it.

## Changes
- Add shared HTTP client factory in packages/shared/src/http-client.ts:
  - createHttpClient(config: { tracerName, clientName })
  - Returns httpClient(url, options) with OpenTelemetry tracing, propagates trace context, sets standard headers, supports timeout, JSON body handling, error handling, and span lifecycle.
- Export API surface from shared:
  - createHttpClient
  - HttpClientOptions
  - HttpClientConfig
- Update apps/api/src/lib/http-client.ts:
  - Replace internal implementation with a thin wrapper using createHttpClient({ tracerName: "llmgateway-api", clientName: "api-http-client" })
  - Export HttpClientOptions types re-exported from shared
- Update apps/gateway/src/lib/http-client.ts:
  - Similar wrapper using tracerName: "llmgateway-gateway", clientName: "gateway-http-client"
  - Re-export HttpClientOptions types
- Update dependencies:
  - Add @opentelemetry/api to packages/shared (needed by new shared http client)
- Update index exports to surface new http client API from shared.

## Rationale
- Reduces duplication and drift across apps
- Ensures consistent tracing, headers, timeouts, and error handling
- Simplifies future improvements by centralizing behavior

## API surface
- New: createHttpClient(config)
- Exports: HttpClientOptions, HttpClientConfig
- App adapters export a httpClient instance configured for their context

## Migration / Compatibility
- No breaking changes for existing call sites: consumer types are re-exported from shared
- If you previously imported HttpClientOptions from app/http-client.ts, you should now import from the shared package (typing remains the same)

## Tests / Validation
- [x] Build both apps successfully
- [x] Ensure httpClient adds trace headers to requests
- [x] Verify spans are created with correct tracerName and client name
- [x] Confirm JSON request bodies are serialized when needed
- [x] Timeout handling via AbortSignal.timeout

## Notes
- Dependency and lockfile updates reflect the new shared HTTP client and OpenTelemetry integration

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a25d4180-2c95-4d14-b737-867328adee94