### PR TITLE
feat(admin): add disable organization toggle

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -4059,6 +4059,110 @@ admin.openapi(giftCreditsRoute, async (c) => {
 	});
 });
 
+// --- Set Organization Status ---
+
+const orgStatusSchema = z.enum(["active", "deleted"]);
+
+const setOrganizationStatusRoute = createRoute({
+	method: "patch",
+	path: "/organizations/{orgId}/status",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						status: orgStatusSchema,
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+						status: orgStatusSchema,
+					}),
+				},
+			},
+			description: "Organization status updated.",
+		},
+		403: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Personal organizations cannot be disabled.",
+		},
+		404: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Organization not found.",
+		},
+	},
+});
+
+admin.openapi(setOrganizationStatusRoute, async (c) => {
+	const user = c.get("user");
+	const { orgId } = c.req.valid("param");
+	const { status } = c.req.valid("json");
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId } },
+	});
+
+	if (!org) {
+		throw new HTTPException(404, { message: "Organization not found" });
+	}
+
+	if (status === "deleted" && org.isPersonal) {
+		throw new HTTPException(403, {
+			message: "Personal organizations cannot be disabled.",
+		});
+	}
+
+	await db
+		.update(tables.organization)
+		.set({ status })
+		.where(eq(tables.organization.id, orgId));
+
+	await logAuditEvent({
+		organizationId: orgId,
+		userId: user!.id,
+		action:
+			status === "deleted" ? "organization.delete" : "organization.update",
+		resourceType: "organization",
+		resourceId: orgId,
+		metadata: {
+			resourceName: org.name,
+			previousStatus: org.status ?? "active",
+			newStatus: status,
+			source: "admin",
+		},
+	});
+
+	return c.json({
+		message:
+			status === "deleted"
+				? "Organization disabled successfully"
+				: "Organization re-enabled successfully",
+		status,
+	});
+});
+
 // --- Delete User ---
 
 const deleteUserRoute = createRoute({

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -3056,6 +3056,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "active" | "deleted";
+                    };
+                };
+            };
+            responses: {
+                /** @description Organization status updated. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            /** @enum {string} */
+                            status: "active" | "deleted";
+                        };
+                    };
+                };
+                /** @description Personal organizations cannot be disabled. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/admin/users/{userId}": {
         parameters: {
             query?: never;

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1381,6 +1381,12 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
+	if (organization.status === "deleted") {
+		throw new HTTPException(410, {
+			message: "Organization has been disabled and is no longer accessible",
+		});
+	}
+
 	const retryProjectContext = {
 		mode: project.mode,
 		organizationId: project.organizationId,

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -369,6 +369,12 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 		});
 	}
 
+	if (organization.status === "deleted") {
+		throw new HTTPException(410, {
+			message: "Organization has been disabled and is no longer accessible",
+		});
+	}
+
 	const retentionLevel = organization.retentionLevel ?? "none";
 
 	let providerKey: InferSelectModel<typeof tables.providerKey> | undefined;

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -79,6 +79,13 @@ async function authenticateRequest(c: {
 		return { error: "Could not find organization", status: 500 as const };
 	}
 
+	if (organization.status === "deleted") {
+		return {
+			error: "Organization has been disabled and is no longer accessible",
+			status: 410 as const,
+		};
+	}
+
 	return { apiKey, project, organization };
 }
 

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -586,6 +586,12 @@ async function requireRequestContext(c: Context): Promise<RequestContext> {
 		});
 	}
 
+	if (organization.status === "deleted") {
+		throw new HTTPException(410, {
+			message: "Organization has been disabled and is no longer accessible",
+		});
+	}
+
 	const requestId = c.req.header("x-request-id")?.trim() || shortid(40);
 
 	return {

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -3056,6 +3056,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "active" | "deleted";
+                    };
+                };
+            };
+            responses: {
+                /** @description Organization status updated. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            /** @enum {string} */
+                            status: "active" | "deleted";
+                        };
+                    };
+                };
+                /** @description Personal organizations cannot be disabled. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/admin/users/{userId}": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -3056,6 +3056,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "active" | "deleted";
+                    };
+                };
+            };
+            responses: {
+                /** @description Organization status updated. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            /** @enum {string} */
+                            status: "active" | "deleted";
+                        };
+                    };
+                };
+                /** @description Personal organizations cannot be disabled. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/admin/users/{userId}": {
         parameters: {
             query?: never;

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { DeleteUserButton } from "@/components/delete-user-button";
+import { OrgStatusToggleButton } from "@/components/org-status-toggle-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,7 +21,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
-import { deleteUser } from "@/lib/admin-organizations";
+import { deleteUser, setOrganizationStatus } from "@/lib/admin-organizations";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
@@ -186,6 +187,15 @@ export default async function OrganizationsPage({
 
 		const success = await deleteUser(userId);
 		return { success };
+	}
+
+	async function handleToggleOrgStatus(
+		orgId: string,
+		status: "active" | "deleted",
+	): Promise<{ success: boolean; error?: string }> {
+		"use server";
+
+		return await setOrganizationStatus(orgId, status);
 	}
 
 	return (
@@ -375,13 +385,21 @@ export default async function OrganizationsPage({
 										</Badge>
 									</TableCell>
 									<TableCell>
-										{org.ownerUserId && (
-											<DeleteUserButton
-												userId={org.ownerUserId}
-												userEmail={org.ownerEmail ?? org.billingEmail}
-												onDelete={handleDeleteUser}
+										<div className="flex items-center gap-1">
+											<OrgStatusToggleButton
+												orgId={org.id}
+												orgName={org.name}
+												currentStatus={org.status}
+												onToggle={handleToggleOrgStatus}
 											/>
-										)}
+											{org.ownerUserId && (
+												<DeleteUserButton
+													userId={org.ownerUserId}
+													userEmail={org.ownerEmail ?? org.billingEmail}
+													onDelete={handleDeleteUser}
+												/>
+											)}
+										</div>
 									</TableCell>
 								</TableRow>
 							))

--- a/ee/admin/src/components/org-status-toggle-button.tsx
+++ b/ee/admin/src/components/org-status-toggle-button.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Ban, CircleCheck, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface OrgStatusToggleButtonProps {
+	orgId: string;
+	orgName: string;
+	currentStatus: "active" | "deleted" | string | null | undefined;
+	onToggle: (
+		orgId: string,
+		status: "active" | "deleted",
+	) => Promise<{ success: boolean; error?: string }>;
+}
+
+export function OrgStatusToggleButton({
+	orgId,
+	orgName,
+	currentStatus,
+	onToggle,
+}: OrgStatusToggleButtonProps) {
+	const router = useRouter();
+	const [loading, setLoading] = useState(false);
+
+	const isDisabled = currentStatus === "deleted";
+	const nextStatus: "active" | "deleted" = isDisabled ? "active" : "deleted";
+
+	const handleClick = async () => {
+		const verb = isDisabled ? "re-enable" : "disable";
+		if (
+			!confirm(
+				`Are you sure you want to ${verb} organization "${orgName}"? ${
+					isDisabled
+						? "Members will regain access and gateway requests will resume."
+						: "Members will be signed out and all gateway requests will be rejected with HTTP 410."
+				}`,
+			)
+		) {
+			return;
+		}
+
+		setLoading(true);
+		const result = await onToggle(orgId, nextStatus);
+		setLoading(false);
+
+		if (result.success) {
+			router.refresh();
+		} else if (result.error) {
+			alert(result.error);
+		}
+	};
+
+	return (
+		<Button
+			variant="ghost"
+			size="icon-sm"
+			onClick={handleClick}
+			disabled={loading}
+			className={
+				isDisabled
+					? "text-emerald-600 hover:text-emerald-600"
+					: "text-amber-600 hover:text-amber-600"
+			}
+			title={isDisabled ? "Re-enable organization" : "Disable organization"}
+		>
+			{loading ? (
+				<Loader2 className="h-4 w-4 animate-spin" />
+			) : isDisabled ? (
+				<CircleCheck className="h-4 w-4" />
+			) : (
+				<Ban className="h-4 w-4" />
+			)}
+		</Button>
+	);
+}

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -79,6 +79,29 @@ export async function deleteUser(userId: string): Promise<boolean> {
 	return data?.success ?? false;
 }
 
+export async function setOrganizationStatus(
+	orgId: string,
+	status: "active" | "deleted",
+): Promise<{ success: boolean; error?: string }> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.PATCH(
+		"/admin/organizations/{orgId}/status",
+		{
+			params: { path: { orgId } },
+			body: { status },
+		},
+	);
+
+	if (error || !data) {
+		const message =
+			(error as { message?: string } | undefined)?.message ??
+			"Failed to update organization status";
+		return { success: false, error: message };
+	}
+
+	return { success: true };
+}
+
 export async function getLogContent(logId: string): Promise<string | null> {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/logs/{id}", {

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -3056,6 +3056,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "active" | "deleted";
+                    };
+                };
+            };
+            responses: {
+                /** @description Organization status updated. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            /** @enum {string} */
+                            status: "active" | "deleted";
+                        };
+                    };
+                };
+                /** @description Personal organizations cannot be disabled. */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/admin/users/{userId}": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

