### PR TITLE
fix: enable haiku 4.5 json

### DIFF
--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -170,54 +170,6 @@ describe("e2e individual tests", () => {
 	);
 
 	test(
-		"JSON output mode works for Claude Haiku 4.5",
-		getTestOptions({ completions: false }),
-		async () => {
-			const envVarName = getProviderEnvVar("anthropic");
-			const envVarValue = envVarName ? process.env[envVarName] : undefined;
-			if (!envVarValue) {
-				console.log(
-					"Skipping Claude Haiku 4.5 JSON output test - no Anthropic API key provided",
-				);
-				return;
-			}
-
-			const { token } = await createTestData("json-haiku");
-
-			const res = await app.request("/v1/chat/completions", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer ${token}`,
-				},
-				body: JSON.stringify({
-					model: "anthropic/claude-haiku-4-5",
-					messages: [
-						{
-							role: "system",
-							content:
-								"You are a helpful assistant. Always respond with valid JSON.",
-						},
-						{
-							role: "user",
-							content: 'Return a JSON object with "message": "Hello"',
-						},
-					],
-					response_format: { type: "json_object" },
-				}),
-			});
-
-			expect(res.status).toBe(200);
-
-			const json = await res.json();
-			expect(json).toHaveProperty("choices[0].message.content");
-			const content = json.choices[0].message.content;
-			expect(() => JSON.parse(content)).not.toThrow();
-			expect(JSON.parse(content)).toHaveProperty("message");
-		},
-	);
-
-	test(
 		"Tool calls error for unsupported model",
 		getTestOptions({ completions: false }),
 		async () => {

--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -130,19 +130,19 @@ describe("e2e individual tests", () => {
 	}
 
 	test(
-		"JSON output mode error for unsupported model",
+		"JSON output mode works for Claude Haiku 4.5",
 		getTestOptions({ completions: false }),
 		async () => {
 			const envVarName = getProviderEnvVar("anthropic");
 			const envVarValue = envVarName ? process.env[envVarName] : undefined;
 			if (!envVarValue) {
 				console.log(
-					"Skipping JSON output error test - no Anthropic API key provided",
+					"Skipping Claude Haiku 4.5 JSON output test - no Anthropic API key provided",
 				);
 				return;
 			}
 
-			const { token } = await createTestData("json-error");
+			const { token } = await createTestData("json-haiku");
 
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -154,18 +154,26 @@ describe("e2e individual tests", () => {
 					model: "anthropic/claude-haiku-4-5",
 					messages: [
 						{
+							role: "system",
+							content:
+								"You are a helpful assistant. Always respond with valid JSON.",
+						},
+						{
 							role: "user",
-							content: "Hello",
+							content: 'Return a JSON object with "message": "Hello"',
 						},
 					],
 					response_format: { type: "json_object" },
 				}),
 			});
 
-			expect(res.status).toBe(400);
+			expect(res.status).toBe(200);
 
-			const text = await res.text();
-			expect(text).toContain("does not support JSON output mode");
+			const json = await res.json();
+			expect(json).toHaveProperty("choices[0].message.content");
+			const content = json.choices[0].message.content;
+			expect(() => JSON.parse(content)).not.toThrow();
+			expect(JSON.parse(content)).toHaveProperty("message");
 		},
 	);
 

--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -130,6 +130,46 @@ describe("e2e individual tests", () => {
 	}
 
 	test(
+		"JSON output mode error for unsupported model",
+		getTestOptions({ completions: false }),
+		async () => {
+			const envVarName = getProviderEnvVar("openai");
+			const envVarValue = envVarName ? process.env[envVarName] : undefined;
+			if (!envVarValue) {
+				console.log(
+					"Skipping JSON output error test - no OpenAI API key provided",
+				);
+				return;
+			}
+
+			const { token } = await createTestData("json-error");
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+				},
+				body: JSON.stringify({
+					model: "openai/gpt-4o-mini-search-preview",
+					messages: [
+						{
+							role: "user",
+							content: "Hello",
+						},
+					],
+					response_format: { type: "json_object" },
+				}),
+			});
+
+			expect(res.status).toBe(400);
+
+			const text = await res.text();
+			expect(text).toContain("does not support JSON output mode");
+		},
+	);
+
+	test(
 		"JSON output mode works for Claude Haiku 4.5",
 		getTestOptions({ completions: false }),
 		async () => {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -5434,6 +5434,10 @@ chat.openapi(completions, async (c) => {
 				const shouldBufferForHealing =
 					streamingIsJsonResponseFormat &&
 					(streamingResponseHealingEnabled === true ||
+						(usedProvider === "anthropic" &&
+							response_format?.type === "json_object") ||
+						(usedProvider === "aws-bedrock" &&
+							response_format?.type === "json_object") ||
 						usedProvider === "novita" ||
 						splitTaggedReasoning);
 
@@ -8744,6 +8748,10 @@ chat.openapi(completions, async (c) => {
 	const shouldHealNonStreaming =
 		isJsonResponseFormat &&
 		(responseHealingEnabled === true ||
+			(usedProvider === "anthropic" &&
+				response_format?.type === "json_object") ||
+			(usedProvider === "aws-bedrock" &&
+				response_format?.type === "json_object") ||
 			usedProvider === "novita" ||
 			splitTaggedReasoning);
 

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -413,6 +413,7 @@ export const anthropicModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				jsonOutput: true,
 				jsonOutputSchema: true,
 				webSearch: true,
 				webSearchPrice: 0.01, // $10 per 1000 searches
@@ -431,6 +432,7 @@ export const anthropicModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				jsonOutput: true,
 				jsonOutputSchema: true,
 			},
 		],
@@ -456,6 +458,7 @@ export const anthropicModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				jsonOutput: true,
 				jsonOutputSchema: true,
 				webSearch: true,
 				webSearchPrice: 0.01, // $10 per 1000 searches
@@ -474,6 +477,7 @@ export const anthropicModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				jsonOutput: true,
 				jsonOutputSchema: true,
 			},
 		],


### PR DESCRIPTION
## Summary
- mark Claude Haiku 4.5 and its dated mappings as supporting `response_format: { type: "json_object" }`
- auto-heal Anthropic and Bedrock `json_object` responses so fenced JSON is normalized before returning
- replace the old unsupported-model regression with a passing Haiku 4.5 JSON-mode e2e assertion

## Verification
- `pnpm exec vitest run packages/actions/src/prepare-request-body.spec.ts apps/gateway/src/chat/tools/heal-json-response.spec.ts --no-file-parallelism`
- `TEST_MODELS="anthropic/claude-haiku-4-5" pnpm test:e2e -- apps/gateway/src/chat-json.e2e.ts apps/gateway/src/api-individual.e2e.ts`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON output format enabled for Anthropic models.

* **Bug Fixes / Improvements**
  * Improved JSON response handling and “healing” for Anthropic and AWS Bedrock providers to produce more reliable JSON outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->