### PR TITLE
feat(models): add kimi-k2.6 moonshot model

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -323,4 +323,29 @@ export const moonshotModels = [
 			},
 		],
 	},
+	{
+		id: "kimi-k2.6",
+		name: "Kimi K2.6",
+		description:
+			"Moonshot's latest native multimodal model with long-term code writing, thinking, and agentic capabilities.",
+		family: "moonshot",
+		releasedAt: new Date("2026-04-20"),
+		providers: [
+			{
+				providerId: "moonshot",
+				modelName: "kimi-k2.6",
+				inputPrice: 0.95 / 1e6,
+				cachedInputPrice: 0.16 / 1e6,
+				outputPrice: 4.0 / 1e6,
+				requestPrice: 0,
+				contextSize: 262144,
+				maxOutput: 262144,
+				reasoning: true,
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary
- Add Moonshot's `kimi-k2.6` native multimodal model via the `moonshot` provider
- Pricing: $0.95/M input, $0.16/M cached input, $4.00/M output
- 262,144 token context window with reasoning, vision, tools, and JSON output

## Test plan
- [ ] Model appears in gateway model list
- [ ] Routes correctly to Moonshot provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kimi K2.6 model support with multimodal vision processing, tool integration, JSON output generation, streaming responses, and advanced reasoning capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->