### PR TITLE
feat: add nano banana pro cost simulator

### DIFF
--- a/apps/ui/src/app/nano-banana-simulator/[discount]/opengraph-image.tsx
+++ b/apps/ui/src/app/nano-banana-simulator/[discount]/opengraph-image.tsx
@@ -1,0 +1,197 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+function parseDiscount(value: string): number {
+	const parsed = Number(value);
+	if (isNaN(parsed) || parsed < 1 || parsed > 99) {
+		return 20;
+	}
+	return Math.round(parsed);
+}
+
+export default async function NanoBananaSimulatorOgImage({
+	params,
+}: {
+	params: Promise<{ discount: string }>;
+}) {
+	const { discount: raw } = await params;
+	const discount = parseDiscount(raw);
+
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "space-between",
+					alignItems: "stretch",
+					background: "#000000",
+					color: "white",
+					fontFamily:
+						"system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+					padding: 60,
+					boxSizing: "border-box",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						alignItems: "center",
+						gap: 16,
+					}}
+				>
+					<svg
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 218 232"
+						width={48}
+						height={48}
+					>
+						<path
+							d="M218 59.4686c0-4.1697-2.351-7.9813-6.071-9.8441L119.973 3.58361s2.926 3.32316 2.926 7.01529V218.833c0 4.081-2.926 7.016-2.926 7.016l15.24-7.468c2.964-2.232 7.187-7.443 7.438-16.006.293-9.976.61-84.847.732-121.0353.487-3.6678 4.096-11.0032 14.63-11.0032 10.535 0 29.262 5.1348 37.309 7.7022 2.439.7336 7.608 4.1812 8.779 12.1036 1.17 7.9223.975 59.0507.731 83.6247 0 2.445.137 7.069 6.653 7.069 6.515 0 6.515-7.069 6.515-7.069V59.4686Z"
+							fill="#ffffff"
+						/>
+						<path
+							d="M149.235 86.323c0-5.5921 5.132-9.7668 10.589-8.6132l31.457 6.6495c4.061.8585 6.967 4.4207 6.967 8.5824v81.9253c0 5.868 5.121 9.169 5.121 9.169l-51.9-12.658c-1.311-.32-2.234-1.498-2.234-2.852V86.323ZM99.7535 1.15076c7.2925-3.60996 15.8305 1.71119 15.8305 9.86634V220.983c0 8.155-8.538 13.476-15.8305 9.866L6.11596 184.496C2.37105 182.642 0 178.818 0 174.63v-17.868l49.7128 19.865c4.0474 1.617 8.4447-1.372 8.4449-5.741 0-2.66-1.6975-5.022-4.2142-5.863L0 146.992v-14.305l40.2756 7.708c3.9656.759 7.6405-2.289 7.6405-6.337 0-3.286-2.4628-6.048-5.7195-6.413L0 122.917V108.48l78.5181-3.014c4.1532-.16 7.4381-3.582 7.4383-7.7498 0-4.6256-4.0122-8.2229-8.5964-7.7073L0 98.7098V82.4399l53.447-17.8738c2.3764-.7948 3.9791-3.0254 3.9792-5.5374 0-4.0961-4.0978-6.9185-7.9106-5.4486L0 72.6695V57.3696c.0000304-4.1878 2.37107-8.0125 6.11596-9.8664L99.7535 1.15076Z"
+							fill="#ffffff"
+						/>
+					</svg>
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							gap: 8,
+							fontSize: 24,
+							color: "#9CA3AF",
+						}}
+					>
+						<span style={{ color: "#ffffff", fontWeight: 600 }}>
+							LLM Gateway
+						</span>
+						<span style={{ opacity: 0.6 }}>•</span>
+						<span>Cost Simulator</span>
+					</div>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						justifyContent: "center",
+						flex: 1,
+						gap: 32,
+					}}
+				>
+					<h1
+						style={{
+							fontSize: 64,
+							fontWeight: 700,
+							margin: 0,
+							letterSpacing: "-0.02em",
+							textAlign: "center",
+						}}
+					>
+						Nano Banana Pro
+					</h1>
+
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							gap: 24,
+						}}
+					>
+						<div
+							style={{
+								display: "flex",
+								flexDirection: "column",
+								alignItems: "center",
+								backgroundColor: "#1a1a1a",
+								border: "2px solid rgba(255,255,255,0.15)",
+								borderRadius: 20,
+								padding: "24px 48px",
+								gap: 4,
+							}}
+						>
+							<span style={{ fontSize: 20, color: "#9CA3AF" }}>
+								Google AI Studio
+							</span>
+							<span style={{ fontSize: 48, fontWeight: 700 }}>Full Price</span>
+						</div>
+
+						<span
+							style={{
+								fontSize: 40,
+								color: "#9CA3AF",
+								fontWeight: 700,
+							}}
+						>
+							vs
+						</span>
+
+						<div
+							style={{
+								display: "flex",
+								flexDirection: "column",
+								alignItems: "center",
+								backgroundColor: "rgba(22, 163, 74, 0.15)",
+								border: "2px solid rgba(22, 163, 74, 0.4)",
+								borderRadius: 20,
+								padding: "24px 48px",
+								gap: 4,
+							}}
+						>
+							<span style={{ fontSize: 20, color: "#9CA3AF" }}>
+								LLM Gateway
+							</span>
+							<span
+								style={{
+									fontSize: 48,
+									fontWeight: 700,
+									color: "#4ade80",
+								}}
+							>
+								{discount}% Off
+							</span>
+						</div>
+					</div>
+
+					<p
+						style={{
+							fontSize: 24,
+							color: "#9CA3AF",
+							margin: 0,
+							textAlign: "center",
+						}}
+					>
+						Save on Gemini 3 Pro image generation
+					</p>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						justifyContent: "flex-end",
+						fontSize: 20,
+						color: "#9CA3AF",
+					}}
+				>
+					<span>llmgateway.io</span>
+				</div>
+			</div>
+		),
+		size,
+	);
+}

