### PR TITLE
fix: prevent startup crashes when Stripe/PostHog env vars are missing

### DIFF
--- a/apps/api/src/posthog.ts
+++ b/apps/api/src/posthog.ts
@@ -1,6 +1,12 @@
 import { PostHog } from "posthog-node";
 
-export const posthog = new PostHog(process.env.POSTHOG_KEY ?? "key", {
-	host: process.env.POSTHOG_HOST ?? "none",
-	disabled: !process.env.POSTHOG_KEY || !process.env.POSTHOG_HOST,
-});
+const posthogDisabled = !process.env.POSTHOG_KEY || !process.env.POSTHOG_HOST;
+
+// PostHog requires a non-empty API key even when disabled, so we use a placeholder
+export const posthog = new PostHog(
+	process.env.POSTHOG_KEY ?? "phc_placeholder",
+	{
+		host: process.env.POSTHOG_HOST ?? "https://localhost",
+		disabled: posthogDisabled,
+	},
+);

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -13,7 +13,7 @@ import {
 	type DevPlanTier,
 } from "@llmgateway/shared";
 
-import { stripe } from "./payments.js";
+import { getStripe } from "./payments.js";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -243,7 +243,7 @@ devPlans.openapi(subscribe, async (c) => {
 	try {
 		const stripeCustomerId = await ensureStripeCustomer(personalOrg.id);
 
-		const session = await stripe.checkout.sessions.create({
+		const session = await getStripe().checkout.sessions.create({
 			customer: stripeCustomerId,
 			mode: "subscription",
 			line_items: [
@@ -356,9 +356,12 @@ devPlans.openapi(cancel, async (c) => {
 	}
 
 	try {
-		await stripe.subscriptions.update(personalOrg.devPlanStripeSubscriptionId, {
-			cancel_at_period_end: true,
-		});
+		await getStripe().subscriptions.update(
+			personalOrg.devPlanStripeSubscriptionId,
+			{
+				cancel_at_period_end: true,
+			},
+		);
 
 		await logAuditEvent({
 			organizationId: personalOrg.id,
@@ -444,7 +447,7 @@ devPlans.openapi(resume, async (c) => {
 	}
 
 	try {
-		const subscription = await stripe.subscriptions.retrieve(
+		const subscription = await getStripe().subscriptions.retrieve(
 			personalOrg.devPlanStripeSubscriptionId,
 		);
 
@@ -454,9 +457,12 @@ devPlans.openapi(resume, async (c) => {
 			});
 		}
 
-		await stripe.subscriptions.update(personalOrg.devPlanStripeSubscriptionId, {
-			cancel_at_period_end: false,
-		});
+		await getStripe().subscriptions.update(
+			personalOrg.devPlanStripeSubscriptionId,
+			{
+				cancel_at_period_end: false,
+			},
+		);
 
 		await logAuditEvent({
 			organizationId: personalOrg.id,
@@ -566,24 +572,27 @@ devPlans.openapi(changeTier, async (c) => {
 	}
 
 	try {
-		const subscription = await stripe.subscriptions.retrieve(
+		const subscription = await getStripe().subscriptions.retrieve(
 			personalOrg.devPlanStripeSubscriptionId,
 		);
 
 		// Update subscription with new tier
-		await stripe.subscriptions.update(personalOrg.devPlanStripeSubscriptionId, {
-			items: [
-				{
-					id: subscription.items.data[0].id,
-					price: newPriceId,
+		await getStripe().subscriptions.update(
+			personalOrg.devPlanStripeSubscriptionId,
+			{
+				items: [
+					{
+						id: subscription.items.data[0].id,
+						price: newPriceId,
+					},
+				],
+				proration_behavior: "create_prorations",
+				metadata: {
+					...subscription.metadata,
+					devPlan: newTier,
 				},
-			],
-			proration_behavior: "create_prorations",
-			metadata: {
-				...subscription.metadata,
-				devPlan: newTier,
 			},
-		});
+		);
 
 		// Update local database immediately
 		const newCreditsLimit = getDevPlanCreditsLimit(newTier);

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -8,7 +8,7 @@ import { logAuditEvent } from "@llmgateway/audit";
 import { db } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
-import { stripe } from "./payments.js";
+import { getStripe } from "./payments.js";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -117,7 +117,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 		}
 
 		// Create Stripe Checkout session
-		const session = await stripe.checkout.sessions.create({
+		const session = await getStripe().checkout.sessions.create({
 			customer: stripeCustomerId,
 			mode: "subscription",
 			line_items: [
@@ -234,7 +234,7 @@ subscriptions.openapi(cancelProSubscription, async (c) => {
 
 	try {
 		// Cancel the subscription at the end of the current period
-		await stripe.subscriptions.update(organization.stripeSubscriptionId, {
+		await getStripe().subscriptions.update(organization.stripeSubscriptionId, {
 			cancel_at_period_end: true,
 		});
 
@@ -324,7 +324,7 @@ subscriptions.openapi(resumeProSubscription, async (c) => {
 
 	try {
 		// Check if subscription is actually cancelled
-		const subscription = await stripe.subscriptions.retrieve(
+		const subscription = await getStripe().subscriptions.retrieve(
 			organization.stripeSubscriptionId,
 		);
 
@@ -335,7 +335,7 @@ subscriptions.openapi(resumeProSubscription, async (c) => {
 		}
 
 		// Resume the subscription by setting cancel_at_period_end to false
-		await stripe.subscriptions.update(organization.stripeSubscriptionId, {
+		await getStripe().subscriptions.update(organization.stripeSubscriptionId, {
 			cancel_at_period_end: false,
 		});
 
@@ -425,7 +425,7 @@ subscriptions.openapi(upgradeToYearlyPlan, async (c) => {
 
 	try {
 		// Get current subscription to check if it's already yearly
-		const subscription = await stripe.subscriptions.retrieve(
+		const subscription = await getStripe().subscriptions.retrieve(
 			organization.stripeSubscriptionId,
 		);
 
@@ -445,7 +445,7 @@ subscriptions.openapi(upgradeToYearlyPlan, async (c) => {
 		}
 
 		// Update subscription to yearly plan
-		await stripe.subscriptions.update(organization.stripeSubscriptionId, {
+		await getStripe().subscriptions.update(organization.stripeSubscriptionId, {
 			items: [
 				{
 					id: subscription.items.data[0].id,
@@ -533,7 +533,7 @@ subscriptions.openapi(getSubscriptionStatus, async (c) => {
 	let billingCycle: "monthly" | "yearly" | null = null;
 	if (organization.stripeSubscriptionId) {
 		try {
-			const subscription = await stripe.subscriptions.retrieve(
+			const subscription = await getStripe().subscriptions.retrieve(
 				organization.stripeSubscriptionId,
 			);
 			const currentPriceId = subscription.items.data[0]?.price.id;


### PR DESCRIPTION
## Summary
- **PostHog**: The constructor now validates that the API key is a non-empty string even when `disabled: true`. Changed the fallback from `"key"` to `"phc_placeholder"` which passes validation.
- **Stripe**: Replaced eager `new Stripe(...)` at module load time with lazy `getStripe()` initialization. The Stripe client is only created on first actual use, so missing `STRIPE_SECRET_KEY` no longer crashes the process at startup.
- Affects `apps/api` (posthog.ts, payments.ts, stripe.ts, dev-plans.ts, subscriptions.ts) and `apps/worker` (worker.ts).

## Test plan
- [ ] Verify API and worker start without `POSTHOG_KEY`, `POSTHOG_HOST`, or `STRIPE_SECRET_KEY` set
- [ ] Verify Stripe operations still work correctly when `STRIPE_SECRET_KEY` is provided
- [ ] Verify PostHog tracking works when `POSTHOG_KEY` and `POSTHOG_HOST` are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated analytics defaults and added a disabled flag for safer local/dev behavior.
* **Refactor**
  * Converted Stripe client to a lazy-initialized accessor across payment, subscription, and worker flows; added secret-key validation and instance caching for more reliable startup and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->