### PR TITLE
docs(image-gen): correct image_quality default to auto

### DIFF
--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -738,10 +738,10 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
   }'
 ```
 
-| Parameter       | Type   | Description                                                                          |
-| --------------- | ------ | ------------------------------------------------------------------------------------ |
-| `image_size`    | string | Image dimensions in `WIDTHxHEIGHT` format, or `"auto"` to let the model choose.      |
-| `image_quality` | string | One of `"low"`, `"medium"`, `"high"`, or `"auto"`. Defaults to `"low"` when omitted. |
+| Parameter       | Type   | Description                                                                           |
+| --------------- | ------ | ------------------------------------------------------------------------------------- |
+| `image_size`    | string | Image dimensions in `WIDTHxHEIGHT` format, or `"auto"` to let the model choose.       |
+| `image_quality` | string | One of `"low"`, `"medium"`, `"high"`, or `"auto"`. Defaults to `"auto"` when omitted. |
 
 <Callout type="warning">
 	OpenAI image models do **not** accept `aspect_ratio`. Always specify


### PR DESCRIPTION
## Summary
- `image_quality` defaults to `"auto"` when omitted, not `"low"` — fix the docs to match actual behavior.

## Test plan
- [ ] Confirm the rendered docs page reads `Defaults to "auto" when omitted.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image generation configuration documentation. The `image_quality` parameter now defaults to `"auto"` when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->