### PR TITLE
chore(models): deactivate claude-3-5-sonnet-20240620

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -535,6 +535,7 @@ export const anthropicModels = [
 				test: "skip",
 				providerId: "anthropic",
 				modelName: "claude-3-5-sonnet-20240620",
+				deactivatedAt: new Date("2026-02-19"),
 				inputPrice: 3.0 / 1e6,
 				outputPrice: 15.0 / 1e6,
 				cachedInputPrice: 0.3 / 1e6,


### PR DESCRIPTION
## Summary
- Deactivate `claude-3-5-sonnet-20240620` (Claude 3.5 Sonnet Old) by setting `deactivatedAt` to `2026-02-19`

## Test plan
- [ ] Verify model no longer appears as active in the gateway
- [ ] Confirm build passes with `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked two Anthropic model versions (claude-3-7-sonnet-latest and claude-3-5-sonnet-20240620) for deactivation on February 19, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->