### PR TITLE
fix: correct id format for Together AI provider

### DIFF
--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -355,7 +355,7 @@ export function transformResponseToOpenai(
 			break;
 		}
 		case "inference.net":
-		case "together.ai":
+		case "together-ai":
 		case "groq": {
 			if (!transformedResponse.id) {
 				transformedResponse = {

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1217,7 +1217,7 @@ export function transformStreamingToOpenai(
 		case "nebius":
 		case "canopywave":
 		case "inference.net":
-		case "together.ai":
+		case "together-ai":
 		case "custom":
 		case "nanogpt":
 		case "bytedance":

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -195,7 +195,7 @@ describe("fallback and error status code handling", () => {
 			{
 				id: "provider-key-together",
 				token: "sk-together-key",
-				provider: "together.ai",
+				provider: "together-ai",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
 			},
@@ -209,7 +209,7 @@ describe("fallback and error status code handling", () => {
 		]);
 	}
 
-	async function setupSingleProviderWithMultipleKeys(provider = "together.ai") {
+	async function setupSingleProviderWithMultipleKeys(provider = "together-ai") {
 		await ensureBaseFixtures();
 
 		await db.insert(tables.apiKey).values({
@@ -826,7 +826,7 @@ describe("fallback and error status code handling", () => {
 
 		beforeEach(async () => {
 			await setupMultiProviderKeys();
-			await setRoutingMetrics(modelId, "together.ai", 0);
+			await setRoutingMetrics(modelId, "together-ai", 0);
 			await setRoutingMetrics(modelId, "cerebras", 100);
 		});
 
@@ -835,7 +835,7 @@ describe("fallback and error status code handling", () => {
 				{
 					id: "iam-allow-together",
 					ruleType: "allow_providers",
-					providers: ["together.ai"],
+					providers: ["together-ai"],
 				},
 			]);
 
@@ -846,20 +846,20 @@ describe("fallback and error status code handling", () => {
 					Authorization: "Bearer real-token",
 				},
 				body: JSON.stringify({
-					model: "together.ai/glm-4.7",
+					model: "together-ai/glm-4.7",
 					messages: [{ role: "user", content: "Hello!" }],
 				}),
 			});
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
-			expect(json.metadata.used_provider).toBe("together.ai");
-			expect(json.metadata.requested_provider).toBe("together.ai");
+			expect(json.metadata.used_provider).toBe("together-ai");
+			expect(json.metadata.requested_provider).toBe("together-ai");
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);
-			expect(logs[0].usedProvider).toBe("together.ai");
-			expect(logs[0].routingMetadata?.selectedProvider).toBe("together.ai");
+			expect(logs[0].usedProvider).toBe("together-ai");
+			expect(logs[0].routingMetadata?.selectedProvider).toBe("together-ai");
 			expect(logs[0].routingMetadata?.selectionReason).not.toBe(
 				"low-uptime-fallback",
 			);
@@ -881,19 +881,19 @@ describe("fallback and error status code handling", () => {
 					Authorization: "Bearer real-token",
 				},
 				body: JSON.stringify({
-					model: "together.ai/glm-4.7",
+					model: "together-ai/glm-4.7",
 					messages: [{ role: "user", content: "Hello!" }],
 				}),
 			});
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
-			expect(json.metadata.used_provider).toBe("together.ai");
+			expect(json.metadata.used_provider).toBe("together-ai");
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);
-			expect(logs[0].usedProvider).toBe("together.ai");
-			expect(logs[0].routingMetadata?.selectedProvider).toBe("together.ai");
+			expect(logs[0].usedProvider).toBe("together-ai");
+			expect(logs[0].routingMetadata?.selectedProvider).toBe("together-ai");
 			expect(logs[0].routingMetadata?.selectionReason).not.toBe(
 				"low-uptime-fallback",
 			);
@@ -904,7 +904,7 @@ describe("fallback and error status code handling", () => {
 				{
 					id: "iam-allow-together-combo",
 					ruleType: "allow_providers",
-					providers: ["together.ai"],
+					providers: ["together-ai"],
 				},
 				{
 					id: "iam-deny-cerebras-combo",
@@ -920,19 +920,19 @@ describe("fallback and error status code handling", () => {
 					Authorization: "Bearer real-token",
 				},
 				body: JSON.stringify({
-					model: "together.ai/glm-4.7",
+					model: "together-ai/glm-4.7",
 					messages: [{ role: "user", content: "Hello!" }],
 				}),
 			});
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
-			expect(json.metadata.used_provider).toBe("together.ai");
+			expect(json.metadata.used_provider).toBe("together-ai");
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);
-			expect(logs[0].usedProvider).toBe("together.ai");
-			expect(logs[0].routingMetadata?.selectedProvider).toBe("together.ai");
+			expect(logs[0].usedProvider).toBe("together-ai");
+			expect(logs[0].routingMetadata?.selectedProvider).toBe("together-ai");
 			expect(logs[0].routingMetadata?.selectionReason).not.toBe(
 				"low-uptime-fallback",
 			);
@@ -1567,10 +1567,10 @@ describe("fallback and error status code handling", () => {
 		test("content filter hit reroutes away from content-filter providers and records it in routing metadata", async () => {
 			await setupMultiProviderKeys();
 
-			const togetherProvider = getProviderDefinition("together.ai");
+			const togetherProvider = getProviderDefinition("together-ai");
 			expect(togetherProvider).toBeDefined();
 			if (!togetherProvider) {
-				throw new Error("Missing together.ai provider fixture");
+				throw new Error("Missing together-ai provider fixture");
 			}
 
 			const originalContentFilterFlag = togetherProvider.contentFilter;
@@ -1611,11 +1611,11 @@ describe("fallback and error status code handling", () => {
 					selectedProvider: "cerebras",
 					contentFilterMatched: true,
 					contentFilterRerouted: true,
-					contentFilterExcludedProviders: ["together.ai"],
+					contentFilterExcludedProviders: ["together-ai"],
 				});
 				expect(log.routingMetadata?.providerScores).toContainEqual(
 					expect.objectContaining({
-						providerId: "together.ai",
+						providerId: "together-ai",
 						contentFilterProvider: true,
 						excludedByContentFilter: true,
 					}),
@@ -1657,10 +1657,10 @@ describe("fallback and error status code handling", () => {
 		test("content filter monitor mode does not reroute away from content-filter providers", async () => {
 			await setupMultiProviderKeys();
 
-			const togetherProvider = getProviderDefinition("together.ai");
+			const togetherProvider = getProviderDefinition("together-ai");
 			expect(togetherProvider).toBeDefined();
 			if (!togetherProvider) {
-				throw new Error("Missing together.ai provider fixture");
+				throw new Error("Missing together-ai provider fixture");
 			}
 
 			const originalContentFilterFlag = togetherProvider.contentFilter;
@@ -1695,10 +1695,10 @@ describe("fallback and error status code handling", () => {
 				expect(logs.length).toBe(1);
 
 				const log = logs[0];
-				expect(log.usedProvider).toBe("together.ai");
+				expect(log.usedProvider).toBe("together-ai");
 				expect(log.internalContentFilter).toBe(true);
 				expect(log.routingMetadata).toMatchObject({
-					selectedProvider: "together.ai",
+					selectedProvider: "together-ai",
 					contentFilterMatched: true,
 					contentFilterRerouted: false,
 				});
@@ -1707,7 +1707,7 @@ describe("fallback and error status code handling", () => {
 				).toBeUndefined();
 				expect(log.routingMetadata?.providerScores).not.toContainEqual(
 					expect.objectContaining({
-						providerId: "together.ai",
+						providerId: "together-ai",
 						excludedByContentFilter: true,
 					}),
 				);
@@ -2107,7 +2107,7 @@ describe("fallback and error status code handling", () => {
 				},
 				body: JSON.stringify({
 					// Explicit provider prefix - retry disabled
-					model: "together.ai/glm-4.7",
+					model: "together-ai/glm-4.7",
 					messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
 				}),
 			});
@@ -2119,7 +2119,7 @@ describe("fallback and error status code handling", () => {
 		});
 
 		test("non-streaming: retries another key for the same explicit provider before provider fallback", async () => {
-			await setupSingleProviderWithMultipleKeys("together.ai");
+			await setupSingleProviderWithMultipleKeys("together-ai");
 
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -2128,7 +2128,7 @@ describe("fallback and error status code handling", () => {
 					Authorization: "Bearer real-token",
 				},
 				body: JSON.stringify({
-					model: "together.ai/glm-4.7",
+					model: "together-ai/glm-4.7",
 					messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
 				}),
 			});
@@ -2136,16 +2136,16 @@ describe("fallback and error status code handling", () => {
 			expect(res.status).toBe(200);
 			const json = await res.json();
 
-			expect(json.metadata.used_provider).toBe("together.ai");
+			expect(json.metadata.used_provider).toBe("together-ai");
 			expect(json.metadata.routing).toBeDefined();
 			expect(json.metadata.routing).toHaveLength(2);
 			expect(json.metadata.routing[0]).toMatchObject({
-				provider: "together.ai",
+				provider: "together-ai",
 				status_code: 500,
 				succeeded: false,
 			});
 			expect(json.metadata.routing[1]).toMatchObject({
-				provider: "together.ai",
+				provider: "together-ai",
 				succeeded: true,
 			});
 
@@ -2155,18 +2155,18 @@ describe("fallback and error status code handling", () => {
 			);
 			expect(successLog?.routingMetadata?.routing).toHaveLength(2);
 			expect(successLog?.routingMetadata?.routing?.[0]?.provider).toBe(
-				"together.ai",
+				"together-ai",
 			);
 			expect(successLog?.routingMetadata?.routing?.[1]?.provider).toBe(
-				"together.ai",
+				"together-ai",
 			);
 		});
 
 		test("non-streaming: retries another key for the same provider when X-No-Fallback is set", async () => {
-			await setupSingleProviderWithMultipleKeys("together.ai");
-			const primaryKeyHash = getApiKeyFingerprint("together.ai-primary-token");
+			await setupSingleProviderWithMultipleKeys("together-ai");
+			const primaryKeyHash = getApiKeyFingerprint("together-ai-primary-token");
 			const secondaryKeyHash = getApiKeyFingerprint(
-				"together.ai-secondary-token",
+				"together-ai-secondary-token",
 			);
 
 			const res = await app.request("/v1/chat/completions", {
@@ -2177,7 +2177,7 @@ describe("fallback and error status code handling", () => {
 					"X-No-Fallback": "true",
 				},
 				body: JSON.stringify({
-					model: "together.ai/glm-4.7",
+					model: "together-ai/glm-4.7",
 					messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
 				}),
 			});
@@ -2185,7 +2185,7 @@ describe("fallback and error status code handling", () => {
 			expect(res.status).toBe(200);
 			const json = await res.json();
 
-			expect(json.metadata.used_provider).toBe("together.ai");
+			expect(json.metadata.used_provider).toBe("together-ai");
 			expect(json.metadata.routing).toBeDefined();
 			expect(json.metadata.routing).toHaveLength(2);
 			const jsonRoutingHashes = json.metadata.routing.map(
@@ -2195,12 +2195,12 @@ describe("fallback and error status code handling", () => {
 				new Set([primaryKeyHash, secondaryKeyHash]),
 			);
 			expect(json.metadata.routing[0]).toMatchObject({
-				provider: "together.ai",
+				provider: "together-ai",
 				status_code: 500,
 				succeeded: false,
 			});
 			expect(json.metadata.routing[1]).toMatchObject({
-				provider: "together.ai",
+				provider: "together-ai",
 				succeeded: true,
 			});
 
@@ -2221,10 +2221,10 @@ describe("fallback and error status code handling", () => {
 				),
 			).toEqual(new Set([primaryKeyHash, secondaryKeyHash]));
 			expect(successLog?.routingMetadata?.routing?.[0]).toMatchObject({
-				provider: "together.ai",
+				provider: "together-ai",
 			});
 			expect(successLog?.routingMetadata?.routing?.[1]).toMatchObject({
-				provider: "together.ai",
+				provider: "together-ai",
 			});
 		});
 
@@ -2340,10 +2340,10 @@ describe("fallback and error status code handling", () => {
 		});
 
 		test("streaming: retries another key for the same provider after timeout", async () => {
-			await setupSingleProviderWithMultipleKeys("together.ai");
-			const primaryKeyHash = getApiKeyFingerprint("together.ai-primary-token");
+			await setupSingleProviderWithMultipleKeys("together-ai");
+			const primaryKeyHash = getApiKeyFingerprint("together-ai-primary-token");
 			const secondaryKeyHash = getApiKeyFingerprint(
-				"together.ai-secondary-token",
+				"together-ai-secondary-token",
 			);
 			const originalStreamingTimeout = process.env.AI_STREAMING_TIMEOUT_MS;
 			process.env.AI_STREAMING_TIMEOUT_MS = "10";
@@ -2357,7 +2357,7 @@ describe("fallback and error status code handling", () => {
 						"X-No-Fallback": "true",
 					},
 					body: JSON.stringify({
-						model: "together.ai/glm-4.7",
+						model: "together-ai/glm-4.7",
 						messages: [{ role: "user", content: "TRIGGER_TIMEOUT_FAIL_ONCE" }],
 						stream: true,
 					}),
@@ -2388,12 +2388,12 @@ describe("fallback and error status code handling", () => {
 					),
 				).toEqual(new Set([primaryKeyHash, secondaryKeyHash]));
 				expect(successLog?.routingMetadata?.routing?.[0]).toMatchObject({
-					provider: "together.ai",
+					provider: "together-ai",
 					status_code: 0,
 					succeeded: false,
 				});
 				expect(successLog?.routingMetadata?.routing?.[1]).toMatchObject({
-					provider: "together.ai",
+					provider: "together-ai",
 					succeeded: true,
 				});
 			} finally {
@@ -2459,7 +2459,7 @@ describe("fallback and error status code handling", () => {
 				{
 					id: "iam-retry-allow-together",
 					ruleType: "allow_providers",
-					providers: ["together.ai"],
+					providers: ["together-ai"],
 				},
 			]);
 
@@ -2479,7 +2479,7 @@ describe("fallback and error status code handling", () => {
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);
-			expect(logs[0].usedProvider).toBe("together.ai");
+			expect(logs[0].usedProvider).toBe("together-ai");
 			expect(logs.some((log) => log.usedProvider === "cerebras")).toBe(false);
 		});
 
@@ -2509,7 +2509,7 @@ describe("fallback and error status code handling", () => {
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);
-			expect(logs[0].usedProvider).toBe("together.ai");
+			expect(logs[0].usedProvider).toBe("together-ai");
 			expect(logs.some((log) => log.usedProvider === "cerebras")).toBe(false);
 		});
 
@@ -2519,7 +2519,7 @@ describe("fallback and error status code handling", () => {
 				{
 					id: "iam-retry-allow-together-combo",
 					ruleType: "allow_providers",
-					providers: ["together.ai"],
+					providers: ["together-ai"],
 				},
 				{
 					id: "iam-retry-deny-cerebras-combo",
@@ -2544,7 +2544,7 @@ describe("fallback and error status code handling", () => {
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);
-			expect(logs[0].usedProvider).toBe("together.ai");
+			expect(logs[0].usedProvider).toBe("together-ai");
 			expect(logs.some((log) => log.usedProvider === "cerebras")).toBe(false);
 		});
 	});

--- a/apps/ui/src/components/landing/hero.tsx
+++ b/apps/ui/src/components/landing/hero.tsx
@@ -42,7 +42,7 @@ const transitionVariants: { item: Variants } = {
 const PROVIDER_LOGOS: { name: string; providerId: ProviderId }[] = [
 	{ name: "OpenAI", providerId: "openai" },
 	{ name: "Anthropic", providerId: "anthropic" },
-	{ name: "Together AI", providerId: "together.ai" },
+	{ name: "Together AI", providerId: "together-ai" },
 	{ name: "Groq", providerId: "groq" },
 	{ name: "xAI", providerId: "xai" },
 	{ name: "DeepSeek", providerId: "deepseek" },

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -12,7 +12,7 @@ export const providerLogoUrls: Partial<
 	"google-vertex": ProviderIcons["google-vertex"],
 	quartz: ProviderIcons.quartz,
 	"inference.net": ProviderIcons["inference.net"],
-	"together.ai": ProviderIcons["together.ai"],
+	"together-ai": ProviderIcons["together-ai"],
 	mistral: ProviderIcons.mistral,
 	groq: ProviderIcons.groq,
 	xai: ProviderIcons.xai,

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -175,7 +175,7 @@ export function getProviderEndpoint(
 			case "inference.net":
 				url = "https://api.inference.net";
 				break;
-			case "together.ai":
+			case "together-ai":
 				url = "https://api.together.ai";
 				break;
 			case "mistral":

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1971,7 +1971,7 @@ export async function prepareRequestBody(
 			break;
 		}
 		case "inference.net":
-		case "together.ai": {
+		case "together-ai": {
 			if (usedModel.startsWith(`${usedProvider}/`)) {
 				requestBody.model = usedModel.substring(usedProvider.length + 1);
 			}

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -1742,7 +1742,7 @@ export const googleModels = [
 		providers: [
 			{
 				test: "skip",
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "google/gemma-2-27b-it",
 				inputPrice: 0.08 / 1e6,
 				outputPrice: 0.08 / 1e6,

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -50,7 +50,7 @@ export const metaModels = [
 				jsonOutput: false,
 			},
 			{
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
 				// Retired from Together.ai serverless API
 				deactivatedAt: new Date("2026-03-27"),
@@ -315,7 +315,7 @@ export const metaModels = [
 		releasedAt: new Date("2025-04-05"),
 		providers: [
 			{
-				providerId: "together.ai",
+				providerId: "together-ai",
 				stability: "unstable" as const,
 				modelName: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
 				inputPrice: 0.18 / 1e6,

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -40,7 +40,7 @@ export const minimaxModels = [
 				jsonOutput: true,
 			},
 			{
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "MiniMaxAI/MiniMax-M2.7",
 				inputPrice: 0.3 / 1e6,
 				cachedInputPrice: 0.06 / 1e6,
@@ -139,7 +139,7 @@ export const minimaxModels = [
 			},
 			{
 				deactivatedAt: new Date("2026-04-27"),
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "MiniMaxAI/MiniMax-M2.5",
 				inputPrice: 0.3 / 1e6,
 				outputPrice: 1.2 / 1e6,

--- a/packages/models/src/models/mistral.ts
+++ b/packages/models/src/models/mistral.ts
@@ -32,7 +32,7 @@ export const mistralModels = [
 		providers: [
 			{
 				deactivatedAt: new Date("2026-04-16"),
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "mistralai/mixtral-8x7b-instruct-v0.1",
 				inputPrice: 0.06 / 1e6,
 				outputPrice: 0.06 / 1e6,
@@ -55,7 +55,7 @@ export const mistralModels = [
 		providers: [
 			{
 				deactivatedAt: new Date("2025-11-13"),
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "mistralai/mistral-7b-instruct-v0.1",
 				inputPrice: 0.06 / 1e6,
 				outputPrice: 0.06 / 1e6,

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -257,7 +257,7 @@ export const moonshotModels = [
 				jsonOutput: true,
 			},
 			{
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "moonshotai/Kimi-K2.5",
 				// Together.ai intermittently returns 500 for this model (~98.7% uptime)
 				// Ref: https://status.together.ai

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -88,7 +88,7 @@ export const zaiModels = [
 			},
 			{
 				deactivatedAt: new Date("2026-04-22"),
-				providerId: "together.ai",
+				providerId: "together-ai",
 				modelName: "zai-org/GLM-5",
 				inputPrice: 1 / 1e6,
 				outputPrice: 3.2 / 1e6,
@@ -520,7 +520,7 @@ export const zaiModels = [
 				jsonOutput: false, // Returns JSON wrapped in markdown code blocks
 			},
 			{
-				providerId: "together.ai",
+				providerId: "together-ai",
 				test: "skip", // skip tests due to reasoning issues
 				modelName: "zai-org/GLM-4.7",
 				inputPrice: 0.45 / 1e6,

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -483,7 +483,7 @@ export const providers = [
 		announcement: null,
 	},
 	{
-		id: "together.ai",
+		id: "together-ai",
 		name: "Together AI",
 		description:
 			"Together AI is a platform for running large language models in the cloud with fast inference.",

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1253,7 +1253,7 @@ export const ProviderIcons = {
 	mistral: MistralIcon,
 	openai: OpenAIIcon,
 	perplexity: PerplexityIcon,
-	"together.ai": TogetherAIIcon,
+	"together-ai": TogetherAIIcon,
 	xai: XAIIcon,
 	moonshot: MoonshotIcon,
 	novita: NovitaIcon,
@@ -1283,7 +1283,7 @@ export const providerLogoUrls: Partial<
 	"google-vertex": ProviderIcons["google-vertex"],
 	quartz: ProviderIcons.quartz,
 	"inference.net": ProviderIcons["inference.net"],
-	"together.ai": ProviderIcons["together.ai"],
+	"together-ai": ProviderIcons["together-ai"],
 	mistral: ProviderIcons.mistral,
 	groq: ProviderIcons.groq,
 	xai: ProviderIcons.xai,
@@ -1311,7 +1311,7 @@ export const getProviderLogoDarkModeClasses = () => {
 export const getProviderIcon = (
 	provider: string,
 ): React.FC<React.SVGProps<SVGSVGElement>> => {
-	// First try the exact provider name (for keys like "together.ai", "inference.net")
+	// First try the exact provider name (for keys like "together-ai", "inference.net")
 	if (ProviderIcons[provider as ProviderIconKey]) {
 		return ProviderIcons[provider as ProviderIconKey];
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the Together provider identifier from "together.ai" to "together-ai" across models, UI, routing, streaming, request/response handling, provider metadata, and tests to ensure consistent provider recognition and logo/endpoint mapping throughout the product.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->