### PR TITLE
test: skip e2e tests when provider env vars missing

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { db, tables } from "@llmgateway/db";
 import {
 	type ModelDefinition,
+	getProviderDefinition,
 	getProviderEnvVar,
 	models,
 	type ProviderModelMapping,
@@ -101,6 +102,23 @@ if (specifiedModels) {
 }
 if (specifiedProviders) {
 	console.log(`TEST_PROVIDERS specified: ${specifiedProviders.join(", ")}`);
+}
+
+function hasAllRequiredProviderEnvVars(providerId: string): boolean {
+	const def = getProviderDefinition(providerId);
+	if (!def) {
+		return false;
+	}
+	const required = def.env.required as Record<string, string | undefined>;
+	for (const envVarName of Object.values(required)) {
+		if (!envVarName) {
+			continue;
+		}
+		if (!process.env[envVarName]) {
+			return false;
+		}
+	}
+	return true;
 }
 
 // Filter models based on test skip/only property
@@ -293,6 +311,14 @@ export const testModels = filteredModels
 				if (provider.test === "skip") {
 					continue;
 				}
+
+				// Skip providers whose required env vars aren't set (no creds to hit them)
+				if (
+					provider.test !== "only" &&
+					!hasAllRequiredProviderEnvVars(provider.providerId)
+				) {
+					continue;
+				}
 			}
 
 			// Skip unstable providers if not in full mode, unless they have test: "only" or are in TEST_MODELS/TEST_PROVIDERS
@@ -379,6 +405,14 @@ export const providerModels = filteredModels
 			} else {
 				// Skip providers marked with test: "skip" (only when TEST_MODELS/TEST_PROVIDERS is not specified)
 				if (provider.test === "skip") {
+					continue;
+				}
+
+				// Skip providers whose required env vars aren't set (no creds to hit them)
+				if (
+					provider.test !== "only" &&
+					!hasAllRequiredProviderEnvVars(provider.providerId)
+				) {
 					continue;
 				}
 


### PR DESCRIPTION
## Summary
- Filter out provider mappings in `testModels`/`providerModels` whose required env vars (`apiKey`, `baseUrl`) aren't set in the environment.
- Fixes the `JSON output streaming 'bluestone/deepseek-v3.2'` e2e failure (and any other bluestone tests) when `LLM_BLUESTONE_API_KEY`/`LLM_BLUESTONE_BASE_URL` aren't configured in the test environment.
- `TEST_MODELS`/`TEST_PROVIDERS` overrides and `test: "only"` still bypass the filter so explicit requests aren't swallowed.

## Test plan
- [ ] CI e2e run no longer includes `bluestone/*` test cases when bluestone env vars are unset.
- [ ] Running with `TEST_MODELS=bluestone/deepseek-v3.2` still targets bluestone (override behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test validation logic to verify required environment variables are available before running provider-specific tests, ensuring more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->