### PR TITLE
feat: capture optional name on signup w/ email fallback

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -169,6 +169,57 @@ describe("API auth hooks functionality", () => {
 		// In self-hosted mode, email should be automatically verified
 		expect(user?.emailVerified).toBe(true);
 	});
+
+	test("should infer name from email when name is not provided", async () => {
+		const suffix = Date.now();
+		const email = `john.doe+${suffix}@example.com`;
+		const password = "Password123!";
+
+		const signUpResponse = await apiAuth.handler(
+			new Request("http://localhost:4002/auth/sign-up/email", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"CF-Connecting-IP": `192.168.20.${Math.floor(Math.random() * 255)}`,
+				},
+				body: JSON.stringify({ email, password }),
+			}),
+		);
+
+		expect(signUpResponse.status).toBe(200);
+
+		const user = await db.query.user.findFirst({
+			where: { email: { eq: email } },
+		});
+
+		expect(user).not.toBeNull();
+		expect(user?.name).toBe("John Doe");
+	});
+
+	test("should preserve a provided name on signup", async () => {
+		const email = `someone-${Date.now()}@example.com`;
+		const password = "Password123!";
+
+		const signUpResponse = await apiAuth.handler(
+			new Request("http://localhost:4002/auth/sign-up/email", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"CF-Connecting-IP": `192.168.21.${Math.floor(Math.random() * 255)}`,
+				},
+				body: JSON.stringify({ email, password, name: "Alice Wonder" }),
+			}),
+		);
+
+		expect(signUpResponse.status).toBe(200);
+
+		const user = await db.query.user.findFirst({
+			where: { email: { eq: email } },
+		});
+
+		expect(user).not.toBeNull();
+		expect(user?.name).toBe("Alice Wonder");
+	});
 });
 
 describe("Auth rate limiting", () => {

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -8,6 +8,7 @@ import { Redis } from "ioredis";
 import { notifyUserSignup } from "@/utils/discord.js";
 import { validateEmail } from "@/utils/email-validation.js";
 import { sendTransactionalEmail } from "@/utils/email.js";
+import { resolveSignupName } from "@/utils/infer-name.js";
 
 import { db, eq, tables, shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
@@ -719,6 +720,16 @@ The LLM Gateway Team`.trim();
 						}
 					}
 
+					// Apply name fallback for email/password signup before user creation
+					if (ctx.path.startsWith("/sign-up/email")) {
+						const body = ctx.body as
+							| { email?: string; name?: string | null }
+							| undefined;
+						if (body?.email) {
+							body.name = resolveSignupName(body.name, body.email);
+						}
+					}
+
 					// Check and record rate limit for ALL signup attempts (skip in development)
 					if (
 						ctx.path.startsWith("/sign-up") &&
@@ -821,8 +832,20 @@ The LLM Gateway Team`.trim();
 
 					const dbUser = await db.query.user.findFirst({
 						where: { id: { eq: userId } },
-						columns: { status: true },
+						columns: { status: true, name: true, email: true },
 					});
+
+					if (dbUser && !dbUser.name?.trim() && dbUser.email) {
+						const inferredName = resolveSignupName(null, dbUser.email);
+						if (inferredName) {
+							await db
+								.update(tables.user)
+								.set({ name: inferredName })
+								.where(eq(tables.user.id, userId));
+							newSession.user.name = inferredName;
+						}
+					}
+
 					if (dbUser?.status === "deactivated") {
 						await db
 							.delete(tables.session)

--- a/apps/api/src/utils/infer-name.spec.ts
+++ b/apps/api/src/utils/infer-name.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { inferNameFromEmail, resolveSignupName } from "./infer-name.js";
+
+describe("inferNameFromEmail", () => {
+	test("splits dotted local parts into title-cased words", () => {
+		expect(inferNameFromEmail("john.doe@example.com")).toBe("John Doe");
+	});
+
+	test("handles underscores and hyphens", () => {
+		expect(inferNameFromEmail("john_doe@example.com")).toBe("John Doe");
+		expect(inferNameFromEmail("john-doe@example.com")).toBe("John Doe");
+	});
+
+	test("title-cases a single token", () => {
+		expect(inferNameFromEmail("john@example.com")).toBe("John");
+	});
+
+	test("strips plus-addressing suffix", () => {
+		expect(inferNameFromEmail("john.doe+spam@example.com")).toBe("John Doe");
+	});
+
+	test("returns empty string when local part is empty", () => {
+		expect(inferNameFromEmail("@example.com")).toBe("");
+	});
+
+	test("normalizes uppercase input", () => {
+		expect(inferNameFromEmail("JOHN.DOE@example.com")).toBe("John Doe");
+	});
+});
+
+describe("resolveSignupName", () => {
+	test("returns the provided name when it is non-empty", () => {
+		expect(resolveSignupName("Jane Smith", "john.doe@example.com")).toBe(
+			"Jane Smith",
+		);
+	});
+
+	test("trims whitespace from provided name", () => {
+		expect(resolveSignupName("  Jane Smith  ", "john.doe@example.com")).toBe(
+			"Jane Smith",
+		);
+	});
+
+	test("falls back to email inference when name is empty", () => {
+		expect(resolveSignupName("", "john.doe@example.com")).toBe("John Doe");
+		expect(resolveSignupName("   ", "john.doe@example.com")).toBe("John Doe");
+		expect(resolveSignupName(null, "john.doe@example.com")).toBe("John Doe");
+		expect(resolveSignupName(undefined, "john.doe@example.com")).toBe(
+			"John Doe",
+		);
+	});
+});

--- a/apps/api/src/utils/infer-name.ts
+++ b/apps/api/src/utils/infer-name.ts
@@ -1,0 +1,29 @@
+export function inferNameFromEmail(email: string): string {
+	const localPart = email.split("@")[0] ?? "";
+	const cleaned = localPart.replace(/\+.*$/, "");
+	const tokens = cleaned
+		.split(/[._-]+/)
+		.map((token) => token.trim())
+		.filter((token) => token.length > 0);
+
+	if (tokens.length === 0) {
+		return "";
+	}
+
+	return tokens
+		.map(
+			(token) => token.charAt(0).toUpperCase() + token.slice(1).toLowerCase(),
+		)
+		.join(" ");
+}
+
+export function resolveSignupName(
+	name: string | null | undefined,
+	email: string,
+): string {
+	const trimmed = name?.trim();
+	if (trimmed) {
+		return trimmed;
+	}
+	return inferNameFromEmail(email);
+}

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -27,7 +27,7 @@ import { useAuth } from "@/lib/auth-client";
 import { useAppConfig } from "@/lib/config";
 
 const formSchema = z.object({
-	name: z.string().min(2, { message: "Name is required" }),
+	name: z.string().optional(),
 	email: z.string().email({ message: "Please enter a valid email address" }),
 	password: z
 		.string()
@@ -88,7 +88,7 @@ function SignupForm() {
 
 		const { error } = await signUp.email(
 			{
-				name: values.name,
+				name: values.name?.trim() ?? "",
 				email: values.email,
 				password: values.password,
 			},
@@ -264,9 +264,13 @@ function SignupForm() {
 									name="name"
 									render={({ field }) => (
 										<FormItem>
-											<FormLabel>Name</FormLabel>
+											<FormLabel>Name (optional)</FormLabel>
 											<FormControl>
-												<Input placeholder="John Doe" {...field} />
+												<Input
+													placeholder="John Doe"
+													autoComplete="name"
+													{...field}
+												/>
 											</FormControl>
 											<FormMessage />
 										</FormItem>

--- a/apps/playground/src/app/signup/page.tsx
+++ b/apps/playground/src/app/signup/page.tsx
@@ -26,7 +26,7 @@ import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 
 const formSchema = z.object({
-	name: z.string().min(2, { message: "Name is required" }),
+	name: z.string().optional(),
 	email: z.string().email({ message: "Please enter a valid email address" }),
 	password: z
 		.string()
@@ -83,7 +83,7 @@ function Signup() {
 
 		const { error } = await signUp.email(
 			{
-				name: values.name,
+				name: values.name?.trim() ?? "",
 				email: values.email,
 				password: values.password,
 			},
@@ -145,9 +145,13 @@ function Signup() {
 							name="name"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Name</FormLabel>
+									<FormLabel>Name (optional)</FormLabel>
 									<FormControl>
-										<Input placeholder="John Doe" {...field} />
+										<Input
+											placeholder="John Doe"
+											autoComplete="name"
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -30,6 +30,7 @@ import { useFetchClient } from "@/lib/fetch-client";
 
 const createFormSchema = (isHosted: boolean) =>
 	z.object({
+		name: z.string().optional(),
 		email: isHosted
 			? z
 					.string()
@@ -73,6 +74,7 @@ export default function Signup() {
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),
 		defaultValues: {
+			name: "",
 			email: "",
 			password: "",
 			newsletter: true,
@@ -84,7 +86,7 @@ export default function Signup() {
 
 		const { error } = await signUp.email(
 			{
-				name: "",
+				name: values.name?.trim() ?? "",
 				email: values.email,
 				password: values.password,
 			},
@@ -271,6 +273,23 @@ export default function Signup() {
 				{/* Email form */}
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+						<FormField
+							control={form.control}
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name (optional)</FormLabel>
+									<FormControl>
+										<Input
+											placeholder="John Doe"
+											autoComplete="name"
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 						<FormField
 							control={form.control}
 							name="email"


### PR DESCRIPTION
## Summary

- Added an optional **Name** field to all signup forms (UI, Playground, DevPass).
- Added a server-side fallback in the Better Auth `before` hook for `/sign-up/email` that infers a display name from the email local part when no name is provided (e.g., `john.doe@example.com` → "John Doe", strips `+suffix`).
- Mirrored the fallback in the `after` hook so OAuth signups also persist a name to the DB if the provider didn't supply one.
- New `inferNameFromEmail` / `resolveSignupName` helpers in `apps/api/src/utils/infer-name.ts` with unit tests.
- New auth-config integration tests covering name inference on signup and preservation of explicitly provided names.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`
- [x] `pnpm exec vitest run apps/api/src/utils/infer-name.spec.ts` (9 passing)
- [x] `pnpm exec vitest run apps/api/src/auth/config.spec.ts` (15 passing, includes 2 new name-fallback tests)
- [x] `pnpm exec vitest run apps/api/src/routes/user.spec.ts` (10 passing — confirms profile-name update path is unaffected)
- [ ] Manual smoke: sign up via UI without a name → user record stores inferred name.
- [ ] Manual smoke: sign up via Playground / DevPass with name → preserved as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Name is now optional during signup; when omitted the system infers a display name from the email (handles dots/underscores/hyphens, plus-addressing, and title-cases tokens). Provided names are preserved (trimmed) as entered.

* **Tests**
  * Added tests covering name inference and signup behaviors; adjusted signup test expectations accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->