### PR TITLE
feat(models): add gpt-5.4-mini and nano

### DIFF
--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1463,7 +1463,7 @@ export const openaiModels = [
 		description:
 			"Cheapest GPT-5.4-class model for simple high-volume tasks like classification and data extraction.",
 		family: "openai",
-		releasedAt: new Date("2026-03-06"),
+		releasedAt: new Date("2026-03-17"),
 		providers: [
 			{
 				providerId: "openai",


### PR DESCRIPTION
## Summary
- Add OpenAI GPT-5.4 Mini ($0.75/$4.50 per 1M tokens) — strong mini model for coding, computer use, and subagents
- Add OpenAI GPT-5.4 Nano ($0.20/$1.25 per 1M tokens) — cheapest GPT-5.4-class model for high-volume tasks

Both models support 400K context, 128K max output, reasoning, vision, tools, web search, and structured outputs.

## Test plan
- [x] E2E tests pass with `TEST_MODELS="openai/gpt-5.4-mini,openai/gpt-5.4-nano"` (80 passed)
- [x] Prompt caching verified with cached tokens confirmed
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two new OpenAI models, gpt-5.4-mini and gpt-5.4-nano. Both models are available with published pricing, context size and max output limits, and enable advanced capabilities including streaming, vision, tools, web search, reasoning, and structured JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->