### PR TITLE
fix(gateway): map mistral error finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -109,6 +109,27 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps Mistral finish reasons correctly", () => {
+		expect(getUnifiedFinishReason("stop", "mistral")).toBe(
+			UnifiedFinishReason.COMPLETED,
+		);
+		expect(getUnifiedFinishReason("length", "mistral")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(getUnifiedFinishReason("model_length", "mistral")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(getUnifiedFinishReason("tool_calls", "mistral")).toBe(
+			UnifiedFinishReason.TOOL_CALLS,
+		);
+		expect(getUnifiedFinishReason("content_filter", "mistral")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+		expect(getUnifiedFinishReason("error", "mistral")).toBe(
+			UnifiedFinishReason.UPSTREAM_ERROR,
+		);
+	});
+
 	it("handles special cases", () => {
 		expect(getUnifiedFinishReason("canceled", "any-provider")).toBe(
 			UnifiedFinishReason.CANCELED,

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -113,6 +113,27 @@ export function getUnifiedFinishReason(
 				return UnifiedFinishReason.UNKNOWN;
 			}
 			break;
+		case "mistral":
+			if (finishReason === "stop") {
+				return UnifiedFinishReason.COMPLETED;
+			}
+			if (
+				finishReason === "length" ||
+				finishReason === "model_length" ||
+				finishReason === "incomplete"
+			) {
+				return UnifiedFinishReason.LENGTH_LIMIT;
+			}
+			if (finishReason === "content_filter") {
+				return UnifiedFinishReason.CONTENT_FILTER;
+			}
+			if (finishReason === "tool_calls") {
+				return UnifiedFinishReason.TOOL_CALLS;
+			}
+			if (finishReason === "error") {
+				return UnifiedFinishReason.UPSTREAM_ERROR;
+			}
+			break;
 		default: // OpenAI format (also used by inference.net and other providers)
 			if (finishReason === "stop") {
 				return UnifiedFinishReason.COMPLETED;


### PR DESCRIPTION
## Summary
- Mistral can return `finish_reason: "error"` for model errors, which previously logged a noisy "Unknown finish reason encountered" error and mapped to `UNKNOWN`.
- Add a Mistral-specific branch in `getUnifiedFinishReason` that maps `error` → `UPSTREAM_ERROR` and also handles Mistral's `model_length` → `LENGTH_LIMIT`.

## Test plan
- [x] `pnpm test:unit` (added Mistral mapping test cases in `logs.spec.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Mistral provider finish reason tracking and standardized mapping.

* **Tests**
  * Added test coverage for Mistral provider finish reason mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->