### PR TITLE
test(gateway): add output modality tests for all gemini image-preview models

### DIFF
--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -154,6 +154,44 @@ describe("Models API", () => {
 		]);
 	});
 
+	test("GET /v1/models should include proper output modalities for gemini-3.1-flash-image-preview", async () => {
+		const res = await app.request("/v1/models?include_deactivated=true");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+
+		const imageModel = json.data.find(
+			(model: any) => model.id === "gemini-3.1-flash-image-preview",
+		);
+
+		expect(imageModel).toBeDefined();
+		expect(imageModel.architecture.output_modalities).toContain("text");
+		expect(imageModel.architecture.output_modalities).toContain("image");
+		expect(imageModel.architecture.output_modalities).toEqual([
+			"text",
+			"image",
+		]);
+	});
+
+	test("GET /v1/models should include proper output modalities for gemini-3-pro-image-preview", async () => {
+		const res = await app.request("/v1/models?include_deactivated=true");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+
+		const imageModel = json.data.find(
+			(model: any) => model.id === "gemini-3-pro-image-preview",
+		);
+
+		expect(imageModel).toBeDefined();
+		expect(imageModel.architecture.output_modalities).toContain("text");
+		expect(imageModel.architecture.output_modalities).toContain("image");
+		expect(imageModel.architecture.output_modalities).toEqual([
+			"text",
+			"image",
+		]);
+	});
+
 	test("GET /v1/models should include stability information for models", async () => {
 		const res = await app.request("/v1/models?include_deactivated=true");
 		expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- All three gemini image-preview models (`gemini-3.1-flash-image-preview`, `gemini-2.5-flash-image-preview`, `gemini-3-pro-image-preview`) already have `output: ["text", "image"]` set in the model definitions in `packages/models/src/models/google.ts`
- Added missing tests for `gemini-3.1-flash-image-preview` and `gemini-3-pro-image-preview` in `apps/gateway/src/models/models.spec.ts` to verify they correctly return `output_modalities: ["text", "image"]` in the `/v1/models` API response, matching the existing test for `gemini-2.5-flash-image-preview`

## Test plan
- [x] All 10 tests in `models.spec.ts` pass
- [x] New tests verify `gemini-3.1-flash-image-preview` has `output_modalities: ["text", "image"]`
- [x] New tests verify `gemini-3-pro-image-preview` has `output_modalities: ["text", "image"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for Gemini image-preview model capabilities to ensure proper output format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->