### PR TITLE
chore: ignore next dev types

### DIFF
--- a/apps/code/tsconfig.json
+++ b/apps/code/tsconfig.json
@@ -24,6 +24,13 @@
 			"@/*": ["./src/*"]
 		}
 	},
-	"include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next-env.d.ts"],
-	"exclude": ["node_modules", ".next-dev"]
+	"include": [
+		"next-env.d.ts",
+		"*.ts",
+		"*.tsx",
+		"src/**/*.ts",
+		"src/**/*.tsx",
+		".next/types/**/*.ts"
+	],
+	"exclude": ["node_modules", ".next", ".next-dev"]
 }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -23,11 +23,18 @@
 		"isolatedModules": true
 	},
 	"include": [
-		"**/*.ts",
-		"**/*.tsx",
-		".next/types/**/*.ts",
 		"next-env.d.ts",
+		"*.ts",
+		"*.tsx",
+		"app/**/*.ts",
+		"app/**/*.tsx",
+		"components/**/*.ts",
+		"components/**/*.tsx",
+		"lib/**/*.ts",
+		"lib/**/*.tsx",
+		"scripts/**/*.ts",
+		".next/types/**/*.ts",
 		"out/types/**/*.ts"
 	],
-	"exclude": ["node_modules", ".next-dev"]
+	"exclude": ["node_modules", ".next", ".next-dev"]
 }

--- a/apps/playground/tsconfig.json
+++ b/apps/playground/tsconfig.json
@@ -26,11 +26,13 @@
 		}
 	},
 	"include": [
-		"**/*.ts",
-		"**/*.tsx",
+		"next-env.d.ts",
+		"*.ts",
+		"*.tsx",
+		"src/**/*.ts",
+		"src/**/*.tsx",
 		"./.content-collections/generated/index.d.ts",
-		".next/types/**/*.ts",
-		"next-env.d.ts"
+		".next/types/**/*.ts"
 	],
-	"exclude": ["node_modules", ".next-dev"]
+	"exclude": ["node_modules", ".next", ".next-dev"]
 }

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -26,11 +26,13 @@
 		}
 	},
 	"include": [
-		"**/*.ts",
-		"**/*.tsx",
+		"next-env.d.ts",
+		"*.ts",
+		"*.tsx",
+		"src/**/*.ts",
+		"src/**/*.tsx",
 		"./.content-collections/generated/index.d.ts",
-		".next/types/**/*.ts",
-		"next-env.d.ts"
+		".next/types/**/*.ts"
 	],
-	"exclude": ["node_modules", ".next-dev"]
+	"exclude": ["node_modules", ".next", ".next-dev"]
 }

--- a/ee/admin/tsconfig.json
+++ b/ee/admin/tsconfig.json
@@ -26,11 +26,13 @@
 		}
 	},
 	"include": [
-		"**/*.ts",
-		"**/*.tsx",
+		"next-env.d.ts",
+		"*.ts",
+		"*.tsx",
+		"src/**/*.ts",
+		"src/**/*.tsx",
 		"./.content-collections/generated/index.d.ts",
-		".next/types/**/*.ts",
-		"next-env.d.ts"
+		".next/types/**/*.ts"
 	],
-	"exclude": ["node_modules", ".next-dev"]
+	"exclude": ["node_modules", ".next", ".next-dev"]
 }


### PR DESCRIPTION
## Summary
- narrow Next app tsconfig include globs to explicit source/config paths
- exclude both `.next` and `.next-dev` from TypeScript program inputs
- prevent stale dev route type files from breaking `tsc` during builds

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm build`

## Notes
- Full root build passed, including `apps/playground`
- This fixes the prior failure from `.next-dev/dev/types/routes.d.ts` being picked up during build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configurations across multiple applications to refine file inclusion and exclusion patterns for more precise compilation scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->