### PR TITLE
fix(gateway): use base model ID for IAM check

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -516,10 +516,9 @@ chat.openapi(completions, async (c) => {
 		organization.devPlan !== "none" &&
 		!organization.devPlanAllowAllModels
 	) {
-		const modelDef = models.find((m) => m.id === requestedModel);
-		if (modelDef && !isCodingModel(modelDef)) {
+		if (!isCodingModel(modelInfo)) {
 			throw new HTTPException(403, {
-				message: `Model ${requestedModel} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
+				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
 			});
 		}
 	}
@@ -551,7 +550,7 @@ chat.openapi(completions, async (c) => {
 	// Validate IAM rules for model access
 	const iamValidation = await validateModelAccess(
 		apiKey.id,
-		requestedModel,
+		modelInfo.id,
 		requestedProvider,
 	);
 	if (!iamValidation.allowed) {


### PR DESCRIPTION
## Summary
- IAM validation and coding model restriction were receiving the provider-specific model name (e.g. Bedrock's `anthropic.claude-opus-4-5-20251101-v1:0`) instead of the canonical model ID (`claude-opus-4-5`), causing spurious 403 errors
- Pass `modelInfo.id` (already resolved by `resolveModelInfo()`) to `validateModelAccess()` instead of `requestedModel`
- Use already-resolved `modelInfo` for the coding model restriction check instead of re-looking up by `requestedModel`, which also silently bypassed the check when the lookup returned `undefined`

## Test plan
- [ ] Send a request with a provider-prefixed Bedrock model (e.g. `bedrock/anthropic.claude-opus-4-5-20251101-v1:0`) and verify it no longer returns 403
- [ ] Verify IAM allow/deny model rules still work correctly with base model IDs
- [ ] Verify coding model restriction still blocks non-coding models on dev plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved model validation logic by utilizing resolved model information directly for eligibility and access checks, streamlining the validation process and reducing unnecessary intermediate lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->