### PR TITLE
feat(admin): remove minute time windows

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3624,10 +3624,6 @@ admin.openapi(getModelStats, async (c) => {
 // --- Shared history helpers (used by model detail + history endpoints) ---
 
 const historyWindowSchema = z.enum([
-	"1m",
-	"2m",
-	"5m",
-	"15m",
 	"1h",
 	"2h",
 	"4h",
@@ -3639,10 +3635,6 @@ const historyWindowSchema = z.enum([
 
 function getHistoryStartDate(window: string): Date {
 	const windowMinutes: Record<string, number> = {
-		"1m": 1,
-		"2m": 2,
-		"5m": 5,
-		"15m": 15,
 		"1h": 60,
 		"2h": 120,
 		"4h": 240,

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -21,18 +21,7 @@ import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
 
-export type HistoryWindow =
-	| "1m"
-	| "2m"
-	| "5m"
-	| "15m"
-	| "1h"
-	| "2h"
-	| "4h"
-	| "12h"
-	| "24h"
-	| "2d"
-	| "7d";
+export type HistoryWindow = "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
 
 export interface HistoryDataPoint {
 	timestamp: string;
@@ -73,10 +62,6 @@ const chartConfigs: Record<ActiveMetric, ChartConfig> = {
 };
 
 export const windowOptions: { value: HistoryWindow; label: string }[] = [
-	{ value: "1m", label: "1m" },
-	{ value: "2m", label: "2m" },
-	{ value: "5m", label: "5m" },
-	{ value: "15m", label: "15m" },
 	{ value: "1h", label: "1h" },
 	{ value: "2h", label: "2h" },
 	{ value: "4h", label: "4h" },

--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -26,10 +26,6 @@ import type { ModelProviderMappingEntry } from "@/lib/types";
 
 function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
 	const map: Record<PageWindow, HistoryWindow> = {
-		"1m": "1m",
-		"2m": "2m",
-		"5m": "5m",
-		"15m": "15m",
 		"1h": "1h",
 		"2h": "2h",
 		"4h": "4h",

--- a/ee/admin/src/components/models-table.tsx
+++ b/ee/admin/src/components/models-table.tsx
@@ -24,10 +24,6 @@ import type { ModelStats } from "@/lib/types";
 
 function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
 	const map: Record<PageWindow, HistoryWindow> = {
-		"1m": "1m",
-		"2m": "2m",
-		"5m": "5m",
-		"15m": "15m",
 		"1h": "1h",
 		"2h": "2h",
 		"4h": "4h",

--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -26,10 +26,6 @@ import type { ProviderStats } from "@/lib/types";
 
 function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
 	const map: Record<PageWindow, HistoryWindow> = {
-		"1m": "1m",
-		"2m": "2m",
-		"5m": "5m",
-		"15m": "15m",
 		"1h": "1h",
 		"2h": "2h",
 		"4h": "4h",

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/ee/admin/src/lib/page-window.ts
+++ b/ee/admin/src/lib/page-window.ts
@@ -1,21 +1,6 @@
-export type PageWindow =
-	| "1m"
-	| "2m"
-	| "5m"
-	| "15m"
-	| "1h"
-	| "2h"
-	| "4h"
-	| "12h"
-	| "24h"
-	| "2d"
-	| "7d";
+export type PageWindow = "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
 
 export const pageWindowOptions: { value: PageWindow; label: string }[] = [
-	{ value: "1m", label: "1m" },
-	{ value: "2m", label: "2m" },
-	{ value: "5m", label: "5m" },
-	{ value: "15m", label: "15m" },
 	{ value: "1h", label: "1h" },
 	{ value: "2h", label: "2h" },
 	{ value: "4h", label: "4h" },
@@ -40,10 +25,6 @@ export function windowToFromTo(window: PageWindow): {
 } {
 	const now = new Date();
 	const windowMinutes: Record<PageWindow, number> = {
-		"1m": 1,
-		"2m": 2,
-		"5m": 5,
-		"15m": 15,
 		"1h": 60,
 		"2h": 120,
 		"4h": 240,


### PR DESCRIPTION
- Drop 1m/2m/5m/15m from PageWindow and HistoryWindow types and option lists
- Prune historyWindowSchema and getHistoryStartDate in apps/api/src/routes/admin.ts
- Update toHistoryWindow maps in mappings/providers/models tables
- Regenerate openapi.json and ee/admin/src/lib/api/v1.d.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Removed support for minute-level time window selections (1m, 2m, 5m, 15m) from history viewing features. Users can now only select hourly or longer time periods (1h, 2h, 4h, 12h, 24h, 2d, 7d) when viewing historical data across analytics components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->