### PR TITLE
feat: add migration guides to landing page

### DIFF
--- a/apps/ui/content-collections.ts
+++ b/apps/ui/content-collections.ts
@@ -78,6 +78,20 @@ const guides = defineCollection({
 	}),
 });
 
+const migrations = defineCollection({
+	name: "migrations",
+	directory: "src/content/migrations",
+	include: "**/*.md",
+	schema: z.object({
+		id: z.string(),
+		slug: z.string(),
+		title: z.string(),
+		description: z.string(),
+		date: z.string(),
+		fromProvider: z.string(),
+	}),
+});
+
 export default defineConfig({
-	collections: [changelog, blog, legal, guides],
+	collections: [changelog, blog, legal, guides, migrations],
 });

--- a/apps/ui/src/app/migration/[slug]/opengraph-image.tsx
+++ b/apps/ui/src/app/migration/[slug]/opengraph-image.tsx
@@ -1,0 +1,297 @@
+import { ImageResponse } from "next/og";
+
+import type { Migration } from "content-collections";
+
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+// OpenRouter Icon
+const OpenRouterIcon = () => (
+	<svg
+		fill="#ffffff"
+		fillRule="evenodd"
+		viewBox="0 0 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+		width={80}
+		height={80}
+	>
+		<path d="m16.804 1.957 7.22 4.105v.087L16.73 10.21l.017-2.117-.821-.03c-1.059-.028-1.611.002-2.268.11-1.064.175-2.038.577-3.147 1.352L8.345 11.03c-.284.195-.495.336-.68.455l-.515.322-.397.234.385.23.53.338c.476.314 1.17.796 2.701 1.866 1.11.775 2.083 1.177 3.147 1.352l.3.045c.694.091 1.375.094 2.825.033l.022-2.159 7.22 4.105v.087L16.589 22l.014-1.862-.635.022c-1.386.042-2.137.002-3.138-.162-1.694-.28-3.26-.926-4.881-2.059l-2.158-1.5a21.997 21.997 0 0 0-.755-.498l-.467-.28a55.927 55.927 0 0 0-.76-.43C2.908 14.73.563 14.116 0 14.116V9.888l.14.004c.564-.007 2.91-.622 3.809-1.124l1.016-.58.438-.274c.428-.28 1.072-.726 2.686-1.853 1.621-1.133 3.186-1.78 4.881-2.059 1.152-.19 1.974-.213 3.814-.138z" />
+	</svg>
+);
+
+// Vercel Icon
+const VercelIcon = () => (
+	<svg viewBox="0 0 76 65" fill="#ffffff" width={80} height={80}>
+		<path d="M37.5274 0L75.0548 65H0L37.5274 0Z" />
+	</svg>
+);
+
+// LiteLLM Icon (Train emoji as text)
+const LiteLLMIcon = () => (
+	<div
+		style={{
+			fontSize: 64,
+			display: "flex",
+			alignItems: "center",
+			justifyContent: "center",
+		}}
+	>
+		🚅
+	</div>
+);
+
+// Arrow Icon for migration
+const ArrowIcon = () => (
+	<svg
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		width={48}
+		height={48}
+	>
+		<path
+			d="M5 12h14M12 5l7 7-7 7"
+			stroke="#9CA3AF"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+// LLM Gateway Icon
+const LLMGatewayIcon = () => (
+	<svg
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 218 232"
+		width={80}
+		height={80}
+	>
+		<path
+			d="M218 59.4686c0-4.1697-2.351-7.9813-6.071-9.8441L119.973 3.58361s2.926 3.32316 2.926 7.01529V218.833c0 4.081-2.926 7.016-2.926 7.016l15.24-7.468c2.964-2.232 7.187-7.443 7.438-16.006.293-9.976.61-84.847.732-121.0353.487-3.6678 4.096-11.0032 14.63-11.0032 10.535 0 29.262 5.1348 37.309 7.7022 2.439.7336 7.608 4.1812 8.779 12.1036 1.17 7.9223.975 59.0507.731 83.6247 0 2.445.137 7.069 6.653 7.069 6.515 0 6.515-7.069 6.515-7.069V59.4686Z"
+			fill="#ffffff"
+		/>
+		<path
+			d="M149.235 86.323c0-5.5921 5.132-9.7668 10.589-8.6132l31.457 6.6495c4.061.8585 6.967 4.4207 6.967 8.5824v81.9253c0 5.868 5.121 9.169 5.121 9.169l-51.9-12.658c-1.311-.32-2.234-1.498-2.234-2.852V86.323ZM99.7535 1.15076c7.2925-3.60996 15.8305 1.71119 15.8305 9.86634V220.983c0 8.155-8.538 13.476-15.8305 9.866L6.11596 184.496C2.37105 182.642 0 178.818 0 174.63v-17.868l49.7128 19.865c4.0474 1.617 8.4447-1.372 8.4449-5.741 0-2.66-1.6975-5.022-4.2142-5.863L0 146.992v-14.305l40.2756 7.708c3.9656.759 7.6405-2.289 7.6405-6.337 0-3.286-2.4628-6.048-5.7195-6.413L0 122.917V108.48l78.5181-3.014c4.1532-.16 7.4381-3.582 7.4383-7.7498 0-4.6256-4.0122-8.2229-8.5964-7.7073L0 98.7098V82.4399l53.447-17.8738c2.3764-.7948 3.9791-3.0254 3.9792-5.5374 0-4.0961-4.0978-6.9185-7.9106-5.4486L0 72.6695V57.3696c.0000304-4.1878 2.37107-8.0125 6.11596-9.8664L99.7535 1.15076Z"
+			fill="#ffffff"
+		/>
+	</svg>
+);
+
+// Map provider names to their icons
+function getIconForProvider(provider: string) {
+	const iconMap: Record<string, () => React.JSX.Element> = {
+		OpenRouter: OpenRouterIcon,
+		"Vercel AI Gateway": VercelIcon,
+		LiteLLM: LiteLLMIcon,
+	};
+
+	return iconMap[provider] || OpenRouterIcon;
+}
+
+export default async function MigrationOgImage({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { allMigrations } = await import("content-collections");
+	const { slug } = await params;
+
+	const migration = allMigrations.find(
+		(migration: Migration) => migration.slug === slug,
+	);
+
+	if (!migration) {
+		return new ImageResponse(
+			(
+				<div
+					style={{
+						width: "100%",
+						height: "100%",
+						display: "flex",
+						background: "#000000",
+					}}
+				/>
+			),
+			size,
+		);
+	}
+
+	const ProviderIcon = getIconForProvider(migration.fromProvider);
+
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "space-between",
+					alignItems: "stretch",
+					background: "#000000",
+					color: "white",
+					fontFamily:
+						"system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+					padding: 60,
+					boxSizing: "border-box",
+				}}
+			>
+				{/* Header with logo */}
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						alignItems: "center",
+						gap: 16,
+					}}
+				>
+					<svg
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 218 232"
+						width={48}
+						height={48}
+					>
+						<path
+							d="M218 59.4686c0-4.1697-2.351-7.9813-6.071-9.8441L119.973 3.58361s2.926 3.32316 2.926 7.01529V218.833c0 4.081-2.926 7.016-2.926 7.016l15.24-7.468c2.964-2.232 7.187-7.443 7.438-16.006.293-9.976.61-84.847.732-121.0353.487-3.6678 4.096-11.0032 14.63-11.0032 10.535 0 29.262 5.1348 37.309 7.7022 2.439.7336 7.608 4.1812 8.779 12.1036 1.17 7.9223.975 59.0507.731 83.6247 0 2.445.137 7.069 6.653 7.069 6.515 0 6.515-7.069 6.515-7.069V59.4686Z"
+							fill="#ffffff"
+						/>
+						<path
+							d="M149.235 86.323c0-5.5921 5.132-9.7668 10.589-8.6132l31.457 6.6495c4.061.8585 6.967 4.4207 6.967 8.5824v81.9253c0 5.868 5.121 9.169 5.121 9.169l-51.9-12.658c-1.311-.32-2.234-1.498-2.234-2.852V86.323ZM99.7535 1.15076c7.2925-3.60996 15.8305 1.71119 15.8305 9.86634V220.983c0 8.155-8.538 13.476-15.8305 9.866L6.11596 184.496C2.37105 182.642 0 178.818 0 174.63v-17.868l49.7128 19.865c4.0474 1.617 8.4447-1.372 8.4449-5.741 0-2.66-1.6975-5.022-4.2142-5.863L0 146.992v-14.305l40.2756 7.708c3.9656.759 7.6405-2.289 7.6405-6.337 0-3.286-2.4628-6.048-5.7195-6.413L0 122.917V108.48l78.5181-3.014c4.1532-.16 7.4381-3.582 7.4383-7.7498 0-4.6256-4.0122-8.2229-8.5964-7.7073L0 98.7098V82.4399l53.447-17.8738c2.3764-.7948 3.9791-3.0254 3.9792-5.5374 0-4.0961-4.0978-6.9185-7.9106-5.4486L0 72.6695V57.3696c.0000304-4.1878 2.37107-8.0125 6.11596-9.8664L99.7535 1.15076Z"
+							fill="#ffffff"
+						/>
+					</svg>
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							gap: 8,
+							fontSize: 24,
+							color: "#9CA3AF",
+						}}
+					>
+						<span style={{ color: "#ffffff", fontWeight: 600 }}>
+							LLM Gateway
+						</span>
+						<span style={{ opacity: 0.6 }}>•</span>
+						<span>Migration Guide</span>
+					</div>
+				</div>
+
+				{/* Main content */}
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						justifyContent: "center",
+						flex: 1,
+						gap: 48,
+					}}
+				>
+					{/* Migration icons */}
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							gap: 32,
+						}}
+					>
+						{/* From provider icon */}
+						<div
+							style={{
+								width: 120,
+								height: 120,
+								borderRadius: 20,
+								backgroundColor: "#1a1a1a",
+								border: "2px solid rgba(255,255,255,0.1)",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								padding: 16,
+							}}
+						>
+							<ProviderIcon />
+						</div>
+
+						{/* Arrow */}
+						<ArrowIcon />
+
+						{/* LLM Gateway icon */}
+						<div
+							style={{
+								width: 120,
+								height: 120,
+								borderRadius: 20,
+								backgroundColor: "#1a1a1a",
+								border: "2px solid rgba(59,130,246,0.5)",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								padding: 16,
+							}}
+						>
+							<LLMGatewayIcon />
+						</div>
+					</div>
+
+					{/* Title and description */}
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+							gap: 24,
+							maxWidth: 1000,
+						}}
+					>
+						<h1
+							style={{
+								fontSize: 64,
+								fontWeight: 700,
+								margin: 0,
+								letterSpacing: "-0.03em",
+								textAlign: "center",
+								lineHeight: 1.1,
+							}}
+						>
+							{migration.title}
+						</h1>
+						<p
+							style={{
+								fontSize: 28,
+								color: "#9CA3AF",
+								margin: 0,
+								textAlign: "center",
+								lineHeight: 1.3,
+							}}
+						>
+							{migration.description}
+						</p>
+					</div>
+				</div>
+
+				{/* Footer */}
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						justifyContent: "flex-end",
+						fontSize: 20,
+						color: "#9CA3AF",
+					}}
+				>
+					<span>llmgateway.io</span>
+				</div>
+			</div>
+		),
+		size,
+	);
+}

