### PR TITLE
feat(routing): weight cache support for large prompts

### DIFF
--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -49,6 +49,10 @@ The algorithm calculates a weighted score for each available provider and select
 
 For non-streaming requests, the latency weight (10%) is redistributed proportionally to the other factors since time-to-first-token is less relevant when waiting for the complete response.
 
+**Cache Support for Large Prompts**:
+
+When the estimated prompt is at least 5,000 tokens, an additional 20% weight is added to the score for whether each provider supports prompt caching (advertised via a cached input price). Providers that support caching score better than ones that do not, since caching can substantially reduce the cost of large or repeated prompts. Below the 5k threshold, this weight is dropped entirely — caching has little impact on small prompts, so cache support is ignored. The selected provider's cache support is exposed as `cacheSupported` on the routing metadata.
+
 **Exponential Uptime Penalty**:
 
 Providers with uptime below 95% receive an additional exponential penalty that increases rapidly as uptime drops:

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -244,6 +244,7 @@ function collapseProvidersToBestRegionPerProvider(
 	options: {
 		metricsMap: Map<string, ProviderMetrics>;
 		isStreaming: boolean;
+		promptTokens?: number;
 	},
 ): ProviderModelMapping[] {
 	const providersById = new Map<string, ProviderModelMapping[]>();
@@ -1086,6 +1087,28 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// Estimate prompt tokens once so all routing decisions can reuse the
+	// same value (e.g. cache-support weighting kicks in for large prompts).
+	let routingPromptTokens = 0;
+	if (messages && messages.length > 0) {
+		try {
+			routingPromptTokens = encodeChatMessages(messages);
+		} catch {
+			const messageTokens = messages.reduce(
+				(acc, m) => acc + (m.content?.length ?? 0),
+				0,
+			);
+			routingPromptTokens = Math.max(1, Math.round(messageTokens / 4));
+		}
+	}
+	if (tools && tools.length > 0) {
+		try {
+			routingPromptTokens += Math.round(JSON.stringify(tools).length / 4);
+		} catch {
+			routingPromptTokens += tools.length * 100;
+		}
+	}
+
 	// Extract and validate source from x-source header with HTTP-Referer fallback
 	let source = validateSource(
 		c.req.header("x-source"),
@@ -1500,34 +1523,9 @@ chat.openapi(completions, async (c) => {
 		(usedProvider === "llmgateway" && usedModel === "auto") ||
 		usedModel === "auto"
 	) {
-		// Estimate prompt/input tokens first so auto-routing can react to large prompts
-		let estimatedInputTokens = 0;
-
-		// Estimate prompt tokens from messages
-		if (messages && messages.length > 0) {
-			try {
-				estimatedInputTokens = encodeChatMessages(messages);
-			} catch {
-				// Fallback to simple estimation if encoding fails
-				const messageTokens = messages.reduce(
-					(acc, m) => acc + (m.content?.length ?? 0),
-					0,
-				);
-				estimatedInputTokens = Math.max(1, Math.round(messageTokens / 4));
-			}
-		}
-
-		// Add tool definitions to context estimation
-		if (tools && tools.length > 0) {
-			try {
-				const toolsString = JSON.stringify(tools);
-				const toolTokens = Math.round(toolsString.length / 4);
-				estimatedInputTokens += toolTokens;
-			} catch {
-				// Fallback estimation for tools
-				estimatedInputTokens += tools.length * 100; // Rough estimate per tool
-			}
-		}
+		// Reuse the prompt-token estimate computed earlier so auto-routing can
+		// react to large prompts when picking a model.
+		const estimatedInputTokens = routingPromptTokens;
 
 		// Estimate the full context needed based on the request
 		let requiredContextSize = estimatedInputTokens;
@@ -1746,13 +1744,18 @@ chat.openapi(completions, async (c) => {
 					{
 						metricsMap,
 						isStreaming: stream,
+						promptTokens: routingPromptTokens,
 					},
 				);
 
 			const cheapestResult = getCheapestFromAvailableProviders(
 				providerAgnosticSelectedProviders,
 				selectedModel,
-				{ metricsMap, isStreaming: stream },
+				{
+					metricsMap,
+					isStreaming: stream,
+					promptTokens: routingPromptTokens,
+				},
 			);
 
 			if (cheapestResult) {
@@ -1912,6 +1915,7 @@ chat.openapi(completions, async (c) => {
 						{
 							metricsMap,
 							isStreaming: stream,
+							promptTokens: routingPromptTokens,
 						},
 					);
 
@@ -2096,6 +2100,7 @@ chat.openapi(completions, async (c) => {
 							{
 								metricsMap: allMetricsMap,
 								isStreaming: stream,
+								promptTokens: routingPromptTokens,
 							},
 						);
 
@@ -2233,7 +2238,11 @@ chat.openapi(completions, async (c) => {
 							collapseProvidersToBestRegionPerProvider(
 								availableModelProviders,
 								modelWithPricing,
-								{ metricsMap: allMetricsMap, isStreaming: stream },
+								{
+									metricsMap: allMetricsMap,
+									isStreaming: stream,
+									promptTokens: routingPromptTokens,
+								},
 							);
 
 						// Filter to only providers with better uptime than the original
@@ -2258,7 +2267,11 @@ chat.openapi(completions, async (c) => {
 							const cheapestResult = getCheapestFromAvailableProviders(
 								betterUptimeProviders,
 								modelWithPricing,
-								{ metricsMap: allMetricsMap, isStreaming: stream },
+								{
+									metricsMap: allMetricsMap,
+									isStreaming: stream,
+									promptTokens: routingPromptTokens,
+								},
 							);
 
 							// Get price info for the original requested provider to include in scores
@@ -2435,13 +2448,21 @@ chat.openapi(completions, async (c) => {
 					collapseProvidersToBestRegionPerProvider(
 						routingCandidates,
 						modelWithPricing,
-						{ metricsMap, isStreaming: stream },
+						{
+							metricsMap,
+							isStreaming: stream,
+							promptTokens: routingPromptTokens,
+						},
 					);
 
 				const cheapestResult = getCheapestFromAvailableProviders(
 					providerAgnosticCandidates,
 					modelWithPricing,
-					{ metricsMap, isStreaming: stream },
+					{
+						metricsMap,
+						isStreaming: stream,
+						promptTokens: routingPromptTokens,
+					},
 				);
 
 				if (cheapestResult) {
@@ -2608,6 +2629,7 @@ chat.openapi(completions, async (c) => {
 						{
 							metricsMap,
 							isStreaming: stream,
+							promptTokens: routingPromptTokens,
 						},
 					);
 

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -13,6 +13,7 @@ interface ProviderScore<T extends AvailableModelProvider> {
 	uptime?: number;
 	latency?: number;
 	throughput?: number;
+	cacheSupported?: boolean;
 }
 
 // Scoring weights
@@ -24,6 +25,11 @@ const IMAGE_PRICE_WEIGHT = 0.5; // Higher weight for image generation models
 const UPTIME_WEIGHT = 0.5;
 const THROUGHPUT_WEIGHT = 0.05;
 const LATENCY_WEIGHT = 0.025;
+const CACHE_WEIGHT = 0.2;
+
+// Prompt-token threshold above which prompt caching becomes a meaningful
+// cost lever, so a provider's cache support starts to influence routing.
+const CACHE_PROMPT_TOKEN_THRESHOLD = 5000;
 
 // Uptime threshold below which exponential penalty kicks in
 const UPTIME_PENALTY_THRESHOLD = 95;
@@ -99,6 +105,7 @@ export interface RoutingMetadata {
 		throughput?: number;
 		price: number;
 		priority?: number;
+		cacheSupported?: boolean;
 		// Populated after retry loop if this provider was attempted and failed
 		failed?: boolean;
 		status_code?: number;
@@ -147,6 +154,48 @@ export interface ProviderSelectionOptions {
 	metricsMap?: Map<string, ProviderMetrics>;
 	isStreaming?: boolean;
 	videoPricing?: VideoPricingContext;
+	/**
+	 * Estimated prompt tokens for the request. When provided and at or above
+	 * CACHE_PROMPT_TOKEN_THRESHOLD, cache support is factored into the
+	 * weighted score.
+	 */
+	promptTokens?: number;
+}
+
+function providerSupportsCaching(
+	providerInfo:
+		| {
+				cachedInputPrice?: number;
+				pricingTiers?: ProviderModelMapping["pricingTiers"];
+				regions?: ProviderModelMapping["regions"];
+		  }
+		| undefined,
+): boolean {
+	if (!providerInfo) {
+		return false;
+	}
+	if (providerInfo.cachedInputPrice !== undefined) {
+		return true;
+	}
+	if (
+		providerInfo.pricingTiers?.some(
+			(tier) => tier.cachedInputPrice !== undefined,
+		)
+	) {
+		return true;
+	}
+	if (
+		providerInfo.regions?.some(
+			(region) =>
+				region.cachedInputPrice !== undefined ||
+				region.pricingTiers?.some(
+					(tier) => tier.cachedInputPrice !== undefined,
+				),
+		)
+	) {
+		return true;
+	}
+	return false;
 }
 
 export interface VideoPricingContext {
@@ -248,9 +297,14 @@ export function getCheapestFromAvailableProviders<
 	const metricsMap = options?.metricsMap;
 	const isStreaming = options?.isStreaming ?? false;
 	const videoPricing = options?.videoPricing;
+	const promptTokens = options?.promptTokens;
 	// Use higher price weight for image generation models
 	const isImageModel = modelWithPricing.output?.includes("image") ?? false;
 	const effectivePriceWeight = isImageModel ? IMAGE_PRICE_WEIGHT : PRICE_WEIGHT;
+	// Cache support only matters once the prompt is large enough for caching
+	// to meaningfully reduce cost. Below that threshold the weight is zero.
+	const cacheSupportRelevant =
+		promptTokens !== undefined && promptTokens >= CACHE_PROMPT_TOKEN_THRESHOLD;
 	if (availableModelProviders.length === 0) {
 		return null;
 	}
@@ -313,6 +367,9 @@ export function getCheapestFromAvailableProviders<
 						throughput: metrics?.throughput,
 						price: getProviderSelectionPrice(providerInfo, videoPricing),
 						priority,
+						cacheSupported: providerSupportsCaching(
+							providerInfo as ProviderModelMapping | undefined,
+						),
 					};
 				}),
 			},
@@ -348,6 +405,9 @@ export function getCheapestFromAvailableProviders<
 			uptime: metrics?.uptime,
 			latency: metrics?.averageLatency,
 			throughput: metrics?.throughput,
+			cacheSupported: providerSupportsCaching(
+				providerInfo as ProviderModelMapping | undefined,
+			),
 		});
 	}
 
@@ -403,21 +463,29 @@ export function getCheapestFromAvailableProviders<
 			/* eslint-enable no-mixed-operators */
 		}
 
+		// Cache score: 0 when this provider supports prompt caching, 1 otherwise.
+		// Only weighted in when the prompt is large enough for caching to matter.
+		const cacheScore = providerScore.cacheSupported ? 0 : 1;
+
 		// Calculate base weighted score (lower is better)
-		// When not streaming, latency weight (0.1) is redistributed to other factors
-		// Image generation models use 2x price weight
+		// When not streaming, latency weight is redistributed to other factors
+		// Image generation models use a higher price weight, and cache weight is
+		// dropped for short prompts where caching has no measurable effect.
 		const effectiveLatencyWeight = isStreaming ? LATENCY_WEIGHT : 0;
+		const effectiveCacheWeight = cacheSupportRelevant ? CACHE_WEIGHT : 0;
 		const weightSum =
 			effectivePriceWeight +
 			UPTIME_WEIGHT +
 			THROUGHPUT_WEIGHT +
-			effectiveLatencyWeight;
+			effectiveLatencyWeight +
+			effectiveCacheWeight;
 		/* eslint-disable no-mixed-operators */
 		const baseScore =
 			(effectivePriceWeight / weightSum) * priceScore +
 			(UPTIME_WEIGHT / weightSum) * uptimeScore +
 			(THROUGHPUT_WEIGHT / weightSum) * throughputScore +
-			(effectiveLatencyWeight / weightSum) * latencyScore;
+			(effectiveLatencyWeight / weightSum) * latencyScore +
+			(effectiveCacheWeight / weightSum) * cacheScore;
 		/* eslint-enable no-mixed-operators */
 
 		// Apply provider priority: lower priority = higher score (less preferred)
@@ -459,6 +527,7 @@ export function getCheapestFromAvailableProviders<
 				throughput: p.throughput,
 				price: p.price, // Keep full precision for very small prices
 				priority,
+				cacheSupported: p.cacheSupported,
 			};
 		}),
 	};

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -895,4 +895,123 @@ describe("getCheapestFromAvailableProviders", () => {
 			}),
 		).toBe(0.03);
 	});
+
+	describe("cache support weighting", () => {
+		const cacheTestModel = {
+			id: "cache-test-model",
+			name: "Cache Test Model",
+			family: "openai" as const,
+			providers: [
+				{
+					providerId: "openai" as const,
+					modelName: "cache-test",
+					inputPrice: 1.0 / 1e6,
+					outputPrice: 2.0 / 1e6,
+					cachedInputPrice: 0.1 / 1e6,
+					streaming: true as const,
+				},
+				{
+					providerId: "deepseek" as const,
+					modelName: "cache-test",
+					inputPrice: 1.0 / 1e6,
+					outputPrice: 2.0 / 1e6,
+					streaming: true as const,
+				},
+			],
+		};
+
+		const equalMetrics = new Map([
+			[
+				metricsKey("cache-test-model", "openai"),
+				{
+					modelId: "cache-test-model",
+					providerId: "openai",
+					uptime: 99.5,
+					averageLatency: 200,
+					throughput: 100,
+					totalRequests: 100,
+				},
+			],
+			[
+				metricsKey("cache-test-model", "deepseek"),
+				{
+					modelId: "cache-test-model",
+					providerId: "deepseek",
+					uptime: 99.5,
+					averageLatency: 200,
+					throughput: 100,
+					totalRequests: 100,
+				},
+			],
+		]);
+
+		it("does not factor cache support when prompt is below the threshold", () => {
+			const result = getCheapestFromAvailableProviders(
+				cacheTestModel.providers,
+				cacheTestModel,
+				{ metricsMap: equalMetrics, promptTokens: 1000 },
+			);
+
+			const openai = result?.metadata.providerScores.find(
+				(p) => p.providerId === "openai",
+			);
+			const deepseek = result?.metadata.providerScores.find(
+				(p) => p.providerId === "deepseek",
+			);
+
+			expect(openai?.score).toBe(deepseek?.score);
+		});
+
+		it("prefers a cache-supporting provider when prompt is large", () => {
+			const result = getCheapestFromAvailableProviders(
+				cacheTestModel.providers,
+				cacheTestModel,
+				{ metricsMap: equalMetrics, promptTokens: 8000 },
+			);
+
+			expect(result?.provider.providerId).toBe("openai");
+
+			const openai = result?.metadata.providerScores.find(
+				(p) => p.providerId === "openai",
+			);
+			const deepseek = result?.metadata.providerScores.find(
+				(p) => p.providerId === "deepseek",
+			);
+
+			expect(openai?.cacheSupported).toBe(true);
+			expect(deepseek?.cacheSupported).toBe(false);
+			expect((openai?.score ?? 0) < (deepseek?.score ?? 0)).toBe(true);
+		});
+
+		it("does not override a much cheaper non-cache provider for large prompts", () => {
+			const cheapNoCacheModel = {
+				...cacheTestModel,
+				providers: [
+					{
+						providerId: "openai" as const,
+						modelName: "cache-test",
+						inputPrice: 10.0 / 1e6,
+						outputPrice: 20.0 / 1e6,
+						cachedInputPrice: 1.0 / 1e6,
+						streaming: true as const,
+					},
+					{
+						providerId: "deepseek" as const,
+						modelName: "cache-test",
+						inputPrice: 1.0 / 1e6,
+						outputPrice: 2.0 / 1e6,
+						streaming: true as const,
+					},
+				],
+			};
+
+			const result = getCheapestFromAvailableProviders(
+				cheapNoCacheModel.providers,
+				cheapNoCacheModel,
+				{ metricsMap: equalMetrics, promptTokens: 10_000 },
+			);
+
+			expect(result?.provider.providerId).toBe("deepseek");
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Add a 0.2-weight cache-support component to `getCheapestFromAvailableProviders` so providers that advertise `cachedInputPrice` are preferred when prompts are large enough for caching to matter.
- Gate the new weight on a 5k prompt-token threshold — below that, the weight is dropped entirely, so short-prompt routing is unchanged.
- Estimate prompt tokens once at the top of the chat handler (reusing the auto-routing estimate) and plumb it through every routing call site.
- Expose `cacheSupported` on routing metadata for visibility.

## Test plan
- [x] `npx vitest run --no-file-parallelism packages/actions packages/models packages/db` (99 passed)
- [x] `pnpm build:core`
- [x] `pnpm format` / `pnpm lint`
- [ ] Spot-check routing decisions in staging with prompts above and below 5k tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider selection now favors cache-capable providers for large requests, improving cost efficiency.

* **Performance**
  * Routing now consolidates token estimation to avoid redundant work and make routing decisions more consistent.

* **Tests**
  * Added tests verifying cache-aware selection behavior across different prompt sizes.

* **Documentation**
  * Updated routing docs to describe cache-support scoring and metadata exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->