### PR TITLE
fix: emit canonical OpenAI finish_reason in streaming

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -125,6 +125,7 @@ import { getProviderEnv } from "./tools/get-provider-env.js";
 import { hasMeaningfulAssistantOutput } from "./tools/has-meaningful-assistant-output.js";
 import { healJsonResponse } from "./tools/heal-json-response.js";
 import { isModelTrulyFree } from "./tools/is-model-truly-free.js";
+import { mapFinishReasonToOpenai } from "./tools/map-finish-reason-to-openai.js";
 import { messagesContainImages } from "./tools/messages-contain-images.js";
 import { mightBeCompleteJson } from "./tools/might-be-complete-json.js";
 import { normalizeStreamingError } from "./tools/normalize-streaming-error.js";
@@ -7034,7 +7035,11 @@ chat.openapi(completions, async (c) => {
 										{
 											index: 0,
 											delta: {},
-											finish_reason: finishReason,
+											finish_reason: mapFinishReasonToOpenai(
+												finishReason,
+												usedProvider,
+												!!streamingToolCalls && streamingToolCalls.length > 0,
+											),
 										},
 									],
 								};
@@ -7227,7 +7232,11 @@ chat.openapi(completions, async (c) => {
 										{
 											index: 0,
 											delta: {},
-											finish_reason: finishReason ?? "stop",
+											finish_reason: mapFinishReasonToOpenai(
+												finishReason,
+												usedProvider,
+												!!streamingToolCalls && streamingToolCalls.length > 0,
+											),
 										},
 									],
 								};

--- a/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
+++ b/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
@@ -1,0 +1,83 @@
+import type { Provider } from "@llmgateway/models";
+
+/**
+ * Map a provider-specific finish reason to an OpenAI-canonical value
+ * (one of: "stop", "length", "tool_calls", "content_filter").
+ *
+ * Without this mapping, OpenAI-compatible clients (such as the Vercel AI
+ * SDK) fall back to "other" when they receive raw provider values like
+ * Google's "STOP" / "MAX_TOKENS" or Anthropic's "end_turn" / "tool_use".
+ */
+export function mapFinishReasonToOpenai(
+	finishReason: string | null | undefined,
+	usedProvider: Provider | string | null | undefined,
+	hasToolCalls = false,
+	promptBlockReason?: string,
+): string {
+	if (promptBlockReason) {
+		switch (promptBlockReason) {
+			case "SAFETY":
+			case "PROHIBITED_CONTENT":
+			case "BLOCKLIST":
+			case "OTHER":
+				return "content_filter";
+			default:
+				return "stop";
+		}
+	}
+
+	switch (usedProvider) {
+		case "google-ai-studio":
+		case "glacier":
+		case "google-vertex":
+		case "quartz":
+		case "obsidian":
+			if (!finishReason) {
+				return hasToolCalls ? "tool_calls" : "stop";
+			}
+			switch (finishReason) {
+				case "STOP":
+					return hasToolCalls ? "tool_calls" : "stop";
+				case "MAX_TOKENS":
+					return "length";
+				case "MALFORMED_FUNCTION_CALL":
+				case "UNEXPECTED_TOOL_CALL":
+					return "tool_calls";
+				case "SAFETY":
+				case "PROHIBITED_CONTENT":
+				case "RECITATION":
+				case "BLOCKLIST":
+				case "SPII":
+				case "LANGUAGE":
+				case "IMAGE_SAFETY":
+				case "IMAGE_PROHIBITED_CONTENT":
+				case "IMAGE_RECITATION":
+				case "IMAGE_OTHER":
+				case "NO_IMAGE":
+					return "content_filter";
+				default:
+					return "stop";
+			}
+		case "anthropic":
+			if (!finishReason) {
+				return hasToolCalls ? "tool_calls" : "stop";
+			}
+			switch (finishReason) {
+				case "end_turn":
+				case "stop_sequence":
+					return "stop";
+				case "max_tokens":
+					return "length";
+				case "tool_use":
+					return "tool_calls";
+				default:
+					return "stop";
+			}
+		default:
+			// OpenAI-format providers already emit canonical values
+			if (!finishReason) {
+				return hasToolCalls ? "tool_calls" : "stop";
+			}
+			return finishReason;
+	}
+}

--- a/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
+++ b/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
@@ -7,6 +7,9 @@ import type { Provider } from "@llmgateway/models";
  * Without this mapping, OpenAI-compatible clients (such as the Vercel AI
  * SDK) fall back to "other" when they receive raw provider values like
  * Google's "STOP" / "MAX_TOKENS" or Anthropic's "end_turn" / "tool_use".
