### PR TITLE
fix(gateway): capture bedrock streaming errors

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -72,6 +72,10 @@ import { countInputImages } from "./tools/count-input-images.js";
 import { createLogEntry } from "./tools/create-log-entry.js";
 import { estimateTokensFromContent } from "./tools/estimate-tokens-from-content.js";
 import { estimateTokens } from "./tools/estimate-tokens.js";
+import {
+	extractAwsBedrockHttpError,
+	extractAwsBedrockStreamError,
+} from "./tools/extract-aws-bedrock-error.js";
 import { extractContent } from "./tools/extract-content.js";
 import { extractCustomHeaders } from "./tools/extract-custom-headers.js";
 import { extractErrorCause } from "./tools/extract-error-cause.js";
@@ -2887,7 +2891,11 @@ chat.openapi(completions, async (c) => {
 					}
 
 					if (!res.ok) {
-						const errorResponseText = await res.text();
+						const rawErrorResponseText = await res.text();
+						const errorResponseText =
+							usedProvider === "aws-bedrock"
+								? extractAwsBedrockHttpError(res, rawErrorResponseText)
+								: rawErrorResponseText;
 
 						// Determine the finish reason for error handling
 						const finishReason = getFinishReasonFromError(
@@ -3247,6 +3255,7 @@ chat.openapi(completions, async (c) => {
 				let binaryBuffer = new Uint8Array(0); // Buffer for binary event streams (AWS Bedrock)
 				let rawUpstreamData = ""; // Raw data received from upstream provider
 				const isAwsBedrock = usedProvider === "aws-bedrock";
+				let shouldTerminateStream = false;
 
 				// Response healing for streaming mode
 				const streamingResponseHealingEnabled = plugins?.some(
@@ -3742,6 +3751,53 @@ chat.openapi(completions, async (c) => {
 									continue;
 								}
 
+								const awsBedrockStreamError =
+									usedProvider === "aws-bedrock"
+										? extractAwsBedrockStreamError(data)
+										: null;
+								if (awsBedrockStreamError) {
+									const errorType = getFinishReasonFromError(
+										awsBedrockStreamError.statusCode,
+										awsBedrockStreamError.responseText,
+									);
+
+									streamingError = {
+										message: awsBedrockStreamError.message,
+										type: errorType,
+										code: awsBedrockStreamError.eventType,
+										details: {
+											statusCode: awsBedrockStreamError.statusCode,
+											statusText: awsBedrockStreamError.eventType,
+											responseText: awsBedrockStreamError.responseText,
+										},
+									};
+									finishReason = errorType;
+
+									await writeSSEAndCache({
+										event: "error",
+										data: JSON.stringify({
+											error: {
+												message: awsBedrockStreamError.message,
+												type: errorType,
+												code: awsBedrockStreamError.eventType,
+												param: null,
+												responseText: awsBedrockStreamError.responseText,
+											},
+										}),
+										id: String(eventId++),
+									});
+									await writeSSEAndCache({
+										event: "done",
+										data: "[DONE]",
+										id: String(eventId++),
+									});
+									doneSent = true;
+									shouldTerminateStream = true;
+									processedLength = eventEnd;
+									searchStart = eventEnd;
+									break;
+								}
+
 								// Transform streaming responses to OpenAI format for all providers
 								const transformedData = transformStreamingToOpenai(
 									usedProvider,
@@ -4185,6 +4241,10 @@ chat.openapi(completions, async (c) => {
 						// Remove processed data from buffer
 						if (processedLength > 0) {
 							buffer = bufferCopy.slice(processedLength);
+						}
+
+						if (shouldTerminateStream) {
+							break;
 						}
 					}
 				} catch (error) {
@@ -4808,15 +4868,42 @@ chat.openapi(completions, async (c) => {
 						hasError: streamingError !== null,
 						errorDetails: streamingError
 							? {
-									statusCode: 500,
-									statusText: "Streaming Error",
+									statusCode:
+										typeof streamingError === "object" &&
+										streamingError !== null &&
+										"details" in streamingError &&
+										typeof streamingError.details === "object" &&
+										streamingError.details !== null &&
+										"statusCode" in streamingError.details &&
+										typeof streamingError.details.statusCode === "number"
+											? streamingError.details.statusCode
+											: 500,
+									statusText:
+										typeof streamingError === "object" &&
+										streamingError !== null &&
+										"details" in streamingError &&
+										typeof streamingError.details === "object" &&
+										streamingError.details !== null &&
+										"statusText" in streamingError.details &&
+										typeof streamingError.details.statusText === "string"
+											? streamingError.details.statusText
+											: "Streaming Error",
 									responseText:
 										typeof streamingError === "object" &&
-										"details" in streamingError
-											? JSON.stringify(streamingError) // Store structured error as JSON string
-											: streamingError instanceof Error
-												? streamingError.message
-												: String(streamingError),
+										streamingError !== null &&
+										"details" in streamingError &&
+										typeof streamingError.details === "object" &&
+										streamingError.details !== null &&
+										"responseText" in streamingError.details &&
+										typeof streamingError.details.responseText === "string"
+											? streamingError.details.responseText
+											: typeof streamingError === "object" &&
+												  streamingError !== null &&
+												  "details" in streamingError
+												? JSON.stringify(streamingError)
+												: streamingError instanceof Error
+													? streamingError.message
+													: String(streamingError),
 								}
 							: null,
 						streamed: true,
@@ -5380,7 +5467,11 @@ chat.openapi(completions, async (c) => {
 			// Body read can throw TimeoutError if the abort signal fires during consumption
 			let errorResponseText: string;
 			try {
-				errorResponseText = await res.text();
+				const rawErrorResponseText = await res.text();
+				errorResponseText =
+					usedProvider === "aws-bedrock"
+						? extractAwsBedrockHttpError(res, rawErrorResponseText)
+						: rawErrorResponseText;
 			} catch (bodyError) {
 				if (isTimeoutError(bodyError)) {
 					const errorMessage =

--- a/apps/gateway/src/chat/tools/extract-aws-bedrock-error.spec.ts
+++ b/apps/gateway/src/chat/tools/extract-aws-bedrock-error.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	extractAwsBedrockHttpError,
+	extractAwsBedrockStreamError,
+} from "./extract-aws-bedrock-error.js";
+
+describe("extractAwsBedrockHttpError", () => {
+	it("falls back to x-amzn headers when the body is empty json", () => {
+		const response = new Response("{}", {
+			status: 400,
+			headers: {
+				"x-amzn-errormessage":
+					"The provided model identifier is invalid for this account.",
+				"x-amzn-errortype": "ValidationException",
+			},
+		});
+
+		expect(extractAwsBedrockHttpError(response, "{}")).toBe(
+			JSON.stringify({
+				message: "The provided model identifier is invalid for this account.",
+				type: "ValidationException",
+			}),
+		);
+	});
+});
+
+describe("extractAwsBedrockStreamError", () => {
+	it("extracts exception metadata from aws eventstream frames", () => {
+		expect(
+			extractAwsBedrockStreamError({
+				__aws_event_type: "modelStreamErrorException",
+				message: "The stream failed before the first token.",
+				originalStatusCode: 400,
+			}),
+		).toEqual({
+			eventType: "modelStreamErrorException",
+			message: "The stream failed before the first token.",
+			statusCode: 400,
+			responseText: JSON.stringify({
+				message: "The stream failed before the first token.",
+				type: "modelStreamErrorException",
+				originalStatusCode: 400,
+			}),
+		});
+	});
+});

--- a/apps/gateway/src/chat/tools/extract-aws-bedrock-error.ts
+++ b/apps/gateway/src/chat/tools/extract-aws-bedrock-error.ts
@@ -1,0 +1,90 @@
+const AWS_BEDROCK_EVENT_STATUS_CODES: Record<string, number> = {
+	accessDeniedException: 403,
+	internalServerException: 500,
+	modelNotReadyException: 503,
+	modelStreamErrorException: 502,
+	modelTimeoutException: 504,
+	resourceNotFoundException: 404,
+	serviceQuotaExceededException: 429,
+	serviceUnavailableException: 503,
+	throttlingException: 429,
+	validationException: 400,
+};
+
+function extractJsonMessage(body: string): string | undefined {
+	if (!body || body === "{}") {
+		return undefined;
+	}
+
+	try {
+		const json = JSON.parse(body);
+		return (
+			json?.message ??
+			json?.Message ??
+			json?.originalMessage ??
+			json?.error?.message ??
+			undefined
+		);
+	} catch {
+		return undefined;
+	}
+}
+
+export function extractAwsBedrockHttpError(
+	response: Response,
+	errorResponseText: string,
+): string {
+	const normalizedBody = errorResponseText.trim();
+	const messageFromBody = extractJsonMessage(normalizedBody);
+
+	if (messageFromBody) {
+		return normalizedBody;
+	}
+
+	const headerMessage = response.headers.get("x-amzn-errormessage");
+	const headerType = response.headers.get("x-amzn-errortype");
+
+	if (headerMessage || headerType) {
+		return JSON.stringify({
+			message: headerMessage ?? `AWS Bedrock ${headerType ?? "error"}`,
+			type: headerType ?? null,
+		});
+	}
+
+	return normalizedBody;
+}
+
+export function extractAwsBedrockStreamError(data: any): {
+	eventType: string;
+	message: string;
+	statusCode: number;
+	responseText: string;
+} | null {
+	const eventType = data?.__aws_event_type;
+	if (typeof eventType !== "string" || !eventType.endsWith("Exception")) {
+		return null;
+	}
+
+	const message =
+		data?.originalMessage ??
+		data?.message ??
+		data?.Message ??
+		`AWS Bedrock ${eventType}`;
+	const statusCode =
+		typeof data?.originalStatusCode === "number"
+			? data.originalStatusCode
+			: (AWS_BEDROCK_EVENT_STATUS_CODES[eventType] ?? 500);
+
+	return {
+		eventType,
+		message,
+		statusCode,
+		responseText: JSON.stringify({
+			message,
+			type: eventType,
+			...(typeof data?.originalStatusCode === "number"
+				? { originalStatusCode: data.originalStatusCode }
+				: {}),
+		}),
+	};
+}

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -455,6 +455,46 @@ describe("fallback and error status code handling", () => {
 			expect(log.streamed).toBe(true);
 			expect(log.errorDetails?.statusCode).toBe(429);
 		});
+
+		test("streaming aws-bedrock 400 surfaces x-amzn error headers", async () => {
+			await setupKeys("aws-bedrock");
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "aws-bedrock/claude-sonnet-4-6",
+					messages: [{ role: "user", content: "TRIGGER_BEDROCK_HEADER_ERROR" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasError).toBe(true);
+			expect(streamResult.errorEvents.length).toBeGreaterThan(0);
+
+			const errorEvent = streamResult.errorEvents[0];
+			expect(errorEvent.error.type).toBe("gateway_error");
+			expect(errorEvent.error.message).toContain(
+				"The provided model identifier is invalid for this account.",
+			);
+			expect(errorEvent.error.responseText).toContain("ValidationException");
+
+			const logs = await waitForLogs(1);
+			const log = logs[0];
+			expect(log.finishReason).toBe("gateway_error");
+			expect(log.hasError).toBe(true);
+			expect(log.streamed).toBe(true);
+			expect(log.errorDetails?.statusCode).toBe(400);
+			expect(log.errorDetails?.responseText).toContain(
+				"The provided model identifier is invalid for this account.",
+			);
+		});
 	});
 
 	describe("deactivated provider fallback with metadata", () => {

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -373,6 +373,54 @@ mockOpenAIServer.post("/v1beta/models/:model\\:generateContent", async (c) => {
 	});
 });
 
+mockOpenAIServer.post("/model/:model/converse", async (c) => {
+	const body = await c.req.json();
+	const userMessage = body.messages?.[0]?.content?.[0]?.text ?? "";
+
+	if (userMessage.includes("TRIGGER_BEDROCK_HEADER_ERROR")) {
+		c.header(
+			"x-amzn-errormessage",
+			"The provided model identifier is invalid for this account.",
+		);
+		c.header("x-amzn-errortype", "ValidationException");
+		c.status(400);
+		return c.json({});
+	}
+
+	return c.json({
+		output: {
+			message: {
+				role: "assistant",
+				content: [{ text: `Bedrock mock response: ${userMessage}` }],
+			},
+		},
+		stopReason: "end_turn",
+		usage: {
+			inputTokens: 10,
+			outputTokens: 20,
+			totalTokens: 30,
+		},
+	});
+});
+
+mockOpenAIServer.post("/model/:model/converse-stream", async (c) => {
+	const body = await c.req.json();
+	const userMessage = body.messages?.[0]?.content?.[0]?.text ?? "";
+
+	if (userMessage.includes("TRIGGER_BEDROCK_HEADER_ERROR")) {
+		c.header(
+			"x-amzn-errormessage",
+			"The provided model identifier is invalid for this account.",
+		);
+		c.header("x-amzn-errortype", "ValidationException");
+		c.status(400);
+		return c.json({});
+	}
+
+	c.header("content-type", "application/vnd.amazon.eventstream");
+	return c.body("");
+});
+
 let server: any = null;
 
 export function startMockServer(port = 3001): string {


### PR DESCRIPTION
## Summary
- extract AWS Bedrock error details from `x-amzn-*` headers when streaming/non-streaming HTTP errors return an empty `{}` body
- surface AWS Bedrock eventstream exception frames as SSE error events instead of dropping them and later reporting a generic empty-response failure
- preserve the upstream Bedrock status/type in streaming logs and add focused Bedrock error-path tests

## Verification
- `pnpm exec vitest run apps/gateway/src/chat/tools/extract-aws-bedrock-error.spec.ts`
- `pnpm exec tsc -p apps/gateway/tsconfig.json --noEmit`
- `apps/gateway/src/fallback.spec.ts` includes a Bedrock streaming regression test, but I could not execute the integration suite in this VPS because local Postgres/Redis services are unavailable here

## Root Cause
AWS Bedrock streaming failures could arrive either as:
1. an HTTP error with an empty `{}` body plus `x-amzn-errormessage` / `x-amzn-errortype` headers, or
2. an AWS eventstream exception frame mid-stream.

The gateway previously treated both cases as having no useful provider message, so the user only saw a generic `gateway_error` or an eventual empty-stream error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for AWS Bedrock provider with improved error message clarity and better extraction of error information from API responses.
  * Improved streaming error detection and graceful stream termination when AWS Bedrock encounters errors.

* **Tests**
  * Added comprehensive test coverage for AWS Bedrock error scenarios, including both streaming and non-streaming error paths with header-based error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->