### PR TITLE
fix(gateway): track uptime for used provider

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1832,7 +1832,11 @@ chat.openapi(completions, async (c) => {
 		);
 	}
 
-	const baseModelName = finalModelInfo?.id || usedModel;
+	// Use the canonical model ID from modelInfo (set before any routing/fallback)
+	// This ensures correct stats tracking when low-uptime fallback changes the provider
+	// Fall back to finalModelInfo.id or usedModel for edge cases like custom providers
+	const baseModelName =
+		(modelInfo as ModelDefinition)?.id || finalModelInfo?.id || usedModel;
 
 	// Check if this is an image generation model
 	const imageGenProviderMapping = finalModelInfo?.providers.find(

--- a/apps/worker/src/services/stats-calculator.spec.ts
+++ b/apps/worker/src/services/stats-calculator.spec.ts
@@ -569,7 +569,7 @@ describe("stats-calculator", () => {
 					duration: 2000,
 					requestedModel: "gpt-4",
 					requestedProvider: "anthropic",
-					usedModel: "openai/gpt-4",
+					usedModel: "anthropic/gpt-4", // Must match usedProvider for correct stats tracking
 					usedProvider: "anthropic",
 					responseSize: 150,
 					hasError: true,


### PR DESCRIPTION
## Summary

- Fixes uptime tracking to use the actual provider that handled a request, not the originally requested one
- When low-uptime fallback routes to a different provider, stats are now correctly attributed to the fallback provider
- Fixes test data inconsistency where `usedModel` had wrong provider prefix

## Test plan

- [x] Existing stats-calculator tests pass (17 tests)
- [x] Provider-metrics tests pass (19 tests)
- [x] Build succeeds
- [ ] Verify uptime stats are correctly attributed after low-uptime fallback in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model identifier resolution to ensure the correct model is used for statistics and logging when routing or fallback occurs.

* **Tests**
  * Aligned test data to ensure model and provider pairs are correctly matched in statistics calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->