### PR TITLE
fix(moonshot): non-empty reasoning_content for k2.5/k2.6

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -954,9 +954,12 @@ export async function prepareRequestBody(
 	// DeepSeek (and Moonshot) thinking-mode endpoints reject assistant messages
 	// containing tool_calls unless `reasoning_content` is present. OpenAI-compat
 	// clients usually drop reasoning between turns, so translate the OpenAI-style
-	// `reasoning` field back to provider-style `reasoning_content`, defaulting to
-	// an empty string when neither is present.
+	// `reasoning` field back to provider-style `reasoning_content`. DeepSeek
+	// accepts an empty string, but Moonshot's newer reasoning models (kimi-k2.5,
+	// kimi-k2.6) treat an empty string as missing — use a single space as a
+	// non-empty placeholder there.
 	if (usedProvider === "deepseek" || usedProvider === "moonshot") {
+		const fallback = usedProvider === "moonshot" ? " " : "";
 		processedMessages = processedMessages.map((m) => {
 			if (
 				m.role !== "assistant" ||
@@ -967,7 +970,8 @@ export async function prepareRequestBody(
 			) {
 				return m;
 			}
-			return { ...m, reasoning_content: m.reasoning ?? "" };
+			const reasoning = m.reasoning ?? fallback;
+			return { ...m, reasoning_content: reasoning || fallback };
 		});
 	}
 


### PR DESCRIPTION
## Summary

The `chat-toolcalls-result` e2e suite was failing for `moonshot/kimi-k2.5` and `moonshot/kimi-k2.6` with:

> thinking is enabled but reasoning_content is missing in assistant tool call message at index N

Verified directly against `api.moonshot.ai`:
- `reasoning_content: "placeholder"` → 200
- `reasoning_content: ""` → 400 (treated as missing on k2.5 / k2.6)
- `reasoning_content: " "` → 200

`kimi-k2-thinking` and DeepSeek's V4 reasoning models still accept the empty-string fallback added in #2092, so this only adjusts the Moonshot path.

## Changes

- `packages/actions/src/prepare-request-body.ts`: when re-injecting `reasoning_content` for a Moonshot assistant tool-call turn that came in without reasoning, use a single space instead of `""`. DeepSeek behavior is unchanged.

## Test plan

- [x] `TEST_MODELS="moonshot/kimi-k2.5,moonshot/kimi-k2.6,moonshot/kimi-k2-thinking" pnpm test:e2e apps/gateway/src/chat-toolcalls-result.e2e.ts` — passes
- [x] `TEST_MODELS="moonshot/kimi-k2.5,moonshot/kimi-k2.6,moonshot/kimi-k2-thinking,deepseek/deepseek-v4-pro,deepseek/deepseek-v4-flash" pnpm test:e2e chat-toolcalls chat-toolcalls-result` — all green (regression check on shared code path)
- [x] `pnpm test:unit` — 959 / 959 pass
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning content handling for DeepSeek and Moonshot providers with provider-specific fallback behavior for better API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->