### PR TITLE
chore(xai): deactivate retired Grok models on 2026-05-15

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -31,6 +31,7 @@ export const xaiModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				deactivatedAt: new Date("2026-05-15"),
 			},
 		],
 	},
@@ -169,6 +170,7 @@ export const xaiModels = [
 				test: "skip",
 				providerId: "xai",
 				modelName: "grok-4-0709",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 3.0 / 1e6,
 				outputPrice: 15.0 / 1e6,
 				pricingTiers: [
@@ -251,6 +253,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-fast-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -293,6 +296,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-fast-non-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -335,6 +339,7 @@ export const xaiModels = [
 				test: "skip",
 				providerId: "xai",
 				modelName: "grok-code-fast-1",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				cachedInputPrice: 0.02 / 1e6,
 				outputPrice: 1.5 / 1e6,
@@ -359,6 +364,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-1-fast-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -420,6 +426,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-1-fast-non-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -480,6 +487,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-fast-non-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -513,6 +521,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-fast-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -557,6 +566,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-1-fast-non-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -607,6 +617,7 @@ export const xaiModels = [
 			{
 				providerId: "xai",
 				modelName: "grok-4-1-fast-reasoning",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0.2 / 1e6,
 				outputPrice: 0.5 / 1e6,
 				pricingTiers: [
@@ -842,6 +853,7 @@ export const xaiModels = [
 				test: "skip",
 				providerId: "xai",
 				modelName: "grok-imagine-image-pro",
+				deactivatedAt: new Date("2026-05-15"),
 				inputPrice: 0,
 				outputPrice: 0,
 				requestPrice: 0.07,


### PR DESCRIPTION
## Summary
- xAI is retiring the following models from its API effective **May 15, 2026 at 12:00pm PT**. After that date, requests to these models will fail.
- Mark each affected `xai` provider entry with `deactivatedAt: 2026-05-15` so the gateway stops routing to them at the cutoff.
- Models deactivated: `grok-3`, `grok-4-0709`, `grok-code-fast-1`, `grok-4-fast-reasoning`, `grok-4-fast-non-reasoning`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, `grok-imagine-image-pro`.
- The unified `grok-4-fast` and `grok-4-1-fast` route entries also have their xAI providers (both reasoning and non-reasoning variants) marked deactivated.
- The `azure-ai-foundry` providers for `grok-4-1-fast-reasoning` / `grok-4-1-fast-non-reasoning` are unaffected and remain active.

Note on Veo: the screenshot references Veo 2 / Veo 3 retirement on 2026-06-30. The gateway only ships Veo 3.1 entries, and PR #2082 already migrated the Vertex `modelName` to the GA `-001` IDs, so no changes are needed here.

## Test plan
- [ ] Verify retired Grok models stop being routed via xAI after 2026-05-15
- [ ] Verify `grok-4-1-fast-reasoning` / `grok-4-1-fast-non-reasoning` still resolve via `azure-ai-foundry` after the cutoff
- [ ] Verify non-retired Grok models (`grok-4`, `grok-4.3`, `grok-3-mini`, etc.) continue to route normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deactivation schedules for select XAI model providers, including image and vision-related capabilities. Changes take effect on 2026-05-15 and 2026-03-27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->