### PR TITLE
fix(gateway): add SSE keepalive pings

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4296,6 +4296,10 @@ chat.openapi(completions, async (c) => {
 					}
 				}
 
+				// Clean up keepalive before any potentially-throwing operations (insertLog, etc.)
+				// clearInterval is idempotent so calling it multiple times is safe
+				clearKeepalive();
+
 				// Check if we should bill cancelled requests
 				const billCancelledRequests = shouldBillCancelledRequests();
 
@@ -4512,9 +4516,6 @@ chat.openapi(completions, async (c) => {
 					}
 				}
 			}
-
-			// Clean up keepalive on normal completion
-			clearKeepalive();
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Adds periodic SSE comment pings (`: ping`) every 15 seconds during streaming responses
- Prevents proxy/load balancer timeouts by keeping connections alive through intermediate infrastructure
- SSE comments are ignored by clients per the SSE specification

## Problem
Long-running streaming requests (reasoning models, web search, tool execution) can experience 502 errors when:
- GCP Load Balancer `backendServices.timeoutSec` (default 30s) is exceeded
- Nginx `proxy_read_timeout` (default 60s) is exceeded
- Other intermediate proxies kill "idle" connections

The issue occurs during the gap between when streaming starts and when the first token arrives from the upstream provider.

## Solution
Send SSE comment lines (`: ping\n\n`) every 15 seconds. Per the SSE specification, lines starting with `:` are comment lines that clients ignore, but they still:
1. Send bytes over the wire
2. Keep TCP connections alive
3. Reset proxy/load balancer idle timers

## Test plan
- [ ] Manual test with streaming requests to verify pings are sent
- [ ] Verify SSE clients (EventSource) ignore the ping comments
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added keepalive mechanism for chat streaming to maintain connection stability during active sessions, preventing potential timeouts for extended conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->