### PR TITLE
fix(gateway): re-check credits on env-var retry

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2852,6 +2852,9 @@ chat.openapi(completions, async (c) => {
 				: 0;
 		const totalAvailableCredits = regularCredits + devPlanCreditsRemaining;
 
+		// We trust the bare `modelInfo.free` flag here: free models are always
+		// marked explicitly in the catalog, so a `free: true` model is intended
+		// to be usable without credits. Do not switch this to isModelTrulyFree.
 		if (
 			totalAvailableCredits <= 0 &&
 			!free_models_only &&

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -111,6 +111,40 @@ interface OrgInfo {
 	devPlanExpiresAt: Date | null;
 }
 
+// Mirrors the initial credit gate in chat.ts so retry/fallback paths that
+// switch to LLMGateway env-var tokens cannot be used to bill an organization
+// with non-positive credits. Free models (explicitly flagged in the catalog)
+// are exempt.
+function assertOrganizationHasCreditsForEnvFallback(
+	organization: OrgInfo,
+	modelInfo: ModelDefinition,
+): void {
+	if (modelInfo.free) {
+		return;
+	}
+	const regularCredits = parseFloat(organization.credits ?? "0");
+	const devPlanCreditsRemaining =
+		organization.devPlan !== "none"
+			? parseFloat(organization.devPlanCreditsLimit ?? "0") -
+				parseFloat(organization.devPlanCreditsUsed ?? "0")
+			: 0;
+	const totalAvailableCredits = regularCredits + devPlanCreditsRemaining;
+	if (totalAvailableCredits > 0) {
+		return;
+	}
+	if (organization.devPlan !== "none" && devPlanCreditsRemaining <= 0) {
+		const renewalDate = organization.devPlanExpiresAt
+			? new Date(organization.devPlanExpiresAt).toLocaleDateString()
+			: "your next billing date";
+		throw new HTTPException(402, {
+			message: `Dev Plan credit limit reached. Upgrade your plan or wait for renewal on ${renewalDate}.`,
+		});
+	}
+	throw new HTTPException(402, {
+		message: `Organization ${organization.id} has insufficient credits`,
+	});
+}
+
 export function formatUsedModelForDisplay(
 	usedProvider: string,
 	baseModelName: string,
@@ -185,6 +219,7 @@ export async function resolveProviderContext(
 
 		usedToken = providerKey.token;
 	} else if (project.mode === "credits") {
+		assertOrganizationHasCreditsForEnvFallback(organization, modelInfo);
 		const envResult = getProviderEnv(usedProvider as Provider, {
 			excludedIndices: options.excludedEnvKeyIndices,
 		});
@@ -211,6 +246,7 @@ export async function resolveProviderContext(
 		if (providerKey) {
 			usedToken = providerKey.token;
 		} else {
+			assertOrganizationHasCreditsForEnvFallback(organization, modelInfo);
 			const envResult = getProviderEnv(usedProvider as Provider, {
 				excludedIndices: options.excludedEnvKeyIndices,
 			});


### PR DESCRIPTION
## Summary
- The initial credit gate in `chat.ts` only fires when the first attempt is about to use LLMGateway env-var tokens; BYOK paths intentionally skip it so a $0-credits org can still use its own provider key.
- Retry/fallback went through `resolveProviderContext`, which switched to env-var tokens without re-validating credits, allowing a primary BYOK attempt to fail over and bill the org via `used_mode="credits"` with $0 balance.
- Mirror the same gate inside `resolveProviderContext` so the env-var fallback paths (credits and hybrid-no-key branches) refuse fallback when total available credits are non-positive, preserving the BYOK-with-$0 use case.
- Added a clarifying comment in `chat.ts` explaining that the bare `modelInfo.free` flag is intentional and `isModelTrulyFree` should not be substituted here.

## Test plan
- [ ] `pnpm test:unit` passes
- [ ] Repro a hybrid-mode org with $0 credits + a deliberately broken BYOK key on a paid model — request should now 402 instead of falling back and billing credits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit validation to accurately determine which models are available when organization credits are insufficient
  * Added mandatory credit verification before using backup authentication methods
  * Enhanced error response messages for low-credit scenarios with plan type and renewal date information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->