### PR TITLE
feat(gateway): add pending log tracking for timeout detection

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -17,7 +17,12 @@ import {
 import { isCodingModel } from "@/lib/coding-models.js";
 import { calculateCosts, shouldBillCancelledRequests } from "@/lib/costs.js";
 import { throwIamException, validateModelAccess } from "@/lib/iam.js";
-import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import {
+	calculateDataStorageCost,
+	insertLog,
+	insertPendingLog,
+	updateLog,
+} from "@/lib/logs.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
 import {
@@ -1654,6 +1659,42 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
+	// Insert pending log to track requests that may timeout or be cancelled
+	// This is done before cache checks so we can detect issues with the request flow
+	let pendingLogId: string | null = null;
+	try {
+		pendingLogId = await insertPendingLog({
+			requestId,
+			organizationId: project.organizationId,
+			projectId: apiKey.projectId,
+			apiKeyId: apiKey.id,
+			requestedModel: initialRequestedModel,
+			requestedProvider: requestedProvider || null,
+			mode: project.mode,
+			usedMode: providerKey?.id ? "api-keys" : "credits",
+			messages,
+			streamed: stream || false,
+			source: source || null,
+			userAgent: userAgent || null,
+		});
+	} catch (error) {
+		// Log the error but don't fail the request - we can still process without tracking
+		logger.warn("Failed to insert pending log, continuing without tracking", {
+			requestId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	// Helper to finalize log - updates pending log if available, otherwise inserts new log
+	const finalizeLog = async (
+		logData: Parameters<typeof insertLog>[0],
+	): Promise<unknown> => {
+		if (pendingLogId) {
+			return await updateLog({ ...logData, logId: pendingLogId });
+		}
+		return await insertLog(logData);
+	};
+
 	// Check if caching is enabled for this project
 	const { enabled: cachingEnabled, duration: cacheDuration } =
 		await isCachingEnabled(project.id);
@@ -1794,7 +1835,7 @@ chat.openapi(completions, async (c) => {
 					inputImageCount,
 				);
 
-				await insertLog({
+				await finalizeLog({
 					...baseLogEntry,
 					duration: 0, // No processing time for cached response
 					timeToFirstToken: null, // Not applicable for cached response
@@ -1918,7 +1959,7 @@ chat.openapi(completions, async (c) => {
 					inputImageCount,
 				);
 
-				await insertLog({
+				await finalizeLog({
 					...baseLogEntry,
 					duration,
 					timeToFirstToken: null, // Not applicable for cached response
@@ -2306,7 +2347,7 @@ chat.openapi(completions, async (c) => {
 						undefined, // No plugin results for error case
 					);
 
-					await insertLog({
+					await finalizeLog({
 						...baseLogEntry,
 						duration: Date.now() - startTime,
 						timeToFirstToken: null,
@@ -2425,7 +2466,7 @@ chat.openapi(completions, async (c) => {
 						undefined, // No plugin results for canceled request
 					);
 
-					await insertLog({
+					await finalizeLog({
 						...baseLogEntry,
 						duration: Date.now() - startTime,
 						timeToFirstToken: null, // Not applicable for canceled request
@@ -2533,7 +2574,7 @@ chat.openapi(completions, async (c) => {
 						undefined, // No plugin results for error case
 					);
 
-					await insertLog({
+					await finalizeLog({
 						...baseLogEntry,
 						duration: Date.now() - startTime,
 						timeToFirstToken: null, // Not applicable for error case
@@ -2692,7 +2733,7 @@ chat.openapi(completions, async (c) => {
 					undefined, // No plugin results for error case
 				);
 
-				await insertLog({
+				await finalizeLog({
 					...baseLogEntry,
 					duration: Date.now() - startTime,
 					timeToFirstToken: null, // Not applicable for error case
@@ -4057,7 +4098,7 @@ chat.openapi(completions, async (c) => {
 				const shouldIncludeTokensForBilling =
 					!canceled || (canceled && billCancelledRequests);
 
-				await insertLog({
+				await finalizeLog({
 					...baseLogEntry,
 					duration,
 					timeToFirstToken,
@@ -4289,7 +4330,7 @@ chat.openapi(completions, async (c) => {
 			undefined, // No plugin results for error case
 		);
 
-		await insertLog({
+		await finalizeLog({
 			...baseLogEntry,
 			duration,
 			timeToFirstToken: null, // Not applicable for error case
@@ -4421,7 +4462,7 @@ chat.openapi(completions, async (c) => {
 			undefined, // No plugin results for canceled request
 		);
 
-		await insertLog({
+		await finalizeLog({
 			...baseLogEntry,
 			duration,
 			timeToFirstToken: null, // Not applicable for canceled request
@@ -4533,7 +4574,7 @@ chat.openapi(completions, async (c) => {
 			undefined, // No plugin results for error case
 		);
 
-		await insertLog({
+		await finalizeLog({
 			...baseLogEntry,
 			duration,
 			timeToFirstToken: null, // Not applicable for error case
@@ -4859,7 +4900,7 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	await insertLog({
+	await finalizeLog({
 		...baseLogEntry,
 		duration,
 		timeToFirstToken: null, // Not applicable for non-streaming requests

--- a/packages/cache/src/redis.ts
+++ b/packages/cache/src/redis.ts
@@ -16,6 +16,7 @@ redisClient.on("error", (err) =>
 );
 
 export const LOG_QUEUE = "log_queue_" + process.env.NODE_ENV;
+export const LOG_UPDATE_QUEUE = "log_update_queue_" + process.env.NODE_ENV;
 
 export async function publishToQueue(
 	queue: string,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -18,6 +18,7 @@ import type { errorDetails, tools, toolChoice, toolResults } from "./types.js";
 import type z from "zod";
 
 export const UnifiedFinishReason = {
+	PENDING: "pending",
 	COMPLETED: "completed",
 	LENGTH_LIMIT: "length_limit",
 	CONTENT_FILTER: "content_filter",


### PR DESCRIPTION
## Summary
- Insert pending log entry at the start of `/v1/chat/completions` requests to track requests that may timeout or be cancelled
- Add `pending` status to `UnifiedFinishReason` enum for tracking in-flight requests
- Add `insertPendingLog()` function for synchronous pending log insertion at request start
- Add `updateLog()` function and `LOG_UPDATE_QUEUE` for async log updates when request completes
- Add `processLogUpdateQueue()` worker loop to handle log updates

## Test plan
- [ ] Verify pending logs are created at request start
- [ ] Verify logs are updated to final status on successful completion
- [ ] Verify logs are updated on error/timeout/cancellation
- [ ] Query for `unifiedFinishReason='pending'` logs older than 5 minutes to detect stuck requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-flight request tracking to provide real-time visibility into ongoing operations
  * Introduced asynchronous log update capability for more accurate final state recording after request completion
  * New "pending" status to distinguish in-progress requests from completed ones

* **Infrastructure**
  * Enhanced backend worker with retry logic and queue processing for reliable log updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->