### PR TITLE
test(gateway): make vertex routing metrics test explicit

### DIFF
--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -309,8 +309,11 @@ describe("videos", () => {
 	test("/v1/videos uses routing metrics to pick the best eligible provider", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
 		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
+		const originalGoogleVertexVideoOutputBucket =
+			process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
 		process.env.LLM_GOOGLE_CLOUD_PROJECT = "test-project";
 		process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
+		process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET = "vertex-test-bucket";
 
 		try {
 			await db.insert(tables.apiKey).values({
@@ -385,6 +388,12 @@ describe("videos", () => {
 				process.env.LLM_GOOGLE_VERTEX_REGION = originalGoogleVertexRegion;
 			} else {
 				delete process.env.LLM_GOOGLE_VERTEX_REGION;
+			}
+			if (originalGoogleVertexVideoOutputBucket !== undefined) {
+				process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET =
+					originalGoogleVertexVideoOutputBucket;
+			} else {
+				delete process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
 			}
 		}
 	});


### PR DESCRIPTION
## Summary
- make the routing-metrics video spec explicitly configure a Vertex output bucket
- keep the test focused on provider scoring instead of implicit retention/storage defaults
- restore the bucket env var in test cleanup

## Verification
- pnpm vitest run packages/actions/src/models.spec.ts -t "should use per-second pricing for video providers"
- source-level validation of the weighted-score selector for  still prefers  over  with the spec metrics

## Notes
- I could not run the DB-backed  locally in this VPS because local PostgreSQL and Redis could not be started non-interactively here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring consistent environment variable setup and teardown during video provider routing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->