### PR TITLE
feat(gateway): make zai thinking opt-in via reasoning_effort

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1295,10 +1295,14 @@ export async function prepareRequestBody(
 			if (presence_penalty !== undefined) {
 				requestBody.presence_penalty = presence_penalty;
 			}
-			// ZAI/GLM models use 'thinking' parameter for reasoning instead of 'reasoning_effort'
+			// ZAI/GLM models use a `thinking` parameter instead of `reasoning_effort`.
+			// Mirror the OpenAI/Anthropic/Google contract: thinking is opt-in via
+			// `reasoning_effort`. Unset or `minimal` => disabled, anything else => enabled.
 			if (supportsReasoning) {
+				const wantsThinking =
+					reasoning_effort !== undefined && reasoning_effort !== "minimal";
 				requestBody.thinking = {
-					type: "enabled",
+					type: wantsThinking ? "enabled" : "disabled",
 				};
 			}
 			// Add sensitive_word_check if provided (Z.ai specific)


### PR DESCRIPTION
## Summary

- Drive ZAI/GLM's `thinking` parameter from `reasoning_effort` so the user controls thinking, matching the contract on openai/anthropic/google. Unset or `minimal` => `{ type: "disabled" }`; anything else => `{ type: "enabled" }`.

## Why

Previously the gateway forced `thinking: { type: "enabled" }` on every reasoning-capable GLM model. End users sending `reasoning_effort: minimal` still got full thinking, and there was no way to disable it via the API. Now thinking is opt-in via the standard reasoning param — matches the Alibaba fix in #2116.

## Test plan

- [x] `pnpm test:unit` (992 passed)
- [x] e2e for `zai/glm-4.6`: basic, reasoning, reasoning+streaming, JSON, JSON streaming, streaming all pass
- [x] e2e for `zai/glm-4.5` and `zai/glm-5`: basic, reasoning, reasoning+streaming, JSON all pass
- [x] glm-4.6 JSON e2e × 5 runs: 5/5 pass
- [x] `pnpm format`
- [x] `pnpm build`

`zai/glm-4.7-flash` upstream rate-limited (429 `code:1302`) during the run — unrelated to this change; the gateway test setup retries handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reasoning request handling to conditionally enable reasoning based on effort level settings, providing more granular control over when reasoning is activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->