### PR TITLE
fix(gateway): handle null content in content filter

### DIFF
--- a/apps/gateway/src/chat/tools/check-content-filter.spec.ts
+++ b/apps/gateway/src/chat/tools/check-content-filter.spec.ts
@@ -75,6 +75,16 @@ describe("checkContentFilter", () => {
 		).toBe("blocked");
 	});
 
+	it("ignores messages with null content", () => {
+		process.env.LLM_CONTENT_FILTER_KEYWORDS = "blocked";
+		expect(
+			checkContentFilter([
+				{ role: "user", content: null as unknown as string },
+				{ role: "user", content: "safe content" },
+			]),
+		).toBeNull();
+	});
+
 	it("trims whitespace from keywords", () => {
 		process.env.LLM_CONTENT_FILTER_KEYWORDS = " banned , blocked ";
 		expect(

--- a/apps/gateway/src/chat/tools/check-content-filter.ts
+++ b/apps/gateway/src/chat/tools/check-content-filter.ts
@@ -61,9 +61,15 @@ function getFilterKeywords(): string[] {
 	return cachedKeywords;
 }
 
-function extractTextFromContent(content: string | MessageContent[]): string {
+function extractTextFromContent(
+	content: string | MessageContent[] | null | undefined,
+): string {
 	if (typeof content === "string") {
 		return content;
+	}
+
+	if (!Array.isArray(content)) {
+		return "";
 	}
 
 	return content


### PR DESCRIPTION
## Summary
- guard the gateway content filter against null or missing message content
- treat malformed content as empty text instead of throwing from `.map()`
- add a regression test for `content: null`

## Testing
- pnpm exec vitest run /home/ariana/project/apps/gateway/src/chat/tools/check-content-filter.spec.ts