### PR TITLE
chore: hardcode production URLs in code app

### DIFF
--- a/apps/code/src/lib/config-server.ts
+++ b/apps/code/src/lib/config-server.ts
@@ -14,18 +14,17 @@ export interface AppConfig {
 }
 
 export function getConfig(): AppConfig {
-	const apiUrl = process.env.API_URL ?? "http://localhost:4002";
+	const apiUrl = "https://api.llmgateway.io";
 	return {
-		hosted: process.env.HOSTED === "true",
+		hosted: true,
 		apiUrl,
 		apiBackendUrl: process.env.API_BACKEND_URL ?? apiUrl,
-		uiUrl: process.env.UI_URL ?? "http://localhost:3002",
-		playgroundUrl: process.env.PLAYGROUND_URL ?? "http://localhost:3003",
-		docsUrl: process.env.DOCS_URL ?? "http://localhost:3005",
-		githubUrl:
-			process.env.GITHUB_URL ?? "https://github.com/theopenco/llmgateway",
-		discordUrl: process.env.DISCORD_URL ?? "https://llmgateway.io/discord",
-		twitterUrl: process.env.TWITTER_URL ?? "https://x.com/llmgateway",
+		uiUrl: "https://llmgateway.io",
+		playgroundUrl: "https://chat.llmgateway.io",
+		docsUrl: "https://docs.llmgateway.io",
+		githubUrl: "https://github.com/theopenco/llmgateway",
+		discordUrl: "https://llmgateway.io/discord",
+		twitterUrl: "https://x.com/llmgateway",
 		posthogKey: process.env.POSTHOG_KEY,
 		posthogHost: process.env.POSTHOG_HOST,
 		stripePublishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,


### PR DESCRIPTION
## Summary
- Hardcode production URLs in `apps/code/src/lib/config-server.ts` instead of reading from env vars with localhost fallbacks
- Sets `hosted: true`, `apiUrl`, `uiUrl`, `playgroundUrl`, `docsUrl`, `githubUrl`, `discordUrl`, and `twitterUrl` to their production values
- Keeps `apiBackendUrl`, `posthogKey`, `posthogHost`, and `stripePublishableKey` as env vars (runtime/secret values)

## Test plan
- [ ] Verify code app loads correctly with hardcoded URLs
- [ ] Verify all links (docs, playground, UI, GitHub, Discord, Twitter) point to correct production destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Configuration system updated to use hardcoded production URLs for core services while maintaining environment variable support for API backend, analytics, and payment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->