### PR TITLE
fix(worker): make shutdown promptly cancel inflight work

### DIFF
--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -1,3 +1,5 @@
+import { interruptibleSleep, isStopRequested } from "@/shutdown.js";
+
 import {
 	and,
 	db,
@@ -189,7 +191,7 @@ async function sendAndRecord(
 
 	if (process.env.EMAIL_FOLLOW_UPS === "true") {
 		await sendFollowUpEmail({ to: recipientEmail, subject, text });
-		await new Promise((resolve) => setTimeout(resolve, 1000));
+		await interruptibleSleep(1000);
 	} else {
 		logger.info("Follow-up email (dry run)", {
 			kind: "email_follow_up",
@@ -233,6 +235,9 @@ async function processNoPurchaseEmails(): Promise<void> {
 		);
 
 	for (const { organizationId } of eligibleOrgs) {
+		if (isStopRequested()) {
+			break;
+		}
 		try {
 			const email = await getOrgRecipientEmail(organizationId);
 			if (!email) {
@@ -298,6 +303,9 @@ async function processLowUsageEmails(): Promise<void> {
 	`);
 
 	for (const row of rows.rows) {
+		if (isStopRequested()) {
+			break;
+		}
 		const organizationId = row.organization_id;
 		try {
 			const email = await getOrgRecipientEmail(organizationId);
@@ -372,6 +380,9 @@ async function processNoRepurchaseEmails(): Promise<void> {
 	`);
 
 	for (const row of rows.rows) {
+		if (isStopRequested()) {
+			break;
+		}
 		const organizationId = row.organization_id;
 		try {
 			const email = await getOrgRecipientEmail(organizationId);

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -50,11 +50,27 @@ function fetchWithSignals(
 ): Promise<Response> {
 	const stopSignal = getStopSignal();
 	const timeoutSignal = AbortSignal.timeout(timeoutMs);
-	const signal =
-		typeof AbortSignal.any === "function"
-			? AbortSignal.any([stopSignal, timeoutSignal])
-			: stopSignal;
-	return fetch(url, { ...init, signal });
+	return fetch(url, {
+		...init,
+		signal: AbortSignal.any([stopSignal, timeoutSignal]),
+	});
+}
+
+function isShutdownAbort(error: unknown): boolean {
+	if (!isStopRequested()) {
+		return false;
+	}
+	if (error instanceof Error && error.name === "AbortError") {
+		return true;
+	}
+	if (
+		error instanceof Error &&
+		error.cause instanceof Error &&
+		error.cause.name === "AbortError"
+	) {
+		return true;
+	}
+	return false;
 }
 
 const MAX_WEBHOOK_ATTEMPTS = 8;
@@ -2008,6 +2024,14 @@ export async function processPendingVideoJobs(): Promise<void> {
 				}
 			}
 		} catch (error) {
+			if (isShutdownAbort(error)) {
+				logger.info("Skipping video job poll bookkeeping due to shutdown", {
+					videoJobId: job.id,
+					upstreamId: job.upstreamId,
+				});
+				break;
+			}
+
 			const message = error instanceof Error ? error.message : String(error);
 			logger.error(
 				"Error polling video job",
@@ -2256,6 +2280,17 @@ async function deliverWebhook(
 			});
 		});
 	} catch (error) {
+		if (isShutdownAbort(error)) {
+			logger.info(
+				"Skipping webhook delivery bookkeeping due to shutdown; will retry on next worker run",
+				{
+					videoJobId: job.id,
+					deliveryId: delivery.id,
+				},
+			);
+			return;
+		}
+
 		const message =
 			error instanceof Error ? error.message : "Unknown webhook delivery error";
 

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -1,5 +1,7 @@
 import { createHmac } from "node:crypto";
 
+import { getStopSignal, isStopRequested } from "@/shutdown.js";
+
 import { redisClient } from "@llmgateway/cache";
 import {
 	and,
@@ -37,6 +39,23 @@ import {
 	parseGcsUri,
 } from "@llmgateway/shared/gcs";
 import { buildSignedGatewayVideoLogContentUrl } from "@llmgateway/shared/video-access";
+
+const UPSTREAM_FETCH_TIMEOUT_MS = 30_000;
+const WEBHOOK_DELIVERY_TIMEOUT_MS = 30_000;
+
+function fetchWithSignals(
+	url: string,
+	init: RequestInit,
+	timeoutMs: number,
+): Promise<Response> {
+	const stopSignal = getStopSignal();
+	const timeoutSignal = AbortSignal.timeout(timeoutMs);
+	const signal =
+		typeof AbortSignal.any === "function"
+			? AbortSignal.any([stopSignal, timeoutSignal])
+			: stopSignal;
+	return fetch(url, { ...init, signal });
+}
 
 const MAX_WEBHOOK_ATTEMPTS = 8;
 const WEBHOOK_BASE_DELAY_MS = 30_000;
@@ -1069,7 +1088,7 @@ async function fetchJsonResponse(
 	body: Record<string, unknown>;
 	response: Response;
 }> {
-	const response = await fetch(url, init);
+	const response = await fetchWithSignals(url, init, UPSTREAM_FETCH_TIMEOUT_MS);
 	const text = await response.text();
 
 	let body: Record<string, unknown> = {};
@@ -1813,14 +1832,18 @@ async function fetchUpstreamContentMetadata(
 		providerContext.baseUrl,
 		`/v1/videos/${job.upstreamId}/content`,
 	);
-	const response = await fetch(url, {
-		method: "GET",
-		headers: {
-			Authorization: `Bearer ${providerContext.token}`,
-			Accept: "application/json",
+	const response = await fetchWithSignals(
+		url,
+		{
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${providerContext.token}`,
+				Accept: "application/json",
+			},
+			redirect: "manual",
 		},
-		redirect: "manual",
-	});
+		UPSTREAM_FETCH_TIMEOUT_MS,
+	);
 	const contentType = response.headers.get("Content-Type") ?? "";
 	if (!contentType.toLowerCase().includes("application/json")) {
 		return null;
@@ -1886,6 +1909,9 @@ export async function processPendingVideoJobs(): Promise<void> {
 	const jobsToPoll = await claimDueVideoJobsForPolling(now);
 
 	for (const job of jobsToPoll) {
+		if (isStopRequested()) {
+			break;
+		}
 		try {
 			const upstreamStatus = await fetchUpstreamStatus(job);
 			let enrichedUpstreamStatus = upstreamStatus;
@@ -2079,6 +2105,9 @@ export async function processPendingVideoJobs(): Promise<void> {
 		.limit(25);
 
 	for (const job of terminalJobsToFinalize) {
+		if (isStopRequested()) {
+			break;
+		}
 		try {
 			await finalizeVideoJob(job);
 		} catch (error) {
@@ -2144,12 +2173,16 @@ async function deliverWebhook(
 	const startedAt = new Date();
 
 	try {
-		const response = await fetch(delivery.targetUrl, {
-			method: "POST",
-			headers,
-			body: payload,
-			redirect: "manual",
-		});
+		const response = await fetchWithSignals(
+			delivery.targetUrl,
+			{
+				method: "POST",
+				headers,
+				body: payload,
+				redirect: "manual",
+			},
+			WEBHOOK_DELIVERY_TIMEOUT_MS,
+		);
 		const responseText = (await response.text()).slice(0, 4000);
 
 		if (response.ok) {
@@ -2280,6 +2313,9 @@ export async function processPendingWebhookDeliveries(): Promise<void> {
 		.limit(25);
 
 	for (const delivery of dueDeliveries) {
+		if (isStopRequested()) {
+			break;
+		}
 		const job = await db
 			.select()
 			.from(tables.videoJob)

--- a/apps/worker/src/shutdown.spec.ts
+++ b/apps/worker/src/shutdown.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import {
+	getStopSignal,
+	interruptibleSleep,
+	isStopRequested,
+	requestStop,
+	resetShutdown,
+} from "./shutdown.js";
+
+describe("shutdown", () => {
+	beforeEach(() => {
+		resetShutdown();
+	});
+
+	afterEach(() => {
+		resetShutdown();
+	});
+
+	test("isStopRequested is false initially", () => {
+		expect(isStopRequested()).toBe(false);
+	});
+
+	test("requestStop flips isStopRequested and aborts the signal", () => {
+		const signal = getStopSignal();
+		expect(signal.aborted).toBe(false);
+
+		requestStop();
+
+		expect(isStopRequested()).toBe(true);
+		expect(signal.aborted).toBe(true);
+	});
+
+	test("interruptibleSleep resolves promptly after requestStop", async () => {
+		const start = Date.now();
+		const sleepPromise = interruptibleSleep(60_000);
+
+		setTimeout(() => requestStop(), 20);
+
+		await sleepPromise;
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeLessThan(500);
+	});
+
+	test("interruptibleSleep returns immediately when stop already requested", async () => {
+		requestStop();
+		const start = Date.now();
+		await interruptibleSleep(10_000);
+		expect(Date.now() - start).toBeLessThan(50);
+	});
+
+	test("interruptibleSleep waits for the requested duration when no stop", async () => {
+		const start = Date.now();
+		await interruptibleSleep(120);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+	});
+
+	test("resetShutdown re-enables sleeping and provides a fresh non-aborted signal", async () => {
+		const firstSignal = getStopSignal();
+		requestStop();
+		expect(firstSignal.aborted).toBe(true);
+		expect(isStopRequested()).toBe(true);
+
+		resetShutdown();
+
+		const freshSignal = getStopSignal();
+		expect(freshSignal).not.toBe(firstSignal);
+		expect(freshSignal.aborted).toBe(false);
+		expect(isStopRequested()).toBe(false);
+
+		const start = Date.now();
+		await interruptibleSleep(60);
+		expect(Date.now() - start).toBeGreaterThanOrEqual(50);
+	});
+
+	test("requestStop is idempotent", () => {
+		requestStop();
+		const signal = getStopSignal();
+		expect(signal.aborted).toBe(true);
+		// second call should not throw nor swap the controller
+		requestStop();
+		expect(getStopSignal()).toBe(signal);
+	});
+
+	test("interruptibleSleep clears its timer when stop wakes it", async () => {
+		const sleepPromise = interruptibleSleep(60_000);
+		setTimeout(() => requestStop(), 5);
+		await sleepPromise;
+		// If the timer was not cleared, vitest would hang waiting for it after the test.
+		// Reaching this point confirms the timer was cleared.
+		expect(isStopRequested()).toBe(true);
+	});
+});

--- a/apps/worker/src/shutdown.ts
+++ b/apps/worker/src/shutdown.ts
@@ -1,0 +1,51 @@
+let shouldStop = false;
+let stopSignalPromise: Promise<void> = Promise.resolve();
+let resolveStopSignal: () => void = () => {};
+let stopAbortController = new AbortController();
+
+function initStopSignal(): void {
+	stopSignalPromise = new Promise<void>((resolve) => {
+		resolveStopSignal = resolve;
+	});
+	stopAbortController = new AbortController();
+}
+
+initStopSignal();
+
+export function resetShutdown(): void {
+	shouldStop = false;
+	initStopSignal();
+}
+
+export function isStopRequested(): boolean {
+	return shouldStop;
+}
+
+export function requestStop(): void {
+	if (shouldStop) {
+		return;
+	}
+	shouldStop = true;
+	resolveStopSignal();
+	stopAbortController.abort();
+}
+
+export function getStopSignal(): AbortSignal {
+	return stopAbortController.signal;
+}
+
+export async function interruptibleSleep(ms: number): Promise<void> {
+	if (shouldStop || ms <= 0) {
+		return;
+	}
+	let timer: NodeJS.Timeout | undefined;
+	await Promise.race([
+		new Promise<void>((resolve) => {
+			timer = setTimeout(resolve, ms);
+		}),
+		stopSignalPromise,
+	]);
+	if (timer !== undefined) {
+		clearTimeout(timer);
+	}
+}

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -50,6 +50,12 @@ import {
 	processPendingVideoJobs,
 	processPendingWebhookDeliveries,
 } from "./services/video-jobs.js";
+import {
+	interruptibleSleep,
+	isStopRequested,
+	requestStop,
+	resetShutdown,
+} from "./shutdown.js";
 
 // Configuration for current minute history calculation interval (defaults to 5 seconds)
 const CURRENT_MINUTE_HISTORY_INTERVAL_SECONDS =
@@ -264,6 +270,9 @@ export async function processAutoTopUp(): Promise<void> {
 		});
 
 		for (const org of filteredOrgs) {
+			if (isStopRequested()) {
+				break;
+			}
 			try {
 				// Check if there's a recent pending transaction
 				const recentTransaction = await db.query.transaction.findFirst({
@@ -577,7 +586,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 
 		// Process all organizations in batches (no plan distinction)
 		let hasMoreRecords = true;
-		while (hasMoreRecords) {
+		while (hasMoreRecords && !isStopRequested()) {
 			const batchResult = await db.transaction(async (tx) => {
 				// Hint the planner to prefer index scans for this transaction.
 				// Without this, PostgreSQL's default random_page_cost=4 causes it to
@@ -1197,15 +1206,18 @@ export async function processLogQueue(): Promise<void> {
 						? insertError
 						: new Error(String(insertError));
 
-				if (attempt < MAX_RETRIES) {
+				if (attempt < MAX_RETRIES && !isStopRequested()) {
 					const delay = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s, 8s, 16s, ...
 					logger.warn(
 						`Failed to insert logs (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${delay}ms...`,
 						lastError,
 					);
-					await new Promise((resolve) => {
-						setTimeout(resolve, delay);
-					});
+					await interruptibleSleep(delay);
+					if (isStopRequested()) {
+						break;
+					}
+				} else {
+					break;
 				}
 			}
 		}
@@ -1247,50 +1259,24 @@ export async function processLogQueue(): Promise<void> {
 }
 
 let isWorkerRunning = false;
-let shouldStop = false;
 let activeLoops = 0;
 let stopFailed = false;
-
-/**
- * Sleep that can be interrupted by shouldStop.
- * Breaks long delays into short chunks so loops exit promptly on shutdown.
- */
-async function interruptibleSleep(ms: number): Promise<void> {
-	const chunkMs = 500;
-	let remaining = ms;
-
-	while (remaining > 0 && !shouldStop) {
-		await new Promise((resolve) => {
-			setTimeout(resolve, Math.min(remaining, chunkMs));
-		});
-		remaining -= chunkMs;
-	}
-}
 
 // Independent worker loops
 async function runLogQueueLoop() {
 	activeLoops++;
 	logger.info("Starting log queue processing loop...");
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await processLogQueue();
-
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 1000);
-					});
-				}
+				await interruptibleSleep(1000);
 			} catch (error) {
 				logger.error(
 					"Error in log queue loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1307,25 +1293,17 @@ async function runAutoTopUpLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await processAutoTopUp();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in auto top-up loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1342,25 +1320,17 @@ async function runBatchProcessLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await batchProcessLogs();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in batch process loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1386,7 +1356,7 @@ async function runMinutelyHistoryLoop() {
 			);
 		}
 
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			// Calculate delay to next minute boundary
 			const now = new Date();
 			const nextMinute = new Date(
@@ -1402,7 +1372,7 @@ async function runMinutelyHistoryLoop() {
 
 			await interruptibleSleep(delay);
 
-			if (shouldStop) {
+			if (isStopRequested()) {
 				break;
 			}
 
@@ -1429,25 +1399,17 @@ async function runCurrentMinuteHistoryLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await calculateCurrentMinuteHistory();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in current minute history loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1464,25 +1426,17 @@ async function runVideoJobsLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await processPendingVideoJobs();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in video jobs loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1499,25 +1453,17 @@ async function runVideoWebhookLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await processPendingWebhookDeliveries();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in video webhook loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1543,7 +1489,7 @@ async function runAggregatedStatsLoop() {
 			);
 		}
 
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			const now = new Date();
 			const nextRun = new Date(
 				now.getFullYear(),
@@ -1559,7 +1505,7 @@ async function runAggregatedStatsLoop() {
 
 			await interruptibleSleep(delay);
 
-			if (shouldStop) {
+			if (isStopRequested()) {
 				break;
 			}
 
@@ -1586,25 +1532,17 @@ async function runProjectStatsLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await refreshProjectHourlyStats();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in project stats loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1621,25 +1559,17 @@ async function runDataRetentionLoop() {
 	);
 
 	try {
-		while (!shouldStop) {
+		while (!isStopRequested()) {
 			try {
 				await cleanupExpiredLogData();
 
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, interval);
-					});
-				}
+				await interruptibleSleep(interval);
 			} catch (error) {
 				logger.error(
 					"Error in data retention loop",
 					error instanceof Error ? error : new Error(String(error)),
 				);
-				if (!shouldStop) {
-					await new Promise((resolve) => {
-						setTimeout(resolve, 5000);
-					});
-				}
+				await interruptibleSleep(5000);
 			}
 		}
 	} finally {
@@ -1669,7 +1599,7 @@ export async function startWorker() {
 	}
 
 	isWorkerRunning = true;
-	shouldStop = false;
+	resetShutdown();
 	logger.info("Starting worker application...");
 
 	// Initialize providers and models sync - must complete before other stats syncs
@@ -1733,7 +1663,7 @@ export async function startWorker() {
 	void runBatchProcessLoop();
 	void runDataRetentionLoop();
 	void runFollowUpEmailsLoop({
-		shouldStop: () => shouldStop,
+		shouldStop: isStopRequested,
 		acquireLock,
 		releaseLock,
 		interruptibleSleep,
@@ -1753,7 +1683,7 @@ export async function stopWorker(): Promise<boolean> {
 	}
 
 	logger.info("Stopping worker...");
-	shouldStop = true;
+	requestStop();
 
 	// Wait for all loops to finish by polling activeLoops counter
 	const maxWaitTime = 15000; // 15 seconds timeout
@@ -1772,7 +1702,7 @@ export async function stopWorker(): Promise<boolean> {
 				`Timeout reached (${maxWaitTime}ms) while waiting for worker loops to exit. ${activeLoops} loop(s) still active. Worker stop failed.`,
 			);
 			stopFailed = true;
-			// Keep shouldStop = true and isWorkerRunning = true to prevent new loops from starting
+			// Keep stop state and isWorkerRunning = true to prevent new loops from starting
 			return false;
 		}
 


### PR DESCRIPTION
Loops sleep via setTimeout that don't observe shouldStop, and fetch()
calls have no timeout. SIGTERM during a long sleep (auto-topup 2m,
data-retention 5m) or hung upstream poll exceeds the 15s shutdown
budget. Centralize shutdown state in shutdown.ts: a stop AbortController
plus a stop-signal Promise the new interruptibleSleep races against.
Replace per-loop setTimeout sleeps with interruptibleSleep, thread the
abort signal into video-job and webhook fetches with a 30s timeout, and
short-circuit per-item inner loops on stop.

https://claude.ai/code/session_01BY1g5cpuGDLPAAPcYsdooY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker shutdown was unified and made cooperative across background jobs, making loops and retries exit promptly during shutdown.
  * Network operations and delivery attempts now respect shutdown signals and per-request time limits for cleaner termination.
* **Tests**
  * Added tests verifying shutdown signaling and interruptible sleep behavior to prevent hangs during stop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->