### PR TITLE
chore: remove Pro plan mentions from docs and code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ LLM Gateway is available under a dual license:
 
 - Advanced billing and subscription management
 - Extended data retention (90 days vs 3 days)
-- Provider API key management (Pro plan)
+- Provider API key management
 - Team and organization management
 - Priority support
 - And more to be defined

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -86,11 +86,11 @@ subscriptions.openapi(createProSubscription, async (c) => {
 
 	const organization = userOrganization.organization;
 
-	// Block Pro plan for personal orgs (dev plan only)
+	// Block paid subscriptions for personal orgs (dev plan only)
 	if (organization.isPersonal) {
 		throw new HTTPException(403, {
 			message:
-				"Pro plan is not available for personal organizations. Please use Dev Plans at code.llmgateway.io or create a regular organization.",
+				"Paid subscriptions are not available for personal organizations. Please use Dev Plans at code.llmgateway.io or create a regular organization.",
 		});
 	}
 

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -387,7 +387,7 @@ async function handleCheckoutSessionCompleted(
 				},
 			});
 		} else {
-			// Handle regular pro plan subscription
+			// Handle regular pro subscription
 			// Skip setting plan to "pro" for personal orgs - they use devPlan field instead
 			if (organization.isPersonal) {
 				logger.warn(
@@ -407,7 +407,7 @@ async function handleCheckoutSessionCompleted(
 				.returning();
 
 			logger.info(
-				`Successfully upgraded organization ${organizationId} to pro plan via checkout. Updated rows: ${result.length}`,
+				`Successfully upgraded organization ${organizationId} to pro tier via checkout. Updated rows: ${result.length}`,
 			);
 
 			// Check for existing transaction to avoid duplicates
@@ -1550,7 +1550,7 @@ async function handleInvoicePaymentSucceeded(
 			},
 		});
 	} else {
-		// Handle regular pro plan subscription
+		// Handle regular pro subscription
 		// Create transaction record for subscription start
 		const [transaction] = await db
 			.insert(tables.transaction)
@@ -1566,7 +1566,7 @@ async function handleInvoicePaymentSucceeded(
 			})
 			.returning();
 
-		// Update organization to pro plan and mark subscription as not cancelled
+		// Update organization to pro tier and mark subscription as not cancelled
 		try {
 			const result = await db
 				.update(tables.organization)
@@ -1578,7 +1578,7 @@ async function handleInvoicePaymentSucceeded(
 				.returning();
 
 			logger.info(
-				`Successfully upgraded organization ${organizationId} to pro plan. Updated rows: ${result.length}`,
+				`Successfully upgraded organization ${organizationId} to pro tier. Updated rows: ${result.length}`,
 			);
 
 			logger.info(
@@ -1626,7 +1626,7 @@ async function handleInvoicePaymentSucceeded(
 			});
 		} catch (error) {
 			logger.error(
-				`Error updating organization ${organizationId} to pro plan:`,
+				`Error updating organization ${organizationId} to pro tier:`,
 				error as Error,
 			);
 			throw error;
@@ -1719,7 +1719,7 @@ async function handleSubscriptionUpdated(
 			`Updated dev plan subscription for organization ${organizationId}, expires at: ${expiresAt}, cancelled: ${!isSubscriptionActive}`,
 		);
 	} else {
-		// Handle regular pro plan subscription update
+		// Handle regular pro subscription update
 		const wasSubscriptionCancelled = organization.subscriptionCancelled;
 
 		// Create transaction record for subscription cancellation if it was cancelled
@@ -1854,7 +1854,7 @@ async function handleSubscriptionDeleted(
 			`Ended dev plan ${previousDevPlan} for organization ${organizationId}`,
 		);
 	} else {
-		// Handle regular pro plan subscription deletion
+		// Handle regular pro subscription deletion
 		// Create transaction record for subscription end
 		await db.insert(tables.transaction).values({
 			organizationId,

--- a/apps/docs/content/learn/api-keys.mdx
+++ b/apps/docs/content/learn/api-keys.mdx
@@ -117,8 +117,7 @@ feature page](/features/api-keys).
 The page also shows how many API keys your current project is using relative to
 your plan allowance.
 
-- **Free**: Lower API key count limit
-- **Pro**: Higher API key count limit
+- **Free**: Standard API key count limit
 - **Enterprise**: Custom limits
 
 If you reach the project key limit, the **Create API Key** button is disabled

--- a/apps/docs/content/learn/billing.mdx
+++ b/apps/docs/content/learn/billing.mdx
@@ -18,7 +18,7 @@ Displays your current credit balance. Credits are consumed as you make API reque
 
 View and manage your subscription:
 
-- See your current plan (Free, Pro, or Enterprise)
+- See your current plan (Free or Enterprise)
 - Billing cycle information
 - Click **Manage Subscription** to upgrade, downgrade, or cancel
 

--- a/apps/docs/content/learn/policies.mdx
+++ b/apps/docs/content/learn/policies.mdx
@@ -16,9 +16,8 @@ Control how long your request logs and activity data are stored. The retention p
 
 | Plan           | Retention Period |
 | -------------- | ---------------- |
-| **Free**       | 3 days           |
-| **Pro**        | 7 days           |
-| **Enterprise** | 90 days          |
+| **Free**       | 30 days          |
+| **Enterprise** | Custom           |
 
 After the retention period expires, request logs and associated data are automatically deleted.
 

--- a/apps/docs/content/migrations/litellm.mdx
+++ b/apps/docs/content/migrations/litellm.mdx
@@ -29,16 +29,16 @@ Both services use OpenAI-compatible endpoints, so migration is a two-line change
 
 ## Why Teams Switch to LLM Gateway
 
-| What You Get             | LiteLLM (Self-Hosted) | LLM Gateway          |
-| ------------------------ | --------------------- | -------------------- |
-| OpenAI-compatible API    | Yes                   | Yes                  |
-| Infrastructure to manage | Yes (you run it)      | No (we run it)       |
-| Managed cloud option     | No                    | Yes                  |
-| Analytics dashboard      | Basic                 | Per-request detail   |
-| Response caching         | Manual setup          | Built-in, automatic  |
-| Cost tracking            | Via callbacks         | Native, real-time    |
-| Provider key management  | Config file           | Web UI with rotation |
-| Uptime & scaling         | You handle it         | 99.9% SLA (Pro/Ent)  |
+| What You Get             | LiteLLM (Self-Hosted) | LLM Gateway            |
+| ------------------------ | --------------------- | ---------------------- |
+| OpenAI-compatible API    | Yes                   | Yes                    |
+| Infrastructure to manage | Yes (you run it)      | No (we run it)         |
+| Managed cloud option     | No                    | Yes                    |
+| Analytics dashboard      | Basic                 | Per-request detail     |
+| Response caching         | Manual setup          | Built-in, automatic    |
+| Cost tracking            | Via callbacks         | Native, real-time      |
+| Provider key management  | Config file           | Web UI with rotation   |
+| Uptime & scaling         | You handle it         | 99.9% SLA (Enterprise) |
 
 Still want to self-host? LLM Gateway is [open source under AGPLv3](https://llmgateway.io/blog/how-to-self-host-llm-gateway)—same features, your infrastructure.
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -9123,7 +9123,7 @@ chat.openapi(completions, async (c) => {
 					dataStorageCost: costs.dataStorageCost,
 				}
 			: null,
-		false, // showUpgradeMessage - never show since Pro plan is removed
+		false, // showUpgradeMessage
 		annotations,
 		routingAttempts.length > 0 ? routingAttempts : null,
 		requestId,

--- a/apps/ui/src/content/blog/2025-11-28-black-friday-credits-promo.md
+++ b/apps/ui/src/content/blog/2025-11-28-black-friday-credits-promo.md
@@ -2,8 +2,8 @@
 id: blog-black-friday-credits-promo
 slug: black-friday-llmgateway-credits
 date: 2025-11-28
-title: Black Friday at LLM Gateway – 50% Off Credits & Pro Plan
-summary: Use the BLACKFRIDAY promo code to get 50% off credits and the Pro plan for a limited time.
+title: Black Friday at LLM Gateway – 50% Off Credits
+summary: Use the BLACKFRIDAY promo code to get 50% off credits for a limited time.
 categories: ["Announcements"]
 image:
   src: "/blog/black-friday-llmgateway.png"
@@ -14,7 +14,7 @@ image:
 
 We're excited to launch our **Black Friday credits promotion** – a simple way to cut your LLM costs in half while keeping the same unified LLM Gateway experience.
 
-For a limited time, you can **get 50% off both credits and the Pro plan** by using the promo code:
+For a limited time, you can **get 50% off credits** by using the promo code:
 
 > **BLACKFRIDAY**
 

--- a/apps/ui/src/content/blog/2025-12-01-cyber-monday-credits-promo.md
+++ b/apps/ui/src/content/blog/2025-12-01-cyber-monday-credits-promo.md
@@ -2,8 +2,8 @@
 id: blog-cyber-monday-credits-promo
 slug: cyber-monday-llmgateway-credits
 date: 2025-12-01
-title: Cyber Monday at LLM Gateway – 50% Off Credits & Pro Plan
-summary: Use the CYBERMONDAY promo code to get 50% off credits and the Pro plan for a limited time.
+title: Cyber Monday at LLM Gateway – 50% Off Credits
+summary: Use the CYBERMONDAY promo code to get 50% off credits for a limited time.
 categories: ["Announcements"]
 image:
   src: "/blog/cyber-monday-llmgateway.png"
@@ -14,7 +14,7 @@ image:
 
 We're excited to launch our **Cyber Monday credits promotion** – a simple way to cut your LLM costs in half while keeping the same unified LLM Gateway experience.
 
-For a limited time, you can **get 50% off both credits and the Pro plan** by using the promo code:
+For a limited time, you can **get 50% off credits** by using the promo code:
 
 > **CYBERMONDAY**
 

--- a/apps/ui/src/content/blog/2025-12-18-q4-2025.md
+++ b/apps/ui/src/content/blog/2025-12-18-q4-2025.md
@@ -212,10 +212,6 @@ We've added support for major cloud providers and new partners:
 - **Decimal.js** — Precise cost calculations
 - **Shared UI package** — Reusable components across apps
 
-## 📢 Pro Plan Pricing Update
-
-Starting **December 19th, 2025**, Pro plan fees will increase from **0% to 1%**. This remains **80% less** than the 5% fee on the Free plan, ensuring you continue to get exceptional value as you scale.
-
 ---
 
 **[Explore all models](/models)** | **[Try the Playground](https://chat.llmgateway.io)** | **[Get started now](/signup)** 🚀

--- a/apps/ui/src/content/changelog/2025-05-01-gateway-v1-launch.md
+++ b/apps/ui/src/content/changelog/2025-05-01-gateway-v1-launch.md
@@ -79,7 +79,7 @@ Choose the billing approach that works for you:
 
 **Credits Mode** - Use our credit system with transparent pricing
 
-**API Keys Mode** - Use your own provider API keys (Pro plan)
+**API Keys Mode** - Use your own provider API keys
 
 **Hybrid Mode** - Automatic fallback between API keys and credits
 
@@ -109,23 +109,19 @@ Multi-dimensional analytics:
 
 **Error analysis** Detailed error tracking and debugging
 
-## 🔧 Pro Plan Features
+## 🔧 Bring Your Own Keys
 
 ### Use Your Own API Keys
 
-The biggest Pro feature - use your own provider keys **with reduced fees**:
+Use your own provider keys with full transparency:
 
 **Direct cost control** Pay providers directly at their rates
-
-**2.5% LLM Gateway fees** Half the free plan rate on your API key usage
 
 **Hybrid mode** Automatic fallback to credits when keys hit limits
 
 **Full transparency** See exactly what you're paying each provider
 
-### Enhanced Billing Management
-
-**Flexible billing** Monthly ($50) or yearly ($500, save 20%)
+### Billing Management
 
 **Auto top-up** Configurable credit thresholds and amounts
 

--- a/apps/ui/src/content/changelog/2025-06-15-pro-subscription-launch.md
+++ b/apps/ui/src/content/changelog/2025-06-15-pro-subscription-launch.md
@@ -11,7 +11,7 @@ image:
   height: 677
 ---
 
-> **Update (January 2026):** All Pro features are now available on the Free plan. See our [announcement](/changelog/pro-features-now-free) for details.
+> **Update (January 2026):** All paid subscription features are now available for free. See our [announcement](/changelog/pro-features-now-free) for details.
 
 ## Bring Your Own Provider Keys
 
@@ -57,7 +57,7 @@ Choose the billing approach that works best for your team:
 
 Use our credit system with transparent pricing
 
-**Free plan**: 5% service fee | **Pro plan**: 2.5% gateway fees (50% discount)
+**Free plan**: 5% service fee | **Subscription**: 2.5% gateway fees (50% discount)
 
 **API Keys Mode** (Pro only)
 

--- a/apps/ui/src/content/changelog/2026-01-21-pro-features-now-free.md
+++ b/apps/ui/src/content/changelog/2026-01-21-pro-features-now-free.md
@@ -3,7 +3,7 @@ id: "36"
 slug: "pro-features-now-free"
 date: "2026-01-21"
 title: "Pro Features Now Free for Everyone"
-summary: "We're simplifying our pricing. All Pro plan features are now free for everyone — BYOK, team management, 30-day data retention, and more."
+summary: "We're simplifying our pricing. All paid subscription features are now free for everyone — BYOK, team management, 30-day data retention, and more."
 image:
   src: "/changelog/pro-features-free.jpeg"
   alt: "Pro features now free for everyone"
@@ -13,7 +13,7 @@ image:
 
 ## Simpler Pricing, More Value
 
-We're retiring the Pro plan and making all its features available to everyone for free. No more complicated tiers — just straightforward, transparent pricing.
+We're retiring our paid subscription tier and making all its features available to everyone for free. No more complicated tiers — just straightforward, transparent pricing.
 
 ### What's Now Free for Everyone
 

--- a/apps/ui/src/content/legal/privacy.md
+++ b/apps/ui/src/content/legal/privacy.md
@@ -94,7 +94,6 @@ Each provider processes data under their own privacy terms.
 If you belong to an organization:
 
 - Owners and Admins can view and manage member data and roles.
-- Team features are available on the **Pro plan** and above.
 - Access is limited by assigned roles (Owner, Admin, Developer, Restricted Access).
 
 You can manage permissions from the **Team Settings** page.

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -11,22 +11,13 @@ function getImageSizeErrorMessage(
 	const isHosted = process.env.HOSTED === "true";
 	const isPaidMode = process.env.PAID_MODE === "true";
 
-	// Get the pro limit for upgrade messaging
-	const proLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_PRO_MB) || 100;
-
 	let message = `Image size (${actualSizeMB.toFixed(1)}MB) exceeds your current limit of ${maxSizeMB}MB.`;
 
-	// Only show upgrade message in hosted paid mode
 	if (isHosted && isPaidMode) {
-		if (userPlan === "free") {
-			message += ` Upgrade to Pro plan for ${proLimitMB}MB image uploads.`;
-		} else if (userPlan === "pro") {
-			message += ` Contact us for Enterprise plans with higher limits.`;
-		} else if (userPlan === "enterprise") {
+		if (userPlan === "enterprise") {
 			message += ` Contact us to increase your Enterprise plan limits.`;
 		} else {
-			// When plan is unknown, provide generic upgrade message
-			message += ` Upgrade your plan for higher limits (Pro: ${proLimitMB}MB).`;
+			message += ` Contact us for Enterprise plans with higher limits.`;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Sweeps every "Pro plan" mention left in the repo so nothing positions Pro plan as a current product (it was retired Jan 2026 with all features made free).
- Updates user-facing surfaces: docs (billing, policies, api-keys, litellm migration), legal/privacy, the personal-org subscription error, the image-size upgrade message, and chat upgrade-message comment.
- Cleans historical changelog/blog copy: edits the v1 launch, Pro subscription launch, "Pro features now free" changelogs and the BF/CM/Q4 2025 blog entries to drop "Pro plan" wording while keeping the rest of the history intact.
- Updates internal log/comment strings in `apps/api/src/stripe.ts` from "pro plan" → "pro tier" / "pro subscription"; no behavior change.
- Updates `AGENTS.md` `Provider API key management (Pro plan)` → `Provider API key management`.

## Test plan

- [x] `pnpm format`
- [x] `pnpm --filter api build`, `pnpm --filter docs build`, `pnpm --filter ui build`, `pnpm --filter @llmgateway/actions build`
- [x] `tsc --noEmit` in `apps/gateway` (full repo `pnpm build` fails on a pre-existing `zstdDecompress` issue under Node 20.10, unrelated to this PR)
- [x] `grep -rni "pro plan"` across source returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plan and pricing documentation
  * Revised data retention periods: Free plan now 30 days, Enterprise plan now custom
  * Removed Pro plan references from feature documentation, promotional content, and API key management guides

* **Updates**
  * Simplified subscription messaging and upgrade prompts for consistency across the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->