### PR TITLE
feat(admin): add provider/mapping detail pages

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3667,6 +3667,9 @@ const modelDetailSchema = z.object({
 		status: z.string(),
 		logsCount: z.number(),
 		errorsCount: z.number(),
+		clientErrorsCount: z.number(),
+		gatewayErrorsCount: z.number(),
+		upstreamErrorsCount: z.number(),
 		cachedCount: z.number(),
 		avgTimeToFirstToken: z.number().nullable(),
 		providerCount: z.number(),
@@ -3766,6 +3769,9 @@ admin.openapi(getModelDetail, async (c) => {
 				status: model.status,
 				logsCount: totalLogs,
 				errorsCount: totalErrors,
+				clientErrorsCount: 0,
+				gatewayErrorsCount: 0,
+				upstreamErrorsCount: 0,
 				cachedCount: totalCached,
 				avgTimeToFirstToken: null,
 				providerCount: statsRows.length,
@@ -3784,7 +3790,7 @@ admin.openapi(getModelDetail, async (c) => {
 	}
 
 	// Global view
-	const [mappings, statsRows] = await Promise.all([
+	const [mappings, statsRows, aggRow] = await Promise.all([
 		db
 			.select({
 				providerId: tables.modelProviderMapping.providerId,
@@ -3797,15 +3803,27 @@ admin.openapi(getModelDetail, async (c) => {
 			.select({
 				providerId: modelProviderMappingHistory.providerId,
 				logsCount:
-					sql<number>`SUM(${modelProviderMappingHistory.logsCount})`.as(
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
 						"logs_count",
 					),
 				errorsCount:
-					sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
 						"errors_count",
 					),
+				clientErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+						"upstream_errors_count",
+					),
 				cachedCount:
-					sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
 						"cached_count",
 					),
 				avgTtft:
@@ -3821,6 +3839,45 @@ admin.openapi(getModelDetail, async (c) => {
 				),
 			)
 			.groupBy(modelProviderMappingHistory.providerId),
+		db
+			.select({
+				logsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+						"logs_count",
+					),
+				errorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+						"errors_count",
+					),
+				clientErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+						"upstream_errors_count",
+					),
+				cachedCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+						"cached_count",
+					),
+				avgTtft: sql<
+					number | null
+				>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
+					"avg_ttft",
+				),
+			})
+			.from(modelProviderMappingHistory)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.modelId, modelId),
+					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+				),
+			),
 	]);
 
 	const providerIds = mappings.map((m) => m.providerId);
@@ -3857,6 +3914,9 @@ admin.openapi(getModelDetail, async (c) => {
 		};
 	});
 
+	const agg = aggRow[0];
+	const hasWindowData = Number(agg?.logsCount ?? 0) > 0;
+
 	return c.json({
 		model: {
 			id: model.id,
@@ -3865,10 +3925,27 @@ admin.openapi(getModelDetail, async (c) => {
 			free: model.free,
 			stability: model.stability,
 			status: model.status,
-			logsCount: model.logsCount,
-			errorsCount: model.errorsCount,
-			cachedCount: model.cachedCount,
-			avgTimeToFirstToken: model.avgTimeToFirstToken,
+			logsCount: hasWindowData ? Number(agg?.logsCount ?? 0) : model.logsCount,
+			errorsCount: hasWindowData
+				? Number(agg?.errorsCount ?? 0)
+				: model.errorsCount,
+			clientErrorsCount: hasWindowData
+				? Number(agg?.clientErrorsCount ?? 0)
+				: model.clientErrorsCount,
+			gatewayErrorsCount: hasWindowData
+				? Number(agg?.gatewayErrorsCount ?? 0)
+				: model.gatewayErrorsCount,
+			upstreamErrorsCount: hasWindowData
+				? Number(agg?.upstreamErrorsCount ?? 0)
+				: model.upstreamErrorsCount,
+			cachedCount: hasWindowData
+				? Number(agg?.cachedCount ?? 0)
+				: model.cachedCount,
+			avgTimeToFirstToken: hasWindowData
+				? agg?.avgTtft !== undefined && agg?.avgTtft !== null
+					? Number(agg.avgTtft)
+					: model.avgTimeToFirstToken
+				: model.avgTimeToFirstToken,
 			providerCount: providerStats.length,
 			updatedAt: model.updatedAt.toISOString(),
 		},

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -4036,6 +4036,9 @@ const historyDataPointSchema = z.object({
 	timestamp: z.string(),
 	logsCount: z.number(),
 	errorsCount: z.number(),
+	clientErrorsCount: z.number(),
+	gatewayErrorsCount: z.number(),
+	upstreamErrorsCount: z.number(),
 	cachedCount: z.number(),
 	avgTtft: z.number().nullable(),
 	avgDuration: z.number().nullable(),
@@ -4058,6 +4061,9 @@ function mapHistoryRows(
 		minuteTimestamp: Date;
 		logsCount: number;
 		errorsCount: number;
+		clientErrorsCount?: number;
+		gatewayErrorsCount?: number;
+		upstreamErrorsCount?: number;
 		cachedCount: number;
 		totalDuration: number;
 		totalTimeToFirstToken: number;
@@ -4095,6 +4101,9 @@ function mapHistoryRows(
 			timestamp: r.minuteTimestamp.toISOString(),
 			logsCount,
 			errorsCount,
+			clientErrorsCount: Number(r.clientErrorsCount ?? 0),
+			gatewayErrorsCount: Number(r.gatewayErrorsCount ?? 0),
+			upstreamErrorsCount: Number(r.upstreamErrorsCount ?? 0),
 			cachedCount,
 			avgTtft:
 				nonCached > 0 ? Math.round(totalTimeToFirstToken / nonCached) : null,
@@ -4144,6 +4153,18 @@ admin.openapi(getProviderHistory, async (c) => {
 				errorsCount:
 					sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
 						"errors_count",
+					),
+				clientErrorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.clientErrorsCount})`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.gatewayErrorsCount})`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.upstreamErrorsCount})`.as(
+						"upstream_errors_count",
 					),
 				cachedCount:
 					sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
@@ -4262,6 +4283,9 @@ admin.openapi(getModelHistory, async (c) => {
 				timestamp: r.hourTimestamp.toISOString(),
 				logsCount: Number(r.logsCount),
 				errorsCount: Number(r.errorsCount),
+				clientErrorsCount: 0,
+				gatewayErrorsCount: 0,
+				upstreamErrorsCount: 0,
 				cachedCount: Number(r.cachedCount),
 				avgTtft: null,
 				avgDuration: null,
@@ -4278,6 +4302,17 @@ admin.openapi(getModelHistory, async (c) => {
 			errorsCount: sql<number>`SUM(${modelHistory.errorsCount})`.as(
 				"errors_count",
 			),
+			clientErrorsCount: sql<number>`SUM(${modelHistory.clientErrorsCount})`.as(
+				"client_errors_count",
+			),
+			gatewayErrorsCount:
+				sql<number>`SUM(${modelHistory.gatewayErrorsCount})`.as(
+					"gateway_errors_count",
+				),
+			upstreamErrorsCount:
+				sql<number>`SUM(${modelHistory.upstreamErrorsCount})`.as(
+					"upstream_errors_count",
+				),
 			cachedCount: sql<number>`SUM(${modelHistory.cachedCount})`.as(
 				"cached_count",
 			),
@@ -4375,6 +4410,9 @@ admin.openapi(getMappingHistory, async (c) => {
 				timestamp: r.hourTimestamp.toISOString(),
 				logsCount: Number(r.logsCount),
 				errorsCount: Number(r.errorsCount),
+				clientErrorsCount: 0,
+				gatewayErrorsCount: 0,
+				upstreamErrorsCount: 0,
 				cachedCount: Number(r.cachedCount),
 				avgTtft: null,
 				avgDuration: null,
@@ -4384,7 +4422,7 @@ admin.openapi(getMappingHistory, async (c) => {
 		});
 	}
 
-	const [minuteRows, hourlyRows] = await Promise.all([
+	const [minuteRows, hourlyRows, hourlyErrorRows] = await Promise.all([
 		db
 			.select({
 				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
@@ -4395,6 +4433,18 @@ admin.openapi(getMappingHistory, async (c) => {
 				errorsCount:
 					sql<number>`SUM(${modelProviderMappingHistory.errorsCount})`.as(
 						"errors_count",
+					),
+				clientErrorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.clientErrorsCount})`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.gatewayErrorsCount})`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`SUM(${modelProviderMappingHistory.upstreamErrorsCount})`.as(
+						"upstream_errors_count",
 					),
 				cachedCount:
 					sql<number>`SUM(${modelProviderMappingHistory.cachedCount})`.as(
@@ -4455,6 +4505,21 @@ admin.openapi(getMappingHistory, async (c) => {
 			)
 			.groupBy(projectHourlyModelStats.hourTimestamp)
 			.orderBy(asc(projectHourlyModelStats.hourTimestamp)),
+		db
+			.select({
+				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
+				clientErrorsCount: modelProviderMappingHistory.clientErrorsCount,
+				gatewayErrorsCount: modelProviderMappingHistory.gatewayErrorsCount,
+				upstreamErrorsCount: modelProviderMappingHistory.upstreamErrorsCount,
+			})
+			.from(modelProviderMappingHistory)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.providerId, providerId),
+					eq(modelProviderMappingHistory.modelId, modelId),
+					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+				),
+			),
 	]);
 
 	const hasMinuteData = minuteRows.some((r) => Number(r.logsCount) > 0);
@@ -4538,16 +4603,39 @@ admin.openapi(getMappingHistory, async (c) => {
 		}
 	}
 
+	const errorBreakdownByHour = new Map<
+		string,
+		{ client: number; gateway: number; upstream: number }
+	>();
+	for (const r of hourlyErrorRows) {
+		const hk = getHourFloor(r.minuteTimestamp);
+		const existing = errorBreakdownByHour.get(hk);
+		const client = Number(r.clientErrorsCount);
+		const gateway = Number(r.gatewayErrorsCount);
+		const upstream = Number(r.upstreamErrorsCount);
+		if (existing) {
+			existing.client += client;
+			existing.gateway += gateway;
+			existing.upstream += upstream;
+		} else {
+			errorBreakdownByHour.set(hk, { client, gateway, upstream });
+		}
+	}
+
 	const data = hourlyRows.map((r) => {
 		const logsCount = Number(r.logsCount);
 		const errorsCount = Number(r.errorsCount);
 		const cachedCount = Number(r.cachedCount);
 		const hk = new Date(r.hourTimestamp).toISOString();
 		const latency = latencyByHour.get(hk);
+		const errorBreakdown = errorBreakdownByHour.get(hk);
 		return {
 			timestamp: hk,
 			logsCount,
 			errorsCount,
+			clientErrorsCount: errorBreakdown?.client ?? 0,
+			gatewayErrorsCount: errorBreakdown?.gateway ?? 0,
+			upstreamErrorsCount: errorBreakdown?.upstream ?? 0,
 			cachedCount,
 			avgTtft:
 				latency && latency.nonCached > 0
@@ -4563,6 +4651,424 @@ admin.openapi(getMappingHistory, async (c) => {
 	});
 
 	return c.json({ data });
+});
+
+// Provider detail – aggregated stats + per-model breakdown for the window
+const providerModelStatsSchema = z.object({
+	modelId: z.string(),
+	modelName: z.string(),
+	mappingId: z.string(),
+	region: z.string().nullable(),
+	status: z.string(),
+	logsCount: z.number(),
+	errorsCount: z.number(),
+	clientErrorsCount: z.number(),
+	gatewayErrorsCount: z.number(),
+	upstreamErrorsCount: z.number(),
+	cachedCount: z.number(),
+	avgTimeToFirstToken: z.number().nullable(),
+	updatedAt: z.string(),
+});
+
+const providerDetailSchema = z.object({
+	provider: z.object({
+		id: z.string(),
+		name: z.string(),
+		color: z.string().nullable(),
+		description: z.string(),
+		website: z.string().nullable(),
+		status: z.string(),
+		logsCount: z.number(),
+		errorsCount: z.number(),
+		clientErrorsCount: z.number(),
+		gatewayErrorsCount: z.number(),
+		upstreamErrorsCount: z.number(),
+		cachedCount: z.number(),
+		avgTimeToFirstToken: z.number().nullable(),
+		modelCount: z.number(),
+		updatedAt: z.string(),
+	}),
+	models: z.array(providerModelStatsSchema),
+});
+
+const getProviderDetail = createRoute({
+	method: "get",
+	path: "/providers/{providerId}",
+	request: {
+		params: z.object({ providerId: z.string() }),
+		query: z.object({
+			window: historyWindowSchema.default("4h").optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": { schema: providerDetailSchema.openapi({}) },
+			},
+			description: "Provider detail with per-model stats.",
+		},
+	},
+});
+
+admin.openapi(getProviderDetail, async (c) => {
+	const { providerId } = c.req.valid("param");
+	const query = c.req.valid("query");
+	const window = query.window ?? "4h";
+	const startDate = getHistoryStartDate(window);
+
+	const providerRow = await db.query.provider.findFirst({
+		where: { id: { eq: providerId } },
+	});
+
+	if (!providerRow) {
+		throw new HTTPException(404, { message: "Provider not found" });
+	}
+
+	const [mappings, statsRows, aggRow] = await Promise.all([
+		db
+			.select({
+				id: tables.modelProviderMapping.id,
+				modelId: tables.modelProviderMapping.modelId,
+				modelName: tables.modelProviderMapping.modelName,
+				region: tables.modelProviderMapping.region,
+				status: tables.modelProviderMapping.status,
+				avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+				updatedAt: tables.modelProviderMapping.updatedAt,
+			})
+			.from(tables.modelProviderMapping)
+			.where(eq(tables.modelProviderMapping.providerId, providerId)),
+		db
+			.select({
+				modelId: modelProviderMappingHistory.modelId,
+				logsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+						"logs_count",
+					),
+				errorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+						"errors_count",
+					),
+				clientErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+						"upstream_errors_count",
+					),
+				cachedCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+						"cached_count",
+					),
+				avgTtft: sql<
+					number | null
+				>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
+					"avg_ttft",
+				),
+			})
+			.from(modelProviderMappingHistory)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.providerId, providerId),
+					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+				),
+			)
+			.groupBy(modelProviderMappingHistory.modelId),
+		db
+			.select({
+				logsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+						"logs_count",
+					),
+				errorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+						"errors_count",
+					),
+				clientErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+						"upstream_errors_count",
+					),
+				cachedCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+						"cached_count",
+					),
+				avgTtft: sql<
+					number | null
+				>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
+					"avg_ttft",
+				),
+			})
+			.from(modelProviderMappingHistory)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.providerId, providerId),
+					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+				),
+			),
+	]);
+
+	const statsByModel = new Map(statsRows.map((r) => [r.modelId, r]));
+
+	const modelsOut = mappings.map((m) => {
+		const s = statsByModel.get(m.modelId);
+		return {
+			modelId: m.modelId,
+			modelName: m.modelName,
+			mappingId: m.id,
+			region: m.region,
+			status: m.status,
+			logsCount: Number(s?.logsCount ?? 0),
+			errorsCount: Number(s?.errorsCount ?? 0),
+			clientErrorsCount: Number(s?.clientErrorsCount ?? 0),
+			gatewayErrorsCount: Number(s?.gatewayErrorsCount ?? 0),
+			upstreamErrorsCount: Number(s?.upstreamErrorsCount ?? 0),
+			cachedCount: Number(s?.cachedCount ?? 0),
+			avgTimeToFirstToken:
+				s?.avgTtft !== undefined && s?.avgTtft !== null
+					? Number(s.avgTtft)
+					: m.avgTimeToFirstToken,
+			updatedAt: m.updatedAt.toISOString(),
+		};
+	});
+
+	const agg = aggRow[0];
+	const hasWindowData = Number(agg?.logsCount ?? 0) > 0;
+
+	return c.json({
+		provider: {
+			id: providerRow.id,
+			name: providerRow.name,
+			color: providerRow.color,
+			description: providerRow.description,
+			website: providerRow.website,
+			status: providerRow.status,
+			logsCount: hasWindowData
+				? Number(agg?.logsCount ?? 0)
+				: providerRow.logsCount,
+			errorsCount: hasWindowData
+				? Number(agg?.errorsCount ?? 0)
+				: providerRow.errorsCount,
+			clientErrorsCount: hasWindowData
+				? Number(agg?.clientErrorsCount ?? 0)
+				: providerRow.clientErrorsCount,
+			gatewayErrorsCount: hasWindowData
+				? Number(agg?.gatewayErrorsCount ?? 0)
+				: providerRow.gatewayErrorsCount,
+			upstreamErrorsCount: hasWindowData
+				? Number(agg?.upstreamErrorsCount ?? 0)
+				: providerRow.upstreamErrorsCount,
+			cachedCount: hasWindowData
+				? Number(agg?.cachedCount ?? 0)
+				: providerRow.cachedCount,
+			avgTimeToFirstToken: hasWindowData
+				? agg?.avgTtft !== undefined && agg?.avgTtft !== null
+					? Number(agg.avgTtft)
+					: providerRow.avgTimeToFirstToken
+				: providerRow.avgTimeToFirstToken,
+			modelCount: mappings.length,
+			updatedAt: providerRow.updatedAt.toISOString(),
+		},
+		models: modelsOut,
+	});
+});
+
+// Mapping detail – aggregated stats for a provider/model mapping in the window
+const mappingDetailSchema = z.object({
+	mapping: z.object({
+		id: z.string(),
+		modelId: z.string(),
+		modelName: z.string(),
+		providerId: z.string(),
+		providerName: z.string(),
+		region: z.string().nullable(),
+		status: z.string(),
+		inputPrice: z.string().nullable(),
+		outputPrice: z.string().nullable(),
+		cachedInputPrice: z.string().nullable(),
+		imageInputPrice: z.string().nullable(),
+		requestPrice: z.string().nullable(),
+		contextSize: z.number().nullable(),
+		maxOutput: z.number().nullable(),
+		streaming: z.boolean(),
+		logsCount: z.number(),
+		errorsCount: z.number(),
+		clientErrorsCount: z.number(),
+		gatewayErrorsCount: z.number(),
+		upstreamErrorsCount: z.number(),
+		cachedCount: z.number(),
+		avgTimeToFirstToken: z.number().nullable(),
+		updatedAt: z.string(),
+	}),
+});
+
+const getMappingDetail = createRoute({
+	method: "get",
+	path: "/providers/{providerId}/models/{modelId}",
+	request: {
+		params: z.object({
+			providerId: z.string(),
+			modelId: z.string(),
+		}),
+		query: z.object({
+			window: historyWindowSchema.default("4h").optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": { schema: mappingDetailSchema.openapi({}) },
+			},
+			description: "Mapping detail with aggregated stats for the window.",
+		},
+	},
+});
+
+admin.openapi(getMappingDetail, async (c) => {
+	const { providerId, modelId } = c.req.valid("param");
+	const query = c.req.valid("query");
+	const window = query.window ?? "4h";
+	const startDate = getHistoryStartDate(window);
+
+	const mappingRow = await db
+		.select({
+			id: tables.modelProviderMapping.id,
+			modelId: tables.modelProviderMapping.modelId,
+			modelName: tables.modelProviderMapping.modelName,
+			providerId: tables.modelProviderMapping.providerId,
+			providerName: tables.provider.name,
+			region: tables.modelProviderMapping.region,
+			status: tables.modelProviderMapping.status,
+			inputPrice: tables.modelProviderMapping.inputPrice,
+			outputPrice: tables.modelProviderMapping.outputPrice,
+			cachedInputPrice: tables.modelProviderMapping.cachedInputPrice,
+			imageInputPrice: tables.modelProviderMapping.imageInputPrice,
+			requestPrice: tables.modelProviderMapping.requestPrice,
+			contextSize: tables.modelProviderMapping.contextSize,
+			maxOutput: tables.modelProviderMapping.maxOutput,
+			streaming: tables.modelProviderMapping.streaming,
+			logsCount: tables.modelProviderMapping.logsCount,
+			errorsCount: tables.modelProviderMapping.errorsCount,
+			clientErrorsCount: tables.modelProviderMapping.clientErrorsCount,
+			gatewayErrorsCount: tables.modelProviderMapping.gatewayErrorsCount,
+			upstreamErrorsCount: tables.modelProviderMapping.upstreamErrorsCount,
+			cachedCount: tables.modelProviderMapping.cachedCount,
+			avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+			updatedAt: tables.modelProviderMapping.updatedAt,
+		})
+		.from(tables.modelProviderMapping)
+		.innerJoin(
+			tables.provider,
+			eq(tables.provider.id, tables.modelProviderMapping.providerId),
+		)
+		.where(
+			and(
+				eq(tables.modelProviderMapping.providerId, providerId),
+				eq(tables.modelProviderMapping.modelId, modelId),
+			),
+		)
+		.limit(1);
+
+	if (mappingRow.length === 0) {
+		throw new HTTPException(404, { message: "Mapping not found" });
+	}
+
+	const m = mappingRow[0];
+
+	const [aggRow] = await db
+		.select({
+			logsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+					"logs_count",
+				),
+			errorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+					"errors_count",
+				),
+			clientErrorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+					"client_errors_count",
+				),
+			gatewayErrorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+					"gateway_errors_count",
+				),
+			upstreamErrorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+					"upstream_errors_count",
+				),
+			cachedCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+					"cached_count",
+				),
+			avgTtft: sql<
+				number | null
+			>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
+				"avg_ttft",
+			),
+		})
+		.from(modelProviderMappingHistory)
+		.where(
+			and(
+				eq(modelProviderMappingHistory.modelProviderMappingId, m.id),
+				gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+			),
+		);
+
+	const hasWindowData = Number(aggRow?.logsCount ?? 0) > 0;
+
+	return c.json({
+		mapping: {
+			id: m.id,
+			modelId: m.modelId,
+			modelName: m.modelName,
+			providerId: m.providerId,
+			providerName: m.providerName,
+			region: m.region,
+			status: m.status,
+			inputPrice: m.inputPrice,
+			outputPrice: m.outputPrice,
+			cachedInputPrice: m.cachedInputPrice,
+			imageInputPrice: m.imageInputPrice,
+			requestPrice: m.requestPrice,
+			contextSize: m.contextSize,
+			maxOutput: m.maxOutput,
+			streaming: m.streaming,
+			logsCount: hasWindowData ? Number(aggRow?.logsCount ?? 0) : m.logsCount,
+			errorsCount: hasWindowData
+				? Number(aggRow?.errorsCount ?? 0)
+				: m.errorsCount,
+			clientErrorsCount: hasWindowData
+				? Number(aggRow?.clientErrorsCount ?? 0)
+				: m.clientErrorsCount,
+			gatewayErrorsCount: hasWindowData
+				? Number(aggRow?.gatewayErrorsCount ?? 0)
+				: m.gatewayErrorsCount,
+			upstreamErrorsCount: hasWindowData
+				? Number(aggRow?.upstreamErrorsCount ?? 0)
+				: m.upstreamErrorsCount,
+			cachedCount: hasWindowData
+				? Number(aggRow?.cachedCount ?? 0)
+				: m.cachedCount,
+			avgTimeToFirstToken: hasWindowData
+				? aggRow?.avgTtft !== undefined && aggRow?.avgTtft !== null
+					? Number(aggRow.avgTtft)
+					: m.avgTimeToFirstToken
+				: m.avgTimeToFirstToken,
+			updatedAt: m.updatedAt.toISOString(),
+		},
+	});
 });
 
 // --- Cost by model endpoints ---

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -3108,6 +3108,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3159,6 +3162,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3211,12 +3217,153 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
                                 totalCost: number;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Provider detail with per-model stats. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            provider: {
+                                id: string;
+                                name: string;
+                                color: string | null;
+                                description: string;
+                                website: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                modelCount: number;
+                                updatedAt: string;
+                            };
+                            models: {
+                                modelId: string;
+                                modelName: string;
+                                mappingId: string;
+                                region: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}/models/{modelId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                    modelId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Mapping detail with aggregated stats for the window. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            mapping: {
+                                id: string;
+                                modelId: string;
+                                modelName: string;
+                                providerId: string;
+                                providerName: string;
+                                region: string | null;
+                                status: string;
+                                inputPrice: string | null;
+                                outputPrice: string | null;
+                                cachedInputPrice: string | null;
+                                imageInputPrice: string | null;
+                                requestPrice: string | null;
+                                contextSize: number | null;
+                                maxOutput: number | null;
+                                streaming: boolean;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            };
                         };
                     };
                 };

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2946,6 +2946,9 @@ export interface paths {
                                 status: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -3108,6 +3108,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3159,6 +3162,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3211,12 +3217,153 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
                                 totalCost: number;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Provider detail with per-model stats. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            provider: {
+                                id: string;
+                                name: string;
+                                color: string | null;
+                                description: string;
+                                website: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                modelCount: number;
+                                updatedAt: string;
+                            };
+                            models: {
+                                modelId: string;
+                                modelName: string;
+                                mappingId: string;
+                                region: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}/models/{modelId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                    modelId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Mapping detail with aggregated stats for the window. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            mapping: {
+                                id: string;
+                                modelId: string;
+                                modelName: string;
+                                providerId: string;
+                                providerName: string;
+                                region: string | null;
+                                status: string;
+                                inputPrice: string | null;
+                                outputPrice: string | null;
+                                cachedInputPrice: string | null;
+                                imageInputPrice: string | null;
+                                requestPrice: string | null;
+                                contextSize: number | null;
+                                maxOutput: number | null;
+                                streaming: boolean;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            };
                         };
                     };
                 };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2946,6 +2946,9 @@ export interface paths {
                                 status: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -3108,6 +3108,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3159,6 +3162,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3211,12 +3217,153 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
                                 totalCost: number;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Provider detail with per-model stats. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            provider: {
+                                id: string;
+                                name: string;
+                                color: string | null;
+                                description: string;
+                                website: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                modelCount: number;
+                                updatedAt: string;
+                            };
+                            models: {
+                                modelId: string;
+                                modelName: string;
+                                mappingId: string;
+                                region: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}/models/{modelId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                    modelId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Mapping detail with aggregated stats for the window. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            mapping: {
+                                id: string;
+                                modelId: string;
+                                modelName: string;
+                                providerId: string;
+                                providerName: string;
+                                region: string | null;
+                                status: string;
+                                inputPrice: string | null;
+                                outputPrice: string | null;
+                                cachedInputPrice: string | null;
+                                imageInputPrice: string | null;
+                                requestPrice: string | null;
+                                contextSize: number | null;
+                                maxOutput: number | null;
+                                streaming: boolean;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            };
                         };
                     };
                 };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2946,6 +2946,9 @@ export interface paths {
                                 status: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;

--- a/ee/admin/src/app/model-provider-mappings/[providerId]/[modelId]/page.tsx
+++ b/ee/admin/src/app/model-provider-mappings/[providerId]/[modelId]/page.tsx
@@ -1,0 +1,72 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Suspense } from "react";
+
+import { MappingDetailClient } from "@/components/mapping-detail-client";
+import { Button } from "@/components/ui/button";
+import { requireSession } from "@/lib/require-session";
+import { createServerApiClient } from "@/lib/server-api";
+
+export default async function MappingDetailPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ providerId: string; modelId: string }>;
+	searchParams?: Promise<{ window?: string }>;
+}) {
+	await requireSession();
+
+	const { providerId, modelId } = await params;
+	const decodedModelId = decodeURIComponent(modelId);
+	const searchParamsData = await searchParams;
+	const window = searchParamsData?.window;
+
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET(
+		"/admin/providers/{providerId}/models/{modelId}",
+		{
+			params: {
+				path: { providerId, modelId: encodeURIComponent(decodedModelId) },
+				query: {
+					...(window ? { window } : {}),
+				} as any,
+			},
+		},
+	);
+
+	if (!data) {
+		return (
+			<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
+				<Button variant="ghost" size="sm" asChild>
+					<Link href="/model-provider-mappings">
+						<ArrowLeft className="mr-1 h-4 w-4" />
+						Back to Mappings
+					</Link>
+				</Button>
+				<div className="flex h-64 items-center justify-center text-muted-foreground">
+					Mapping not found
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
+			<div className="flex items-center gap-3">
+				<Button variant="ghost" size="sm" asChild>
+					<Link href="/model-provider-mappings">
+						<ArrowLeft className="mr-1 h-4 w-4" />
+						Back
+					</Link>
+				</Button>
+			</div>
+			<Suspense>
+				<MappingDetailClient
+					providerId={providerId}
+					modelId={decodedModelId}
+					mapping={data.mapping}
+				/>
+			</Suspense>
+		</div>
+	);
+}

--- a/ee/admin/src/app/providers/[providerId]/page.tsx
+++ b/ee/admin/src/app/providers/[providerId]/page.tsx
@@ -1,0 +1,70 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Suspense } from "react";
+
+import { ProviderDetailClient } from "@/components/provider-detail-client";
+import { Button } from "@/components/ui/button";
+import { requireSession } from "@/lib/require-session";
+import { createServerApiClient } from "@/lib/server-api";
+
+export default async function ProviderDetailPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ providerId: string }>;
+	searchParams?: Promise<{ window?: string }>;
+}) {
+	await requireSession();
+
+	const { providerId } = await params;
+	const searchParamsData = await searchParams;
+	const window = searchParamsData?.window;
+
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/providers/{providerId}", {
+		params: {
+			path: { providerId },
+			query: {
+				...(window ? { window } : {}),
+			} as any,
+		},
+	});
+
+	if (!data) {
+		return (
+			<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
+				<Button variant="ghost" size="sm" asChild>
+					<Link href="/providers">
+						<ArrowLeft className="mr-1 h-4 w-4" />
+						Back to Providers
+					</Link>
+				</Button>
+				<div className="flex h-64 items-center justify-center text-muted-foreground">
+					Provider not found
+				</div>
+			</div>
+		);
+	}
+
+	const { provider, models } = data;
+
+	return (
+		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
+			<div className="flex items-center gap-3">
+				<Button variant="ghost" size="sm" asChild>
+					<Link href="/providers">
+						<ArrowLeft className="mr-1 h-4 w-4" />
+						Back
+					</Link>
+				</Button>
+			</div>
+			<Suspense>
+				<ProviderDetailClient
+					providerId={providerId}
+					providerInfo={provider}
+					models={models}
+				/>
+			</Suspense>
+		</div>
+	);
+}

--- a/ee/admin/src/components/detail-stat-cards.tsx
+++ b/ee/admin/src/components/detail-stat-cards.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+function formatNumber(n: number) {
+	return new Intl.NumberFormat("en-US").format(n);
+}
+
+export interface DetailStats {
+	logsCount: number;
+	errorsCount: number;
+	clientErrorsCount: number;
+	gatewayErrorsCount: number;
+	upstreamErrorsCount: number;
+	cachedCount: number;
+	avgTimeToFirstToken: number | null;
+}
+
+export function DetailStatCards({
+	stats,
+	loading,
+}: {
+	stats: DetailStats;
+	loading?: boolean;
+}) {
+	const errorRate =
+		stats.logsCount > 0
+			? ((stats.errorsCount / stats.logsCount) * 100).toFixed(1)
+			: "0.0";
+
+	return (
+		<>
+			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<StatCard
+					label="Total Requests"
+					value={formatNumber(stats.logsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Errors"
+					value={
+						<>
+							{formatNumber(stats.errorsCount)}{" "}
+							<span className="text-sm text-muted-foreground">
+								({errorRate}%)
+							</span>
+						</>
+					}
+					loading={loading}
+				/>
+				<StatCard
+					label="Cached"
+					value={formatNumber(stats.cachedCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Avg TTFT"
+					value={
+						stats.avgTimeToFirstToken !== null
+							? `${Math.round(stats.avgTimeToFirstToken)}ms`
+							: "\u2014"
+					}
+					loading={loading}
+				/>
+			</section>
+
+			<section className="grid gap-4 sm:grid-cols-3">
+				<StatCard
+					label="Client Errors"
+					value={formatNumber(stats.clientErrorsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Gateway Errors"
+					value={formatNumber(stats.gatewayErrorsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Upstream Errors"
+					value={formatNumber(stats.upstreamErrorsCount)}
+					loading={loading}
+				/>
+			</section>
+		</>
+	);
+}
+
+export function StatCard({
+	label,
+	value,
+	loading,
+}: {
+	label: string;
+	value: React.ReactNode;
+	loading?: boolean;
+}) {
+	return (
+		<div className="rounded-xl border border-border/60 p-4 shadow-sm">
+			<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+				{label}
+			</p>
+			<p
+				className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
+			>
+				{value}
+			</p>
+		</div>
+	);
+}

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -145,6 +145,21 @@ export function HistoryChart({
 
 	const ttftPoints = data.filter((d) => d.avgTtft !== null);
 	const durationPoints = data.filter((d) => d.avgDuration !== null);
+	const throughputPoints = data.filter(
+		(d) =>
+			d.avgDuration !== null &&
+			(d.avgDuration ?? 0) > 0 &&
+			d.logsCount > 0 &&
+			d.totalTokens > 0,
+	);
+	const throughputTotalMs = throughputPoints.reduce((sum, d) => {
+		const durationMs = (d.avgDuration ?? 0) * d.logsCount;
+		return sum + durationMs;
+	}, 0);
+	const throughputTotalTokens = throughputPoints.reduce(
+		(sum, d) => sum + d.totalTokens,
+		0,
+	);
 	const summaryStats = {
 		totalRequests: data.reduce((sum, d) => sum + d.logsCount, 0),
 		totalErrors: data.reduce((sum, d) => sum + d.errorsCount, 0),
@@ -163,6 +178,10 @@ export function HistoryChart({
 						durationPoints.reduce((sum, d) => sum + (d.avgDuration ?? 0), 0) /
 							durationPoints.length,
 					)
+				: null,
+		tokensPerSecond:
+			throughputTotalMs > 0
+				? Math.round(throughputTotalTokens / (throughputTotalMs / 1000))
 				: null,
 		errorRate:
 			data.reduce((sum, d) => sum + d.logsCount, 0) > 0
@@ -250,6 +269,14 @@ export function HistoryChart({
 							Avg Duration:{" "}
 							<strong className="text-foreground">
 								{summaryStats.avgDuration}ms
+							</strong>
+						</span>
+					)}
+					{summaryStats.tokensPerSecond !== null && (
+						<span>
+							t/s:{" "}
+							<strong className="text-foreground">
+								{summaryStats.tokensPerSecond.toLocaleString()}
 							</strong>
 						</span>
 					)}

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -38,6 +38,9 @@ export interface HistoryDataPoint {
 	timestamp: string;
 	logsCount: number;
 	errorsCount: number;
+	clientErrorsCount?: number;
+	gatewayErrorsCount?: number;
+	upstreamErrorsCount?: number;
 	cachedCount: number;
 	avgTtft: number | null;
 	avgDuration: number | null;
@@ -53,8 +56,9 @@ const chartConfigs: Record<ActiveMetric, ChartConfig> = {
 		cachedCount: { label: "Cached", color: "hsl(142 71% 45%)" },
 	},
 	errors: {
-		errorsCount: { label: "Errors", color: "hsl(0 84% 60%)" },
-		logsCount: { label: "Total", color: "hsl(221 83% 53%)" },
+		clientErrorsCount: { label: "Client", color: "hsl(38 92% 50%)" },
+		gatewayErrorsCount: { label: "Gateway", color: "hsl(262 83% 58%)" },
+		upstreamErrorsCount: { label: "Upstream", color: "hsl(0 84% 60%)" },
 	},
 	latency: {
 		avgTtft: { label: "Avg TTFT (ms)", color: "hsl(262 83% 58%)" },
@@ -139,17 +143,25 @@ export function HistoryChart({
 	const config = chartConfigs[activeMetric];
 	const dataKeys = Object.keys(config);
 
+	const ttftPoints = data.filter((d) => d.avgTtft !== null);
+	const durationPoints = data.filter((d) => d.avgDuration !== null);
 	const summaryStats = {
 		totalRequests: data.reduce((sum, d) => sum + d.logsCount, 0),
 		totalErrors: data.reduce((sum, d) => sum + d.errorsCount, 0),
+		totalTokens: data.reduce((sum, d) => sum + d.totalTokens, 0),
 		totalCost: data.reduce((sum, d) => sum + d.totalCost, 0),
 		avgTtft:
-			data.filter((d) => d.avgTtft !== null).length > 0
+			ttftPoints.length > 0
 				? Math.round(
-						data
-							.filter((d) => d.avgTtft !== null)
-							.reduce((sum, d) => sum + (d.avgTtft ?? 0), 0) /
-							data.filter((d) => d.avgTtft !== null).length,
+						ttftPoints.reduce((sum, d) => sum + (d.avgTtft ?? 0), 0) /
+							ttftPoints.length,
+					)
+				: null,
+		avgDuration:
+			durationPoints.length > 0
+				? Math.round(
+						durationPoints.reduce((sum, d) => sum + (d.avgDuration ?? 0), 0) /
+							durationPoints.length,
 					)
 				: null,
 		errorRate:
@@ -161,6 +173,19 @@ export function HistoryChart({
 					).toFixed(1)
 				: "0.0",
 	};
+
+	function formatCompact(n: number): string {
+		if (n >= 1_000_000_000) {
+			return `${(n / 1_000_000_000).toFixed(1)}B`;
+		}
+		if (n >= 1_000_000) {
+			return `${(n / 1_000_000).toFixed(1)}M`;
+		}
+		if (n >= 1_000) {
+			return `${(n / 1_000).toFixed(1)}k`;
+		}
+		return n.toLocaleString();
+	}
 
 	return (
 		<Card>
@@ -186,7 +211,7 @@ export function HistoryChart({
 						</div>
 					)}
 				</div>
-				<div className="flex items-center gap-4 text-xs text-muted-foreground">
+				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
 					<span>
 						Reqs:{" "}
 						<strong className="text-foreground">
@@ -201,6 +226,12 @@ export function HistoryChart({
 						({summaryStats.errorRate}%)
 					</span>
 					<span>
+						Tokens:{" "}
+						<strong className="text-foreground">
+							{formatCompact(summaryStats.totalTokens)}
+						</strong>
+					</span>
+					<span>
 						Cost:{" "}
 						<strong className="text-foreground">
 							${summaryStats.totalCost.toFixed(4)}
@@ -211,6 +242,14 @@ export function HistoryChart({
 							Avg TTFT:{" "}
 							<strong className="text-foreground">
 								{summaryStats.avgTtft}ms
+							</strong>
+						</span>
+					)}
+					{summaryStats.avgDuration !== null && (
+						<span>
+							Avg Duration:{" "}
+							<strong className="text-foreground">
+								{summaryStats.avgDuration}ms
 							</strong>
 						</span>
 					)}

--- a/ee/admin/src/components/mapping-detail-client.tsx
+++ b/ee/admin/src/components/mapping-detail-client.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import { HistoryChart, windowOptions } from "@/components/history-chart";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getMappingDetail, getMappingHistory } from "@/lib/admin-history";
+
+import { getProviderIcon } from "@llmgateway/shared";
+
+import type { HistoryWindow } from "@/components/history-chart";
+import type { MappingDetail } from "@/lib/types";
+
+function formatNumber(n: number) {
+	return new Intl.NumberFormat("en-US").format(n);
+}
+
+function formatPrice(price: string | null) {
+	if (!price) {
+		return "\u2014";
+	}
+	const num = parseFloat(price);
+	if (num === 0) {
+		return "Free";
+	}
+	if (num < 0.001) {
+		return `$${(num * 1_000_000).toFixed(2)}/M`;
+	}
+	return `$${num.toFixed(4)}`;
+}
+
+const validWindows = new Set<HistoryWindow>(windowOptions.map((o) => o.value));
+
+function parseHistoryWindow(value: string | null): HistoryWindow {
+	if (value && validWindows.has(value as HistoryWindow)) {
+		return value as HistoryWindow;
+	}
+	return "24h";
+}
+
+export function MappingDetailClient({
+	providerId,
+	modelId,
+	mapping: initialMapping,
+}: {
+	providerId: string;
+	modelId: string;
+	mapping: MappingDetail;
+}) {
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
+	const window = parseHistoryWindow(searchParams.get("window"));
+	const [loading, setLoading] = useState(false);
+	const [mapping, setMapping] = useState<MappingDetail>(initialMapping);
+
+	const loadDetail = useCallback(
+		async (w: HistoryWindow) => {
+			setLoading(true);
+			try {
+				const data = await getMappingDetail(providerId, modelId, w);
+				if (data) {
+					setMapping(data.mapping);
+				}
+			} finally {
+				setLoading(false);
+			}
+		},
+		[providerId, modelId],
+	);
+
+	useEffect(() => {
+		void loadDetail(window);
+	}, [loadDetail, window]);
+
+	const fetchHistory = useCallback(
+		async (w: HistoryWindow) => {
+			return await getMappingHistory(providerId, modelId, w);
+		},
+		[providerId, modelId],
+	);
+
+	const ProviderIcon = getProviderIcon(providerId);
+	const errorRate =
+		mapping.logsCount > 0
+			? ((mapping.errorsCount / mapping.logsCount) * 100).toFixed(1)
+			: "0.0";
+	const displayName =
+		mapping.modelName !== mapping.modelId ? mapping.modelName : mapping.modelId;
+
+	return (
+		<>
+			<header className="flex items-start gap-3">
+				<ProviderIcon className="mt-1 h-8 w-8 shrink-0 dark:text-white" />
+				<div>
+					<h1 className="text-3xl font-semibold tracking-tight">
+						{mapping.providerId}/{mapping.modelId}
+					</h1>
+					<p className="mt-1 text-sm text-muted-foreground">
+						{mapping.providerName} / {displayName}
+					</p>
+					<div className="mt-3 flex flex-wrap items-center gap-2">
+						<Badge
+							variant={mapping.status === "active" ? "secondary" : "outline"}
+						>
+							{mapping.status}
+						</Badge>
+						{mapping.region && (
+							<Badge variant="outline">{mapping.region}</Badge>
+						)}
+						{mapping.streaming && <Badge variant="outline">streaming</Badge>}
+					</div>
+				</div>
+			</header>
+
+			<div className="flex flex-wrap items-center gap-1">
+				{windowOptions.map((opt) => (
+					<Button
+						key={opt.value}
+						variant={window === opt.value ? "default" : "outline"}
+						size="sm"
+						className="h-7 px-2 text-xs"
+						onClick={() => {
+							const params = new URLSearchParams(searchParams.toString());
+							params.set("window", opt.value);
+							router.replace(`${pathname}?${params.toString()}`, {
+								scroll: false,
+							});
+						}}
+					>
+						{opt.label}
+					</Button>
+				))}
+			</div>
+
+			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<StatCard
+					label="Total Requests"
+					value={formatNumber(mapping.logsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Errors"
+					value={
+						<>
+							{formatNumber(mapping.errorsCount)}{" "}
+							<span className="text-sm text-muted-foreground">
+								({errorRate}%)
+							</span>
+						</>
+					}
+					loading={loading}
+				/>
+				<StatCard
+					label="Cached"
+					value={formatNumber(mapping.cachedCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Avg TTFT"
+					value={
+						mapping.avgTimeToFirstToken !== null
+							? `${Math.round(mapping.avgTimeToFirstToken)}ms`
+							: "\u2014"
+					}
+					loading={loading}
+				/>
+			</section>
+
+			<section className="grid gap-4 sm:grid-cols-3">
+				<StatCard
+					label="Client Errors"
+					value={formatNumber(mapping.clientErrorsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Gateway Errors"
+					value={formatNumber(mapping.gatewayErrorsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Upstream Errors"
+					value={formatNumber(mapping.upstreamErrorsCount)}
+					loading={loading}
+				/>
+			</section>
+
+			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<StatCard label="Input Price" value={formatPrice(mapping.inputPrice)} />
+				<StatCard
+					label="Output Price"
+					value={formatPrice(mapping.outputPrice)}
+				/>
+				<StatCard
+					label="Context"
+					value={
+						mapping.contextSize
+							? `${(mapping.contextSize / 1000).toFixed(0)}K`
+							: "\u2014"
+					}
+				/>
+				<StatCard
+					label="Max Output"
+					value={
+						mapping.maxOutput
+							? `${mapping.maxOutput.toLocaleString("en-US")}`
+							: "\u2014"
+					}
+				/>
+			</section>
+
+			<section className="space-y-4">
+				<HistoryChart
+					title={`${mapping.providerName} / ${displayName} — History`}
+					description="Request volume, errors, latency, and tokens over time"
+					fetchData={fetchHistory}
+					externalWindow={window}
+				/>
+			</section>
+		</>
+	);
+}
+
+function StatCard({
+	label,
+	value,
+	loading,
+}: {
+	label: string;
+	value: React.ReactNode;
+	loading?: boolean;
+}) {
+	return (
+		<div className="rounded-xl border border-border/60 p-4 shadow-sm">
+			<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+				{label}
+			</p>
+			<p
+				className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
+			>
+				{value}
+			</p>
+		</div>
+	);
+}

--- a/ee/admin/src/components/mapping-detail-client.tsx
+++ b/ee/admin/src/components/mapping-detail-client.tsx
@@ -156,7 +156,7 @@ export function MappingDetailClient({
 
 			<section className="space-y-4">
 				<HistoryChart
-					title={`${mapping.providerName} / ${displayName} — History`}
+					title={`${mapping.providerId}/${mapping.modelId} — History`}
 					description="Request volume, errors, latency, and tokens over time"
 					fetchData={fetchHistory}
 					externalWindow={window}

--- a/ee/admin/src/components/mapping-detail-client.tsx
+++ b/ee/admin/src/components/mapping-detail-client.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
+import { DetailStatCards, StatCard } from "@/components/detail-stat-cards";
 import { HistoryChart, windowOptions } from "@/components/history-chart";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,10 +13,6 @@ import { getProviderIcon } from "@llmgateway/shared";
 
 import type { HistoryWindow } from "@/components/history-chart";
 import type { MappingDetail } from "@/lib/types";
-
-function formatNumber(n: number) {
-	return new Intl.NumberFormat("en-US").format(n);
-}
 
 function formatPrice(price: string | null) {
 	if (!price) {
@@ -83,10 +80,6 @@ export function MappingDetailClient({
 	);
 
 	const ProviderIcon = getProviderIcon(providerId);
-	const errorRate =
-		mapping.logsCount > 0
-			? ((mapping.errorsCount / mapping.logsCount) * 100).toFixed(1)
-			: "0.0";
 	const displayName =
 		mapping.modelName !== mapping.modelId ? mapping.modelName : mapping.modelId;
 
@@ -135,57 +128,7 @@ export function MappingDetailClient({
 				))}
 			</div>
 
-			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-				<StatCard
-					label="Total Requests"
-					value={formatNumber(mapping.logsCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Errors"
-					value={
-						<>
-							{formatNumber(mapping.errorsCount)}{" "}
-							<span className="text-sm text-muted-foreground">
-								({errorRate}%)
-							</span>
-						</>
-					}
-					loading={loading}
-				/>
-				<StatCard
-					label="Cached"
-					value={formatNumber(mapping.cachedCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Avg TTFT"
-					value={
-						mapping.avgTimeToFirstToken !== null
-							? `${Math.round(mapping.avgTimeToFirstToken)}ms`
-							: "\u2014"
-					}
-					loading={loading}
-				/>
-			</section>
-
-			<section className="grid gap-4 sm:grid-cols-3">
-				<StatCard
-					label="Client Errors"
-					value={formatNumber(mapping.clientErrorsCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Gateway Errors"
-					value={formatNumber(mapping.gatewayErrorsCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Upstream Errors"
-					value={formatNumber(mapping.upstreamErrorsCount)}
-					loading={loading}
-				/>
-			</section>
+			<DetailStatCards stats={mapping} loading={loading} />
 
 			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
 				<StatCard label="Input Price" value={formatPrice(mapping.inputPrice)} />
@@ -220,28 +163,5 @@ export function MappingDetailClient({
 				/>
 			</section>
 		</>
-	);
-}
-
-function StatCard({
-	label,
-	value,
-	loading,
-}: {
-	label: string;
-	value: React.ReactNode;
-	loading?: boolean;
-}) {
-	return (
-		<div className="rounded-xl border border-border/60 p-4 shadow-sm">
-			<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-				{label}
-			</p>
-			<p
-				className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
-			>
-				{value}
-			</p>
-		</div>
 	);
 }

--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -251,7 +251,7 @@ function MappingRow({
 						id={`mapping-history-${mapping.providerId}-${mapping.modelId}`}
 					>
 						<HistoryChart
-							title={`${mapping.providerName} / ${mapping.modelName !== mapping.modelId ? mapping.modelName : mapping.modelId} — History`}
+							title={`${mapping.providerId}/${mapping.modelId} — History`}
 							description="Request volume, errors, latency, and tokens over time"
 							fetchData={fetchData}
 							externalWindow={externalWindow}

--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -153,14 +153,20 @@ function MappingRow({
 							<p className="text-xs text-muted-foreground">
 								{mapping.providerId}
 							</p>
-							<span className="font-medium">{mapping.providerName}</span>
+							<Link
+								href={`/providers/${encodeURIComponent(mapping.providerId)}`}
+								className="font-medium hover:underline"
+								onClick={(e) => e.stopPropagation()}
+							>
+								{mapping.providerName}
+							</Link>
 						</div>
 					</div>
 				</TableCell>
 				<TableCell>
 					<div>
 						<Link
-							href={`/models/${encodeURIComponent(mapping.modelId)}`}
+							href={`/model-provider-mappings/${encodeURIComponent(mapping.providerId)}/${encodeURIComponent(mapping.modelId)}`}
 							className="font-medium hover:underline"
 							onClick={(e) => e.stopPropagation()}
 						>

--- a/ee/admin/src/components/model-detail-client.tsx
+++ b/ee/admin/src/components/model-detail-client.tsx
@@ -3,52 +3,17 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-import { windowOptions } from "@/components/history-chart";
+import { DetailStatCards } from "@/components/detail-stat-cards";
+import { HistoryChart, windowOptions } from "@/components/history-chart";
 import { ModelProviderCharts } from "@/components/model-provider-charts";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getModelDetail, getModelHistory } from "@/lib/admin-history";
 
-import type {
-	HistoryWindow,
-	HistoryDataPoint,
-} from "@/components/history-chart";
-import type { ModelProviderStats } from "@/lib/types";
+import type { HistoryWindow } from "@/components/history-chart";
+import type { ModelDetailResponse, ModelProviderStats } from "@/lib/types";
 
-function formatNumber(n: number) {
-	return new Intl.NumberFormat("en-US").format(n);
-}
-
-function aggregateStats(data: HistoryDataPoint[]) {
-	const totalRequests = data.reduce((sum, d) => sum + d.logsCount, 0);
-	const totalErrors = data.reduce((sum, d) => sum + d.errorsCount, 0);
-	const totalCached = data.reduce((sum, d) => sum + d.cachedCount, 0);
-	const ttftPoints = data.filter((d) => d.avgTtft !== null);
-	const avgTtft =
-		ttftPoints.length > 0
-			? Math.round(
-					ttftPoints.reduce((sum, d) => sum + (d.avgTtft ?? 0), 0) /
-						ttftPoints.length,
-				)
-			: null;
-	const errorRate =
-		totalRequests > 0
-			? ((totalErrors / totalRequests) * 100).toFixed(1)
-			: "0.0";
-	return { totalRequests, totalErrors, totalCached, avgTtft, errorRate };
-}
-
-interface ModelInfo {
-	logsCount: number;
-	errorsCount: number;
-	cachedCount: number;
-	avgTimeToFirstToken: number | null;
-	family: string;
-	status: string;
-	free: boolean;
-	name: string;
-	id: string;
-}
+type ModelInfo = ModelDetailResponse["model"];
 
 const validWindows = new Set<HistoryWindow>(windowOptions.map((o) => o.value));
 
@@ -73,33 +38,17 @@ export function ModelDetailClient({
 	const pathname = usePathname();
 	const window = parseHistoryWindow(searchParams.get("window"));
 	const [loading, setLoading] = useState(true);
+	const [info, setInfo] = useState<ModelInfo>(allTimeStats);
 	const [providers, setProviders] =
 		useState<ModelProviderStats[]>(initialProviders);
-	const [stats, setStats] = useState({
-		totalRequests: allTimeStats.logsCount,
-		totalErrors: allTimeStats.errorsCount,
-		totalCached: allTimeStats.cachedCount,
-		avgTtft: allTimeStats.avgTimeToFirstToken
-			? Math.round(allTimeStats.avgTimeToFirstToken)
-			: null,
-		errorRate:
-			allTimeStats.logsCount > 0
-				? ((allTimeStats.errorsCount / allTimeStats.logsCount) * 100).toFixed(1)
-				: "0.0",
-	});
 
 	const loadStats = useCallback(
 		async (w: HistoryWindow) => {
 			setLoading(true);
 			try {
-				const [historyData, detailData] = await Promise.all([
-					getModelHistory(modelId, w),
-					getModelDetail(modelId, w),
-				]);
-				if (historyData) {
-					setStats(aggregateStats(historyData));
-				}
+				const detailData = await getModelDetail(modelId, w);
 				if (detailData) {
+					setInfo(detailData.model);
 					setProviders(detailData.providers);
 				}
 			} finally {
@@ -112,6 +61,13 @@ export function ModelDetailClient({
 	useEffect(() => {
 		void loadStats(window);
 	}, [loadStats, window]);
+
+	const fetchHistory = useCallback(
+		async (w: HistoryWindow) => {
+			return await getModelHistory(modelId, w);
+		},
+		[modelId],
+	);
 
 	const displayName =
 		allTimeStats.name !== allTimeStats.id ? allTimeStats.name : allTimeStats.id;
@@ -156,50 +112,15 @@ export function ModelDetailClient({
 				))}
 			</div>
 
-			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-				<div className="rounded-xl border border-border/60 p-4 shadow-sm">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Total Requests
-					</p>
-					<p
-						className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
-					>
-						{formatNumber(stats.totalRequests)}
-					</p>
-				</div>
-				<div className="rounded-xl border border-border/60 p-4 shadow-sm">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Errors
-					</p>
-					<p
-						className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
-					>
-						{formatNumber(stats.totalErrors)}{" "}
-						<span className="text-sm text-muted-foreground">
-							({stats.errorRate}%)
-						</span>
-					</p>
-				</div>
-				<div className="rounded-xl border border-border/60 p-4 shadow-sm">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Cached
-					</p>
-					<p
-						className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
-					>
-						{formatNumber(stats.totalCached)}
-					</p>
-				</div>
-				<div className="rounded-xl border border-border/60 p-4 shadow-sm">
-					<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Avg TTFT
-					</p>
-					<p
-						className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
-					>
-						{stats.avgTtft !== null ? `${stats.avgTtft}ms` : "\u2014"}
-					</p>
-				</div>
+			<DetailStatCards stats={info} loading={loading} />
+
+			<section className="space-y-4">
+				<HistoryChart
+					title={`${displayName} — History`}
+					description="Aggregated across all providers. Request volume, errors, latency, and tokens over time"
+					fetchData={fetchHistory}
+					externalWindow={window}
+				/>
 			</section>
 
 			<section className="space-y-4">

--- a/ee/admin/src/components/provider-detail-client.tsx
+++ b/ee/admin/src/components/provider-detail-client.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import { HistoryChart, windowOptions } from "@/components/history-chart";
+import { ProviderModelsTable } from "@/components/provider-models-table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getProviderDetail, getProviderHistory } from "@/lib/admin-history";
+
+import { getProviderIcon } from "@llmgateway/shared";
+
+import type { HistoryWindow } from "@/components/history-chart";
+import type { ProviderDetailResponse, ProviderModelStats } from "@/lib/types";
+
+type ProviderInfo = ProviderDetailResponse["provider"];
+
+function formatNumber(n: number) {
+	return new Intl.NumberFormat("en-US").format(n);
+}
+
+const validWindows = new Set<HistoryWindow>(windowOptions.map((o) => o.value));
+
+function parseHistoryWindow(value: string | null): HistoryWindow {
+	if (value && validWindows.has(value as HistoryWindow)) {
+		return value as HistoryWindow;
+	}
+	return "24h";
+}
+
+export function ProviderDetailClient({
+	providerId,
+	providerInfo,
+	models: initialModels,
+}: {
+	providerId: string;
+	providerInfo: ProviderInfo;
+	models: ProviderModelStats[];
+}) {
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
+	const window = parseHistoryWindow(searchParams.get("window"));
+	const [loading, setLoading] = useState(false);
+	const [info, setInfo] = useState<ProviderInfo>(providerInfo);
+	const [models, setModels] = useState<ProviderModelStats[]>(initialModels);
+
+	const loadDetail = useCallback(
+		async (w: HistoryWindow) => {
+			setLoading(true);
+			try {
+				const data = await getProviderDetail(providerId, w);
+				if (data) {
+					setInfo(data.provider);
+					setModels(data.models);
+				}
+			} finally {
+				setLoading(false);
+			}
+		},
+		[providerId],
+	);
+
+	useEffect(() => {
+		void loadDetail(window);
+	}, [loadDetail, window]);
+
+	const fetchHistory = useCallback(
+		async (w: HistoryWindow) => {
+			return await getProviderHistory(providerId, w);
+		},
+		[providerId],
+	);
+
+	const ProviderIcon = getProviderIcon(providerId);
+	const errorRate =
+		info.logsCount > 0
+			? ((info.errorsCount / info.logsCount) * 100).toFixed(1)
+			: "0.0";
+
+	return (
+		<>
+			<header className="flex items-start gap-3">
+				<ProviderIcon className="mt-1 h-8 w-8 shrink-0 dark:text-white" />
+				<div>
+					<h1 className="text-3xl font-semibold tracking-tight">{info.name}</h1>
+					<p className="mt-1 text-sm text-muted-foreground">{info.id}</p>
+					<div className="mt-3 flex flex-wrap items-center gap-2">
+						<Badge variant={info.status === "active" ? "secondary" : "outline"}>
+							{info.status}
+						</Badge>
+					</div>
+				</div>
+			</header>
+
+			<div className="flex flex-wrap items-center gap-1">
+				{windowOptions.map((opt) => (
+					<Button
+						key={opt.value}
+						variant={window === opt.value ? "default" : "outline"}
+						size="sm"
+						className="h-7 px-2 text-xs"
+						onClick={() => {
+							const params = new URLSearchParams(searchParams.toString());
+							params.set("window", opt.value);
+							router.replace(`${pathname}?${params.toString()}`, {
+								scroll: false,
+							});
+						}}
+					>
+						{opt.label}
+					</Button>
+				))}
+			</div>
+
+			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<StatCard
+					label="Total Requests"
+					value={formatNumber(info.logsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Errors"
+					value={
+						<>
+							{formatNumber(info.errorsCount)}{" "}
+							<span className="text-sm text-muted-foreground">
+								({errorRate}%)
+							</span>
+						</>
+					}
+					loading={loading}
+				/>
+				<StatCard
+					label="Cached"
+					value={formatNumber(info.cachedCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Avg TTFT"
+					value={
+						info.avgTimeToFirstToken !== null
+							? `${Math.round(info.avgTimeToFirstToken)}ms`
+							: "\u2014"
+					}
+					loading={loading}
+				/>
+			</section>
+
+			<section className="grid gap-4 sm:grid-cols-3">
+				<StatCard
+					label="Client Errors"
+					value={formatNumber(info.clientErrorsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Gateway Errors"
+					value={formatNumber(info.gatewayErrorsCount)}
+					loading={loading}
+				/>
+				<StatCard
+					label="Upstream Errors"
+					value={formatNumber(info.upstreamErrorsCount)}
+					loading={loading}
+				/>
+			</section>
+
+			<section className="space-y-4">
+				<HistoryChart
+					title={`${info.name} — History`}
+					description="Request volume, errors, latency, and tokens over time"
+					fetchData={fetchHistory}
+					externalWindow={window}
+				/>
+			</section>
+
+			<section className="space-y-4">
+				<h2 className="text-xl font-semibold">
+					Models{" "}
+					<span className="text-sm font-normal text-muted-foreground">
+						({models.length})
+					</span>
+				</h2>
+				<div className="min-w-0 overflow-x-auto rounded-lg border border-border/60 bg-card">
+					<ProviderModelsTable providerId={providerId} models={models} />
+				</div>
+			</section>
+		</>
+	);
+}
+
+function StatCard({
+	label,
+	value,
+	loading,
+}: {
+	label: string;
+	value: React.ReactNode;
+	loading?: boolean;
+}) {
+	return (
+		<div className="rounded-xl border border-border/60 p-4 shadow-sm">
+			<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+				{label}
+			</p>
+			<p
+				className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
+			>
+				{value}
+			</p>
+		</div>
+	);
+}

--- a/ee/admin/src/components/provider-detail-client.tsx
+++ b/ee/admin/src/components/provider-detail-client.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
+import { DetailStatCards } from "@/components/detail-stat-cards";
 import { HistoryChart, windowOptions } from "@/components/history-chart";
 import { ProviderModelsTable } from "@/components/provider-models-table";
 import { Badge } from "@/components/ui/badge";
@@ -15,10 +16,6 @@ import type { HistoryWindow } from "@/components/history-chart";
 import type { ProviderDetailResponse, ProviderModelStats } from "@/lib/types";
 
 type ProviderInfo = ProviderDetailResponse["provider"];
-
-function formatNumber(n: number) {
-	return new Intl.NumberFormat("en-US").format(n);
-}
 
 const validWindows = new Set<HistoryWindow>(windowOptions.map((o) => o.value));
 
@@ -74,10 +71,6 @@ export function ProviderDetailClient({
 	);
 
 	const ProviderIcon = getProviderIcon(providerId);
-	const errorRate =
-		info.logsCount > 0
-			? ((info.errorsCount / info.logsCount) * 100).toFixed(1)
-			: "0.0";
 
 	return (
 		<>
@@ -114,57 +107,7 @@ export function ProviderDetailClient({
 				))}
 			</div>
 
-			<section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-				<StatCard
-					label="Total Requests"
-					value={formatNumber(info.logsCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Errors"
-					value={
-						<>
-							{formatNumber(info.errorsCount)}{" "}
-							<span className="text-sm text-muted-foreground">
-								({errorRate}%)
-							</span>
-						</>
-					}
-					loading={loading}
-				/>
-				<StatCard
-					label="Cached"
-					value={formatNumber(info.cachedCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Avg TTFT"
-					value={
-						info.avgTimeToFirstToken !== null
-							? `${Math.round(info.avgTimeToFirstToken)}ms`
-							: "\u2014"
-					}
-					loading={loading}
-				/>
-			</section>
-
-			<section className="grid gap-4 sm:grid-cols-3">
-				<StatCard
-					label="Client Errors"
-					value={formatNumber(info.clientErrorsCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Gateway Errors"
-					value={formatNumber(info.gatewayErrorsCount)}
-					loading={loading}
-				/>
-				<StatCard
-					label="Upstream Errors"
-					value={formatNumber(info.upstreamErrorsCount)}
-					loading={loading}
-				/>
-			</section>
+			<DetailStatCards stats={info} loading={loading} />
 
 			<section className="space-y-4">
 				<HistoryChart
@@ -187,28 +130,5 @@ export function ProviderDetailClient({
 				</div>
 			</section>
 		</>
-	);
-}
-
-function StatCard({
-	label,
-	value,
-	loading,
-}: {
-	label: string;
-	value: React.ReactNode;
-	loading?: boolean;
-}) {
-	return (
-		<div className="rounded-xl border border-border/60 p-4 shadow-sm">
-			<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-				{label}
-			</p>
-			<p
-				className={`mt-1 text-2xl font-semibold tabular-nums ${loading ? "opacity-50" : ""}`}
-			>
-				{value}
-			</p>
-		</div>
 	);
 }

--- a/ee/admin/src/components/provider-models-table.tsx
+++ b/ee/admin/src/components/provider-models-table.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+import type { ProviderModelStats } from "@/lib/types";
+
+function formatNumber(n: number) {
+	return new Intl.NumberFormat("en-US").format(n);
+}
+
+export function ProviderModelsTable({
+	providerId,
+	models,
+}: {
+	providerId: string;
+	models: ProviderModelStats[];
+}) {
+	if (models.length === 0) {
+		return (
+			<div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+				No models served by this provider
+			</div>
+		);
+	}
+
+	return (
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Model</TableHead>
+					<TableHead>Region</TableHead>
+					<TableHead>Status</TableHead>
+					<TableHead>Requests</TableHead>
+					<TableHead>Errors</TableHead>
+					<TableHead>Client</TableHead>
+					<TableHead>Gateway</TableHead>
+					<TableHead>Upstream</TableHead>
+					<TableHead>Error Rate</TableHead>
+					<TableHead>Cached</TableHead>
+					<TableHead>Avg TTFT</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{models.map((m) => {
+					const errorRate =
+						m.logsCount > 0
+							? ((m.errorsCount / m.logsCount) * 100).toFixed(1)
+							: "0.0";
+					return (
+						<TableRow key={m.mappingId} className="hover:bg-muted/50">
+							<TableCell>
+								<Link
+									href={`/model-provider-mappings/${encodeURIComponent(providerId)}/${encodeURIComponent(m.modelId)}`}
+									className="font-medium hover:underline"
+								>
+									{m.modelId}
+								</Link>
+								{m.modelName !== m.modelId && (
+									<p className="text-xs text-muted-foreground">{m.modelName}</p>
+								)}
+							</TableCell>
+							<TableCell className="text-xs text-muted-foreground">
+								{m.region ?? "\u2014"}
+							</TableCell>
+							<TableCell>
+								<Badge
+									variant={m.status === "active" ? "secondary" : "outline"}
+								>
+									{m.status}
+								</Badge>
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{formatNumber(m.logsCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{formatNumber(m.errorsCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{formatNumber(m.clientErrorsCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{formatNumber(m.gatewayErrorsCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{formatNumber(m.upstreamErrorsCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">{errorRate}%</TableCell>
+							<TableCell className="tabular-nums">
+								{formatNumber(m.cachedCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{m.avgTimeToFirstToken !== null
+									? `${Math.round(m.avgTimeToFirstToken)}ms`
+									: "\u2014"}
+							</TableCell>
+						</TableRow>
+					);
+				})}
+			</TableBody>
+		</Table>
+	);
+}

--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -140,7 +140,13 @@ function ProviderRow({
 					<div className="flex items-center gap-2">
 						<ProviderIcon className="h-5 w-5 shrink-0 dark:text-white" />
 						<div>
-							<span className="font-medium">{provider.name}</span>
+							<Link
+								href={`/providers/${encodeURIComponent(provider.id)}`}
+								className="font-medium hover:underline"
+								onClick={(e) => e.stopPropagation()}
+							>
+								{provider.name}
+							</Link>
 							<p className="text-xs text-muted-foreground">{provider.id}</p>
 						</div>
 					</div>

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -61,6 +61,42 @@ export async function getModelDetail(modelId: string, window?: HistoryWindow) {
 	return data ?? null;
 }
 
+export async function getProviderDetail(
+	providerId: string,
+	window?: HistoryWindow,
+) {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/providers/{providerId}", {
+		params: {
+			path: { providerId },
+			query: {
+				...(window ? { window } : {}),
+			} as any,
+		},
+	});
+	return data ?? null;
+}
+
+export async function getMappingDetail(
+	providerId: string,
+	modelId: string,
+	window?: HistoryWindow,
+) {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET(
+		"/admin/providers/{providerId}/models/{modelId}",
+		{
+			params: {
+				path: { providerId, modelId: encodeURIComponent(modelId) },
+				query: {
+					...(window ? { window } : {}),
+				} as any,
+			},
+		},
+	);
+	return data ?? null;
+}
+
 export async function getGlobalCostByModel(window: TokenWindow) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/admin/metrics/cost-by-model", {

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -3108,6 +3108,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3159,6 +3162,9 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
@@ -3211,12 +3217,153 @@ export interface paths {
                                 timestamp: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTtft: number | null;
                                 avgDuration: number | null;
                                 totalTokens: number;
                                 totalCost: number;
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Provider detail with per-model stats. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            provider: {
+                                id: string;
+                                name: string;
+                                color: string | null;
+                                description: string;
+                                website: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                modelCount: number;
+                                updatedAt: string;
+                            };
+                            models: {
+                                modelId: string;
+                                modelName: string;
+                                mappingId: string;
+                                region: string | null;
+                                status: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/providers/{providerId}/models/{modelId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                };
+                header?: never;
+                path: {
+                    providerId: string;
+                    modelId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Mapping detail with aggregated stats for the window. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            mapping: {
+                                id: string;
+                                modelId: string;
+                                modelName: string;
+                                providerId: string;
+                                providerName: string;
+                                region: string | null;
+                                status: string;
+                                inputPrice: string | null;
+                                outputPrice: string | null;
+                                cachedInputPrice: string | null;
+                                imageInputPrice: string | null;
+                                requestPrice: string | null;
+                                contextSize: number | null;
+                                maxOutput: number | null;
+                                streaming: boolean;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTimeToFirstToken: number | null;
+                                updatedAt: string;
+                            };
                         };
                     };
                 };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2946,6 +2946,9 @@ export interface paths {
                                 status: string;
                                 logsCount: number;
                                 errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
                                 providerCount: number;

--- a/ee/admin/src/lib/types.ts
+++ b/ee/admin/src/lib/types.ts
@@ -82,6 +82,16 @@ export type ModelStats = ModelsListResponse["models"][number];
 export type ModelDetailResponse = GetJsonResponse<"/admin/models/{modelId}">;
 export type ModelProviderStats = ModelDetailResponse["providers"][number];
 
+// Provider detail
+export type ProviderDetailResponse =
+	GetJsonResponse<"/admin/providers/{providerId}">;
+export type ProviderModelStats = ProviderDetailResponse["models"][number];
+
+// Mapping detail
+export type MappingDetailResponse =
+	GetJsonResponse<"/admin/providers/{providerId}/models/{modelId}">;
+export type MappingDetail = MappingDetailResponse["mapping"];
+
 // History
 export type HistoryResponse =
 	GetJsonResponse<"/admin/providers/{providerId}/history">;


### PR DESCRIPTION
## Summary
- Add provider detail page (`/providers/[providerId]`) and model-provider mapping detail page (`/model-provider-mappings/[providerId]/[modelId]`), mirroring the existing model detail page. Provider rows and mapping rows in the list tables now link to these detail pages.
- Backend: new `/admin/providers/{providerId}` and `/admin/providers/{providerId}/models/{modelId}` endpoints return window-aware aggregated stats plus per-model/per-mapping rollups.
- History chart: the **Errors** tab now overlays client/gateway/upstream error counts (instead of a single errors line vs total). The summary row now also shows **Tokens** and **Avg Duration** alongside existing stats — applies to all three detail pages since they share `HistoryChart`.
- History endpoints (`/admin/providers/{providerId}/history`, `/admin/models/{modelId}/history`, `/admin/providers/{providerId}/models/{modelId}/history`) now include `clientErrorsCount`, `gatewayErrorsCount`, `upstreamErrorsCount` per data point, aggregated from `modelProviderMappingHistory`.

## Test plan
- [ ] Visit `/providers` and confirm provider name links to `/providers/{providerId}` detail
- [ ] Visit `/model-provider-mappings` and confirm model cell links to `/model-provider-mappings/{providerId}/{modelId}` detail
- [ ] On each detail page (provider / model / mapping): switch window selector and confirm stats + chart refresh
- [ ] Open **Errors** tab on the chart and confirm three overlaid series (client/gateway/upstream)
- [ ] Confirm summary row shows Reqs, Errors (+%), Tokens, Cost, Avg TTFT, Avg Duration
- [ ] Run `pnpm build`, `pnpm lint`, `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider detail page with aggregated stats and per-model breakdown.
  * Model‑mapping detail page showing mapping stats and history.
  * New provider models table and detailed stat cards showing client/gateway/upstream error counts.

* **Enhancements**
  * History charts show error breakdown by origin, per-minute granularity with hourly overlays, token metrics, and improved summary metrics.
  * Tables link to provider and mapping detail pages and surface richer stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->