### PR TITLE
fix(gateway): block llmgateway provider in credits mode

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1429,7 +1429,10 @@ chat.openapi(completions, async (c) => {
 	let configIndex = 0; // Index for round-robin environment variables
 	let envVarName: string | undefined; // Environment variable name for health tracking
 
-	if (project.mode === "credits" && usedProvider === "custom") {
+	if (
+		project.mode === "credits" &&
+		(usedProvider === "custom" || usedProvider === "llmgateway")
+	) {
 		throw new HTTPException(400, {
 			message:
 				"Custom providers are not supported in credits mode. Please change your project settings to API keys or hybrid mode.",


### PR DESCRIPTION
## Summary
- Fix confusing error "No API key set in environment for provider: llmgateway" when using the "custom" model in credits mode
- The "custom" model uses providerId "llmgateway", but the credits mode check only blocked `provider === "custom"`
- Now also blocks `provider === "llmgateway"` in credits mode with the correct error message

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test:unit` passes (390 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended credits-mode restrictions: The llmgateway provider is now blocked in credits mode, aligning with existing custom provider limitations. Requests using these providers in credits mode will be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->