### PR TITLE
fix(chat): close response reader to prevent fd leak

### DIFF
--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -133,6 +133,9 @@ chat.openapi(completionRoute, async (c) => {
 						data: JSON.stringify({ error: "Streaming failed" }),
 						event: "error",
 					});
+				} finally {
+					// Clean up the reader to prevent file descriptor leaks
+					await reader.cancel();
 				}
 			});
 		} else {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4037,6 +4037,8 @@ chat.openapi(completions, async (c) => {
 					};
 				}
 			} finally {
+				// Clean up the reader to prevent file descriptor leaks
+				await reader.cancel();
 				// Clean up the event listeners
 				c.req.raw.signal.removeEventListener("abort", onAbort);
 


### PR DESCRIPTION
## Summary
- Add `reader.cancel()` in finally block of gateway streaming handler to properly release file descriptors
- Add finally block with `reader.cancel()` to API chat streaming handler

Previously, the response body reader was never closed, leaking file descriptors under load.

## Test plan
- [x] Build passes
- [ ] Verify no file descriptor leaks under sustained streaming load

🤖 Generated with [Claude Code](https://claude.com/claude-code)