### PR TITLE
fix(playground): add dark mode support for code blocks

### DIFF
--- a/apps/playground/src/components/ai-elements/reasoning.tsx
+++ b/apps/playground/src/components/ai-elements/reasoning.tsx
@@ -14,6 +14,12 @@ import {
 import { cn } from "@/lib/utils";
 
 import type { ComponentProps, ReactNode } from "react";
+import type { BundledTheme } from "shiki";
+
+const shikiTheme: [BundledTheme, BundledTheme] = [
+	"github-light",
+	"github-dark",
+];
 
 interface ReasoningContextValue {
 	isStreaming: boolean;
@@ -181,7 +187,9 @@ export const ReasoningContent = memo(
 			)}
 			{...props}
 		>
-			<Streamdown {...props}>{children}</Streamdown>
+			<Streamdown shikiTheme={shikiTheme} {...props}>
+				{children}
+			</Streamdown>
 		</CollapsibleContent>
 	),
 );

--- a/apps/playground/src/components/ai-elements/response.tsx
+++ b/apps/playground/src/components/ai-elements/response.tsx
@@ -5,7 +5,14 @@ import { Streamdown } from "streamdown";
 
 import { cn } from "@/lib/utils";
 
+import type { BundledTheme } from "shiki";
+
 type ResponseProps = ComponentProps<typeof Streamdown>;
+
+const shikiTheme: [BundledTheme, BundledTheme] = [
+	"github-light",
+	"github-dark",
+];
 
 export const Response = memo(
 	({ className, ...props }: ResponseProps) => (
@@ -14,6 +21,7 @@ export const Response = memo(
 				"size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
 				className,
 			)}
+			shikiTheme={shikiTheme}
 			{...props}
 		/>
 	),


### PR DESCRIPTION
## Summary
- Add `shikiTheme` prop with dual themes (`github-light`, `github-dark`) to Streamdown components
- Fixes code block syntax highlighting in dark mode for AI chat responses
- Applied to both `Response` and `ReasoningContent` components

## Test plan
- [ ] Open playground in dark mode
- [ ] Send a message that generates a code block response
- [ ] Verify code blocks have proper dark theme styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enhanced code syntax highlighting with light and dark theme support for improved readability in displayed code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->