### PR TITLE
fix(gateway): cerebras tool call fixes

### DIFF
--- a/packages/models/src/prepare-request-body.spec.ts
+++ b/packages/models/src/prepare-request-body.spec.ts
@@ -435,4 +435,61 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		// Should have strict: true on function
 		expect(requestBody.tools[0].function.strict).toBe(true);
 	});
+
+	test("should strip unsupported string fields from Cerebras tool parameters", async () => {
+		const toolsWithStringFields = [
+			{
+				type: "function" as const,
+				function: {
+					name: "fetch_url",
+					description: "Fetch a URL",
+					parameters: {
+						type: "object",
+						properties: {
+							url: { type: "string", format: "uri" },
+							email: { type: "string", format: "email" },
+							name: { type: "string", minLength: 1, maxLength: 100 },
+							code: { type: "string", pattern: "^[A-Z]+$" },
+							plainString: { type: "string" },
+						},
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"cerebras",
+			"llama-4-scout-17b-16e-instruct",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithStringFields,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].function.parameters;
+
+		// Should strip format field from string schemas
+		expect(params.properties.url.format).toBeUndefined();
+		expect(params.properties.email.format).toBeUndefined();
+		// Should strip minLength/maxLength
+		expect(params.properties.name.minLength).toBeUndefined();
+		expect(params.properties.name.maxLength).toBeUndefined();
+		// Should strip pattern
+		expect(params.properties.code.pattern).toBeUndefined();
+		// Should preserve type
+		expect(params.properties.url.type).toBe("string");
+		expect(params.properties.email.type).toBe("string");
+		expect(params.properties.name.type).toBe("string");
+		expect(params.properties.code.type).toBe("string");
+		expect(params.properties.plainString.type).toBe("string");
+	});
 });


### PR DESCRIPTION
## Summary
- Adds `ensureAdditionalPropertiesFalse()` function that recursively adds `additionalProperties: false` to all object-type JSON schemas
- Applies this transformation to Cerebras tool parameters to fix 422 errors when using MCP tools or other external tools that don't include this property

## Test plan
- [x] Added unit test verifying Cerebras tools get `additionalProperties: false` on root and nested objects
- [x] Existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Cerebras model compatibility with enhanced schema validation and automatic parameter sanitization for tool definitions and JSON response schemas.

* **Tests**
  * Added tests validating Cerebras-specific schema processing, including proper handling of strict parameter enforcement and removal of unsupported schema constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->