### PR TITLE
feat(infra): add nginx-auth config with logging disabled

### DIFF
--- a/infra/nginx-auth.conf
+++ b/infra/nginx-auth.conf
@@ -1,0 +1,29 @@
+worker_processes auto;
+
+events {
+	worker_connections 1024;
+}
+
+http {
+	access_log off;
+
+	server {
+		listen 80;
+		server_name localhost;
+
+		location = /auth {
+			internal;
+			proxy_pass http://api:80/auth/session;
+			proxy_pass_request_body off;
+			proxy_set_header Content-Length "";
+			proxy_set_header X-Original-URI $request_uri;
+			proxy_set_header X-Original-Method $request_method;
+			proxy_set_header Cookie $http_cookie;
+		}
+
+		location /health {
+			return 200 "healthy\n";
+			add_header Content-Type text/plain;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `infra/nginx-auth.conf` for the nginx-auth pod
- Sets `access_log off` at the `http` level to silence all request logs in this pod
- Auth subrequests (`/auth`) proxy to `api:80/auth/session` with cookie forwarding
- Includes a `/health` endpoint for readiness probes

## Why

The nginx-auth pod handles `auth_request` subrequests from ingress-nginx to validate sessions before proxying to backend services. Without `access_log off`, every incoming HTTP request to any protected service generates an extra log line in this pod — creating significant log noise at scale.

## Test plan

- [ ] Verify nginx-auth pod starts without errors using the new config
- [ ] Confirm no access logs are written for auth subrequests
- [ ] Confirm `/health` endpoint returns 200
- [ ] Confirm `/auth` proxies correctly to the API session endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured request routing and authentication proxy integration
  * Added system health monitoring endpoint
  * Enhanced infrastructure setup for improved request handling and security
<!-- end of auto-generated comment: release notes by coderabbit.ai -->