### PR TITLE
fix(gateway): add missing providers to streaming transform switch

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1137,7 +1137,24 @@ export function transformStreamingToOpenai(
 
 		case "mistral":
 		case "novita":
-		case "zai": {
+		case "zai":
+		case "groq":
+		case "cerebras":
+		case "xai":
+		case "deepseek":
+		case "alibaba":
+		case "moonshot":
+		case "perplexity":
+		case "nebius":
+		case "canopywave":
+		case "inference.net":
+		case "together.ai":
+		case "custom":
+		case "cloudrift":
+		case "nanogpt":
+		case "bytedance":
+		case "minimax":
+		case "llmgateway": {
 			// Transform standard OpenAI streaming format with finish reason mapping
 			transformedData = transformOpenaiStreaming(data, usedModel);
 


### PR DESCRIPTION
## Summary
- Added explicit `case` entries for all 15 OpenAI-compatible providers (`groq`, `cerebras`, `xai`, `deepseek`, `alibaba`, `moonshot`, `perplexity`, `nebius`, `canopywave`, `inference.net`, `together.ai`, `custom`, `cloudrift`, `nanogpt`, `bytedance`, `minimax`, `llmgateway`) in the streaming transform switch statement
- These providers were falling through to the `default` case, producing noisy `[streaming] Unknown provider using OpenAI fallback` warnings on every single streaming chunk
- The `default` case is preserved as a safety net for any future providers not yet added

## Test plan
- [ ] Verify streaming works for `nanogpt` provider without warnings
- [ ] Verify streaming works for other previously-missing providers (e.g. `groq`, `deepseek`)
- [ ] Confirm `default` case still triggers for truly unknown providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streaming compatibility with additional AI providers including Groq, Cerebras, DeepSeek, Perplexity, Alibaba, Moonshot, Together.AI, and more
  * Improved consistency in how response completion states are reported across different providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->