### PR TITLE
fix(api): skip subscription PIs in topup webhook

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -832,7 +832,12 @@ async function handlePaymentIntentSucceeded(
 	const paymentIntent = event.data.object;
 	const { metadata, amount } = paymentIntent;
 
-	// Get the credit amount (base amount without fees) from metadata
+	// payment_intent.succeeded also fires for subscription invoice payments;
+	// only credit top-up payment intents set baseAmount in metadata.
+	if (paymentIntent.metadata.baseAmount === undefined) {
+		return;
+	}
+
 	const creditAmount = Number(paymentIntent.metadata.baseAmount);
 	if (!Number.isFinite(creditAmount) || creditAmount <= 0) {
 		logger.error("Invalid baseAmount in payment intent metadata", {


### PR DESCRIPTION
## Summary
- Production was logging `Invalid baseAmount in payment intent metadata` at ERROR severity for subscription payments. The `payment_intent.succeeded` webhook fires for all payment intents — including those generated by subscription invoices — but `handlePaymentIntentSucceeded` is only meant to credit top-ups (which carry `baseAmount` in metadata).
- Subscription PIs are already processed via `invoice.payment_succeeded`, so the topup handler now returns early when `baseAmount` is absent rather than logging an error.
- The `Invalid baseAmount` error remains for the genuine bug case (baseAmount present but malformed/non-positive).

## Test plan
- [ ] Trigger a subscription purchase in staging and confirm the topup error no longer fires
- [ ] Trigger a credit top-up via PaymentElement and confirm credits are still applied
- [ ] Trigger an auto top-up and confirm the pending transaction is still completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed payment processing to correctly handle subscription-related payments, preventing unnecessary errors during transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->