### PR TITLE
fix: auto-routed requests not retried on upstream errors

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -912,6 +912,8 @@ chat.openapi(completions, async (c) => {
 			usedModel = "gpt-5-nano";
 			usedProvider = "openai";
 		}
+		// Clear requestedProvider so retry/fallback logic knows this was auto-routed
+		requestedProvider = undefined;
 	} else if (
 		(usedProvider === "llmgateway" && usedModel === "custom") ||
 		usedModel === "custom"


### PR DESCRIPTION
## Summary
- Fixes a bug where requests using `llmgateway/auto` were never retried on upstream errors (e.g. timeouts), even when other providers were available
- `parseModelInput("llmgateway/auto")` sets `requestedProvider = "llmgateway"`, but after auto-routing resolves the actual provider, `requestedProvider` was never cleared
- `shouldRetryRequest()` checks `requestedProvider` first and returns `false` if truthy, blocking all retries/fallback

## Test plan
- [x] Unit tests pass (`retry-with-fallback.spec.ts` — 25 tests)
- [x] TypeScript compiles with no errors
- [ ] Verify in production that `llmgateway/auto` requests now fall back to alternative providers on upstream timeout/error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-routing logic in the chat gateway to ensure fallback mechanisms function correctly when the system automatically selects a provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->