### PR TITLE
fix(ui): handle null tool results in log card

### DIFF
--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -794,41 +794,46 @@ export function LogCard({ log }: { log: Partial<Log> }) {
 										</h5>
 										<div className="space-y-2">
 											{Array.isArray(log.toolResults) ? (
-												log.toolResults.map((toolCall, index: number) => (
-													<div
-														key={index}
-														className="rounded-md border p-3 overflow-scroll"
-													>
-														<div className="grid gap-2 text-xs">
-															<div className="flex justify-between">
-																<span className="font-medium">
-																	{toolCall.function?.name ||
-																		"Unknown Function"}
-																</span>
-																<span className="text-muted-foreground">
-																	ID: {toolCall.id || "N/A"}
-																</span>
-															</div>
-															{toolCall.function?.arguments && (
-																<div className="space-y-1">
-																	<div className="text-muted-foreground">
-																		Arguments:
-																	</div>
-																	<pre className="text-xs bg-white dark:bg-gray-900 rounded border p-2 overflow-auto max-h-32 text-wrap">
-																		{typeof toolCall.function.arguments ===
-																		"string"
-																			? toolCall.function.arguments
-																			: JSON.stringify(
-																					toolCall.function.arguments,
-																					null,
-																					2,
-																				)}
-																	</pre>
+												log.toolResults
+													.filter(
+														(tc): tc is NonNullable<typeof tc> =>
+															tc !== null && tc !== undefined,
+													)
+													.map((toolCall, index: number) => (
+														<div
+															key={index}
+															className="rounded-md border p-3 overflow-scroll"
+														>
+															<div className="grid gap-2 text-xs">
+																<div className="flex justify-between">
+																	<span className="font-medium">
+																		{toolCall.function?.name ||
+																			"Unknown Function"}
+																	</span>
+																	<span className="text-muted-foreground">
+																		ID: {toolCall.id || "N/A"}
+																	</span>
 																</div>
-															)}
+																{toolCall.function?.arguments && (
+																	<div className="space-y-1">
+																		<div className="text-muted-foreground">
+																			Arguments:
+																		</div>
+																		<pre className="text-xs bg-white dark:bg-gray-900 rounded border p-2 overflow-auto max-h-32 text-wrap">
+																			{typeof toolCall.function.arguments ===
+																			"string"
+																				? toolCall.function.arguments
+																				: JSON.stringify(
+																						toolCall.function.arguments,
+																						null,
+																						2,
+																					)}
+																		</pre>
+																	</div>
+																)}
+															</div>
 														</div>
-													</div>
-												))
+													))
 											) : (
 												<div className="rounded-md border p-3">
 													<pre className="max-h-40 text-xs overflow-auto whitespace-pre-wrap break-words">


### PR DESCRIPTION
## Summary
- Fix TypeError when expanding log cards with null tool results
- Filter out null/undefined entries from toolResults array before rendering

## Test plan
- [x] Verified build passes
- [ ] Expand log cards with tool results to confirm no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the dashboard log display by properly handling and filtering out null or missing tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->