### PR TITLE
fix: downgrade cache hit/miss logs to trace level

### DIFF
--- a/packages/db/src/redis-cache.ts
+++ b/packages/db/src/redis-cache.ts
@@ -57,7 +57,7 @@ export class RedisCache extends Cache {
 				}
 			}
 
-			logger.debug(`Cache hit for key: ${key}`, { tables });
+			logger.trace(`Cache hit for key: ${key}`, { tables });
 			return parsed.data;
 		} catch (error) {
 			logger.error(
@@ -115,7 +115,7 @@ export class RedisCache extends Cache {
 			}
 
 			await pipeline.exec();
-			logger.debug(`Cached query result for key: ${hashedQuery}`, {
+			logger.trace(`Cached query result for key: ${hashedQuery}`, {
 				tables,
 				tags: config?.tags,
 				isTag,
@@ -149,7 +149,7 @@ export class RedisCache extends Cache {
 				await this.invalidateByTables(tables);
 			}
 
-			logger.debug("Cache invalidated on mutation", { tables, tags });
+			logger.trace("Cache invalidated on mutation", { tables, tags });
 		} catch (error) {
 			logger.error(
 				"Error invalidating cache on mutation",
@@ -289,7 +289,7 @@ export class RedisCache extends Cache {
 				}
 				await pipeline.exec();
 
-				logger.debug(`Invalidated ${keysArray.length} cache entries`, {
+				logger.trace(`Invalidated ${keysArray.length} cache entries`, {
 					tables,
 				});
 			}


### PR DESCRIPTION
Move verbose cache operation logs (hit, miss, invalidation) from debug to trace level, so they don't appear by default. The default project log level is debug, which filters out trace logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved observability by adjusting logging verbosity for cache operations to provide more detailed diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->