### PR TITLE
fix(playground): default gpt-image-2 to low/1024x1024

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -127,7 +127,10 @@ export default function ChatPageClient({
 		const config = getModelImageConfig(getInitialModel());
 		return config.isGptImage ? config.defaultSize : "1024x1024";
 	});
-	const [imageQuality, setImageQuality] = useState<string>("auto");
+	const [imageQuality, setImageQuality] = useState<string>(() => {
+		const config = getModelImageConfig(getInitialModel());
+		return config.defaultQuality ?? "auto";
+	});
 	const [imageCount, setImageCount] = useState<1 | 2 | 3 | 4>(1);
 	const [webSearchEnabled, setWebSearchEnabled] = useState(enableWebSearch);
 	const [isLoading, setIsLoading] = useState(false);
@@ -892,9 +895,7 @@ export default function ChatPageClient({
 	useEffect(() => {
 		const config = getModelImageConfig(selectedModel);
 		if (config.usesPixelDimensions) {
-			if (config.isGptImage && alibabaImageSize === "1024x1024") {
-				setAlibabaImageSize(config.defaultSize);
-			} else if (!config.availableSizes.includes(alibabaImageSize as never)) {
+			if (!config.availableSizes.includes(alibabaImageSize as never)) {
 				setAlibabaImageSize(config.defaultSize);
 			}
 		} else if (!config.availableSizes.includes(imageSize as never)) {
@@ -1246,7 +1247,10 @@ function ExtraChatPanel({
 		const config = getModelImageConfig(initialModel);
 		return config.isGptImage ? config.defaultSize : "1024x1024";
 	});
-	const [imageQuality, setImageQuality] = useState<string>("auto");
+	const [imageQuality, setImageQuality] = useState<string>(() => {
+		const config = getModelImageConfig(initialModel);
+		return config.defaultQuality ?? "auto";
+	});
 	const [imageCount, setImageCount] = useState<1 | 2 | 3 | 4>(1);
 	const [webSearchEnabled, setWebSearchEnabled] = useState(false);
 	const [text, setText] = useState("");
@@ -1317,9 +1321,7 @@ function ExtraChatPanel({
 	useEffect(() => {
 		const config = getModelImageConfig(selectedModel);
 		if (config.usesPixelDimensions) {
-			if (config.isGptImage && alibabaImageSize === "1024x1024") {
-				setAlibabaImageSize(config.defaultSize);
-			} else if (!config.availableSizes.includes(alibabaImageSize as never)) {
+			if (!config.availableSizes.includes(alibabaImageSize as never)) {
 				setAlibabaImageSize(config.defaultSize);
 			}
 		} else if (!config.availableSizes.includes(imageSize as never)) {

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -901,8 +901,11 @@ export default function ChatPageClient({
 		} else if (!config.availableSizes.includes(imageSize as never)) {
 			setImageSize(config.defaultSize);
 		}
-		if (!config.supportsQuality && imageQuality !== "auto") {
-			setImageQuality("auto");
+		if (
+			config.supportsQuality &&
+			!(config.availableQualities as readonly string[]).includes(imageQuality)
+		) {
+			setImageQuality(config.defaultQuality ?? "auto");
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [selectedModel]);
@@ -1327,8 +1330,11 @@ function ExtraChatPanel({
 		} else if (!config.availableSizes.includes(imageSize as never)) {
 			setImageSize(config.defaultSize);
 		}
-		if (!config.supportsQuality && imageQuality !== "auto") {
-			setImageQuality("auto");
+		if (
+			config.supportsQuality &&
+			!(config.availableQualities as readonly string[]).includes(imageQuality)
+		) {
+			setImageQuality(config.defaultQuality ?? "auto");
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [selectedModel]);

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -223,7 +223,7 @@ export default function ImagePageClient({
 			setImageSize(config.defaultSize);
 		}
 		if (
-			!config.supportsQuality ||
+			config.supportsQuality &&
 			!(config.availableQualities as readonly string[]).includes(imageQuality)
 		) {
 			setImageQuality(config.defaultQuality ?? "auto");

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -104,7 +104,11 @@ export default function ImagePageClient({
 		const config = getModelImageConfig(primaryModel);
 		return config.isGptImage ? config.defaultSize : "1024x1024";
 	});
-	const [imageQuality, setImageQuality] = useState<string>("auto");
+	const [imageQuality, setImageQuality] = useState<string>(() => {
+		const primaryModel = selectedModels[0] ?? "";
+		const config = getModelImageConfig(primaryModel);
+		return config.defaultQuality ?? "auto";
+	});
 	const [imageCount, setImageCount] = useState<1 | 2 | 3 | 4>(1);
 
 	// Input images for image-edit models
@@ -208,9 +212,7 @@ export default function ImagePageClient({
 		const primaryModel = selectedModels[0] ?? "";
 		const config = getModelImageConfig(primaryModel);
 		if (config.usesPixelDimensions) {
-			if (config.isGptImage && alibabaImageSize === "1024x1024") {
-				setAlibabaImageSize(config.defaultSize);
-			} else if (
+			if (
 				!(config.availableSizes as readonly string[]).includes(alibabaImageSize)
 			) {
 				setAlibabaImageSize(config.defaultSize);

--- a/apps/playground/src/lib/image-gen.ts
+++ b/apps/playground/src/lib/image-gen.ts
@@ -73,13 +73,13 @@ export function getModelImageConfig(model: string) {
 				? (["0.5K", "1K", "2K", "4K"] as const)
 				: (["1K", "2K", "4K"] as const);
 
-	const defaultSize = isGptImage ? "auto" : isSeedream ? "2K" : "1K";
+	const defaultSize = isGptImage ? "1024x1024" : isSeedream ? "2K" : "1K";
 
 	const supportsQuality = isGptImage;
 	const availableQualities = isGptImage
 		? (["auto", "low", "medium", "high"] as const)
 		: ([] as readonly string[]);
-	const defaultQuality: string | undefined = isGptImage ? "auto" : undefined;
+	const defaultQuality: string | undefined = isGptImage ? "low" : undefined;
 
 	const maxInputImages = getMaxInputImages(lower);
 


### PR DESCRIPTION
## Summary
- Default OpenAI **gpt-image-2** to `low` quality and `1024x1024` resolution in the chat playground and standalone image studio so first-time generations are cheaper.
- Users can still pick higher values (medium/high quality, larger sizes) from the existing dropdowns — only the initial defaults change.
- Removed the now-redundant special case that swapped `1024x1024` → `auto` when switching to gpt-image, since `1024x1024` is now the proper gpt-image default.

## Test plan
- [ ] Open `/` in the playground with gpt-image-2 selected → resolution shows `1024x1024`, quality shows `Low`.
- [ ] Open `/image` (image studio) with gpt-image-2 → same defaults appear.
- [ ] Switch model to a non-gpt-image image-gen model and back → controls still show valid values.
- [ ] Pick a different quality/size, then switch model away and back → existing user selection is preserved (not clobbered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image quality now initializes based on the selected model’s configuration rather than a fixed value.
  * Image size synchronization simplified for consistent behavior across models (removed special-case exceptions).
  * Default image generation settings updated for better initial size and quality handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->