### PR TITLE
fix(playground): prevent new chat on follow-up

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -552,27 +552,7 @@ export default function ChatPageClient({
 
 	const ensureCurrentChat = async (userMessage?: string): Promise<string> => {
 		if (chatIdRef.current) {
-			// Verify the chat still exists by trying to fetch it
-			try {
-				const response = await fetch(`/api/chats/${chatIdRef.current}`, {
-					method: "GET",
-					headers: { "Content-Type": "application/json" },
-				});
-
-				if (response.ok) {
-					return chatIdRef.current;
-				} else {
-					// Clear the stale chat ID
-					chatIdRef.current = null;
-					setCurrentChatId(null);
-					// Fall through to create new chat
-				}
-			} catch {
-				// Clear the stale chat ID
-				chatIdRef.current = null;
-				setCurrentChatId(null);
-				// Fall through to create new chat
-			}
+			return chatIdRef.current;
 		}
 
 		try {


### PR DESCRIPTION
## Summary

Fixes the bug where follow-up messages in the playground were creating new conversations instead of staying in the same one.

## Root Cause

The `ensureCurrentChat()` function was making a fetch call to `/api/chats/{id}` to verify if the chat existed. This endpoint doesn't exist in the playground app (it only exists in the backend API at `localhost:4002`). The fetch would fail with a 404, causing the function to clear `chatIdRef.current` and create a new chat for every follow-up message.

## Solution

Simplified `ensureCurrentChat()` to just return the existing `chatIdRef.current` if it exists. The existing error handling (lines 634-660) already properly handles cases where a chat doesn't exist - if `addMessage` gets a 404, it clears the chat ID and creates a new one.

## Test plan

- [x] Start playground in development mode
- [x] Send a message to start a conversation
- [x] Send follow-up messages
- [x] Verify follow-up messages stay in the same conversation
- [x] Run `pnpm format`
- [x] Run `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chat session initialization performance by reducing redundant verification operations when an active chat session is already established.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->