### PR TITLE
fix(moonshot): strip temperature for kimi-k2.6

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -363,6 +363,12 @@ export const moonshotModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+				supportedParameters: [
+					"max_tokens",
+					"response_format",
+					"tools",
+					"tool_choice",
+				],
 			},
 			{
 				providerId: "canopywave",


### PR DESCRIPTION
## Summary
- Moonshot's `kimi-k2.6` rejects any temperature other than `1` (`invalid temperature: only 1 is allowed for this model`).
- Add `supportedParameters` to the moonshot provider mapping so temperature (and other unsupported params) get stripped before forwarding, matching the existing `kimi-k2.5` setup.

## Test plan
- [ ] Send a chat request to `moonshot/kimi-k2.6` with a non-`1` temperature and confirm it no longer 400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced parameter support for the kimi-k2.6 model, enabling configuration of token limits, response formatting, and tool usage options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->