### PR TITLE
fix(api): treat provider validation errors as 400 instead of 500

### DIFF
--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -214,7 +214,7 @@ keysProvider.openapi(create, async (c) => {
 		const modelPart = validationResult.model
 			? ` using model ${validationResult.model}`
 			: "";
-		throw new HTTPException(500, {
+		throw new HTTPException(400, {
 			message: `Error from provider: ${errorMessage}${statusPart}${modelPart}. Please try again later or contact support.`,
 		});
 	}


### PR DESCRIPTION
## Summary
- Changed HTTP status for upstream provider validation errors (e.g. "credit balance too low") from 500 to 400 in `keys-provider.ts`
- These are not gateway server errors — the existing `logger.warn` already captures the details at the right severity level
- The global error handler only logs `HTTPException` with status >= 500 as errors, so this change prevents false error-level alerts

## Test plan
- [ ] Verify that provider validation failures (e.g. invalid key, low balance) return HTTP 400
- [ ] Confirm these are no longer logged at ERROR severity
- [ ] Confirm the existing `logger.warn` still captures the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP error status code for provider validation failures—now returns 400 (Bad Request) instead of 500 (Internal Server Error), improving error handling accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->