### PR TITLE
feat(xai): add grok-4.3 model

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -716,6 +716,48 @@ export const xaiModels = [
 		],
 	},
 	{
+		id: "grok-4-3",
+		name: "Grok 4.3",
+		description:
+			"xAI's flagship reasoning model with 1M context, vision, and tool support.",
+		family: "xai",
+		releasedAt: new Date("2026-04-30"),
+		providers: [
+			{
+				providerId: "xai",
+				modelName: "grok-4.3",
+				inputPrice: 1.25 / 1e6,
+				outputPrice: 2.5 / 1e6,
+				cachedInputPrice: 0.3125 / 1e6,
+				pricingTiers: [
+					{
+						name: "Up to 200K",
+						upToTokens: 200000,
+						inputPrice: 1.25 / 1e6,
+						outputPrice: 2.5 / 1e6,
+						cachedInputPrice: 0.3125 / 1e6,
+					},
+					{
+						name: "Over 200K",
+						upToTokens: Infinity,
+						inputPrice: 2.5 / 1e6,
+						outputPrice: 5.0 / 1e6,
+						cachedInputPrice: 0,
+					},
+				],
+				requestPrice: 0,
+				contextSize: 1_000_000,
+				maxOutput: undefined,
+				streaming: true,
+				vision: true,
+				reasoning: true,
+				tools: true,
+				jsonOutput: true,
+				supportedParameters: xaiSupportedParamsNoFreqPresence,
+			},
+		],
+	},
+	{
 		id: "grok-imagine-image-pro",
 		name: "Grok Imagine Image Pro",
 		description:


### PR DESCRIPTION
## Summary
- Add `grok-4.3` to the xAI provider in `packages/models`
- Includes 1M context window, vision, reasoning, tools, JSON output, and streaming support
- Tiered pricing: $1.25/$2.50 per 1M input/output tokens up to 200K, doubled above

## Test plan
- [x] `TEST_MODELS="xai/grok-4-3" pnpm test:e2e` — all 74 tests pass
- [x] `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Grok 4.3 model with advanced capabilities including streaming, vision analysis, reasoning, tool usage, and structured output. Features an expanded context window for handling larger documents and conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->