### PR TITLE
feat(devpass): require cached-input pricing for coding plans

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -23,7 +23,10 @@ import {
 	findActiveProviderKeys,
 	findProviderKeysByProviders,
 } from "@/lib/cached-queries.js";
-import { isCodingModel } from "@/lib/coding-models.js";
+import {
+	isCodingModel,
+	providerSupportsCachedInput,
+} from "@/lib/coding-models.js";
 import { calculateCosts, shouldBillCancelledRequests } from "@/lib/costs.js";
 import { throwIamException, validateModelAccess } from "@/lib/iam.js";
 import {
@@ -1409,17 +1412,40 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
-	// Validate coding model restriction for dev plan personal orgs
-	// This check must happen BEFORE capability checks to give the right error message
-	if (
+	// Coding plans only allow models/provider mappings with cached input pricing.
+	// The model-level check denies models with no cached mapping at all.
+	// The specific-provider check denies a request like `groq/gpt-oss-120b` where the
+	// model qualifies as coding overall but the named mapping itself is uncached.
+	const isDevPlanRestricted = Boolean(
 		organization?.isPersonal &&
-		organization.devPlan !== "none" &&
-		!organization.devPlanAllowAllModels
-	) {
+			organization.devPlan !== "none" &&
+			!organization.devPlanAllowAllModels,
+	);
+	if (isDevPlanRestricted) {
 		if (!isCodingModel(modelInfo)) {
 			throw new HTTPException(403, {
 				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
 			});
+		}
+
+		if (
+			requestedProvider &&
+			requestedProvider !== "llmgateway" &&
+			requestedProvider !== "custom"
+		) {
+			const requestedProviderMappings = modelInfo.providers.filter(
+				(p) =>
+					p.providerId === requestedProvider &&
+					(requestedRegion === undefined || p.region === requestedRegion),
+			);
+			if (
+				requestedProviderMappings.length > 0 &&
+				!requestedProviderMappings.some(providerSupportsCachedInput)
+			) {
+				throw new HTTPException(403, {
+					message: `Provider ${requestedProvider} does not offer cached input pricing for model ${modelInfo.id}. Coding plans require providers with prompt caching support; choose another provider or enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+				});
+			}
 		}
 	}
 
@@ -1478,6 +1504,19 @@ chat.openapi(completions, async (c) => {
 				iamAllowedProviders.includes(p.providerId),
 			)
 		: routingExpandedModelProviders;
+
+	if (isDevPlanRestricted) {
+		iamFilteredModelProviders = iamFilteredModelProviders.filter(
+			providerSupportsCachedInput,
+		);
+		expandedIamFilteredModelProviders =
+			expandedIamFilteredModelProviders.filter(providerSupportsCachedInput);
+		if (iamFilteredModelProviders.length === 0) {
+			throw new HTTPException(403, {
+				message: `No provider with cached input pricing is available for model ${modelInfo.id}. Coding plans require providers with prompt caching support; enable access to all models in your dashboard settings at code.llmgateway.io/dashboard to use this model.`,
+			});
+		}
+	}
 
 	// Validate the custom provider against the database if one was requested
 	if (requestedProvider === "custom" && customProviderName) {
@@ -1635,8 +1674,12 @@ chat.openapi(completions, async (c) => {
 						candidateAllowedProviders.includes(provider.providerId)),
 			);
 
+			const cachedFilteredProviders = isDevPlanRestricted
+				? availableModelProviders.filter(providerSupportsCachedInput)
+				: availableModelProviders;
+
 			// Filter by context size requirement, reasoning capability, and deprecation status
-			const suitableProviders = availableModelProviders.filter((provider) => {
+			const suitableProviders = cachedFilteredProviders.filter((provider) => {
 				// Skip deprecated provider mappings
 				if (provider.deprecatedAt && now > provider.deprecatedAt!) {
 					return false;
@@ -1830,6 +1873,13 @@ chat.openapi(completions, async (c) => {
 					allowedProviders.includes(p.providerId),
 				)
 			: expandAllProviderRegions(modelInfo.providers);
+		if (isDevPlanRestricted) {
+			iamFilteredModelProviders = iamFilteredModelProviders.filter(
+				providerSupportsCachedInput,
+			);
+			expandedIamFilteredModelProviders =
+				expandedIamFilteredModelProviders.filter(providerSupportsCachedInput);
+		}
 	} else if (
 		(usedProvider === "llmgateway" && usedModel === "custom") ||
 		usedModel === "custom"

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1896,9 +1896,17 @@ chat.openapi(completions, async (c) => {
 		usedProvider !== "llmgateway" &&
 		usedProvider !== "custom"
 	) {
-		const sameProviderMappings = modelInfo.providers.filter(
+		const allSameProviderMappings = modelInfo.providers.filter(
 			(p) => p.providerId === usedProvider,
 		);
+		const sameProviderMappings = isDevPlanRestricted
+			? allSameProviderMappings.filter(providerSupportsCachedInput)
+			: allSameProviderMappings;
+		if (isDevPlanRestricted && sameProviderMappings.length === 0) {
+			throw new HTTPException(403, {
+				message: `Provider ${usedProvider} does not offer cached input pricing for model ${modelInfo.id}. Coding plans require providers with prompt caching support; choose another provider or enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+			});
+		}
 		const sameProviderRegionalMappings = sameProviderMappings.filter(
 			(p) => p.region,
 		);
@@ -1927,6 +1935,15 @@ chat.openapi(completions, async (c) => {
 			const providerLockedRegions = lockedRegion
 				? new Map([[usedProvider, lockedRegion]])
 				: undefined;
+			if (
+				isDevPlanRestricted &&
+				lockedRegion &&
+				!sameProviderMappings.some((p) => p.region === lockedRegion)
+			) {
+				throw new HTTPException(403, {
+					message: `Region '${lockedRegion}' for provider ${usedProvider} does not offer cached input pricing for model ${modelInfo.id}. Coding plans require providers with prompt caching support; choose another region or enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+				});
+			}
 			const eligibleMappings = filterEligibleModelProviders(
 				sameProviderRoutingMappings,
 				{

--- a/apps/gateway/src/lib/coding-models.spec.ts
+++ b/apps/gateway/src/lib/coding-models.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { isCodingModel, providerSupportsCachedInput } from "./coding-models.js";
+
+import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
+
+const baseProvider: ProviderModelMapping = {
+	providerId: "openai",
+	modelName: "test-model",
+	streaming: true,
+	tools: true,
+	jsonOutputSchema: true,
+	cachedInputPrice: 0.1 / 1e6,
+};
+
+const baseModel: ModelDefinition = {
+	id: "test-model",
+	name: "Test Model",
+	family: "openai",
+	providers: [baseProvider],
+};
+
+describe("providerSupportsCachedInput", () => {
+	it("returns true when cachedInputPrice is set to a positive number", () => {
+		expect(providerSupportsCachedInput({ cachedInputPrice: 0.1 / 1e6 })).toBe(
+			true,
+		);
+	});
+
+	it("returns true when cachedInputPrice is zero", () => {
+		expect(providerSupportsCachedInput({ cachedInputPrice: 0 })).toBe(true);
+	});
+
+	it("returns false when cachedInputPrice is undefined", () => {
+		expect(providerSupportsCachedInput({})).toBe(false);
+	});
+
+	it("returns false when cachedInputPrice is null", () => {
+		expect(
+			providerSupportsCachedInput({
+				cachedInputPrice: null as unknown as undefined,
+			}),
+		).toBe(false);
+	});
+});
+
+describe("isCodingModel", () => {
+	it("returns true when at least one stable provider has cached pricing, tools, JSON output, and streaming", () => {
+		expect(isCodingModel(baseModel)).toBe(true);
+	});
+
+	it("returns false when free", () => {
+		expect(isCodingModel({ ...baseModel, free: true })).toBe(false);
+	});
+
+	it("returns false when stability is unstable", () => {
+		expect(isCodingModel({ ...baseModel, stability: "unstable" })).toBe(false);
+	});
+
+	it("returns false when no provider has cached input pricing", () => {
+		const provider = { ...baseProvider };
+		delete provider.cachedInputPrice;
+		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
+	});
+
+	it("returns false when the only cached provider is unstable", () => {
+		const provider: ProviderModelMapping = {
+			...baseProvider,
+			stability: "unstable",
+		};
+		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
+	});
+
+	it("returns false when no provider supports tools", () => {
+		const provider: ProviderModelMapping = { ...baseProvider, tools: false };
+		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
+	});
+
+	it("returns false when no provider supports JSON output", () => {
+		const provider: ProviderModelMapping = {
+			...baseProvider,
+			jsonOutput: false,
+			jsonOutputSchema: false,
+		};
+		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
+	});
+
+	it("returns false when streaming is explicitly disabled", () => {
+		const provider: ProviderModelMapping = {
+			...baseProvider,
+			streaming: false,
+		};
+		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
+	});
+
+	it("returns true when at least one provider qualifies even if others do not", () => {
+		const cachedProvider = baseProvider;
+		const uncachedProvider: ProviderModelMapping = {
+			providerId: "groq",
+			modelName: "test-model",
+			streaming: true,
+			tools: true,
+			jsonOutputSchema: true,
+		};
+		expect(
+			isCodingModel({
+				...baseModel,
+				providers: [uncachedProvider, cachedProvider],
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/gateway/src/lib/coding-models.ts
+++ b/apps/gateway/src/lib/coding-models.ts
@@ -1,4 +1,10 @@
-import type { ModelDefinition } from "@llmgateway/models";
+import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
+
+export function providerSupportsCachedInput(
+	p: Pick<ProviderModelMapping, "cachedInputPrice">,
+): boolean {
+	return p.cachedInputPrice !== null && p.cachedInputPrice !== undefined;
+}
 
 /**
  * Checks if a model qualifies as a "coding model".
@@ -39,8 +45,7 @@ export function isCodingModel(model: ModelDefinition): boolean {
 		const hasStreaming = p.streaming !== false;
 
 		// Must have cached input pricing
-		const hasCachedInputPrice =
-			p.cachedInputPrice !== null && p.cachedInputPrice !== undefined;
+		const hasCachedInputPrice = providerSupportsCachedInput(p);
 
 		return hasJsonOutput && hasTools && hasStreaming && hasCachedInputPrice;
 	});


### PR DESCRIPTION
## Summary

- Coding-plan personal orgs (`devPlan != "none"`, `!devPlanAllowAllModels`) gate models via `isCodingModel`, but the check passes if any provider mapping has `cachedInputPrice` — so a request like `groq/gpt-oss-120b` slips through and hits an uncached upstream, blowing through credit allowance.
- Deny specific provider requests whose mapping lacks `cachedInputPrice`, and filter post-IAM / auto-routing candidates so canonical mappings only resolve to cached providers.
- Adds a `providerSupportsCachedInput` helper plus unit tests (`apps/gateway/src/lib/coding-models.spec.ts`).

## Test plan

- [x] `pnpm vitest run apps/gateway/src/lib/coding-models.spec.ts` — 13 new tests pass
- [x] `pnpm --filter gateway build` — clean
- [ ] Manual: dev-plan org + `groq/gpt-oss-120b` returns 403; canonical `gpt-oss-120b` routes to bytedance only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter coding-plan validation that enforces cached-input pricing support when restricted.

* **Bug Fixes**
  * Provider and model selection now consistently filter out providers lacking cached-input support, preventing incompatible routing or direct-selection failures.

* **Tests**
  * Added tests covering cached-input support checks and coding-model qualification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->