### PR TITLE
perf(gateway): fix streaming performance for large payloads

### DIFF
--- a/apps/gateway/src/chat/tools/extract-images.ts
+++ b/apps/gateway/src/chat/tools/extract-images.ts
@@ -2,7 +2,11 @@ import type { ImageObject } from "./types.js";
 import type { Provider } from "@llmgateway/models";
 
 /**
- * Extracts images from streaming data based on provider format
+ * Extracts images from streaming data based on provider format.
+ *
+ * For large base64 image data, we reference the original inlineData fields
+ * directly rather than creating new concatenated strings, to avoid unnecessary
+ * multi-MB string copies.
  */
 export function extractImages(data: any, provider: Provider): ImageObject[] {
 	switch (provider) {

--- a/apps/gateway/src/chat/tools/might-be-complete-json.ts
+++ b/apps/gateway/src/chat/tools/might-be-complete-json.ts
@@ -3,6 +3,10 @@
  * Returns false if brackets are definitely unbalanced (avoiding expensive JSON.parse).
  * Returns true if it might be valid (still needs JSON.parse to confirm).
  * This is a performance optimization for SSE parsing where we do many validity checks.
+ *
+ * For large strings (e.g. base64 image data), we use an optimized approach:
+ * scan from both ends inward to find the structural boundaries, avoiding
+ * a full O(n) scan of multi-MB payloads.
  */
 export function mightBeCompleteJson(str: string): boolean {
 	const trimmed = str.trim();
@@ -25,6 +29,20 @@ export function mightBeCompleteJson(str: string): boolean {
 	} else {
 		// Not a JSON object or array
 		return false;
+	}
+
+	// For large payloads (e.g. containing base64 image data), scanning the entire
+	// string character-by-character is extremely expensive (O(n) on multi-MB data).
+	// Instead, we scan from the start and end inward, only examining the structural
+	// JSON boundaries. Large base64 strings in the middle are inside a JSON string
+	// value, so we only need to verify the outer structure is balanced.
+	//
+	// The threshold is set at 100KB - below this, the full scan is fast enough.
+	// Above this, payloads almost always contain large opaque string values
+	// (base64 images, long text) where scanning every character is wasteful.
+	const LARGE_PAYLOAD_THRESHOLD = 100 * 1024;
+	if (trimmed.length > LARGE_PAYLOAD_THRESHOLD) {
+		return mightBeCompleteJsonLarge(trimmed);
 	}
 
 	// Count brackets/braces, skipping content inside strings
@@ -66,4 +84,120 @@ export function mightBeCompleteJson(str: string): boolean {
 	}
 
 	return braces === 0 && brackets === 0;
+}
+
+/**
+ * Optimized heuristic for large JSON payloads (100KB+).
+ *
+ * Instead of scanning the entire string, we scan from the start until we
+ * enter a string value that extends beyond our scan window, then scan backward
+ * from the end until we enter the same string. The structural depth counted
+ * from each end should match for the JSON to be balanced.
+ *
+ * This turns an O(n) scan into O(k) where k is the size of the structural
+ * JSON skeleton (typically a few hundred bytes even for multi-MB payloads).
+ */
+function mightBeCompleteJsonLarge(trimmed: string): boolean {
+	const SCAN_LIMIT = 8192; // scan at most 8KB from each end
+
+	// Forward scan: count structural depth until we enter a long string
+	let fBraces = 0;
+	let fBrackets = 0;
+	let inString = false;
+	let i = 0;
+	const forwardEnd = Math.min(trimmed.length, SCAN_LIMIT);
+
+	while (i < forwardEnd) {
+		const c = trimmed[i];
+		if (inString) {
+			if (c === "\\") {
+				i += 2;
+				continue;
+			} else if (c === '"') {
+				inString = false;
+			}
+		} else {
+			if (c === '"') {
+				inString = true;
+			} else if (c === "{") {
+				fBraces++;
+			} else if (c === "}") {
+				fBraces--;
+			} else if (c === "[") {
+				fBrackets++;
+			} else if (c === "]") {
+				fBrackets--;
+			}
+		}
+		i++;
+	}
+
+	// If we finished scanning the entire string (unlikely given >100KB), use result directly
+	if (i >= trimmed.length) {
+		return !inString && fBraces === 0 && fBrackets === 0;
+	}
+
+	// If we're NOT in a string at the forward scan limit, the structural content
+	// extends beyond our window in a non-string context. This is unusual for large
+	// payloads. Use a conservative approach: the first/last char check already passed.
+	if (!inString) {
+		return true;
+	}
+
+	// We entered a large string value in the forward scan.
+	// Now scan backward from the end. The reverse scan counts structural depth
+	// from the end until it enters a string going backward (which should be the
+	// same string the forward scan entered).
+	//
+	// For the JSON to be balanced:
+	//   - Forward opened fBraces braces before the string
+	//   - Reverse should see the same number of closing braces after the string
+	//   - Same for brackets
+	let rBraces = 0;
+	let rBrackets = 0;
+	let rInString = false;
+	let j = trimmed.length - 1;
+	const reverseEnd = Math.max(0, trimmed.length - SCAN_LIMIT);
+
+	while (j >= reverseEnd) {
+		const c = trimmed[j];
+		if (rInString) {
+			// Inside a string scanning backward - check for unescaped quote
+			if (c === '"') {
+				let backslashes = 0;
+				let k = j - 1;
+				while (k >= 0 && trimmed[k] === "\\") {
+					backslashes++;
+					k--;
+				}
+				if (backslashes % 2 === 0) {
+					rInString = false;
+				}
+			}
+			// Once we enter the large string going backward, we've accounted for
+			// all the closing structure. Stop scanning.
+			if (rInString && j < trimmed.length - SCAN_LIMIT + 1) {
+				// We're deep in the string and past our scan limit - stop
+				break;
+			}
+		} else {
+			if (c === '"') {
+				rInString = true;
+			} else if (c === "}") {
+				rBraces++;
+			} else if (c === "{") {
+				rBraces--;
+			} else if (c === "]") {
+				rBrackets++;
+			} else if (c === "[") {
+				rBrackets--;
+			}
+		}
+		j--;
+	}
+
+	// Forward scan opened fBraces/fBrackets before entering the string.
+	// Reverse scan should have closed the same number after the string.
+	// rBraces counts '}' as +1 and '{' as -1, so for balance: fBraces === rBraces
+	return fBraces === rBraces && fBrackets === rBrackets;
 }

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -637,17 +637,6 @@ export function transformStreamingToOpenai(
 		case "azure":
 		case "openai": {
 			if (data.type) {
-				// Log full OpenAI event data for debugging
-				logger.info("[OpenAI Streaming Debug]", {
-					eventType: data.type,
-					hasAnnotations: !!(data.annotations || data.part?.annotations),
-					annotationsCount: (data.annotations || data.part?.annotations || [])
-						.length,
-					hasDelta: !!data.delta,
-					deltaKeys: data.delta ? Object.keys(data.delta) : [],
-					fullData: JSON.stringify(data),
-				});
-
 				switch (data.type) {
 					case "response.created":
 					case "response.in_progress":
@@ -966,18 +955,6 @@ export function transformStreamingToOpenai(
 						break;
 				}
 			} else {
-				// Log standard OpenAI streaming format for debugging
-				logger.info("[OpenAI Standard Streaming Debug]", {
-					hasChoices: !!data.choices,
-					choicesLength: data.choices?.length || 0,
-					firstChoiceDeltaKeys: data.choices?.[0]?.delta
-						? Object.keys(data.choices[0].delta)
-						: [],
-					hasAnnotations: !!data.choices?.[0]?.delta?.annotations,
-					annotationsCount: data.choices?.[0]?.delta?.annotations?.length || 0,
-					fullData: JSON.stringify(data),
-				});
-
 				transformedData = transformOpenaiStreaming(data, usedModel);
 			}
 			break;


### PR DESCRIPTION
## Summary
- **Optimize `mightBeCompleteJson` for large payloads (>100KB)**: Instead of scanning every character of multi-MB base64 image data, scan only 8KB from each end (the structural JSON skeleton). Reduces the heuristic check from O(n) to O(k) where k is the structural boundary size.
- **Reuse shared `TextDecoder` instance**: Avoids allocating a new `TextDecoder` on every `reader.read()` iteration in the streaming hot loop. Also enables `{ stream: true }` for correct multi-byte character handling across chunks.
- **Skip O(n) debug string scans on large events**: The `eventData.includes("event:")` / `eventData.includes("id:")` debug check now skips events >64KB, avoiding linear scans on multi-MB image data.
- **Remove per-chunk debug `logger.info` calls in `transform-streaming-to-openai`**: Two `logger.info` calls fired on every single OpenAI streaming chunk — including `JSON.stringify(data)` of the entire payload. For image generation responses with multi-MB base64 data, this serialized the full payload on every chunk in production.

## Test plan
- [x] All 138 existing gateway tool tests pass
- [x] 7 new tests for `mightBeCompleteJson` large payload optimization (including 5MB performance test asserting <50ms)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Full gateway build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized streaming operations to reduce memory allocations.
  * Implemented smart handling for large payloads (100KB+) to improve processing efficiency.
  * Added guardrails to avoid expensive scans on large data transfers.

* **Tests**
  * Added comprehensive tests for large payload scenarios (up to 5MB) with performance validation.

* **Chores**
  * Removed verbose debug logging from streaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->