### PR TITLE
chore(models): mark vertex claude as unstable

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -375,6 +375,7 @@ export const anthropicModels = [
 			{
 				test: "skip",
 				providerId: "google-vertex",
+				stability: "unstable" as const,
 				modelName: "claude-sonnet-4-6",
 				inputPrice: 3.0 / 1e6,
 				outputPrice: 15.0 / 1e6,
@@ -806,6 +807,7 @@ export const anthropicModels = [
 			{
 				test: "skip",
 				providerId: "google-vertex",
+				stability: "unstable" as const,
 				modelName: "claude-opus-4-5@20251101",
 				inputPrice: 5.0 / 1e6,
 				outputPrice: 25.0 / 1e6,


### PR DESCRIPTION
## Summary
- Mark Claude models on the `google-vertex` provider (`claude-sonnet-4-6`, `claude-opus-4-5@20251101`) as `stability: "unstable"` so they are excluded from auto routing.

## Test plan
- [ ] Verify auto-routing no longer selects Vertex Claude models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked specific Claude models (Sonnet 4.6 and Opus 4.5) as unstable in the provider registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->