### PR TITLE
fix: classify ByteDance sensitive content blocks

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -46,6 +46,21 @@ describe("getFinishReasonFromError", () => {
 		expect(getFinishReasonFromError(500, azureError)).toBe("upstream_error");
 	});
 
+	it("returns content_filter for ByteDance SensitiveContentDetected", () => {
+		const bytedanceError = JSON.stringify({
+			error: {
+				code: "SensitiveContentDetected",
+				message:
+					"The request failed because the input text may contain sensitive information.",
+				param: "",
+				type: "BadRequest",
+			},
+		});
+		expect(getFinishReasonFromError(400, bytedanceError)).toBe(
+			"content_filter",
+		);
+	});
+
 	it("returns client_error for zai content filter", () => {
 		expect(
 			getFinishReasonFromError(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -34,6 +34,11 @@ export function getFinishReasonFromError(
 		return "content_filter";
 	}
 
+	// ByteDance / DeepSeek provider moderation block
+	if (errorText?.includes("SensitiveContentDetected")) {
+		return "content_filter";
+	}
+
 	// xAI (Grok) content safety violations (e.g. SAFETY_CHECK_TYPE_CSAM, usage guidelines)
 	if (
 		statusCode === 403 &&


### PR DESCRIPTION
## Summary
- classify ByteDance/DeepSeek `SensitiveContentDetected` errors as `content_filter`
- preserve the existing content-filter response handling in both streaming and non-streaming chat paths by fixing the shared classifier
- add unit coverage for the provider error payload shown in logs

## Testing
- pnpm vitest run /home/ariana/project/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to correctly categorize content filtering errors from additional providers.

* **Tests**
  * Added test coverage for new content filtering error classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->