--- a/apps/ui/src/app/migration/[slug]/page.tsx
+++ b/apps/ui/src/app/migration/[slug]/page.tsx
@@ -1,0 +1,110 @@
+import { ArrowLeftIcon } from "lucide-react";
+import Markdown from "markdown-to-jsx";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import Footer from "@/components/landing/footer";
+import { HeroRSC } from "@/components/landing/hero-rsc";
+import { getMarkdownOptions } from "@/lib/utils/markdown";
+
+import type { Migration } from "content-collections";
+import type { Metadata } from "next";
+
+interface MigrationPageProps {
+	params: Promise<{ slug: string }>;
+}
+
+export default async function MigrationPage({ params }: MigrationPageProps) {
+	const { allMigrations } = await import("content-collections");
+
+	const { slug } = await params;
+
+	const migration = allMigrations.find(
+		(migration: Migration) => migration.slug === slug,
+	);
+
+	if (!migration) {
+		notFound();
+	}
+
+	return (
+		<>
+			<HeroRSC navbarOnly />
+			<div className="min-h-screen bg-white text-black dark:bg-black dark:text-white pt-30">
+				<main className="container mx-auto px-4 py-8">
+					<div className="max-w-4xl mx-auto">
+						<div className="mb-8">
+							<Link
+								href="/migration"
+								className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+							>
+								<ArrowLeftIcon className="mr-2 h-4 w-4" />
+								Back to migration guides
+							</Link>
+						</div>
+
+						<article className="prose prose-lg dark:prose-invert max-w-none">
+							<header className="mb-8">
+								<div className="mb-4 inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+									From {migration.fromProvider}
+								</div>
+								<h1 className="text-4xl font-bold mb-4">{migration.title}</h1>
+								<div className="text-muted-foreground">
+									{migration.description && (
+										<p className="text-lg mb-2">{migration.description}</p>
+									)}
+								</div>
+							</header>
+
+							<div className="prose prose-lg dark:prose-invert max-w-none">
+								<Markdown options={getMarkdownOptions()}>
+									{migration.content}
+								</Markdown>
+							</div>
+						</article>
+					</div>
+				</main>
+				<Footer />
+			</div>
+		</>
+	);
+}
+
+export async function generateStaticParams() {
+	const { allMigrations } = await import("content-collections");
+
+	return allMigrations.map((migration: Migration) => ({
+		slug: migration.slug,
+	}));
+}
+
+export async function generateMetadata({
+	params,
+}: MigrationPageProps): Promise<Metadata> {
+	const { allMigrations } = await import("content-collections");
+
+	const { slug } = await params;
+
+	const migration = allMigrations.find(
+		(migration: Migration) => migration.slug === slug,
+	);
+
+	if (!migration) {
+		return {};
+	}
+
+	return {
+		title: `${migration.title} - Migration Guides - LLM Gateway`,
+		description: migration.description || "Migration guide for LLM Gateway",
+		openGraph: {
+			title: `${migration.title} - Migration Guides - LLM Gateway`,
+			description: migration.description || "Migration guide for LLM Gateway",
+			type: "article",
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: `${migration.title} - Migration Guides - LLM Gateway`,
+			description: migration.description || "Migration guide for LLM Gateway",
+		},
+	};
+}

