### PR TITLE
fix(gateway): fall back across providers on 401/403

### DIFF
--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -19,9 +19,12 @@ describe("isRetryableErrorType", () => {
 		expect(isRetryableErrorType("upstream_timeout")).toBe(true);
 	});
 
+	it("retries on gateway errors (e.g. 401/403 from provider)", () => {
+		expect(isRetryableErrorType("gateway_error")).toBe(true);
+	});
+
 	it("does not retry on non-retryable error types", () => {
 		expect(isRetryableErrorType("client_error")).toBe(false);
-		expect(isRetryableErrorType("gateway_error")).toBe(false);
 		expect(isRetryableErrorType("content_filter")).toBe(false);
 	});
 });
@@ -57,8 +60,14 @@ describe("shouldRetryRequest", () => {
 			shouldRetryRequest({ ...defaultOpts, errorType: "client_error" }),
 		).toBe(false);
 		expect(
-			shouldRetryRequest({ ...defaultOpts, errorType: "gateway_error" }),
+			shouldRetryRequest({ ...defaultOpts, errorType: "content_filter" }),
 		).toBe(false);
+	});
+
+	it("retries on gateway errors so auto-route can fall back over 401/403", () => {
+		expect(
+			shouldRetryRequest({ ...defaultOpts, errorType: "gateway_error" }),
+		).toBe(true);
 	});
 
 	it("does not retry when max retries exceeded", () => {

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -257,6 +257,11 @@ describe("getErrorType", () => {
 		expect(getErrorType(503)).toBe("upstream_error");
 	});
 
+	it("returns gateway_error for 401/403 auth status codes", () => {
+		expect(getErrorType(401)).toBe("gateway_error");
+		expect(getErrorType(403)).toBe("gateway_error");
+	});
+
 	it("returns upstream_error for other status codes", () => {
 		expect(getErrorType(400)).toBe("upstream_error");
 		expect(getErrorType(404)).toBe("upstream_error");

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -4,7 +4,8 @@ export type RetryableErrorType =
 	| "network_error"
 	| "provider_error"
 	| "upstream_error"
-	| "upstream_timeout";
+	| "upstream_timeout"
+	| "gateway_error";
 
 export interface RoutingAttempt {
 	provider: string;
@@ -27,7 +28,8 @@ export function isRetryableErrorType(errorType: string): boolean {
 		errorType === "network_error" ||
 		errorType === "provider_error" ||
 		errorType === "upstream_error" ||
-		errorType === "upstream_timeout"
+		errorType === "upstream_timeout" ||
+		errorType === "gateway_error"
 	);
 }
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -125,5 +125,8 @@ export function getErrorType(statusCode: number): string {
 	if (statusCode === 429) {
 		return "rate_limited";
 	}
+	if (statusCode === 401 || statusCode === 403) {
+		return "gateway_error";
+	}
 	return "upstream_error";
 }

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -1935,43 +1935,6 @@ describe("fallback and error status code handling", () => {
 			expect(json).toHaveProperty("error");
 		});
 
-		test("non-streaming: retries on 401 across providers and surfaces gateway_error when all fail", async () => {
-			await setupMultiProviderKeys();
-
-			const res = await app.request("/v1/chat/completions", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
-				},
-				body: JSON.stringify({
-					model: "glm-4.7",
-					messages: [{ role: "user", content: "TRIGGER_STATUS_401" }],
-				}),
-			});
-
-			// All configured providers return 401, so the request still fails
-			// but should now show retry attempts in the routing metadata.
-			expect(res.status).toBe(500);
-			const json = await res.json();
-			expect(json).toHaveProperty("error");
-			expect(json.error.type).toBe("gateway_error");
-
-			const logs = await waitForLogs(2);
-			expect(logs.length).toBeGreaterThanOrEqual(2);
-
-			const finalLog = logs.find(
-				(l: Log) => (l.routingMetadata?.routing?.length ?? 0) >= 2,
-			);
-			expect(finalLog).toBeDefined();
-			expect(finalLog!.hasError).toBe(true);
-			expect(finalLog!.finishReason).toBe("gateway_error");
-			expect(finalLog!.routingMetadata!.routing![0]).toHaveProperty(
-				"status_code",
-				401,
-			);
-		});
-
 		test("non-streaming: retries on 403 and succeeds on fallback provider", async () => {
 			await setupMultiProviderKeys();
 

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -1935,7 +1935,7 @@ describe("fallback and error status code handling", () => {
 			expect(json).toHaveProperty("error");
 		});
 
-		test("non-streaming: does not retry on non-retryable 401 error", async () => {
+		test("non-streaming: retries on 401 across providers and surfaces gateway_error when all fail", async () => {
 			await setupMultiProviderKeys();
 
 			const res = await app.request("/v1/chat/completions", {
@@ -1950,16 +1950,59 @@ describe("fallback and error status code handling", () => {
 				}),
 			});
 
-			// 401 is not retryable, so the gateway should return the error
+			// All configured providers return 401, so the request still fails
+			// but should now show retry attempts in the routing metadata.
 			expect(res.status).toBe(500);
 			const json = await res.json();
 			expect(json).toHaveProperty("error");
 			expect(json.error.type).toBe("gateway_error");
 
-			const logs = await waitForLogs(1);
-			const log = logs[0];
-			expect(log.finishReason).toBe("gateway_error");
-			expect(log.hasError).toBe(true);
+			const logs = await waitForLogs(2);
+			expect(logs.length).toBeGreaterThanOrEqual(2);
+
+			const finalLog = logs.find(
+				(l: Log) => (l.routingMetadata?.routing?.length ?? 0) >= 2,
+			);
+			expect(finalLog).toBeDefined();
+			expect(finalLog!.hasError).toBe(true);
+			expect(finalLog!.finishReason).toBe("gateway_error");
+			expect(finalLog!.routingMetadata!.routing![0]).toHaveProperty(
+				"status_code",
+				401,
+			);
+		});
+
+		test("non-streaming: retries on 403 and succeeds on fallback provider", async () => {
+			await setupMultiProviderKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "glm-4.7",
+					messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE_403 hello" }],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+
+			expect(json).toHaveProperty(["choices", 0, "message", "content"]);
+			expect(json.metadata.routing).toBeDefined();
+			expect(json.metadata.routing.length).toBeGreaterThanOrEqual(2);
+			expect(json.metadata.routing[0]).toMatchObject({
+				status_code: 403,
+				error_type: "gateway_error",
+				succeeded: false,
+			});
+			expect(
+				json.metadata.routing[json.metadata.routing.length - 1],
+			).toMatchObject({
+				succeeded: true,
+			});
 		});
 
 		test("non-streaming: retries on 404 and succeeds on fallback provider", async () => {

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -750,7 +750,9 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		return c.json(statusTrigger.errorResponse);
 	}
 
-	// Check if this request should fail on the first attempt but succeed on retry
+	// Check if this request should fail on the first attempt but succeed on retry.
+	// These triggers are mutually exclusive — TRIGGER_FAIL_ONCE_404/_403 are
+	// substrings of the generic TRIGGER_FAIL_ONCE, so order specific → generic.
 	if (userMessage.includes("TRIGGER_FAIL_ONCE_404")) {
 		failOnceCounter++;
 		if (failOnceCounter === 1) {
@@ -765,9 +767,7 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 			});
 		}
 		// Subsequent requests succeed - fall through to normal response
-	}
-
-	if (userMessage.includes("TRIGGER_FAIL_ONCE_403")) {
+	} else if (userMessage.includes("TRIGGER_FAIL_ONCE_403")) {
 		failOnceCounter++;
 		if (failOnceCounter === 1) {
 			c.status(403);
@@ -780,10 +780,7 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 			});
 		}
 		// Subsequent requests succeed - fall through to normal response
-	}
-
-	// Check if this request should fail on the first attempt but succeed on retry
-	if (userMessage.includes("TRIGGER_FAIL_ONCE")) {
+	} else if (userMessage.includes("TRIGGER_FAIL_ONCE")) {
 		failOnceCounter++;
 		if (failOnceCounter === 1) {
 			c.status(500);

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -767,6 +767,21 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		// Subsequent requests succeed - fall through to normal response
 	}
 
+	if (userMessage.includes("TRIGGER_FAIL_ONCE_403")) {
+		failOnceCounter++;
+		if (failOnceCounter === 1) {
+			c.status(403);
+			return c.json({
+				error: {
+					message:
+						"Authentication failed: Please make sure your API Key is valid.",
+					type: "authentication_error",
+				},
+			});
+		}
+		// Subsequent requests succeed - fall through to normal response
+	}
+
 	// Check if this request should fail on the first attempt but succeed on retry
 	if (userMessage.includes("TRIGGER_FAIL_ONCE")) {
 		failOnceCounter++;


### PR DESCRIPTION
## Summary
- Treat `gateway_error` (401/403 from a provider) as a retryable error type so auto-routing falls back to the next cheapest provider instead of returning the upstream auth failure to the caller.
- Existing guards in `shouldRetryRequest` still hold: a request that targets a specific provider, sets `X-No-Fallback`, or hits the `custom`/`llmgateway` provider is not retried.
- Add a `TRIGGER_FAIL_ONCE_403` mock and a fallback success test; rework the prior "401 doesn't retry" assertion to verify it now retries through providers and surfaces `gateway_error` only after exhaustion.

## Test plan
- [x] `pnpm exec vitest run apps/gateway/src/chat/tools/retry-with-fallback.spec.ts apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts`
- [x] `pnpm build:core`
- [ ] Manual: in the playground with auto-route, force aws-bedrock to 403 and confirm the request now succeeds via a fallback provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry logic now treats authentication/gateway failures (401/403) as retryable, allowing automatic fallback to alternate providers and improving success on transient gateway errors.

* **Tests**
  * Added and updated tests covering gateway-error retry behavior, multi-attempt fallback routing, and mock scenarios that simulate transient 401/403 failures to ensure reliable retry/fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->