+ *
+ * This function is idempotent: passing an already-canonical value returns
+ * it unchanged, regardless of the provider.
  */
 export function mapFinishReasonToOpenai(
 	finishReason: string | null | undefined,
@@ -24,6 +27,14 @@ export function mapFinishReasonToOpenai(
 			default:
 				return "stop";
 		}
+	}
+
+	switch (finishReason) {
+		case "stop":
+		case "length":
+		case "tool_calls":
+		case "content_filter":
+			return finishReason;
 	}
 
 	switch (usedProvider) {
@@ -54,6 +65,7 @@ export function mapFinishReasonToOpenai(
 				case "IMAGE_RECITATION":
 				case "IMAGE_OTHER":
 				case "NO_IMAGE":
+				case "OTHER":
 					return "content_filter";
 				default:
 					return "stop";
@@ -75,6 +87,7 @@ export function mapFinishReasonToOpenai(
 			}
 		default:
 			// OpenAI-format providers already emit canonical values
+			// (the idempotency switch above handles the canonical cases)
 			if (!finishReason) {
 				return hasToolCalls ? "tool_calls" : "stop";
 			}

--- a/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
+++ b/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
@@ -18,15 +18,7 @@ export function mapFinishReasonToOpenai(
 	promptBlockReason?: string,
 ): string {
 	if (promptBlockReason) {
-		switch (promptBlockReason) {
-			case "SAFETY":
-			case "PROHIBITED_CONTENT":
-			case "BLOCKLIST":
-			case "OTHER":
-				return "content_filter";
-			default:
-				return "stop";
-		}
+		return "content_filter";
 	}
 
 	switch (finishReason) {

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -1,3 +1,5 @@
+import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
+
 import type { RoutingAttempt } from "./retry-with-fallback.js";
 import type { Annotation, ImageObject } from "./types.js";
 import type { Provider } from "@llmgateway/models";
@@ -201,28 +203,11 @@ export function transformResponseToOpenai(
 							...(images && images.length > 0 && { images }),
 							...(annotations && annotations.length > 0 && { annotations }),
 						},
-						finish_reason: (() => {
-							// Map Google finish reasons to OpenAI format for the response
-							if (!finishReason) {
-								return "stop";
-							}
-							if (finishReason === "STOP") {
-								return toolResults ? "tool_calls" : "stop";
-							}
-							if (finishReason === "MAX_TOKENS") {
-								return "length";
-							}
-							if (
-								finishReason === "SAFETY" ||
-								finishReason === "PROHIBITED_CONTENT" ||
-								finishReason === "RECITATION" ||
-								finishReason === "BLOCKLIST" ||
-								finishReason === "SPII"
-							) {
-								return "content_filter";
-							}
-							return "stop";
-						})(),
+						finish_reason: mapFinishReasonToOpenai(
+							finishReason,
+							usedProvider,
+							!!toolResults,
+						),
 					},
 				],
 				usage: buildUsageObject(
@@ -266,14 +251,11 @@ export function transformResponseToOpenai(
 							...(toolResults && { tool_calls: toolResults }),
 							...(annotations && annotations.length > 0 && { annotations }),
 						},
-						finish_reason:
-							finishReason === "end_turn"
-								? "stop"
-								: finishReason === "tool_use"
-									? "tool_calls"
-									: finishReason === "max_tokens"
-										? "length"
-										: "stop",
+						finish_reason: mapFinishReasonToOpenai(
+							finishReason,
+							usedProvider,
+							!!toolResults,
+						),
 					},
 				],
 				usage: buildUsageObject(

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -4,6 +4,7 @@ import { logger } from "@llmgateway/logger";
 import { calculatePromptTokensFromMessages } from "./calculate-prompt-tokens.js";
 import { extractImages } from "./extract-images.js";
 import { adjustGoogleCandidateTokens } from "./extract-token-usage.js";
+import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
 import { transformOpenaiStreaming } from "./transform-openai-streaming.js";
 
 import type { Annotation, StreamingDelta } from "./types.js";
@@ -262,14 +263,7 @@ export function transformStreamingToOpenai(
 							delta: {
 								role: "assistant",
 							},
-							finish_reason:
-								stopReason === "end_turn"
-									? "stop"
-									: stopReason === "tool_use"
-										? "tool_calls"
-										: stopReason === "max_tokens"
-											? "length"
-											: "stop",
+							finish_reason: mapFinishReasonToOpenai(stopReason, usedProvider),
 						},
 					],
 					usage: normalizeAnthropicUsage(data.usage),
@@ -287,14 +281,7 @@ export function transformStreamingToOpenai(
 							delta: {
 								role: "assistant",
 							},
-							finish_reason:
-								stopReason === "end_turn"
-									? "stop"
-									: stopReason === "tool_use"
-										? "tool_calls"
-										: stopReason === "max_tokens"
-											? "length"
-											: "stop",
+							finish_reason: mapFinishReasonToOpenai(stopReason, usedProvider),
 						},
 					],
 					usage: normalizeAnthropicUsage(data.usage),
