### PR TITLE
fix(api): reject provider keys with non-ASCII chars

### DIFF
--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -130,6 +130,22 @@ describe("provider keys route", () => {
 		expect(providerKey?.provider).toBe("inference.net");
 	});
 
+	test("POST /keys/provider rejects token with non-ASCII characters", async () => {
+		const res = await app.request("/keys/provider", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({
+				provider: "openai",
+				token: "sk-realprefix••••••••",
+				organizationId: "test-org-id",
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
 	test("POST /keys/provider with invalid provider", async () => {
 		const res = await app.request("/keys/provider", {
 			method: "POST",

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -51,7 +51,13 @@ const createProviderKeySchema = z.object({
 			message:
 				"Invalid provider. Must be one of the supported providers or 'custom'.",
 		}),
-	token: z.string().min(1, "API key is required"),
+	token: z
+		.string()
+		.min(1, "API key is required")
+		.regex(
+			/^[\x21-\x7E]+$/,
+			"API key contains invalid characters. Make sure you copied the actual key, not a masked version.",
+		),
 	name: z
 		.string()
 		.regex(/^[a-z]+$/, "Name must contain only lowercase letters a-z")


### PR DESCRIPTION
## Summary

A user pasted a masked API key (the dashboard displays the key as the first 12 chars followed by U+2022 bullets) into the create-provider-key form. The bullet character (code 8226) is outside the ByteString range, so when the validation flow built an `Authorization: Bearer …` header from it, `fetch` threw:

```
TypeError: Cannot convert argument to a ByteString because the character at index 19 has a value of 8226 which is greater than 255.
```

The exception was caught by `validateProviderKey`'s outer `try/catch` and surfaced as an opaque internal error in logs (seen for `zai`/`glm-4-32b-0414-128k`, but the bug is provider-agnostic).

Fix: validate at the Zod schema level that the submitted token contains only printable ASCII (`\x21-\x7E`). Real provider keys are always alphanumeric/dashes/underscores, and this gives the user a clear 400 with a helpful message instead of a confusing internal error.

## Test plan

- [x] Added `POST /keys/provider rejects token with non-ASCII characters` unit test
- [x] `pnpm test:unit -- keys-provider.spec` — all 12 tests pass
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced provider token validation to ensure tokens contain only standard ASCII characters. The API now responds with an HTTP 400 error when non-ASCII characters are submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->