### PR TITLE
feat(docs): add introduction page

### DIFF
--- a/apps/docs/components/ai-tooling-cards.tsx
+++ b/apps/docs/components/ai-tooling-cards.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+	ArrowRight,
+	Bot,
+	FileText,
+	Plug,
+	ScrollText,
+	Sparkles,
+} from "lucide-react";
+import Link from "next/link";
+import { usePostHog } from "posthog-js/react";
+
+import type { ReactNode } from "react";
+
+interface Tool {
+	title: string;
+	description: string;
+	href: string;
+	icon: ReactNode;
+}
+
+const tools: Tool[] = [
+	{
+		title: "llms.txt",
+		description:
+			"Machine-readable index of all documentation pages for LLM consumption.",
+		href: "/llms.txt",
+		icon: <FileText className="size-5" />,
+	},
+	{
+		title: "llms-full.txt",
+		description:
+			"Complete documentation content in a single file for full-context LLM ingestion.",
+		href: "/llms-full.txt",
+		icon: <ScrollText className="size-5" />,
+	},
+	{
+		title: "MCP Server",
+		description:
+			"Use LLM Gateway as an MCP server for Claude Code, Cursor, and other MCP-compatible clients.",
+		href: "/guides/mcp",
+		icon: <Plug className="size-5" />,
+	},
+	{
+		title: "Agent Skills",
+		description:
+			"Packaged instructions and guidelines for AI coding agents to generate higher-quality code.",
+		href: "/guides/agent-skills",
+		icon: <Sparkles className="size-5" />,
+	},
+	{
+		title: "Templates & Agents",
+		description:
+			"Pre-built templates and agent configurations to get started quickly.",
+		href: "https://llmgateway.io/templates",
+		icon: <Bot className="size-5" />,
+	},
+];
+
+export function AIToolingCards() {
+	const posthog = usePostHog();
+
+	return (
+		<div className="not-prose grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+			{tools.map((tool) => (
+				<Link
+					key={tool.href}
+					href={tool.href}
+					onClick={() => {
+						posthog.capture("docs_ai_tooling_card_click", {
+							tool: tool.title,
+							href: tool.href,
+						});
+					}}
+					className="group relative flex flex-col gap-3 rounded-xl border border-fd-border bg-fd-card p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-fd-primary/40"
+				>
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-3">
+							<div className="rounded-lg bg-fd-primary/10 p-2 text-fd-primary transition-colors duration-200 group-hover:bg-fd-primary/20">
+								{tool.icon}
+							</div>
+							<h3 className="text-sm font-semibold tracking-tight text-fd-foreground">
+								{tool.title}
+							</h3>
+						</div>
+						<ArrowRight className="size-4 -translate-x-1 text-fd-muted-foreground opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 group-hover:text-fd-primary" />
+					</div>
+					<p className="text-[13px] leading-relaxed text-fd-muted-foreground">
+						{tool.description}
+					</p>
+				</Link>
+			))}
+		</div>
+	);
+}

