### PR TITLE
docs(opencode): document X-No-Fallback header

### DIFF
--- a/apps/docs/content/guides/opencode.mdx
+++ b/apps/docs/content/guides/opencode.mdx
@@ -105,6 +105,32 @@ The built-in provider gives you access to all standard LLM Gateway models. If yo
 
 After updating `config.json`, restart OpenCode to see the new models.
 
+## Locking to a Specific Provider
+
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — pass the `X-No-Fallback` header. Requests will then be sent only to the provider you specified, with no automatic fallback.
+
+```json
+{
+	"provider": {
+		"llmgateway": {
+			"npm": "@ai-sdk/openai-compatible",
+			"name": "LLM Gateway",
+			"options": {
+				"baseURL": "https://api.llmgateway.io/v1",
+				"headers": {
+					"X-No-Fallback": "true"
+				}
+			}
+		}
+	}
+}
+```
+
+<Callout type="warn">
+	Disabling fallback means requests will fail if the chosen provider is down.
+	See the [routing docs](/docs/features/routing) for details.
+</Callout>
+
 ## Switching Models
 
 Select a different model directly in the OpenCode interface, or update the `model` field in your configuration:


### PR DESCRIPTION
## Summary
- Add a "Locking to a Specific Provider" section to the OpenCode integration guide showing how to set the `X-No-Fallback: "true"` header inside `options.headers` of `config.json`, for users who want to lock into a specific provider/model mapping (e.g. fixed price) and skip automatic failover.

## Test plan
- [ ] Verify the docs page renders correctly at `/docs/guides/opencode`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for locking requests to a specific provider, explaining header-based configuration to disable automatic failover
  * Includes JSON configuration example and warning about implications when the selected provider is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->