### PR TITLE
fix: disable moonshot thinking for tools

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -803,16 +803,7 @@ export async function prepareRequestBody(
 	}
 
 	if (forcesToolUse && usedProvider === "moonshot") {
-		const providerMapping = modelDef?.providers.find(
-			(p) => p.modelName === usedModel && p.providerId === usedProvider,
-		);
-		const isExplicitThinkingModel =
-			providerMapping &&
-			"reasoning" in providerMapping &&
-			providerMapping.reasoning === true;
-		if (!isExplicitThinkingModel) {
-			requestBody.thinking = { enabled: false };
-		}
+		requestBody.thinking = { enabled: false };
 	}
 
 	// Override temperature to 1 for GPT-5 models (they only support temperature = 1)


### PR DESCRIPTION
## Summary
- disable Moonshot thinking when tool use is forced so kimi-k2.5 accepts required tool calls
- preserve existing Moonshot reasoning metadata in model definitions
- validate with Moonshot tool-call tests plus format/build

## Validation
- pnpm vitest run apps/gateway/src/chat-toolcalls.e2e.ts -c vitest/vitest.e2e.config.mts --reporter=verbose
- pnpm vitest run apps/gateway/src/chat-toolcalls-result.e2e.ts -c vitest/vitest.e2e.config.mts --reporter=verbose
- pnpm format
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal request handling logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->