### PR TITLE
fix(gateway): enable retry/fallback for auto-routed model requests

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -439,7 +439,7 @@ chat.openapi(completions, async (c) => {
 		requestedModel,
 		parseResult.requestedProvider,
 	);
-	const modelInfo = modelInfoResult.modelInfo;
+	let modelInfo = modelInfoResult.modelInfo;
 	const allModelProviders = modelInfoResult.allModelProviders;
 	let requestedProvider = modelInfoResult.requestedProvider;
 
@@ -887,6 +887,21 @@ chat.openapi(completions, async (c) => {
 			// Default fallback if no suitable model is found - use cheapest allowed model
 			usedModel = "gpt-5-nano";
 			usedProvider = "openai";
+		}
+		// Update modelInfo to the selected model so retry/fallback logic can find
+		// alternative providers. Without this, modelInfo still points to the "auto"
+		// model definition which only has "llmgateway" as a provider, preventing retries.
+		if (selectedModel) {
+			modelInfo = {
+				...selectedModel,
+				providers: selectedProviders,
+			};
+		} else {
+			// Fallback case: look up the default model definition
+			const fallbackModelDef = models.find((m) => m.id === "gpt-5-nano");
+			if (fallbackModelDef) {
+				modelInfo = fallbackModelDef;
+			}
 		}
 		// Clear requestedProvider so retry/fallback logic knows this was auto-routed
 		requestedProvider = undefined;


### PR DESCRIPTION
## Summary
- After auto routing selects a real model (e.g. `gpt-5-nano`), `modelInfo` still pointed to the `auto` model definition which only has `llmgateway` as a provider
- This caused `selectNextProvider()` in both the streaming and non-streaming retry loops to never find matching providers, silently disabling all retry/fallback behavior for auto-routed requests
- Updates `modelInfo` to the selected model's definition (with filtered providers) after auto routing completes

## Test plan
- [ ] Verify auto-routed requests retry on 5xx/429/network errors by testing with a provider that returns errors
- [ ] Verify root model requests (e.g. `gpt-4o` without provider prefix) still retry correctly (regression check)
- [ ] Verify provider-specific requests (e.g. `openai/gpt-4o`) still skip retries as expected
- [ ] Existing unit tests pass (140/140 in `apps/gateway/src/chat/tools/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model auto-routing to properly update provider information after routing decisions, ensuring correct fallback and retry behavior.
  * Improved reliability of model selection when auto-routing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->