### PR TITLE
feat(logs): include org, project, api key names into activity log

### DIFF
--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -177,6 +177,9 @@ describe("logs route", () => {
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
+			expect(json.logs[0].organizationName).toBe("Test Organization");
+			expect(json.logs[0].projectName).toBe("Test Project");
+			expect(json.logs[0].apiKeyName).toBe("Test API Key");
 			expect(json.logs[0].gatewayContentFilterResponse).toEqual([
 				{
 					id: "modr-test-log-id-1",
@@ -206,6 +209,9 @@ describe("logs route", () => {
 
 			expect(res.status).toBe(200);
 			const json = await res.json();
+			expect(json.log.organizationName).toBe("Test Organization");
+			expect(json.log.projectName).toBe("Test Project");
+			expect(json.log.apiKeyName).toBe("Test API Key");
 			expect(json.log.gatewayContentFilterResponse).toEqual([
 				{
 					id: "modr-test-log-id-1",

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -12,6 +12,7 @@ import {
 	eq,
 	errorDetails,
 	gatewayContentFilterResponseSchema,
+	getTableColumns,
 	gt,
 	gte,
 	type InferSelectModel,
@@ -32,6 +33,13 @@ import type { ServerTypes } from "@/vars.js";
 export const logs = new OpenAPIHono<ServerTypes>();
 
 type LogRecord = InferSelectModel<typeof tables.log>;
+
+const logSelection = {
+	...getTableColumns(tables.log),
+	organizationName: tables.organization.name,
+	projectName: tables.project.name,
+	apiKeyName: tables.apiKey.description,
+};
 
 async function enrichLogsWithVideoContentUrls<T extends LogRecord>(
 	logEntries: T[],
@@ -57,8 +65,11 @@ const logSchema = z.object({
 	createdAt: z.date(),
 	updatedAt: z.date(),
 	organizationId: z.string(),
+	organizationName: z.string().nullable().optional(),
 	projectId: z.string(),
+	projectName: z.string().nullable().optional(),
 	apiKeyId: z.string(),
+	apiKeyName: z.string().nullable().optional(),
 	duration: z.number(),
 	requestedModel: z.string(),
 	requestedProvider: z.string().nullable(),
@@ -569,7 +580,15 @@ logs.openapi(get, async (c) => {
 			: [desc(tables.log.createdAt), desc(tables.log.id)];
 
 	// Execute the query using select
-	let dbQuery = db.select().from(tables.log);
+	let dbQuery = db
+		.select(logSelection)
+		.from(tables.log)
+		.leftJoin(
+			tables.organization,
+			eq(tables.log.organizationId, tables.organization.id),
+		)
+		.leftJoin(tables.project, eq(tables.log.projectId, tables.project.id))
+		.leftJoin(tables.apiKey, eq(tables.log.apiKeyId, tables.apiKey.id));
 
 	if (finalWhereClause) {
 		// @ts-ignore
@@ -779,9 +798,17 @@ logs.openapi(getById, async (c) => {
 
 	const { id } = c.req.valid("param");
 
-	const log = await db.query.log.findFirst({
-		where: { id },
-	});
+	const [log] = await db
+		.select(logSelection)
+		.from(tables.log)
+		.leftJoin(
+			tables.organization,
+			eq(tables.log.organizationId, tables.organization.id),
+		)
+		.leftJoin(tables.project, eq(tables.log.projectId, tables.project.id))
+		.leftJoin(tables.apiKey, eq(tables.log.apiKeyId, tables.apiKey.id))
+		.where(eq(tables.log.id, id))
+		.limit(1);
 
 	if (!log) {
 		throw new HTTPException(404, { message: "Log not found" });

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -884,8 +884,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;
@@ -1129,8 +1132,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -884,8 +884,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;
@@ -1129,8 +1132,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -38,6 +38,12 @@ import { cn } from "@/lib/utils";
 import type { LogDetailData } from "@/types/activity";
 import type { Log } from "@llmgateway/db";
 
+type LogWithResources = Log & {
+	organizationName?: string | null;
+	projectName?: string | null;
+	apiKeyName?: string | null;
+};
+
 interface ImageConfig {
 	aspect_ratio?: string;
 	image_size?: string;
@@ -55,11 +61,13 @@ interface LogDetailClientProps {
 	logId: string;
 }
 
-function CopyButton({ value }: { value: string }) {
+function CopyButton({ value, label }: { value: string; label: string }) {
 	const [copied, setCopied] = useState(false);
 	return (
 		<button
 			type="button"
+			aria-label={label}
+			title={label}
 			onClick={() => {
 				void navigator.clipboard.writeText(value);
 				setCopied(true);
@@ -69,6 +77,30 @@ function CopyButton({ value }: { value: string }) {
 		>
 			{copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
 		</button>
+	);
+}
+
+function RelatedResourceValue({
+	id,
+	name,
+	copyLabel,
+}: {
+	id: string;
+	name?: string | null;
+	copyLabel: string;
+}) {
+	const displayName = name?.trim();
+
+	return (
+		<span className="min-w-0 space-y-0.5 text-right">
+			{displayName && <span className="block break-words">{displayName}</span>}
+			<span className="flex min-w-0 items-center justify-end gap-1.5 font-mono text-xs text-muted-foreground break-all">
+				<span className="min-w-0 break-all">
+					{displayName ? `ID: ${id}` : id}
+				</span>
+				<CopyButton value={id} label={copyLabel} />
+			</span>
+		</span>
 	);
 }
 
@@ -343,7 +375,7 @@ export function LogDetailClient({
 			? new Date(data.log.lastVideoDownloadedAt)
 			: null,
 		videoDownloadCount: data.log.videoDownloadCount ?? 0,
-	} as Log;
+	} as LogWithResources;
 
 	const imageConfig = (log.params as { image_config?: ImageConfig } | null)
 		?.image_config;
@@ -916,7 +948,10 @@ export function LogDetailClient({
 									value={
 										<span className="inline-flex items-center gap-2">
 											<span className="font-mono text-xs">{log.requestId}</span>
-											<CopyButton value={log.requestId} />
+											<CopyButton
+												value={log.requestId}
+												label="Copy request ID"
+											/>
 										</span>
 									}
 								/>
@@ -925,20 +960,28 @@ export function LogDetailClient({
 									value={
 										<span className="inline-flex items-center gap-2">
 											<span className="font-mono text-xs">{log.id}</span>
-											<CopyButton value={log.id} />
+											<CopyButton value={log.id} label="Copy log ID" />
 										</span>
 									}
 								/>
 								<Field
-									label="Project ID"
+									label="Project"
 									value={
-										<span className="font-mono text-xs">{log.projectId}</span>
+										<RelatedResourceValue
+											id={log.projectId}
+											name={log.projectName}
+											copyLabel="Copy project ID"
+										/>
 									}
 								/>
 								<Field
-									label="API Key ID"
+									label="API Key"
 									value={
-										<span className="font-mono text-xs">{log.apiKeyId}</span>
+										<RelatedResourceValue
+											id={log.apiKeyId}
+											name={log.apiKeyName}
+											copyLabel="Copy API key ID"
+										/>
 									}
 								/>
 								<Field label="Mode" value={log.mode || "?"} />

--- a/apps/ui/src/components/dashboard/log-card.tsx
+++ b/apps/ui/src/components/dashboard/log-card.tsx
@@ -12,6 +12,12 @@ import {
 
 import type { Log } from "@llmgateway/db";
 
+type DashboardLog = Partial<Log> & {
+	organizationName?: string | null;
+	projectName?: string | null;
+	apiKeyName?: string | null;
+};
+
 function NextLink({
 	href,
 	className,
@@ -33,7 +39,7 @@ export function LogCard({
 	orgId,
 	projectId,
 }: {
-	log: Partial<Log>;
+	log: DashboardLog;
 	orgId?: string;
 	projectId?: string;
 }) {
@@ -65,6 +71,7 @@ export function LogCard({
 			getDetailUrl={getDetailUrl}
 			getRetriedUrl={getRetriedUrl}
 			renderLink={NextLink}
+			showCopyButtons
 			isUserFacing
 			fetchImageContent={fetchImageContent}
 		/>

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -884,8 +884,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;
@@ -1129,8 +1132,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -884,8 +884,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;
@@ -1129,8 +1132,11 @@ export interface paths {
                                 createdAt: string;
                                 updatedAt: string;
                                 organizationId: string;
+                                organizationName?: string | null;
                                 projectId: string;
+                                projectName?: string | null;
                                 apiKeyId: string;
+                                apiKeyName?: string | null;
                                 duration: number;
                                 requestedModel: string;
                                 requestedProvider: string | null;

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -5,6 +5,7 @@ import {
 	AlertCircle,
 	AudioWaveform,
 	Ban,
+	Check,
 	CheckCircle2,
 	ChevronDown,
 	ChevronUp,
@@ -147,8 +148,11 @@ export interface LogCardData {
 	createdAt: string | Date;
 	requestId?: string | null;
 	projectId?: string | null;
+	projectName?: string | null;
 	organizationId?: string | null;
+	organizationName?: string | null;
 	apiKeyId?: string | null;
+	apiKeyName?: string | null;
 	source?: string | null;
 	mode?: string | null;
 	usedMode?: string | null;
@@ -214,6 +218,70 @@ function formatApiKeyHash(hash: string) {
 
 function copyToClipboard(text: string) {
 	void navigator.clipboard.writeText(text);
+}
+
+function CopyMetadataButton({
+	value,
+	label,
+}: {
+	value: string;
+	label: string;
+}) {
+	const [copied, setCopied] = useState(false);
+
+	return (
+		<button
+			type="button"
+			aria-label={label}
+			title={copied ? "Copied" : label}
+			className="text-muted-foreground hover:text-foreground"
+			onClick={() => {
+				copyToClipboard(value);
+				setCopied(true);
+				setTimeout(() => setCopied(false), 1500);
+			}}
+		>
+			{copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+		</button>
+	);
+}
+
+function RelatedResourceValue({
+	id,
+	name,
+	copyLabel,
+	showCopyButton,
+}: {
+	id?: string | null;
+	name?: string | null;
+	copyLabel: string;
+	showCopyButton: boolean;
+}) {
+	if (!id) {
+		return <span className="text-muted-foreground">—</span>;
+	}
+
+	const displayName = name?.trim();
+
+	return (
+		<span className="min-w-0 space-y-0.5 break-all">
+			{displayName && <span className="block break-words">{displayName}</span>}
+			<span className="flex min-w-0 items-center gap-1.5 font-mono text-xs text-muted-foreground break-all">
+				<span className="min-w-0 break-all">
+					{displayName ? `ID: ${id}` : id}
+				</span>
+				{showCopyButton && <CopyMetadataButton value={id} label={copyLabel} />}
+			</span>
+		</span>
+	);
+}
+
+function PlainIdValue({ id }: { id?: string | null }) {
+	return (
+		<span className="min-w-0 space-y-0.5">
+			<span className="block font-mono text-xs break-all">{id ?? "—"}</span>
+		</span>
+	);
 }
 
 function renderParams(obj: Record<string, any>, depth = 0): React.ReactNode {
@@ -514,13 +582,9 @@ export function LogCard({
 							<h4 className="text-sm font-medium">Request Details</h4>
 							<div className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm">
 								<div className="text-muted-foreground">Project ID</div>
-								<div className="font-mono text-xs break-all">
-									{log.projectId}
-								</div>
+								<PlainIdValue id={log.projectId} />
 								<div className="text-muted-foreground">API Key</div>
-								<div className="font-mono text-xs break-all">
-									{log.apiKeyId}
-								</div>
+								<PlainIdValue id={log.apiKeyId} />
 								<div className="text-muted-foreground">Requested Model</div>
 								<div className="font-mono text-xs break-all">
 									{log.requestedModel}
@@ -955,12 +1019,10 @@ export function LogCard({
 								<div className="flex items-center gap-1 font-mono text-xs break-all">
 									<span>{log.requestId ?? "—"}</span>
 									{showCopyButtons && log.requestId && (
-										<button
-											className="text-muted-foreground hover:text-foreground"
-											onClick={() => copyToClipboard(log.requestId!)}
-										>
-											<Copy className="h-3 w-3" />
-										</button>
+										<CopyMetadataButton
+											value={log.requestId}
+											label="Copy request ID"
+										/>
 									)}
 								</div>
 								{showLogId && (
@@ -969,12 +1031,10 @@ export function LogCard({
 										<div className="flex items-center gap-1 font-mono text-xs break-all">
 											<span>{log.id}</span>
 											{showCopyButtons && (
-												<button
-													className="text-muted-foreground hover:text-foreground"
-													onClick={() => copyToClipboard(log.id)}
-												>
-													<Copy className="h-3 w-3" />
-												</button>
+												<CopyMetadataButton
+													value={log.id}
+													label="Copy log ID"
+												/>
 											)}
 										</div>
 									</>
@@ -983,42 +1043,27 @@ export function LogCard({
 								<div className="font-mono text-xs break-all">
 									{log.source ?? "-"}
 								</div>
-								<div className="text-muted-foreground">Project ID</div>
-								<div className="flex items-center gap-1 font-mono text-xs break-all">
-									<span>{log.projectId}</span>
-									{showCopyButtons && log.projectId && (
-										<button
-											className="text-muted-foreground hover:text-foreground"
-											onClick={() => copyToClipboard(log.projectId!)}
-										>
-											<Copy className="h-3 w-3" />
-										</button>
-									)}
-								</div>
-								<div className="text-muted-foreground">Organization ID</div>
-								<div className="flex items-center gap-1 font-mono text-xs break-all">
-									<span>{log.organizationId}</span>
-									{showCopyButtons && log.organizationId && (
-										<button
-											className="text-muted-foreground hover:text-foreground"
-											onClick={() => copyToClipboard(log.organizationId!)}
-										>
-											<Copy className="h-3 w-3" />
-										</button>
-									)}
-								</div>
-								<div className="text-muted-foreground">API Key ID</div>
-								<div className="flex items-center gap-1 font-mono text-xs break-all">
-									<span>{log.apiKeyId}</span>
-									{showCopyButtons && log.apiKeyId && (
-										<button
-											className="text-muted-foreground hover:text-foreground"
-											onClick={() => copyToClipboard(log.apiKeyId!)}
-										>
-											<Copy className="h-3 w-3" />
-										</button>
-									)}
-								</div>
+								<div className="text-muted-foreground">Project</div>
+								<RelatedResourceValue
+									id={log.projectId}
+									name={log.projectName}
+									copyLabel="Copy project ID"
+									showCopyButton={showCopyButtons}
+								/>
+								<div className="text-muted-foreground">Organization</div>
+								<RelatedResourceValue
+									id={log.organizationId}
+									name={log.organizationName}
+									copyLabel="Copy organization ID"
+									showCopyButton={showCopyButtons}
+								/>
+								<div className="text-muted-foreground">API Key</div>
+								<RelatedResourceValue
+									id={log.apiKeyId}
+									name={log.apiKeyName}
+									copyLabel="Copy API key ID"
+									showCopyButton={showCopyButtons}
+								/>
 								<div className="text-muted-foreground">Mode</div>
 								<div>{log.mode ?? "?"}</div>
 								<div className="text-muted-foreground">Used Mode</div>


### PR DESCRIPTION
## Summary

- API `/logs` and `/logs/{id}` now return `organizationName`, `projectName`, and `apiKeyName` alongside their IDs, resolved via `leftJoin` against the `organization`, `project`, and `apiKey` tables (one round trip, matches the join pattern as in [`apps/api/src/routes/admin.ts`](https://github.com/theopenco/llmgateway/blob/main/apps/api/src/routes/admin.ts#L1294-L1311).

- The shared `LogCard` shows resolved names next to each ID and a copy-to-clipboard control so users can copy the raw ID without selecting text.

# Before
<img width="823" height="313" alt="Image" src="https://github.com/user-attachments/assets/f7a1cddc-60c1-4d56-8740-66253c525b53" />

# After 
<img width="733" height="350" alt="image" src="https://github.com/user-attachments/assets/e9640efe-b380-40ba-bdac-56e7a8091d89" />


Fixes #1864 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log entries now display friendly names for organizations, projects, and API keys alongside identifiers for improved readability.

* **UI/UX Improvements**
  * Enhanced metadata display in log detail pages and log cards with improved copy functionality for IDs and resource names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->