### PR TITLE
feat: restore 5% BYOK fee for api-keys mode usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,11 @@ PASSKEY_RP_NAME=LLMGateway
 # This fee is applied when users pay with credits using our API keys
 PLATFORM_FEE_PERCENTAGE=0.05
 
+# Fee percentage for BYOK (Bring Your Own Keys) usage (default: 5%)
+# This fee is applied when users use their own provider API keys
+# Set to 0 to disable BYOK fees
+BYOK_FEE_PERCENTAGE=0.05
+
 # Set to "true" to bill cancelled requests based on estimated token usage (default: true)
 # When enabled, cancelled requests will be billed for prompt tokens and any partial
 # completion tokens that were streamed before cancellation, plus request costs

--- a/apps/ui/src/components/landing/faq.tsx
+++ b/apps/ui/src/components/landing/faq.tsx
@@ -13,7 +13,7 @@ const faqData = [
 	{
 		question: "What makes LLM Gateway different from OpenRouter?",
 		answer:
-			"Unlike OpenRouter, LLM Gateway offers: Full self-hosting under an AGPLv3 license – run the gateway entirely on your infra. Deeper, real-time cost & latency analytics for every request. Bring Your Own Keys for free. Flexible enterprise add-ons (dedicated shard, custom SLAs).",
+			"Unlike OpenRouter, LLM Gateway offers: Full self-hosting under an AGPLv3 license – run the gateway entirely on your infra. Deeper, real-time cost & latency analytics for every request. Bring Your Own Keys with just 5% tracking fee. Flexible enterprise add-ons (dedicated shard, custom SLAs).",
 	},
 	{
 		question: "What models do you support?",
@@ -28,7 +28,7 @@ const faqData = [
 	{
 		question: "How much does it cost?",
 		answer:
-			"Credits: Pay-as-you-go with a flat 5% platform fee. BYOK: Use your own provider API keys for free. Enterprise: Custom SLA, dedicated infrastructure, and volume discounts. Self-host: Deploy free forever under AGPLv3 license.",
+			"Credits: Pay-as-you-go with a flat 5% platform fee. BYOK: Use your own provider API keys with just 5% tracking fee. Enterprise: Custom SLA, dedicated infrastructure, and volume discounts. Self-host: Deploy free forever under AGPLv3 license.",
 	},
 ];
 
@@ -105,7 +105,7 @@ export function Faq() {
 									</li>
 									<li>
 										<strong>Bring Your Own Keys</strong> – use your own provider
-										API keys for free
+										API keys with just 5% tracking fee
 									</li>
 									<li>
 										Flexible <strong>enterprise add‑ons</strong> (dedicated
@@ -177,10 +177,10 @@ export function Faq() {
 										use any model with a flat 5% platform fee on purchases.
 									</li>
 									<li>
-										<strong>Bring Your Own Keys – free:</strong> Use your own
+										<strong>Bring Your Own Keys – 5% fee:</strong> Use your own
 										LLM provider API keys (OpenAI, Anthropic, Google, etc.) and
-										pay providers directly. Usage tracking and analytics
-										included at no extra cost.
+										pay providers directly. We charge just 5% to track usage and
+										provide analytics.
 									</li>
 									<li>
 										<strong>Enterprise:</strong> Custom SLA, dedicated

--- a/apps/ui/src/components/landing/pricing-plans.tsx
+++ b/apps/ui/src/components/landing/pricing-plans.tsx
@@ -59,7 +59,7 @@ export function PricingPlans() {
 			features: [
 				"Access to ALL models",
 				"Pay with credits (5% fee)",
-				"Bring Your Own Keys (free)",
+				"Bring Your Own Keys (5% fee)",
 				"30-day data retention",
 				"Team Management",
 				"Advanced Analytics",

--- a/apps/ui/src/components/pricing/pricing-table.tsx
+++ b/apps/ui/src/components/pricing/pricing-table.tsx
@@ -85,7 +85,7 @@ const pricingFeatures: PricingFeature[] = [
 	{
 		name: "Bring Your Own Keys (BYOK)",
 		description: "Use your own provider API keys",
-		free: "Included",
+		free: "5% fee",
 		enterprise: "Custom limits",
 	},
 	{

--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -152,8 +152,11 @@ describe("Log Processing", () => {
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.01);
 		});
 
-		test("should not deduct credits for api-keys mode logs (no BYOK fee)", async () => {
+		test("should deduct only BYOK fee (5%) for api-keys mode logs", async () => {
 			const initialCredits = Number(testOrg.credits);
+			const cost = 0.01;
+			const byokFeePercentage = 0.05; // 5%
+			const expectedFee = cost * byokFeePercentage;
 
 			// Insert unprocessed log with api-keys mode
 			await db.insert(log).values({
@@ -161,7 +164,7 @@ describe("Log Processing", () => {
 				organizationId: testOrg.id,
 				projectId: testProject.id,
 				apiKeyId: testApiKey.id,
-				cost: 0.01,
+				cost: cost,
 				cached: false,
 				usedMode: "api-keys",
 				duration: 2000,
@@ -176,12 +179,12 @@ describe("Log Processing", () => {
 			// Process the logs
 			await batchProcessLogs();
 
-			// Verify no credits were deducted for api-keys mode
+			// Verify only BYOK fee was deducted (not full cost)
 			const updatedOrg = await db.query.organization.findFirst({
 				where: { id: { eq: testOrg.id } },
 			});
 
-			expect(Number(updatedOrg!.credits)).toBe(initialCredits);
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - expectedFee);
 		});
 
 		test("should update API key usage for all non-cached logs with cost", async () => {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -24,7 +24,7 @@ import {
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import { hasErrorCode } from "@llmgateway/models";
-import { calculateFees } from "@llmgateway/shared";
+import { BYOK_FEE_PERCENTAGE, calculateFees } from "@llmgateway/shared";
 
 import { runFollowUpEmailsLoop } from "./services/follow-up-emails.js";
 import {
@@ -601,17 +601,29 @@ export async function batchProcessLogs(): Promise<void> {
 							currentOrgCost.plus(new Decimal(row.cost)),
 						);
 					} else if (row.used_mode === "api-keys") {
-						// In API keys mode, only deduct storage cost (data retention billing)
+						// In API keys mode, charge BYOK fee (% of tracked cost) + storage cost
+						let totalToDeduct = new Decimal(0);
+
+						// Add BYOK fee (e.g., 5% of the tracked cost)
+						if (row.cost) {
+							const byokFee = new Decimal(row.cost).times(BYOK_FEE_PERCENTAGE);
+							totalToDeduct = totalToDeduct.plus(byokFee);
+						}
+
+						// Add storage cost if applicable
 						if (row.data_storage_cost) {
-							const storageCost = new Decimal(row.data_storage_cost);
-							if (storageCost.greaterThan(0)) {
-								const currentOrgCost =
-									orgCosts.get(row.organization_id) ?? new Decimal(0);
-								orgCosts.set(
-									row.organization_id,
-									currentOrgCost.plus(storageCost),
-								);
-							}
+							totalToDeduct = totalToDeduct.plus(
+								new Decimal(row.data_storage_cost),
+							);
+						}
+
+						if (totalToDeduct.greaterThan(0)) {
+							const currentOrgCost =
+								orgCosts.get(row.organization_id) ?? new Decimal(0);
+							orgCosts.set(
+								row.organization_id,
+								currentOrgCost.plus(totalToDeduct),
+							);
 						}
 					}
 				}

--- a/packages/shared/src/fees.ts
+++ b/packages/shared/src/fees.ts
@@ -10,6 +10,12 @@ export interface FeeCalculationInput {
 
 const PLATFORM_FEE_PERCENTAGE = 0.05; // Fixed 5% for all users
 
+// Fee percentage for BYOK (Bring Your Own Keys) usage - charged on tracked costs
+// when users use their own provider API keys
+export const BYOK_FEE_PERCENTAGE = parseFloat(
+	process.env.BYOK_FEE_PERCENTAGE ?? "0.05",
+);
+
 export function calculateFees(input: FeeCalculationInput): FeeBreakdown {
 	const { amount } = input;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export {
+	BYOK_FEE_PERCENTAGE,
 	calculateFees,
 	type FeeBreakdown,
 	type FeeCalculationInput,


### PR DESCRIPTION
## Summary
- Re-introduces the BYOK (Bring Your Own Key) fee that was removed in 6a37a4c7, now set at **5%** (previously 1%)
- When users use their own provider API keys (`api-keys` mode), 5% of the tracked request cost is deducted from their organization credits
- Fee is configurable via `BYOK_FEE_PERCENTAGE` environment variable (default: 0.05)

## Changes
- **`packages/shared/src/fees.ts`** — Restored `BYOK_FEE_PERCENTAGE` export (default 0.05)
- **`apps/worker/src/worker.ts`** — Restored BYOK fee charging logic in batch log processing for api-keys mode
- **`apps/worker/src/log-processing.spec.ts`** — Updated test to expect 5% BYOK fee deduction
- **`.env.example`** — Added `BYOK_FEE_PERCENTAGE=0.05` configuration
- **UI (faq, pricing-plans, pricing-table)** — Updated marketing copy from "free" to "5% fee"

## Test plan
- [ ] Verify worker correctly deducts 5% BYOK fee from org credits for api-keys mode logs
- [ ] Verify credits mode logs still deduct full cost (unchanged)
- [ ] Verify cached logs are not charged (unchanged)
- [ ] Verify `BYOK_FEE_PERCENTAGE` env var overrides the default
- [ ] Verify pricing/FAQ pages reflect the 5% fee

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ, pricing plans, and pricing pages to reflect Bring Your Own Keys (BYOK) now includes a 5% tracking fee instead of being offered free.

* **Chores**
  * Updated system configuration and fee calculation logic to properly handle BYOK tracking fee deductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->