### PR TITLE
fix: pass images to Alibaba image edits

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -498,21 +498,38 @@ export async function prepareRequestBody(
 
 	// Handle Alibaba image generation models
 	if (imageGenerations && usedProvider === "alibaba") {
-		// Extract prompt from last user message
+		// Extract prompt and images from last user message
 		const lastUserMessage = [...messages]
 			.reverse()
 			.find((m) => m.role === "user");
 		let prompt = "";
+		const imageUrls: string[] = [];
 		if (lastUserMessage) {
 			if (typeof lastUserMessage.content === "string") {
 				prompt = lastUserMessage.content;
 			} else if (Array.isArray(lastUserMessage.content)) {
-				prompt = lastUserMessage.content
-					.filter((p): p is { type: "text"; text: string } => p.type === "text")
-					.map((p) => p.text)
-					.join("\n");
+				for (const part of lastUserMessage.content) {
+					if (part.type === "text" && part.text) {
+						prompt += (prompt ? "\n" : "") + part.text;
+					} else if (part.type === "image_url" && part.image_url) {
+						const url =
+							typeof part.image_url === "string"
+								? part.image_url
+								: part.image_url.url;
+						if (url) {
+							imageUrls.push(url);
+						}
+					}
+				}
 			}
 		}
+
+		// Build Alibaba DashScope content array: images first, then text
+		const alibabaContent: any[] = [];
+		for (const url of imageUrls) {
+			alibabaContent.push({ image: url });
+		}
+		alibabaContent.push({ text: prompt });
 
 		// Alibaba DashScope multimodal generation format
 		const alibabaImageRequest: any = {
@@ -521,7 +538,7 @@ export async function prepareRequestBody(
 				messages: [
 					{
 						role: "user",
-						content: [{ text: prompt }],
+						content: alibabaContent,
 					},
 				],
 			},


### PR DESCRIPTION
## Summary
- Fix Alibaba image edit models (`qwen-image-edit-plus`, `qwen-image-edit-max`) failing with `"the message must contain 1~3 image content items. Got 0 image items"`
- The Alibaba provider translation in `prepareRequestBody` only extracted text from message content, ignoring `image_url` parts
- Now extracts images and converts them to Alibaba's `{ "image": "url" }` format in the content array

## Test plan
- [ ] Test `qwen-image-edit-plus` with an input image via ChatWise
- [ ] Test `qwen-image-edit-max` with an input image
- [ ] Verify `qwen-image` (text-to-image generation) still works
- [ ] Unit tests pass (626/626)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alibaba image generation now supports multimodal inputs, enabling users to include images alongside text prompts for more powerful content generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->