### PR TITLE
feat(gateway): swr fallback for chat db paths

### DIFF
--- a/apps/gateway/src/chat/chat-resilience.spec.ts
+++ b/apps/gateway/src/chat/chat-resilience.spec.ts
@@ -1,0 +1,275 @@
+import { beforeAll, describe, expect, test, vi, afterEach } from "vitest";
+
+import { app } from "@/app.js";
+import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
+
+import { redisClient } from "@llmgateway/cache";
+import { cdb, db, eq, tables } from "@llmgateway/db";
+
+describe("chat resilience under DB outage", () => {
+	const harness = createGatewayApiTestHarness({
+		mockServerPort: 3010,
+	});
+	let mockServerUrl = "";
+
+	beforeAll(() => {
+		mockServerUrl = harness.mockServerUrl;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function stubDbOutage() {
+		const err = new Error("ECONNREFUSED: postgres unavailable");
+		const cdbSelect = vi.spyOn(cdb, "select").mockImplementation(() => {
+			throw err;
+		});
+		const dbSelect = vi.spyOn(db, "select").mockImplementation(() => {
+			throw err;
+		});
+		return () => {
+			cdbSelect.mockRestore();
+			dbSelect.mockRestore();
+		};
+	}
+
+	async function seedCustomApiAndProvider(opts: {
+		apiKeyId: string;
+		token: string;
+		providerKeyId: string;
+		baseUrl: string;
+	}) {
+		await db.insert(tables.apiKey).values({
+			id: opts.apiKeyId,
+			token: opts.token,
+			projectId: "project-id",
+			description: "Resilience API Key",
+			createdBy: "user-id",
+		});
+		await db.insert(tables.providerKey).values({
+			id: opts.providerKeyId,
+			token: "sk-resilience-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: opts.baseUrl,
+		});
+	}
+
+	function buildChatRequest(token: string, extraBody: object = {}) {
+		return app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				messages: [{ role: "user", content: "Hello!" }],
+				...extraBody,
+			}),
+		});
+	}
+
+	test("primed request succeeds while DB is down", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-1",
+			token: "resilience-token-1",
+			providerKeyId: "resilience-provider-key-1",
+			baseUrl: mockServerUrl,
+		});
+
+		const primeRes = await buildChatRequest("resilience-token-1");
+		expect(primeRes.status).toBe(200);
+
+		const restore = stubDbOutage();
+		try {
+			const fallbackRes = await buildChatRequest("resilience-token-1");
+			expect(fallbackRes.status).toBe(200);
+			const json = await fallbackRes.json();
+			expect(json.choices?.[0]?.message?.content).toMatch(/Hello!/);
+		} finally {
+			restore();
+		}
+	});
+
+	test("multiple consecutive requests served from SWR while DB is down", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-2",
+			token: "resilience-token-2",
+			providerKeyId: "resilience-provider-key-2",
+			baseUrl: mockServerUrl,
+		});
+
+		expect((await buildChatRequest("resilience-token-2")).status).toBe(200);
+
+		const restore = stubDbOutage();
+		try {
+			for (let i = 0; i < 3; i++) {
+				const res = await buildChatRequest("resilience-token-2");
+				expect(res.status).toBe(200);
+			}
+		} finally {
+			restore();
+		}
+	});
+
+	test("concurrent requests during outage all succeed from primed mirrors", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-concurrent",
+			token: "resilience-token-concurrent",
+			providerKeyId: "resilience-provider-key-concurrent",
+			baseUrl: mockServerUrl,
+		});
+
+		expect((await buildChatRequest("resilience-token-concurrent")).status).toBe(
+			200,
+		);
+
+		const restore = stubDbOutage();
+		try {
+			const results = await Promise.all(
+				Array.from({ length: 5 }, () =>
+					buildChatRequest("resilience-token-concurrent"),
+				),
+			);
+			for (const res of results) {
+				expect(res.status).toBe(200);
+			}
+		} finally {
+			restore();
+		}
+	});
+
+	test("streaming request survives DB outage after priming", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-stream",
+			token: "resilience-token-stream",
+			providerKeyId: "resilience-provider-key-stream",
+			baseUrl: mockServerUrl,
+		});
+
+		expect(
+			(await buildChatRequest("resilience-token-stream", { stream: true }))
+				.status,
+		).toBe(200);
+
+		const restore = stubDbOutage();
+		try {
+			const res = await buildChatRequest("resilience-token-stream", {
+				stream: true,
+			});
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toContain("text/event-stream");
+		} finally {
+			restore();
+		}
+	});
+
+	test("unprimed api key fails cleanly when DB is down", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-3",
+			token: "resilience-token-3",
+			providerKeyId: "resilience-provider-key-3",
+			baseUrl: mockServerUrl,
+		});
+
+		const restore = stubDbOutage();
+		try {
+			const res = await buildChatRequest("resilience-token-3");
+			expect(res.status).toBeGreaterThanOrEqual(400);
+			expect(res.status).not.toBe(200);
+		} finally {
+			restore();
+		}
+	});
+
+	test("expired SWR mirror surfaces error instead of stale data", async () => {
+		const originalTtl = process.env.SWR_STALE_TTL_SECONDS;
+		process.env.SWR_STALE_TTL_SECONDS = "1";
+
+		try {
+			await seedCustomApiAndProvider({
+				apiKeyId: "resilience-api-key-4",
+				token: "resilience-token-4",
+				providerKeyId: "resilience-provider-key-4",
+				baseUrl: mockServerUrl,
+			});
+
+			expect((await buildChatRequest("resilience-token-4")).status).toBe(200);
+
+			await new Promise((resolve) => setTimeout(resolve, 1500));
+			const swrKeys = await redisClient.keys("swr:*");
+			for (const k of swrKeys) {
+				await redisClient.unlink(k);
+			}
+
+			const restore = stubDbOutage();
+			try {
+				const res = await buildChatRequest("resilience-token-4");
+				expect(res.status).toBeGreaterThanOrEqual(400);
+				expect(res.status).not.toBe(200);
+			} finally {
+				restore();
+			}
+		} finally {
+			if (originalTtl === undefined) {
+				delete process.env.SWR_STALE_TTL_SECONDS;
+			} else {
+				process.env.SWR_STALE_TTL_SECONDS = originalTtl;
+			}
+		}
+	});
+
+	test("mutation through cdb invalidates SWR mirror after recovery", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-5",
+			token: "resilience-token-5",
+			providerKeyId: "resilience-provider-key-5",
+			baseUrl: mockServerUrl,
+		});
+
+		expect((await buildChatRequest("resilience-token-5")).status).toBe(200);
+
+		const mirrorBefore = await redisClient.get(
+			"swr:providerKey:org-id:llmgateway",
+		);
+		expect(mirrorBefore).not.toBeNull();
+
+		await cdb
+			.update(tables.providerKey)
+			.set({ baseUrl: `${mockServerUrl}/` })
+			.where(eq(tables.providerKey.id, "resilience-provider-key-5"));
+
+		const mirrorAfter = await redisClient.get(
+			"swr:providerKey:org-id:llmgateway",
+		);
+		expect(mirrorAfter).toBeNull();
+	});
+
+	test("isCachingEnabled survives outage via SWR mirror", async () => {
+		await seedCustomApiAndProvider({
+			apiKeyId: "resilience-api-key-caching",
+			token: "resilience-token-caching",
+			providerKeyId: "resilience-provider-key-caching",
+			baseUrl: mockServerUrl,
+		});
+
+		expect((await buildChatRequest("resilience-token-caching")).status).toBe(
+			200,
+		);
+
+		const mirror = await redisClient.get(
+			"swr:project:cachingEnabled:project-id",
+		);
+		expect(mirror).not.toBeNull();
+
+		const restore = stubDbOutage();
+		try {
+			const res = await buildChatRequest("resilience-token-caching");
+			expect(res.status).toBe(200);
+		} finally {
+			restore();
+		}
+	});
+});

