### PR TITLE
feat(playground): auto-send x-no-fallback for provider-specific requests

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -388,10 +388,12 @@ export default function ChatPageClient({
 						: undefined
 				: undefined;
 
-			// Hidden feature: check localStorage for no-fallback setting
-			const noFallback =
+			// Automatically disable provider fallback for provider-specific model selections
+			const isProviderSpecific = selectedModel.includes("/");
+			const localStorageOverride =
 				typeof window !== "undefined" &&
 				localStorage.getItem("llmgateway_no_fallback") === "true";
+			const noFallback = isProviderSpecific || localStorageOverride;
 
 			// Get enabled MCP servers
 			const enabledMcpServers = getEnabledMcpServers();
@@ -1204,9 +1206,11 @@ function ExtraChatPanel({
 						: undefined
 				: undefined;
 
-			const noFallback =
+			const isProviderSpecific = selectedModel.includes("/");
+			const localStorageOverride =
 				typeof window !== "undefined" &&
 				localStorage.getItem("llmgateway_no_fallback") === "true";
+			const noFallback = isProviderSpecific || localStorageOverride;
 
 			const mergedOptions = {
 				...options,

--- a/apps/playground/src/components/playground/group-chat-client.tsx
+++ b/apps/playground/src/components/playground/group-chat-client.tsx
@@ -284,8 +284,17 @@ export default function GroupChatClient({
 			],
 		};
 
+		const isProviderSpecific = currentModel.includes("/");
+		const localStorageOverride =
+			typeof window !== "undefined" &&
+			localStorage.getItem("llmgateway_no_fallback") === "true";
+		const noFallback = isProviderSpecific || localStorageOverride;
+
 		try {
 			await sendMessage(userUiMessage as any, {
+				headers: {
+					...(noFallback ? { "x-no-fallback": "true" } : {}),
+				},
 				body: {
 					model: currentModel,
 				},


### PR DESCRIPTION
## Summary

Automatically include `x-no-fallback` header when users select a provider-specific model (e.g., `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`). This prevents silent provider fallback and ensures users test the provider they explicitly chose.

## Changes

- Updated main chat and comparison panel to detect provider-specific models
- Added no-fallback support to group chat (previously missing)
- Preserved localStorage override for power users

## Test plan

- Select "auto" or bare model name → header NOT sent
- Select provider-specific model (contains "/") → header IS sent
- Run `pnpm build` and verify no regressions

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fallback handling in chat requests now adapts based on the selected model and user configuration.
  * Added fallback control options for both standard and group chat operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->