### PR TITLE
fix(gateway): downgrade reasoning log level

### DIFF
--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -103,7 +103,7 @@ export function validateModelCapabilities(
 		);
 
 		if (!supportsReasoning) {
-			logger.error(
+			logger.warn(
 				`Reasoning effort specified for non-reasoning model: ${requestedModel}`,
 				{
 					requestedModel,


### PR DESCRIPTION
## Summary
- Downgrade `logger.error` to `logger.warn` for reasoning_effort validation on non-reasoning models
- Client validation errors (400) should not trigger production error alerts (level 50)
- HTTP 400 response to the client remains unchanged

## Test plan
- [x] Verified locally with `curl` that the 400 response is still returned
- [ ] Confirm gateway logs show `level: 40` (warn) instead of `level: 50` (error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging severity for model capability validation warnings. When reasoning effort is specified for non-reasoning models, the system now logs this as a warning rather than an error while maintaining the same validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->