### PR TITLE
fix(gateway): set usedRegion in low-uptime fallback

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2238,6 +2238,7 @@ chat.openapi(completions, async (c) => {
 							if (cheapestResult) {
 								usedProvider = cheapestResult.provider.providerId;
 								usedModel = cheapestResult.provider.modelName;
+								usedRegion = cheapestResult.provider.region;
 								routingMetadata = {
 									...cheapestResult.metadata,
 									selectionReason: "low-uptime-fallback",


### PR DESCRIPTION
## Summary

- When the low-uptime fallback routes to a different provider, also update `usedRegion` to match the selected provider's region.
- The sibling rate-limit fallback block at `apps/gateway/src/chat/chat.ts:2072-2075` already updates all three (`usedProvider`, `usedModel`, `usedRegion`); the low-uptime block was only updating two, leaving a stale region.

## Why it matters

A stale `usedRegion` propagates into region-specific env-token lookup (`getRegionSpecificEnvValue`), endpoint URL construction, and logs. When falling back from a regional provider (e.g. a Vertex/Bedrock region) to a provider in a different region, this could lead to picking wrong credentials or hitting an unintended regional endpoint.

## Change

Single-line addition in `apps/gateway/src/chat/chat.ts` mirroring the rate-limit fallback:

```ts
usedRegion = cheapestResult.provider.region;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where region information wasn't being properly updated when the system automatically switches to a fallback provider during low-availability scenarios, ensuring more reliable routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->