### PR TITLE
feat(ui): add per-model uptime page

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -500,65 +500,85 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 	const WINDOW_MS = WINDOW_MINUTES * 60_000;
 	const since = new Date(Date.now() - WINDOW_MS);
 
-	const rows = await db
-		.select({
-			minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
-			providerId: modelProviderMappingHistory.providerId,
-			providerName: tables.provider.name,
-			logsCount:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
-					"logs_count",
+	// Active providers serving this model — included even if they have no
+	// recent traffic so the page can render an idle state for them.
+	const [activeProviders, rows] = await Promise.all([
+		db
+			.select({
+				providerId: tables.modelProviderMapping.providerId,
+				providerName: tables.provider.name,
+			})
+			.from(tables.modelProviderMapping)
+			.innerJoin(
+				tables.provider,
+				eq(tables.modelProviderMapping.providerId, tables.provider.id),
+			)
+			.where(
+				and(
+					eq(tables.modelProviderMapping.modelId, modelId),
+					eq(tables.modelProviderMapping.status, "active"),
 				),
-			errorsCount:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
-					"errors_count",
-				),
-			clientErrorsCount:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
-					"client_errors_count",
-				),
-			gatewayErrorsCount:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
-					"gateway_errors_count",
-				),
-			upstreamErrorsCount:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
-					"upstream_errors_count",
-				),
-			cachedCount:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
-					"cached_count",
-				),
-			totalDuration:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalDuration}), 0)`.as(
-					"total_duration",
-				),
-			totalTimeToFirstToken:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`.as(
-					"total_ttft",
-				),
-			totalTokens:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTokens}), 0)`.as(
-					"total_tokens",
-				),
-		})
-		.from(modelProviderMappingHistory)
-		.innerJoin(
-			tables.provider,
-			eq(modelProviderMappingHistory.providerId, tables.provider.id),
-		)
-		.where(
-			and(
-				eq(modelProviderMappingHistory.modelId, modelId),
-				gte(modelProviderMappingHistory.minuteTimestamp, since),
 			),
-		)
-		.groupBy(
-			modelProviderMappingHistory.minuteTimestamp,
-			modelProviderMappingHistory.providerId,
-			tables.provider.name,
-		)
-		.orderBy(asc(modelProviderMappingHistory.minuteTimestamp));
+		db
+			.select({
+				minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
+				providerId: modelProviderMappingHistory.providerId,
+				providerName: tables.provider.name,
+				logsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+						"logs_count",
+					),
+				errorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+						"errors_count",
+					),
+				clientErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+						"client_errors_count",
+					),
+				gatewayErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+						"gateway_errors_count",
+					),
+				upstreamErrorsCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+						"upstream_errors_count",
+					),
+				cachedCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+						"cached_count",
+					),
+				totalDuration:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalDuration}), 0)`.as(
+						"total_duration",
+					),
+				totalTimeToFirstToken:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`.as(
+						"total_ttft",
+					),
+				totalTokens:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTokens}), 0)`.as(
+						"total_tokens",
+					),
+			})
+			.from(modelProviderMappingHistory)
+			.innerJoin(
+				tables.provider,
+				eq(modelProviderMappingHistory.providerId, tables.provider.id),
+			)
+			.where(
+				and(
+					eq(modelProviderMappingHistory.modelId, modelId),
+					gte(modelProviderMappingHistory.minuteTimestamp, since),
+				),
+			)
+			.groupBy(
+				modelProviderMappingHistory.minuteTimestamp,
+				modelProviderMappingHistory.providerId,
+				tables.provider.name,
+			)
+			.orderBy(asc(modelProviderMappingHistory.minuteTimestamp)),
+	]);
 
 	const byProvider = new Map<
 		string,
@@ -579,6 +599,17 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			}>;
 		}
 	>();
