### PR TITLE
fix(playground): bypass Safari ITP blocking

### DIFF
--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -288,12 +288,15 @@ interface McpClientWrapper {
 }
 
 export async function POST(req: Request) {
-	const user = await getUser();
+	const headerApiKey = req.headers.get("x-llmgateway-key") || undefined;
 
-	if (!user) {
-		return new Response(JSON.stringify({ error: "Unauthorized" }), {
-			status: 401,
-		});
+	if (!headerApiKey) {
+		const user = await getUser();
+		if (!user) {
+			return new Response(JSON.stringify({ error: "Unauthorized" }), {
+				status: 401,
+			});
+		}
 	}
 
 	const body = await req.json();
@@ -313,8 +316,6 @@ export async function POST(req: Request) {
 			status: 400,
 		});
 	}
-
-	const headerApiKey = req.headers.get("x-llmgateway-key") || undefined;
 	const headerModel = req.headers.get("x-llmgateway-model") || undefined;
 	const noFallbackHeader = req.headers.get("x-no-fallback") || undefined;
 

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -24,8 +24,10 @@ import {
 } from "@/hooks/useChats";
 import { useMcpServers } from "@/hooks/useMcpServers";
 import { useUser } from "@/hooks/useUser";
+import { useAppConfig } from "@/lib/config";
 import { parseImageFile } from "@/lib/image-utils";
 import { mapModels } from "@/lib/mapmodels";
+import { isSafari } from "@/lib/safari";
 import { getErrorMessage } from "@/lib/utils";
 
 import type {
@@ -78,9 +80,11 @@ export default function ChatPageClient({
 	enableWebSearch = false,
 }: ChatPageClientProps) {
 	const { user, isLoading: isUserLoading } = useUser();
+	const config = useAppConfig();
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
+	const playgroundKeyRef = useRef<string | null>(null);
 
 	const mapped = useMemo(
 		() => mapModels(models, providers),
@@ -413,6 +417,9 @@ export default function ChatPageClient({
 				headers: {
 					...(options?.headers || {}),
 					...(noFallback ? { "x-no-fallback": "true" } : {}),
+					...(playgroundKeyRef.current
+						? { "x-llmgateway-key": playgroundKeyRef.current }
+						: {}),
 				},
 				body: {
 					...(options?.body || {}),
@@ -562,6 +569,7 @@ export default function ChatPageClient({
 		// Reset ref when user logs out or project is unset
 		if (!isAuthenticated || !selectedProject) {
 			ensuredProjectRef.current = null;
+			playgroundKeyRef.current = null;
 			return;
 		}
 
@@ -574,18 +582,36 @@ export default function ChatPageClient({
 				return;
 			}
 			try {
-				await fetch("/api/ensure-playground-key", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ projectId: selectedProject.id }),
-				});
+				if (isSafari()) {
+					const res = await fetch(`${config.apiUrl}/playground/ensure-key`, {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						credentials: "include",
+						body: JSON.stringify({ projectId: selectedProject.id }),
+					});
+					if (res.ok) {
+						const data = (await res.json()) as {
+							ok: boolean;
+							token?: string;
+						};
+						if (data.token) {
+							playgroundKeyRef.current = data.token;
+						}
+					}
+				} else {
+					await fetch("/api/ensure-playground-key", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ projectId: selectedProject.id }),
+					});
+				}
 				ensuredProjectRef.current = selectedProject.id;
 			} catch {
 				// ignore for now
 			}
 		};
 		ensureKey();
-	}, [isAuthenticated, selectedOrganization, selectedProject]);
+	}, [isAuthenticated, selectedOrganization, selectedProject, config.apiUrl]);
 
 	const ensureCurrentChat = async (userMessage?: string): Promise<string> => {
 		if (chatIdRef.current) {
@@ -1069,6 +1095,7 @@ export default function ChatPageClient({
 													extraSubmitRefs.current[panelId] = fn;
 												}}
 												resetToken={comparisonResetToken}
+												safariApiKey={playgroundKeyRef.current ?? undefined}
 											/>
 										</div>
 									))
@@ -1096,6 +1123,7 @@ interface ExtraChatPanelProps {
 		submit: (content: string) => Promise<void> | void,
 	) => void;
 	resetToken: number;
