### PR TITLE
fix: timeout stuck video creation

### DIFF
--- a/apps/gateway/src/lib/timeout-config.ts
+++ b/apps/gateway/src/lib/timeout-config.ts
@@ -44,6 +44,20 @@ export function getTimeoutMs(): number {
 	return 180000;
 }
 
+/**
+ * Gets the upstream video creation timeout.
+ * Video job creation should fail fast enough to return a JSON error before
+ * callers hit their own route/runtime timeout limits.
+ * Default: 45 seconds or 5 seconds below the gateway timeout, whichever is lower.
+ */
+export function getVideoCreateTimeoutMs(): number {
+	const envValue = Number(process.env.AI_VIDEO_CREATE_TIMEOUT_MS);
+	if (envValue > 0) {
+		return envValue;
+	}
+	return Math.min(45000, Math.max(1000, getGatewayTimeoutMs() - 5000));
+}
+
 // Legacy exports for backwards compatibility (read at module load time)
 // These should be avoided in new code - use the getter functions instead
 export const GATEWAY_TIMEOUT_MS = getGatewayTimeoutMs();
@@ -64,6 +78,13 @@ export function createStreamingTimeoutSignal(): AbortSignal {
  */
 export function createTimeoutSignal(): AbortSignal {
 	return AbortSignal.timeout(getTimeoutMs());
+}
+
+/**
+ * Creates an AbortSignal that will abort after the video creation timeout.
+ */
+export function createVideoCreateTimeoutSignal(): AbortSignal {
+	return AbortSignal.timeout(getVideoCreateTimeoutMs());
 }
 
 /**

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -53,6 +53,26 @@ function extractTimeoutDelay(content: string): number | null {
 	return null;
 }
 
+function extractProviderSpecificTimeoutDelay(
+	content: string,
+	provider: "obsidian" | "avalanche" | "vertex",
+): number | null {
+	const token =
+		provider === "vertex"
+			? "TRIGGER_VERTEX_ONLY_TIMEOUT"
+			: provider === "avalanche"
+				? "TRIGGER_AVALANCHE_ONLY_TIMEOUT"
+				: "TRIGGER_OBSIDIAN_ONLY_TIMEOUT";
+	const match = content.match(new RegExp(`${token}_(\\d+)`));
+	if (match) {
+		return parseInt(match[1], 10);
+	}
+	if (content.includes(token)) {
+		return 5000;
+	}
+	return null;
+}
+
 // Helper to extract a specific HTTP status code from message content
 // e.g., "TRIGGER_STATUS_429" -> { statusCode: 429, errorResponse: {...} }
 function extractStatusCodeTrigger(
@@ -511,6 +531,10 @@ mockOpenAIServer.post("/v1/videos", async (c) => {
 		? await c.req.parseBody({ all: true })
 		: await c.req.json();
 	const prompt = typeof body.prompt === "string" ? body.prompt : "";
+	const timeoutDelay = extractProviderSpecificTimeoutDelay(prompt, "obsidian");
+	if (timeoutDelay) {
+		await delay(timeoutDelay);
+	}
 	const statusTrigger = extractStatusCodeTrigger(prompt);
 	if (statusTrigger) {
 		c.status(statusTrigger.statusCode as any);
@@ -560,6 +584,10 @@ mockOpenAIServer.post("/v1/videos", async (c) => {
 mockOpenAIServer.post("/api/v1/veo/generate", async (c) => {
 	const body = await c.req.json();
 	const prompt = typeof body.prompt === "string" ? body.prompt : "";
+	const timeoutDelay = extractProviderSpecificTimeoutDelay(prompt, "avalanche");
+	if (timeoutDelay) {
+		await delay(timeoutDelay);
+	}
 	if (
 		prompt.includes("TRIGGER_STATUS_500_AVALANCHE_ONLY") ||
 		prompt.includes("TRIGGER_AVALANCHE_ONLY_500")
@@ -690,6 +718,13 @@ mockOpenAIServer.post(
 					"string"
 					? ((body.instances[0] as Record<string, unknown>).prompt as string)
 					: "";
+			const timeoutDelay = extractProviderSpecificTimeoutDelay(
+				prompt,
+				"vertex",
+			);
+			if (timeoutDelay) {
+				await delay(timeoutDelay);
+			}
 			if (
 				prompt.includes("TRIGGER_STATUS_500_VERTEX_ONLY") ||
 				prompt.includes("TRIGGER_VERTEX_ONLY_500")

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -510,6 +510,165 @@ describe("videos", () => {
 		}
 	});
 
+	test("/v1/videos returns 504 when upstream create times out before job creation", async () => {
+		const originalVideoCreateTimeout = process.env.AI_VIDEO_CREATE_TIMEOUT_MS;
+		process.env.AI_VIDEO_CREATE_TIMEOUT_MS = "50";
+
+		try {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "obsidian",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const res = await app.request("/v1/videos", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "obsidian/veo-3.1-generate-preview",
+					prompt:
+						"TRIGGER_OBSIDIAN_ONLY_TIMEOUT_200 A robot dancing in the rain",
+					seconds: 8,
+				}),
+			});
+
+			expect(res.status).toBe(504);
+			const json = await res.json();
+			expect(JSON.stringify(json)).toContain(
+				"Video creation timed out while waiting for the upstream provider",
+			);
+
+			const videoJobs = await db.query.videoJob.findMany();
+			expect(videoJobs).toHaveLength(0);
+		} finally {
+			if (originalVideoCreateTimeout !== undefined) {
+				process.env.AI_VIDEO_CREATE_TIMEOUT_MS = originalVideoCreateTimeout;
+			} else {
+				delete process.env.AI_VIDEO_CREATE_TIMEOUT_MS;
+			}
+		}
+	});
+
+	test("/v1/videos falls back after an upstream create timeout", async () => {
+		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
+		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
+		const originalVideoCreateTimeout = process.env.AI_VIDEO_CREATE_TIMEOUT_MS;
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "test-project";
+		process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
+		process.env.AI_VIDEO_CREATE_TIMEOUT_MS = "50";
+
+		try {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			await db.insert(tables.providerKey).values([
+				{
+					id: "provider-key-avalanche",
+					token: "sk-avalanche-key",
+					provider: "avalanche",
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+				},
+				{
+					id: "provider-key-vertex",
+					token: "vertex-test-token",
+					provider: "google-vertex",
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+				},
+			]);
+
+			await setRoutingMetrics("veo-3.1-generate-preview", "avalanche", {
+				uptime: 70,
+				latency: 300,
+				throughput: 50,
+			});
+			await setRoutingMetrics("veo-3.1-generate-preview", "google-vertex", {
+				uptime: 99.9,
+				latency: 80,
+				throughput: 180,
+			});
+
+			const res = await app.request("/v1/videos", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "veo-3.1-generate-preview",
+					prompt:
+						"TRIGGER_VERTEX_ONLY_TIMEOUT_200 A cinematic city skyline at dusk",
+					size: "1920x1080",
+					seconds: 8,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const json = await res.json();
+			const videoJob = await db.query.videoJob.findFirst({
+				where: { id: { eq: json.id } },
+			});
+			expect(videoJob?.usedProvider).toBe("avalanche");
+			expect(
+				videoJob?.routingMetadata?.routing?.map((attempt) => ({
+					provider: attempt.provider,
+					succeeded: attempt.succeeded,
+					status_code: attempt.status_code,
+					error_type: attempt.error_type,
+				})),
+			).toEqual([
+				{
+					provider: "google-vertex",
+					succeeded: false,
+					status_code: 504,
+					error_type: "upstream_error",
+				},
+				{
+					provider: "avalanche",
+					succeeded: true,
+					status_code: 200,
+					error_type: "none",
+				},
+			]);
+		} finally {
+			if (originalGoogleCloudProject !== undefined) {
+				process.env.LLM_GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
+			} else {
+				delete process.env.LLM_GOOGLE_CLOUD_PROJECT;
+			}
+			if (originalGoogleVertexRegion !== undefined) {
+				process.env.LLM_GOOGLE_VERTEX_REGION = originalGoogleVertexRegion;
+			} else {
+				delete process.env.LLM_GOOGLE_VERTEX_REGION;
+			}
+			if (originalVideoCreateTimeout !== undefined) {
+				process.env.AI_VIDEO_CREATE_TIMEOUT_MS = originalVideoCreateTimeout;
+			} else {
+				delete process.env.AI_VIDEO_CREATE_TIMEOUT_MS;
+			}
+		}
+	});
+
 	test("/v1/videos supports retrieve and content for completed jobs", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -15,6 +15,11 @@ import {
 	findProviderKey,
 } from "@/lib/cached-queries.js";
 import { validateModelAccess } from "@/lib/iam.js";
+import {
+	createVideoCreateTimeoutSignal,
+	getVideoCreateTimeoutMs,
+	isTimeoutError,
+} from "@/lib/timeout-config.js";
 
 import {
 	getCheapestFromAvailableProviders,
@@ -1958,7 +1963,30 @@ async function fetchUpstreamJson(
 	url: string,
 	init: RequestInit,
 ): Promise<Record<string, unknown>> {
-	const response = await fetch(url, init);
+	const timeoutSignal = createVideoCreateTimeoutSignal();
+	const signal = init.signal
+		? AbortSignal.any([init.signal, timeoutSignal])
+		: timeoutSignal;
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			...init,
+			signal,
+		});
+	} catch (error) {
+		if (isTimeoutError(error)) {
+			logger.warn("Upstream video create request timed out", {
+				url,
+				timeoutMs: getVideoCreateTimeoutMs(),
+			});
+			throw new HTTPException(504, {
+				message:
+					"Video creation timed out while waiting for the upstream provider. Please try again.",
+			});
+		}
+
+		throw error;
+	}
 	const text = await response.text();
 	let body: Record<string, unknown> = {};
 

--- a/apps/playground/src/app/api/video/route.ts
+++ b/apps/playground/src/app/api/video/route.ts
@@ -7,6 +7,19 @@ import { getGatewayErrorMessage, readGatewayResponseBody } from "./utils";
 
 export const maxDuration = 60;
 
+function getVideoCreateProxyTimeoutMs(): number {
+	const envValue = Number(process.env.PLAYGROUND_VIDEO_CREATE_TIMEOUT_MS);
+	if (envValue > 0) {
+		return envValue;
+	}
+
+	return Math.max(1000, maxDuration * 1000 - 5000);
+}
+
+function isTimeoutError(error: unknown): boolean {
+	return error instanceof Error && error.name === "TimeoutError";
+}
+
 export async function POST(req: Request) {
 	const user = await getUser();
 	if (!user) {
@@ -31,16 +44,32 @@ export async function POST(req: Request) {
 	const requestBody = await req.json();
 	const noFallback = req.headers.get("x-no-fallback");
 
-	const response = await fetch(`${gatewayBaseUrl}/v1/videos`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${apiKey}`,
-			"x-source": "chat.llmgateway.io",
-			...(noFallback ? { "x-no-fallback": noFallback } : {}),
-		},
-		body: JSON.stringify(requestBody),
-	});
+	let response: Response;
+	try {
+		response = await fetch(`${gatewayBaseUrl}/v1/videos`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${apiKey}`,
+				"x-source": "chat.llmgateway.io",
+				...(noFallback ? { "x-no-fallback": noFallback } : {}),
+			},
+			body: JSON.stringify(requestBody),
+			signal: AbortSignal.timeout(getVideoCreateProxyTimeoutMs()),
+		});
+	} catch (error) {
+		if (isTimeoutError(error)) {
+			return NextResponse.json(
+				{
+					error:
+						"Video creation timed out before the gateway responded. Please try again.",
+				},
+				{ status: 504 },
+			);
+		}
+
+		throw error;
+	}
 
 	const responseBody = await readGatewayResponseBody(response);
 


### PR DESCRIPTION
## Summary
Add explicit timeouts to video creation so stuck upstream provider requests fail with a clear 504 instead of hanging indefinitely.
Apply the same fail-fast behavior in the playground /api/video proxy so the UI gets JSON before the route times out, and preserve provider fallback when a create call times out.
Add mock-server coverage and gateway tests for timed-out video creation and timeout-driven fallback.

## Verification
pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implemented timeout protection for video creation requests; when creation exceeds the configured timeout, the system returns an error and attempts fallback to alternative providers when available.

* **Tests**
  * Added test coverage for video creation timeout scenarios and provider fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->