### PR TITLE
fix: include provider name in upstream error messages

### DIFF
--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -240,7 +240,7 @@ keysProvider.openapi(create, async (c) => {
 			? ` using model ${validationResult.model}`
 			: "";
 		throw new HTTPException(400, {
-			message: `Error from provider: ${errorMessage}${statusPart}${modelPart}. Please try again later or contact support.`,
+			message: `Error from provider ${provider}: ${errorMessage}${statusPart}${modelPart}. Please try again later or contact support.`,
 		});
 	}
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -5216,7 +5216,7 @@ chat.openapi(completions, async (c) => {
 									// If we can't parse the original error, fall back to our format
 									errorData = {
 										error: {
-											message: `Error from provider: ${res.status} ${res.statusText} ${errorResponseText}`,
+											message: `Error from provider ${usedProvider}: ${res.status} ${res.statusText} ${errorResponseText}`,
 											type: finishReason,
 											param: null,
 											code: finishReason,
@@ -5227,7 +5227,7 @@ chat.openapi(completions, async (c) => {
 							} else {
 								errorData = {
 									error: {
-										message: `Error from provider: ${res.status} ${res.statusText} ${errorResponseText}`,
+										message: `Error from provider ${usedProvider}: ${res.status} ${res.statusText} ${errorResponseText}`,
 										type: finishReason,
 										param: null,
 										code: finishReason,
@@ -8655,7 +8655,7 @@ chat.openapi(completions, async (c) => {
 			return c.json(
 				{
 					error: {
-						message: `Error from provider: ${res.status} ${res.statusText} ${errorResponseText}`,
+						message: `Error from provider ${usedProvider}: ${res.status} ${res.statusText} ${errorResponseText}`,
 						type: finishReason,
 						param: null,
 						code: finishReason,


### PR DESCRIPTION
## Summary
- Append the used provider name to "Error from provider:" messages in the gateway chat error responses and the provider key validation route, so users can immediately tell which provider produced the upstream error.

## Test plan
- [ ] Trigger an upstream provider error via the gateway and confirm the response message reads `Error from provider <provider>: ...`
- [ ] Submit an invalid provider key and confirm the validation error includes the provider name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages across API and gateway services to display the specific upstream provider name instead of generic error prefixes. When API key validation or chat communication failures occur, the error responses now include the specific provider identifier, enabling faster identification and troubleshooting of provider-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->