### PR TITLE
fix(admin): prevent metrics API calls without session

### DIFF
--- a/apps/admin/src/lib/admin-metrics.ts
+++ b/apps/admin/src/lib/admin-metrics.ts
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+
 import { fetchServerData } from "./server-api";
 
 export interface AdminDashboardMetrics {
@@ -13,6 +15,15 @@ export interface AdminDashboardMetrics {
 }
 
 export async function getAdminDashboardMetrics(): Promise<AdminDashboardMetrics | null> {
+	const cookieStore = await cookies();
+	const key = "better-auth.session_token";
+	const sessionCookie = cookieStore.get(key);
+	const secureSessionCookie = cookieStore.get(`__Secure-${key}`);
+
+	if (!sessionCookie && !secureSessionCookie) {
+		return null;
+	}
+
 	const data = await fetchServerData<AdminDashboardMetrics>(
 		"GET",
 		"/admin/metrics",

--- a/apps/admin/src/lib/admin-token-metrics.ts
+++ b/apps/admin/src/lib/admin-token-metrics.ts
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+
 import { fetchServerData } from "./server-api";
 
 export type TokenWindow = "7d" | "30d";
@@ -23,6 +25,15 @@ export interface AdminTokenMetrics {
 export async function getAdminTokenMetrics(
 	window: TokenWindow,
 ): Promise<AdminTokenMetrics | null> {
+	const cookieStore = await cookies();
+	const key = "better-auth.session_token";
+	const sessionCookie = cookieStore.get(key);
+	const secureSessionCookie = cookieStore.get(`__Secure-${key}`);
+
+	if (!sessionCookie && !secureSessionCookie) {
+		return null;
+	}
+
 	const data = await fetchServerData<AdminTokenMetrics>(
 		"GET",
 		"/admin/tokens",


### PR DESCRIPTION
## Summary

- Check for session cookie before fetching admin metrics and token metrics
- Eliminates unnecessary 401 API calls on unauthenticated requests
- Returns null immediately if no session cookie is present, preventing spam to `/admin/metrics`

## Test plan

- [x] Build passes
- [x] No unnecessary API calls on unauthenticated requests to admin pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin dashboard metrics now require valid session authentication before retrieving data.
  * Admin token metrics now require valid session authentication before retrieving data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->