### PR TITLE
fix: auto-topup nudge visibility and low-balance alerts

### DIFF
--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -722,9 +722,6 @@ payments.openapi(createCheckoutSession, async (c) => {
 
 	const defaultBillingUrl = `${process.env.UI_URL ?? "http://localhost:3002"}/dashboard/${organizationId}/org/billing`;
 
-	let successUrl: string;
-	let cancelUrl: string;
-
 	const isAllowedReturn = (() => {
 		if (!returnUrl) {
 			return false;
@@ -739,12 +736,12 @@ payments.openapi(createCheckoutSession, async (c) => {
 		}
 	})();
 
+	const successUrl = `${defaultBillingUrl}?success=true`;
+	let cancelUrl: string;
 	if (isAllowedReturn && returnUrl) {
 		const separator = returnUrl.includes("?") ? "&" : "?";
-		successUrl = `${returnUrl}${separator}success=true`;
 		cancelUrl = `${returnUrl}${separator}canceled=true`;
 	} else {
-		successUrl = `${defaultBillingUrl}?success=true`;
 		cancelUrl = `${defaultBillingUrl}?canceled=true`;
 	}
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -976,7 +976,20 @@ async function checkLowBalanceAlerts(orgIds: string[]): Promise<void> {
 
 		for (const org of orgs) {
 			try {
-				const lastTopUp = Number(org.lastTopUpAmount ?? 0);
+				let lastTopUp = Number(org.lastTopUpAmount ?? 0);
+
+				if (lastTopUp <= 0) {
+					const lastCompletedTopUp = await db.query.transaction.findFirst({
+						where: {
+							organizationId: { eq: org.id },
+							type: { eq: "credit_topup" },
+							status: { eq: "completed" },
+						},
+						orderBy: { createdAt: "desc" },
+					});
+					lastTopUp = Number(lastCompletedTopUp?.creditAmount ?? 0);
+				}
+
 				if (lastTopUp <= 0) {
 					continue;
 				}
@@ -1033,8 +1046,21 @@ async function enqueueLowBalanceEmail(
 	}
 
 	const threshold = emailType === "low_balance_20" ? "20" : "5";
+	const dryRun = process.env.EMAIL_FOLLOW_UPS !== "true";
 
-	if (process.env.EMAIL_FOLLOW_UPS !== "true") {
+	posthog.capture({
+		distinctId: "organization",
+		event: "low_balance_alert_fired",
+		groups: { organization: organizationId },
+		properties: {
+			threshold,
+			currentBalance,
+			organization: organizationId,
+			dryRun,
+		},
+	});
+
+	if (dryRun) {
 		logger.info("Low balance alert (dry run)", {
 			kind: "low_balance_alert",
 			emailType,
@@ -1043,6 +1069,14 @@ async function enqueueLowBalanceEmail(
 			currentBalance,
 			threshold,
 		});
+		await db
+			.insert(tables.followUpEmail)
+			.values({
+				organizationId,
+				emailType,
+				sentTo: "(dry-run)",
+			})
+			.onConflictDoNothing();
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Three production bugs blocking the credit-purchase follow-up funnel, found while investigating PostHog data showing 5 nudge firings against ~100 purchases since deploy and zero low-balance alerts in 9 days.

### 1. Auto-topup nudge — wired to a path almost no one hits

`PaymentStatusHandler` is mounted only on `/dashboard/[orgId]/org/billing` and only fires the nudge when the URL has `?success=true`. But `TopUpCreditsDialog` (invoked from sidebar, dashboard cards, recent-logs, credits-recommendation banner, playground chat/image/video) sends its own `returnUrl`, and the API honored it for both success and cancel — so unless a user happened to open the dialog from the billing page itself, the success redirect bypassed the nudge entirely.

**Fix:** force `credit_topup` success_url to the billing page so the nudge fires for every entry point. `cancel_url` still respects `returnUrl` (less critical UX).

### 2. Low-balance alerts — null `lastTopUpAmount` blocks every existing user

The worker's threshold check early-exits when `lastTopUpAmount <= 0`, and that field is `null` for every org that existed before the feature shipped. They never get an alert until they top up at least once after deploy.

**Fix:** when `lastTopUpAmount` is null/0, derive it from the most recent completed `credit_topup` transaction.

### 3. Low-balance alerts — PostHog event gated behind email send

`posthog.capture("low_balance_alert_sent")` was called only after `sendLowBalanceEmail`, which was itself gated by `EMAIL_FOLLOW_UPS=true`. With the env var off, alerts could be fully working and PostHog would still show zero — making the feature unobservable in dry-run.

**Fix:** capture a new `low_balance_alert_fired` event before the email gate with a `dryRun` property, and insert the `followUpEmail` dedup row in dry-run too so the fired event emits once per cycle instead of every batch. Existing `low_balance_alert_sent` event preserved.

## Test plan

- [ ] Trigger a credit topup from the dashboard sidebar and confirm the success redirect lands on `/dashboard/{orgId}/org/billing?success=true` and the nudge renders
- [ ] Trigger a topup from the playground; confirm same behavior
- [ ] Cancel a checkout from the playground; confirm cancel still returns to the originating page
- [ ] In a dev env with an org that has `lastTopUpAmount IS NULL` and prior `credit_topup` transactions, drop credits below 20% of the historical topup and confirm `low_balance_alert_fired` appears in PostHog with `dryRun: true`
- [ ] Set `EMAIL_FOLLOW_UPS=true` in dev; confirm `low_balance_alert_fired` and `low_balance_alert_sent` both fire and email is sent
- [ ] Re-run the worker batch; confirm dedup prevents repeat firings

## Related

Bonus feature (`SECOND_TOPUP_BONUS_MULTIPLIER`) is env-gated and may simply be off in prod — not a code bug. Verify env vars before declaring it broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing checkout redirect behavior to ensure consistent success page navigation.
  * Enhanced low-balance alert calculation to accurately retrieve payment history when needed.

* **Chores**
  * Added analytics tracking for low-balance alerts with dry-run mode support for testing email notifications without delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->