### PR TITLE
fix(gateway): extract cached tokens from Google's implicit caching

### DIFF
--- a/apps/gateway/src/chat/tools/extract-token-usage.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.ts
@@ -25,6 +25,8 @@ export function extractTokenUsage(
 				completionTokens = data.usageMetadata.candidatesTokenCount ?? null;
 				// Don't use Google's totalTokenCount as it doesn't include reasoning tokens
 				reasoningTokens = data.usageMetadata.thoughtsTokenCount ?? null;
+				// Extract cached tokens from Google's implicit caching
+				cachedTokens = data.usageMetadata.cachedContentTokenCount ?? null;
 
 				// If candidatesTokenCount is missing and we have content or images, estimate it
 				if (

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -340,6 +340,8 @@ export function parseProviderResponse(
 			promptTokens = json.usageMetadata?.promptTokenCount || null;
 			completionTokens = json.usageMetadata?.candidatesTokenCount || null;
 			reasoningTokens = json.usageMetadata?.thoughtsTokenCount || null;
+			// Extract cached tokens from Google's implicit caching
+			cachedTokens = json.usageMetadata?.cachedContentTokenCount || null;
 			// Don't use Google's totalTokenCount as it doesn't include reasoning tokens
 			totalTokens = null;
 

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -307,6 +307,10 @@ export function transformStreamingToOpenai(
 				const toolUsePromptTokenCount =
 					usageMetadata.toolUsePromptTokenCount || 0;
 
+				// Extract cached tokens from Google's implicit caching
+				const cachedContentTokenCount =
+					usageMetadata.cachedContentTokenCount || 0;
+
 				const totalTokenCount =
 					typeof usageMetadata.totalTokenCount === "number" &&
 					usageMetadata.totalTokenCount > 0
@@ -324,6 +328,13 @@ export function transformStreamingToOpenai(
 
 				if (reasoningTokenCount) {
 					usage.reasoning_tokens = reasoningTokenCount;
+				}
+
+				// Include cached tokens in OpenAI-compatible format
+				if (cachedContentTokenCount > 0) {
+					usage.prompt_tokens_details = {
+						cached_tokens: cachedContentTokenCount,
+					};
 				}
 
 				// I am exposing this google-specific metric under a provider-specific namespace


### PR DESCRIPTION
## Summary
- Extract `cachedContentTokenCount` from Google's `usageMetadata` response
- Map it to OpenAI-compatible `prompt_tokens_details.cached_tokens` format
- Applied to both streaming (`transform-streaming-to-openai.ts`, `extract-token-usage.ts`) and non-streaming (`parse-provider-response.ts`) paths

## Context

Google's implicit caching reports cached token counts via `usageMetadata.cachedContentTokenCount`, but the gateway wasn't extracting this field. This meant `cached_tokens` was always 0 even when Google successfully cached tokens.

**Note:** According to [Google's forum](https://discuss.ai.google.dev/t/implicit-context-caching-does-not-work-with-gemini-3-pro-preview/111253), Gemini 3 Pro requires 4096 tokens minimum for implicit caching to trigger. The actual caching behavior depends on Google's side meeting cache hit conditions.

## Test plan
- [ ] Run `httpyac gemini.http --all` twice with >4096 token prompts and verify `cached_tokens` reflects actual cached token count from Google

🤖 Generated with [Claude Code](https://claude.com/claude-code)