### PR TITLE
fix(playground): vision vs image gen detection

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -377,6 +377,15 @@ export default function ChatPageClient({
 
 	const sendMessageWithHeaders = useCallback(
 		(message: any, options?: any) => {
+			// Check if the user message contains image attachments (vision request)
+			const hasImageAttachments = message.parts?.some(
+				(p: any) => p.type === "file" && p.mediaType?.startsWith("image/"),
+			);
+
+			// Only use image gen when the model supports it AND user didn't attach images for vision
+			const useImageGen =
+				supportsImageGen && !(supportsImages && hasImageAttachments);
+
 			// Check if model uses WIDTHxHEIGHT format (Alibaba or ZAI)
 			const usesPixelDimensions =
 				selectedModel.toLowerCase().includes("alibaba") ||
@@ -384,30 +393,22 @@ export default function ChatPageClient({
 				selectedModel.toLowerCase().includes("zai") ||
 				selectedModel.toLowerCase().includes("cogview");
 
-			// Only send image_config if user has explicitly selected non-default values
-			const hasNonDefaultCount = imageCount > 1;
-			const imageConfig = supportsImageGen
+			// Always send n explicitly to prevent providers from defaulting to >1
+			const imageConfig = useImageGen
 				? usesPixelDimensions
-					? // For Alibaba/ZAI, don't send image_config with default size
-						alibabaImageSize !== "1024x1024" || hasNonDefaultCount
-						? {
-								...(alibabaImageSize !== "1024x1024" && {
-									image_size: alibabaImageSize,
-								}),
-								...(hasNonDefaultCount && { n: imageCount }),
-							}
-						: undefined
-					: imageAspectRatio !== "auto" ||
-						  imageSize !== "1K" ||
-						  hasNonDefaultCount
-						? {
-								...(imageAspectRatio !== "auto" && {
-									aspect_ratio: imageAspectRatio,
-								}),
-								...(imageSize !== "1K" && { image_size: imageSize }),
-								...(hasNonDefaultCount && { n: imageCount }),
-							}
-						: undefined
+					? {
+							...(alibabaImageSize !== "1024x1024" && {
+								image_size: alibabaImageSize,
+							}),
+							n: imageCount,
+						}
+					: {
+							...(imageAspectRatio !== "auto" && {
+								aspect_ratio: imageAspectRatio,
+							}),
+							...(imageSize !== "1K" && { image_size: imageSize }),
+							n: imageCount,
+						}
 				: undefined;
 
 			// Automatically disable provider fallback for provider-specific model selections
@@ -430,7 +431,7 @@ export default function ChatPageClient({
 					...(options?.body ?? {}),
 					...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
 					...(imageConfig ? { image_config: imageConfig } : {}),
-					...(supportsImageGen ? { is_image_gen: true } : {}),
+					...(useImageGen ? { is_image_gen: true } : {}),
 					...(webSearchEnabled && supportsWebSearch
 						? { web_search: true }
 						: {}),
@@ -446,6 +447,7 @@ export default function ChatPageClient({
 			sendMessage,
 			reasoningEffort,
 			supportsImageGen,
+			supportsImages,
 			imageAspectRatio,
 			imageSize,
 			alibabaImageSize,
@@ -1236,6 +1238,15 @@ function ExtraChatPanel({
 
 	const sendMessageWithHeaders = useCallback(
 		(message: any, options?: any) => {
+			// Check if the user message contains image attachments (vision request)
+			const hasImageAttachments = message.parts?.some(
+				(p: any) => p.type === "file" && p.mediaType?.startsWith("image/"),
+			);
+
+			// Only use image gen when the model supports it AND user didn't attach images for vision
+			const useImageGen =
+				supportsImageGen && !(supportsImages && hasImageAttachments);
+
 			// Check if model uses WIDTHxHEIGHT format (Alibaba or ZAI)
 			const usesPixelDimensions =
 				selectedModel.toLowerCase().includes("alibaba") ||
@@ -1243,30 +1254,22 @@ function ExtraChatPanel({
 				selectedModel.toLowerCase().includes("zai") ||
 				selectedModel.toLowerCase().includes("cogview");
 
-			// Only send image_config if user has explicitly selected non-default values
-			const hasNonDefaultCount = imageCount > 1;
-			const imageConfig = supportsImageGen
+			// Always send n explicitly to prevent providers from defaulting to >1
+			const imageConfig = useImageGen
 				? usesPixelDimensions
-					? // For Alibaba/ZAI, don't send image_config with default size
-						alibabaImageSize !== "1024x1024" || hasNonDefaultCount
-						? {
-								...(alibabaImageSize !== "1024x1024" && {
-									image_size: alibabaImageSize,
-								}),
-								...(hasNonDefaultCount && { n: imageCount }),
-							}
-						: undefined
-					: imageAspectRatio !== "auto" ||
-						  imageSize !== "1K" ||
-						  hasNonDefaultCount
-						? {
-								...(imageAspectRatio !== "auto" && {
-									aspect_ratio: imageAspectRatio,
-								}),
-								...(imageSize !== "1K" && { image_size: imageSize }),
-								...(hasNonDefaultCount && { n: imageCount }),
-							}
-						: undefined
+					? {
+							...(alibabaImageSize !== "1024x1024" && {
+								image_size: alibabaImageSize,
+							}),
+							n: imageCount,
+						}
+					: {
+							...(imageAspectRatio !== "auto" && {
+								aspect_ratio: imageAspectRatio,
+							}),
+							...(imageSize !== "1K" && { image_size: imageSize }),
+							n: imageCount,
+						}
 				: undefined;
 
 			const isProviderSpecific = selectedModel.includes("/");
@@ -1285,7 +1288,7 @@ function ExtraChatPanel({
 					...(options?.body ?? {}),
 					...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
 					...(imageConfig ? { image_config: imageConfig } : {}),
-					...(supportsImageGen ? { is_image_gen: true } : {}),
+					...(useImageGen ? { is_image_gen: true } : {}),
 					...(webSearchEnabled && supportsWebSearch
 						? { web_search: true }
 						: {}),
@@ -1298,6 +1301,7 @@ function ExtraChatPanel({
 			sendMessage,
 			reasoningEffort,
 			supportsImageGen,
+			supportsImages,
 			imageAspectRatio,
 			imageSize,
 			alibabaImageSize,

--- a/apps/playground/src/components/playground/chat-ui.tsx
+++ b/apps/playground/src/components/playground/chat-ui.tsx
@@ -68,6 +68,48 @@ import { parseImagePartToDataUrl } from "@/lib/image-utils";
 
 import type { UIMessage, ChatRequestOptions, ChatStatus } from "ai";
 
+function AspectRatioIcon({
+	ratio,
+	className = "",
+}: {
+	ratio: string;
+	className?: string;
+}) {
+	const maxSize = 14;
+	let w: number;
+	let h: number;
+
+	if (ratio === "auto") {
+		w = maxSize;
+		h = maxSize;
+	} else {
+		const [rw, rh] = ratio.split(":").map(Number);
+		const scale = maxSize / Math.max(rw, rh);
+		w = Math.max(4, Math.round(rw * scale));
+		h = Math.max(4, Math.round(rh * scale));
+	}
+
+	return (
+		<svg
+			width={maxSize}
+			height={maxSize}
+			viewBox={`0 0 ${maxSize} ${maxSize}`}
+			className={`shrink-0 ${className}`}
+		>
+			<rect
+				x={(maxSize - w) / 2}
+				y={(maxSize - h) / 2}
+				width={w}
+				height={h}
+				rx={1}
+				fill="none"
+				stroke="currentColor"
+				strokeWidth={1.5}
+			/>
+		</svg>
+	);
+}
+
 interface ChatUIProps {
 	messages: UIMessage[];
 	supportsImages: boolean;
@@ -731,21 +773,30 @@ export const ChatUI = ({
 											<SelectValue placeholder="Aspect ratio" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="auto">Auto</SelectItem>
-											<SelectItem value="1:1">1:1</SelectItem>
-											<SelectItem value="9:16">9:16</SelectItem>
-											<SelectItem value="16:9">16:9</SelectItem>
-											<SelectItem value="3:4">3:4</SelectItem>
-											<SelectItem value="4:3">4:3</SelectItem>
-											<SelectItem value="3:2">3:2</SelectItem>
-											<SelectItem value="2:3">2:3</SelectItem>
-											<SelectItem value="5:4">5:4</SelectItem>
-											<SelectItem value="4:5">4:5</SelectItem>
-											<SelectItem value="21:9">21:9</SelectItem>
-											<SelectItem value="1:4">1:4</SelectItem>
-											<SelectItem value="4:1">4:1</SelectItem>
-											<SelectItem value="1:8">1:8</SelectItem>
-											<SelectItem value="8:1">8:1</SelectItem>
+											{[
+												"auto",
+												"1:1",
+												"9:16",
+												"16:9",
+												"3:4",
+												"4:3",
+												"3:2",
+												"2:3",
+												"5:4",
+												"4:5",
+												"21:9",
+												"1:4",
+												"4:1",
+												"1:8",
+												"8:1",
+											].map((r) => (
+												<SelectItem key={r} value={r}>
+													<span className="flex items-center gap-2">
+														<AspectRatioIcon ratio={r} />
+														{r === "auto" ? "Auto" : r}
+													</span>
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 									<Select value={imageSize} onValueChange={setImageSize}>


### PR DESCRIPTION
## Summary
- Detect image attachments in user messages to distinguish vision requests from image generation, preventing models that support both from incorrectly routing to image gen
- Always send `n` explicitly in image_config to prevent providers from defaulting to >1 images
- Add `AspectRatioIcon` SVG component for visual ratio previews in the aspect ratio dropdown

## Test plan
- [ ] Attach an image to a model that supports both vision and image gen — should use vision (no `is_image_gen` flag)
- [ ] Send a text-only prompt to an image gen model — should still trigger image generation
- [ ] Verify aspect ratio dropdown shows visual icons for each ratio
- [ ] Verify image count is always sent in image_config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image attachments in messages are now automatically detected and processed.
  * Image configuration, including size and aspect ratio, is dynamically optimized based on the selected model.
  * Aspect ratio selection now displays visual icons for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->