### PR TITLE
fix: preserve zero value for cached tokens instead of coercing to null

### DIFF
--- a/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+
+import { extractTokenUsage } from "./extract-token-usage.js";
+
+describe("extractTokenUsage", () => {
+	describe("aws-bedrock", () => {
+		it("returns cachedTokens as 0 when cacheReadInputTokens is 0", () => {
+			const data = {
+				usage: {
+					inputTokens: 100,
+					cacheReadInputTokens: 0,
+					cacheWriteInputTokens: 50,
+					outputTokens: 200,
+					totalTokens: 350,
+				},
+			};
+
+			const result = extractTokenUsage(data, "aws-bedrock");
+
+			expect(result.cachedTokens).toBe(0);
+			expect(result.promptTokens).toBe(150); // 100 + 0 + 50
+			expect(result.completionTokens).toBe(200);
+			expect(result.totalTokens).toBe(350);
+		});
+
+		it("returns cachedTokens with correct value when cacheReadInputTokens > 0", () => {
+			const data = {
+				usage: {
+					inputTokens: 100,
+					cacheReadInputTokens: 500,
+					cacheWriteInputTokens: 0,
+					outputTokens: 200,
+					totalTokens: 800,
+				},
+			};
+
+			const result = extractTokenUsage(data, "aws-bedrock");
+
+			expect(result.cachedTokens).toBe(500);
+			expect(result.promptTokens).toBe(600); // 100 + 500 + 0
+		});
+
+		it("returns cachedTokens as 0 when cacheReadInputTokens is missing", () => {
+			const data = {
+				usage: {
+					inputTokens: 100,
+					outputTokens: 200,
+					totalTokens: 300,
+				},
+			};
+
+			const result = extractTokenUsage(data, "aws-bedrock");
+
+			// cacheReadInputTokens is undefined, ?? 0 gives 0
+			expect(result.cachedTokens).toBe(0);
+			expect(result.promptTokens).toBe(100);
+		});
+
+		it("returns null for all fields when usage is missing", () => {
+			const data = {};
+
+			const result = extractTokenUsage(data, "aws-bedrock");
+
+			expect(result.cachedTokens).toBeNull();
+			expect(result.promptTokens).toBeNull();
+			expect(result.completionTokens).toBeNull();
+		});
+	});
+
+	describe("anthropic", () => {
+		it("returns cachedTokens as 0 when cache_read_input_tokens is 0", () => {
+			const data = {
+				usage: {
+					input_tokens: 100,
+					cache_creation_input_tokens: 50,
+					cache_read_input_tokens: 0,
+					output_tokens: 200,
+				},
+			};
+
+			const result = extractTokenUsage(data, "anthropic");
+
+			expect(result.cachedTokens).toBe(0);
+			expect(result.promptTokens).toBe(150); // 100 + 50 + 0
+			expect(result.completionTokens).toBe(200);
+		});
+
+		it("returns cachedTokens with correct value when cache_read_input_tokens > 0", () => {
+			const data = {
+				usage: {
+					input_tokens: 100,
+					cache_creation_input_tokens: 0,
+					cache_read_input_tokens: 800,
+					output_tokens: 200,
+				},
+			};
+
+			const result = extractTokenUsage(data, "anthropic");
+
+			expect(result.cachedTokens).toBe(800);
+			expect(result.promptTokens).toBe(900); // 100 + 0 + 800
+		});
+
+		it("returns cachedTokens as 0 when cache_read_input_tokens is missing", () => {
+			const data = {
+				usage: {
+					input_tokens: 100,
+					output_tokens: 200,
+				},
+			};
+
+			const result = extractTokenUsage(data, "anthropic");
+
+			// cache_read_input_tokens is undefined, ?? 0 gives 0
+			expect(result.cachedTokens).toBe(0);
+			expect(result.promptTokens).toBe(100);
+		});
+
+		it("returns null for all fields when usage is missing", () => {
+			const data = {};
+
+			const result = extractTokenUsage(data, "anthropic");
+
+			expect(result.cachedTokens).toBeNull();
+			expect(result.promptTokens).toBeNull();
+			expect(result.completionTokens).toBeNull();
+		});
+	});
+
+	describe("openai (default)", () => {
+		it("returns cachedTokens from prompt_tokens_details.cached_tokens", () => {
+			const data = {
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 200,
+					total_tokens: 300,
+					prompt_tokens_details: {
+						cached_tokens: 50,
+					},
+				},
+			};
+
+			const result = extractTokenUsage(data, "openai");
+
+			expect(result.cachedTokens).toBe(50);
+		});
+
+		it("returns null cachedTokens when prompt_tokens_details is missing", () => {
+			const data = {
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 200,
+					total_tokens: 300,
+				},
+			};
+
+			const result = extractTokenUsage(data, "openai");
+
+			expect(result.cachedTokens).toBeNull();
+		});
+	});
+});

