### PR TITLE
fix: classify 401 as upstream error

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -3,6 +3,7 @@
  * 5xx status codes indicate upstream provider errors
  * 429 status codes indicate upstream rate limiting (treated as upstream error)
  * 404 status codes indicate model/endpoint not found at provider (treated as upstream error)
+ * 401/403 status codes indicate authentication/authorization issues at provider (treated as upstream error)
  * Other 4xx status codes indicate client/gateway errors
  * Special client errors (like JSON format validation) are classified as client_error
  */
@@ -21,6 +22,11 @@ export function getFinishReasonFromError(
 
 	// 404 from upstream provider indicates model/endpoint not found at provider
 	if (statusCode === 404) {
+		return "upstream_error";
+	}
+
+	// 401 from upstream provider indicates invalid/expired API key at provider
+	if (statusCode === 401) {
 		return "upstream_error";
 	}
 


### PR DESCRIPTION
Treat 401 (Unauthorized) responses as upstream errors in uptime monitoring, alongside 403 and other provider-level errors. This ensures 401s are properly tracked in analytics. Keys receiving 401 are already permanently blacklisted by the round-robin routing system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for authentication and authorization failures from service providers, ensuring they are properly classified and managed by the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->