### PR TITLE
chore: add build:ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	],
 	"scripts": {
 		"build": "TURBO_TOKEN=turbotokenoss turbo run build 2>&1",
+		"build:ci": "TURBO_TOKEN=turbotokenoss turbo run build --concurrency=1 2>&1",
 		"build:core": "turbo run build --filter=!ui --filter=!docs --filter=!playground --filter=!admin",
 		"clean": "find . -path \"./node_modules\" -prune -o \\( -type d -name \"dist\" -o -name \".turbo\" -o -name \".source\" -o -name \".vercel\" -o -name \".out\" -o -name \".next-dev\" -o -name \".next\" \\) -exec rm -rf {} +",
 		"clean:node_modules": "find . -type d -name \"node_modules\" -exec rm -rf {} +",


### PR DESCRIPTION
## Summary
- Adds a dedicated build:ci script to run Turbo build with a fixed concurrency of 1 for CI.

## Changes
### package.json
- Added `build:ci` script: `TURBO_TOKEN=turbotokenoss turbo run build --concurrency=1 2>&1`

## Rationale
- Ensures deterministic CI builds by limiting Turbo's concurrency, reducing resource contention and improving reproducibility.

## How to Use
- In CI, run: `npm run build:ci` (or `yarn build:ci`)

## Test plan
- [x] Run locally: `npm run build:ci` to verify it runs Turbo build with concurrency limited to 1
- [x] Ensure CI environment can access TURBO_TOKEN as in existing build scripts

## Notes
- This is a scripts-only change; no application code changes.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fb2c02ce-2352-4cf2-9b67-0a1a2e257db6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new build script for continuous integration pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->