### PR TITLE
fix(ui,playground): improve mobile logs & error handling

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -138,6 +138,7 @@ export default function ChatPageClient({
 	);
 	const chatIdRef = useRef(currentChatId);
 	const isNewChatRef = useRef(false);
+	const errorOccurredRef = useRef(false);
 	const panelIdCounterRef = useRef(1);
 	// Flag to indicate we should clear messages on next URL change (set by handleChatSelect)
 	const shouldClearMessagesRef = useRef(false);
@@ -145,6 +146,7 @@ export default function ChatPageClient({
 	const { messages, setMessages, sendMessage, status, stop, regenerate } =
 		useChat({
 			onError: async (e) => {
+				errorOccurredRef.current = true;
 				const msg = getErrorMessage(e);
 				setError(msg);
 				toast.error(msg);
@@ -169,6 +171,12 @@ export default function ChatPageClient({
 			},
 			onFinish: async ({ message }) => {
 				isNewChatRef.current = false;
+
+				// If an error already occurred during streaming, skip saving the response
+				if (errorOccurredRef.current) {
+					errorOccurredRef.current = false;
+					return;
+				}
 
 				// Wait for chatId to be available (handleUserMessage might still be running)
 				let chatId = chatIdRef.current;
@@ -627,6 +635,7 @@ export default function ChatPageClient({
 
 		setError(null);
 		setIsLoading(true);
+		errorOccurredRef.current = false;
 
 		const isNewChat = !chatIdRef.current;
 		if (isNewChat) {

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -122,72 +122,105 @@ export function LogCard({
 	return (
 		<div className="rounded-lg border bg-card text-card-foreground shadow-sm max-w-full overflow-hidden">
 			<div
-				className={`flex items-start gap-4 p-4 ${isExpanded ? "border-b" : ""}`}
+				className={`flex items-start gap-3 p-4 ${isExpanded ? "border-b" : ""}`}
 			>
-				<div className={`mt-0.5 rounded-full p-1.5 ${bgColor}`}>
+				<div className={`mt-0.5 rounded-full p-1.5 ${bgColor} shrink-0`}>
 					<StatusIcon className={`h-5 w-5 ${color}`} />
 				</div>
-				<div className="flex-1 space-y-1 min-w-0">
-					<div className="flex items-start justify-between gap-4">
-						<div className="flex items-center gap-2 flex-1 min-w-0">
-							<p className="font-medium break-words max-w-none line-clamp-2">
-								{log.content ||
-									(log.unifiedFinishReason === "tool_calls" && log.toolResults
-										? Array.isArray(log.toolResults)
-											? `Tool calls: ${log.toolResults.map((tr) => tr.function?.name || "unknown").join(", ")}`
-											: "Tool calls executed"
-										: "---")}
-							</p>
-							{!log.content &&
-								log.unifiedFinishReason !== "tool_calls" &&
-								!log.hasError &&
-								!log.canceled &&
-								!retentionEnabled && (
-									<TooltipProvider>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<Info className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-											</TooltipTrigger>
-											<TooltipContent>
-												<p>
-													Enable retention in organization policies to store
-													response content
-												</p>
-											</TooltipContent>
-										</Tooltip>
-									</TooltipProvider>
-								)}
-						</div>
-						<div className="flex items-center gap-1.5 flex-shrink-0">
-							{log.retried && (
+				<div className="flex-1 min-w-0 space-y-2">
+					<div className="flex items-start justify-between gap-2">
+						<div className="flex-1 min-w-0">
+							<div className="flex items-center gap-2 min-w-0">
+								<p className="font-medium break-words max-w-none line-clamp-2">
+									{log.content ||
+										(log.unifiedFinishReason === "tool_calls" && log.toolResults
+											? Array.isArray(log.toolResults)
+												? `Tool calls: ${log.toolResults.map((tr) => tr.function?.name || "unknown").join(", ")}`
+												: "Tool calls executed"
+											: "---")}
+								</p>
+								{!log.content &&
+									log.unifiedFinishReason !== "tool_calls" &&
+									!log.hasError &&
+									!log.canceled &&
+									!retentionEnabled && (
+										<TooltipProvider>
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<Info className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+												</TooltipTrigger>
+												<TooltipContent>
+													<p>
+														Enable retention in organization policies to store
+														response content
+													</p>
+												</TooltipContent>
+											</Tooltip>
+										</TooltipProvider>
+									)}
+							</div>
+							<div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
 								<Badge
-									variant="outline"
-									className="gap-1 text-amber-600 border-amber-300 bg-amber-50"
-								>
-									<RefreshCw className="h-3 w-3" />
-									Retried
-								</Badge>
-							)}
-							<Badge
-								variant={
-									log.hasError
-										? "destructive"
-										: log.unifiedFinishReason === "content_filter"
+									variant={
+										log.hasError
 											? "destructive"
-											: "default"
-								}
+											: log.unifiedFinishReason === "content_filter"
+												? "destructive"
+												: "default"
+									}
+								>
+									{log.unifiedFinishReason}
+								</Badge>
+								{log.retried && (
+									<Badge
+										variant="outline"
+										className="gap-1 text-amber-600 border-amber-300 bg-amber-50"
+									>
+										<RefreshCw className="h-3 w-3" />
+										Retried
+									</Badge>
+								)}
+							</div>
+						</div>
+						<div className="flex items-center gap-1 shrink-0">
+							{orgId && projectId && log.id && (
+								<Button
+									asChild
+									variant="ghost"
+									size="sm"
+									className="h-8 w-8 p-0"
+								>
+									<Link
+										href={`/dashboard/${orgId}/${projectId}/activity/${log.id}`}
+										prefetch={false}
+									>
+										<ExternalLink className="h-4 w-4" />
+										<span className="sr-only">View details</span>
+									</Link>
+								</Button>
+							)}
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-8 w-8 p-0"
+								onClick={toggleExpand}
 							>
-								{log.unifiedFinishReason}
-							</Badge>
+								{isExpanded ? (
+									<ChevronUp className="h-4 w-4" />
+								) : (
+									<ChevronDown className="h-4 w-4" />
+								)}
+								<span className="sr-only">Toggle details</span>
+							</Button>
 						</div>
 					</div>
-					<div className="flex flex-wrap items-center gap-x-4 gap-y-1 pt-1 text-sm text-muted-foreground">
-						<div className="flex items-center gap-1">
-							<Package className="h-3.5 w-3.5" />
-							<span>{log.usedModel}</span>
+					<div className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-sm text-muted-foreground sm:flex sm:flex-wrap sm:items-center sm:gap-x-4 sm:gap-y-1">
+						<div className="flex items-center gap-1 col-span-2">
+							<Package className="h-3.5 w-3.5 shrink-0" />
+							<span className="truncate">{log.usedModel}</span>
 						</div>
 						<div className="flex items-center gap-1">
-							<Zap className="h-3.5 w-3.5" />
+							<Zap className="h-3.5 w-3.5 shrink-0" />
 							<span>
 								{log.cached
 									? "Fully cached"
@@ -197,7 +230,7 @@ export function LogCard({
 							</span>
 						</div>
 						<div className="flex items-center gap-1">
-							<Clock className="h-3.5 w-3.5" />
+							<Clock className="h-3.5 w-3.5 shrink-0" />
 							<span>
 								{log.totalTokens} tokens
 								{log.cachedTokens && Number(log.cachedTokens) > 0 && (
@@ -206,14 +239,14 @@ export function LogCard({
 							</span>
 						</div>
 						<div className="flex items-center gap-1">
-							<Clock className="h-3.5 w-3.5" />
+							<Clock className="h-3.5 w-3.5 shrink-0" />
 							<span>{formatDuration(log.duration ?? 0)}</span>
 						</div>
 						<TooltipProvider>
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<div className="flex items-center gap-1">
-										<Coins className="h-3.5 w-3.5" />
+										<Coins className="h-3.5 w-3.5 shrink-0" />
 										<span>
 											{log.cost
 												? `$${log.cost.toFixed(6)}`
@@ -235,52 +268,28 @@ export function LogCard({
 						</TooltipProvider>
 						{log.discount && log.discount !== 1 && (
 							<div className="flex items-center gap-1 text-emerald-600">
-								<TrendingDown className="h-3.5 w-3.5" />
+								<TrendingDown className="h-3.5 w-3.5 shrink-0" />
 								<span>{(log.discount * 100).toFixed(0)}% off</span>
 							</div>
 						)}
 						{log.source && (
 							<div className="flex items-center gap-1">
-								<LinkIcon className="h-3.5 w-3.5" />
+								<LinkIcon className="h-3.5 w-3.5 shrink-0" />
 								<span>{log.source}</span>
 							</div>
 						)}
 						{log.plugins && log.plugins.length > 0 && (
 							<div className="flex items-center gap-1">
-								<Plug className="h-3.5 w-3.5" />
+								<Plug className="h-3.5 w-3.5 shrink-0" />
 								<span>
 									{log.plugins.length} plugin{log.plugins.length > 1 ? "s" : ""}
 								</span>
 							</div>
 						)}
-						<span className="ml-auto">{formattedTime}</span>
+						<span className="col-span-2 sm:ml-auto text-xs">
+							{formattedTime}
+						</span>
 					</div>
-				</div>
-				<div className="flex items-center gap-1">
-					{orgId && projectId && log.id && (
-						<Button asChild variant="ghost" size="sm" className="h-8 w-8 p-0">
-							<Link
-								href={`/dashboard/${orgId}/${projectId}/activity/${log.id}`}
-								prefetch={false}
-							>
-								<ExternalLink className="h-4 w-4" />
-								<span className="sr-only">View details</span>
-							</Link>
-						</Button>
-					)}
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-8 w-8 p-0"
-						onClick={toggleExpand}
-					>
-						{isExpanded ? (
-							<ChevronUp className="h-4 w-4" />
-						) : (
-							<ChevronDown className="h-4 w-4" />
-						)}
-						<span className="sr-only">Toggle details</span>
-					</Button>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary
- **Activity logs mobile layout**: Restructured the log card header to use a 2-column CSS grid on mobile instead of flex-wrap, moved badges below content preview, and added `shrink-0` to icons to prevent squishing on narrow screens
- **Playground error cascading**: Added an `errorOccurredRef` flag so that when `onError` fires (e.g. upstream provider error), `onFinish` skips saving the empty response — preventing confusing follow-up errors like "Either content or images must be provided"

## Test plan
- [ ] View activity logs on a mobile-width screen and verify the card metrics display in a clean 2-column grid
- [ ] On desktop, verify logs still display with the flex-wrap row layout as before
- [ ] In the playground, trigger a provider error (e.g. use a non-existent model) and confirm only the original error toast appears, not cascading save errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during message streaming to prevent saving partial or erroneous responses.

* **Style**
  * Redesigned log card layout with enhanced responsiveness and better organization of response metrics and cost information.
  * Added collapsible controls and dynamic status badge variants for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->