### PR TITLE
fix(gateway): classify openai safety rejection as content_filter

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -92,6 +92,18 @@ describe("getFinishReasonFromError", () => {
 		).toBe("client_error");
 	});
 
+	it("returns content_filter for OpenAI safety system rejection", () => {
+		const openaiError = JSON.stringify({
+			error: {
+				code: "moderation_blocked",
+				message: "Your request was rejected by the safety system.",
+				param: null,
+				type: "image_generation_user_error",
+			},
+		});
+		expect(getFinishReasonFromError(400, openaiError)).toBe("content_filter");
+	});
+
 	it("returns content_filter for xAI 403 safety rejection", () => {
 		expect(
 			getFinishReasonFromError(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -55,6 +55,11 @@ export function getFinishReasonFromError(
 		return "content_filter";
 	}
 
+	// OpenAI safety system rejection (e.g. gpt-image-2 image generation)
+	if (errorText?.includes("Your request was rejected by the safety system")) {
+		return "content_filter";
+	}
+
 	// 401/403 usually indicate invalid or unauthorized provider credentials
 	if (statusCode === 401 || statusCode === 403) {
 		return "gateway_error";


### PR DESCRIPTION
## Summary
- OpenAI (e.g. gpt-image-2) can reject requests with `"Your request was rejected by the safety system."`. Previously this fell through to `client_error`; now it's classified as `content_filter`.

## Test plan
- [x] Added unit test in `get-finish-reason-from-error.spec.ts`
- [x] `pnpm test:unit` passes
- [x] `pnpm build` passes
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to properly identify OpenAI safety system rejections as content filter blocks instead of gateway errors.

* **Tests**
  * Added test coverage to validate correct classification of safety rejection payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->