### PR TITLE
fix(auth): trigger notifications for OAuth signups

### DIFF
--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -57,8 +57,10 @@ async function sendDiscordNotification(
 export async function notifyUserSignup(
 	email: string,
 	name: string | null | undefined,
+	authMethod?: string,
 ): Promise<void> {
 	const displayName = name || "Unknown";
+	const method = authMethod || "Unknown";
 
 	await sendDiscordNotification({
 		embeds: [
@@ -74,6 +76,11 @@ export async function notifyUserSignup(
 					{
 						name: "Name",
 						value: displayName,
+						inline: true,
+					},
+					{
+						name: "Auth Method",
+						value: method,
 						inline: true,
 					},
 				],


### PR DESCRIPTION
## Summary
- Fix Discord notification not triggering for GitHub OAuth signups
- Fix Resend contact creation not working for OAuth signups
- Add auth method field to Discord signup notifications (shows Email, Github, etc.)

## Test plan
- [ ] Sign up with GitHub OAuth and verify Discord notification is sent
- [ ] Verify notification includes "Github" as auth method
- [ ] Sign up with email/password and verify notification shows "Email"
- [ ] Verify Resend contact is created for OAuth signups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord signup notifications now display the authentication method used alongside user details.

* **Bug Fixes**
  * Improved OAuth signup detection to accurately identify and route provider-specific notifications.
  * Email verification notifications now include accurate provider information based on signup method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->