### PR TITLE
fix(gateway): map azure 400 prompt filter to content_filter

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -113,6 +113,22 @@ describe("getFinishReasonFromError", () => {
 		).toBe("content_filter");
 	});
 
+	it("returns content_filter for Azure OpenAI prompt content filter", () => {
+		const azurePromptFilterError = JSON.stringify({
+			error: {
+				message:
+					"The response was filtered due to the prompt triggering Microsoft's content management policy. Please modify your prompt and retry.",
+				type: null,
+				param: "prompt",
+				code: "content_filter",
+				status: 400,
+			},
+		});
+		expect(getFinishReasonFromError(400, azurePromptFilterError)).toBe(
+			"content_filter",
+		);
+	});
+
 	it("returns client_error for other 400 errors", () => {
 		expect(getFinishReasonFromError(400, "some other error")).toBe(
 			"client_error",

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -55,6 +55,12 @@ export function getFinishReasonFromError(
 		return "content_filter";
 	}
 
+	// Azure OpenAI prompt-side content filter (distinct from ResponsibleAIPolicyViolation,
+	// which fires on the response side and includes inner_error details)
+	if (errorText?.includes("Microsoft's content management policy")) {
+		return "content_filter";
+	}
+
 	// OpenAI safety system rejection (e.g. gpt-image-2 image generation)
 	if (errorText?.includes("Your request was rejected by the safety system")) {
 		return "content_filter";


### PR DESCRIPTION
## Summary
- Classify Azure OpenAI 400 prompt-side content filter responses (\`Microsoft's content management policy\` / \`code: "content_filter"\`) as \`content_filter\` instead of \`client_error\`.
- This complements the existing \`ResponsibleAIPolicyViolation\` check, which only fires on response-side filtering.

## Test plan
- [x] \`pnpm test:unit get-finish-reason-from-error\` (15/15 passing, including new Azure 400 prompt-filter case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for Azure OpenAI content policy violations to ensure accurate handling.

* **Tests**
  * Added test coverage for Azure OpenAI prompt filter error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->