--- a/apps/ui/src/app/nano-banana-simulator/[discount]/page.tsx
+++ b/apps/ui/src/app/nano-banana-simulator/[discount]/page.tsx
@@ -1,0 +1,48 @@
+import Footer from "@/components/landing/footer";
+import { HeroRSC } from "@/components/landing/hero-rsc";
+import { CostCalculator } from "@/components/nano-banana-simulator/cost-calculator";
+import { PricingBreakdown } from "@/components/nano-banana-simulator/pricing-breakdown";
+import { SimulatorCta } from "@/components/nano-banana-simulator/simulator-cta";
+import { SimulatorHero } from "@/components/nano-banana-simulator/simulator-hero";
+
+import type { Metadata } from "next";
+
+interface PageProps {
+	params: Promise<{ discount: string }>;
+}
+
+function parseDiscount(value: string): number {
+	const parsed = Number(value);
+	if (isNaN(parsed) || parsed < 1 || parsed > 99) {
+		return 20;
+	}
+	return Math.round(parsed);
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { discount: raw } = await params;
+	const discount = parseDiscount(raw);
+
+	return {
+		title: "Nano Banana Pro Cost Simulator - LLM Gateway",
+		description: `See how much you save on Gemini 3 Pro image generation with LLM Gateway. ${discount}% savings compared to Google AI Studio direct pricing.`,
+	};
+}
+
+export default async function NanoBananaSimulatorPage({ params }: PageProps) {
+	const { discount: raw } = await params;
+	const discount = parseDiscount(raw);
+
+	return (
+		<>
+			<HeroRSC navbarOnly />
+			<SimulatorHero discount={discount} />
+			<CostCalculator discount={discount} />
+			<PricingBreakdown discount={discount} />
+			<SimulatorCta discount={discount} />
+			<Footer />
+		</>
+	);
+}

--- a/apps/ui/src/app/nano-banana-simulator/page.tsx
+++ b/apps/ui/src/app/nano-banana-simulator/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function NanoBananaSimulatorPage() {
+	redirect("/nano-banana-simulator/20");
+}

