### PR TITLE
refactor(gateway): separate streaming and plain request timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,10 +46,15 @@ TIMEOUT_MS=5000
 # Defaults to 300000ms (5 minutes)
 # GATEWAY_TIMEOUT_MS=300000
 
-# AI API request timeout in milliseconds - maximum time for upstream provider calls
+# AI API request timeout in milliseconds for streaming requests
 # Should be shorter than GATEWAY_TIMEOUT_MS to allow for error handling
 # Defaults to 240000ms (4 minutes) or 80% of GATEWAY_TIMEOUT_MS, whichever is smaller
-# AI_REQUEST_TIMEOUT_MS=240000
+# AI_STREAMING_TIMEOUT_MS=240000
+
+# AI API request timeout in milliseconds for plain (non-streaming) requests
+# Non-streaming requests use a shorter timeout since they don't benefit from incremental responses
+# Defaults to 80000ms (80 seconds)
+# AI_TIMEOUT_MS=80000
 
 # =============================================================================
 # WORKER CONFIGURATION

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -793,20 +793,28 @@ describe("test", () => {
 	// Timeout tests - use a short timeout via env var to test timeout handling
 	describe("Timeout handling", () => {
 		let originalTimeout: string | undefined;
+		let originalStreamingTimeout: string | undefined;
 
 		beforeAll(() => {
-			// Save original env value
-			originalTimeout = process.env.AI_REQUEST_TIMEOUT_MS;
+			// Save original env values
+			originalTimeout = process.env.AI_TIMEOUT_MS;
+			originalStreamingTimeout = process.env.AI_STREAMING_TIMEOUT_MS;
 			// Set a short timeout for testing (2 seconds)
-			process.env.AI_REQUEST_TIMEOUT_MS = "2000";
+			process.env.AI_TIMEOUT_MS = "2000";
+			process.env.AI_STREAMING_TIMEOUT_MS = "2000";
 		});
 
 		afterAll(() => {
-			// Restore original env value
+			// Restore original env values
 			if (originalTimeout !== undefined) {
-				process.env.AI_REQUEST_TIMEOUT_MS = originalTimeout;
+				process.env.AI_TIMEOUT_MS = originalTimeout;
 			} else {
-				delete process.env.AI_REQUEST_TIMEOUT_MS;
+				delete process.env.AI_TIMEOUT_MS;
+			}
+			if (originalStreamingTimeout !== undefined) {
+				process.env.AI_STREAMING_TIMEOUT_MS = originalStreamingTimeout;
+			} else {
+				delete process.env.AI_STREAMING_TIMEOUT_MS;
 			}
 		});
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -18,7 +18,11 @@ import { isCodingModel } from "@/lib/coding-models.js";
 import { calculateCosts, shouldBillCancelledRequests } from "@/lib/costs.js";
 import { throwIamException, validateModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
-import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
+import {
+	createCombinedSignal,
+	createStreamingCombinedSignal,
+	isTimeoutError,
+} from "@/lib/timeout-config.js";
 
 import {
 	getCheapestFromAvailableProviders,
@@ -2141,7 +2145,7 @@ chat.openapi(completions, async (c) => {
 				}
 
 				// Create a combined signal for both timeout and cancellation
-				const fetchSignal = createCombinedSignal(
+				const fetchSignal = createStreamingCombinedSignal(
 					requestCanBeCanceled ? controller : undefined,
 				);
 
@@ -4113,6 +4117,7 @@ chat.openapi(completions, async (c) => {
 		}
 
 		// Create a combined signal for both timeout and cancellation
+		// Non-streaming requests use a shorter timeout (default 80s)
 		const fetchSignal = createCombinedSignal(
 			requestCanBeCanceled ? controller : undefined,
 		);


### PR DESCRIPTION
## Summary

Add distinct timeout configurations for streaming and non-streaming requests with clearer naming. Non-streaming requests now default to 80 seconds (AI_TIMEOUT_MS) while streaming requests use 4 minutes (AI_STREAMING_TIMEOUT_MS).

## Changes

- Renamed environment variables to clarify their purpose
- Added separate timeout functions for streaming vs non-streaming requests
- Non-streaming requests use shorter timeout (80s default) for faster failure detection
- Updated tests to work with new timeout configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Separated AI request timeout handling into distinct streaming and non-streaming configurations for improved request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->