### PR TITLE
chore: rename code.llmgateway.io to devpass.llmgateway.io

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,7 +228,7 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 STRIPE_PRO_MONTHLY_PRICE_ID=price_your_pro_plan_price_id
 STRIPE_PRO_YEARLY_PRICE_ID=price_your_pro_plan_price_id
 
-# Dev Plans Stripe Price IDs (for code.llmgateway.io)
+# Dev Plans Stripe Price IDs (for devpass.llmgateway.io)
 STRIPE_DEV_PLAN_LITE_PRICE_ID=price_your_dev_plan_lite_price_id
 STRIPE_DEV_PLAN_PRO_PRICE_ID=price_your_dev_plan_pro_price_id
 STRIPE_DEV_PLAN_MAX_PRICE_ID=price_your_dev_plan_max_price_id

--- a/.env.unified.example
+++ b/.env.unified.example
@@ -135,7 +135,7 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 STRIPE_PRO_MONTHLY_PRICE_ID=price_your_pro_plan_price_id
 STRIPE_PRO_YEARLY_PRICE_ID=price_your_pro_plan_price_id
 
-# Dev Plans Stripe Price IDs (for code.llmgateway.io)
+# Dev Plans Stripe Price IDs (for devpass.llmgateway.io)
 STRIPE_DEV_PLAN_LITE_PRICE_ID=price_your_dev_plan_lite_price_id
 STRIPE_DEV_PLAN_PRO_PRICE_ID=price_your_dev_plan_pro_price_id
 STRIPE_DEV_PLAN_MAX_PRICE_ID=price_your_dev_plan_max_price_id

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -162,7 +162,7 @@ organization.openapi(getOrganizations, async (c) => {
 	const organizations = userOrganizations
 		.map((uo) => uo.organization!)
 		.filter((org) => org.status !== "deleted")
-		// Hide personal orgs from regular UI - they are only visible on code.llmgateway.io
+		// Hide personal orgs from regular UI - they are only visible on devpass.llmgateway.io
 		.filter((org) => !org.isPersonal);
 
 	return c.json({
@@ -663,7 +663,7 @@ organization.openapi(deleteOrganization, async (c) => {
 	if (userOrganization.organization?.isPersonal) {
 		throw new HTTPException(403, {
 			message:
-				"Personal organizations cannot be deleted. Please cancel your dev plan at code.llmgateway.io instead.",
+				"Personal organizations cannot be deleted. Please cancel your dev plan at devpass.llmgateway.io instead.",
 		});
 	}
 

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -90,7 +90,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 	if (organization.isPersonal) {
 		throw new HTTPException(403, {
 			message:
-				"Paid subscriptions are not available for personal organizations. Please use Dev Plans at code.llmgateway.io or create a regular organization.",
+				"Paid subscriptions are not available for personal organizations. Please use Dev Plans at devpass.llmgateway.io or create a regular organization.",
 		});
 	}
 

--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -23,7 +23,7 @@ const geistMono = Geist_Mono({
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-	metadataBase: new URL("https://code.llmgateway.io"),
+	metadataBase: new URL("https://devpass.llmgateway.io"),
 	title: {
 		default: "DevPass by LLM Gateway - All-Access Dev Plans for AI Coding",
 		template: "%s | DevPass by LLM Gateway",
@@ -53,7 +53,7 @@ export const metadata: Metadata = {
 			"One subscription, every coding model. Fixed-price dev plans for Claude Code, Cursor, Cline, and any OpenAI-compatible tool.",
 		images: ["/opengraph.png?v=1"],
 		type: "website",
-		url: "https://code.llmgateway.io",
+		url: "https://devpass.llmgateway.io",
 		siteName: "DevPass by LLM Gateway",
 		locale: "en_US",
 	},
@@ -71,7 +71,7 @@ const webSiteSchema = {
 	"@context": "https://schema.org",
 	"@type": "WebSite",
 	name: "DevPass by LLM Gateway",
-	url: "https://code.llmgateway.io",
+	url: "https://devpass.llmgateway.io",
 	description:
 		"Fixed-price dev plans for AI-powered coding with Claude Code, Cursor, Cline, and any OpenAI-compatible tool. One subscription, every model.",
 	publisher: {

--- a/apps/code/src/app/legal/privacy/page.tsx
+++ b/apps/code/src/app/legal/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
 				(&ldquo;we&rdquo;, &ldquo;our&rdquo;, or &ldquo;us&rdquo;) collects,
 				uses, and protects information when you use <strong>DevPass</strong>,
 				our flat-rate subscription for AI coding tools, available at{" "}
-				<a href="https://code.llmgateway.io">code.llmgateway.io</a>.
+				<a href="https://devpass.llmgateway.io">devpass.llmgateway.io</a>.
 			</p>
 			<hr />
 			<h2>1. Information We Collect</h2>
@@ -192,8 +192,8 @@ export default function PrivacyPage() {
 			<p>
 				We may update this Policy from time to time. The latest version is
 				always available at{" "}
-				<a href="https://code.llmgateway.io/legal/privacy">
-					code.llmgateway.io/legal/privacy
+				<a href="https://devpass.llmgateway.io/legal/privacy">
+					devpass.llmgateway.io/legal/privacy
 				</a>
 				. Material changes will be communicated by email or in-app notice.
 			</p>

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -22,9 +22,9 @@ export default function TermsPage() {
 				<strong>LLM Gateway</strong> (&ldquo;we&rdquo;, &ldquo;our&rdquo;, or
 				&ldquo;us&rdquo;). These Terms of Use (&ldquo;Terms&rdquo;) govern your
 				access to and use of DevPass, including the website at{" "}
-				<a href="https://code.llmgateway.io">code.llmgateway.io</a>, the DevPass
-				dashboard, related APIs, SDKs, and any DevPass-branded products or
-				services (collectively, the &ldquo;Service&rdquo;).
+				<a href="https://devpass.llmgateway.io">devpass.llmgateway.io</a>, the
+				DevPass dashboard, related APIs, SDKs, and any DevPass-branded products
+				or services (collectively, the &ldquo;Service&rdquo;).
 			</p>
 			<p>
 				By accessing or using the Service, you agree to be bound by these Terms.
@@ -205,8 +205,8 @@ export default function TermsPage() {
 			<p>
 				We may update these Terms from time to time. The latest version will
 				always be available at{" "}
-				<a href="https://code.llmgateway.io/legal/terms">
-					code.llmgateway.io/legal/terms
+				<a href="https://devpass.llmgateway.io/legal/terms">
+					devpass.llmgateway.io/legal/terms
 				</a>
 				. Material changes will be communicated by email or in-app notice.
 				Continued use after changes constitutes acceptance of the updated Terms.

--- a/apps/code/src/app/robots.ts
+++ b/apps/code/src/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
 				disallow: ["/dashboard/", "/login", "/signup", "/api/"],
 			},
 		],
-		sitemap: "https://code.llmgateway.io/sitemap.xml",
+		sitemap: "https://devpass.llmgateway.io/sitemap.xml",
 	};
 }

--- a/apps/code/src/app/sitemap.ts
+++ b/apps/code/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const baseUrl = "https://code.llmgateway.io";
+	const baseUrl = "https://devpass.llmgateway.io";
 
 	return [
 		{

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1466,7 +1466,7 @@ chat.openapi(completions, async (c) => {
 	) {
 		if (!isCodingModel(modelInfo)) {
 			throw new HTTPException(403, {
-				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
+				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at devpass.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
 			});
 		}
 	}

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -42,12 +42,12 @@ const nextConfig: NextConfig = {
 			},
 			{
 				source: "/code",
-				destination: "https://code.llmgateway.io",
+				destination: "https://devpass.llmgateway.io",
 				permanent: true,
 			},
 			{
 				source: "/devpass",
-				destination: "https://code.llmgateway.io",
+				destination: "https://devpass.llmgateway.io",
 				permanent: true,
 			},
 			{

--- a/apps/ui/src/components/integrations/integration-cards.tsx
+++ b/apps/ui/src/components/integrations/integration-cards.tsx
@@ -109,7 +109,7 @@ const integrations: Integration[] = [
 function DevPlansCta() {
 	return (
 		<a
-			href="https://code.llmgateway.io"
+			href="https://devpass.llmgateway.io"
 			target="_blank"
 			rel="noopener noreferrer"
 			className="group relative mb-10 block overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-background via-background to-muted/40 transition-all duration-500 hover:border-foreground/20 hover:shadow-[0_0_40px_-12px_rgba(0,0,0,0.15)] dark:hover:shadow-[0_0_40px_-12px_rgba(255,255,255,0.06)]"

--- a/apps/ui/src/components/landing/footer.tsx
+++ b/apps/ui/src/components/landing/footer.tsx
@@ -116,7 +116,7 @@ export default function Footer() {
 								</li>
 								<li>
 									<a
-										href="https://code.llmgateway.io"
+										href="https://devpass.llmgateway.io"
 										target="_blank"
 										rel="noopener noreferrer"
 										className="text-sm hover:underline underline-offset-4 hover:text-foreground"

--- a/apps/ui/src/components/landing/navbar.tsx
+++ b/apps/ui/src/components/landing/navbar.tsx
@@ -154,7 +154,7 @@ export const Navbar = ({
 		},
 		{
 			title: "DevPass",
-			href: "https://code.llmgateway.io",
+			href: "https://devpass.llmgateway.io",
 			description:
 				"Fixed-price monthly plans for Claude Code, Cursor, and every coding tool.",
 			icon: Code,

--- a/apps/ui/src/content/changelog/2026-01-29-dev-plans-web-search-minimax.md
+++ b/apps/ui/src/content/changelog/2026-01-29-dev-plans-web-search-minimax.md
@@ -15,7 +15,7 @@ image:
 
 We're launching **Dev Plans** — a new way to plan and execute software projects with AI assistance. Break down complex features into actionable steps, get implementation guidance, and ship faster.
 
-**[Try Dev Plans now](https://code.llmgateway.io)** — we're looking for early feedback to shape the product.
+**[Try Dev Plans now](https://devpass.llmgateway.io)** — we're looking for early feedback to shape the product.
 
 ### What you can do
 
@@ -177,7 +177,7 @@ Eight new models from ByteDance including GPT-OSS-120B variants. **[View all Byt
 
 ---
 
-**[Try Dev Plans](https://code.llmgateway.io)** — your feedback shapes the product.
+**[Try Dev Plans](https://devpass.llmgateway.io)** — your feedback shapes the product.
 
 **[Explore new models](/models)** — find the right model for your use case.
 

--- a/apps/ui/src/content/changelog/2026-03-23-video-gen-sessions-and-more.md
+++ b/apps/ui/src/content/changelog/2026-03-23-video-gen-sessions-and-more.md
@@ -67,7 +67,7 @@ New MiniMax M2.7 model mappings added across providers.
 
 ## UI & Platform Improvements
 
-- **[Redesigned Code app](https://code.llmgateway.io)** — Fresh look for the dev plans and coding tools dashboard
+- **[Redesigned Code app](https://devpass.llmgateway.io)** — Fresh look for the dev plans and coding tools dashboard
 - **Revamped admin dashboard** — Improved performance on models, mappings, and providers pages
 - **[Cost simulator](/cost-simulator) revamp** — Updated cost simulator with better navigation
 - **Activity log filters** — Improved filtering in activity logs


### PR DESCRIPTION
## Summary

- Replaces every reference to \`code.llmgateway.io\` with \`devpass.llmgateway.io\` across the repo (16 files): \`apps/code\` site metadata, sitemap, robots, legal pages; landing/footer/navbar links and integration card; API/gateway error messages; \`.env\` examples; and two changelog entries.

## Test plan

- [ ] \`apps/code\` builds; \`/sitemap.xml\` and \`/robots.txt\` point to \`devpass.llmgateway.io\`.
- [ ] Landing footer, navbar, and integration card links open the new domain.
- [ ] API/gateway error messages mention \`devpass.llmgateway.io\` for personal-org subscription, deletion, and coding-plan model errors.
- [ ] \`/code\` and \`/devpass\` redirects on \`apps/ui\` resolve to the new host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all application domain references from `code.llmgateway.io` to `devpass.llmgateway.io`, including external links, error messages, metadata, SEO configuration, and redirects across the platform to reflect the domain migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->