### PR TITLE
fix(api): unify no-fallback override

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -517,6 +517,90 @@ describe("api", () => {
 		expect(JSON.stringify(json)).not.toContain('"path":["size"]');
 	});
 
+	test("/v1/images/generations forwards X-No-Fallback to chat completions", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-image-no-fallback",
+			token: "real-token-image-no-fallback",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const originalRequest: typeof app.request = app.request.bind(app);
+		let forwardedNoFallbackHeader: string | null | undefined;
+
+		const requestSpy = vi
+			.spyOn(app, "request")
+			.mockImplementation(
+				async (...args: Parameters<typeof app.request>): Promise<Response> => {
+					const [input, init] = args;
+					if (input === "/v1/chat/completions") {
+						const headers = new Headers(init?.headers);
+						forwardedNoFallbackHeader = headers.get("x-no-fallback");
+
+						return new Response(
+							JSON.stringify({
+								id: "chatcmpl-image-no-fallback",
+								object: "chat.completion",
+								created: 1774549411,
+								model: "gemini-3-pro-image-preview",
+								choices: [
+									{
+										index: 0,
+										message: {
+											role: "assistant",
+											content: null,
+											images: [
+												{
+													image_url: {
+														url: "data:image/png;base64,aGVsbG8=",
+													},
+												},
+											],
+										},
+										finish_reason: "stop",
+									},
+								],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									total_tokens: 2,
+								},
+							}),
+							{
+								status: 200,
+								headers: {
+									"Content-Type": "application/json",
+								},
+							},
+						);
+					}
+
+					return await originalRequest(...args);
+				},
+			);
+
+		try {
+			const res = await app.request("/v1/images/generations", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-image-no-fallback",
+					"x-no-fallback": "true",
+				},
+				body: JSON.stringify({
+					model: "gemini-3-pro-image-preview",
+					prompt: "Generate a mountain at sunrise",
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(forwardedNoFallbackHeader).toBe("true");
+		} finally {
+			requestSpy.mockRestore();
+		}
+	});
+
 	test("/v1/images/generations returns empty data for content filter", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-image-generation-content-filter",

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -601,6 +601,96 @@ describe("api", () => {
 		}
 	});
 
