### PR TITLE
feat(admin): restore minute windows for model/provider pages

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3624,6 +3624,10 @@ admin.openapi(getModelStats, async (c) => {
 // --- Shared history helpers (used by model detail + history endpoints) ---
 
 const historyWindowSchema = z.enum([
+	"1m",
+	"2m",
+	"5m",
+	"15m",
 	"1h",
 	"2h",
 	"4h",
@@ -3635,6 +3639,10 @@ const historyWindowSchema = z.enum([
 
 function getHistoryStartDate(window: string): Date {
 	const windowMinutes: Record<string, number> = {
+		"1m": 1,
+		"2m": 2,
+		"5m": 5,
+		"15m": 15,
 		"1h": 60,
 		"2h": 120,
 		"4h": 240,

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/ee/admin/src/app/model-provider-mappings/page.tsx
+++ b/ee/admin/src/app/model-provider-mappings/page.tsx
@@ -6,7 +6,11 @@ import { Suspense } from "react";
 import { MappingsTable } from "@/components/mappings-table";
 import { TimeWindowSelector } from "@/components/time-window-selector";
 import { Button } from "@/components/ui/button";
-import { parsePageWindow, windowToFromTo } from "@/lib/page-window";
+import {
+	pageWindowOptionsWithMinutes,
+	parsePageWindow,
+	windowToFromTo,
+} from "@/lib/page-window";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 
@@ -167,7 +171,10 @@ export default async function ModelProviderMappingsPage({
 					</div>
 				</div>
 				<Suspense>
-					<TimeWindowSelector current={pageWindow} />
+					<TimeWindowSelector
+						current={pageWindow}
+						options={pageWindowOptionsWithMinutes}
+					/>
 				</Suspense>
 			</div>
 

--- a/ee/admin/src/app/models/page.tsx
+++ b/ee/admin/src/app/models/page.tsx
@@ -6,7 +6,11 @@ import { Suspense } from "react";
 import { ModelsTable } from "@/components/models-table";
 import { TimeWindowSelector } from "@/components/time-window-selector";
 import { Button } from "@/components/ui/button";
-import { parsePageWindow, windowToFromTo } from "@/lib/page-window";
+import {
+	pageWindowOptionsWithMinutes,
+	parsePageWindow,
+	windowToFromTo,
+} from "@/lib/page-window";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 
@@ -172,7 +176,10 @@ export default async function ModelsPage({
 					</div>
 				</div>
 				<Suspense>
-					<TimeWindowSelector current={pageWindow} />
+					<TimeWindowSelector
+						current={pageWindow}
+						options={pageWindowOptionsWithMinutes}
+					/>
 				</Suspense>
 			</div>
 

--- a/ee/admin/src/app/providers/page.tsx
+++ b/ee/admin/src/app/providers/page.tsx
@@ -4,7 +4,11 @@ import { Suspense } from "react";
 import { ProvidersTable } from "@/components/providers-table";
 import { TimeWindowSelector } from "@/components/time-window-selector";
 import { Button } from "@/components/ui/button";
-import { parsePageWindow, windowToFromTo } from "@/lib/page-window";
+import {
+	pageWindowOptionsWithMinutes,
+	parsePageWindow,
+	windowToFromTo,
+} from "@/lib/page-window";
 import { createServerApiClient } from "@/lib/server-api";
 
 import type { paths } from "@/lib/api/v1";
@@ -112,7 +116,10 @@ export default async function ProvidersPage({
 					</div>
 				</div>
 				<Suspense>
-					<TimeWindowSelector current={pageWindow} />
+					<TimeWindowSelector
+						current={pageWindow}
+						options={pageWindowOptionsWithMinutes}
+					/>
 				</Suspense>
 			</div>
 

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -21,7 +21,18 @@ import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
 
-export type HistoryWindow = "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+export type HistoryWindow =
+	| "1m"
+	| "2m"
+	| "5m"
+	| "15m"
+	| "1h"
+	| "2h"
+	| "4h"
+	| "12h"
+	| "24h"
+	| "2d"
+	| "7d";
 
 export interface HistoryDataPoint {
 	timestamp: string;
@@ -62,6 +73,10 @@ const chartConfigs: Record<ActiveMetric, ChartConfig> = {
 };
 
 export const windowOptions: { value: HistoryWindow; label: string }[] = [
+	{ value: "1m", label: "1m" },
+	{ value: "2m", label: "2m" },
+	{ value: "5m", label: "5m" },
+	{ value: "15m", label: "15m" },
 	{ value: "1h", label: "1h" },
 	{ value: "2h", label: "2h" },
 	{ value: "4h", label: "4h" },

--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -26,6 +26,10 @@ import type { ModelProviderMappingEntry } from "@/lib/types";
 
 function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
 	const map: Record<PageWindow, HistoryWindow> = {
+		"1m": "1m",
+		"2m": "2m",
+		"5m": "5m",
+		"15m": "15m",
 		"1h": "1h",
 		"2h": "2h",
 		"4h": "4h",

--- a/ee/admin/src/components/models-table.tsx
+++ b/ee/admin/src/components/models-table.tsx
@@ -24,6 +24,10 @@ import type { ModelStats } from "@/lib/types";
 
 function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
 	const map: Record<PageWindow, HistoryWindow> = {
+		"1m": "1m",
+		"2m": "2m",
+		"5m": "5m",
+		"15m": "15m",
 		"1h": "1h",
 		"2h": "2h",
 		"4h": "4h",

--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -26,6 +26,10 @@ import type { ProviderStats } from "@/lib/types";
 
 function toHistoryWindow(pageWindow: PageWindow): HistoryWindow {
 	const map: Record<PageWindow, HistoryWindow> = {
+		"1m": "1m",
+		"2m": "2m",
+		"5m": "5m",
+		"15m": "15m",
 		"1h": "1h",
 		"2h": "2h",
 		"4h": "4h",

--- a/ee/admin/src/components/time-window-selector.tsx
+++ b/ee/admin/src/components/time-window-selector.tsx
@@ -8,7 +8,13 @@ import { pageWindowOptions } from "@/lib/page-window";
 
 import type { PageWindow } from "@/lib/page-window";
 
-export function TimeWindowSelector({ current }: { current: PageWindow }) {
+export function TimeWindowSelector({
+	current,
+	options = pageWindowOptions,
+}: {
+	current: PageWindow;
+	options?: { value: PageWindow; label: string }[];
+}) {
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
@@ -27,7 +33,7 @@ export function TimeWindowSelector({ current }: { current: PageWindow }) {
 
 	return (
 		<div className="flex items-center gap-1">
-			{pageWindowOptions.map((opt) => (
+			{options.map((opt) => (
 				<Button
 					key={opt.value}
 					variant={current === opt.value ? "default" : "outline"}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2941,7 +2941,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3112,7 +3112,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3165,7 +3165,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3219,7 +3219,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                     projectId?: string;
                 };
                 header?: never;
@@ -3274,7 +3274,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {
@@ -3346,7 +3346,7 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    window?: "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+                    window?: "1m" | "2m" | "5m" | "15m" | "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
                 };
                 header?: never;
                 path: {

--- a/ee/admin/src/lib/page-window.ts
+++ b/ee/admin/src/lib/page-window.ts
@@ -1,4 +1,15 @@
-export type PageWindow = "1h" | "2h" | "4h" | "12h" | "24h" | "2d" | "7d";
+export type PageWindow =
+	| "1m"
+	| "2m"
+	| "5m"
+	| "15m"
+	| "1h"
+	| "2h"
+	| "4h"
+	| "12h"
+	| "24h"
+	| "2d"
+	| "7d";
 
 export const pageWindowOptions: { value: PageWindow; label: string }[] = [
 	{ value: "1h", label: "1h" },
@@ -10,10 +21,33 @@ export const pageWindowOptions: { value: PageWindow; label: string }[] = [
 	{ value: "7d", label: "7d" },
 ];
 
-const validWindows = new Set<PageWindow>(pageWindowOptions.map((o) => o.value));
+export const pageWindowOptionsWithMinutes: {
+	value: PageWindow;
+	label: string;
+}[] = [
+	{ value: "1m", label: "1m" },
+	{ value: "2m", label: "2m" },
+	{ value: "5m", label: "5m" },
+	{ value: "15m", label: "15m" },
+	...pageWindowOptions,
+];
+
+const allValidWindows = new Set<PageWindow>([
+	"1m",
+	"2m",
+	"5m",
+	"15m",
+	"1h",
+	"2h",
+	"4h",
+	"12h",
+	"24h",
+	"2d",
+	"7d",
+]);
 
 export function parsePageWindow(value: string | undefined): PageWindow {
-	if (value && validWindows.has(value as PageWindow)) {
+	if (value && allValidWindows.has(value as PageWindow)) {
 		return value as PageWindow;
 	}
 	return "4h";
@@ -25,6 +59,10 @@ export function windowToFromTo(window: PageWindow): {
 } {
 	const now = new Date();
 	const windowMinutes: Record<PageWindow, number> = {
+		"1m": 1,
+		"2m": 2,
+		"5m": 5,
+		"15m": 15,
 		"1h": 60,
 		"2h": 120,
 		"4h": 240,


### PR DESCRIPTION
Minute-grain windows (1m/2m/5m/15m) were removed everywhere in #2123,
but the model, provider, and mapping pages query minute history
(modelProviderMappingHistory). Only the org-specific project pages
use hourly aggregation (projectHourlyModelStats), so keep those
restricted to hourly+ windows.

- Restore 1m/2m/5m/15m in historyWindowSchema/getHistoryStartDate
- Restore them in HistoryWindow + windowOptions (detail clients)
- Add pageWindowOptionsWithMinutes alongside the hourly-only set
- TimeWindowSelector now accepts an options prop, defaulting to
  hourly-only; /models, /providers, /model-provider-mappings opt
  into the minute-aware set
- Restore minute mappings in toHistoryWindow helpers
- Regenerate v1.d.ts type files

https://claude.ai/code/session_012xtwDJkQYTzkiQrrPkZznC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for minute-granularity time window options (1m, 2m, 5m, 15m) in the admin interface for model providers, models, and providers pages, enabling more precise historical data filtering and analysis beyond hour/day ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->