### PR TITLE
feat(admin): persist global-stats filters in URL

### DIFF
--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -2,7 +2,8 @@
 
 import { format, parseISO } from "date-fns";
 import { BarChart3, Coins, Cpu, Layers } from "lucide-react";
-import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
 import {
 	CartesianGrid,
 	Cell,
@@ -96,6 +97,28 @@ const timeseriesChartConfig = {
 
 type TimeseriesMetric = keyof typeof timeseriesChartConfig;
 
+const VALID_RANGES: Range[] = ["7d", "30d", "90d", "365d"];
+const VALID_GROUPS: GroupBy[] = ["model", "source"];
+const VALID_METRICS: TimeseriesMetric[] = [
+	"requestCount",
+	"cost",
+	"totalTokens",
+];
+
+function parseRange(value: string | null): Range {
+	return VALID_RANGES.includes(value as Range) ? (value as Range) : "30d";
+}
+
+function parseGroupBy(value: string | null): GroupBy {
+	return VALID_GROUPS.includes(value as GroupBy) ? (value as GroupBy) : "model";
+}
+
+function parseMetric(value: string | null): TimeseriesMetric {
+	return VALID_METRICS.includes(value as TimeseriesMetric)
+		? (value as TimeseriesMetric)
+		: "cost";
+}
+
 function StatCard({
 	label,
 	value,
@@ -169,9 +192,35 @@ function compactMetricFormatter(metric: TimeseriesMetric) {
 }
 
 export function GlobalStatsClient() {
-	const [range, setRange] = useState<Range>("30d");
-	const [groupBy, setGroupBy] = useState<GroupBy>("model");
-	const [chartMetric, setChartMetric] = useState<TimeseriesMetric>("cost");
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+
+	const range = parseRange(searchParams.get("range"));
+	const groupBy = parseGroupBy(searchParams.get("groupBy"));
+	const chartMetric = parseMetric(searchParams.get("metric"));
+
+	const updateParam = useCallback(
+		(key: string, value: string) => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.set(key, value);
+			router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+		},
+		[router, pathname, searchParams],
+	);
+
+	const setRange = useCallback(
+		(value: Range) => updateParam("range", value),
+		[updateParam],
+	);
+	const setGroupBy = useCallback(
+		(value: GroupBy) => updateParam("groupBy", value),
+		[updateParam],
+	);
+	const setChartMetric = useCallback(
+		(value: TimeseriesMetric) => updateParam("metric", value),
+		[updateParam],
+	);
 
 	const $api = useApi();
 	const { data, isLoading, isError } = $api.useQuery(

--- a/ee/admin/src/app/global-stats/page.tsx
+++ b/ee/admin/src/app/global-stats/page.tsx
@@ -1,8 +1,14 @@
+import { Suspense } from "react";
+
 import { requireSession } from "@/lib/require-session";
 
 import { GlobalStatsClient } from "./client";
 
 export default async function Page() {
 	await requireSession();
-	return <GlobalStatsClient />;
+	return (
+		<Suspense>
+			<GlobalStatsClient />
+		</Suspense>
+	);
 }


### PR DESCRIPTION
## Summary
- Range, group-by, and metric toggles on the admin global-stats page now read/write to URL query params (`range`, `groupBy`, `metric`), making the view linkable and shareable.
- Wraps the client in a `Suspense` boundary as required by `useSearchParams`.

## Test plan
- [ ] Open `/global-stats` and click each range/group/metric button — URL should update without page reload
- [ ] Reload the page with params (e.g. `?range=90d&groupBy=source&metric=totalTokens`) and confirm UI reflects them
- [ ] Verify invalid/missing params fall back to defaults (`30d`, `model`, `cost`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard filter selections (date range, grouping options, and metrics) are now preserved in the URL, enabling users to share and bookmark specific filtered views with colleagues.

* **Improvements**
  * Enhanced loading experience and optimized performance for the global statistics dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->