### PR TITLE
fix(gateway): enforce credit check for paid models

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
-import { db, tables } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
 import { app } from "./app.js";
@@ -2835,5 +2835,80 @@ describe("api", () => {
 			const json = await res.json();
 			expect(json).toHaveProperty("choices.[0].message.content");
 		}, 10000);
+	});
+
+	describe("free_models_only does not bypass credit checks", () => {
+		// Disable data retention for these tests so the data-retention credit
+		// check at chat.ts:3072 doesn't mask the gate we actually want to test.
+		async function disableRetention() {
+			await db
+				.update(tables.organization)
+				.set({ retentionLevel: "none" })
+				.where(eq(tables.organization.id, "org-id"));
+		}
+
+		test("hybrid mode + paid model + free_models_only returns 402 with no credits", async () => {
+			await harness.setProjectMode("hybrid");
+			await harness.setOrganizationCredits("0");
+			await disableRetention();
+
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "claude-opus-4-7",
+					free_models_only: true,
+					messages: [{ role: "user", content: "Hello!" }],
+				}),
+			});
+
+			expect(res.status).toBe(402);
+			const json = await res.json();
+			expect(json.message).toBe(
+				"No API key set for provider and organization has insufficient credits",
+			);
+		});
+
+		test("credits mode + paid model + free_models_only returns 402 with no credits", async () => {
+			await harness.setProjectMode("credits");
+			await harness.setOrganizationCredits("0");
+			await disableRetention();
+
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "claude-opus-4-7",
+					free_models_only: true,
+					messages: [{ role: "user", content: "Hello!" }],
+				}),
+			});
+
+			expect(res.status).toBe(402);
+			const json = await res.json();
+			expect(json.message).toBe("Organization org-id has insufficient credits");
+		});
 	});
 });

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -2847,68 +2847,95 @@ describe("api", () => {
 				.where(eq(tables.organization.id, "org-id"));
 		}
 
+		// Stub the provider env var so the routing finds the provider as
+		// "available" and the request reaches the credit gate. Without it CI
+		// rejects earlier with 400 (no providers configured).
+		function stubOpenAIEnv() {
+			const previous = process.env.LLM_OPENAI_API_KEY;
+			process.env.LLM_OPENAI_API_KEY = "sk-openai-test";
+			return () => {
+				if (previous === undefined) {
+					delete process.env.LLM_OPENAI_API_KEY;
+				} else {
+					process.env.LLM_OPENAI_API_KEY = previous;
+				}
+			};
+		}
+
 		test("hybrid mode + paid model + free_models_only returns 402 with no credits", async () => {
 			await harness.setProjectMode("hybrid");
 			await harness.setOrganizationCredits("0");
 			await disableRetention();
+			const restoreEnv = stubOpenAIEnv();
 
-			await db.insert(tables.apiKey).values({
-				id: "token-id",
-				token: "real-token",
-				projectId: "project-id",
-				description: "Test API Key",
-				createdBy: "user-id",
-			});
+			try {
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
 
-			const res = await app.request("/v1/chat/completions", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer real-token`,
-				},
-				body: JSON.stringify({
-					model: "claude-opus-4-7",
-					free_models_only: true,
-					messages: [{ role: "user", content: "Hello!" }],
-				}),
-			});
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer real-token`,
+					},
+					body: JSON.stringify({
+						model: "gpt-4o-mini",
+						free_models_only: true,
+						messages: [{ role: "user", content: "Hello!" }],
+					}),
+				});
 
-			expect(res.status).toBe(402);
-			const json = await res.json();
-			expect(json.message).toBe(
-				"No API key set for provider and organization has insufficient credits",
-			);
+				expect(res.status).toBe(402);
+				const json = await res.json();
+				expect(json.message).toBe(
+					"No API key set for provider and organization has insufficient credits",
+				);
+			} finally {
+				restoreEnv();
+			}
 		});
 
 		test("credits mode + paid model + free_models_only returns 402 with no credits", async () => {
 			await harness.setProjectMode("credits");
 			await harness.setOrganizationCredits("0");
 			await disableRetention();
+			const restoreEnv = stubOpenAIEnv();
 
-			await db.insert(tables.apiKey).values({
-				id: "token-id",
-				token: "real-token",
-				projectId: "project-id",
-				description: "Test API Key",
-				createdBy: "user-id",
-			});
+			try {
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
 
-			const res = await app.request("/v1/chat/completions", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer real-token`,
-				},
-				body: JSON.stringify({
-					model: "claude-opus-4-7",
-					free_models_only: true,
-					messages: [{ role: "user", content: "Hello!" }],
-				}),
-			});
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer real-token`,
+					},
+					body: JSON.stringify({
+						model: "gpt-4o-mini",
+						free_models_only: true,
+						messages: [{ role: "user", content: "Hello!" }],
+					}),
+				});
 
-			expect(res.status).toBe(402);
-			const json = await res.json();
-			expect(json.message).toBe("Organization org-id has insufficient credits");
+				expect(res.status).toBe(402);
+				const json = await res.json();
+				expect(json.message).toBe(
+					"Organization org-id has insufficient credits",
+				);
+			} finally {
+				restoreEnv();
+			}
 		});
 	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2854,7 +2854,6 @@ chat.openapi(completions, async (c) => {
 
 		if (
 			totalAvailableCredits <= 0 &&
-			!free_models_only &&
 			!((finalModelInfo ?? modelInfo) as ModelDefinition).free
 		) {
 			if (organization.devPlan !== "none" && devPlanCreditsRemaining <= 0) {
@@ -2928,7 +2927,6 @@ chat.openapi(completions, async (c) => {
 
 			if (
 				totalAvailableCredits <= 0 &&
-				!free_models_only &&
 				!isModelTrulyFree((finalModelInfo ?? modelInfo) as ModelDefinition)
 			) {
 				if (organization.devPlan !== "none" && devPlanCreditsRemaining <= 0) {


### PR DESCRIPTION
## Summary

Fixes a credit-bypass that let paid traffic run on gateway-managed keys against organizations with zero credits, accumulating negative balances.

**Root cause:** the credit gate in `apps/gateway/src/chat/chat.ts` (in both credits and hybrid modes) was unconditionally short-circuited whenever the request body included `"free_models_only": true`. The clause was added in commit 970b25637 on the assumption that auto routing would already filter to free models — but `free_models_only` is **only consulted in the auto-routing branch (chat.ts:1614)**. A request like `model: "claude-opus-4-7"` + `free_models_only: true` skipped the auto-router entirely, the gate evaluated `true && !true && true → false`, and the call ran on env-var provider tokens against an org with 0 credits.

The dashboard's Quick Start snippet ships both `model: "auto"` and `free_models_only: true`, so a copy-paste with the model swapped to a real one was enough to trigger the bypass.

**Fix:** drop the `!free_models_only` short-circuit from both checks. The remaining model-level free check (`!modelInfo.free` / `!isModelTrulyFree(finalModelInfo ?? modelInfo)`) is sufficient: legitimate `model: "auto"` + `free_models_only: true` calls still bypass the gate because the auto-router resolves to a free model and `isModelTrulyFree(finalModelInfo)` returns true. The flag itself stays in place so onboarding (which relies on free-model auto-routing) and the public quick-start example keep working.

## Changes

- `apps/gateway/src/chat/chat.ts:2856` — remove `!free_models_only &&` from the credits-mode credit gate
- `apps/gateway/src/chat/chat.ts:2929` — remove `!free_models_only &&` from the hybrid-mode credit gate

Total: 1 file, +0 / −2 lines.

## Test plan

- [ ] Manual: org with 0 credits, hybrid mode, no provider keys → `{ "model": "claude-opus-4-7", "free_models_only": true }` → expect 402 (previously succeeded and went negative)
- [ ] Manual: org with 0 credits → `{ "model": "auto", "free_models_only": true }` → still routes to a free model and succeeds
- [ ] Manual: org with 0 credits → free model directly → still works
- [ ] Manual: paid model with sufficient credits → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-routing no longer treats "free model" selection separately; model fallback and insufficient-credit errors are now consistent and unified.
  * Credit checks now block requests when available credits are zero, regardless of whether a free-model flag was provided.

* **Tests**
  * Added tests ensuring the free-model flag does not bypass credit enforcement and that 402 responses are returned for insufficient credits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->