+	test("/v1/images/edits forwards X-No-Fallback to chat completions", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-image-edits-no-fallback",
+			token: "real-token-image-edits-no-fallback",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const originalRequest: typeof app.request = app.request.bind(app);
+		let forwardedNoFallbackHeader: string | null | undefined;
+
+		const requestSpy = vi
+			.spyOn(app, "request")
+			.mockImplementation(
+				async (...args: Parameters<typeof app.request>): Promise<Response> => {
+					const [input, init] = args;
+					if (input === "/v1/chat/completions") {
+						const headers = new Headers(init?.headers);
+						forwardedNoFallbackHeader = headers.get("x-no-fallback");
+
+						return new Response(
+							JSON.stringify({
+								id: "chatcmpl-image-edit-no-fallback",
+								object: "chat.completion",
+								created: 1774549411,
+								model: "gemini-3-pro-image-preview",
+								choices: [
+									{
+										index: 0,
+										message: {
+											role: "assistant",
+											content: null,
+											images: [
+												{
+													image_url: {
+														url: "data:image/png;base64,aGVsbG8=",
+													},
+												},
+											],
+										},
+										finish_reason: "stop",
+									},
+								],
+								usage: {
+									prompt_tokens: 1,
+									completion_tokens: 1,
+									total_tokens: 2,
+								},
+							}),
+							{
+								status: 200,
+								headers: {
+									"Content-Type": "application/json",
+								},
+							},
+						);
+					}
+
+					return await originalRequest(...args);
+				},
+			);
+
+		try {
+			const res = await app.request("/v1/images/edits", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-image-edits-no-fallback",
+					"x-no-fallback": "true",
+				},
+				body: JSON.stringify({
+					model: "gemini-3-pro-image-preview",
+					prompt: "Add a neon city reflection to this image",
+					images: [
+						{
+							image_url:
+								"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAJFBMVEX///////9MaXH///////////////////////////////////8ZR3RTAAAADHRSTlP+jgB78KRmvTse21aub7wnAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAc0lEQVR42l3PWRIDIQgE0G5Z1fvfN7hMKhO+5BWtgraqU933qWG1BkCg0jfkahcAyt4QQOiFKmJI+oWhezRwI0Zx1rzRZ44C7gRIMws8oKDFiT4QdHvBNMUL1LKu3KAnUu+fCWndp/98Xf6Xm1846+dZ/wNI2AJy5D7oXAAAAABJRU5ErkJggg==",
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(forwardedNoFallbackHeader).toBe("true");
+		} finally {
+			requestSpy.mockRestore();
+		}
+	});
+
 	test("/v1/images/generations returns empty data for content filter", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-image-generation-content-filter",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -39,6 +39,7 @@ import {
 	providerRateLimitWindows,
 } from "@/lib/provider-rate-limit.js";
 import { getResponsesContext } from "@/lib/responses-context.js";
+import { getNoFallbackRoutingMetadata } from "@/lib/routing-metadata.js";
 import {
 	createCombinedSignal,
 	createStreamingCombinedSignal,
@@ -453,16 +454,6 @@ function addContentFilterRoutingMetadata(
 				? contentFilterExcludedProviders
 				: undefined,
 		providerScores,
-	};
-}
-
-function getNoFallbackRoutingMetadata(
-	noFallback: boolean,
-	xNoFallbackHeaderSet: boolean,
-): Pick<RoutingMetadata, "noFallback" | "xNoFallbackHeaderSet"> {
-	return {
-		...(noFallback ? { noFallback: true } : {}),
-		...(xNoFallbackHeaderSet ? { xNoFallbackHeaderSet: true } : {}),
 	};
 }
 
@@ -2090,6 +2081,10 @@ chat.openapi(completions, async (c) => {
 									originalProviderScore,
 									...cheapestResult.metadata.providerScores,
 								],
+								...getNoFallbackRoutingMetadata(
+									noFallback,
+									xNoFallbackHeaderSet,
+								),
 							};
 						}
 					}
@@ -2252,6 +2247,10 @@ chat.openapi(completions, async (c) => {
 										originalProviderScore,
 										...cheapestResult.metadata.providerScores,
 									],
+									...getNoFallbackRoutingMetadata(
+										noFallback,
+										xNoFallbackHeaderSet,
+									),
 								};
 							}
 						}

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -456,6 +456,16 @@ function addContentFilterRoutingMetadata(
 	};
 }
 
