### PR TITLE
fix: return 0 completion tokens for empty content

### DIFF
--- a/apps/gateway/src/chat/tools/estimate-tokens-from-content.ts
+++ b/apps/gateway/src/chat/tools/estimate-tokens-from-content.ts
@@ -2,5 +2,8 @@
  * Estimates tokens from content length using simple division
  */
 export function estimateTokensFromContent(content: string): number {
+	if (!content) {
+		return 0;
+	}
 	return Math.max(1, Math.round(content.length / 4));
 }

--- a/apps/gateway/src/lib/prompt-tokens.spec.ts
+++ b/apps/gateway/src/lib/prompt-tokens.spec.ts
@@ -8,7 +8,7 @@ describe("Prompt token calculation", () => {
 	describe("estimateTokensFromContent", () => {
 		it("should estimate tokens from content length", () => {
 			expect(estimateTokensFromContent("Hello world")).toBe(3); // 11 chars / 4 = 2.75, rounded to 3
-			expect(estimateTokensFromContent("")).toBe(1); // Always at least 1
+			expect(estimateTokensFromContent("")).toBe(0); // Empty content = 0 tokens
 			expect(
 				estimateTokensFromContent(
 					"A very long message that should result in more tokens",
@@ -16,8 +16,11 @@ describe("Prompt token calculation", () => {
 			).toBe(13); // 53 chars / 4 = 13.25, rounded to 13
 		});
 
-		it("should always return at least 1 token", () => {
-			expect(estimateTokensFromContent("")).toBe(1);
+		it("should return 0 for empty content", () => {
+			expect(estimateTokensFromContent("")).toBe(0);
+		});
+
+		it("should return at least 1 token for non-empty content", () => {
 			expect(estimateTokensFromContent("A")).toBe(1);
 		});
 	});


### PR DESCRIPTION
## Summary
- `estimateTokensFromContent("")` was returning 1 instead of 0 due to `Math.max(1, ...)`, causing error and content_filter responses to report 1 completion token instead of 0
- Added early return of 0 for empty content strings

## Test plan
- [x] Updated unit tests to verify empty content returns 0 tokens
- [x] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved token estimation accuracy for empty content. Empty inputs now correctly estimate to 0 tokens instead of 1, preventing inflated token counts and providing more precise usage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->