### PR TITLE
fix(gateway): use 504 for upstream timeouts

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -845,13 +845,13 @@ describe("test", () => {
 				}),
 			});
 
-			// Request should fail with 502 Bad Gateway (upstream timeout)
-			expect(res.status).toBe(502);
+			// Request should fail with 504 Gateway Timeout (upstream timeout)
+			expect(res.status).toBe(504);
 
 			const json = await res.json();
 			expect(json).toHaveProperty("error");
-			expect(json.error.type).toBe("upstream_error");
-			expect(json.error.code).toBe("fetch_failed");
+			expect(json.error.type).toBe("upstream_timeout");
+			expect(json.error.code).toBe("timeout");
 
 			// Wait for the log to be written
 			const logs = await waitForLogs(1);


### PR DESCRIPTION
## Summary
- Return HTTP 504 Gateway Timeout instead of 502 Bad Gateway for upstream provider timeout errors
- Aligns with RFC 7231 semantics where 504 is specifically for "gateway did not receive a timely response from upstream"
- Helps clients implement different retry strategies (504 = worth retrying with backoff)

## Changes
| Scenario | Status Code | Type | Code |
|----------|-------------|------|------|
| Timeout | **504** | `upstream_timeout` | `timeout` |
| Connection failure | 502 | `upstream_error` | `fetch_failed` |

## Test plan
- [x] Unit tests updated and passing
- [x] Gateway builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for upstream provider communication by distinguishing timeout errors from other connection failures, returning appropriate HTTP status codes (504 Gateway Timeout for timeouts, 502 Bad Gateway for connection errors) and providing clearer, more specific error messages for each scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->