### PR TITLE
fix(playground): add schema for MCP generate-image tool

### DIFF
--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -477,6 +477,55 @@ export async function POST(req: Request) {
 								return { response: extracted };
 							},
 						});
+					} else if (toolName === "generate-image") {
+						// Generate image tool - requires prompt parameter
+						allTools[prefixedName] = tool({
+							description:
+								"Generate images from text prompts using AI image generation models. Returns generated images based on the provided description.",
+							inputSchema: z.object({
+								prompt: z
+									.string()
+									.describe(
+										"Text description of the image to generate, e.g. 'a futuristic city skyline at sunset with flying cars'",
+									),
+								model: z
+									.string()
+									.optional()
+									.default("qwen-image-plus")
+									.describe(
+										"Image generation model to use (e.g., 'qwen-image-plus', 'qwen-image-max')",
+									),
+								size: z
+									.string()
+									.optional()
+									.default("1024x1024")
+									.describe(
+										"Image size in WxH format (e.g., '1024x1024', '1024x768', '768x1024')",
+									),
+								n: z
+									.number()
+									.optional()
+									.default(1)
+									.describe("Number of images to generate (1-4)"),
+							}),
+							execute: async (args) => {
+								const result = await originalTool.execute(args);
+								const extracted = extractMcpResult(result);
+								return { images: extracted };
+							},
+						});
+					} else if (toolName === "list-image-models") {
+						// List image models tool - no required parameters
+						allTools[prefixedName] = tool({
+							description:
+								"List all available image generation models with their capabilities and pricing. Use this to discover which models can be used with generate-image.",
+							inputSchema: z.object({}),
+							execute: async (args) => {
+								const result = await originalTool.execute(args);
+								const extracted = extractMcpResult(result);
+								return { models: extracted };
+							},
+						});
 					} else {
 						// For unknown tools, use a permissive schema
 						allTools[prefixedName] = tool({


### PR DESCRIPTION
## Summary
- Added explicit input schemas for `generate-image` and `list-image-models` MCP tools in the playground chat route
- Previously these tools fell into the generic passthrough schema handler (`z.object({}).passthrough()`) which didn't specify required parameters
- This caused LLMs to call `generate-image` with empty parameters `{}`, resulting in validation errors

## Root Cause
When MCP tools are loaded in the playground, they are wrapped with AI SDK tool definitions. The code had explicit schemas for `list-models` and `chat` tools, but `generate-image` and `list-image-models` fell into the generic else block that used a permissive passthrough schema.

Without knowing the required parameters, the LLM would call the tool without the required `prompt` parameter.

## Test plan
- [ ] Test using `generate-image` tool in playground with MCP enabled
- [ ] Verify the LLM correctly extracts the prompt from user messages
- [ ] Verify `list-image-models` tool works without parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generate images via chat interface with customizable prompt, model, size, and quantity options
  * Display available image generation models

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->