### PR TITLE
feat: disable STATS_BACKFILL_ENABLED by default (opt-in)

### DIFF
--- a/apps/worker/src/services/project-stats-aggregator.ts
+++ b/apps/worker/src/services/project-stats-aggregator.ts
@@ -389,9 +389,9 @@ async function recalculateApiKeyHourlyModelStats(
 const STATS_BATCH_SIZE = Number(process.env.STATS_BATCH_SIZE) || 100;
 
 // Phase 1: Backfill — process hours with no stats rows yet
-// STATS_BACKFILL_ENABLED: "true" (default) or "false"
+// STATS_BACKFILL_ENABLED: "true" or "false" (default)
 // STATS_BACKFILL_DAYS: how far back to look (default: 30, 0 = unlimited)
-const STATS_BACKFILL_ENABLED = process.env.STATS_BACKFILL_ENABLED !== "false";
+const STATS_BACKFILL_ENABLED = process.env.STATS_BACKFILL_ENABLED === "true";
 const STATS_BACKFILL_DAYS = Number(process.env.STATS_BACKFILL_DAYS) || 30;
 
 // Phase 2: Stale detection — re-process hours where new logs arrived after aggregation


### PR DESCRIPTION
## Summary
- Change `STATS_BACKFILL_ENABLED` from opt-out (enabled by default) to opt-in (disabled by default)
- Set `STATS_BACKFILL_ENABLED=true` to explicitly enable stats backfill processing

## Test plan
- [ ] Verify worker starts without `STATS_BACKFILL_ENABLED` set and backfill does not run
- [ ] Verify setting `STATS_BACKFILL_ENABLED=true` enables backfill as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Stats backfill feature now defaults to disabled. Users must explicitly enable it to activate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->