### PR TITLE
ci: trigger infra update after image merge

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -414,8 +414,8 @@ jobs:
       - name: Trigger infra image update
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
+          COMMIT_MSG=$(echo "${{ github.event.head_commit.message }}" | head -n1)
           gh workflow run update-image.yml \
             --repo theopenco/llmgateway-infra \
             -f repository="${{ github.repository }}" \


### PR DESCRIPTION
## Summary
- Adds a `trigger-infra-update` job to `images.yml` that dispatches the `update-image` workflow in `llmgateway-infra` directly after split images are merged
- Replaces the polling approach (10s interval, 15min timeout) with a direct workflow dispatch, so images are guaranteed to exist when the infra workflow runs
- Only triggers on push events (main/hotfix), not PRs or releases
- Uses the existing `GH_TOKEN` secret for cross-repo workflow dispatch

## Companion PR
- theopenco/llmgateway-infra: removes the image polling step (should be merged together)

## Test plan
- [ ] Verify `GH_TOKEN` secret has `actions:write` permission on `theopenco/llmgateway-infra`
- [ ] Push to main and confirm the infra workflow is triggered after merge-split completes
- [ ] Verify the infra PR is created with the correct image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expose a short commit SHA as a workflow output for downstream steps.
  * Add a workflow job that, after successful pushes and prerequisite steps, triggers an external infrastructure update and forwards repository, short SHA, and commit message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->