### PR TITLE
fix(gateway): warn when providers omit finish reason

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -205,4 +205,25 @@ describe("parseProviderResponse", () => {
 			expect(result.cachedTokens).toBe(0);
 		});
 	});
+
+	describe("alibaba finish reason handling", () => {
+		it("returns null when Alibaba omits finish_reason in chat completions", () => {
+			const json = {
+				choices: [
+					{
+						message: { content: "Hello", role: "assistant" },
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse("alibaba", "deepseek-v3.2", json);
+
+			expect(result.finishReason).toBeNull();
+		});
+	});
 });

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -1,12 +1,36 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UnifiedFinishReason } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 
 import {
 	calculateDataStorageCost,
 	getUnifiedFinishReason,
 	isExpectedUnknownFinishReason,
+	insertLog,
 } from "./logs.js";
+
+vi.mock("@llmgateway/cache", () => ({
+	LOG_QUEUE: "log-queue",
+	publishToQueue: vi.fn().mockResolvedValue(undefined),
+	redisClient: {
+		get: vi.fn(),
+		set: vi.fn(),
+		setex: vi.fn(),
+		del: vi.fn(),
+	},
+}));
+
+vi.mock("@llmgateway/instrumentation", () => ({
+	recordChatCompletionMetrics: vi.fn(),
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
 
 describe("getUnifiedFinishReason", () => {
 	it("maps OpenAI finish reasons correctly", () => {
@@ -182,5 +206,48 @@ describe("calculateDataStorageCost", () => {
 	it("handles string token values", () => {
 		const cost = calculateDataStorageCost("500000", "0", "500000", "0");
 		expect(cost).toBe("0.01");
+	});
+});
+
+describe("insertLog", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("warns when the provider response has no original finish reason", async () => {
+		await insertLog({
+			requestId: "req_missing_finish_reason",
+			usedProvider: "alibaba",
+			usedModel: "deepseek-v3.2",
+			finishReason: null,
+			canceled: false,
+			streamed: false,
+			hasError: false,
+		} as any);
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Missing original finish reason from provider response",
+			expect.objectContaining({
+				requestId: "req_missing_finish_reason",
+				provider: "alibaba",
+				model: "deepseek-v3.2",
+				streamed: false,
+				hasError: false,
+			}),
+		);
+	});
+
+	it("does not warn when a finish reason is present", async () => {
+		await insertLog({
+			requestId: "req_with_finish_reason",
+			usedProvider: "openai",
+			usedModel: "gpt-5.4",
+			finishReason: "stop",
+			canceled: false,
+			streamed: false,
+			hasError: false,
+		} as any);
+
+		expect(logger.warn).not.toHaveBeenCalled();
 	});
 });

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -189,6 +189,17 @@ export async function insertLog(logData: LogInsertData): Promise<unknown> {
 		if (logData.canceled) {
 			logData.unifiedFinishReason = UnifiedFinishReason.CANCELED;
 		} else {
+			if (!logData.finishReason) {
+				logger.warn("Missing original finish reason from provider response", {
+					requestId: logData.requestId,
+					provider: logData.usedProvider,
+					model: logData.usedModel,
+					streamed: logData.streamed,
+					hasError: logData.hasError,
+					errorDetails: logData.errorDetails,
+				});
+			}
+
 			logData.unifiedFinishReason = getUnifiedFinishReason(
 				logData.finishReason,
 				logData.usedProvider,


### PR DESCRIPTION
## Summary
- warn when a provider response is missing the original finish reason before unified normalization
- keep existing unknown-finish-reason error logging for unexpected mapped values
- add coverage for the missing-finish-reason warning path and Alibaba responses without `finish_reason`

## Root cause
Alibaba/OpenAI-format parsing reads `choices[0].finish_reason`. If the upstream response omits that field, the original finish reason stays `null`, so the unified finish reason becomes `unknown` without any explicit signal that the provider omitted the field.

## Test plan
- pnpm -C /home/one/llmgateway build:core
- pnpm -C /home/one/llmgateway exec vitest run apps/gateway/src/lib/logs.spec.ts apps/gateway/src/chat/tools/parse-provider-response.spec.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for Alibaba chat completion parsing when finish reason is absent.
  * Added tests for logging behavior when finish reason is missing or present.

* **Bug Fixes**
  * Emit a warning when chat completion logs lack a finish reason.
  * Preserve explicit empty or falsy values (instead of overwriting them) in various UI displays and API responses so shown labels and metadata remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->