### PR TITLE
refactor: consolidate force-dynamic to root layouts

### DIFF
--- a/apps/code/src/app/coding-models/page.tsx
+++ b/apps/code/src/app/coding-models/page.tsx
@@ -13,8 +13,6 @@ export const metadata: Metadata = {
 		"High-performance AI models optimized for coding tasks with tool support, JSON output, streaming, and prompt caching.",
 };
 
-export const dynamic = "force-dynamic";
-
 export default function CodingModelsPage() {
 	const config = getConfig();
 

--- a/apps/code/src/app/dashboard/page.tsx
+++ b/apps/code/src/app/dashboard/page.tsx
@@ -1,7 +1,5 @@
 import DashboardClient from "./DashboardClient";
 
-export const dynamic = "force-dynamic";
-
 export default function Dashboard() {
 	return <DashboardClient />;
 }

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -42,8 +42,6 @@ const plans = [
 	},
 ];
 
-export const dynamic = "force-dynamic";
-
 export default function LandingPage() {
 	return (
 		<div className="min-h-screen bg-background">

--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -14,8 +14,6 @@ export interface GatewayModel {
 	architecture?: { input_modalities?: string[] };
 }
 
-export const dynamic = "force-dynamic";
-
 export default async function GroupPage({
 	searchParams,
 }: {

--- a/apps/playground/src/app/page.tsx
+++ b/apps/playground/src/app/page.tsx
@@ -14,8 +14,6 @@ export interface GatewayModel {
 	architecture?: { input_modalities?: string[] };
 }
 
-export const dynamic = "force-dynamic";
-
 export default async function ChatPage({
 	searchParams,
 }: {

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
@@ -4,9 +4,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { LogsData } from "@/types/activity";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 export default async function ActivityPage({
 	params,
 	searchParams,

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/api-keys/[keyId]/iam/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/api-keys/[keyId]/iam/page.tsx
@@ -3,8 +3,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { ApiKey } from "@/lib/types";
 
-export const dynamic = "force-dynamic";
-
 export default async function IamRulesPage({
 	params,
 }: {

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/api-keys/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/api-keys/page.tsx
@@ -3,9 +3,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { ApiKey } from "@/lib/types";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 export default async function ApiKeysPage({
 	params,
 }: {

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/layout.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/layout.tsx
@@ -6,9 +6,6 @@ import { fetchServerData } from "@/lib/server-api";
 import type { Project } from "@/lib/types";
 import type { ReactNode } from "react";
 
-// Force dynamic rendering since this layout uses cookies for authentication
-export const dynamic = "force-dynamic";
-
 interface ProjectLayoutProps {
 	children: ReactNode;
 	params: Promise<{ orgId: string; projectId: string }>;

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/model-usage/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/model-usage/page.tsx
@@ -3,8 +3,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { ActivitT } from "@/types/activity";
 
-export const dynamic = "force-dynamic";
-
 export default async function ModelUsagePage({
 	params,
 	searchParams,

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
@@ -3,9 +3,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { ActivitT } from "@/types/activity";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 export default async function Dashboard({
 	params,
 	searchParams,

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/usage/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/usage/page.tsx
@@ -3,9 +3,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { ActivitT } from "@/types/activity";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 export default async function UsagePage({
 	params,
 }: {

--- a/apps/ui/src/app/dashboard/[orgId]/layout.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/layout.tsx
@@ -7,8 +7,6 @@ import { fetchServerData } from "@/lib/server-api";
 import type { User, Project } from "@/lib/types";
 import type { ReactNode } from "react";
 
-export const dynamic = "force-dynamic";
-
 interface OrgLayoutProps {
 	children: ReactNode;
 	params: Promise<{ orgId: string }>;

--- a/apps/ui/src/app/dashboard/[orgId]/org/provider-keys/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/provider-keys/page.tsx
@@ -3,9 +3,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { ProviderKeyOptions } from "@llmgateway/db";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 interface ProviderKeysData {
 	providerKeys: {
 		id: string;

--- a/apps/ui/src/app/dashboard/[orgId]/org/referrals/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/referrals/page.tsx
@@ -2,8 +2,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import { ReferralsClient } from "./referrals-client";
 
-export const dynamic = "force-dynamic";
-
 interface Transaction {
 	id: string;
 	createdAt: string;

--- a/apps/ui/src/app/dashboard/[orgId]/org/transactions/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/transactions/page.tsx
@@ -1,9 +1,6 @@
 import { TransactionsClient } from "@/components/billing/transactions-client";
 import { fetchServerData } from "@/lib/server-api";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 interface Transaction {
 	id: string;
 	createdAt: string;

--- a/apps/ui/src/app/dashboard/layout.tsx
+++ b/apps/ui/src/app/dashboard/layout.tsx
@@ -4,9 +4,6 @@ import { getUser } from "@/lib/getUser";
 
 import type { ReactNode } from "react";
 
-// Force dynamic rendering since this layout uses cookies for authentication
-export const dynamic = "force-dynamic";
-
 interface DashboardLayoutProps {
 	children: ReactNode;
 }

--- a/apps/ui/src/app/dashboard/page.tsx
+++ b/apps/ui/src/app/dashboard/page.tsx
@@ -5,9 +5,6 @@ import { fetchServerData } from "@/lib/server-api";
 
 import type { User } from "@/lib/types";
 
-// Force dynamic rendering since this page uses cookies for authentication
-export const dynamic = "force-dynamic";
-
 export default async function DashboardPage() {
 	// Fetch user data server-side
 	const initialUserData = await fetchServerData<

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -20,6 +20,8 @@ const geistMono = Geist_Mono({
 	display: "swap",
 });
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
 	metadataBase: new URL("https://llmgateway.io"),
 	title: {

--- a/apps/ui/src/app/onboarding/page.tsx
+++ b/apps/ui/src/app/onboarding/page.tsx
@@ -5,9 +5,6 @@ import { OnboardingClient } from "./onboarding-client";
 
 import type { User } from "@/lib/types";
 
-// Force dynamic rendering since this page uses server-side data fetching with cookies
-export const dynamic = "force-dynamic";
-
 export default async function OnboardingPage() {
 	const initialUserData = await fetchServerData<{ user: User }>(
 		"GET",


### PR DESCRIPTION
## Summary
- Removed `export const dynamic = "force-dynamic"` from 19 individual page/layout files across ui, playground, and code apps
- Added it to the UI root layout (`apps/ui/src/app/layout.tsx`) — the other 4 root layouts (playground, code, admin, docs) already had it
- Since `force-dynamic` in a root layout applies to all child routes, per-page declarations were redundant

## Test plan
- [x] `pnpm build` passes successfully
- [x] All Next.js apps show routes as dynamic (`ƒ`) in build output
- [ ] Verify dashboard pages still render correctly with SSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized rendering configuration across dashboard pages, settings interfaces, and management areas for improved performance and caching behavior.
  * Root layout updated to enforce dynamic rendering, ensuring consistent data availability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->