### PR TITLE
fix(admin): project mapping history chart shows empty

### DIFF
--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -38,10 +38,7 @@ export async function getMappingHistory(
 		"/admin/providers/{providerId}/models/{modelId}/history",
 		{
 			params: {
-				path: {
-					providerId,
-					modelId: encodeURIComponent(modelId),
-				},
+				path: { providerId, modelId },
 				query: { window, ...(projectId ? { projectId } : {}) },
 			},
 		},


### PR DESCRIPTION
## Summary

The expandable history chart on the per-project Model-Provider Mappings page rendered "No data for this time window" even when the row above had non-zero requests/tokens/cost.

Root cause: `getMappingHistory` called `encodeURIComponent(modelId)` before passing it to `openapi-fetch`, which already encodes path params. For project rows, `modelId` is the LLMGateway-formatted `usedModel` (e.g. `aws-bedrock/claude-opus-4-6`), so the `/` got double-encoded (`%2F` → `%252F`). The server decoded once and looked up `aws-bedrock%2Fclaude-opus-4-6`, which never matches `project_hourly_model_stats.used_model`.

The other call sites of `getMappingHistory` (global mappings) pass model IDs without slashes, which is why the bug only shows on the project page.

## Test plan

- [ ] Open `/organizations/<orgId>/projects/<projectId>/model-provider-mappings?window=2d`
- [ ] Expand a row — chart now shows hourly buckets matching the row totals
- [ ] Switch between `1h`/`24h`/`2d`/`7d` and confirm the chart updates
- [ ] Global `/model-provider-mappings/[providerId]/[modelId]` chart still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model identifiers in admin history API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->