### PR TITLE
fix: sanitize bedrock tool schemas

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -585,6 +585,92 @@ describe("prepareRequestBody - Google AI Studio", () => {
 });
 
 describe("prepareRequestBody - AWS Bedrock", () => {
+	test("should sanitize complex tool schemas for Bedrock Converse", async () => {
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"anthropic.claude-sonnet-4-6",
+			[{ role: "user", content: "Run a tool" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			[
+				{
+					type: "function" as const,
+					function: {
+						name: "exec",
+						description: "Execute shell commands",
+						parameters: {
+							type: "object",
+							required: ["command"],
+							properties: {
+								command: {
+									type: "string",
+									minLength: 1,
+								},
+								env: {
+									type: "object",
+									patternProperties: {
+										"^(.*)$": {
+											type: "string",
+											minLength: 1,
+										},
+									},
+								},
+								yieldMs: {
+									type: "number",
+									minimum: 0,
+								},
+								fields: {
+									type: "array",
+									items: {
+										type: "object",
+										additionalProperties: true,
+										properties: {},
+									},
+								},
+							},
+							additionalProperties: false,
+						},
+					},
+				},
+			],
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const schema = requestBody.toolConfig.tools[0].toolSpec.inputSchema.json;
+
+		expect(schema).toEqual({
+			type: "object",
+			required: ["command"],
+			properties: {
+				command: {
+					type: "string",
+				},
+				env: {
+					type: "object",
+					properties: {},
+				},
+				yieldMs: {
+					type: "number",
+				},
+				fields: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: {},
+					},
+				},
+			},
+		});
+	});
+
 	test("should group consecutive tool results into a single user message", async () => {
 		const requestBody = (await prepareRequestBody(
 			"aws-bedrock",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -278,6 +278,109 @@ function stripUnsupportedSchemaProperties(
 }
 
 /**
+ * Recursively sanitizes tool input schemas for AWS Bedrock Converse.
+ * Bedrock is stricter than Anthropic's direct API and rejects several JSON Schema
+ * keywords that appear in OpenAI-style tool definitions from external agents.
+ *
+ * We intentionally keep a conservative subset that Bedrock accepts reliably:
+ * type, description, properties, items, required, enum, default, anyOf, oneOf, allOf.
+ */
+function sanitizeBedrockSchema(
+	schema: any,
+	rootDefs?: Record<string, any>,
+): any {
+	if (!schema || typeof schema !== "object") {
+		return schema;
+	}
+
+	if (Array.isArray(schema)) {
+		return schema.map((item) => sanitizeBedrockSchema(item, rootDefs));
+	}
+
+	const defs = rootDefs ?? schema.$defs ?? schema.definitions ?? {};
+
+	if (typeof schema.$ref === "string") {
+		const resolved = resolveRef(schema.$ref, defs);
+		if (resolved) {
+			const expanded = sanitizeBedrockSchema({ ...resolved }, defs);
+			if (schema.description && !expanded.description) {
+				expanded.description = schema.description;
+			}
+			if (schema.default !== undefined && expanded.default === undefined) {
+				expanded.default = schema.default;
+			}
+			return expanded;
+		}
+	}
+
+	const cleaned: any = {};
+	const allowedKeys = new Set([
+		"type",
+		"description",
+		"properties",
+		"items",
+		"required",
+		"enum",
+		"default",
+		"anyOf",
+		"oneOf",
+		"allOf",
+	]);
+
+	for (const [key, value] of Object.entries(schema)) {
+		if (!allowedKeys.has(key)) {
+			continue;
+		}
+
+		if (key === "description" && typeof value === "string" && !value.trim()) {
+			continue;
+		}
+
+		if (
+			key === "properties" &&
+			value &&
+			typeof value === "object" &&
+			!Array.isArray(value)
+		) {
+			cleaned.properties = Object.fromEntries(
+				Object.entries(value).map(([propertyName, propertyValue]) => [
+					propertyName,
+					sanitizeBedrockSchema(propertyValue, defs),
+				]),
+			);
+			continue;
+		}
+
+		if (value && typeof value === "object") {
+			cleaned[key] = sanitizeBedrockSchema(value, defs);
+		} else {
+			cleaned[key] = value;
+		}
+	}
+
+	if (
+		cleaned.required &&
+		Array.isArray(cleaned.required) &&
+		cleaned.properties &&
+		typeof cleaned.properties === "object"
+	) {
+		const existingProps = Object.keys(cleaned.properties);
+		cleaned.required = cleaned.required.filter((prop: string) =>
+			existingProps.includes(prop),
+		);
+		if (cleaned.required.length === 0) {
+			delete cleaned.required;
+		}
+	}
+
+	if (cleaned.type === "object" && !cleaned.properties) {
+		cleaned.properties = {};
+	}
+
+	return cleaned;
+}
+
+/**
  * Transforms messages for models that don't support system roles by converting system messages to user messages
  */
 function transformMessagesForNoSystemRole(messages: any[]): any[] {
@@ -1344,7 +1447,12 @@ export async function prepareRequestBody(
 								name: tool.function.name,
 								description: tool.function.description,
 								inputSchema: {
-									json: tool.function.parameters,
+									json: sanitizeBedrockSchema(
+										tool.function.parameters ?? {
+											type: "object",
+											properties: {},
+										},
+									),
 								},
 							},
 						})),


### PR DESCRIPTION
## Summary
- sanitize AWS Bedrock tool input schemas before sending them to Converse
- keep a conservative JSON schema subset for Bedrock and resolve `$ref` definitions
- add a regression test covering OpenClaw-style tool schemas that previously triggered `SerializationException`

## Verification
- pnpm exec vitest run packages/actions/src/prepare-request-body.spec.ts --no-file-parallelism
- pnpm format
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AWS Bedrock schema handling with automatic sanitization of complex tool schemas for enhanced compatibility.

* **Tests**
  * Added test coverage for complex tool schema sanitization in AWS Bedrock integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->