### PR TITLE
feat(worker): add traceId to request log

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -84,6 +84,7 @@ const schema = z.object({
 			responseText: z.string(),
 		})
 		.nullable(),
+	trace_id: z.string().nullable(),
 });
 
 export async function acquireLock(key: string): Promise<boolean> {
@@ -588,6 +589,7 @@ export async function batchProcessLogs(): Promise<void> {
 					reasoning_tokens: log.reasoningTokens,
 					cached_tokens: log.cachedTokens,
 					error_details: log.errorDetails,
+					trace_id: log.traceId,
 				})
 				.from(log)
 				.leftJoin(tables.project, eq(tables.project.id, log.projectId))
@@ -641,6 +643,7 @@ export async function batchProcessLogs(): Promise<void> {
 					reasoningTokens: row.reasoning_tokens,
 					cachedTokens: row.cached_tokens,
 					errorDetails: row.error_details,
+					traceId: row.trace_id,
 				});
 
 				if (row.cost && row.cost > 0 && !row.cached) {


### PR DESCRIPTION
## Summary
- Adds `traceId` field to the worker's log processing output for better request tracing
- Includes traceId in the `kind: "log-process"` log entries for correlation with OpenTelemetry traces

## Test plan
- [x] Build passes
- [ ] Verify traceId appears in worker logs when processing requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Log processing now includes optional trace ID field to improve debugging and traceability of logs across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->