### PR TITLE
fix(gateway): consume rate-limit slot on fallback retry

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4273,14 +4273,16 @@ chat.openapi(completions, async (c) => {
 							break;
 						}
 
-						// Check if the fallback candidate is rate-limited
-						const retryRateLimitPeek = await peekProviderRateLimit(
+						// Check and consume a rate-limit slot for the fallback candidate.
+						// Using checkProviderRateLimit (not peek) so RPM/RPD counters include
+						// requests routed to a provider via fallback, not just the initial pick.
+						const retryRateLimitResult = await checkProviderRateLimit(
 							project.organizationId,
 							nextProvider.providerId,
 							modelInfo.id,
 							nextProvider.modelName,
 						);
-						if (retryRateLimitPeek.rateLimited) {
+						if (retryRateLimitResult.rateLimited) {
 							failedProviderIds.add(
 								providerRetryKey(nextProvider.providerId, nextProvider.region),
 							);
@@ -7767,14 +7769,16 @@ chat.openapi(completions, async (c) => {
 				break;
 			}
 
-			// Check if the fallback candidate is rate-limited
-			const retryRateLimitPeek = await peekProviderRateLimit(
+			// Check and consume a rate-limit slot for the fallback candidate.
+			// Using checkProviderRateLimit (not peek) so RPM/RPD counters include
+			// requests routed to a provider via fallback, not just the initial pick.
+			const retryRateLimitResult = await checkProviderRateLimit(
 				project.organizationId,
 				nextProvider.providerId,
 				modelInfo.id,
 				nextProvider.modelName,
 			);
-			if (retryRateLimitPeek.rateLimited) {
+			if (retryRateLimitResult.rateLimited) {
 				failedProviderIds.add(
 					providerRetryKey(nextProvider.providerId, nextProvider.region),
 				);


### PR DESCRIPTION
## Summary

- Replace `peekProviderRateLimit` with `checkProviderRateLimit` on the fallback-retry path so RPM/RPD counters include requests that reach a provider via fallback, not only the initial pick.
- Applies to both streaming and non-streaming paths in `apps/gateway/src/chat/chat.ts`.

## Why

Peeking at the rate limit never consumed a slot, so retry-fallback hits went uncounted. A provider with `RPD=1` could be routed to many times in a row via the fallback path because every retry only peeked — the initial pick was the only request that counted against the budget. This is how a `gemini-3-pro-image-preview` request was routed to `obsidian` past its configured daily cap.

## Test plan

- [ ] `pnpm test:unit` — `retry-with-fallback.spec.ts` still passes (26 tests locally)
- [ ] Verify in staging: a provider with `RPD=1` routed to via fallback consumes its slot and is skipped on subsequent fallback attempts within the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback provider retry logic to properly handle rate-limited services, preventing wasted retry attempts and marking rate-limited providers as failed more effectively in both streaming and non-streaming chat requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->