### PR TITLE
fix: correct reversed discount display in logs

### DIFF
--- a/apps/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx
+++ b/apps/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx
@@ -91,7 +91,7 @@ function LogRow({ log }: { log: ProjectLogEntry }) {
 					{log.discount && log.discount !== 1 && (
 						<div className="flex items-center gap-1 text-emerald-600">
 							<TrendingDown className="h-3 w-3" />
-							<span>{((1 - log.discount) * 100).toFixed(0)}% off</span>
+							<span>{(log.discount * 100).toFixed(0)}% off</span>
 						</div>
 					)}
 					{log.source && (

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -225,7 +225,7 @@ export function LogCard({
 						{log.discount && log.discount !== 1 && (
 							<div className="flex items-center gap-1 text-emerald-600">
 								<TrendingDown className="h-3.5 w-3.5" />
-								<span>{((1 - log.discount) * 100).toFixed(0)}% off</span>
+								<span>{(log.discount * 100).toFixed(0)}% off</span>
 							</div>
 						)}
 						{log.source && (
@@ -560,7 +560,7 @@ export function LogCard({
 											<>
 												<div>Discount Applied</div>
 												<div className="text-green-600">
-													{((1 - log.discount) * 100).toFixed(0)}% off
+													{(log.discount * 100).toFixed(0)}% off
 												</div>
 											</>
 										)}


### PR DESCRIPTION
## Summary
- Fixed discount percentage being displayed as the inverse (e.g., 20% off showing as 80% off)
- The `log.discount` value already represents the percentage off directly (0.2 = 20% off), so the formula `(1 - discount) * 100` was incorrect — changed to `discount * 100`
- Fixed in 3 places: log card compact view, log card expanded cost details, and admin project logs

## Test plan
- [ ] Verify logs with discounted models (e.g., gemini-3-image-pro on obsidian) show correct discount percentage
- [ ] Verify discount displays correctly in both the UI dashboard and admin dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected discount percentage calculations in log entries and dashboard components to accurately display the applied discount rate instead of the previously calculated inverse percentage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->