### PR TITLE
fix(images): map openai SSE moderation to content_filter

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -8787,85 +8787,89 @@ chat.openapi(completions, async (c) => {
 			const collapsed = collapseImageGenSse(text);
 			if ("error" in collapsed) {
 				const sseErrorText = JSON.stringify(collapsed.error);
-				const sseFinishReason = getFinishReasonFromError(
-					res.status,
+				const isContentFilter =
+					getFinishReasonFromError(res.status, sseErrorText) ===
+					"content_filter";
+				const sseLogPluginIds = plugins?.map((p) => p.id) ?? [];
+				const sseLogEntry = createLogEntry(
+					requestId,
+					project,
+					apiKey,
+					providerKey?.id,
+					usedModelFormatted!,
+					usedModelMapping,
+					usedProvider,
+					initialRequestedModel,
+					requestedProvider,
+					messages,
+					temperature,
+					max_tokens,
+					top_p,
+					frequency_penalty,
+					presence_penalty,
+					reasoning_effort,
+					reasoning_max_tokens,
+					effort,
+					response_format,
+					tools,
+					tool_choice,
+					source,
+					customHeaders,
+					debugMode,
+					userAgent,
+					image_config,
+					routingMetadata,
+					rawBody,
 					sseErrorText,
+					requestBody,
+					sseErrorText,
+					sseLogPluginIds,
+					undefined,
 				);
 
-				if (sseFinishReason === "content_filter") {
+				await insertLogEntry({
+					...sseLogEntry,
+					duration: Date.now() - startTime,
+					timeToFirstToken: null,
+					timeToFirstReasoningToken: null,
+					responseSize: text.length,
+					content: null,
+					reasoningContent: null,
+					finishReason: isContentFilter ? "content_filter" : "upstream_error",
+					promptTokens: null,
+					completionTokens: null,
+					totalTokens: null,
+					reasoningTokens: null,
+					cachedTokens: null,
+					hasError: !isContentFilter,
+					streamed: false,
+					canceled: false,
+					errorDetails: isContentFilter
+						? null
+						: {
+								statusCode: res.status,
+								statusText: res.statusText,
+								responseText: sseErrorText,
+							},
+					cachedInputCost: null,
+					requestCost: null,
+					webSearchCost: null,
+					imageInputTokens: null,
+					imageOutputTokens: null,
+					imageInputCost: null,
+					imageOutputCost: null,
+					estimatedCost: false,
+					discount: null,
+					dataStorageCost: "0",
+					cached: false,
+					toolResults: null,
+				});
+
+				if (isContentFilter) {
 					// OpenAI/Azure returned a moderation rejection inside the SSE
 					// stream (e.g. moderation_blocked / "Your request was rejected
 					// by the safety system"). Surface it as a normal chat completion
 					// with finish_reason: "content_filter" instead of a 502.
-					const contentFilterPluginIds = plugins?.map((p) => p.id) ?? [];
-					const contentFilterLogEntry = createLogEntry(
-						requestId,
-						project,
-						apiKey,
-						providerKey?.id,
-						usedModelFormatted!,
-						usedModelMapping,
-						usedProvider,
-						initialRequestedModel,
-						requestedProvider,
-						messages,
-						temperature,
-						max_tokens,
-						top_p,
-						frequency_penalty,
-						presence_penalty,
-						reasoning_effort,
-						reasoning_max_tokens,
-						effort,
-						response_format,
-						tools,
-						tool_choice,
-						source,
-						customHeaders,
-						debugMode,
-						userAgent,
-						image_config,
-						routingMetadata,
-						rawBody,
-						sseErrorText,
-						requestBody,
-						sseErrorText,
-						contentFilterPluginIds,
-						undefined,
-					);
-
-					await insertLogEntry({
-						...contentFilterLogEntry,
-						duration: Date.now() - startTime,
-						timeToFirstToken: null,
-						timeToFirstReasoningToken: null,
-						responseSize: text.length,
-						content: null,
-						reasoningContent: null,
-						finishReason: "content_filter",
-						promptTokens: null,
-						completionTokens: null,
-						totalTokens: null,
-						reasoningTokens: null,
-						cachedTokens: null,
-						hasError: false,
-						streamed: false,
-						canceled: false,
-						errorDetails: null,
-						cachedInputCost: null,
-						requestCost: null,
-						webSearchCost: null,
-						imageInputTokens: null,
-						imageOutputTokens: null,
-						imageInputCost: null,
-						imageOutputCost: null,
-						estimatedCost: false,
-						discount: null,
-						dataStorageCost: "0",
-						cached: false,
-						toolResults: null,
-					});
-
 					return c.json({
 						id: `chatcmpl-${Date.now()}`,
 						object: "chat.completion",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -8786,6 +8786,118 @@ chat.openapi(completions, async (c) => {
 			const text = await res.text();
 			const collapsed = collapseImageGenSse(text);
 			if ("error" in collapsed) {
+				const sseErrorText = JSON.stringify(collapsed.error);
+				const sseFinishReason = getFinishReasonFromError(
+					res.status,
+					sseErrorText,
+				);
+
+				if (sseFinishReason === "content_filter") {
+					// OpenAI/Azure returned a moderation rejection inside the SSE
+					// stream (e.g. moderation_blocked / "Your request was rejected
+					// by the safety system"). Surface it as a normal chat completion
+					// with finish_reason: "content_filter" instead of a 502.
+					const contentFilterPluginIds = plugins?.map((p) => p.id) ?? [];
+					const contentFilterLogEntry = createLogEntry(
+						requestId,
+						project,
+						apiKey,
+						providerKey?.id,
+						usedModelFormatted!,
+						usedModelMapping,
+						usedProvider,
+						initialRequestedModel,
+						requestedProvider,
+						messages,
+						temperature,
+						max_tokens,
+						top_p,
+						frequency_penalty,
+						presence_penalty,
+						reasoning_effort,
+						reasoning_max_tokens,
+						effort,
+						response_format,
+						tools,
+						tool_choice,
+						source,
+						customHeaders,
+						debugMode,
+						userAgent,
+						image_config,
+						routingMetadata,
+						rawBody,
+						sseErrorText,
+						requestBody,
+						sseErrorText,
+						contentFilterPluginIds,
+						undefined,
+					);
+
+					await insertLogEntry({
+						...contentFilterLogEntry,
+						duration: Date.now() - startTime,
+						timeToFirstToken: null,
+						timeToFirstReasoningToken: null,
+						responseSize: text.length,
+						content: null,
+						reasoningContent: null,
+						finishReason: "content_filter",
+						promptTokens: null,
+						completionTokens: null,
+						totalTokens: null,
+						reasoningTokens: null,
+						cachedTokens: null,
+						hasError: false,
+						streamed: false,
+						canceled: false,
+						errorDetails: null,
+						cachedInputCost: null,
+						requestCost: null,
+						webSearchCost: null,
+						imageInputTokens: null,
+						imageOutputTokens: null,
+						imageInputCost: null,
+						imageOutputCost: null,
+						estimatedCost: false,
+						discount: null,
+						dataStorageCost: "0",
+						cached: false,
+						toolResults: null,
+					});
+
+					return c.json({
+						id: `chatcmpl-${Date.now()}`,
+						object: "chat.completion",
+						created: Math.floor(Date.now() / 1000),
+						model: `${usedProvider}/${baseModelName}`,
+						choices: [
+							{
+								index: 0,
+								message: {
+									role: "assistant",
+									content: null,
+								},
+								finish_reason: "content_filter",
+							},
+						],
+						usage: {
+							prompt_tokens: 0,
+							completion_tokens: 0,
+							total_tokens: 0,
+						},
+						metadata: {
+							request_id: requestId,
+							requested_model: initialRequestedModel,
+							requested_provider: requestedProvider,
+							used_model: baseModelName,
+							used_provider: usedProvider,
+							...(usedRegion && { used_region: usedRegion }),
+							underlying_used_model: usedModel,
+						},
+					});
+				}
+
 				logger.warn("Image generation SSE collapse failed", {
 					usedProvider,
 					usedModel,

--- a/apps/gateway/src/chat/tools/collapse-image-gen-sse.spec.ts
+++ b/apps/gateway/src/chat/tools/collapse-image-gen-sse.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { collapseImageGenSse } from "./collapse-image-gen-sse.js";
+import { getFinishReasonFromError } from "./get-finish-reason-from-error.js";
 
 describe("collapseImageGenSse", () => {
 	test("returns json from a completed event after partial events", () => {
@@ -172,6 +173,28 @@ describe("collapseImageGenSse", () => {
 			return;
 		}
 		expect(result.error.code).toBe("missing_image");
+	});
+
+	test("OpenAI moderation_blocked error event maps to content_filter finish reason", () => {
+		const text = [
+			`data: ${JSON.stringify({
+				error: {
+					code: "moderation_blocked",
+					message:
+						"Your request was rejected by the safety system. If you believe this is an error, contact us at help.openai.com and include the request ID req_abc123.",
+					type: "image_generation_user_error",
+				},
+			})}`,
+		].join("\n");
+		const result = collapseImageGenSse(text);
+		expect("error" in result).toBe(true);
+		if (!("error" in result)) {
+			return;
+		}
+		expect(result.error.code).toBe("moderation_blocked");
+		expect(getFinishReasonFromError(200, JSON.stringify(result.error))).toBe(
+			"content_filter",
+		);
 	});
 
 	test("ignores [DONE] sentinel and unparseable lines", () => {


### PR DESCRIPTION
## Summary

When OpenAI/Azure `gpt-image-*` returns `moderation_blocked` ("Your request was rejected by the safety system") inside the forced-upstream SSE stream, the gateway was throwing a `502 Image generation SSE collapse failed`. It now surfaces as a normal chat completion with `finish_reason: "content_filter"` (matching the existing HTTP-error content_filter branch) and writes a log row.

- Classify SSE collapse errors via `getFinishReasonFromError`; if `content_filter`, return a 200 chat completion with `finish_reason: "content_filter"`. Other SSE errors keep the existing 502 path.
- Insert a log entry on both branches (previously the SSE collapse failure path didn't log to db at all): `finishReason` is `content_filter` or `upstream_error`, `hasError` flipped accordingly, `errorDetails` populated for non-content_filter.
- Added a unit test that feeds a real `moderation_blocked` SSE event through `collapseImageGenSse` + `getFinishReasonFromError` to lock in the wire-up.

## Test plan

- [x] `pnpm --filter gateway build`
- [x] `vitest run apps/gateway/src/chat/tools/collapse-image-gen-sse.spec.ts apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts` — 24/24 pass
- [ ] Manual: image generation request to `gpt-image-2` with a prompt that trips OpenAI moderation — expect 200 with `finish_reason: "content_filter"` and a content_filter log row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for image generation to properly distinguish between content moderation rejections and other upstream failures. Content-filtered requests now return a completed response with appropriate finish reason, rather than propagating as errors.

* **Tests**
  * Added test coverage validating content filter detection in image generation streams and confirming proper response mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->