### PR TITLE
fix(gateway): map Anthropic refusal to content filter

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -137,7 +137,14 @@ const anthropicResponseSchema = z.object({
 	model: z.string(),
 	content: z.array(anthropicContentBlockSchema),
 	stop_reason: z
-		.enum(["end_turn", "max_tokens", "stop_sequence", "tool_use"])
+		.enum([
+			"end_turn",
+			"max_tokens",
+			"stop_sequence",
+			"tool_use",
+			"pause_turn",
+			"refusal",
+		])
 		.nullable(),
 	stop_sequence: z.string().nullable(),
 	usage: z.object({

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -32,6 +32,9 @@ describe("getUnifiedFinishReason", () => {
 		expect(getUnifiedFinishReason("end_turn", "anthropic")).toBe(
 			UnifiedFinishReason.COMPLETED,
 		);
+		expect(getUnifiedFinishReason("refusal", "anthropic")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
 	});
 
 	it("maps Google AI Studio finish reasons correctly (original Google format)", () => {

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -78,6 +78,9 @@ export function getUnifiedFinishReason(
 			if (finishReason === "tool_use") {
 				return UnifiedFinishReason.TOOL_CALLS;
 			}
+			if (finishReason === "refusal") {
+				return UnifiedFinishReason.CONTENT_FILTER;
+			}
 			break;
 		case "google-ai-studio":
 		case "glacier":


### PR DESCRIPTION
## Summary
- Map Anthropic's `refusal` stop_reason to `CONTENT_FILTER` so it no longer logs as an unknown finish reason.
- Widen the Anthropic passthrough response schema's `stop_reason` enum to also accept `refusal` and `pause_turn`.
- Add unit coverage for the new mapping.

## Test plan
- [x] `pnpm test:unit` (959 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Anthropic API response validation to support additional finish reason values, enabling better handling of API responses including content filter refusals.
  * Improved unified finish reason mapping for Anthropic responses to properly categorize content-filtered outputs.

* **Tests**
  * Added test coverage to verify correct mapping of new finish reason types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->