### PR TITLE
fix: add streaming buffer size limit

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3247,9 +3247,9 @@ chat.openapi(completions, async (c) => {
 						chunk = new TextDecoder().decode(value);
 					}
 
-					// Warn on large chunks (1MB+)
+					// Log error on large chunks (1MB+) - should almost never happen
 					if (chunk.length > 1024 * 1024) {
-						logger.warn(
+						logger.error(
 							`Large chunk received: ${(chunk.length / 1024 / 1024).toFixed(2)}MB`,
 						);
 					}


### PR DESCRIPTION
Uncomment and re-enable the buffer size protection that prevents unbounded memory growth during streaming responses. Change default limit from 10MB to 50MB and make it configurable via MAX_STREAMING_BUFFER_MB environment variable.

This fixes OOM crashes from large streaming responses by clearing the buffer when it exceeds the configured size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable streaming buffer limit via environment variable (default 50 MB). The system now automatically manages memory by clearing buffers when they exceed the configured threshold, with warning logs for visibility.

* **Improvements**
  * Enhanced memory efficiency across all streaming operations through consistent buffer management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->