### PR TITLE
fix(playground): use correct Stripe live publishable key

### DIFF
--- a/apps/playground/src/lib/stripe.ts
+++ b/apps/playground/src/lib/stripe.ts
@@ -10,7 +10,7 @@ function getStripePromise() {
 	stripePromise ??= loadStripe(
 		process.env.NODE_ENV === "development"
 			? "pk_test_51RRXM1CYKGHizcWTfXxFSEzN8gsUQkg2efi2FN5KO2M2hxdV9QPCjeZMPaZQHSAatxpK9wDcSeilyYU14gz2qA2p00R4q5xU1R"
-			: "pk_live_51RRXM1CYKGHizcWTSyLJiSJKGpUIlsU4GWHTCiZrCZtL2dSmH1Y8CZd0Q6eeAjJPINaKQCJGxNRJkEDHOJhYnNMU00DFZ7ACOn",
+			: "pk_live_51RRXLsEAkKxa3kRayCPr9oW8dUp7mIzwev1FVpM3jpKU3StLaaiKvXCEPkewabL5hRip4IXLzFlFTLC4RpFWRknN00lX2vgZHP",
 	);
 	return stripePromise;
 }


### PR DESCRIPTION
The hardcoded pk_live key in apps/playground/src/lib/stripe.ts pointed
to a different Stripe account (51RRXM1...) than the one the API's
STRIPE_SECRET_KEY belongs to (51RRXLs..., matching apps/ui). Stripe
rejected payment confirmations from the playground with
"Invalid API Key provided: pk_live_***ACOn" because the publishable
key didn't match the account that issued the payment intent.

Aligning the playground's pk_live key with the UI's so credit top-ups
in the playground work for hosted users.

https://claude.ai/code/session_012q7978w4MPKTxkUjnGXYQr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration for payment processing integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->