### PR TITLE
feat(gateway): make alibaba thinking opt-in via reasoning_effort

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1031,15 +1031,13 @@ export async function prepareRequestBody(
 		}
 	}
 
-	// qwen3.6-35b-a3b returns empty content ~40% of the time when json_object
-	// is combined with thinking; force thinking off when JSON is requested.
-	if (
-		usedProvider === "alibaba" &&
-		usedModel === "qwen3.6-35b-a3b" &&
-		(response_format?.type === "json_object" ||
-			response_format?.type === "json_schema")
-	) {
-		requestBody.enable_thinking = false;
+	// Alibaba's API defaults `enable_thinking` to ON for thinking models.
+	// Mirror the OpenAI/Anthropic/Google/ZAI contract: thinking is opt-in via
+	// `reasoning_effort`. Unset or `minimal` => off, anything else => on.
+	if (usedProvider === "alibaba" && supportsReasoning) {
+		const wantsThinking =
+			reasoning_effort !== undefined && reasoning_effort !== "minimal";
+		requestBody.enable_thinking = wantsThinking;
 	}
 
 	if (forcesToolUse && usedProvider === "moonshot") {


### PR DESCRIPTION
## Summary

- Drive Alibaba's `enable_thinking` from `reasoning_effort` so the user controls thinking, matching the contract on openai/anthropic/google/zai. Unset or `minimal` => thinking off; anything else => thinking on.
- Drops the per-model qwen3.6-35b-a3b JSON workaround from #2114 — the empty-output bug only manifested when thinking was on, which now requires explicit user opt-in.

## Why

Previously the gateway never sent `enable_thinking` to Alibaba, so thinking inherited Alibaba's per-model default (ON for the qwen3.6 series). End users sending `reasoning_effort: minimal` still got full thinking, and qwen3.6-35b-a3b's JSON+thinking mode failed ~40% of the time. The proper fix is to make thinking opt-in via the standard reasoning param rather than papering over the JSON case.

## Test plan

- [x] `pnpm test:unit` (992 passed)
- [x] e2e for `alibaba/qwen3.6-{max-preview,plus,35b-a3b}:singapore` — 92 passed across basic, streaming, reasoning, JSON, tools, toolcall-result
- [x] qwen3.6-35b-a3b JSON e2e × 5 runs — 5/5 pass (previously 60% with thinking on)
- [x] Sanity: `alibaba/qwen3-max-2026-01-23:singapore` reasoning + streaming + basic + JSON all pass
- [x] `pnpm format`
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning feature control for Alibaba providers. Thinking is now properly enabled or disabled based on reasoning effort settings rather than response format, ensuring consistent behavior across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->