### PR TITLE
feat: delete resend contact when banning org

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -390,6 +390,37 @@ async function createResendContact(
 	}
 }
 
+export async function deleteResendContact(email: string): Promise<void> {
+	const client = getResendClient();
+
+	if (!client) {
+		logger.debug("RESEND_API_KEY not configured, skipping contact deletion");
+		return;
+	}
+
+	try {
+		const { error } = await client.contacts.remove({
+			audienceId: resendAudienceId,
+			email,
+		});
+
+		if (error) {
+			logger.warn("Resend API error during contact deletion", {
+				email,
+				errorMessage: error.message,
+			});
+			return;
+		}
+
+		logger.info("Successfully deleted Resend contact", { email });
+	} catch (error) {
+		logger.error("Failed to delete Resend contact", {
+			...(error instanceof Error ? { err: error } : { error }),
+			email,
+		});
+	}
+}
+
 export async function updateResendContact(
 	email: string,
 	options?: {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { deleteResendContact } from "@/auth/config.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
@@ -4226,6 +4227,17 @@ admin.openapi(setOrganizationStatusRoute, async (c) => {
 			}
 		}
 	});
+
+	if (status === "deleted" && memberUserIds.length > 0) {
+		const members = await db.query.user.findMany({
+			where: { id: { in: memberUserIds } },
+			columns: { email: true },
+		});
+
+		await Promise.all(
+			members.map((member) => deleteResendContact(member.email)),
+		);
+	}
 
 	await logAuditEvent({
 		organizationId: orgId,


### PR DESCRIPTION
## Summary
- When admins ban (status=deleted) an organization via the admin dashboard, also remove each member's Resend contact via the Resend API
- Errors from Resend are logged but ignored, matching the existing `createResendContact` / `updateResendContact` pattern
- Only fires on the deleted transition; re-enabling an org is unchanged

## Test plan
- [ ] Ban an org via the admin UI and confirm members' contacts are removed from the configured Resend audience
- [ ] Ban an org with `RESEND_API_KEY` unset and confirm the request still succeeds
- [ ] Ban an org whose member email was already removed from Resend and confirm no failure (warning is logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Organization deletion now automatically removes associated member email contacts from the contact system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->