### PR TITLE
feat(ui): animated collapsible sidebar

### DIFF
--- a/apps/ui/src/components/dashboard/animated-nav-icons.tsx
+++ b/apps/ui/src/components/dashboard/animated-nav-icons.tsx
@@ -33,9 +33,7 @@ export function AnimatedLayoutDashboard({ isHovered }: AnimatedIconProps) {
 					{...rect}
 					initial={false}
 					animate={
-						isHovered
-							? { translateY: [0, -1.5, 0], opacity: [1, 0.6, 1] }
-							: {}
+						isHovered ? { translateY: [0, -1.5, 0], opacity: [1, 0.6, 1] } : {}
 					}
 					transition={{ duration: 0.3, delay: i * 0.06, ease: "easeInOut" }}
 				/>
@@ -199,9 +197,7 @@ export function AnimatedShieldAlert({ isHovered }: AnimatedIconProps) {
 				d="M12 8v4"
 				initial={false}
 				animate={
-					isHovered
-						? { translateX: [0, -1, 1, -1, 1, 0] }
-						: { translateX: 0 }
+					isHovered ? { translateX: [0, -1, 1, -1, 1, 0] } : { translateX: 0 }
 				}
 				transition={{ duration: 0.4, ease: "easeInOut" }}
 			/>
@@ -237,9 +233,7 @@ export function AnimatedBotMessageSquare({ isHovered }: AnimatedIconProps) {
 			<motion.path
 				d="M12 6V2H8"
 				initial={false}
-				animate={
-					isHovered ? { rotate: [0, -10, 10, -5, 0] } : { rotate: 0 }
-				}
+				animate={isHovered ? { rotate: [0, -10, 10, -5, 0] } : { rotate: 0 }}
 				transition={{ duration: 0.5, ease: "easeInOut" }}
 				style={{ transformOrigin: "12px 6px" }}
 			/>
@@ -253,17 +247,13 @@ export function AnimatedBotMessageSquare({ isHovered }: AnimatedIconProps) {
 			<motion.path
 				d="M2 12h2"
 				initial={false}
-				animate={
-					isHovered ? { translateX: [0, -1.5, 0] } : { translateX: 0 }
-				}
+				animate={isHovered ? { translateX: [0, -1.5, 0] } : { translateX: 0 }}
 				transition={{ duration: 0.3, ease: "easeInOut" }}
 			/>
 			<motion.path
 				d="M20 12h2"
 				initial={false}
-				animate={
-					isHovered ? { translateX: [0, 1.5, 0] } : { translateX: 0 }
-				}
+				animate={isHovered ? { translateX: [0, 1.5, 0] } : { translateX: 0 }}
 				transition={{ duration: 0.3, ease: "easeInOut" }}
 			/>
 			<path d="M20 16a2 2 0 0 1-2 2H8.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 4 20.286V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2z" />

--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -23,6 +23,7 @@ import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
 import { useMemo, useState, useEffect } from "react";
 
+import { TopUpCreditsDialog } from "@/components/credits/top-up-credits-dialog";
 import {
 	AnimatedActivity,
 	AnimatedBarChart3,
@@ -37,7 +38,6 @@ import {
 	AnimatedShield,
 	AnimatedShieldAlert,
 } from "@/components/dashboard/animated-nav-icons";
-import { TopUpCreditsDialog } from "@/components/credits/top-up-credits-dialog";
 import { ReferralDialog } from "@/components/dashboard/referral-dialog";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { useUser } from "@/hooks/useUser";

--- a/apps/ui/src/components/dashboard/top-bar.tsx
+++ b/apps/ui/src/components/dashboard/top-bar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Separator } from "@/lib/components/separator";
 import { usePathname } from "next/navigation";
 
 import { ModelSearch } from "@/components/shared/model-search";
+import { Separator } from "@/lib/components/separator";
 import { SidebarTrigger } from "@/lib/components/sidebar";
 
 import { ProjectSwitcher } from "./project-switcher";


### PR DESCRIPTION
## Summary
- Add per-SVG-element framer-motion hover animations for all 12 sidebar navigation icons (e.g., gear rotates, bars grow from bottom, heartbeat line draws itself, keys jiggle)
- Make sidebar collapsible with icon-only mode using shadcn `collapsible="icon"` pattern — shows tooltips, logo without title, and avatar when collapsed
- Add `SidebarTrigger` toggle button in the top bar and `SidebarRail` for edge-click toggling

## Test plan
- [ ] Verify sidebar collapses to icon-only mode when clicking the trigger or rail
- [ ] Verify tooltips appear on all nav items when sidebar is collapsed
- [ ] Verify each sidebar icon animates with unique per-SVG-element animation on hover
- [ ] Verify org switcher, credits display, upgrade CTA, and user name/email are hidden when collapsed
- [ ] Verify logo shows without title text when collapsed
- [ ] Verify mobile sidebar still works correctly (sheet overlay)
- [ ] Verify navigation and active states work correctly in both expanded and collapsed modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard navigation icons replaced with a suite of animated, hover-aware SVG icons for richer visual feedback.
  * Sidebar rail UI element added and a persistent sidebar trigger included in the top bar for easier access on mobile.

* **Style**
  * Sidebar and top-bar layout refined with improved spacing and hover-based visibility controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->