### PR TITLE
fix(gateway): avoid double counting cached tokens in storage cost

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -137,9 +137,11 @@ describe("calculateDataStorageCost", () => {
 		expect(cost).toBe("0.01"); // 1M tokens * $0.01 per 1M = $0.01
 	});
 
-	it("includes all token types in calculation", () => {
-		// 250k prompt + 250k cached + 250k completion + 250k reasoning = 1M tokens
-		const cost = calculateDataStorageCost(250000, 250000, 250000, 250000);
+	it("does not double-count cached tokens when promptTokens already includes them", () => {
+		// promptTokens is the canonical input count in gateway logs.
+		// cachedTokens is tracked separately for pricing and diagnostics, but should
+		// not increase storage accounting a second time.
+		const cost = calculateDataStorageCost(500000, 250000, 250000, 250000);
 		expect(cost).toBe("0.01"); // 1M tokens * $0.01 per 1M = $0.01
 	});
 

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -144,7 +144,9 @@ function getErrorTypeFromUnifiedFinishReason(
 
 /**
  * Calculate data storage cost based on token usage
- * $0.01 per 1M tokens (total tokens = input + cached + output + reasoning)
+ * $0.01 per 1M tokens (total tokens = input + output + reasoning)
+ * promptTokens is the canonical total input count and already includes cached
+ * input tokens for providers that report them separately.
  * Returns "0" if retention level is "none" since no data is stored
  */
 export function calculateDataStorageCost(
@@ -160,11 +162,10 @@ export function calculateDataStorageCost(
 	}
 
 	const prompt = Number(promptTokens) || 0;
-	const cached = Number(cachedTokens) || 0;
 	const completion = Number(completionTokens) || 0;
 	const reasoning = Number(reasoningTokens) || 0;
 
-	const totalTokens = prompt + cached + completion + reasoning;
+	const totalTokens = prompt + completion + reasoning;
 
 	// $0.01 per 1M tokens
 	const cost = (totalTokens / 1_000_000) * 0.01;


### PR DESCRIPTION
## Summary
- stop adding `cachedTokens` twice when calculating `dataStorageCost`
- document that `promptTokens` is the canonical total input count
- add a regression test covering cached-token storage accounting

## Testing
- pnpm --filter gateway exec vitest run src/lib/logs.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed token cost calculation to prevent double-counting of cached tokens. The system now correctly recognizes that prompt token counts already include cached tokens where applicable, ensuring accurate cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->