### PR TITLE
fix: prevent /me fetch loop on devpass dashboard

### DIFF
--- a/apps/code/src/app/dashboard/page.tsx
+++ b/apps/code/src/app/dashboard/page.tsx
@@ -1,5 +1,18 @@
+import { redirect } from "next/navigation";
+
+import { fetchServerData } from "@/lib/server-api";
+
 import DashboardClient from "./DashboardClient";
 
-export default function Dashboard() {
+export default async function Dashboard() {
+	const userData = await fetchServerData<{ user: { id: string } } | null>(
+		"GET",
+		"/user/me",
+	);
+
+	if (!userData?.user) {
+		redirect("/login?returnUrl=/dashboard");
+	}
+
 	return <DashboardClient />;
 }


### PR DESCRIPTION
## Summary
- Move the unauthenticated check on `/dashboard` from the client-side `useUser` redirect to a server-side guard. The page now `await`s `/user/me` via `fetchServerData` and `redirect()`s to `/login?returnUrl=/dashboard` when there is no session, so `DashboardClient` never hydrates while logged out and the client-side `useUser` → 401 → `router.push` cycle that produced the `/me` fetch loop can't trigger.
- Mirrors the existing pattern in `apps/ui/src/app/dashboard/page.tsx`.

## Test plan
- [ ] Visit http://localhost:3004/dashboard while logged out — server redirects to `/login?returnUrl=/dashboard`, no repeated `/user/me` calls in the network tab.
- [ ] Visit `/dashboard` while logged in — page renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard now enforces user authentication requirements, automatically redirecting unauthenticated users to the login page with return URL handling to seamlessly return to the dashboard after successful authentication.
  * Dashboard now retrieves and displays current user information on page load, providing a personalized dashboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->