### PR TITLE
feat(gateway): add /v1/images/edits endpoint

### DIFF
--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -537,9 +537,11 @@ images.openapi(edits, async (c) => {
 		imageUrls.push(...request.images);
 	}
 
+	const isProd = process.env.NODE_ENV === "production";
+
 	// Fetch and convert all images to base64 in parallel
 	const imageResults = await Promise.all(
-		imageUrls.map((url) => processImageUrl(url)),
+		imageUrls.map((url) => processImageUrl(url, isProd)),
 	);
 
 	// Build message content parts: images first, then text
@@ -556,7 +558,7 @@ images.openapi(edits, async (c) => {
 
 	// If mask provided, fetch it and add as additional image
 	if (request.mask) {
-		const maskResult = await processImageUrl(request.mask);
+		const maskResult = await processImageUrl(request.mask, isProd);
 		contentParts.push({
 			type: "image_url",
 			image_url: {


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible `/v1/images/edits` endpoint that accepts input images (URLs or base64 data URLs), an edit prompt, and optional mask
- Extract shared helpers (`extractImagesFromChatResponse`, `forwardToChatCompletions`, `forwardHeaders`) from the generations handler to reduce duplication
- Internally routes to chat completions models with image generation capabilities, same architecture as `/v1/images/generations`

## Test plan
- [x] `pnpm build` passes
- [x] Manual test: `POST /v1/images/edits` with base64 image + prompt returns edited image in OpenAI-compatible response format
- [ ] Verify with URL-based image input
- [ ] Verify with multiple images via `images` array
- [ ] Verify with mask image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image editing via a new /edits endpoint, letting users submit an image (and optional mask) to produce edited results with created timestamps and image data arrays.
  * Improved image generation flow so generations and edits share a unified processing and response format, with better prompt handling for higher-quality outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->