### PR TITLE
fix: use runtime GCP project for storage

### DIFF
--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -695,10 +695,12 @@ describe.skip("videos", () => {
 
 	test("/v1/videos uses routing metrics to pick the best eligible provider", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
+		const originalRuntimeGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
 		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
 		const originalGoogleVertexVideoOutputBucket =
 			process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
-		process.env.LLM_GOOGLE_CLOUD_PROJECT = "test-project";
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "provider-project";
+		process.env.GOOGLE_CLOUD_PROJECT = "runtime-project";
 		process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
 		process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET = "vertex-test-bucket";
 
@@ -770,6 +772,11 @@ describe.skip("videos", () => {
 				process.env.LLM_GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
 			} else {
 				delete process.env.LLM_GOOGLE_CLOUD_PROJECT;
+			}
+			if (originalRuntimeGoogleCloudProject !== undefined) {
+				process.env.GOOGLE_CLOUD_PROJECT = originalRuntimeGoogleCloudProject;
+			} else {
+				delete process.env.GOOGLE_CLOUD_PROJECT;
 			}
 			if (originalGoogleVertexRegion !== undefined) {
 				process.env.LLM_GOOGLE_VERTEX_REGION = originalGoogleVertexRegion;
@@ -1286,12 +1293,14 @@ describe.skip("videos", () => {
 
 	test("/v1/videos supports completed google-vertex jobs", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
+		const originalRuntimeGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
 		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
 		const originalGoogleVertexVideoOutputBucket =
 			process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
 		const originalGoogleVertexSignedUrlBaseUrl =
 			process.env.LLM_GOOGLE_VERTEX_TEST_SIGNED_URL_BASE_URL;
-		process.env.LLM_GOOGLE_CLOUD_PROJECT = "test-project";
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "provider-project";
+		process.env.GOOGLE_CLOUD_PROJECT = "runtime-project";
 		process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
 		process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET = "vertex-test-bucket";
 		process.env.LLM_GOOGLE_VERTEX_TEST_SIGNED_URL_BASE_URL = `${mockServerUrl}/mock-gcs`;
@@ -1337,6 +1346,14 @@ describe.skip("videos", () => {
 			expect(videoJob).toBeTruthy();
 			expect(videoJob?.usedProvider).toBe("google-vertex");
 			expect(videoJob?.usedModel).toBe("veo-3.1-generate-preview");
+			expect(videoJob?.upstreamId).toContain("projects/runtime-project/");
+			expect(
+				(
+					videoJob?.upstreamStatusResponse as {
+						google_vertex_project_id?: string;
+					} | null
+				)?.google_vertex_project_id,
+			).toBe("runtime-project");
 
 			setMockVideoStatus(videoJob!.upstreamId, "completed");
 			await processPendingVideoJobs();
@@ -1380,6 +1397,11 @@ describe.skip("videos", () => {
 			} else {
 				delete process.env.LLM_GOOGLE_CLOUD_PROJECT;
 			}
+			if (originalRuntimeGoogleCloudProject !== undefined) {
+				process.env.GOOGLE_CLOUD_PROJECT = originalRuntimeGoogleCloudProject;
+			} else {
+				delete process.env.GOOGLE_CLOUD_PROJECT;
+			}
 			if (originalGoogleVertexRegion !== undefined) {
 				process.env.LLM_GOOGLE_VERTEX_REGION = originalGoogleVertexRegion;
 			} else {
@@ -1402,10 +1424,12 @@ describe.skip("videos", () => {
 
 	test("/v1/videos accepts 10 second google-vertex jobs", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
+		const originalRuntimeGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
 		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
 		const originalGoogleVertexVideoOutputBucket =
 			process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
-		process.env.LLM_GOOGLE_CLOUD_PROJECT = "test-project";
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "provider-project";
+		process.env.GOOGLE_CLOUD_PROJECT = "runtime-project";
 		process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
 		process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET = "vertex-test-bucket";
 
@@ -1454,6 +1478,11 @@ describe.skip("videos", () => {
 				process.env.LLM_GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
 			} else {
 				delete process.env.LLM_GOOGLE_CLOUD_PROJECT;
+			}
+			if (originalRuntimeGoogleCloudProject !== undefined) {
+				process.env.GOOGLE_CLOUD_PROJECT = originalRuntimeGoogleCloudProject;
+			} else {
+				delete process.env.GOOGLE_CLOUD_PROJECT;
 			}
 			if (originalGoogleVertexRegion !== undefined) {
 				process.env.LLM_GOOGLE_VERTEX_REGION = originalGoogleVertexRegion;
@@ -2259,12 +2288,14 @@ describe.skip("videos", () => {
 
 	test("/v1/videos keeps inline vertex output when no GCS bucket is configured", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
+		const originalRuntimeGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
 		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
 		const originalGoogleVertexVideoOutputBucket =
 			process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
 		const originalGoogleVertexSignedUrlBaseUrl =
 			process.env.LLM_GOOGLE_VERTEX_TEST_SIGNED_URL_BASE_URL;
-		process.env.LLM_GOOGLE_CLOUD_PROJECT = "test-project";
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "provider-project";
+		process.env.GOOGLE_CLOUD_PROJECT = "runtime-project";
 		process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
 		delete process.env.LLM_GOOGLE_VERTEX_VIDEO_OUTPUT_BUCKET;
 		delete process.env.LLM_GOOGLE_VERTEX_TEST_SIGNED_URL_BASE_URL;
@@ -2307,6 +2338,14 @@ describe.skip("videos", () => {
 				where: { id: { eq: created.id } },
 			});
 			expect(videoJob?.storageUri).toBeNull();
+			expect(videoJob?.upstreamId).toContain("projects/provider-project/");
+			expect(
+				(
+					videoJob?.upstreamStatusResponse as {
+						google_vertex_project_id?: string;
+					} | null
+				)?.google_vertex_project_id,
+			).toBe("provider-project");
 
 			setMockVideoStatus(videoJob!.upstreamId, "completed");
 			await processPendingVideoJobs();
@@ -2341,6 +2380,11 @@ describe.skip("videos", () => {
 				process.env.LLM_GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
 			} else {
 				delete process.env.LLM_GOOGLE_CLOUD_PROJECT;
+			}
+			if (originalRuntimeGoogleCloudProject !== undefined) {
+				process.env.GOOGLE_CLOUD_PROJECT = originalRuntimeGoogleCloudProject;
+			} else {
+				delete process.env.GOOGLE_CLOUD_PROJECT;
 			}
 			if (originalGoogleVertexRegion !== undefined) {
 				process.env.LLM_GOOGLE_VERTEX_REGION = originalGoogleVertexRegion;

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -2758,7 +2758,20 @@ async function createGoogleVertexVideoJob(
 	upstreamRequest: Record<string, unknown>;
 	upstreamResponse: Record<string, unknown>;
 }> {
-	if (!providerContext.vertexProjectId || !providerContext.vertexRegion) {
+	const outputBucket = getGoogleVertexVideoOutputBucket();
+	const storageProjectId = process.env.GOOGLE_CLOUD_PROJECT?.trim();
+	const vertexProjectId = outputBucket
+		? storageProjectId
+		: providerContext.vertexProjectId;
+
+	if (outputBucket && !storageProjectId) {
+		throw new HTTPException(500, {
+			message:
+				"GOOGLE_CLOUD_PROJECT environment variable is required for google-vertex video output storage",
+		});
+	}
+
+	if (!vertexProjectId || !providerContext.vertexRegion) {
 		throw new HTTPException(500, {
 			message:
 				"Google Vertex video generation requires project and region metadata",
@@ -2775,7 +2788,6 @@ async function createGoogleVertexVideoJob(
 				? "frames"
 				: "none",
 	);
-	const outputBucket = getGoogleVertexVideoOutputBucket();
 	const outputStorageUri = outputBucket
 		? buildVertexVideoOutputStorageUri({
 				bucket: outputBucket,
@@ -2787,7 +2799,7 @@ async function createGoogleVertexVideoJob(
 		: null;
 	const upstreamUrl = joinUrl(
 		providerContext.baseUrl,
-		`/v1/projects/${providerContext.vertexProjectId}/locations/${providerContext.vertexRegion}/publishers/google/models/${upstreamModelName}:predictLongRunning`,
+		`/v1/projects/${vertexProjectId}/locations/${providerContext.vertexRegion}/publishers/google/models/${upstreamModelName}:predictLongRunning`,
 	);
 	const authenticatedUpstreamUrl = appendQueryParam(
 		upstreamUrl,
@@ -2845,7 +2857,7 @@ async function createGoogleVertexVideoJob(
 				name: upstreamId,
 				status: rawResponse.done === true ? "completed" : "queued",
 				duration: durationSeconds,
-				google_vertex_project_id: providerContext.vertexProjectId,
+				google_vertex_project_id: vertexProjectId,
 				google_vertex_region: providerContext.vertexRegion,
 				google_vertex_model_name: upstreamModelName,
 				google_vertex_generate_audio: includeAudio,

--- a/packages/shared/src/gcs.spec.ts
+++ b/packages/shared/src/gcs.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockGetSignedUrl = vi.fn();
+const mockFile = vi.fn(() => ({
+	getSignedUrl: mockGetSignedUrl,
+}));
+const mockBucket = vi.fn(() => ({
+	file: mockFile,
+}));
+const storageConstructor = vi.fn(function MockStorage() {
+	return {
+		bucket: mockBucket,
+	};
+});
+
+vi.mock("@google-cloud/storage", () => ({
+	Storage: storageConstructor,
+}));
+
+const originalGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;
+const originalNodeEnv = process.env.NODE_ENV;
+
+async function loadGcsModule() {
+	vi.resetModules();
+	return await import("./gcs.js");
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetSignedUrl.mockResolvedValue(["https://signed.example/video.mp4"]);
+	process.env.NODE_ENV = "production";
+	delete process.env.GOOGLE_CLOUD_PROJECT;
+});
+
+afterEach(() => {
+	if (originalGoogleCloudProject === undefined) {
+		delete process.env.GOOGLE_CLOUD_PROJECT;
+	} else {
+		process.env.GOOGLE_CLOUD_PROJECT = originalGoogleCloudProject;
+	}
+
+	if (originalNodeEnv === undefined) {
+		delete process.env.NODE_ENV;
+	} else {
+		process.env.NODE_ENV = originalNodeEnv;
+	}
+});
+
+describe("createSignedGcsReadUrl", () => {
+	test("uses GOOGLE_CLOUD_PROJECT for the storage client", async () => {
+		process.env.GOOGLE_CLOUD_PROJECT = "runtime-project";
+		const { createSignedGcsReadUrl } = await loadGcsModule();
+
+		const signedUrl = await createSignedGcsReadUrl(
+			"gs://bucket/path/video.mp4",
+		);
+
+		expect(signedUrl).toBe("https://signed.example/video.mp4");
+		expect(storageConstructor).toHaveBeenCalledWith({
+			projectId: "runtime-project",
+		});
+	});
+
+	test("does not override the storage project when GOOGLE_CLOUD_PROJECT is unset", async () => {
+		const { createSignedGcsReadUrl } = await loadGcsModule();
+
+		const signedUrl = await createSignedGcsReadUrl(
+			"gs://bucket/path/video.mp4",
+		);
+
+		expect(signedUrl).toBe("https://signed.example/video.mp4");
+		expect(storageConstructor).toHaveBeenCalledWith();
+	});
+});

--- a/packages/shared/src/gcs.ts
+++ b/packages/shared/src/gcs.ts
@@ -11,7 +11,8 @@ export interface ParsedGcsUri {
 }
 
 function getStorageClient(): Storage {
-	storageClient ??= new Storage();
+	const projectId = process.env.GOOGLE_CLOUD_PROJECT?.trim();
+	storageClient ??= projectId ? new Storage({ projectId }) : new Storage();
 
 	return storageClient;
 }


### PR DESCRIPTION
## Summary
- use `GOOGLE_CLOUD_PROJECT` for google-vertex video jobs when a GCS output bucket is configured
- keep `LLM_GOOGLE_CLOUD_PROJECT` for normal provider-scoped vertex config
- add coverage for runtime-project storage behavior and GCS client project selection

## Verification
- `pnpm format`
- `pnpm exec vitest run packages/shared/src/gcs.spec.ts --no-file-parallelism`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced environment configuration to support runtime Google Cloud Project settings for video processing and cloud storage operations.

* **Tests**
  * Added new test suite for Google Cloud Storage signed URL generation.
  * Updated video job tests to validate Google Cloud Project configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->