### PR TITLE
fix(routing): exclude client errors from uptime score

### DIFF
--- a/apps/worker/src/services/stats-calculator.spec.ts
+++ b/apps/worker/src/services/stats-calculator.spec.ts
@@ -1002,6 +1002,50 @@ describe("stats-calculator", () => {
 			expect(mapping.routingTotalRequests).toBe(20);
 		});
 
+		it("should exclude client errors from routing uptime", async () => {
+			const now = new Date("2024-01-01T12:30:00.000Z");
+
+			// 30 logs total: 4 client errors + 2 upstream errors = 6 total errors
+			// Routing uptime should only penalize the 2 upstream errors (provider's fault).
+			await db.insert(modelProviderMappingHistory).values([
+				{
+					modelId: "gpt-4",
+					providerId: "openai",
+					modelProviderMappingId: "mapping-1",
+					minuteTimestamp: minutesAgo(now, 4),
+					logsCount: 30,
+					errorsCount: 6,
+					clientErrorsCount: 4,
+					gatewayErrorsCount: 0,
+					upstreamErrorsCount: 2,
+					cachedCount: 0,
+					totalOutputTokens: 600,
+					totalDuration: 3000,
+					totalTimeToFirstToken: 900,
+					totalTimeToFirstReasoningToken: 0,
+				},
+			]);
+
+			await calculateAggregatedStatistics();
+
+			const mappings = await db
+				.select()
+				.from(modelProviderMapping)
+				.where(
+					and(
+						eq(modelProviderMapping.modelId, "gpt-4"),
+						eq(modelProviderMapping.providerId, "openai"),
+					),
+				);
+
+			const mapping = mappings[0]!;
+			// Display stats keep the full error count
+			expect(mapping.errorsCount).toBe(6);
+			expect(mapping.clientErrorsCount).toBe(4);
+			// Routing uptime ignores client errors: (30 - 2) / 30 * 100 ≈ 93.33%
+			expect(mapping.routingUptime).toBeCloseTo((28 / 30) * 100, 2);
+		});
+
 		it("should set routing metrics to null when no TTFT or duration data", async () => {
 			const now = new Date("2024-01-01T12:30:00.000Z");
 

--- a/apps/worker/src/services/stats-calculator.ts
+++ b/apps/worker/src/services/stats-calculator.ts
@@ -893,7 +893,10 @@ export async function calculateAggregatedStatistics() {
 			totalCached: number;
 			// Weighted sums (for routing metrics)
 			weightedLogs: number;
-			weightedErrors: number;
+			// weightedRoutingErrors excludes client_error: caller-fault failures
+			// (e.g. malformed requests, validation rejections) shouldn't count
+			// against a provider's routing uptime score.
+			weightedRoutingErrors: number;
 			weightedDuration: number;
 			weightedOutputTokens: number;
 			weightedTTFT: number;
@@ -918,7 +921,7 @@ export async function calculateAggregatedStatistics() {
 					totalUpstreamErrors: 0,
 					totalCached: 0,
 					weightedLogs: 0,
-					weightedErrors: 0,
+					weightedRoutingErrors: 0,
 					weightedDuration: 0,
 					weightedOutputTokens: 0,
 					weightedTTFT: 0,
@@ -939,7 +942,11 @@ export async function calculateAggregatedStatistics() {
 
 			// Weighted sums
 			agg.weightedLogs += row.logsCount * weight;
-			agg.weightedErrors += row.errorsCount * weight;
+			const routingErrors = Math.max(
+				0,
+				row.errorsCount - row.clientErrorsCount,
+			);
+			agg.weightedRoutingErrors += routingErrors * weight;
 			agg.weightedDuration += row.totalDuration * weight;
 			agg.weightedOutputTokens += row.totalOutputTokens * weight;
 			agg.weightedTTFT += row.totalTimeToFirstToken * weight;
@@ -961,7 +968,7 @@ export async function calculateAggregatedStatistics() {
 			let routingTotalRequests: number | null = null;
 
 			if (agg.weightedLogs > 0) {
-				const successfulRequests = agg.weightedLogs - agg.weightedErrors;
+				const successfulRequests = agg.weightedLogs - agg.weightedRoutingErrors;
 				routingUptime = (successfulRequests / agg.weightedLogs) * 100;
 
 				const effectiveTTFT =


### PR DESCRIPTION
## Summary
The worker's `routingUptime` calculation was subtracting *all* errors from logs, including 4xx client errors (malformed requests, validation failures) that are caller-fault — so providers got penalized in the cheapest-from-available scoring for users sending bad input. The fix subtracts `clientErrorsCount` from the per-row error count before applying tier weights, while leaving displayed `errorsCount` totals unchanged. Affects only `apps/worker/src/services/stats-calculator.ts` (one bookkeeping field rename + the actual exclusion); the gateway reads the precomputed `routingUptime` so no gateway-side change is needed.

## Test plan
- [x] `pnpm exec vitest run apps/worker/src/services/stats-calculator.spec.ts` — 22 tests pass, including a new case asserting 4 client + 2 upstream errors out of 30 logs yields ~93.33% (28/30) uptime, not 80%.
- [x] `pnpm --filter worker build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved routing uptime metrics calculation to properly differentiate between client-side and upstream errors. Client failures are now excluded from routing uptime calculations while being tracked separately, providing more accurate service health measurement and visibility.
* Enhanced error tracking with explicit distinction between total errors, client errors, and routing-related errors for better diagnostic insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->