### PR TITLE
feat(provider-mappings): filter by JSON support

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1226,6 +1226,23 @@ chat.openapi(completions, async (c) => {
 					return false;
 				}
 
+				// Check JSON output capability if json_object or json_schema response format is requested
+				if (
+					response_format?.type === "json_object" ||
+					response_format?.type === "json_schema"
+				) {
+					if ((provider as ProviderModelMapping).jsonOutput !== true) {
+						return false;
+					}
+				}
+
+				// Check JSON schema output capability if json_schema response format is requested
+				if (response_format?.type === "json_schema") {
+					if ((provider as ProviderModelMapping).jsonOutputSchema !== true) {
+						return false;
+					}
+				}
+
 				return contextSizeMet;
 			});
 
@@ -1376,6 +1393,7 @@ chat.openapi(completions, async (c) => {
 
 				// Filter model providers to only those available (excluding the low-uptime one)
 				// If web search is requested, also filter to providers that support it
+				// If JSON output is requested, also filter to providers that support it
 				const availableModelProviders = modelInfo.providers.filter(
 					(provider) => {
 						if (!availableProviders.includes(provider.providerId)) {
@@ -1386,7 +1404,26 @@ chat.openapi(completions, async (c) => {
 						}
 						// If web search tool is requested, only include providers that support it
 						if (webSearchTool) {
-							return (provider as ProviderModelMapping).webSearch === true;
+							if ((provider as ProviderModelMapping).webSearch !== true) {
+								return false;
+							}
+						}
+						// If JSON output is requested, only include providers that support it
+						if (
+							response_format?.type === "json_object" ||
+							response_format?.type === "json_schema"
+						) {
+							if ((provider as ProviderModelMapping).jsonOutput !== true) {
+								return false;
+							}
+						}
+						// If JSON schema output is requested, only include providers that support it
+						if (response_format?.type === "json_schema") {
+							if (
+								(provider as ProviderModelMapping).jsonOutputSchema !== true
+							) {
+								return false;
+							}
 						}
 						return true;
 					},
@@ -1497,13 +1534,31 @@ chat.openapi(completions, async (c) => {
 
 			// Filter model providers to only those available
 			// If web search is requested, also filter to providers that support it
+			// If JSON output is requested, also filter to providers that support it
 			const availableModelProviders = modelInfo.providers.filter((provider) => {
 				if (!availableProviders.includes(provider.providerId)) {
 					return false;
 				}
 				// If web search tool is requested, only include providers that support it
 				if (webSearchTool) {
-					return (provider as ProviderModelMapping).webSearch === true;
+					if ((provider as ProviderModelMapping).webSearch !== true) {
+						return false;
+					}
+				}
+				// If JSON output is requested, only include providers that support it
+				if (
+					response_format?.type === "json_object" ||
+					response_format?.type === "json_schema"
+				) {
+					if ((provider as ProviderModelMapping).jsonOutput !== true) {
+						return false;
+					}
+				}
+				// If JSON schema output is requested, only include providers that support it
+				if (response_format?.type === "json_schema") {
+					if ((provider as ProviderModelMapping).jsonOutputSchema !== true) {
+						return false;
+					}
 				}
 				return true;
 			});


### PR DESCRIPTION
## Summary
- Restrict model provider options to those that support JSON outputs when JSON-based response formats are requested (json_object or json_schema).
- Enforce jsonOutputSchema requirement when json_schema is requested.
- Keep existing behavior for non-JSON formats and other features (e.g., web search) unchanged.

## Changes
### Filtering logic
- In chat.openapi completions flow, when response_format.type is json_object or json_schema, require provider.jsonOutput === true.
- When response_format.type is json_schema, require provider.jsonOutputSchema === true.
- In the availableModelProviders filtering, add checks so that providers are excluded if they don’t support the required JSON features when JSON is requested (json_object/json_schema).
- Ensure existing filters (e.g., webSearch) remain effective and are not disrupted by JSON-related checks.

### Comments
- Added inline comments to clarify the filtering decisions and when JSON capabilities are validated.

## Test plan
- [x] With response_format set to json_object, verify that only providers with jsonOutput === true are offered.
- [x] With response_format set to json_schema, verify that providers satisfy both jsonOutput === true and jsonOutputSchema === true.
- [x] Use non-JSON response formats (e.g., default) and confirm no changes to provider filtering.
- [x] When web search is requested, ensure JSON-related filters do not regress web search filtering and behavior remains correct."

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/28d2ff64-8ab8-407c-9aac-fd4b4aae108e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JSON response format handling by ensuring only compatible providers process json_object and json_schema requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->