--- a/apps/ui/src/components/nano-banana-simulator/cost-calculator.tsx
+++ b/apps/ui/src/components/nano-banana-simulator/cost-calculator.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+
+import { Badge } from "@/lib/components/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/lib/components/card";
+import { Input } from "@/lib/components/input";
+import { Label } from "@/lib/components/label";
+import { Slider } from "@/lib/components/slider";
+
+function formatCurrency(value: number): string {
+	return `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export function CostCalculator({ discount }: { discount: number }) {
+	const [monthlySpend, setMonthlySpend] = useState(72000);
+
+	const multiplier = 1 - discount / 100;
+	const gatewayTotal = monthlySpend * multiplier;
+	const savings = monthlySpend - gatewayTotal;
+
+	return (
+		<section className="w-full py-12 md:py-16">
+			<div className="container mx-auto px-4 md:px-6 max-w-4xl">
+				<div className="space-y-8">
+					<div className="space-y-3">
+						<div className="flex items-center justify-between gap-4">
+							<Label>Estimated monthly spend on Google AI Studio</Label>
+							<div className="relative">
+								<span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">
+									$
+								</span>
+								<Input
+									type="number"
+									value={monthlySpend}
+									min={100}
+									max={500000}
+									step={100}
+									onChange={(e) => {
+										const parsed = parseFloat(e.target.value);
+										if (!isNaN(parsed)) {
+											setMonthlySpend(Math.min(500000, Math.max(100, parsed)));
+										}
+									}}
+									className="w-36 text-right pl-7"
+								/>
+							</div>
+						</div>
+						<Slider
+							value={[monthlySpend]}
+							min={100}
+							max={500000}
+							step={100}
+							onValueChange={([v]) => {
+								if (v !== undefined) {
+									setMonthlySpend(v);
+								}
+							}}
+						/>
+						<div className="flex justify-between text-xs text-muted-foreground">
+							<span>$100</span>
+							<span>$500,000</span>
+						</div>
+					</div>
+
+					<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+						<Card>
+							<CardHeader>
+								<CardDescription>Google AI Studio Direct</CardDescription>
+								<CardTitle className="text-2xl">
+									{formatCurrency(monthlySpend)}
+									<span className="text-sm font-normal text-muted-foreground">
+										/mo
+									</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent className="text-sm text-muted-foreground">
+								Full price, no discount
+							</CardContent>
+						</Card>
+
+						<Card className="border-green-200 dark:border-green-900">
+							<CardHeader>
+								<CardDescription>LLM Gateway</CardDescription>
+								<CardTitle className="text-2xl text-green-600 dark:text-green-400">
+									{formatCurrency(gatewayTotal)}
+									<span className="text-sm font-normal text-muted-foreground">
+										/mo
+									</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent className="text-sm text-muted-foreground">
+								{discount}% discount applied
+							</CardContent>
+						</Card>
+					</div>
+
+					<div className="rounded-lg border bg-green-50 dark:bg-green-950/30 border-green-200 dark:border-green-900 p-6 text-center">
+						<p className="text-sm text-muted-foreground mb-1">
+							Your estimated monthly savings
+						</p>
+						<p className="text-3xl font-bold text-green-600 dark:text-green-400">
+							{formatCurrency(savings)}
+						</p>
+						<Badge className="mt-2 bg-green-600 hover:bg-green-600 text-white">
+							{discount}% savings
+						</Badge>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/ui/src/components/nano-banana-simulator/pricing-breakdown.tsx
+++ b/apps/ui/src/components/nano-banana-simulator/pricing-breakdown.tsx
@@ -1,0 +1,71 @@
+import { Badge } from "@/lib/components/badge";
+
+const baseRows = [
+	{ metric: "Text Input", google: 2.0, unit: "/1M", prefix: "" },
+	{ metric: "Text Output", google: 12.0, unit: "/1M", prefix: "" },
+	{ metric: "Cached Input", google: 0.2, unit: "/1M", prefix: "" },
+	{ metric: "Image Output", google: 120.0, unit: "/1M", prefix: "" },
+	{ metric: "Per Image (~1K)", google: 0.13, unit: "", prefix: "~" },
+] as const;
+
+function formatPrice(value: number, prefix = ""): string {
+	if (value < 1) {
+		return `${prefix}$${value.toFixed(3)}`;
+	}
+	return `${prefix}$${value.toFixed(2)}`;
+}
+
+export function PricingBreakdown({ discount }: { discount: number }) {
+	const multiplier = 1 - discount / 100;
+
+	return (
+		<section className="w-full py-12 md:py-16">
+			<div className="container mx-auto px-4 md:px-6 max-w-3xl">
+				<div className="text-center mb-8">
+					<Badge variant="outline" className="mb-4">
+						Pricing Breakdown
+					</Badge>
+					<h2 className="text-2xl font-bold tracking-tighter sm:text-3xl">
+						Detailed Price Comparison
+					</h2>
+				</div>
+
+				<div className="overflow-x-auto rounded-lg border">
+					<table className="w-full text-sm">
+						<thead>
+							<tr className="border-b bg-muted/50">
+								<th className="px-4 py-3 text-left font-medium">Metric</th>
+								<th className="px-4 py-3 text-right font-medium">
+									Google AI Studio
+								</th>
+								<th className="px-4 py-3 text-right font-medium">
+									LLM Gateway
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{baseRows.map((row) => (
+								<tr key={row.metric} className="border-b last:border-b-0">
+									<td className="px-4 py-3 font-medium">{row.metric}</td>
+									<td className="px-4 py-3 text-right text-muted-foreground">
+										{formatPrice(row.google, row.prefix)}
+										{row.unit}
+									</td>
+									<td className="px-4 py-3 text-right font-semibold text-green-600 dark:text-green-400">
+										{formatPrice(row.google * multiplier, row.prefix)}
+										{row.unit}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+
+				<p className="text-xs text-muted-foreground text-center mt-4">
+					LLM Gateway prices reflect a {discount}% discount off Google AI Studio
+					direct pricing.
+				</p>
+			</div>
+		</section>
+	);
+}

--- a/apps/ui/src/components/nano-banana-simulator/simulator-cta.tsx
+++ b/apps/ui/src/components/nano-banana-simulator/simulator-cta.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+
+import { AuthLink } from "@/components/shared/auth-link";
+import { Button } from "@/lib/components/button";
+
+export function SimulatorCta({ discount }: { discount: number }) {
+	return (
+		<section className="py-20 border-t border-zinc-200 dark:border-zinc-800">
+			<div className="container mx-auto px-4">
+				<div className="max-w-3xl mx-auto text-center">
+					<h2 className="text-3xl font-bold tracking-tight mb-6 text-zinc-900 dark:text-white">
+						Start Saving on Image Generation Today
+					</h2>
+					<p className="text-zinc-600 dark:text-zinc-400 mb-10">
+						Get {discount}% off Gemini 3 Pro image generation with LLM Gateway.
+						No credit card required to start.
+					</p>
+
+					<div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+						<Button
+							className="bg-zinc-900 dark:bg-white text-white dark:text-black hover:bg-zinc-700 dark:hover:bg-zinc-200 px-8 py-6 text-base w-full sm:w-auto font-medium"
+							asChild
+						>
+							<AuthLink href="/signup">Create Free Account</AuthLink>
+						</Button>
+						<Button
+							variant="outline"
+							className="border-zinc-300 dark:border-zinc-800 bg-transparent text-zinc-900 dark:text-white hover:text-black dark:hover:text-white hover:border-zinc-500 dark:hover:border-zinc-700 px-8 py-6 text-base w-full sm:w-auto"
+							asChild
+						>
+							<Link href="/models" prefetch={true}>
+								Explore All Models
+							</Link>
+						</Button>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/ui/src/components/nano-banana-simulator/simulator-hero.tsx
+++ b/apps/ui/src/components/nano-banana-simulator/simulator-hero.tsx
@@ -1,0 +1,22 @@
+import { Badge } from "@/lib/components/badge";
+
+export function SimulatorHero({ discount }: { discount: number }) {
+	return (
+		<section className="w-full pt-24 pb-12 md:pt-32 md:pb-16">
+			<div className="container mx-auto px-4 md:px-6">
+				<div className="text-center max-w-3xl mx-auto">
+					<Badge variant="outline" className="mb-4">
+						Cost Simulator
+					</Badge>
+					<h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl mb-4">
+						Nano Banana Pro Cost Simulator
+					</h1>
+					<p className="text-xl text-muted-foreground">
+						Calculate your savings on Gemini 3 Pro image generation. LLM Gateway
+						offers {discount}% off Google AI Studio direct pricing.
+					</p>
+				</div>
+			</div>
+		</section>
+	);
+}


### PR DESCRIPTION
## Summary
- Add `/nano-banana-simulator` marketing page showing savings on Gemini 3 Pro image generation via LLM Gateway vs Google AI Studio direct pricing
- Discount % is configurable via URL path segment (e.g. `/nano-banana-simulator/40` for 40%), defaulting to 20%
- Includes dynamic OpenGraph image that reflects the discount for correct social media previews
- Interactive cost calculator with spend slider, side-by-side price comparison cards, savings banner, and detailed pricing breakdown table

## Test plan
- [ ] Visit `/nano-banana-simulator` — should redirect to `/nano-banana-simulator/20`
- [ ] Visit `/nano-banana-simulator/40` — page shows 40% discount throughout
- [ ] Verify slider + number input update costs correctly
- [ ] Visit `/nano-banana-simulator/40/opengraph-image` — should render OG image with "40% Off"
- [ ] Inspect page source for correct `og:image` meta tag
- [ ] Test invalid discount values (e.g. `/nano-banana-simulator/0`, `/nano-banana-simulator/abc`) — should fall back to 20%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nano Banana Simulator—an interactive cost calculator showing savings with dynamic discount pricing (1-99%)
  * Includes adjustable monthly spend slider, detailed pricing comparison table, and shareable OpenGraph images
  * Launched with promotional CTAs and dedicated landing pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->