+
+	// Seed with active providers so idle ones still render
+	for (const p of activeProviders) {
+		if (!byProvider.has(p.providerId)) {
+			byProvider.set(p.providerId, {
+				providerId: p.providerId,
+				providerName: p.providerName ?? p.providerId,
+				points: [],
+			});
+		}
+	}
 
 	for (const r of rows) {
 		const key = r.providerId;

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -5,6 +5,7 @@ import { findArenaMatch, getArenaBenchmarks } from "@/lib/arena-benchmarks.js";
 
 import {
 	and,
+	asc,
 	db,
 	eq,
 	gte,
@@ -432,4 +433,242 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 	};
 
 	return c.json({ modelId, providers, arena });
+});
+
+// --- Public per-provider uptime/history (last 4h) ---
+
+const uptimePointSchema = z.object({
+	timestamp: z.string(),
+	logsCount: z.number(),
+	errorsCount: z.number(),
+	clientErrorsCount: z.number(),
+	gatewayErrorsCount: z.number(),
+	upstreamErrorsCount: z.number(),
+	cachedCount: z.number(),
+	avgTtft: z.number().nullable(),
+	avgDuration: z.number().nullable(),
+	totalTokens: z.number(),
+});
+
+const uptimeProviderSchema = z.object({
+	providerId: z.string(),
+	providerName: z.string(),
+	logsCount: z.number(),
+	errorsCount: z.number(),
+	upstreamErrorsCount: z.number(),
+	uptime: z.number().nullable(),
+	avgTtft: z.number().nullable(),
+	avgDuration: z.number().nullable(),
+	tokensPerSecond: z.number().nullable(),
+	points: z.array(uptimePointSchema),
+});
+
+const modelUptimeSchema = z.object({
+	modelId: z.string(),
+	windowMinutes: z.number(),
+	providers: z.array(uptimeProviderSchema),
+});
+
+const modelUptimeRoute = createRoute({
+	operationId: "internal_get_model_uptime",
+	summary: "Get model uptime",
+	description:
+		"Returns per-provider request volume, errors, latency, and throughput for a specific model over the last 4 hours.",
+	method: "get",
+	path: "/models/{modelId}/uptime",
+	request: {
+		params: z.object({
+			modelId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: modelUptimeSchema,
+				},
+			},
+			description: "Per-provider uptime time series for the last 4 hours.",
+		},
+	},
+});
+
+internalModels.openapi(modelUptimeRoute, async (c) => {
+	const { modelId } = c.req.valid("param");
+
+	const WINDOW_MINUTES = 240; // 4h
+	const WINDOW_MS = WINDOW_MINUTES * 60_000;
+	const since = new Date(Date.now() - WINDOW_MS);
+
+	const rows = await db
+		.select({
+			minuteTimestamp: modelProviderMappingHistory.minuteTimestamp,
+			providerId: modelProviderMappingHistory.providerId,
+			providerName: tables.provider.name,
+			logsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+					"logs_count",
+				),
+			errorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+					"errors_count",
+				),
+			clientErrorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+					"client_errors_count",
+				),
+			gatewayErrorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+					"gateway_errors_count",
+				),
+			upstreamErrorsCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+					"upstream_errors_count",
+				),
+			cachedCount:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+					"cached_count",
+				),
+			totalDuration:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalDuration}), 0)`.as(
+					"total_duration",
+				),
+			totalTimeToFirstToken:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`.as(
+					"total_ttft",
+				),
+			totalTokens:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTokens}), 0)`.as(
+					"total_tokens",
+				),
+		})
+		.from(modelProviderMappingHistory)
+		.innerJoin(
+			tables.provider,
+			eq(modelProviderMappingHistory.providerId, tables.provider.id),
+		)
+		.where(
+			and(
+				eq(modelProviderMappingHistory.modelId, modelId),
+				gte(modelProviderMappingHistory.minuteTimestamp, since),
+			),
+		)
+		.groupBy(
+			modelProviderMappingHistory.minuteTimestamp,
+			modelProviderMappingHistory.providerId,
+			tables.provider.name,
+		)
+		.orderBy(asc(modelProviderMappingHistory.minuteTimestamp));
+
+	const byProvider = new Map<
+		string,
+		{
+			providerId: string;
+			providerName: string;
+			points: Array<{
+				timestamp: string;
+				logsCount: number;
+				errorsCount: number;
+				clientErrorsCount: number;
+				gatewayErrorsCount: number;
+				upstreamErrorsCount: number;
+				cachedCount: number;
+				totalDuration: number;
+				totalTimeToFirstToken: number;
+				totalTokens: number;
+			}>;
+		}
+	>();
+
+	for (const r of rows) {
+		const key = r.providerId;
+		const entry = byProvider.get(key) ?? {
+			providerId: r.providerId,
+			providerName: r.providerName ?? r.providerId,
+			points: [],
+		};
+		entry.points.push({
+			timestamp: r.minuteTimestamp.toISOString(),
+			logsCount: Number(r.logsCount),
+			errorsCount: Number(r.errorsCount),
+			clientErrorsCount: Number(r.clientErrorsCount),
+			gatewayErrorsCount: Number(r.gatewayErrorsCount),
+			upstreamErrorsCount: Number(r.upstreamErrorsCount),
+			cachedCount: Number(r.cachedCount),
+			totalDuration: Number(r.totalDuration),
+			totalTimeToFirstToken: Number(r.totalTimeToFirstToken),
+			totalTokens: Number(r.totalTokens),
+		});
+		byProvider.set(key, entry);
+	}
+
+	const providers = Array.from(byProvider.values()).map((p) => {
+		let totalLogs = 0;
+		let totalErrors = 0;
+		let totalUpstreamErrors = 0;
+		let totalCached = 0;
+		let totalDuration = 0;
+		let totalTtft = 0;
+		let totalTokens = 0;
+
+		const points = p.points.map((pt) => {
+			totalLogs += pt.logsCount;
+			totalErrors += pt.errorsCount;
+			totalUpstreamErrors += pt.upstreamErrorsCount;
+			totalCached += pt.cachedCount;
+			totalDuration += pt.totalDuration;
+			totalTtft += pt.totalTimeToFirstToken;
+			totalTokens += pt.totalTokens;
+			const nonCached = pt.logsCount - pt.cachedCount;
+			return {
+				timestamp: pt.timestamp,
+				logsCount: pt.logsCount,
+				errorsCount: pt.errorsCount,
+				clientErrorsCount: pt.clientErrorsCount,
+				gatewayErrorsCount: pt.gatewayErrorsCount,
+				upstreamErrorsCount: pt.upstreamErrorsCount,
+				cachedCount: pt.cachedCount,
+				avgTtft:
+					nonCached > 0
+						? Math.round(pt.totalTimeToFirstToken / nonCached)
+						: null,
+				avgDuration:
+					pt.logsCount > 0 ? Math.round(pt.totalDuration / pt.logsCount) : null,
+				totalTokens: pt.totalTokens,
+			};
+		});
+
+		const nonCachedTotal = totalLogs - totalCached;
+		const uptime =
+			totalLogs > 0
+				? Math.round(((totalLogs - totalUpstreamErrors) / totalLogs) * 1000) /
+					10
+				: null;
+		const tokensPerSecond =
+			totalDuration > 0
+				? Math.round(totalTokens / (totalDuration / 1000))
+				: null;
+
+		return {
+			providerId: p.providerId,
+			providerName: p.providerName,
+			logsCount: totalLogs,
+			errorsCount: totalErrors,
+			upstreamErrorsCount: totalUpstreamErrors,
+			uptime,
+			avgTtft:
+				nonCachedTotal > 0 ? Math.round(totalTtft / nonCachedTotal) : null,
+			avgDuration: totalLogs > 0 ? Math.round(totalDuration / totalLogs) : null,
+			tokensPerSecond,
+			points,
+		};
+	});
+
+	providers.sort((a, b) => b.logsCount - a.logsCount);
+
+	return c.json({
+		modelId,
+		windowMinutes: WINDOW_MINUTES,
+		providers,
+	});
 });

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -267,6 +267,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/models/{modelId}/uptime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get model uptime
+         * @description Returns per-provider request volume, errors, latency, and throughput for a specific model over the last 4 hours.
+         */
+        get: operations["internal_get_model_uptime"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/discounts/model/{modelId}": {
         parameters: {
             query?: never;
@@ -8735,6 +8755,54 @@ export interface operations {
                             source: string;
                             fetchedAt: string;
                         };
+                    };
+                };
+            };
+        };
+    };
+    internal_get_model_uptime: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                modelId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Per-provider uptime time series for the last 4 hours. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        modelId: string;
+                        windowMinutes: number;
+                        providers: {
+                            providerId: string;
+                            providerName: string;
+                            logsCount: number;
+                            errorsCount: number;
+                            upstreamErrorsCount: number;
+                            uptime: number | null;
+                            avgTtft: number | null;
+                            avgDuration: number | null;
+                            tokensPerSecond: number | null;
+                            points: {
+                                timestamp: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTtft: number | null;
+                                avgDuration: number | null;
+                                totalTokens: number;
+                            }[];
+                        }[];
                     };
                 };
             };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -267,6 +267,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/models/{modelId}/uptime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get model uptime
+         * @description Returns per-provider request volume, errors, latency, and throughput for a specific model over the last 4 hours.
+         */
+        get: operations["internal_get_model_uptime"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/discounts/model/{modelId}": {
         parameters: {
             query?: never;
@@ -8735,6 +8755,54 @@ export interface operations {
                             source: string;
                             fetchedAt: string;
                         };
+                    };
+                };
+            };
+        };
+    };
+    internal_get_model_uptime: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                modelId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Per-provider uptime time series for the last 4 hours. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        modelId: string;
+                        windowMinutes: number;
+                        providers: {
+                            providerId: string;
+                            providerName: string;
+                            logsCount: number;
+                            errorsCount: number;
+                            upstreamErrorsCount: number;
+                            uptime: number | null;
+                            avgTtft: number | null;
+                            avgDuration: number | null;
+                            tokensPerSecond: number | null;
+                            points: {
+                                timestamp: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTtft: number | null;
+                                avgDuration: number | null;
+                                totalTokens: number;
+                            }[];
+                        }[];
                     };
                 };
             };

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -1,4 +1,5 @@
 import {
+	Activity,
 	AlertTriangle,
 	ArrowLeft,
 	Zap,
@@ -310,6 +311,14 @@ export default async function ModelPage({ params }: PageProps) {
 								className="gap-2"
 								iconClassName="h-3 w-3"
 							/>
+
+							<Link
+								href={`/models/${encodeURIComponent(decodedName)}/uptime`}
+								className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2.5 py-1 text-xs md:text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+							>
+								<Activity className="h-3.5 w-3.5" />
+								View uptime
+							</Link>
 						</div>
 
 						<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 text-sm text-muted-foreground mb-4">

--- a/apps/ui/src/app/models/[name]/uptime/page.tsx
+++ b/apps/ui/src/app/models/[name]/uptime/page.tsx
@@ -1,0 +1,426 @@
+import {
+	Activity,
+	ArrowLeft,
+	Clock,
+	Gauge,
+	ShieldCheck,
+	Zap,
+} from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import Footer from "@/components/landing/footer";
+import { Navbar } from "@/components/landing/navbar";
+import { ModelUptimeCharts } from "@/components/models/model-uptime-charts";
+import { Badge } from "@/lib/components/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/lib/components/card";
+
+import {
+	models as modelDefinitions,
+	providers as providerDefinitions,
+	expandAllProviderRegions,
+	type ModelDefinition,
+} from "@llmgateway/models";
+
+import type { Metadata } from "next";
+
+interface PageProps {
+	params: Promise<{ name: string }>;
+}
+
+export default async function ModelUptimePage({ params }: PageProps) {
+	const { name } = await params;
+	const decodedName = decodeURIComponent(name);
+
+	const modelDef = modelDefinitions.find(
+		(m) => m.id === decodedName,
+	) as ModelDefinition;
+
+	if (!modelDef) {
+		notFound();
+	}
+
+	const expandedProviders = expandAllProviderRegions(modelDef.providers);
+	const providerNames = Array.from(
+		new Set(
+			expandedProviders.map((p) => {
+				const info = providerDefinitions.find((pd) => pd.id === p.providerId);
+				return info?.name ?? p.providerId;
+			}),
+		),
+	);
+	const providerCount = providerNames.length;
+	const modelLabel = modelDef.name ?? modelDef.id;
+	const modelUrl = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
+	const uptimeUrl = `${modelUrl}/uptime`;
+
+	const breadcrumbSchema = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: "https://llmgateway.io",
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Models",
+				item: "https://llmgateway.io/models",
+			},
+			{
+				"@type": "ListItem",
+				position: 3,
+				name: modelLabel,
+				item: modelUrl,
+			},
+			{
+				"@type": "ListItem",
+				position: 4,
+				name: "Uptime",
+				item: uptimeUrl,
+			},
+		],
+	};
+
+	const datasetSchema = {
+		"@context": "https://schema.org",
+		"@type": "Dataset",
+		name: `${modelLabel} provider uptime — last 4 hours`,
+		description: `Live request volume, error rates, latency (TTFT and total duration), and throughput for every provider serving ${modelLabel} on LLM Gateway, refreshed every minute over the last 4 hours.`,
+		url: uptimeUrl,
+		isAccessibleForFree: true,
+		license: "https://llmgateway.io/legal/terms",
+		creator: {
+			"@type": "Organization",
+			name: "LLM Gateway",
+			url: "https://llmgateway.io",
+		},
+		variableMeasured: [
+			"Requests",
+			"Error rate",
+			"Time to first token (TTFT)",
+			"Average duration",
+			"Tokens per second",
+			"Uptime percent",
+		],
+		temporalCoverage: "PT4H",
+		keywords: [
+			modelLabel,
+			"uptime",
+			"latency",
+			"reliability",
+			"AI model status",
+		],
+	};
+
+	const faqSchema = {
+		"@context": "https://schema.org",
+		"@type": "FAQPage",
+		mainEntity: [
+			{
+				"@type": "Question",
+				name: `How is ${modelLabel} uptime measured?`,
+				acceptedAnswer: {
+					"@type": "Answer",
+					text: `Uptime is the share of requests that completed successfully on the upstream provider over the last 4 hours. Client errors (4xx from your request) and gateway errors are excluded so the number reflects the provider's reliability, not user errors.`,
+				},
+			},
+			{
+				"@type": "Question",
+				name: `Which providers serve ${modelLabel}?`,
+				acceptedAnswer: {
+					"@type": "Answer",
+					text: `${modelLabel} is currently served by ${providerCount} provider${providerCount === 1 ? "" : "s"}: ${providerNames.join(", ")}. LLM Gateway routes requests to the best healthy provider in real time.`,
+				},
+			},
+			{
+				"@type": "Question",
+				name: `What is TTFT and why does it matter?`,
+				acceptedAnswer: {
+					"@type": "Answer",
+					text: `TTFT (time to first token) is the latency between the request and the first streamed token. Lower TTFT means the model starts responding faster — critical for chat UIs and agent loops.`,
+				},
+			},
+			{
+				"@type": "Question",
+				name: `How often does this page update?`,
+				acceptedAnswer: {
+					"@type": "Answer",
+					text: `Charts refresh every minute and aggregate the most recent 4 hours of traffic across all LLM Gateway projects. Data points are bucketed by minute.`,
+				},
+			},
+		],
+	};
+
+	return (
+		<>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{
+					__html: JSON.stringify(breadcrumbSchema),
+				}}
+			/>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{
+					__html: JSON.stringify(datasetSchema),
+				}}
+			/>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{
+					__html: JSON.stringify(faqSchema),
+				}}
+			/>
+			<Navbar />
+			<div className="min-h-screen bg-background pt-24 md:pt-32 pb-16">
+				<div className="container mx-auto px-4 py-8">
+					<div className="mb-6">
+						<Link
+							href={`/models/${encodeURIComponent(decodedName)}`}
+							className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+						>
+							<ArrowLeft className="mr-2 h-4 w-4" />
+							Back to {modelLabel}
+						</Link>
+					</div>
+
+					<header className="mb-8 max-w-3xl">
+						<div className="flex items-center gap-2 mb-3">
+							<Badge variant="outline" className="gap-1.5">
+								<span className="relative flex h-2 w-2">
+									<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+									<span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+								</span>
+								Live
+							</Badge>
+							<Badge variant="outline">Last 4 hours</Badge>
+						</div>
+						<h1 className="text-3xl md:text-4xl font-bold tracking-tight mb-3">
+							{modelLabel} uptime &amp; latency
+						</h1>
+						<p className="text-muted-foreground text-base md:text-lg">
+							Real-time reliability for every provider serving{" "}
+							<strong className="text-foreground">{modelLabel}</strong> on LLM
+							Gateway. Compare success rates, time-to-first-token, throughput,
+							and error breakdown across {providerCount} provider
+							{providerCount === 1 ? "" : "s"} so you can pick the fastest, most
+							stable route for your workload.
+						</p>
+					</header>
+
+					<div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-10">
+						<MetricCard
+							icon={ShieldCheck}
+							label="Uptime"
+							value="Per provider"
+							hint="Share of requests with no upstream error"
+						/>
+						<MetricCard
+							icon={Clock}
+							label="Latency"
+							value="TTFT + duration"
+							hint="Time to first token and total duration in ms"
+						/>
+						<MetricCard
+							icon={Gauge}
+							label="Throughput"
+							value="Tokens / sec"
+							hint="Sustained generation speed across requests"
+						/>
+						<MetricCard
+							icon={Activity}
+							label="Errors"
+							value="Client / gateway / upstream"
+							hint="Failure source breakdown"
+						/>
+					</div>
+
+					<section className="mb-8">
+						<div className="flex flex-col md:flex-row md:items-end md:justify-between mb-6 gap-2">
+							<div>
+								<h2 className="text-xl md:text-2xl font-semibold mb-1">
+									Provider performance
+								</h2>
+								<p className="text-sm text-muted-foreground">
+									Each card shows live traffic from the last 4 hours. Switch
+									tabs to inspect requests, errors, latency, or token volume.
+								</p>
+							</div>
+						</div>
+						<ModelUptimeCharts modelId={decodedName} />
+					</section>
+
+					<section className="mb-12">
+						<Card>
+							<CardHeader>
+								<CardTitle className="text-lg flex items-center gap-2">
+									<Zap className="h-4 w-4 text-primary" />
+									How LLM Gateway uses these metrics
+								</CardTitle>
+								<CardDescription>
+									Routing happens automatically — these charts show the data
+									behind it.
+								</CardDescription>
+							</CardHeader>
+							<CardContent className="text-sm text-muted-foreground space-y-3">
+								<p>
+									Every {modelLabel} request flowing through LLM Gateway is
+									scored on uptime, latency, and throughput. When an upstream
+									provider degrades, traffic shifts to the next-best healthy
+									endpoint without any client-side changes.
+								</p>
+								<p>
+									Use this page to verify SLA performance, debug regressions, or
+									pick a primary provider for a self-hosted deployment.
+								</p>
+							</CardContent>
+						</Card>
+					</section>
+
+					<section className="mb-4">
+						<h2 className="text-xl md:text-2xl font-semibold mb-4">
+							Frequently asked questions
+						</h2>
+						<div className="grid gap-4 md:grid-cols-2">
+							<FaqItem
+								question={`How is ${modelLabel} uptime measured?`}
+								answer={`Uptime is the share of requests that completed successfully on the upstream provider over the last 4 hours. Client errors (4xx from your request) and gateway errors are excluded so the number reflects the provider's reliability, not user errors.`}
+							/>
+							<FaqItem
+								question={`Which providers serve ${modelLabel}?`}
+								answer={`${modelLabel} is currently served by ${providerCount} provider${providerCount === 1 ? "" : "s"}: ${providerNames.join(", ")}. LLM Gateway routes requests to the best healthy provider in real time.`}
+							/>
+							<FaqItem
+								question="What is TTFT and why does it matter?"
+								answer="TTFT (time to first token) is the latency between the request and the first streamed token. Lower TTFT means the model starts responding faster — critical for chat UIs and agent loops."
+							/>
+							<FaqItem
+								question="How often does this page update?"
+								answer="Charts refresh every minute and aggregate the most recent 4 hours of traffic across all LLM Gateway projects. Data points are bucketed by minute."
+							/>
+						</div>
+					</section>
+				</div>
+			</div>
+			<Footer />
+		</>
+	);
+}
+
+function MetricCard({
+	icon: Icon,
+	label,
+	value,
+	hint,
+}: {
+	icon: typeof Activity;
+	label: string;
+	value: string;
+	hint: string;
+}) {
+	return (
+		<div className="rounded-lg border border-border/60 bg-muted/30 p-4">
+			<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground mb-2">
+				<Icon className="h-3.5 w-3.5" />
+				{label}
+			</div>
+			<div className="text-base font-semibold">{value}</div>
+			<div className="text-xs text-muted-foreground mt-1">{hint}</div>
+		</div>
+	);
+}
+
+function FaqItem({ question, answer }: { question: string; answer: string }) {
+	return (
+		<div className="rounded-lg border border-border/60 p-5">
+			<h3 className="font-semibold mb-2">{question}</h3>
+			<p className="text-sm text-muted-foreground">{answer}</p>
+		</div>
+	);
+}
+
+export async function generateStaticParams() {
+	return modelDefinitions.map((model) => ({
+		name: encodeURIComponent(model.id),
+	}));
+}
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { name } = await params;
+	const decodedName = decodeURIComponent(name);
+	const model = modelDefinitions.find((m) => m.id === decodedName) as
+		| ModelDefinition
+		| undefined;
+
+	if (!model) {
+		return {};
+	}
+
+	const expandedProviders = expandAllProviderRegions(model.providers);
+	const providerCount = new Set(expandedProviders.map((p) => p.providerId))
+		.size;
+	const modelLabel = model.name ?? model.id;
+
+	const title = `${modelLabel} Uptime & Latency — Live Provider Status`;
+	const description = `Live ${modelLabel} reliability across ${providerCount} provider${providerCount === 1 ? "" : "s"}: uptime %, time-to-first-token, throughput, and error rates from the last 4 hours.`;
+
+	const canonical = `/models/${encodeURIComponent(decodedName)}/uptime`;
+	const primaryProvider = model.providers[0]?.providerId || "default";
+	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`;
+
+	return {
+		title,
+		description,
+		alternates: {
+			canonical,
+		},
+		keywords: [
+			`${modelLabel} uptime`,
+			`${modelLabel} latency`,
+			`${modelLabel} status`,
+			`${modelLabel} reliability`,
+			`${modelLabel} TTFT`,
+			"LLM Gateway",
+			"AI model status",
+		],
+		openGraph: {
+			title,
+			description,
+			type: "website",
+			url: canonical,
+			images: [
+				{
+					url: ogImageUrl,
+					width: 1200,
+					height: 630,
+					alt: `${modelLabel} uptime status`,
+				},
+			],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+			images: [ogImageUrl],
+		},
+		robots: {
+			index: true,
+			follow: true,
+		},
+	};
+}

--- a/apps/ui/src/app/sitemap.ts
+++ b/apps/ui/src/app/sitemap.ts
@@ -190,6 +190,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.8,
 		});
 
+		// Model uptime page
+		modelPages.push({
+			url: `${baseUrl}/models/${encodeURIComponent(model.id)}/uptime`,
+			lastModified: new Date(),
+			changeFrequency: "hourly",
+			priority: 0.7,
+		});
+
 		// Model + provider pages
 		const uniqueProviders = Array.from(
 			new Set(model.providers.map((p) => p.providerId)),

--- a/apps/ui/src/components/models/model-uptime-charts.tsx
+++ b/apps/ui/src/components/models/model-uptime-charts.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { Activity, AlertTriangle, Clock, Gauge, Zap } from "lucide-react";
+import {
+	Activity,
+	AlertTriangle,
+	Clock,
+	Gauge,
+	RefreshCw,
+	Zap,
+} from "lucide-react";
 import { useState } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { Badge } from "@/lib/components/badge";
+import { Button } from "@/lib/components/button";
 import {
 	Card,
 	CardContent,
@@ -20,44 +27,18 @@ import {
 	ChartTooltipContent,
 	type ChartConfig,
 } from "@/lib/components/chart";
-import { useAppConfig } from "@/lib/config";
+import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
 
+import type { paths } from "@/lib/api/v1";
+
 type ActiveMetric = "requests" | "errors" | "latency" | "tokens";
 
-interface UptimePoint {
-	timestamp: string;
-	logsCount: number;
-	errorsCount: number;
-	clientErrorsCount: number;
-	gatewayErrorsCount: number;
-	upstreamErrorsCount: number;
-	cachedCount: number;
-	avgTtft: number | null;
-	avgDuration: number | null;
-	totalTokens: number;
-}
-
-interface UptimeProvider {
-	providerId: string;
-	providerName: string;
-	logsCount: number;
-	errorsCount: number;
-	upstreamErrorsCount: number;
-	uptime: number | null;
-	avgTtft: number | null;
-	avgDuration: number | null;
-	tokensPerSecond: number | null;
-	points: UptimePoint[];
-}
-
-interface UptimeResponse {
-	modelId: string;
-	windowMinutes: number;
-	providers: UptimeProvider[];
-}
+type UptimeResponse =
+	paths["/internal/models/{modelId}/uptime"]["get"]["responses"]["200"]["content"]["application/json"];
+type UptimeProvider = UptimeResponse["providers"][number];
 
 const chartConfigs: Record<ActiveMetric, ChartConfig> = {
 	requests: {
@@ -199,10 +180,19 @@ function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 					/>
 				</div>
 
-				<div className="flex items-center gap-1 border-b pb-2">
+				<div
+					role="tablist"
+					aria-label="Metric"
+					className="flex items-center gap-1 border-b pb-2"
+				>
 					{metricTabs.map((tab) => (
 						<button
 							key={tab.key}
+							id={`metric-tab-${provider.providerId}-${tab.key}`}
+							role="tab"
+							type="button"
+							aria-selected={activeMetric === tab.key}
+							aria-controls={`metric-panel-${provider.providerId}-${tab.key}`}
 							className={cn(
 								"rounded-md px-3 py-1 text-xs font-medium transition-colors",
 								activeMetric === tab.key
@@ -216,7 +206,12 @@ function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 					))}
 				</div>
 			</CardHeader>
-			<CardContent className="px-2 pb-4 sm:px-6">
+			<CardContent
+				id={`metric-panel-${provider.providerId}-${activeMetric}`}
+				role="tabpanel"
+				aria-labelledby={`metric-tab-${provider.providerId}-${activeMetric}`}
+				className="px-2 pb-4 sm:px-6"
+			>
 				{provider.points.length === 0 ? (
 					<div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
 						No traffic in the last 4 hours
@@ -321,22 +316,17 @@ function Stat({
 }
 
 export function ModelUptimeCharts({ modelId }: { modelId: string }) {
-	const config = useAppConfig();
+	const api = useApi();
 
-	const { data, isLoading, isError } = useQuery<UptimeResponse>({
-		queryKey: ["model-uptime", modelId],
-		queryFn: async () => {
-			const response = await fetch(
-				`${config.apiUrl}/internal/models/${encodeURIComponent(modelId)}/uptime`,
-			);
-			if (!response.ok) {
-				throw new Error("Failed to fetch uptime");
-			}
-			return await response.json();
+	const { data, isLoading, isError, refetch } = api.useQuery(
+		"get",
+		"/internal/models/{modelId}/uptime",
+		{ params: { path: { modelId } } },
+		{
+			refetchInterval: 60_000,
+			staleTime: 30_000,
 		},
-		refetchInterval: 60_000,
-		staleTime: 30_000,
-	});
+	);
 
 	if (isLoading) {
 		return (
@@ -351,7 +341,27 @@ export function ModelUptimeCharts({ modelId }: { modelId: string }) {
 		);
 	}
 
-	if (isError || !data || data.providers.length === 0) {
+	if (isError) {
+		return (
+			<Card>
+				<CardContent className="flex h-40 flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+					<AlertTriangle className="h-6 w-6 text-destructive" />
+					<span>Unable to load uptime data. Please try again.</span>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => refetch()}
+						className="gap-2"
+					>
+						<RefreshCw className="h-3.5 w-3.5" />
+						Retry
+					</Button>
+				</CardContent>
+			</Card>
+		);
+	}
+
+	if (!data || data.providers.length === 0) {
 		return (
 			<Card>
 				<CardContent className="flex h-40 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">

--- a/apps/ui/src/components/models/model-uptime-charts.tsx
+++ b/apps/ui/src/components/models/model-uptime-charts.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { Activity, AlertTriangle, Clock, Gauge, Zap } from "lucide-react";
+import { useState } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import { Badge } from "@/lib/components/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/lib/components/card";
+import {
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+	type ChartConfig,
+} from "@/lib/components/chart";
+import { useAppConfig } from "@/lib/config";
+import { cn } from "@/lib/utils";
+
+import { getProviderIcon } from "@llmgateway/shared/components";
+
+type ActiveMetric = "requests" | "errors" | "latency" | "tokens";
+
+interface UptimePoint {
+	timestamp: string;
+	logsCount: number;
+	errorsCount: number;
+	clientErrorsCount: number;
+	gatewayErrorsCount: number;
+	upstreamErrorsCount: number;
+	cachedCount: number;
+	avgTtft: number | null;
+	avgDuration: number | null;
+	totalTokens: number;
+}
+
+interface UptimeProvider {
+	providerId: string;
+	providerName: string;
+	logsCount: number;
+	errorsCount: number;
+	upstreamErrorsCount: number;
+	uptime: number | null;
+	avgTtft: number | null;
+	avgDuration: number | null;
+	tokensPerSecond: number | null;
+	points: UptimePoint[];
+}
+
+interface UptimeResponse {
+	modelId: string;
+	windowMinutes: number;
+	providers: UptimeProvider[];
+}
+
+const chartConfigs: Record<ActiveMetric, ChartConfig> = {
+	requests: {
+		logsCount: { label: "Requests", color: "hsl(221 83% 53%)" },
+		cachedCount: { label: "Cached", color: "hsl(142 71% 45%)" },
+	},
+	errors: {
+		clientErrorsCount: { label: "Client", color: "hsl(38 92% 50%)" },
+		gatewayErrorsCount: { label: "Gateway", color: "hsl(262 83% 58%)" },
+		upstreamErrorsCount: { label: "Upstream", color: "hsl(0 84% 60%)" },
+	},
+	latency: {
+		avgTtft: { label: "Avg TTFT (ms)", color: "hsl(262 83% 58%)" },
+		avgDuration: { label: "Avg Duration (ms)", color: "hsl(221 83% 53%)" },
+	},
+	tokens: {
+		totalTokens: { label: "Tokens", color: "hsl(32 95% 44%)" },
+	},
+};
+
+const metricTabs: { key: ActiveMetric; label: string }[] = [
+	{ key: "requests", label: "Requests" },
+	{ key: "errors", label: "Errors" },
+	{ key: "latency", label: "Latency" },
+	{ key: "tokens", label: "Tokens" },
+];
+
+function formatCompact(n: number): string {
+	if (n >= 1_000_000_000) {
+		return `${(n / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (n >= 1_000_000) {
+		return `${(n / 1_000_000).toFixed(1)}M`;
+	}
+	if (n >= 1_000) {
+		return `${(n / 1_000).toFixed(1)}k`;
+	}
+	return n.toLocaleString();
+}
+
+function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
+	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("requests");
+	const ProviderIcon = getProviderIcon(provider.providerId);
+	const config = chartConfigs[activeMetric];
+	const dataKeys = Object.keys(config);
+
+	const errorRate =
+		provider.logsCount > 0
+			? Math.round((provider.errorsCount / provider.logsCount) * 1000) / 10
+			: 0;
+
+	const uptimeColor =
+		provider.uptime === null
+			? "text-muted-foreground"
+			: provider.uptime >= 99.5
+				? "text-green-600 dark:text-green-500"
+				: provider.uptime >= 95
+					? "text-yellow-600 dark:text-yellow-500"
+					: "text-red-600 dark:text-red-500";
+
+	return (
+		<Card>
+			<CardHeader className="space-y-4 pb-2">
+				<div className="flex flex-wrap items-start justify-between gap-3">
+					<div className="flex items-center gap-3">
+						<div className="rounded-md border border-border/60 bg-muted/40 p-2">
+							{ProviderIcon ? (
+								<ProviderIcon className="h-5 w-5 shrink-0 dark:text-white" />
+							) : (
+								<Activity className="h-5 w-5 shrink-0" />
+							)}
+						</div>
+						<div>
+							<CardTitle className="text-base flex items-center gap-2">
+								{provider.providerName}
+								<Badge variant="outline" className="text-[10px] uppercase">
+									{provider.providerId}
+								</Badge>
+							</CardTitle>
+							<CardDescription className="text-xs">
+								Last 4 hours · {provider.points.length} data points
+							</CardDescription>
+						</div>
+					</div>
+					{provider.uptime !== null && (
+						<div className="flex flex-col items-end">
+							<span
+								className={cn("text-2xl font-bold tabular-nums", uptimeColor)}
+							>
+								{provider.uptime.toFixed(1)}%
+							</span>
+							<span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+								Uptime
+							</span>
+						</div>
+					)}
+				</div>
+
+				<div className="grid grid-cols-2 sm:grid-cols-4 gap-3 pt-1">
+					<Stat
+						icon={Activity}
+						label="Requests"
+						value={formatCompact(provider.logsCount)}
+						sub={`${formatCompact(provider.errorsCount)} errors (${errorRate}%)`}
+					/>
+					<Stat
+						icon={Clock}
+						label="Avg TTFT"
+						value={provider.avgTtft !== null ? `${provider.avgTtft}ms` : "—"}
+						sub={
+							provider.avgDuration !== null
+								? `${provider.avgDuration}ms duration`
+								: undefined
+						}
+					/>
+					<Stat
+						icon={Gauge}
+						label="Throughput"
+						value={
+							provider.tokensPerSecond !== null
+								? `${provider.tokensPerSecond.toLocaleString()} t/s`
+								: "—"
+						}
+					/>
+					<Stat
+						icon={AlertTriangle}
+						label="Upstream errors"
+						value={formatCompact(provider.upstreamErrorsCount)}
+						sub={
+							provider.logsCount > 0
+								? `${(
+										Math.round(
+											(provider.upstreamErrorsCount / provider.logsCount) *
+												10000,
+										) / 100
+									).toFixed(2)}% rate`
+								: undefined
+						}
+					/>
+				</div>
+
+				<div className="flex items-center gap-1 border-b pb-2">
+					{metricTabs.map((tab) => (
+						<button
+							key={tab.key}
+							className={cn(
+								"rounded-md px-3 py-1 text-xs font-medium transition-colors",
+								activeMetric === tab.key
+									? "bg-primary text-primary-foreground"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+							onClick={() => setActiveMetric(tab.key)}
+						>
+							{tab.label}
+						</button>
+					))}
+				</div>
+			</CardHeader>
+			<CardContent className="px-2 pb-4 sm:px-6">
+				{provider.points.length === 0 ? (
+					<div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+						No traffic in the last 4 hours
+					</div>
+				) : (
+					<ChartContainer
+						config={config}
+						className="aspect-auto h-[200px] w-full"
+					>
+						<AreaChart
+							data={provider.points}
+							margin={{ left: 0, right: 8, top: 4, bottom: 0 }}
+						>
+							<CartesianGrid vertical={false} strokeDasharray="3 3" />
+							<XAxis
+								dataKey="timestamp"
+								tickLine={false}
+								axisLine={false}
+								tickMargin={8}
+								minTickGap={40}
+								tickFormatter={(value: string) =>
+									format(new Date(value), "HH:mm")
+								}
+							/>
+							<YAxis
+								tickLine={false}
+								axisLine={false}
+								tickMargin={4}
+								width={50}
+								tickFormatter={(value: number) =>
+									value >= 1000
+										? `${(value / 1000).toFixed(1)}k`
+										: String(value)
+								}
+							/>
+							<ChartTooltip
+								content={
+									<ChartTooltipContent
+										labelFormatter={(value: string) =>
+											format(new Date(value), "MMM d, HH:mm")
+										}
+										formatter={(value, name) => {
+											const label = config[name as string]?.label ?? name;
+											const formatted =
+												activeMetric === "latency"
+													? `${Math.round(Number(value))}ms`
+													: Number(value).toLocaleString();
+											return (
+												<span>
+													{label}: <strong>{formatted}</strong>
+												</span>
+											);
+										}}
+									/>
+								}
+							/>
+							{dataKeys.map((key, i) => (
+								<Area
+									key={key}
+									dataKey={key}
+									type="monotone"
+									stroke={`var(--color-${key})`}
+									fill={`var(--color-${key})`}
+									fillOpacity={i === 0 ? 0.15 : 0.05}
+									strokeWidth={2}
+									isAnimationActive={false}
+								/>
+							))}
+						</AreaChart>
+					</ChartContainer>
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+function Stat({
+	icon: Icon,
+	label,
+	value,
+	sub,
+}: {
+	icon: typeof Activity;
+	label: string;
+	value: string;
+	sub?: string;
+}) {
+	return (
+		<div className="space-y-0.5">
+			<div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+				<Icon className="h-3 w-3" />
+				{label}
+			</div>
+			<div className="text-base font-semibold tabular-nums">{value}</div>
+			{sub && (
+				<div className="text-[11px] text-muted-foreground tabular-nums">
+					{sub}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export function ModelUptimeCharts({ modelId }: { modelId: string }) {
+	const config = useAppConfig();
+
+	const { data, isLoading, isError } = useQuery<UptimeResponse>({
+		queryKey: ["model-uptime", modelId],
+		queryFn: async () => {
+			const response = await fetch(
+				`${config.apiUrl}/internal/models/${encodeURIComponent(modelId)}/uptime`,
+			);
+			if (!response.ok) {
+				throw new Error("Failed to fetch uptime");
+			}
+			return await response.json();
+		},
+		refetchInterval: 60_000,
+		staleTime: 30_000,
+	});
+
+	if (isLoading) {
+		return (
+			<div className="space-y-6">
+				{[1, 2, 3].map((i) => (
+					<div
+						key={i}
+						className="h-[360px] animate-pulse rounded-lg border border-border bg-muted/30"
+					/>
+				))}
+			</div>
+		);
+	}
+
+	if (isError || !data || data.providers.length === 0) {
+		return (
+			<Card>
+				<CardContent className="flex h-40 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+					<Zap className="h-6 w-6" />
+					No uptime data is available for this model in the last 4 hours.
+				</CardContent>
+			</Card>
+		);
+	}
+
+	return (
+		<div className="space-y-6">
+			{data.providers.map((provider) => (
+				<ProviderUptimeCard key={provider.providerId} provider={provider} />
+			))}
+		</div>
+	);
+}

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -267,6 +267,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/models/{modelId}/uptime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get model uptime
+         * @description Returns per-provider request volume, errors, latency, and throughput for a specific model over the last 4 hours.
+         */
+        get: operations["internal_get_model_uptime"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/discounts/model/{modelId}": {
         parameters: {
             query?: never;
@@ -8735,6 +8755,54 @@ export interface operations {
                             source: string;
                             fetchedAt: string;
                         };
+                    };
+                };
+            };
+        };
+    };
+    internal_get_model_uptime: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                modelId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Per-provider uptime time series for the last 4 hours. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        modelId: string;
+                        windowMinutes: number;
+                        providers: {
+                            providerId: string;
+                            providerName: string;
+                            logsCount: number;
+                            errorsCount: number;
+                            upstreamErrorsCount: number;
+                            uptime: number | null;
+                            avgTtft: number | null;
+                            avgDuration: number | null;
+                            tokensPerSecond: number | null;
+                            points: {
+                                timestamp: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTtft: number | null;
+                                avgDuration: number | null;
+                                totalTokens: number;
+                            }[];
+                        }[];
                     };
                 };
             };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -267,6 +267,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/models/{modelId}/uptime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get model uptime
+         * @description Returns per-provider request volume, errors, latency, and throughput for a specific model over the last 4 hours.
+         */
+        get: operations["internal_get_model_uptime"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/discounts/model/{modelId}": {
         parameters: {
             query?: never;
@@ -8735,6 +8755,54 @@ export interface operations {
                             source: string;
                             fetchedAt: string;
                         };
+                    };
+                };
+            };
+        };
+    };
+    internal_get_model_uptime: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                modelId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Per-provider uptime time series for the last 4 hours. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        modelId: string;
+                        windowMinutes: number;
+                        providers: {
+                            providerId: string;
+                            providerName: string;
+                            logsCount: number;
+                            errorsCount: number;
+                            upstreamErrorsCount: number;
+                            uptime: number | null;
+                            avgTtft: number | null;
+                            avgDuration: number | null;
+                            tokensPerSecond: number | null;
+                            points: {
+                                timestamp: string;
+                                logsCount: number;
+                                errorsCount: number;
+                                clientErrorsCount: number;
+                                gatewayErrorsCount: number;
+                                upstreamErrorsCount: number;
+                                cachedCount: number;
+                                avgTtft: number | null;
+                                avgDuration: number | null;
+                                totalTokens: number;
+                            }[];
+                        }[];
                     };
                 };
             };


