### PR TITLE
fix(payments): land credit topup success on billing page

### DIFF
--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -722,9 +722,6 @@ payments.openapi(createCheckoutSession, async (c) => {
 
 	const defaultBillingUrl = `${process.env.UI_URL ?? "http://localhost:3002"}/dashboard/${organizationId}/org/billing`;
 
-	let successUrl: string;
-	let cancelUrl: string;
-
 	const isAllowedReturn = (() => {
 		if (!returnUrl) {
 			return false;
@@ -739,12 +736,12 @@ payments.openapi(createCheckoutSession, async (c) => {
 		}
 	})();
 
+	const successUrl = `${defaultBillingUrl}?success=true`;
+	let cancelUrl: string;
 	if (isAllowedReturn && returnUrl) {
 		const separator = returnUrl.includes("?") ? "&" : "?";
-		successUrl = `${returnUrl}${separator}success=true`;
 		cancelUrl = `${returnUrl}${separator}canceled=true`;
 	} else {
-		successUrl = `${defaultBillingUrl}?success=true`;
 		cancelUrl = `${defaultBillingUrl}?canceled=true`;
 	}
 


### PR DESCRIPTION
## Summary

The auto-topup nudge fires from `PaymentStatusHandler`, which is only mounted on `/dashboard/[orgId]/org/billing` and only triggers when the URL has `?success=true`. But `TopUpCreditsDialog` is invoked from 9+ entry points (sidebar, dashboard cards, recent-logs, credits-recommendation banner, playground chat/image/video) and each one passes its own `returnUrl`. The API honored that returnUrl for success, so most checkouts redirected back to a page where the nudge component doesn't exist.

PostHog data: 5 nudge firings clustered into 3 days post-deploy, then zero for 9+ days against ~80 credit purchases. The nudge isn't broken — it's just wired to a path almost no one takes.

This change forces `credit_topup` success_url to the billing page so the nudge mounts for every entry point. Cancel still respects `returnUrl` (UX impact there is smaller and the cancel-flow doesn't drive the nudge).

## Test plan

- [ ] Trigger a credit topup from the dashboard sidebar → success redirects to `/dashboard/{orgId}/org/billing?success=true` and the nudge renders
- [ ] Trigger a topup from the playground → same behavior
- [ ] Cancel a checkout from the playground → returns to the originating page (returnUrl preserved for cancel)
- [ ] Watch `auto_topup_nudge_shown` in PostHog for 24h post-deploy and confirm fire-rate roughly tracks `credits_purchased`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated checkout success URL handling to consistently use the default billing URL rather than conditionally using user-provided URLs, ensuring more reliable post-purchase redirects. Cancellation URL behavior remains conditional based on availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->