@@ -350,50 +337,6 @@ export function transformStreamingToOpenai(
 		case "google-vertex":
 		case "quartz":
 		case "obsidian": {
-			const mapFinishReason = (
-				finishReason?: string,
-				hasFunctionCalls?: boolean,
-				promptBlockReason?: string,
-			): string => {
-				if (promptBlockReason) {
-					switch (promptBlockReason) {
-						case "SAFETY":
-						case "PROHIBITED_CONTENT":
-						case "BLOCKLIST":
-						case "OTHER":
-							return "content_filter";
-						default:
-							return "stop";
-					}
-				}
-
-				if (!finishReason) {
-					return hasFunctionCalls ? "tool_calls" : "stop";
-				}
-
-				switch (finishReason) {
-					case "STOP":
-						return hasFunctionCalls ? "tool_calls" : "stop";
-					case "MAX_TOKENS":
-						return "length";
-					case "MALFORMED_FUNCTION_CALL":
-					case "UNEXPECTED_TOOL_CALL":
-						return "tool_calls";
-					case "SAFETY":
-					case "PROHIBITED_CONTENT":
-					case "RECITATION":
-					case "BLOCKLIST":
-					case "SPII":
-					case "LANGUAGE":
-					case "IMAGE_SAFETY":
-					case "IMAGE_PROHIBITED_CONTENT":
-					case "NO_IMAGE":
-						return "content_filter";
-					default:
-						return "stop";
-				}
-			};
-
 			const buildUsage = (
 				usageMetadata: any | undefined,
 				messagesForFallback: any[],
@@ -673,8 +616,9 @@ export function transformStreamingToOpenai(
 										? candidate.index
 										: candidateIdx,
 								delta: { role: "assistant" },
-								finish_reason: mapFinishReason(
+								finish_reason: mapFinishReasonToOpenai(
 									finishReason,
+									usedProvider,
 									candidateHasFunctionCalls,
 									promptBlockReason,
 								),
@@ -684,8 +628,9 @@ export function transformStreamingToOpenai(
 							{
 								index: 0,
 								delta: { role: "assistant" },
-								finish_reason: mapFinishReason(
+								finish_reason: mapFinishReasonToOpenai(
 									firstCandidate?.finishReason,
+									usedProvider,
 									false,
 									promptBlockReason,
 								),


### PR DESCRIPTION
## Summary

- Streaming responses were emitting raw provider finish reasons (e.g. Google's `STOP`/`MAX_TOKENS`, Anthropic's `end_turn`/`tool_use`) in the OpenAI-format SSE finish chunk. OpenAI-compatible clients (Vercel AI SDK and similar) map anything outside the canonical set (`stop`/`length`/`tool_calls`/`content_filter`) to `other`, which surfaced as a yellow "other" banner in the playground.
- Consolidated the mapping into a single helper `mapFinishReasonToOpenai` and reused it in the non-streaming transform, streaming transform, and the two SSE synthesis sites in `chat.ts`. Previously there were three near-duplicate inline mappers — two in the transforms and an implicit raw pass-through in `chat.ts` — which is how the streaming path drifted out of sync with non-streaming.
- Internal unified-finish-reason logging (`getUnifiedFinishReason` stored on the log row) is unchanged — the raw provider value is still what we record.

## Test plan

- [x] Unit: `transform-streaming-to-openai.spec.ts` + `transform-response-to-openai.spec.ts` pass (11 tests).
- [x] Manual: `curl` against local gateway with `google-vertex/gemini-2.5-flash-lite` now emits `"finish_reason":"stop"` (previously `"STOP"`).
- [ ] Verify in the playground that the "other" banner no longer shows for Google/Anthropic completions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized completion reason values reported to clients across providers, mapping diverse provider signals to OpenAI-style reasons (stop, length, tool_calls, content_filter).
  * Improved consistency for streaming and non-streaming events, better distinguishing tool-call terminations and content/safety blocks so end-of-response markers are clearer and less ambiguous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->