### PR TITLE
feat(ui): require cached input pricing for Chat & Code categories

### DIFF
--- a/apps/ui/src/components/models/all-models.tsx
+++ b/apps/ui/src/components/models/all-models.tsx
@@ -512,7 +512,7 @@ export function AllModels({ children, models, providers }: AllModelsProps) {
 			if (filters.category && filters.category !== "all") {
 				switch (filters.category) {
 					case "code": {
-						// Code generation: needs tools, JSON output, streaming
+						// Code generation: needs tools, JSON output, streaming, and cached input pricing
 						if (model.free) {
 							return false;
 						}
@@ -526,7 +526,8 @@ export function AllModels({ children, models, providers }: AllModelsProps) {
 							(p) =>
 								(p.provider.jsonOutput || p.provider.jsonOutputSchema) &&
 								p.provider.tools &&
-								p.provider.streaming,
+								p.provider.streaming &&
+								p.provider.cachedInputPrice !== null,
 						);
 						if (!hasCodeCapabilities) {
 							return false;
@@ -534,9 +535,10 @@ export function AllModels({ children, models, providers }: AllModelsProps) {
 						break;
 					}
 					case "chat": {
-						// Chat & Assistants: general chat models with streaming
+						// Chat & Assistants: general chat models with streaming and cached input pricing
 						const hasStreaming = model.providerDetails.some(
-							(p) => p.provider.streaming,
+							(p) =>
+								p.provider.streaming && p.provider.cachedInputPrice !== null,
 						);
 						if (!hasStreaming) {
 							return false;


### PR DESCRIPTION
## Summary
- Filter "Chat & Assistants" and "Code generation" model categories to only include models that have a `cachedInputPrice` set on at least one provider mapping
- Models without cached input token pricing are now excluded from these two categories

## Test plan
- [ ] Verify "Chat & Assistants" category no longer shows models without `cachedInputPrice`
- [ ] Verify "Code generation" category no longer shows models without `cachedInputPrice`
- [ ] Verify other categories (Reasoning, Creative, Image, Multimodal) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model filtering for code and chat use cases to now require cached input pricing support in addition to streaming capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->