### PR TITLE
fix: omit empty gemini reasoning

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -16,6 +16,45 @@ vi.mock("@llmgateway/logger", () => ({
 }));
 
 describe("parseProviderResponse", () => {
+	describe("google reasoning output", () => {
+		it("treats missing thought text as null when only thought signatures are returned", () => {
+			const json = {
+				candidates: [
+					{
+						content: {
+							role: "model",
+							parts: [
+								{
+									text: "OK",
+									thoughtSignature: "sig-123",
+								},
+							],
+						},
+						finishReason: "STOP",
+					},
+				],
+				usageMetadata: {
+					promptTokenCount: 5,
+					candidatesTokenCount: 1,
+					totalTokenCount: 50,
+					thoughtsTokenCount: 44,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"google-vertex",
+				"gemini-3-flash-preview",
+				json,
+			);
+
+			expect(result.content).toBe("OK");
+			expect(result.reasoningContent).toBeNull();
+			expect(result.reasoningTokens).toBe(44);
+			expect(result.completionTokens).toBe(45);
+			expect(result.finishReason).toBe("STOP");
+		});
+	});
+
 	describe("aws-bedrock cachedTokens", () => {
 		it("returns cachedTokens as 0 when cacheReadInputTokens is 0", () => {
 			const json = {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -218,9 +218,13 @@ export function parseProviderResponse(
 			const contentParts = parts.filter((part: any) => !part.thought);
 			const reasoningParts = parts.filter((part: any) => part.thought);
 
-			content = contentParts.map((part: any) => part.text).join("") ?? null;
-			reasoningContent =
-				reasoningParts.map((part: any) => part.text).join("") ?? null;
+			const textContent = contentParts.map((part: any) => part.text).join("");
+			const thoughtContent = reasoningParts
+				.map((part: any) => part.text)
+				.join("");
+
+			content = textContent.length > 0 ? textContent : null;
+			reasoningContent = thoughtContent.length > 0 ? thoughtContent : null;
 
 			// Extract images from Google response parts
 			const imageParts = parts.filter((part: any) => part.inlineData);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed response parsing for Google Vertex AI and related providers to properly handle empty text and reasoning segments, ensuring null values are returned instead of empty strings.

* **Tests**
  * Added test coverage for Google Vertex AI reasoning output parsing, including scenarios with missing thought content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->