### PR TITLE
fix(gateway): report concrete model id for virtual models

### DIFF
--- a/apps/gateway/src/chat/tools/resolve-provider-context.spec.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { formatUsedModelForDisplay } from "./resolve-provider-context.js";
+import {
+	formatUsedModelForDisplay,
+	resolveBaseModelName,
+} from "./resolve-provider-context.js";
 
 describe("formatUsedModelForDisplay", () => {
 	it("uses the provider id for built-in providers", () => {
@@ -12,6 +15,31 @@ describe("formatUsedModelForDisplay", () => {
 	it("uses the custom provider name for custom providers", () => {
 		expect(formatUsedModelForDisplay("custom", "gpt-5.4-nano", "stuff")).toBe(
 			"stuff/gpt-5.4-nano",
+		);
+	});
+});
+
+describe("resolveBaseModelName", () => {
+	it("returns the concrete catalog id when the upstream modelName matches one", () => {
+		// grok-4-1-fast is a virtual model that routes to grok-4-1-fast-(non-)reasoning.
+		// The displayed base model name should be the concrete variant, not the virtual id.
+		expect(
+			resolveBaseModelName("grok-4-1-fast", "grok-4-1-fast-non-reasoning"),
+		).toBe("grok-4-1-fast-non-reasoning");
+		expect(
+			resolveBaseModelName("grok-4-1-fast", "grok-4-1-fast-reasoning"),
+		).toBe("grok-4-1-fast-reasoning");
+	});
+
+	it("falls back to the parent model id when the modelName is a provider-specific name", () => {
+		expect(resolveBaseModelName("gpt-4o-mini", "gpt-4o-mini-2024-07-18")).toBe(
+			"gpt-4o-mini",
+		);
+	});
+
+	it("falls back to the stripped model name when no parent id is provided", () => {
+		expect(resolveBaseModelName(undefined, "totally-unknown-model")).toBe(
+			"totally-unknown-model",
 		);
 	});
 });

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -17,6 +17,7 @@ import {
 	getProviderEnvVar,
 	hasMaxTokens,
 	type ModelDefinition,
+	models,
 	type OpenAIRequestBody,
 	type OpenAIToolInput,
 	type Provider,
@@ -166,6 +167,23 @@ export function formatUsedModelForDisplay(
 }
 
 /**
+ * Resolve the catalog model id to display as the used model.
+ *
+ * When the parent `modelInfo` is a virtual catalog entry (e.g.
+ * `grok-4-1-fast`) the provider mapping's modelName points at a concrete
+ * sibling model (e.g. `grok-4-1-fast-non-reasoning`). Prefer that concrete
+ * catalog id so the displayed used_model reflects the variant actually
+ * invoked instead of the virtual id, which is never a real upstream model.
+ */
+export function resolveBaseModelName(
+	parentModelId: string | undefined,
+	strippedModelName: string,
+): string {
+	const concreteModelDef = models.find((m) => m.id === strippedModelName);
+	return concreteModelDef?.id ?? parentModelId ?? strippedModelName;
+}
+
+/**
  * Resolves all provider-dependent context needed to make a fetch request.
  * This includes token resolution, URL building, parameter stripping,
  * request body preparation, and header construction.
@@ -189,7 +207,7 @@ export async function resolveProviderContext(
 		usedModel,
 		providerMapping.region,
 	);
-	const baseModelName = modelInfo.id || strippedModelName;
+	const baseModelName = resolveBaseModelName(modelInfo.id, strippedModelName);
 	const usedModelMapping = usedModel;
 	const usedModelFormatted = formatUsedModelForDisplay(
 		usedProvider,


### PR DESCRIPTION
## Summary

- The retry/fallback path's `resolveProviderContext` used `modelInfo.id` as the displayed base model name. For virtual catalog entries like `grok-4-1-fast` that id is the virtual one, not the concrete sibling the request actually flows to (`grok-4-1-fast-non-reasoning` or `grok-4-1-fast-reasoning`).
- Result: logs showed `used_model = azure-ai-foundry/grok-4-1-fast`, even though `used_model_provider_mapping = grok-4-1-fast-non-reasoning`. The virtual id is never a real upstream model and shouldn't appear there.
- Fix: resolve to the concrete sibling catalog id when the provider mapping's `modelName` matches one. Extracted as `resolveBaseModelName` for testability.

## Test plan

- [x] Added unit tests covering virtual → concrete resolution, provider-specific fallback, and unknown fallback
- [x] `pnpm exec vitest run apps/gateway/src/chat --no-file-parallelism` — 305/305 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for model name resolution, including virtual-to-concrete model mapping and fallback handling.

* **Bug Fixes**
  * Improved model name resolution to correctly map virtual upstream models to concrete variants with appropriate fallbacks for provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->