### PR TITLE
fix(anthropic): drop extra message fields on forward

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "apps/gateway/**"
+      - "packages/actions/**"
       - "packages/models/**"
       - "packages/shared/**"
       - "**/*.e2e.ts"

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -274,15 +274,10 @@ export async function transformAnthropicMessages(
 			continue;
 		}
 
-		// Remove tool_calls and tool_call_id from the message as Anthropic doesn't expect these fields
-		const { tool_calls: _, tool_call_id: __, ...messageWithoutToolFields } = m;
-
 		// Map role correctly for Anthropic (no system or tool roles)
-		const anthropicRole =
-			messageWithoutToolFields.role === "assistant" ? "assistant" : "user";
+		const anthropicRole = m.role === "assistant" ? "assistant" : "user";
 
 		results.push({
-			...messageWithoutToolFields,
 			content: filteredContent,
 			role: anthropicRole,
 		});


### PR DESCRIPTION
## Summary
- Only forward `role` and `content` when building Anthropic messages; previously the spread leaked `reasoning_details`, `reasoning`, `reasoning_content`, and `name` through to `/v1/messages`, which rejects unknown fields with `messages.N.<field>: Extra inputs are not permitted`.
- Matches Anthropic's upstream `MessageParam` (generated from their OpenAPI spec), which defines exactly `content` and `role`.

## Test plan
- [x] `pnpm build`
- [x] `pnpm test:unit` (959 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Message transformation now emits Anthropic-format messages that contain only content and role, removing other message fields.

* **Chores**
  * End-to-end CI workflow trigger updated to also run when files under the actions package are modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->