### PR TITLE
fix: skip env vars for BYOK provider URLs

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3188,6 +3188,7 @@ chat.openapi(completions, async (c) => {
 			configIndex,
 			isImageGeneration,
 			usedRegion,
+			providerKey !== undefined,
 		);
 
 		// If region is still unset but the provider supports regions, resolve the

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -275,6 +275,9 @@ export async function resolveProviderContext(
 		providerMappingForSelected?.imageGenerations === true;
 
 	// --- URL resolution ---
+	// When using a provider key (BYOK), skip env vars entirely —
+	// only the provider key's baseUrl or hardcoded provider defaults should be used.
+	const isBYOK = providerKey !== undefined;
 	const url = getProviderEndpoint(
 		usedProvider as Provider,
 		providerKey?.baseUrl ?? undefined,
@@ -292,6 +295,7 @@ export async function resolveProviderContext(
 		configIndex,
 		isImageGeneration,
 		usedRegion,
+		isBYOK,
 	);
 
 	if (!url) {

--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -169,4 +169,115 @@ describe("getProviderEndpoint", () => {
 			"https://vertex-2.example/v1/projects/project-b/locations/us-central1/publishers/google/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
 		);
 	});
+
+	describe("skipEnvVars (BYOK mode)", () => {
+		it("uses hardcoded default for google-ai-studio instead of env var", () => {
+			process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL =
+				"https://studio-override.example";
+
+			const endpoint = getProviderEndpoint(
+				"google-ai-studio",
+				undefined, // no baseUrl
+				"gemini-2.5-flash",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe(
+				"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+			);
+		});
+
+		it("uses hardcoded default for openai regardless of skipEnvVars", () => {
+			const endpoint = getProviderEndpoint(
+				"openai",
+				undefined,
+				"gpt-4o",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe("https://api.openai.com/v1/chat/completions");
+		});
+
+		it("uses hardcoded default for google-vertex base URL in skipEnvVars mode", () => {
+			process.env.LLM_GOOGLE_VERTEX_BASE_URL =
+				"https://vertex-override.example";
+
+			const endpoint = getProviderEndpoint(
+				"google-vertex",
+				undefined,
+				"gemini-2.5-flash-lite",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe(
+				"https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash-lite:generateContent",
+			);
+		});
+
+		it("uses hardcoded default for aws-bedrock base URL in skipEnvVars mode", () => {
+			const endpoint = getProviderEndpoint(
+				"aws-bedrock",
+				undefined,
+				"anthropic.claude-3-5-sonnet-20241022-v2:0",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe(
+				"https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
+			);
+		});
+
+		it("still uses explicit baseUrl even when skipEnvVars is true", () => {
+			const endpoint = getProviderEndpoint(
+				"google-ai-studio",
+				"https://my-custom-base.example",
+				"gemini-2.5-flash",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe(
+				"https://my-custom-base.example/v1beta/models/gemini-2.5-flash:generateContent",
+			);
+		});
+	});
 });

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -17,6 +17,7 @@ function buildVertexCompatibleEndpoint(
 	token: string | undefined,
 	stream: boolean | undefined,
 	configIndex: number | undefined,
+	skipEnvVars?: boolean,
 ): string {
 	const endpoint = stream ? "streamGenerateContent" : "generateContent";
 	const model = modelName ?? "gemini-2.5-flash-lite";
@@ -35,9 +36,13 @@ function buildVertexCompatibleEndpoint(
 			: baseEndpoint;
 	}
 
-	const projectId = getProviderEnvValue(provider, "project", configIndex);
-	const region =
-		getProviderEnvValue(provider, "region", configIndex, "global") ?? "global";
+	const projectId = skipEnvVars
+		? undefined
+		: getProviderEnvValue(provider, "project", configIndex);
+	const region = skipEnvVars
+		? "global"
+		: (getProviderEnvValue(provider, "region", configIndex, "global") ??
+			"global");
 
 	if (!projectId) {
 		const providerEnv = getProviderEnvConfig(provider);
@@ -74,6 +79,7 @@ export function getProviderEndpoint(
 	configIndex?: number,
 	imageGenerations?: boolean,
 	region?: string,
+	skipEnvVars?: boolean,
 ): string {
 	let modelName = model;
 	if (model && model !== "custom") {
@@ -88,6 +94,18 @@ export function getProviderEndpoint(
 		}
 	}
 	let url: string | undefined;
+
+	// Helper: read env value only when not in BYOK mode (skipEnvVars).
+	// In BYOK mode, only the hardcoded default is used.
+	const envValueOrDefault = (
+		p: Parameters<typeof getProviderEnvValue>[0],
+		key: string,
+		defaultValue?: string,
+	): string | undefined =>
+		skipEnvVars
+			? defaultValue
+			: (getProviderEnvValue(p, key, configIndex, defaultValue) ??
+				defaultValue);
 
 	// Generic region-based base URL resolution.
 	// Any provider with a regionConfig + endpointMap can use this.
@@ -122,15 +140,16 @@ export function getProviderEndpoint(
 				break;
 			case "google-ai-studio":
 				url =
-					getProviderEnvValue(
+					envValueOrDefault(
 						"google-ai-studio",
 						"baseUrl",
-						configIndex,
 						"https://generativelanguage.googleapis.com",
 					) ?? "https://generativelanguage.googleapis.com";
 				break;
 			case "glacier":
-				url = getProviderEnvValue("glacier", "baseUrl", configIndex);
+				url = skipEnvVars
+					? undefined
+					: getProviderEnvValue("glacier", "baseUrl", configIndex);
 				if (!url) {
 					throw new Error(
 						"Glacier provider requires LLM_GLACIER_BASE_URL environment variable",
@@ -139,15 +158,16 @@ export function getProviderEndpoint(
 				break;
 			case "google-vertex":
 				url =
-					getProviderEnvValue(
+					envValueOrDefault(
 						"google-vertex",
 						"baseUrl",
-						configIndex,
 						"https://aiplatform.googleapis.com",
 					) ?? "https://aiplatform.googleapis.com";
 				break;
 			case "quartz":
-				url = getProviderEnvValue("quartz", "baseUrl", configIndex);
+				url = skipEnvVars
+					? undefined
+					: getProviderEnvValue("quartz", "baseUrl", configIndex);
 				if (!url) {
 					throw new Error(
 						"Quartz provider requires LLM_QUARTZ_BASE_URL environment variable",
@@ -155,7 +175,9 @@ export function getProviderEndpoint(
 				}
 				break;
 			case "obsidian":
-				url = getProviderEnvValue("obsidian", "baseUrl", configIndex);
+				url = skipEnvVars
+					? undefined
+					: getProviderEnvValue("obsidian", "baseUrl", configIndex);
 				if (!url) {
 					throw new Error(
 						"Obsidian provider requires LLM_OBSIDIAN_BASE_URL environment variable",
@@ -220,17 +242,18 @@ export function getProviderEndpoint(
 				break;
 			case "aws-bedrock":
 				url =
-					getProviderEnvValue(
+					envValueOrDefault(
 						"aws-bedrock",
 						"baseUrl",
-						configIndex,
 						"https://bedrock-runtime.us-east-1.amazonaws.com",
 					) ?? "https://bedrock-runtime.us-east-1.amazonaws.com";
 				break;
 			case "azure": {
 				const resource =
 					providerKeyOptions?.azure_resource ??
-					getProviderEnvValue("azure", "resource", configIndex);
+					(skipEnvVars
+						? undefined
+						: getProviderEnvValue("azure", "resource", configIndex));
 
 				if (!resource) {
 					const azureEnv = getProviderEnvConfig("azure");
@@ -319,6 +342,7 @@ export function getProviderEndpoint(
 				token,
 				stream,
 				configIndex,
+				skipEnvVars,
 			);
 		case "perplexity":
 			return `${url}/chat/completions`;
@@ -332,8 +356,14 @@ export function getProviderEndpoint(
 		case "aws-bedrock": {
 			const prefix =
 				providerKeyOptions?.aws_bedrock_region_prefix ??
-				getProviderEnvValue("aws-bedrock", "region", configIndex, "global.") ??
-				"global.";
+				(skipEnvVars
+					? "global."
+					: (getProviderEnvValue(
+							"aws-bedrock",
+							"region",
+							configIndex,
+							"global.",
+						) ?? "global."));
 
 			const endpoint = stream ? "converse-stream" : "converse";
 			return `${url}/model/${prefix}${modelName}/${endpoint}`;
@@ -341,35 +371,39 @@ export function getProviderEndpoint(
 		case "azure": {
 			const deploymentType =
 				providerKeyOptions?.azure_deployment_type ??
-				getProviderEnvValue(
-					"azure",
-					"deploymentType",
-					configIndex,
-					"ai-foundry",
-				) ??
-				"ai-foundry";
+				(skipEnvVars
+					? "ai-foundry"
+					: (getProviderEnvValue(
+							"azure",
+							"deploymentType",
+							configIndex,
+							"ai-foundry",
+						) ?? "ai-foundry"));
 
 			if (deploymentType === "openai") {
 				// Traditional Azure (deployment-based)
 				const apiVersion =
 					providerKeyOptions?.azure_api_version ??
-					getProviderEnvValue(
-						"azure",
-						"apiVersion",
-						configIndex,
-						"2024-10-21",
-					) ??
-					"2024-10-21";
+					(skipEnvVars
+						? "2024-10-21"
+						: (getProviderEnvValue(
+								"azure",
+								"apiVersion",
+								configIndex,
+								"2024-10-21",
+							) ?? "2024-10-21"));
 
 				return `${url}/openai/deployments/${modelName}/chat/completions?api-version=${apiVersion}`;
 			} else {
 				// Azure AI Foundry (unified endpoint)
-				const useResponsesApiEnv = getProviderEnvValue(
-					"azure",
-					"useResponsesApi",
-					configIndex,
-					"true",
-				);
+				const useResponsesApiEnv = skipEnvVars
+					? "true"
+					: getProviderEnvValue(
+							"azure",
+							"useResponsesApi",
+							configIndex,
+							"true",
+						);
 
 				if (model && useResponsesApiEnv !== "false") {
 					const modelDef = models.find(

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -17,7 +17,6 @@ function buildVertexCompatibleEndpoint(
 	token: string | undefined,
 	stream: boolean | undefined,
 	configIndex: number | undefined,
-	skipEnvVars?: boolean,
 ): string {
 	const endpoint = stream ? "streamGenerateContent" : "generateContent";
 	const model = modelName ?? "gemini-2.5-flash-lite";
@@ -36,13 +35,9 @@ function buildVertexCompatibleEndpoint(
 			: baseEndpoint;
 	}
 
-	const projectId = skipEnvVars
-		? undefined
-		: getProviderEnvValue(provider, "project", configIndex);
-	const region = skipEnvVars
-		? "global"
-		: (getProviderEnvValue(provider, "region", configIndex, "global") ??
-			"global");
+	const projectId = getProviderEnvValue(provider, "project", configIndex);
+	const region =
+		getProviderEnvValue(provider, "region", configIndex, "global") ?? "global";
 
 	if (!projectId) {
 		const providerEnv = getProviderEnvConfig(provider);
@@ -342,7 +337,6 @@ export function getProviderEndpoint(
 				token,
 				stream,
 				configIndex,
-				skipEnvVars,
 			);
 		case "perplexity":
 			return `${url}/chat/completions`;
@@ -356,14 +350,8 @@ export function getProviderEndpoint(
 		case "aws-bedrock": {
 			const prefix =
 				providerKeyOptions?.aws_bedrock_region_prefix ??
-				(skipEnvVars
-					? "global."
-					: (getProviderEnvValue(
-							"aws-bedrock",
-							"region",
-							configIndex,
-							"global.",
-						) ?? "global."));
+				getProviderEnvValue("aws-bedrock", "region", configIndex, "global.") ??
+				"global.";
 
 			const endpoint = stream ? "converse-stream" : "converse";
 			return `${url}/model/${prefix}${modelName}/${endpoint}`;
@@ -371,39 +359,35 @@ export function getProviderEndpoint(
 		case "azure": {
 			const deploymentType =
 				providerKeyOptions?.azure_deployment_type ??
-				(skipEnvVars
-					? "ai-foundry"
-					: (getProviderEnvValue(
-							"azure",
-							"deploymentType",
-							configIndex,
-							"ai-foundry",
-						) ?? "ai-foundry"));
+				getProviderEnvValue(
+					"azure",
+					"deploymentType",
+					configIndex,
+					"ai-foundry",
+				) ??
+				"ai-foundry";
 
 			if (deploymentType === "openai") {
 				// Traditional Azure (deployment-based)
 				const apiVersion =
 					providerKeyOptions?.azure_api_version ??
-					(skipEnvVars
-						? "2024-10-21"
-						: (getProviderEnvValue(
-								"azure",
-								"apiVersion",
-								configIndex,
-								"2024-10-21",
-							) ?? "2024-10-21"));
+					getProviderEnvValue(
+						"azure",
+						"apiVersion",
+						configIndex,
+						"2024-10-21",
+					) ??
+					"2024-10-21";
 
 				return `${url}/openai/deployments/${modelName}/chat/completions?api-version=${apiVersion}`;
 			} else {
 				// Azure AI Foundry (unified endpoint)
-				const useResponsesApiEnv = skipEnvVars
-					? "true"
-					: getProviderEnvValue(
-							"azure",
-							"useResponsesApi",
-							configIndex,
-							"true",
-						);
+				const useResponsesApiEnv = getProviderEnvValue(
+					"azure",
+					"useResponsesApi",
+					configIndex,
+					"true",
+				);
 
 				if (model && useResponsesApiEnv !== "false") {
 					const modelDef = models.find(

--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -196,6 +196,7 @@ export async function validateProviderKey(
 			undefined, // configIndex
 			undefined, // imageGenerations
 			validationRegion,
+			true, // skipEnvVars - provider key validation is always BYOK context
 		);
 
 		// Check if max_tokens is supported


### PR DESCRIPTION
## Summary
- When BYOK (`api-keys` mode) is active, `getProviderEndpoint` no longer reads internal env vars (e.g. `LLM_GOOGLE_AI_STUDIO_BASE_URL`, `LLM_GOOGLE_VERTEX_BASE_URL`, `LLM_AZURE_RESOURCE`) to construct provider URLs
- Adds a `skipEnvVars` parameter that is set automatically when a `providerKey` is present — only the provider key's explicit `baseUrl` or the hardcoded provider default is used
- Provider key options (`azure_resource`, `aws_bedrock_region_prefix`, etc.) still take priority when set

## Test plan
- [x] All existing `get-provider-endpoint` tests pass
- [x] 5 new tests verify `skipEnvVars` behavior: google-ai-studio, openai, google-vertex, aws-bedrock, and explicit baseUrl override
- [x] Full build passes
- [ ] Manual test: BYOK request with env vars set should use hardcoded defaults, not env var values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit BYOK behavior: requests using a provided provider key now consistently bypass environment-variable endpoint lookups, improving predictable endpoint selection.

* **Tests**
  * Added tests covering BYOK/skip-env behavior across providers to ensure endpoints are resolved correctly when a provider key is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->