+function getNoFallbackRoutingMetadata(
+	noFallback: boolean,
+	xNoFallbackHeaderSet: boolean,
+): Pick<RoutingMetadata, "noFallback" | "xNoFallbackHeaderSet"> {
+	return {
+		...(noFallback ? { noFallback: true } : {}),
+		...(xNoFallbackHeaderSet ? { xNoFallbackHeaderSet: true } : {}),
+	};
+}
+
 function withUsedApiKeyHash(
 	routingMetadata: RoutingMetadata | undefined,
 	usedApiKeyHash: string | undefined,
@@ -1099,6 +1109,9 @@ chat.openapi(completions, async (c) => {
 		);
 
 	// Check for X-No-Fallback header to disable provider fallback on low uptime
+	const xNoFallbackHeaderSet =
+		c.req.raw.headers.has("x-no-fallback") ||
+		c.req.raw.headers.has("X-No-Fallback");
 	const noFallback =
 		c.req.raw.headers.get("x-no-fallback") === "true" ||
 		c.req.raw.headers.get("X-No-Fallback") === "true";
@@ -1711,7 +1724,7 @@ chat.openapi(completions, async (c) => {
 				usedRegion = cheapestResult.provider.region;
 				routingMetadata = {
 					...cheapestResult.metadata,
-					...(noFallback ? { noFallback: true } : {}),
+					...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
 				};
 			} else {
 				// Fallback to first available provider if price comparison fails
@@ -2392,7 +2405,7 @@ chat.openapi(completions, async (c) => {
 					routingMetadata = addContentFilterRoutingMetadata(
 						{
 							...cheapestResult.metadata,
-							...(noFallback ? { noFallback: true } : {}),
+							...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
 						},
 						contentFilterMatched,
 						contentFilterRoutingExcludedProviders,
@@ -2579,7 +2592,7 @@ chat.openapi(completions, async (c) => {
 				selectedProvider: usedProvider,
 				selectionReason,
 				providerScores: allProviderScores,
-				...(noFallback ? { noFallback: true } : {}),
+				...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
 			},
 			contentFilterMatched,
 			contentFilterRoutingExcludedProviders,

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -1561,6 +1561,7 @@ describe("fallback and error status code handling", () => {
 			const log = logs[0];
 			expect(log.routingMetadata).toBeTruthy();
 			expect(log.routingMetadata).toHaveProperty("noFallback", true);
+			expect(log.routingMetadata).toHaveProperty("xNoFallbackHeaderSet", true);
 		});
 
 		test("content filter hit reroutes away from content-filter providers and records it in routing metadata", async () => {

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -278,6 +278,10 @@ async function extractImagesFromChatResponse(
 }
 
 function forwardHeaders(c: Context): Record<string, string> {
+	const noFallbackHeader =
+		c.req.raw.headers.get("x-no-fallback") ??
+		c.req.raw.headers.get("X-No-Fallback");
+
 	return {
 		"Content-Type": "application/json",
 		Authorization: c.req.header("Authorization") ?? "",
@@ -286,7 +290,7 @@ function forwardHeaders(c: Context): Record<string, string> {
 		"x-request-id": c.req.header("x-request-id") ?? "",
 		"x-source": c.req.header("x-source") ?? "",
 		"x-debug": c.req.header("x-debug") ?? "",
-		"x-no-fallback": c.req.header("x-no-fallback") ?? "",
+		...(noFallbackHeader !== null ? { "x-no-fallback": noFallbackHeader } : {}),
 		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
 	};
 }

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -286,6 +286,7 @@ function forwardHeaders(c: Context): Record<string, string> {
 		"x-request-id": c.req.header("x-request-id") ?? "",
 		"x-source": c.req.header("x-source") ?? "",
 		"x-debug": c.req.header("x-debug") ?? "",
+		"x-no-fallback": c.req.header("x-no-fallback") ?? "",
 		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
 	};
 }

--- a/apps/gateway/src/lib/routing-metadata.ts
+++ b/apps/gateway/src/lib/routing-metadata.ts
@@ -1,0 +1,11 @@
+import type { RoutingMetadata } from "@llmgateway/actions";
+
+export function getNoFallbackRoutingMetadata(
+	noFallback: boolean,
+	xNoFallbackHeaderSet: boolean,
+): Partial<RoutingMetadata> {
+	return {
+		...(noFallback ? { noFallback: true } : {}),
+		...(xNoFallbackHeaderSet ? { xNoFallbackHeaderSet: true } : {}),
+	};
+}

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -90,6 +90,49 @@ describe("videos", () => {
 		).toBe("1280x720");
 	});
 
+	test("/v1/videos records X-No-Fallback routing metadata", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-video-no-fallback",
+			token: "real-token-video-no-fallback",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-video-no-fallback",
+			token: "sk-test-key-video-no-fallback",
+			provider: "obsidian",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-video-no-fallback",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "veo-3.1-generate-preview",
+				prompt: "A robot dancing in the rain",
+				seconds: 8,
+			}),
+		});
+
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: json.id } },
+		});
+		expect(videoJob?.routingMetadata).toMatchObject({
+			noFallback: true,
+			xNoFallbackHeaderSet: true,
+		});
+	});
+
 	test("/v1/videos rejects sizes that obsidian does not support", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -610,6 +610,16 @@ function isNoFallbackEnabled(c: Context): boolean {
 	);
 }
 
