### PR TITLE
feat: enable response healing in JSON e2e tests and streaming

### DIFF
--- a/apps/gateway/src/chat-json.e2e.ts
+++ b/apps/gateway/src/chat-json.e2e.ts
@@ -54,6 +54,7 @@ describe("e2e", getConcurrentTestOptions(), () => {
 					},
 				],
 				response_format: { type: "json_object" },
+				plugins: [{ id: "response-healing" }],
 			}),
 		});
 
@@ -134,6 +135,7 @@ describe("e2e", getConcurrentTestOptions(), () => {
 						strict: true,
 					},
 				},
+				plugins: [{ id: "response-healing" }],
 			}),
 		});
 
@@ -199,6 +201,7 @@ describe("e2e", getConcurrentTestOptions(), () => {
 					],
 					response_format: { type: "json_object" },
 					stream: true,
+					plugins: [{ id: "response-healing" }],
 				}),
 			});
 
@@ -292,6 +295,7 @@ describe("e2e", getConcurrentTestOptions(), () => {
 						},
 					},
 					stream: true,
+					plugins: [{ id: "response-healing" }],
 				}),
 			});
 

--- a/apps/gateway/src/chat-response-healing.e2e.ts
+++ b/apps/gateway/src/chat-response-healing.e2e.ts
@@ -1,6 +1,7 @@
 import { serve } from "@hono/node-server";
 import "dotenv/config";
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import {
 	afterAll,
 	beforeAll,
@@ -11,7 +12,7 @@ import {
 } from "vitest";
 
 import { app } from "@/app.js";
-import { clearCache } from "@/test-utils/test-helpers.js";
+import { clearCache, readAll } from "@/test-utils/test-helpers.js";
 
 import { db, tables } from "@llmgateway/db";
 
@@ -35,6 +36,58 @@ mockServer.post("/v1/chat/completions", async (c) => {
 			},
 			500,
 		);
+	}
+
+	// Check if streaming is requested
+	const body = await c.req.json();
+	if (body.stream) {
+		// Return streaming response
+		return streamSSE(c, async (stream) => {
+			// Split content into chunks for streaming simulation
+			const chunks = mockResponseContent.split("");
+			for (let i = 0; i < chunks.length; i++) {
+				await stream.writeSSE({
+					data: JSON.stringify({
+						id: "chatcmpl-mock",
+						object: "chat.completion.chunk",
+						created: Math.floor(Date.now() / 1000),
+						model: "mock-model",
+						choices: [
+							{
+								index: 0,
+								delta: {
+									content: chunks[i],
+								},
+								finish_reason: null,
+							},
+						],
+					}),
+					id: String(i),
+				});
+			}
+			// Send final chunk with finish_reason
+			await stream.writeSSE({
+				data: JSON.stringify({
+					id: "chatcmpl-mock",
+					object: "chat.completion.chunk",
+					created: Math.floor(Date.now() / 1000),
+					model: "mock-model",
+					choices: [
+						{
+							index: 0,
+							delta: {},
+							finish_reason: "stop",
+						},
+					],
+				}),
+				id: String(chunks.length),
+			});
+			await stream.writeSSE({
+				data: "[DONE]",
+				event: "done",
+				id: String(chunks.length + 1),
+			});
+		});
 	}
 
 	return c.json({
@@ -477,6 +530,273 @@ describe("Response Healing E2E", () => {
 			// Content should be unchanged since healing failed
 			const content = json.choices[0].message.content;
 			expect(content).toBe("This is not JSON at all, just plain text.");
+		});
+	});
+
+	describe("Streaming response healing", () => {
+		test("should heal JSON wrapped in markdown code blocks when streaming", async () => {
+			setMockResponse('```json\n{"healed": true}\n```');
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "Return JSON" }],
+					response_format: { type: "json_object" },
+					plugins: [{ id: "response-healing" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasValidSSE).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter(
+					(chunk: { choices?: Array<{ delta?: { content?: string } }> }) =>
+						chunk.choices?.[0]?.delta?.content,
+				)
+				.map(
+					(chunk: { choices: Array<{ delta: { content: string } }> }) =>
+						chunk.choices[0].delta.content,
+				);
+			const fullContent = contentChunks.join("");
+
+			// The healed content should be valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			expect(JSON.parse(fullContent)).toEqual({ healed: true });
+		});
+
+		test("should heal JSON with trailing commas when streaming", async () => {
+			setMockResponse('{"name": "test", "value": 123,}');
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "Return JSON" }],
+					response_format: { type: "json_object" },
+					plugins: [{ id: "response-healing" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasValidSSE).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter(
+					(chunk: { choices?: Array<{ delta?: { content?: string } }> }) =>
+						chunk.choices?.[0]?.delta?.content,
+				)
+				.map(
+					(chunk: { choices: Array<{ delta: { content: string } }> }) =>
+						chunk.choices[0].delta.content,
+				);
+			const fullContent = contentChunks.join("");
+
+			// The healed content should be valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			expect(JSON.parse(fullContent)).toEqual({ name: "test", value: 123 });
+		});
+
+		test("should heal truncated JSON when streaming", async () => {
+			setMockResponse('{"data": {"nested": true');
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "Return JSON" }],
+					response_format: { type: "json_object" },
+					plugins: [{ id: "response-healing" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasValidSSE).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter(
+					(chunk: { choices?: Array<{ delta?: { content?: string } }> }) =>
+						chunk.choices?.[0]?.delta?.content,
+				)
+				.map(
+					(chunk: { choices: Array<{ delta: { content: string } }> }) =>
+						chunk.choices[0].delta.content,
+				);
+			const fullContent = contentChunks.join("");
+
+			// The healed content should be valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			expect(JSON.parse(fullContent)).toEqual({ data: { nested: true } });
+		});
+
+		test("should return valid JSON without healing when streaming response is already valid", async () => {
+			setMockResponse('{"message": "Hello World"}');
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "Return JSON" }],
+					response_format: { type: "json_object" },
+					plugins: [{ id: "response-healing" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasValidSSE).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter(
+					(chunk: { choices?: Array<{ delta?: { content?: string } }> }) =>
+						chunk.choices?.[0]?.delta?.content,
+				)
+				.map(
+					(chunk: { choices: Array<{ delta: { content: string } }> }) =>
+						chunk.choices[0].delta.content,
+				);
+			const fullContent = contentChunks.join("");
+
+			// The content should be valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			expect(JSON.parse(fullContent)).toEqual({ message: "Hello World" });
+		});
+
+		test("should work with json_schema response format when streaming", async () => {
+			setMockResponse(
+				'```json\n{"temperature": "72F", "conditions": "sunny"}\n```',
+			);
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "What is the weather?" }],
+					response_format: {
+						type: "json_schema",
+						json_schema: {
+							name: "weather_response",
+							description: "Weather information",
+							schema: {
+								type: "object",
+								properties: {
+									temperature: { type: "string" },
+									conditions: { type: "string" },
+								},
+								required: ["temperature", "conditions"],
+							},
+						},
+					},
+					plugins: [{ id: "response-healing" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasValidSSE).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter(
+					(chunk: { choices?: Array<{ delta?: { content?: string } }> }) =>
+						chunk.choices?.[0]?.delta?.content,
+				)
+				.map(
+					(chunk: { choices: Array<{ delta: { content: string } }> }) =>
+						chunk.choices[0].delta.content,
+				);
+			const fullContent = contentChunks.join("");
+
+			// The healed content should be valid JSON
+			expect(() => JSON.parse(fullContent)).not.toThrow();
+			expect(JSON.parse(fullContent)).toEqual({
+				temperature: "72F",
+				conditions: "sunny",
+			});
+		});
+
+		test("should not heal streaming when plugin is not enabled", async () => {
+			// Set malformed JSON response
+			setMockResponse('{"name": "test",}');
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "Return JSON" }],
+					response_format: { type: "json_object" },
+					// No plugins array - healing should not be applied
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasValidSSE).toBe(true);
+
+			// Collect all content from the stream
+			const contentChunks = streamResult.chunks
+				.filter(
+					(chunk: { choices?: Array<{ delta?: { content?: string } }> }) =>
+						chunk.choices?.[0]?.delta?.content,
+				)
+				.map(
+					(chunk: { choices: Array<{ delta: { content: string } }> }) =>
+						chunk.choices[0].delta.content,
+				);
+			const fullContent = contentChunks.join("");
+
+			// The content should still be the malformed JSON since healing is not enabled
+			expect(fullContent).toBe('{"name": "test",}');
 		});
 	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2885,6 +2885,21 @@ chat.openapi(completions, async (c) => {
 			let rawUpstreamData = ""; // Raw data received from upstream provider
 			const isAwsBedrock = usedProvider === "aws-bedrock";
 
+			// Response healing for streaming - buffer content and apply healing at the end
+			const streamingResponseHealingEnabled = plugins?.some(
+				(p) => p.id === "response-healing",
+			);
+			const isStreamingJsonResponseFormat =
+				response_format?.type === "json_object" ||
+				response_format?.type === "json_schema";
+			const shouldBufferForHealing =
+				streamingResponseHealingEnabled && isStreamingJsonResponseFormat;
+			// Store buffered chunks for response healing - we'll send them at the end
+			const bufferedContentChunks: Array<{
+				data: Record<string, unknown>;
+				eventId: number;
+			}> = [];
+
 			try {
 				while (true) {
 					const { done, value } = await reader.read();
@@ -3483,10 +3498,25 @@ chat.openapi(completions, async (c) => {
 								}
 							}
 
-							await writeSSEAndCache({
-								data: JSON.stringify(transformedData),
-								id: String(eventId++),
-							});
+							// For response healing with JSON response formats, buffer content chunks
+							// and send them at the end with healing applied
+							const hasContentToBuffer =
+								shouldBufferForHealing &&
+								transformedData.choices?.[0]?.delta?.content;
+
+							if (hasContentToBuffer) {
+								// Buffer the chunk for later healing
+								bufferedContentChunks.push({
+									data: structuredClone(transformedData),
+									eventId: eventId++,
+								});
+							} else {
+								// Send immediately (non-content chunks or healing not enabled)
+								await writeSSEAndCache({
+									data: JSON.stringify(transformedData),
+									id: String(eventId++),
+								});
+							}
 
 							// Extract usage data from transformedData to update tracking variables
 							if (transformedData.usage && usedProvider === "openai") {
@@ -3964,6 +3994,64 @@ chat.openapi(completions, async (c) => {
 						);
 					}
 				} else {
+					// Apply response healing for buffered JSON content
+					if (
+						shouldBufferForHealing &&
+						bufferedContentChunks.length > 0 &&
+						fullContent
+					) {
+						try {
+							const healingResult = healJsonResponse(fullContent);
+							if (healingResult.healed) {
+								logger.debug("Streaming response healing applied", {
+									method: healingResult.healingMethod,
+									originalLength: healingResult.originalContent.length,
+									healedLength: healingResult.content.length,
+								});
+								// Send healed content as a single chunk
+								const healedChunk = {
+									id: `chatcmpl-${Date.now()}`,
+									object: "chat.completion.chunk",
+									created: Math.floor(Date.now() / 1000),
+									model: usedModel,
+									choices: [
+										{
+											index: 0,
+											delta: {
+												content: healingResult.content,
+											},
+											finish_reason: null,
+										},
+									],
+								};
+								await writeSSEAndCache({
+									data: JSON.stringify(healedChunk),
+									id: String(eventId++),
+								});
+							} else {
+								// Content was already valid, send buffered chunks
+								for (const bufferedChunk of bufferedContentChunks) {
+									await writeSSEAndCache({
+										data: JSON.stringify(bufferedChunk.data),
+										id: String(bufferedChunk.eventId),
+									});
+								}
+							}
+						} catch (error) {
+							logger.error(
+								"Error applying streaming response healing",
+								error instanceof Error ? error : new Error(String(error)),
+							);
+							// On error, send original buffered chunks
+							for (const bufferedChunk of bufferedContentChunks) {
+								await writeSSEAndCache({
+									data: JSON.stringify(bufferedChunk.data),
+									id: String(bufferedChunk.eventId),
+								});
+							}
+						}
+					}
+
 					// Send final usage chunk if we need to send usage data
 					// This includes cases where:
 					// 1. No usage tokens were provided at all (all null)


### PR DESCRIPTION
## Summary

- Enable response-healing plugin in all JSON and JSON schema e2e tests (non-streaming and streaming)
- Implement streaming response healing by buffering content chunks when healing is enabled
- Add comprehensive streaming tests for various malformed JSON scenarios

## Changes

**chat-json.e2e.ts**: Added `plugins: [{ id: "response-healing" }]` to all 4 JSON tests (JSON output, JSON schema, and their streaming variants).

**chat.ts**: Implemented streaming response healing with buffering - when response healing is enabled for JSON formats, content chunks are buffered instead of sent immediately, healing is applied at stream end, and the healed content is sent as a single SSE chunk.

**chat-response-healing.e2e.ts**: Added streaming support to mock server and 6 new streaming test cases covering markdown extraction, trailing comma removal, truncation handling, and schema validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added response-healing plugin to automatically fix malformed JSON in streaming responses, including handling trailing commas and incomplete JSON chunks.
  * Extended response healing support for json_object and json_schema response formats in streaming mode.

* **Tests**
  * Added comprehensive end-to-end tests for response healing across multiple scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->