### PR TITLE
fix: allow null content in chat messages

### DIFF
--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -9,26 +9,29 @@ export const completionsRequestSchema = z.object({
 			role: z.string().openapi({
 				example: "user",
 			}),
-			content: z.union([
-				z.string().openapi({
-					example: "Hello!",
-				}),
-				z.array(
-					z.union([
-						z.object({
-							type: z.literal("text"),
-							text: z.string(),
-						}),
-						z.object({
-							type: z.literal("image_url"),
-							image_url: z.object({
-								url: z.string(),
-								detail: z.enum(["low", "high", "auto"]).optional(),
+			content: z
+				.union([
+					z.string().openapi({
+						example: "Hello!",
+					}),
+					z.array(
+						z.union([
+							z.object({
+								type: z.literal("text"),
+								text: z.string(),
 							}),
-						}),
-					]),
-				),
-			]),
+							z.object({
+								type: z.literal("image_url"),
+								image_url: z.object({
+									url: z.string(),
+									detail: z.enum(["low", "high", "auto"]).optional(),
+								}),
+							}),
+						]),
+					),
+				])
+				.nullable()
+				.optional(),
 			name: z.string().optional(),
 			tool_call_id: z.string().optional(),
 			tool_calls: z


### PR DESCRIPTION
## Summary
- Per the OpenAI API spec, assistant messages with tool calls can have `content: null`
- The Zod validation schema only accepted `string | array`, rejecting `null` with a 400 error
- This broke clients (e.g. OpenClaw) that send full chat history including tool call messages with `content: null`
- Added `.nullable().optional()` to the content field in the completions request schema

## Test plan
- [x] All 445 unit tests pass
- [x] Full production build succeeds
- [ ] Verify requests with `content: null` in assistant tool call messages are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The chat completions API now accepts messages with optional or null content fields, improving request validation and handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->