### PR TITLE
fix(gateway): add obsidian to streaming

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3786,7 +3786,8 @@ chat.openapi(completions, async (c) => {
 								// For Google providers, add usage information when available
 								if (
 									usedProvider === "google-ai-studio" ||
-									usedProvider === "google-vertex"
+									usedProvider === "google-vertex" ||
+									usedProvider === "obsidian"
 								) {
 									const usage = extractTokenUsage(
 										data,
@@ -3955,6 +3956,7 @@ chat.openapi(completions, async (c) => {
 								const contentChunk = extractContent(
 									usedProvider === "google-ai-studio" ||
 										usedProvider === "google-vertex" ||
+										usedProvider === "obsidian" ||
 										usedProvider === "anthropic"
 										? data
 										: transformedData,
@@ -4036,6 +4038,7 @@ chat.openapi(completions, async (c) => {
 								const reasoningContentChunk = extractReasoning(
 									usedProvider === "google-ai-studio" ||
 										usedProvider === "google-vertex" ||
+										usedProvider === "obsidian" ||
 										usedProvider === "anthropic"
 										? data
 										: transformedData,
@@ -4370,7 +4373,8 @@ chat.openapi(completions, async (c) => {
 					// These include both finishReason values and promptFeedback.blockReason values
 					const isGoogleContentFilterStreaming =
 						(usedProvider === "google-ai-studio" ||
-							usedProvider === "google-vertex") &&
+							usedProvider === "google-vertex" ||
+							usedProvider === "obsidian") &&
 						(finishReason === "SAFETY" ||
 							finishReason === "PROHIBITED_CONTENT" ||
 							finishReason === "RECITATION" ||
@@ -4752,7 +4756,8 @@ chat.openapi(completions, async (c) => {
 					// Enhanced logging for Google models streaming to debug missing responses
 					if (
 						usedProvider === "google-ai-studio" ||
-						usedProvider === "google-vertex"
+						usedProvider === "google-vertex" ||
+						usedProvider === "obsidian"
 					) {
 						logger.debug("Google model streaming response completed", {
 							usedProvider,


### PR DESCRIPTION
## Summary
- The `obsidian` provider uses Google's raw data format (`candidates[0].content.parts`) but was missing from 5 conditionals in the streaming path of `chat.ts`
- This caused `extractContent()` and `extractReasoning()` to receive transformed OpenAI-format data instead of raw provider data, resulting in empty content/reasoning being persisted for obsidian streaming responses
- Added `obsidian` to all 5 Google-provider groupings: content extraction, reasoning extraction, token usage, content filter check, and debug logging

## Test plan
- [x] Verified with `TEST_PROVIDERS=obsidian pnpm test:e2e` — all streaming tests pass (`chat-streaming.e2e.ts` 5/5)
- [x] `pnpm build` passes (17/17 tasks)
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Obsidian provider now fully supports token usage tracking, enabling accurate cost monitoring and usage insights
- Added reasoning content extraction capabilities for enhanced analytical features
- Enabled web search integration support
- Optimized streaming performance and behavior improvements
- Enhanced logging and diagnostics functionality for better troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->