### PR TITLE
feat: decouple gateway caching from data retention

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -724,6 +724,9 @@ const getStatus = createRoute({
 						projectId: z.string().nullable(),
 						apiKey: z.string().nullable(),
 						devPlanAllowAllModels: z.boolean(),
+						cachingEnabled: z.boolean(),
+						cacheDurationSeconds: z.number(),
+						retentionLevel: z.enum(["retain", "none"]),
 					}),
 				},
 			},
@@ -770,6 +773,9 @@ devPlans.openapi(getStatus, async (c) => {
 			projectId: null,
 			apiKey: null,
 			devPlanAllowAllModels: false,
+			cachingEnabled: false,
+			cacheDurationSeconds: 60,
+			retentionLevel: "none" as const,
 		});
 	}
 
@@ -780,6 +786,8 @@ devPlans.openapi(getStatus, async (c) => {
 	// Get API key and project if user has an active dev plan
 	let apiKey: string | null = null;
 	let projectId: string | null = null;
+	let cachingEnabled = false;
+	let cacheDurationSeconds = 60;
 	if (personalOrg.devPlan !== "none") {
 		// Find the default project for this org. Order by createdAt asc so we
 		// always return the original "Default Project" rather than whichever
@@ -797,6 +805,8 @@ devPlans.openapi(getStatus, async (c) => {
 
 		if (project) {
 			projectId = project.id;
+			cachingEnabled = project.cachingEnabled;
+			cacheDurationSeconds = project.cacheDurationSeconds;
 			apiKey = await getOrCreatePersonalOrgApiKey(
 				personalOrg.id,
 				project.id,
@@ -821,6 +831,9 @@ devPlans.openapi(getStatus, async (c) => {
 		projectId,
 		apiKey,
 		devPlanAllowAllModels: personalOrg.devPlanAllowAllModels,
+		cachingEnabled,
+		cacheDurationSeconds,
+		retentionLevel: personalOrg.retentionLevel,
 	});
 });
 
@@ -834,6 +847,9 @@ const updateSettings = createRoute({
 				"application/json": {
 					schema: z.object({
 						devPlanAllowAllModels: z.boolean().optional(),
+						cachingEnabled: z.boolean().optional(),
+						cacheDurationSeconds: z.number().min(10).max(31536000).optional(),
+						retentionLevel: z.enum(["retain", "none"]).optional(),
 					}),
 				},
 			},
@@ -846,6 +862,9 @@ const updateSettings = createRoute({
 					schema: z.object({
 						success: z.boolean(),
 						devPlanAllowAllModels: z.boolean(),
+						cachingEnabled: z.boolean(),
+						cacheDurationSeconds: z.number(),
+						retentionLevel: z.enum(["retain", "none"]),
 					}),
 				},
 			},
@@ -856,7 +875,12 @@ const updateSettings = createRoute({
 
 devPlans.openapi(updateSettings, async (c) => {
 	const user = c.get("user");
-	const { devPlanAllowAllModels } = c.req.valid("json");
+	const {
+		devPlanAllowAllModels,
+		cachingEnabled,
+		cacheDurationSeconds,
+		retentionLevel,
+	} = c.req.valid("json");
 
 	if (!user) {
 		throw new HTTPException(401, {
@@ -890,11 +914,19 @@ devPlans.openapi(updateSettings, async (c) => {
 		});
 	}
 
-	const updateData: { devPlanAllowAllModels?: boolean } = {};
+	const updateData: {
+		devPlanAllowAllModels?: boolean;
+		retentionLevel?: "retain" | "none";
+	} = {};
 
 	if (devPlanAllowAllModels !== undefined) {
 		updateData.devPlanAllowAllModels = devPlanAllowAllModels;
 	}
+	if (retentionLevel !== undefined) {
+		updateData.retentionLevel = retentionLevel;
+	}
+
+	const changes: Record<string, { old: unknown; new: unknown }> = {};
 
 	if (Object.keys(updateData).length > 0) {
 		await db
@@ -902,7 +934,6 @@ devPlans.openapi(updateSettings, async (c) => {
 			.set(updateData)
 			.where(eq(tables.organization.id, personalOrg.id));
 
-		const changes: Record<string, { old: unknown; new: unknown }> = {};
 		if (
 			devPlanAllowAllModels !== undefined &&
 			devPlanAllowAllModels !== personalOrg.devPlanAllowAllModels
@@ -912,22 +943,83 @@ devPlans.openapi(updateSettings, async (c) => {
 				new: devPlanAllowAllModels,
 			};
 		}
-
-		if (Object.keys(changes).length > 0) {
-			await logAuditEvent({
-				organizationId: personalOrg.id,
-				userId: user.id,
-				action: "dev_plan.update_settings",
-				resourceType: "dev_plan",
-				metadata: { changes },
-			});
+		if (
+			retentionLevel !== undefined &&
+			retentionLevel !== personalOrg.retentionLevel
+		) {
+			changes.retentionLevel = {
+				old: personalOrg.retentionLevel,
+				new: retentionLevel,
+			};
 		}
+	}
+
+	const project = await db.query.project.findFirst({
+		where: {
+			organizationId: {
+				eq: personalOrg.id,
+			},
+		},
+		orderBy: {
+			createdAt: "asc",
+		},
+	});
+
+	const projectUpdate: {
+		cachingEnabled?: boolean;
+		cacheDurationSeconds?: number;
+	} = {};
+	if (cachingEnabled !== undefined) {
+		projectUpdate.cachingEnabled = cachingEnabled;
+	}
+	if (cacheDurationSeconds !== undefined) {
+		projectUpdate.cacheDurationSeconds = cacheDurationSeconds;
+	}
+
+	if (project && Object.keys(projectUpdate).length > 0) {
+		await db
+			.update(tables.project)
+			.set(projectUpdate)
+			.where(eq(tables.project.id, project.id));
+
+		if (
+			cachingEnabled !== undefined &&
+			cachingEnabled !== project.cachingEnabled
+		) {
+			changes.cachingEnabled = {
+				old: project.cachingEnabled,
+				new: cachingEnabled,
+			};
+		}
+		if (
+			cacheDurationSeconds !== undefined &&
+			cacheDurationSeconds !== project.cacheDurationSeconds
+		) {
+			changes.cacheDurationSeconds = {
+				old: project.cacheDurationSeconds,
+				new: cacheDurationSeconds,
+			};
+		}
+	}
+
+	if (Object.keys(changes).length > 0) {
+		await logAuditEvent({
+			organizationId: personalOrg.id,
+			userId: user.id,
+			action: "dev_plan.update_settings",
+			resourceType: "dev_plan",
+			metadata: { changes },
+		});
 	}
 
 	return c.json({
 		success: true,
 		devPlanAllowAllModels:
 			devPlanAllowAllModels ?? personalOrg.devPlanAllowAllModels,
+		cachingEnabled: cachingEnabled ?? project?.cachingEnabled ?? false,
+		cacheDurationSeconds:
+			cacheDurationSeconds ?? project?.cacheDurationSeconds ?? 60,
+		retentionLevel: retentionLevel ?? personalOrg.retentionLevel,
 	});
 });
 

--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -464,6 +464,9 @@ export default function DashboardClient() {
 							devPlanAllowAllModels={
 								devPlanStatus?.devPlanAllowAllModels ?? false
 							}
+							cachingEnabled={devPlanStatus?.cachingEnabled ?? false}
+							cacheDurationSeconds={devPlanStatus?.cacheDurationSeconds ?? 60}
+							retentionLevel={devPlanStatus?.retentionLevel ?? "none"}
 						/>
 
 						{/* Change plan */}

--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -1,31 +1,64 @@
 "use client";
 
-import { AlertTriangle } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useApi } from "@/lib/fetch-client";
 
 interface DevPlanSettingsProps {
 	devPlanAllowAllModels: boolean;
+	cachingEnabled: boolean;
+	cacheDurationSeconds: number;
+	retentionLevel: "retain" | "none";
 }
 
 export default function DevPlanSettings({
-	devPlanAllowAllModels: initialValue,
+	devPlanAllowAllModels: initialAllowAllModels,
+	cachingEnabled: initialCachingEnabled,
+	cacheDurationSeconds: initialCacheDurationSeconds,
+	retentionLevel: initialRetentionLevel,
 }: DevPlanSettingsProps) {
 	const api = useApi();
-	const [allowAllModels, setAllowAllModels] = useState(initialValue);
-	const [isUpdating, setIsUpdating] = useState(false);
+	const queryClient = useQueryClient();
+	const [allowAllModels, setAllowAllModels] = useState(initialAllowAllModels);
+	const [isUpdatingAllowAll, setIsUpdatingAllowAll] = useState(false);
+
+	const [cachingEnabled, setCachingEnabled] = useState(initialCachingEnabled);
+	const [cacheDuration, setCacheDuration] = useState(
+		initialCacheDurationSeconds,
+	);
+	const [savedCacheDuration, setSavedCacheDuration] = useState(
+		initialCacheDurationSeconds,
+	);
+	const [isSavingCaching, setIsSavingCaching] = useState(false);
+	const [isTogglingCaching, setIsTogglingCaching] = useState(false);
+
+	const [retainData, setRetainData] = useState(
+		initialRetentionLevel === "retain",
+	);
+	const [isUpdatingRetention, setIsUpdatingRetention] = useState(false);
 
 	const updateSettingsMutation = api.useMutation(
 		"patch",
 		"/dev-plans/settings",
 	);
 
-	const handleToggle = async (checked: boolean) => {
-		setIsUpdating(true);
+	const invalidateStatus = () =>
+		queryClient.invalidateQueries({
+			predicate: (query) => {
+				const key = query.queryKey;
+				return Array.isArray(key) && key[1] === "/dev-plans/status";
+			},
+		});
+
+	const handleAllowAllToggle = async (checked: boolean) => {
+		setIsUpdatingAllowAll(true);
 		try {
 			await updateSettingsMutation.mutateAsync({
 				body: { devPlanAllowAllModels: checked },
@@ -37,50 +70,193 @@ export default function DevPlanSettings({
 		} catch {
 			toast.error("Failed to update settings");
 		} finally {
-			setIsUpdating(false);
+			setIsUpdatingAllowAll(false);
+		}
+	};
+
+	const handleCachingToggle = async (checked: boolean) => {
+		setIsTogglingCaching(true);
+		try {
+			await updateSettingsMutation.mutateAsync({
+				body: { cachingEnabled: checked },
+			});
+			setCachingEnabled(checked);
+			await invalidateStatus();
+			toast.success(checked ? "Caching enabled" : "Caching disabled");
+		} catch {
+			toast.error("Failed to update caching");
+		} finally {
+			setIsTogglingCaching(false);
+		}
+	};
+
+	const handleSaveCacheDuration = async () => {
+		if (
+			!Number.isFinite(cacheDuration) ||
+			cacheDuration < 10 ||
+			cacheDuration > 31536000
+		) {
+			toast.error("Cache duration must be between 10 and 31,536,000 seconds");
+			return;
+		}
+		setIsSavingCaching(true);
+		try {
+			await updateSettingsMutation.mutateAsync({
+				body: { cacheDurationSeconds: cacheDuration },
+			});
+			setSavedCacheDuration(cacheDuration);
+			await invalidateStatus();
+			toast.success("Cache duration updated");
+		} catch {
+			toast.error("Failed to update cache duration");
+		} finally {
+			setIsSavingCaching(false);
+		}
+	};
+
+	const handleRetentionToggle = async (checked: boolean) => {
+		setIsUpdatingRetention(true);
+		try {
+			await updateSettingsMutation.mutateAsync({
+				body: { retentionLevel: checked ? "retain" : "none" },
+			});
+			setRetainData(checked);
+			await invalidateStatus();
+			toast.success(
+				checked ? "Data retention enabled" : "Switched to metadata-only",
+			);
+		} catch {
+			toast.error("Failed to update data retention");
+		} finally {
+			setIsUpdatingRetention(false);
 		}
 	};
 
 	return (
 		<div>
 			<h2 className="mb-4 font-semibold">Settings</h2>
-			<div className="rounded-xl border p-5 space-y-4">
-				<div className="flex items-center justify-between gap-4">
-					<div className="space-y-0.5">
-						<Label htmlFor="allow-all-models" className="text-sm font-medium">
-							Allow all models
-						</Label>
-						<p className="text-xs text-muted-foreground">
-							Enable access beyond the curated coding model list
-						</p>
+			<div className="space-y-4">
+				<div className="rounded-xl border p-5 space-y-4">
+					<div className="flex items-center justify-between gap-4">
+						<div className="space-y-0.5">
+							<Label htmlFor="allow-all-models" className="text-sm font-medium">
+								Allow all models
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Enable access beyond the curated coding model list
+							</p>
+						</div>
+						<Switch
+							id="allow-all-models"
+							checked={allowAllModels}
+							onCheckedChange={handleAllowAllToggle}
+							disabled={isUpdatingAllowAll}
+						/>
 					</div>
-					<Switch
-						id="allow-all-models"
-						checked={allowAllModels}
-						onCheckedChange={handleToggle}
-						disabled={isUpdating}
-					/>
+
+					{allowAllModels && (
+						<div className="flex gap-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-3.5">
+							<AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
+							<p className="text-xs leading-relaxed text-muted-foreground">
+								<span className="font-medium text-yellow-600 dark:text-yellow-400">
+									Prompt caching may not be available.
+								</span>{" "}
+								Coding models are selected because they support prompt caching,
+								which reduces costs and latency. Non-curated models may cost
+								more.
+							</p>
+						</div>
+					)}
+
+					{!allowAllModels && (
+						<p className="text-xs text-muted-foreground rounded-lg bg-muted p-3.5">
+							Using coding-optimized models with prompt caching, tool calling,
+							JSON output, and streaming.
+						</p>
+					)}
 				</div>
 
-				{allowAllModels && (
-					<div className="flex gap-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-3.5">
-						<AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
-						<p className="text-xs leading-relaxed text-muted-foreground">
-							<span className="font-medium text-yellow-600 dark:text-yellow-400">
-								Prompt caching may not be available.
-							</span>{" "}
-							Coding models are selected because they support prompt caching,
-							which reduces costs and latency. Non-curated models may cost more.
+				<div className="rounded-xl border p-5 space-y-4">
+					<div className="flex items-center justify-between gap-4">
+						<div className="space-y-0.5">
+							<Label htmlFor="enable-caching" className="text-sm font-medium">
+								Request caching
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Cache identical LLM requests to reduce cost and latency
+							</p>
+						</div>
+						<Switch
+							id="enable-caching"
+							checked={cachingEnabled}
+							onCheckedChange={handleCachingToggle}
+							disabled={isTogglingCaching}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label
+							htmlFor="cache-duration"
+							className={`text-sm font-medium ${
+								!cachingEnabled ? "text-muted-foreground" : ""
+							}`}
+						>
+							Cache duration (seconds)
+						</Label>
+						<div className="flex items-center gap-2">
+							<Input
+								id="cache-duration"
+								type="number"
+								min={10}
+								max={31536000}
+								className="w-40 h-9"
+								value={cacheDuration}
+								onChange={(e) => setCacheDuration(Number(e.target.value))}
+								disabled={!cachingEnabled}
+							/>
+							<Button
+								type="button"
+								size="sm"
+								variant="outline"
+								onClick={handleSaveCacheDuration}
+								disabled={
+									!cachingEnabled ||
+									isSavingCaching ||
+									cacheDuration === savedCacheDuration
+								}
+							>
+								{isSavingCaching && (
+									<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+								)}
+								Save
+							</Button>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Min 10, max 31,536,000 (1 year). Changes may take up to 5 minutes
+							to take effect.
 						</p>
 					</div>
-				)}
+				</div>
 
-				{!allowAllModels && (
-					<p className="text-xs text-muted-foreground rounded-lg bg-muted p-3.5">
-						Using coding-optimized models with prompt caching, tool calling,
-						JSON output, and streaming.
-					</p>
-				)}
+				<div className="rounded-xl border p-5 space-y-4">
+					<div className="flex items-center justify-between gap-4">
+						<div className="space-y-0.5">
+							<Label htmlFor="retain-data" className="text-sm font-medium">
+								Retain request data
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Store full request and response payloads for analytics and
+								debugging. When off, only metadata is kept.
+							</p>
+						</div>
+						<Switch
+							id="retain-data"
+							checked={retainData}
+							onCheckedChange={handleRetentionToggle}
+							disabled={isUpdatingRetention}
+						/>
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -7676,6 +7676,10 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };
@@ -7713,6 +7717,10 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
+                        cachingEnabled?: boolean;
+                        cacheDurationSeconds?: number;
+                        /** @enum {string} */
+                        retentionLevel?: "retain" | "none";
                     };
                 };
             };
@@ -7726,6 +7734,10 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -7676,6 +7676,10 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };
@@ -7713,6 +7717,10 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
+                        cachingEnabled?: boolean;
+                        cacheDurationSeconds?: number;
+                        /** @enum {string} */
+                        retentionLevel?: "retain" | "none";
                     };
                 };
             };
@@ -7726,6 +7734,10 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };

--- a/apps/ui/src/components/settings/caching-settings.tsx
+++ b/apps/ui/src/components/settings/caching-settings.tsx
@@ -1,11 +1,9 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import * as React from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { Alert, AlertDescription } from "@/lib/components/alert";
 import { Button } from "@/lib/components/button";
 import {
 	Form,
@@ -67,19 +65,6 @@ export function CachingSettings({
 
 	const api = useApi();
 
-	// Fetch organization to check retention level
-	const { data: organizationsData } = api.useQuery("get", "/orgs");
-	const organization = organizationsData?.organizations?.find(
-		(org) => org.id === orgId,
-	);
-	const isMetadataOnlyRetention = organization?.retentionLevel === "none";
-
-	// Override form value if organization uses metadata-only retention
-	React.useEffect(() => {
-		if (isMetadataOnlyRetention) {
-			form.setValue("cachingEnabled", false);
-		}
-	}, [isMetadataOnlyRetention, form]);
 	const updateProject = api.useMutation("patch", "/projects/{id}", {
 		onSuccess: () => {
 			const queryKey = api.queryOptions("get", "/orgs/{id}/projects", {
@@ -128,16 +113,6 @@ export function CachingSettings({
 
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-					{isMetadataOnlyRetention && (
-						<Alert>
-							<AlertDescription>
-								🔒 Caching is disabled because your organization is using
-								metadata-only data retention. To enable caching, switch to
-								"Retain All Data" in the organization policies settings.
-							</AlertDescription>
-						</Alert>
-					)}
-
 					<FormField
 						control={form.control}
 						name="cachingEnabled"
@@ -147,17 +122,10 @@ export function CachingSettings({
 									<Switch
 										checked={field.value}
 										onCheckedChange={field.onChange}
-										disabled={isMetadataOnlyRetention}
 									/>
 								</FormControl>
 								<div className="space-y-1 leading-none">
-									<FormLabel
-										className={
-											isMetadataOnlyRetention ? "text-muted-foreground" : ""
-										}
-									>
-										Enable request caching
-									</FormLabel>
+									<FormLabel>Enable request caching</FormLabel>
 								</div>
 							</FormItem>
 						)}
@@ -175,7 +143,7 @@ export function CachingSettings({
 										min={10}
 										max={31536000}
 										className="w-32"
-										disabled={!cachingEnabled || isMetadataOnlyRetention}
+										disabled={!cachingEnabled}
 										{...field}
 										onChange={(e) => field.onChange(Number(e.target.value))}
 									/>
@@ -194,10 +162,7 @@ export function CachingSettings({
 					<div className="flex justify-end">
 						<Button
 							type="submit"
-							disabled={
-								(form.formState.isSubmitting || updateProject.isPending) ??
-								isMetadataOnlyRetention
-							}
+							disabled={form.formState.isSubmitting || updateProject.isPending}
 						>
 							{form.formState.isSubmitting || updateProject.isPending
 								? "Saving..."

--- a/apps/ui/src/components/settings/organization-retention-settings.tsx
+++ b/apps/ui/src/components/settings/organization-retention-settings.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
-import * as React from "react";
 import { useState } from "react";
 
 import { Alert, AlertDescription } from "@/lib/components/alert";
@@ -29,16 +28,6 @@ export function OrganizationRetentionSettings() {
 		selectedOrganization?.retentionLevel ?? "retain",
 	);
 
-	// Fetch projects to check if any have caching enabled
-	const { data: projectsData } = api.useQuery("get", "/orgs/{id}/projects", {
-		params: { path: { id: selectedOrganization?.id ?? "" } },
-		enabled: !!selectedOrganization?.id,
-	});
-
-	const projectsWithCaching =
-		projectsData?.projects?.filter((project) => project.cachingEnabled) ?? [];
-	const hasCachingEnabled = projectsWithCaching.length > 0;
-
 	if (!selectedOrganization) {
 		return (
 			<div className="space-y-2">
@@ -50,33 +39,16 @@ export function OrganizationRetentionSettings() {
 		);
 	}
 
-	const updateProject = api.useMutation("patch", "/projects/{id}");
-
 	const handleSave = async () => {
 		try {
-			// Update organization retention level
 			await updateOrganization.mutateAsync({
 				params: { path: { id: selectedOrganization.id } },
 				body: { retentionLevel },
 			});
 
-			// If switching to metadata-only and there are projects with caching enabled,
-			// disable caching for all those projects
-			if (retentionLevel === "none" && hasCachingEnabled) {
-				for (const project of projectsWithCaching) {
-					await updateProject.mutateAsync({
-						params: { path: { id: project.id } },
-						body: { cachingEnabled: false },
-					});
-				}
-			}
-
 			toast({
 				title: "Settings saved",
-				description:
-					retentionLevel === "none" && hasCachingEnabled
-						? `Data retention settings updated. Caching disabled for ${projectsWithCaching.length} project${projectsWithCaching.length > 1 ? "s" : ""}.`
-						: "Your data retention settings have been updated.",
+				description: "Your data retention settings have been updated.",
 			});
 		} catch {
 			toast({
@@ -104,17 +76,6 @@ export function OrganizationRetentionSettings() {
 			<Separator />
 
 			<div className="space-y-4">
-				{retentionLevel === "none" && hasCachingEnabled && (
-					<Alert>
-						<AlertDescription>
-							⚠️ {projectsWithCaching.length} project
-							{projectsWithCaching.length > 1 ? "s" : ""} currently have caching
-							enabled. Switching to metadata-only retention will disable caching
-							for all projects.
-						</AlertDescription>
-					</Alert>
-				)}
-
 				<RadioGroup
 					value={retentionLevel}
 					onValueChange={(value: "retain" | "none") => setRetentionLevel(value)}

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -7676,6 +7676,10 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };
@@ -7713,6 +7717,10 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
+                        cachingEnabled?: boolean;
+                        cacheDurationSeconds?: number;
+                        /** @enum {string} */
+                        retentionLevel?: "retain" | "none";
                     };
                 };
             };
@@ -7726,6 +7734,10 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -7676,6 +7676,10 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };
@@ -7713,6 +7717,10 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
+                        cachingEnabled?: boolean;
+                        cacheDurationSeconds?: number;
+                        /** @enum {string} */
+                        retentionLevel?: "retain" | "none";
                     };
                 };
             };
@@ -7726,6 +7734,10 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
+                            cachingEnabled: boolean;
+                            cacheDurationSeconds: number;
+                            /** @enum {string} */
+                            retentionLevel: "retain" | "none";
                         };
                     };
                 };


### PR DESCRIPTION
## Summary
- Caching is fully Redis-backed (`packages/cache`, `isCachingEnabled` in `packages/db/src/cache-helpers.ts`) — cache hits never read from Postgres `log` rows, so requiring `retentionLevel === "retain"` was a UI policy, not a technical dependency. Drop that gate everywhere.
- In `apps/ui`, remove the metadata-only retention lock from project caching settings and stop auto-disabling per-project caching when an org switches retention to `"none"`.
- In the DevPass dashboard (`apps/code`), add a Settings card with three independent toggles: Request caching, Cache duration (seconds), and Retain request data.
- Extend `GET /dev-plans/status` with `cachingEnabled`, `cacheDurationSeconds`, and `retentionLevel` (read off the personal org's default project + org).
- Extend `PATCH /dev-plans/settings` to accept `cachingEnabled`, `cacheDurationSeconds`, and `retentionLevel`. Project-level fields update the personal org's default project; retention updates the org. All changes are audit-logged.

## Test plan
- [ ] Subscribe to a dev plan in DevPass, toggle Request caching on, then send the same chat completion through the dev-plan API key twice — second response should be served from Redis (no provider call).
- [ ] Change cache duration, hit Save, reload — value persists; project row in DB has the new `cacheDurationSeconds`.
- [ ] Toggle Retain request data off, then on, on the DevPass dashboard — `organization.retentionLevel` flips between `"none"` and `"retain"`.
- [ ] With retention = `"none"` and caching = `true`, verify cache hits still work (no DB log row needed).
- [ ] In the main UI's project caching settings, with org retention = `"none"`, the toggle is now usable (was previously locked).
- [ ] In the main UI's organization retention settings, switching to `"none"` no longer auto-disables caching on existing projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Request caching is now configurable for dev plans with adjustable duration (10 seconds to 1 year).
  * Data retention level can be managed through settings (retain vs. metadata-only).

* **Improvements**
  * Simplified settings interface for managing caching and retention configurations.
  * Dev plan status now reports caching and retention configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->