### PR TITLE
docs(code): update SoulForge description and bullets

### DIFF
--- a/apps/code/src/app/dashboard/components/QuickStart.tsx
+++ b/apps/code/src/app/dashboard/components/QuickStart.tsx
@@ -66,7 +66,8 @@ function buildSnippets(apiKey: string): Record<ToolId, Snippet> {
 		soulforge: {
 			exports: [],
 			command: "soulforge",
-			comment: "# /keys, paste your LLM Gateway key — caches cut ~50% tokens",
+			comment:
+				"# inside: /keys → paste your DevPass key (or: soulforge --set-key llmgateway <key>)",
 		},
 		autohand: {
 			exports: [

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -41,9 +41,9 @@ const featuredTools = [
 		name: "SoulForge",
 		icon: SoulForgeIcon,
 		description:
-			"Saves ~50% of tokens on multi-turn coding sessions. Instead of grepping and dumping whole files into the chat, SoulForge builds a live map of your codebase and lets the agent jump straight to the function it needs — one symbol at a time. Less waste, faster turns, cleaner edits. Pair with DevPass to effectively double your monthly usage.",
+			"Graph-powered coding agent. Maps your repo on launch and edits TypeScript by symbol name, not by find-and-replace. Roughly half the tokens of an equivalent Claude Code or OpenCode session. Pair with DevPass to double your monthly usage.",
 		setup: "/keys → paste your key",
-		highlight: "Saves ~50% tokens",
+		highlight: "Graph-powered · −50%",
 	},
 ];
 
@@ -82,7 +82,7 @@ export default function LandingPage() {
 								<span className="font-semibold text-foreground">$3</span> of
 								model usage at provider rates. Pair it with{" "}
 								<span className="font-semibold text-foreground">SoulForge</span>{" "}
-								and prompt caching pushes that to roughly{" "}
+								— the graph-powered agent — and that stretches to roughly{" "}
 								<span className="font-semibold text-foreground">$6</span>.
 							</p>
 							<p className="mx-auto mb-10 max-w-xl text-sm text-muted-foreground">

--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -148,7 +148,7 @@ const usageRows: UsageRow[] = [
 		emphasis: true,
 	},
 	{
-		label: "Effective with SoulForge (~50% token cut)",
+		label: "Effective with SoulForge (~50% fewer tokens)",
 		lite: `~${formatUsd(liteCredits * 2)}`,
 		pro: `~${formatUsd(proCredits * 2)}`,
 		max: `~${formatUsd(maxCredits * 2)}`,
@@ -302,7 +302,8 @@ export default function PricingPage() {
 								<span className="font-semibold text-foreground">$3</span> of
 								model usage at provider rates — and roughly{" "}
 								<span className="font-semibold text-foreground">$6</span> when
-								you pair DevPass with SoulForge.
+								you pair DevPass with SoulForge, the graph-powered agent that
+								treats your code as structure, not strings.
 							</p>
 						</div>
 					</div>
@@ -415,8 +416,8 @@ export default function PricingPage() {
 							Usage is metered at each provider&apos;s published per-token rate
 							(input, output, and cached tokens). Every request shows its dollar
 							value in your dashboard in real time. SoulForge savings vary by
-							workload — 50% is typical for multi-turn agent sessions where the
-							system prompt and codebase context stay stable.
+							workload — ~50% is typical when the agent works through a real
+							project over multiple turns.
 						</p>
 					</div>
 				</section>

--- a/apps/code/src/components/PricingPlans.tsx
+++ b/apps/code/src/components/PricingPlans.tsx
@@ -240,7 +240,8 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 									/>
 									<div>
 										<span className="font-semibold">With SoulForge</span> →
-										prompt caching cuts ~50% of tokens, stretching your{" "}
+										graph-powered context cuts roughly half the tokens,
+										stretching your{" "}
 										<span className="font-mono font-semibold tabular-nums">
 											{formatUsd(usageValue)}
 										</span>{" "}

--- a/apps/code/src/components/SoulForgeBoost.tsx
+++ b/apps/code/src/components/SoulForgeBoost.tsx
@@ -21,10 +21,9 @@ export function SoulForgeBoost() {
 							</span>
 						</h2>
 						<p className="mb-6 text-base leading-relaxed text-muted-foreground">
-							SoulForge is a coding agent built around aggressive prompt caching
-							and context reuse. Point it at LLM Gateway and it sends roughly
-							half the tokens of an equivalent Claude Code session — same model,
-							same task, smaller bill.
+							Most AI tools treat your code as text. They grep, they paste, they
+							match strings. SoulForge treats code as structure. Same model,
+							same task, half the bill.
 						</p>
 						<ul className="mb-8 space-y-3">
 							<li className="flex items-start gap-3 text-sm">
@@ -33,10 +32,10 @@ export function SoulForgeBoost() {
 								</div>
 								<span className="text-muted-foreground">
 									<span className="font-medium text-foreground">
-										Prompt caching by default
+										Sees the whole codebase at once
 									</span>{" "}
-									— system prompt, tools, and project context are cached on
-									every provider that supports it.
+									— a live map of every file and how they connect, across
+									TypeScript, Python, Rust, Go, Java, and 30+ more.
 								</span>
 							</li>
 							<li className="flex items-start gap-3 text-sm">
@@ -45,10 +44,10 @@ export function SoulForgeBoost() {
 								</div>
 								<span className="text-muted-foreground">
 									<span className="font-medium text-foreground">
-										Context-aware compaction
+										The first AST editor for AI
 									</span>{" "}
-									— SoulForge prunes stale turns instead of replaying the whole
-									conversation.
+									— edits TypeScript and JavaScript by symbol name, not by
+									find-and-replace. Cleaner changes, fewer retries.
 								</span>
 							</li>
 							<li className="flex items-start gap-3 text-sm">
@@ -98,7 +97,7 @@ export function SoulForgeBoost() {
 									<div className="absolute inset-0 bg-[repeating-linear-gradient(135deg,transparent_0,transparent_6px,rgba(0,0,0,0.04)_6px,rgba(0,0,0,0.04)_12px)] dark:bg-[repeating-linear-gradient(135deg,transparent_0,transparent_6px,rgba(255,255,255,0.04)_6px,rgba(255,255,255,0.04)_12px)]" />
 								</div>
 								<p className="mt-1.5 text-xs text-muted-foreground">
-									Standard agent loop, no aggressive caching
+									Greps, pastes, retries
 								</p>
 							</div>
 
@@ -122,7 +121,7 @@ export function SoulForgeBoost() {
 									<div className="absolute inset-y-0 left-0 w-1/2 bg-emerald-500/70" />
 								</div>
 								<p className="mt-1.5 text-xs text-muted-foreground">
-									Prompt-cache hits on every reusable prefix
+									Jumps straight to what matters
 								</p>
 							</div>
 
@@ -158,9 +157,8 @@ export function SoulForgeBoost() {
 					</div>
 				</div>
 				<p className="mt-8 text-center text-xs text-muted-foreground">
-					Actual savings vary by workload. The 50% figure is typical for
-					multi-turn agent sessions where the system prompt and codebase context
-					stay stable.
+					Savings vary by workload. ~50% is typical when the agent works through
+					a real project over multiple turns.
 				</p>
 			</div>
 		</section>

--- a/apps/code/src/components/TerminalPreview.tsx
+++ b/apps/code/src/components/TerminalPreview.tsx
@@ -57,7 +57,8 @@ const snippets: Record<
 	soulforge: {
 		lines: [],
 		command: "soulforge",
-		comment: "# /keys, paste your LLM Gateway key — caches cut ~50% tokens",
+		comment:
+			"# inside: /keys → paste your DevPass key (or: soulforge --set-key llmgateway <key>)",
 	},
 	autohand: {
 		lines: [

--- a/apps/ui/src/components/apps/app-metadata.ts
+++ b/apps/ui/src/components/apps/app-metadata.ts
@@ -136,7 +136,7 @@ export const APP_METADATA: Record<string, AppMetadata> = {
 		displayName: "SoulForge",
 		url: "https://soulforge.proxysoul.com/",
 		description:
-			"Aggressive prompt caching cuts roughly 50% of tokens on multi-turn agent runs.",
+			"Graph-powered coding agent. Treats code as structure, not strings. Roughly half the tokens on multi-turn coding sessions.",
 		category: "coding",
 		Icon: SoulForgeIcon,
 	},


### PR DESCRIPTION
- update SoulForge copy on landing, pricing, and apps pages
- update boost section bullets and chart captions
- update terminal hint with /keys and --set-key flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SoulForge marketing and UI copy to emphasize a graph-powered coding agent and roughly 50% token savings in multi-turn workflows
  * Revised setup instructions to instruct users to paste/configure a DevPass key
  * Harmonized messaging across landing, pricing, feature cards, and previews
<!-- end of auto-generated comment: release notes by coderabbit.ai -->