### PR TITLE
fix(gateway): map novita 'abort' finish reason to 'canceled'

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -99,6 +99,48 @@ describe("parseProviderResponse", () => {
 		});
 	});
 
+	describe("novita finish reason mapping", () => {
+		it("maps 'abort' finish reason to 'canceled'", () => {
+			const json = {
+				choices: [
+					{
+						message: { content: "Hello", role: "assistant" },
+						finish_reason: "abort",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse("novita", "glm-4", json);
+
+			expect(result.finishReason).toBe("canceled");
+		});
+
+		it("maps 'end_turn' finish reason to 'stop'", () => {
+			const json = {
+				choices: [
+					{
+						message: { content: "Hello", role: "assistant" },
+						finish_reason: "end_turn",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse("novita", "glm-4", json);
+
+			expect(result.finishReason).toBe("stop");
+		});
+	});
+
 	describe("anthropic cachedTokens", () => {
 		it("returns cachedTokens as 0 when cache_read_input_tokens is 0", () => {
 			const json = {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -401,6 +401,8 @@ export function parseProviderResponse(
 			// Map non-standard finish reasons to OpenAI-compatible values
 			if (finishReason === "end_turn") {
 				finishReason = "stop";
+			} else if (finishReason === "abort") {
+				finishReason = "canceled";
 			} else if (finishReason === "tool_use") {
 				finishReason = "tool_calls";
 			}

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1161,6 +1161,8 @@ export function transformStreamingToOpenai(
 			// Map non-standard finish reasons to OpenAI-compatible values
 			if (transformedData?.choices?.[0]?.finish_reason === "end_turn") {
 				transformedData.choices[0].finish_reason = "stop";
+			} else if (transformedData?.choices?.[0]?.finish_reason === "abort") {
+				transformedData.choices[0].finish_reason = "canceled";
 			} else if (transformedData?.choices?.[0]?.finish_reason === "tool_use") {
 				transformedData.choices[0].finish_reason = "tool_calls";
 			}


### PR DESCRIPTION
## Summary
- Map novita/mistral provider's `abort` finish reason to `canceled` in both non-streaming (`parse-provider-response.ts`) and streaming (`transform-streaming-to-openai.ts`) response paths
- Fixes `"Unknown finish reason encountered"` error logs for novita GLM models that return `abort` as their finish reason
- `abort` maps to `canceled` (not `stop`) since it indicates the generation was cut short, not completed successfully
- Adds test coverage for the `abort` finish reason mapping

## Test plan
- [x] New tests verify `abort` → `canceled` mapping for novita provider
- [x] New tests verify `end_turn` → `stop` mapping still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)