### PR TITLE
perf(routing): faster provider downtime reaction

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1512,7 +1512,7 @@ async function runVideoWebhookLoop() {
 async function runAggregatedStatsLoop() {
 	activeLoops++;
 	logger.info(
-		"Starting aggregated stats loop (every 5min, aligned to 5-min boundary)...",
+		"Starting aggregated stats loop (every 1min, aligned to minute boundary)...",
 	);
 
 	try {
@@ -1527,18 +1527,16 @@ async function runAggregatedStatsLoop() {
 		}
 
 		while (!shouldStop) {
-			// Calculate delay to next 5-minute boundary
 			const now = new Date();
-			const currentMinute = now.getMinutes();
-			const nextFiveMinuteMark = Math.ceil((currentMinute + 1) / 5) * 5;
-			const nextRun = new Date(now);
-			nextRun.setSeconds(0, 100); // 100ms buffer
-			if (nextFiveMinuteMark >= 60) {
-				nextRun.setMinutes(0);
-				nextRun.setHours(nextRun.getHours() + 1);
-			} else {
-				nextRun.setMinutes(nextFiveMinuteMark);
-			}
+			const nextRun = new Date(
+				now.getFullYear(),
+				now.getMonth(),
+				now.getDate(),
+				now.getHours(),
+				now.getMinutes() + 1,
+				0,
+				100, // 100ms buffer
+			);
 
 			const delay = nextRun.getTime() - now.getTime();
 
@@ -1698,7 +1696,7 @@ export async function startWorker() {
 		`- Video webhooks: runs every ${VIDEO_WEBHOOK_POLL_INTERVAL_SECONDS} seconds for callback delivery`,
 	);
 	logger.info(
-		"- Aggregated stats: runs every 5 minutes at minute boundaries (0, 5, 10, 15, etc.)",
+		"- Aggregated stats: runs every 1 minute at the start of each minute",
 	);
 	logger.info(
 		`- Project hourly stats: runs every ${PROJECT_STATS_REFRESH_INTERVAL_SECONDS} seconds for dashboard aggregations`,

--- a/packages/db/src/provider-metrics.ts
+++ b/packages/db/src/provider-metrics.ts
@@ -54,7 +54,8 @@ async function fetchAllProviderMetricsRows(): Promise<ProviderMetricsRow[]> {
 					routingTotalRequests: modelProviderMapping.routingTotalRequests,
 				})
 				.from(modelProviderMapping)
-				.where(eq(modelProviderMapping.status, "active")),
+				.where(eq(modelProviderMapping.status, "active"))
+				.$withCache({ config: { ex: 10 } }),
 	);
 }
 


### PR DESCRIPTION
## Summary
- Worker recomputes `model_provider_mapping.routing_*` every 1 min aligned to the start of each minute (was every 5 min on a 5-min boundary).
- Gateway caches the provider-metrics query for 10 s via `$withCache` (was the cdb default of 60 s).
- Worst-case end-to-end lag from log → routing decision drops from ~6 min to ~1 min 10 s.

The gateway's routing scorer in `getCheapestFromAvailableProviders` reads `routing_uptime` / `routing_latency` / `routing_throughput` from `model_provider_mapping`. Those columns are written only by `calculateAggregatedStatistics` in the worker, which previously ran on a 5-minute cadence — that was the dominant lag, not the gateway cache.

## Test plan
- [x] `pnpm build` passes across all packages
- [x] `pnpm format` clean
- [x] `packages/db/src/provider-metrics.spec.ts` — 15/15 pass
- [x] `apps/worker/src/services/stats-calculator.spec.ts` — 21/21 pass
- [ ] Verify in staging that routing metrics update visibly within ~1 minute after a provider degrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Aggregated statistics now collect and update every minute instead of every 5 minutes, providing more frequent metric snapshots and improved data freshness.

* **Chores**
  * Optimized provider metrics database queries through improved caching mechanisms for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->