### PR TITLE
fix(streaming): handle anthropic ping chunk silently

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -305,22 +305,7 @@ export function transformStreamingToOpenai(
 					usage: normalizeAnthropicUsage(data.usage),
 				};
 			} else if (data.type === "ping") {
-				transformedData = {
-					id: data.id ?? `chatcmpl-${Date.now()}`,
-					object: "chat.completion.chunk",
-					created: data.created ?? Math.floor(Date.now() / 1000),
-					model: data.model ?? usedModel,
-					choices: [
-						{
-							index: 0,
-							delta: {
-								role: "assistant",
-							},
-							finish_reason: null,
-						},
-					],
-					usage: normalizeAnthropicUsage(data.usage),
-				};
+				return null;
 			} else {
 				logger.warn("[streaming] Unrecognized Anthropic chunk", {
 					provider: usedProvider,

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -304,6 +304,23 @@ export function transformStreamingToOpenai(
 					],
 					usage: normalizeAnthropicUsage(data.usage),
 				};
+			} else if (data.type === "ping") {
+				transformedData = {
+					id: data.id ?? `chatcmpl-${Date.now()}`,
+					object: "chat.completion.chunk",
+					created: data.created ?? Math.floor(Date.now() / 1000),
+					model: data.model ?? usedModel,
+					choices: [
+						{
+							index: 0,
+							delta: {
+								role: "assistant",
+							},
+							finish_reason: null,
+						},
+					],
+					usage: normalizeAnthropicUsage(data.usage),
+				};
 			} else {
 				logger.warn("[streaming] Unrecognized Anthropic chunk", {
 					provider: usedProvider,


### PR DESCRIPTION
## Summary
- Recognize Anthropic streaming `ping` keepalive events as a known chunk type and emit a no-op delta, eliminating the noisy `Unrecognized Anthropic chunk` warn log seen on `claude-haiku-4-5`.

## Test plan
- [ ] Trigger an Anthropic streaming completion and confirm no `Unrecognized Anthropic chunk` warnings for `type: "ping"` are logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming handling for external AI responses: lightweight "ping" heartbeat messages are now ignored rather than being treated as data, reducing spurious warnings and preventing placeholder content from appearing in streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->