--- a/apps/docs/components/feature-cards.tsx
+++ b/apps/docs/components/feature-cards.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import {
+	ArrowRight,
+	Bandage,
+	Braces,
+	Brain,
+	ChevronDown,
+	ClipboardList,
+	Columns3Cog,
+	Database,
+	DollarSign,
+	Eye,
+	Globe,
+	Image,
+	Key,
+	Link as LinkIcon,
+	MessageCircle,
+	Route,
+	Shield,
+	Zap,
+} from "lucide-react";
+import Link from "next/link";
+import { usePostHog } from "posthog-js/react";
+import { useState } from "react";
+
+import type { ReactNode } from "react";
+
+interface Feature {
+	title: string;
+	description: string;
+	href: string;
+	icon: ReactNode;
+}
+
+const features: Feature[] = [
+	// Core gateway value
+	{
+		title: "Routing",
+		description:
+			"Intelligently route requests to the best available models and providers.",
+		href: "/features/routing",
+		icon: <Route className="size-5" />,
+	},
+	{
+		title: "Caching",
+		description: "Reduce costs and latency by caching identical requests.",
+		href: "/features/caching",
+		icon: <Zap className="size-5" />,
+	},
+	{
+		title: "Image Generation",
+		description:
+			"Generate images using AI models through the OpenAI-compatible API.",
+		href: "/features/image-generation",
+		icon: <Image className="size-5" />,
+	},
+	// Model capabilities
+	{
+		title: "Web Search",
+		description:
+			"Enable real-time web search capabilities for up-to-date information.",
+		href: "/features/web-search",
+		icon: <Globe className="size-5" />,
+	},
+	{
+		title: "Reasoning",
+		description:
+			"Use reasoning-capable models that show their step-by-step thought process.",
+		href: "/features/reasoning",
+		icon: <Brain className="size-5" />,
+	},
+	{
+		title: "Vision",
+		description:
+			"Send images to vision-enabled models using URLs or inline base64 data.",
+		href: "/features/vision",
+		icon: <Eye className="size-5" />,
+	},
+	// Operations & management
+	{
+		title: "Cost Breakdown",
+		description:
+			"Get real-time cost information for each API request directly in the response.",
+		href: "/features/cost-breakdown",
+		icon: <DollarSign className="size-5" />,
+	},
+	{
+		title: "API Keys & IAM",
+		description:
+			"Manage API keys with fine-grained access control and IAM rules.",
+		href: "/features/api-keys",
+		icon: <Key className="size-5" />,
+	},
+	{
+		title: "Guardrails",
+		description:
+			"Protect your LLM usage with content guardrails that detect and block harmful content.",
+		href: "/features/guardrails",
+		icon: <Shield className="size-5" />,
+	},
+	{
+		title: "Audit Logs",
+		description:
+			"Track all organization activity with comprehensive audit logs.",
+		href: "/features/audit-logs",
+		icon: <ClipboardList className="size-5" />,
+	},
+	// Developer experience & compatibility
+	{
+		title: "Custom Providers",
+		description:
+			"Integrate custom OpenAI-compatible providers for enhanced flexibility.",
+		href: "/features/custom-providers",
+		icon: <Columns3Cog className="size-5" />,
+	},
+	{
+		title: "Anthropic API",
+		description: "Access any model through the familiar Anthropic API format.",
+		href: "/features/anthropic-endpoint",
+		icon: <MessageCircle className="size-5" />,
+	},
+	{
+		title: "Response Healing",
+		description:
+			"Automatically repair malformed JSON responses from AI models.",
+		href: "/features/response-healing",
+		icon: <Bandage className="size-5" />,
+	},
+	{
+		title: "Data Retention",
+		description:
+			"Store and access your full request and response data for debugging and analytics.",
+		href: "/features/data-retention",
+		icon: <Database className="size-5" />,
+	},
+	{
+		title: "Source Attribution",
+		description:
+			"Use the X-Source header to identify your domain for public usage statistics.",
+		href: "/features/source",
+		icon: <LinkIcon className="size-5" />,
+	},
+	{
+		title: "Metadata",
+		description:
+			"Send additional context and metadata to LLM Gateway using custom headers.",
+		href: "/features/metadata",
+		icon: <Braces className="size-5" />,
+	},
+];
+
+const INITIAL_COUNT = 6;
+
+export function FeatureCards() {
+	const posthog = usePostHog();
+	const [expanded, setExpanded] = useState(false);
+
+	const visible = expanded ? features : features.slice(0, INITIAL_COUNT);
+	const remaining = features.length - INITIAL_COUNT;
+
+	return (
+		<div className="not-prose">
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+				{visible.map((feature) => (
+					<Link
+						key={feature.href}
+						href={feature.href}
+						onClick={() => {
+							posthog.capture("docs_feature_card_click", {
+								feature: feature.title,
+								href: feature.href,
+							});
+						}}
+						className="group relative flex flex-col gap-3 rounded-xl border border-fd-border bg-fd-card p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-fd-primary/40"
+					>
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-3">
+								<div className="rounded-lg bg-fd-primary/10 p-2 text-fd-primary transition-colors duration-200 group-hover:bg-fd-primary/20">
+									{feature.icon}
+								</div>
+								<h3 className="text-sm font-semibold tracking-tight text-fd-foreground">
+									{feature.title}
+								</h3>
+							</div>
+							<ArrowRight className="size-4 -translate-x-1 text-fd-muted-foreground opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 group-hover:text-fd-primary" />
+						</div>
+						<p className="text-[13px] leading-relaxed text-fd-muted-foreground">
+							{feature.description}
+						</p>
+					</Link>
+				))}
+			</div>
+			{!expanded && (
+				<button
+					type="button"
+					onClick={() => setExpanded(true)}
+					className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-fd-border bg-fd-card px-4 py-2.5 text-sm font-medium text-fd-muted-foreground transition-colors duration-200 hover:bg-fd-accent hover:text-fd-foreground"
+				>
+					Show {remaining} more features
+					<ChevronDown className="size-4" />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -1,52 +1,26 @@
 ---
-title: Overview
-description: Introduction to LLM Gateway, an open-source API gateway for LLMs.
-icon: Notebook
+title: Introduction
+description: LLM Gateway is an open-source API gateway for Large Language Models. Route requests to multiple providers, manage API keys, track usage, and optimize costs.
+icon: BookOpen
 ---
 
-# LLM Gateway
+import { FeatureCards } from "@/components/feature-cards";
+import { AIToolingCards } from "@/components/ai-tooling-cards";
 
-LLM Gateway is an open-source API gateway for Large Language Models (LLMs). It acts as a middleware between your applications and various LLM providers, allowing you to:
+LLM Gateway is an open-source API gateway that sits between your applications and LLM providers like OpenAI, Anthropic, Google AI Studio, and more. It provides a unified, OpenAI-compatible API interface with built-in cost tracking, caching, and intelligent routing.
 
-- Route requests to multiple LLM providers (OpenAI, Anthropic, Google AI Studio, and others)
-- Manage API keys for different providers in one place
-- Track token usage and costs across all your LLM interactions
-- Analyze performance metrics to optimize your LLM usage
+## Features
 
-## Analyzing Your LLM Requests
+<FeatureCards />
 
-LLM Gateway provides detailed insights into your LLM usage:
+## AI Tooling
 
-- **Usage Metrics**: Track the number of requests, tokens used, and response times
-- **Cost Analysis**: Monitor spending across different models and providers
-- **Performance Tracking**: Identify patterns and optimize your prompts based on actual usage data
-- **Breakdown by Model**: Compare different models' performance and cost-effectiveness
+LLM Gateway is built to work seamlessly with AI agents and development tools.
 
-All this data is automatically collected and presented in an intuitive dashboard, helping you make informed decisions about your LLM strategy.
+<AIToolingCards />
 
-## Getting Started
+## Next Steps
 
-Using LLM Gateway is simple. Just swap out your current LLM provider URL with the LLM Gateway API endpoint:
-
-```bash
-curl -X POST https://api.llmgateway.io/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
-  -d '{
-  "model": "gpt-4o",
-  "messages": [
-    {"role": "user", "content": "Hello, how are you?"}
-  ]
-}'
-```
-
-LLM Gateway maintains compatibility with the OpenAI API format, making migration seamless.
-
-## Hosted vs. Self-Hosted
-
-You can use LLM Gateway in two ways:
-
-- **Hosted Version**: For immediate use without setup, visit [llmgateway.io](https://llmgateway.io) to create an account and get an API key.
-- **Self-Hosted**: Deploy LLM Gateway on your own infrastructure for complete control over your data and configuration.
-
-The self-hosted version offers additional customization options and ensures your LLM traffic never leaves your infrastructure if desired.
+- [**Quickstart**](/quick-start) — Get up and running in minutes
+- [**Overview**](/overview) — Learn more about what LLM Gateway offers
+- [**Self-Host**](/self-host) — Deploy on your own infrastructure

--- a/apps/docs/content/meta.json
+++ b/apps/docs/content/meta.json
@@ -6,6 +6,7 @@
 	"pages": [
 		"---Developer Docs---",
 		"index",
+		"overview",
 		"quick-start",
 		"self-host",
 		"features",

--- a/apps/docs/content/overview.mdx
+++ b/apps/docs/content/overview.mdx
@@ -1,0 +1,52 @@
+---
+title: Overview
+description: Introduction to LLM Gateway, an open-source API gateway for LLMs.
+icon: Notebook
+---
+
+# LLM Gateway
+
+LLM Gateway is an open-source API gateway for Large Language Models (LLMs). It acts as a middleware between your applications and various LLM providers, allowing you to:
+
+- Route requests to multiple LLM providers (OpenAI, Anthropic, Google AI Studio, and others)
+- Manage API keys for different providers in one place
+- Track token usage and costs across all your LLM interactions
+- Analyze performance metrics to optimize your LLM usage
+
+## Analyzing Your LLM Requests
+
+LLM Gateway provides detailed insights into your LLM usage:
+
+- **Usage Metrics**: Track the number of requests, tokens used, and response times
+- **Cost Analysis**: Monitor spending across different models and providers
+- **Performance Tracking**: Identify patterns and optimize your prompts based on actual usage data
+- **Breakdown by Model**: Compare different models' performance and cost-effectiveness
+
+All this data is automatically collected and presented in an intuitive dashboard, helping you make informed decisions about your LLM strategy.
+
+## Getting Started
+
+Using LLM Gateway is simple. Just swap out your current LLM provider URL with the LLM Gateway API endpoint:
+
+```bash
+curl -X POST https://api.llmgateway.io/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -d '{
+  "model": "gpt-4o",
+  "messages": [
+    {"role": "user", "content": "Hello, how are you?"}
+  ]
+}'
+```
+
+LLM Gateway maintains compatibility with the OpenAI API format, making migration seamless.
+
+## Hosted vs. Self-Hosted
+
+You can use LLM Gateway in two ways:
+
+- **Hosted Version**: For immediate use without setup, visit [llmgateway.io](https://llmgateway.io) to create an account and get an API key.
+- **Self-Hosted**: Deploy LLM Gateway on your own infrastructure for complete control over your data and configuration.
+
+The self-hosted version offers additional customization options and ensures your LLM traffic never leaves your infrastructure if desired.


### PR DESCRIPTION
## Summary
- Add new Introduction index page with interactive feature cards and AI tooling cards
- Move previous Overview content to `/overview` route
- Add PostHog tracking events (`docs_feature_card_click`, `docs_ai_tooling_card_click`) to measure which docs pages users navigate to most
- Show top 6 features (Routing, Caching, Image Gen, Web Search, Reasoning, Vision) with expand button for remaining 10
- Add AI Tooling section covering llms.txt, llms-full.txt, MCP, Agent Skills, and Templates & Agents

## Test plan
- [ ] Verify `/` renders the new Introduction page with feature cards grid
- [ ] Verify `/overview` renders the previous Overview content
- [ ] Verify feature cards expand/collapse works
- [ ] Verify PostHog events fire on card clicks
- [ ] Verify sidebar navigation shows both Introduction and Overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive AI Tooling Cards with analytics tracking on card clicks
  * Added expandable Feature Cards component with "Show more" functionality

* **Documentation**
  * Reorganized documentation homepage with improved modular component layout
  * Added new Overview page with getting started guides and deployment options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->