### PR TITLE
feat: split bluestone think-tag reasoning

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -148,6 +148,8 @@ export const deepseekModels = [
 				maxOutput: 32768,
 				jsonOutput: true,
 				streaming: true,
+				reasoning: true,
+				splitTaggedReasoning: true,
 				vision: false,
 				tools: true,
 			},


### PR DESCRIPTION
## Summary
- Enable `<think>`-tag reasoning extraction for bluestone's deepseek-v3.2 by setting `reasoning: true` and `splitTaggedReasoning: true`, routing it through the existing tagged-reasoning pipeline for both streaming and non-streaming responses.

## Test plan
- [ ] `TEST_MODELS="deepseek/deepseek-v3.2" pnpm test:e2e` (bluestone provider variant)
- [ ] Manually verify a bluestone response emitting `<think>...</think>` has reasoning split into `reasoning_content` / `delta.reasoning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Enabled advanced reasoning capabilities for the deepseek-v3.2 model with improved reasoning output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->