### PR TITLE
fix(payment): surface Stripe errors

### DIFF
--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -7,6 +7,7 @@ import { ensureStripeCustomer } from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import { db, eq, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 import {
 	calculateFees,
 	CREDIT_TOP_UP_MAX_AMOUNT,
@@ -14,7 +15,10 @@ import {
 } from "@llmgateway/shared";
 
 import type { ServerTypes } from "@/vars.js";
-import type { ClientErrorStatusCode } from "hono/utils/http-status";
+import type {
+	ClientErrorStatusCode,
+	ServerErrorStatusCode,
+} from "hono/utils/http-status";
 
 let _stripe: Stripe | null = null;
 
@@ -624,8 +628,21 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 		}
 
 		if (err instanceof Stripe.errors.StripeError) {
+			logger.error("Stripe error on credit top-up", err, {
+				organizationId: userOrganization.organization.id,
+				userId: user.id,
+				paymentMethodId,
+				amount,
+				stripeType: err.type,
+				stripeCode: err.code,
+				stripeStatusCode: err.statusCode,
+				stripeRequestId: err.requestId,
+			});
+
 			throw new HTTPException(
-				(err.statusCode ?? 400) as ClientErrorStatusCode,
+				(err.statusCode ?? 400) as
+					| ClientErrorStatusCode
+					| ServerErrorStatusCode,
 				{
 					message: err.message,
 				},

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -14,6 +14,7 @@ import {
 } from "@llmgateway/shared";
 
 import type { ServerTypes } from "@/vars.js";
+import type { ClientErrorStatusCode } from "hono/utils/http-status";
 
 let _stripe: Stripe | null = null;
 
@@ -620,6 +621,15 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 			throw new HTTPException(402, {
 				message: userMessage,
 			});
+		}
+
+		if (err instanceof Stripe.errors.StripeError) {
+			throw new HTTPException(
+				(err.statusCode ?? 400) as ClientErrorStatusCode,
+				{
+					message: err.message,
+				},
+			);
 		}
 
 		throw err;


### PR DESCRIPTION
Surface Stripe API errors as proper HTTP responses (with the status code Stripe returned) instead of bubbling up as generic 500s.
Also log the underlying Stripe error server-side with org/user/payment context and Stripe's `requestId` for support follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for saved payment method top-up operations to provide more informative error messages and appropriate HTTP status codes when payment failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->