### PR TITLE
fix: onboarding and dashboard UX improvements

### DIFF
--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -646,6 +646,45 @@ function UserDropdownMenu({
 	);
 }
 
+function useInviteBannerEligible(
+	selectedOrganization: Organization | null,
+): boolean {
+	const [eligible, setEligible] = useState(false);
+
+	useEffect(() => {
+		if (!selectedOrganization) {
+			return;
+		}
+
+		// Check if user has been active for at least 7 days
+		const orgCreatedAt = new Date(selectedOrganization.createdAt);
+		const daysSinceCreation =
+			(Date.now() - orgCreatedAt.getTime()) / (1000 * 60 * 60 * 24);
+		if (daysSinceCreation >= 7) {
+			setEligible(true);
+			return;
+		}
+
+		// Check if user has purchased credits (credits > 0)
+		if (Number(selectedOrganization.credits) > 0) {
+			setEligible(true);
+			return;
+		}
+
+		// Check if user has made 50+ API calls (set by dashboard)
+		const hasEnoughCalls =
+			localStorage.getItem("user_has_50_plus_calls") === "true";
+		if (hasEnoughCalls) {
+			setEligible(true);
+			return;
+		}
+
+		setEligible(false);
+	}, [selectedOrganization]);
+
+	return eligible;
+}
+
 function UpgradeCTA({
 	show,
 	onHide,
@@ -655,7 +694,9 @@ function UpgradeCTA({
 	onHide: () => void;
 	selectedOrganization: Organization | null;
 }) {
-	if (!show || !selectedOrganization) {
+	const eligible = useInviteBannerEligible(selectedOrganization);
+
+	if (!show || !selectedOrganization || !eligible) {
 		return null;
 	}
 

--- a/apps/ui/src/components/shared/quick-start-snippet.tsx
+++ b/apps/ui/src/components/shared/quick-start-snippet.tsx
@@ -22,7 +22,8 @@ export function QuickStartSection({
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer ${keyPlaceholder}" \\
   -d '{
-  "model": "gemini-3-flash-preview",
+  "model": "auto",
+  "free_models_only": true,
   "messages": [
     {"role": "user", "content": "Hello!"}
   ]
@@ -36,8 +37,10 @@ const client = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-  model: "gemini-3-flash-preview",
-  messages: [{ role: "user", content: "Hello!" }]
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+  // @ts-expect-error LLM Gateway extension
+  free_models_only: true,
 });`;
 
 	const code = activeTab === "curl" ? curlExample : tsExample;


### PR DESCRIPTION
## Summary
- **Quick Start snippet model mismatch**: Changed cURL and TypeScript snippets from `gemini-3-flash-preview` (paid) to `model: "auto"` with `free_models_only: true`, matching the "Try it now" section so new users' first self-initiated API call succeeds without credits
- **Dashboard empty state**: When user has < 5 API calls, replaces the empty Usage Overview chart with a "Get Started" card containing the Quick Start snippet, contextual message acknowledging the onboarding test call, and links to Docs/Playground/Models
- **Invite banner delay**: The "Invite your friends" sidebar CTA now only appears after the user has been active 7+ days, made 50+ API calls, or purchased credits — no longer shown immediately on first dashboard visit

## Test plan
- [ ] Create a new test account with email signup
- [ ] Verify the onboarding "Try it now" works with the free model
- [ ] Copy the Quick Start cURL snippet and run it — should succeed with $0 credits
- [ ] Verify the dashboard shows "Get Started" card instead of empty chart
- [ ] Verify the "Get Started" card acknowledges the onboarding test call
- [ ] Verify the invite banner does NOT appear for a brand-new user
- [ ] Verify the invite banner appears for users with 7+ day old accounts
- [ ] Verify after 5+ API calls, the normal Usage Overview chart replaces the Get Started card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Get Started card for new dashboard users with quick links to documentation, playground, and available models.
  * Dashboard now tracks user activity and intelligently manages upgrade prompts based on usage metrics and organization eligibility.

* **Improvements**
  * Updated code snippet examples to use automatic model selection for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->