### PR TITLE
fix(moonshot): downgrade tool_choice for reasoning models

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1001,7 +1001,20 @@ export async function prepareRequestBody(
 	}
 
 	if (forcesToolUse && usedProvider === "moonshot") {
-		requestBody.thinking = { enabled: false };
+		const providerMapping = modelDef?.providers.find(
+			(p) => p.modelName === usedModel && p.providerId === usedProvider,
+		);
+		const isReasoningModel =
+			providerMapping &&
+			"reasoning" in providerMapping &&
+			providerMapping.reasoning === true;
+		if (isReasoningModel) {
+			// Moonshot rejects tool_choice="required" (and forced function choice)
+			// when thinking is enabled, and thinking cannot be disabled on
+			// reasoning models. Downgrade to "auto" so the request still works.
+			resolvedToolChoice = "auto";
+			requestBody.tool_choice = "auto";
+		}
 	}
 
 	// Override temperature to 1 for GPT-5 models (they only support temperature = 1)


### PR DESCRIPTION
## Summary
- Moonshot's API rejects `tool_choice: "required"` (and forced function choice) with `tool_choice 'required' is incompatible with thinking enabled` when called against reasoning models like `kimi-k2.5`. Thinking cannot be disabled on these models — the previously sent `thinking: { enabled: false }` parameter is silently ignored.
- Downgrade `tool_choice` to `"auto"` for Moonshot reasoning models so the request still succeeds. The model still calls the tool when the prompt clearly demands it.

## Test plan
- [x] `TEST_MODELS="moonshot/kimi-k2.5" pnpm test:e2e` (was: 3 failures in `chat-toolcalls.e2e.ts` and `chat-toolcalls-result.e2e.ts`; now: all pass)
- [x] `pnpm vitest run packages/actions` (60 passed)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request failures that occurred when using reasoning models with forced tool selection by automatically adjusting tool parameters for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->