### PR TITLE
fix: improve activity log filters

### DIFF
--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -241,6 +241,62 @@ describe("logs route", () => {
 		});
 	});
 
+	describe("unique models route", () => {
+		test("should return providers from usedProvider and models from usedModel", async () => {
+			const params = new URLSearchParams({ projectId: "test-project-id" });
+			const res = await app.request("/logs/unique-models?" + params, {
+				method: "GET",
+				headers: {
+					Cookie: token,
+				},
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.models).toEqual(["gpt-4"]);
+			expect(json.providers).toEqual(["openai"]);
+		});
+
+		test("should scope unique models and providers to the selected project", async () => {
+			await db.insert(tables.log).values({
+				id: "test-log-id-3",
+				requestId: "test-log-id-3",
+				organizationId: "test-org-id",
+				projectId: "test-project-id",
+				apiKeyId: "test-api-key-id",
+				duration: 150,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "openai/gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 1500,
+				content: "Test response content 3",
+				finishReason: "stop",
+				promptTokens: "15",
+				completionTokens: "25",
+				totalTokens: "40",
+				temperature: 0.6,
+				maxTokens: 150,
+				messages: JSON.stringify([{ role: "user", content: "Hello 3" }]),
+				mode: "api-keys",
+				usedMode: "api-keys",
+			});
+
+			const params = new URLSearchParams({ projectId: "test-project-id" });
+			const res = await app.request("/logs/unique-models?" + params, {
+				method: "GET",
+				headers: {
+					Cookie: token,
+				},
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.models).toEqual(["gpt-4", "gpt-4o-mini"]);
+			expect(json.providers).toEqual(["openai"]);
+		});
+	});
+
 	// Tests for pagination functionality
 	describe("pagination functionality", () => {
 		beforeEach(async () => {

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -140,35 +140,6 @@ const getById = createRoute({
 	},
 });
 
-logs.openapi(getById, async (c) => {
-	const user = c.get("user");
-
-	if (!user) {
-		throw new HTTPException(401, { message: "Unauthorized" });
-	}
-
-	const { id } = c.req.valid("param");
-
-	const log = await db.query.log.findFirst({
-		where: { id },
-	});
-
-	if (!log) {
-		throw new HTTPException(404, { message: "Log not found" });
-	}
-
-	// Verify user has access to this log's organization
-	const organizationIds = await getActiveUserOrganizationIds(user.id);
-
-	if (!organizationIds.includes(log.organizationId)) {
-		throw new HTTPException(403, {
-			message: "You don't have access to this log",
-		});
-	}
-
-	return c.json({ log });
-});
-
 const querySchema = z.object({
 	apiKeyId: z.string().optional().openapi({
 		description: "Filter logs by API key ID",
@@ -695,43 +666,75 @@ logs.openapi(uniqueModelsGet, async (c) => {
 		whereConditions.push(inArray(tables.log.projectId, projectIds));
 	}
 
-	// Execute query to get distinct usedModel values
 	const finalWhereClause =
 		whereConditions.length > 0 ? and(...whereConditions) : undefined;
 
-	const uniqueUsedModels = await db
-		.selectDistinct({ usedModel: tables.log.usedModel })
-		.from(tables.log)
-		.where(finalWhereClause!);
+	const [uniqueUsedModels, uniqueUsedProviders] = await Promise.all([
+		db
+			.selectDistinct({ usedModel: tables.log.usedModel })
+			.from(tables.log)
+			.where(finalWhereClause!),
+		db
+			.selectDistinct({ usedProvider: tables.log.usedProvider })
+			.from(tables.log)
+			.where(finalWhereClause!),
+	]);
 
-	// Extract model names and provider names from usedModel field
-	const modelNames: string[] = [];
-	const providerNames: string[] = [];
+	const modelNames = new Set<string>();
+	const providerNames = new Set<string>();
+
+	for (const row of uniqueUsedProviders) {
+		if (row.usedProvider) {
+			providerNames.add(row.usedProvider);
+		}
+	}
 
 	for (const row of uniqueUsedModels) {
 		const usedModel = row.usedModel;
 		if (!usedModel) {
 			continue;
 		}
+
 		const slashIndex = usedModel.indexOf("/");
 		if (slashIndex !== -1) {
-			const provider = usedModel.substring(0, slashIndex);
-			const model = usedModel.substring(slashIndex + 1);
-			if (!providerNames.includes(provider)) {
-				providerNames.push(provider);
-			}
-			if (!modelNames.includes(model)) {
-				modelNames.push(model);
-			}
+			providerNames.add(usedModel.substring(0, slashIndex));
+			modelNames.add(usedModel.substring(slashIndex + 1));
 		} else {
-			if (!modelNames.includes(usedModel)) {
-				modelNames.push(usedModel);
-			}
+			modelNames.add(usedModel);
 		}
 	}
 
 	return c.json({
-		models: modelNames.sort(),
-		providers: providerNames.sort(),
+		models: Array.from(modelNames).sort(),
+		providers: Array.from(providerNames).sort(),
 	});
+});
+
+logs.openapi(getById, async (c) => {
+	const user = c.get("user");
+
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.valid("param");
+
+	const log = await db.query.log.findFirst({
+		where: { id },
+	});
+
+	if (!log) {
+		throw new HTTPException(404, { message: "Log not found" });
+	}
+
+	// Verify user has access to this log's organization
+	const organizationIds = await getActiveUserOrganizationIds(user.id);
+
+	if (!organizationIds.includes(log.organizationId)) {
+		throw new HTTPException(403, {
+			message: "You don't have access to this log",
+		});
+	}
+
+	return c.json({ log });
 });

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -746,168 +746,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/logs/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Single log entry */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            log: {
-                                id: string;
-                                requestId: string;
-                                createdAt: string;
-                                updatedAt: string;
-                                organizationId: string;
-                                projectId: string;
-                                apiKeyId: string;
-                                duration: number;
-                                requestedModel: string;
-                                requestedProvider: string | null;
-                                usedModel: string;
-                                usedProvider: string;
-                                responseSize: number;
-                                content: string | null;
-                                reasoningContent: string | null;
-                                unifiedFinishReason: string | null;
-                                finishReason: string | null;
-                                promptTokens: string | null;
-                                completionTokens: string | null;
-                                totalTokens: string | null;
-                                reasoningTokens: string | null;
-                                messages?: unknown;
-                                temperature: number | null;
-                                maxTokens: number | null;
-                                topP: number | null;
-                                frequencyPenalty: number | null;
-                                presencePenalty: number | null;
-                                reasoningEffort: string | null;
-                                reasoningMaxTokens: number | null;
-                                responseFormat?: unknown;
-                                tools: ({
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        description?: string;
-                                        parameters?: {
-                                            [key: string]: unknown;
-                                        };
-                                    };
-                                } | {
-                                    /** @enum {string} */
-                                    type: "web_search";
-                                    user_location?: {
-                                        city?: string;
-                                        region?: string;
-                                        country?: string;
-                                        timezone?: string;
-                                    };
-                                    /** @enum {string} */
-                                    search_context_size?: "low" | "medium" | "high";
-                                    max_uses?: number;
-                                })[] | null;
-                                toolChoice: "none" | "auto" | "required" | {
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                    };
-                                } | unknown;
-                                toolResults: {
-                                    id: string;
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        arguments: string;
-                                    };
-                                }[] | null;
-                                hasError: boolean | null;
-                                errorDetails: {
-                                    statusCode: number;
-                                    statusText: string;
-                                    responseText: string;
-                                    cause?: string;
-                                } | null;
-                                cost: number | null;
-                                inputCost: number | null;
-                                outputCost: number | null;
-                                requestCost: number | null;
-                                imageInputTokens: string | null;
-                                imageOutputTokens: string | null;
-                                imageInputCost: number | null;
-                                imageOutputCost: number | null;
-                                estimatedCost: boolean | null;
-                                canceled: boolean | null;
-                                streamed: boolean | null;
-                                cached: boolean | null;
-                                customHeaders?: unknown;
-                                /** @enum {string} */
-                                mode: "api-keys" | "credits" | "hybrid";
-                                /** @enum {string} */
-                                usedMode: "api-keys" | "credits";
-                                source: string | null;
-                                routingMetadata?: {
-                                    availableProviders?: string[];
-                                    selectedProvider?: string;
-                                    selectionReason?: string;
-                                    providerScores?: {
-                                        providerId: string;
-                                        score: number;
-                                        uptime?: number;
-                                        latency?: number;
-                                        price?: number;
-                                    }[];
-                                    routing?: {
-                                        provider: string;
-                                        model: string;
-                                        status_code: number;
-                                        error_type: string;
-                                        succeeded: boolean;
-                                    }[];
-                                } | null;
-                                retried?: boolean | null;
-                                retriedByLogId?: string | null;
-                            };
-                        };
-                    };
-                };
-                /** @description Log not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/logs": {
         parameters: {
             query?: never;
@@ -1122,6 +960,168 @@ export interface paths {
                             providers: string[];
                         };
                     };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Single log entry */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            log: {
+                                id: string;
+                                requestId: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                organizationId: string;
+                                projectId: string;
+                                apiKeyId: string;
+                                duration: number;
+                                requestedModel: string;
+                                requestedProvider: string | null;
+                                usedModel: string;
+                                usedProvider: string;
+                                responseSize: number;
+                                content: string | null;
+                                reasoningContent: string | null;
+                                unifiedFinishReason: string | null;
+                                finishReason: string | null;
+                                promptTokens: string | null;
+                                completionTokens: string | null;
+                                totalTokens: string | null;
+                                reasoningTokens: string | null;
+                                messages?: unknown;
+                                temperature: number | null;
+                                maxTokens: number | null;
+                                topP: number | null;
+                                frequencyPenalty: number | null;
+                                presencePenalty: number | null;
+                                reasoningEffort: string | null;
+                                reasoningMaxTokens: number | null;
+                                responseFormat?: unknown;
+                                tools: ({
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        description?: string;
+                                        parameters?: {
+                                            [key: string]: unknown;
+                                        };
+                                    };
+                                } | {
+                                    /** @enum {string} */
+                                    type: "web_search";
+                                    user_location?: {
+                                        city?: string;
+                                        region?: string;
+                                        country?: string;
+                                        timezone?: string;
+                                    };
+                                    /** @enum {string} */
+                                    search_context_size?: "low" | "medium" | "high";
+                                    max_uses?: number;
+                                })[] | null;
+                                toolChoice: "none" | "auto" | "required" | {
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                    };
+                                } | unknown;
+                                toolResults: {
+                                    id: string;
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        arguments: string;
+                                    };
+                                }[] | null;
+                                hasError: boolean | null;
+                                errorDetails: {
+                                    statusCode: number;
+                                    statusText: string;
+                                    responseText: string;
+                                    cause?: string;
+                                } | null;
+                                cost: number | null;
+                                inputCost: number | null;
+                                outputCost: number | null;
+                                requestCost: number | null;
+                                imageInputTokens: string | null;
+                                imageOutputTokens: string | null;
+                                imageInputCost: number | null;
+                                imageOutputCost: number | null;
+                                estimatedCost: boolean | null;
+                                canceled: boolean | null;
+                                streamed: boolean | null;
+                                cached: boolean | null;
+                                customHeaders?: unknown;
+                                /** @enum {string} */
+                                mode: "api-keys" | "credits" | "hybrid";
+                                /** @enum {string} */
+                                usedMode: "api-keys" | "credits";
+                                source: string | null;
+                                routingMetadata?: {
+                                    availableProviders?: string[];
+                                    selectedProvider?: string;
+                                    selectionReason?: string;
+                                    providerScores?: {
+                                        providerId: string;
+                                        score: number;
+                                        uptime?: number;
+                                        latency?: number;
+                                        price?: number;
+                                    }[];
+                                    routing?: {
+                                        provider: string;
+                                        model: string;
+                                        status_code: number;
+                                        error_type: string;
+                                        succeeded: boolean;
+                                    }[];
+                                } | null;
+                                retried?: boolean | null;
+                                retriedByLogId?: string | null;
+                            };
+                        };
+                    };
+                };
+                /** @description Log not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
             };
         };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -746,168 +746,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/logs/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Single log entry */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            log: {
-                                id: string;
-                                requestId: string;
-                                createdAt: string;
-                                updatedAt: string;
-                                organizationId: string;
-                                projectId: string;
-                                apiKeyId: string;
-                                duration: number;
-                                requestedModel: string;
-                                requestedProvider: string | null;
-                                usedModel: string;
-                                usedProvider: string;
-                                responseSize: number;
-                                content: string | null;
-                                reasoningContent: string | null;
-                                unifiedFinishReason: string | null;
-                                finishReason: string | null;
-                                promptTokens: string | null;
-                                completionTokens: string | null;
-                                totalTokens: string | null;
-                                reasoningTokens: string | null;
-                                messages?: unknown;
-                                temperature: number | null;
-                                maxTokens: number | null;
-                                topP: number | null;
-                                frequencyPenalty: number | null;
-                                presencePenalty: number | null;
-                                reasoningEffort: string | null;
-                                reasoningMaxTokens: number | null;
-                                responseFormat?: unknown;
-                                tools: ({
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        description?: string;
-                                        parameters?: {
-                                            [key: string]: unknown;
-                                        };
-                                    };
-                                } | {
-                                    /** @enum {string} */
-                                    type: "web_search";
-                                    user_location?: {
-                                        city?: string;
-                                        region?: string;
-                                        country?: string;
-                                        timezone?: string;
-                                    };
-                                    /** @enum {string} */
-                                    search_context_size?: "low" | "medium" | "high";
-                                    max_uses?: number;
-                                })[] | null;
-                                toolChoice: "none" | "auto" | "required" | {
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                    };
-                                } | unknown;
-                                toolResults: {
-                                    id: string;
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        arguments: string;
-                                    };
-                                }[] | null;
-                                hasError: boolean | null;
-                                errorDetails: {
-                                    statusCode: number;
-                                    statusText: string;
-                                    responseText: string;
-                                    cause?: string;
-                                } | null;
-                                cost: number | null;
-                                inputCost: number | null;
-                                outputCost: number | null;
-                                requestCost: number | null;
-                                imageInputTokens: string | null;
-                                imageOutputTokens: string | null;
-                                imageInputCost: number | null;
-                                imageOutputCost: number | null;
-                                estimatedCost: boolean | null;
-                                canceled: boolean | null;
-                                streamed: boolean | null;
-                                cached: boolean | null;
-                                customHeaders?: unknown;
-                                /** @enum {string} */
-                                mode: "api-keys" | "credits" | "hybrid";
-                                /** @enum {string} */
-                                usedMode: "api-keys" | "credits";
-                                source: string | null;
-                                routingMetadata?: {
-                                    availableProviders?: string[];
-                                    selectedProvider?: string;
-                                    selectionReason?: string;
-                                    providerScores?: {
-                                        providerId: string;
-                                        score: number;
-                                        uptime?: number;
-                                        latency?: number;
-                                        price?: number;
-                                    }[];
-                                    routing?: {
-                                        provider: string;
-                                        model: string;
-                                        status_code: number;
-                                        error_type: string;
-                                        succeeded: boolean;
-                                    }[];
-                                } | null;
-                                retried?: boolean | null;
-                                retriedByLogId?: string | null;
-                            };
-                        };
-                    };
-                };
-                /** @description Log not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/logs": {
         parameters: {
             query?: never;
@@ -1122,6 +960,168 @@ export interface paths {
                             providers: string[];
                         };
                     };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Single log entry */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            log: {
+                                id: string;
+                                requestId: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                organizationId: string;
+                                projectId: string;
+                                apiKeyId: string;
+                                duration: number;
+                                requestedModel: string;
+                                requestedProvider: string | null;
+                                usedModel: string;
+                                usedProvider: string;
+                                responseSize: number;
+                                content: string | null;
+                                reasoningContent: string | null;
+                                unifiedFinishReason: string | null;
+                                finishReason: string | null;
+                                promptTokens: string | null;
+                                completionTokens: string | null;
+                                totalTokens: string | null;
+                                reasoningTokens: string | null;
+                                messages?: unknown;
+                                temperature: number | null;
+                                maxTokens: number | null;
+                                topP: number | null;
+                                frequencyPenalty: number | null;
+                                presencePenalty: number | null;
+                                reasoningEffort: string | null;
+                                reasoningMaxTokens: number | null;
+                                responseFormat?: unknown;
+                                tools: ({
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        description?: string;
+                                        parameters?: {
+                                            [key: string]: unknown;
+                                        };
+                                    };
+                                } | {
+                                    /** @enum {string} */
+                                    type: "web_search";
+                                    user_location?: {
+                                        city?: string;
+                                        region?: string;
+                                        country?: string;
+                                        timezone?: string;
+                                    };
+                                    /** @enum {string} */
+                                    search_context_size?: "low" | "medium" | "high";
+                                    max_uses?: number;
+                                })[] | null;
+                                toolChoice: "none" | "auto" | "required" | {
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                    };
+                                } | unknown;
+                                toolResults: {
+                                    id: string;
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        arguments: string;
+                                    };
+                                }[] | null;
+                                hasError: boolean | null;
+                                errorDetails: {
+                                    statusCode: number;
+                                    statusText: string;
+                                    responseText: string;
+                                    cause?: string;
+                                } | null;
+                                cost: number | null;
+                                inputCost: number | null;
+                                outputCost: number | null;
+                                requestCost: number | null;
+                                imageInputTokens: string | null;
+                                imageOutputTokens: string | null;
+                                imageInputCost: number | null;
+                                imageOutputCost: number | null;
+                                estimatedCost: boolean | null;
+                                canceled: boolean | null;
+                                streamed: boolean | null;
+                                cached: boolean | null;
+                                customHeaders?: unknown;
+                                /** @enum {string} */
+                                mode: "api-keys" | "credits" | "hybrid";
+                                /** @enum {string} */
+                                usedMode: "api-keys" | "credits";
+                                source: string | null;
+                                routingMetadata?: {
+                                    availableProviders?: string[];
+                                    selectedProvider?: string;
+                                    selectionReason?: string;
+                                    providerScores?: {
+                                        providerId: string;
+                                        score: number;
+                                        uptime?: number;
+                                        latency?: number;
+                                        price?: number;
+                                    }[];
+                                    routing?: {
+                                        provider: string;
+                                        model: string;
+                                        status_code: number;
+                                        error_type: string;
+                                        succeeded: boolean;
+                                    }[];
+                                } | null;
+                                retried?: boolean | null;
+                                retriedByLogId?: string | null;
+                            };
+                        };
+                    };
+                };
+                /** @description Log not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
             };
         };

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
@@ -1,36 +1,9 @@
 import { RecentLogs } from "@/components/activity/recent-logs";
 import { Card, CardContent } from "@/lib/components/card";
+import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { LogsData } from "@/types/activity";
-
-function extractUniqueModelsFromLogs(logs: LogsData["logs"] | undefined) {
-	if (!logs?.length) {
-		return { models: [] as string[], providers: [] as string[] };
-	}
-
-	const providerSet = new Set<string>();
-	const modelSet = new Set<string>();
-
-	for (const log of logs) {
-		if (log.usedProvider) {
-			providerSet.add(log.usedProvider);
-		}
-		if (log.usedModel) {
-			const slashIndex = log.usedModel.indexOf("/");
-			modelSet.add(
-				slashIndex !== -1
-					? log.usedModel.substring(slashIndex + 1)
-					: log.usedModel,
-			);
-		}
-	}
-
-	return {
-		models: Array.from(modelSet).sort(),
-		providers: Array.from(providerSet).sort(),
-	};
-}
 
 export default async function ActivityPage({
 	params,
@@ -88,26 +61,33 @@ export default async function ActivityPage({
 		logsQueryParams.limit = searchParamsData.limit;
 	}
 
-	// Fetch a larger batch for extracting unique models/providers, and the filtered page
-	const [initialLogsData, allRecentLogs] = await Promise.all([
+	const [initialLogsData, providers, models] = await Promise.all([
 		fetchServerData<LogsData>("GET", "/logs", {
 			params: {
 				query: logsQueryParams,
 			},
 		}),
-		// Fetch unfiltered logs to populate model/provider dropdowns
-		fetchServerData<LogsData>("GET", "/logs", {
-			params: {
-				query: {
-					orderBy: "createdAt_desc",
-					projectId,
-					limit: "100",
-				},
-			},
-		}),
+		fetchProviders(),
+		fetchModels(),
 	]);
 
-	const initialUniqueModels = extractUniqueModelsFromLogs(allRecentLogs?.logs);
+	const providerOptions = providers
+		.map((provider) => ({
+			id: provider.id,
+			label: provider.name ?? provider.id,
+		}))
+		.toSorted((a, b) => a.label.localeCompare(b.label));
+
+	const modelOptions = models
+		.map((model) => ({
+			id: model.id,
+			label: model.name ?? model.id,
+			aliases: model.aliases ?? [],
+			providerIds: Array.from(
+				new Set(model.mappings.map((mapping) => mapping.providerId)),
+			).toSorted(),
+		}))
+		.toSorted((a, b) => a.label.localeCompare(b.label));
 
 	return (
 		<div className="flex flex-col">
@@ -119,7 +99,8 @@ export default async function ActivityPage({
 						<CardContent>
 							<RecentLogs
 								initialData={initialLogsData ?? undefined}
-								initialUniqueModels={initialUniqueModels}
+								providerOptions={providerOptions}
+								modelOptions={modelOptions}
 								projectId={projectId}
 								orgId={orgId}
 							/>

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -1,7 +1,15 @@
 "use client";
 
+import { Check, ChevronsUpDown } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useDeferredValue,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 
 import { LogCard } from "@/components/dashboard/log-card";
 import {
@@ -9,7 +17,19 @@ import {
 	DateRangeSelect,
 } from "@/components/date-range-select";
 import { Button } from "@/lib/components/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/lib/components/command";
 import { Input } from "@/lib/components/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/lib/components/popover";
 import {
 	Select,
 	SelectContent,
@@ -18,6 +38,7 @@ import {
 	SelectValue,
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
+import { cn } from "@/lib/utils";
 
 import type { paths } from "@/lib/api/v1";
 import type { Log } from "@llmgateway/db";
@@ -36,14 +57,24 @@ const UnifiedFinishReason = {
 type ApiLog =
 	paths["/logs"]["get"]["responses"][200]["content"]["application/json"]["logs"][number];
 
+interface ProviderOption {
+	id: string;
+	label: string;
+}
+
+interface ModelOption {
+	id: string;
+	label: string;
+	aliases: string[];
+	providerIds: string[];
+}
+
 interface RecentLogsProps {
 	initialData?:
 		| paths["/logs"]["get"]["responses"][200]["content"]["application/json"]
 		| undefined;
-	initialUniqueModels?: {
-		models: string[];
-		providers: string[];
-	};
+	providerOptions: ProviderOption[];
+	modelOptions: ModelOption[];
 	projectId: string | null;
 	orgId?: string | null;
 }
@@ -60,12 +91,15 @@ function toUiLog(log: ApiLog): Partial<Log> {
 
 export function RecentLogs({
 	initialData,
-	initialUniqueModels,
+	providerOptions,
+	modelOptions,
 	projectId,
 	orgId,
 }: RecentLogsProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
+	const [modelPickerOpen, setModelPickerOpen] = useState(false);
+	const [modelSearch, setModelSearch] = useState("");
 
 	// Initialize state from URL parameters
 	const [dateRange, setDateRange] = useState<DateRange | undefined>();
@@ -86,6 +120,7 @@ export function RecentLogs({
 	);
 
 	const api = useApi();
+	const deferredModelSearch = useDeferredValue(modelSearch);
 
 	const scrollPositionRef = useRef<number>(0);
 	const isFilteringRef = useRef<boolean>(false);
@@ -227,30 +262,35 @@ export function RecentLogs({
 	// Flatten all pages into a single array of logs
 	const allLogs = data?.pages.flatMap((page) => page?.logs ?? []) ?? [];
 
-	// Build unique models/providers from SSR data + loaded logs
-	const uniqueModels = useMemo(() => {
-		const providerSet = new Set<string>(initialUniqueModels?.providers ?? []);
-		const modelSet = new Set<string>(initialUniqueModels?.models ?? []);
+	const selectedModelOption = useMemo(
+		() => modelOptions.find((option) => option.id === model),
+		[model, modelOptions],
+	);
 
-		for (const log of allLogs) {
-			if (log.usedProvider) {
-				providerSet.add(log.usedProvider);
-			}
-			if (log.usedModel) {
-				const slashIndex = log.usedModel.indexOf("/");
-				modelSet.add(
-					slashIndex !== -1
-						? log.usedModel.substring(slashIndex + 1)
-						: log.usedModel,
-				);
-			}
-		}
+	const filteredModelOptions = useMemo(() => {
+		const normalizedSearch = deferredModelSearch
+			.trim()
+			.toLowerCase()
+			.replace(/[\s/_-]/g, "");
 
-		return {
-			providers: Array.from(providerSet).sort(),
-			models: Array.from(modelSet).sort(),
-		};
-	}, [allLogs, initialUniqueModels]);
+		return modelOptions.filter((option) => {
+			if (provider && !option.providerIds.includes(provider)) {
+				return false;
+			}
+
+			if (!normalizedSearch) {
+				return true;
+			}
+
+			const searchFields = [option.id, option.label, ...option.aliases];
+			return searchFields.some((field) =>
+				field
+					.toLowerCase()
+					.replace(/[\s/_-]/g, "")
+					.includes(normalizedSearch),
+			);
+		});
+	}, [deferredModelSearch, modelOptions, provider]);
 
 	const handleDateRangeChange = (_value: string, range: DateRange) => {
 		setDateRange(range);
@@ -260,6 +300,33 @@ export function RecentLogs({
 			endDate: range.end?.toISOString(),
 		});
 	};
+
+	const handleProviderChange = useCallback(
+		(value: string) => {
+			isFilteringRef.current = true;
+			scrollPositionRef.current = window.scrollY;
+
+			const nextProvider = value === "all" ? undefined : value;
+			const shouldClearModel =
+				model !== undefined &&
+				nextProvider !== undefined &&
+				!modelOptions.some(
+					(option) =>
+						option.id === model && option.providerIds.includes(nextProvider),
+				);
+
+			setProvider(nextProvider);
+			if (shouldClearModel) {
+				setModel(undefined);
+			}
+
+			updateUrlWithFilters({
+				provider: nextProvider,
+				model: shouldClearModel ? undefined : model,
+			});
+		},
+		[model, modelOptions, updateUrlWithFilters],
+	);
 
 	if (!projectId) {
 		return (
@@ -300,39 +367,89 @@ export function RecentLogs({
 					</SelectContent>
 				</Select>
 
-				<Select
-					onValueChange={handleFilterChange("provider", setProvider)}
-					value={provider ?? "all"}
-				>
+				<Select onValueChange={handleProviderChange} value={provider ?? "all"}>
 					<SelectTrigger className="w-[160px]">
 						<SelectValue placeholder="Filter by provider" />
 					</SelectTrigger>
 					<SelectContent>
 						<SelectItem value="all">All providers</SelectItem>
-						{(uniqueModels?.providers ?? []).map((p) => (
-							<SelectItem key={p} value={p}>
-								{p}
+						{providerOptions.map((option) => (
+							<SelectItem key={option.id} value={option.id}>
+								{option.label}
 							</SelectItem>
 						))}
 					</SelectContent>
 				</Select>
 
-				<Select
-					onValueChange={handleFilterChange("model", setModel)}
-					value={model ?? "all"}
-				>
-					<SelectTrigger className="w-[200px]">
-						<SelectValue placeholder="Filter by model" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="all">All models</SelectItem>
-						{(uniqueModels?.models ?? []).map((m) => (
-							<SelectItem key={m} value={m}>
-								{m}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
+				<Popover open={modelPickerOpen} onOpenChange={setModelPickerOpen}>
+					<PopoverTrigger asChild>
+						<Button
+							variant="outline"
+							role="combobox"
+							aria-expanded={modelPickerOpen}
+							className="w-[260px] justify-between"
+						>
+							<span className="truncate">
+								{selectedModelOption?.label ?? model ?? "Filter by model"}
+							</span>
+							<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent className="w-[320px] p-0" align="start">
+						<Command shouldFilter={false}>
+							<CommandInput
+								placeholder="Search models..."
+								value={modelSearch}
+								onValueChange={setModelSearch}
+							/>
+							<CommandList>
+								<CommandEmpty>No models found.</CommandEmpty>
+								<CommandItem
+									value="all"
+									onSelect={() => {
+										handleFilterChange("model", setModel)("all");
+										setModelPickerOpen(false);
+										setModelSearch("");
+									}}
+								>
+									<Check
+										className={cn(
+											"h-4 w-4",
+											!model ? "opacity-100" : "opacity-0",
+										)}
+									/>
+									All models
+								</CommandItem>
+								{filteredModelOptions.map((option) => (
+									<CommandItem
+										key={option.id}
+										value={`${option.id} ${option.label} ${option.aliases.join(" ")}`}
+										onSelect={() => {
+											handleFilterChange("model", setModel)(option.id);
+											setModelPickerOpen(false);
+											setModelSearch("");
+										}}
+									>
+										<Check
+											className={cn(
+												"h-4 w-4",
+												model === option.id ? "opacity-100" : "opacity-0",
+											)}
+										/>
+										<div className="flex min-w-0 flex-col">
+											<span className="truncate">{option.label}</span>
+											{option.label !== option.id ? (
+												<span className="truncate text-xs text-muted-foreground">
+													{option.id}
+												</span>
+											) : null}
+										</div>
+									</CommandItem>
+								))}
+							</CommandList>
+						</Command>
+					</PopoverContent>
+				</Popover>
 
 				<Input
 					placeholder="Custom header key (e.g., uid)"

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -746,168 +746,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/logs/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Single log entry */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            log: {
-                                id: string;
-                                requestId: string;
-                                createdAt: string;
-                                updatedAt: string;
-                                organizationId: string;
-                                projectId: string;
-                                apiKeyId: string;
-                                duration: number;
-                                requestedModel: string;
-                                requestedProvider: string | null;
-                                usedModel: string;
-                                usedProvider: string;
-                                responseSize: number;
-                                content: string | null;
-                                reasoningContent: string | null;
-                                unifiedFinishReason: string | null;
-                                finishReason: string | null;
-                                promptTokens: string | null;
-                                completionTokens: string | null;
-                                totalTokens: string | null;
-                                reasoningTokens: string | null;
-                                messages?: unknown;
-                                temperature: number | null;
-                                maxTokens: number | null;
-                                topP: number | null;
-                                frequencyPenalty: number | null;
-                                presencePenalty: number | null;
-                                reasoningEffort: string | null;
-                                reasoningMaxTokens: number | null;
-                                responseFormat?: unknown;
-                                tools: ({
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        description?: string;
-                                        parameters?: {
-                                            [key: string]: unknown;
-                                        };
-                                    };
-                                } | {
-                                    /** @enum {string} */
-                                    type: "web_search";
-                                    user_location?: {
-                                        city?: string;
-                                        region?: string;
-                                        country?: string;
-                                        timezone?: string;
-                                    };
-                                    /** @enum {string} */
-                                    search_context_size?: "low" | "medium" | "high";
-                                    max_uses?: number;
-                                })[] | null;
-                                toolChoice: "none" | "auto" | "required" | {
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                    };
-                                } | unknown;
-                                toolResults: {
-                                    id: string;
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        arguments: string;
-                                    };
-                                }[] | null;
-                                hasError: boolean | null;
-                                errorDetails: {
-                                    statusCode: number;
-                                    statusText: string;
-                                    responseText: string;
-                                    cause?: string;
-                                } | null;
-                                cost: number | null;
-                                inputCost: number | null;
-                                outputCost: number | null;
-                                requestCost: number | null;
-                                imageInputTokens: string | null;
-                                imageOutputTokens: string | null;
-                                imageInputCost: number | null;
-                                imageOutputCost: number | null;
-                                estimatedCost: boolean | null;
-                                canceled: boolean | null;
-                                streamed: boolean | null;
-                                cached: boolean | null;
-                                customHeaders?: unknown;
-                                /** @enum {string} */
-                                mode: "api-keys" | "credits" | "hybrid";
-                                /** @enum {string} */
-                                usedMode: "api-keys" | "credits";
-                                source: string | null;
-                                routingMetadata?: {
-                                    availableProviders?: string[];
-                                    selectedProvider?: string;
-                                    selectionReason?: string;
-                                    providerScores?: {
-                                        providerId: string;
-                                        score: number;
-                                        uptime?: number;
-                                        latency?: number;
-                                        price?: number;
-                                    }[];
-                                    routing?: {
-                                        provider: string;
-                                        model: string;
-                                        status_code: number;
-                                        error_type: string;
-                                        succeeded: boolean;
-                                    }[];
-                                } | null;
-                                retried?: boolean | null;
-                                retriedByLogId?: string | null;
-                            };
-                        };
-                    };
-                };
-                /** @description Log not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/logs": {
         parameters: {
             query?: never;
@@ -1122,6 +960,168 @@ export interface paths {
                             providers: string[];
                         };
                     };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Single log entry */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            log: {
+                                id: string;
+                                requestId: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                organizationId: string;
+                                projectId: string;
+                                apiKeyId: string;
+                                duration: number;
+                                requestedModel: string;
+                                requestedProvider: string | null;
+                                usedModel: string;
+                                usedProvider: string;
+                                responseSize: number;
+                                content: string | null;
+                                reasoningContent: string | null;
+                                unifiedFinishReason: string | null;
+                                finishReason: string | null;
+                                promptTokens: string | null;
+                                completionTokens: string | null;
+                                totalTokens: string | null;
+                                reasoningTokens: string | null;
+                                messages?: unknown;
+                                temperature: number | null;
+                                maxTokens: number | null;
+                                topP: number | null;
+                                frequencyPenalty: number | null;
+                                presencePenalty: number | null;
+                                reasoningEffort: string | null;
+                                reasoningMaxTokens: number | null;
+                                responseFormat?: unknown;
+                                tools: ({
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        description?: string;
+                                        parameters?: {
+                                            [key: string]: unknown;
+                                        };
+                                    };
+                                } | {
+                                    /** @enum {string} */
+                                    type: "web_search";
+                                    user_location?: {
+                                        city?: string;
+                                        region?: string;
+                                        country?: string;
+                                        timezone?: string;
+                                    };
+                                    /** @enum {string} */
+                                    search_context_size?: "low" | "medium" | "high";
+                                    max_uses?: number;
+                                })[] | null;
+                                toolChoice: "none" | "auto" | "required" | {
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                    };
+                                } | unknown;
+                                toolResults: {
+                                    id: string;
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        arguments: string;
+                                    };
+                                }[] | null;
+                                hasError: boolean | null;
+                                errorDetails: {
+                                    statusCode: number;
+                                    statusText: string;
+                                    responseText: string;
+                                    cause?: string;
+                                } | null;
+                                cost: number | null;
+                                inputCost: number | null;
+                                outputCost: number | null;
+                                requestCost: number | null;
+                                imageInputTokens: string | null;
+                                imageOutputTokens: string | null;
+                                imageInputCost: number | null;
+                                imageOutputCost: number | null;
+                                estimatedCost: boolean | null;
+                                canceled: boolean | null;
+                                streamed: boolean | null;
+                                cached: boolean | null;
+                                customHeaders?: unknown;
+                                /** @enum {string} */
+                                mode: "api-keys" | "credits" | "hybrid";
+                                /** @enum {string} */
+                                usedMode: "api-keys" | "credits";
+                                source: string | null;
+                                routingMetadata?: {
+                                    availableProviders?: string[];
+                                    selectedProvider?: string;
+                                    selectionReason?: string;
+                                    providerScores?: {
+                                        providerId: string;
+                                        score: number;
+                                        uptime?: number;
+                                        latency?: number;
+                                        price?: number;
+                                    }[];
+                                    routing?: {
+                                        provider: string;
+                                        model: string;
+                                        status_code: number;
+                                        error_type: string;
+                                        succeeded: boolean;
+                                    }[];
+                                } | null;
+                                retried?: boolean | null;
+                                retriedByLogId?: string | null;
+                            };
+                        };
+                    };
+                };
+                /** @description Log not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
             };
         };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -746,168 +746,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/logs/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Single log entry */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            log: {
-                                id: string;
-                                requestId: string;
-                                createdAt: string;
-                                updatedAt: string;
-                                organizationId: string;
-                                projectId: string;
-                                apiKeyId: string;
-                                duration: number;
-                                requestedModel: string;
-                                requestedProvider: string | null;
-                                usedModel: string;
-                                usedProvider: string;
-                                responseSize: number;
-                                content: string | null;
-                                reasoningContent: string | null;
-                                unifiedFinishReason: string | null;
-                                finishReason: string | null;
-                                promptTokens: string | null;
-                                completionTokens: string | null;
-                                totalTokens: string | null;
-                                reasoningTokens: string | null;
-                                messages?: unknown;
-                                temperature: number | null;
-                                maxTokens: number | null;
-                                topP: number | null;
-                                frequencyPenalty: number | null;
-                                presencePenalty: number | null;
-                                reasoningEffort: string | null;
-                                reasoningMaxTokens: number | null;
-                                responseFormat?: unknown;
-                                tools: ({
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        description?: string;
-                                        parameters?: {
-                                            [key: string]: unknown;
-                                        };
-                                    };
-                                } | {
-                                    /** @enum {string} */
-                                    type: "web_search";
-                                    user_location?: {
-                                        city?: string;
-                                        region?: string;
-                                        country?: string;
-                                        timezone?: string;
-                                    };
-                                    /** @enum {string} */
-                                    search_context_size?: "low" | "medium" | "high";
-                                    max_uses?: number;
-                                })[] | null;
-                                toolChoice: "none" | "auto" | "required" | {
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                    };
-                                } | unknown;
-                                toolResults: {
-                                    id: string;
-                                    /** @enum {string} */
-                                    type: "function";
-                                    function: {
-                                        name: string;
-                                        arguments: string;
-                                    };
-                                }[] | null;
-                                hasError: boolean | null;
-                                errorDetails: {
-                                    statusCode: number;
-                                    statusText: string;
-                                    responseText: string;
-                                    cause?: string;
-                                } | null;
-                                cost: number | null;
-                                inputCost: number | null;
-                                outputCost: number | null;
-                                requestCost: number | null;
-                                imageInputTokens: string | null;
-                                imageOutputTokens: string | null;
-                                imageInputCost: number | null;
-                                imageOutputCost: number | null;
-                                estimatedCost: boolean | null;
-                                canceled: boolean | null;
-                                streamed: boolean | null;
-                                cached: boolean | null;
-                                customHeaders?: unknown;
-                                /** @enum {string} */
-                                mode: "api-keys" | "credits" | "hybrid";
-                                /** @enum {string} */
-                                usedMode: "api-keys" | "credits";
-                                source: string | null;
-                                routingMetadata?: {
-                                    availableProviders?: string[];
-                                    selectedProvider?: string;
-                                    selectionReason?: string;
-                                    providerScores?: {
-                                        providerId: string;
-                                        score: number;
-                                        uptime?: number;
-                                        latency?: number;
-                                        price?: number;
-                                    }[];
-                                    routing?: {
-                                        provider: string;
-                                        model: string;
-                                        status_code: number;
-                                        error_type: string;
-                                        succeeded: boolean;
-                                    }[];
-                                } | null;
-                                retried?: boolean | null;
-                                retriedByLogId?: string | null;
-                            };
-                        };
-                    };
-                };
-                /** @description Log not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/logs": {
         parameters: {
             query?: never;
@@ -1122,6 +960,168 @@ export interface paths {
                             providers: string[];
                         };
                     };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Single log entry */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            log: {
+                                id: string;
+                                requestId: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                organizationId: string;
+                                projectId: string;
+                                apiKeyId: string;
+                                duration: number;
+                                requestedModel: string;
+                                requestedProvider: string | null;
+                                usedModel: string;
+                                usedProvider: string;
+                                responseSize: number;
+                                content: string | null;
+                                reasoningContent: string | null;
+                                unifiedFinishReason: string | null;
+                                finishReason: string | null;
+                                promptTokens: string | null;
+                                completionTokens: string | null;
+                                totalTokens: string | null;
+                                reasoningTokens: string | null;
+                                messages?: unknown;
+                                temperature: number | null;
+                                maxTokens: number | null;
+                                topP: number | null;
+                                frequencyPenalty: number | null;
+                                presencePenalty: number | null;
+                                reasoningEffort: string | null;
+                                reasoningMaxTokens: number | null;
+                                responseFormat?: unknown;
+                                tools: ({
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        description?: string;
+                                        parameters?: {
+                                            [key: string]: unknown;
+                                        };
+                                    };
+                                } | {
+                                    /** @enum {string} */
+                                    type: "web_search";
+                                    user_location?: {
+                                        city?: string;
+                                        region?: string;
+                                        country?: string;
+                                        timezone?: string;
+                                    };
+                                    /** @enum {string} */
+                                    search_context_size?: "low" | "medium" | "high";
+                                    max_uses?: number;
+                                })[] | null;
+                                toolChoice: "none" | "auto" | "required" | {
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                    };
+                                } | unknown;
+                                toolResults: {
+                                    id: string;
+                                    /** @enum {string} */
+                                    type: "function";
+                                    function: {
+                                        name: string;
+                                        arguments: string;
+                                    };
+                                }[] | null;
+                                hasError: boolean | null;
+                                errorDetails: {
+                                    statusCode: number;
+                                    statusText: string;
+                                    responseText: string;
+                                    cause?: string;
+                                } | null;
+                                cost: number | null;
+                                inputCost: number | null;
+                                outputCost: number | null;
+                                requestCost: number | null;
+                                imageInputTokens: string | null;
+                                imageOutputTokens: string | null;
+                                imageInputCost: number | null;
+                                imageOutputCost: number | null;
+                                estimatedCost: boolean | null;
+                                canceled: boolean | null;
+                                streamed: boolean | null;
+                                cached: boolean | null;
+                                customHeaders?: unknown;
+                                /** @enum {string} */
+                                mode: "api-keys" | "credits" | "hybrid";
+                                /** @enum {string} */
+                                usedMode: "api-keys" | "credits";
+                                source: string | null;
+                                routingMetadata?: {
+                                    availableProviders?: string[];
+                                    selectedProvider?: string;
+                                    selectionReason?: string;
+                                    providerScores?: {
+                                        providerId: string;
+                                        score: number;
+                                        uptime?: number;
+                                        latency?: number;
+                                        price?: number;
+                                    }[];
+                                    routing?: {
+                                        provider: string;
+                                        model: string;
+                                        status_code: number;
+                                        error_type: string;
+                                        succeeded: boolean;
+                                    }[];
+                                } | null;
+                                retried?: boolean | null;
+                                retriedByLogId?: string | null;
+                            };
+                        };
+                    };
+                };
+                /** @description Log not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
                 };
             };
         };


### PR DESCRIPTION
This fixes the activity log filter UX by switching the page from log-derived filter options to the full active provider/model catalog. The model filter is now a searchable client-side combobox, and provider changes clear incompatible model selections automatically. On the API side, `/logs/unique-models` is no longer shadowed by `/logs/{id}` and now derives providers from `usedProvider` while still normalizing model IDs from `usedModel`. The generated OpenAPI type files were refreshed for the frontend apps, and logs route coverage was added for the unique models endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable model picker with real-time search in activity filters.

* **Refactor**
  * Optimized model and provider data fetching with parallel requests.
  * Enhanced filtering logic for improved performance and UX.

* **Tests**
  * Added test coverage for unique models and providers endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->