### PR TITLE
feat(admin): add DevPass subscribers page

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -27,6 +27,7 @@ import {
 	modelHistory,
 } from "@llmgateway/db";
 import { models, providers } from "@llmgateway/models";
+import { DEV_PLAN_PRICES } from "@llmgateway/shared";
 import {
 	getResendClient,
 	fromEmail,
@@ -6925,6 +6926,895 @@ admin.openapi(getPaymentFailures, async (c) => {
 			})),
 		},
 		totalCount: Number(totalCountResult?.count ?? 0),
+	});
+});
+
+// =============================================================================
+// DevPass admin routes
+// =============================================================================
+
+const devpassTierSchema = z.enum(["lite", "pro", "max", "none"]);
+const devpassStatusSchema = z.enum([
+	"active",
+	"cancelled_pending",
+	"expired",
+	"churned",
+]);
+
+const devpassSubscriberSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	billingEmail: z.string(),
+	ownerUserId: z.string().nullable(),
+	ownerName: z.string().nullable(),
+	ownerEmail: z.string().nullable(),
+	tier: devpassTierSchema,
+	status: devpassStatusSchema,
+	hasPaymentIssue: z.boolean(),
+	creditsUsed: z.string(),
+	creditsLimit: z.string(),
+	utilizationPct: z.number().nullable(),
+	cycleStart: z.string().nullable(),
+	cycleDaysIn: z.number().nullable(),
+	expiresAt: z.string().nullable(),
+	cancelled: z.boolean(),
+	allowAllModels: z.boolean(),
+	mrr: z.number(),
+	realCost: z.number(),
+	margin: z.number(),
+	subscribedSince: z.string().nullable(),
+	tierChanges: z.number(),
+	lastPaymentFailureAt: z.string().nullable(),
+	createdAt: z.string(),
+});
+
+const devpassKpisSchema = z.object({
+	activeByTier: z.object({
+		lite: z.number(),
+		pro: z.number(),
+		max: z.number(),
+	}),
+	totalActive: z.number(),
+	cancelledPending: z.number(),
+	churned: z.number(),
+	grossMrr: z.number(),
+	startsThisMonth: z.number(),
+	endsThisMonth: z.number(),
+	netNewThisMonth: z.number(),
+	weightedAvgUtilization: z.number(),
+	totalRealCostCycle: z.number(),
+	totalMrrCycle: z.number(),
+	totalMargin: z.number(),
+});
+
+const devpassListSchema = z.object({
+	subscribers: z.array(devpassSubscriberSchema),
+	total: z.number(),
+	kpis: devpassKpisSchema,
+	limit: z.number(),
+	offset: z.number(),
+});
+
+const devpassSortBySchema = z.enum([
+	"name",
+	"billingEmail",
+	"tier",
+	"createdAt",
+	"cycleStart",
+	"expiresAt",
+	"subscribedSince",
+	"utilizationPct",
+	"realCost",
+	"margin",
+	"mrr",
+	"creditsUsed",
+]);
+
+const devpassUtilizationSchema = z.enum(["low", "healthy", "high", "over"]);
+
+const getDevpassSubscribers = createRoute({
+	method: "get",
+	path: "/devpass",
+	request: {
+		query: z.object({
+			limit: z.coerce.number().min(1).max(100).default(50).optional(),
+			offset: z.coerce.number().min(0).default(0).optional(),
+			search: z.string().optional(),
+			tier: devpassTierSchema.optional(),
+			status: devpassStatusSchema.optional(),
+			utilization: devpassUtilizationSchema.optional(),
+			marginNegative: z.coerce.boolean().optional(),
+			showChurned: z.coerce.boolean().default(false).optional(),
+			sortBy: devpassSortBySchema.default("subscribedSince").optional(),
+			sortOrder: sortOrderSchema.default("desc").optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: devpassListSchema.openapi({}),
+				},
+			},
+			description: "List of DevPass subscribers.",
+		},
+	},
+});
+
+const devpassTransactionSchema = z.object({
+	id: z.string(),
+	createdAt: z.string(),
+	type: z.string(),
+	amount: z.string().nullable(),
+	creditAmount: z.string().nullable(),
+	currency: z.string(),
+	status: z.string(),
+	description: z.string().nullable(),
+});
+
+const devpassPaymentFailureSchema = z.object({
+	id: z.string(),
+	createdAt: z.string(),
+	amount: z.string().nullable(),
+	currency: z.string(),
+	declineCode: z.string().nullable(),
+	failureMessage: z.string().nullable(),
+	source: z.string().nullable(),
+});
+
+const devpassDetailSchema = z.object({
+	subscriber: devpassSubscriberSchema,
+	transactions: z.array(devpassTransactionSchema),
+	paymentFailures: z.array(devpassPaymentFailureSchema),
+});
+
+const getDevpassSubscriber = createRoute({
+	method: "get",
+	path: "/devpass/{orgId}",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: devpassDetailSchema.openapi({}),
+				},
+			},
+			description: "DevPass subscriber detail.",
+		},
+		404: {
+			description: "Subscriber not found.",
+		},
+	},
+});
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+function tierPriceOf(tier: string): number {
+	if (tier === "lite" || tier === "pro" || tier === "max") {
+		return DEV_PLAN_PRICES[tier];
+	}
+	return 0;
+}
+
+function deriveStatus(
+	tier: string,
+	cancelled: boolean,
+	expiresAt: Date | null,
+	now: Date,
+): "active" | "cancelled_pending" | "expired" | "churned" {
+	if (tier === "none") {
+		return "churned";
+	}
+	if (expiresAt && expiresAt.getTime() <= now.getTime()) {
+		return "expired";
+	}
+	if (cancelled) {
+		return "cancelled_pending";
+	}
+	return "active";
+}
+
+admin.openapi(getDevpassSubscribers, async (c) => {
+	const query = c.req.valid("query");
+	const limit = query.limit ?? 50;
+	const offset = query.offset ?? 0;
+	const search = query.search;
+	const tierFilter = query.tier;
+	const statusFilter = query.status;
+	const utilizationFilter = query.utilization;
+	const marginNegative = query.marginNegative ?? false;
+	const showChurned = query.showChurned ?? false;
+	const sortBy = query.sortBy ?? "subscribedSince";
+	const sortOrder = query.sortOrder ?? "desc";
+
+	const now = new Date();
+	const monthStart = new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+	);
+
+	// Subquery: real provider cost in current cycle, per org
+	const realCostSub = db
+		.select({
+			organizationId: tables.project.organizationId,
+			realCost:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+					"real_cost",
+				),
+		})
+		.from(projectHourlyStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyStats.projectId, tables.project.id),
+		)
+		.innerJoin(
+			tables.organization,
+			and(
+				eq(tables.project.organizationId, tables.organization.id),
+				isNotNull(tables.organization.devPlanBillingCycleStart),
+				sql`${projectHourlyStats.hourTimestamp} >= ${tables.organization.devPlanBillingCycleStart}`,
+			),
+		)
+		.groupBy(tables.project.organizationId)
+		.as("real_cost_sub");
+
+	// Subquery: first dev_plan_start (subscribedSince) and tier change count
+	const subscribedSinceSub = db
+		.select({
+			organizationId: tables.transaction.organizationId,
+			firstStart: sql<string>`MIN(${tables.transaction.createdAt})`.as(
+				"first_start",
+			),
+		})
+		.from(tables.transaction)
+		.where(eq(tables.transaction.type, "dev_plan_start"))
+		.groupBy(tables.transaction.organizationId)
+		.as("subscribed_since_sub");
+
+	const tierChangesSub = db
+		.select({
+			organizationId: tables.transaction.organizationId,
+			count: sql<number>`COUNT(*)`.as("tier_change_count"),
+		})
+		.from(tables.transaction)
+		.where(
+			inArray(tables.transaction.type, [
+				"dev_plan_upgrade",
+				"dev_plan_downgrade",
+			]),
+		)
+		.groupBy(tables.transaction.organizationId)
+		.as("tier_changes_sub");
+
+	const lastPaymentFailureSub = db
+		.select({
+			organizationId: tables.paymentFailure.organizationId,
+			lastFailureAt: sql<string>`MAX(${tables.paymentFailure.createdAt})`.as(
+				"last_failure_at",
+			),
+		})
+		.from(tables.paymentFailure)
+		.groupBy(tables.paymentFailure.organizationId)
+		.as("last_payment_failure_sub");
+
+	const ownerSub = db
+		.select({
+			organizationId: tables.userOrganization.organizationId,
+			userId: tables.user.id,
+			userName: tables.user.name,
+			userEmail: tables.user.email,
+		})
+		.from(tables.userOrganization)
+		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
+		.where(eq(tables.userOrganization.role, "owner"))
+		.as("owner_sub");
+
+	const tierPriceExpr = sql<number>`CASE
+		WHEN ${tables.organization.devPlan} = 'lite' THEN ${DEV_PLAN_PRICES.lite}
+		WHEN ${tables.organization.devPlan} = 'pro' THEN ${DEV_PLAN_PRICES.pro}
+		WHEN ${tables.organization.devPlan} = 'max' THEN ${DEV_PLAN_PRICES.max}
+		ELSE 0
+	END`;
+
+	const utilizationExpr = sql<number | null>`CASE
+		WHEN CAST(${tables.organization.devPlanCreditsLimit} AS NUMERIC) > 0
+		THEN (CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC)
+			/ CAST(${tables.organization.devPlanCreditsLimit} AS NUMERIC)) * 100
+		ELSE NULL
+	END`;
+
+	const realCostExpr = sql<number>`COALESCE(CAST(${realCostSub.realCost} AS NUMERIC), 0)`;
+	const marginExpr = sql<number>`(${tierPriceExpr}) - COALESCE(CAST(${realCostSub.realCost} AS NUMERIC), 0)`;
+
+	const conditions = [];
+
+	// DevPass scope: subscribers (devPlan != 'none') OR (showChurned && has past dev_plan_start)
+	if (showChurned) {
+		conditions.push(
+			or(
+				ne(tables.organization.devPlan, "none"),
+				isNotNull(subscribedSinceSub.firstStart),
+			)!,
+		);
+	} else {
+		conditions.push(ne(tables.organization.devPlan, "none"));
+	}
+
+	if (tierFilter) {
+		conditions.push(eq(tables.organization.devPlan, tierFilter));
+	}
+
+	if (statusFilter === "active") {
+		conditions.push(ne(tables.organization.devPlan, "none"));
+		conditions.push(eq(tables.organization.devPlanCancelled, false));
+		conditions.push(
+			or(
+				isNull(tables.organization.devPlanExpiresAt),
+				sql`${tables.organization.devPlanExpiresAt} > NOW()`,
+			)!,
+		);
+	} else if (statusFilter === "cancelled_pending") {
+		conditions.push(ne(tables.organization.devPlan, "none"));
+		conditions.push(eq(tables.organization.devPlanCancelled, true));
+		conditions.push(
+			or(
+				isNull(tables.organization.devPlanExpiresAt),
+				sql`${tables.organization.devPlanExpiresAt} > NOW()`,
+			)!,
+		);
+	} else if (statusFilter === "expired") {
+		conditions.push(ne(tables.organization.devPlan, "none"));
+		conditions.push(isNotNull(tables.organization.devPlanExpiresAt));
+		conditions.push(sql`${tables.organization.devPlanExpiresAt} <= NOW()`);
+	} else if (statusFilter === "churned") {
+		conditions.push(eq(tables.organization.devPlan, "none"));
+		conditions.push(isNotNull(subscribedSinceSub.firstStart));
+	}
+
+	if (utilizationFilter === "low") {
+		conditions.push(sql`${utilizationExpr} < 20`);
+	} else if (utilizationFilter === "healthy") {
+		conditions.push(sql`${utilizationExpr} >= 20 AND ${utilizationExpr} <= 80`);
+	} else if (utilizationFilter === "high") {
+		conditions.push(sql`${utilizationExpr} > 80 AND ${utilizationExpr} <= 100`);
+	} else if (utilizationFilter === "over") {
+		conditions.push(sql`${utilizationExpr} > 100`);
+	}
+
+	if (marginNegative) {
+		conditions.push(sql`${marginExpr} < 0`);
+	}
+
+	if (search) {
+		const searchLower = search.toLowerCase();
+		conditions.push(
+			or(
+				sql`LOWER(${tables.organization.name}) LIKE ${`%${searchLower}%`}`,
+				sql`LOWER(${tables.organization.billingEmail}) LIKE ${`%${searchLower}%`}`,
+				sql`${tables.organization.id} LIKE ${`%${search}%`}`,
+				sql`LOWER(${ownerSub.userEmail}) LIKE ${`%${searchLower}%`}`,
+			)!,
+		);
+	}
+
+	const whereClause = and(...conditions);
+
+	const orderFn = sortOrder === "asc" ? asc : desc;
+	const sortColumnMap = {
+		name: tables.organization.name,
+		billingEmail: tables.organization.billingEmail,
+		tier: tables.organization.devPlan,
+		createdAt: tables.organization.createdAt,
+		cycleStart: tables.organization.devPlanBillingCycleStart,
+		expiresAt: tables.organization.devPlanExpiresAt,
+		subscribedSince: sql`${subscribedSinceSub.firstStart}`,
+		utilizationPct: sql`${utilizationExpr}`,
+		realCost: sql`${realCostExpr}`,
+		margin: sql`${marginExpr}`,
+		mrr: sql`${tierPriceExpr}`,
+		creditsUsed: sql`CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC)`,
+	} as const;
+	const sortColumn = sortColumnMap[sortBy];
+
+	const baseSelect = db
+		.select({
+			id: tables.organization.id,
+			name: tables.organization.name,
+			billingEmail: tables.organization.billingEmail,
+			tier: tables.organization.devPlan,
+			creditsUsed: tables.organization.devPlanCreditsUsed,
+			creditsLimit: tables.organization.devPlanCreditsLimit,
+			cycleStart: tables.organization.devPlanBillingCycleStart,
+			expiresAt: tables.organization.devPlanExpiresAt,
+			cancelled: tables.organization.devPlanCancelled,
+			allowAllModels: tables.organization.devPlanAllowAllModels,
+			createdAt: tables.organization.createdAt,
+			paymentFailureCount: tables.organization.paymentFailureCount,
+			utilizationPct: utilizationExpr,
+			mrr: tierPriceExpr,
+			realCost: realCostExpr,
+			margin: marginExpr,
+			subscribedSince: subscribedSinceSub.firstStart,
+			tierChanges: sql<number>`COALESCE(${tierChangesSub.count}, 0)`,
+			lastPaymentFailureAt: lastPaymentFailureSub.lastFailureAt,
+			ownerUserId: ownerSub.userId,
+			ownerName: ownerSub.userName,
+			ownerEmail: ownerSub.userEmail,
+		})
+		.from(tables.organization)
+		.leftJoin(
+			realCostSub,
+			eq(tables.organization.id, realCostSub.organizationId),
+		)
+		.leftJoin(
+			subscribedSinceSub,
+			eq(tables.organization.id, subscribedSinceSub.organizationId),
+		)
+		.leftJoin(
+			tierChangesSub,
+			eq(tables.organization.id, tierChangesSub.organizationId),
+		)
+		.leftJoin(
+			lastPaymentFailureSub,
+			eq(tables.organization.id, lastPaymentFailureSub.organizationId),
+		)
+		.leftJoin(ownerSub, eq(tables.organization.id, ownerSub.organizationId));
+
+	const rows = await baseSelect
+		.where(whereClause)
+		.orderBy(orderFn(sortColumn))
+		.limit(limit)
+		.offset(offset);
+
+	// Total count with same filters
+	const countSelect = db
+		.select({ count: sql<number>`COUNT(*)` })
+		.from(tables.organization)
+		.leftJoin(
+			realCostSub,
+			eq(tables.organization.id, realCostSub.organizationId),
+		)
+		.leftJoin(
+			subscribedSinceSub,
+			eq(tables.organization.id, subscribedSinceSub.organizationId),
+		)
+		.leftJoin(
+			tierChangesSub,
+			eq(tables.organization.id, tierChangesSub.organizationId),
+		)
+		.leftJoin(
+			lastPaymentFailureSub,
+			eq(tables.organization.id, lastPaymentFailureSub.organizationId),
+		)
+		.leftJoin(ownerSub, eq(tables.organization.id, ownerSub.organizationId));
+
+	const [countRow] = await countSelect.where(whereClause);
+	const total = Number(countRow?.count ?? 0);
+
+	// KPI strip — always over the full active subscriber base, unfiltered
+	const activeRows = await db
+		.select({
+			tier: tables.organization.devPlan,
+			count: sql<number>`COUNT(*)`,
+		})
+		.from(tables.organization)
+		.where(
+			and(
+				ne(tables.organization.devPlan, "none"),
+				eq(tables.organization.devPlanCancelled, false),
+				or(
+					isNull(tables.organization.devPlanExpiresAt),
+					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
+				)!,
+			),
+		)
+		.groupBy(tables.organization.devPlan);
+
+	const activeByTier = { lite: 0, pro: 0, max: 0 };
+	for (const r of activeRows) {
+		const tierKey = r.tier as keyof typeof activeByTier;
+		if (tierKey in activeByTier) {
+			activeByTier[tierKey] = Number(r.count);
+		}
+	}
+	const totalActive = activeByTier.lite + activeByTier.pro + activeByTier.max;
+	const liteMrr = activeByTier.lite * DEV_PLAN_PRICES.lite;
+	const proMrr = activeByTier.pro * DEV_PLAN_PRICES.pro;
+	const maxMrr = activeByTier.max * DEV_PLAN_PRICES.max;
+	const grossMrr = liteMrr + proMrr + maxMrr;
+
+	const [cancelledPendingRow] = await db
+		.select({ count: sql<number>`COUNT(*)` })
+		.from(tables.organization)
+		.where(
+			and(
+				ne(tables.organization.devPlan, "none"),
+				eq(tables.organization.devPlanCancelled, true),
+				or(
+					isNull(tables.organization.devPlanExpiresAt),
+					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
+				)!,
+			),
+		);
+	const cancelledPending = Number(cancelledPendingRow?.count ?? 0);
+
+	const [churnedRow] = await db
+		.select({
+			count: sql<number>`COUNT(DISTINCT ${tables.transaction.organizationId})`,
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "dev_plan_start"),
+				eq(tables.organization.devPlan, "none"),
+			),
+		);
+	const churned = Number(churnedRow?.count ?? 0);
+
+	const [startsRow] = await db
+		.select({ count: sql<number>`COUNT(*)` })
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.type, "dev_plan_start"),
+				gte(tables.transaction.createdAt, monthStart),
+			),
+		);
+	const startsThisMonth = Number(startsRow?.count ?? 0);
+
+	const [endsRow] = await db
+		.select({ count: sql<number>`COUNT(*)` })
+		.from(tables.transaction)
+		.where(
+			and(
+				inArray(tables.transaction.type, ["dev_plan_cancel", "dev_plan_end"]),
+				gte(tables.transaction.createdAt, monthStart),
+			),
+		);
+	const endsThisMonth = Number(endsRow?.count ?? 0);
+
+	// Weighted utilization across active subscribers
+	const [utilRow] = await db
+		.select({
+			totalUsed: sql<string>`COALESCE(SUM(CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC)), 0)`,
+			totalLimit: sql<string>`COALESCE(SUM(CAST(${tables.organization.devPlanCreditsLimit} AS NUMERIC)), 0)`,
+		})
+		.from(tables.organization)
+		.where(
+			and(
+				ne(tables.organization.devPlan, "none"),
+				or(
+					isNull(tables.organization.devPlanExpiresAt),
+					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
+				)!,
+			),
+		);
+	const totalUsed = Number(utilRow?.totalUsed ?? 0);
+	const totalLimit = Number(utilRow?.totalLimit ?? 0);
+	const weightedAvgUtilization =
+		totalLimit > 0 ? (totalUsed / totalLimit) * 100 : 0;
+
+	// Cycle-windowed totals across all current subscribers (sum of rows already covers this)
+	let totalRealCostCycle = 0;
+	let totalMrrCycle = 0;
+	for (const r of rows) {
+		totalRealCostCycle += Number(r.realCost ?? 0);
+		totalMrrCycle += Number(r.mrr ?? 0);
+	}
+	// For total margin, compute against the active universe — a separate query
+	const [marginRow] = await db
+		.select({
+			totalCost: sql<string>`COALESCE(SUM(CAST(${realCostSub.realCost} AS NUMERIC)), 0)`,
+			totalMrr: sql<string>`COALESCE(SUM(${tierPriceExpr}), 0)`,
+		})
+		.from(tables.organization)
+		.leftJoin(
+			realCostSub,
+			eq(tables.organization.id, realCostSub.organizationId),
+		)
+		.where(ne(tables.organization.devPlan, "none"));
+	const universeRealCost = Number(marginRow?.totalCost ?? 0);
+	const universeMrr = Number(marginRow?.totalMrr ?? 0);
+	const totalMargin = universeMrr - universeRealCost;
+
+	const subscribers = rows.map((row) => {
+		const tier = row.tier;
+		const cancelled = row.cancelled;
+		const expiresAt = row.expiresAt;
+		const status = deriveStatus(tier, cancelled, expiresAt, now);
+
+		const cycleStart = row.cycleStart;
+		const cycleDaysIn = cycleStart
+			? Math.max(
+					0,
+					Math.floor(
+						(now.getTime() - cycleStart.getTime()) / (1000 * 60 * 60 * 24),
+					),
+				)
+			: null;
+
+		const utilizationPctRaw = row.utilizationPct;
+		const utilizationPct =
+			utilizationPctRaw === null || utilizationPctRaw === undefined
+				? null
+				: Number(utilizationPctRaw);
+
+		const lastPaymentFailureAt = row.lastPaymentFailureAt
+			? new Date(row.lastPaymentFailureAt).toISOString()
+			: null;
+		const hasPaymentIssue =
+			(row.paymentFailureCount ?? 0) > 0 ||
+			(lastPaymentFailureAt !== null &&
+				new Date(lastPaymentFailureAt).getTime() >
+					now.getTime() - THIRTY_DAYS_MS);
+
+		return {
+			id: row.id,
+			name: row.name,
+			billingEmail: row.billingEmail,
+			ownerUserId: row.ownerUserId ?? null,
+			ownerName: row.ownerName ?? null,
+			ownerEmail: row.ownerEmail ?? null,
+			tier,
+			status,
+			hasPaymentIssue,
+			creditsUsed: String(row.creditsUsed),
+			creditsLimit: String(row.creditsLimit),
+			utilizationPct,
+			cycleStart: cycleStart ? cycleStart.toISOString() : null,
+			cycleDaysIn,
+			expiresAt: expiresAt ? expiresAt.toISOString() : null,
+			cancelled,
+			allowAllModels: row.allowAllModels,
+			mrr: Number(row.mrr ?? 0),
+			realCost: Number(row.realCost ?? 0),
+			margin: Number(row.margin ?? 0),
+			subscribedSince: row.subscribedSince
+				? new Date(row.subscribedSince).toISOString()
+				: null,
+			tierChanges: Number(row.tierChanges ?? 0),
+			lastPaymentFailureAt,
+			createdAt: row.createdAt.toISOString(),
+		};
+	});
+
+	return c.json({
+		subscribers,
+		total,
+		kpis: {
+			activeByTier,
+			totalActive,
+			cancelledPending,
+			churned,
+			grossMrr,
+			startsThisMonth,
+			endsThisMonth,
+			netNewThisMonth: startsThisMonth - endsThisMonth,
+			weightedAvgUtilization,
+			totalRealCostCycle,
+			totalMrrCycle,
+			totalMargin,
+		},
+		limit,
+		offset,
+	});
+});
+
+admin.openapi(getDevpassSubscriber, async (c) => {
+	const { orgId } = c.req.valid("param");
+	const now = new Date();
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId } },
+	});
+
+	if (!org) {
+		throw new HTTPException(404, { message: "Subscriber not found" });
+	}
+
+	const owner = await db
+		.select({
+			userId: tables.user.id,
+			userName: tables.user.name,
+			userEmail: tables.user.email,
+		})
+		.from(tables.userOrganization)
+		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
+		.where(
+			and(
+				eq(tables.userOrganization.organizationId, orgId),
+				eq(tables.userOrganization.role, "owner"),
+			),
+		)
+		.limit(1);
+
+	const [firstStartRow] = await db
+		.select({
+			firstStart: sql<string>`MIN(${tables.transaction.createdAt})`,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				eq(tables.transaction.type, "dev_plan_start"),
+			),
+		);
+
+	const [tierChangesRow] = await db
+		.select({
+			count: sql<number>`COUNT(*)`,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				inArray(tables.transaction.type, [
+					"dev_plan_upgrade",
+					"dev_plan_downgrade",
+				]),
+			),
+		);
+
+	const [realCostRow] = org.devPlanBillingCycleStart
+		? await db
+				.select({
+					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+				})
+				.from(projectHourlyStats)
+				.innerJoin(
+					tables.project,
+					eq(projectHourlyStats.projectId, tables.project.id),
+				)
+				.where(
+					and(
+						eq(tables.project.organizationId, orgId),
+						gte(projectHourlyStats.hourTimestamp, org.devPlanBillingCycleStart),
+					),
+				)
+		: [{ total: "0" }];
+
+	const realCost = Number(realCostRow?.total ?? 0);
+	const mrr = tierPriceOf(org.devPlan);
+	const margin = mrr - realCost;
+
+	const status = deriveStatus(
+		org.devPlan,
+		org.devPlanCancelled,
+		org.devPlanExpiresAt,
+		now,
+	);
+	const utilizationPct =
+		Number(org.devPlanCreditsLimit) > 0
+			? (Number(org.devPlanCreditsUsed) / Number(org.devPlanCreditsLimit)) * 100
+			: null;
+	const cycleDaysIn = org.devPlanBillingCycleStart
+		? Math.max(
+				0,
+				Math.floor(
+					(now.getTime() - org.devPlanBillingCycleStart.getTime()) /
+						(1000 * 60 * 60 * 24),
+				),
+			)
+		: null;
+
+	const [lastFailureRow] = await db
+		.select({
+			lastFailureAt: sql<string>`MAX(${tables.paymentFailure.createdAt})`,
+		})
+		.from(tables.paymentFailure)
+		.where(eq(tables.paymentFailure.organizationId, orgId));
+
+	const hasPaymentIssue =
+		(org.paymentFailureCount ?? 0) > 0 ||
+		(lastFailureRow?.lastFailureAt !== undefined &&
+			lastFailureRow.lastFailureAt !== null &&
+			new Date(lastFailureRow.lastFailureAt).getTime() >
+				now.getTime() - THIRTY_DAYS_MS);
+
+	const subscriber = {
+		id: org.id,
+		name: org.name,
+		billingEmail: org.billingEmail,
+		ownerUserId: owner[0]?.userId ?? null,
+		ownerName: owner[0]?.userName ?? null,
+		ownerEmail: owner[0]?.userEmail ?? null,
+		tier: org.devPlan,
+		status,
+		hasPaymentIssue,
+		creditsUsed: String(org.devPlanCreditsUsed),
+		creditsLimit: String(org.devPlanCreditsLimit),
+		utilizationPct,
+		cycleStart: org.devPlanBillingCycleStart
+			? org.devPlanBillingCycleStart.toISOString()
+			: null,
+		cycleDaysIn,
+		expiresAt: org.devPlanExpiresAt ? org.devPlanExpiresAt.toISOString() : null,
+		cancelled: org.devPlanCancelled,
+		allowAllModels: org.devPlanAllowAllModels,
+		mrr,
+		realCost,
+		margin,
+		subscribedSince: firstStartRow?.firstStart
+			? new Date(firstStartRow.firstStart).toISOString()
+			: null,
+		tierChanges: Number(tierChangesRow?.count ?? 0),
+		lastPaymentFailureAt: lastFailureRow?.lastFailureAt
+			? new Date(lastFailureRow.lastFailureAt).toISOString()
+			: null,
+		createdAt: org.createdAt.toISOString(),
+	};
+
+	const transactions = await db
+		.select({
+			id: tables.transaction.id,
+			createdAt: tables.transaction.createdAt,
+			type: tables.transaction.type,
+			amount: tables.transaction.amount,
+			creditAmount: tables.transaction.creditAmount,
+			currency: tables.transaction.currency,
+			status: tables.transaction.status,
+			description: tables.transaction.description,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				inArray(tables.transaction.type, [
+					"dev_plan_start",
+					"dev_plan_upgrade",
+					"dev_plan_downgrade",
+					"dev_plan_cancel",
+					"dev_plan_end",
+					"dev_plan_renewal",
+				]),
+			),
+		)
+		.orderBy(desc(tables.transaction.createdAt))
+		.limit(100);
+
+	const paymentFailures = await db
+		.select({
+			id: tables.paymentFailure.id,
+			createdAt: tables.paymentFailure.createdAt,
+			amount: tables.paymentFailure.amount,
+			currency: tables.paymentFailure.currency,
+			declineCode: tables.paymentFailure.declineCode,
+			failureMessage: tables.paymentFailure.failureMessage,
+			source: tables.paymentFailure.source,
+		})
+		.from(tables.paymentFailure)
+		.where(eq(tables.paymentFailure.organizationId, orgId))
+		.orderBy(desc(tables.paymentFailure.createdAt))
+		.limit(50);
+
+	return c.json({
+		subscriber,
+		transactions: transactions.map((t) => ({
+			id: t.id,
+			createdAt: t.createdAt.toISOString(),
+			type: t.type,
+			amount: t.amount ?? null,
+			creditAmount: t.creditAmount ?? null,
+			currency: t.currency,
+			status: t.status,
+			description: t.description ?? null,
+		})),
+		paymentFailures: paymentFailures.map((p) => ({
+			id: p.id,
+			createdAt: p.createdAt.toISOString(),
+			amount: p.amount ?? null,
+			currency: p.currency,
+			declineCode: p.declineCode ?? null,
+			failureMessage: p.failureMessage ?? null,
+			source: p.source ?? null,
+		})),
 	});
 });
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7501,15 +7501,8 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const weightedAvgUtilization =
 		totalLimit > 0 ? (totalUsed / totalLimit) * 100 : 0;
 
