### PR TITLE
fix: deactivate Cerebras glm-4.6 provider

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -404,6 +404,7 @@ export const zaiModels = [
 				// Cerebras: FP16/FP8 (weights only)
 				providerId: "cerebras",
 				test: "skip",
+				deactivatedAt: new Date("2026-01-20"),
 				modelName: "zai-glm-4.6",
 				inputPrice: 2.25 / 1e6,
 				outputPrice: 2.75 / 1e6,


### PR DESCRIPTION
## Summary
- Deactivate the Cerebras provider for `glm-4.6` as it was deprecated on 2026-01-20
- Source: https://inference-docs.cerebras.ai/support/deprecation
- Other providers (zai, novita) remain active for `glm-4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)