### PR TITLE
fix(models): add missing canopywave cache pricing

### DIFF
--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -29,6 +29,7 @@ export const minimaxModels = [
 				test: "skip",
 				modelName: "minimax/minimax-m2.5",
 				inputPrice: 0.27 / 1e6,
+				cachedInputPrice: 0.03 / 1e6,
 				outputPrice: 1.08 / 1e6,
 				discount: 0.3,
 				requestPrice: 0,

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -204,6 +204,7 @@ export const moonshotModels = [
 				test: "skip",
 				modelName: "moonshotai/kimi-k2.5",
 				inputPrice: 0.5 / 1e6,
+				cachedInputPrice: 0.1 / 1e6,
 				outputPrice: 2.8 / 1e6,
 				discount: 0.3,
 				requestPrice: 0,

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -31,6 +31,7 @@ export const zaiModels = [
 				test: "skip",
 				modelName: "zai/glm-5",
 				inputPrice: 0.9 / 1e6,
+				cachedInputPrice: 0.2 / 1e6,
 				outputPrice: 3.1 / 1e6,
 				discount: 0.3,
 				requestPrice: 0,


### PR DESCRIPTION
## Summary
- add missing `cachedInputPrice` values for canopywave `minimax-m2.5`, `kimi-k2.5`, and `glm-5`
- keep `deepseek-v3.2` unchanged because its canopywave cache price is already present
- note that `Mimo-V2-Flash` is not currently defined in the models catalog

## Testing
- `pnpm --filter @llmgateway/models build`