### PR TITLE
chore: deprecate claude-3-5-haiku-20241022

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -70,6 +70,8 @@ export const anthropicModels = [
 				tools: true,
 				webSearch: true,
 				webSearchPrice: 0.01, // $10 per 1000 searches
+				deprecatedAt: new Date("2026-01-21"),
+				deactivatedAt: new Date("2026-02-19T17:00:00Z"),
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
- Add deprecation dates for `claude-3-5-haiku-20241022` model based on Anthropic's deprecation announcement

| Field | Value | Meaning |
|-------|-------|---------|
| `deprecatedAt` | `2026-01-21` | Date of deprecation announcement |
| `deactivatedAt` | `2026-02-19T17:00:00Z` | February 19, 2026 at 9 AM PT (service end) |

## Test plan
- [x] Build passes
- [x] Format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Claude 3.7 Sonnet model deprecation schedule has been announced. The model will be deprecated on January 21, 2026, and fully deactivated on February 19, 2026.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->