### PR TITLE
fix(images): keep edits URL on retry for openai/azure

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4043,6 +4043,34 @@ chat.openapi(completions, async (c) => {
 		if (forceImageStreamUpstream) {
 			requestBody = injectImageStreamParams(requestBody);
 		}
+		// resolveProviderContext only knows the base /images/generations endpoint;
+		// mirror the post-prepareRequestBody URL swap so retry fallbacks still hit
+		// /images/edits when the body is multipart FormData.
+		if (
+			isImageGeneration &&
+			usedProvider === "openai" &&
+			url &&
+			requestBody instanceof FormData
+		) {
+			url = url.replace("/v1/images/generations", "/v1/images/edits");
+		}
+		if (
+			isImageGeneration &&
+			usedProvider === "azure" &&
+			url &&
+			requestBody instanceof FormData
+		) {
+			url = url.replace("/images/generations", "/images/edits");
+		}
+		if (
+			isImageGeneration &&
+			usedProvider === "xai" &&
+			url &&
+			!(requestBody instanceof FormData) &&
+			("image" in requestBody || "images" in requestBody)
+		) {
+			url = url.replace("/v1/images/generations", "/v1/images/edits");
+		}
 		supportsReasoning = ctx.supportsReasoning;
 		splitTaggedReasoning = ctx.splitTaggedReasoning ?? false;
 		temperature = ctx.temperature;


### PR DESCRIPTION
## Summary

OpenAI gpt-image-2 image-edit requests (FormData / multipart) were failing with:

> Unsupported content type: 'multipart/form-data'. This API method only accepts 'application/json' requests…

…on retries (e.g. alternate-key fallback, post-error retry). Azure happened to mask the same bug because we tested it less frequently against this code path.

## Root cause

For OpenAI/Azure gpt-image-* edits, `prepareRequestBody` returns a multipart `FormData`, and `chat.ts` swaps the upstream URL from `/images/generations` to `/images/edits` to match. That swap was only applied on the initial pass. `applyResolvedProviderContext` then overwrote `url` from `resolveProviderContext`, which only knows the base `/images/generations` endpoint, and never re-ran the swap. Any retry (same-provider alternate key or HTTP-error fallback) shipped the multipart body to `/images/generations`, and OpenAI 400'd.

## Fix

Mirror the same OpenAI / Azure / xAI URL-to-`/edits` swap inside `applyResolvedProviderContext`, so retries land on the same endpoint as the initial attempt.

## Test plan

- [ ] OpenAI gpt-image-2 edits with input image, force a same-provider retry → upstream still hits `/v1/images/edits`
- [ ] Azure gpt-image-2 edits regression (deployment-based + ai-foundry URLs)
- [ ] OpenAI / Azure pure generations (no input image, JSON body) still hit `/v1/images/generations`
- [ ] xAI image edits retry still hits `/v1/images/edits`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced retry and fallback handling for image generation and editing requests to ensure proper endpoint targeting across OpenAI, Azure, and xAI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->