### PR TITLE
fix(gateway): prevent reasoning token double-counting

### DIFF
--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -265,8 +265,19 @@ export function calculateCosts(
 		.times(inputPrice)
 		.times(discountMultiplier);
 
-	// For Google models, reasoning tokens are billed at the output token rate
-	const totalOutputTokens = calculatedCompletionTokens + (reasoningTokens || 0);
+	// For Google and Anthropic models, reasoning tokens are separate from completion tokens
+	// and need to be added. For OpenAI-compatible providers (including Cerebras),
+	// completion_tokens already includes reasoning_tokens, so we don't add them again.
+	const providersWithSeparateReasoningTokens = [
+		"google-ai-studio",
+		"google-vertex",
+		"anthropic",
+	];
+	const shouldAddReasoningTokens =
+		providersWithSeparateReasoningTokens.includes(provider);
+	const totalOutputTokens =
+		calculatedCompletionTokens +
+		(shouldAddReasoningTokens ? reasoningTokens || 0 : 0);
 
 	// Calculate output cost, handling separate image output pricing if applicable
 	let outputCost: Decimal;


### PR DESCRIPTION
## Summary
- Fix double-counting of reasoning tokens for OpenAI-compatible providers (including Cerebras/GLM-4.7)
- For OpenAI-compatible APIs, `completion_tokens` already includes `reasoning_tokens`
- Only add reasoning tokens separately for Google and Anthropic where they are reported as distinct values

## Test plan
- [x] Existing unit tests pass (`pnpm test:unit`)
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed token cost calculations to properly handle reasoning tokens across different AI providers. Output token counts now correctly reflect provider-specific behavior for accurate cost reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->