### PR TITLE
feat(admin): add delete for chat & contact

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6022,4 +6022,86 @@ admin.openapi(markChatSupportRead, async (c) => {
 	return c.json({ success: true });
 });
 
+// ── Delete Chat Support Conversation ──────────────────────────────────────────
+
+const deleteChatSupportConversation = createRoute({
+	method: "delete",
+	path: "/chat-support-logs/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ success: z.boolean() }).openapi({}),
+				},
+			},
+			description: "Conversation deleted.",
+		},
+		404: {
+			description: "Conversation not found.",
+		},
+	},
+});
+
+admin.openapi(deleteChatSupportConversation, async (c) => {
+	const { id } = c.req.valid("param");
+
+	const existing = await db.query.chatSupportConversation.findFirst({
+		where: { id: { eq: id } },
+	});
+
+	if (!existing) {
+		throw new HTTPException(404, { message: "Conversation not found" });
+	}
+
+	await db
+		.delete(tables.chatSupportConversation)
+		.where(eq(tables.chatSupportConversation.id, id));
+
+	return c.json({ success: true });
+});
+
+// ── Delete Contact Submission ─────────────────────────────────────────────────
+
+const deleteContactSubmission = createRoute({
+	method: "delete",
+	path: "/contact-submissions/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ success: z.boolean() }).openapi({}),
+				},
+			},
+			description: "Submission deleted.",
+		},
+		404: {
+			description: "Submission not found.",
+		},
+	},
+});
+
+admin.openapi(deleteContactSubmission, async (c) => {
+	const { id } = c.req.valid("param");
+
+	const existing = await db.query.enterpriseContactSubmission.findFirst({
+		where: { id: { eq: id } },
+	});
+
+	if (!existing) {
+		throw new HTTPException(404, { message: "Submission not found" });
+	}
+
+	await db
+		.delete(tables.enterpriseContactSubmission)
+		.where(eq(tables.enterpriseContactSubmission.id, id));
+
+	return c.json({ success: true });
+});
+
 export default admin;

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -3566,7 +3566,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Submission deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Submission not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -3813,7 +3843,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Conversation deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Conversation not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -3566,7 +3566,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Submission deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Submission not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -3813,7 +3843,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Conversation deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Conversation not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -3566,7 +3566,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Submission deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Submission not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -3813,7 +3843,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Conversation deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Conversation not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;

