### PR TITLE
fix: include cached tokens in bedrock streaming

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1155,6 +1155,11 @@ export function transformStreamingToOpenai(
 					],
 				};
 			} else if (eventType === "metadata" && data.usage) {
+				const inputTokens = data.usage.inputTokens ?? 0;
+				const cacheReadTokens = data.usage.cacheReadInputTokens ?? 0;
+				const cacheWriteTokens = data.usage.cacheWriteInputTokens ?? 0;
+				const promptTokens = inputTokens + cacheReadTokens + cacheWriteTokens;
+
 				transformedData = {
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion.chunk",
@@ -1168,9 +1173,14 @@ export function transformStreamingToOpenai(
 						},
 					],
 					usage: {
-						prompt_tokens: data.usage.inputTokens ?? 0,
+						prompt_tokens: promptTokens,
 						completion_tokens: data.usage.outputTokens ?? 0,
 						total_tokens: data.usage.totalTokens ?? 0,
+						...(cacheReadTokens > 0 && {
+							prompt_tokens_details: {
+								cached_tokens: cacheReadTokens,
+							},
+						}),
 					},
 				};
 			} else {


### PR DESCRIPTION
## Summary
Fixed prompt caching token reporting for AWS Bedrock streaming responses. The streaming metadata event handler was only passing `inputTokens` to `prompt_tokens`, ignoring `cacheReadInputTokens` and `cacheWriteInputTokens`. This caused cached token counts to always be zero for streaming requests (which Claude Code uses).

## Changes
- Extract and sum all token types (`inputTokens`, `cacheReadInputTokens`, `cacheWriteInputTokens`) for `prompt_tokens` calculation
- Include `prompt_tokens_details.cached_tokens` in streaming usage when cache hits are present

## Impact
Cached tokens now properly report in streaming mode, allowing accurate billing discounts and cache hit visibility for Claude Code users on AWS Bedrock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved token usage calculation for AWS Bedrock integration to accurately account for all token types, including cached tokens.
  * Enhanced token consumption visibility with detailed reporting of cached token usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->