### PR TITLE
feat(frontend): add /api/health route to all frontend apps

### DIFF
--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+export async function GET() {
+	return Response.json({
+		status: "ok",
+		sha: process.env.APP_VERSION ?? "v0.0.0-unknown",
+	});
+}

--- a/apps/docs/app/api/health/route.ts
+++ b/apps/docs/app/api/health/route.ts
@@ -1,0 +1,6 @@
+export async function GET() {
+	return Response.json({
+		status: "ok",
+		sha: process.env.APP_VERSION ?? "v0.0.0-unknown",
+	});
+}

--- a/apps/playground/src/app/api/health/route.ts
+++ b/apps/playground/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+export async function GET() {
+	return Response.json({
+		status: "ok",
+		sha: process.env.APP_VERSION ?? "v0.0.0-unknown",
+	});
+}

--- a/apps/ui/src/app/api/health/route.ts
+++ b/apps/ui/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+export async function GET() {
+	return Response.json({
+		status: "ok",
+		sha: process.env.APP_VERSION ?? "v0.0.0-unknown",
+	});
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/health` endpoint to `apps/ui`, `apps/admin`, `apps/playground`, and `apps/docs`
- Each route returns JSON with `status: "ok"` and `sha` (populated from `APP_VERSION` env var, falling back to `"v0.0.0-unknown"`)
- Consistent with the pattern used in `apps/api` and `apps/gateway`

## Test plan

- [ ] Hit `/api/health` on each frontend app and verify JSON response
- [ ] Verify `sha` reflects `APP_VERSION` env var when set
- [ ] Verify fallback `"v0.0.0-unknown"` when `APP_VERSION` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoints across all applications for monitoring deployment status and version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->