### PR TITLE
fix(lint): stabilize content-collections import order

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,6 +122,10 @@ export default [
 							group: "internal",
 							position: "before",
 						},
+						{
+							pattern: "content-collections",
+							group: "internal",
+						},
 					],
 					pathGroupsExcludedImportTypes: ["builtin", "type"],
 				},


### PR DESCRIPTION
## Summary
- Pin `content-collections` (the tsconfig path alias mapped to the gitignored `./.content-collections/generated/`) to the `internal` pathGroup in `eslint.config.mjs`.
- Without this, `import/order` classifies the import as `external` when the generated folder is missing and `internal` when it exists, causing `pnpm format` to produce drift in UI files depending on whether `pnpm generate` has run.

## Test plan
- [ ] `pnpm format` is a no-op on a fresh checkout without `.content-collections/generated/`
- [ ] `pnpm format` is a no-op after running `pnpm generate` so the folder is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated import ordering configuration for improved code organization standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->