### PR TITLE
fix: retry on 401/403 auth errors and provider billing 400s

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -64,15 +64,32 @@ describe("getFinishReasonFromError", () => {
 		).toBe("client_error");
 	});
 
+	it("returns upstream_error for 401/403 auth errors", () => {
+		expect(getFinishReasonFromError(401)).toBe("upstream_error");
+		expect(getFinishReasonFromError(403)).toBe("upstream_error");
+	});
+
+	it("returns upstream_error for provider billing errors at 400", () => {
+		expect(
+			getFinishReasonFromError(
+				400,
+				'{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}',
+			),
+		).toBe("upstream_error");
+
+		expect(getFinishReasonFromError(400, "insufficient_quota")).toBe(
+			"upstream_error",
+		);
+
+		expect(
+			getFinishReasonFromError(400, "Please check your billing settings"),
+		).toBe("upstream_error");
+	});
+
 	it("returns gateway_error for other 400 errors", () => {
 		expect(getFinishReasonFromError(400, "some other error")).toBe(
 			"gateway_error",
 		);
-	});
-
-	it("returns gateway_error for 401/403 auth errors", () => {
-		expect(getFinishReasonFromError(401)).toBe("gateway_error");
-		expect(getFinishReasonFromError(403)).toBe("gateway_error");
 	});
 
 	it("returns gateway_error when no error text provided", () => {

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -3,7 +3,9 @@
  * 5xx status codes indicate upstream provider errors
  * 429 status codes indicate upstream rate limiting (treated as upstream error)
  * 404 status codes indicate model/endpoint not found at provider (treated as upstream error)
- * 401/403 status codes indicate authentication/authorization issues (gateway configuration errors)
+ * 401/403 status codes indicate authentication/authorization issues at the provider
+ *   (e.g. expired key, insufficient credits) — treated as upstream errors so requests
+ *   can be retried on other providers
  * Other 4xx status codes indicate client/gateway errors
  * Special client errors (like JSON format validation) are classified as client_error
  *
@@ -29,6 +31,13 @@ export function getFinishReasonFromError(
 		return "upstream_error";
 	}
 
+	// 401/403 from upstream provider indicates auth/billing issues with the provider key
+	// (e.g. expired key, insufficient credits, revoked access)
+	// These are provider-specific and should be retried on other providers
+	if (statusCode === 401 || statusCode === 403) {
+		return "upstream_error";
+	}
+
 	// Azure OpenAI content filter (ResponsibleAIPolicyViolation)
 	if (errorText?.includes("ResponsibleAIPolicyViolation")) {
 		return "content_filter";
@@ -51,6 +60,16 @@ export function getFinishReasonFromError(
 			errorText.includes("the word 'json'")
 		) {
 			return "client_error";
+		}
+
+		// Provider billing/credit errors returned as 400 (e.g. Anthropic "credit balance is too low")
+		// These are provider-specific issues, not client errors
+		if (
+			errorText.includes("credit balance") ||
+			errorText.includes("insufficient_quota") ||
+			errorText.includes("billing")
+		) {
+			return "upstream_error";
 		}
 	}
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -24,10 +24,13 @@ describe("isRetryableError", () => {
 		expect(isRetryableError(0)).toBe(true);
 	});
 
+	it("retries on 401/403 auth errors", () => {
+		expect(isRetryableError(401)).toBe(true);
+		expect(isRetryableError(403)).toBe(true);
+	});
+
 	it("does not retry on client errors", () => {
 		expect(isRetryableError(400)).toBe(false);
-		expect(isRetryableError(401)).toBe(false);
-		expect(isRetryableError(403)).toBe(false);
 		expect(isRetryableError(404)).toBe(false);
 		expect(isRetryableError(422)).toBe(false);
 	});
@@ -62,6 +65,11 @@ describe("shouldRetryRequest", () => {
 		expect(shouldRetryRequest({ ...defaultOpts, noFallback: true })).toBe(
 			false,
 		);
+	});
+
+	it("retries on auth error status codes", () => {
+		expect(shouldRetryRequest({ ...defaultOpts, statusCode: 401 })).toBe(true);
+		expect(shouldRetryRequest({ ...defaultOpts, statusCode: 403 })).toBe(true);
 	});
 
 	it("does not retry on non-retryable status codes", () => {

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -15,11 +15,20 @@ export type FailedAttempt = RoutingAttempt;
 
 /**
  * Checks if an HTTP status code (or 0 for network errors) is retryable.
- * Retryable: 5xx server errors, 429 rate limits, 0 (network failures/timeouts).
- * NOT retryable: 404 (model not found), 400 (client error), 401/403 (auth).
+ * Retryable: 5xx server errors, 429 rate limits, 401/403 auth errors, 0 (network failures/timeouts).
+ * NOT retryable: 404 (model not found), 400 (client error).
+ *
+ * 401/403 are retryable because they indicate provider-specific auth/billing issues
+ * (e.g. expired key, insufficient credits) — the request itself may succeed on another provider.
  */
 export function isRetryableError(statusCode: number): boolean {
-	return statusCode === 429 || statusCode >= 500 || statusCode === 0;
+	return (
+		statusCode === 429 ||
+		statusCode === 401 ||
+		statusCode === 403 ||
+		statusCode >= 500 ||
+		statusCode === 0
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Make 401/403 auth errors retryable so requests fall through to other providers
- Classify 401/403 as `upstream_error` instead of `gateway_error`
- Detect billing-related 400 errors (e.g. Anthropic "credit balance is too low") as `upstream_error`

## Details

Previously, a 400 from Anthropic with "Your credit balance is too low" was:
1. Classified as `gateway_error` by `getFinishReasonFromError` (catch-all for unrecognized 4xx)
2. Not retried because `isRetryableError(400)` returned `false`
3. Returned to the caller as HTTP 500 with `type: "gateway_error"`

This is wrong — the error is provider-specific (that provider's key has no credits), not a problem with the client's request. The gateway should retry on another provider.

### Changes

**`isRetryableError`**: Added 401 and 403 as retryable status codes. These indicate provider-specific auth/billing issues that may succeed on another provider.

**`getFinishReasonFromError`**:
- 401/403 → `upstream_error` (was `gateway_error`)
- 400 with billing keywords (`credit balance`, `insufficient_quota`, `billing`) → `upstream_error` (was `gateway_error`)

### Tests updated
- `isRetryableError`: 401/403 now return `true`
- `shouldRetryRequest`: 401/403 now trigger retries
- `getFinishReasonFromError`: 401/403 return `upstream_error`, billing 400s return `upstream_error`

## Test plan

- [ ] Verify unit tests pass (`get-finish-reason-from-error.spec.ts`, `retry-with-fallback.spec.ts`)
- [ ] Test: Anthropic returns 400 "credit balance too low" → should retry on next provider instead of returning 500
- [ ] Test: Provider returns 401/403 → should retry on next provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for upstream provider authentication and billing failures. HTTP 401/403 status codes and billing-related 400-level errors are now correctly classified as retriable. This enables the system to automatically attempt alternative providers, improving service resilience and reducing unnecessary error propagation to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->