--- a/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
+++ b/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
@@ -26,7 +26,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useFetchClient } from "@/lib/fetch-client";
+import { useApi, useFetchClient } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
 function timeAgo(dateString: string): string {
@@ -136,6 +136,7 @@ interface ConversationDetail {
 
 export function ChatSupportLogsClient() {
 	const $fetch = useFetchClient();
+	const $api = useApi();
 	const queryClient = useQueryClient();
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [search, setSearch] = useState("");
@@ -244,23 +245,22 @@ export function ChatSupportLogsClient() {
 		},
 	});
 
-	const deleteMutation = useMutation({
-		mutationFn: async (id: string) => {
-			await $fetch.DELETE("/admin/chat-support-logs/{id}", {
-				params: { path: { id } },
-			});
+	const deleteMutation = $api.useMutation(
+		"delete",
+		"/admin/chat-support-logs/{id}",
+		{
+			onSuccess: () => {
+				setSelectedId(null);
+				setDeleteDialogOpen(false);
+				void queryClient.invalidateQueries({
+					queryKey: ["chat-support-logs"],
+				});
+				void queryClient.invalidateQueries({
+					queryKey: ["chat-support-read-statuses"],
+				});
+			},
 		},
-		onSuccess: () => {
-			setSelectedId(null);
-			setDeleteDialogOpen(false);
-			void queryClient.invalidateQueries({
-				queryKey: ["chat-support-logs"],
-			});
-			void queryClient.invalidateQueries({
-				queryKey: ["chat-support-read-statuses"],
-			});
-		},
-	});
+	);
 
 	useEffect(() => {
 		if (detail?.messages && selectedId) {
@@ -802,7 +802,9 @@ export function ChatSupportLogsClient() {
 							disabled={deleteMutation.isPending}
 							onClick={() => {
 								if (selectedId) {
-									deleteMutation.mutate(selectedId);
+									deleteMutation.mutate({
+										params: { path: { id: selectedId } },
+									});
 								}
 							}}
 						>

--- a/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
+++ b/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
@@ -11,10 +11,20 @@ import {
 	Monitor,
 	Search,
 	Send,
+	Trash2,
 	User,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useFetchClient } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
@@ -131,6 +141,7 @@ export function ChatSupportLogsClient() {
 	const [search, setSearch] = useState("");
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [replyText, setReplyText] = useState("");
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const replyInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -229,6 +240,24 @@ export function ChatSupportLogsClient() {
 			});
 			void queryClient.invalidateQueries({
 				queryKey: ["chat-support-logs"],
+			});
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: async (id: string) => {
+			await $fetch.DELETE("/admin/chat-support-logs/{id}", {
+				params: { path: { id } },
+			});
+		},
+		onSuccess: () => {
+			setSelectedId(null);
+			setDeleteDialogOpen(false);
+			void queryClient.invalidateQueries({
+				queryKey: ["chat-support-logs"],
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["chat-support-read-statuses"],
 			});
 		},
 	});
@@ -727,6 +756,19 @@ export function ChatSupportLogsClient() {
 								</div>
 							</div>
 						</ScrollArea>
+
+						{/* Delete conversation */}
+						<div className="border-t border-border/60 p-4">
+							<Button
+								variant="destructive"
+								size="sm"
+								className="w-full"
+								onClick={() => setDeleteDialogOpen(true)}
+							>
+								<Trash2 className="mr-2 h-3.5 w-3.5" />
+								Delete Conversation
+							</Button>
+						</div>
 					</>
 				) : (
 					<div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-muted-foreground">
@@ -737,6 +779,38 @@ export function ChatSupportLogsClient() {
 					</div>
 				)}
 			</div>
+
+			{/* Delete confirmation dialog */}
+			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete Conversation</DialogTitle>
+						<DialogDescription>
+							This will permanently delete the conversation and all its
+							messages. This action cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setDeleteDialogOpen(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							disabled={deleteMutation.isPending}
+							onClick={() => {
+								if (selectedId) {
+									deleteMutation.mutate(selectedId);
+								}
+							}}
+						>
+							{deleteMutation.isPending ? "Deleting..." : "Delete"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
+++ b/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	AlertTriangle,
 	ArrowLeft,
@@ -26,7 +26,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useApi, useFetchClient } from "@/lib/fetch-client";
+import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
 function timeAgo(dateString: string): string {
@@ -115,27 +115,7 @@ function parseDevice(userAgent: string): string {
 	return `${browser} on ${os}`;
 }
 
-interface ConversationDetail {
-	id: string;
-	createdAt: string;
-	updatedAt: string;
-	name: string | null;
-	email: string | null;
-	ipAddress: string | null;
-	userAgent: string | null;
-	messageCount: number;
-	escalatedAt: string | null;
-	messages: {
-		id: string;
-		createdAt: string;
-		role: string;
-		content: string;
-		sequence: number;
-	}[];
-}
-
 export function ChatSupportLogsClient() {
-	const $fetch = useFetchClient();
 	const $api = useApi();
 	const queryClient = useQueryClient();
 	const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -146,41 +126,27 @@ export function ChatSupportLogsClient() {
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const replyInputRef = useRef<HTMLTextAreaElement>(null);
 
-	const { data: readStatusData } = useQuery({
-		queryKey: ["chat-support-read-statuses"],
-		queryFn: async () => {
-			const { data } = await $fetch.GET(
-				"/admin/chat-support-logs/read-statuses",
-			);
-			return data?.readStatuses ?? {};
-		},
-	});
+	const { data: readStatusData } = $api.useQuery(
+		"get",
+		"/admin/chat-support-logs/read-statuses",
+	);
 
-	const readMap = readStatusData ?? {};
+	const readMap = readStatusData?.readStatuses ?? {};
 
-	const markReadMutation = useMutation({
-		mutationFn: async ({
-			id,
-			messageCount,
-		}: {
-			id: string;
-			messageCount: number;
-		}) => {
-			await $fetch.POST("/admin/chat-support-logs/{id}/read", {
-				params: { path: { id } },
-				body: { messageCount },
-			});
+	const markReadMutation = $api.useMutation(
+		"post",
+		"/admin/chat-support-logs/{id}/read",
+		{
+			onSuccess: () => {
+				void queryClient.invalidateQueries({
+					queryKey: $api.queryOptions(
+						"get",
+						"/admin/chat-support-logs/read-statuses",
+					).queryKey,
+				});
+			},
 		},
-		onSuccess: (_data, variables) => {
-			queryClient.setQueryData<Record<string, number>>(
-				["chat-support-read-statuses"],
-				(old) => ({
-					...old,
-					[variables.id]: variables.messageCount,
-				}),
-			);
-		},
-	});
+	);
 	const markRead = markReadMutation.mutate;
 
 	useEffect(() => {
@@ -188,62 +154,54 @@ export function ChatSupportLogsClient() {
 		return () => clearTimeout(timer);
 	}, [search]);
 
-	const { data: listData, isLoading: listLoading } = useQuery({
-		queryKey: ["chat-support-logs", debouncedSearch],
-		queryFn: async () => {
-			const { data } = await $fetch.GET("/admin/chat-support-logs", {
-				params: {
-					query: {
-						limit: 100,
-						offset: 0,
-						search: debouncedSearch || undefined,
-					},
+	const { data: listData, isLoading: listLoading } = $api.useQuery(
+		"get",
+		"/admin/chat-support-logs",
+		{
+			params: {
+				query: {
+					limit: 100,
+					offset: 0,
+					search: debouncedSearch || undefined,
 				},
-			});
-			return data ?? { conversations: [], total: 0 };
+			},
 		},
-	});
+	);
 
 	const conversations = useMemo(
 		() => listData?.conversations ?? [],
 		[listData?.conversations],
 	);
 
-	const { data: detail, isLoading: detailLoading } = useQuery({
-		queryKey: ["chat-support-log", selectedId],
-		queryFn: async () => {
-			if (!selectedId) {
-				return null;
-			}
-			const { data } = await $fetch.GET("/admin/chat-support-logs/{id}", {
-				params: { path: { id: selectedId } },
-			});
-			return (data as ConversationDetail | undefined) ?? null;
+	const { data: detail, isLoading: detailLoading } = $api.useQuery(
+		"get",
+		"/admin/chat-support-logs/{id}",
+		{
+			params: { path: { id: selectedId! } },
 		},
-		enabled: !!selectedId,
-	});
+		{
+			enabled: !!selectedId,
+		},
+	);
 
-	const replyMutation = useMutation({
-		mutationFn: async ({ id, content }: { id: string; content: string }) => {
-			const { data } = await $fetch.POST(
-				"/admin/chat-support-logs/{id}/reply",
-				{
-					params: { path: { id } },
-					body: { content },
-				},
-			);
-			return data;
+	const replyMutation = $api.useMutation(
+		"post",
+		"/admin/chat-support-logs/{id}/reply",
+		{
+			onSuccess: () => {
+				setReplyText("");
+				void queryClient.invalidateQueries({
+					queryKey: $api.queryOptions("get", "/admin/chat-support-logs/{id}", {
+						params: { path: { id: selectedId! } },
+					}).queryKey,
+				});
+				void queryClient.invalidateQueries({
+					queryKey: $api.queryOptions("get", "/admin/chat-support-logs")
+						.queryKey,
+				});
+			},
 		},
-		onSuccess: () => {
-			setReplyText("");
-			void queryClient.invalidateQueries({
-				queryKey: ["chat-support-log", selectedId],
-			});
-			void queryClient.invalidateQueries({
-				queryKey: ["chat-support-logs"],
-			});
-		},
-	});
+	);
 
 	const deleteMutation = $api.useMutation(
 		"delete",
@@ -253,10 +211,14 @@ export function ChatSupportLogsClient() {
 				setSelectedId(null);
 				setDeleteDialogOpen(false);
 				void queryClient.invalidateQueries({
-					queryKey: ["chat-support-logs"],
+					queryKey: $api.queryOptions("get", "/admin/chat-support-logs")
+						.queryKey,
 				});
 				void queryClient.invalidateQueries({
-					queryKey: ["chat-support-read-statuses"],
+					queryKey: $api.queryOptions(
+						"get",
+						"/admin/chat-support-logs/read-statuses",
+					).queryKey,
 				});
 			},
 		},
@@ -266,8 +228,8 @@ export function ChatSupportLogsClient() {
 		if (detail?.messages && selectedId) {
 			messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
 			markRead({
-				id: selectedId,
-				messageCount: detail.messages.length,
+				params: { path: { id: selectedId } },
+				body: { messageCount: detail.messages.length },
 			});
 		}
 	}, [detail?.messages, selectedId, markRead]);
@@ -278,7 +240,10 @@ export function ChatSupportLogsClient() {
 			setReplyText("");
 			const conv = conversations.find((c) => c.id === id);
 			if (conv) {
-				markRead({ id, messageCount: conv.messageCount });
+				markRead({
+					params: { path: { id } },
+					body: { messageCount: conv.messageCount },
+				});
 			}
 		},
 		[conversations, markRead],
@@ -290,7 +255,10 @@ export function ChatSupportLogsClient() {
 		if (!trimmed || !selectedId || replyMutation.isPending) {
 			return;
 		}
-		replyMutation.mutate({ id: selectedId, content: trimmed });
+		replyMutation.mutate({
+			params: { path: { id: selectedId } },
+			body: { content: trimmed },
+		});
 	};
 
 	const handleReplyKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
+++ b/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
@@ -458,6 +458,14 @@ export function ChatSupportLogsClient() {
 									<span className="text-xs font-medium">Escalated</span>
 								</div>
 							)}
+							<button
+								type="button"
+								onClick={() => setDeleteDialogOpen(true)}
+								className="ml-auto flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive xl:hidden"
+							>
+								<Trash2 className="h-4 w-4" />
+								<span className="sr-only">Delete conversation</span>
+							</button>
 						</div>
 
 						{/* Messages */}

--- a/ee/admin/src/app/contact-submissions/[id]/delete-button.tsx
+++ b/ee/admin/src/app/contact-submissions/[id]/delete-button.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { useFetchClient } from "@/lib/fetch-client";
+
+export function DeleteSubmissionButton({ id }: { id: string }) {
+	const $fetch = useFetchClient();
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+
+	const handleDelete = async () => {
+		setDeleting(true);
+		await $fetch.DELETE("/admin/contact-submissions/{id}", {
+			params: { path: { id } },
+		});
+		setDeleting(false);
+		setOpen(false);
+		router.push("/contact-submissions");
+	};
+
+	return (
+		<>
+			<Button variant="destructive" size="sm" onClick={() => setOpen(true)}>
+				<Trash2 className="mr-2 h-3.5 w-3.5" />
+				Delete
+			</Button>
+
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete Submission</DialogTitle>
+						<DialogDescription>
+							This will permanently delete this contact submission. This action
+							cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setOpen(false)}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							disabled={deleting}
+							onClick={handleDelete}
+						>
+							{deleting ? "Deleting..." : "Delete"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/ee/admin/src/app/contact-submissions/[id]/delete-button.tsx
+++ b/ee/admin/src/app/contact-submissions/[id]/delete-button.tsx
@@ -13,23 +13,23 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { useFetchClient } from "@/lib/fetch-client";
+import { useApi } from "@/lib/fetch-client";
 
 export function DeleteSubmissionButton({ id }: { id: string }) {
-	const $fetch = useFetchClient();
+	const $api = useApi();
 	const router = useRouter();
 	const [open, setOpen] = useState(false);
-	const [deleting, setDeleting] = useState(false);
 
-	const handleDelete = async () => {
-		setDeleting(true);
-		await $fetch.DELETE("/admin/contact-submissions/{id}", {
-			params: { path: { id } },
-		});
-		setDeleting(false);
-		setOpen(false);
-		router.push("/contact-submissions");
-	};
+	const deleteMutation = $api.useMutation(
+		"delete",
+		"/admin/contact-submissions/{id}",
+		{
+			onSuccess: () => {
+				setOpen(false);
+				router.push("/contact-submissions");
+			},
+		},
+	);
 
 	return (
 		<>
@@ -53,10 +53,14 @@ export function DeleteSubmissionButton({ id }: { id: string }) {
 						</Button>
 						<Button
 							variant="destructive"
-							disabled={deleting}
-							onClick={handleDelete}
+							disabled={deleteMutation.isPending}
+							onClick={() => {
+								deleteMutation.mutate({
+									params: { path: { id } },
+								});
+							}}
 						>
-							{deleting ? "Deleting..." : "Delete"}
+							{deleteMutation.isPending ? "Deleting..." : "Delete"}
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/ee/admin/src/app/contact-submissions/[id]/delete-button.tsx
+++ b/ee/admin/src/app/contact-submissions/[id]/delete-button.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -17,6 +18,7 @@ import { useApi } from "@/lib/fetch-client";
 
 export function DeleteSubmissionButton({ id }: { id: string }) {
 	const $api = useApi();
+	const queryClient = useQueryClient();
 	const router = useRouter();
 	const [open, setOpen] = useState(false);
 
@@ -26,6 +28,10 @@ export function DeleteSubmissionButton({ id }: { id: string }) {
 		{
 			onSuccess: () => {
 				setOpen(false);
+				void queryClient.invalidateQueries({
+					queryKey: $api.queryOptions("get", "/admin/contact-submissions")
+						.queryKey,
+				});
 				router.push("/contact-submissions");
 			},
 		},

--- a/ee/admin/src/app/contact-submissions/[id]/page.tsx
+++ b/ee/admin/src/app/contact-submissions/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 
+import { DeleteSubmissionButton } from "./delete-button";
 import { ReplyForm } from "./reply-form";
 
 function formatDate(dateString: string) {
@@ -89,6 +90,7 @@ export default async function ContactSubmissionDetailPage({
 					<Badge variant={getStatusBadgeVariant(data.spamFilterStatus)}>
 						{getStatusLabel(data.spamFilterStatus)}
 					</Badge>
+					<DeleteSubmissionButton id={data.id} />
 				</div>
 				<p className="text-sm text-muted-foreground">
 					Submitted {formatDate(data.createdAt)}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -3566,7 +3566,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Submission deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Submission not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -3813,7 +3843,37 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Conversation deleted. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Conversation not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;


### PR DESCRIPTION
## Summary
- Add `DELETE /admin/chat-support-logs/{id}` API endpoint (cascades to messages + read statuses)
- Add `DELETE /admin/contact-submissions/{id}` API endpoint
- Add delete button with confirmation dialog in chat support logs right panel
- Add delete button with confirmation dialog on contact submission detail page

## Test plan
- [ ] Open a chat support conversation in admin, click "Delete Conversation" in the right panel, confirm deletion
- [ ] Open a contact submission detail page, click "Delete" next to the name, confirm deletion
- [ ] Verify deleted items no longer appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can delete chat support conversations via a destructive button with confirmation.
  * Admins can delete contact submissions from the detail page via a destructive button with confirmation and automatic return to the list.

* **Bug Fixes / Reliability**
  * Delete actions validate existence, disable controls while processing, show "Deleting..." state, and refresh related lists and read-statuses after success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->