+	safariApiKey?: string;
 }
 
 function ExtraChatPanel({
@@ -1109,6 +1137,7 @@ function ExtraChatPanel({
 	setSyncedText,
 	onRegisterExternalSubmit,
 	resetToken,
+	safariApiKey,
 }: ExtraChatPanelProps) {
 	const [selectedModel, setSelectedModel] = useState(initialModel);
 	const [reasoningEffort, setReasoningEffort] = useState<
@@ -1234,6 +1263,7 @@ function ExtraChatPanel({
 				headers: {
 					...(options?.headers || {}),
 					...(noFallback ? { "x-no-fallback": "true" } : {}),
+					...(safariApiKey ? { "x-llmgateway-key": safariApiKey } : {}),
 				},
 				body: {
 					...(options?.body || {}),
@@ -1257,6 +1287,7 @@ function ExtraChatPanel({
 			selectedModel,
 			webSearchEnabled,
 			supportsWebSearch,
+			safariApiKey,
 		],
 	);
 

--- a/apps/playground/src/components/playground/group-chat-client.tsx
+++ b/apps/playground/src/components/playground/group-chat-client.tsx
@@ -13,7 +13,9 @@ import { GroupChatUI } from "@/components/playground/group-chat-ui";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useUser } from "@/hooks/useUser";
+import { useAppConfig } from "@/lib/config";
 import { mapModels } from "@/lib/mapmodels";
+import { isSafari } from "@/lib/safari";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
 
@@ -46,9 +48,11 @@ export default function GroupChatClient({
 	selectedProject,
 }: GroupChatClientProps) {
 	const { user, isLoading: isUserLoading } = useUser();
+	const config = useAppConfig();
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
+	const playgroundKeyRef = useRef<string | null>(null);
 
 	const mapped = useMemo(
 		() => mapModels(models, providers),
@@ -88,6 +92,7 @@ export default function GroupChatClient({
 	useEffect(() => {
 		if (!isAuthenticated || !selectedProject) {
 			ensuredProjectRef.current = null;
+			playgroundKeyRef.current = null;
 			return;
 		}
 
@@ -99,18 +104,36 @@ export default function GroupChatClient({
 				return;
 			}
 			try {
-				await fetch("/api/ensure-playground-key", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ projectId: selectedProject.id }),
-				});
+				if (isSafari()) {
+					const res = await fetch(`${config.apiUrl}/playground/ensure-key`, {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						credentials: "include",
+						body: JSON.stringify({ projectId: selectedProject.id }),
+					});
+					if (res.ok) {
+						const data = (await res.json()) as {
+							ok: boolean;
+							token?: string;
+						};
+						if (data.token) {
+							playgroundKeyRef.current = data.token;
+						}
+					}
+				} else {
+					await fetch("/api/ensure-playground-key", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ projectId: selectedProject.id }),
+					});
+				}
 				ensuredProjectRef.current = selectedProject.id;
 			} catch {
 				// ignore for now
 			}
 		};
 		ensureKey();
-	}, [isAuthenticated, selectedOrganization, selectedProject]);
+	}, [isAuthenticated, selectedOrganization, selectedProject, config.apiUrl]);
 
 	const addModel = (modelId: string) => {
 		if (selectedModels.length < 5 && !selectedModels.includes(modelId)) {
@@ -294,6 +317,9 @@ export default function GroupChatClient({
 			await sendMessage(userUiMessage as any, {
 				headers: {
 					...(noFallback ? { "x-no-fallback": "true" } : {}),
+					...(playgroundKeyRef.current
+						? { "x-llmgateway-key": playgroundKeyRef.current }
+						: {}),
 				},
 				body: {
 					model: currentModel,

--- a/apps/playground/src/lib/safari.ts
+++ b/apps/playground/src/lib/safari.ts
@@ -1,0 +1,9 @@
+export function isSafari(): boolean {
+	if (typeof navigator === "undefined") {
+		return false;
+	}
+	const ua = navigator.userAgent;
+	return (
+		ua.includes("Safari") && !ua.includes("Chrome") && !ua.includes("Chromium")
+	);
+}


### PR DESCRIPTION
## Summary
- Safari's ITP blocks cross-subdomain cookies, causing `getUser()` to fail with "Unauthorized" in the playground chat route even when the user is logged in
- On Safari, the playground now fetches the API key directly from the backend (`credentials: "include"`) and passes it via `x-llmgateway-key` header
- The chat API route skips session auth when `x-llmgateway-key` is present (the gateway validates the key)

## Test plan
- [ ] Open playground in Safari, send a message — should no longer get "Unauthorized"
- [ ] Open playground in Chrome — behavior unchanged (cookie-based auth still used)
- [ ] Test comparison panels in Safari (ExtraChatPanel receives the Safari API key)
- [ ] Test group chat in Safari
- [ ] Verify `pnpm build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API key-based authentication support via x-llmgateway-key header as alternative to user authentication
  * Improved Safari browser compatibility with dedicated gateway key provisioning and management for authenticated sessions

* **Refactor**
  * Reworked authentication flow to support both API key and user-based authentication methods
  * Enhanced request headers to conditionally include gateway credentials when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->