### PR TITLE
fix(actions): group Bedrock tool results

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -583,3 +583,100 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		expect(params.properties.plainString.type).toBe("string");
 	});
 });
+
+describe("prepareRequestBody - AWS Bedrock", () => {
+	test("should group consecutive tool results into a single user message", async () => {
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"anthropic.claude-sonnet-4-6",
+			[
+				{ role: "user", content: "What is the weather and time in Berlin?" },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "tool_1",
+							type: "function",
+							function: {
+								name: "get_weather",
+								arguments: JSON.stringify({ city: "Berlin" }),
+							},
+						},
+						{
+							id: "tool_2",
+							type: "function",
+							function: {
+								name: "get_time",
+								arguments: JSON.stringify({ city: "Berlin" }),
+							},
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "tool_1",
+					content: JSON.stringify({ temperature: 17, unit: "celsius" }),
+				},
+				{
+					role: "tool",
+					tool_call_id: "tool_2",
+					content: JSON.stringify({ time: "20:52" }),
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(3);
+		expect(requestBody.messages[0]).toEqual({
+			role: "user",
+			content: [{ text: "What is the weather and time in Berlin?" }],
+		});
+		expect(requestBody.messages[1].role).toBe("assistant");
+		expect(requestBody.messages[1].content).toHaveLength(2);
+		expect(requestBody.messages[1].content[0]).toEqual({
+			toolUse: {
+				toolUseId: "tool_1",
+				name: "get_weather",
+				input: { city: "Berlin" },
+			},
+		});
+		expect(requestBody.messages[1].content[1]).toEqual({
+			toolUse: {
+				toolUseId: "tool_2",
+				name: "get_time",
+				input: { city: "Berlin" },
+			},
+		});
+		expect(requestBody.messages[2]).toEqual({
+			role: "user",
+			content: [
+				{
+					toolResult: {
+						toolUseId: "tool_1",
+						content: [
+							{ text: JSON.stringify({ temperature: 17, unit: "celsius" }) },
+						],
+					},
+				},
+				{
+					toolResult: {
+						toolUseId: "tool_2",
+						content: [{ text: JSON.stringify({ time: "20:52" }) }],
+					},
+				},
+			],
+		});
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1200,31 +1200,57 @@ export async function prepareRequestBody(
 				}
 			}
 
-			// Transform non-system messages to Bedrock format
-			requestBody.messages = bedrockNonSystemMessages.map((msg: any) => {
-				// Map OpenAI roles to Bedrock roles
-				const role =
-					msg.role === "user" || msg.role === "tool" ? "user" : "assistant";
+			// Transform non-system messages to Bedrock format.
+			// Bedrock expects all tool results for an assistant tool_use turn to be grouped
+			// into the next user message instead of split across multiple user messages.
+			const bedrockMessages: any[] = [];
+			let pendingToolResultMessage: any | null = null;
 
-				const bedrockMessage: any = {
-					role: role,
-					content: [],
-				};
+			const flushPendingToolResults = () => {
+				if (pendingToolResultMessage?.content?.length) {
+					bedrockMessages.push(pendingToolResultMessage);
+				}
+				pendingToolResultMessage = null;
+			};
 
-				// Handle tool results (from role: "tool")
-				if (msg.role === "tool") {
-					bedrockMessage.content.push({
+			for (const msg of bedrockNonSystemMessages) {
+				const originalRole =
+					msg.role === "user" && msg.tool_call_id ? "tool" : msg.role;
+
+				if (originalRole === "tool" && msg.tool_call_id) {
+					pendingToolResultMessage ??= {
+						role: "user",
+						content: [],
+					};
+
+					const textContent =
+						typeof msg.content === "string"
+							? msg.content
+							: JSON.stringify(msg.content ?? "");
+
+					pendingToolResultMessage.content.push({
 						toolResult: {
 							toolUseId: msg.tool_call_id,
 							content: [
 								{
-									text: msg.content ?? "",
+									text:
+										textContent && textContent.trim()
+											? textContent
+											: "No output",
 								},
 							],
 						},
 					});
-					return bedrockMessage;
+					continue;
 				}
+
+				flushPendingToolResults();
+
+				const role = msg.role === "user" ? "user" : "assistant";
+				const bedrockMessage: any = {
+					role,
+					content: [],
+				};
 
 				// Handle assistant messages with tool calls
 				if (msg.role === "assistant" && msg.tool_calls) {
@@ -1246,7 +1272,8 @@ export async function prepareRequestBody(
 						});
 					});
 
-					return bedrockMessage;
+					bedrockMessages.push(bedrockMessage);
+					continue;
 				}
 
 				// Handle regular content (user/assistant messages)
@@ -1300,8 +1327,11 @@ export async function prepareRequestBody(
 					});
 				}
 
-				return bedrockMessage;
-			});
+				bedrockMessages.push(bedrockMessage);
+			}
+
+			flushPendingToolResults();
+			requestBody.messages = bedrockMessages;
 
 			// Transform tools from OpenAI format to Bedrock format
 			if (tools && tools.length > 0) {


### PR DESCRIPTION
## Summary
- group consecutive AWS Bedrock tool results into a single user message
- preserve existing Bedrock tool use and cache point handling for non-tool messages
- add a regression test for multi-tool follow-up payloads

## Problem
AWS Bedrock Converse expects all `toolResult` blocks answering an assistant `toolUse` turn to appear in the next single `user` message. We were emitting each OpenAI-style `tool` message as its own Bedrock message, which can trigger errors like:

`Expected toolResult blocks at messages.N.content for the following Ids ...`

## Testing
- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for consecutive tool result handling in AWS Bedrock integrations.

* **Improvements**
  * Optimized tool result aggregation logic in message preparation for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->