### PR TITLE
feat(ui): add refresh button to RecentLogs and ProjectLogs components

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, ChevronsUpDown, Sparkles, X } from "lucide-react";
+import { Check, ChevronsUpDown, RefreshCw, Sparkles, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
 	useCallback,
@@ -304,10 +304,12 @@ export function RecentLogs({
 	const {
 		data,
 		isLoading,
+		isRefetching,
 		error,
 		fetchNextPage,
 		hasNextPage,
 		isFetchingNextPage,
+		refetch,
 	} = api.useInfiniteQuery(
 		"get",
 		"/logs",
@@ -559,6 +561,19 @@ export function RecentLogs({
 					}}
 					className="w-[200px]"
 				/>
+
+				<Button
+					type="button"
+					variant="outline"
+					onClick={() => void refetch()}
+					disabled={isLoading || isRefetching}
+					className="gap-2"
+				>
+					<RefreshCw
+						className={cn("h-4 w-4", isRefetching && "animate-spin")}
+					/>
+					{isRefetching ? "Refreshing..." : "Refresh"}
+				</Button>
 			</div>
 
 			{isLoading ? (

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -562,18 +562,18 @@ export function RecentLogs({
 					className="w-[200px]"
 				/>
 
-				<Button
-					type="button"
-					variant="outline"
-					onClick={() => void refetch()}
-					disabled={isLoading || isRefetching}
-					className="gap-2"
-				>
-					<RefreshCw
-						className={cn("h-4 w-4", isRefetching && "animate-spin")}
-					/>
-					{isRefetching ? "Refreshing..." : "Refresh"}
-				</Button>
+			<Button
+				type="button"
+				variant="outline"
+				onClick={() => void refetch()}
+				disabled={isLoading || isRefetching || isFetchingNextPage}
+				className="gap-2"
+			>
+				<RefreshCw
+					className={cn("h-4 w-4", isRefetching && "animate-spin")}
+				/>
+				{isRefetching ? "Refreshing..." : "Refresh"}
+			</Button>
 			</div>
 
 			{isLoading ? (

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -562,18 +562,18 @@ export function RecentLogs({
 					className="w-[200px]"
 				/>
 
-			<Button
-				type="button"
-				variant="outline"
-				onClick={() => void refetch()}
-				disabled={isLoading || isRefetching || isFetchingNextPage}
-				className="gap-2"
-			>
-				<RefreshCw
-					className={cn("h-4 w-4", isRefetching && "animate-spin")}
-				/>
-				{isRefetching ? "Refreshing..." : "Refresh"}
-			</Button>
+				<Button
+					type="button"
+					variant="outline"
+					onClick={() => void refetch()}
+					disabled={isLoading || isRefetching || isFetchingNextPage}
+					className="gap-2"
+				>
+					<RefreshCw
+						className={cn("h-4 w-4", isRefetching && "animate-spin")}
+					/>
+					{isRefetching ? "Refreshing..." : "Refresh"}
+				</Button>
 			</div>
 
 			{isLoading ? (

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
+import { Check, ChevronsUpDown, Loader2, RefreshCw } from "lucide-react";
 import {
 	useCallback,
 	useDeferredValue,
@@ -81,6 +81,7 @@ export function ProjectLogsSection({
 	const [logs, setLogs] = useState<ProjectLogEntry[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [loadingMore, setLoadingMore] = useState(false);
+	const [refreshing, setRefreshing] = useState(false);
 	const [pagination, setPagination] = useState<
 		ProjectLogsResponse["pagination"] | null
 	>(null);
@@ -114,9 +115,11 @@ export function ProjectLogsSection({
 	}, [provider, model, source, unifiedFinishReason]);
 
 	const loadLogs = useCallback(
-		async (cursor?: string) => {
+		async (cursor?: string, options?: { background?: boolean }) => {
 			if (cursor) {
 				setLoadingMore(true);
+			} else if (options?.background) {
+				setRefreshing(true);
 			} else {
 				setLoading(true);
 			}
@@ -142,6 +145,7 @@ export function ProjectLogsSection({
 			} finally {
 				setLoading(false);
 				setLoadingMore(false);
+				setRefreshing(false);
 			}
 		},
 		[orgId, projectId, getFilters],
@@ -320,6 +324,18 @@ export function ProjectLogsSection({
 						))}
 					</SelectContent>
 				</Select>
+
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					disabled={loading || loadingMore || refreshing}
+					onClick={() => void loadLogs(undefined, { background: true })}
+					className="gap-2"
+				>
+					<RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin")} />
+					{refreshing ? "Refreshing..." : "Refresh"}
+				</Button>
 			</div>
 
 			{loading ? (


### PR DESCRIPTION
- Introduced a refresh button in both RecentLogs in customer dashboard and ProjectLogs sections in admin dashboard to allow users to manually refresh the logs.
- The button displays a loading state while data is being fetched, enhancing user experience.

<img width="1054" height="252" alt="image" src="https://github.com/user-attachments/assets/a9a6ff3f-1231-4e67-acc6-f0e734612777" />
<img width="745" height="179" alt="image" src="https://github.com/user-attachments/assets/5c34fd93-08e7-41c8-bf52-159ad24e0c63" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual "Refresh" buttons in logs views for immediate updates.
  * Buttons show an animated icon and change label to indicate "Refreshing..." during refresh.
  * Background refresh capability provides non-disruptive updates without resetting the main loading state.
  * Buttons auto-disable while loading, fetching more data, or refreshing to prevent duplicate actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->