### PR TITLE
fix: use SSE for chat support streaming

### DIFF
--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -1,4 +1,9 @@
-import { streamText, convertToModelMessages, type UIMessage } from "ai";
+import {
+	streamText,
+	convertToModelMessages,
+	JsonToSseTransformStream,
+	type UIMessage,
+} from "ai";
 import { Hono } from "hono";
 
 import { redisClient } from "@/auth/config.js";
@@ -335,11 +340,66 @@ publicChatSupport.post("/", async (c) => {
 		},
 	});
 
-	return result.toTextStreamResponse({
+	// Pipe the UI message stream through SSE. SSE (`text/event-stream`) is far
+	// more reliable than raw `text/plain` streams on mobile Safari and through
+	// intermediate proxies, which tend to buffer `text/plain` responses and
+	// surface as "Load failed" errors on iOS.
+	const uiStream = result.toUIMessageStream({
+		onError: (error) => {
+			logger.error("Chat support streaming error", {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return error instanceof Error
+				? error.message
+				: "Something went wrong. Please try again.";
+		},
+	});
+	const sseStream = uiStream.pipeThrough(new JsonToSseTransformStream());
+
+	// Emit keepalive SSE comments so long-running streams aren't torn down by
+	// proxies/load balancers before the first chunk is flushed.
+	const KEEPALIVE_INTERVAL_MS = 15_000;
+	const encoder = new TextEncoder();
+	const reader = sseStream.getReader();
+	const streamWithKeepalive = new ReadableStream<Uint8Array>({
+		start(controller) {
+			const keepalive = setInterval(() => {
+				try {
+					controller.enqueue(encoder.encode(": ping\n\n"));
+				} catch {
+					clearInterval(keepalive);
+				}
+			}, KEEPALIVE_INTERVAL_MS);
+
+			void (async () => {
+				try {
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) {
+							clearInterval(keepalive);
+							controller.close();
+							return;
+						}
+						controller.enqueue(encoder.encode(value));
+					}
+				} catch (err) {
+					clearInterval(keepalive);
+					controller.error(err);
+				}
+			})();
+		},
+		cancel() {
+			void reader.cancel();
+		},
+	});
+
+	return new Response(streamWithKeepalive, {
 		headers: {
-			"Cache-Control": "no-cache, no-store, no-transform",
-			"X-Accel-Buffering": "no",
-			"Content-Type": "text/plain; charset=utf-8",
+			"content-type": "text/event-stream",
+			"cache-control": "no-cache, no-transform",
+			connection: "keep-alive",
+			"x-vercel-ai-ui-message-stream": "v1",
+			"x-accel-buffering": "no",
 		},
 	});
 });

--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -349,9 +349,7 @@ publicChatSupport.post("/", async (c) => {
 			logger.error("Chat support streaming error", {
 				error: error instanceof Error ? error.message : String(error),
 			});
-			return error instanceof Error
-				? error.message
-				: "Something went wrong. Please try again.";
+			return "Something went wrong. Please try again.";
 		},
 	});
 	const sseStream = uiStream.pipeThrough(new JsonToSseTransformStream());

--- a/apps/ui/src/components/chat-support.tsx
+++ b/apps/ui/src/components/chat-support.tsx
@@ -3,7 +3,7 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import { createCodePlugin } from "@streamdown/code";
 import { useMutation } from "@tanstack/react-query";
-import { TextStreamChatTransport } from "ai";
+import { DefaultChatTransport } from "ai";
 import {
 	MessageCircle,
 	X,
@@ -94,12 +94,8 @@ export function ChatSupport() {
 	const chat = useMemo(
 		() =>
 			new Chat({
-				transport: new TextStreamChatTransport({
+				transport: new DefaultChatTransport({
 					api: `${config.apiUrl}/public/chat-support`,
-					credentials: "include",
-					headers: {
-						"Content-Type": "application/json",
-					},
 					body: {
 						name: effectiveName,
 						email: effectiveEmail,


### PR DESCRIPTION
iOS WebKit (Safari and Chrome/iPhone) buffers cross-origin
`text/plain` streaming responses, producing "Load failed" when the
first chunk isn't flushed in time. Switch the support chat to the
UIMessage SSE protocol with keepalive pings, matching the
playground pipeline. Also:

- Surface stream errors via `toUIMessageStream({ onError })`
- Drop `credentials: include` on the public endpoint (not needed)
- Swap `TextStreamChatTransport` for `DefaultChatTransport`

https://claude.ai/code/session_01WCuk295FGYJ64mca1AHEmj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chat support now streams messages using a UI-friendly event stream with keepalive pings to keep connections stable.
  * Streaming errors surface concise user-facing feedback instead of failing silently.
  * Client-side chat transport updated for more reliable and consistent message delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->