### PR TITLE
fix(gateway): handle network_error finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -47,6 +47,9 @@ export function getUnifiedFinishReason(
 	if (finishReason === "upstream_error") {
 		return UnifiedFinishReason.UPSTREAM_ERROR;
 	}
+	if (finishReason === "network_error") {
+		return UnifiedFinishReason.UPSTREAM_ERROR;
+	}
 	if (finishReason === "client_error") {
 		return UnifiedFinishReason.CLIENT_ERROR;
 	}


### PR DESCRIPTION
## Summary
- Map `network_error` finish reason to `UPSTREAM_ERROR` to prevent "Unknown finish reason encountered" errors from providers like zai

## Test plan
- [x] Build passes
- [ ] Verify logs no longer show "Unknown finish reason encountered" for `network_error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for network-related failures to ensure consistent classification and reporting of network errors across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->