### PR TITLE
fix(gateway): allow all origins for CORS

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -70,14 +70,7 @@ app.use("*", honoRequestLogger);
 app.use(
 	"*",
 	cors({
-		origin: process.env.ORIGIN_URLS?.split(",") || [
-			"https://docs.llmgateway.io",
-			"http://localhost:3002",
-			"http://localhost:3003",
-			"http://localhost:3004",
-			"http://localhost:3005",
-			"http://localhost:3006",
-		],
+		origin: "*",
 		allowHeaders: [
 			"Content-Type",
 			"Authorization",
@@ -88,7 +81,6 @@ app.use(
 		allowMethods: ["POST", "GET", "OPTIONS", "PUT", "PATCH", "DELETE"],
 		exposeHeaders: ["Content-Length", "mcp-session-id"],
 		maxAge: 600,
-		credentials: true,
 	}),
 );
 


### PR DESCRIPTION
## Summary
- Fix CORS blocking external clients (e.g., `control.triplo.ai`) from accessing the gateway API
- Change CORS origin from restrictive list to `"*"` since this is a public API
- Remove `credentials: true` (incompatible with wildcard origin, and not needed since the API uses Bearer token authentication)

## Test plan
- [ ] Verify external clients can make requests to `/v1/models` without CORS errors
- [ ] Verify preflight OPTIONS requests return proper `Access-Control-Allow-Origin: *` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CORS configuration to accept requests from any origin
  * Disabled credential support for cross-origin requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->