### PR TITLE
fix: protect playground API key from deletion and deactivation

### DIFF
--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -538,6 +538,14 @@ keysApi.openapi(deleteKey, async (c) => {
 		});
 	}
 
+	// Prevent deletion of the auto-generated playground key
+	if (apiKey.description === "Auto-generated playground key") {
+		throw new HTTPException(403, {
+			message:
+				"Cannot delete the playground API key. This key is required for the playground to function.",
+		});
+	}
+
 	// Check user role and permissions
 	const projectOrgId = apiKey.project.organizationId;
 	const userOrg = userOrgs.find((org) => org.organizationId === projectOrgId);
@@ -688,6 +696,17 @@ keysApi.openapi(updateStatus, async (c) => {
 	if (!apiKey.project) {
 		throw new HTTPException(404, {
 			message: "Project not found for API key",
+		});
+	}
+
+	// Prevent deactivation of the auto-generated playground key
+	if (
+		apiKey.description === "Auto-generated playground key" &&
+		status === "inactive"
+	) {
+		throw new HTTPException(403, {
+			message:
+				"Cannot deactivate the playground API key. This key is required for the playground to function.",
 		});
 	}
 

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -618,44 +618,50 @@ export function ApiKeysList({
 													Manage IAM Rules
 												</Link>
 											</DropdownMenuItem>
-											<DropdownMenuSeparator />
-											<DropdownMenuItem
-												onClick={() => toggleStatus(key.id, key.status)}
-											>
-												{key.status === "active" ? "Deactivate" : "Activate"}{" "}
-												Key
-											</DropdownMenuItem>
-											<DropdownMenuSeparator />
-											<AlertDialog>
-												<AlertDialogTrigger asChild>
+											{key.description !== "Auto-generated playground key" && (
+												<>
+													<DropdownMenuSeparator />
 													<DropdownMenuItem
-														onSelect={(e) => e.preventDefault()}
-														className="text-destructive focus:text-destructive"
+														onClick={() => toggleStatus(key.id, key.status)}
 													>
-														Delete
+														{key.status === "active"
+															? "Deactivate"
+															: "Activate"}{" "}
+														Key
 													</DropdownMenuItem>
-												</AlertDialogTrigger>
-												<AlertDialogContent>
-													<AlertDialogHeader>
-														<AlertDialogTitle>
-															Are you absolutely sure?
-														</AlertDialogTitle>
-														<AlertDialogDescription>
-															This action cannot be undone. This will
-															permanently delete the API key and it will no
-															longer be able to access your account.
-														</AlertDialogDescription>
-													</AlertDialogHeader>
-													<AlertDialogFooter>
-														<AlertDialogCancel>Cancel</AlertDialogCancel>
-														<AlertDialogAction
-															onClick={() => deleteKey(key.id)}
-														>
-															Delete
-														</AlertDialogAction>
-													</AlertDialogFooter>
-												</AlertDialogContent>
-											</AlertDialog>
+													<DropdownMenuSeparator />
+													<AlertDialog>
+														<AlertDialogTrigger asChild>
+															<DropdownMenuItem
+																onSelect={(e) => e.preventDefault()}
+																className="text-destructive focus:text-destructive"
+															>
+																Delete
+															</DropdownMenuItem>
+														</AlertDialogTrigger>
+														<AlertDialogContent>
+															<AlertDialogHeader>
+																<AlertDialogTitle>
+																	Are you absolutely sure?
+																</AlertDialogTitle>
+																<AlertDialogDescription>
+																	This action cannot be undone. This will
+																	permanently delete the API key and it will no
+																	longer be able to access your account.
+																</AlertDialogDescription>
+															</AlertDialogHeader>
+															<AlertDialogFooter>
+																<AlertDialogCancel>Cancel</AlertDialogCancel>
+																<AlertDialogAction
+																	onClick={() => deleteKey(key.id)}
+																>
+																	Delete
+																</AlertDialogAction>
+															</AlertDialogFooter>
+														</AlertDialogContent>
+													</AlertDialog>
+												</>
+											)}
 										</DropdownMenuContent>
 									</DropdownMenu>
 								</TableCell>
@@ -708,41 +714,48 @@ export function ApiKeysList({
 											Manage IAM Rules
 										</Link>
 									</DropdownMenuItem>
-									<DropdownMenuSeparator />
-									<DropdownMenuItem
-										onClick={() => toggleStatus(key.id, key.status)}
-									>
-										{key.status === "active" ? "Deactivate" : "Activate"} Key
-									</DropdownMenuItem>
-									<DropdownMenuSeparator />
-									<AlertDialog>
-										<AlertDialogTrigger asChild>
+									{key.description !== "Auto-generated playground key" && (
+										<>
+											<DropdownMenuSeparator />
 											<DropdownMenuItem
-												onSelect={(e) => e.preventDefault()}
-												className="text-destructive focus:text-destructive"
+												onClick={() => toggleStatus(key.id, key.status)}
 											>
-												Delete
+												{key.status === "active" ? "Deactivate" : "Activate"}{" "}
+												Key
 											</DropdownMenuItem>
-										</AlertDialogTrigger>
-										<AlertDialogContent>
-											<AlertDialogHeader>
-												<AlertDialogTitle>
-													Are you absolutely sure?
-												</AlertDialogTitle>
-												<AlertDialogDescription>
-													This action cannot be undone. This will permanently
-													delete the API key and it will no longer be able to
-													access your account.
-												</AlertDialogDescription>
-											</AlertDialogHeader>
-											<AlertDialogFooter>
-												<AlertDialogCancel>Cancel</AlertDialogCancel>
-												<AlertDialogAction onClick={() => deleteKey(key.id)}>
-													Delete
-												</AlertDialogAction>
-											</AlertDialogFooter>
-										</AlertDialogContent>
-									</AlertDialog>
+											<DropdownMenuSeparator />
+											<AlertDialog>
+												<AlertDialogTrigger asChild>
+													<DropdownMenuItem
+														onSelect={(e) => e.preventDefault()}
+														className="text-destructive focus:text-destructive"
+													>
+														Delete
+													</DropdownMenuItem>
+												</AlertDialogTrigger>
+												<AlertDialogContent>
+													<AlertDialogHeader>
+														<AlertDialogTitle>
+															Are you absolutely sure?
+														</AlertDialogTitle>
+														<AlertDialogDescription>
+															This action cannot be undone. This will
+															permanently delete the API key and it will no
+															longer be able to access your account.
+														</AlertDialogDescription>
+													</AlertDialogHeader>
+													<AlertDialogFooter>
+														<AlertDialogCancel>Cancel</AlertDialogCancel>
+														<AlertDialogAction
+															onClick={() => deleteKey(key.id)}
+														>
+															Delete
+														</AlertDialogAction>
+													</AlertDialogFooter>
+												</AlertDialogContent>
+											</AlertDialog>
+										</>
+									)}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						</div>


### PR DESCRIPTION
## Summary
- Adds a backend guard on `DELETE /keys/api/{id}` to reject deletion of the auto-generated playground API key (returns 403)
- Hides the "Deactivate" and "Delete" actions in the API keys dropdown menu (both desktop and mobile views) for the playground key
- No rename endpoint exists, so renaming is already impossible

## Test plan
- [ ] Verify the playground API key no longer shows "Deactivate" or "Delete" in the dropdown menu
- [ ] Verify calling `DELETE /keys/api/{id}` directly for the playground key returns a 403 error
- [ ] Verify other API keys can still be deleted and deactivated normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental deletion of the required auto-generated playground API key.
  * Prevented deactivation of the required auto-generated playground API key.
  * Added confirmation dialog for API key deletion operations to reduce unintended deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->