### PR TITLE
fix: use Drizzle and() for passkey delete WHERE clause

### DIFF
--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+describe("user passkey deletion", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+
+		// Insert two passkeys for the test user
+		await db.insert(tables.passkey).values([
+			{
+				id: "passkey-1",
+				publicKey: "pk-1",
+				userId: "test-user-id",
+				credentialID: "cred-1",
+				counter: 0,
+			},
+			{
+				id: "passkey-2",
+				publicKey: "pk-2",
+				userId: "test-user-id",
+				credentialID: "cred-2",
+				counter: 0,
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.passkey);
+		await deleteAll();
+	});
+
+	it("DELETE /me/passkeys/:id should only delete the specified passkey", async () => {
+		// Delete passkey-1
+		const res = await app.request("/user/me/passkeys/passkey-1", {
+			method: "DELETE",
+			headers: {
+				Cookie: token,
+			},
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.message).toBe("Passkey deleted successfully");
+
+		// Verify passkey-1 is gone
+		const deletedPasskey = await db.query.passkey.findFirst({
+			where: {
+				id: {
+					eq: "passkey-1",
+				},
+			},
+		});
+		expect(deletedPasskey).toBeUndefined();
+
+		// Verify passkey-2 still exists
+		const remainingPasskey = await db.query.passkey.findFirst({
+			where: {
+				id: {
+					eq: "passkey-2",
+				},
+			},
+		});
+		expect(remainingPasskey).toBeDefined();
+		expect(remainingPasskey!.id).toBe("passkey-2");
+	});
+
+	it("DELETE /me/passkeys/:id should not delete passkeys belonging to other users", async () => {
+		// Create another user and their passkey
+		await db.insert(tables.user).values({
+			id: "other-user-id",
+			name: "Other User",
+			email: "other@example.com",
+			emailVerified: true,
+		});
+
+		await db.insert(tables.passkey).values({
+			id: "passkey-other",
+			publicKey: "pk-other",
+			userId: "other-user-id",
+			credentialID: "cred-other",
+			counter: 0,
+		});
+
+		// Attempt to delete the other user's passkey as the test user
+		const res = await app.request("/user/me/passkeys/passkey-other", {
+			method: "DELETE",
+			headers: {
+				Cookie: token,
+			},
+		});
+
+		// The request completes (no row matched both conditions)
+		expect(res.status).toBe(200);
+
+		// The other user's passkey should still exist
+		const otherPasskey = await db.query.passkey.findFirst({
+			where: {
+				id: {
+					eq: "passkey-other",
+				},
+			},
+		});
+		expect(otherPasskey).toBeDefined();
+		expect(otherPasskey!.userId).toBe("other-user-id");
+
+		// Clean up
+		await db
+			.delete(tables.passkey)
+			.where(eq(tables.passkey.id, "passkey-other"));
+		await db.delete(tables.user).where(eq(tables.user.id, "other-user-id"));
+	});
+
+	it("DELETE /me/passkeys/:id should require authentication", async () => {
+		const res = await app.request("/user/me/passkeys/passkey-1", {
+			method: "DELETE",
+		});
+		expect(res.status).toBe(401);
+	});
+});

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { apiAuth as auth, updateResendContact } from "@/auth/config.js";
 
-import { db, eq, tables } from "@llmgateway/db";
+import { and, db, eq, tables } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -132,7 +132,9 @@ user.openapi(deletePasskey, async (c) => {
 
 	await db
 		.delete(tables.passkey)
-		.where(eq(tables.passkey.id, id) && eq(tables.passkey.userId, authUser.id));
+		.where(
+			and(eq(tables.passkey.id, id), eq(tables.passkey.userId, authUser.id)),
+		);
 
 	return c.json({
 		message: "Passkey deleted successfully",


### PR DESCRIPTION
## Summary

- **Security fix**: The passkey delete endpoint (`DELETE /user/me/passkeys/:id`) used JavaScript `&&` instead of Drizzle ORM's `and()` to combine WHERE conditions. Since `A && B` returns `B` when `A` is truthy, the `eq(passkey.id, id)` condition was silently dropped, causing the query to match **all** passkeys for the authenticated user rather than just the specified one. This means deleting any single passkey would delete **all** passkeys belonging to that user.
- **Fix**: Import and use `and()` from `@llmgateway/db` to properly combine both `eq()` conditions in the SQL WHERE clause.
- **Tests**: Added `user.spec.ts` with 3 integration tests covering: deleting a specific passkey without affecting others, cross-user passkey isolation, and authentication requirement.

## Test plan

- [x] Verify `DELETE /user/me/passkeys/:id` only deletes the specified passkey (passkey-2 remains)
- [x] Verify a user cannot delete another user's passkey via this endpoint
- [x] Verify unauthenticated requests are rejected with 401
- [x] All 39 existing test files pass (526/527 tests pass; 1 pre-existing flaky timeout test in gateway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue with the passkey deletion endpoint that now correctly validates and processes removal requests with proper security checks.

* **Tests**
  * Added thorough test coverage for passkey deletion operations, validating successful removal of user passkeys, enforcing authentication requirements, and preventing unauthorized cross-user deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->