### PR TITLE
fix(gateway): force temperature=1 when thinking is enabled for Anthropic models

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1014,6 +1014,8 @@ export async function prepareRequestBody(
 					type: "enabled",
 					budget_tokens: thinkingBudget,
 				};
+				// Anthropic requires temperature to be exactly 1 when thinking is enabled
+				temperature = 1;
 			}
 
 			// Add optional parameters if they are provided
@@ -1290,6 +1292,8 @@ export async function prepareRequestBody(
 					type: "enabled",
 					budget_tokens: thinkingBudget,
 				};
+				// Anthropic requires temperature to be exactly 1 when thinking is enabled
+				inferenceConfig.temperature = 1;
 				// Ensure max_tokens is sufficient for thinking + response
 				const minMaxTokens = Math.max(1024, thinkingBudget + 1000);
 				if (


### PR DESCRIPTION
## Summary
- Anthropic's API requires `temperature` to be exactly `1` when extended thinking is enabled, otherwise it returns an error
- Forces `temperature = 1` in both the **Anthropic direct API** and **AWS Bedrock Converse API** code paths when thinking is enabled
- Other Anthropic-based providers were audited — only these two provider cases (`anthropic` and `aws-bedrock`) are affected

## Test plan
- [ ] Send a request with `reasoning_effort` set and a custom `temperature` (e.g. 0.7) to an Anthropic model via the direct provider — should succeed with temperature forced to 1
- [ ] Send the same request via AWS Bedrock — should succeed with temperature forced to 1
- [ ] Send a request without reasoning enabled — temperature should pass through unchanged
- [ ] Build passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Anthropic models with extended thinking enabled now enforce a fixed temperature setting to ensure consistent response generation across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->