### PR TITLE
fix(azure): preserve responses API streaming events

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -200,4 +200,73 @@ describe("transformStreamingToOpenai", () => {
 		expect(result).toBeNull();
 		expect(warn).not.toHaveBeenCalled();
 	});
+
+	it("drops Azure prompt-filter-only leading chunk", () => {
+		const result = transformStreamingToOpenai(
+			"azure",
+			"gpt-5.5",
+			{
+				id: "",
+				object: "",
+				created: 0,
+				model: "",
+				choices: [],
+				prompt_filter_results: [
+					{ prompt_index: 0, content_filter_results: {} },
+				],
+			},
+			[],
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("preserves Azure Responses API output_text deltas", () => {
+		const result = transformStreamingToOpenai(
+			"azure",
+			"gpt-5.5",
+			{
+				type: "response.output_text.delta",
+				content_index: 0,
+				delta: "Hi",
+				item_id: "msg_123",
+				output_index: 1,
+				sequence_number: 6,
+			},
+			[],
+		);
+
+		expect(result?.choices?.[0]?.delta?.content).toBe("Hi");
+	});
+
+	it("preserves Azure Responses API response.completed usage", () => {
+		const result = transformStreamingToOpenai(
+			"azure",
+			"gpt-5.5",
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_123",
+					created_at: 1234567890,
+					model: "gpt-5.5",
+					usage: {
+						input_tokens: 8,
+						output_tokens: 17,
+						total_tokens: 25,
+						output_tokens_details: { reasoning_tokens: 9 },
+					},
+				},
+				sequence_number: 11,
+			},
+			[],
+		);
+
+		expect(result?.usage).toMatchObject({
+			prompt_tokens: 8,
+			completion_tokens: 17,
+			total_tokens: 25,
+			reasoning_tokens: 9,
+		});
+		expect(result?.choices?.[0]?.finish_reason).toBe("stop");
+	});
 });

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -684,8 +684,11 @@ export function transformStreamingToOpenai(
 			// path passes the empty values through and breaks downstream
 			// hasOpenAIFormat checks. Drop it — if any prompt filter actually
 			// fires, Azure surfaces it via a content_filter error/finish_reason.
+			// Responses API events also lack top-level id/object/choices/usage
+			// but always carry a `type` field, so guard against dropping them.
 			if (
 				usedProvider === "azure" &&
+				!data.type &&
 				!data.id &&
 				!data.object &&
 				(!data.choices || data.choices.length === 0) &&
@@ -1243,8 +1246,10 @@ export function transformStreamingToOpenai(
 			// Azure AI Foundry mirrors Azure OpenAI's prompt-filter-only leading
 			// chunk on some models — empty id/object/choices, no usage. Drop it
 			// for the same reason: it breaks downstream hasOpenAIFormat checks.
+			// Skip the guard for Responses API events (identified by `data.type`).
 			if (
 				usedProvider === "azure-ai-foundry" &&
+				!data.type &&
 				!data.id &&
 				!data.object &&
 				(!data.choices || data.choices.length === 0) &&


### PR DESCRIPTION
## Summary

Streaming requests to `azure/gpt-5.5` (and any other Azure model with `supportsResponsesApi: true`) returned:

```
{"code":"upstream_error","message":"Response finished successfully but returned no content or tool calls"}
```

The Azure prompt-filter-only chunk guard at `transform-streaming-to-openai.ts:687` was dropping **every** Responses API event because those events also lack top-level `id`/`object`/`choices`/`usage` (their data lives under `data.response.*` or alongside a `type` field). With every chunk transformed to `null`, no content/tokens accumulated and the empty-response detector at `chat/chat.ts:7204` fired.

Fix: only drop the chunk when `data.type` is also absent — Responses API events always carry `type` (`response.created`, `response.output_text.delta`, `response.completed`, …); the chat-completions prompt-filter chunk does not.

Same guard for `azure-ai-foundry` got the same treatment defensively (no current model triggers it, but the shape is identical).

## Test plan

- [x] Unit tests added for prompt-filter drop, output_text delta passthrough, and `response.completed` usage extraction (11 tests total pass)
- [x] Reproduced the original error against the local gateway with `azure/gpt-5.5` streaming
- [x] Verified fix with `x-no-fallback: true` — `used_provider: "azure"`, content streams, usage reported correctly
- [x] `pnpm build` clean
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved streaming transformation issue for Azure providers where valid response events were being incorrectly filtered and discarded.

* **Tests**
  * Added test cases for Azure streaming support, covering event filtering and response usage token mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->