### PR TITLE
fix(gateway): only fallback to better uptime

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1595,34 +1595,34 @@ chat.openapi(completions, async (c) => {
 						};
 
 						if (cheapestResult) {
-							usedProvider = cheapestResult.provider.providerId;
-							usedModel = cheapestResult.provider.modelName;
-							routingMetadata = {
-								...cheapestResult.metadata,
-								selectionReason: "low-uptime-fallback",
-								originalProvider: requestedProvider,
-								originalProviderUptime: metrics.uptime,
-								// Add the original provider's score to the scores array
-								providerScores: [
-									originalProviderScore,
-									...cheapestResult.metadata.providerScores,
-								],
-							};
-						} else {
-							// Use first available provider as fallback
-							usedProvider = availableModelProviders[0].providerId;
-							usedModel = availableModelProviders[0].modelName;
-							routingMetadata = {
-								availableProviders: availableModelProviders.map(
-									(p) => p.providerId,
-								),
-								selectedProvider: usedProvider,
-								selectionReason: "low-uptime-fallback",
-								providerScores: [originalProviderScore],
-								originalProvider: requestedProvider,
-								originalProviderUptime: metrics.uptime,
-							};
+							// Check if the fallback provider has better uptime than the original
+							// If no metrics exist for the fallback, assume it's 100% (no data = assume good)
+							const fallbackMetrics = allMetricsMap.get(
+								`${modelWithPricing.id}:${cheapestResult.provider.providerId}`,
+							);
+							const fallbackUptime = fallbackMetrics?.uptime ?? 100;
+
+							// Only fall back if the alternative has better uptime
+							// This prevents falling back to a provider that's equally bad or worse
+							if (fallbackUptime > metrics.uptime) {
+								usedProvider = cheapestResult.provider.providerId;
+								usedModel = cheapestResult.provider.modelName;
+								routingMetadata = {
+									...cheapestResult.metadata,
+									selectionReason: "low-uptime-fallback",
+									originalProvider: requestedProvider,
+									originalProviderUptime: metrics.uptime,
+									// Add the original provider's score to the scores array
+									providerScores: [
+										originalProviderScore,
+										...cheapestResult.metadata.providerScores,
+									],
+								};
+							}
+							// If fallback is not better, don't change usedProvider (keep original)
 						}
+						// Note: removed the else branch - if no good fallback exists,
+						// we keep the original provider instead of blindly using first available
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Only perform low-uptime fallback when the alternative provider has better uptime
- Prevents falling back from a provider with 62% uptime to one with 0% uptime
- If no better alternative exists, stick with the original provider

## Problem
When `google-ai-studio` had 62% uptime (below the 90% threshold), the system was falling back to `google-vertex` which had **0% uptime** - making the situation worse and incorrectly penalizing `google-ai-studio`'s uptime score.

## Test plan
- [x] Unit tests pass
- [ ] Verify fallback only occurs when alternative has better uptime
- [ ] Verify original provider is used when no better alternatives exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced provider selection logic to prioritize fallback providers only when they offer better reliability, improving overall service stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->