### PR TITLE
feat(billing): raise credit top-up minimum to $10

### DIFF
--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -41,7 +41,10 @@ export const payments = new OpenAPIHono<ServerTypes>();
 const creditTopUpAmountSchema = z
 	.number()
 	.int()
-	.min(CREDIT_TOP_UP_MIN_AMOUNT, "Minimum top-up amount is $5.")
+	.min(
+		CREDIT_TOP_UP_MIN_AMOUNT,
+		`Minimum top-up amount is $${CREDIT_TOP_UP_MIN_AMOUNT}.`,
+	)
 	.max(CREDIT_TOP_UP_MAX_AMOUNT, "Maximum top-up amount is $5000.");
 
 export async function isInternationalPaymentMethod(

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -329,7 +329,7 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 ```
 
 <Callout type="success">
-	Adding even a small amount of credits to your account (e.g., $5) will
+	Adding even a small amount of credits to your account (e.g., $10) will
 	immediately upgrade your free model rate limits from 5 requests per 10 minutes
 	to 20 requests per minute.
 </Callout>

--- a/apps/docs/content/resources/rate-limits.mdx
+++ b/apps/docs/content/resources/rate-limits.mdx
@@ -91,7 +91,7 @@ To unlock elevated rate limits for free models:
 - Monitor your usage patterns through the dashboard
 
 <Callout type="success">
-	Adding even a small amount of credits to your account (e.g., $5) will
+	Adding even a small amount of credits to your account (e.g., $10) will
 	immediately upgrade your free model rate limits from 5 requests per 10 minutes
 	to 20 requests per minute.
 </Callout>

--- a/packages/shared/src/fees.ts
+++ b/packages/shared/src/fees.ts
@@ -10,7 +10,7 @@ export interface FeeCalculationInput {
 	isInternational?: boolean;
 }
 
-export const CREDIT_TOP_UP_MIN_AMOUNT = 5;
+export const CREDIT_TOP_UP_MIN_AMOUNT = 10;
 export const CREDIT_TOP_UP_MAX_AMOUNT = 5000;
 
 export const AUTO_TOP_UP_DEFAULT_THRESHOLD = 5;


### PR DESCRIPTION
## Summary
- Raises the manual credit top-up minimum from `$5` to `$10` via `CREDIT_TOP_UP_MIN_AMOUNT` in `packages/shared/src/fees.ts`.
- Updates the API validation error message in `apps/api/src/routes/payments.ts` to render the constant instead of a hard-coded `$5`.
- Updates the rate-limit / routing docs callouts that suggested adding `$5` of credits to instead suggest `$10`.

Auto top-up settings are intentionally left unchanged.

## Test plan
- [ ] `pnpm format` clean
- [ ] Manual: top-up dialog rejects `$5`, accepts `$10`
- [ ] Manual: API `/payments/create-payment-intent` rejects `amount: 5` with the new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Product Updates**
  * Minimum credit top-up amount increased to $10 (from $5). Payment validation will now enforce the new minimum threshold across all credit top-up transactions.

* **Documentation**
  * Updated rate limits and routing guides to reflect the new minimum credit top-up requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->