### PR TITLE
fix(azure): force upstream SSE for streamed image gen

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3719,13 +3719,15 @@ chat.openapi(completions, async (c) => {
 	// When the provider only supports streaming, force it even if the client didn't request it.
 	// The upstream request uses effectiveStream; the client response uses stream.
 	const forceStream = streamingSupport === "only" && !stream;
-	// Force upstream SSE for OpenAI/Azure gpt-image-* even when the client requested
-	// non-streaming. partial_images=1 keeps the connection alive past Azure's 122s
-	// synchronous wall and lets us use AI_STREAMING_TIMEOUT_MS (240s default) instead
-	// of AI_TIMEOUT_MS (180s). The SSE response is collapsed back into the regular
-	// non-streaming JSON shape before the client sees it.
+	// Force upstream SSE for OpenAI/Azure gpt-image-* regardless of what the client
+	// requested. For image generation the upstream request is always non-streaming
+	// (effectiveStream is forced false above when faking streaming for the client),
+	// so partial_images=1 is needed in both cases to keep the connection alive past
+	// Azure's 122s synchronous wall and to use AI_STREAMING_TIMEOUT_MS (240s default)
+	// instead of AI_TIMEOUT_MS (180s). The SSE response is collapsed back into the
+	// regular non-streaming JSON shape before being returned (or re-wrapped as fake
+	// SSE for clients that requested streaming).
 	let forceImageStreamUpstream =
-		!stream &&
 		isImageGeneration &&
 		(usedProvider === "openai" || usedProvider === "azure");
 	const effectiveStream = fakeStreamingForImageGen
@@ -4036,7 +4038,6 @@ chat.openapi(completions, async (c) => {
 		requestCanBeCanceled = ctx.requestCanBeCanceled;
 		isImageGeneration = ctx.isImageGeneration;
 		forceImageStreamUpstream =
-			!stream &&
 			isImageGeneration &&
 			(usedProvider === "openai" || usedProvider === "azure");
 		if (forceImageStreamUpstream) {


### PR DESCRIPTION
## Summary
- Azure `gpt-image-2` with `stream=true` never returned a final image because `forceImageStreamUpstream` was gated on `!stream`.
- For image generation the upstream request is always non-streaming (`effectiveStream` is forced false when faking streaming for the client), so without `partial_images=1` the request hit Azure's 122s synchronous wall and timed out.
- Drop the `!stream` gate in both call sites so upstream SSE injection (and the longer streaming timeout) applies whether or not the client requested streaming. The existing `collapseImageGenSse` + `fakeStreamingForImageGen` wiring already handles re-wrapping the response for streaming clients.

## Test plan
- [ ] Streaming request to Azure `gpt-image-2` returns the final image instead of timing out
- [ ] Non-streaming request to Azure `gpt-image-2` still works (regression check)
- [ ] OpenAI `gpt-image-*` streaming and non-streaming still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized image generation streaming for OpenAI and Azure models to ensure consistent upstream handling across all client requests, improving reliability for image generation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->