-	// Cycle-windowed totals across all current subscribers (sum of rows already covers this)
-	let totalRealCostCycle = 0;
-	let totalMrrCycle = 0;
-	for (const r of rows) {
-		totalRealCostCycle += Number(r.realCost ?? 0);
-		totalMrrCycle += Number(r.mrr ?? 0);
-	}
-	// For total margin, compute against the active universe — a separate query
-	const [marginRow] = await db
+	// Cycle-windowed totals across the active subscriber universe (not paginated)
+	const [universeRow] = await db
 		.select({
 			totalCost: sql<string>`COALESCE(SUM(CAST(${realCostSub.realCost} AS NUMERIC)), 0)`,
 			totalMrr: sql<string>`COALESCE(SUM(${tierPriceExpr}), 0)`,
@@ -7520,9 +7513,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			eq(tables.organization.id, realCostSub.organizationId),
 		)
 		.where(ne(tables.organization.devPlan, "none"));
-	const universeRealCost = Number(marginRow?.totalCost ?? 0);
-	const universeMrr = Number(marginRow?.totalMrr ?? 0);
-	const totalMargin = universeMrr - universeRealCost;
+	const totalRealCostCycle = Number(universeRow?.totalCost ?? 0);
+	const totalMrrCycle = Number(universeRow?.totalMrr ?? 0);
+	const totalMargin = totalMrrCycle - totalRealCostCycle;
 
 	const subscribers = rows.map((row) => {
 		const tier = row.tier;
@@ -7646,6 +7639,10 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 				eq(tables.transaction.type, "dev_plan_start"),
 			),
 		);
+
+	if (org.devPlan === "none" && !firstStartRow?.firstStart) {
+		throw new HTTPException(404, { message: "Subscriber not found" });
+	}
 
 	const [tierChangesRow] = await db
 		.select({

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4304,6 +4304,194 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                    offset?: number | null;
+                    search?: string;
+                    tier?: "lite" | "pro" | "max" | "none";
+                    status?: "active" | "cancelled_pending" | "expired" | "churned";
+                    utilization?: "low" | "healthy" | "high" | "over";
+                    marginNegative?: boolean | null;
+                    showChurned?: boolean | null;
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortOrder?: "asc" | "desc";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of DevPass subscribers. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscribers: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            }[];
+                            total: number;
+                            kpis: {
+                                activeByTier: {
+                                    lite: number;
+                                    pro: number;
+                                    max: number;
+                                };
+                                totalActive: number;
+                                cancelledPending: number;
+                                churned: number;
+                                grossMrr: number;
+                                startsThisMonth: number;
+                                endsThisMonth: number;
+                                netNewThisMonth: number;
+                                weightedAvgUtilization: number;
+                                totalRealCostCycle: number;
+                                totalMrrCycle: number;
+                                totalMargin: number;
+                            };
+                            limit: number;
+                            offset: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/{orgId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass subscriber detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscriber: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            };
+                            transactions: {
+                                id: string;
+                                createdAt: string;
+                                type: string;
+                                amount: string | null;
+                                creditAmount: string | null;
+                                currency: string;
+                                status: string;
+                                description: string | null;
+                            }[];
+                            paymentFailures: {
+                                id: string;
+                                createdAt: string;
+                                amount: string | null;
+                                currency: string;
+                                declineCode: string | null;
+                                failureMessage: string | null;
+                                source: string | null;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Subscriber not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/keys/api": {
         parameters: {
             query?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4304,6 +4304,194 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                    offset?: number | null;
+                    search?: string;
+                    tier?: "lite" | "pro" | "max" | "none";
+                    status?: "active" | "cancelled_pending" | "expired" | "churned";
+                    utilization?: "low" | "healthy" | "high" | "over";
+                    marginNegative?: boolean | null;
+                    showChurned?: boolean | null;
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortOrder?: "asc" | "desc";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of DevPass subscribers. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscribers: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            }[];
+                            total: number;
+                            kpis: {
+                                activeByTier: {
+                                    lite: number;
+                                    pro: number;
+                                    max: number;
+                                };
+                                totalActive: number;
+                                cancelledPending: number;
+                                churned: number;
+                                grossMrr: number;
+                                startsThisMonth: number;
+                                endsThisMonth: number;
+                                netNewThisMonth: number;
+                                weightedAvgUtilization: number;
+                                totalRealCostCycle: number;
+                                totalMrrCycle: number;
+                                totalMargin: number;
+                            };
+                            limit: number;
+                            offset: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/{orgId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass subscriber detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscriber: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            };
+                            transactions: {
+                                id: string;
+                                createdAt: string;
+                                type: string;
+                                amount: string | null;
+                                creditAmount: string | null;
+                                currency: string;
+                                status: string;
+                                description: string | null;
+                            }[];
+                            paymentFailures: {
+                                id: string;
+                                createdAt: string;
+                                amount: string | null;
+                                currency: string;
+                                declineCode: string | null;
+                                failureMessage: string | null;
+                                source: string | null;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Subscriber not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/keys/api": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4304,6 +4304,194 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                    offset?: number | null;
+                    search?: string;
+                    tier?: "lite" | "pro" | "max" | "none";
+                    status?: "active" | "cancelled_pending" | "expired" | "churned";
+                    utilization?: "low" | "healthy" | "high" | "over";
+                    marginNegative?: boolean | null;
+                    showChurned?: boolean | null;
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortOrder?: "asc" | "desc";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of DevPass subscribers. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscribers: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            }[];
+                            total: number;
+                            kpis: {
+                                activeByTier: {
+                                    lite: number;
+                                    pro: number;
+                                    max: number;
+                                };
+                                totalActive: number;
+                                cancelledPending: number;
+                                churned: number;
+                                grossMrr: number;
+                                startsThisMonth: number;
+                                endsThisMonth: number;
+                                netNewThisMonth: number;
+                                weightedAvgUtilization: number;
+                                totalRealCostCycle: number;
+                                totalMrrCycle: number;
+                                totalMargin: number;
+                            };
+                            limit: number;
+                            offset: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/{orgId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass subscriber detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscriber: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            };
+                            transactions: {
+                                id: string;
+                                createdAt: string;
+                                type: string;
+                                amount: string | null;
+                                creditAmount: string | null;
+                                currency: string;
+                                status: string;
+                                description: string | null;
+                            }[];
+                            paymentFailures: {
+                                id: string;
+                                createdAt: string;
+                                amount: string | null;
+                                currency: string;
+                                declineCode: string | null;
+                                failureMessage: string | null;
+                                source: string | null;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Subscriber not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/keys/api": {
         parameters: {
             query?: never;

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -1,0 +1,432 @@
+import {
+	AlertCircle,
+	ArrowLeft,
+	Building2,
+	CreditCard,
+	Receipt,
+} from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { requireSession } from "@/lib/require-session";
+import { createServerApiClient } from "@/lib/server-api";
+import { cn } from "@/lib/utils";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+const currencyFormatterPrecise = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
+function formatDate(dateString: string | null) {
+	if (!dateString) {
+		return "—";
+	}
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function formatDateTime(dateString: string) {
+	return new Date(dateString).toLocaleString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+function formatTransactionType(type: string) {
+	return type.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function getTransactionTypeBadgeVariant(
+	type: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	if (type.includes("cancel") || type.includes("end")) {
+		return "destructive";
+	}
+	if (type.includes("start") || type.includes("renewal")) {
+		return "default";
+	}
+	if (type.includes("upgrade") || type.includes("downgrade")) {
+		return "secondary";
+	}
+	return "outline";
+}
+
+function getTierBadgeVariant(
+	tier: string,
+): "default" | "secondary" | "outline" {
+	switch (tier) {
+		case "max":
+			return "default";
+		case "pro":
+			return "secondary";
+		case "lite":
+			return "outline";
+		default:
+			return "outline";
+	}
+}
+
+function getStatusBadgeVariant(
+	status: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	switch (status) {
+		case "active":
+			return "secondary";
+		case "cancelled_pending":
+			return "outline";
+		case "expired":
+			return "destructive";
+		case "churned":
+			return "outline";
+		default:
+			return "outline";
+	}
+}
+
+function formatStatus(status: string) {
+	if (status === "cancelled_pending") {
+		return "cancel pending";
+	}
+	return status;
+}
+
+function SignInPrompt() {
+	return (
+		<div className="flex min-h-screen items-center justify-center px-4">
+			<div className="w-full max-w-md text-center">
+				<div className="mb-8">
+					<h1 className="text-3xl font-semibold tracking-tight">
+						Admin Dashboard
+					</h1>
+					<p className="mt-2 text-sm text-muted-foreground">
+						Sign in to access the admin dashboard
+					</p>
+				</div>
+				<Button asChild size="lg" className="w-full">
+					<Link href="/login">Sign In</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+export default async function DevpassDetailPage({
+	params,
+}: {
+	params: Promise<{ orgId: string }>;
+}) {
+	await requireSession();
+
+	const { orgId } = await params;
+
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/devpass/{orgId}", {
+		params: { path: { orgId } },
+	});
+
+	if (data === null) {
+		return <SignInPrompt />;
+	}
+
+	if (!data) {
+		notFound();
+	}
+
+	const sub = data.subscriber;
+	const utilizationClamped =
+		sub.utilizationPct === null
+			? 0
+			: Math.min(100, Math.max(0, sub.utilizationPct));
+	const utilizationTone =
+		sub.utilizationPct === null
+			? "bg-muted"
+			: sub.utilizationPct < 20
+				? "bg-amber-500"
+				: sub.utilizationPct > 100
+					? "bg-rose-500"
+					: sub.utilizationPct > 80
+						? "bg-orange-500"
+						: "bg-emerald-500";
+
+	return (
+		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
+			<div className="flex items-center gap-2">
+				<Button variant="ghost" size="sm" asChild>
+					<Link href="/devpass">
+						<ArrowLeft className="h-4 w-4" />
+						Back
+					</Link>
+				</Button>
+			</div>
+
+			<header className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-start">
+				<div className="space-y-2">
+					<div className="flex items-center gap-3">
+						<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+							<Building2 className="h-5 w-5" />
+						</div>
+						<div>
+							<h1 className="text-2xl font-semibold tracking-tight">
+								{sub.name}
+							</h1>
+							<p className="text-sm text-muted-foreground">{sub.id}</p>
+						</div>
+					</div>
+					<div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+						<span>{sub.ownerEmail ?? sub.billingEmail}</span>
+						<span>•</span>
+						<span>Subscribed {formatDate(sub.subscribedSince)}</span>
+					</div>
+					<div className="flex flex-wrap items-center gap-2">
+						<Badge variant={getTierBadgeVariant(sub.tier)}>
+							Tier: {sub.tier}
+						</Badge>
+						<Badge variant={getStatusBadgeVariant(sub.status)}>
+							{formatStatus(sub.status)}
+						</Badge>
+						{sub.hasPaymentIssue && (
+							<Badge variant="destructive" className="gap-1">
+								<AlertCircle className="h-3 w-3" />
+								payment issue
+							</Badge>
+						)}
+						{sub.allowAllModels && (
+							<Badge variant="outline">all-models access</Badge>
+						)}
+					</div>
+				</div>
+				<Button variant="outline" size="sm" asChild>
+					<Link href={`/organizations/${sub.id}`}>Open in Organizations</Link>
+				</Button>
+			</header>
+
+			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
+						Cycle utilization
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{sub.utilizationPct === null
+							? "—"
+							: `${sub.utilizationPct.toFixed(1)}%`}
+					</div>
+					<div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+						<div
+							className={cn("h-full", utilizationTone)}
+							style={{ width: `${utilizationClamped}%` }}
+						/>
+					</div>
+					<div className="mt-2 text-xs tabular-nums text-muted-foreground">
+						{currencyFormatter.format(parseFloat(sub.creditsUsed))} of{" "}
+						{currencyFormatter.format(parseFloat(sub.creditsLimit))}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						{sub.cycleDaysIn !== null
+							? `Day ${sub.cycleDaysIn} of cycle`
+							: "No active cycle"}
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
+						MRR
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{currencyFormatter.format(sub.mrr)}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						Renews {formatDate(sub.expiresAt)}
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
+						Real provider cost (cycle)
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{currencyFormatterPrecise.format(sub.realCost)}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						From hourly project stats
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
+						Margin
+					</div>
+					<div
+						className={cn(
+							"mt-2 text-2xl font-semibold tabular-nums",
+							sub.margin < 0
+								? "text-rose-600 dark:text-rose-400"
+								: "text-emerald-600 dark:text-emerald-400",
+						)}
+					>
+						{currencyFormatter.format(sub.margin)}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						{sub.tierChanges} tier change
+						{sub.tierChanges === 1 ? "" : "s"} all time
+					</div>
+				</div>
+			</section>
+
+			<Tabs defaultValue="transactions">
+				<TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
+					<TabsTrigger value="transactions">
+						<Receipt className="mr-1.5 h-4 w-4" />
+						Subscription history ({data.transactions.length})
+					</TabsTrigger>
+					<TabsTrigger value="payment-failures">
+						<CreditCard className="mr-1.5 h-4 w-4" />
+						Payment failures ({data.paymentFailures.length})
+					</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="transactions">
+					<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Date</TableHead>
+									<TableHead>Event</TableHead>
+									<TableHead>Amount</TableHead>
+									<TableHead>Credits</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead>Description</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{data.transactions.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={6}
+											className="h-24 text-center text-muted-foreground"
+										>
+											No subscription events recorded
+										</TableCell>
+									</TableRow>
+								) : (
+									data.transactions.map((t) => (
+										<TableRow key={t.id}>
+											<TableCell className="text-muted-foreground">
+												{formatDateTime(t.createdAt)}
+											</TableCell>
+											<TableCell>
+												<Badge variant={getTransactionTypeBadgeVariant(t.type)}>
+													{formatTransactionType(t.type)}
+												</Badge>
+											</TableCell>
+											<TableCell className="tabular-nums">
+												{t.amount
+													? currencyFormatter.format(parseFloat(t.amount))
+													: "—"}
+											</TableCell>
+											<TableCell className="tabular-nums">
+												{t.creditAmount
+													? currencyFormatter.format(parseFloat(t.creditAmount))
+													: "—"}
+											</TableCell>
+											<TableCell>
+												<Badge
+													variant={
+														t.status === "completed"
+															? "secondary"
+															: t.status === "failed"
+																? "destructive"
+																: "outline"
+													}
+												>
+													{t.status}
+												</Badge>
+											</TableCell>
+											<TableCell className="max-w-[300px] truncate text-muted-foreground">
+												{t.description ?? "—"}
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+
+				<TabsContent value="payment-failures">
+					<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Date</TableHead>
+									<TableHead>Amount</TableHead>
+									<TableHead>Decline code</TableHead>
+									<TableHead>Source</TableHead>
+									<TableHead>Message</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{data.paymentFailures.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="h-24 text-center text-muted-foreground"
+										>
+											No payment failures
+										</TableCell>
+									</TableRow>
+								) : (
+									data.paymentFailures.map((p) => (
+										<TableRow key={p.id}>
+											<TableCell className="text-muted-foreground">
+												{formatDateTime(p.createdAt)}
+											</TableCell>
+											<TableCell className="tabular-nums">
+												{p.amount
+													? currencyFormatter.format(parseFloat(p.amount))
+													: "—"}
+											</TableCell>
+											<TableCell>
+												{p.declineCode ? (
+													<Badge variant="outline">{p.declineCode}</Badge>
+												) : (
+													<span className="text-muted-foreground">—</span>
+												)}
+											</TableCell>
+											<TableCell className="text-muted-foreground text-sm">
+												{p.source ?? "—"}
+											</TableCell>
+											<TableCell className="max-w-[400px] truncate text-muted-foreground text-sm">
+												{p.failureMessage ?? "—"}
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -1,0 +1,842 @@
+import {
+	AlertCircle,
+	ArrowDown,
+	ArrowUp,
+	ArrowUpDown,
+	ChevronLeft,
+	ChevronRight,
+	Search,
+	TrendingDown,
+	TrendingUp,
+	Users,
+	Wallet,
+} from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { requireSession } from "@/lib/require-session";
+import { createServerApiClient } from "@/lib/server-api";
+import { cn } from "@/lib/utils";
+
+type SortBy =
+	| "name"
+	| "billingEmail"
+	| "tier"
+	| "createdAt"
+	| "cycleStart"
+	| "expiresAt"
+	| "subscribedSince"
+	| "utilizationPct"
+	| "realCost"
+	| "margin"
+	| "mrr"
+	| "creditsUsed";
+type SortOrder = "asc" | "desc";
+
+type TierFilter = "lite" | "pro" | "max" | "none" | "";
+type StatusFilter = "active" | "cancelled_pending" | "expired" | "churned" | "";
+type UtilFilter = "low" | "healthy" | "high" | "over" | "";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+const currencyFormatterPrecise = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
+function formatDate(dateString: string | null) {
+	if (!dateString) {
+		return "—";
+	}
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function getTierBadgeVariant(
+	tier: string,
+): "default" | "secondary" | "outline" {
+	switch (tier) {
+		case "max":
+			return "default";
+		case "pro":
+			return "secondary";
+		case "lite":
+			return "outline";
+		default:
+			return "outline";
+	}
+}
+
+function getStatusBadgeVariant(
+	status: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	switch (status) {
+		case "active":
+			return "secondary";
+		case "cancelled_pending":
+			return "outline";
+		case "expired":
+			return "destructive";
+		case "churned":
+			return "outline";
+		default:
+			return "outline";
+	}
+}
+
+function formatStatus(status: string) {
+	if (status === "cancelled_pending") {
+		return "cancel pending";
+	}
+	return status;
+}
+
+function SortableHeader({
+	label,
+	sortKey,
+	currentSortBy,
+	currentSortOrder,
+	queryString,
+}: {
+	label: string;
+	sortKey: SortBy;
+	currentSortBy: SortBy;
+	currentSortOrder: SortOrder;
+	queryString: string;
+}) {
+	const isActive = currentSortBy === sortKey;
+	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
+
+	const baseParams = new URLSearchParams(queryString);
+	baseParams.set("sortBy", sortKey);
+	baseParams.set("sortOrder", nextOrder);
+	baseParams.set("page", "1");
+	const href = `/devpass?${baseParams.toString()}`;
+
+	return (
+		<Link
+			href={href}
+			className={cn(
+				"flex items-center gap-1 hover:text-foreground transition-colors",
+				isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+		>
+			{label}
+			{isActive ? (
+				currentSortOrder === "asc" ? (
+					<ArrowUp className="h-3.5 w-3.5" />
+				) : (
+					<ArrowDown className="h-3.5 w-3.5" />
+				)
+			) : (
+				<ArrowUpDown className="h-3.5 w-3.5 opacity-50" />
+			)}
+		</Link>
+	);
+}
+
+function UtilBar({ pct }: { pct: number | null }) {
+	if (pct === null) {
+		return <span className="text-muted-foreground">—</span>;
+	}
+	const clamped = Math.min(100, Math.max(0, pct));
+	const tone =
+		pct < 20
+			? "bg-amber-500"
+			: pct > 100
+				? "bg-rose-500"
+				: pct > 80
+					? "bg-orange-500"
+					: "bg-emerald-500";
+	return (
+		<div className="flex items-center gap-2">
+			<div className="h-1.5 w-20 overflow-hidden rounded-full bg-muted">
+				<div className={cn("h-full", tone)} style={{ width: `${clamped}%` }} />
+			</div>
+			<span className="tabular-nums text-xs text-muted-foreground">
+				{pct.toFixed(0)}%
+			</span>
+		</div>
+	);
+}
+
+function FilterPill({
+	label,
+	value,
+	currentValue,
+	queryString,
+	paramName,
+}: {
+	label: string;
+	value: string;
+	currentValue: string;
+	queryString: string;
+	paramName: string;
+}) {
+	const params = new URLSearchParams(queryString);
+	if (currentValue === value) {
+		params.delete(paramName);
+	} else {
+		params.set(paramName, value);
+	}
+	params.set("page", "1");
+	const isActive = currentValue === value;
+	return (
+		<Link
+			href={`/devpass?${params.toString()}`}
+			className={cn(
+				"inline-flex h-7 items-center rounded-full border px-3 text-xs font-medium transition-colors",
+				isActive
+					? "border-foreground bg-foreground text-background"
+					: "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground",
+			)}
+		>
+			{label}
+		</Link>
+	);
+}
+
+function ToggleLink({
+	label,
+	value,
+	queryString,
+	paramName,
+}: {
+	label: string;
+	value: boolean;
+	queryString: string;
+	paramName: string;
+}) {
+	const params = new URLSearchParams(queryString);
+	if (value) {
+		params.delete(paramName);
+	} else {
+		params.set(paramName, "true");
+	}
+	params.set("page", "1");
+	return (
+		<Link
+			href={`/devpass?${params.toString()}`}
+			className={cn(
+				"inline-flex h-7 items-center rounded-full border px-3 text-xs font-medium transition-colors",
+				value
+					? "border-foreground bg-foreground text-background"
+					: "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground",
+			)}
+		>
+			{label}
+		</Link>
+	);
+}
+
+function SignInPrompt() {
+	return (
+		<div className="flex min-h-screen items-center justify-center px-4">
+			<div className="w-full max-w-md text-center">
+				<div className="mb-8">
+					<h1 className="text-3xl font-semibold tracking-tight">
+						Admin Dashboard
+					</h1>
+					<p className="mt-2 text-sm text-muted-foreground">
+						Sign in to access the admin dashboard
+					</p>
+				</div>
+				<Button asChild size="lg" className="w-full">
+					<Link href="/login">Sign In</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+export default async function DevpassPage({
+	searchParams,
+}: {
+	searchParams?: Promise<{
+		page?: string;
+		search?: string;
+		sortBy?: string;
+		sortOrder?: string;
+		tier?: string;
+		status?: string;
+		utilization?: string;
+		marginNegative?: string;
+		showChurned?: string;
+	}>;
+}) {
+	await requireSession();
+
+	const params = await searchParams;
+	const page = Math.max(1, parseInt(params?.page ?? "1", 10));
+	const search = params?.search ?? "";
+	const sortBy = (params?.sortBy as SortBy) || "subscribedSince";
+	const sortOrder = (params?.sortOrder as SortOrder) || "desc";
+	const tier = (params?.tier as TierFilter) || "";
+	const status = (params?.status as StatusFilter) || "";
+	const utilization = (params?.utilization as UtilFilter) || "";
+	const marginNegative = params?.marginNegative === "true";
+	const showChurned = params?.showChurned === "true";
+	const limit = 25;
+	const offset = (page - 1) * limit;
+
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/devpass", {
+		params: {
+			query: {
+				limit,
+				offset,
+				search: search || undefined,
+				tier: tier || undefined,
+				status: status || undefined,
+				utilization: utilization || undefined,
+				marginNegative: marginNegative || undefined,
+				showChurned,
+				sortBy,
+				sortOrder,
+			},
+		},
+	});
+
+	if (!data) {
+		return <SignInPrompt />;
+	}
+
+	const totalPages = Math.ceil(data.total / limit);
+
+	const queryParams = new URLSearchParams();
+	if (search) {
+		queryParams.set("search", search);
+	}
+	if (tier) {
+		queryParams.set("tier", tier);
+	}
+	if (status) {
+		queryParams.set("status", status);
+	}
+	if (utilization) {
+		queryParams.set("utilization", utilization);
+	}
+	if (marginNegative) {
+		queryParams.set("marginNegative", "true");
+	}
+	if (showChurned) {
+		queryParams.set("showChurned", "true");
+	}
+	queryParams.set("sortBy", sortBy);
+	queryParams.set("sortOrder", sortOrder);
+	const queryString = queryParams.toString();
+
+	async function handleSearch(formData: FormData) {
+		"use server";
+		const searchValue = formData.get("search") as string;
+		const sortByValue = formData.get("sortBy") as string;
+		const sortOrderValue = formData.get("sortOrder") as string;
+		const tierValue = formData.get("tier") as string;
+		const statusValue = formData.get("status") as string;
+		const utilValue = formData.get("utilization") as string;
+		const marginValue = formData.get("marginNegative") as string;
+		const churnValue = formData.get("showChurned") as string;
+		const sp = new URLSearchParams();
+		if (searchValue) {
+			sp.set("search", searchValue);
+		}
+		if (tierValue) {
+			sp.set("tier", tierValue);
+		}
+		if (statusValue) {
+			sp.set("status", statusValue);
+		}
+		if (utilValue) {
+			sp.set("utilization", utilValue);
+		}
+		if (marginValue) {
+			sp.set("marginNegative", "true");
+		}
+		if (churnValue) {
+			sp.set("showChurned", "true");
+		}
+		sp.set("sortBy", sortByValue);
+		sp.set("sortOrder", sortOrderValue);
+		sp.set("page", "1");
+		redirect(`/devpass?${sp.toString()}`);
+	}
+
+	const kpis = data.kpis;
+
+	return (
+		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
+			<header className="space-y-2">
+				<h1 className="text-3xl font-semibold tracking-tight">DevPass</h1>
+				<p className="text-sm text-muted-foreground">
+					Subscribers across Lite, Pro and Max — current cycle utilization, real
+					provider cost, and margin.
+				</p>
+			</header>
+
+			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+						<Users className="h-3.5 w-3.5" />
+						Active subscribers
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{kpis.totalActive}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						Lite {kpis.activeByTier.lite} · Pro {kpis.activeByTier.pro} · Max{" "}
+						{kpis.activeByTier.max}
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+						<Wallet className="h-3.5 w-3.5" />
+						Gross MRR
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{currencyFormatter.format(kpis.grossMrr)}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						Net new this month:{" "}
+						<span
+							className={cn(
+								"font-medium",
+								kpis.netNewThisMonth > 0
+									? "text-emerald-600 dark:text-emerald-400"
+									: kpis.netNewThisMonth < 0
+										? "text-rose-600 dark:text-rose-400"
+										: "",
+							)}
+						>
+							{kpis.netNewThisMonth > 0 ? "+" : ""}
+							{kpis.netNewThisMonth}
+						</span>{" "}
+						({kpis.startsThisMonth} starts / {kpis.endsThisMonth} ends)
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+						<TrendingUp className="h-3.5 w-3.5" />
+						Avg utilization
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{kpis.weightedAvgUtilization.toFixed(1)}%
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						Weighted across active subs
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+						{kpis.totalMargin >= 0 ? (
+							<TrendingUp className="h-3.5 w-3.5" />
+						) : (
+							<TrendingDown className="h-3.5 w-3.5" />
+						)}
+						Cycle margin
+					</div>
+					<div
+						className={cn(
+							"mt-2 text-2xl font-semibold tabular-nums",
+							kpis.totalMargin < 0 ? "text-rose-600 dark:text-rose-400" : "",
+						)}
+					>
+						{currencyFormatter.format(kpis.totalMargin)}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						{currencyFormatter.format(kpis.totalRealCostCycle)} cost / page
+					</div>
+				</div>
+			</section>
+
+			<form
+				action={handleSearch}
+				className="flex flex-col gap-3 rounded-lg border border-border/60 bg-card p-4"
+			>
+				<input type="hidden" name="sortBy" value={sortBy} />
+				<input type="hidden" name="sortOrder" value={sortOrder} />
+				<input type="hidden" name="tier" value={tier} />
+				<input type="hidden" name="status" value={status} />
+				<input type="hidden" name="utilization" value={utilization} />
+				<input
+					type="hidden"
+					name="marginNegative"
+					value={marginNegative ? "true" : ""}
+				/>
+				<input
+					type="hidden"
+					name="showChurned"
+					value={showChurned ? "true" : ""}
+				/>
+				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+					<div className="relative flex-1">
+						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+						<input
+							type="text"
+							name="search"
+							placeholder="Search by org name, email, owner, or ID..."
+							defaultValue={search}
+							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+						/>
+					</div>
+					<Button type="submit" size="sm">
+						Search
+					</Button>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs uppercase tracking-wide text-muted-foreground">
+						Tier
+					</span>
+					<FilterPill
+						label="Lite"
+						value="lite"
+						currentValue={tier}
+						queryString={queryString}
+						paramName="tier"
+					/>
+					<FilterPill
+						label="Pro"
+						value="pro"
+						currentValue={tier}
+						queryString={queryString}
+						paramName="tier"
+					/>
+					<FilterPill
+						label="Max"
+						value="max"
+						currentValue={tier}
+						queryString={queryString}
+						paramName="tier"
+					/>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs uppercase tracking-wide text-muted-foreground">
+						Status
+					</span>
+					<FilterPill
+						label="Active"
+						value="active"
+						currentValue={status}
+						queryString={queryString}
+						paramName="status"
+					/>
+					<FilterPill
+						label="Cancel pending"
+						value="cancelled_pending"
+						currentValue={status}
+						queryString={queryString}
+						paramName="status"
+					/>
+					<FilterPill
+						label="Expired"
+						value="expired"
+						currentValue={status}
+						queryString={queryString}
+						paramName="status"
+					/>
+					<FilterPill
+						label="Churned"
+						value="churned"
+						currentValue={status}
+						queryString={queryString}
+						paramName="status"
+					/>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs uppercase tracking-wide text-muted-foreground">
+						Utilization
+					</span>
+					<FilterPill
+						label="< 20%"
+						value="low"
+						currentValue={utilization}
+						queryString={queryString}
+						paramName="utilization"
+					/>
+					<FilterPill
+						label="20–80%"
+						value="healthy"
+						currentValue={utilization}
+						queryString={queryString}
+						paramName="utilization"
+					/>
+					<FilterPill
+						label="80–100%"
+						value="high"
+						currentValue={utilization}
+						queryString={queryString}
+						paramName="utilization"
+					/>
+					<FilterPill
+						label="Over cap"
+						value="over"
+						currentValue={utilization}
+						queryString={queryString}
+						paramName="utilization"
+					/>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="text-xs uppercase tracking-wide text-muted-foreground">
+						Other
+					</span>
+					<ToggleLink
+						label="Negative margin only"
+						value={marginNegative}
+						queryString={queryString}
+						paramName="marginNegative"
+					/>
+					<ToggleLink
+						label="Show churned"
+						value={showChurned}
+						queryString={queryString}
+						paramName="showChurned"
+					/>
+				</div>
+				<p className="text-xs text-muted-foreground">
+					{data.total} subscriber{data.total === 1 ? "" : "s"} match current
+					filters
+				</p>
+			</form>
+
+			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>
+								<SortableHeader
+									label="Subscriber"
+									sortKey="name"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Tier"
+									sortKey="tier"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Utilization"
+									sortKey="utilizationPct"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Cycle"
+									sortKey="cycleStart"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Renews"
+									sortKey="expiresAt"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="MRR"
+									sortKey="mrr"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Real cost"
+									sortKey="realCost"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Margin"
+									sortKey="margin"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Since"
+									sortKey="subscribedSince"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>Δ tier</TableHead>
+							<TableHead>Payments</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{data.subscribers.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={12}
+									className="h-24 text-center text-muted-foreground"
+								>
+									No subscribers match
+								</TableCell>
+							</TableRow>
+						) : (
+							data.subscribers.map((sub) => (
+								<TableRow key={sub.id}>
+									<TableCell>
+										<Link
+											href={`/devpass/${sub.id}`}
+											className="font-medium text-foreground hover:underline"
+										>
+											{sub.name}
+										</Link>
+										<p className="text-xs text-muted-foreground">
+											{sub.ownerEmail ?? sub.billingEmail}
+										</p>
+									</TableCell>
+									<TableCell>
+										<Badge variant={getTierBadgeVariant(sub.tier)}>
+											{sub.tier}
+										</Badge>
+									</TableCell>
+									<TableCell>
+										<Badge variant={getStatusBadgeVariant(sub.status)}>
+											{formatStatus(sub.status)}
+										</Badge>
+									</TableCell>
+									<TableCell>
+										<UtilBar pct={sub.utilizationPct} />
+										<p className="mt-1 text-xs tabular-nums text-muted-foreground">
+											{currencyFormatter.format(parseFloat(sub.creditsUsed))} /{" "}
+											{currencyFormatter.format(parseFloat(sub.creditsLimit))}
+										</p>
+									</TableCell>
+									<TableCell className="text-muted-foreground text-xs">
+										{sub.cycleDaysIn !== null ? `Day ${sub.cycleDaysIn}` : "—"}
+									</TableCell>
+									<TableCell className="text-muted-foreground text-xs">
+										{sub.expiresAt ? formatDate(sub.expiresAt) : "—"}
+									</TableCell>
+									<TableCell className="tabular-nums">
+										{currencyFormatter.format(sub.mrr)}
+									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground">
+										{currencyFormatterPrecise.format(sub.realCost)}
+									</TableCell>
+									<TableCell
+										className={cn(
+											"tabular-nums",
+											sub.margin < 0
+												? "text-rose-600 dark:text-rose-400"
+												: "text-emerald-600 dark:text-emerald-400",
+										)}
+									>
+										{currencyFormatter.format(sub.margin)}
+									</TableCell>
+									<TableCell className="text-muted-foreground text-xs">
+										{formatDate(sub.subscribedSince)}
+									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground text-xs">
+										{sub.tierChanges}
+									</TableCell>
+									<TableCell>
+										{sub.hasPaymentIssue ? (
+											<Badge variant="destructive" className="gap-1">
+												<AlertCircle className="h-3 w-3" />
+												failed
+											</Badge>
+										) : (
+											<span className="text-xs text-muted-foreground">ok</span>
+										)}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{totalPages > 1 && (
+				<div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<p className="text-sm text-muted-foreground">
+						Showing {offset + 1} to {Math.min(offset + limit, data.total)} of{" "}
+						{data.total}
+					</p>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" size="sm" asChild disabled={page <= 1}>
+							<Link
+								href={`/devpass?${(() => {
+									const sp = new URLSearchParams(queryString);
+									sp.set("page", String(page - 1));
+									return sp.toString();
+								})()}`}
+								className={page <= 1 ? "pointer-events-none opacity-50" : ""}
+							>
+								<ChevronLeft className="h-4 w-4" />
+								Previous
+							</Link>
+						</Button>
+						<span className="text-sm text-muted-foreground">
+							Page {page} of {totalPages}
+						</span>
+						<Button
+							variant="outline"
+							size="sm"
+							asChild
+							disabled={page >= totalPages}
+						>
+							<Link
+								href={`/devpass?${(() => {
+									const sp = new URLSearchParams(queryString);
+									sp.set("page", String(page + 1));
+									return sp.toString();
+								})()}`}
+								className={
+									page >= totalPages ? "pointer-events-none opacity-50" : ""
+								}
+							>
+								Next
+								<ChevronRight className="h-4 w-4" />
+							</Link>
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -28,24 +28,51 @@ import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
 
-type SortBy =
-	| "name"
-	| "billingEmail"
-	| "tier"
-	| "createdAt"
-	| "cycleStart"
-	| "expiresAt"
-	| "subscribedSince"
-	| "utilizationPct"
-	| "realCost"
-	| "margin"
-	| "mrr"
-	| "creditsUsed";
-type SortOrder = "asc" | "desc";
+const SORT_BY_VALUES = [
+	"name",
+	"billingEmail",
+	"tier",
+	"createdAt",
+	"cycleStart",
+	"expiresAt",
+	"subscribedSince",
+	"utilizationPct",
+	"realCost",
+	"margin",
+	"mrr",
+	"creditsUsed",
+] as const;
+type SortBy = (typeof SORT_BY_VALUES)[number];
 
-type TierFilter = "lite" | "pro" | "max" | "none" | "";
-type StatusFilter = "active" | "cancelled_pending" | "expired" | "churned" | "";
-type UtilFilter = "low" | "healthy" | "high" | "over" | "";
+const SORT_ORDER_VALUES = ["asc", "desc"] as const;
+type SortOrder = (typeof SORT_ORDER_VALUES)[number];
+
+const TIER_VALUES = ["lite", "pro", "max", "none"] as const;
+type TierFilter = (typeof TIER_VALUES)[number] | "";
+
+const STATUS_VALUES = [
+	"active",
+	"cancelled_pending",
+	"expired",
+	"churned",
+] as const;
+type StatusFilter = (typeof STATUS_VALUES)[number] | "";
+
+const UTIL_VALUES = ["low", "healthy", "high", "over"] as const;
+type UtilFilter = (typeof UTIL_VALUES)[number] | "";
+
+function pickEnum<T extends readonly string[]>(
+	allowed: T,
+	raw: string | undefined,
+	fallback: T[number] | "",
+): T[number] | "" {
+	if (!raw) {
+		return fallback;
+	}
+	return (allowed as readonly string[]).includes(raw)
+		? (raw as T[number])
+		: fallback;
+}
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
 	style: "currency",
@@ -285,13 +312,22 @@ export default async function DevpassPage({
 	await requireSession();
 
 	const params = await searchParams;
-	const page = Math.max(1, parseInt(params?.page ?? "1", 10));
+	const rawPage = parseInt(params?.page ?? "1", 10);
+	const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
 	const search = params?.search ?? "";
-	const sortBy = (params?.sortBy as SortBy) || "subscribedSince";
-	const sortOrder = (params?.sortOrder as SortOrder) || "desc";
-	const tier = (params?.tier as TierFilter) || "";
-	const status = (params?.status as StatusFilter) || "";
-	const utilization = (params?.utilization as UtilFilter) || "";
+	const sortBy =
+		(pickEnum(SORT_BY_VALUES, params?.sortBy, "subscribedSince") as SortBy) ||
+		"subscribedSince";
+	const sortOrder =
+		(pickEnum(SORT_ORDER_VALUES, params?.sortOrder, "desc") as SortOrder) ||
+		"desc";
+	const tier = pickEnum(TIER_VALUES, params?.tier, "") as TierFilter;
+	const status = pickEnum(STATUS_VALUES, params?.status, "") as StatusFilter;
+	const utilization = pickEnum(
+		UTIL_VALUES,
+		params?.utilization,
+		"",
+	) as UtilFilter;
 	const marginNegative = params?.marginNegative === "true";
 	const showChurned = params?.showChurned === "true";
 	const limit = 25;
@@ -461,7 +497,8 @@ export default async function DevpassPage({
 						{currencyFormatter.format(kpis.totalMargin)}
 					</div>
 					<div className="mt-1 text-xs text-muted-foreground">
-						{currencyFormatter.format(kpis.totalRealCostCycle)} cost / page
+						{currencyFormatter.format(kpis.totalRealCostCycle)} provider cost
+						this cycle
 					</div>
 				</div>
 			</section>

--- a/ee/admin/src/components/admin-shell.tsx
+++ b/ee/admin/src/components/admin-shell.tsx
@@ -14,6 +14,7 @@ import {
 	MessageCircle,
 	Percent,
 	Server,
+	Sparkles,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -83,6 +84,7 @@ export function AdminShell({ children }: AdminShellProps) {
 
 	const isDashboard = pathname === "/" || pathname === "";
 	const isOrganizations = pathname.startsWith("/organizations");
+	const isDevpass = pathname.startsWith("/devpass");
 	const isDiscounts = pathname === "/discounts";
 	const isRateLimits = pathname === "/rate-limits";
 	const isProviders = pathname === "/providers";
@@ -141,6 +143,14 @@ export function AdminShell({ children }: AdminShellProps) {
 									<SidebarMenuButton isActive={isOrganizations} size="lg">
 										<Building2 className="h-4 w-4" />
 										<span>Organizations</span>
+									</SidebarMenuButton>
+								</Link>
+							</SidebarMenuItem>
+							<SidebarMenuItem>
+								<Link href="/devpass" className="block">
+									<SidebarMenuButton isActive={isDevpass} size="lg">
+										<Sparkles className="h-4 w-4" />
+										<span>DevPass</span>
 									</SidebarMenuButton>
 								</Link>
 							</SidebarMenuItem>

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4304,6 +4304,194 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                    offset?: number | null;
+                    search?: string;
+                    tier?: "lite" | "pro" | "max" | "none";
+                    status?: "active" | "cancelled_pending" | "expired" | "churned";
+                    utilization?: "low" | "healthy" | "high" | "over";
+                    marginNegative?: boolean | null;
+                    showChurned?: boolean | null;
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortOrder?: "asc" | "desc";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List of DevPass subscribers. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscribers: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            }[];
+                            total: number;
+                            kpis: {
+                                activeByTier: {
+                                    lite: number;
+                                    pro: number;
+                                    max: number;
+                                };
+                                totalActive: number;
+                                cancelledPending: number;
+                                churned: number;
+                                grossMrr: number;
+                                startsThisMonth: number;
+                                endsThisMonth: number;
+                                netNewThisMonth: number;
+                                weightedAvgUtilization: number;
+                                totalRealCostCycle: number;
+                                totalMrrCycle: number;
+                                totalMargin: number;
+                            };
+                            limit: number;
+                            offset: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/{orgId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass subscriber detail. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            subscriber: {
+                                id: string;
+                                name: string;
+                                billingEmail: string;
+                                ownerUserId: string | null;
+                                ownerName: string | null;
+                                ownerEmail: string | null;
+                                /** @enum {string} */
+                                tier: "lite" | "pro" | "max" | "none";
+                                /** @enum {string} */
+                                status: "active" | "cancelled_pending" | "expired" | "churned";
+                                hasPaymentIssue: boolean;
+                                creditsUsed: string;
+                                creditsLimit: string;
+                                utilizationPct: number | null;
+                                cycleStart: string | null;
+                                cycleDaysIn: number | null;
+                                expiresAt: string | null;
+                                cancelled: boolean;
+                                allowAllModels: boolean;
+                                mrr: number;
+                                realCost: number;
+                                margin: number;
+                                subscribedSince: string | null;
+                                tierChanges: number;
+                                lastPaymentFailureAt: string | null;
+                                createdAt: string;
+                            };
+                            transactions: {
+                                id: string;
+                                createdAt: string;
+                                type: string;
+                                amount: string | null;
+                                creditAmount: string | null;
+                                currency: string;
+                                status: string;
+                                description: string | null;
+                            }[];
+                            paymentFailures: {
+                                id: string;
+                                createdAt: string;
+                                amount: string | null;
+                                currency: string;
+                                declineCode: string | null;
+                                failureMessage: string | null;
+                                source: string | null;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Subscriber not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/keys/api": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

Adds a `/devpass` admin view (list + detail) for monitoring current Dev Plans subscribers (Lite/Pro/Max). The page is tuned to the three things the existing `/organizations` view doesn't surface for a flat-rate subscription product:

- **Cycle utilization** — strongest churn / over-cap signal
- **Real provider cost vs MRR** — unit-margin per subscriber
- **Subscription lifecycle state** — active / cancel-pending / expired / churned, plus payment-failure overlay

## What's in it

**API** (`apps/api/src/routes/admin.ts`):
- `GET /admin/devpass` — paginated, filterable, sortable subscriber list with KPI strip
- `GET /admin/devpass/{orgId}` — subscriber detail with subscription event timeline + payment failures

**Admin UI** (`ee/admin/src/app/devpass/`):
- KPI strip: active by tier, gross MRR, net new this month, weighted utilization, total cycle margin
- Filters: tier, status, utilization band (<20% / 20–80% / 80–100% / over cap), negative-margin only, show-churned toggle
- Sortable columns including computed ones (utilization, real cost, margin, subscribed-since)
- Detail page mirrors the data with a per-subscriber cycle utilization bar, MRR / real cost / margin cards, and tabs for subscription events and payment failures
- Sidebar nav entry under Organizations

**Data sources**: `organization.devPlan*` columns, `transaction` (`dev_plan_*` types), `paymentFailure`, `projectHourlyStats.cost` windowed to the current `devPlanBillingCycleStart`.

## Test plan

- [ ] Visit `/devpass` as admin — list renders, KPI strip populated
- [ ] Tier / status / utilization filters narrow the list correctly
- [ ] Sort by utilization, real cost, margin, subscribed-since works asc/desc
- [ ] "Show churned" surfaces orgs whose `devPlan = 'none'` but had a past `dev_plan_start`
- [ ] "Negative margin only" only shows rows where real cost > MRR
- [ ] Search matches name, billing email, owner email, org id
- [ ] Click into a row → `/devpass/{orgId}` loads with utilization bar + cycle stats
- [ ] Subscription history tab lists `dev_plan_*` transactions chronologically
- [ ] Payment failures tab lists Stripe failures for the org
- [ ] Sidebar "DevPass" item highlights when on the page
- [ ] `pnpm --filter api build` and `pnpm --filter admin build` succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced DevPass analytics dashboard for comprehensive subscriber monitoring
  * Search, multi‑filter (tier/status/utilization/margin‑negative/churn), sort and paginated subscriber list
  * Global KPIs and per‑subscriber billing metrics (MRR, real cost, margin, utilization)
  * Detailed subscriber profiles with transaction and payment‑failure histories and indicators
  * Admin navigation updated with a dedicated DevPass section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->