### PR TITLE
feat(log-detail): conditionally show balance text

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -305,7 +305,11 @@ export function LogDetailClient({
 									</div>
 								</TooltipTrigger>
 								<TooltipContent>
-									<p>Provider cost — not deducted from your balance</p>
+									<p>
+										Provider cost
+										{log.usedMode === "api-keys" &&
+											" — not deducted from your balance"}
+									</p>
 								</TooltipContent>
 							</Tooltip>
 						</TooltipProvider>
@@ -440,7 +444,9 @@ export function LogDetailClient({
 							<div className="rounded-lg border bg-card p-4 space-y-4">
 								<div>
 									<p className="text-xs text-muted-foreground mb-2">
-										Provider pricing — not deducted from your balance
+										Provider pricing
+										{log.usedMode === "api-keys" &&
+											" — not deducted from your balance"}
 									</p>
 									<div className="text-muted-foreground">
 										<Field

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -213,7 +213,11 @@ export function LogCard({
 									</div>
 								</TooltipTrigger>
 								<TooltipContent>
-									<p>Provider cost — not deducted from your balance</p>
+									<p>
+										Provider cost
+										{log.usedMode === "api-keys" &&
+											" — not deducted from your balance"}
+									</p>
 								</TooltipContent>
 							</Tooltip>
 						</TooltipProvider>
@@ -498,7 +502,9 @@ export function LogCard({
 							<div className="rounded-md border p-3 space-y-3">
 								<div>
 									<p className="text-xs text-muted-foreground mb-2">
-										Provider pricing — not deducted from your balance
+										Provider pricing
+										{log.usedMode === "api-keys" &&
+											" — not deducted from your balance"}
 									</p>
 									<div className="grid grid-cols-2 gap-2 text-sm text-muted-foreground">
 										<div>Input Cost</div>


### PR DESCRIPTION
## Summary
Updated provider cost messaging to only display "not deducted from your balance" text when using API keys mode. This clarifies that provider costs may be handled differently depending on the authentication method used.

## Changes
- Modified tooltip and label text in `log-detail-client.tsx` to conditionally append the balance deduction disclaimer based on `log.usedMode === "api-keys"`
- Applied the same conditional logic to `log-card.tsx` for consistency across the dashboard
- Updated 4 instances of provider cost/pricing messaging across both components

## Implementation Details
The changes use inline conditional rendering to append the " — not deducted from your balance" text only when the log's `usedMode` is "api-keys". This ensures users see accurate information about cost handling based on their authentication method, while avoiding misleading messaging for other modes.

https://claude.ai/code/session_01EiTZcynDaoX8qKXCVyuVU9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified billing information: Cost-related tooltips and descriptions now explicitly indicate when provider charges are not deducted from your account balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->