### PR TITLE
fix(models): remove unstable flag from MiniMax M2.1

### DIFF
--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -53,7 +53,6 @@ export const minimaxModels = [
 		providers: [
 			{
 				providerId: "minimax",
-				stability: "unstable",
 				modelName: "MiniMax-M2.1",
 				inputPrice: 0.27 / 1e6,
 				outputPrice: 1.1 / 1e6,


### PR DESCRIPTION
## Summary
- Remove `stability: "unstable"` flag from MiniMax M2.1 provider
- The timeout issues that originally caused this flag have been resolved

## Test plan
- [x] Ran E2E tests with `TEST_MODELS="minimax/minimax-m2.1"` - all 14 test files passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the stability property from the minimax M2.1 provider configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->