### PR TITLE
refactor(auth): centralize auth checks

### DIFF
--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -2,6 +2,8 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { userHasOrganizationAccess } from "@/utils/authorization.js";
+
 import { db, eq, tables } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
@@ -158,18 +160,8 @@ organization.openapi(getProjects, async (c) => {
 
 	const { id } = c.req.param();
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: {
-				eq: user.id,
-			},
-			organizationId: {
-				eq: id,
-			},
-		},
-	});
-
-	if (!userOrganization) {
+	const hasAccess = await userHasOrganizationAccess(user.id, id);
+	if (!hasAccess) {
 		throw new HTTPException(403, {
 			message: "You do not have access to this organization",
 		});
@@ -553,18 +545,8 @@ organization.openapi(getTransactions, async (c) => {
 
 	const { id } = c.req.param();
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: {
-				eq: user.id,
-			},
-			organizationId: {
-				eq: id,
-			},
-		},
-	});
-
-	if (!userOrganization) {
+	const hasAccess = await userHasOrganizationAccess(user.id, id);
+	if (!hasAccess) {
 		throw new HTTPException(403, {
 			message: "You do not have access to this organization",
 		});
@@ -618,18 +600,8 @@ organization.openapi(getReferralStats, async (c) => {
 
 	const { id } = c.req.param();
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: {
-				eq: user.id,
-			},
-			organizationId: {
-				eq: id,
-			},
-		},
-	});
-
-	if (!userOrganization) {
+	const hasAccess = await userHasOrganizationAccess(user.id, id);
+	if (!hasAccess) {
 		throw new HTTPException(403, {
 			message: "You do not have access to this organization",
 		});

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -2,6 +2,8 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { getUserOrganizationIds } from "@/utils/authorization.js";
+
 import { db, eq, tables } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
@@ -118,18 +120,7 @@ projects.openapi(getProject, async (c) => {
 
 	const { id } = c.req.param();
 
-	const userOrgs = await db.query.userOrganization.findMany({
-		where: {
-			userId: {
-				eq: user.id,
-			},
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	const orgIds = userOrgs.map((uo) => uo.organization!.id);
+	const orgIds = await getUserOrganizationIds(user.id);
 
 	const project = await db.query.project.findFirst({
 		where: {

--- a/apps/api/src/utils/authorization.ts
+++ b/apps/api/src/utils/authorization.ts
@@ -1,0 +1,96 @@
+import { db } from "@llmgateway/db";
+
+/**
+ * Get all organization IDs that a user belongs to
+ * @param userId - The user ID to check
+ * @returns Promise<string[]> - Array of organization IDs
+ */
+export async function getUserOrganizationIds(
+	userId: string,
+): Promise<string[]> {
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: {
+			userId: {
+				eq: userId,
+			},
+		},
+		with: {
+			organization: true,
+		},
+	});
+	return userOrgs.map((uo) => uo.organization!.id);
+}
+
+/**
+ * Get all project IDs that a user has access to through their organizations
+ * @param userId - The user ID to check
+ * @returns Promise<string[]> - Array of project IDs
+ */
+export async function getUserProjectIds(userId: string): Promise<string[]> {
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: {
+			userId: {
+				eq: userId,
+			},
+		},
+		with: {
+			organization: {
+				with: {
+					projects: true,
+				},
+			},
+		},
+	});
+
+	return userOrgs.flatMap((org) =>
+		org
+			.organization!.projects.filter((project) => project.status !== "deleted")
+			.map((project) => project.id),
+	);
+}
+
+/**
+ * Get all active (non-deleted) organization IDs that a user belongs to
+ * @param userId - The user ID to check
+ * @returns Promise<string[]> - Array of active organization IDs
+ */
+export async function getActiveUserOrganizationIds(
+	userId: string,
+): Promise<string[]> {
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: {
+			userId: {
+				eq: userId,
+			},
+		},
+		with: {
+			organization: true,
+		},
+	});
+	return userOrgs
+		.filter((uo) => uo.organization?.status !== "deleted")
+		.map((uo) => uo.organization!.id);
+}
+
+/**
+ * Check if a user has access to a specific organization
+ * @param userId - The user ID to check
+ * @param organizationId - The organization ID to check access for
+ * @returns Promise<boolean> - true if user has access
+ */
+export async function userHasOrganizationAccess(
+	userId: string,
+	organizationId: string,
+): Promise<boolean> {
+	const userOrg = await db.query.userOrganization.findFirst({
+		where: {
+			userId: {
+				eq: userId,
+			},
+			organizationId: {
+				eq: organizationId,
+			},
+		},
+	});
+	return !!userOrg;
+}


### PR DESCRIPTION
## Summary
Centralizes and standardizes authorization logic by introducing a shared authorization utility and refactoring routes to consume it. This reduces duplicated queries and ensures consistent access checks across the API.

## Changes
- New utility module: apps/api/src/utils/authorization.ts
  - getUserOrganizationIds(userId): returns all organization IDs the user belongs to
  - getUserProjectIds(userId): returns all non-deleted project IDs accessible via user’s organizations
  - getActiveUserOrganizationIds(userId): returns active (non-deleted) organization IDs
  - userHasOrganizationAccess(userId, organizationId): checks if user has access to a specific organization
- Route refactors to use shared helpers:
  - activity.ts: use getUserOrganizationIds for membership checks
  - keys-api.ts: use getUserProjectIds to validate project access
  - keys-provider.ts: use getActiveUserOrganizationIds for listing and access checks
  - logs.ts: use getActiveUserOrganizationIds for organization filtering
  - organization.ts: use userHasOrganizationAccess to guard endpoints
  - projects.ts: use getUserOrganizationIds to determine accessible organizations

## Why
- Eliminates duplicated authorization logic scattered across multiple routes
- Improves maintainability and reduces risk of inconsistent permission checks
- Provides a single source of truth for user-organization/project access relationships

## Testing plan
- Manual/API validation
  - Activity endpoints: verify that users receive activities only for organizations they belong to; empty results when no organizations exist for the user
  - Keys API: ensure creation/update respects project access via getUserProjectIds; unauthorized access returns 403
  - Keys provider: listing and key operations respect active organizations via getActiveUserOrganizationIds
  - Logs: retrieving logs scoped by organization respects active memberships
  - Organization routes: access to projects, transactions, and referral stats is guarded by userHasOrganizationAccess
  - Projects: project retrieval honors user’s organization memberships
- Edge cases
  - Users with no organizations
  - Organizations marked as deleted
  - Deleted projects are excluded from accessible project IDs

## Compatibility & migrations
- No breaking changes to API contracts; behavior remains the same but uses centralized helpers
- No data migrations required

## Documentation
- Internal helper functions are not exposed as public API; future docs can reference the shared authorization module as the single source for access rules


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e7471ef7-b6c7-4f3d-a6a7-b7fc815a1985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal API authorization logic across multiple endpoints.
  * Streamlined permission verification processes.
  * No changes to end-user-facing functionality or API responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->