### PR TITLE
fix: prevent test deadlock in auth config tests

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -51,31 +51,21 @@ describe("API auth configuration", () => {
 
 describe("API auth hooks functionality", () => {
 	beforeEach(async () => {
-		// Clean up any existing data
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-
-		await Promise.all([
-			db.delete(tables.organization),
-			db.delete(tables.user),
-			db.delete(tables.account),
-		]);
+		// Clean up any existing data (sequential to avoid deadlocks)
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.project);
+		await db.delete(tables.account);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
 	});
 
 	afterEach(async () => {
-		// Clean up after tests
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-
-		await Promise.all([
-			db.delete(tables.organization),
-			db.delete(tables.user),
-			db.delete(tables.account),
-		]);
+		// Clean up after tests (sequential to avoid deadlocks)
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.project);
+		await db.delete(tables.account);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
 	});
 
 	test("should create default organization and project on signup", async () => {
@@ -180,34 +170,24 @@ describe("API auth hooks functionality", () => {
 
 describe("Auth rate limiting", () => {
 	beforeEach(async () => {
-		// Clean up any existing data
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-
-		await Promise.all([
-			db.delete(tables.organization),
-			db.delete(tables.user),
-			db.delete(tables.account),
-		]);
+		// Clean up any existing data (sequential to avoid deadlocks)
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.project);
+		await db.delete(tables.account);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
 
 		// Clear Redis rate limit data
 		await redisClient.flushdb();
 	});
 
 	afterEach(async () => {
-		// Clean up after tests
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-
-		await Promise.all([
-			db.delete(tables.organization),
-			db.delete(tables.user),
-			db.delete(tables.account),
-		]);
+		// Clean up after tests (sequential to avoid deadlocks)
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.project);
+		await db.delete(tables.account);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
 
 		// Clear Redis rate limit data
 		await redisClient.flushdb();


### PR DESCRIPTION
Sequential database deletes avoid deadlocks caused by parallel deletes on related tables with foreign key constraints. Changes delete operations in the proper order: child tables before parent tables.

**Test Results:** All 376 tests pass (31 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved database cleanup reliability in test suites by adjusting cleanup execution order to prevent potential issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->