### PR TITLE
fix(billing): harden invoice.payment_failed handler

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1695,10 +1695,17 @@ async function handleInvoicePaymentFailed(
 ) {
 	const invoice = event.data.object;
 	const { customer, metadata } = invoice;
-	const subscription = (invoice as any).subscription;
+	// Stripe v18 removed the top-level `Invoice.subscription` from the typed
+	// surface. The subscription that produced this invoice now lives under
+	// `invoice.parent.subscription_details`. Fall back to the per-line item
+	// pointer for invoices created before this restructuring landed.
+	const parentSubscription =
+		invoice.parent?.subscription_details?.subscription ?? null;
 
-	let subscriptionId =
-		typeof subscription === "string" ? subscription : subscription?.id;
+	let subscriptionId: string | null | undefined =
+		typeof parentSubscription === "string"
+			? parentSubscription
+			: parentSubscription?.id;
 	if (
 		!subscriptionId &&
 		invoice.lines &&
@@ -1746,10 +1753,39 @@ async function handleInvoicePaymentFailed(
 		return;
 	}
 
+	// Webhook delivery isn't guaranteed in order. Smart Retries can have
+	// recovered the invoice (or the customer paid out-of-band) before this
+	// event reaches us — in which case the subscription is already back to
+	// active/trialing and we'd freeze a healthy account. Fetch the live
+	// subscription state and only freeze on a confirmed failure status.
+	let liveSubscription: Stripe.Subscription;
+	try {
+		liveSubscription = await getStripe().subscriptions.retrieve(subscriptionId);
+	} catch (error) {
+		logger.error(
+			`Failed to retrieve subscription ${subscriptionId} for failed invoice ${invoice.id}`,
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		return;
+	}
+
+	const failureStatuses: Stripe.Subscription.Status[] = [
+		"past_due",
+		"unpaid",
+		"incomplete",
+		"incomplete_expired",
+	];
+	if (!failureStatuses.includes(liveSubscription.status)) {
+		logger.info(
+			`Skipping freeze for organization ${organizationId}: subscription ${subscriptionId} is ${liveSubscription.status} (invoice ${invoice.id})`,
+		);
+		return;
+	}
+
 	await freezeDevPlanCredits(
 		organizationId,
 		organization,
-		`invoice.payment_failed (invoice ${invoice.id})`,
+		`invoice.payment_failed (invoice ${invoice.id}, status ${liveSubscription.status})`,
 	);
 }
 


### PR DESCRIPTION
## Summary

Two follow-up fixes to the dev-plan freeze handler added in #2137.

### 1. Stripe v18 typed access (replace `as any` cast)
`Stripe v18.1.1` removed `Invoice.subscription` from the typed surface. The cast `(invoice as any).subscription` worked at runtime because Stripe still returns the legacy field, but it bypasses TypeScript and could break on a future minor.

Switched to the typed access path: `invoice.parent?.subscription_details?.subscription`. The existing fallback to `firstLineItem.parent.subscription_item_details.subscription` is kept for invoices without a top-level subscription pointer. Adjusted the `subscriptionId` type to `string | null | undefined` since the line-item field is `string | null`.

### 2. Verify subscription state before freezing
Webhooks aren't delivered in order. Possible races:
- Smart Retries already recovered the failed invoice → status is back to `active`.
- Customer paid out-of-band → status is `active`.
- Webhook delayed long enough that the subscription has since recovered.

In any of these, the handler would have frozen a healthy account. The complementary check in `handleSubscriptionUpdated` (#2137) would eventually unfreeze, but only if a subsequent `subscription.updated` event arrives.

Now the handler retrieves the live subscription via `stripe.subscriptions.retrieve(...)` before freezing and only proceeds when status is in `[past_due, unpaid, incomplete, incomplete_expired]`. If the retrieve itself fails, we log and bail without freezing (fail safe).

This makes the handler consistent with `handleSubscriptionUpdated` and aligns failure detection with Stripe's authoritative state, not the webhook-event timing.

### Out of scope
- The same `(invoice as any).subscription` cast exists in `handleInvoicePaymentSucceeded` (preexisting). Not touching here to keep this PR scoped to the recently-added handler; can be a follow-up.

## Test plan

- [ ] Manual: simulate `invoice.payment_failed` for a sub whose live status is `active` (race condition) → expect log "Skipping freeze ... is active", no DB change.
- [ ] Manual: simulate `invoice.payment_failed` for a sub whose live status is `past_due` → expect freeze.
- [ ] Manual: simulate `invoice.payment_failed` with `subscription.retrieve` failure (e.g., expired sub id) → expect error log, no freeze.
- [ ] `pnpm --filter api build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced invoice payment failure handling to verify current subscription status before freezing credits, reducing false-positive account freezes for subscriptions that have already recovered from payment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->