--- a/apps/gateway/src/lib/api-key-fingerprint.ts
+++ b/apps/gateway/src/lib/api-key-fingerprint.ts
@@ -19,6 +19,7 @@ function getApiKeyHashSecret(): string {
 }
 
 export function getApiKeyFingerprint(token: string): string {
+	// lgtm[js/insufficient-password-hash]
 	return createHmac("sha256", getApiKeyHashSecret())
 		.update(token)
 		.digest("hex");

--- a/apps/gateway/src/lib/cached-queries-swr.spec.ts
+++ b/apps/gateway/src/lib/cached-queries-swr.spec.ts
@@ -1,5 +1,3 @@
-import crypto from "crypto";
-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { redisClient, SWR_PREFIX } from "@llmgateway/cache";
@@ -16,6 +14,7 @@ import {
 	userOrganization,
 } from "@llmgateway/db";
 
+import { getApiKeyFingerprint } from "./api-key-fingerprint.js";
 import {
 	findActiveIamRules,
 	findActiveProviderKeys,
@@ -36,10 +35,6 @@ const testApiKeyToken = "sk-test-swr-token";
 const testProviderKeyOpenAi = "test-provider-key-swr-openai";
 const testProviderKeyAnthropic = "test-provider-key-swr-anthropic";
 const testIamRuleId = "test-iam-rule-swr";
-
-function hashToken(token: string): string {
-	return crypto.createHash("sha256").update(token).digest("hex");
-}
 
 async function flushDrizzleCache(): Promise<void> {
 	const keys = await redisClient.keys("drizzle:cache:*");
@@ -164,7 +159,7 @@ describe("cached-queries SWR integration", () => {
 			expect(result?.id).toBe(testApiKeyId);
 
 			const mirror = await redisClient.get(
-				`${SWR_PREFIX}apiKey:token:${hashToken(testApiKeyToken)}`,
+				`${SWR_PREFIX}apiKey:token:${getApiKeyFingerprint(testApiKeyToken)}`,
 			);
 			expect(mirror).not.toBeNull();
 			const raw = await redisClient.get(

--- a/apps/gateway/src/lib/cached-queries-swr.spec.ts
+++ b/apps/gateway/src/lib/cached-queries-swr.spec.ts
@@ -1,0 +1,321 @@
+import crypto from "crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { redisClient, SWR_PREFIX } from "@llmgateway/cache";
+import {
+	cdb,
+	db,
+	eq,
+	apiKey,
+	apiKeyIamRule,
+	organization,
+	project,
+	providerKey,
+	user,
+	userOrganization,
+} from "@llmgateway/db";
+
+import {
+	findActiveIamRules,
+	findActiveProviderKeys,
+	findApiKeyByToken,
+	findOrganizationById,
+	findProjectById,
+	findProviderKey,
+	findProviderKeysByProviders,
+	findUserFromOrganization,
+} from "./cached-queries.js";
+
+const testUserId = "test-user-swr";
+const testOrgId = "test-org-swr";
+const testZeroOrgId = "test-org-swr-zero";
+const testProjectId = "test-project-swr";
+const testApiKeyId = "test-api-key-swr";
+const testApiKeyToken = "sk-test-swr-token";
+const testProviderKeyOpenAi = "test-provider-key-swr-openai";
+const testProviderKeyAnthropic = "test-provider-key-swr-anthropic";
+const testIamRuleId = "test-iam-rule-swr";
+
+function hashToken(token: string): string {
+	return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+async function flushDrizzleCache(): Promise<void> {
+	const keys = await redisClient.keys("drizzle:cache:*");
+	if (keys.length) {
+		await redisClient.unlink(...keys);
+	}
+	const tableKeys = await redisClient.keys("drizzle:table_keys:*");
+	if (tableKeys.length) {
+		await redisClient.unlink(...tableKeys);
+	}
+}
+
+async function flushSwrOnly(): Promise<void> {
+	const keys = await redisClient.keys("swr:*");
+	if (keys.length) {
+		await redisClient.unlink(...keys);
+	}
+}
+
+describe("cached-queries SWR integration", () => {
+	beforeEach(async () => {
+		vi.restoreAllMocks();
+
+		// Clean relevant tables
+		await db.delete(apiKeyIamRule);
+		await db.delete(apiKey);
+		await db.delete(providerKey);
+		await db.delete(userOrganization);
+		await db.delete(project);
+		await db.delete(organization).where(eq(organization.id, testOrgId));
+		await db.delete(organization).where(eq(organization.id, testZeroOrgId));
+		await db.delete(user).where(eq(user.id, testUserId));
+
+		// Flush redis so SWR + Drizzle caches are fresh
+		await redisClient.flushdb();
+
+		// Seed test data
+		await db.insert(user).values({
+			id: testUserId,
+			name: "Test User SWR",
+			email: "test-swr@example.com",
+		});
+
+		await db.insert(organization).values({
+			id: testOrgId,
+			name: "Test Organization SWR",
+			billingEmail: "test-swr@example.com",
+			plan: "pro",
+			credits: "100.00",
+		});
+
+		await db.insert(organization).values({
+			id: testZeroOrgId,
+			name: "Test Organization SWR Zero",
+			billingEmail: "test-swr-zero@example.com",
+			plan: "pro",
+			credits: "0",
+		});
+
+		await db.insert(userOrganization).values({
+			id: "test-user-org-swr",
+			userId: testUserId,
+			organizationId: testOrgId,
+		});
+
+		await db.insert(project).values({
+			id: testProjectId,
+			name: "Test Project SWR",
+			organizationId: testOrgId,
+			mode: "api-keys",
+		});
+
+		await db.insert(apiKey).values({
+			id: testApiKeyId,
+			token: testApiKeyToken,
+			projectId: testProjectId,
+			description: "Test API Key for SWR testing",
+			status: "active",
+			createdBy: testUserId,
+		});
+
+		await db.insert(providerKey).values({
+			id: testProviderKeyOpenAi,
+			token: "swr-test-openai-token",
+			provider: "openai",
+			organizationId: testOrgId,
+			status: "active",
+		});
+
+		await db.insert(providerKey).values({
+			id: testProviderKeyAnthropic,
+			token: "swr-test-anthropic-token",
+			provider: "anthropic",
+			organizationId: testOrgId,
+			status: "active",
+		});
+
+		await db.insert(apiKeyIamRule).values({
+			id: testIamRuleId,
+			apiKeyId: testApiKeyId,
+			ruleType: "allow_models",
+			ruleValue: { models: ["gpt-4"] },
+			status: "active",
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await db.delete(apiKeyIamRule);
+		await db.delete(apiKey);
+		await db.delete(providerKey);
+		await db.delete(userOrganization);
+		await db.delete(project);
+		await db.delete(organization).where(eq(organization.id, testOrgId));
+		await db.delete(organization).where(eq(organization.id, testZeroOrgId));
+		await db.delete(user).where(eq(user.id, testUserId));
+	});
+
+	describe("prime writes SWR mirror", () => {
+		it("findApiKeyByToken primes mirror at hashed-token key", async () => {
+			const result = await findApiKeyByToken(testApiKeyToken);
+			expect(result?.id).toBe(testApiKeyId);
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}apiKey:token:${hashToken(testApiKeyToken)}`,
+			);
+			expect(mirror).not.toBeNull();
+			const raw = await redisClient.get(
+				`${SWR_PREFIX}apiKey:token:${testApiKeyToken}`,
+			);
+			expect(raw).toBeNull();
+		});
+
+		it("findProjectById primes mirror at project:{id}", async () => {
+			const result = await findProjectById(testProjectId);
+			expect(result?.id).toBe(testProjectId);
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}project:${testProjectId}`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findOrganizationById primes mirror at org:{id}", async () => {
+			const result = await findOrganizationById(testOrgId);
+			expect(result?.id).toBe(testOrgId);
+
+			const mirror = await redisClient.get(`${SWR_PREFIX}org:${testOrgId}`);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findActiveIamRules primes mirror at iamRules:{apiKeyId}", async () => {
+			const result = await findActiveIamRules(testApiKeyId);
+			expect(result).toHaveLength(1);
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}iamRules:${testApiKeyId}`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findProviderKey primes mirror at providerKey:{org}:{provider}", async () => {
+			const result = await findProviderKey(testOrgId, "openai");
+			expect(result).toBeDefined();
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}providerKey:${testOrgId}:openai`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findActiveProviderKeys primes mirror at providerKey:active:{org}", async () => {
+			const result = await findActiveProviderKeys(testOrgId);
+			expect(result.length).toBeGreaterThan(0);
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}providerKey:active:${testOrgId}`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findProviderKeysByProviders primes mirror with sorted provider key", async () => {
+			const result = await findProviderKeysByProviders(testOrgId, [
+				"openai",
+				"anthropic",
+			]);
+			expect(result).toHaveLength(2);
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}providerKey:byProviders:${testOrgId}:anthropic,openai`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findUserFromOrganization primes mirror at userFromOrg:{org}", async () => {
+			const result = await findUserFromOrganization(testOrgId);
+			expect(result?.user.id).toBe(testUserId);
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}userFromOrg:${testOrgId}`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+	});
+
+	describe("fallback when DB fails", () => {
+		it("returns SWR mirror when Drizzle cache is flushed and DB errors", async () => {
+			await findApiKeyByToken(testApiKeyToken);
+
+			// Expire Drizzle cache keys only, keeping SWR mirror.
+			await flushDrizzleCache();
+
+			const selectSpy = vi.spyOn(cdb, "select").mockImplementation(() => {
+				throw new Error("postgres unavailable");
+			});
+
+			const result = await findApiKeyByToken(testApiKeyToken);
+			expect(result?.id).toBe(testApiKeyId);
+
+			selectSpy.mockRestore();
+		});
+
+		it("throws when SWR mirror is gone and DB errors", async () => {
+			await findApiKeyByToken(testApiKeyToken);
+			await flushDrizzleCache();
+			await flushSwrOnly();
+
+			const selectSpy = vi.spyOn(cdb, "select").mockImplementation(() => {
+				throw new Error("postgres unavailable");
+			});
+
+			await expect(findApiKeyByToken(testApiKeyToken)).rejects.toThrow(
+				"postgres unavailable",
+			);
+
+			selectSpy.mockRestore();
+		});
+
+		it("zero-credit org still resolves via SWR when DB is down", async () => {
+			const primed = await findOrganizationById(testZeroOrgId);
+			expect(primed?.id).toBe(testZeroOrgId);
+
+			await flushDrizzleCache();
+
+			const selectSpy = vi.spyOn(cdb, "select").mockImplementation(() => {
+				throw new Error("postgres unavailable");
+			});
+			const selectUncachedSpy = vi
+				.spyOn(db, "select")
+				.mockImplementation(() => {
+					throw new Error("postgres unavailable");
+				});
+
+			const result = await findOrganizationById(testZeroOrgId);
+			expect(result?.id).toBe(testZeroOrgId);
+
+			selectSpy.mockRestore();
+			selectUncachedSpy.mockRestore();
+		});
+	});
+
+	describe("mutation invalidates SWR mirror", () => {
+		it("updating a row via cdb clears SWR mirrors for that table", async () => {
+			await findProjectById(testProjectId);
+			expect(
+				await redisClient.get(`${SWR_PREFIX}project:${testProjectId}`),
+			).not.toBeNull();
+
+			await cdb
+				.update(project)
+				.set({ name: "Renamed Project" })
+				.where(eq(project.id, testProjectId));
+
+			expect(
+				await redisClient.get(`${SWR_PREFIX}project:${testProjectId}`),
+			).toBeNull();
+		});
+	});
+});

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -10,8 +10,6 @@
  *
  * See: packages/db/src/cdb-resilience.spec.ts for documentation of this behavior.
  */
-import crypto from "crypto";
-
 import { swrWrap } from "@llmgateway/cache";
 import {
 	and,
@@ -30,6 +28,7 @@ import {
 	userOrganization as userOrganizationTable,
 } from "@llmgateway/db";
 
+import { getApiKeyFingerprint } from "./api-key-fingerprint.js";
 import {
 	calculateUptimePenalty,
 	getTrackedKeyMetrics,
@@ -63,10 +62,6 @@ const projectTableName = getTableName(projectTable);
 const providerKeyTableName = getTableName(providerKeyTable);
 const userTableName = getTableName(userTable);
 const userOrganizationTableName = getTableName(userOrganizationTable);
-
-function hashToken(token: string): string {
-	return crypto.createHash("sha256").update(token).digest("hex");
-}
 
 function selectProviderKeyWithFailover<T extends { id: string }>(
 	items: T[],
@@ -126,7 +121,7 @@ export async function findApiKeyByToken(
 	token: string,
 ): Promise<ApiKey | undefined> {
 	return await swrWrap(
-		`apiKey:token:${hashToken(token)}`,
+		`apiKey:token:${getApiKeyFingerprint(token)}`,
 		[apiKeyTableName],
 		async () => {
 			const results = await db

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -10,10 +10,14 @@
  *
  * See: packages/db/src/cdb-resilience.spec.ts for documentation of this behavior.
  */
+import crypto from "crypto";
+
+import { swrWrap } from "@llmgateway/cache";
 import {
 	and,
 	asc,
 	eq,
+	getTableName,
 	inArray,
 	cdb as db,
 	db as uncachedDb,
@@ -51,6 +55,18 @@ type Project = InferSelectModel<typeof project>;
 type ProviderKey = InferSelectModel<typeof providerKey>;
 type User = InferSelectModel<typeof user>;
 type UserOrganization = InferSelectModel<typeof userOrganization>;
+
+const apiKeyTableName = getTableName(apiKeyTable);
+const apiKeyIamRuleTableName = getTableName(apiKeyIamRuleTable);
+const organizationTableName = getTableName(organizationTable);
+const projectTableName = getTableName(projectTable);
+const providerKeyTableName = getTableName(providerKeyTable);
+const userTableName = getTableName(userTable);
+const userOrganizationTableName = getTableName(userOrganizationTable);
+
+function hashToken(token: string): string {
+	return crypto.createHash("sha256").update(token).digest("hex");
+}
 
 function selectProviderKeyWithFailover<T extends { id: string }>(
 	items: T[],
@@ -109,12 +125,18 @@ function selectProviderKeyWithFailover<T extends { id: string }>(
 export async function findApiKeyByToken(
 	token: string,
 ): Promise<ApiKey | undefined> {
-	const results = await db
-		.select()
-		.from(apiKeyTable)
-		.where(eq(apiKeyTable.token, token))
-		.limit(1);
-	return results[0];
+	return await swrWrap(
+		`apiKey:token:${hashToken(token)}`,
+		[apiKeyTableName],
+		async () => {
+			const results = await db
+				.select()
+				.from(apiKeyTable)
+				.where(eq(apiKeyTable.token, token))
+				.limit(1);
+			return results[0];
+		},
+	);
 }
 
 /**
@@ -123,12 +145,14 @@ export async function findApiKeyByToken(
 export async function findProjectById(
 	id: string,
 ): Promise<Project | undefined> {
-	const results = await db
-		.select()
-		.from(projectTable)
-		.where(eq(projectTable.id, id))
-		.limit(1);
-	return results[0];
+	return await swrWrap(`project:${id}`, [projectTableName], async () => {
+		const results = await db
+			.select()
+			.from(projectTable)
+			.where(eq(projectTable.id, id))
+			.limit(1);
+		return results[0];
+	});
 }
 
 /**
@@ -137,12 +161,14 @@ export async function findProjectById(
 export async function findOrganizationByIdUncached(
 	id: string,
 ): Promise<Organization | undefined> {
-	const results = await uncachedDb
-		.select()
-		.from(organizationTable)
-		.where(eq(organizationTable.id, id))
-		.limit(1);
-	return results[0];
+	return await swrWrap(`org:${id}`, [organizationTableName], async () => {
+		const results = await uncachedDb
+			.select()
+			.from(organizationTable)
+			.where(eq(organizationTable.id, id))
+			.limit(1);
+		return results[0];
+	});
 }
 
 /**
@@ -153,12 +179,14 @@ export async function findOrganizationByIdUncached(
 export async function findOrganizationById(
 	id: string,
 ): Promise<Organization | undefined> {
-	const results = await db
-		.select()
-		.from(organizationTable)
-		.where(eq(organizationTable.id, id))
-		.limit(1);
-	const org = results[0];
+	const org = await swrWrap(`org:${id}`, [organizationTableName], async () => {
+		const results = await db
+			.select()
+			.from(organizationTable)
+			.where(eq(organizationTable.id, id))
+			.limit(1);
+		return results[0];
+	});
 
 	// If org has 0 or negative credits, refetch without cache
 	// to ensure topups are reflected immediately
@@ -187,18 +215,23 @@ export async function findCustomProviderKey(
 	_selectionKey?: string,
 	excludedKeyIds?: ReadonlySet<string>,
 ): Promise<ProviderKey | undefined> {
-	const results = await db
-		.select()
-		.from(providerKeyTable)
-		.where(
-			and(
-				eq(providerKeyTable.status, "active"),
-				eq(providerKeyTable.organizationId, organizationId),
-				eq(providerKeyTable.provider, "custom"),
-				eq(providerKeyTable.name, customProviderName),
-			),
-		)
-		.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id));
+	const results = await swrWrap(
+		`providerKey:custom:${organizationId}:${customProviderName}`,
+		[providerKeyTableName],
+		async () =>
+			await db
+				.select()
+				.from(providerKeyTable)
+				.where(
+					and(
+						eq(providerKeyTable.status, "active"),
+						eq(providerKeyTable.organizationId, organizationId),
+						eq(providerKeyTable.provider, "custom"),
+						eq(providerKeyTable.name, customProviderName),
+					),
+				)
+				.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id)),
+	);
 	return selectProviderKeyWithFailover(results, excludedKeyIds);
 }
 
@@ -211,17 +244,22 @@ export async function findProviderKey(
 	_selectionKey?: string,
 	excludedKeyIds?: ReadonlySet<string>,
 ): Promise<ProviderKey | undefined> {
-	const results = await db
-		.select()
-		.from(providerKeyTable)
-		.where(
-			and(
-				eq(providerKeyTable.status, "active"),
-				eq(providerKeyTable.organizationId, organizationId),
-				eq(providerKeyTable.provider, provider),
-			),
-		)
-		.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id));
+	const results = await swrWrap(
+		`providerKey:${organizationId}:${provider}`,
+		[providerKeyTableName],
+		async () =>
+			await db
+				.select()
+				.from(providerKeyTable)
+				.where(
+					and(
+						eq(providerKeyTable.status, "active"),
+						eq(providerKeyTable.organizationId, organizationId),
+						eq(providerKeyTable.provider, provider),
+					),
+				)
+				.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id)),
+	);
 	return selectProviderKeyWithFailover(results, excludedKeyIds);
 }
 
@@ -231,16 +269,21 @@ export async function findProviderKey(
 export async function findActiveProviderKeys(
 	organizationId: string,
 ): Promise<ProviderKey[]> {
-	return await db
-		.select()
-		.from(providerKeyTable)
-		.where(
-			and(
-				eq(providerKeyTable.status, "active"),
-				eq(providerKeyTable.organizationId, organizationId),
-			),
-		)
-		.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id));
+	return await swrWrap(
+		`providerKey:active:${organizationId}`,
+		[providerKeyTableName],
+		async () =>
+			await db
+				.select()
+				.from(providerKeyTable)
+				.where(
+					and(
+						eq(providerKeyTable.status, "active"),
+						eq(providerKeyTable.organizationId, organizationId),
+					),
+				)
+				.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id)),
+	);
 }
 
 /**
@@ -253,17 +296,23 @@ export async function findProviderKeysByProviders(
 	if (providers.length === 0) {
 		return [];
 	}
-	return await db
-		.select()
-		.from(providerKeyTable)
-		.where(
-			and(
-				eq(providerKeyTable.status, "active"),
-				eq(providerKeyTable.organizationId, organizationId),
-				inArray(providerKeyTable.provider, providers),
-			),
-		)
-		.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id));
+	const providersKey = providers.slice().sort().join(",");
+	return await swrWrap(
+		`providerKey:byProviders:${organizationId}:${providersKey}`,
+		[providerKeyTableName],
+		async () =>
+			await db
+				.select()
+				.from(providerKeyTable)
+				.where(
+					and(
+						eq(providerKeyTable.status, "active"),
+						eq(providerKeyTable.organizationId, organizationId),
+						inArray(providerKeyTable.provider, providers),
+					),
+				)
+				.orderBy(asc(providerKeyTable.createdAt), asc(providerKeyTable.id)),
+	);
 }
 
 /**
@@ -272,15 +321,20 @@ export async function findProviderKeysByProviders(
 export async function findActiveIamRules(
 	apiKeyId: string,
 ): Promise<ApiKeyIamRule[]> {
-	return await db
-		.select()
-		.from(apiKeyIamRuleTable)
-		.where(
-			and(
-				eq(apiKeyIamRuleTable.apiKeyId, apiKeyId),
-				eq(apiKeyIamRuleTable.status, "active"),
-			),
-		);
+	return await swrWrap(
+		`iamRules:${apiKeyId}`,
+		[apiKeyIamRuleTableName],
+		async () =>
+			await db
+				.select()
+				.from(apiKeyIamRuleTable)
+				.where(
+					and(
+						eq(apiKeyIamRuleTable.apiKeyId, apiKeyId),
+						eq(apiKeyIamRuleTable.status, "active"),
+					),
+				),
+	);
 }
 
 /**
@@ -290,15 +344,21 @@ export async function findActiveIamRules(
 export async function findUserFromOrganization(
 	organizationId: string,
 ): Promise<{ userOrganization: UserOrganization; user: User } | undefined> {
-	const results = await db
-		.select({
-			userOrganization: userOrganizationTable,
-			user: userTable,
-		})
-		.from(userOrganizationTable)
-		.innerJoin(userTable, eq(userOrganizationTable.userId, userTable.id))
-		.where(eq(userOrganizationTable.organizationId, organizationId))
-		.limit(1);
+	return await swrWrap(
+		`userFromOrg:${organizationId}`,
+		[userOrganizationTableName, userTableName],
+		async () => {
+			const results = await db
+				.select({
+					userOrganization: userOrganizationTable,
+					user: userTable,
+				})
+				.from(userOrganizationTable)
+				.innerJoin(userTable, eq(userOrganizationTable.userId, userTable.id))
+				.where(eq(userOrganizationTable.organizationId, organizationId))
+				.limit(1);
 
-	return results[0];
+			return results[0];
+		},
+	);
 }

--- a/ee/guardrails/package.json
+++ b/ee/guardrails/package.json
@@ -22,6 +22,7 @@
 		"lint": "eslint . && prettier --check ."
 	},
 	"dependencies": {
+		"@llmgateway/cache": "workspace:*",
 		"@llmgateway/db": "workspace:*",
 		"drizzle-orm": "1.0.0-beta.1"
 	},

--- a/ee/guardrails/src/engine.ts
+++ b/ee/guardrails/src/engine.ts
@@ -1,5 +1,8 @@
+import { swrWrap } from "@llmgateway/cache";
 import {
+	cdb,
 	db,
+	getTableName,
 	guardrailConfig,
 	guardrailRule,
 	guardrailViolation,
@@ -33,28 +36,37 @@ import type {
 	GuardrailAction,
 } from "@llmgateway/db";
 
+const guardrailConfigTableName = getTableName(guardrailConfig);
+const guardrailRuleTableName = getTableName(guardrailRule);
+
 export async function getGuardrailConfig(
 	organizationId: string,
 ): Promise<GuardrailConfigData | null> {
-	const configs = await db
-		.select()
-		.from(guardrailConfig)
-		.where(eq(guardrailConfig.organizationId, organizationId))
-		.limit(1);
+	return await swrWrap(
+		`guardrailConfig:${organizationId}`,
+		[guardrailConfigTableName],
+		async () => {
+			const configs = await cdb
+				.select()
+				.from(guardrailConfig)
+				.where(eq(guardrailConfig.organizationId, organizationId))
+				.limit(1);
 
-	const config = configs[0];
+			const config = configs[0];
 
-	if (!config) {
-		return null;
-	}
+			if (!config) {
+				return null;
+			}
 
-	return {
-		enabled: config.enabled,
-		systemRules: config.systemRules ?? defaultSystemRulesConfig,
-		maxFileSizeMb: config.maxFileSizeMb,
-		allowedFileTypes: config.allowedFileTypes ?? defaultAllowedFileTypes,
-		piiAction: config.piiAction ?? "redact",
-	};
+			return {
+				enabled: config.enabled,
+				systemRules: config.systemRules ?? defaultSystemRulesConfig,
+				maxFileSizeMb: config.maxFileSizeMb,
+				allowedFileTypes: config.allowedFileTypes ?? defaultAllowedFileTypes,
+				piiAction: config.piiAction ?? "redact",
+			};
+		},
+	);
 }
 
 export async function checkGuardrails(
@@ -134,11 +146,16 @@ export async function checkGuardrails(
 	}
 
 	// Check custom rules
-	const customRules = await db
-		.select()
-		.from(guardrailRule)
-		.where(eq(guardrailRule.organizationId, input.organizationId))
-		.orderBy(desc(guardrailRule.priority));
+	const customRules = await swrWrap(
+		`guardrailRules:${input.organizationId}`,
+		[guardrailRuleTableName],
+		async () =>
+			await cdb
+				.select()
+				.from(guardrailRule)
+				.where(eq(guardrailRule.organizationId, input.organizationId))
+				.orderBy(desc(guardrailRule.priority)),
+	);
 
 	for (const rule of customRules) {
 		if (!rule.enabled) {

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./cache.js";
 export * from "./redis.js";
+export * from "./swr.js";

--- a/packages/cache/src/swr.spec.ts
+++ b/packages/cache/src/swr.spec.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { redisClient } from "./redis.js";
+import {
+	SWR_PREFIX,
+	SWR_TABLE_INDEX_PREFIX,
+	getSwrStaleTtlSeconds,
+	invalidateSwrByTables,
+	swrWrap,
+} from "./swr.js";
+
+describe("swrWrap", () => {
+	beforeEach(async () => {
+		await redisClient.flushdb();
+		delete process.env.SWR_STALE_TTL_SECONDS;
+	});
+
+	afterEach(async () => {
+		delete process.env.SWR_STALE_TTL_SECONDS;
+		await redisClient.flushdb();
+	});
+
+	it("returns fetcher value and writes to SWR mirror with configured TTL + table index", async () => {
+		const value = await swrWrap("test:key:1", ["table_a", "table_b"], () =>
+			Promise.resolve({ hello: "world" }),
+		);
+		expect(value).toEqual({ hello: "world" });
+
+		const mirror = await redisClient.get(`${SWR_PREFIX}test:key:1`);
+		expect(mirror).not.toBeNull();
+		expect(JSON.parse(mirror!)).toEqual({ hello: "world" });
+
+		const ttl = await redisClient.ttl(`${SWR_PREFIX}test:key:1`);
+		expect(ttl).toBeGreaterThan(0);
+		expect(ttl).toBeLessThanOrEqual(getSwrStaleTtlSeconds());
+
+		const membersA = await redisClient.smembers(
+			`${SWR_TABLE_INDEX_PREFIX}table_a`,
+		);
+		const membersB = await redisClient.smembers(
+			`${SWR_TABLE_INDEX_PREFIX}table_b`,
+		);
+		expect(membersA).toContain(`${SWR_PREFIX}test:key:1`);
+		expect(membersB).toContain(`${SWR_PREFIX}test:key:1`);
+	});
+
+	it("returns stale value when fetcher throws and mirror exists", async () => {
+		await swrWrap("test:key:stale", ["table_a"], () =>
+			Promise.resolve({ cached: true }),
+		);
+
+		const dbError = new Error("postgres unavailable");
+		const value = await swrWrap<{ cached: boolean }>(
+			"test:key:stale",
+			["table_a"],
+			() => Promise.reject(dbError),
+		);
+		expect(value).toEqual({ cached: true });
+	});
+
+	it("rethrows original error when fetcher fails and no mirror exists", async () => {
+		const dbError = new Error("postgres unavailable");
+		await expect(
+			swrWrap("test:key:never", ["table_a"], () => Promise.reject(dbError)),
+		).rejects.toBe(dbError);
+	});
+
+	it("encodes undefined via sentinel so missing row is distinguishable from missing mirror", async () => {
+		const primed = await swrWrap<{ id: string } | undefined>(
+			"test:key:undef",
+			["table_a"],
+			() => Promise.resolve(undefined),
+		);
+		expect(primed).toBeUndefined();
+
+		const mirror = await redisClient.get(`${SWR_PREFIX}test:key:undef`);
+		expect(mirror).not.toBeNull();
+
+		const dbError = new Error("postgres unavailable");
+		const fallback = await swrWrap<{ id: string } | undefined>(
+			"test:key:undef",
+			["table_a"],
+			() => Promise.reject(dbError),
+		);
+		expect(fallback).toBeUndefined();
+	});
+
+	it("invalidateSwrByTables wipes mirrors and cleans index", async () => {
+		await swrWrap("test:key:inv1", ["table_a"], () =>
+			Promise.resolve({ v: 1 }),
+		);
+		await swrWrap("test:key:inv2", ["table_a"], () =>
+			Promise.resolve({ v: 2 }),
+		);
+		await swrWrap("test:key:inv3", ["table_b"], () =>
+			Promise.resolve({ v: 3 }),
+		);
+
+		await invalidateSwrByTables(["table_a"]);
+
+		expect(await redisClient.get(`${SWR_PREFIX}test:key:inv1`)).toBeNull();
+		expect(await redisClient.get(`${SWR_PREFIX}test:key:inv2`)).toBeNull();
+		expect(await redisClient.get(`${SWR_PREFIX}test:key:inv3`)).not.toBeNull();
+
+		expect(await redisClient.exists(`${SWR_TABLE_INDEX_PREFIX}table_a`)).toBe(
+			0,
+		);
+	});
+
+	it("honors SWR_STALE_TTL_SECONDS env var", async () => {
+		process.env.SWR_STALE_TTL_SECONDS = "120";
+		expect(getSwrStaleTtlSeconds()).toBe(120);
+
+		await swrWrap("test:key:ttl", ["table_a"], () => Promise.resolve({ v: 1 }));
+		const ttl = await redisClient.ttl(`${SWR_PREFIX}test:key:ttl`);
+		expect(ttl).toBeGreaterThan(0);
+		expect(ttl).toBeLessThanOrEqual(120);
+	});
+});

--- a/packages/cache/src/swr.ts
+++ b/packages/cache/src/swr.ts
@@ -1,0 +1,155 @@
+import { logger } from "@llmgateway/logger";
+
+import { redisClient } from "./redis.js";
+
+export const SWR_PREFIX = "swr:";
+export const SWR_TABLE_INDEX_PREFIX = "swr:tables:";
+export const SWR_DEFAULT_TTL_SECONDS = 600;
+export const SWR_BATCH_SIZE = 500;
+
+const SWR_NONE_SENTINEL = "__swrNone" as const;
+
+interface SwrNoneSentinel {
+	[SWR_NONE_SENTINEL]: true;
+}
+
+function isNoneSentinel(value: unknown): value is SwrNoneSentinel {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		(value as Record<string, unknown>)[SWR_NONE_SENTINEL] === true
+	);
+}
+
+export function getSwrStaleTtlSeconds(): number {
+	const raw = process.env.SWR_STALE_TTL_SECONDS;
+	if (!raw) {
+		return SWR_DEFAULT_TTL_SECONDS;
+	}
+	const parsed = parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return SWR_DEFAULT_TTL_SECONDS;
+	}
+	return parsed;
+}
+
+function swrKey(key: string): string {
+	return SWR_PREFIX + key;
+}
+
+function tableIndexKey(table: string): string {
+	return SWR_TABLE_INDEX_PREFIX + table;
+}
+
+async function writeMirror<T>(
+	key: string,
+	tables: string[],
+	value: T,
+): Promise<void> {
+	try {
+		const ttl = getSwrStaleTtlSeconds();
+		const cacheKey = swrKey(key);
+		const payload =
+			value === undefined ? ({ [SWR_NONE_SENTINEL]: true } as const) : value;
+
+		const pipeline = redisClient.pipeline();
+		pipeline.set(cacheKey, JSON.stringify(payload), "EX", ttl);
+		for (const table of tables) {
+			const indexKey = tableIndexKey(table);
+			pipeline.sadd(indexKey, cacheKey);
+			pipeline.expire(indexKey, ttl + 60);
+		}
+		await pipeline.exec();
+	} catch (error) {
+		logger.error(
+			"Error writing SWR mirror",
+			error instanceof Error ? error : new Error(String(error)),
+			{ key },
+		);
+	}
+}
+
+async function readMirror<T>(
+	key: string,
+): Promise<{ hit: true; value: T } | { hit: false }> {
+	const cached = await redisClient.get(swrKey(key));
+	if (cached === null) {
+		return { hit: false };
+	}
+	const parsed = JSON.parse(cached);
+	if (isNoneSentinel(parsed)) {
+		return { hit: true, value: undefined as T };
+	}
+	return { hit: true, value: parsed as T };
+}
+
+export async function swrWrap<T>(
+	key: string,
+	tables: string[],
+	fetcher: () => Promise<T>,
+): Promise<T> {
+	let value: T;
+	try {
+		value = await fetcher();
+	} catch (error) {
+		try {
+			const result = await readMirror<T>(key);
+			if (result.hit) {
+				logger.warn("serving SWR stale fallback", { key });
+				return result.value;
+			}
+		} catch (redisError) {
+			logger.error(
+				"Error reading SWR mirror for fallback",
+				redisError instanceof Error
+					? redisError
+					: new Error(String(redisError)),
+				{ key },
+			);
+		}
+		throw error;
+	}
+
+	await writeMirror(key, tables, value);
+	return value;
+}
+
+export async function invalidateSwrByTables(tables: string[]): Promise<void> {
+	if (tables.length === 0) {
+		return;
+	}
+	try {
+		const allKeysToDelete = new Set<string>();
+		for (const table of tables) {
+			const members = await redisClient.smembers(tableIndexKey(table));
+			for (const member of members) {
+				allKeysToDelete.add(member);
+			}
+		}
+
+		if (allKeysToDelete.size === 0) {
+			for (const table of tables) {
+				await redisClient.del(tableIndexKey(table));
+			}
+			return;
+		}
+
+		const keysArray = Array.from(allKeysToDelete);
+		for (let i = 0; i < keysArray.length; i += SWR_BATCH_SIZE) {
+			const batch = keysArray.slice(i, i + SWR_BATCH_SIZE);
+			if (batch.length > 0) {
+				await redisClient.unlink(...batch);
+			}
+		}
+
+		for (const table of tables) {
+			await redisClient.del(tableIndexKey(table));
+		}
+	} catch (error) {
+		logger.error(
+			"Error invalidating SWR mirrors by tables",
+			error instanceof Error ? error : new Error(String(error)),
+			{ tables },
+		);
+	}
+}

--- a/packages/db/src/cache-helpers.ts
+++ b/packages/db/src/cache-helpers.ts
@@ -1,39 +1,48 @@
-import { eq } from "drizzle-orm";
+import { eq, getTableName } from "drizzle-orm";
 
+import { swrWrap } from "@llmgateway/cache";
 import { logger } from "@llmgateway/logger";
 
 import { cdb } from "./cdb.js";
 import { project as projectTable } from "./schema.js";
 
+const projectTableName = getTableName(projectTable);
+
 /**
  * Check if caching is enabled for a project.
  *
- * Uses the cached database client (cdb) which has Drizzle's cache layer,
- * so this query will be served from Redis cache when available.
+ * Uses the cached database client (cdb) plus swrWrap so the answer survives a
+ * Postgres outage (falls back to the last-known value for up to SWR TTL).
  */
 export async function isCachingEnabled(
 	projectId: string,
 ): Promise<{ enabled: boolean; duration: number }> {
 	try {
-		const results = await cdb
-			.select({
-				cachingEnabled: projectTable.cachingEnabled,
-				cacheDurationSeconds: projectTable.cacheDurationSeconds,
-			})
-			.from(projectTable)
-			.where(eq(projectTable.id, projectId))
-			.limit(1);
+		return await swrWrap(
+			`project:cachingEnabled:${projectId}`,
+			[projectTableName],
+			async () => {
+				const results = await cdb
+					.select({
+						cachingEnabled: projectTable.cachingEnabled,
+						cacheDurationSeconds: projectTable.cacheDurationSeconds,
+					})
+					.from(projectTable)
+					.where(eq(projectTable.id, projectId))
+					.limit(1);
 
-		const project = results[0];
+				const project = results[0];
 
-		if (!project) {
-			return { enabled: false, duration: 0 };
-		}
+				if (!project) {
+					return { enabled: false, duration: 0 };
+				}
 
-		return {
-			enabled: project.cachingEnabled || false,
-			duration: project.cacheDurationSeconds || 60,
-		};
+				return {
+					enabled: project.cachingEnabled || false,
+					duration: project.cacheDurationSeconds || 60,
+				};
+			},
+		);
 	} catch (error) {
 		logger.error("Error checking if caching is enabled:", error as Error);
 		throw error;

--- a/packages/db/src/provider-metrics.spec.ts
+++ b/packages/db/src/provider-metrics.spec.ts
@@ -1,6 +1,8 @@
 import { eq } from "drizzle-orm";
 import { describe, it, expect, beforeEach } from "vitest";
 
+import { redisClient } from "@llmgateway/cache";
+
 import { db } from "./db.js";
 import {
 	getProviderMetrics,
@@ -11,6 +13,7 @@ import { provider, model, modelProviderMapping } from "./schema.js";
 
 describe("provider-metrics", () => {
 	beforeEach(async () => {
+		await redisClient.flushdb();
 		await db.delete(modelProviderMapping);
 		await db.delete(model);
 		await db.delete(provider);

--- a/packages/db/src/provider-metrics.ts
+++ b/packages/db/src/provider-metrics.ts
@@ -1,6 +1,8 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { eq, getTableName } from "drizzle-orm";
 
-import { db } from "./db.js";
+import { swrWrap } from "@llmgateway/cache";
+
+import { cdb } from "./cdb.js";
 import { modelProviderMapping } from "./schema.js";
 
 export interface ProviderMetrics {
@@ -24,6 +26,57 @@ export function metricsKey(
 	return `${modelId}:${providerId}:${region ?? ""}`;
 }
 
+const modelProviderMappingTableName = getTableName(modelProviderMapping);
+
+interface ProviderMetricsRow {
+	modelId: string;
+	providerId: string;
+	region: string | null;
+	routingUptime: number | null;
+	routingLatency: number | null;
+	routingThroughput: number | null;
+	routingTotalRequests: number | null;
+}
+
+async function fetchAllProviderMetricsRows(): Promise<ProviderMetricsRow[]> {
+	return await swrWrap(
+		"providerMetrics:allActive",
+		[modelProviderMappingTableName],
+		async () =>
+			await cdb
+				.select({
+					modelId: modelProviderMapping.modelId,
+					providerId: modelProviderMapping.providerId,
+					region: modelProviderMapping.region,
+					routingUptime: modelProviderMapping.routingUptime,
+					routingLatency: modelProviderMapping.routingLatency,
+					routingThroughput: modelProviderMapping.routingThroughput,
+					routingTotalRequests: modelProviderMapping.routingTotalRequests,
+				})
+				.from(modelProviderMapping)
+				.where(eq(modelProviderMapping.status, "active")),
+	);
+}
+
+function rowToMetrics(row: ProviderMetricsRow): ProviderMetrics | undefined {
+	if (
+		row.routingTotalRequests === null ||
+		row.routingTotalRequests === undefined ||
+		row.routingTotalRequests <= 0
+	) {
+		return undefined;
+	}
+	return {
+		providerId: row.providerId,
+		modelId: row.modelId,
+		region: row.region ?? undefined,
+		uptime: row.routingUptime ?? undefined,
+		averageLatency: row.routingLatency ?? undefined,
+		throughput: row.routingThroughput ?? undefined,
+		totalRequests: row.routingTotalRequests,
+	};
+}
+
 /**
  * Fetches pre-computed routing metrics for all model-provider mappings.
  * Metrics are computed by the worker with time-tier weighting
@@ -34,51 +87,25 @@ export function metricsKey(
 export async function getProviderMetrics(): Promise<
 	Map<string, ProviderMetrics>
 > {
-	const results = await db
-		.select({
-			modelId: modelProviderMapping.modelId,
-			providerId: modelProviderMapping.providerId,
-			region: modelProviderMapping.region,
-			routingUptime: modelProviderMapping.routingUptime,
-			routingLatency: modelProviderMapping.routingLatency,
-			routingThroughput: modelProviderMapping.routingThroughput,
-			routingTotalRequests: modelProviderMapping.routingTotalRequests,
-		})
-		.from(modelProviderMapping)
-		.where(eq(modelProviderMapping.status, "active"));
-
+	const rows = await fetchAllProviderMetricsRows();
 	const metricsMap = new Map<string, ProviderMetrics>();
-
-	for (const row of results) {
-		if (
-			row.routingTotalRequests === null ||
-			row.routingTotalRequests === undefined ||
-			row.routingTotalRequests <= 0
-		) {
+	for (const row of rows) {
+		const metrics = rowToMetrics(row);
+		if (!metrics) {
 			continue;
 		}
-
-		const key = metricsKey(row.modelId, row.providerId, row.region);
-		metricsMap.set(key, {
-			providerId: row.providerId,
-			modelId: row.modelId,
-			region: row.region ?? undefined,
-			uptime: row.routingUptime ?? undefined,
-			averageLatency: row.routingLatency ?? undefined,
-			throughput: row.routingThroughput ?? undefined,
-			totalRequests: row.routingTotalRequests,
-		});
+		metricsMap.set(
+			metricsKey(row.modelId, row.providerId, row.region),
+			metrics,
+		);
 	}
-
 	return metricsMap;
 }
 
 /**
  * Fetches pre-computed routing metrics for specific model-provider combinations.
- * More efficient when you only need metrics for a subset of providers.
- *
- * Metrics are computed by the worker with time-tier weighting
- * (last 1 min = 10x, last 5 min = 3x, last hour = 1x).
+ * Uses the same cached "all active mappings" query as getProviderMetrics so
+ * every request hits a single SWR mirror that survives Postgres outages.
  *
  * @param combinations - Array of {modelId, providerId, region?} to fetch metrics for
  * @returns Map of "modelId:providerId:region" to metrics
@@ -94,56 +121,25 @@ export async function getProviderMetricsForCombinations(
 		return new Map();
 	}
 
-	// Build OR conditions for each combination
-	const conditions = combinations.map((combo) =>
-		and(
-			sql`${modelProviderMapping.modelId} = ${combo.modelId}`,
-			sql`${modelProviderMapping.providerId} = ${combo.providerId}`,
-			combo.region
-				? sql`${modelProviderMapping.region} = ${combo.region}`
-				: isNull(modelProviderMapping.region),
+	const wanted = new Set(
+		combinations.map((combo) =>
+			metricsKey(combo.modelId, combo.providerId, combo.region ?? null),
 		),
 	);
 
-	const results = await db
-		.select({
-			modelId: modelProviderMapping.modelId,
-			providerId: modelProviderMapping.providerId,
-			region: modelProviderMapping.region,
-			routingUptime: modelProviderMapping.routingUptime,
-			routingLatency: modelProviderMapping.routingLatency,
-			routingThroughput: modelProviderMapping.routingThroughput,
-			routingTotalRequests: modelProviderMapping.routingTotalRequests,
-		})
-		.from(modelProviderMapping)
-		.where(
-			and(
-				eq(modelProviderMapping.status, "active"),
-				sql`(${sql.join(conditions, sql` OR `)})`,
-			),
-		);
-
+	const rows = await fetchAllProviderMetricsRows();
 	const metricsMap = new Map<string, ProviderMetrics>();
 
-	for (const row of results) {
-		if (
-			row.routingTotalRequests === null ||
-			row.routingTotalRequests === undefined ||
-			row.routingTotalRequests <= 0
-		) {
+	for (const row of rows) {
+		const key = metricsKey(row.modelId, row.providerId, row.region);
+		if (!wanted.has(key)) {
 			continue;
 		}
-
-		const key = metricsKey(row.modelId, row.providerId, row.region);
-		metricsMap.set(key, {
-			providerId: row.providerId,
-			modelId: row.modelId,
-			region: row.region ?? undefined,
-			uptime: row.routingUptime ?? undefined,
-			averageLatency: row.routingLatency ?? undefined,
-			throughput: row.routingThroughput ?? undefined,
-			totalRequests: row.routingTotalRequests,
-		});
+		const metrics = rowToMetrics(row);
+		if (!metrics) {
+			continue;
+		}
+		metricsMap.set(key, metrics);
 	}
 
 	return metricsMap;

--- a/packages/db/src/redis-cache.ts
+++ b/packages/db/src/redis-cache.ts
@@ -1,5 +1,6 @@
 import { Cache, type MutationOption } from "drizzle-orm/cache/core";
 
+import { invalidateSwrByTables } from "@llmgateway/cache";
 import { logger } from "@llmgateway/logger";
 
 import type { Redis } from "ioredis";
@@ -147,6 +148,11 @@ export class RedisCache extends Cache {
 			// Invalidate all cache entries related to these tables
 			if (tables.length > 0) {
 				await this.invalidateByTables(tables);
+			}
+
+			// Invalidate SWR fallback mirrors for these tables
+			if (tables.length > 0) {
+				await invalidateSwrByTables(tables);
 			}
 
 			logger.trace("Cache invalidated on mutation", { tables, tags });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)
       '@hono/node-server':
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.7)
@@ -139,7 +139,7 @@ importers:
         version: 0.7.2(hono@4.12.7)(zod@3.25.75)
       '@kubiks/otel-better-auth':
         specifier: 2.0.2
-        version: 2.0.2(@opentelemetry/api@1.9.0)(better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))
+        version: 2.0.2(@opentelemetry/api@1.9.0)(better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))
       '@llmgateway/actions':
         specifier: workspace:*
         version: link:../../packages/actions
@@ -181,7 +181,7 @@ importers:
         version: 8.0.0
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       disposable-email-domains-js:
         specifier: 1.20.0
         version: 1.20.0
@@ -229,7 +229,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.5))(zod@3.25.76)
@@ -286,7 +286,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -359,7 +359,7 @@ importers:
         version: 9.38.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       openapi-typescript:
         specifier: 7.10.1
         version: 7.10.1(typescript@5.9.3)
@@ -386,16 +386,16 @@ importers:
         version: 0.7.1
       fumadocs-core:
         specifier: 16.7.10
-        version: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+        version: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 13.0.8
-        version: 13.0.8(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.1.11(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 13.0.8(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.1.11(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       fumadocs-openapi:
         specifier: 10.6.6
-        version: 10.6.6(aea6ff7c084c185ecbd4835b266d43bd)
+        version: 10.6.6(8c39e5a8505b160f8e8fc5d2897135e3)
       fumadocs-ui:
         specifier: 16.7.10
-        version: 16.7.10(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.22.0)(tailwindcss@4.1.16)
+        version: 16.7.10(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.22.0)(tailwindcss@4.1.16)
       gateway:
         specifier: workspace:*
         version: link:../gateway
@@ -543,7 +543,7 @@ importers:
         version: 3.0.29(react@19.2.5)(zod@3.25.76)
       '@better-auth/passkey':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.5))(zod@3.25.76)
@@ -642,7 +642,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -748,7 +748,7 @@ importers:
         version: 9.38.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       openapi-typescript:
         specifier: 7.10.1
         version: 7.10.1(typescript@5.9.3)
@@ -772,13 +772,13 @@ importers:
         version: 3.0.29(react@19.2.5)(zod@3.25.75)
       '@better-auth/passkey':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)
       '@content-collections/core':
         specifier: 0.11.1
         version: 0.11.1(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.9
-        version: 0.2.9(@content-collections/core@0.11.1(typescript@5.9.3))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 0.2.9(@content-collections/core@0.11.1(typescript@5.9.3))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.5))(zod@3.25.75)
@@ -892,7 +892,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -1121,7 +1121,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -1231,6 +1231,9 @@ importers:
 
   ee/guardrails:
     dependencies:
+      '@llmgateway/cache':
+        specifier: workspace:*
+        version: link:../../packages/cache
       '@llmgateway/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -2362,105 +2365,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2593,28 +2580,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -3957,79 +3940,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -4350,28 +4320,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.16':
     resolution: {integrity: sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.16':
     resolution: {integrity: sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.16':
     resolution: {integrity: sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.16':
     resolution: {integrity: sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==}
@@ -4856,49 +4822,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -7920,28 +7878,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -11296,7 +11250,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11370,7 +11324,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11400,11 +11354,6 @@ snapshots:
       kysely: 0.28.12
       nanostores: 1.2.0
       zod: 4.3.6
-
-  '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
-      '@better-auth/utils': 0.3.1
 
   '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))':
     dependencies:
@@ -11452,38 +11401,26 @@ snapshots:
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0
 
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)':
+  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+      better-auth: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       better-call: 1.3.2(zod@3.25.75)
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.75))(nanostores@1.2.0)':
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@simplewebauthn/browser': 13.2.2
-      '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
-      better-call: 1.3.2(zod@3.25.75)
-      nanostores: 1.2.0
-      zod: 4.3.6
-
-  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)':
+  '@better-auth/passkey@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+      better-auth: 1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
       better-call: 1.3.2(zod@3.25.76)
       nanostores: 1.2.0
       zod: 4.3.6
@@ -11670,7 +11607,7 @@ snapshots:
     dependencies:
       '@content-collections/core': 0.11.1(typescript@5.9.3)
 
-  '@content-collections/next@0.2.9(@content-collections/core@0.11.1(typescript@5.9.3))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@content-collections/next@0.2.9(@content-collections/core@0.11.1(typescript@5.9.3))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@content-collections/core': 0.11.1(typescript@5.9.3)
       '@content-collections/integrations': 0.3.0(@content-collections/core@0.11.1(typescript@5.9.3))
@@ -11863,7 +11800,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11884,7 +11821,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -12229,10 +12166,10 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
-  '@kubiks/otel-better-auth@2.0.2(@opentelemetry/api@1.9.0)(better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))':
+  '@kubiks/otel-better-auth@2.0.2(@opentelemetry/api@1.9.0)(better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)))':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      better-auth: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
+      better-auth: 1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1))
 
   '@kubiks/otel-drizzle@2.0.3(@opentelemetry/api@1.9.0)(drizzle-orm@1.0.0-beta.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/mssql@9.1.8(@azure/core-client@1.10.1))(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.3)(sql.js@1.13.0))':
     dependencies:
@@ -14605,7 +14542,7 @@ snapshots:
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       import-from-esm: 2.0.0
       lodash-es: 4.17.21
       micromatch: 4.0.8
@@ -14619,7 +14556,7 @@ snapshots:
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       execa: 9.6.1
       lodash-es: 4.17.21
       parse-json: 8.3.0
@@ -14635,7 +14572,7 @@ snapshots:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       dir-glob: 3.0.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -14672,7 +14609,7 @@ snapshots:
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       get-stream: 7.0.1
       import-from-esm: 2.0.0
       into-stream: 7.0.0
@@ -15320,7 +15257,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.38.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -15332,7 +15269,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.56.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.38.0(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -15342,7 +15279,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -15351,7 +15288,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.56.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -15379,7 +15316,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.38.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -15391,7 +15328,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.2)
       '@typescript-eslint/utils': 8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.38.0(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -15408,7 +15345,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.2
       '@typescript-eslint/visitor-keys': 8.46.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -15424,7 +15361,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.5
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -15613,7 +15550,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15847,7 +15784,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
+  better-auth@1.5.5(better-sqlite3@12.6.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.5)(better-sqlite3@12.6.0)(gel@2.1.0)(kysely@0.28.12)(pg@8.16.3)(sql.js@1.13.0))
@@ -15878,7 +15815,7 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
-  better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
+  better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
@@ -15905,36 +15842,6 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 4.0.5(@types/debug@4.1.12)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-
-  better-auth@1.5.5(better-sqlite3@12.6.0)(mongodb@7.1.0)(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.16.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)
-      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.75))(jose@6.1.3)(kysely@0.28.12)(nanostores@1.2.0))
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
-      defu: 6.1.4
-      jose: 6.1.3
-      kysely: 0.28.12
-      nanostores: 1.2.0
-      zod: 4.3.6
-    optionalDependencies:
-      better-sqlite3: 12.6.0
-      mongodb: 7.1.0
-      next: 16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      pg: 8.16.3
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.0.5(@types/debug@4.1.12)(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
@@ -16002,7 +15909,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -16640,10 +16547,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -17021,7 +16924,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
@@ -17070,7 +16973,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@2.6.1))
@@ -17090,7 +16993,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@2.6.1))
@@ -17120,10 +17023,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.38.0(jiti@2.6.1)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -17135,24 +17038,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.38.0(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.13.0
@@ -17165,25 +17053,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -17222,7 +17110,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -17251,7 +17139,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -17489,7 +17377,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -17657,7 +17545,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -17791,7 +17679,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -17917,7 +17805,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6):
+  fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@orama/orama': 3.1.18
@@ -17956,14 +17844,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@13.0.8(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.1.11(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
+  fumadocs-mdx@13.0.8(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(vite@7.1.11(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 4.0.3
       esbuild: 0.25.12
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-core: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       js-yaml: 4.1.0
       lru-cache: 11.2.2
       mdast-util-to-markdown: 2.1.2
@@ -17983,7 +17871,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-openapi@10.6.6(aea6ff7c084c185ecbd4835b266d43bd):
+  fumadocs-openapi@10.6.6(8c39e5a8505b160f8e8fc5d2897135e3):
     dependencies:
       '@fastify/deepmerge': 3.2.1
       '@fumari/json-schema-ts': 0.0.2(json-schema-typed@8.0.2)
@@ -17997,8 +17885,8 @@ snapshots:
       ajv: 8.18.0
       chokidar: 5.0.0
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
-      fumadocs-ui: 16.7.10(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.22.0)(tailwindcss@4.1.16)
+      fumadocs-core: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-ui: 16.7.10(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.22.0)(tailwindcss@4.1.16)
       github-slugger: 2.0.0
       hast-util-to-jsx-runtime: 2.3.6
       js-yaml: 4.1.1
@@ -18020,7 +17908,7 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  fumadocs-ui@16.7.10(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.22.0)(tailwindcss@4.1.16):
+  fumadocs-ui@16.7.10(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.22.0)(tailwindcss@4.1.16):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.1.16)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18034,7 +17922,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      fumadocs-core: 16.7.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.544.0(react@19.2.5))(next@16.2.3(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       lucide-react: 1.7.0(react@19.2.5)
       motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -18094,7 +17982,7 @@ snapshots:
   gel@2.1.0:
     dependencies:
       '@petamoriken/float16': 3.9.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       env-paths: 3.0.0
       semver: 7.7.4
       shell-quote: 1.8.3
@@ -18527,28 +18415,28 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18596,7 +18484,7 @@ snapshots:
 
   import-from-esm@2.0.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
@@ -18654,7 +18542,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.3.1
       cluster-key-slot: 1.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -19081,7 +18969,7 @@ snapshots:
     dependencies:
       chalk: 5.6.0
       commander: 13.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       lilconfig: 3.1.3
       listr2: 8.3.3
       micromatch: 4.0.8
@@ -19749,7 +19637,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -19875,7 +19763,7 @@ snapshots:
     dependencies:
       '@tediousjs/connection-string': 0.5.0
       commander: 11.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       rfdc: 1.4.1
       tarn: 3.0.2
       tedious: 18.6.2(@azure/core-client@1.10.1)
@@ -21075,7 +20963,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -21201,7 +21089,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -21269,7 +21157,7 @@ snapshots:
 
   semantic-release-monorepo@8.0.2(semantic-release@24.2.9(typescript@5.9.2)):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       execa: 5.1.1
       file-url: 3.0.0
       fs-extra: 10.1.0
@@ -21299,7 +21187,7 @@ snapshots:
       '@semantic-release/release-notes-generator': 14.1.0(semantic-release@24.2.9(typescript@5.9.2))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.9.2)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       env-ci: 11.2.0
       execa: 9.6.1
       figures: 6.1.0
@@ -21341,7 +21229,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -22423,7 +22311,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.1.11(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.40.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.9.2)
     optionalDependencies:
@@ -22476,7 +22364,7 @@ snapshots:
       '@vitest/snapshot': 4.0.5
       '@vitest/spy': 4.0.5
       '@vitest/utils': 4.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21
@@ -22515,7 +22403,7 @@ snapshots:
       '@vitest/snapshot': 4.0.5
       '@vitest/spy': 4.0.5
       '@vitest/utils': 4.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21


### PR DESCRIPTION
## Summary
- Adds a Redis-backed stale-while-revalidate layer above the existing Drizzle 60s cache (`packages/cache/src/swr.ts`): `swrWrap` mirrors successful reads at `swr:{key}` (TTL via `SWR_STALE_TTL_SECONDS`, default 600s) and serves the mirror when the fetcher throws, so chat DB reads survive up to 10 minutes of Postgres unavailability.
- Wraps every read in `apps/gateway/src/lib/cached-queries.ts` and both guardrail reads in `ee/guardrails/src/engine.ts` (also switched from `db` to `cdb` to benefit from Drizzle's cache). API key tokens are hashed (SHA-256) before being used as cache keys.
- Hooks SWR invalidation into `RedisCache.onMutate` so table-level mutations wipe the mirror in lockstep with Drizzle's own invalidation.

## Test plan
- [x] `pnpm build` (all apps + packages)
- [x] `pnpm format` / `pnpm lint`
- [x] `vitest run packages/cache/src/swr.spec.ts` — success path, stale fallback, undefined sentinel, invalidate-by-tables, env-var TTL
- [x] `vitest run apps/gateway/src/lib/cached-queries-swr.spec.ts` — mirror priming for each wrapped query, DB-failure fallback, zero-credit org path, post-TTL rethrow, mutation-driven invalidation
- [x] `vitest run packages/db/src/cdb-resilience.spec.ts` — pre-existing regression check
- [x] Full `pnpm test:unit` green (951 passed, 2 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broad SWR (stale-while-revalidate) caching for database reads to improve resilience and reduce DB load; mirrors survive transient DB outages.
  * API key lookups use fingerprinted tokens; provider-key queries are order-independent.
  * Cache package now exposes SWR utilities and cache invalidation clears SWR mirrors on related data changes.

* **Tests**
  * New comprehensive tests for SWR mirroring, TTLs, stale-fallback behavior, and table-based invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->