### PR TITLE
fix: downgrade Anthropic->OpenAI client error logs from error to warn

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -461,12 +461,17 @@ anthropic.openapi(messages, async (c) => {
 	});
 
 	if (!response.ok) {
-		// Don't log 402/429 as errors - they're expected business logic responses (insufficient credits, rate limiting)
+		// Don't log 402/429 - they're expected business logic responses (insufficient credits, rate limiting)
 		if (response.status !== 402 && response.status !== 429) {
-			logger.error("Anthropic -> OpenAI request failed", {
+			const logPayload = {
 				status: response.status,
 				statusText: response.statusText,
-			});
+			};
+			if (response.status >= 500) {
+				logger.error("Anthropic -> OpenAI request failed", logPayload);
+			} else {
+				logger.warn("Anthropic -> OpenAI request failed", logPayload);
+			}
 		}
 		const errorData = await response.text();
 		throw new HTTPException(


### PR DESCRIPTION
## Summary
- Downgraded logging for 4xx responses in the Anthropic->OpenAI proxy from `logger.error` to `logger.warn`
- 5xx (server errors) remain logged at error level
- Client errors like 401 (unauthorized) are expected responses and shouldn't trigger error-level alerts

## Test plan
- [ ] Verify 4xx responses (e.g. 401, 400, 403) are logged at warn level
- [ ] Verify 5xx responses are still logged at error level
- [ ] Verify 402 and 429 are still excluded from logging entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error logging with more granular severity levels: server errors now logged as critical errors, client errors (excluding rate limits and authentication errors) logged as warnings. This enhancement enables better system diagnostics and more targeted error tracking for improved issue resolution.

* **Refactor**
  * Consolidated response logging implementation for better code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->