### PR TITLE
fix(ui): chat support hydration mismatch

### DIFF
--- a/apps/ui/src/components/chat-support.tsx
+++ b/apps/ui/src/components/chat-support.tsx
@@ -78,11 +78,17 @@ export function ChatSupport() {
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
 	const prevMessageCountRef = useRef(0);
-	const [clientId] = useState(() => getOrCreateClientId());
+	const [clientId, setClientId] = useState("");
+	const [mounted, setMounted] = useState(false);
 
-	const isLoggedIn = !!user;
-	const effectiveName = isLoggedIn ? (user.name ?? "") : userName;
-	const effectiveEmail = isLoggedIn ? (user.email ?? "") : userEmail;
+	useEffect(() => {
+		setClientId(getOrCreateClientId());
+		setMounted(true);
+	}, []);
+
+	const isLoggedIn = mounted && !!user;
+	const effectiveName = isLoggedIn ? (user?.name ?? "") : userName;
+	const effectiveEmail = isLoggedIn ? (user?.email ?? "") : userEmail;
 	const isIdentified = isLoggedIn || hasIdentified;
 
 	const chat = useMemo(


### PR DESCRIPTION
## Summary
- Defer identification-dependent rendering in `ChatSupport` behind a `mounted` flag so server and initial client render match
- `useUser()` can return cached data on the client's first render while being null on the server, which flipped `isIdentified` and caused the hydration mismatch
- Also moved `sessionStorage`-based `clientId` init into the mount effect (same SSR/CSR divergence)

## Test plan
- [ ] Reload a page with `<ChatSupport />` as a logged-in user and confirm no hydration warning
- [ ] Reload as anonymous user and confirm welcome form still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved chat support component initialization to properly establish client identification and user authentication state
* Enhanced state handling during component mounting and rendering for greater stability across different contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->