### PR TITLE
feat: add xigege.me to email blocklist

### DIFF
--- a/apps/api/src/utils/email-validation.ts
+++ b/apps/api/src/utils/email-validation.ts
@@ -13,6 +13,7 @@ const BLACKLISTED_DOMAINS = [
 	"15p.me",
 	"vsheerid.me",
 	"addy.io",
+	"xigege.me",
 ];
 
 export function validateEmail(email: string): EmailValidationResult {


### PR DESCRIPTION
https://claude.ai/code/session_01VeLNyXFWQxrgWq9A1gb5jk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email validation now correctly rejects the "xigege.me" domain as blacklisted, preventing invalid emails from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->