### PR TITLE
fix: use root model ID for playground link on model detail page

### DIFF
--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -215,7 +215,7 @@ export default async function ModelPage({ params }: PageProps) {
 							/>
 
 							<a
-								href={`${config.playgroundUrl}?model=${encodeURIComponent(`${modelDef.providers[0]?.providerId}/${modelDef.id}`)}`}
+								href={`${config.playgroundUrl}?model=${encodeURIComponent(modelDef.id)}`}
 								target="_blank"
 								rel="noopener noreferrer"
 							>


### PR DESCRIPTION
## Summary
- The "Try in Playground" button on the model detail page (`/models/[name]`) was using `providers[0].providerId/modelId` which hardcoded the first provider mapping
- Changed it to use just the root model ID (`modelDef.id`), so the playground opens with auto-routing instead of a specific provider

## Test plan
- [ ] Navigate to a model detail page (e.g. `/models/gpt-4o-mini`)
- [ ] Click "Try in Playground" and verify the URL contains just the model ID (e.g. `?model=gpt-4o-mini`) rather than a provider-prefixed ID (e.g. `?model=openai%2Fgpt-4o-mini`)
- [ ] Verify the playground correctly selects the "Auto" provider for the model
- [ ] Verify provider-specific "Try in Playground" buttons (on provider cards and `/models/[name]/[provider]` page) still use provider-prefixed IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Try in Playground" link on the Model page to correctly identify and load models in the Playground interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->