### PR TITLE
fix(gateway): handle OpenAI "incomplete" finish reason

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4273,6 +4273,7 @@ chat.openapi(completions, async (c) => {
 						!streamingError &&
 						finishReason &&
 						finishReason !== "content_filter" &&
+						finishReason !== "incomplete" &&
 						!isGoogleContentFilterStreaming &&
 						(!calculatedCompletionTokens || calculatedCompletionTokens === 0) &&
 						(!calculatedReasoningTokens || calculatedReasoningTokens === 0) &&
@@ -5984,6 +5985,7 @@ chat.openapi(completions, async (c) => {
 	const hasEmptyNonStreamingResponse =
 		!!finishReason &&
 		finishReason !== "content_filter" &&
+		finishReason !== "incomplete" &&
 		!isGoogleContentFilter &&
 		(!calculatedCompletionTokens || calculatedCompletionTokens === 0) &&
 		(!calculatedReasoningTokens || calculatedReasoningTokens === 0) &&

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -105,7 +105,7 @@ export function getUnifiedFinishReason(
 			if (finishReason === "stop") {
 				return UnifiedFinishReason.COMPLETED;
 			}
-			if (finishReason === "length") {
+			if (finishReason === "length" || finishReason === "incomplete") {
 				return UnifiedFinishReason.LENGTH_LIMIT;
 			}
 			if (finishReason === "content_filter") {


### PR DESCRIPTION
## Summary
- OpenAI's newer models (e.g. `gpt-5.2`) and the Responses API return `finish_reason: "incomplete"` (or `status: "incomplete"`) when a response is cut short due to `max_output_tokens`. This was unmapped in the gateway, causing it to be classified as `UNKNOWN` and triggering the empty response error path — returning a false 500 "Streaming Error" to clients.
- Maps `"incomplete"` to `LENGTH_LIMIT` in `getUnifiedFinishReason()` (alongside `"length"`)
- Excludes `"incomplete"` from the empty response error detection in both streaming and non-streaming paths, preventing false 500s
- Handles `response.incomplete` Responses API streaming event with proper `finish_reason` mapping and usage extraction (previously fell into the unrecognized event default case)

## Context
This affects both direct OpenAI and Azure OpenAI paths — Azure uses the same OpenAI format and falls into the `default` case in all provider switches, so the fix covers both.

The `"incomplete"` finish reason originates from two sources:
1. **Chat Completions API**: Newer OpenAI models can return `finish_reason: "incomplete"` directly in streaming chunks
2. **Responses API**: The `status: "incomplete"` field is passed through as `finishReason = json.status` in `parse-provider-response.ts` (line 565)

## Test plan
- [x] Build passes
- [ ] Verify that `openai/gpt-5.2` requests with `finish_reason: "incomplete"` no longer produce 500 errors
- [ ] Verify logs show `unifiedFinishReason: "length_limit"` instead of `"unknown"` for incomplete responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete API responses to prevent misclassification as error states.
  * Enhanced support for content filter detection in streaming responses.
  * Refined response status classification for better logging accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->