### PR TITLE
fix(gateway): classify provider 400s as upstream errors

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -64,9 +64,9 @@ describe("getFinishReasonFromError", () => {
 		).toBe("client_error");
 	});
 
-	it("returns gateway_error for other 400 errors", () => {
+	it("returns upstream_error for other 400 errors", () => {
 		expect(getFinishReasonFromError(400, "some other error")).toBe(
-			"gateway_error",
+			"upstream_error",
 		);
 	});
 
@@ -75,7 +75,7 @@ describe("getFinishReasonFromError", () => {
 		expect(getFinishReasonFromError(403)).toBe("gateway_error");
 	});
 
-	it("returns gateway_error when no error text provided", () => {
-		expect(getFinishReasonFromError(400)).toBe("gateway_error");
+	it("returns upstream_error when no error text provided", () => {
+		expect(getFinishReasonFromError(400)).toBe("upstream_error");
 	});
 });

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -4,7 +4,7 @@
  * 429 status codes indicate upstream rate limiting (treated as upstream error)
  * 404 status codes indicate model/endpoint not found at provider (treated as upstream error)
  * 401/403 status codes indicate authentication/authorization issues (gateway configuration errors)
- * Other 4xx status codes indicate client/gateway errors
+ * Other 4xx status codes indicate upstream provider request rejections
  * Special client errors (like JSON format validation) are classified as client_error
  *
  * Note: Error classification is separate from health tracking. The health tracking system
@@ -27,6 +27,11 @@ export function getFinishReasonFromError(
 	// 404 from upstream provider indicates model/endpoint not found at provider
 	if (statusCode === 404) {
 		return "upstream_error";
+	}
+
+	// 401/403 indicate gateway/provider credential or permission problems
+	if (statusCode === 401 || statusCode === 403) {
+		return "gateway_error";
 	}
 
 	// Azure OpenAI content filter (ResponsibleAIPolicyViolation)
@@ -62,5 +67,5 @@ export function getFinishReasonFromError(
 		}
 	}
 
-	return "gateway_error";
+	return "upstream_error";
 }

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -184,6 +184,37 @@ describe("fallback and error status code handling", () => {
 			expect(log.errorDetails?.responseText).toContain("rate_limit");
 		});
 
+		test("400 bad request is classified as upstream_error with correct error details in DB log", async () => {
+			await setupCustomKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "TRIGGER_STATUS_400" }],
+				}),
+			});
+
+			expect(res.status).toBe(500);
+			const json = await res.json();
+			expect(json).toHaveProperty("error");
+			expect(json.error.type).toBe("upstream_error");
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+
+			const log = logs[0];
+			expect(log.finishReason).toBe("upstream_error");
+			expect(log.hasError).toBe(true);
+			expect(log.errorDetails).toBeTruthy();
+			expect(log.errorDetails?.statusCode).toBe(400);
+			expect(log.errorDetails?.responseText).toContain("invalid_request");
+		});
+
 		test("404 not found is classified as upstream_error with correct error details in DB log", async () => {
 			await setupCustomKeys();
 
@@ -454,6 +485,41 @@ describe("fallback and error status code handling", () => {
 			expect(log.hasError).toBe(true);
 			expect(log.streamed).toBe(true);
 			expect(log.errorDetails?.statusCode).toBe(429);
+		});
+
+		test("streaming 400 bad request returns upstream_error SSE event and logs upstream_error", async () => {
+			await setupCustomKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "TRIGGER_STATUS_400" }],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.hasError).toBe(true);
+			expect(streamResult.errorEvents.length).toBeGreaterThan(0);
+
+			const errorEvent = streamResult.errorEvents[0];
+			expect(errorEvent.error.type).toBe("upstream_error");
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+
+			const log = logs[0];
+			expect(log.finishReason).toBe("upstream_error");
+			expect(log.hasError).toBe(true);
+			expect(log.streamed).toBe(true);
+			expect(log.errorDetails?.statusCode).toBe(400);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- classify generic upstream `400 Bad Request` provider responses as `upstream_error` instead of `gateway_error`
- keep the explicit exceptions unchanged: `401`/`403` remain `gateway_error`, `429` remains `upstream_error`, and known content-filter / client-validation cases still map to `content_filter` / `client_error`
- add regression coverage for both shared finish-reason logic and gateway fallback handling in streaming and non-streaming paths

## Verification
- `pnpm exec vitest run apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts`
- `pnpm exec tsc -p apps/gateway/tsconfig.json --noEmit`
- `apps/gateway/src/fallback.spec.ts` now includes 400 regressions, but I could not run that integration suite on this VPS because local Postgres/Redis services are unavailable here

## Why
A provider returning `400` means the upstream provider rejected the request payload. That is not a gateway-internal failure, so logging and surfacing it as `gateway_error` was misleading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to distinguish between gateway-level authentication/permission issues and upstream provider request rejections.
  * 400-level errors are now correctly categorized as upstream provider errors for more accurate diagnostics.

* **Tests**
  * Extended test coverage for error handling in both streaming and non-streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->