### PR TITLE
fix(stats): faster backfill and prevent overlap

### DIFF
--- a/apps/worker/src/services/project-stats-aggregator.ts
+++ b/apps/worker/src/services/project-stats-aggregator.ts
@@ -24,23 +24,29 @@ function formatUTCTimestamp(date: Date): string {
 }
 
 /**
- * Get the current hour start as a UTC timestamp string
+ * Truncate a Date to the start of its UTC hour
  */
-function getCurrentHourStart(): string {
-	const now = new Date();
+function truncateToHourUTC(date: Date): string {
 	return formatUTCTimestamp(
 		new Date(
 			Date.UTC(
-				now.getUTCFullYear(),
-				now.getUTCMonth(),
-				now.getUTCDate(),
-				now.getUTCHours(),
+				date.getUTCFullYear(),
+				date.getUTCMonth(),
+				date.getUTCDate(),
+				date.getUTCHours(),
 				0,
 				0,
 				0,
 			),
 		),
 	);
+}
+
+/**
+ * Get the current hour start as a UTC timestamp string
+ */
+function getCurrentHourStart(): string {
+	return truncateToHourUTC(new Date());
 }
 
 /**
@@ -416,7 +422,7 @@ export async function processRecentLogs() {
 		if (STATS_BACKFILL_ENABLED) {
 			const backfillStart =
 				STATS_BACKFILL_DAYS > 0
-					? formatUTCTimestamp(
+					? truncateToHourUTC(
 							new Date(Date.now() - STATS_BACKFILL_DAYS * 24 * 60 * 60 * 1000),
 						)
 					: undefined;
@@ -505,7 +511,7 @@ export async function processRecentLogs() {
 		if (STATS_STALE_ENABLED) {
 			const staleStart =
 				STATS_STALE_DAYS > 0
-					? formatUTCTimestamp(
+					? truncateToHourUTC(
 							new Date(Date.now() - STATS_STALE_DAYS * 24 * 60 * 60 * 1000),
 						)
 					: undefined;


### PR DESCRIPTION
## Summary

- Replace slow LEFT JOIN backfill discovery (scanned all 10M+ logs every run) with sequential hour-based iteration using `generate_series` + `NOT EXISTS` against the small stats table
- Fix gap detection: use `NOT EXISTS` to find actual unprocessed hours instead of frontier-based approach (`max(hour_timestamp) + 1`) which skipped gaps left by previous partial runs
- Add concurrency guard (`isRunning` flag) to prevent overlapping runs from stacking up DB connections when a batch takes longer than the refresh interval
- Change log-process log level to `trace`

## Test plan

- [x] `pnpm build:core` passes
- [ ] Verify backfill processes hours with gaps (not just from frontier forward)
- [ ] Verify DB connection count stays stable under load
- [ ] Verify aggregation counts match log counts after full backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of project statistics aggregation with enhanced hourly processing logic.
  * Fixed potential concurrency issues in statistics refresh operations with added safeguards.

* **Chores**
  * Updated internal processing to use standardized hourly boundaries for consistent statistics reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->