### PR TITLE
fix: surface devpass subscribe API error message

### DIFF
--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -240,8 +240,16 @@ export default function DashboardClient() {
 				posthog.capture("dev_plan_subscribe_started", { tier, cycle });
 			}
 			window.location.href = result.checkoutUrl;
-		} catch {
-			toast.error("Failed to start subscription");
+		} catch (error: unknown) {
+			const apiMessage =
+				error && typeof error === "object" && "message" in error
+					? (error as { message?: unknown }).message
+					: undefined;
+			toast.error(
+				typeof apiMessage === "string" && apiMessage.length > 0
+					? apiMessage
+					: "Failed to start subscription",
+			);
 		} finally {
 			setSubscribingTier(null);
 		}


### PR DESCRIPTION
## Summary
- The devpass subscribe flow swallowed the API error in `handleSubscribe`, so users always saw a generic "Failed to start subscription" toast — even when the API returned a clear, actionable message like "Email verification required".
- The catch block now extracts `error.message` from the rejected mutation and surfaces it, falling back to the generic message only when no message is present.

## Test plan
- [ ] Sign up for a new devpass account and, before verifying email, click subscribe — toast should now read "Email verification required".
- [ ] Verify email and subscribe — flow should still redirect to Stripe Checkout as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for dev plan subscription failures by displaying specific API error details instead of generic notifications, providing users with clearer feedback when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->