### PR TITLE
fix: map gemini 0.5k image size

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -163,6 +163,84 @@ describe("prepareRequestBody - Anthropic", () => {
 });
 
 describe("prepareRequestBody - Google AI Studio", () => {
+	test("should map gateway 0.5K image size to Google 512", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-3.1-flash-image-preview",
+			[
+				{
+					role: "user",
+					content: "Generate a small colorful abstract painting",
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+			20,
+			null,
+			undefined,
+			{
+				aspect_ratio: "1:1",
+				image_size: "0.5K",
+			},
+		)) as any;
+
+		expect(requestBody.generationConfig.imageConfig).toEqual({
+			aspectRatio: "1:1",
+			imageSize: "512",
+		});
+		expect(requestBody.generationConfig.responseModalities).toEqual([
+			"TEXT",
+			"IMAGE",
+		]);
+	});
+
+	test("should map gateway 0.5K image size to Google 512 for Vertex", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-vertex",
+			"gemini-3.1-flash-image-preview",
+			[
+				{
+					role: "user",
+					content: "Generate a small colorful abstract painting",
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+			20,
+			null,
+			undefined,
+			{
+				aspect_ratio: "1:1",
+				image_size: "0.5K",
+			},
+		)) as any;
+
+		expect(requestBody.generationConfig.imageConfig).toEqual({
+			aspectRatio: "1:1",
+			imageSize: "512",
+		});
+	});
+
 	test("should set thinkingBudget when reasoning_effort is provided", async () => {
 		const requestBody = (await prepareRequestBody(
 			"google-ai-studio",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -277,6 +277,14 @@ function stripUnsupportedSchemaProperties(
 	return cleaned;
 }
 
+function mapGoogleImageSize(imageSize: string): string {
+	if (imageSize === "0.5K") {
+		return "512";
+	}
+
+	return imageSize;
+}
+
 /**
  * Recursively sanitizes tool input schemas for AWS Bedrock Converse.
  * Bedrock is stricter than Anthropic's direct API and rejects several JSON Schema
@@ -1720,7 +1728,7 @@ export async function prepareRequestBody(
 				}
 				if (image_config.image_size !== undefined) {
 					requestBody.generationConfig.imageConfig.imageSize =
-						image_config.image_size;
+						mapGoogleImageSize(image_config.image_size);
 				}
 			}
 


### PR DESCRIPTION
## Summary
- map gateway `image_config.image_size: "0.5K"` to Google `imageSize: "512"`
- keep the public gateway API unchanged for end users
- add request-body tests for both Google AI Studio and Google Vertex

## Repro
The local request to `/v1/chat/completions` with `google-vertex/gemini-3.1-flash-image-preview` and `image_size: "0.5K"` failed with `INVALID_ARGUMENT` before this change.

## Validation
- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts --no-file-parallelism`
- local live curl against `http://localhost:4001/v1/chat/completions` with `image_size: "0.5K"` for Google Vertex
- local live curl against `http://localhost:4001/v1/chat/completions` with `image_size: "0.5K"` for Google AI Studio
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed image sizing behavior for Google AI Studio and Google Vertex gateways to properly handle and convert image size values.

* **Tests**
  * Added test cases validating image sizing and aspect ratio handling for Google providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->