### PR TITLE
fix(gateway): add org, project, and API key IDs to provider error logs

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2788,6 +2788,9 @@ chat.openapi(completions, async (c) => {
 								requestedProvider,
 								usedModel,
 								initialRequestedModel,
+								organizationId: project.organizationId,
+								projectId: apiKey.projectId,
+								apiKeyId: apiKey.id,
 							});
 						}
 
@@ -5383,6 +5386,9 @@ chat.openapi(completions, async (c) => {
 					requestedProvider,
 					usedModel,
 					initialRequestedModel,
+					organizationId: project.organizationId,
+					projectId: apiKey.projectId,
+					apiKeyId: apiKey.id,
 				});
 			}
 


### PR DESCRIPTION
## Summary
- Added `organizationId`, `projectId`, and `apiKeyId` to the "Provider error" warning logs in both the streaming and non-streaming chat completion paths
- Makes it easier to trace provider errors back to specific tenants and API keys for debugging

## Test plan
- [ ] Verify gateway builds without type errors
- [ ] Trigger a provider error and confirm the new fields appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error diagnostics with additional contextual information to improve issue tracking and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->