### PR TITLE
fix(gateway): raise default image upload limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,8 +112,11 @@ BILL_CANCELLED_REQUESTS=true
 # IMAGE UPLOAD LIMITS
 # =============================================================================
 
-# Maximum image size in MB (default: 100)
-IMAGE_SIZE_LIMIT_MB=100
+# Maximum image size in MB for free plans (default: 50)
+IMAGE_SIZE_LIMIT_FREE_MB=50
+
+# Maximum image size in MB for pro plans (default: 100)
+IMAGE_SIZE_LIMIT_PRO_MB=100
 
 # =============================================================================
 # LLM PROVIDER API KEYS

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -613,7 +613,7 @@ chat.openapi(completions, async (c) => {
 	const retentionLevel = organization?.retentionLevel ?? "none";
 
 	// Get image size limits from environment variables or use defaults
-	const freeLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_FREE_MB) || 10;
+	const freeLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_FREE_MB) || 50;
 	const proLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_PRO_MB) || 100;
 
 	// Determine max image size based on plan


### PR DESCRIPTION
## Summary
- raise the default free-plan image upload limit from 10 MB to 50 MB
- update the example env configuration to document the active free/pro image limit variables

## Testing
- pnpm --filter gateway build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Implemented plan-specific image upload size limits: free tier increased to 50 MB, pro tier set to 100 MB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->