### PR TITLE
fix(worker): block on provider/model sync before stats

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1080,17 +1080,16 @@ export async function startWorker() {
 	shouldStop = false;
 	logger.info("Starting worker application...");
 
-	// Initialize providers and models sync
-	void syncProvidersAndModels()
-		.then(() => {
-			logger.info("Initial sync completed");
-		})
-		.catch((error) => {
-			logger.error(
-				"Error during initial sync",
-				error instanceof Error ? error : new Error(String(error)),
-			);
-		});
+	// Initialize providers and models sync - must complete before other stats syncs
+	try {
+		await syncProvidersAndModels();
+		logger.info("Initial sync completed");
+	} catch (error) {
+		logger.error(
+			"Error during initial sync",
+			error instanceof Error ? error : new Error(String(error)),
+		);
+	}
 
 	void backfillHistoryIfNeeded()
 		.then(() => {


### PR DESCRIPTION
Ensures providers and models are synced to database before starting stats calculations, which depend on model/provider data existing.

This prevents stats syncs from failing when they query for models/providers that haven't been loaded yet.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and initialization sequencing in the worker startup process. The initial provider and models synchronization now completes before the startup sequence continues, ensuring more predictable error handling during initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->