### PR TITLE
fix(models): strip image content for non-vision models

### DIFF
--- a/packages/models/src/prepare-request-body.ts
+++ b/packages/models/src/prepare-request-body.ts
@@ -5,11 +5,13 @@ import {
 } from "./models.js";
 import { transformAnthropicMessages } from "./transform-anthropic-messages.js";
 import { transformGoogleMessages } from "./transform-google-messages.js";
+import { isTextContent } from "./types.js";
 
 import type { ProviderId } from "./providers.js";
 import type {
 	BaseMessage,
 	FunctionParameter,
+	MessageContent,
 	OpenAIFunctionToolInput,
 	OpenAIRequestBody,
 	OpenAIResponsesRequestBody,
@@ -26,6 +28,28 @@ function isFunctionTool(
 	tool: OpenAIToolInput,
 ): tool is OpenAIFunctionToolInput {
 	return tool.type === "function";
+}
+
+/**
+ * Converts message content to text-only format for models that don't support vision.
+ * Extracts only text content from array format and converts to string.
+ */
+function stripImageContentFromMessages(messages: BaseMessage[]): BaseMessage[] {
+	return messages.map((msg) => {
+		if (Array.isArray(msg.content)) {
+			// Extract only text content from the array
+			const textParts = msg.content
+				.filter((part: MessageContent) => isTextContent(part))
+				.map((part: MessageContent) => (isTextContent(part) ? part.text : ""));
+			// Join text parts into a single string
+			const textContent = textParts.join("\n").trim();
+			return {
+				...msg,
+				content: textContent || "",
+			};
+		}
+		return msg;
+	});
 }
 
 /**
@@ -575,6 +599,15 @@ export async function prepareRequestBody(
 				return responsesBody;
 			} else {
 				// Use regular chat completions format
+
+				// Check if model supports vision - if not, strip image content from messages
+				const supportsVision =
+					(providerMapping as ProviderModelMapping)?.vision === true;
+				if (!supportsVision) {
+					requestBody.messages =
+						stripImageContentFromMessages(processedMessages);
+				}
+
 				if (stream) {
 					requestBody.stream_options = {
 						include_usage: true,
@@ -651,6 +684,16 @@ export async function prepareRequestBody(
 			break;
 		}
 		case "zai": {
+			// Check if model supports vision - if not, strip image content from messages
+			const zaiProviderMapping = modelDef?.providers.find(
+				(p) => p.providerId === "zai",
+			);
+			const zaiSupportsVision =
+				(zaiProviderMapping as ProviderModelMapping)?.vision === true;
+			if (!zaiSupportsVision) {
+				requestBody.messages = stripImageContentFromMessages(processedMessages);
+			}
+
 			if (stream) {
 				requestBody.stream_options = {
 					include_usage: true,
@@ -1245,6 +1288,16 @@ export async function prepareRequestBody(
 		}
 		case "inference.net":
 		case "together.ai": {
+			// Check if model supports vision - if not, strip image content from messages
+			const togetherProviderMapping = modelDef?.providers.find(
+				(p) => p.providerId === usedProvider,
+			);
+			const togetherSupportsVision =
+				(togetherProviderMapping as ProviderModelMapping)?.vision === true;
+			if (!togetherSupportsVision) {
+				requestBody.messages = stripImageContentFromMessages(processedMessages);
+			}
+
 			if (usedModel.startsWith(`${usedProvider}/`)) {
 				requestBody.model = usedModel.substring(usedProvider.length + 1);
 			}
@@ -1268,6 +1321,16 @@ export async function prepareRequestBody(
 			break;
 		}
 		case "cerebras": {
+			// Check if model supports vision - if not, strip image content from messages
+			const cerebrasProviderMapping = modelDef?.providers.find(
+				(p) => p.providerId === "cerebras",
+			);
+			const cerebrasSupportsVision =
+				(cerebrasProviderMapping as ProviderModelMapping)?.vision === true;
+			if (!cerebrasSupportsVision) {
+				requestBody.messages = stripImageContentFromMessages(processedMessages);
+			}
+
 			if (stream) {
 				requestBody.stream_options = {
 					include_usage: true,
@@ -1328,6 +1391,16 @@ export async function prepareRequestBody(
 			break;
 		}
 		default: {
+			// Check if model supports vision - if not, strip image content from messages
+			const defaultProviderMapping = modelDef?.providers.find(
+				(p) => p.providerId === usedProvider,
+			);
+			const defaultSupportsVision =
+				(defaultProviderMapping as ProviderModelMapping)?.vision === true;
+			if (!defaultSupportsVision) {
+				requestBody.messages = stripImageContentFromMessages(processedMessages);
+			}
+
 			if (stream) {
 				requestBody.stream_options = {
 					include_usage: true,


### PR DESCRIPTION
## Summary
- Adds `stripImageContentFromMessages` helper function to extract only text content from multimodal messages
- Applies this transformation for OpenAI, ZAI, Together.ai, Inference.net, Cerebras, and other OpenAI-compatible providers when the model doesn't support vision (`vision: false`)
- Converts array content with `image_url` objects to plain string content

## Problem
When sending messages containing images to models without vision support (like `gpt-4o-mini` with `vision: false`), the OpenAI API rejects the request with:
```
{"error":{"message":"messages[1].content must be a string","type":"invalid_request_error","param":"messages[1].content"}}
```

## Test plan
- [ ] Test with a non-vision model (e.g., gpt-4o-mini) and multimodal content - should now work without error
- [ ] Test with a vision model (e.g., gpt-4o) and multimodal content - should continue working with images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message processing for AI models without image support. The system now automatically removes image content from messages when sending requests to vision-incompatible models, ensuring text-only content is properly transmitted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->