### PR TITLE
fix(gateway): map OpenAI finish reasons from Google

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -82,6 +82,24 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps OpenAI-format finish reasons returned by Google providers", () => {
+		expect(getUnifiedFinishReason("stop", "google-ai-studio")).toBe(
+			UnifiedFinishReason.COMPLETED,
+		);
+		expect(getUnifiedFinishReason("length", "google-ai-studio")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(getUnifiedFinishReason("tool_calls", "google-ai-studio")).toBe(
+			UnifiedFinishReason.TOOL_CALLS,
+		);
+		expect(getUnifiedFinishReason("length", "google-vertex")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(
+			getUnifiedFinishReason("MALFORMED_FUNCTION_CALL", "google-ai-studio"),
+		).toBe(UnifiedFinishReason.TOOL_CALLS);
+	});
+
 	it("maps Glacier finish reasons like Google AI Studio", () => {
 		expect(getUnifiedFinishReason("STOP", "glacier")).toBe(
 			UnifiedFinishReason.COMPLETED,

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -87,11 +87,18 @@ export function getUnifiedFinishReason(
 		case "google-vertex":
 		case "quartz":
 			// Google finish reasons (original format, not mapped to OpenAI)
-			if (finishReason === "STOP") {
+			if (finishReason === "STOP" || finishReason === "stop") {
 				return UnifiedFinishReason.COMPLETED;
 			}
-			if (finishReason === "MAX_TOKENS") {
+			if (finishReason === "MAX_TOKENS" || finishReason === "length") {
 				return UnifiedFinishReason.LENGTH_LIMIT;
+			}
+			if (
+				finishReason === "MALFORMED_FUNCTION_CALL" ||
+				finishReason === "UNEXPECTED_TOOL_CALL" ||
+				finishReason === "tool_calls"
+			) {
+				return UnifiedFinishReason.TOOL_CALLS;
 			}
 			if (
 				finishReason === "SAFETY" ||


### PR DESCRIPTION
## Summary
- Google providers (`google-ai-studio`, `google-vertex`, `glacier`, `quartz`) sometimes return OpenAI-format finish reasons (e.g. `length`, `stop`, `tool_calls`) instead of the native Google values (`MAX_TOKENS`, `STOP`, etc.).
- Without mapping, these fall through to `UNKNOWN`, which logs an `"Unknown finish reason encountered"` error (observed in production for `google-ai-studio/gemini-2.5-pro` with `finishReason: "length"`).
- Adds OpenAI-format aliases to the Google branch of `getUnifiedFinishReason`, plus `MALFORMED_FUNCTION_CALL` / `UNEXPECTED_TOOL_CALL` → `TOOL_CALLS`.

## Test plan
- [x] `pnpm test:unit logs.spec` passes (added cases for `length`/`stop`/`tool_calls`/`MALFORMED_FUNCTION_CALL` on Google providers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of finish reason mappings for Google providers, now supporting additional formats and tool-call related scenarios.

* **Tests**
  * Added test coverage for Google provider finish reason mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->