### PR TITLE
feat(devpass): tweak dashboard settings layout

### DIFF
--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -389,36 +389,6 @@ export default function DashboardClient() {
 			<main className="container mx-auto px-4 py-8 max-w-6xl">
 				{hasActivePlan ? (
 					<div className="space-y-10">
-						{/* Top row: subscription controls (cancel/resume) */}
-						<div className="flex justify-end">
-							{devPlanStatus?.devPlanCancelled ? (
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={handleResume}
-									disabled={isResuming}
-								>
-									{isResuming && (
-										<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-									)}
-									Resume subscription
-								</Button>
-							) : (
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={handleCancel}
-									disabled={isCancelling}
-									className="text-muted-foreground"
-								>
-									{isCancelling && (
-										<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-									)}
-									Cancel subscription
-								</Button>
-							)}
-						</div>
-
 						{/* Usage — full-width with metrics + chart */}
 						<UsageOverview
 							projectId={devPlanStatus?.projectId ?? null}
@@ -487,6 +457,36 @@ export default function DashboardClient() {
 							subscribingTier={subscribingTier}
 							onChangeTier={handleChangeTier}
 						/>
+
+						{/* Subscription controls (cancel/resume) */}
+						<div className="flex justify-end">
+							{devPlanStatus?.devPlanCancelled ? (
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={handleResume}
+									disabled={isResuming}
+								>
+									{isResuming && (
+										<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+									)}
+									Resume subscription
+								</Button>
+							) : (
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={handleCancel}
+									disabled={isCancelling}
+									className="text-muted-foreground"
+								>
+									{isCancelling && (
+										<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+									)}
+									Cancel subscription
+								</Button>
+							)}
+						</div>
 					</div>
 				) : (
 					<div className="space-y-10">

--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -209,7 +209,8 @@ export default function DevPlanSettings({
 							<p className="text-xs text-muted-foreground">
 								Store full request and response payloads for analytics and
 								debugging. When off, only metadata is kept. Storage is billed,
-								and this is only required when using the Responses API.
+								and this is only required when using the Responses API or for
+								debugging purposes.
 							</p>
 						</div>
 						<Switch

--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle, ChevronDown, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -43,6 +43,8 @@ export default function DevPlanSettings({
 		initialRetentionLevel === "retain",
 	);
 	const [isUpdatingRetention, setIsUpdatingRetention] = useState(false);
+
+	const [advancedOpen, setAdvancedOpen] = useState(false);
 
 	const updateSettingsMutation = api.useMutation(
 		"patch",
@@ -139,46 +141,6 @@ export default function DevPlanSettings({
 				<div className="rounded-xl border p-5 space-y-4">
 					<div className="flex items-center justify-between gap-4">
 						<div className="space-y-0.5">
-							<Label htmlFor="allow-all-models" className="text-sm font-medium">
-								Allow all models
-							</Label>
-							<p className="text-xs text-muted-foreground">
-								Enable access beyond the curated coding model list
-							</p>
-						</div>
-						<Switch
-							id="allow-all-models"
-							checked={allowAllModels}
-							onCheckedChange={handleAllowAllToggle}
-							disabled={isUpdatingAllowAll}
-						/>
-					</div>
-
-					{allowAllModels && (
-						<div className="flex gap-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-3.5">
-							<AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
-							<p className="text-xs leading-relaxed text-muted-foreground">
-								<span className="font-medium text-yellow-600 dark:text-yellow-400">
-									Prompt caching may not be available.
-								</span>{" "}
-								Coding models are selected because they support prompt caching,
-								which reduces costs and latency. Non-curated models may cost
-								more.
-							</p>
-						</div>
-					)}
-
-					{!allowAllModels && (
-						<p className="text-xs text-muted-foreground rounded-lg bg-muted p-3.5">
-							Using coding-optimized models with prompt caching, tool calling,
-							JSON output, and streaming.
-						</p>
-					)}
-				</div>
-
-				<div className="rounded-xl border p-5 space-y-4">
-					<div className="flex items-center justify-between gap-4">
-						<div className="space-y-0.5">
 							<Label htmlFor="enable-caching" className="text-sm font-medium">
 								Request caching
 							</Label>
@@ -246,7 +208,8 @@ export default function DevPlanSettings({
 							</Label>
 							<p className="text-xs text-muted-foreground">
 								Store full request and response payloads for analytics and
-								debugging. When off, only metadata is kept.
+								debugging. When off, only metadata is kept. Storage is billed,
+								and this is only required when using the Responses API.
 							</p>
 						</div>
 						<Switch
@@ -256,6 +219,67 @@ export default function DevPlanSettings({
 							disabled={isUpdatingRetention}
 						/>
 					</div>
+				</div>
+
+				<div className="rounded-xl border">
+					<button
+						type="button"
+						onClick={() => setAdvancedOpen((open) => !open)}
+						aria-expanded={advancedOpen}
+						className="flex w-full items-center justify-between gap-4 p-5 text-left"
+					>
+						<span className="text-sm font-medium">Advanced</span>
+						<ChevronDown
+							className={`h-4 w-4 text-muted-foreground transition-transform ${
+								advancedOpen ? "rotate-180" : ""
+							}`}
+						/>
+					</button>
+
+					{advancedOpen && (
+						<div className="border-t p-5 space-y-4">
+							<div className="flex items-center justify-between gap-4">
+								<div className="space-y-0.5">
+									<Label
+										htmlFor="allow-all-models"
+										className="text-sm font-medium"
+									>
+										Allow all models
+									</Label>
+									<p className="text-xs text-muted-foreground">
+										Enable access beyond the curated coding model list
+									</p>
+								</div>
+								<Switch
+									id="allow-all-models"
+									checked={allowAllModels}
+									onCheckedChange={handleAllowAllToggle}
+									disabled={isUpdatingAllowAll}
+								/>
+							</div>
+
+							{allowAllModels && (
+								<div className="flex gap-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-3.5">
+									<AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
+									<p className="text-xs leading-relaxed text-muted-foreground">
+										<span className="font-medium text-yellow-600 dark:text-yellow-400">
+											Prompt caching may not be available.
+										</span>{" "}
+										Coding models are selected because they support prompt
+										caching, which reduces costs and latency. Non-curated models
+										may cost more.
+									</p>
+								</div>
+							)}
+
+							{!allowAllModels && (
+								<p className="text-xs text-muted-foreground rounded-lg bg-muted p-3.5">
+									Using coding-optimized models with prompt caching, tool
+									calling, JSON output, and streaming.
+								</p>
+							)}
+						</div>
+					)}
 				</div>
 			</div>
 		</div>

--- a/apps/docs/content/features/caching.mdx
+++ b/apps/docs/content/features/caching.mdx
@@ -38,18 +38,19 @@ Caching can dramatically reduce costs for applications with repetitive requests:
 
 ## Requirements
 
-<Callout type="warning">
-	Caching requires [Data Retention](/features/data-retention) to be enabled with
-	"Retain All Data" level. This allows LLM Gateway to store and retrieve
-	response payloads.
+<Callout type="info">
+	Caching is **free** and **independent** of [Data
+	Retention](/features/data-retention). Cached responses live in a short-lived
+	cache (TTL-bound, typically seconds to minutes) and are not stored as
+	long-term request data — you do not need to enable data retention to use
+	caching.
 </Callout>
 
 To use caching:
 
-1. Enable **Data Retention** in your organization settings with "Retain All Data" level
-2. Enable **Caching** in your project settings under Preferences
-3. Configure the cache duration (TTL) as needed
-4. Make requests as normal—caching is automatic
+1. Enable **Caching** in your project settings under Preferences
+2. Configure the cache duration (TTL) as needed
+3. Make requests as normal—caching is automatic
 
 ## Cache Key Generation
 
@@ -192,16 +193,13 @@ Caching may not be suitable for:
 - Time-sensitive information
 - Creative tasks requiring variety
 
-## Storage Costs
+## Pricing
 
-Since caching requires data retention, storage costs apply:
-
-- **Rate**: $0.01 per 1 million tokens
-- **Applies to**: All tokens in cached requests and responses
-
-See [Data Retention](/features/data-retention) for complete pricing details.
+Caching is **completely free**. Cached responses are held in a short-lived
+in-memory cache (bounded by your configured TTL) and do not incur storage
+charges. Storage costs only apply if you separately enable [Data
+Retention](/features/data-retention) for full request/response payloads.
 
 <Callout type="success">
-	The cost savings from caching typically far outweigh the storage costs,
-	especially for applications with high request duplication.
+	Caching reduces both inference cost and latency at no additional charge.
 </Callout>


### PR DESCRIPTION
## Summary
- Move the **Cancel subscription** button from the very top of the DevPass dashboard to the very bottom (after the change-plan section).
- Update **Retain request data** copy to note that storage is billed and that retention is only required when using the Responses API.
- Hide **Allow all models** behind a collapsible **Advanced** section, collapsed by default.

> Note: the original ask included "also make sure the cache duration." which I couldn't fully parse. The cache duration field is unchanged — let me know what you wanted there and I'll follow up.

## Test plan
- [ ] Open the DevPass dashboard with an active plan and verify the cancel/resume button now sits below the "Change plan" card.
- [ ] Verify the retention setting copy shows the new billing/Responses-API note.
- [ ] Verify "Allow all models" is hidden under the new "Advanced" section and that toggling it open/closed works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible "Advanced" settings section to better organize advanced plan options, moving less-common toggles into it.
  * Adjusted subscription control placement on the dashboard to improve layout and user flow.

* **Documentation**
  * Clarified retention settings with expanded billing and API guidance.
  * Updated caching docs: caching is free, short-lived, and independent of data retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->