### PR TITLE
fix(costs): count input images for gemini-3.1-flash-image-preview

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -434,7 +434,8 @@ chat.openapi(completions, async (c) => {
 
 	// Count input images from messages for cost calculation
 	const inputImageCount =
-		requestedModel === "gemini-3-pro-image-preview"
+		requestedModel === "gemini-3-pro-image-preview" ||
+		requestedModel === "gemini-3.1-flash-image-preview"
 			? countInputImages(messages)
 			: 0;
 

--- a/apps/gateway/src/chat/tools/count-input-images.ts
+++ b/apps/gateway/src/chat/tools/count-input-images.ts
@@ -3,7 +3,7 @@ const IMAGE_URL_PATTERN = /https:\/\/[^\s]+/gi;
 
 /**
  * Counts images in messages for cost calculation.
- * Used primarily for gemini-3-pro-image-preview model pricing.
+ * Used primarily for Gemini image model pricing (gemini-3-pro-image-preview, gemini-3.1-flash-image-preview).
  * Counts both image_url type content parts and image URLs found in text content.
  */
 export function countInputImages(messages: any[]): number {


### PR DESCRIPTION
## Summary
- Added `gemini-3.1-flash-image-preview` to the input image counting condition in `chat.ts` so image costs are correctly calculated for that model
- Updated doc comment in `count-input-images.ts` to reflect both supported image models

## Test plan
- [ ] Verify cost calculation includes input images when using `gemini-3.1-flash-image-preview`
- [ ] Verify existing `gemini-3-pro-image-preview` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended image counting functionality to support an additional Gemini model variant in cost calculations.

* **Documentation**
  * Updated documentation to reflect expanded model support in the image counting feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->