### PR TITLE
feat: playground, admin, ui polish

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -398,9 +398,12 @@ admin.openapi(getMetrics, async (c) => {
 	const { from, to } = query;
 
 	let startDate: Date | null = null;
+	let endDate: Date | null = null;
 	if (from && to) {
 		startDate = new Date(from + "T00:00:00");
 		startDate.setUTCHours(0, 0, 0, 0);
+		endDate = new Date(to + "T23:59:59");
+		endDate.setUTCHours(23, 59, 59, 999);
 	} else {
 		const range = query.range ?? "all";
 		const rangeDays: Record<string, number | null> = {
@@ -418,13 +421,50 @@ admin.openapi(getMetrics, async (c) => {
 		}
 	}
 
+	const userDateFilter =
+		startDate && endDate
+			? and(
+					gte(tables.user.createdAt, startDate),
+					lte(tables.user.createdAt, endDate),
+				)
+			: startDate
+				? gte(tables.user.createdAt, startDate)
+				: undefined;
+	const transactionDateFilter =
+		startDate && endDate
+			? and(
+					gte(tables.transaction.createdAt, startDate),
+					lte(tables.transaction.createdAt, endDate),
+				)
+			: startDate
+				? gte(tables.transaction.createdAt, startDate)
+				: undefined;
+	const orgDateFilter =
+		startDate && endDate
+			? and(
+					gte(tables.organization.createdAt, startDate),
+					lte(tables.organization.createdAt, endDate),
+				)
+			: startDate
+				? gte(tables.organization.createdAt, startDate)
+				: undefined;
+	const projectStatsDateFilter =
+		startDate && endDate
+			? and(
+					gte(projectHourlyStats.hourTimestamp, startDate),
+					lte(projectHourlyStats.hourTimestamp, endDate),
+				)
+			: startDate
+				? gte(projectHourlyStats.hourTimestamp, startDate)
+				: undefined;
+
 	// Total signups
 	const [signupsRow] = await db
 		.select({
 			count: sql<number>`COUNT(*)`.as("count"),
 		})
 		.from(tables.user)
-		.where(startDate ? gte(tables.user.createdAt, startDate) : undefined);
+		.where(userDateFilter);
 
 	const totalSignups = Number(signupsRow?.count ?? 0);
 
@@ -434,14 +474,7 @@ admin.openapi(getMetrics, async (c) => {
 			count: sql<number>`COUNT(*)`.as("count"),
 		})
 		.from(tables.user)
-		.where(
-			startDate
-				? and(
-						eq(tables.user.emailVerified, true),
-						gte(tables.user.createdAt, startDate),
-					)
-				: eq(tables.user.emailVerified, true),
-		);
+		.where(and(eq(tables.user.emailVerified, true), userDateFilter));
 
 	const verifiedUsers = Number(verifiedRow?.count ?? 0);
 
@@ -455,12 +488,7 @@ admin.openapi(getMetrics, async (c) => {
 		})
 		.from(tables.transaction)
 		.where(
-			startDate
-				? and(
-						eq(tables.transaction.status, "completed"),
-						gte(tables.transaction.createdAt, startDate),
-					)
-				: eq(tables.transaction.status, "completed"),
+			and(eq(tables.transaction.status, "completed"), transactionDateFilter),
 		);
 
 	const payingCustomers = Number(payingRow?.count ?? 0);
@@ -475,16 +503,11 @@ admin.openapi(getMetrics, async (c) => {
 		})
 		.from(tables.transaction)
 		.where(
-			startDate
-				? and(
-						eq(tables.transaction.status, "completed"),
-						ne(tables.transaction.type, "credit_gift"),
-						gte(tables.transaction.createdAt, startDate),
-					)
-				: and(
-						eq(tables.transaction.status, "completed"),
-						ne(tables.transaction.type, "credit_gift"),
-					),
+			and(
+				eq(tables.transaction.status, "completed"),
+				ne(tables.transaction.type, "credit_gift"),
+				transactionDateFilter,
+			),
 		);
 
 	const totalRevenue = Number(revenueRow?.value ?? 0);
@@ -495,9 +518,7 @@ admin.openapi(getMetrics, async (c) => {
 			count: sql<number>`COUNT(*)`.as("count"),
 		})
 		.from(tables.organization)
-		.where(
-			startDate ? gte(tables.organization.createdAt, startDate) : undefined,
-		);
+		.where(orgDateFilter);
 
 	const totalOrganizations = Number(orgsRow?.count ?? 0);
 
@@ -511,12 +532,7 @@ admin.openapi(getMetrics, async (c) => {
 		})
 		.from(tables.transaction)
 		.where(
-			startDate
-				? and(
-						eq(tables.transaction.status, "completed"),
-						gte(tables.transaction.createdAt, startDate),
-					)
-				: eq(tables.transaction.status, "completed"),
+			and(eq(tables.transaction.status, "completed"), transactionDateFilter),
 		);
 
 	const totalToppedUp = Number(toppedUpRow?.value ?? 0);
@@ -530,9 +546,7 @@ admin.openapi(getMetrics, async (c) => {
 				),
 		})
 		.from(projectHourlyStats)
-		.where(
-			startDate ? gte(projectHourlyStats.hourTimestamp, startDate) : undefined,
-		);
+		.where(projectStatsDateFilter);
 
 	const totalSpent = Number(spentRow?.value ?? 0);
 
@@ -546,16 +560,11 @@ admin.openapi(getMetrics, async (c) => {
 		})
 		.from(tables.transaction)
 		.where(
-			startDate
-				? and(
-						eq(tables.transaction.status, "completed"),
-						ne(tables.transaction.type, "credit_gift"),
-						gte(tables.transaction.createdAt, startDate),
-					)
-				: and(
-						eq(tables.transaction.status, "completed"),
-						ne(tables.transaction.type, "credit_gift"),
-					),
+			and(
+				eq(tables.transaction.status, "completed"),
+				ne(tables.transaction.type, "credit_gift"),
+				transactionDateFilter,
+			),
 		);
 
 	const totalProcessed = Number(processedRow?.value ?? 0);

--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -14,6 +14,7 @@ import { cookies } from "next/headers";
 import { z } from "zod";
 
 import { getUser } from "@/lib/getUser";
+import { getModelImageConfig } from "@/lib/image-gen";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 
@@ -259,6 +260,25 @@ interface McpServerConfig {
 	enabled: boolean;
 }
 
+interface ImageFilePart {
+	type: "file";
+	url: string;
+	mediaType: string;
+}
+
+function isImageFilePart(value: unknown): value is ImageFilePart {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const v = value as Record<string, unknown>;
+	return (
+		v.type === "file" &&
+		typeof v.url === "string" &&
+		typeof v.mediaType === "string" &&
+		v.mediaType.startsWith("image/")
+	);
+}
+
 interface ChatRequestBody {
 	messages: UIMessage[];
 	model?: string;
@@ -373,6 +393,8 @@ export async function POST(req: Request) {
 	// Use generateImage for image generation models in chat mode
 	if (is_image_gen) {
 		try {
+			const maxInputImages = getModelImageConfig(selectedModel).maxInputImages;
+
 			const lastUserMessage = [...messages]
 				.reverse()
 				.find((m) => m.role === "user");
@@ -387,13 +409,10 @@ export async function POST(req: Request) {
 						.map((p) => p.text)
 						.join("\n");
 					for (const p of lastUserMessage.parts) {
-						if (
-							p.type === "file" &&
-							"url" in p &&
-							typeof p.url === "string" &&
-							"mediaType" in p &&
-							typeof p.mediaType === "string"
-						) {
+						if (fileParts.length >= maxInputImages) {
+							break;
+						}
+						if (isImageFilePart(p)) {
 							fileParts.push({
 								url: p.url,
 								mediaType: p.mediaType,
@@ -413,27 +432,17 @@ export async function POST(req: Request) {
 						(m) =>
 							m.role === "assistant" &&
 							Array.isArray(m.parts) &&
-							m.parts.some(
-								(p: any) =>
-									p?.type === "file" &&
-									typeof p?.url === "string" &&
-									typeof p?.mediaType === "string" &&
-									p.mediaType.startsWith("image/"),
-							),
+							m.parts.some(isImageFilePart),
 					);
 				if (
 					lastAssistantWithImage &&
 					Array.isArray(lastAssistantWithImage.parts)
 				) {
 					for (const p of lastAssistantWithImage.parts) {
-						if (
-							p.type === "file" &&
-							"url" in p &&
-							typeof p.url === "string" &&
-							"mediaType" in p &&
-							typeof p.mediaType === "string" &&
-							p.mediaType.startsWith("image/")
-						) {
+						if (fileParts.length >= maxInputImages) {
+							break;
+						}
+						if (isImageFilePart(p)) {
 							fileParts.push({
 								url: p.url,
 								mediaType: p.mediaType,

--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -403,6 +403,46 @@ export async function POST(req: Request) {
 				}
 			}
 
+			// If the current user message did not upload any images, fall back to
+			// the most recent assistant-generated image(s) so that follow-up prompts
+			// can edit the previously generated output.
+			if (fileParts.length === 0) {
+				const lastAssistantWithImage = [...messages]
+					.reverse()
+					.find(
+						(m) =>
+							m.role === "assistant" &&
+							Array.isArray(m.parts) &&
+							m.parts.some(
+								(p: any) =>
+									p?.type === "file" &&
+									typeof p?.url === "string" &&
+									typeof p?.mediaType === "string" &&
+									p.mediaType.startsWith("image/"),
+							),
+					);
+				if (
+					lastAssistantWithImage &&
+					Array.isArray(lastAssistantWithImage.parts)
+				) {
+					for (const p of lastAssistantWithImage.parts) {
+						if (
+							p.type === "file" &&
+							"url" in p &&
+							typeof p.url === "string" &&
+							"mediaType" in p &&
+							typeof p.mediaType === "string" &&
+							p.mediaType.startsWith("image/")
+						) {
+							fileParts.push({
+								url: p.url,
+								mediaType: p.mediaType,
+							});
+						}
+					}
+				}
+			}
+
 			if (!prompt.trim()) {
 				return new Response(
 					JSON.stringify({ error: "Missing prompt for image generation" }),

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -758,11 +758,11 @@ export default function ChatPageClient({
 			);
 			for (const result of results) {
 				if (result.status === "rejected") {
-					// Don't surface comparison errors as hard failures
-					console.warn(
-						"Failed to mirror prompt to comparison window",
-						result.reason,
-					);
+					// Don't surface comparison errors as hard failures;
+					// capture as telemetry instead of logging to console.
+					posthog.capture("playground_mirror_prompt_failure", {
+						reason: String(result.reason),
+					});
 				}
 			}
 		}

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -753,15 +753,15 @@ export default function ChatPageClient({
 		// submitted prompt into each extra window as a separate user message.
 		if (syncInput) {
 			const submitFns = Object.values(extraSubmitRefs.current);
-			for (const submit of submitFns) {
-				try {
-					await submit(content);
-				} catch (mirrorError) {
+			const results = await Promise.allSettled(
+				submitFns.map((submit) => submit(content)),
+			);
+			for (const result of results) {
+				if (result.status === "rejected") {
 					// Don't surface comparison errors as hard failures
-
 					console.warn(
 						"Failed to mirror prompt to comparison window",
-						mirrorError,
+						result.reason,
 					);
 				}
 			}

--- a/apps/playground/src/components/playground/image-controls.tsx
+++ b/apps/playground/src/components/playground/image-controls.tsx
@@ -24,8 +24,6 @@ import { getModelImageConfig } from "@/lib/image-gen";
 
 import type { AspectRatio } from "@/lib/image-gen";
 
-const MAX_INPUT_IMAGES = 4;
-
 interface InputImage {
 	dataUrl: string;
 	mediaType: string;
@@ -96,6 +94,7 @@ export function ImageControls({
 	// Derive config from first selected model (settings apply globally)
 	const primaryModel = selectedModels[0] ?? "";
 	const config = getModelImageConfig(primaryModel);
+	const maxInputImages = config.maxInputImages;
 
 	const addImageFile = useCallback(
 		(file: File) => {
@@ -108,7 +107,7 @@ export function ImageControls({
 			const reader = new FileReader();
 			reader.onload = () => {
 				setInputImages((prev) => {
-					if (prev.length >= MAX_INPUT_IMAGES) {
+					if (prev.length >= maxInputImages) {
 						return prev;
 					}
 					return [
@@ -134,7 +133,7 @@ export function ImageControls({
 	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const files = Array.from(e.target.files ?? []);
 		for (const file of files) {
-			if (inputImages.length >= MAX_INPUT_IMAGES) {
+			if (inputImages.length >= maxInputImages) {
 				break;
 			}
 			addImageFile(file);
@@ -146,7 +145,7 @@ export function ImageControls({
 	// Paste handler for images
 	const handlePaste = useCallback(
 		(e: React.ClipboardEvent) => {
-			if (!isEditModel || inputImages.length >= MAX_INPUT_IMAGES) {
+			if (!isEditModel || inputImages.length >= maxInputImages) {
 				return;
 			}
 			const items = Array.from(e.clipboardData.items);
@@ -169,7 +168,7 @@ export function ImageControls({
 		(e: React.DragEvent) => {
 			e.preventDefault();
 			e.stopPropagation();
-			if (isEditModel && inputImages.length < MAX_INPUT_IMAGES) {
+			if (isEditModel && inputImages.length < maxInputImages) {
 				setIsDragging(true);
 			}
 		},
@@ -193,7 +192,7 @@ export function ImageControls({
 			e.preventDefault();
 			e.stopPropagation();
 			setIsDragging(false);
-			if (!isEditModel || inputImages.length >= MAX_INPUT_IMAGES) {
+			if (!isEditModel || inputImages.length >= maxInputImages) {
 				return;
 			}
 			const files = Array.from(e.dataTransfer.files);
@@ -213,6 +212,14 @@ export function ImageControls({
 		return () => window.removeEventListener("dragend", handleWindowDragEnd);
 	}, []);
 
+	// Trim attached images if the selected model's per-model upload limit
+	// is lower than the number of currently attached images.
+	useEffect(() => {
+		setInputImages((prev) =>
+			prev.length > maxInputImages ? prev.slice(0, maxInputImages) : prev,
+		);
+	}, [maxInputImages, setInputImages]);
+
 	const removeImage = (index: number) => {
 		setInputImages((prev) => prev.filter((_, i) => i !== index));
 	};
@@ -231,14 +238,12 @@ export function ImageControls({
 						isDragging ? "border-primary bg-primary/5 ring-1 ring-primary" : ""
 					}`}
 				>
-					{isDragging &&
-						isEditModel &&
-						inputImages.length < MAX_INPUT_IMAGES && (
-							<div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-								<ImagePlus className="h-4 w-4 mr-2" />
-								Drop image here
-							</div>
-						)}
+					{isDragging && isEditModel && inputImages.length < maxInputImages && (
+						<div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+							<ImagePlus className="h-4 w-4 mr-2" />
+							Drop image here
+						</div>
+					)}
 					{isEditModel && inputImages.length > 0 && (
 						<div className="flex flex-wrap gap-2 px-3 pt-3">
 							{inputImages.map((img, i) => (
@@ -296,7 +301,7 @@ export function ImageControls({
 						disabled={
 							isGenerating ||
 							!isEditModel ||
-							inputImages.length >= MAX_INPUT_IMAGES
+							inputImages.length >= maxInputImages
 						}
 						title={
 							!isEditModel
@@ -307,7 +312,7 @@ export function ImageControls({
 						<ImagePlus className="h-4 w-4 mr-1.5" />
 						{inputImages.length === 0
 							? "Add image"
-							: `${inputImages.length}/${MAX_INPUT_IMAGES}`}
+							: `${inputImages.length}/${maxInputImages}`}
 					</Button>
 					{!config.usesPixelDimensions && (
 						<>

--- a/apps/playground/src/components/playground/image-controls.tsx
+++ b/apps/playground/src/components/playground/image-controls.tsx
@@ -118,7 +118,7 @@ export function ImageControls({
 			};
 			reader.readAsDataURL(file);
 		},
-		[isEditModel, setInputImages],
+		[isEditModel, setInputImages, maxInputImages],
 	);
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -160,7 +160,7 @@ export function ImageControls({
 				}
 			}
 		},
-		[isEditModel, inputImages.length, addImageFile],
+		[isEditModel, inputImages.length, addImageFile, maxInputImages],
 	);
 
 	// Drag-and-drop handlers
@@ -172,7 +172,7 @@ export function ImageControls({
 				setIsDragging(true);
 			}
 		},
-		[isEditModel, inputImages.length],
+		[isEditModel, inputImages.length, maxInputImages],
 	);
 
 	const handleDragLeave = useCallback((e: React.DragEvent) => {
@@ -202,7 +202,7 @@ export function ImageControls({
 				}
 			}
 		},
-		[isEditModel, inputImages.length, addImageFile],
+		[isEditModel, inputImages.length, addImageFile, maxInputImages],
 	);
 
 	// Reset drag state when mouse leaves the window

--- a/apps/playground/src/lib/image-gen.ts
+++ b/apps/playground/src/lib/image-gen.ts
@@ -56,13 +56,43 @@ export function getModelImageConfig(model: string) {
 
 	const defaultSize = isSeedream ? "2K" : "1K";
 
+	const maxInputImages = getMaxInputImages(lower);
+
 	return {
 		usesPixelDimensions,
 		isSeedream,
 		isGemini31FlashImage,
 		availableSizes,
 		defaultSize,
+		maxInputImages,
 	};
+}
+
+function getMaxInputImages(lowerModel: string): number {
+	// xAI Grok Imagine only supports a single reference image per generation.
+	if (lowerModel.includes("grok-imagine")) {
+		return 1;
+	}
+	// Google Gemini image models (Nano Banana family) support up to 3 reference images.
+	if (
+		lowerModel.includes("gemini") &&
+		(lowerModel.includes("-image") || lowerModel.includes("flash-image"))
+	) {
+		return 3;
+	}
+	// ByteDance Seedream 4.x accepts up to 10 reference images.
+	if (lowerModel.includes("seedream")) {
+		return 10;
+	}
+	// Alibaba Qwen-Image-Edit (plus/max) supports multi-image editing.
+	if (lowerModel.includes("qwen-image-edit")) {
+		return 5;
+	}
+	// ZAI CogView / GLM-Image: single-image conditioning at most.
+	if (lowerModel.includes("cogview") || lowerModel.includes("glm-image")) {
+		return 1;
+	}
+	return 4;
 }
 
 export async function parseImageStream(

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -307,7 +307,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 							/>
 
 							<ModelCtaButton
-								modelId={`${decodedProvider}/${decodedName}`}
+								modelId={decodedName}
 								size="sm"
 								className="gap-2"
 								iconClassName="h-3 w-3"

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -305,7 +305,7 @@ export default async function ModelPage({ params }: PageProps) {
 							/>
 
 							<ModelCtaButton
-								modelId={`${modelProviders[0]?.providerId}/${decodedName}`}
+								modelId={decodedName}
 								size="sm"
 								className="gap-2"
 								iconClassName="h-3 w-3"

--- a/apps/ui/src/components/date-range-picker.tsx
+++ b/apps/ui/src/components/date-range-picker.tsx
@@ -68,6 +68,11 @@ function buildPresets(): DatePreset[] {
 			getRange: () => ({ from: subDays(today, 6), to: today }),
 		},
 		{
+			label: "Today",
+			value: "today",
+			getRange: () => ({ from: today, to: today }),
+		},
+		{
 			label: "This week",
 			value: "this_week",
 			getRange: () => ({

--- a/apps/ui/src/components/date-range-select.tsx
+++ b/apps/ui/src/components/date-range-select.tsx
@@ -1,4 +1,4 @@
-import { subDays, subHours, subMinutes } from "date-fns";
+import { startOfDay, subDays, subHours, subMinutes } from "date-fns";
 import { ChevronDownIcon } from "lucide-react";
 import * as React from "react";
 import { useMemo, useState } from "react";
@@ -23,6 +23,14 @@ interface RelativeTimeOption {
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOption[] = [
+	{
+		label: "Today",
+		value: "today",
+		getRange: () => ({
+			start: startOfDay(new Date()),
+			end: new Date(),
+		}),
+	},
 	{
 		label: "Last 1 minute",
 		value: "1m",

--- a/ee/admin/src/components/date-range-picker.tsx
+++ b/ee/admin/src/components/date-range-picker.tsx
@@ -170,7 +170,9 @@ function findMatchingPreset(
 	presets: DatePreset[],
 ): string {
 	for (const preset of presets) {
-		if (preset.value === "custom") {
+		// "all_time" is tracked via the absence of from/to in the URL, not
+		// by concrete range equality — skip it here.
+		if (preset.value === "custom" || preset.value === "all_time") {
 			continue;
 		}
 		const range = preset.getRange();
@@ -192,13 +194,19 @@ export function getDateRangeFromParams(searchParams: URLSearchParams) {
 		return {
 			from: new Date(fromParam + "T00:00:00"),
 			to: new Date(toParam + "T00:00:00"),
+			isAllTime: false,
 		};
 	}
 
+	// Default: no from/to in URL means "all time". Return concrete dates
+	// for calendar/display purposes only; callers that build API requests
+	// should rely on isAllTime (and omit from/to params) to let the backend
+	// use its native all-time aggregate path.
 	const today = new Date();
 	return {
 		from: new Date(2020, 0, 1),
 		to: today,
+		isAllTime: true,
 	};
 }
 
@@ -337,11 +345,11 @@ export function DateRangePicker() {
 	const [search, setSearch] = useState("");
 	const [showCalendar, setShowCalendar] = useState(false);
 
-	const { from, to } = getDateRangeFromParams(searchParams);
+	const { from, to, isAllTime } = getDateRangeFromParams(searchParams);
 	const presets = useMemo(() => buildPresets(), []);
 	const activePreset = useMemo(
-		() => findMatchingPreset(from, to, presets),
-		[from, to, presets],
+		() => (isAllTime ? "all_time" : findMatchingPreset(from, to, presets)),
+		[from, to, presets, isAllTime],
 	);
 
 	const filteredPresets = useMemo(
@@ -362,9 +370,25 @@ export function DateRangePicker() {
 		router.push(`${pathname}?${params.toString()}`);
 	};
 
+	const clearDateRange = () => {
+		const params = new URLSearchParams(searchParams.toString());
+		params.delete("range");
+		params.delete("from");
+		params.delete("to");
+		const qs = params.toString();
+		router.push(qs ? `${pathname}?${qs}` : pathname);
+	};
+
 	const handlePresetSelect = (preset: DatePreset) => {
 		if (preset.value === "custom") {
 			setShowCalendar(true);
+			return;
+		}
+		// "All time" leaves the URL without from/to so the API uses its
+		// native all-time aggregate path instead of a concrete 2020→today range.
+		if (preset.value === "all_time") {
+			clearDateRange();
+			setOpen(false);
 			return;
 		}
 		const range = preset.getRange();

--- a/ee/admin/src/components/date-range-picker.tsx
+++ b/ee/admin/src/components/date-range-picker.tsx
@@ -63,6 +63,11 @@ function buildPresets(): DatePreset[] {
 			getRange: () => ({ from: subDays(today, 6), to: today }),
 		},
 		{
+			label: "Today",
+			value: "today",
+			getRange: () => ({ from: today, to: today }),
+		},
+		{
 			label: "This week",
 			value: "this_week",
 			getRange: () => ({
@@ -192,7 +197,7 @@ export function getDateRangeFromParams(searchParams: URLSearchParams) {
 
 	const today = new Date();
 	return {
-		from: subDays(today, 30),
+		from: new Date(2020, 0, 1),
 		to: today,
 	};
 }


### PR DESCRIPTION
## Summary

**apps/ui**
- "Try in Playground" on model detail pages uses the root model ID (model-card button unchanged).
- Added **Today** preset to `date-range-picker` and `date-range-select`.

**admin / api**
- Fixed `getMetrics` in `apps/api/src/routes/admin.ts`: added upper-bound (`lte(endDate)`) filter to all 8 queries so bounded ranges like "last week" return correct revenue/signups/orgs/stats.
- Admin `date-range-picker`: added **Today** preset; default range is now **All time**.

**apps/playground**
- Comparison mode with sync on now fans out prompts to all extra windows in parallel (`Promise.allSettled`) instead of sequentially.
- Chat image-generation: if the latest user message has no uploaded image, the most recent assistant-generated image is passed into `generateImage`, so follow-up prompts can edit the previously generated output.
- Per-model input-image limits surfaced from `getModelImageConfig(model).maxInputImages`:
  - grok-imagine (pro/std): 1
  - google gemini image / nano-banana: 3
  - bytedance seedream: 10
  - alibaba qwen-image-edit: 5
  - zai cogview / glm-image: 1
  - default: 4
- `ImageControls` uses the per-model limit and clamps currently-attached images when the limit shrinks (e.g. switching to grok-imagine).

## Test plan

- [ ] UI: model detail "Try in Playground" deep-links to the root model id in playground
- [ ] UI: "Today" preset appears in both `date-range-picker` and `date-range-select`
- [ ] Admin: default landing shows "All time"; selecting "Last week" produces correct revenue/signups
- [ ] Admin: "Today" preset works
- [ ] Playground: with sync on, multiple comparison windows receive and begin streaming simultaneously
- [ ] Playground: generate an image, then send a follow-up edit prompt without attaching a file — the previous image is used as input
- [ ] Playground image studio: selecting grok-imagine caps uploads at 1; seedream allows up to 10; switching models trims existing attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reuse generated images in follow-up prompts (falls back to prior assistant images)
  * Added "Today" preset option to date range pickers
  * Per-model image upload limits with automatic trimming when limits change

* **Improvements**
  * Admin metrics support inclusive date ranges for more accurate reporting
  * Multiple submit operations run concurrently with improved error reporting
  * Model identifier format standardized for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->