### PR TITLE
docs: add gemini-3.1-flash-image-preview image generation docs

### DIFF
--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -590,10 +590,10 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
   }'
 ```
 
-| Parameter      | Type   | Description                                                                                                |
-| -------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
-| `aspect_ratio` | string | The aspect ratio of the generated image. Options: `"1:1"`, `"16:9"`, `"4:3"`, `"5:4"`                      |
-| `image_size`   | string | The resolution of the generated image. Options: `"1K"` (1024x1024), `"2K"` (2048x2048), `"4K"` (4096x4096) |
+| Parameter      | Type   | Description                                                                                                                                   |
+| -------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aspect_ratio` | string | The aspect ratio of the generated image. Options: `"1:1"`, `"2:3"`, `"3:2"`, `"3:4"`, `"4:3"`, `"4:5"`, `"5:4"`, `"9:16"`, `"16:9"`, `"21:9"` |
+| `image_size`   | string | The resolution of the generated image. Options: `"1K"` (1024x1024), `"2K"` (2048x2048), `"4K"` (4096x4096)                                    |
 
 #### gemini-3.1-flash-image-preview
 
@@ -615,10 +615,10 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
   }'
 ```
 
-| Parameter      | Type   | Description                                                                                                                             |
-| -------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `aspect_ratio` | string | The aspect ratio of the generated image. Options: `"1:1"`, `"16:9"`, `"4:3"`, `"5:4"`                                                   |
-| `image_size`   | string | The resolution of the generated image. Options: `"0.5K"` (512x512), `"1K"` (1024x1024, default), `"2K"` (2048x2048), `"4K"` (4096x4096) |
+| Parameter      | Type   | Description                                                                                                                                                                       |
+| -------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aspect_ratio` | string | The aspect ratio of the generated image. Options: `"1:1"`, `"1:4"`, `"1:8"`, `"2:3"`, `"3:2"`, `"3:4"`, `"4:1"`, `"4:3"`, `"4:5"`, `"5:4"`, `"8:1"`, `"9:16"`, `"16:9"`, `"21:9"` |
+| `image_size`   | string | The resolution of the generated image. Options: `"0.5K"` (512x512), `"1K"` (1024x1024, default), `"2K"` (2048x2048), `"4K"` (4096x4096)                                           |
 
 <Callout type="info">
 	`gemini-3.1-flash-image-preview` uniquely supports `"0.5K"` resolution, which


### PR DESCRIPTION
## Summary

- Add `gemini-3.1-flash-image-preview` model to the Google Models section of the image generation docs
- Add available Google models overview table listing both `gemini-3-pro-image-preview` and `gemini-3.1-flash-image-preview`
- Document the flash model's supported resolutions: `0.5K`, `1K` (default), `2K`, `4K`

## Test plan
- [ ] Visit `/features/image-generation#google-models` and verify both models are documented
- [ ] Confirm flash model section shows `image_size` only (no `aspect_ratio`)
- [ ] Confirm `0.5K` resolution is listed with the callout note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Available Google models" section and expanded Image Configuration docs to include two new Google image-generation model variants.
  * Included model-specific examples, request snippets, and image_config parameter tables with expanded aspect_ratio and image_size options.
  * Added a callout that one model uniquely supports 0.5K resolution and mirrored the new model details across relevant sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->