### PR TITLE
fix: harden helper edge cases

### DIFF
--- a/packages/models/src/provider.spec.ts
+++ b/packages/models/src/provider.spec.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+	getProviderEnvValue,
+	hasProviderEnvironmentToken,
+} from "./provider.js";
+
+const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+
+const originalOpenAiApiKey = process.env[OPENAI_API_KEY_ENV];
+
+afterEach(() => {
+	if (originalOpenAiApiKey === undefined) {
+		Reflect.deleteProperty(process.env, OPENAI_API_KEY_ENV);
+		return;
+	}
+
+	process.env[OPENAI_API_KEY_ENV] = originalOpenAiApiKey;
+});
+
+describe("provider environment helpers", () => {
+	test("treats whitespace-only provider tokens as missing", () => {
+		process.env[OPENAI_API_KEY_ENV] = "   ";
+
+		expect(hasProviderEnvironmentToken("openai")).toBe(false);
+	});
+
+	test("returns the default value when the configured env var is whitespace-only", () => {
+		process.env[OPENAI_API_KEY_ENV] = "   ";
+
+		expect(getProviderEnvValue("openai", "apiKey", undefined, "fallback")).toBe(
+			"fallback",
+		);
+	});
+});

--- a/packages/models/src/provider.ts
+++ b/packages/models/src/provider.ts
@@ -33,7 +33,7 @@ export function hasProviderEnvironmentToken(
 	provider: Provider | string,
 ): boolean {
 	const envVar = getProviderEnvVar(provider);
-	return envVar ? Boolean(process.env[envVar]) : false;
+	return envVar ? Boolean(process.env[envVar]?.trim()) : false;
 }
 
 export function getProviderEnvValue(
@@ -62,7 +62,7 @@ export function getProviderEnvValue(
 
 	const envValue = process.env[envVarName];
 
-	if (!envValue) {
+	if (!envValue?.trim()) {
 		return defaultValue;
 	}
 

--- a/packages/shared/src/gcs.spec.ts
+++ b/packages/shared/src/gcs.spec.ts
@@ -46,7 +46,23 @@ afterEach(() => {
 	}
 });
 
-describe("createSignedGcsReadUrl", () => {
+describe("gcs", () => {
+	test("buildGcsUri trims the bucket and normalizes the object path", async () => {
+		const { buildGcsUri } = await loadGcsModule();
+
+		expect(buildGcsUri("  bucket  ", " /nested//video.mp4 ")).toBe(
+			"gs://bucket/nested/video.mp4",
+		);
+	});
+
+	test("buildGcsUri rejects empty normalized paths", async () => {
+		const { buildGcsUri } = await loadGcsModule();
+
+		expect(() => buildGcsUri("bucket", " / / ")).toThrow(
+			"GCS object path is required",
+		);
+	});
+
 	test("uses GOOGLE_CLOUD_PROJECT for the storage client", async () => {
 		process.env.GOOGLE_CLOUD_PROJECT = "runtime-project";
 		const { createSignedGcsReadUrl } = await loadGcsModule();

--- a/packages/shared/src/gcs.ts
+++ b/packages/shared/src/gcs.ts
@@ -60,8 +60,18 @@ export function parseGcsUri(
 }
 
 export function buildGcsUri(bucket: string, objectPath: string): string {
+	const normalizedBucket = bucket.trim();
 	const normalizedPath = getNormalizedObjectPath(objectPath);
-	return `gs://${bucket}/${normalizedPath}`;
+
+	if (!normalizedBucket) {
+		throw new Error("GCS bucket is required");
+	}
+
+	if (!normalizedPath) {
+		throw new Error("GCS object path is required");
+	}
+
+	return `gs://${normalizedBucket}/${normalizedPath}`;
 }
 
 export function buildVertexVideoOutputStorageUri(input: {

--- a/packages/shared/src/video-access.spec.ts
+++ b/packages/shared/src/video-access.spec.ts
@@ -72,6 +72,16 @@ describe("video access tokens", () => {
 		expect(verifyVideoContentAccessToken(token, "log-3")).toBe(true);
 	});
 
+	test("requires an explicit truthy opt-in for the development fallback", () => {
+		process.env.NODE_ENV = "test";
+		setOptionalEnv(VIDEO_CONTENT_TOKEN_SECRET_ENV, undefined);
+		process.env[VIDEO_CONTENT_TOKEN_ALLOW_DEV_ENV] = "false";
+
+		expect(() => createVideoContentAccessToken("log-3b")).toThrow(
+			/LLM_VIDEO_CONTENT_JWT_SECRET/,
+		);
+	});
+
 	test("fails closed without a configured secret or explicit opt-in", () => {
 		process.env.NODE_ENV = "test";
 		setOptionalEnv(VIDEO_CONTENT_TOKEN_SECRET_ENV, undefined);

--- a/packages/shared/src/video-access.ts
+++ b/packages/shared/src/video-access.ts
@@ -13,6 +13,11 @@ interface VideoContentTokenPayload {
 	exp: number;
 }
 
+function isExplicitDevFallbackEnabled(): boolean {
+	const value = process.env[VIDEO_CONTENT_TOKEN_ALLOW_DEV_ENV]?.trim();
+	return value === "true" || value === "1";
+}
+
 function getVideoContentTokenSecret(): string {
 	const configuredSecret = process.env[VIDEO_CONTENT_TOKEN_SECRET_ENV]?.trim();
 	if (configuredSecret) {
@@ -21,7 +26,7 @@ function getVideoContentTokenSecret(): string {
 
 	if (
 		process.env.NODE_ENV === "development" ||
-		process.env[VIDEO_CONTENT_TOKEN_ALLOW_DEV_ENV]?.trim()
+		isExplicitDevFallbackEnabled()
 	) {
 		return DEV_VIDEO_CONTENT_TOKEN_SECRET;
 	}


### PR DESCRIPTION
## Summary
- require explicit truthy opt-in before falling back to the development video token secret
- treat whitespace-only provider environment variables as missing credentials
- trim and validate generated GCS URIs so empty object paths are rejected

## Test plan
- pnpm exec vitest run packages/shared/src/video-access.spec.ts packages/shared/src/gcs.spec.ts packages/models/src/provider.spec.ts

## Notes
- `pnpm --filter @llmgateway/shared build` still reports pre-existing unrelated type-resolution issues in shared component files, so verification was done with targeted tests for the touched helpers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitespace handling for provider environment variables—whitespace-only values now treated as empty.
  * Enhanced validation for GCS bucket names and object paths with whitespace trimming.
  * Stricter validation for video content access token development mode settings.

* **Tests**
  * Added tests for provider environment variable whitespace handling.
  * Added tests for GCS URI normalization with whitespace.
  * Added tests for video access token development mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->