### PR TITLE
fix(billing): close dev plan upgrade payment bypass

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -591,13 +591,21 @@ devPlans.openapi(changeTier, async (c) => {
 		});
 	}
 
+	const isUpgrade =
+		DEV_PLAN_PRICES[newTier] >
+		DEV_PLAN_PRICES[personalOrg.devPlan as DevPlanTier];
+
 	try {
 		const subscription = await getStripe().subscriptions.retrieve(
 			personalOrg.devPlanStripeSubscriptionId,
 		);
 
-		// Update subscription with new tier
-		await getStripe().subscriptions.update(
+		// For upgrades, charge the prorated amount synchronously and reject the
+		// upgrade if the customer's payment method can't cover it. Without this,
+		// Stripe leaves the subscription on the new (higher) price even when the
+		// proration invoice fails — letting the user spend at the upgraded tier
+		// while we never collect.
+		const updated = await getStripe().subscriptions.update(
 			personalOrg.devPlanStripeSubscriptionId,
 			{
 				items: [
@@ -606,7 +614,10 @@ devPlans.openapi(changeTier, async (c) => {
 						price: newPriceId,
 					},
 				],
-				proration_behavior: "create_prorations",
+				proration_behavior: isUpgrade ? "always_invoice" : "create_prorations",
+				payment_behavior: isUpgrade
+					? "error_if_incomplete"
+					: "allow_incomplete",
 				metadata: {
 					...subscription.metadata,
 					devPlan: newTier,
@@ -615,11 +626,19 @@ devPlans.openapi(changeTier, async (c) => {
 			},
 		);
 
-		// Update local database immediately
+		if (
+			isUpgrade &&
+			updated.status !== "active" &&
+			updated.status !== "trialing"
+		) {
+			throw new HTTPException(402, {
+				message:
+					"Upgrade payment could not be collected. Update your payment method and try again.",
+			});
+		}
+
+		// Only update local DB after Stripe confirms the upgrade is paid/active.
 		const newCreditsLimit = getDevPlanCreditsLimit(newTier);
-		const isUpgrade =
-			DEV_PLAN_PRICES[newTier] >
-			DEV_PLAN_PRICES[personalOrg.devPlan as DevPlanTier];
 
 		await db
 			.update(tables.organization)
@@ -654,10 +673,27 @@ devPlans.openapi(changeTier, async (c) => {
 			success: true,
 		});
 	} catch (error) {
+		if (error instanceof HTTPException) {
+			throw error;
+		}
 		logger.error(
 			"Stripe dev plan tier change error",
 			error instanceof Error ? error : new Error(String(error)),
 		);
+		// Stripe returns StripeCardError / StripeInvalidRequestError when an
+		// upgrade can't be collected (declined card, no payment method on file,
+		// etc.). Surface this to the caller as a 402 instead of a generic 500
+		// so the UI can prompt the user to update billing.
+		const errCode =
+			typeof error === "object" && error !== null && "code" in error
+				? String((error as { code?: unknown }).code)
+				: undefined;
+		if (errCode === "card_declined" || errCode === "invoice_payment_required") {
+			throw new HTTPException(402, {
+				message:
+					"Upgrade payment could not be collected. Update your payment method and try again.",
+			});
+		}
 		throw new HTTPException(500, {
 			message: "Failed to change dev plan tier",
 		});

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1659,6 +1659,37 @@ async function freezeDevPlanCredits(
 	);
 }
 
+async function restoreDevPlanCredits(
+	organizationId: string,
+	organization: {
+		devPlan: DevPlanTier | "none" | null;
+		devPlanCreditsLimit: string | null;
+	},
+	reason: string,
+) {
+	// Counterpart to freezeDevPlanCredits: when the subscription returns to a
+	// healthy state, raise the credit limit back to the tier's expected cap so
+	// previously-frozen accounts aren't permanently stuck at the freeze value.
+	if (!organization.devPlan || organization.devPlan === "none") {
+		return;
+	}
+	const expectedLimit = getDevPlanCreditsLimit(organization.devPlan);
+	const currentLimit = parseFloat(organization.devPlanCreditsLimit ?? "0");
+	if (currentLimit >= expectedLimit) {
+		return;
+	}
+	await db
+		.update(tables.organization)
+		.set({
+			devPlanCreditsLimit: expectedLimit.toString(),
+		})
+		.where(eq(tables.organization.id, organizationId));
+
+	logger.info(
+		`Restored dev plan credits for organization ${organizationId} (reason: ${reason}); credits limit raised from ${currentLimit} to ${expectedLimit}`,
+	);
+}
+
 async function handleInvoicePaymentFailed(
 	event: Stripe.InvoicePaymentFailedEvent,
 ) {
@@ -1796,6 +1827,17 @@ async function handleSubscriptionUpdated(
 		];
 		if (nonActiveStatuses.includes(subscription.status)) {
 			await freezeDevPlanCredits(
+				organizationId,
+				organization,
+				`subscription.updated status=${subscription.status}`,
+			);
+		} else if (
+			subscription.status === "active" ||
+			subscription.status === "trialing"
+		) {
+			// Recover from a previous freeze (e.g. dunning resolved). No-op when
+			// the limit is already at or above the tier's expected cap.
+			await restoreDevPlanCredits(
 				organizationId,
 				organization,
 				`subscription.updated status=${subscription.status}`,

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -215,6 +215,9 @@ stripeRoutes.openapi(webhookHandler, async (c) => {
 			case "invoice.payment_succeeded":
 				await handleInvoicePaymentSucceeded(event);
 				break;
+			case "invoice.payment_failed":
+				await handleInvoicePaymentFailed(event);
+				break;
 			case "customer.subscription.created":
 				await handleSubscriptionCreated(event);
 				break;
@@ -1634,6 +1637,91 @@ async function handleInvoicePaymentSucceeded(
 	}
 }
 
+async function freezeDevPlanCredits(
+	organizationId: string,
+	organization: { devPlanCreditsUsed: string | null },
+	reason: string,
+) {
+	// Cap the devPlan credit limit at what's already been used so the gateway's
+	// `limit - used` balance check returns 0. Stops further dev-plan spend
+	// without revoking the tier (so we don't lose the tier metadata before
+	// dunning resolves one way or the other).
+	const used = organization.devPlanCreditsUsed ?? "0";
+	await db
+		.update(tables.organization)
+		.set({
+			devPlanCreditsLimit: used,
+		})
+		.where(eq(tables.organization.id, organizationId));
+
+	logger.warn(
+		`Froze dev plan credits for organization ${organizationId} (reason: ${reason}); credits limit set to ${used}`,
+	);
+}
+
+async function handleInvoicePaymentFailed(
+	event: Stripe.InvoicePaymentFailedEvent,
+) {
+	const invoice = event.data.object;
+	const { customer, metadata } = invoice;
+	const subscription = (invoice as any).subscription;
+
+	let subscriptionId =
+		typeof subscription === "string" ? subscription : subscription?.id;
+	if (
+		!subscriptionId &&
+		invoice.lines &&
+		invoice.lines.data &&
+		invoice.lines.data.length > 0
+	) {
+		const firstLineItem = invoice.lines.data[0];
+		if (
+			firstLineItem.parent &&
+			firstLineItem.parent.subscription_item_details
+		) {
+			subscriptionId =
+				firstLineItem.parent.subscription_item_details.subscription;
+		}
+	}
+
+	if (!subscriptionId) {
+		logger.info("Invoice payment failed but not for a subscription, skipping");
+		return;
+	}
+
+	const result = await resolveOrganizationFromStripeEvent({
+		metadata: metadata as { organizationId?: string } | undefined,
+		customer: typeof customer === "string" ? customer : customer?.id,
+		subscription: subscriptionId,
+		lines: invoice.lines,
+	});
+
+	if (!result) {
+		logger.error(
+			`Organization not found for failed invoice (customer: ${customer}, subscription: ${subscriptionId})`,
+		);
+		return;
+	}
+
+	const { organizationId, organization } = result;
+
+	const isDevPlan =
+		organization.devPlanStripeSubscriptionId === subscriptionId &&
+		organization.devPlan !== "none";
+
+	if (!isDevPlan) {
+		// Pro subscription failures are tracked via payment_intent.payment_failed
+		// (with email throttling). Nothing extra to do here.
+		return;
+	}
+
+	await freezeDevPlanCredits(
+		organizationId,
+		organization,
+		`invoice.payment_failed (invoice ${invoice.id})`,
+	);
+}
+
 async function handleSubscriptionUpdated(
 	event: Stripe.CustomerSubscriptionUpdatedEvent,
 ) {
@@ -1695,6 +1783,24 @@ async function handleSubscriptionUpdated(
 				devPlanCancelled: !isSubscriptionActive,
 			})
 			.where(eq(tables.organization.id, organizationId));
+
+		// If Stripe is reporting the subscription as past_due / unpaid /
+		// incomplete, freeze further dev-plan spend. Without this, customers
+		// keep burning credits during dunning (or after a failed mid-cycle
+		// upgrade) while we never collect the invoice.
+		const nonActiveStatuses: Stripe.Subscription.Status[] = [
+			"past_due",
+			"unpaid",
+			"incomplete",
+			"incomplete_expired",
+		];
+		if (nonActiveStatuses.includes(subscription.status)) {
+			await freezeDevPlanCredits(
+				organizationId,
+				organization,
+				`subscription.updated status=${subscription.status}`,
+			);
+		}
 
 		// Track dev plan reactivation if it was previously cancelled and is now active
 		if (isSubscriptionActive && wasDevPlanCancelled) {


### PR DESCRIPTION
## Summary

A user on the **lite** dev plan ($29/mo) could upgrade to **max** ($179/mo) and keep max-tier credit access ($537) even when the upgrade payment failed. Found via admin dashboard: tier=max, payment=failed, utilization 100% ($537/$537), MRR $179, real cost $537.51 — a $358 loss per occurrence.

### Root cause
1. `POST /v1/dev-plans/change-tier` called `stripe.subscriptions.update(...)` with `proration_behavior: "create_prorations"` and no `payment_behavior`. Default is `allow_incomplete` — the subscription flips to the new price even if Stripe can't collect the prorated invoice.
2. The handler then **immediately** wrote `devPlan: "max"` and `devPlanCreditsLimit: "537"` locally, before any payment confirmation.
3. The Stripe webhook switch had **no `invoice.payment_failed` case** (only `payment_intent.payment_failed` for one-time charges).
4. `customer.subscription.updated` only inspected `cancel_at_period_end` — never `subscription.status`, so `past_due` / `unpaid` / `incomplete` never rolled the tier back.
5. The gateway's credit gate (`apps/gateway/src/chat/chat.ts`) only checks `devPlanCreditsLimit - devPlanCreditsUsed`, so the elevated limit kept being honored.

### Fixes
- **`apps/api/src/routes/dev-plans.ts`** — for upgrades, pass `proration_behavior: "always_invoice"` + `payment_behavior: "error_if_incomplete"`. Verify `subscription.status` is `active|trialing` before updating local DB. Re-throw `HTTPException` from the catch and surface Stripe `card_declined` / `invoice_payment_required` as 402 instead of a generic 500.
- **`apps/api/src/stripe.ts`** — new `handleInvoicePaymentFailed` handler + switch case. For dev-plan subscriptions, freezes credits by setting `devPlanCreditsLimit = devPlanCreditsUsed` (gateway balance check returns 0).
- **`apps/api/src/stripe.ts`** — in `handleSubscriptionUpdated`, also freeze dev-plan credits when `subscription.status` is `past_due | unpaid | incomplete | incomplete_expired`. Catches the dunning window after a failed renewal.

### Out of scope (follow-ups)
- Reconciling `devPlan` from `subscription.items[].price` for tier changes made via Stripe portal (not via our API).
- Subscription-status column on `organization` so the gateway can return a clearer 402 ("billing past due") instead of just zero credits.
- One-off remediation script for the affected user (cap their remaining credits and write off the loss).

## Test plan

- [ ] Manual: subscribe to lite, change-tier to max with a known-bad card → expect 402, no DB tier change, no Stripe price change.
- [ ] Manual: subscribe to lite with good card, change-tier to max → expect 200, immediate prorated charge, DB updated.
- [ ] Manual: simulate `invoice.payment_failed` webhook for an active dev-plan sub → confirm `devPlanCreditsLimit` drops to current `devPlanCreditsUsed`, gateway returns 402 on next request.
- [ ] Manual: simulate `customer.subscription.updated` with `status: "past_due"` for a dev-plan sub → same freeze behavior.
- [ ] `pnpm --filter api build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment validation and error handling for plan tier changes: upgrades are rejected if the subscription isn't active/trialing, and clearer billing error responses are returned for declined or required-payment situations.

* **New Features**
  * Dev-plan credits are automatically frozen when invoice payments fail or subscription enters a payment-inactive state, and restored when billing returns to healthy status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->