+function getNoFallbackRoutingMetadata(
+	noFallback: boolean,
+	xNoFallbackHeaderSet: boolean,
+): Pick<RoutingMetadata, "noFallback" | "xNoFallbackHeaderSet"> {
+	return {
+		...(noFallback ? { noFallback: true } : {}),
+		...(xNoFallbackHeaderSet ? { xNoFallbackHeaderSet: true } : {}),
+	};
+}
+
 function extractToken(c: Context): string {
 	const auth = c.req.header("Authorization");
 	const xApiKey = c.req.header("x-api-key");
@@ -1405,6 +1415,7 @@ async function resolveVideoExecution(
 	organizationId: string,
 	requestId: string,
 	noFallback: boolean,
+	xNoFallbackHeaderSet: boolean,
 ): Promise<ResolvedVideoExecution> {
 	const videoPricing: VideoPricingContext = {
 		durationSeconds: videoDurationSeconds,
@@ -1553,7 +1564,7 @@ async function resolveVideoExecution(
 								},
 								...betterResult.metadata.providerScores,
 							],
-							...(noFallback ? { noFallback: true } : {}),
+							...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
 						};
 
 						const orderedProviderIds = [
@@ -1589,7 +1600,7 @@ async function resolveVideoExecution(
 			if (cheapestResult) {
 				routingMetadata = {
 					...cheapestResult.metadata,
-					...(noFallback ? { noFallback: true } : {}),
+					...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
 				};
 				const orderedProviderIds = [
 					cheapestResult.provider.providerId,
@@ -1629,7 +1640,7 @@ async function resolveVideoExecution(
 			score: provider.providerId === orderedMappings[0].providerId ? 0 : 1,
 			price: getProviderSelectionPrice(provider, videoPricing),
 		})),
-		...(noFallback ? { noFallback: true } : {}),
+		...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
 	};
 
 	const providerMapping = orderedMappings[0];
@@ -3220,6 +3231,9 @@ videos.openapi(createVideo, async (c) => {
 	);
 	const debugMode = isDebugMode(c);
 	const noFallback = isNoFallbackEnabled(c);
+	const xNoFallbackHeaderSet =
+		c.req.raw.headers.has("x-no-fallback") ||
+		c.req.raw.headers.has("X-No-Fallback");
 
 	const modelInfo = models.find((model) => model.id === normalizedModel);
 	if (!modelInfo) {
@@ -3264,6 +3278,7 @@ videos.openapi(createVideo, async (c) => {
 		organization.id,
 		requestId,
 		noFallback,
+		xNoFallbackHeaderSet,
 	);
 
 	const videoId = shortid();

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -17,6 +17,7 @@ import {
 	findProviderKey,
 } from "@/lib/cached-queries.js";
 import { validateModelAccess } from "@/lib/iam.js";
+import { getNoFallbackRoutingMetadata } from "@/lib/routing-metadata.js";
 
 import {
 	getCheapestFromAvailableProviders,
@@ -608,16 +609,6 @@ function isNoFallbackEnabled(c: Context): boolean {
 		c.req.raw.headers.get("x-no-fallback") === "true" ||
 		c.req.raw.headers.get("x-no-fallback") === "1"
 	);
-}
-
-function getNoFallbackRoutingMetadata(
-	noFallback: boolean,
-	xNoFallbackHeaderSet: boolean,
-): Pick<RoutingMetadata, "noFallback" | "xNoFallbackHeaderSet"> {
-	return {
-		...(noFallback ? { noFallback: true } : {}),
-		...(xNoFallbackHeaderSet ? { xNoFallbackHeaderSet: true } : {}),
-	};
 }
 
 function extractToken(c: Context): string {

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -27,6 +27,7 @@ import { useMcpServers } from "@/hooks/useMcpServers";
 import { useUser } from "@/hooks/useUser";
 import { parseImageFile } from "@/lib/image-utils";
 import { mapModels } from "@/lib/mapmodels";
+import { shouldDisableFallback } from "@/lib/no-fallback";
 import { getErrorMessage } from "@/lib/utils";
 
 import type {
@@ -424,12 +425,7 @@ export default function ChatPageClient({
 						}
 				: undefined;
 
-			// Automatically disable provider fallback for provider-specific model selections
-			const isProviderSpecific = selectedModel.includes("/");
-			const localStorageOverride =
-				typeof window !== "undefined" &&
-				localStorage.getItem("llmgateway_no_fallback") === "true";
-			const noFallback = isProviderSpecific || localStorageOverride;
+			const noFallback = shouldDisableFallback(selectedModel);
 
 			// Get enabled MCP servers
 			const enabledMcpServers = getEnabledMcpServers();
@@ -1298,11 +1294,7 @@ function ExtraChatPanel({
 						}
 				: undefined;
 
-			const isProviderSpecific = selectedModel.includes("/");
-			const localStorageOverride =
-				typeof window !== "undefined" &&
-				localStorage.getItem("llmgateway_no_fallback") === "true";
-			const noFallback = isProviderSpecific || localStorageOverride;
+			const noFallback = shouldDisableFallback(selectedModel);
 
 			const mergedOptions = {
 				...options,

--- a/apps/playground/src/components/playground/group-chat-client.tsx
+++ b/apps/playground/src/components/playground/group-chat-client.tsx
@@ -15,6 +15,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useUser } from "@/hooks/useUser";
 import { mapModels } from "@/lib/mapmodels";
+import { shouldDisableFallback } from "@/lib/no-fallback";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
 
@@ -299,11 +300,7 @@ export default function GroupChatClient({
 			],
 		};
 
-		const isProviderSpecific = currentModel.includes("/");
-		const localStorageOverride =
-			typeof window !== "undefined" &&
-			localStorage.getItem("llmgateway_no_fallback") === "true";
-		const noFallback = isProviderSpecific || localStorageOverride;
+		const noFallback = shouldDisableFallback(currentModel);
 
 		try {
 			await sendMessage(userUiMessage as any, {

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -16,6 +16,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { useUser } from "@/hooks/useUser";
 import { getModelImageConfig } from "@/lib/image-gen";
 import { mapModels } from "@/lib/mapmodels";
+import { shouldDisableFallback } from "@/lib/no-fallback";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
 import type { AspectRatio, GalleryItem } from "@/lib/image-gen";
@@ -266,14 +267,14 @@ export default function ImagePageClient({
 			pendingRef.current = selectedModels.length;
 
 			for (const modelId of selectedModels) {
-				const isProviderSpecific = modelId.includes("/");
+				const noFallback = shouldDisableFallback(modelId);
 				void (async () => {
 					try {
 						const response = await fetch("/api/image", {
 							method: "POST",
 							headers: {
 								"Content-Type": "application/json",
-								...(isProviderSpecific ? { "x-no-fallback": "true" } : {}),
+								...(noFallback ? { "x-no-fallback": "true" } : {}),
 							},
 							body: JSON.stringify({
 								prompt: currentPrompt,

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -15,6 +15,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { useUser } from "@/hooks/useUser";
 import { useFetchClient } from "@/lib/fetch-client";
 import { mapModels } from "@/lib/mapmodels";
+import { shouldDisableFallback } from "@/lib/no-fallback";
 import {
 	getNormalizedVideoRequestSelection,
 	getSupportedVideoRequestOptions,
@@ -427,7 +428,7 @@ export default function VideoPageClient({
 			pendingRef.current = selectedModels.length;
 
 			for (const modelId of selectedModels) {
-				const isProviderSpecific = modelId.includes("/");
+				const noFallback = shouldDisableFallback(modelId);
 				const controllerKey = `${itemId}-${modelId}`;
 				const controller = new AbortController();
 				abortControllersRef.current.set(controllerKey, controller);
@@ -438,7 +439,7 @@ export default function VideoPageClient({
 							method: "POST",
 							headers: {
 								"Content-Type": "application/json",
-								...(isProviderSpecific ? { "x-no-fallback": "true" } : {}),
+								...(noFallback ? { "x-no-fallback": "true" } : {}),
 							},
 							body: JSON.stringify({
 								model: modelId,

--- a/apps/playground/src/lib/no-fallback.ts
+++ b/apps/playground/src/lib/no-fallback.ts
@@ -1,0 +1,10 @@
+export const NO_FALLBACK_LOCAL_STORAGE_KEY = "llmgateway_no_fallback";
+
+export function shouldDisableFallback(modelId: string): boolean {
+	const isProviderSpecific = modelId.includes("/");
+	const localStorageOverride =
+		typeof window !== "undefined" &&
+		localStorage.getItem(NO_FALLBACK_LOCAL_STORAGE_KEY) === "true";
+
+	return isProviderSpecific || localStorageOverride;
+}

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -117,6 +117,8 @@ export interface RoutingMetadata {
 	originalProviderRateLimited?: boolean;
 	// Whether fallback was disabled via X-No-Fallback header
 	noFallback?: boolean;
+	// Whether the request explicitly included an X-No-Fallback header
+	xNoFallbackHeaderSet?: boolean;
 	// Whether the gateway content filter matched for the request before upstream routing
 	contentFilterMatched?: boolean;
 	// Whether routing excluded content-filter providers in favor of alternatives

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -564,6 +564,7 @@ export const log = pgTable(
 			originalProviderUptime?: number;
 			originalProviderRateLimited?: boolean;
 			noFallback?: boolean;
+			xNoFallbackHeaderSet?: boolean;
 			contentFilterMatched?: boolean;
 			contentFilterRerouted?: boolean;
 			contentFilterExcludedProviders?: string[];
@@ -728,6 +729,7 @@ export const videoJob = pgTable(
 			originalProviderUptime?: number;
 			originalProviderRateLimited?: boolean;
 			noFallback?: boolean;
+			xNoFallbackHeaderSet?: boolean;
 			contentFilterMatched?: boolean;
 			contentFilterRerouted?: boolean;
 			contentFilterExcludedProviders?: string[];

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -51,6 +51,8 @@ interface RoutingMetadata {
 	selectionReason?: string;
 	usedApiKeyHash?: string;
 	availableProviders?: string[];
+	xNoFallbackHeaderSet?: boolean;
+	noFallback?: boolean;
 	providerScores?: Array<{
 		providerId: string;
 		region?: string;
@@ -556,6 +558,19 @@ export function LogCard({
 												<span className="text-muted-foreground">Key</span>
 												<span className="font-mono">
 													{formatApiKeyHash(routingMetadata.usedApiKeyHash)}
+												</span>
+											</div>
+										)}
+										{routingMetadata.xNoFallbackHeaderSet !== undefined && (
+											<div className="flex justify-between">
+												<span className="text-muted-foreground">
+													X-No-Fallback
+												</span>
+												<span className="font-mono">
+													{routingMetadata.xNoFallbackHeaderSet
+														? "set"
+														: "unset"}
+													{routingMetadata.noFallback ? " (active)" : ""}
 												</span>
 											</div>
 										)}


### PR DESCRIPTION
## What changed
- added a shared playground helper for deciding when fallback should be disabled
- applied the same `x-no-fallback` logic across chat, group chat, image studio, and video studio
- kept provider-specific model selection behavior intact while also honoring the local `llmgateway_no_fallback` override everywhere

## Why
Image and video studio requests already forwarded `x-no-fallback` in their API routes, but their client pages only set the header for provider-specific models. That meant the local override worked in chat flows but not consistently in image/video flows.

## Impact
- setting `localStorage["llmgateway_no_fallback"] = "true"` now affects all playground request flows
- provider-specific selections still force `x-no-fallback` as before
- behavior is now consistent across the playground UI

## Validation
- `pnpm format`
- `pnpm --filter playground build`
- attempted `pnpm build`, but it is currently blocked by an unrelated existing `apps/ui` build error: missing `canvas-confetti` in `apps/ui/src/components/credits/top-up-credits-dialog.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified fallback determination across playground chat, image, and video flows for consistent behavior.

* **New Features**
  * Routing Info in Request Details now shows an "X-No-Fallback" row indicating header presence and whether fallback is active.
  * Gateway now preserves and records the no-fallback header state in routing metadata for image/video requests.

* **Tests**
  * Added end-to-end tests validating the downstream forwarding and recording of the no-fallback header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->