### PR TITLE
feat(google): deprecate gemini-3-pro-preview

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -487,8 +487,7 @@ export const googleModels = [
 	{
 		id: "gemini-pro-latest",
 		name: "Gemini Pro Latest",
-		description:
-			"Always points to the latest Gemini Pro model.",
+		description: "Always points to the latest Gemini Pro model.",
 		family: "google",
 		releasedAt: new Date("2026-02-27"),
 		providers: [


### PR DESCRIPTION
## Summary
- Add `deprecatedAt` (2026-02-27) and `deactivatedAt` (2026-03-09) to `gemini-3-pro-preview` on both google-ai-studio and google-vertex providers
- Add `gemini-pro-latest` model entry — Google's auto-updating `-latest` alias (currently resolves to `gemini-3.1-pro-preview`)

Ref: Google email announcing Gemini 3 Pro Preview discontinuation on March 9, 2026, and `-latest` alias switch to Gemini 3.1 Pro Preview on March 6, 2026.

## Test plan
- [x] `pnpm format` passes
- [x] `pnpm build` passes
- [x] Gateway routes `gemini-pro-latest` correctly to Google AI Studio
- [x] Gateway routes `gemini-3-pro-preview` correctly (still active until March 9)
- [ ] Verify with valid Google API key that `gemini-pro-latest` returns responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google's latest Gemini model with provider integration, capability flags (reasoning, streaming, vision, tools, web search, structured output), context/output limits, and pricing tiers.

* **Deprecations**
  * Previous Gemini Pro preview models are now marked deprecated with scheduled deactivation dates across providers for lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->