### PR TITLE
fix: treat xAI content safety 403 as content_filter

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -34,6 +34,14 @@ export function getFinishReasonFromError(
 		return "content_filter";
 	}
 
+	// xAI (Grok) content safety violations (e.g. SAFETY_CHECK_TYPE_CSAM, usage guidelines)
+	if (
+		statusCode === 403 &&
+		errorText?.includes("Content violates usage guidelines")
+	) {
+		return "content_filter";
+	}
+
 	// zai content filter
 	if (
 		errorText?.includes(


### PR DESCRIPTION
## Summary
- xAI (Grok) returns HTTP 403 with `"Content violates usage guidelines"` for content safety violations (e.g. `SAFETY_CHECK_TYPE_CSAM`)
- Previously this was classified as `gateway_error`, causing HTTP 500 error responses and permanent API key blacklisting
- Now correctly classified as `content_filter`, returning HTTP 200 with `finish_reason: "content_filter"` and `content: null` — matching the existing behavior for Azure and other provider content filters

## Test plan
- [ ] Verify that a 403 from xAI with `"Content violates usage guidelines"` returns `finish_reason: "content_filter"` (HTTP 200)
- [ ] Verify that a normal 403 (e.g. invalid API key) still returns `gateway_error`
- [ ] Verify the API key is **not** permanently blacklisted on content filter hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of content policy violations to properly identify and report them when blocked by content safety filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->