### PR TITLE
fix: redirect devpass cancel to /dashboard

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -266,7 +266,7 @@ devPlans.openapi(subscribe, async (c) => {
 			],
 			allow_promotion_codes: true,
 			success_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?success=true`,
-			cancel_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard/plans?canceled=true`,
+			cancel_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?canceled=true`,
 			metadata: {
 				organizationId: personalOrg.id,
 				subscriptionType: "dev_plan",


### PR DESCRIPTION
## Summary
- Stripe checkout cancel for devpass redirected to `/dashboard/plans?canceled=true`, which 404s. Point it at `/dashboard?canceled=true` on the same host instead.

## Test plan
- [ ] Start a devpass checkout, cancel, verify the browser lands on `/dashboard?canceled=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subscription checkout cancellation to redirect to the main dashboard instead of the plans page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->