### PR TITLE
fix(gateway): filter providers in reasoning check

### DIFF
--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -90,7 +90,13 @@ export function validateModelCapabilities(
 		requestedModel !== "auto" &&
 		requestedModel !== "custom"
 	) {
-		const supportsReasoning = modelInfo.providers.some(
+		const providersToCheck = requestedProvider
+			? modelInfo.providers.filter(
+					(p) => (p as ProviderModelMapping).providerId === requestedProvider,
+				)
+			: modelInfo.providers;
+
+		const supportsReasoning = providersToCheck.some(
 			(provider) => (provider as ProviderModelMapping).reasoning === true,
 		);
 


### PR DESCRIPTION
When a specific provider is requested, the reasoning capability check now only examines that provider's reasoning support instead of checking all providers. This aligns the reasoning check with the pattern used by other capability checks (JSON output, JSON schema, tools).

## Changes
- Filter `modelInfo.providers` by `requestedProvider` when checking reasoning support
- Maintain existing logging and error handling behavior

## Testing
All 419 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model capability validation to consistently apply provider filtering across all capability checks, including reasoning capabilities. This ensures that when a specific provider is selected, all capability validations properly respect that constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->