### PR TITLE
fix(gateway): respect RPM limits in low-uptime fallback

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2326,7 +2326,26 @@ chat.openapi(completions, async (c) => {
 						),
 				);
 
-				if (availableModelProviders.length > 0) {
+				// Exclude alternatives that are already at their RPM/RPD cap so the
+				// low-uptime fallback doesn't route into a rate-limited provider.
+				// Fail-open: if all alternatives are rate-limited, keep them all.
+				const rateLimitedAlternatives = await filterRateLimitedProviders(
+					project.organizationId,
+					availableModelProviders.map((p) => ({
+						providerId: p.providerId,
+						model: baseModelId,
+						providerModelName: p.modelName,
+					})),
+				);
+				const nonRateLimitedAlternatives = availableModelProviders.filter(
+					(p) => !rateLimitedAlternatives.has(p.providerId),
+				);
+				const uptimeFallbackCandidates =
+					nonRateLimitedAlternatives.length > 0
+						? nonRateLimitedAlternatives
+						: availableModelProviders;
+
+				if (uptimeFallbackCandidates.length > 0) {
 					const rawModelForFallback = models.find((m) => m.id === baseModelId);
 					const modelWithPricing = rawModelForFallback
 						? {
@@ -2339,7 +2358,7 @@ chat.openapi(completions, async (c) => {
 
 					if (modelWithPricing) {
 						// Fetch metrics for all available providers
-						const metricsCombinations = availableModelProviders.map((p) => ({
+						const metricsCombinations = uptimeFallbackCandidates.map((p) => ({
 							modelId: resolveMetricsModelId(modelWithPricing.id, p.modelName),
 							providerId: p.providerId,
 							region: p.region,
@@ -2349,7 +2368,7 @@ chat.openapi(completions, async (c) => {
 							await getProviderMetricsForCombinations(metricsCombinations);
 						const providerAgnosticCandidates =
 							collapseProvidersToBestRegionPerProvider(
-								availableModelProviders,
+								uptimeFallbackCandidates,
 								modelWithPricing,
 								{
 									metricsMap: allMetricsMap,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -39,6 +39,7 @@ import {
 	filterRateLimitedProviders,
 	getExceededProviderRateLimitLabels,
 	peekProviderRateLimit,
+	pickNonRateLimitedCandidates,
 	providerRateLimitWindows,
 } from "@/lib/provider-rate-limit.js";
 import { getResponsesContext } from "@/lib/responses-context.js";
@@ -2161,23 +2162,11 @@ chat.openapi(completions, async (c) => {
 					return true;
 				});
 
-				// Also filter out rate-limited alternatives
-				const rateLimitedAlternatives = await filterRateLimitedProviders(
+				const candidatesForRouting = await pickNonRateLimitedCandidates(
 					project.organizationId,
-					availableModelProviders.map((p) => ({
-						providerId: p.providerId,
-						model: baseModelId,
-						providerModelName: p.modelName,
-					})),
+					baseModelId,
+					availableModelProviders,
 				);
-				const nonRateLimitedAlternatives = availableModelProviders.filter(
-					(p) => !rateLimitedAlternatives.has(p.providerId),
-				);
-
-				const candidatesForRouting =
-					nonRateLimitedAlternatives.length > 0
-						? nonRateLimitedAlternatives
-						: availableModelProviders;
 
 				if (candidatesForRouting.length > 0) {
 					const rawModelForFallback = models.find((m) => m.id === baseModelId);
@@ -2326,33 +2315,11 @@ chat.openapi(completions, async (c) => {
 						),
 				);
 
-				// Exclude alternatives that are already at their RPM/RPD cap so the
-				// low-uptime fallback doesn't route into a rate-limited provider.
-				// Dedupe by providerId+modelName since region-expanded variants share
-				// the same rate-limit window. Fail-open if all alternatives are capped.
-				const uniqueRateLimitCandidates = Array.from(
-					new Map(
-						availableModelProviders.map((p) => [
-							`${p.providerId}:${p.modelName}`,
-							{
-								providerId: p.providerId,
-								model: baseModelId,
-								providerModelName: p.modelName,
-							},
-						]),
-					).values(),
-				);
-				const rateLimitedAlternatives = await filterRateLimitedProviders(
+				const uptimeFallbackCandidates = await pickNonRateLimitedCandidates(
 					project.organizationId,
-					uniqueRateLimitCandidates,
+					baseModelId,
+					availableModelProviders,
 				);
-				const nonRateLimitedAlternatives = availableModelProviders.filter(
-					(p) => !rateLimitedAlternatives.has(p.providerId),
-				);
-				const uptimeFallbackCandidates =
-					nonRateLimitedAlternatives.length > 0
-						? nonRateLimitedAlternatives
-						: availableModelProviders;
 
 				if (uptimeFallbackCandidates.length > 0) {
 					const rawModelForFallback = models.find((m) => m.id === baseModelId);

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2328,14 +2328,23 @@ chat.openapi(completions, async (c) => {
 
 				// Exclude alternatives that are already at their RPM/RPD cap so the
 				// low-uptime fallback doesn't route into a rate-limited provider.
-				// Fail-open: if all alternatives are rate-limited, keep them all.
+				// Dedupe by providerId+modelName since region-expanded variants share
+				// the same rate-limit window. Fail-open if all alternatives are capped.
+				const uniqueRateLimitCandidates = Array.from(
+					new Map(
+						availableModelProviders.map((p) => [
+							`${p.providerId}:${p.modelName}`,
+							{
+								providerId: p.providerId,
+								model: baseModelId,
+								providerModelName: p.modelName,
+							},
+						]),
+					).values(),
+				);
 				const rateLimitedAlternatives = await filterRateLimitedProviders(
 					project.organizationId,
-					availableModelProviders.map((p) => ({
-						providerId: p.providerId,
-						model: baseModelId,
-						providerModelName: p.modelName,
-					})),
+					uniqueRateLimitCandidates,
 				);
 				const nonRateLimitedAlternatives = availableModelProviders.filter(
 					(p) => !rateLimitedAlternatives.has(p.providerId),

--- a/apps/gateway/src/lib/provider-rate-limit.spec.ts
+++ b/apps/gateway/src/lib/provider-rate-limit.spec.ts
@@ -5,6 +5,7 @@ import {
 	filterRateLimitedProviders,
 	getExceededProviderRateLimitLabels,
 	peekProviderRateLimit,
+	pickNonRateLimitedCandidates,
 } from "./provider-rate-limit.js";
 
 vi.mock("@llmgateway/cache", () => ({
@@ -242,6 +243,94 @@ describe("filterRateLimitedProviders", () => {
 
 		expect(result.has("openai")).toBe(true);
 		expect(result.has("anthropic")).toBe(false);
+	});
+});
+
+describe("pickNonRateLimitedCandidates", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	const cappedRpm = {
+		maxRpm: 10,
+		maxRpd: 0,
+		rpmSource: "global_provider",
+		rpdSource: "none",
+		rpmRateLimitId: "rl-rpm",
+	} as const;
+
+	const openRpm = {
+		maxRpm: 100,
+		maxRpd: 0,
+		rpmSource: "global_provider",
+		rpdSource: "none",
+		rpmRateLimitId: "rl-rpm",
+	} as const;
+
+	it("drops a rate-limited candidate so the router falls back to the next one", async () => {
+		vi.mocked(mockDb.getEffectiveRateLimit)
+			.mockResolvedValueOnce(cappedRpm)
+			.mockResolvedValueOnce(openRpm);
+		vi.mocked(redis.zcard).mockResolvedValueOnce(10).mockResolvedValueOnce(20);
+		vi.mocked(redis.zrange).mockResolvedValueOnce([
+			"member",
+			Date.now().toString(),
+		]);
+
+		const result = await pickNonRateLimitedCandidates("org-1", "glm-4.7", [
+			{ providerId: "together-ai", modelName: "glm-4.7" },
+			{ providerId: "cerebras", modelName: "glm-4.7" },
+		]);
+
+		expect(result).toEqual([{ providerId: "cerebras", modelName: "glm-4.7" }]);
+	});
+
+	it("fails open when every candidate is rate-limited", async () => {
+		vi.mocked(mockDb.getEffectiveRateLimit)
+			.mockResolvedValueOnce(cappedRpm)
+			.mockResolvedValueOnce(cappedRpm);
+		vi.mocked(redis.zcard).mockResolvedValueOnce(10).mockResolvedValueOnce(10);
+		vi.mocked(redis.zrange)
+			.mockResolvedValueOnce(["m1", Date.now().toString()])
+			.mockResolvedValueOnce(["m2", Date.now().toString()]);
+
+		const candidates = [
+			{ providerId: "together-ai", modelName: "glm-4.7" },
+			{ providerId: "cerebras", modelName: "glm-4.7" },
+		];
+		const result = await pickNonRateLimitedCandidates(
+			"org-1",
+			"glm-4.7",
+			candidates,
+		);
+
+		expect(result).toEqual(candidates);
+	});
+
+	it("dedupes peeks across region-expanded variants of the same provider+model", async () => {
+		vi.mocked(mockDb.getEffectiveRateLimit).mockResolvedValueOnce(openRpm);
+		vi.mocked(redis.zcard).mockResolvedValueOnce(0);
+
+		const candidates = [
+			{ providerId: "alibaba", modelName: "glm-4.6", region: "singapore" },
+			{ providerId: "alibaba", modelName: "glm-4.6", region: "cn-beijing" },
+			{ providerId: "alibaba", modelName: "glm-4.6", region: "us-east-1" },
+		];
+		const result = await pickNonRateLimitedCandidates(
+			"org-1",
+			"glm-4.6",
+			candidates,
+		);
+
+		expect(vi.mocked(mockDb.getEffectiveRateLimit)).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(candidates);
+	});
+
+	it("returns an empty list unchanged without calling Redis", async () => {
+		const result = await pickNonRateLimitedCandidates("org-1", "glm-4.7", []);
+
+		expect(result).toEqual([]);
+		expect(vi.mocked(mockDb.getEffectiveRateLimit)).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/gateway/src/lib/provider-rate-limit.ts
+++ b/apps/gateway/src/lib/provider-rate-limit.ts
@@ -274,6 +274,44 @@ export async function filterRateLimitedProviders(
 }
 
 /**
+ * Pick fallback candidates that are not at their RPM/RPD cap.
+ * Dedupes peeks by providerId+modelName since region-expanded variants share
+ * the same rate-limit window. Falls open to the original candidates if every
+ * one is capped, so callers always get a non-empty list when input was non-empty.
+ */
+export async function pickNonRateLimitedCandidates<
+	T extends { providerId: string; modelName: string },
+>(organizationId: string, baseModelId: string, candidates: T[]): Promise<T[]> {
+	if (candidates.length === 0) {
+		return candidates;
+	}
+
+	const uniquePeekCandidates = Array.from(
+		new Map(
+			candidates.map((p) => [
+				`${p.providerId}:${p.modelName}`,
+				{
+					providerId: p.providerId,
+					model: baseModelId,
+					providerModelName: p.modelName,
+				},
+			]),
+		).values(),
+	);
+
+	const rateLimited = await filterRateLimitedProviders(
+		organizationId,
+		uniquePeekCandidates,
+	);
+
+	const nonRateLimited = candidates.filter(
+		(p) => !rateLimited.has(p.providerId),
+	);
+
+	return nonRateLimited.length > 0 ? nonRateLimited : candidates;
+}
+
+/**
  * Check configurable provider/model caps stored in the database.
  * Uses a Redis sliding window approach identical to free model rate limiting.
  */


### PR DESCRIPTION
## Summary
- The low-uptime fallback path in `apps/gateway/src/chat/chat.ts` selected an alternative provider based only on uptime and price, ignoring per-provider RPM/RPD caps. A request that was rerouted away from a low-uptime provider could land on another provider that was already at its rate limit, causing an avoidable 429 at `checkProviderRateLimit` right after.
- Filter `availableModelProviders` through `filterRateLimitedProviders` before scoring, with fail-open if every alternative is capped. This mirrors the existing rate-limit fallback path (same file, lines ~2056–2071), so the two fallback paths now share the same RPM-aware candidate selection.

## Test plan
- [ ] `pnpm build` — passed locally
- [ ] `pnpm lint` — passed locally
- [ ] Manually exercise: requested provider below 90% uptime, best-priced alternative at RPM cap → request routes to the next-cheapest non-capped alternative, not the capped one
- [ ] Manually exercise: all alternatives are capped → fails open and still attempts fallback instead of getting stuck on the low-uptime provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback provider selection to prefer non-rate-limited candidates when available, ensuring uptime comparisons, scoring, and routing use healthier alternatives while still allowing fail-open behavior when all candidates are capped.
* **Tests**
  * Added coverage for selecting non-rate-limited candidates, deduplication of rate-limit checks, empty-input handling, and fail-open scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->