### PR TITLE
fix(logs): render routing score price without rounding

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -712,9 +712,7 @@ export function LogDetailClient({
 																	</span>
 																)}
 																{score.price !== undefined && (
-																	<span className="ml-2">
-																		${(score.price * 1_000_000).toFixed(2)}/M
-																	</span>
+																	<span className="ml-2">${score.price}</span>
 																)}
 																{score.cacheSupported && (
 																	<span className="ml-2">cache</span>

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -713,7 +713,7 @@ export function LogDetailClient({
 																)}
 																{score.price !== undefined && (
 																	<span className="ml-2">
-																		${score.price.toFixed(10)}
+																		${(score.price * 1_000_000).toFixed(2)}/M
 																	</span>
 																)}
 																{score.cacheSupported && (

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -723,7 +723,7 @@ export function LogCard({
 																	)}
 																	{score.price !== undefined && (
 																		<span className="ml-2">
-																			${score.price.toFixed(6)}
+																			${(score.price * 1_000_000).toFixed(2)}/M
 																		</span>
 																	)}
 																	{score.priority !== undefined &&

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -722,9 +722,7 @@ export function LogCard({
 																		</span>
 																	)}
 																	{score.price !== undefined && (
-																		<span className="ml-2">
-																			${(score.price * 1_000_000).toFixed(2)}/M
-																		</span>
+																		<span className="ml-2">${score.price}</span>
 																	)}
 																	{score.priority !== undefined &&
 																		score.priority !== 1 && (


### PR DESCRIPTION
## Summary
- Routing score price was rendered with `toFixed(6)` / `toFixed(10)`, so very small per-token prices collapsed to `$0.000000`.
- Drop the rounding so the raw value is shown. This works for both per-token and per-request fallback prices (`getProviderSelectionPrice` falls back to `requestPrice`), avoiding a misleading per-million label.

## Test plan
- [ ] Open a log detail view with `routingMetadata.providerScores` populated and confirm the price renders the actual number instead of `$0.000000`.
- [ ] Confirm the same in the shared log card (expanded routing info).

🤖 Generated with [Claude Code](https://claude.com/claude-code)