### PR TITLE
fix: hide zero request price in model comparison

### DIFF
--- a/apps/ui/src/components/models/model-comparison.tsx
+++ b/apps/ui/src/components/models/model-comparison.tsx
@@ -235,7 +235,10 @@ function getPricingSummary(
 ): PricingSummary | undefined {
 	const entries = providers
 		.filter(
-			(provider) => provider[field] !== undefined && provider[field] !== null,
+			(provider) =>
+				provider[field] !== undefined &&
+				provider[field] !== null &&
+				provider[field] !== 0,
 		)
 		.map((provider) => {
 			const rawValue = provider[field] as number;


### PR DESCRIPTION
## Summary
- Filter out providers with a price of `0` in `getPricingSummary` so the model comparison page shows `—` instead of `$0.0000/1K requests via Google AI Studio`

## Test plan
- [ ] Open model comparison page for models with free providers (e.g. Gemini via Google AI Studio)
- [ ] Verify "Request Price" row shows `—` instead of `$0.0000/1K requests`
- [ ] Verify models with non-zero request prices still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pricing summary calculations to properly exclude zero-valued pricing information, ensuring accurate best-price display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->