### PR TITLE
fix: separate error classification from health tracking

### DIFF
--- a/apps/gateway/src/lib/api-key-health.ts
+++ b/apps/gateway/src/lib/api-key-health.ts
@@ -1,6 +1,10 @@
 /**
  * In-memory API key health tracking for uptime-aware routing
  * Tracks consecutive errors per API key and temporarily blacklists unhealthy keys
+ *
+ * Note: Health tracking is separate from error classification (get-finish-reason-from-error.ts).
+ * While 401/403 errors are classified as "gateway_error" for logging purposes,
+ * they are still tracked here for uptime routing to permanently blacklist invalid keys.
  */
 
 export interface KeyHealth {


### PR DESCRIPTION
## Summary
- Separates error classification (for logging) from health tracking (for uptime routing)
- 401/403 errors are now classified as `gateway_error` for proper logging/analytics
- Health tracking independently handles 401/403 for permanent key blacklisting (unchanged behavior)

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All unit tests pass (`pnpm test:unit`)
- [ ] Manual test with invalid API key to verify health tracking still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal error classification and health tracking logic for improved gateway infrastructure stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->