### PR TITLE
docs: fix unified docker run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ docker run -d \
   -v llmgateway_postgres:/var/lib/postgresql/data \
   -v llmgateway_redis:/var/lib/redis \
   -e AUTH_SECRET="$LLM_GATEWAY_SECRET" \
-  -e POSTGRES_PASSWORD="$LLM_GATEWAY_SECRET" \
-  -e DATABASE_URL="postgres://postgres:$LLM_GATEWAY_SECRET@localhost:5432/llmgateway" \
   ghcr.io/theopenco/llmgateway-unified:latest
 ```
 

--- a/apps/docs/content/self-host.mdx
+++ b/apps/docs/content/self-host.mdx
@@ -34,8 +34,6 @@ docker run -d \
   -v llmgateway_postgres:/var/lib/postgresql/data \
   -v llmgateway_redis:/var/lib/redis \
   -e AUTH_SECRET="$LLM_GATEWAY_SECRET" \
-  -e POSTGRES_PASSWORD="$LLM_GATEWAY_SECRET" \
-  -e DATABASE_URL="postgres://postgres:$LLM_GATEWAY_SECRET@localhost:5432/llmgateway" \
   ghcr.io/theopenco/llmgateway-unified:latest
 ```
 

--- a/scripts/run-unified-container.sh
+++ b/scripts/run-unified-container.sh
@@ -8,8 +8,6 @@ set -euo pipefail
 CONTAINER_NAME="${CONTAINER_NAME:-llmgateway}"
 POSTGRES_VOLUME="${POSTGRES_VOLUME:-llmgateway_postgres}"
 REDIS_VOLUME="${REDIS_VOLUME:-llmgateway_redis}"
-POSTGRES_DB="${POSTGRES_DB:-llmgateway}"
-POSTGRES_USER="${POSTGRES_USER:-postgres}"
 
 if [ -z "${LLM_GATEWAY_SECRET:-}" ]; then
     echo "LLM_GATEWAY_SECRET is not set." >&2
@@ -39,10 +37,6 @@ docker run -d \
     -v "$POSTGRES_VOLUME:/var/lib/postgresql/data" \
     -v "$REDIS_VOLUME:/var/lib/redis" \
     -e AUTH_SECRET="$LLM_GATEWAY_SECRET" \
-    -e POSTGRES_PASSWORD="$LLM_GATEWAY_SECRET" \
-    -e POSTGRES_DB="$POSTGRES_DB" \
-    -e POSTGRES_USER="$POSTGRES_USER" \
-    -e DATABASE_URL="postgres://$POSTGRES_USER:$LLM_GATEWAY_SECRET@localhost:5432/$POSTGRES_DB" \
     ghcr.io/theopenco/llmgateway-unified:latest
 
 echo "Container started. Follow logs with:"


### PR DESCRIPTION
## Summary
- replace the broken unified  bind-mount example with named Docker volumes
- document that Docker auto-creates the named volumes and why bind-mounting  fails
- add a helper script and README example that keep  and  aligned
- fix the self-host docs to download  for the unified compose flow

## Testing
- 
- verified docs references for the unified image launch command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Self‑Hosted With Docker section: use Docker‑managed named volumes for DB/Redis, explicit warning against bind‑mounting host DB data, updated env examples to require exporting a secret, and revised compose/env guidance.
* **Chores**
  * Added a helper script to launch the unified container image that validates the required secret, creates volumes, publishes service ports, and prints follow‑up log instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->