### PR TITLE
fix: hide per-request pricing when price is 0

### DIFF
--- a/apps/playground/src/components/model-selector.tsx
+++ b/apps/playground/src/components/model-selector.tsx
@@ -1208,7 +1208,8 @@ export function ModelSelector({
 														aggregate.maxOutput !== undefined;
 
 													const hasImagePricing =
-														aggregate.minRequestPrice !== undefined ||
+														(aggregate.minRequestPrice !== undefined &&
+															aggregate.minRequestPrice > 0) ||
 														aggregate.minImageInputPrice !== undefined ||
 														aggregate.minImageOutputPrice !== undefined;
 
@@ -1281,19 +1282,21 @@ export function ModelSelector({
 															{hasImagePricing && (
 																<div className="pt-2">
 																	<div className="grid grid-cols-2 gap-3">
-																		{aggregate.minRequestPrice !==
-																			undefined && (
-																			<div className="space-y-1">
-																				<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-																					Per Request
-																				</span>
-																				<p className="text-xs font-mono">
-																					$
-																					{aggregate.minRequestPrice.toFixed(3)}
-																					/req
-																				</p>
-																			</div>
-																		)}
+																		{aggregate.minRequestPrice !== undefined &&
+																			aggregate.minRequestPrice > 0 && (
+																				<div className="space-y-1">
+																					<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+																						Per Request
+																					</span>
+																					<p className="text-xs font-mono">
+																						$
+																						{aggregate.minRequestPrice.toFixed(
+																							3,
+																						)}
+																						/req
+																					</p>
+																				</div>
+																			)}
 																		{aggregate.minImageInputPrice !==
 																			undefined && (
 																			<div className="space-y-1">
@@ -1486,39 +1489,41 @@ export function ModelSelector({
 														previewEntry.mapping?.imageInputPrice) && (
 														<div className="pt-2">
 															<div className="grid grid-cols-2 gap-3">
-																{previewEntry.mapping?.requestPrice !==
-																	undefined && (
-																	<div className="space-y-1">
-																		<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-																			Per Request
-																		</span>
-																		<p className="text-xs font-mono">
-																			{(() => {
-																				const price = getMappingPriceInfo(
-																					previewEntry.mapping,
-																					"request",
-																				);
-																				if (
-																					price.original &&
-																					price.discounted &&
-																					price.original !== price.discounted
-																				) {
-																					return (
-																						<>
-																							<span className="line-through text-muted-foreground">
-																								{price.original}
-																							</span>{" "}
-																							<span className="text-green-500">
-																								{price.discounted}
-																							</span>
-																						</>
+																{previewEntry.mapping?.requestPrice &&
+																	parseFloat(
+																		previewEntry.mapping.requestPrice,
+																	) > 0 && (
+																		<div className="space-y-1">
+																			<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+																				Per Request
+																			</span>
+																			<p className="text-xs font-mono">
+																				{(() => {
+																					const price = getMappingPriceInfo(
+																						previewEntry.mapping,
+																						"request",
 																					);
-																				}
-																				return price.label;
-																			})()}
-																		</p>
-																	</div>
-																)}
+																					if (
+																						price.original &&
+																						price.discounted &&
+																						price.original !== price.discounted
+																					) {
+																						return (
+																							<>
+																								<span className="line-through text-muted-foreground">
+																									{price.original}
+																								</span>{" "}
+																								<span className="text-green-500">
+																									{price.discounted}
+																								</span>
+																							</>
+																						);
+																					}
+																					return price.label;
+																				})()}
+																			</p>
+																		</div>
+																	)}
 																{previewEntry.mapping?.imageInputPrice !==
 																	undefined && (
 																	<div className="space-y-1">
@@ -1677,7 +1682,8 @@ export function ModelSelector({
 												aggregate.maxOutput !== undefined;
 
 											const hasImagePricing =
-												aggregate.minRequestPrice !== undefined ||
+												(aggregate.minRequestPrice !== undefined &&
+													aggregate.minRequestPrice > 0) ||
 												aggregate.minImageInputPrice !== undefined ||
 												aggregate.minImageOutputPrice !== undefined;
 
@@ -1747,17 +1753,18 @@ export function ModelSelector({
 													{hasImagePricing && (
 														<div className="pt-2">
 															<div className="grid grid-cols-2 gap-3">
-																{aggregate.minRequestPrice !== undefined && (
-																	<div className="space-y-1">
-																		<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-																			Per Request
-																		</span>
-																		<p className="text-sm font-mono">
-																			${aggregate.minRequestPrice.toFixed(3)}
-																			/req
-																		</p>
-																	</div>
-																)}
+																{aggregate.minRequestPrice !== undefined &&
+																	aggregate.minRequestPrice > 0 && (
+																		<div className="space-y-1">
+																			<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+																				Per Request
+																			</span>
+																			<p className="text-sm font-mono">
+																				${aggregate.minRequestPrice.toFixed(3)}
+																				/req
+																			</p>
+																		</div>
+																	)}
 																{aggregate.minImageInputPrice !== undefined && (
 																	<div className="space-y-1">
 																		<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -1946,39 +1953,40 @@ export function ModelSelector({
 														Image Pricing
 													</span>
 													<div className="grid grid-cols-2 gap-3">
-														{selectedDetails.mapping?.requestPrice !==
-															undefined && (
-															<div className="space-y-1">
-																<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-																	Per Request
-																</span>
-																<p className="text-sm font-mono">
-																	{(() => {
-																		const price = getMappingPriceInfo(
-																			selectedDetails.mapping,
-																			"request",
-																		);
-																		if (
-																			price.original &&
-																			price.discounted &&
-																			price.original !== price.discounted
-																		) {
-																			return (
-																				<>
-																					<span className="line-through text-muted-foreground">
-																						{price.original}
-																					</span>{" "}
-																					<span className="text-green-500">
-																						{price.discounted}
-																					</span>
-																				</>
+														{selectedDetails.mapping?.requestPrice &&
+															parseFloat(selectedDetails.mapping.requestPrice) >
+																0 && (
+																<div className="space-y-1">
+																	<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+																		Per Request
+																	</span>
+																	<p className="text-sm font-mono">
+																		{(() => {
+																			const price = getMappingPriceInfo(
+																				selectedDetails.mapping,
+																				"request",
 																			);
-																		}
-																		return price.label;
-																	})()}
-																</p>
-															</div>
-														)}
+																			if (
+																				price.original &&
+																				price.discounted &&
+																				price.original !== price.discounted
+																			) {
+																				return (
+																					<>
+																						<span className="line-through text-muted-foreground">
+																							{price.original}
+																						</span>{" "}
+																						<span className="text-green-500">
+																							{price.discounted}
+																						</span>
+																					</>
+																				);
+																			}
+																			return price.label;
+																		})()}
+																	</p>
+																</div>
+															)}
 														{selectedDetails.mapping?.imageInputPrice !==
 															undefined && (
 															<div className="space-y-1">

--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -357,7 +357,7 @@ export function ModelProviderCard({
 							</div>
 						</div>
 					)}
-					{provider.requestPrice !== undefined && (
+					{provider.requestPrice !== undefined && provider.requestPrice > 0 && (
 						<div className="grid grid-cols-3 gap-3 mt-3">
 							<div className="col-span-3">
 								<div className="text-muted-foreground text-xs mb-1">

--- a/apps/ui/src/components/models/models-list.tsx
+++ b/apps/ui/src/components/models/models-list.tsx
@@ -185,11 +185,12 @@ export function ModelsList() {
 											tokens
 										</div>
 									)}
-									{provider.requestPrice !== undefined && (
-										<div>
-											Request: ${provider.requestPrice * 1000} / 1K requests
-										</div>
-									)}
+									{provider.requestPrice !== undefined &&
+										provider.requestPrice > 0 && (
+											<div>
+												Request: ${provider.requestPrice * 1000} / 1K requests
+											</div>
+										)}
 								</div>
 							))}
 						</div>

--- a/packages/shared/src/components/model-selector.tsx
+++ b/packages/shared/src/components/model-selector.tsx
@@ -1190,7 +1190,8 @@ export function ModelSelector({
 														aggregate.maxOutput !== undefined;
 
 													const hasImagePricing =
-														aggregate.minRequestPrice !== undefined ||
+														(aggregate.minRequestPrice !== undefined &&
+															aggregate.minRequestPrice > 0) ||
 														aggregate.minImageInputPrice !== undefined ||
 														aggregate.minImageOutputPrice !== undefined;
 
@@ -1263,19 +1264,21 @@ export function ModelSelector({
 															{hasImagePricing && (
 																<div className="pt-2">
 																	<div className="grid grid-cols-2 gap-3">
-																		{aggregate.minRequestPrice !==
-																			undefined && (
-																			<div className="space-y-1">
-																				<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-																					Per Request
-																				</span>
-																				<p className="text-xs font-mono">
-																					$
-																					{aggregate.minRequestPrice.toFixed(3)}
-																					/req
-																				</p>
-																			</div>
-																		)}
+																		{aggregate.minRequestPrice !== undefined &&
+																			aggregate.minRequestPrice > 0 && (
+																				<div className="space-y-1">
+																					<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+																						Per Request
+																					</span>
+																					<p className="text-xs font-mono">
+																						$
+																						{aggregate.minRequestPrice.toFixed(
+																							3,
+																						)}
+																						/req
+																					</p>
+																				</div>
+																			)}
 																		{aggregate.minImageInputPrice !==
 																			undefined && (
 																			<div className="space-y-1">
@@ -1473,38 +1476,39 @@ export function ModelSelector({
 															</span>
 															<div className="grid grid-cols-2 gap-3">
 																{previewEntry.mapping?.requestPrice !==
-																	undefined && (
-																	<div className="space-y-1">
-																		<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-																			Per Request
-																		</span>
-																		<p className="text-xs font-mono">
-																			{(() => {
-																				const price = getMappingPriceInfo(
-																					previewEntry.mapping,
-																					"request",
-																				);
-																				if (
-																					price.original &&
-																					price.discounted &&
-																					price.original !== price.discounted
-																				) {
-																					return (
-																						<>
-																							<span className="line-through text-muted-foreground">
-																								{price.original}
-																							</span>{" "}
-																							<span className="text-green-500">
-																								{price.discounted}
-																							</span>
-																						</>
+																	undefined &&
+																	previewEntry.mapping?.requestPrice > 0 && (
+																		<div className="space-y-1">
+																			<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+																				Per Request
+																			</span>
+																			<p className="text-xs font-mono">
+																				{(() => {
+																					const price = getMappingPriceInfo(
+																						previewEntry.mapping,
+																						"request",
 																					);
-																				}
-																				return price.label;
-																			})()}
-																		</p>
-																	</div>
-																)}
+																					if (
+																						price.original &&
+																						price.discounted &&
+																						price.original !== price.discounted
+																					) {
+																						return (
+																							<>
+																								<span className="line-through text-muted-foreground">
+																									{price.original}
+																								</span>{" "}
+																								<span className="text-green-500">
+																									{price.discounted}
+																								</span>
+																							</>
+																						);
+																					}
+																					return price.label;
+																				})()}
+																			</p>
+																		</div>
+																	)}
 																{previewEntry.mapping?.imageInputPrice !==
 																	undefined && (
 																	<div className="space-y-1">
@@ -1696,7 +1700,8 @@ export function ModelSelector({
 												aggregate.maxOutput !== undefined;
 
 											const hasImagePricing =
-												aggregate.minRequestPrice !== undefined ||
+												(aggregate.minRequestPrice !== undefined &&
+													aggregate.minRequestPrice > 0) ||
 												aggregate.minImageInputPrice !== undefined ||
 												aggregate.minImageOutputPrice !== undefined;
 
@@ -1766,17 +1771,18 @@ export function ModelSelector({
 													{hasImagePricing && (
 														<div className="pt-2">
 															<div className="grid grid-cols-2 gap-3">
-																{aggregate.minRequestPrice !== undefined && (
-																	<div className="space-y-1">
-																		<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-																			Per Request
-																		</span>
-																		<p className="text-sm font-mono">
-																			${aggregate.minRequestPrice.toFixed(3)}
-																			/req
-																		</p>
-																	</div>
-																)}
+																{aggregate.minRequestPrice !== undefined &&
+																	aggregate.minRequestPrice > 0 && (
+																		<div className="space-y-1">
+																			<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+																				Per Request
+																			</span>
+																			<p className="text-sm font-mono">
+																				${aggregate.minRequestPrice.toFixed(3)}
+																				/req
+																			</p>
+																		</div>
+																	)}
 																{aggregate.minImageInputPrice !== undefined && (
 																	<div className="space-y-1">
 																		<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -1967,38 +1973,39 @@ export function ModelSelector({
 													</span>
 													<div className="grid grid-cols-2 gap-3">
 														{selectedDetails.mapping?.requestPrice !==
-															undefined && (
-															<div className="space-y-1">
-																<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-																	Per Request
-																</span>
-																<p className="text-sm font-mono">
-																	{(() => {
-																		const price = getMappingPriceInfo(
-																			selectedDetails.mapping,
-																			"request",
-																		);
-																		if (
-																			price.original &&
-																			price.discounted &&
-																			price.original !== price.discounted
-																		) {
-																			return (
-																				<>
-																					<span className="line-through text-muted-foreground">
-																						{price.original}
-																					</span>{" "}
-																					<span className="text-green-500">
-																						{price.discounted}
-																					</span>
-																				</>
+															undefined &&
+															selectedDetails.mapping?.requestPrice > 0 && (
+																<div className="space-y-1">
+																	<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+																		Per Request
+																	</span>
+																	<p className="text-sm font-mono">
+																		{(() => {
+																			const price = getMappingPriceInfo(
+																				selectedDetails.mapping,
+																				"request",
 																			);
-																		}
-																		return price.label;
-																	})()}
-																</p>
-															</div>
-														)}
+																			if (
+																				price.original &&
+																				price.discounted &&
+																				price.original !== price.discounted
+																			) {
+																				return (
+																					<>
+																						<span className="line-through text-muted-foreground">
+																							{price.original}
+																						</span>{" "}
+																						<span className="text-green-500">
+																							{price.discounted}
+																						</span>
+																					</>
+																				);
+																			}
+																			return price.label;
+																		})()}
+																	</p>
+																</div>
+															)}
 														{selectedDetails.mapping?.imageInputPrice !==
 															undefined && (
 															<div className="space-y-1">


### PR DESCRIPTION
## Summary

Fixed an issue where the "Per Request" pricing section was displaying with discount styling even when the request price was 0 or not set. Now the section is completely hidden when the price is not greater than 0.

## Changes

- Updated model card components to check if request price > 0 before displaying
- Applied fixes across both shared and app-specific model selector components
- Includes fixes for playground and UI components

## Testing

Build and format checks pass successfully. All pricing logic properly validates request price before rendering the per-request section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved per-request pricing visibility in model selectors by filtering out zero-value pricing entries, ensuring only positive-cost options are displayed across all pricing views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->