### PR TITLE
test(json): add streaming tests for JSON output modes

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -373,6 +373,37 @@ export const streamingWebSearchModels = webSearchModels.filter((m) =>
 	}),
 );
 
+export const jsonOutputModels = testModels.filter((m) =>
+	m.providers.some((p: ProviderModelMapping) => p.jsonOutput === true),
+);
+
+export const streamingJsonOutputModels = jsonOutputModels.filter((m) =>
+	m.providers.some((p: ProviderModelMapping) => {
+		// Check model-level streaming first, then fall back to provider-level
+		if (p.streaming !== undefined) {
+			return p.streaming;
+		}
+		const provider = providers.find((pr) => pr.id === p.providerId);
+		return provider?.streaming;
+	}),
+);
+
+export const jsonSchemaOutputModels = testModels.filter((m) =>
+	m.providers.some((p: ProviderModelMapping) => p.jsonOutputSchema === true),
+);
+
+export const streamingJsonSchemaOutputModels = jsonSchemaOutputModels.filter(
+	(m) =>
+		m.providers.some((p: ProviderModelMapping) => {
+			// Check model-level streaming first, then fall back to provider-level
+			if (p.streaming !== undefined) {
+				return p.streaming;
+			}
+			const provider = providers.find((pr) => pr.id === p.providerId);
+			return provider?.streaming;
+		}),
+);
+
 export async function createProviderKey(
 	provider: string,
 	token: string,

--- a/apps/gateway/src/chat-json.e2e.ts
+++ b/apps/gateway/src/chat-json.e2e.ts
@@ -9,8 +9,11 @@ import {
 	getConcurrentTestOptions,
 	getTestOptions,
 	logMode,
+	streamingJsonOutputModels,
+	streamingJsonSchemaOutputModels,
 	testModels,
 } from "@/chat-helpers.e2e.js";
+import { readAll } from "@/test-utils/test-helpers.js";
 
 import type { ProviderModelMapping } from "@llmgateway/models";
 
@@ -69,15 +72,8 @@ describe("e2e", getConcurrentTestOptions(), () => {
 
 	test.each(
 		testModels.filter((m) => {
-			// Check if any provider for this model supports jsonOutput
-			if (
-				!m.providers.some(
-					(provider) => (provider as ProviderModelMapping).jsonOutput === true,
-				)
-			) {
-				return false;
-			}
-			// Check if the specific provider(s) for this test case support jsonOutputSchema
+			// Check if any provider for this model supports jsonOutputSchema
+			// Note: Some providers (like Anthropic) support json_schema without json_object mode
 			return m.providers.some(
 				(provider) =>
 					(provider as ProviderModelMapping).jsonOutputSchema === true,
@@ -177,4 +173,183 @@ describe("e2e", getConcurrentTestOptions(), () => {
 			expect(data.conditions.length).toBeGreaterThan(0);
 		}
 	});
+
+	test.each(streamingJsonOutputModels)(
+		"JSON output streaming $model",
+		getTestOptions(),
+		async ({ model }) => {
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: model,
+					messages: [
+						{
+							role: "system",
+							content:
+								"You are a helpful assistant. Always respond with valid JSON.",
+						},
+						{
+							role: "user",
+							content: 'Return a JSON object with "message": "Hello World"',
+						},
+					],
+					response_format: { type: "json_object" },
+					stream: true,
+				}),
+			});
+
+			if (res.status !== 200) {
+				console.log("response:", await res.text());
+				throw new Error(`Request failed with status ${res.status}`);
+			}
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			if (logMode) {
+				console.log("streamResult", JSON.stringify(streamResult, null, 2));
+			}
+
+			expect(streamResult.hasValidSSE).toBe(true);
+			expect(streamResult.eventCount).toBeGreaterThan(0);
+			expect(streamResult.hasContent).toBe(true);
+			expect(streamResult.hasOpenAIFormat).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter((chunk) => chunk.choices?.[0]?.delta?.content)
+				.map((chunk) => chunk.choices[0].delta.content);
+			const fullContent = contentChunks.join("");
+
+			// Validate that the streamed content is valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			const parsedContent = JSON.parse(fullContent);
+			expect(parsedContent).toHaveProperty("message");
+		},
+	);
+
+	test.each(streamingJsonSchemaOutputModels)(
+		"JSON schema output streaming $model",
+		getTestOptions(),
+		async ({ model }) => {
+			// Define the Zod schema that matches our JSON schema payload
+			const weatherResponseSchema = z
+				.object({
+					location: z.string(),
+					temperature: z.string(),
+					conditions: z.string(),
+				})
+				.strict();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: model,
+					messages: [
+						{
+							role: "system",
+							content: "You are a helpful assistant.",
+						},
+						{
+							role: "user",
+							content: "What is the weather like today?",
+						},
+					],
+					response_format: {
+						type: "json_schema",
+						json_schema: {
+							name: "weather_response",
+							description: "A response about the weather",
+							schema: {
+								type: "object",
+								properties: {
+									location: {
+										type: "string",
+										description: "The location for the weather",
+									},
+									temperature: {
+										type: "string",
+										description: "The temperature",
+									},
+									conditions: {
+										type: "string",
+										description: "The weather conditions",
+									},
+								},
+								required: ["location", "temperature", "conditions"],
+								additionalProperties: false,
+							},
+							strict: true,
+						},
+					},
+					stream: true,
+				}),
+			});
+
+			if (res.status !== 200) {
+				console.log("response:", await res.text());
+				throw new Error(`Request failed with status ${res.status}`);
+			}
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			if (logMode) {
+				console.log(
+					"json_schema streaming",
+					JSON.stringify(streamResult, null, 2),
+				);
+			}
+
+			expect(streamResult.hasValidSSE).toBe(true);
+			expect(streamResult.eventCount).toBeGreaterThan(0);
+			expect(streamResult.hasContent).toBe(true);
+			expect(streamResult.hasOpenAIFormat).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter((chunk) => chunk.choices?.[0]?.delta?.content)
+				.map((chunk) => chunk.choices[0].delta.content);
+			const fullContent = contentChunks.join("");
+
+			// Validate that the streamed content is valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			const parsedContent = JSON.parse(fullContent);
+
+			// Validate the parsed content matches the exact schema using Zod
+			const validationResult = weatherResponseSchema.safeParse(parsedContent);
+			if (!validationResult.success) {
+				console.error(
+					"Schema validation failed:",
+					JSON.stringify(validationResult.error.format(), null, 2),
+				);
+				console.error(
+					"Received content:",
+					JSON.stringify(parsedContent, null, 2),
+				);
+			}
+			expect(validationResult.success).toBe(true);
+
+			// Additional type-safe assertions after validation
+			if (validationResult.success) {
+				const data = validationResult.data;
+				expect(typeof data.location).toBe("string");
+				expect(typeof data.temperature).toBe("string");
+				expect(typeof data.conditions).toBe("string");
+				expect(data.location.length).toBeGreaterThan(0);
+				expect(data.temperature.length).toBeGreaterThan(0);
+				expect(data.conditions.length).toBeGreaterThan(0);
+			}
+		},
+	);
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -826,10 +826,7 @@ chat.openapi(completions, async (c) => {
 		providers: activeProviders,
 	};
 
-	if (
-		response_format?.type === "json_object" ||
-		response_format?.type === "json_schema"
-	) {
+	if (response_format?.type === "json_object") {
 		// Filter providers by requestedProvider if specified
 		const providersToCheck = requestedProvider
 			? modelInfo.providers.filter(
@@ -837,7 +834,7 @@ chat.openapi(completions, async (c) => {
 				)
 			: modelInfo.providers;
 
-		// Check if the provider(s) support JSON output
+		// Check if the provider(s) support JSON output mode
 		const supportsJsonOutput = providersToCheck.some(
 			(provider) => (provider as ProviderModelMapping).jsonOutput === true,
 		);
@@ -847,21 +844,27 @@ chat.openapi(completions, async (c) => {
 				message: `Model ${requestedModel} does not support JSON output mode`,
 			});
 		}
+	}
 
-		// Additional validation for json_schema type
-		if (response_format?.type === "json_schema") {
-			// For non-auto/custom models, check if the provider supports json_schema
-			if (requestedModel !== "auto" && requestedModel !== "custom") {
-				const supportsJsonSchema = providersToCheck.some(
-					(provider) =>
-						(provider as ProviderModelMapping).jsonOutputSchema === true,
-				);
+	if (response_format?.type === "json_schema") {
+		// Filter providers by requestedProvider if specified
+		const providersToCheck = requestedProvider
+			? modelInfo.providers.filter(
+					(p) => (p as ProviderModelMapping).providerId === requestedProvider,
+				)
+			: modelInfo.providers;
 
-				if (!supportsJsonSchema) {
-					throw new HTTPException(400, {
-						message: `Model ${requestedModel} does not support JSON schema output mode. Use response_format type 'json_object' instead.`,
-					});
-				}
+		// For non-auto/custom models, check if the provider supports json_schema
+		if (requestedModel !== "auto" && requestedModel !== "custom") {
+			const supportsJsonSchema = providersToCheck.some(
+				(provider) =>
+					(provider as ProviderModelMapping).jsonOutputSchema === true,
+			);
+
+			if (!supportsJsonSchema) {
+				throw new HTTPException(400, {
+					message: `Model ${requestedModel} does not support JSON schema output mode`,
+				});
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Adds comprehensive streaming tests for both `json_object` and `json_schema` response formats. Fixes gateway validation to correctly distinguish between the two modes, allowing Anthropic models to use structured outputs via `json_schema` without requiring `json_object` support.

## Test plan
- JSON output streaming with OpenAI, Google, and Anthropic models
- JSON schema output streaming with all models supporting structured outputs
- Verified non-streaming tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming support for JSON schema response formats in chat completions.

* **Bug Fixes**
  * Improved error messages when JSON output formats are unsupported.

* **Improvements**
  * Enhanced provider validation for JSON object and schema outputs with improved fallback logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->