--- a/apps/ui/src/app/migration/page.tsx
+++ b/apps/ui/src/app/migration/page.tsx
@@ -1,0 +1,121 @@
+import { ArrowRightIcon } from "lucide-react";
+import Link from "next/link";
+
+import Footer from "@/components/landing/footer";
+import { HeroRSC } from "@/components/landing/hero-rsc";
+
+import type { Migration } from "content-collections";
+
+export const metadata = {
+	title: "Migration Guides | LLM Gateway",
+	description:
+		"Step-by-step guides to migrate from OpenRouter, Vercel AI Gateway, LiteLLM, and other LLM providers to LLM Gateway.",
+	openGraph: {
+		title: "Migration Guides | LLM Gateway",
+		description:
+			"Step-by-step guides to migrate from OpenRouter, Vercel AI Gateway, LiteLLM, and other LLM providers to LLM Gateway.",
+	},
+};
+
+const providerIcons: Record<string, React.ReactNode> = {
+	OpenRouter: (
+		<svg
+			fill="currentColor"
+			fillRule="evenodd"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			className="h-8 w-8"
+		>
+			<path d="m16.804 1.957 7.22 4.105v.087L16.73 10.21l.017-2.117-.821-.03c-1.059-.028-1.611.002-2.268.11-1.064.175-2.038.577-3.147 1.352L8.345 11.03c-.284.195-.495.336-.68.455l-.515.322-.397.234.385.23.53.338c.476.314 1.17.796 2.701 1.866 1.11.775 2.083 1.177 3.147 1.352l.3.045c.694.091 1.375.094 2.825.033l.022-2.159 7.22 4.105v.087L16.589 22l.014-1.862-.635.022c-1.386.042-2.137.002-3.138-.162-1.694-.28-3.26-.926-4.881-2.059l-2.158-1.5a21.997 21.997 0 0 0-.755-.498l-.467-.28a55.927 55.927 0 0 0-.76-.43C2.908 14.73.563 14.116 0 14.116V9.888l.14.004c.564-.007 2.91-.622 3.809-1.124l1.016-.58.438-.274c.428-.28 1.072-.726 2.686-1.853 1.621-1.133 3.186-1.78 4.881-2.059 1.152-.19 1.974-.213 3.814-.138z" />
+		</svg>
+	),
+	"Vercel AI Gateway": (
+		<svg viewBox="0 0 76 65" fill="currentColor" className="h-8 w-8">
+			<path d="M37.5274 0L75.0548 65H0L37.5274 0Z" />
+		</svg>
+	),
+	LiteLLM: <span className="text-3xl">🚅</span>,
+};
+
+export default async function MigrationPage() {
+	const { allMigrations } = await import("content-collections");
+
+	return (
+		<div>
+			<HeroRSC navbarOnly />
+			<section className="py-20 sm:py-28">
+				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+					<div className="mx-auto max-w-2xl text-center mb-16">
+						<h1 className="mb-4 text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+							Migration Guides
+						</h1>
+						<p className="text-lg text-muted-foreground leading-relaxed">
+							Switch to LLM Gateway from other LLM providers with minimal code
+							changes. Our OpenAI-compatible API makes migration
+							straightforward.
+						</p>
+					</div>
+
+					<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+						{allMigrations.map((migration: Migration) => (
+							<Link
+								key={migration.slug}
+								href={`/migration/${migration.slug}`}
+								className="group relative flex flex-col rounded-xl border border-border bg-card p-6 transition-all hover:border-primary/50 hover:shadow-lg"
+							>
+								<div className="mb-4 flex h-14 w-14 items-center justify-center rounded-lg bg-muted text-muted-foreground group-hover:bg-primary/10 group-hover:text-primary transition-colors">
+									{providerIcons[migration.fromProvider] || (
+										<svg
+											viewBox="0 0 24 24"
+											fill="none"
+											xmlns="http://www.w3.org/2000/svg"
+											className="h-8 w-8"
+										>
+											<path
+												d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+												stroke="currentColor"
+												strokeWidth="2"
+												strokeLinecap="round"
+												strokeLinejoin="round"
+											/>
+										</svg>
+									)}
+								</div>
+								<h2 className="mb-2 text-xl font-semibold group-hover:text-primary transition-colors">
+									{migration.title}
+								</h2>
+								<p className="mb-4 text-sm text-muted-foreground flex-grow">
+									{migration.description}
+								</p>
+								<div className="flex items-center text-sm font-medium text-primary">
+									Read guide
+									<ArrowRightIcon className="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1" />
+								</div>
+							</Link>
+						))}
+					</div>
+
+					<div className="mt-16 mx-auto max-w-2xl text-center">
+						<div className="rounded-xl border border-border bg-muted/50 p-8">
+							<h2 className="mb-2 text-xl font-semibold">
+								Don't see your provider?
+							</h2>
+							<p className="mb-4 text-muted-foreground">
+								LLM Gateway's OpenAI-compatible API works with any client that
+								supports OpenAI. Just change the base URL and API key.
+							</p>
+							<Link
+								href="https://docs.llmgateway.io/quick-start"
+								className="inline-flex items-center text-sm font-medium text-primary hover:underline"
+							>
+								View Quick Start Guide
+								<ArrowRightIcon className="ml-1 h-4 w-4" />
+							</Link>
+						</div>
+					</div>
+				</div>
+			</section>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/ui/src/components/landing/hero-rsc.tsx
+++ b/apps/ui/src/components/landing/hero-rsc.tsx
@@ -1,5 +1,6 @@
 import { GitHubStars } from "./github-stars";
 import { Hero } from "./hero";
+import { allMigrations } from "content-collections";
 
 export const HeroRSC = async ({
 	navbarOnly,
@@ -8,8 +9,16 @@ export const HeroRSC = async ({
 	navbarOnly?: boolean;
 	sticky?: boolean;
 }) => {
+	const migrations = navbarOnly
+		? []
+		: allMigrations.map((m) => ({
+				slug: m.slug,
+				title: m.title,
+				fromProvider: m.fromProvider,
+			}));
+
 	return (
-		<Hero navbarOnly={navbarOnly} sticky={sticky}>
+		<Hero navbarOnly={navbarOnly} sticky={sticky} migrations={migrations}>
 			<GitHubStars />
 		</Hero>
 	);

--- a/apps/ui/src/components/landing/hero.tsx
+++ b/apps/ui/src/components/landing/hero.tsx
@@ -60,14 +60,52 @@ const PROVIDER_LOGOS: { name: string; providerId: ProviderId }[] = [
 	{ name: "Inference.net", providerId: "inference.net" },
 ];
 
+interface MigrationData {
+	slug: string;
+	title: string;
+	fromProvider: string;
+}
+
+const providerIcons: Record<string, React.ReactNode> = {
+	OpenRouter: (
+		<svg
+			fill="currentColor"
+			fillRule="evenodd"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			className="size-5"
+			aria-hidden="true"
+		>
+			<path d="m16.804 1.957 7.22 4.105v.087L16.73 10.21l.017-2.117-.821-.03c-1.059-.028-1.611.002-2.268.11-1.064.175-2.038.577-3.147 1.352L8.345 11.03c-.284.195-.495.336-.68.455l-.515.322-.397.234.385.23.53.338c.476.314 1.17.796 2.701 1.866 1.11.775 2.083 1.177 3.147 1.352l.3.045c.694.091 1.375.094 2.825.033l.022-2.159 7.22 4.105v.087L16.589 22l.014-1.862-.635.022c-1.386.042-2.137.002-3.138-.162-1.694-.28-3.26-.926-4.881-2.059l-2.158-1.5a21.997 21.997 0 0 0-.755-.498l-.467-.28a55.927 55.927 0 0 0-.76-.43C2.908 14.73.563 14.116 0 14.116V9.888l.14.004c.564-.007 2.91-.622 3.809-1.124l1.016-.58.438-.274c.428-.28 1.072-.726 2.686-1.853 1.621-1.133 3.186-1.78 4.881-2.059 1.152-.19 1.974-.213 3.814-.138z" />
+		</svg>
+	),
+	"Vercel AI Gateway": (
+		<svg
+			viewBox="0 0 76 65"
+			fill="currentColor"
+			className="size-5"
+			aria-hidden="true"
+		>
+			<path d="M37.5274 0L75.0548 65H0L37.5274 0Z" />
+		</svg>
+	),
+	LiteLLM: (
+		<span className="text-lg" role="img" aria-label="LiteLLM">
+			🚅
+		</span>
+	),
+};
+
 export function Hero({
 	navbarOnly,
 	sticky = true,
 	children,
+	migrations = [],
 }: {
 	navbarOnly?: boolean;
 	sticky?: boolean;
 	children: React.ReactNode;
+	migrations?: MigrationData[];
 }) {
 	const config = useAppConfig();
 
@@ -168,6 +206,7 @@ export function Hero({
 													className="size-4 text-green-500"
 													fill="currentColor"
 													viewBox="0 0 20 20"
+													aria-hidden="true"
 												>
 													<path
 														fillRule="evenodd"
@@ -182,6 +221,7 @@ export function Hero({
 													className="size-4 text-green-500"
 													fill="currentColor"
 													viewBox="0 0 20 20"
+													aria-hidden="true"
 												>
 													<path
 														fillRule="evenodd"
@@ -196,6 +236,7 @@ export function Hero({
 													className="size-4 text-green-500"
 													fill="currentColor"
 													viewBox="0 0 20 20"
+													aria-hidden="true"
 												>
 													<path
 														fillRule="evenodd"
@@ -222,6 +263,61 @@ export function Hero({
 								</div>
 							</div>
 
+							{/* Migration guides section */}
+							{migrations.length > 0 && (
+								<AnimatedGroup
+									variants={{
+										container: {
+											visible: {
+												transition: {
+													staggerChildren: 0.05,
+													delayChildren: 0.6,
+												},
+											},
+										},
+										...transitionVariants,
+									}}
+								>
+									<div className="mx-auto mt-10 max-w-4xl px-6">
+										<p className="mb-4 text-center text-sm text-muted-foreground">
+											Switching from another provider?
+										</p>
+										<div className="flex flex-wrap items-center justify-center gap-3">
+											{migrations.map((migration) => (
+												<Link
+													key={migration.slug}
+													href={`/migration/${migration.slug}`}
+													className="group/card flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2 text-sm transition-colors hover:border-primary/50 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+												>
+													<span className="flex size-6 items-center justify-center text-muted-foreground transition-colors group-hover/card:text-foreground">
+														{providerIcons[migration.fromProvider] || (
+															<ChevronRight
+																className="size-4"
+																aria-hidden="true"
+															/>
+														)}
+													</span>
+													<span className="text-muted-foreground transition-colors group-hover/card:text-foreground">
+														{migration.fromProvider}
+													</span>
+													<ArrowRight
+														className="size-3 text-muted-foreground transition-transform group-hover/card:translate-x-0.5 group-hover/card:text-primary"
+														aria-hidden="true"
+													/>
+												</Link>
+											))}
+											<Link
+												href="/migration"
+												className="flex items-center gap-1 rounded-full px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+											>
+												<span>View all</span>
+												<ChevronRight className="size-3" aria-hidden="true" />
+											</Link>
+										</div>
+									</div>
+								</AnimatedGroup>
+							)}
+
 							<AnimatedGroup
 								variants={{
 									container: {
@@ -244,14 +340,14 @@ export function Hero({
 										<Image
 											className="bg-background aspect-15/8 relative hidden rounded-2xl dark:block"
 											src="/new-hero.png"
-											alt="app screen"
+											alt="LLM Gateway dashboard showing analytics and API usage"
 											width={2696}
 											height={1386}
 										/>
 										<Image
 											className="z-2 border-border/25 aspect-15/8 relative rounded-2xl border dark:hidden"
 											src="/new-hero-light.png"
-											alt="app screen"
+											alt="LLM Gateway dashboard showing analytics and API usage"
 											width={2696}
 											height={1386}
 										/>

--- a/apps/ui/src/content/migrations/litellm.md
+++ b/apps/ui/src/content/migrations/litellm.md
@@ -1,0 +1,294 @@
+---
+id: litellm
+slug: litellm
+title: Migrate from LiteLLM
+description: How to migrate from LiteLLM proxy to LLM Gateway for a managed solution with analytics
+date: 2026-01-20
+fromProvider: LiteLLM
+---
+
+LiteLLM is an excellent open-source library for unifying LLM APIs. LLM Gateway offers similar functionality as a managed service with additional features like built-in analytics, caching, and a web dashboard.
+
+## Quick Migration
+
+Since both services expose OpenAI-compatible endpoints, migration is straightforward:
+
+```diff
+- const baseURL = "http://localhost:4000/v1";  // LiteLLM proxy
++ const baseURL = "https://api.llmgateway.io/v1";
+
+- const apiKey = process.env.LITELLM_API_KEY;
++ const apiKey = process.env.LLM_GATEWAY_API_KEY;
+```
+
+## Why Migrate to LLM Gateway?
+
+| Feature                  | LiteLLM       | LLM Gateway   |
+| ------------------------ | ------------- | ------------- |
+| OpenAI-compatible API    | Yes           | Yes           |
+| Self-hosting             | Required      | Optional      |
+| Managed cloud service    | No            | Yes           |
+| Built-in dashboard       | Basic         | Comprehensive |
+| Response caching         | Manual setup  | Built-in      |
+| Cost analytics           | Via callbacks | Native        |
+| Provider management      | Config file   | Web UI        |
+| Maintenance              | Self-managed  | Managed       |
+| Anthropic-compatible API | Yes           | Yes           |
+
+For a detailed feature-by-feature comparison, see [LLM Gateway vs LiteLLM](/compare/litellm).
+
+## Migration Steps
+
+### 1. Get Your LLM Gateway API Key
+
+Sign up at [llmgateway.io/signup](/signup) and create an API key from your dashboard.
+
+### 2. Map Your Models
+
+LLM Gateway supports two model ID formats:
+
+**Root Model IDs** (without provider prefix) - Uses smart routing to automatically select the best provider based on uptime, throughput, price, and latency:
+
+```
+gpt-5.2
+claude-opus-4-5-20251101
+gemini-3-flash-preview
+```
+
+**Provider-Prefixed Model IDs** - Routes to a specific provider with automatic failover if uptime drops below 90%:
+
+```
+openai/gpt-5.2
+anthropic/claude-opus-4-5-20251101
+google-ai-studio/gemini-3-flash-preview
+```
+
+This means many LiteLLM model names work directly with LLM Gateway:
+
+| LiteLLM Model                    | LLM Gateway Model                                                 |
+| -------------------------------- | ----------------------------------------------------------------- |
+| gpt-5.2                          | gpt-5.2 or openai/gpt-5.2                                         |
+| claude-opus-4-5-20251101         | claude-opus-4-5-20251101 or anthropic/claude-opus-4-5-20251101    |
+| gemini/gemini-3-flash-preview    | gemini-3-flash-preview or google-ai-studio/gemini-3-flash-preview |
+| bedrock/claude-opus-4-5-20251101 | claude-opus-4-5-20251101 or aws-bedrock/claude-opus-4-5-20251101  |
+
+For more details on routing behavior, see the [routing documentation](https://docs.llmgateway.io/features/routing).
+
+### 3. Update Your Code
+
+#### Python with OpenAI SDK
+
+```python
+from openai import OpenAI
+
+# Before (LiteLLM proxy)
+client = OpenAI(
+    base_url="http://localhost:4000/v1",
+    api_key=os.environ["LITELLM_API_KEY"]
+)
+
+response = client.chat.completions.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# After (LLM Gateway) - model name can stay the same!
+client = OpenAI(
+    base_url="https://api.llmgateway.io/v1",
+    api_key=os.environ["LLM_GATEWAY_API_KEY"]
+)
+
+response = client.chat.completions.create(
+    model="gpt-4",  # or "openai/gpt-4" to target a specific provider
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+#### Python with LiteLLM Library
+
+If you're using the LiteLLM library directly, you can point it to LLM Gateway:
+
+```python
+import litellm
+
+# Before (direct LiteLLM)
+response = litellm.completion(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# After (via LLM Gateway) - same model name works
+response = litellm.completion(
+    model="gpt-4",  # or "openai/gpt-4" to target a specific provider
+    messages=[{"role": "user", "content": "Hello!"}],
+    api_base="https://api.llmgateway.io/v1",
+    api_key=os.environ["LLM_GATEWAY_API_KEY"]
+)
+```
+
+#### TypeScript/JavaScript
+
+```typescript
+import OpenAI from "openai";
+
+// Before (LiteLLM proxy)
+const client = new OpenAI({
+  baseURL: "http://localhost:4000/v1",
+  apiKey: process.env.LITELLM_API_KEY,
+});
+
+// After (LLM Gateway) - same model name works
+const client = new OpenAI({
+  baseURL: "https://api.llmgateway.io/v1",
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+const completion = await client.chat.completions.create({
+  model: "gpt-4", // or "openai/gpt-4" to target a specific provider
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+#### cURL
+
+```bash
+# Before (LiteLLM proxy)
+curl http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+
+# After (LLM Gateway) - same model name works
+curl https://api.llmgateway.io/v1/chat/completions \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+# Use "openai/gpt-4" to target a specific provider
+```
+
+### 4. Migrate Configuration
+
+#### LiteLLM Config (Before)
+
+```yaml
+# litellm_config.yaml
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: gpt-4
+      api_key: sk-...
+  - model_name: claude-3
+    litellm_params:
+      model: claude-3-sonnet-20240229
+      api_key: sk-ant-...
+```
+
+#### LLM Gateway (After)
+
+With LLM Gateway, you don't need a config file. Provider keys are managed in the web dashboard, or you can use the default LLM Gateway keys.
+
+For Pro users who want to use their own keys, configure them in the dashboard under Settings > Provider Keys.
+
+## Streaming Support
+
+LLM Gateway supports streaming identically to LiteLLM:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.llmgateway.io/v1",
+    api_key=os.environ["LLM_GATEWAY_API_KEY"]
+)
+
+stream = client.chat.completions.create(
+    model="openai/gpt-4",
+    messages=[{"role": "user", "content": "Write a story"}],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+## Function/Tool Calling
+
+LLM Gateway supports function calling:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.llmgateway.io/v1",
+    api_key=os.environ["LLM_GATEWAY_API_KEY"]
+)
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather for a location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+            "required": ["location"]
+        }
+    }
+}]
+
+response = client.chat.completions.create(
+    model="openai/gpt-4",
+    messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
+    tools=tools
+)
+```
+
+## Removing LiteLLM Infrastructure
+
+After verifying LLM Gateway works for your use case, you can decommission your LiteLLM proxy:
+
+1. Update all clients to use LLM Gateway endpoints
+2. Monitor the LLM Gateway dashboard for successful requests
+3. Shut down your LiteLLM proxy server
+4. Remove LiteLLM configuration files
+
+## Benefits After Migration
+
+- **No Infrastructure Management**: No proxy servers to maintain or scale
+- **Built-in Analytics**: View costs, latency, and usage in the dashboard
+- **Response Caching**: Automatic caching reduces costs
+- **Web Dashboard**: Manage API keys and view analytics without CLI
+- **Automatic Updates**: New models available immediately
+
+## Self-Hosting LLM Gateway
+
+If you prefer self-hosting like LiteLLM, LLM Gateway is available under AGPLv3:
+
+```bash
+git clone https://github.com/llmgateway/llmgateway
+cd llmgateway
+pnpm install
+pnpm setup
+pnpm dev
+```
+
+This gives you the same benefits as LiteLLM's self-hosted proxy with LLM Gateway's analytics and caching features.
+
+## Full Comparison
+
+Want to see a detailed breakdown of all features? Check out our [LLM Gateway vs LiteLLM comparison page](/compare/litellm).
+
+## Need Help?
+
+- Browse available models at [llmgateway.io/models](/models)
+- Read the [API documentation](https://docs.llmgateway.io)
+- Contact support at contact@llmgateway.io

--- a/apps/ui/src/content/migrations/openrouter.md
+++ b/apps/ui/src/content/migrations/openrouter.md
@@ -1,0 +1,198 @@
+---
+id: openrouter
+slug: openrouter
+title: Migrate from OpenRouter
+description: Step-by-step guide to migrate from OpenRouter to LLM Gateway with minimal code changes
+date: 2026-01-20
+fromProvider: OpenRouter
+---
+
+LLM Gateway provides a drop-in replacement for OpenRouter with OpenAI-compatible endpoints. Since both services follow the OpenAI API format, migration requires minimal changes to your existing code.
+
+## Quick Migration
+
+Replace your OpenRouter configuration with LLM Gateway:
+
+```diff
+- const baseURL = "https://openrouter.ai/api/v1";
+- const apiKey = process.env.OPENROUTER_API_KEY;
++ const baseURL = "https://api.llmgateway.io/v1";
++ const apiKey = process.env.LLM_GATEWAY_API_KEY;
+```
+
+## Why Migrate to LLM Gateway?
+
+Both OpenRouter and LLM Gateway offer robust LLM gateway solutions. Here's how they compare:
+
+| Feature                  | OpenRouter                    | LLM Gateway              |
+| ------------------------ | ----------------------------- | ------------------------ |
+| OpenAI-compatible API    | Yes                           | Yes                      |
+| Multiple providers       | Yes (300+ models)             | Yes                      |
+| Native AI SDK provider   | Yes                           | Yes                      |
+| Response caching         | Yes (prompt caching)          | Yes                      |
+| Analytics dashboard      | Via third-party integrations  | Built-in                 |
+| Cost tracking            | Yes                           | Yes (per-request detail) |
+| Provider key management  | Yes (BYOK)                    | Yes (Pro)                |
+| Self-hosting option      | No                            | Yes (AGPLv3)             |
+| Simpler API (no headers) | Requires HTTP-Referer/X-Title | Just Authorization       |
+| Anthropic-compatible API | No                            | Yes (/v1/messages)       |
+
+For a detailed feature-by-feature comparison, see [LLM Gateway vs OpenRouter](/compare/open-router).
+
+## Migration Steps
+
+### 1. Get Your LLM Gateway API Key
+
+Sign up at [llmgateway.io/signup](/signup) and create an API key from your dashboard.
+
+### 2. Update Environment Variables
+
+```bash
+# Remove OpenRouter credentials
+# OPENROUTER_API_KEY=sk-or-...
+
+# Add LLM Gateway credentials
+export LLM_GATEWAY_API_KEY=llmgtwy_your_key_here
+```
+
+### 3. Update Your Code
+
+#### Using fetch/axios
+
+```typescript
+// Before (OpenRouter)
+const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+    "Content-Type": "application/json",
+    "HTTP-Referer": "https://your-site.com",
+    "X-Title": "Your App Name",
+  },
+  body: JSON.stringify({
+    model: "anthropic/claude-3-5-sonnet",
+    messages: [{ role: "user", content: "Hello!" }],
+  }),
+});
+
+// After (LLM Gateway)
+const response = await fetch("https://api.llmgateway.io/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.LLM_GATEWAY_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    model: "anthropic/claude-3-5-sonnet-20241022",
+    messages: [{ role: "user", content: "Hello!" }],
+  }),
+});
+```
+
+#### Using OpenAI SDK
+
+```typescript
+import OpenAI from "openai";
+
+// Before (OpenRouter)
+const client = new OpenAI({
+  baseURL: "https://openrouter.ai/api/v1",
+  apiKey: process.env.OPENROUTER_API_KEY,
+  defaultHeaders: {
+    "HTTP-Referer": "https://your-site.com",
+    "X-Title": "Your App Name",
+  },
+});
+
+// After (LLM Gateway)
+const client = new OpenAI({
+  baseURL: "https://api.llmgateway.io/v1",
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+// Usage remains the same
+const completion = await client.chat.completions.create({
+  model: "anthropic/claude-3-5-sonnet-20241022",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+```
+
+#### Using Vercel AI SDK
+
+Both OpenRouter and LLM Gateway have native AI SDK providers, making migration straightforward:
+
+```typescript
+import { generateText } from "ai";
+
+// Before (OpenRouter AI SDK Provider)
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+
+const openrouter = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const { text } = await generateText({
+  model: openrouter("gpt-5.2"),
+  prompt: "Hello!",
+});
+
+// After (LLM Gateway AI SDK Provider)
+import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+
+const llmgateway = createLLMGateway({
+  apiKey: process.env.LLMGATEWAY_API_KEY,
+});
+
+const { text } = await generateText({
+  model: llmgateway("gpt-5.2"),
+  prompt: "Hello!",
+});
+```
+
+## Model Name Mapping
+
+Most model names are compatible, but here are some common mappings:
+
+| OpenRouter Model                 | LLM Gateway Model                                                 |
+| -------------------------------- | ----------------------------------------------------------------- |
+| gpt-5.2                          | gpt-5.2 or openai/gpt-5.2                                         |
+| claude-opus-4-5-20251101         | claude-opus-4-5-20251101 or anthropic/claude-opus-4-5-20251101    |
+| gemini/gemini-3-flash-preview    | gemini-3-flash-preview or google-ai-studio/gemini-3-flash-preview |
+| bedrock/claude-opus-4-5-20251101 | claude-opus-4-5-20251101 or aws-bedrock/claude-opus-4-5-20251101  |
+
+Check the [models page](/models) for the full list of available models.
+
+## Streaming Support
+
+LLM Gateway supports streaming responses identically to OpenRouter:
+
+```typescript
+const stream = await client.chat.completions.create({
+  model: "anthropic/claude-3-5-sonnet-20241022",
+  messages: [{ role: "user", content: "Write a story" }],
+  stream: true,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || "");
+}
+```
+
+## Additional Benefits
+
+After migrating to LLM Gateway, you get access to:
+
+- **Response Caching**: Automatic caching for identical requests to reduce costs
+- **Detailed Analytics**: Per-request cost tracking, latency metrics, and usage patterns
+- **Provider Key Management**: Use your own API keys for providers (Pro plan)
+- **Self-Hosting**: Deploy LLM Gateway on your own infrastructure
+
+## Full Comparison
+
+Want to see a detailed breakdown of all features? Check out our [LLM Gateway vs OpenRouter comparison page](/compare/open-router).
+
+## Need Help?
+
+- Browse available models at [llmgateway.io/models](/models)
+- Read the [API documentation](https://docs.llmgateway.io)
+- Contact support at contact@llmgateway.io

--- a/apps/ui/src/content/migrations/vercel-ai-gateway.md
+++ b/apps/ui/src/content/migrations/vercel-ai-gateway.md
@@ -1,0 +1,263 @@
+---
+id: vercel-ai-gateway
+slug: vercel-ai-gateway
+title: Migrate from Vercel AI Gateway
+description: Guide to migrate from Vercel AI Gateway to LLM Gateway for more control and flexibility
+date: 2026-01-20
+fromProvider: Vercel AI Gateway
+---
+
+Vercel AI Gateway provides a unified interface for AI providers within the Vercel ecosystem. LLM Gateway offers similar functionality with additional features like response caching, detailed analytics, and self-hosting options.
+
+## Quick Migration
+
+Replace your Vercel AI SDK provider imports with the LLM Gateway provider:
+
+```diff
+- import { openai } from "@ai-sdk/openai";
+- import { anthropic } from "@ai-sdk/anthropic";
++ import { generateText } from "ai";
++ import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+
++ const llmgateway = createLLMGateway({
++   apiKey: process.env.LLM_GATEWAY_API_KEY
++ });
+
+const { text } = await generateText({
+-   model: openai("gpt-5.2"),
++   model: llmgateway("gpt-5.2"),
+  prompt: "Hello!"
+});
+```
+
+## Why Migrate to LLM Gateway?
+
+| Feature                  | Vercel AI Gateway     | LLM Gateway            |
+| ------------------------ | --------------------- | ---------------------- |
+| AI SDK integration       | Native                | Native + OpenAI compat |
+| Response caching         | No                    | Yes                    |
+| Detailed cost analytics  | Limited               | Comprehensive          |
+| Provider key management  | Per-provider env vars | Centralized (Pro)      |
+| Self-hosting             | No                    | Yes (AGPLv3)           |
+| Rate limiting            | Platform-level        | Customizable           |
+| Anthropic-compatible API | No                    | Yes (/v1/messages)     |
+| Smart routing            | No                    | Yes (auto failover)    |
+
+## Migration Steps
+
+### 1. Get Your LLM Gateway API Key
+
+Sign up at [llmgateway.io/signup](/signup) and create an API key from your dashboard.
+
+### 2. Install the LLM Gateway AI SDK Provider
+
+Install the native LLM Gateway provider for the Vercel AI SDK:
+
+```bash
+pnpm add @llmgateway/ai-sdk-provider
+```
+
+This package provides full compatibility with the Vercel AI SDK and supports all LLM Gateway features.
+
+### 3. Update Your Code
+
+#### Basic Text Generation
+
+```typescript
+// Before (Vercel AI Gateway with native providers)
+import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText } from "ai";
+
+const { text: openaiText } = await generateText({
+  model: openai("gpt-4o"),
+  prompt: "Hello!",
+});
+
+const { text: claudeText } = await generateText({
+  model: anthropic("claude-3-5-sonnet-20241022"),
+  prompt: "Hello!",
+});
+
+// After (LLM Gateway - single provider for all models)
+import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { generateText } from "ai";
+
+const llmgateway = createLLMGateway({
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+const { text: openaiText } = await generateText({
+  model: llmgateway("openai/gpt-4o"),
+  prompt: "Hello!",
+});
+
+const { text: claudeText } = await generateText({
+  model: llmgateway("anthropic/claude-3-5-sonnet-20241022"),
+  prompt: "Hello!",
+});
+```
+
+#### Streaming Responses
+
+```typescript
+import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { streamText } from "ai";
+
+const llmgateway = createLLMGateway({
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+const { textStream } = await streamText({
+  model: llmgateway("anthropic/claude-3-5-sonnet-20241022"),
+  prompt: "Write a poem about coding",
+});
+
+for await (const text of textStream) {
+  process.stdout.write(text);
+}
+```
+
+#### Using in Next.js API Routes
+
+```typescript
+// app/api/chat/route.ts
+import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { streamText } from "ai";
+
+const llmgateway = createLLMGateway({
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = await streamText({
+    model: llmgateway("openai/gpt-4o"),
+    messages,
+  });
+
+  return result.toDataStreamResponse();
+}
+```
+
+#### Alternative: Using OpenAI SDK Adapter
+
+If you prefer not to install a new package, you can use `@ai-sdk/openai` with a custom base URL:
+
+```typescript
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+const llmgateway = createOpenAI({
+  baseURL: "https://api.llmgateway.io/v1",
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+const { text } = await generateText({
+  model: llmgateway("openai/gpt-4o"),
+  prompt: "Hello!",
+});
+```
+
+### 4. Update Environment Variables
+
+```bash
+# Remove individual provider keys (optional - can keep as backup)
+# OPENAI_API_KEY=sk-...
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# Add LLM Gateway key
+export LLM_GATEWAY_API_KEY=llmgtwy_your_key_here
+```
+
+## Model Name Format
+
+LLM Gateway supports two model ID formats:
+
+**Root Model IDs** (without provider prefix) - Uses smart routing to automatically select the best provider based on uptime, throughput, price, and latency:
+
+```
+gpt-4o
+claude-3-5-sonnet-20241022
+gemini-1.5-pro
+```
+
+**Provider-Prefixed Model IDs** - Routes to a specific provider with automatic failover if uptime drops below 90%:
+
+```
+openai/gpt-4o
+anthropic/claude-3-5-sonnet-20241022
+google-ai-studio/gemini-1.5-pro
+```
+
+For more details on routing behavior, see the [routing documentation](https://docs.llmgateway.io/features/routing).
+
+### Model Mapping Examples
+
+| Vercel AI SDK                             | LLM Gateway                                                                                        |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `openai("gpt-4o")`                        | `llmgateway("gpt-4o")` or `llmgateway("openai/gpt-4o")`                                            |
+| `anthropic("claude-3-5-sonnet-20241022")` | `llmgateway("claude-3-5-sonnet-20241022")` or `llmgateway("anthropic/claude-3-5-sonnet-20241022")` |
+| `google("gemini-1.5-pro")`                | `llmgateway("gemini-1.5-pro")` or `llmgateway("google-ai-studio/gemini-1.5-pro")`                  |
+
+Check the [models page](/models) for the full list of available models.
+
+## Tool Calling
+
+LLM Gateway supports tool calling through the AI SDK:
+
+```typescript
+import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { generateText, tool } from "ai";
+import { z } from "zod";
+
+const llmgateway = createLLMGateway({
+  apiKey: process.env.LLM_GATEWAY_API_KEY,
+});
+
+const { text, toolResults } = await generateText({
+  model: llmgateway("openai/gpt-4o"),
+  tools: {
+    weather: tool({
+      description: "Get the weather for a location",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      execute: async ({ location }) => {
+        return { temperature: 72, condition: "sunny" };
+      },
+    }),
+  },
+  prompt: "What's the weather in San Francisco?",
+});
+```
+
+## Benefits After Migration
+
+- **Unified API Key**: One API key for all providers instead of managing multiple
+- **Response Caching**: Automatic caching reduces costs for repeated requests
+- **Cost Analytics**: Track spending per model, per request, with detailed breakdowns
+- **Smart Routing**: Automatic provider selection and failover for reliability
+- **Self-Hosting**: Deploy on your own infrastructure for complete control
+- **No Vendor Lock-in**: OpenAI-compatible API works with any client
+
+## Self-Hosting LLM Gateway
+
+If you prefer self-hosting, LLM Gateway is available under AGPLv3:
+
+```bash
+git clone https://github.com/llmgateway/llmgateway
+cd llmgateway
+pnpm install
+pnpm setup
+pnpm dev
+```
+
+This gives you the same managed experience with full control over your infrastructure.
+
+## Need Help?
+
+- Browse available models at [llmgateway.io/models](/models)
+- Read the [API documentation](https://docs.llmgateway.io)
+- Contact support at contact@llmgateway.io


### PR DESCRIPTION
## Summary
- Add migration guides section to the landing page hero
- Create dedicated migration content pages for OpenRouter, LiteLLM, and Vercel AI Gateway
- Add migrations content collection for managing migration guide content

## Test plan
- [ ] Verify migration guides display correctly on the landing page
- [ ] Test navigation to individual migration guide pages
- [ ] Check responsive layout for migration links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Migration Guides section featuring step-by-step instructions for migrating from OpenRouter, Vercel AI Gateway, and LiteLLM to LLM Gateway.
  * Integrated migration guides on the homepage with quick access links to detailed migration documentation.
  * Each migration guide includes feature comparisons, code examples, and configuration details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->