--- a/apps/gateway/src/chat/tools/extract-token-usage.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.ts
@@ -107,7 +107,7 @@ export function extractTokenUsage(
 				promptTokens = inputTokens + cacheReadTokens + cacheWriteTokens;
 				completionTokens = data.usage.outputTokens ?? null;
 				// Cached tokens are the tokens read from cache (discount applies to these)
-				cachedTokens = cacheReadTokens || null;
+				cachedTokens = cacheReadTokens;
 				totalTokens = data.usage.totalTokens ?? null;
 			}
 			break;
@@ -124,7 +124,7 @@ export function extractTokenUsage(
 				completionTokens = data.usage.output_tokens ?? null;
 				reasoningTokens = data.usage.reasoning_output_tokens ?? null;
 				// Cached tokens are the tokens read from cache (discount applies to these)
-				cachedTokens = cacheReadTokens || null;
+				cachedTokens = cacheReadTokens;
 				totalTokens = (promptTokens ?? 0) + (completionTokens ?? 0);
 			}
 			break;

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { parseProviderResponse } from "./parse-provider-response.js";
+
+vi.mock("@llmgateway/cache", () => ({
+	redisClient: {
+		setex: vi.fn().mockResolvedValue("OK"),
+	},
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+describe("parseProviderResponse", () => {
+	describe("aws-bedrock cachedTokens", () => {
+		it("returns cachedTokens as 0 when cacheReadInputTokens is 0", () => {
+			const json = {
+				output: {
+					message: {
+						content: [{ text: "Hello" }],
+						role: "assistant",
+					},
+				},
+				stopReason: "end_turn",
+				usage: {
+					inputTokens: 100,
+					cacheReadInputTokens: 0,
+					cacheWriteInputTokens: 50,
+					outputTokens: 200,
+					totalTokens: 350,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"aws-bedrock",
+				"anthropic.claude-3-sonnet",
+				json,
+			);
+
+			expect(result.cachedTokens).toBe(0);
+			expect(result.promptTokens).toBe(150); // 100 + 0 + 50
+		});
+
+		it("returns cachedTokens with correct value when cacheReadInputTokens > 0", () => {
+			const json = {
+				output: {
+					message: {
+						content: [{ text: "Hello" }],
+						role: "assistant",
+					},
+				},
+				stopReason: "end_turn",
+				usage: {
+					inputTokens: 100,
+					cacheReadInputTokens: 500,
+					cacheWriteInputTokens: 0,
+					outputTokens: 200,
+					totalTokens: 800,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"aws-bedrock",
+				"anthropic.claude-3-sonnet",
+				json,
+			);
+
+			expect(result.cachedTokens).toBe(500);
+			expect(result.promptTokens).toBe(600); // 100 + 500 + 0
+		});
+
+		it("returns cachedTokens as 0 when cacheReadInputTokens is missing", () => {
+			const json = {
+				output: {
+					message: {
+						content: [{ text: "Hello" }],
+						role: "assistant",
+					},
+				},
+				stopReason: "end_turn",
+				usage: {
+					inputTokens: 100,
+					outputTokens: 200,
+					totalTokens: 300,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"aws-bedrock",
+				"anthropic.claude-3-sonnet",
+				json,
+			);
+
+			expect(result.cachedTokens).toBe(0);
+		});
+	});
+
+	describe("anthropic cachedTokens", () => {
+		it("returns cachedTokens as 0 when cache_read_input_tokens is 0", () => {
+			const json = {
+				content: [{ type: "text", text: "Hello" }],
+				stop_reason: "end_turn",
+				usage: {
+					input_tokens: 100,
+					cache_creation_input_tokens: 50,
+					cache_read_input_tokens: 0,
+					output_tokens: 200,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"anthropic",
+				"claude-3-sonnet",
+				json,
+			);
+
+			expect(result.cachedTokens).toBe(0);
+			expect(result.promptTokens).toBe(150); // 100 + 50 + 0
+		});
+
+		it("returns cachedTokens with correct value when cache_read_input_tokens > 0", () => {
+			const json = {
+				content: [{ type: "text", text: "Hello" }],
+				stop_reason: "end_turn",
+				usage: {
+					input_tokens: 100,
+					cache_creation_input_tokens: 0,
+					cache_read_input_tokens: 800,
+					output_tokens: 200,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"anthropic",
+				"claude-3-sonnet",
+				json,
+			);
+
+			expect(result.cachedTokens).toBe(800);
+			expect(result.promptTokens).toBe(900); // 100 + 0 + 800
+		});
+
+		it("returns cachedTokens as 0 when cache_read_input_tokens is missing", () => {
+			const json = {
+				content: [{ type: "text", text: "Hello" }],
+				stop_reason: "end_turn",
+				usage: {
+					input_tokens: 100,
+					output_tokens: 200,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"anthropic",
+				"claude-3-sonnet",
+				json,
+			);
+
+			expect(result.cachedTokens).toBe(0);
+		});
+	});
+});

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -59,16 +59,16 @@ export function parseProviderResponse(
 
 			// Extract usage tokens (including cached tokens for prompt caching)
 			if (json.usage) {
-				const inputTokens = json.usage.inputTokens || 0;
-				const cacheReadTokens = json.usage.cacheReadInputTokens || 0;
-				const cacheWriteTokens = json.usage.cacheWriteInputTokens || 0;
+				const inputTokens = json.usage.inputTokens ?? 0;
+				const cacheReadTokens = json.usage.cacheReadInputTokens ?? 0;
+				const cacheWriteTokens = json.usage.cacheWriteInputTokens ?? 0;
 
 				// Total prompt tokens = regular input + cache read + cache write
 				promptTokens = inputTokens + cacheReadTokens + cacheWriteTokens;
-				completionTokens = json.usage.outputTokens || null;
-				totalTokens = json.usage.totalTokens || null;
+				completionTokens = json.usage.outputTokens ?? null;
+				totalTokens = json.usage.totalTokens ?? null;
 				// Cached tokens are the tokens read from cache (discount applies to these)
-				cachedTokens = cacheReadTokens || null;
+				cachedTokens = cacheReadTokens;
 			}
 
 			// Extract tool calls if present
@@ -147,16 +147,16 @@ export function parseProviderResponse(
 			// For Anthropic: input_tokens are the non-cached tokens
 			// We need to add cache_creation_input_tokens to get total input tokens
 			if (json.usage) {
-				const inputTokens = json.usage.input_tokens || 0;
-				const cacheCreationTokens = json.usage.cache_creation_input_tokens || 0;
-				const cacheReadTokens = json.usage.cache_read_input_tokens || 0;
+				const inputTokens = json.usage.input_tokens ?? 0;
+				const cacheCreationTokens = json.usage.cache_creation_input_tokens ?? 0;
+				const cacheReadTokens = json.usage.cache_read_input_tokens ?? 0;
 
 				// Total prompt tokens = non-cached + cache creation + cache read
 				promptTokens = inputTokens + cacheCreationTokens + cacheReadTokens;
-				completionTokens = json.usage.output_tokens || null;
-				reasoningTokens = json.usage.reasoning_output_tokens || null;
+				completionTokens = json.usage.output_tokens ?? null;
+				reasoningTokens = json.usage.reasoning_output_tokens ?? null;
 				// Cached tokens are the tokens read from cache (discount applies to these)
-				cachedTokens = cacheReadTokens || null;
+				cachedTokens = cacheReadTokens;
 				totalTokens =
 					promptTokens && completionTokens
 						? promptTokens + completionTokens


### PR DESCRIPTION
## Summary
- Fixed `cachedTokens = cacheReadTokens || null` coercing legitimate `0` values to `null` in both `extract-token-usage.ts` and `parse-provider-response.ts` for AWS Bedrock and Anthropic providers
- Changed `|| 0` to `?? 0` for extracting cache-related fields in `parse-provider-response.ts` to prevent the same class of zero-coercion bug on input extraction
- Added unit tests for `extractTokenUsage` and `parseProviderResponse` verifying correct handling of zero, positive, and missing cached token values

## Problem
The `||` operator treats `0` as falsy in JavaScript. When a provider returns `cacheReadInputTokens: 0` (meaning the cache was checked but had no cached tokens), the expression `cacheReadTokens || null` evaluates to `null`. This makes it impossible to distinguish between:
- **0 cached tokens** — cache was checked, nothing was cached (should be `0`)
- **Cache data not available** — no caching info in the response (should be `null`)

This affects cost calculations since cached tokens receive a pricing discount.

## Changes
| File | Change |
|------|--------|
| `extract-token-usage.ts` | `cachedTokens = cacheReadTokens \|\| null` → `cachedTokens = cacheReadTokens` (lines 110, 127) |
| `parse-provider-response.ts` | Same `\|\| null` → direct assignment fix (lines 71, 159), plus `\|\| 0` → `?? 0` for field extraction (lines 62-64, 68-69, 150-152, 156-157) |
| `extract-token-usage.spec.ts` | New: 10 tests covering AWS Bedrock, Anthropic, and OpenAI cached token handling |
| `parse-provider-response.spec.ts` | New: 6 tests covering AWS Bedrock and Anthropic cached token handling |

## Test plan
- [x] All 124 existing + new unit tests pass (`vitest run apps/gateway/src/chat/tools/`)
- [ ] Verify in staging that cached token values of 0 are correctly stored and displayed
- [ ] Confirm cost calculations are not affected for providers without caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage calculations to correctly preserve zero values instead of converting them to null for cached tokens and other token metrics across AWS Bedrock and Anthropic providers.

* **Tests**
  * Added comprehensive test coverage for token usage extraction and parsing across multiple LLM providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->