### PR TITLE
fix: downgrade stream read error log from error to warning

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4123,7 +4123,7 @@ chat.openapi(completions, async (c) => {
 							},
 						};
 					} else {
-						logger.error(
+						logger.warn(
 							"Error reading stream",
 							error instanceof Error ? error : new Error(String(error)),
 						);


### PR DESCRIPTION
## Summary
- Downgrades the "Error reading stream" log from `logger.error` (level 50) to `logger.warn` (level 40)
- This error (e.g. upstream `ECONNRESET`) is already fully handled: it's logged to the DB with `hasError: true`, and an SSE error event is sent to the client
- Since it's a transient, non-critical condition that occurs during normal operation, it shouldn't trigger error-level alerts

## Test plan
- [ ] Verify the log level change in `apps/gateway/src/chat/chat.ts`
- [ ] Confirm no other behavior changes — error is still recorded in DB and sent to client

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging severity for streaming path errors in the gateway's chat service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->