### PR TITLE
fix(codex): reject n>1 for google images

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1323,6 +1323,37 @@ describe("api", () => {
 		expect(res.status).toBe(400);
 	});
 
+	for (const model of [
+		"gemini-3-pro-image-preview",
+		"gemini-3.1-flash-image-preview",
+	]) {
+		test(`/v1/chat/completions rejects image_config.n > 1 for ${model}`, async () => {
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer fake",
+				},
+				body: JSON.stringify({
+					model,
+					messages: [
+						{
+							role: "user",
+							content: "Generate a simple image of a red circle.",
+						},
+					],
+					image_config: {
+						n: 2,
+					},
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.message).toContain("image_config.n > 1");
+		});
+	}
+
 	// test for missing Content-Type header
 	test("/v1/chat/completions missing Content-Type header", async () => {
 		const res = await app.request("/v1/chat/completions", {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -143,6 +143,11 @@ import { validateModelCapabilities } from "./tools/validate-model-capabilities.j
 import type { OriginalRequestParams } from "./tools/resolve-provider-context.js";
 import type { ServerTypes } from "@/vars.js";
 
+const googleSingleImageModels = new Set([
+	"gemini-3-pro-image-preview",
+	"gemini-3.1-flash-image-preview",
+]);
+
 /**
  * Filter expanded region entries to only those with available API keys.
  * - Non-regional mappings (no region) pass through unchanged.
@@ -669,11 +674,9 @@ chat.openapi(completions, async (c) => {
 	const requestedRegion = parseResult.requestedRegion;
 
 	// Count input images from messages for cost calculation
-	const inputImageCount =
-		requestedModel === "gemini-3-pro-image-preview" ||
-		requestedModel === "gemini-3.1-flash-image-preview"
-			? countInputImages(messages)
-			: 0;
+	const inputImageCount = googleSingleImageModels.has(requestedModel)
+		? countInputImages(messages)
+		: 0;
 
 	// Resolve model info and filter deactivated providers
 	const modelInfoResult = resolveModelInfo(
@@ -730,6 +733,15 @@ chat.openapi(completions, async (c) => {
 	) {
 		throw new HTTPException(400, {
 			message: `Model ${requestedModel} requires at least one image input. Please include an image in your request.`,
+		});
+	}
+
+	if (
+		googleSingleImageModels.has(requestedModel) &&
+		(image_config?.n ?? 1) > 1
+	) {
+		throw new HTTPException(400, {
+			message: `Model ${requestedModel} does not support image_config.n > 1. Use n=1.`,
 		});
 	}
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1722,12 +1722,13 @@ export async function prepareRequestBody(
 			) {
 				// Set responseModalities to enable image output
 				requestBody.generationConfig.responseModalities = ["TEXT", "IMAGE"];
-				requestBody.generationConfig.imageConfig = {};
 				if (image_config.aspect_ratio !== undefined) {
+					requestBody.generationConfig.imageConfig ??= {};
 					requestBody.generationConfig.imageConfig.aspectRatio =
 						image_config.aspect_ratio;
 				}
 				if (image_config.image_size !== undefined) {
+					requestBody.generationConfig.imageConfig ??= {};
 					requestBody.generationConfig.imageConfig.imageSize =
 						mapGoogleImageSize(image_config.image_size);
 				}


### PR DESCRIPTION
## What changed
- reject `image_config.n > 1` for `gemini-3-pro-image-preview`
- reject `image_config.n > 1` for `gemini-3.1-flash-image-preview`
- stop forwarding Google image counts upstream for these chat-completions requests

## Why
Google image-preview chat completions were accepting `n` at the gateway layer, but the local gateway check showed they still returned a single image in practice. The safer behavior is to reject unsupported multi-image requests explicitly instead of implying that `n > 1` might work.

## Impact
Clients now get a clear `400` with guidance to use `n=1` for the two Google image-preview models.

## Root cause
The gateway exposed `image_config.n`, and earlier work attempted to map it into the Google request path. That created the appearance of support even though these models do not provide reliable multi-image output via chat completions.

## Validation
- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts`
- `pnpm vitest run apps/gateway/src/api.spec.ts -t "rejects image_config.n > 1"`
- `pnpm format`
- `pnpm build`
- live local gateway checks against `http://localhost:4001/v1/chat/completions` for both Google image-preview models with `image_config.n: 2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Gemini image-preview models to enforce single-image requests. Requests with multiple images now return a `400` error with a clear message.

* **Tests**
  * Added test cases validating the single-image constraint for supported Gemini models.

* **Refactor**
  * Optimized image configuration initialization to only create configuration objects when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->