### PR TITLE
feat: add GLM-5.1 model

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -2,6 +2,34 @@ import type { ModelDefinition } from "@/models.js";
 
 export const zaiModels = [
 	{
+		id: "glm-5.1",
+		name: "GLM-5.1",
+		description:
+			"Zhipu GLM-5.1 flagship model engineered for long-horizon autonomous tasks with enhanced coding and agentic capabilities.",
+		family: "glm",
+		releasedAt: new Date("2026-04-07"),
+		providers: [
+			{
+				providerId: "zai",
+				modelName: "glm-5.1",
+				inputPrice: 1.4 / 1e6,
+				cachedInputPrice: 0.26 / 1e6,
+				outputPrice: 4.4 / 1e6,
+				discount: 0.1,
+				requestPrice: 0,
+				contextSize: 200000,
+				maxOutput: 128000,
+				streaming: true,
+				reasoning: true,
+				vision: false,
+				tools: true,
+				webSearch: true,
+				webSearchPrice: 0.01,
+				jsonOutput: true,
+			},
+		],
+	},
+	{
 		id: "glm-5",
 		name: "GLM-5",
 		description: "Zhipu GLM-5 with advanced reasoning capabilities.",


### PR DESCRIPTION
## Summary
- Adds Z.AI's new flagship **GLM-5.1** model (released 2026-04-07) to the `zai` provider.
- 744B-param MoE (40B active) tuned for long-horizon agentic tasks and coding (SWE-Bench Pro 58.4).
- Pricing (per [Z.AI official pricing](https://docs.z.ai/guides/overview/pricing)): input \$1.40/M, cached input \$0.26/M, output \$4.40/M.
- Context 200K, max output 128K, supports reasoning, tools, JSON output, web search (\$0.01/search), streaming.

## Test plan
- [ ] `TEST_MODELS="zai/glm-5.1" pnpm test:e2e` passes (local run blocked by an `/etc/hosts` override on the dev machine routing `api.z.ai` → `127.0.0.1`; CI should run cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the glm-5.1 model with streaming, reasoning, tool use, web search, and JSON output capabilities. Supports 200k context window and 128k maximum output tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->