### PR TITLE
fix: increase keepAliveTimeout to prevent 502

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ ADMIN_PORT=3006
 # Health check timeout in milliseconds (defaults to 5000ms)
 TIMEOUT_MS=5000
 
+# HTTP server keep-alive timeout in seconds. Should be higher than load balancer's
+# keepalive timeout to prevent 502 errors. GCP LB uses 600s.
+# Defaults: gateway=620s, api=60s
+# KEEP_ALIVE_TIMEOUT_S=620
+
 # =============================================================================
 # WORKER CONFIGURATION
 # =============================================================================


### PR DESCRIPTION
## Summary

- Increase Node.js `keepAliveTimeout` from default 5s to prevent 502 errors from GCP Load Balancer connection reuse
- Gateway: 620s (above GCP's fixed 600s keepalive timeout)
- API: 60s
- Configurable via `KEEP_ALIVE_TIMEOUT_S` environment variable

## Problem

GCP Load Balancer has a fixed 600s keepalive timeout. Node.js default is 5s. When the Node server closes idle connections before the load balancer expects, the LB sends requests on stale connections → 502 Bad Gateway.

## Test plan

- [ ] Deploy and monitor for reduction in 502 errors
- [ ] Verify servers start correctly with default and custom timeout values

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable HTTP keep-alive timeout settings to improve connection stability and reduce connection-related errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->