### PR TITLE
fix(playground): rewrite SSE keepalive to use Promise.race

### DIFF
--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -672,24 +672,26 @@ export async function POST(req: Request) {
 						timer = setTimeout(() => resolve("ping"), KEEPALIVE_INTERVAL_MS);
 					});
 
-					const winner = await Promise.race([next, ping]);
+					try {
+						const winner = await Promise.race([next, ping]);
 
-					clearTimeout(timer);
+						if (winner === "ping") {
+							controller.enqueue(encoder.encode(": ping\n\n"));
+							continue;
+						}
 
-					if (winner === "ping") {
-						controller.enqueue(encoder.encode(": ping\n\n"));
-						continue;
-					}
+						// Data from upstream
+						const result = winner as ReadableStreamReadResult<string>;
+						if (result.done) {
+							controller.close();
+							return;
+						}
 
-					// Data from upstream
-					const result = winner as ReadableStreamReadResult<string>;
-					if (result.done) {
-						controller.close();
+						controller.enqueue(encoder.encode(result.value));
 						return;
+					} finally {
+						clearTimeout(timer);
 					}
-
-					controller.enqueue(encoder.encode(result.value));
-					return;
 				}
 			},
 			cancel() {


### PR DESCRIPTION
## Summary
- Rewrites the SSE keepalive mechanism in the playground `/api/chat` endpoint to use `Promise.race` instead of `TransformStream` + `setInterval`
- The previous approach relied on `controller.enqueue()` from a `TransformStream.start()` callback delivering pings while the transform's writable side was idle — this could fail to deliver pings depending on the runtime's stream implementation
- The new approach creates a `ReadableStream` that races each upstream `reader.read()` against a 15-second ping timer, guaranteeing `: ping` SSE comments are flushed to the response during idle periods (waiting for first token, tool execution, reasoning)
- Also removes the unnecessary `TextEncoderStream` pipe since encoding is now done inline

## Test plan
- [ ] Verify playground chat streaming still works correctly with short responses
- [ ] Test with a long-running request (e.g. multi-step tool calls) and confirm the connection stays alive
- [ ] Confirm SSE `: ping` comments appear in the network stream every ~15s during idle periods

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat streaming reliability by redesigning the connection keep-alive and downstream streaming behavior, resulting in more stable connections and fewer interruptions during long sessions.
  * Ensures consistent delivery of server-sent events and preserves existing error handling, reducing dropped or delayed messages under adverse network conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->