### PR DESCRIPTION
## Summary
- New `/models/[name]/uptime` page with live per-provider charts (requests, errors, latency, tokens) over the last 4 hours — no cost data
- Public API endpoint `GET /internal/models/{modelId}/uptime` aggregating `model_provider_mapping_history` per provider
- SEO: `generateMetadata` (canonical, OG/Twitter, keywords), JSON-LD (BreadcrumbList, Dataset, FAQPage), sitemap entries with hourly change frequency, and an on-page FAQ section that mirrors the FAQ schema

## Details
- Each provider card shows: color-coded uptime %, total requests + error rate, avg TTFT, avg duration, tokens/sec, upstream error count, and an area chart with Requests / Errors / Latency / Tokens tabs
- Charts auto-refresh every 60s via TanStack Query
- Adds a "View uptime" link from the existing model detail page
- Uses the same recharts + chart primitives as `ee/admin`, but reuses the public `/internal` namespace so the page works for unauthenticated visitors

## Test plan
- [ ] Visit `/models/gpt-5.5-pro/uptime` (or any active model) — confirm provider cards render with data from the last 4 hours
- [ ] Switch between Requests / Errors / Latency / Tokens tabs on each provider card
- [ ] Verify "View uptime" link appears on `/models/[name]` and routes correctly
- [ ] Inspect page source for the three JSON-LD blocks (Breadcrumb, Dataset, FAQ)
- [ ] Hit `/internal/models/<id>/uptime` directly and confirm the JSON shape
- [ ] Confirm the route appears in `/sitemap.xml` for every model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model uptime monitoring showing per-provider metrics for the last 240 minutes.
  * Uptime dashboard with interactive charts for requests, errors, latency, and throughput.
  * "View uptime" link on model pages for quick access to uptime analytics.
  * Live-refreshing charts with retry/error and "no data" states for better UX.
  * Sitemap updated to include per-model uptime pages for discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->