### PR TITLE
fix(admin): time window selector and charts

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2318,12 +2318,16 @@ const providerStatsSchema = z.object({
 	cachedCount: z.number(),
 	avgTimeToFirstToken: z.number().nullable(),
 	modelCount: z.number(),
+	totalTokens: z.number(),
+	totalCost: z.number(),
 	updatedAt: z.string(),
 });
 
 const providersListSchema = z.object({
 	providers: z.array(providerStatsSchema),
 	total: z.number(),
+	totalTokens: z.number(),
+	totalCost: z.number(),
 });
 
 const getProviderStats = createRoute({
@@ -2365,11 +2369,18 @@ admin.openapi(getProviderStats, async (c) => {
 		.as("model_count_sub");
 
 	if (from && to) {
-		const startDate = new Date(from + "T00:00:00");
-		startDate.setUTCHours(0, 0, 0, 0);
-		const endDateExclusive = new Date(to + "T00:00:00");
-		endDateExclusive.setUTCHours(0, 0, 0, 0);
-		endDateExclusive.setDate(endDateExclusive.getDate() + 1);
+		let startDate: Date;
+		let endDateExclusive: Date;
+		if (from.includes("T") || from.includes("Z")) {
+			startDate = new Date(from);
+			endDateExclusive = new Date(to);
+		} else {
+			startDate = new Date(from + "T00:00:00");
+			startDate.setUTCHours(0, 0, 0, 0);
+			endDateExclusive = new Date(to + "T00:00:00");
+			endDateExclusive.setUTCHours(0, 0, 0, 0);
+			endDateExclusive.setDate(endDateExclusive.getDate() + 1);
+		}
 
 		const [statsRows, providerRows, modelCountRows] = await Promise.all([
 			db
@@ -2378,6 +2389,8 @@ admin.openapi(getProviderStats, async (c) => {
 					logsCount: sql<number>`SUM(${projectHourlyModelStats.requestCount})`,
 					errorsCount: sql<number>`SUM(${projectHourlyModelStats.errorCount})`,
 					cachedCount: sql<number>`SUM(${projectHourlyModelStats.cacheCount})`,
+					totalTokens: sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`,
+					totalCost: sql<number>`SUM(${projectHourlyModelStats.cost})`,
 				})
 				.from(projectHourlyModelStats)
 				.where(
@@ -2413,6 +2426,8 @@ admin.openapi(getProviderStats, async (c) => {
 					logsCount: Number(r.logsCount ?? 0),
 					errorsCount: Number(r.errorsCount ?? 0),
 					cachedCount: Number(r.cachedCount ?? 0),
+					totalTokens: Number(r.totalTokens ?? 0),
+					totalCost: Number(r.totalCost ?? 0),
 				},
 			]),
 		);
@@ -2430,6 +2445,8 @@ admin.openapi(getProviderStats, async (c) => {
 			cachedCount: statsMap.get(p.id)?.cachedCount ?? 0,
 			avgTimeToFirstToken: p.avgTimeToFirstToken,
 			modelCount: modelCountMap.get(p.id) ?? 0,
+			totalTokens: statsMap.get(p.id)?.totalTokens ?? 0,
+			totalCost: statsMap.get(p.id)?.totalCost ?? 0,
 			updatedAt: p.updatedAt.toISOString(),
 		}));
 
@@ -2447,7 +2464,15 @@ admin.openapi(getProviderStats, async (c) => {
 			return 0;
 		});
 
-		return c.json({ providers: merged, total: merged.length });
+		const totalTokensAgg = merged.reduce((s, p) => s + p.totalTokens, 0);
+		const totalCostAgg = merged.reduce((s, p) => s + p.totalCost, 0);
+
+		return c.json({
+			providers: merged,
+			total: merged.length,
+			totalTokens: totalTokensAgg,
+			totalCost: totalCostAgg,
+		});
 	}
 
 	const orderFn = sortOrder === "asc" ? asc : desc;
@@ -2495,9 +2520,13 @@ admin.openapi(getProviderStats, async (c) => {
 			cachedCount: r.cachedCount,
 			avgTimeToFirstToken: r.avgTimeToFirstToken,
 			modelCount: Number(r.modelCount),
+			totalTokens: 0,
+			totalCost: 0,
 			updatedAt: r.updatedAt.toISOString(),
 		})),
 		total: rows.length,
+		totalTokens: 0,
+		totalCost: 0,
 	});
 });
 
@@ -2526,6 +2555,8 @@ const modelStatsSchema = z.object({
 	cachedCount: z.number(),
 	avgTimeToFirstToken: z.number().nullable(),
 	providerCount: z.number(),
+	totalTokens: z.number(),
+	totalCost: z.number(),
 	updatedAt: z.string(),
 });
 
@@ -2534,6 +2565,8 @@ const modelsListSchema = z.object({
 	total: z.number(),
 	limit: z.number(),
 	offset: z.number(),
+	totalTokens: z.number(),
+	totalCost: z.number(),
 });
 
 const getModelStats = createRoute({
@@ -2589,11 +2622,18 @@ admin.openapi(getModelStats, async (c) => {
 	const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
 	if (from && to) {
-		const startDate = new Date(from + "T00:00:00");
-		startDate.setUTCHours(0, 0, 0, 0);
-		const endDateExclusive = new Date(to + "T00:00:00");
-		endDateExclusive.setUTCHours(0, 0, 0, 0);
-		endDateExclusive.setDate(endDateExclusive.getDate() + 1);
+		let startDate: Date;
+		let endDateExclusive: Date;
+		if (from.includes("T") || from.includes("Z")) {
+			startDate = new Date(from);
+			endDateExclusive = new Date(to);
+		} else {
+			startDate = new Date(from + "T00:00:00");
+			startDate.setUTCHours(0, 0, 0, 0);
+			endDateExclusive = new Date(to + "T00:00:00");
+			endDateExclusive.setUTCHours(0, 0, 0, 0);
+			endDateExclusive.setDate(endDateExclusive.getDate() + 1);
+		}
 
 		const [statsRows, modelRows, providerCountRows] = await Promise.all([
 			db
@@ -2602,6 +2642,8 @@ admin.openapi(getModelStats, async (c) => {
 					logsCount: sql<number>`SUM(${projectHourlyModelStats.requestCount})`,
 					errorsCount: sql<number>`SUM(${projectHourlyModelStats.errorCount})`,
 					cachedCount: sql<number>`SUM(${projectHourlyModelStats.cacheCount})`,
+					totalTokens: sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`,
+					totalCost: sql<number>`SUM(${projectHourlyModelStats.cost})`,
 				})
 				.from(projectHourlyModelStats)
 				.where(
@@ -2640,6 +2682,8 @@ admin.openapi(getModelStats, async (c) => {
 					logsCount: Number(r.logsCount ?? 0),
 					errorsCount: Number(r.errorsCount ?? 0),
 					cachedCount: Number(r.cachedCount ?? 0),
+					totalTokens: Number(r.totalTokens ?? 0),
+					totalCost: Number(r.totalCost ?? 0),
 				},
 			]),
 		);
@@ -2659,6 +2703,8 @@ admin.openapi(getModelStats, async (c) => {
 			cachedCount: statsMap.get(m.id)?.cachedCount ?? 0,
 			avgTimeToFirstToken: m.avgTimeToFirstToken,
 			providerCount: providerCountMap.get(m.id) ?? 0,
+			totalTokens: statsMap.get(m.id)?.totalTokens ?? 0,
+			totalCost: statsMap.get(m.id)?.totalCost ?? 0,
 			updatedAt: m.updatedAt.toISOString(),
 		}));
 
@@ -2678,8 +2724,17 @@ admin.openapi(getModelStats, async (c) => {
 
 		const total = merged.length;
 		const paginated = merged.slice(offset, offset + limit);
+		const totalTokensAgg = merged.reduce((s, m) => s + m.totalTokens, 0);
+		const totalCostAgg = merged.reduce((s, m) => s + m.totalCost, 0);
 
-		return c.json({ models: paginated, total, limit, offset });
+		return c.json({
+			models: paginated,
+			total,
+			limit,
+			offset,
+			totalTokens: totalTokensAgg,
+			totalCost: totalCostAgg,
+		});
 	}
 
 	const providerCountSub = db
@@ -2752,11 +2807,15 @@ admin.openapi(getModelStats, async (c) => {
 			cachedCount: r.cachedCount,
 			avgTimeToFirstToken: r.avgTimeToFirstToken,
 			providerCount: Number(r.providerCount),
+			totalTokens: 0,
+			totalCost: 0,
 			updatedAt: r.updatedAt.toISOString(),
 		})),
 		total,
 		limit,
 		offset,
+		totalTokens: 0,
+		totalCost: 0,
 	});
 });
 
@@ -2816,17 +2875,32 @@ admin.openapi(getModelDetail, async (c) => {
 		throw new HTTPException(404, { message: "Model not found" });
 	}
 
-	const mappings = await db
-		.select({
-			providerId: tables.modelProviderMapping.providerId,
-			logsCount: tables.modelProviderMapping.logsCount,
-			errorsCount: tables.modelProviderMapping.errorsCount,
-			cachedCount: tables.modelProviderMapping.cachedCount,
-			avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
-			updatedAt: tables.modelProviderMapping.updatedAt,
-		})
-		.from(tables.modelProviderMapping)
-		.where(eq(tables.modelProviderMapping.modelId, modelId));
+	const [mappings, statsRows] = await Promise.all([
+		db
+			.select({
+				providerId: tables.modelProviderMapping.providerId,
+				avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+				updatedAt: tables.modelProviderMapping.updatedAt,
+			})
+			.from(tables.modelProviderMapping)
+			.where(eq(tables.modelProviderMapping.modelId, modelId)),
+		db
+			.select({
+				usedProvider: projectHourlyModelStats.usedProvider,
+				logsCount: sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
+					"logs_count",
+				),
+				errorsCount: sql<number>`SUM(${projectHourlyModelStats.errorCount})`.as(
+					"errors_count",
+				),
+				cachedCount: sql<number>`SUM(${projectHourlyModelStats.cacheCount})`.as(
+					"cached_count",
+				),
+			})
+			.from(projectHourlyModelStats)
+			.where(eq(projectHourlyModelStats.usedModel, modelId))
+			.groupBy(projectHourlyModelStats.usedProvider),
+	]);
 
 	const providerIds = mappings.map((m) => m.providerId);
 	const providerRows =
@@ -2837,16 +2911,29 @@ admin.openapi(getModelDetail, async (c) => {
 			: [];
 
 	const providerNameMap = new Map(providerRows.map((p) => [p.id, p.name]));
+	const providerStatsMap = new Map(
+		statsRows.map((r) => [
+			r.usedProvider,
+			{
+				logsCount: Number(r.logsCount ?? 0),
+				errorsCount: Number(r.errorsCount ?? 0),
+				cachedCount: Number(r.cachedCount ?? 0),
+			},
+		]),
+	);
 
-	const providerStats = mappings.map((m) => ({
-		providerId: m.providerId,
-		providerName: providerNameMap.get(m.providerId) ?? m.providerId,
-		logsCount: m.logsCount,
-		errorsCount: m.errorsCount,
-		cachedCount: m.cachedCount,
-		avgTimeToFirstToken: m.avgTimeToFirstToken,
-		updatedAt: m.updatedAt.toISOString(),
-	}));
+	const providerStats = mappings.map((m) => {
+		const stats = providerStatsMap.get(m.providerId);
+		return {
+			providerId: m.providerId,
+			providerName: providerNameMap.get(m.providerId) ?? m.providerId,
+			logsCount: stats?.logsCount ?? 0,
+			errorsCount: stats?.errorsCount ?? 0,
+			cachedCount: stats?.cachedCount ?? 0,
+			avgTimeToFirstToken: m.avgTimeToFirstToken,
+			updatedAt: m.updatedAt.toISOString(),
+		};
+	});
 
 	return c.json({
 		model: {
@@ -3024,16 +3111,15 @@ admin.openapi(deleteUserRoute, async (c) => {
 // --- History endpoints ---
 
 const historyWindowSchema = z.enum([
-	"1m",
 	"2m",
 	"5m",
 	"15m",
-	"30m",
 	"1h",
 	"2h",
 	"4h",
 	"12h",
 	"24h",
+	"1d",
 	"2d",
 	"7d",
 ]);
@@ -3046,6 +3132,7 @@ const historyDataPointSchema = z.object({
 	avgTtft: z.number().nullable(),
 	avgDuration: z.number().nullable(),
 	totalTokens: z.number(),
+	totalCost: z.number(),
 });
 
 const historyResponseSchema = z.object({
@@ -3054,22 +3141,27 @@ const historyResponseSchema = z.object({
 
 function getHistoryStartDate(window: string): Date {
 	const windowMinutes: Record<string, number> = {
-		"1m": 1,
 		"2m": 2,
 		"5m": 5,
 		"15m": 15,
-		"30m": 30,
 		"1h": 60,
 		"2h": 120,
 		"4h": 240,
 		"12h": 720,
 		"24h": 1440,
+		"1d": 1440,
 		"2d": 2880,
 		"7d": 10080,
 	};
 	const minutes = windowMinutes[window] ?? 240;
-	// eslint-disable-next-line no-mixed-operators
-	return new Date(Date.now() - minutes * 60 * 1000);
+	const ms = minutes * 60 * 1000;
+	return new Date(Date.now() - ms);
+}
+
+function getHourFloor(date: Date): string {
+	const d = new Date(date);
+	d.setMinutes(0, 0, 0);
+	return d.toISOString();
 }
 
 function mapHistoryRows(
@@ -3082,7 +3174,14 @@ function mapHistoryRows(
 		totalTimeToFirstToken: number;
 		totalTokens: number;
 	}[],
+	costByHour: Map<string, number> = new Map(),
 ) {
+	const requestsByHour = new Map<string, number>();
+	for (const r of rows) {
+		const hk = getHourFloor(r.minuteTimestamp);
+		requestsByHour.set(hk, (requestsByHour.get(hk) ?? 0) + Number(r.logsCount));
+	}
+
 	return rows.map((r) => {
 		const logsCount = Number(r.logsCount);
 		const errorsCount = Number(r.errorsCount);
@@ -3091,6 +3190,12 @@ function mapHistoryRows(
 		const totalTimeToFirstToken = Number(r.totalTimeToFirstToken);
 		const totalTokens = Number(r.totalTokens);
 		const nonCached = logsCount - cachedCount;
+
+		const hk = getHourFloor(r.minuteTimestamp);
+		const hourCost = costByHour.get(hk) ?? 0;
+		const hourReqs = requestsByHour.get(hk) ?? 0;
+		const totalCost = hourReqs > 0 ? (logsCount / hourReqs) * hourCost : 0;
+
 		return {
 			timestamp: r.minuteTimestamp.toISOString(),
 			logsCount,
@@ -3100,6 +3205,7 @@ function mapHistoryRows(
 				nonCached > 0 ? Math.round(totalTimeToFirstToken / nonCached) : null,
 			avgDuration: logsCount > 0 ? Math.round(totalDuration / logsCount) : null,
 			totalTokens,
+			totalCost,
 		};
 	});
 }
@@ -3129,45 +3235,71 @@ admin.openapi(getProviderHistory, async (c) => {
 	const query = c.req.valid("query");
 	const window = query.window ?? "4h";
 	const startDate = getHistoryStartDate(window);
+	const hourStartDate = new Date(startDate);
+	hourStartDate.setMinutes(0, 0, 0);
 
-	const rows = await db
-		.select({
-			minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
-			logsCount: sql<number>`SUM(${modelProviderMappingHistory.logsCount})`.as(
-				"logs_count",
-			),
-			errorsCount:
-				sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
-					"errors_count",
+	const [rows, costRows] = await Promise.all([
+		db
+			.select({
+				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
+				logsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.logsCount})`.as(
+						"logs_count",
+					),
+				errorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
+						"errors_count",
+					),
+				cachedCount:
+					sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
+						"cached_count",
+					),
+				totalDuration:
+					sql<number>`SUM(${modelProviderMappingHistory.totalDuration})`.as(
+						"total_duration",
+					),
+				totalTimeToFirstToken:
+					sql<number>`SUM(${modelProviderMappingHistory.totalTimeToFirstToken})`.as(
+						"total_ttft",
+					),
+				totalTokens:
+					sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
+						"total_tokens",
+					),
+			})
+			.from(modelProviderMappingHistory)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.providerId, providerId),
+					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
 				),
-			cachedCount:
-				sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
-					"cached_count",
+			)
+			.groupBy(modelProviderMappingHistory.minuteTimestamp)
+			.orderBy(asc(modelProviderMappingHistory.minuteTimestamp)),
+		db
+			.select({
+				hourTimestamp: projectHourlyModelStats.hourTimestamp,
+				cost: sql<number>`SUM(${projectHourlyModelStats.cost})`,
+			})
+			.from(projectHourlyModelStats)
+			.where(
+				and(
+					eq(projectHourlyModelStats.usedProvider, providerId),
+					gte(projectHourlyModelStats.hourTimestamp, hourStartDate),
 				),
-			totalDuration:
-				sql<number>`SUM(${modelProviderMappingHistory.totalDuration})`.as(
-					"total_duration",
-				),
-			totalTimeToFirstToken:
-				sql<number>`SUM(${modelProviderMappingHistory.totalTimeToFirstToken})`.as(
-					"total_ttft",
-				),
-			totalTokens:
-				sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
-					"total_tokens",
-				),
-		})
-		.from(modelProviderMappingHistory)
-		.where(
-			and(
-				eq(modelProviderMappingHistory.providerId, providerId),
-				gte(modelProviderMappingHistory.minuteTimestamp, startDate),
-			),
-		)
-		.groupBy(modelProviderMappingHistory.minuteTimestamp)
-		.orderBy(asc(modelProviderMappingHistory.minuteTimestamp));
+			)
+			.groupBy(projectHourlyModelStats.hourTimestamp),
+	]);
 
-	return c.json({ data: mapHistoryRows(rows) });
+	const costByHour = new Map<string, number>(
+		costRows.map((r) => {
+			const d = new Date(r.hourTimestamp);
+			d.setMinutes(0, 0, 0);
+			return [d.toISOString(), Number(r.cost)];
+		}),
+	);
+
+	return c.json({ data: mapHistoryRows(rows, costByHour) });
 });
 
 // Model history
@@ -3195,39 +3327,64 @@ admin.openapi(getModelHistory, async (c) => {
 	const query = c.req.valid("query");
 	const window = query.window ?? "4h";
 	const startDate = getHistoryStartDate(window);
+	const hourStartDate = new Date(startDate);
+	hourStartDate.setMinutes(0, 0, 0);
 
-	const rows = await db
-		.select({
-			minuteTimestamp: modelHistory.minuteTimestamp,
-			logsCount: sql<number>`SUM(${modelHistory.logsCount})`.as("logs_count"),
-			errorsCount: sql<number>`SUM(${modelHistory.errorsCount})`.as(
-				"errors_count",
-			),
-			cachedCount: sql<number>`SUM(${modelHistory.cachedCount})`.as(
-				"cached_count",
-			),
-			totalDuration: sql<number>`SUM(${modelHistory.totalDuration})`.as(
-				"total_duration",
-			),
-			totalTimeToFirstToken:
-				sql<number>`SUM(${modelHistory.totalTimeToFirstToken})`.as(
-					"total_ttft",
+	const [rows, costRows] = await Promise.all([
+		db
+			.select({
+				minuteTimestamp: modelHistory.minuteTimestamp,
+				logsCount: sql<number>`SUM(${modelHistory.logsCount})`.as("logs_count"),
+				errorsCount: sql<number>`SUM(${modelHistory.errorsCount})`.as(
+					"errors_count",
 				),
-			totalTokens: sql<number>`SUM(${modelHistory.totalTokens})`.as(
-				"total_tokens",
-			),
-		})
-		.from(modelHistory)
-		.where(
-			and(
-				eq(modelHistory.modelId, modelId),
-				gte(modelHistory.minuteTimestamp, startDate),
-			),
-		)
-		.groupBy(modelHistory.minuteTimestamp)
-		.orderBy(asc(modelHistory.minuteTimestamp));
+				cachedCount: sql<number>`SUM(${modelHistory.cachedCount})`.as(
+					"cached_count",
+				),
+				totalDuration: sql<number>`SUM(${modelHistory.totalDuration})`.as(
+					"total_duration",
+				),
+				totalTimeToFirstToken:
+					sql<number>`SUM(${modelHistory.totalTimeToFirstToken})`.as(
+						"total_ttft",
+					),
+				totalTokens: sql<number>`SUM(${modelHistory.totalTokens})`.as(
+					"total_tokens",
+				),
+			})
+			.from(modelHistory)
+			.where(
+				and(
+					eq(modelHistory.modelId, modelId),
+					gte(modelHistory.minuteTimestamp, startDate),
+				),
+			)
+			.groupBy(modelHistory.minuteTimestamp)
+			.orderBy(asc(modelHistory.minuteTimestamp)),
+		db
+			.select({
+				hourTimestamp: projectHourlyModelStats.hourTimestamp,
+				cost: sql<number>`SUM(${projectHourlyModelStats.cost})`,
+			})
+			.from(projectHourlyModelStats)
+			.where(
+				and(
+					eq(projectHourlyModelStats.usedModel, modelId),
+					gte(projectHourlyModelStats.hourTimestamp, hourStartDate),
+				),
+			)
+			.groupBy(projectHourlyModelStats.hourTimestamp),
+	]);
 
-	return c.json({ data: mapHistoryRows(rows) });
+	const costByHour = new Map<string, number>(
+		costRows.map((r) => {
+			const d = new Date(r.hourTimestamp);
+			d.setMinutes(0, 0, 0);
+			return [d.toISOString(), Number(r.cost)];
+		}),
+	);
+
+	return c.json({ data: mapHistoryRows(rows, costByHour) });
 });
 
 // Mapping history (provider + model)
@@ -3258,46 +3415,107 @@ admin.openapi(getMappingHistory, async (c) => {
 	const query = c.req.valid("query");
 	const window = query.window ?? "4h";
 	const startDate = getHistoryStartDate(window);
+	const hourStartDate = new Date(startDate);
+	hourStartDate.setMinutes(0, 0, 0);
 
-	const rows = await db
-		.select({
-			minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
-			logsCount: sql<number>`SUM(${modelProviderMappingHistory.logsCount})`.as(
-				"logs_count",
-			),
-			errorsCount:
-				sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
+	const [minuteRows, hourlyRows] = await Promise.all([
+		db
+			.select({
+				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
+				logsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.logsCount})`.as(
+						"logs_count",
+					),
+				errorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
+						"errors_count",
+					),
+				cachedCount:
+					sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
+						"cached_count",
+					),
+				totalDuration:
+					sql<number>`SUM(${modelProviderMappingHistory.totalDuration})`.as(
+						"total_duration",
+					),
+				totalTimeToFirstToken:
+					sql<number>`SUM(${modelProviderMappingHistory.totalTimeToFirstToken})`.as(
+						"total_ttft",
+					),
+				totalTokens:
+					sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
+						"total_tokens",
+					),
+			})
+			.from(modelProviderMappingHistory)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.providerId, providerId),
+					eq(modelProviderMappingHistory.modelId, modelId),
+					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+				),
+			)
+			.groupBy(modelProviderMappingHistory.minuteTimestamp)
+			.orderBy(asc(modelProviderMappingHistory.minuteTimestamp)),
+		db
+			.select({
+				hourTimestamp: projectHourlyModelStats.hourTimestamp,
+				logsCount: sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
+					"logs_count",
+				),
+				errorsCount: sql<number>`SUM(${projectHourlyModelStats.errorCount})`.as(
 					"errors_count",
 				),
-			cachedCount:
-				sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
+				cachedCount: sql<number>`SUM(${projectHourlyModelStats.cacheCount})`.as(
 					"cached_count",
 				),
-			totalDuration:
-				sql<number>`SUM(${modelProviderMappingHistory.totalDuration})`.as(
-					"total_duration",
+				totalTokens:
+					sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
+						"total_tokens",
+					),
+				cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			})
+			.from(projectHourlyModelStats)
+			.where(
+				and(
+					eq(projectHourlyModelStats.usedProvider, providerId),
+					eq(projectHourlyModelStats.usedModel, modelId),
+					gte(projectHourlyModelStats.hourTimestamp, hourStartDate),
 				),
-			totalTimeToFirstToken:
-				sql<number>`SUM(${modelProviderMappingHistory.totalTimeToFirstToken})`.as(
-					"total_ttft",
-				),
-			totalTokens:
-				sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
-					"total_tokens",
-				),
-		})
-		.from(modelProviderMappingHistory)
-		.where(
-			and(
-				eq(modelProviderMappingHistory.providerId, providerId),
-				eq(modelProviderMappingHistory.modelId, modelId),
-				gte(modelProviderMappingHistory.minuteTimestamp, startDate),
-			),
-		)
-		.groupBy(modelProviderMappingHistory.minuteTimestamp)
-		.orderBy(asc(modelProviderMappingHistory.minuteTimestamp));
+			)
+			.groupBy(projectHourlyModelStats.hourTimestamp)
+			.orderBy(asc(projectHourlyModelStats.hourTimestamp)),
+	]);
 
-	return c.json({ data: mapHistoryRows(rows) });
+	const hasMinuteData = minuteRows.some((r) => Number(r.logsCount) > 0);
+	if (hasMinuteData) {
+		const costByHour = new Map<string, number>(
+			hourlyRows.map((r) => {
+				const d = new Date(r.hourTimestamp);
+				d.setMinutes(0, 0, 0);
+				return [d.toISOString(), Number(r.cost)];
+			}),
+		);
+		return c.json({ data: mapHistoryRows(minuteRows, costByHour) });
+	}
+
+	const data = hourlyRows.map((r) => {
+		const logsCount = Number(r.logsCount);
+		const errorsCount = Number(r.errorsCount);
+		const cachedCount = Number(r.cachedCount);
+		return {
+			timestamp: new Date(r.hourTimestamp).toISOString(),
+			logsCount,
+			errorsCount,
+			cachedCount,
+			avgTtft: null,
+			avgDuration: null,
+			totalTokens: Number(r.totalTokens),
+			totalCost: Number(r.cost),
+		};
+	});
+
+	return c.json({ data });
 });
 
 // --- Cost by model endpoints ---

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -1,7 +1,7 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
-import { db } from "@llmgateway/db";
+import { and, db, gte, isNull, or, tables } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -93,26 +93,97 @@ const getModelsRoute = createRoute({
 });
 
 internalModels.openapi(getModelsRoute, async (c) => {
-	const models = await db.query.model.findMany({
-		where: {
-			status: { eq: "active" },
-		},
-		with: {
-			modelProviderMappings: {
-				where: {
-					status: { eq: "active" },
+	const now = new Date();
+
+	const [models, globalDiscounts] = await Promise.all([
+		db.query.model.findMany({
+			where: {
+				status: { eq: "active" },
+			},
+			with: {
+				modelProviderMappings: {
+					where: {
+						status: { eq: "active" },
+					},
 				},
 			},
-		},
-		orderBy: {
-			createdAt: "desc",
-		},
-	});
+			orderBy: {
+				createdAt: "desc",
+			},
+		}),
+		db
+			.select({
+				provider: tables.discount.provider,
+				model: tables.discount.model,
+				discountPercent: tables.discount.discountPercent,
+			})
+			.from(tables.discount)
+			.where(
+				and(
+					isNull(tables.discount.organizationId),
+					or(
+						isNull(tables.discount.expiresAt),
+						gte(tables.discount.expiresAt, now),
+					),
+				),
+			),
+	]);
 
-	// Transform to match expected schema (rename modelProviderMappings to mappings)
+	// Helper to find the best global discount for a given provider+model
+	const getGlobalDiscount = (
+		providerId: string,
+		modelId: string,
+		modelName: string,
+	): string | null => {
+		const modelMatches = (dm: string | null) =>
+			dm === modelId || dm === modelName;
+
+		// Precedence: provider+model > provider > model
+		const providerModel = globalDiscounts.find(
+			(d) => d.provider === providerId && modelMatches(d.model),
+		);
+		if (providerModel) {
+			return providerModel.discountPercent;
+		}
+
+		const providerOnly = globalDiscounts.find(
+			(d) => d.provider === providerId && d.model === null,
+		);
+		if (providerOnly) {
+			return providerOnly.discountPercent;
+		}
+
+		const modelOnly = globalDiscounts.find(
+			(d) => d.provider === null && modelMatches(d.model),
+		);
+		if (modelOnly) {
+			return modelOnly.discountPercent;
+		}
+
+		// Fully global (null provider + null model)
+		const fullyGlobal = globalDiscounts.find(
+			(d) => d.provider === null && d.model === null,
+		);
+		if (fullyGlobal) {
+			return fullyGlobal.discountPercent;
+		}
+
+		return null;
+	};
+
+	// Transform and apply effective discount
 	const transformedModels = models.map((model) => ({
 		...model,
-		mappings: model.modelProviderMappings,
+		mappings: model.modelProviderMappings.map((mapping) => {
+			const globalDiscount = getGlobalDiscount(
+				mapping.providerId,
+				model.id,
+				mapping.modelName,
+			);
+			// Global discount takes precedence over hardcoded mapping discount
+			const effectiveDiscount = globalDiscount ?? mapping.discount;
+			return { ...mapping, discount: effectiveDiscount };
+		}),
 	}));
 
 	return c.json({ models: transformedModels });

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2158,9 +2158,13 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 modelCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2218,11 +2222,15 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2411,7 +2419,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2436,6 +2444,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2460,7 +2469,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2485,6 +2494,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2509,7 +2519,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2535,6 +2545,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2158,9 +2158,13 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 modelCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2218,11 +2222,15 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2411,7 +2419,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2436,6 +2444,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2460,7 +2469,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2485,6 +2494,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2509,7 +2519,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2535,6 +2545,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -15,12 +15,17 @@ import { notFound } from "next/navigation";
 import Footer from "@/components/landing/footer";
 import { Navbar } from "@/components/landing/navbar";
 import { CopyModelName } from "@/components/models/copy-model-name";
+import {
+	GlobalDiscountBanner,
+	type DiscountData,
+} from "@/components/models/global-discount-banner";
 import { ModelProviderCard } from "@/components/models/model-provider-card";
 import { ModelStatusBadgeAuto } from "@/components/models/model-status-badge-auto";
 import { ProviderTabs } from "@/components/models/provider-tabs";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 import { getConfig } from "@/lib/config-server";
+import { fetchServerData } from "@/lib/server-api";
 
 import {
 	models as modelDefinitions,
@@ -49,17 +54,85 @@ export default async function ModelProviderPage({ params }: PageProps) {
 		notFound();
 	}
 
-	const providerMapping = modelDef.providers.find(
+	const staticProviderMapping = modelDef.providers.find(
 		(p) => p.providerId === decodedProvider,
 	);
 
-	if (!providerMapping) {
+	if (!staticProviderMapping) {
 		notFound();
 	}
 
 	const providerInfo = providerDefinitions.find(
 		(p) => p.id === decodedProvider,
 	);
+
+	// Fetch global discounts and apply to provider
+	const discountData = await fetchServerData<{ discounts: DiscountData[] }>(
+		"GET",
+		"/public/discounts/model/{modelId}",
+		{ params: { path: { modelId: decodedName } } },
+	);
+	const discounts = discountData?.discounts ?? [];
+	const globalDiscount = (() => {
+		const providerModel = discounts.find(
+			(d) => d.provider === decodedProvider && d.model === decodedName,
+		);
+		if (providerModel) {
+			return parseFloat(providerModel.discountPercent);
+		}
+		const providerOnly = discounts.find(
+			(d) => d.provider === decodedProvider && d.model === null,
+		);
+		if (providerOnly) {
+			return parseFloat(providerOnly.discountPercent);
+		}
+		const modelOnly = discounts.find(
+			(d) => d.provider === null && d.model === decodedName,
+		);
+		if (modelOnly) {
+			return parseFloat(modelOnly.discountPercent);
+		}
+		const fullyGlobal = discounts.find(
+			(d) => d.provider === null && d.model === null,
+		);
+		if (fullyGlobal) {
+			return parseFloat(fullyGlobal.discountPercent);
+		}
+		return undefined;
+	})();
+
+	const providerMapping = {
+		...staticProviderMapping,
+		discount: globalDiscount ?? staticProviderMapping.discount,
+	};
+
+	const bannerDiscount: DiscountData | null = (() => {
+		const providerModel = discounts.find(
+			(d) => d.provider === decodedProvider && d.model === decodedName,
+		);
+		if (providerModel) {
+			return providerModel;
+		}
+		const providerOnly = discounts.find(
+			(d) => d.provider === decodedProvider && d.model === null,
+		);
+		if (providerOnly) {
+			return providerOnly;
+		}
+		const modelOnly = discounts.find(
+			(d) => d.provider === null && d.model === decodedName,
+		);
+		if (modelOnly) {
+			return modelOnly;
+		}
+		const fullyGlobal = discounts.find(
+			(d) => d.provider === null && d.model === null,
+		);
+		if (fullyGlobal) {
+			return fullyGlobal;
+		}
+		return null;
+	})();
 
 	const getStabilityBadgeProps = (stability?: StabilityLevel) => {
 		switch (stability) {
@@ -316,6 +389,12 @@ export default async function ModelProviderPage({ params }: PageProps) {
 							})()}
 						</div>
 					</div>
+
+					{bannerDiscount && (
+						<div className="mb-6">
+							<GlobalDiscountBanner discount={bannerDiscount} />
+						</div>
+					)}
 
 					<div className="mb-8">
 						<h2 className="text-xl md:text-2xl font-semibold mb-4">

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -40,9 +40,7 @@ interface PageProps {
 	params: Promise<{ name: string }>;
 }
 
-async function getCurrentModelDiscount(
-	modelId: string,
-): Promise<DiscountData | null> {
+async function getModelDiscounts(modelId: string): Promise<DiscountData[]> {
 	const data = await fetchServerData<{ discounts: DiscountData[] }>(
 		"GET",
 		"/public/discounts/model/{modelId}",
@@ -53,15 +51,64 @@ async function getCurrentModelDiscount(
 		},
 	);
 
-	return (
-		data?.discounts.find((discount) => {
-			if (!discount.expiresAt || discount.model !== modelId) {
-				return false;
-			}
+	return data?.discounts ?? [];
+}
 
-			return new Date(discount.expiresAt).getTime() > Date.now();
-		}) ?? null
+function getBestDiscount(
+	discounts: DiscountData[],
+	modelId: string,
+): DiscountData | null {
+	// Precedence: model-specific > fully global
+	const modelSpecific = discounts.find((d) => d.model === modelId);
+	if (modelSpecific) {
+		return modelSpecific;
+	}
+
+	const fullyGlobal = discounts.find(
+		(d) => d.provider === null && d.model === null,
 	);
+	if (fullyGlobal) {
+		return fullyGlobal;
+	}
+
+	return null;
+}
+
+function getEffectiveProviderDiscount(
+	discounts: DiscountData[],
+	providerId: string,
+	modelId: string,
+): number | undefined {
+	// Precedence: provider+model > provider > model > fully global
+	const providerModel = discounts.find(
+		(d) => d.provider === providerId && d.model === modelId,
+	);
+	if (providerModel) {
+		return parseFloat(providerModel.discountPercent);
+	}
+
+	const providerOnly = discounts.find(
+		(d) => d.provider === providerId && d.model === null,
+	);
+	if (providerOnly) {
+		return parseFloat(providerOnly.discountPercent);
+	}
+
+	const modelOnly = discounts.find(
+		(d) => d.provider === null && d.model === modelId,
+	);
+	if (modelOnly) {
+		return parseFloat(modelOnly.discountPercent);
+	}
+
+	const fullyGlobal = discounts.find(
+		(d) => d.provider === null && d.model === null,
+	);
+	if (fullyGlobal) {
+		return parseFloat(fullyGlobal.discountPercent);
+	}
+
+	return undefined;
 }
 
 export default async function ModelPage({ params }: PageProps) {
@@ -106,16 +153,24 @@ export default async function ModelPage({ params }: PageProps) {
 		return stability && ["unstable", "experimental"].includes(stability);
 	};
 
+	const allDiscounts = await getModelDiscounts(decodedName);
 	const modelProviders = modelDef.providers.map((provider) => {
 		const providerInfo = providerDefinitions.find(
 			(p) => p.id === provider.providerId,
 		);
+		const globalDiscount = getEffectiveProviderDiscount(
+			allDiscounts,
+			provider.providerId,
+			decodedName,
+		);
 		return {
 			...provider,
 			providerInfo,
+			// Global discount takes precedence over hardcoded
+			discount: globalDiscount ?? provider.discount,
 		};
 	});
-	const currentModelDiscount = await getCurrentModelDiscount(decodedName);
+	const currentModelDiscount = getBestDiscount(allDiscounts, decodedName);
 
 	const breadcrumbSchema = {
 		"@context": "https://schema.org",

--- a/apps/ui/src/components/models/global-discount-banner.tsx
+++ b/apps/ui/src/components/models/global-discount-banner.tsx
@@ -17,7 +17,7 @@ interface GlobalDiscountBannerProps {
 }
 
 export function GlobalDiscountBanner({ discount }: GlobalDiscountBannerProps) {
-	if (!discount || !discount.expiresAt) {
+	if (!discount) {
 		return null;
 	}
 
@@ -34,9 +34,14 @@ export function GlobalDiscountBanner({ discount }: GlobalDiscountBannerProps) {
 				</span>
 				<span className="text-sm text-muted-foreground">
 					{discount.model ? "this model" : "all models"}
-					{discount.provider ? ` via ${discount.provider}` : ""} —
+					{discount.provider ? ` via ${discount.provider}` : ""}
 				</span>
-				<Countdown expiresAt={discount.expiresAt} />
+				{discount.expiresAt && (
+					<>
+						<span className="text-sm text-muted-foreground">—</span>
+						<Countdown expiresAt={discount.expiresAt} />
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2158,9 +2158,13 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 modelCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2218,11 +2222,15 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2411,7 +2419,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2436,6 +2444,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2460,7 +2469,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2485,6 +2494,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2509,7 +2519,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2535,6 +2545,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };

--- a/ee/admin/src/app/model-provider-mappings/page.tsx
+++ b/ee/admin/src/app/model-provider-mappings/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
-import { DateRangePicker } from "@/components/date-range-picker";
+import { TimeWindowSelector } from "@/components/time-window-selector";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,6 +14,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { parsePageWindow, windowToFromTo } from "@/lib/page-window";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
 
@@ -37,17 +38,19 @@ function SortableHeader({
 	currentSortBy,
 	currentSortOrder,
 	search,
+	pageWindow,
 }: {
 	label: string;
 	sortKey: MappingSortBy;
 	currentSortBy: MappingSortBy;
 	currentSortOrder: SortOrder;
 	search: string;
+	pageWindow: string;
 }) {
 	const isActive = currentSortBy === sortKey;
 	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
 	const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
-	const href = `/model-provider-mappings?sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}`;
+	const href = `/model-provider-mappings?sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}&window=${pageWindow}`;
 
 	return (
 		<Link
@@ -154,6 +157,25 @@ function MappingRow({ mapping }: { mapping: ModelProviderMappingEntry }) {
 	);
 }
 
+function formatCompactNumber(value: number): string {
+	if (value >= 1_000_000_000) {
+		return `${(value / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (value >= 1_000_000) {
+		return `${(value / 1_000_000).toFixed(1)}M`;
+	}
+	if (value >= 1_000) {
+		return `${(value / 1_000).toFixed(1)}k`;
+	}
+	return value.toLocaleString("en-US");
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
 export default async function ModelProviderMappingsPage({
 	searchParams,
 }: {
@@ -161,12 +183,15 @@ export default async function ModelProviderMappingsPage({
 		search?: string;
 		sortBy?: string;
 		sortOrder?: string;
+		window?: string;
 	}>;
 }) {
 	const params = await searchParams;
 	const search = params?.search ?? "";
 	const sortBy = (params?.sortBy as MappingSortBy) ?? "logsCount";
 	const sortOrder = (params?.sortOrder as SortOrder) ?? "desc";
+	const pageWindow = parsePageWindow(params?.window);
+	const { from, to } = windowToFromTo(pageWindow);
 
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/admin/model-provider-mappings", {
@@ -199,14 +224,26 @@ export default async function ModelProviderMappingsPage({
 		);
 	}
 
+	// Compute aggregate stats from the mapping data using projectHourlyModelStats via from/to
+	// Since the mappings API doesn't yet return totalTokens/totalCost aggregates,
+	// we derive totals from the models endpoint with the same window
+	const { data: modelsData } = await $api.GET("/admin/models", {
+		params: { query: { limit: 1, offset: 0, from, to } },
+	});
+	const totalTokens = modelsData?.totalTokens ?? 0;
+	const totalCost = modelsData?.totalCost ?? 0;
+	const totalRequests = data.mappings.reduce((s, m) => s + m.logsCount, 0);
+
 	async function handleSearch(formData: FormData) {
 		"use server";
 		const searchValue = formData.get("search") as string;
+		const windowValue = formData.get("window") as string;
 		const searchParam = searchValue
 			? `&search=${encodeURIComponent(searchValue)}`
 			: "";
+		const windowParam = windowValue ? `&window=${windowValue}` : "";
 		redirect(
-			`/model-provider-mappings?sortBy=${sortBy}&sortOrder=${sortOrder}${searchParam}`,
+			`/model-provider-mappings?sortBy=${sortBy}&sortOrder=${sortOrder}${searchParam}${windowParam}`,
 		);
 	}
 
@@ -218,6 +255,7 @@ export default async function ModelProviderMappingsPage({
 				currentSortBy={sortBy}
 				currentSortOrder={sortOrder}
 				search={search}
+				pageWindow={pageWindow}
 			/>
 		</TableHead>
 	);
@@ -237,6 +275,7 @@ export default async function ModelProviderMappingsPage({
 					<form action={handleSearch} className="flex items-center gap-2">
 						<input type="hidden" name="sortBy" value={sortBy} />
 						<input type="hidden" name="sortOrder" value={sortOrder} />
+						<input type="hidden" name="window" value={pageWindow} />
 						<div className="relative">
 							<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 							<input
@@ -251,11 +290,34 @@ export default async function ModelProviderMappingsPage({
 							Search
 						</Button>
 					</form>
-					<Suspense>
-						<DateRangePicker />
-					</Suspense>
 				</div>
 			</header>
+
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+				<div className="flex flex-wrap items-center gap-6 text-sm">
+					<div>
+						<span className="text-muted-foreground">Total Requests</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{formatCompactNumber(totalRequests)}
+						</p>
+					</div>
+					<div>
+						<span className="text-muted-foreground">Total Tokens</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{formatCompactNumber(totalTokens)}
+						</p>
+					</div>
+					<div>
+						<span className="text-muted-foreground">Total Cost</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{currencyFormatter.format(totalCost)}
+						</p>
+					</div>
+				</div>
+				<Suspense>
+					<TimeWindowSelector current={pageWindow} />
+				</Suspense>
+			</div>
 
 			<div className="min-w-0 overflow-x-auto rounded-lg border border-border/60 bg-card">
 				<Table>

--- a/ee/admin/src/app/models/[modelId]/page.tsx
+++ b/ee/admin/src/app/models/[modelId]/page.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
+import { Suspense } from "react";
 
 import { ModelDetailClient } from "@/components/model-detail-client";
 import { Button } from "@/components/ui/button";
@@ -46,11 +47,13 @@ export default async function ModelDetailPage({
 					</Link>
 				</Button>
 			</div>
-			<ModelDetailClient
-				modelId={decodedModelId}
-				allTimeStats={model}
-				providers={providers}
-			/>
+			<Suspense>
+				<ModelDetailClient
+					modelId={decodedModelId}
+					allTimeStats={model}
+					providers={providers}
+				/>
+			</Suspense>
 		</div>
 	);
 }

--- a/ee/admin/src/app/models/page.tsx
+++ b/ee/admin/src/app/models/page.tsx
@@ -3,9 +3,10 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
-import { DateRangePicker } from "@/components/date-range-picker";
 import { ModelsTable } from "@/components/models-table";
+import { TimeWindowSelector } from "@/components/time-window-selector";
 import { Button } from "@/components/ui/button";
+import { parsePageWindow, windowToFromTo } from "@/lib/page-window";
 import { createServerApiClient } from "@/lib/server-api";
 
 import type { paths } from "@/lib/api/v1";
@@ -35,6 +36,25 @@ function SignInPrompt() {
 	);
 }
 
+function formatCompactNumber(value: number): string {
+	if (value >= 1_000_000_000) {
+		return `${(value / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (value >= 1_000_000) {
+		return `${(value / 1_000_000).toFixed(1)}M`;
+	}
+	if (value >= 1_000) {
+		return `${(value / 1_000).toFixed(1)}k`;
+	}
+	return value.toLocaleString("en-US");
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
 export default async function ModelsPage({
 	searchParams,
 }: {
@@ -43,8 +63,7 @@ export default async function ModelsPage({
 		search?: string;
 		sortBy?: string;
 		sortOrder?: string;
-		from?: string;
-		to?: string;
+		window?: string;
 	}>;
 }) {
 	const params = await searchParams;
@@ -52,8 +71,8 @@ export default async function ModelsPage({
 	const search = params?.search ?? "";
 	const sortBy = (params?.sortBy as ModelSortBy) ?? "logsCount";
 	const sortOrder = (params?.sortOrder as SortOrder) || "desc";
-	const from = params?.from;
-	const to = params?.to;
+	const pageWindow = parsePageWindow(params?.window);
+	const { from, to } = windowToFromTo(pageWindow);
 	const limit = 50;
 	const offset = (page - 1) * limit;
 
@@ -67,22 +86,19 @@ export default async function ModelsPage({
 	}
 
 	const totalPages = Math.ceil(data.total / limit);
-	const dateParams = from && to ? `&from=${from}&to=${to}` : "";
 
 	async function handleSearch(formData: FormData) {
 		"use server";
 		const searchValue = formData.get("search") as string;
 		const sortByValue = formData.get("sortBy") as string;
 		const sortOrderValue = formData.get("sortOrder") as string;
-		const fromValue = formData.get("from") as string;
-		const toValue = formData.get("to") as string;
+		const windowValue = formData.get("window") as string;
 		const searchParam = searchValue
 			? `&search=${encodeURIComponent(searchValue)}`
 			: "";
 		const sortParam = `&sortBy=${sortByValue}&sortOrder=${sortOrderValue}`;
-		const datePart =
-			fromValue && toValue ? `&from=${fromValue}&to=${toValue}` : "";
-		redirect(`/models?page=1${searchParam}${sortParam}${datePart}`);
+		const windowParam = windowValue ? `&window=${windowValue}` : "";
+		redirect(`/models?page=1${searchParam}${sortParam}${windowParam}`);
 	}
 
 	return (
@@ -98,8 +114,7 @@ export default async function ModelsPage({
 					<form action={handleSearch} className="flex items-center gap-2">
 						<input type="hidden" name="sortBy" value={sortBy} />
 						<input type="hidden" name="sortOrder" value={sortOrder} />
-						<input type="hidden" name="from" value={from ?? ""} />
-						<input type="hidden" name="to" value={to ?? ""} />
+						<input type="hidden" name="window" value={pageWindow} />
 						<div className="relative">
 							<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 							<input
@@ -114,11 +129,36 @@ export default async function ModelsPage({
 							Search
 						</Button>
 					</form>
-					<Suspense>
-						<DateRangePicker />
-					</Suspense>
 				</div>
 			</header>
+
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+				<div className="flex flex-wrap items-center gap-6 text-sm">
+					<div>
+						<span className="text-muted-foreground">Total Requests</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{formatCompactNumber(
+								data.models.reduce((s, m) => s + m.logsCount, 0),
+							)}
+						</p>
+					</div>
+					<div>
+						<span className="text-muted-foreground">Total Tokens</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{formatCompactNumber(data.totalTokens)}
+						</p>
+					</div>
+					<div>
+						<span className="text-muted-foreground">Total Cost</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{currencyFormatter.format(data.totalCost)}
+						</p>
+					</div>
+				</div>
+				<Suspense>
+					<TimeWindowSelector current={pageWindow} />
+				</Suspense>
+			</div>
 
 			<div className="min-w-0 overflow-x-auto rounded-lg border border-border/60 bg-card">
 				<ModelsTable
@@ -126,8 +166,7 @@ export default async function ModelsPage({
 					sortBy={sortBy}
 					sortOrder={sortOrder}
 					search={search}
-					from={from}
-					to={to}
+					pageWindow={pageWindow}
 				/>
 			</div>
 
@@ -140,7 +179,7 @@ export default async function ModelsPage({
 					<div className="flex items-center gap-2">
 						<Button variant="outline" size="sm" asChild disabled={page <= 1}>
 							<Link
-								href={`/models?page=${page - 1}${search ? `&search=${encodeURIComponent(search)}` : ""}&sortBy=${sortBy}&sortOrder=${sortOrder}${dateParams}`}
+								href={`/models?page=${page - 1}${search ? `&search=${encodeURIComponent(search)}` : ""}&sortBy=${sortBy}&sortOrder=${sortOrder}&window=${pageWindow}`}
 								className={page <= 1 ? "pointer-events-none opacity-50" : ""}
 							>
 								<ChevronLeft className="h-4 w-4" />
@@ -157,7 +196,7 @@ export default async function ModelsPage({
 							disabled={page >= totalPages}
 						>
 							<Link
-								href={`/models?page=${page + 1}${search ? `&search=${encodeURIComponent(search)}` : ""}&sortBy=${sortBy}&sortOrder=${sortOrder}${dateParams}`}
+								href={`/models?page=${page + 1}${search ? `&search=${encodeURIComponent(search)}` : ""}&sortBy=${sortBy}&sortOrder=${sortOrder}&window=${pageWindow}`}
 								className={
 									page >= totalPages ? "pointer-events-none opacity-50" : ""
 								}

--- a/ee/admin/src/app/organizations/[orgId]/org-cost-by-model.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-cost-by-model.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
 import { CostByModelChart } from "@/components/cost-by-model-chart";
@@ -7,10 +8,31 @@ import { getOrgCostByModel } from "@/lib/admin-history";
 
 import type { TokenWindow } from "@/lib/types";
 
+const validWindows = new Set<TokenWindow>([
+	"1h",
+	"4h",
+	"12h",
+	"1d",
+	"7d",
+	"30d",
+	"90d",
+	"365d",
+]);
+
+function parseWindow(value: string | null): TokenWindow {
+	if (value && validWindows.has(value as TokenWindow)) {
+		return value as TokenWindow;
+	}
+	return "1d";
+}
+
 export function OrgCostByModel({ orgId }: { orgId: string }) {
+	const searchParams = useSearchParams();
+	const window = parseWindow(searchParams.get("window"));
+
 	const fetchData = useCallback(
-		async (window: TokenWindow) => {
-			return await getOrgCostByModel(orgId, window);
+		async (w: TokenWindow) => {
+			return await getOrgCostByModel(orgId, w);
 		},
 		[orgId],
 	);
@@ -20,6 +42,7 @@ export function OrgCostByModel({ orgId }: { orgId: string }) {
 			title="Cost by Model"
 			description="Top 20 models by cost for this organization"
 			fetchData={fetchData}
+			externalWindow={window}
 		/>
 	);
 }

--- a/ee/admin/src/app/providers/page.tsx
+++ b/ee/admin/src/app/providers/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import { Suspense } from "react";
 
-import { DateRangePicker } from "@/components/date-range-picker";
 import { ProvidersTable } from "@/components/providers-table";
+import { TimeWindowSelector } from "@/components/time-window-selector";
 import { Button } from "@/components/ui/button";
+import { parsePageWindow, windowToFromTo } from "@/lib/page-window";
 import { createServerApiClient } from "@/lib/server-api";
 
 import type { paths } from "@/lib/api/v1";
@@ -33,21 +34,39 @@ function SignInPrompt() {
 	);
 }
 
+function formatCompactNumber(value: number): string {
+	if (value >= 1_000_000_000) {
+		return `${(value / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (value >= 1_000_000) {
+		return `${(value / 1_000_000).toFixed(1)}M`;
+	}
+	if (value >= 1_000) {
+		return `${(value / 1_000).toFixed(1)}k`;
+	}
+	return value.toLocaleString("en-US");
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
 export default async function ProvidersPage({
 	searchParams,
 }: {
 	searchParams?: Promise<{
 		sortBy?: string;
 		sortOrder?: string;
-		from?: string;
-		to?: string;
+		window?: string;
 	}>;
 }) {
 	const params = await searchParams;
 	const sortBy = (params?.sortBy as ProviderSortBy) ?? "logsCount";
 	const sortOrder = (params?.sortOrder as SortOrder) || "desc";
-	const from = params?.from;
-	const to = params?.to;
+	const pageWindow = parsePageWindow(params?.window);
+	const { from, to } = windowToFromTo(pageWindow);
 
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/admin/providers", {
@@ -67,18 +86,42 @@ export default async function ProvidersPage({
 						{data.total} providers — click a row to view history
 					</p>
 				</div>
-				<Suspense>
-					<DateRangePicker />
-				</Suspense>
 			</header>
+
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+				<div className="flex flex-wrap items-center gap-6 text-sm">
+					<div>
+						<span className="text-muted-foreground">Total Requests</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{formatCompactNumber(
+								data.providers.reduce((s, p) => s + p.logsCount, 0),
+							)}
+						</p>
+					</div>
+					<div>
+						<span className="text-muted-foreground">Total Tokens</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{formatCompactNumber(data.totalTokens)}
+						</p>
+					</div>
+					<div>
+						<span className="text-muted-foreground">Total Cost</span>
+						<p className="text-xl font-semibold tabular-nums">
+							{currencyFormatter.format(data.totalCost)}
+						</p>
+					</div>
+				</div>
+				<Suspense>
+					<TimeWindowSelector current={pageWindow} />
+				</Suspense>
+			</div>
 
 			<div className="min-w-0 overflow-x-auto rounded-lg border border-border/60 bg-card">
 				<ProvidersTable
 					providers={data.providers}
 					sortBy={sortBy}
 					sortOrder={sortOrder}
-					from={from}
-					to={to}
+					pageWindow={pageWindow}
 				/>
 			</div>
 		</div>

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -70,14 +70,17 @@ export function CostByModelChart({
 	title,
 	description,
 	fetchData,
+	externalWindow,
 }: {
 	title: string;
 	description?: string;
 	fetchData: (window: TokenWindow) => Promise<CostByModelData | null>;
+	externalWindow?: TokenWindow;
 }) {
 	const [data, setData] = useState<CostByModelData | null>(null);
 	const [loading, setLoading] = useState(true);
-	const [window, setWindow] = useState<TokenWindow>("7d");
+	const [internalWindow, setInternalWindow] = useState<TokenWindow>("7d");
+	const window = externalWindow ?? internalWindow;
 	const [activeView, setActiveView] = useState<ActiveView>("cost");
 
 	const loadData = useCallback(
@@ -133,19 +136,21 @@ export function CostByModelChart({
 							</div>
 						)}
 					</div>
-					<div className="flex items-center gap-1">
-						{windowOptions.map((opt) => (
-							<Button
-								key={opt.value}
-								variant={window === opt.value ? "default" : "outline"}
-								size="sm"
-								className="h-7 px-2 text-xs"
-								onClick={() => setWindow(opt.value)}
-							>
-								{opt.label}
-							</Button>
-						))}
-					</div>
+					{!externalWindow && (
+						<div className="flex items-center gap-1">
+							{windowOptions.map((opt) => (
+								<Button
+									key={opt.value}
+									variant={window === opt.value ? "default" : "outline"}
+									size="sm"
+									className="h-7 px-2 text-xs"
+									onClick={() => setInternalWindow(opt.value)}
+								>
+									{opt.label}
+								</Button>
+							))}
+						</div>
+					)}
 				</div>
 				<div className="flex items-center gap-1 border-b pb-2">
 					{viewTabs.map((tab) => (
@@ -176,12 +181,15 @@ export function CostByModelChart({
 				) : (
 					<ChartContainer
 						config={config}
-						className="aspect-auto h-[300px] w-full"
+						className="aspect-auto w-full"
+						style={{
+							height: `${Math.max(300, data.models.length * 28)}px`,
+						}}
 					>
 						<BarChart
 							data={data.models}
 							layout="vertical"
-							margin={{ left: 8, right: 8, top: 4, bottom: 0 }}
+							margin={{ left: 8, right: 8, top: 20, bottom: 4 }}
 						>
 							<CartesianGrid horizontal={false} strokeDasharray="3 3" />
 							<YAxis

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -22,16 +22,15 @@ import { cn } from "@/lib/utils";
 import type { ChartConfig } from "@/components/ui/chart";
 
 export type HistoryWindow =
-	| "1m"
 	| "2m"
 	| "5m"
 	| "15m"
-	| "30m"
 	| "1h"
 	| "2h"
 	| "4h"
 	| "12h"
 	| "24h"
+	| "1d"
 	| "2d"
 	| "7d";
 
@@ -43,9 +42,10 @@ export interface HistoryDataPoint {
 	avgTtft: number | null;
 	avgDuration: number | null;
 	totalTokens: number;
+	totalCost: number;
 }
 
-type ActiveMetric = "requests" | "errors" | "latency" | "tokens";
+type ActiveMetric = "requests" | "errors" | "latency" | "tokens" | "cost";
 
 const chartConfigs: Record<ActiveMetric, ChartConfig> = {
 	requests: {
@@ -63,10 +63,12 @@ const chartConfigs: Record<ActiveMetric, ChartConfig> = {
 	tokens: {
 		totalTokens: { label: "Tokens", color: "hsl(32 95% 44%)" },
 	},
+	cost: {
+		totalCost: { label: "Cost ($)", color: "hsl(142 71% 45%)" },
+	},
 };
 
 export const windowOptions: { value: HistoryWindow; label: string }[] = [
-	{ value: "1m", label: "1m" },
 	{ value: "2m", label: "2m" },
 	{ value: "5m", label: "5m" },
 	{ value: "15m", label: "15m" },
@@ -75,6 +77,7 @@ export const windowOptions: { value: HistoryWindow; label: string }[] = [
 	{ value: "4h", label: "4h" },
 	{ value: "12h", label: "12h" },
 	{ value: "24h", label: "24h" },
+	{ value: "1d", label: "1d" },
 	{ value: "2d", label: "2d" },
 	{ value: "7d", label: "7d" },
 ];
@@ -84,6 +87,7 @@ const metricTabs: { key: ActiveMetric; label: string }[] = [
 	{ key: "errors", label: "Errors" },
 	{ key: "latency", label: "Latency" },
 	{ key: "tokens", label: "Tokens" },
+	{ key: "cost", label: "Cost" },
 ];
 
 function formatTimestamp(ts: string, window: HistoryWindow): string {
@@ -255,11 +259,14 @@ export function HistoryChart({
 								axisLine={false}
 								tickMargin={4}
 								width={50}
-								tickFormatter={(value: number) =>
-									value >= 1000
+								tickFormatter={(value: number) => {
+									if (activeMetric === "cost") {
+										return `$${value >= 0.01 ? value.toFixed(2) : value.toFixed(4)}`;
+									}
+									return value >= 1000
 										? `${(value / 1000).toFixed(1)}k`
-										: String(value)
-								}
+										: String(value);
+								}}
 							/>
 							<ChartTooltip
 								content={
@@ -269,10 +276,14 @@ export function HistoryChart({
 										}
 										formatter={(value, name) => {
 											const label = config[name as string]?.label ?? name;
-											const formatted =
-												activeMetric === "latency"
-													? `${Math.round(Number(value))}ms`
-													: Number(value).toLocaleString();
+											let formatted: string;
+											if (activeMetric === "latency") {
+												formatted = `${Math.round(Number(value))}ms`;
+											} else if (activeMetric === "cost") {
+												formatted = `$${Number(value).toFixed(4)}`;
+											} else {
+												formatted = Number(value).toLocaleString();
+											}
 											return (
 												<span>
 													{label}: <strong>{formatted}</strong>

--- a/ee/admin/src/components/model-detail-client.tsx
+++ b/ee/admin/src/components/model-detail-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { windowOptions } from "@/components/history-chart";
@@ -49,6 +50,15 @@ interface AllTimeStats {
 	id: string;
 }
 
+const validWindows = new Set<HistoryWindow>(windowOptions.map((o) => o.value));
+
+function parseHistoryWindow(value: string | null): HistoryWindow {
+	if (value && validWindows.has(value as HistoryWindow)) {
+		return value as HistoryWindow;
+	}
+	return "24h";
+}
+
 export function ModelDetailClient({
 	modelId,
 	allTimeStats,
@@ -58,7 +68,10 @@ export function ModelDetailClient({
 	allTimeStats: AllTimeStats;
 	providers: ModelProviderStats[];
 }) {
-	const [window, setWindow] = useState<HistoryWindow>("4h");
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
+	const window = parseHistoryWindow(searchParams.get("window"));
 	const [loading, setLoading] = useState(true);
 	const [stats, setStats] = useState({
 		totalRequests: allTimeStats.logsCount,
@@ -122,7 +135,13 @@ export function ModelDetailClient({
 						variant={window === opt.value ? "default" : "outline"}
 						size="sm"
 						className="h-7 px-2 text-xs"
-						onClick={() => setWindow(opt.value)}
+						onClick={() => {
+							const params = new URLSearchParams(searchParams.toString());
+							params.set("window", opt.value);
+							router.replace(`${pathname}?${params.toString()}`, {
+								scroll: false,
+							});
+						}}
 					>
 						{opt.label}
 					</Button>

--- a/ee/admin/src/components/models-table.tsx
+++ b/ee/admin/src/components/models-table.tsx
@@ -19,7 +19,25 @@ import { getModelHistory } from "@/lib/admin-history";
 import { cn } from "@/lib/utils";
 
 import type { HistoryWindow } from "@/components/history-chart";
+import type { PageWindow } from "@/lib/page-window";
 import type { ModelStats } from "@/lib/types";
+
+function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
+	const map: Record<PageWindow, HistoryWindow> = {
+		"2m": "2m",
+		"5m": "5m",
+		"15m": "15m",
+		"1h": "1h",
+		"2h": "2h",
+		"4h": "4h",
+		"12h": "12h",
+		"24h": "24h",
+		"1d": "1d",
+		"2d": "2d",
+		"7d": "7d",
+	};
+	return map[pageWindow] ?? "24h";
+}
 
 type ModelSortBy =
 	| "name"
@@ -41,23 +59,21 @@ function SortableHeader({
 	currentSortBy,
 	currentSortOrder,
 	search,
-	from,
-	to,
+	pageWindow,
 }: {
 	label: string;
 	sortKey: ModelSortBy;
 	currentSortBy: ModelSortBy;
 	currentSortOrder: SortOrder;
 	search: string;
-	from?: string;
-	to?: string;
+	pageWindow?: PageWindow;
 }) {
 	const isActive = currentSortBy === sortKey;
 	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
 
 	const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
-	const dateParams = from && to ? `&from=${from}&to=${to}` : "";
-	const href = `/models?page=1&sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}${dateParams}`;
+	const windowParam = pageWindow ? `&window=${pageWindow}` : "";
+	const href = `/models?page=1&sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}${windowParam}`;
 
 	return (
 		<Link
@@ -95,7 +111,13 @@ function formatDate(dateString: string) {
 	});
 }
 
-function ModelRow({ model }: { model: ModelStats }) {
+function ModelRow({
+	model,
+	externalWindow,
+}: {
+	model: ModelStats;
+	externalWindow?: HistoryWindow;
+}) {
 	const [expanded, setExpanded] = useState(false);
 	const errorRate =
 		model.logsCount > 0
@@ -199,6 +221,7 @@ function ModelRow({ model }: { model: ModelStats }) {
 							title={`${model.name !== model.id ? model.name : model.id} — History`}
 							description="Request volume, errors, latency, and tokens over time"
 							fetchData={fetchData}
+							externalWindow={externalWindow}
 						/>
 					</TableCell>
 				</TableRow>
@@ -212,16 +235,16 @@ export function ModelsTable({
 	sortBy = "logsCount",
 	sortOrder = "desc",
 	search = "",
-	from,
-	to,
+	pageWindow,
 }: {
 	models: ModelStats[];
 	sortBy?: ModelSortBy;
 	sortOrder?: SortOrder;
 	search?: string;
-	from?: string;
-	to?: string;
+	pageWindow?: PageWindow;
 }) {
+	const externalWindow = pageWindow ? toHistoryWindow(pageWindow) : undefined;
+
 	const sh = (label: string, sortKey: ModelSortBy) => (
 		<TableHead>
 			<SortableHeader
@@ -230,8 +253,7 @@ export function ModelsTable({
 				currentSortBy={sortBy}
 				currentSortOrder={sortOrder}
 				search={search}
-				from={from}
-				to={to}
+				pageWindow={pageWindow}
 			/>
 		</TableHead>
 	);
@@ -265,7 +287,9 @@ export function ModelsTable({
 						</TableCell>
 					</TableRow>
 				) : (
-					models.map((m) => <ModelRow key={m.id} model={m} />)
+					models.map((m) => (
+						<ModelRow key={m.id} model={m} externalWindow={externalWindow} />
+					))
 				)}
 			</TableBody>
 		</Table>

--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -21,7 +21,25 @@ import { cn } from "@/lib/utils";
 import { getProviderIcon } from "@llmgateway/shared";
 
 import type { HistoryWindow } from "@/components/history-chart";
+import type { PageWindow } from "@/lib/page-window";
 import type { ProviderStats } from "@/lib/types";
+
+function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
+	const map: Record<PageWindow, HistoryWindow> = {
+		"2m": "2m",
+		"5m": "5m",
+		"15m": "15m",
+		"1h": "1h",
+		"2h": "2h",
+		"4h": "4h",
+		"12h": "12h",
+		"24h": "24h",
+		"1d": "1d",
+		"2d": "2d",
+		"7d": "7d",
+	};
+	return map[pageWindow] ?? "24h";
+}
 
 type ProviderSortBy =
 	| "name"
@@ -40,21 +58,19 @@ function SortableHeader({
 	sortKey,
 	currentSortBy,
 	currentSortOrder,
-	from,
-	to,
+	pageWindow,
 }: {
 	label: string;
 	sortKey: ProviderSortBy;
 	currentSortBy: ProviderSortBy;
 	currentSortOrder: SortOrder;
-	from?: string;
-	to?: string;
+	pageWindow?: PageWindow;
 }) {
 	const isActive = currentSortBy === sortKey;
 	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
 
-	const dateParams = from && to ? `&from=${from}&to=${to}` : "";
-	const href = `/providers?sortBy=${sortKey}&sortOrder=${nextOrder}${dateParams}`;
+	const windowParam = pageWindow ? `&window=${pageWindow}` : "";
+	const href = `/providers?sortBy=${sortKey}&sortOrder=${nextOrder}${windowParam}`;
 
 	return (
 		<Link
@@ -92,7 +108,13 @@ function formatDate(dateString: string) {
 	});
 }
 
-function ProviderRow({ provider }: { provider: ProviderStats }) {
+function ProviderRow({
+	provider,
+	externalWindow,
+}: {
+	provider: ProviderStats;
+	externalWindow?: HistoryWindow;
+}) {
 	const [expanded, setExpanded] = useState(false);
 	const errorRate =
 		provider.logsCount > 0
@@ -170,6 +192,7 @@ function ProviderRow({ provider }: { provider: ProviderStats }) {
 							title={`${provider.name} — History`}
 							description="Request volume, errors, latency, and tokens over time"
 							fetchData={fetchData}
+							externalWindow={externalWindow}
 						/>
 					</TableCell>
 				</TableRow>
@@ -182,15 +205,15 @@ export function ProvidersTable({
 	providers,
 	sortBy = "logsCount",
 	sortOrder = "desc",
-	from,
-	to,
+	pageWindow,
 }: {
 	providers: ProviderStats[];
 	sortBy?: ProviderSortBy;
 	sortOrder?: SortOrder;
-	from?: string;
-	to?: string;
+	pageWindow?: PageWindow;
 }) {
+	const externalWindow = pageWindow ? toHistoryWindow(pageWindow) : undefined;
+
 	const sh = (label: string, sortKey: ProviderSortBy) => (
 		<TableHead>
 			<SortableHeader
@@ -198,8 +221,7 @@ export function ProvidersTable({
 				sortKey={sortKey}
 				currentSortBy={sortBy}
 				currentSortOrder={sortOrder}
-				from={from}
-				to={to}
+				pageWindow={pageWindow}
 			/>
 		</TableHead>
 	);
@@ -231,7 +253,13 @@ export function ProvidersTable({
 						</TableCell>
 					</TableRow>
 				) : (
-					providers.map((p) => <ProviderRow key={p.id} provider={p} />)
+					providers.map((p) => (
+						<ProviderRow
+							key={p.id}
+							provider={p}
+							externalWindow={externalWindow}
+						/>
+					))
 				)}
 			</TableBody>
 		</Table>

--- a/ee/admin/src/components/time-window-selector.tsx
+++ b/ee/admin/src/components/time-window-selector.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { Button } from "@/components/ui/button";
+import { pageWindowOptions } from "@/lib/page-window";
+
+import type { PageWindow } from "@/lib/page-window";
+
+export function TimeWindowSelector({ current }: { current: PageWindow }) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+
+	const handleSelect = useCallback(
+		(w: PageWindow) => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.set("window", w);
+			params.delete("from");
+			params.delete("to");
+			params.delete("page");
+			router.push(`${pathname}?${params.toString()}`);
+		},
+		[router, pathname, searchParams],
+	);
+
+	return (
+		<div className="flex items-center gap-1">
+			{pageWindowOptions.map((opt) => (
+				<Button
+					key={opt.value}
+					variant={current === opt.value ? "default" : "outline"}
+					size="sm"
+					onClick={() => handleSelect(opt.value)}
+				>
+					{opt.label}
+				</Button>
+			))}
+		</div>
+	);
+}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2158,9 +2158,13 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 modelCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2218,11 +2222,15 @@ export interface paths {
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;
+                                totalTokens: number;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                            totalTokens: number;
+                            totalCost: number;
                         };
                     };
                 };
@@ -2411,7 +2419,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2436,6 +2444,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2460,7 +2469,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2485,6 +2494,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };
@@ -2509,7 +2519,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "30m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "1d" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -2535,6 +2545,7 @@ export interface paths {
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
+                                totalCost: number;
                             }[];
                         };
                     };

--- a/ee/admin/src/lib/page-window.ts
+++ b/ee/admin/src/lib/page-window.ts
@@ -1,0 +1,59 @@
+export type PageWindow =
+	| "2m"
+	| "5m"
+	| "15m"
+	| "1h"
+	| "2h"
+	| "4h"
+	| "12h"
+	| "24h"
+	| "1d"
+	| "2d"
+	| "7d";
+
+export const pageWindowOptions: { value: PageWindow; label: string }[] = [
+	{ value: "2m", label: "2m" },
+	{ value: "5m", label: "5m" },
+	{ value: "15m", label: "15m" },
+	{ value: "1h", label: "1h" },
+	{ value: "2h", label: "2h" },
+	{ value: "4h", label: "4h" },
+	{ value: "12h", label: "12h" },
+	{ value: "24h", label: "24h" },
+	{ value: "1d", label: "1d" },
+	{ value: "2d", label: "2d" },
+	{ value: "7d", label: "7d" },
+];
+
+const validWindows = new Set<PageWindow>(pageWindowOptions.map((o) => o.value));
+
+export function parsePageWindow(value: string | undefined): PageWindow {
+	if (value && validWindows.has(value as PageWindow)) {
+		return value as PageWindow;
+	}
+	return "24h";
+}
+
+export function windowToFromTo(window: PageWindow): {
+	from: string;
+	to: string;
+} {
+	const now = new Date();
+	const windowMinutes: Record<PageWindow, number> = {
+		"2m": 2,
+		"5m": 5,
+		"15m": 15,
+		"1h": 60,
+		"2h": 120,
+		"4h": 240,
+		"12h": 720,
+		"24h": 1440,
+		"1d": 1440,
+		"2d": 2880,
+		"7d": 10080,
+	};
+	const minutes = windowMinutes[window];
+	const ms = minutes * 60 * 1000;
+	const from = new Date(now.getTime() - ms).toISOString();
+	return { from, to: now.toISOString() };
+}


### PR DESCRIPTION
## Summary
- Replace date range picker with time window buttons (2m–7d) on models, providers, and mappings pages
- Add summary stats (total requests, tokens, cost) above tables on all admin list pages
- Fix per-provider stats on model detail page using `projectHourlyModelStats` instead of stale `modelProviderMapping` counts
- Fix mapping history charts falling back to hourly stats when minute-level data has zero counts
- Add Cost tab to history charts
- Sync model detail page window selection with URL params
- Remove duplicate time selector on org detail page
- Limit time range options to: 2m, 5m, 15m, 1h, 2h, 4h, 12h, 24h, 1d, 2d, 7d

## Test plan
- [ ] Verify time window buttons on /models, /providers, /model-provider-mappings pages
- [ ] Verify stats update when switching time windows
- [ ] Verify per-provider charts on /models/[modelId] show actual data
- [ ] Verify Cost tab in history charts displays cost data
- [ ] Verify org detail page has single time selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cost metrics and aggregated totals (tokens, cost) across admin dashboards and model/provider pages.
  * Introduced global discount banners to display applicable discounts for model/provider combinations.
  * Added new time window selector for simplified date range selection in admin views.
  * Added cost metric to history charts.

* **Enhancements**
  * Improved discount calculation with hierarchical precedence (provider+model, provider, model, global).
  * Enhanced time range handling to support various date input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->