### PR TITLE
fix(gateway): align images edits API contract

### DIFF
--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -105,25 +105,22 @@ result.images.forEach((image, i) => {
 
 ## OpenAI Images Edit API
 
-The `/v1/images/edits` endpoint follows OpenAI's `images.edit` request shape and accepts one or more input images via `images[]`.
+The `/v1/images/edits` endpoint is OpenAI-compatible and supports a focused subset of `images.edit` parameters.
 
 ### Parameters
 
-| Parameter            | Type                                | Required | Description                                                        |
-| -------------------- | ----------------------------------- | -------- | ------------------------------------------------------------------ |
-| `images`             | array of `{ image_url?, file_id? }` | yes      | Input images. `image_url` supports HTTPS URLs and base64 data URLs |
-| `prompt`             | string                              | yes      | A text description of the desired image edit                       |
-| `model`              | string                              | no       | Image editing model                                                |
-| `background`         | enum                                | no       | `transparent`, `opaque`, or `auto`                                 |
-| `input_fidelity`     | enum                                | no       | `high` or `low`                                                    |
-| `moderation`         | enum                                | no       | `low` or `auto`                                                    |
-| `n`                  | integer                             | no       | Number of edited images to generate                                |
-| `output_format`      | enum                                | no       | `png`, `jpeg`, or `webp`                                           |
-| `output_compression` | integer                             | no       | Compression level for `jpeg`/`webp`                                |
-| `quality`            | enum                                | no       | `low`, `medium`, `high`, or `auto`                                 |
-| `size`               | enum                                | no       | `auto`, `1024x1024`, `1536x1024`, `1024x1536`                      |
-| `stream`             | boolean                             | no       | Streaming mode (currently not supported)                           |
-| `user`               | string                              | no       | End-user identifier                                                |
+| Parameter            | Type                     | Required | Description                                                        |
+| -------------------- | ------------------------ | -------- | ------------------------------------------------------------------ |
+| `images`             | array of `{ image_url }` | yes      | Input images. `image_url` supports HTTPS URLs and base64 data URLs |
+| `prompt`             | string                   | yes      | A text description of the desired image edit                       |
+| `model`              | string                   | no       | Image editing model                                                |
+| `background`         | enum                     | no       | `transparent`, `opaque`, or `auto`                                 |
+| `input_fidelity`     | enum                     | no       | `high` or `low`                                                    |
+| `n`                  | integer                  | no       | Number of edited images to generate                                |
+| `output_format`      | enum                     | no       | `png`, `jpeg`, or `webp`                                           |
+| `output_compression` | integer                  | no       | Compression level for `jpeg`/`webp`                                |
+| `quality`            | enum                     | no       | `low`, `medium`, `high`, or `auto`                                 |
+| `size`               | enum                     | no       | `auto`, `1024x1024`, `1536x1024`, `1024x1536`                      |
 
 <Callout type="warning">
 	`mask` is not supported yet on `/v1/images/edits`.

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -392,12 +392,7 @@ images.openapi(generations, async (c) => {
 // --- Image Edits Endpoint ---
 
 const imageEditImageInputSchema = z.object({
-	file_id: z.string().optional().openapi({
-		description:
-			"The File API ID of an uploaded image to use as input. Not supported by LLMGateway yet.",
-		example: "file-abc123",
-	}),
-	image_url: z.string().optional().openapi({
+	image_url: z.string().openapi({
 		description: "A fully qualified HTTPS URL or base64-encoded data URL.",
 		example: "https://example.com/source-image.png",
 	}),
@@ -424,10 +419,6 @@ const imageEditsRequestSchema = z.object({
 		description: "The model to use for image editing.",
 		example: "gemini-3-pro-image-preview",
 	}),
-	moderation: z.enum(["low", "auto"]).optional().openapi({
-		description: "Moderation level for image models.",
-		example: "auto",
-	}),
 	n: z.number().int().min(1).max(10).optional().openapi({
 		description: "The number of edited images to generate.",
 		example: 1,
@@ -440,11 +431,6 @@ const imageEditsRequestSchema = z.object({
 		description: "Output image format.",
 		example: "png",
 	}),
-	partial_images: z.number().int().min(0).max(3).optional().openapi({
-		description:
-			"The number of partial images to generate for streaming responses.",
-		example: 1,
-	}),
 	quality: z.enum(["low", "medium", "high", "auto"]).optional().openapi({
 		description: "Output quality for image models.",
 		example: "high",
@@ -456,15 +442,6 @@ const imageEditsRequestSchema = z.object({
 			description: "Requested output image size.",
 			example: "1024x1024",
 		}),
-	stream: z.boolean().optional().openapi({
-		description: "Stream partial image results as events.",
-		example: false,
-	}),
-	user: z.string().optional().openapi({
-		description:
-			"A unique identifier representing your end-user for abuse monitoring.",
-		example: "user-1234",
-	}),
 });
 
 type ImageEditsRequest = z.infer<typeof imageEditsRequestSchema>;
@@ -596,27 +573,9 @@ images.openapi(edits, async (c) => {
 
 	const request = validationResult.data;
 
-	if (request.stream) {
-		throw new HTTPException(400, {
-			message: "The 'stream' parameter is not supported for /v1/images/edits",
-		});
-	}
-
 	// Collect and validate all input image URLs
 	const imageUrls: string[] = [];
 	for (const [index, image] of request.images.entries()) {
-		if (image.file_id) {
-			throw new HTTPException(400, {
-				message: `images[${index}].file_id is not supported yet`,
-			});
-		}
-
-		if (!image.image_url) {
-			throw new HTTPException(400, {
-				message: `images[${index}] must include image_url`,
-			});
-		}
-
 		if (!isSupportedInputImageUrl(image.image_url)) {
 			throw new HTTPException(400, {
 				message: `images[${index}].image_url must be an https URL or a base64 data URL`,


### PR DESCRIPTION
This PR aligns `/v1/images/edits` with OpenAI's `images.edit` request/response shape and ensures the endpoint is fully documented in OpenAPI output.
The gateway now accepts `images[]` entries with `image_url` or `file_id`, validates `image_url` as either HTTPS or base64 image data URLs, and returns clear 400 errors for unsupported `file_id` and `stream` usage.
It also removes `mask` support for now as requested while keeping explicit documentation that `mask` is not yet supported.
Docs were updated in the image generation feature page to add a dedicated `/v1/images/edits` section with parameter coverage and both HTTPS/base64 curl examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible image edits API supporting HTTPS and base64 image inputs, with richer parameters (background, fidelity, quality, format, size, n) and sensible model defaults for unspecified cases.
  * Faster, per-image processing with clearer per-image error messages.

* **Documentation**
  * Published image edits docs with examples and a warning that mask input is not yet supported; API ordering and examples updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->