### PR TITLE
fix(gateway): handle brackets in JSON strings

### DIFF
--- a/apps/gateway/src/chat/tools/might-be-complete-json.spec.ts
+++ b/apps/gateway/src/chat/tools/might-be-complete-json.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { mightBeCompleteJson } from "./might-be-complete-json.js";
+
+describe("mightBeCompleteJson", () => {
+	it("returns true for simple valid object", () => {
+		expect(mightBeCompleteJson('{"a":1}')).toBe(true);
+	});
+
+	it("returns true for simple valid array", () => {
+		expect(mightBeCompleteJson("[1,2,3]")).toBe(true);
+	});
+
+	it("returns false for incomplete object", () => {
+		expect(mightBeCompleteJson('{"a":1')).toBe(false);
+	});
+
+	it("returns false for incomplete array", () => {
+		expect(mightBeCompleteJson("[1,2")).toBe(false);
+	});
+
+	it("returns false for empty string", () => {
+		expect(mightBeCompleteJson("")).toBe(false);
+	});
+
+	it("returns false for non-JSON", () => {
+		expect(mightBeCompleteJson("hello")).toBe(false);
+	});
+
+	it("handles brackets inside strings correctly", () => {
+		// This is the bug case - brackets inside string values should be ignored
+		expect(mightBeCompleteJson('{"delta":"\\"]"}')).toBe(true);
+	});
+
+	it("handles braces inside strings correctly", () => {
+		expect(mightBeCompleteJson('{"data":"}{{"}')).toBe(true);
+	});
+
+	it("handles escaped quotes inside strings", () => {
+		expect(mightBeCompleteJson('{"text":"say \\"hello\\""}')).toBe(true);
+	});
+
+	it("handles escaped backslashes", () => {
+		expect(mightBeCompleteJson('{"path":"C:\\\\Users"}')).toBe(true);
+	});
+
+	it("returns false for unclosed string", () => {
+		expect(mightBeCompleteJson('{"text":"unclosed}')).toBe(false);
+	});
+
+	it("handles nested objects", () => {
+		expect(mightBeCompleteJson('{"a":{"b":{"c":1}}}')).toBe(true);
+	});
+
+	it("handles arrays with objects", () => {
+		expect(mightBeCompleteJson('[{"a":1},{"b":2}]')).toBe(true);
+	});
+
+	it("handles the actual failing case from production", () => {
+		// This was causing the JSON parse error in production
+		const json =
+			'{"type":"response.function_call_arguments.delta","delta":"\\"]","item_id":"fc_test","output_index":1}';
+		expect(mightBeCompleteJson(json)).toBe(true);
+	});
+
+	it("handles complex nested structure with brackets in strings", () => {
+		const json = '{"choices":[{"delta":{"content":"array[0] = {value}"}}]}';
+		expect(mightBeCompleteJson(json)).toBe(true);
+	});
+
+	it("returns false for actually unbalanced braces", () => {
+		expect(mightBeCompleteJson('{"a":1}}')).toBe(false);
+	});
+
+	it("returns false for actually unbalanced brackets", () => {
+		expect(mightBeCompleteJson("[1,2]]")).toBe(false);
+	});
+});

--- a/apps/gateway/src/chat/tools/might-be-complete-json.ts
+++ b/apps/gateway/src/chat/tools/might-be-complete-json.ts
@@ -27,19 +27,42 @@ export function mightBeCompleteJson(str: string): boolean {
 		return false;
 	}
 
-	// Quick bracket count (doesn't account for strings, but catches obvious imbalances)
+	// Count brackets/braces, skipping content inside strings
 	let braces = 0;
 	let brackets = 0;
-	for (const c of trimmed) {
-		if (c === "{") {
-			braces++;
-		} else if (c === "}") {
-			braces--;
-		} else if (c === "[") {
-			brackets++;
-		} else if (c === "]") {
-			brackets--;
+	let inString = false;
+	let i = 0;
+
+	while (i < trimmed.length) {
+		const c = trimmed[i];
+
+		if (inString) {
+			if (c === "\\") {
+				// Skip escaped character
+				i += 2;
+				continue;
+			} else if (c === '"') {
+				inString = false;
+			}
+		} else {
+			if (c === '"') {
+				inString = true;
+			} else if (c === "{") {
+				braces++;
+			} else if (c === "}") {
+				braces--;
+			} else if (c === "[") {
+				brackets++;
+			} else if (c === "]") {
+				brackets--;
+			}
 		}
+		i++;
+	}
+
+	// If still in string, the JSON is incomplete
+	if (inString) {
+		return false;
 	}
 
 	return braces === 0 && brackets === 0;


### PR DESCRIPTION
## Summary
- Fixed `mightBeCompleteJson` heuristic to skip brackets/braces inside JSON string values
- Added 17 unit tests including the production failure case

The heuristic was incorrectly counting brackets inside strings (e.g., `"delta":"\"]\""`) as unbalanced, causing valid JSON to be marked as incomplete. This led to SSE events being concatenated together during streaming, resulting in JSON parse errors.

## Test plan
- [x] Unit tests pass (`pnpm test:unit`)
- [x] Build succeeds (`pnpm build`)
- [x] Format check passes (`pnpm format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON validation to correctly identify complete and incomplete JSON while properly handling strings containing special characters and escaped quotes.

* **Tests**
  * Added comprehensive unit test suite covering multiple scenarios: simple objects and arrays, incomplete JSON, empty and non-JSON strings, strings with special characters, unclosed strings, nested structures, arrays of objects, and complex edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->