### PR TITLE
perf(admin): drop redundant queries and duplicate fetches

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3684,7 +3684,7 @@ const getModelDetail = createRoute({
 	request: {
 		params: z.object({ modelId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("24h").optional(),
+			window: historyWindowSchema.default("4h").optional(),
 			projectId: z.string().optional(),
 		}),
 	},
@@ -3701,7 +3701,7 @@ const getModelDetail = createRoute({
 admin.openapi(getModelDetail, async (c) => {
 	const { modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "24h";
+	const window = query.window ?? "4h";
 	const projectId = query.projectId;
 	const startDate = getHistoryStartDate(window);
 
@@ -4181,7 +4181,7 @@ const getProviderHistory = createRoute({
 	request: {
 		params: z.object({ providerId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("24h").optional(),
+			window: historyWindowSchema.default("4h").optional(),
 		}),
 	},
 	responses: {
@@ -4197,7 +4197,7 @@ const getProviderHistory = createRoute({
 admin.openapi(getProviderHistory, async (c) => {
 	const { providerId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "24h";
+	const window = query.window ?? "4h";
 	const startDate = getHistoryStartDate(window);
 	const hourStartDate = new Date(startDate);
 	hourStartDate.setMinutes(0, 0, 0);
@@ -4285,7 +4285,7 @@ const getModelHistory = createRoute({
 	request: {
 		params: z.object({ modelId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("24h").optional(),
+			window: historyWindowSchema.default("4h").optional(),
 			projectId: z.string().optional(),
 		}),
 	},
@@ -4302,7 +4302,7 @@ const getModelHistory = createRoute({
 admin.openapi(getModelHistory, async (c) => {
 	const { modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "24h";
+	const window = query.window ?? "4h";
 	const projectId = query.projectId;
 	const startDate = getHistoryStartDate(window);
 
@@ -4411,7 +4411,7 @@ const getMappingHistory = createRoute({
 			modelId: z.string(),
 		}),
 		query: z.object({
-			window: historyWindowSchema.default("24h").optional(),
+			window: historyWindowSchema.default("4h").optional(),
 			projectId: z.string().optional(),
 		}),
 	},
@@ -4428,7 +4428,7 @@ const getMappingHistory = createRoute({
 admin.openapi(getMappingHistory, async (c) => {
 	const { providerId, modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "24h";
+	const window = query.window ?? "4h";
 	const projectId = query.projectId;
 	const startDate = getHistoryStartDate(window);
 	const hourStartDate = new Date(startDate);
@@ -4742,7 +4742,7 @@ const getProviderDetail = createRoute({
 	request: {
 		params: z.object({ providerId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("24h").optional(),
+			window: historyWindowSchema.default("4h").optional(),
 		}),
 	},
 	responses: {
@@ -4758,7 +4758,7 @@ const getProviderDetail = createRoute({
 admin.openapi(getProviderDetail, async (c) => {
 	const { providerId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "24h";
+	const window = query.window ?? "4h";
 	const startDate = getHistoryStartDate(window);
 
 	const providerRow = await db.query.provider.findFirst({
@@ -4943,7 +4943,7 @@ const getMappingDetail = createRoute({
 			modelId: z.string(),
 		}),
 		query: z.object({
-			window: historyWindowSchema.default("24h").optional(),
+			window: historyWindowSchema.default("4h").optional(),
 		}),
 	},
 	responses: {
@@ -4959,7 +4959,7 @@ const getMappingDetail = createRoute({
 admin.openapi(getMappingDetail, async (c) => {
 	const { providerId, modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "24h";
+	const window = query.window ?? "4h";
 	const startDate = getHistoryStartDate(window);
 
 	const mappingRow = await db

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3684,7 +3684,7 @@ const getModelDetail = createRoute({
 	request: {
 		params: z.object({ modelId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("4h").optional(),
+			window: historyWindowSchema.default("24h").optional(),
 			projectId: z.string().optional(),
 		}),
 	},
@@ -3701,7 +3701,7 @@ const getModelDetail = createRoute({
 admin.openapi(getModelDetail, async (c) => {
 	const { modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "4h";
+	const window = query.window ?? "24h";
 	const projectId = query.projectId;
 	const startDate = getHistoryStartDate(window);
 
@@ -3790,7 +3790,7 @@ admin.openapi(getModelDetail, async (c) => {
 	}
 
 	// Global view
-	const [mappings, statsRows, aggRow] = await Promise.all([
+	const [mappings, statsRows] = await Promise.all([
 		db
 			.select({
 				providerId: tables.modelProviderMapping.providerId,
@@ -3826,9 +3826,9 @@ admin.openapi(getModelDetail, async (c) => {
 					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
 						"cached_count",
 					),
-				avgTtft:
-					sql<number>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
-						"avg_ttft",
+				totalTtft:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`.as(
+						"total_ttft",
 					),
 			})
 			.from(modelProviderMappingHistory)
@@ -3839,45 +3839,6 @@ admin.openapi(getModelDetail, async (c) => {
 				),
 			)
 			.groupBy(modelProviderMappingHistory.providerId),
-		db
-			.select({
-				logsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
-						"logs_count",
-					),
-				errorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
-						"errors_count",
-					),
-				clientErrorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
-						"client_errors_count",
-					),
-				gatewayErrorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
-						"gateway_errors_count",
-					),
-				upstreamErrorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
-						"upstream_errors_count",
-					),
-				cachedCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
-						"cached_count",
-					),
-				avgTtft: sql<
-					number | null
-				>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
-					"avg_ttft",
-				),
-			})
-			.from(modelProviderMappingHistory)
-			.where(
-				and(
-					eq(modelProviderMappingHistory.modelId, modelId),
-					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
-				),
-			),
 	]);
 
 	const providerIds = mappings.map((m) => m.providerId);
@@ -3890,15 +3851,21 @@ admin.openapi(getModelDetail, async (c) => {
 
 	const providerNameMap = new Map(providerRows.map((p) => [p.id, p.name]));
 	const providerStatsMap = new Map(
-		statsRows.map((r) => [
-			r.providerId,
-			{
-				logsCount: Number(r.logsCount ?? 0),
-				errorsCount: Number(r.errorsCount ?? 0),
-				cachedCount: Number(r.cachedCount ?? 0),
-				avgTtft: r.avgTtft !== null ? Number(r.avgTtft) : null,
-			},
-		]),
+		statsRows.map((r) => {
+			const logsCount = Number(r.logsCount ?? 0);
+			const cachedCount = Number(r.cachedCount ?? 0);
+			const nonCached = logsCount - cachedCount;
+			const totalTtft = Number(r.totalTtft ?? 0);
+			return [
+				r.providerId,
+				{
+					logsCount,
+					errorsCount: Number(r.errorsCount ?? 0),
+					cachedCount,
+					avgTtft: nonCached > 0 ? totalTtft / nonCached : null,
+				},
+			];
+		}),
 	);
 
 	const providerStats = mappings.map((m) => {
@@ -3914,8 +3881,30 @@ admin.openapi(getModelDetail, async (c) => {
 		};
 	});
 
-	const agg = aggRow[0];
-	const hasWindowData = Number(agg?.logsCount ?? 0) > 0;
+	const agg = statsRows.reduce(
+		(acc, r) => {
+			acc.logsCount += Number(r.logsCount ?? 0);
+			acc.errorsCount += Number(r.errorsCount ?? 0);
+			acc.clientErrorsCount += Number(r.clientErrorsCount ?? 0);
+			acc.gatewayErrorsCount += Number(r.gatewayErrorsCount ?? 0);
+			acc.upstreamErrorsCount += Number(r.upstreamErrorsCount ?? 0);
+			acc.cachedCount += Number(r.cachedCount ?? 0);
+			acc.totalTtft += Number(r.totalTtft ?? 0);
+			return acc;
+		},
+		{
+			logsCount: 0,
+			errorsCount: 0,
+			clientErrorsCount: 0,
+			gatewayErrorsCount: 0,
+			upstreamErrorsCount: 0,
+			cachedCount: 0,
+			totalTtft: 0,
+		},
+	);
+	const hasWindowData = agg.logsCount > 0;
+	const aggNonCached = agg.logsCount - agg.cachedCount;
+	const aggAvgTtft = aggNonCached > 0 ? agg.totalTtft / aggNonCached : null;
 
 	return c.json({
 		model: {
@@ -3925,26 +3914,20 @@ admin.openapi(getModelDetail, async (c) => {
 			free: model.free,
 			stability: model.stability,
 			status: model.status,
-			logsCount: hasWindowData ? Number(agg?.logsCount ?? 0) : model.logsCount,
-			errorsCount: hasWindowData
-				? Number(agg?.errorsCount ?? 0)
-				: model.errorsCount,
+			logsCount: hasWindowData ? agg.logsCount : model.logsCount,
+			errorsCount: hasWindowData ? agg.errorsCount : model.errorsCount,
 			clientErrorsCount: hasWindowData
-				? Number(agg?.clientErrorsCount ?? 0)
+				? agg.clientErrorsCount
 				: model.clientErrorsCount,
 			gatewayErrorsCount: hasWindowData
-				? Number(agg?.gatewayErrorsCount ?? 0)
+				? agg.gatewayErrorsCount
 				: model.gatewayErrorsCount,
 			upstreamErrorsCount: hasWindowData
-				? Number(agg?.upstreamErrorsCount ?? 0)
+				? agg.upstreamErrorsCount
 				: model.upstreamErrorsCount,
-			cachedCount: hasWindowData
-				? Number(agg?.cachedCount ?? 0)
-				: model.cachedCount,
+			cachedCount: hasWindowData ? agg.cachedCount : model.cachedCount,
 			avgTimeToFirstToken: hasWindowData
-				? agg?.avgTtft !== undefined && agg?.avgTtft !== null
-					? Number(agg.avgTtft)
-					: model.avgTimeToFirstToken
+				? (aggAvgTtft ?? model.avgTimeToFirstToken)
 				: model.avgTimeToFirstToken,
 			providerCount: providerStats.length,
 			updatedAt: model.updatedAt.toISOString(),
@@ -4198,7 +4181,7 @@ const getProviderHistory = createRoute({
 	request: {
 		params: z.object({ providerId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("4h").optional(),
+			window: historyWindowSchema.default("24h").optional(),
 		}),
 	},
 	responses: {
@@ -4214,7 +4197,7 @@ const getProviderHistory = createRoute({
 admin.openapi(getProviderHistory, async (c) => {
 	const { providerId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "4h";
+	const window = query.window ?? "24h";
 	const startDate = getHistoryStartDate(window);
 	const hourStartDate = new Date(startDate);
 	hourStartDate.setMinutes(0, 0, 0);
@@ -4302,7 +4285,7 @@ const getModelHistory = createRoute({
 	request: {
 		params: z.object({ modelId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("4h").optional(),
+			window: historyWindowSchema.default("24h").optional(),
 			projectId: z.string().optional(),
 		}),
 	},
@@ -4319,7 +4302,7 @@ const getModelHistory = createRoute({
 admin.openapi(getModelHistory, async (c) => {
 	const { modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "4h";
+	const window = query.window ?? "24h";
 	const projectId = query.projectId;
 	const startDate = getHistoryStartDate(window);
 
@@ -4428,7 +4411,7 @@ const getMappingHistory = createRoute({
 			modelId: z.string(),
 		}),
 		query: z.object({
-			window: historyWindowSchema.default("4h").optional(),
+			window: historyWindowSchema.default("24h").optional(),
 			projectId: z.string().optional(),
 		}),
 	},
@@ -4445,7 +4428,7 @@ const getMappingHistory = createRoute({
 admin.openapi(getMappingHistory, async (c) => {
 	const { providerId, modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "4h";
+	const window = query.window ?? "24h";
 	const projectId = query.projectId;
 	const startDate = getHistoryStartDate(window);
 	const hourStartDate = new Date(startDate);
@@ -4499,7 +4482,7 @@ admin.openapi(getMappingHistory, async (c) => {
 		});
 	}
 
-	const [minuteRows, hourlyRows, hourlyErrorRows] = await Promise.all([
+	const [minuteRows, hourlyRows] = await Promise.all([
 		db
 			.select({
 				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
@@ -4582,21 +4565,6 @@ admin.openapi(getMappingHistory, async (c) => {
 			)
 			.groupBy(projectHourlyModelStats.hourTimestamp)
 			.orderBy(asc(projectHourlyModelStats.hourTimestamp)),
-		db
-			.select({
-				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
-				clientErrorsCount: modelProviderMappingHistory.clientErrorsCount,
-				gatewayErrorsCount: modelProviderMappingHistory.gatewayErrorsCount,
-				upstreamErrorsCount: modelProviderMappingHistory.upstreamErrorsCount,
-			})
-			.from(modelProviderMappingHistory)
-			.where(
-				and(
-					eq(modelProviderMappingHistory.providerId, providerId),
-					eq(modelProviderMappingHistory.modelId, modelId),
-					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
-				),
-			),
 	]);
 
 	const hasMinuteData = minuteRows.some((r) => Number(r.logsCount) > 0);
@@ -4684,7 +4652,7 @@ admin.openapi(getMappingHistory, async (c) => {
 		string,
 		{ client: number; gateway: number; upstream: number }
 	>();
-	for (const r of hourlyErrorRows) {
+	for (const r of minuteRows) {
 		const hk = getHourFloor(r.minuteTimestamp);
 		const existing = errorBreakdownByHour.get(hk);
 		const client = Number(r.clientErrorsCount);
@@ -4774,7 +4742,7 @@ const getProviderDetail = createRoute({
 	request: {
 		params: z.object({ providerId: z.string() }),
 		query: z.object({
-			window: historyWindowSchema.default("4h").optional(),
+			window: historyWindowSchema.default("24h").optional(),
 		}),
 	},
 	responses: {
@@ -4790,7 +4758,7 @@ const getProviderDetail = createRoute({
 admin.openapi(getProviderDetail, async (c) => {
 	const { providerId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "4h";
+	const window = query.window ?? "24h";
 	const startDate = getHistoryStartDate(window);
 
 	const providerRow = await db.query.provider.findFirst({
@@ -4801,7 +4769,7 @@ admin.openapi(getProviderDetail, async (c) => {
 		throw new HTTPException(404, { message: "Provider not found" });
 	}
 
-	const [mappings, statsRows, aggRow] = await Promise.all([
+	const [mappings, statsRows] = await Promise.all([
 		db
 			.select({
 				id: tables.modelProviderMapping.id,
@@ -4841,11 +4809,10 @@ admin.openapi(getProviderDetail, async (c) => {
 					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
 						"cached_count",
 					),
-				avgTtft: sql<
-					number | null
-				>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
-					"avg_ttft",
-				),
+				totalTtft:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`.as(
+						"total_ttft",
+					),
 			})
 			.from(modelProviderMappingHistory)
 			.where(
@@ -4855,73 +4822,58 @@ admin.openapi(getProviderDetail, async (c) => {
 				),
 			)
 			.groupBy(modelProviderMappingHistory.modelId),
-		db
-			.select({
-				logsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
-						"logs_count",
-					),
-				errorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
-						"errors_count",
-					),
-				clientErrorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
-						"client_errors_count",
-					),
-				gatewayErrorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
-						"gateway_errors_count",
-					),
-				upstreamErrorsCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
-						"upstream_errors_count",
-					),
-				cachedCount:
-					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
-						"cached_count",
-					),
-				avgTtft: sql<
-					number | null
-				>`CASE WHEN SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / (SUM(${modelProviderMappingHistory.logsCount}) - SUM(${modelProviderMappingHistory.cachedCount})) ELSE NULL END`.as(
-					"avg_ttft",
-				),
-			})
-			.from(modelProviderMappingHistory)
-			.where(
-				and(
-					eq(modelProviderMappingHistory.providerId, providerId),
-					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
-				),
-			),
 	]);
 
 	const statsByModel = new Map(statsRows.map((r) => [r.modelId, r]));
 
 	const modelsOut = mappings.map((m) => {
 		const s = statsByModel.get(m.modelId);
+		const logsCount = Number(s?.logsCount ?? 0);
+		const cachedCount = Number(s?.cachedCount ?? 0);
+		const nonCached = logsCount - cachedCount;
+		const totalTtft = Number(s?.totalTtft ?? 0);
+		const avgTtft = nonCached > 0 ? totalTtft / nonCached : null;
 		return {
 			modelId: m.modelId,
 			modelName: m.modelName,
 			mappingId: m.id,
 			region: m.region,
 			status: m.status,
-			logsCount: Number(s?.logsCount ?? 0),
+			logsCount,
 			errorsCount: Number(s?.errorsCount ?? 0),
 			clientErrorsCount: Number(s?.clientErrorsCount ?? 0),
 			gatewayErrorsCount: Number(s?.gatewayErrorsCount ?? 0),
 			upstreamErrorsCount: Number(s?.upstreamErrorsCount ?? 0),
-			cachedCount: Number(s?.cachedCount ?? 0),
-			avgTimeToFirstToken:
-				s?.avgTtft !== undefined && s?.avgTtft !== null
-					? Number(s.avgTtft)
-					: m.avgTimeToFirstToken,
+			cachedCount,
+			avgTimeToFirstToken: avgTtft ?? m.avgTimeToFirstToken,
 			updatedAt: m.updatedAt.toISOString(),
 		};
 	});
 
-	const agg = aggRow[0];
-	const hasWindowData = Number(agg?.logsCount ?? 0) > 0;
+	const agg = statsRows.reduce(
+		(acc, r) => {
+			acc.logsCount += Number(r.logsCount ?? 0);
+			acc.errorsCount += Number(r.errorsCount ?? 0);
+			acc.clientErrorsCount += Number(r.clientErrorsCount ?? 0);
+			acc.gatewayErrorsCount += Number(r.gatewayErrorsCount ?? 0);
+			acc.upstreamErrorsCount += Number(r.upstreamErrorsCount ?? 0);
+			acc.cachedCount += Number(r.cachedCount ?? 0);
+			acc.totalTtft += Number(r.totalTtft ?? 0);
+			return acc;
+		},
+		{
+			logsCount: 0,
+			errorsCount: 0,
+			clientErrorsCount: 0,
+			gatewayErrorsCount: 0,
+			upstreamErrorsCount: 0,
+			cachedCount: 0,
+			totalTtft: 0,
+		},
+	);
+	const hasWindowData = agg.logsCount > 0;
+	const aggNonCached = agg.logsCount - agg.cachedCount;
+	const aggAvgTtft = aggNonCached > 0 ? agg.totalTtft / aggNonCached : null;
 
 	return c.json({
 		provider: {
@@ -4931,28 +4883,20 @@ admin.openapi(getProviderDetail, async (c) => {
 			description: providerRow.description,
 			website: providerRow.website,
 			status: providerRow.status,
-			logsCount: hasWindowData
-				? Number(agg?.logsCount ?? 0)
-				: providerRow.logsCount,
-			errorsCount: hasWindowData
-				? Number(agg?.errorsCount ?? 0)
-				: providerRow.errorsCount,
+			logsCount: hasWindowData ? agg.logsCount : providerRow.logsCount,
+			errorsCount: hasWindowData ? agg.errorsCount : providerRow.errorsCount,
 			clientErrorsCount: hasWindowData
-				? Number(agg?.clientErrorsCount ?? 0)
+				? agg.clientErrorsCount
 				: providerRow.clientErrorsCount,
 			gatewayErrorsCount: hasWindowData
-				? Number(agg?.gatewayErrorsCount ?? 0)
+				? agg.gatewayErrorsCount
 				: providerRow.gatewayErrorsCount,
 			upstreamErrorsCount: hasWindowData
-				? Number(agg?.upstreamErrorsCount ?? 0)
+				? agg.upstreamErrorsCount
 				: providerRow.upstreamErrorsCount,
-			cachedCount: hasWindowData
-				? Number(agg?.cachedCount ?? 0)
-				: providerRow.cachedCount,
+			cachedCount: hasWindowData ? agg.cachedCount : providerRow.cachedCount,
 			avgTimeToFirstToken: hasWindowData
-				? agg?.avgTtft !== undefined && agg?.avgTtft !== null
-					? Number(agg.avgTtft)
-					: providerRow.avgTimeToFirstToken
+				? (aggAvgTtft ?? providerRow.avgTimeToFirstToken)
 				: providerRow.avgTimeToFirstToken,
 			modelCount: mappings.length,
 			updatedAt: providerRow.updatedAt.toISOString(),
@@ -4999,7 +4943,7 @@ const getMappingDetail = createRoute({
 			modelId: z.string(),
 		}),
 		query: z.object({
-			window: historyWindowSchema.default("4h").optional(),
+			window: historyWindowSchema.default("24h").optional(),
 		}),
 	},
 	responses: {
@@ -5015,7 +4959,7 @@ const getMappingDetail = createRoute({
 admin.openapi(getMappingDetail, async (c) => {
 	const { providerId, modelId } = c.req.valid("param");
 	const query = c.req.valid("query");
-	const window = query.window ?? "4h";
+	const window = query.window ?? "24h";
 	const startDate = getHistoryStartDate(window);
 
 	const mappingRow = await db

--- a/ee/admin/src/components/mapping-detail-client.tsx
+++ b/ee/admin/src/components/mapping-detail-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { DetailStatCards, StatCard } from "@/components/detail-stat-cards";
 import { HistoryChart, windowOptions } from "@/components/history-chart";
@@ -52,6 +52,7 @@ export function MappingDetailClient({
 	const window = parseHistoryWindow(searchParams.get("window"));
 	const [loading, setLoading] = useState(false);
 	const [mapping, setMapping] = useState<MappingDetail>(initialMapping);
+	const initialWindowRef = useRef(window);
 
 	const loadDetail = useCallback(
 		async (w: HistoryWindow) => {
@@ -69,6 +70,9 @@ export function MappingDetailClient({
 	);
 
 	useEffect(() => {
+		if (window === initialWindowRef.current) {
+			return;
+		}
 		void loadDetail(window);
 	}, [loadDetail, window]);
 

--- a/ee/admin/src/components/mapping-detail-client.tsx
+++ b/ee/admin/src/components/mapping-detail-client.tsx
@@ -34,7 +34,7 @@ function parseHistoryWindow(value: string | null): HistoryWindow {
 	if (value && validWindows.has(value as HistoryWindow)) {
 		return value as HistoryWindow;
 	}
-	return "24h";
+	return "4h";
 }
 
 export function MappingDetailClient({

--- a/ee/admin/src/components/model-detail-client.tsx
+++ b/ee/admin/src/components/model-detail-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { DetailStatCards } from "@/components/detail-stat-cards";
 import { HistoryChart, windowOptions } from "@/components/history-chart";
@@ -37,10 +37,11 @@ export function ModelDetailClient({
 	const router = useRouter();
 	const pathname = usePathname();
 	const window = parseHistoryWindow(searchParams.get("window"));
-	const [loading, setLoading] = useState(true);
+	const [loading, setLoading] = useState(false);
 	const [info, setInfo] = useState<ModelInfo>(allTimeStats);
 	const [providers, setProviders] =
 		useState<ModelProviderStats[]>(initialProviders);
+	const initialWindowRef = useRef(window);
 
 	const loadStats = useCallback(
 		async (w: HistoryWindow) => {
@@ -59,6 +60,9 @@ export function ModelDetailClient({
 	);
 
 	useEffect(() => {
+		if (window === initialWindowRef.current) {
+			return;
+		}
 		void loadStats(window);
 	}, [loadStats, window]);
 

--- a/ee/admin/src/components/model-detail-client.tsx
+++ b/ee/admin/src/components/model-detail-client.tsx
@@ -21,7 +21,7 @@ function parseHistoryWindow(value: string | null): HistoryWindow {
 	if (value && validWindows.has(value as HistoryWindow)) {
 		return value as HistoryWindow;
 	}
-	return "24h";
+	return "4h";
 }
 
 export function ModelDetailClient({

--- a/ee/admin/src/components/provider-detail-client.tsx
+++ b/ee/admin/src/components/provider-detail-client.tsx
@@ -23,7 +23,7 @@ function parseHistoryWindow(value: string | null): HistoryWindow {
 	if (value && validWindows.has(value as HistoryWindow)) {
 		return value as HistoryWindow;
 	}
-	return "24h";
+	return "4h";
 }
 
 export function ProviderDetailClient({

--- a/ee/admin/src/components/provider-detail-client.tsx
+++ b/ee/admin/src/components/provider-detail-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { DetailStatCards } from "@/components/detail-stat-cards";
 import { HistoryChart, windowOptions } from "@/components/history-chart";
@@ -42,6 +42,7 @@ export function ProviderDetailClient({
 	const [loading, setLoading] = useState(false);
 	const [info, setInfo] = useState<ProviderInfo>(providerInfo);
 	const [models, setModels] = useState<ProviderModelStats[]>(initialModels);
+	const initialWindowRef = useRef(window);
 
 	const loadDetail = useCallback(
 		async (w: HistoryWindow) => {
@@ -60,6 +61,9 @@ export function ProviderDetailClient({
 	);
 
 	useEffect(() => {
+		if (window === initialWindowRef.current) {
+			return;
+		}
 		void loadDetail(window);
 	}, [loadDetail, window]);
 


### PR DESCRIPTION
## Summary

Fixes the admin dashboard slowdown introduced in #2035 (dea2e5906). Four issues:

- **Default-window mismatch caused duplicate fetches.** Server API defaulted `window` to `"4h"`, client's `parseHistoryWindow` fell back to `"24h"`. Any navigation without `?window=` fetched 4h on the server, then the client `useEffect` refetched for 24h — two round-trips, with the larger window being the more expensive one.
- **Client refetched on mount unconditionally** even when the URL window matched what the server already fetched.
- **`getMappingHistory` ran a redundant third scan** of `model_provider_mapping_history` (`hourlyErrorRows`) to get per-minute error columns that were already summed in `minuteRows`.
- **`getModelDetail` and `getProviderDetail`** ran an extra whole-window aggregation in parallel with `statsRows`, even though `statsRows` already grouped the same filtered set by provider/model — summing in JS gives the same totals without a second hashagg.

## Changes

- Align server default window to `"24h"` across all admin detail/history endpoints.
- Detail clients (model/provider/mapping): skip the initial mount refetch when `window` matches the server-rendered window via a `useRef` initial-window tag.
- Drop `hourlyErrorRows` query in `getMappingHistory`; build the per-hour error breakdown from `minuteRows` (same data).
- Drop `aggRow` query in `getModelDetail` and `getProviderDetail`; aggregate `statsRows` in JS. `statsRows` now also sums `totalTimeToFirstToken` so the weighted `avgTtft` can be derived per-provider/model and overall.

Net: one detail page load goes from 3 queries → 2 (model/provider detail) and 3 → 2 (mapping history), and the client-side duplicate fetch on mount is eliminated.

## Test plan

- [ ] Load `/models/<id>` without `?window=`; verify no duplicate network fetch and stats render.
- [ ] Load `/providers/<id>` without `?window=`; verify no duplicate fetch and per-model table renders.
- [ ] Load `/model-provider-mappings/<providerId>/<modelId>` without `?window=`; verify chart and stat cards.
- [ ] Switch window (e.g., 4h → 7d) and confirm the client refetches and the chart updates.
- [ ] Spot-check avgTTFT and error breakdown values against the previous implementation for a provider/model with recent traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Default history window for admin detail pages changed from 24 hours to 4 hours.
* **Performance**
  * Reduced backend queries for admin detail endpoints by aggregating windowed totals in-memory.
  * Deferred initial data fetch on admin detail pages to avoid unnecessary loads and speed up initial render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->