### PR TITLE
feat(cache): bump SWR stale TTL default to 4h

### DIFF
--- a/packages/cache/src/swr.ts
+++ b/packages/cache/src/swr.ts
@@ -4,7 +4,7 @@ import { redisClient } from "./redis.js";
 
 export const SWR_PREFIX = "swr:";
 export const SWR_TABLE_INDEX_PREFIX = "swr:tables:";
-export const SWR_DEFAULT_TTL_SECONDS = 600;
+export const SWR_DEFAULT_TTL_SECONDS = 14400;
 export const SWR_BATCH_SIZE = 500;
 
 const SWR_NONE_SENTINEL = "__swrNone" as const;


### PR DESCRIPTION
## Summary
- Bump default `SWR_DEFAULT_TTL_SECONDS` from 600s (10 min) to 14400s (4h) in `packages/cache/src/swr.ts`
- Extends the stale-fallback window during DB outages to maximize gateway uptime
- Env override `SWR_STALE_TTL_SECONDS` still works for per-env tuning

## Why this is safe
- `swrWrap` runs the fetcher first; the mirror is only consulted when the fetcher throws. With DB up, freshness is unaffected.
- Writes through the cached db client still call `invalidateSwrByTables` via `onMutate`, so mirrors are wiped on every mutation regardless of TTL.
- The longer TTL only widens the grace window during DB outages — exactly the resilience win we want.

## Tradeoffs
- Slightly higher Redis memory footprint as mirrors live longer before expiry.
- Edge case: if invalidation failed silently (Redis hiccup) and the DB then goes down, stale data could be served for up to 4h instead of 10 min. Acceptable given the uptime benefit.

## Test plan
- [ ] Existing SWR unit tests still pass (`pnpm --filter @llmgateway/cache test:unit`)
- [ ] Gateway resilience tests still pass (`pnpm --filter gateway test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended cache retention period for improved application performance and reduced load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->