- Adds a `PATCH /admin/organizations/{orgId}/status` endpoint that flips `organization.status` between `active` and `deleted`. Personal/dev orgs are protected (matches the user-facing delete-org rule), and the change is recorded in the audit log.
- Adds a ban/unban toggle button to the admin orgs table (`ee/admin/src/app/organizations/page.tsx`) with a confirm dialog.
- Closes the gap that made the existing `status = "deleted"` flag a no-op for the gateway: chat, moderations, responses, and videos entry points now reject requests for disabled orgs with HTTP 410. Previously only `project.status === "deleted"` was checked, so an org marked `deleted` (via the user-facing flow or now via admin) still served traffic until cache TTL.

## Why

Earlier investigation showed the admin dashboard had no way to ban/disable an organization — the trash icon next to each row deletes the **owner user**, not the org. The org row's `status` column was already in the schema and was filtered in auth/membership queries, but no UI/endpoint exposed it and the gateway didn't enforce it.

## Test plan

- [ ] Build passes (`pnpm build`) ✅
- [ ] Unit tests pass (`pnpm test:unit`) ✅
- [ ] In dev: open admin → Organizations, click the ban icon next to a non-personal org, confirm the org's status badge flips to `deleted`
- [ ] Make a gateway request with an API key belonging to that org → expect HTTP 410 with "Organization has been disabled and is no longer accessible"
- [ ] Click the toggle again to re-enable → traffic resumes
- [ ] Try to disable a personal org → expect HTTP 403
- [ ] Verify an audit log entry is written (`organization.delete` on disable, `organization.update` on re-enable) with `source: "admin"` metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now toggle organization status between active and disabled from the admin panel.
  * All API endpoints now enforce organization status—requests to disabled organizations return a 410 error.
  * Personal organizations cannot be disabled.
  * Audit events are recorded for status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->