### PR TITLE
fix: accept reasoning items in responses API

### DIFF
--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
+import { responsesRequestSchema } from "./schemas.js";
 import { convertChatResponseToResponses } from "./tools/convert-chat-to-responses.js";
 import { convertResponsesInputToMessages } from "./tools/convert-responses-to-chat.js";
 import {
@@ -37,6 +38,54 @@ vi.mock("@llmgateway/logger", () => ({
 		error: vi.fn(),
 	},
 }));
+
+describe("responsesRequestSchema", () => {
+	it("accepts reasoning items with function call outputs", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "gpt-5.3-codex",
+			input: [
+				{
+					type: "reasoning",
+					id: "rs_123",
+					summary: [],
+				},
+				{
+					type: "function_call",
+					call_id: "call_123",
+					name: "view_image",
+					arguments: '{"path":"/tmp/a.png"}',
+				},
+				{
+					type: "function_call_output",
+					call_id: "call_123",
+					output: "tool result",
+				},
+			],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts structured function call outputs", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "gpt-5.3-codex",
+			input: [
+				{
+					type: "function_call_output",
+					call_id: "call_123",
+					output: [
+						{
+							type: "input_text",
+							text: "tool failed: invalid image path",
+						},
+					],
+				},
+			],
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
 
 describe("convertResponsesInputToMessages", () => {
 	it("converts string input to user message", () => {
@@ -124,6 +173,34 @@ describe("convertResponsesInputToMessages", () => {
 			{
 				role: "tool",
 				content: '{"temp": 72}',
+				tool_call_id: "call_123",
+			},
+		]);
+	});
+
+	it("stringifies structured function_call_output for tool messages", () => {
+		const input = [
+			{
+				type: "function_call_output" as const,
+				call_id: "call_123",
+				output: [
+					{
+						type: "input_text" as const,
+						text: "tool failed: invalid image path",
+					},
+				],
+			},
+		];
+		const result = convertResponsesInputToMessages(input);
+		expect(result).toEqual([
+			{
+				role: "tool",
+				content: JSON.stringify([
+					{
+						type: "input_text",
+						text: "tool failed: invalid image path",
+					},
+				]),
 				tool_call_id: "call_123",
 			},
 		]);

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -1,5 +1,26 @@
 import { z } from "@hono/zod-openapi";
 
+const responseInputContentSchema = z.union([
+	z.object({
+		type: z.literal("input_text"),
+		text: z.string(),
+	}),
+	z.object({
+		type: z.literal("input_image"),
+		image_url: z.string().optional(),
+		file_id: z.string().optional(),
+		detail: z.enum(["low", "high", "auto", "original"]).optional(),
+	}),
+	z.object({
+		type: z.literal("input_file"),
+		file_data: z.string().optional(),
+		file_id: z.string().optional(),
+		file_url: z.string().optional(),
+		filename: z.string().optional(),
+		detail: z.enum(["low", "high"]).optional(),
+	}),
+]);
+
 const messageItemSchema = z.object({
 	role: z.enum(["user", "assistant", "system", "developer"]),
 	content: z
@@ -7,10 +28,7 @@ const messageItemSchema = z.object({
 			z.string(),
 			z.array(
 				z.union([
-					z.object({
-						type: z.literal("input_text"),
-						text: z.string(),
-					}),
+					responseInputContentSchema,
 					z.object({
 						type: z.literal("output_text"),
 						text: z.string(),
@@ -18,11 +36,6 @@ const messageItemSchema = z.object({
 					z.object({
 						type: z.literal("text"),
 						text: z.string(),
-					}),
-					z.object({
-						type: z.literal("input_image"),
-						image_url: z.string().optional(),
-						detail: z.enum(["low", "high", "auto"]).optional(),
 					}),
 					z.object({
 						type: z.literal("image_url"),
@@ -61,12 +74,24 @@ const functionCallItemSchema = z.object({
 
 const functionCallOutputItemSchema = z.object({
 	type: z.literal("function_call_output"),
+	id: z.string().optional(),
 	call_id: z.string(),
-	output: z.string(),
+	output: z.union([z.string(), z.array(responseInputContentSchema)]),
+	status: z.enum(["in_progress", "completed", "incomplete"]).optional(),
+});
+
+const reasoningItemSchema = z.object({
+	type: z.literal("reasoning"),
+	id: z.string().optional(),
+	summary: z.array(z.record(z.any())).optional(),
+	content: z.array(z.record(z.any())).optional(),
+	encrypted_content: z.string().optional(),
+	status: z.enum(["in_progress", "completed", "incomplete"]).optional(),
 });
 
 const inputItemSchema = z.union([
 	messageItemSchema,
+	reasoningItemSchema,
 	functionCallItemSchema,
 	functionCallOutputItemSchema,
 ]);

--- a/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
+++ b/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
@@ -80,7 +80,7 @@ export function convertResponsesInputToMessages(
 		if ("type" in item && item.type === "function_call_output") {
 			messages.push({
 				role: "tool",
-				content: item.output,
+				content: serializeFunctionCallOutput(item.output),
 				tool_call_id: item.call_id,
 			});
 			i++;
@@ -128,6 +128,16 @@ export function convertResponsesInputToMessages(
 	}
 
 	return messages;
+}
+
+function serializeFunctionCallOutput(
+	output: string | Array<Record<string, unknown>>,
+): string {
+	if (typeof output === "string") {
+		return output;
+	}
+
+	return JSON.stringify(output);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Align `/v1/responses` input validation with OpenAI Responses API shapes used by Codex tool loops.
- Accept `reasoning` items that GPT-5/Codex must pass back alongside tool outputs.
- Allow `function_call_output.output` to be either a string or structured text/image/file content.
- Preserve provider compatibility by serializing structured tool outputs to string content before chat-completions routing.
## References
- https://platform.openai.com/docs/api-reference/responses/input-items
- https://platform.openai.com/docs/guides/function-calling?api-mode=responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for structured function call outputs with optional status tracking (in progress, completed, incomplete).
  * Introduced reasoning item type for responses.
  * Enhanced input content modeling with expanded metadata support for images and files.

* **Tests**
  * Expanded test coverage for schema validation and response conversion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->