### PR TITLE
feat(provider): hide zero price

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -319,7 +319,8 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 							gap: 28,
 						}}
 					>
-						{(hasTokenPricing || requestPrice !== undefined) && (
+						{(hasTokenPricing ||
+							(requestPrice !== undefined && requestPrice !== 0)) && (
 							<span
 								style={{
 									color: "#6B7280",
@@ -329,7 +330,7 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 									letterSpacing: "0.1em",
 								}}
 							>
-								{requestPrice !== undefined
+								{requestPrice !== undefined && requestPrice !== 0
 									? "Pricing"
 									: "Pricing per 1M tokens"}
 							</span>
@@ -370,7 +371,7 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 							</div>
 
 							{/* Request Price */}
-							{requestPrice !== undefined && (
+							{requestPrice !== undefined && requestPrice !== 0 && (
 								<div
 									style={{
 										display: "flex",


### PR DESCRIPTION
## Summary
Updated the OpenGraph image generation for model providers to hide the pricing section when the request price is zero, treating it the same as when pricing data is unavailable.

## Key Changes
- Modified the conditional logic that determines whether to display the pricing section to check that `requestPrice` is not only defined but also non-zero
- Updated three locations where `requestPrice !== undefined` checks are performed:
  1. The main condition for rendering the pricing container
  2. The label text that determines whether to show "Pricing" or "Pricing per 1M tokens"
  3. The request price display section itself

## Implementation Details
The changes ensure that a zero request price value is treated as "no pricing data available" rather than displaying a $0 price. This prevents confusing or misleading pricing information from appearing in the generated OpenGraph image when request pricing is explicitly set to zero.

https://claude.ai/code/session_015decfVU2maKgnenSbCkmjr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pricing information display on model pages to show pricing only when applicable, with clearer labels for token-based pricing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->