### PR TITLE
fix(video): use GA Veo 3.1 model IDs on Vertex AI

### DIFF
--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -473,7 +473,7 @@ describe("videos", () => {
 			});
 			expect(videoJob).toBeTruthy();
 			expect(videoJob?.usedProvider).toBe("google-vertex");
-			expect(videoJob?.usedModel).toBe("veo-3.1-generate-preview");
+			expect(videoJob?.usedModel).toBe("veo-3.1-generate-001");
 			expect(videoJob?.upstreamId).toContain("projects/runtime-project/");
 			expect(
 				(
@@ -513,7 +513,7 @@ describe("videos", () => {
 				`mock-video-${videoJob!.upstreamId}`,
 			);
 
-			expect(logs[0].usedModelMapping).toBe("veo-3.1-generate-preview");
+			expect(logs[0].usedModelMapping).toBe("veo-3.1-generate-001");
 			expect(logs[0].content).toBe(
 				`http://localhost:4001/v1/videos/logs/${logs[0].id}/content`,
 			);
@@ -820,7 +820,7 @@ describe("videos", () => {
 				where: { id: { eq: created.id } },
 			});
 			expect(videoJob?.usedProvider).toBe("google-vertex");
-			expect(videoJob?.usedModel).toBe("veo-3.1-generate-preview");
+			expect(videoJob?.usedModel).toBe("veo-3.1-generate-001");
 
 			const mockVideo = getMockVideo(videoJob!.upstreamId);
 			expect(mockVideo?.referenceImages).toEqual([

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -776,7 +776,7 @@ function getVideoProviderConstraintReasons(
 		}
 
 		if (isGoogleVertexVideoProvider(provider.providerId)) {
-			if (provider.modelName !== "veo-3.1-generate-preview") {
+			if (provider.modelName !== "veo-3.1-generate-001") {
 				reasons.push(
 					`reference images are currently only supported on ${provider.providerId}/veo-3.1-generate-preview`,
 				);

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -178,7 +178,7 @@ function mappingSupportsVideoRequest(
 
 	if (inputMode === "reference") {
 		if (mapping.providerId === "google-vertex") {
-			if (mapping.modelName !== "veo-3.1-generate-preview") {
+			if (mapping.modelName !== "veo-3.1-generate-001") {
 				return false;
 			}
 		} else if (mapping.providerId === "avalanche") {

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -780,7 +780,7 @@ export const googleModels = [
 	{
 		id: "veo-3.1-generate-preview",
 		name: "Veo 3.1",
-		description: "Google Veo 3.1 preview video generation with audio.",
+		description: "Google Veo 3.1 video generation with audio.",
 		family: "google",
 		output: ["video"],
 		maxVideoDurationSeconds: 10,
@@ -789,7 +789,7 @@ export const googleModels = [
 		providers: [
 			{
 				providerId: "google-vertex",
-				modelName: "veo-3.1-generate-preview",
+				modelName: "veo-3.1-generate-001",
 				inputPrice: undefined,
 				outputPrice: undefined,
 				requestPrice: undefined,
@@ -853,7 +853,7 @@ export const googleModels = [
 	{
 		id: "veo-3.1-fast-generate-preview",
 		name: "Veo 3.1 Fast",
-		description: "Google Veo 3.1 Fast preview video generation with audio.",
+		description: "Google Veo 3.1 Fast video generation with audio.",
 		family: "google",
 		output: ["video"],
 		maxVideoDurationSeconds: 10,
@@ -862,7 +862,7 @@ export const googleModels = [
 		providers: [
 			{
 				providerId: "google-vertex",
-				modelName: "veo-3.1-fast-generate-preview",
+				modelName: "veo-3.1-fast-generate-001",
 				inputPrice: undefined,
 				outputPrice: undefined,
 				requestPrice: undefined,


### PR DESCRIPTION
## Summary
- Google deprecated the `veo-3.1-generate-preview` and `veo-3.1-fast-generate-preview` model IDs on Vertex AI on 2026-04-02, causing the playground errors `Publisher Model ... was not found` and `Permission 'aiplatform.endpoints.predict' denied`.
- Update the upstream `modelName` for the `google-vertex` provider to the GA IDs `veo-3.1-generate-001` and `veo-3.1-fast-generate-001`.
- Keep the public-facing gateway model IDs (`veo-3.1-generate-preview` / `veo-3.1-fast-generate-preview`) unchanged so existing API consumers are not broken.
- Update the internal `modelName` comparison in the gateway and playground that gates reference-image support.

## Test plan
- [ ] Generate a video with `Veo 3.1` in the playground (no inputs)
- [ ] Generate a video with `Veo 3.1 Fast` in the playground (no inputs)
- [ ] Generate a video with `Veo 3.1` using a reference image (verify gating still allows it)
- [ ] Confirm `avalanche/veo-3.1-*` routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Veo 3.1 model identifiers from preview to production variants.
  * Improved handling of reference-image video requests for Google Vertex integrations to ensure correct model selection and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->