### PR TITLE
chore(models): deactivate together-ai minimax-m2.5

### DIFF
--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -138,7 +138,7 @@ export const minimaxModels = [
 				jsonOutput: true,
 			},
 			{
-				deactivatedAt: new Date("2026-04-27"),
+				deactivatedAt: new Date("2026-04-28"),
 				providerId: "together-ai",
 				modelName: "MiniMaxAI/MiniMax-M2.5",
 				inputPrice: 0.3 / 1e6,


### PR DESCRIPTION
## Summary
- Together AI deactivated `MiniMaxAI/MiniMax-M2.5` on 2026-04-28; bump the existing `deactivatedAt` from 2026-04-27 to match the actual cutoff.

## Test plan
- [ ] Confirm the Together AI MiniMax-M2.5 mapping is filtered/blocked from selection after the new date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deactivation date for the minimax-m2.5 model provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->