### PR TITLE
fix(auth): suppress error on passkey cancellation

### DIFF
--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -82,6 +82,10 @@ function LoginForm() {
 					}
 					router.push(returnUrl);
 				} else if (res?.error) {
+					// Don't show error for user cancellation - this is expected when user dismisses passkey prompt
+					if (res.error.message?.toLowerCase().includes("cancelled")) {
+						return;
+					}
 					toast.error(res.error.message || "Failed to sign in with passkey", {
 						style: {
 							backgroundColor: "var(--destructive)",

--- a/apps/playground/src/app/login/page.tsx
+++ b/apps/playground/src/app/login/page.tsx
@@ -75,6 +75,10 @@ export default function Login() {
 					posthog.capture("user_logged_in", { method: "passkey" });
 					router.push(returnUrl);
 				} else if (res?.error) {
+					// Don't show error for user cancellation - this is expected when user dismisses passkey prompt
+					if (res.error.message?.toLowerCase().includes("cancelled")) {
+						return;
+					}
 					toast.error(res.error.message || "Failed to sign in with passkey", {
 						style: {
 							backgroundColor: "var(--destructive)",

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -68,6 +68,10 @@ export default function Login() {
 					posthog.capture("user_logged_in", { method: "passkey" });
 					router.push("/dashboard");
 				} else if (res?.error) {
+					// Don't show error for user cancellation - this is expected when user dismisses passkey prompt
+					if (res.error.message?.toLowerCase().includes("cancelled")) {
+						return;
+					}
 					toast({
 						title: res.error.message || "Failed to sign in with passkey",
 						variant: "destructive",


### PR DESCRIPTION
When user dismisses the passkey prompt on login, the error message "auth cancelled" is returned. This is not an actual error - it's a normal user action. Skip displaying the toast notification for cancellation errors during autofill.

Fixes the issue where users would see an error toast when they choose not to use passkey authentication.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passkey sign-in experience by removing unnecessary error notifications when users cancel authentication prompts. Canceling a passkey request no longer displays an error message. Other authentication errors continue to show appropriate notifications to help users resolve login issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->