### PR TITLE
fix(auth): route verification email back to signup origin

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -16,10 +16,28 @@ import { getResendClient, resendAudienceId } from "@llmgateway/shared/email";
 const apiUrl = process.env.API_URL ?? "http://localhost:4002";
 const cookieDomain = process.env.COOKIE_DOMAIN ?? "localhost";
 const uiUrl = process.env.UI_URL ?? "http://localhost:3002";
+const codeUrl = process.env.CODE_URL ?? "http://localhost:3004";
 const originUrls =
 	process.env.ORIGIN_URLS ??
 	"http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:4002,http://localhost:3006";
 const isHosted = process.env.HOSTED === "true";
+
+function resolveCallbackBaseUrl(request?: Request): string {
+	const originHeader =
+		request?.headers.get("origin") ?? request?.headers.get("referer");
+	if (!originHeader) {
+		return uiUrl;
+	}
+	try {
+		const requestOrigin = new URL(originHeader).origin;
+		if (requestOrigin === new URL(codeUrl).origin) {
+			return codeUrl;
+		}
+	} catch {
+		// fall through to default
+	}
+	return uiUrl;
+}
 
 export const redisClient = new Redis({
 	host: process.env.REDIS_HOST ?? "localhost",
@@ -625,14 +643,18 @@ If you didn't request this, you can safely ignore this email. Your password won'
 							// Send Discord notification for new verified signup
 							await notifyUserSignup(user.email, user.name, "Email");
 						},
-						sendVerificationEmail: async ({
-							user,
-							token,
-						}: {
-							user: { email: string; name?: string | null };
-							token: string;
-						}) => {
-							const url = `${apiUrl}/auth/verify-email?token=${token}&callbackURL=${encodeURIComponent(`${uiUrl}/dashboard?emailVerified=true`)}`;
+						sendVerificationEmail: async (
+							{
+								user,
+								token,
+							}: {
+								user: { email: string; name?: string | null };
+								token: string;
+							},
+							request?: Request,
+						) => {
+							const callbackBase = resolveCallbackBaseUrl(request);
+							const url = `${apiUrl}/auth/verify-email?token=${token}&callbackURL=${encodeURIComponent(`${callbackBase}/dashboard?emailVerified=true`)}`;
 
 							const text = `Hey${user.name ? ` ${user.name}` : ""}!
 


### PR DESCRIPTION
## Summary

- Email verification link callback was hardcoded to `UI_URL`, so users who signed up at https://devpass.llmgateway.io ended up on the main UI dashboard after verifying — making it appear that verification didn't work.
- Use the request `Origin` / `Referer` header in `sendVerificationEmail` to detect when the signup originated from devpass (`CODE_URL`) and route the callback back there. Falls back to `UI_URL` for everything else.

Infra side (`llmgateway-infra/k8s/base/llmgateway/api.yaml`) is already correctly configured: `HOSTED=true`, `CODE_URL=https://devpass.llmgateway.io`, and `ORIGIN_URLS` includes devpass — no infra changes needed.

## Test plan

- [ ] Sign up at https://devpass.llmgateway.io/signup — receive verification email — link redirects back to `devpass.llmgateway.io/dashboard?emailVerified=true`
- [ ] Sign up at https://llmgateway.io/signup — verification link still goes to `llmgateway.io/dashboard?emailVerified=true`
- [ ] Local dev (no Origin/Referer match) — falls back to `UI_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication email verification by dynamically determining callback URLs based on request origin. Users will now receive correctly formatted verification links regardless of how they access the application, with intelligent fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->