### PR TITLE
fix(auth): handle passkey autofill response

### DIFF
--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -74,7 +74,22 @@ function LoginForm() {
 
 	useEffect(() => {
 		if (window.PublicKeyCredential) {
-			void signIn.passkey({ autoFill: true });
+			signIn.passkey({ autoFill: true }).then((res) => {
+				if (res?.data) {
+					queryClient.clear();
+					if (posthogKey) {
+						posthog.capture("user_logged_in", { method: "passkey" });
+					}
+					router.push(returnUrl);
+				} else if (res?.error) {
+					toast.error(res.error.message || "Failed to sign in with passkey", {
+						style: {
+							backgroundColor: "var(--destructive)",
+							color: "var(--destructive-foreground)",
+						},
+					});
+				}
+			});
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);

--- a/apps/playground/src/app/login/page.tsx
+++ b/apps/playground/src/app/login/page.tsx
@@ -69,7 +69,20 @@ export default function Login() {
 
 	useEffect(() => {
 		if (window.PublicKeyCredential) {
-			void signIn.passkey({ autoFill: true });
+			signIn.passkey({ autoFill: true }).then((res) => {
+				if (res?.data) {
+					queryClient.clear();
+					posthog.capture("user_logged_in", { method: "passkey" });
+					router.push(returnUrl);
+				} else if (res?.error) {
+					toast.error(res.error.message || "Failed to sign in with passkey", {
+						style: {
+							backgroundColor: "var(--destructive)",
+							color: "var(--destructive-foreground)",
+						},
+					});
+				}
+			});
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []); // Only run once on mount for autofill

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -62,7 +62,18 @@ export default function Login() {
 
 	useEffect(() => {
 		if (window.PublicKeyCredential) {
-			void signIn.passkey({ autoFill: true });
+			signIn.passkey({ autoFill: true }).then((res) => {
+				if (res?.data) {
+					queryClient.clear();
+					posthog.capture("user_logged_in", { method: "passkey" });
+					router.push("/dashboard");
+				} else if (res?.error) {
+					toast({
+						title: res.error.message || "Failed to sign in with passkey",
+						variant: "destructive",
+					});
+				}
+			});
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []); // Only run once on mount for autofill


### PR DESCRIPTION
## Summary
- Fix 1Password passkey autofill not triggering redirect on successful authentication
- Add error toast when passkey authentication fails (e.g., passkey not found)

## Test plan
- [ ] Test passkey autofill with 1Password - clicking suggestion should now redirect to dashboard
- [ ] Test with invalid/deleted passkey - should show error toast with "Passkey not found" message
- [ ] Verify explicit "Sign in with passkey" button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passkey sign-in error handling with user-facing error messages displayed as notifications.
  * Enhanced sign-in flow with proper feedback on authentication failures.

* **Improvements**
  * Added analytics tracking for successful passkey authentications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->