### PR TITLE
feat: add Codex CLI and Autohand guides

### DIFF
--- a/apps/docs/content/guides/autohand.mdx
+++ b/apps/docs/content/guides/autohand.mdx
@@ -1,0 +1,115 @@
+---
+title: Autohand Integration
+description: Use GPT-5, Claude, Gemini, or any model with Autohand's autonomous coding agent. Simple config, full cost tracking.
+icon: Autohand
+---
+
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Callout } from "fumadocs-ui/components/callout";
+
+Autohand is an autonomous AI coding agent that works in your terminal, IDE, and Slack. With LLM Gateway, you can route all Autohand requests through a single gateway—use any of 180+ models from 60+ providers, with full cost tracking and smart routing.
+
+## Setup
+
+<Steps>
+<Step>
+### Sign Up for LLM Gateway
+
+[Sign up free](https://llmgateway.io/signup) — no credit card required. Copy your API key from the dashboard.
+
+</Step>
+
+<Step>
+### Set Environment Variables
+
+Configure Autohand to use LLM Gateway:
+
+```bash
+export OPENAI_BASE_URL=https://api.llmgateway.io/v1
+export OPENAI_API_KEY=llmgtwy_your_api_key_here
+```
+
+</Step>
+
+<Step>
+### Run Autohand
+
+```bash
+autohand
+```
+
+All requests will now be routed through LLM Gateway.
+
+</Step>
+</Steps>
+
+## Why Use LLM Gateway with Autohand
+
+- **180+ models** — GPT-5, Claude Opus, Gemini, Llama, and more from 60+ providers
+- **Smart routing** — Automatically selects the best provider based on uptime, throughput, price, and latency
+- **Cost tracking** — Monitor exactly how much each autonomous session costs
+- **Single bill** — No need to manage multiple API provider accounts
+- **Response caching** — Repeated requests hit cache automatically
+- **Automatic failover** — If one provider is down, requests route to another
+
+## Configuration File
+
+You can also configure LLM Gateway in Autohand's config file:
+
+```json
+{
+	"provider": {
+		"llmgateway": {
+			"baseUrl": "https://api.llmgateway.io/v1",
+			"apiKey": "llmgtwy_your_api_key_here"
+		}
+	},
+	"model": "gpt-5"
+}
+```
+
+## Choosing Models
+
+You can use any model from the [models page](https://llmgateway.io/models).
+
+| Model               | Best For                                    |
+| ------------------- | ------------------------------------------- |
+| `gpt-5`             | Latest OpenAI flagship, highest quality     |
+| `claude-opus-4-6`   | Anthropic's most capable model              |
+| `claude-sonnet-4-6` | Fast reasoning with extended thinking       |
+| `gemini-2.5-pro`    | Google's latest flagship, 1M context window |
+| `o3`                | Advanced reasoning tasks                    |
+| `gpt-5-mini`        | Cost-effective, quick responses             |
+| `gemini-2.5-flash`  | Fast responses, good for high-volume        |
+| `deepseek-v3.1`     | Open-source with vision and tools           |
+
+## Autohand Features with LLM Gateway
+
+### Terminal (CLI)
+
+Autohand CLI works seamlessly with LLM Gateway. Set the environment variables and use all Autohand commands as normal—multi-file editing, agentic search, and autonomous code generation all work out of the box.
+
+### IDE Integration
+
+Autohand's VS Code and Zed extensions respect the same environment variables. Set them in your shell profile and the IDE integration will automatically route through LLM Gateway.
+
+### Slack Integration
+
+When using Autohand through Slack, configure the LLM Gateway base URL in your Autohand server settings to route all Slack-triggered coding tasks through the gateway.
+
+## Monitoring Usage
+
+Once configured, all Autohand requests appear in your LLM Gateway dashboard:
+
+- **Request logs** — See every prompt and response
+- **Cost breakdown** — Track spending by model and time period
+- **Usage analytics** — Understand your AI usage patterns
+
+<Callout type="info">
+	View all available models on the [models page](https://llmgateway.io/models).
+</Callout>
+
+<Callout type="info">
+	Need help? Join our [Discord community](https://llmgateway.io/discord) for
+	support and troubleshooting assistance.
+</Callout>

--- a/apps/docs/content/guides/codex-cli.mdx
+++ b/apps/docs/content/guides/codex-cli.mdx
@@ -1,0 +1,145 @@
+---
+title: Codex CLI Integration
+description: Use any model with OpenAI's Codex CLI through LLM Gateway. One config file, full cost tracking.
+icon: CodexCli
+---
+
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Callout } from "fumadocs-ui/components/callout";
+
+Codex CLI is OpenAI's open-source terminal coding agent. By default it connects to OpenAI's API, but with LLM Gateway you can route it through a single gateway—use GPT-5.3 Codex, Gemini, Claude, or any of 180+ models while keeping full cost visibility.
+
+One config file. No code changes. Full cost tracking in your dashboard.
+
+## Setup
+
+<Steps>
+<Step>
+### Sign Up for LLM Gateway
+
+[Sign up free](https://llmgateway.io/signup) — no credit card required. Copy your API key from the dashboard.
+
+</Step>
+
+<Step>
+### Set Your API Key
+
+Set your LLM Gateway API key as the OpenAI key:
+
+```bash
+export OPENAI_API_KEY=llmgtwy_your_api_key_here
+```
+
+</Step>
+
+<Step>
+### Create Config File
+
+Create or edit `~/.codex/config.toml`:
+
+```bash
+openai_base_url = "https://api.llmgateway.io/v1"
+model = "auto"
+model_reasoning_effort = "high"
+
+[tui]
+show_tooltips = false
+
+[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.llmgateway.io/v1"
+```
+
+</Step>
+
+<Step>
+### Run Codex CLI
+
+```bash
+codex
+```
+
+All requests will now be routed through LLM Gateway.
+
+</Step>
+</Steps>
+
+## Why This Works
+
+LLM Gateway's `/v1` endpoint is fully OpenAI-compatible. Codex CLI sends requests to our gateway instead of OpenAI directly, and we route them to the right provider behind the scenes. This means:
+
+- **Use any model** — GPT-5.3 Codex, Gemini, Claude, or 180+ others
+- **Keep your workflow** — Codex CLI doesn't know the difference
+- **Track costs** — Every request appears in your LLM Gateway dashboard
+- **Automatic caching** — Repeated requests hit cache, saving money
+
+## Configuration Explained
+
+### Base URL
+
+The `openai_base_url` and `base_url` fields point Codex CLI to LLM Gateway instead of OpenAI:
+
+```bash
+openai_base_url = "https://api.llmgateway.io/v1"
+```
+
+### Model Selection
+
+Use `auto` to let LLM Gateway pick the best model, or set a specific one from the [models page](https://llmgateway.io/models):
+
+```bash
+model = "auto"
+# or pick a specific model
+model = "gpt-5.3-codex"
+```
+
+### Reasoning Effort
+
+Control how much reasoning the model uses. Options are `low`, `medium`, and `high`:
+
+```bash
+model_reasoning_effort = "high"
+```
+
+## Choosing Models
+
+Use `auto` to let LLM Gateway pick the best model automatically, or choose a specific one from the [models page](https://llmgateway.io/models):
+
+```bash
+# let LLM Gateway pick the best model
+model = "auto"
+
+# or pick a specific model
+model = "gpt-5.3-codex"
+```
+
+## What You Get
+
+- **Any model in Codex CLI** — GPT-5.3 Codex for heavy lifting, lighter models for routine tasks
+- **Cost visibility** — See exactly what each coding session costs
+- **One bill** — Stop managing separate accounts for OpenAI, Anthropic, Google
+- **Response caching** — Repeated requests hit cache automatically
+- **Discounts** — Check [discounted models](https://llmgateway.io/models?discounted=true) for savings up to 90%
+
+## Troubleshooting
+
+### Authentication errors
+
+Make sure your `OPENAI_API_KEY` environment variable is set to your LLM Gateway API key (starts with `llmgtwy_`).
+
+### Model not found
+
+Verify the model ID matches exactly what's listed on the [models page](https://llmgateway.io/models). Model IDs are case-sensitive.
+
+### Connection issues
+
+Check that `base_url` is set to `https://api.llmgateway.io/v1` (note the `/v1` at the end).
+
+<Callout type="info">
+	View all available models on the [models page](https://llmgateway.io/models).
+</Callout>
+
+<Callout type="info">
+	Need help? Join our [Discord community](https://llmgateway.io/discord) for
+	support and troubleshooting assistance.
+</Callout>

--- a/apps/docs/lib/custom-icons.tsx
+++ b/apps/docs/lib/custom-icons.tsx
@@ -104,6 +104,102 @@ export const customIcons: Record<string, IconComponent> = {
 			</g>
 		</svg>
 	),
+	CodexCli: (props) => (
+		<svg
+			fill="currentColor"
+			fillRule="evenodd"
+			style={{ flex: "none", lineHeight: "1" }}
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			{...props}
+		>
+			<path
+				clipRule="evenodd"
+				d="M8.086.457a6.105 6.105 0 0 1 3.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 0 0 .107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 0 1-.18 1.631.167.167 0 0 0 .04.155 5.982 5.982 0 0 1 1.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 0 1-2.934 1.851.162.162 0 0 0-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 0 0-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 0 1-2.595-.622 6.058 6.058 0 0 1-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 0 1-.495-1.283 6.11 6.11 0 0 1-.017-3.064.166.166 0 0 0 .008-.074.115.115 0 0 0-.037-.064 5.958 5.958 0 0 1-1.38-2.202 5.196 5.196 0 0 1-.333-1.589 6.915 6.915 0 0 1 .188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 0 0 .087-.087A6.016 6.016 0 0 1 5.635 2.31C6.315 1.464 7.132.846 8.086.457m-.804 7.85a.848.848 0 0 0-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 0 0 1.46.864l1.94-3.272a.849.849 0 0 0 .007-.854zm5.446 6.24a.849.849 0 0 0 0 1.695h4.848a.849.849 0 0 0 0-1.696h-4.848z"
+			/>
+		</svg>
+	),
+	Autohand: (props) => (
+		<svg
+			style={{ flex: "none", lineHeight: "1" }}
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 200 100"
+			{...props}
+		>
+			<circle
+				cx="25"
+				cy="25"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="25" cy="25" r="8" fill="currentColor" />
+			<circle
+				cx="75"
+				cy="25"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="75" cy="25" r="8" fill="currentColor" />
+			<circle
+				cx="125"
+				cy="25"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="125" cy="25" r="8" fill="currentColor" />
+			<circle
+				cx="175"
+				cy="25"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="175" cy="25" r="8" fill="currentColor" />
+			<circle
+				cx="25"
+				cy="75"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="25" cy="75" r="8" fill="currentColor" />
+			<circle
+				cx="75"
+				cy="75"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="75" cy="75" r="8" fill="currentColor" />
+			<circle
+				cx="125"
+				cy="75"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="125" cy="75" r="8" fill="currentColor" />
+			<circle
+				cx="175"
+				cy="75"
+				r="20"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="8"
+			/>
+			<circle cx="175" cy="75" r="8" fill="currentColor" />
+		</svg>
+	),
 	Mcp: (props) => (
 		<svg
 			fill="currentColor"

--- a/apps/ui/src/components/integrations/integration-cards.tsx
+++ b/apps/ui/src/components/integrations/integration-cards.tsx
@@ -6,6 +6,8 @@ import { Card } from "@/lib/components/card";
 
 import {
 	AnthropicIcon,
+	AutohandIcon,
+	CodexIcon,
 	OpenClawIcon,
 	ClineIcon,
 	CursorIcon,
@@ -29,6 +31,14 @@ interface Integration {
 
 const integrations: Integration[] = [
 	{
+		name: "Autohand",
+		description:
+			"Use LLM Gateway with Autohand for autonomous AI-powered coding in your terminal, IDE, and Slack.",
+		href: "/guides/autohand",
+		icon: AutohandIcon,
+		comingSoon: false,
+	},
+	{
 		name: "Claude Code",
 		description:
 			"Use LLM Gateway with Claude Code for AI-powered terminal assistance and coding.",
@@ -44,6 +54,14 @@ const integrations: Integration[] = [
 		icon: CursorIcon,
 		comingSoon: false,
 		badge: "Plan mode only",
+	},
+	{
+		name: "Codex CLI",
+		description:
+			"Use LLM Gateway with OpenAI's Codex CLI for AI-powered terminal coding.",
+		href: "/guides/codex-cli",
+		icon: CodexIcon,
+		comingSoon: false,
 	},
 	{
 		name: "Cline",

--- a/apps/ui/src/content/guides/autohand.md
+++ b/apps/ui/src/content/guides/autohand.md
@@ -1,0 +1,97 @@
+---
+id: autohand
+slug: autohand
+title: Autohand Integration
+description: Use GPT-5, Claude, Gemini, or any model with Autohand's autonomous coding agent. Simple config, full cost tracking.
+date: 2026-03-19
+---
+
+Autohand is an autonomous AI coding agent that works in your terminal, IDE, and Slack. With LLM Gateway, you can route all Autohand requests through a single gateway—use any of 180+ models from 60+ providers, with full cost tracking and smart routing.
+
+## Quick Start
+
+Configure Autohand to use LLM Gateway by setting the base URL and API key:
+
+```bash
+export OPENAI_BASE_URL=https://api.llmgateway.io/v1
+export OPENAI_API_KEY=llmgtwy_your_api_key_here
+```
+
+Then start Autohand as usual:
+
+```bash
+autohand
+```
+
+Autohand will now route all requests through LLM Gateway.
+
+## Configuration File
+
+You can also configure LLM Gateway in Autohand's config file. Add or update the provider settings:
+
+```json
+{
+  "provider": {
+    "llmgateway": {
+      "baseUrl": "https://api.llmgateway.io/v1",
+      "apiKey": "llmgtwy_your_api_key_here"
+    }
+  },
+  "model": "gpt-5"
+}
+```
+
+## Why Use LLM Gateway with Autohand
+
+- **180+ models** — GPT-5, Claude Opus, Gemini, Llama, and more from 60+ providers
+- **Smart routing** — Automatically selects the best provider based on uptime, throughput, price, and latency
+- **Cost tracking** — Monitor exactly how much each autonomous session costs
+- **Single bill** — No need to manage multiple API provider accounts
+- **Response caching** — Repeated requests hit cache automatically
+- **Automatic failover** — If one provider is down, requests route to another
+
+## Choosing Models
+
+You can use any model from the [models page](https://llmgateway.io/models). Popular options for Autohand:
+
+| Model               | Best For                                    |
+| ------------------- | ------------------------------------------- |
+| `gpt-5`             | Latest OpenAI flagship, highest quality     |
+| `claude-opus-4-6`   | Anthropic's most capable model              |
+| `claude-sonnet-4-6` | Fast reasoning with extended thinking       |
+| `gemini-2.5-pro`    | Google's latest flagship, 1M context window |
+| `o3`                | Advanced reasoning tasks                    |
+| `gpt-5-mini`        | Cost-effective, quick responses             |
+| `gemini-2.5-flash`  | Fast responses, good for high-volume        |
+| `deepseek-v3.1`     | Open-source with vision and tools           |
+
+## Autohand Features with LLM Gateway
+
+### Terminal (CLI)
+
+Autohand CLI works seamlessly with LLM Gateway. Set the environment variables and use all Autohand commands as normal—multi-file editing, agentic search, and autonomous code generation all work out of the box.
+
+### IDE Integration
+
+Autohand's VS Code and Zed extensions respect the same environment variables. Set them in your shell profile and the IDE integration will automatically route through LLM Gateway.
+
+### Slack Integration
+
+When using Autohand through Slack, configure the LLM Gateway base URL in your Autohand server settings to route all Slack-triggered coding tasks through the gateway.
+
+## Monitoring Usage
+
+Once configured, all Autohand requests appear in your LLM Gateway dashboard:
+
+- **Request logs** — See every prompt and response
+- **Cost breakdown** — Track spending by model and time period
+- **Usage analytics** — Understand your AI usage patterns
+
+## Get Started
+
+1. [Sign up free](https://llmgateway.io/signup) — no credit card required
+2. Copy your API key from the dashboard
+3. Set the environment variables above
+4. Run `autohand` and start coding
+
+Questions? Check [our docs](https://docs.llmgateway.io) or [join Discord](https://llmgateway.io/discord).

--- a/apps/ui/src/content/guides/codex-cli.md
+++ b/apps/ui/src/content/guides/codex-cli.md
@@ -1,0 +1,120 @@
+---
+id: codex-cli
+slug: codex-cli
+title: Codex CLI Integration
+description: Use any model with OpenAI's Codex CLI through LLM Gateway. One config file, full cost tracking.
+date: 2026-03-19
+---
+
+Codex CLI is OpenAI's open-source terminal coding agent. By default it connects to OpenAI's API, but with LLM Gateway you can route it through a single gateway—use GPT-5.3 Codex, Gemini, Claude, or any of 180+ models while keeping full cost visibility.
+
+One config file. No code changes. Full cost tracking in your dashboard.
+
+## Quick Start
+
+Create or edit your Codex CLI config file at `~/.codex/config.toml`:
+
+```bash
+openai_base_url = "https://api.llmgateway.io/v1"
+model = "auto"
+model_reasoning_effort = "high"
+
+[tui]
+show_tooltips = false
+
+[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.llmgateway.io/v1"
+```
+
+Then set your API key:
+
+```bash
+export OPENAI_API_KEY=llmgtwy_your_api_key_here
+```
+
+Now run Codex CLI as usual:
+
+```bash
+codex
+```
+
+## Why This Works
+
+LLM Gateway's `/v1` endpoint is fully OpenAI-compatible. Codex CLI sends requests to our gateway instead of OpenAI directly, and we route them to the right provider behind the scenes. This means:
+
+- **Use any model** — GPT-5.3 Codex, Gemini, Claude, or 180+ others
+- **Keep your workflow** — Codex CLI doesn't know the difference
+- **Track costs** — Every request appears in your LLM Gateway dashboard
+- **Automatic caching** — Repeated requests hit cache, saving money
+
+## Configuration Explained
+
+### Base URL
+
+The `openai_base_url` and `base_url` fields point Codex CLI to LLM Gateway instead of OpenAI:
+
+```bash
+openai_base_url = "https://api.llmgateway.io/v1"
+```
+
+### Model Selection
+
+Use `auto` to let LLM Gateway pick the best model, or set a specific one from the [models page](https://llmgateway.io/models):
+
+```bash
+model = "auto"
+# or pick a specific model
+model = "gpt-5.3-codex"
+```
+
+### Reasoning Effort
+
+Control how much reasoning the model uses. Options are `low`, `medium`, and `high`:
+
+```bash
+model_reasoning_effort = "high"
+```
+
+## Choosing Models
+
+Use `auto` to let LLM Gateway pick the best model automatically, or choose a specific one from the [models page](https://llmgateway.io/models):
+
+```bash
+# let LLM Gateway pick the best model
+model = "auto"
+
+# or pick a specific model
+model = "gpt-5.3-codex"
+```
+
+## What You Get
+
+- **Any model in Codex CLI** — GPT-5.3 Codex for heavy lifting, lighter models for routine tasks
+- **Cost visibility** — See exactly what each coding session costs
+- **One bill** — Stop managing separate accounts for OpenAI, Anthropic, Google
+- **Response caching** — Repeated requests hit cache automatically
+- **Discounts** — Check [discounted models](/models?discounted=true) for savings up to 90%
+
+## Troubleshooting
+
+### Authentication errors
+
+Make sure your `OPENAI_API_KEY` environment variable is set to your LLM Gateway API key (starts with `llmgtwy_`).
+
+### Model not found
+
+Verify the model ID matches exactly what's listed on the [models page](https://llmgateway.io/models). Model IDs are case-sensitive.
+
+### Connection issues
+
+Check that `base_url` is set to `https://api.llmgateway.io/v1` (note the `/v1` at the end).
+
+## Get Started
+
+1. [Sign up free](https://llmgateway.io/signup) — no credit card required
+2. Copy your API key from the dashboard
+3. Create the config file above
+4. Run `codex` and start coding
+
+Questions? Check [our docs](https://docs.llmgateway.io) or [join Discord](https://llmgateway.io/discord).

--- a/packages/shared/src/components/integration-icons.tsx
+++ b/packages/shared/src/components/integration-icons.tsx
@@ -65,6 +65,102 @@ export const VSCodeIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
 	</svg>
 );
 
+// Codex CLI Icon
+export const CodexIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		fill="currentColor"
+		fillRule="evenodd"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		{...props}
+	>
+		<path
+			clipRule="evenodd"
+			d="M8.086.457a6.105 6.105 0 0 1 3.046-.415c1.333.153 2.521.72 3.564 1.7a.117.117 0 0 0 .107.029c1.408-.346 2.762-.224 4.061.366l.063.03.154.076c1.357.703 2.33 1.77 2.918 3.198.278.679.418 1.388.421 2.126a5.655 5.655 0 0 1-.18 1.631.167.167 0 0 0 .04.155 5.982 5.982 0 0 1 1.578 2.891c.385 1.901-.01 3.615-1.183 5.14l-.182.22a6.063 6.063 0 0 1-2.934 1.851.162.162 0 0 0-.108.102c-.255.736-.511 1.364-.987 1.992-1.199 1.582-2.962 2.462-4.948 2.451-1.583-.008-2.986-.587-4.21-1.736a.145.145 0 0 0-.14-.032c-.518.167-1.04.191-1.604.185a5.924 5.924 0 0 1-2.595-.622 6.058 6.058 0 0 1-2.146-1.781c-.203-.269-.404-.522-.551-.821a7.74 7.74 0 0 1-.495-1.283 6.11 6.11 0 0 1-.017-3.064.166.166 0 0 0 .008-.074.115.115 0 0 0-.037-.064 5.958 5.958 0 0 1-1.38-2.202 5.196 5.196 0 0 1-.333-1.589 6.915 6.915 0 0 1 .188-2.132c.45-1.484 1.309-2.648 2.577-3.493.282-.188.55-.334.802-.438.286-.12.573-.22.861-.304a.129.129 0 0 0 .087-.087A6.016 6.016 0 0 1 5.635 2.31C6.315 1.464 7.132.846 8.086.457m-.804 7.85a.848.848 0 0 0-1.473.842l1.694 2.965-1.688 2.848a.849.849 0 0 0 1.46.864l1.94-3.272a.849.849 0 0 0 .007-.854zm5.446 6.24a.849.849 0 0 0 0 1.695h4.848a.849.849 0 0 0 0-1.696h-4.848z"
+		/>
+	</svg>
+);
+
+// Autohand Icon
+export const AutohandIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
+	props,
+) => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100" {...props}>
+		<circle
+			cx="25"
+			cy="25"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="25" cy="25" r="8" fill="currentColor" />
+		<circle
+			cx="75"
+			cy="25"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="75" cy="25" r="8" fill="currentColor" />
+		<circle
+			cx="125"
+			cy="25"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="125" cy="25" r="8" fill="currentColor" />
+		<circle
+			cx="175"
+			cy="25"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="175" cy="25" r="8" fill="currentColor" />
+		<circle
+			cx="25"
+			cy="75"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="25" cy="75" r="8" fill="currentColor" />
+		<circle
+			cx="75"
+			cy="75"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="75" cy="75" r="8" fill="currentColor" />
+		<circle
+			cx="125"
+			cy="75"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="125" cy="75" r="8" fill="currentColor" />
+		<circle
+			cx="175"
+			cy="75"
+			r="20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="8"
+		/>
+		<circle cx="175" cy="75" r="8" fill="currentColor" />
+	</svg>
+);
+
 // OpenClaw Icon
 export const OpenClawIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 	props,


### PR DESCRIPTION
## Summary
- Add Codex CLI integration guide (apps/ui + apps/docs) with TOML config, model `auto` default
- Add Autohand integration guide (apps/ui + apps/docs) with env var setup and model table
- Add CodexIcon and AutohandIcon to shared integration icons and docs custom icons
- Add both to the integration cards on the guides hub page

## Test plan
- [ ] Verify `/guides/codex-cli` renders correctly on UI
- [ ] Verify `/guides/autohand` renders correctly on UI
- [ ] Verify docs sidebar shows both new guides with correct icons
- [ ] Check integration cards page shows both new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added integration guide for Autohand, including setup instructions, configuration examples, and monitoring via the dashboard.
  * Added integration guide for Codex CLI, covering configuration, model selection, and troubleshooting.

* **New Features**
  * Autohand and Codex CLI integrations are now available in the integrations section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->