### PR TITLE
fix(chat): focus + height polish; feat(admin): devpass margin% + chart

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7393,6 +7393,7 @@ const devpassSubscriberSchema = z.object({
 	mrr: z.number(),
 	realCost: z.number(),
 	margin: z.number(),
+	marginPct: z.number().nullable(),
 	subscribedSince: z.string().nullable(),
 	tierChanges: z.number(),
 	lastPaymentFailureAt: z.string().nullable(),
@@ -7416,6 +7417,7 @@ const devpassKpisSchema = z.object({
 	totalRealCostCycle: z.number(),
 	totalMrrCycle: z.number(),
 	totalMargin: z.number(),
+	marginPct: z.number().nullable(),
 });
 
 const devpassListSchema = z.object({
@@ -7518,6 +7520,47 @@ const getDevpassSubscriber = createRoute({
 		},
 		404: {
 			description: "Subscriber not found.",
+		},
+	},
+});
+
+const devpassTimeseriesPointSchema = z.object({
+	date: z.string(),
+	revenue: z.number(),
+	cost: z.number(),
+	margin: z.number(),
+});
+
+const devpassTimeseriesSchema = z.object({
+	data: z.array(devpassTimeseriesPointSchema),
+	totals: z.object({
+		revenue: z.number(),
+		cost: z.number(),
+		margin: z.number(),
+	}),
+	range: z.object({
+		from: z.string(),
+		to: z.string(),
+	}),
+});
+
+const getDevpassTimeseries = createRoute({
+	method: "get",
+	path: "/devpass/timeseries",
+	request: {
+		query: z.object({
+			from: z.string().optional(),
+			to: z.string().optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: devpassTimeseriesSchema.openapi({}),
+				},
+			},
+			description: "DevPass revenue/cost/margin per day.",
 		},
 	},
 });
@@ -7973,6 +8016,10 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			: null;
 		const hasPaymentIssue = (row.paymentFailureCount ?? 0) > 0;
 
+		const mrrNum = Number(row.mrr ?? 0);
+		const marginNum = Number(row.margin ?? 0);
+		const marginPct = mrrNum > 0 ? (marginNum / mrrNum) * 100 : null;
+
 		return {
 			id: row.id,
 			name: row.name,
@@ -7991,9 +8038,10 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			expiresAt: expiresAt ? expiresAt.toISOString() : null,
 			cancelled,
 			allowAllModels: row.allowAllModels,
-			mrr: Number(row.mrr ?? 0),
+			mrr: mrrNum,
 			realCost: Number(row.realCost ?? 0),
-			margin: Number(row.margin ?? 0),
+			margin: marginNum,
+			marginPct,
 			subscribedSince: row.subscribedSince
 				? new Date(row.subscribedSince).toISOString()
 				: null,
@@ -8002,6 +8050,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			createdAt: row.createdAt.toISOString(),
 		};
 	});
+
+	const kpiMarginPct =
+		totalMrrCycle > 0 ? (totalMargin / totalMrrCycle) * 100 : null;
 
 	return c.json({
 		subscribers,
@@ -8019,6 +8070,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			totalRealCostCycle,
 			totalMrrCycle,
 			totalMargin,
+			marginPct: kpiMarginPct,
 		},
 		limit,
 		offset,
@@ -8135,6 +8187,8 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 
 	const hasPaymentIssue = (org.paymentFailureCount ?? 0) > 0;
 
+	const marginPct = mrr > 0 ? (margin / mrr) * 100 : null;
+
 	const subscriber = {
 		id: org.id,
 		name: org.name,
@@ -8158,6 +8212,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 		mrr,
 		realCost,
 		margin,
+		marginPct,
 		subscribedSince: firstStartRow?.firstStart
 			? new Date(firstStartRow.firstStart).toISOString()
 			: null,
@@ -8232,6 +8287,160 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 			failureMessage: p.failureMessage ?? null,
 			source: p.source ?? null,
 		})),
+	});
+});
+
+const DEV_PLAN_TX_TYPES = [
+	"dev_plan_start",
+	"dev_plan_upgrade",
+	"dev_plan_downgrade",
+	"dev_plan_renewal",
+] as const;
+
+admin.openapi(getDevpassTimeseries, async (c) => {
+	const query = c.req.valid("query");
+	const now = new Date();
+
+	// Resolve range. When no from/to is provided, default to all-time
+	// (anchored to the earliest dev_plan_start, falling back to today).
+	let startDate: Date;
+	let endDate: Date;
+	if (query.from && query.to) {
+		startDate = new Date(query.from + "T00:00:00.000Z");
+		endDate = new Date(query.to + "T23:59:59.999Z");
+	} else {
+		const [oldest] = await db
+			.select({
+				minDate: sql<string>`MIN(${tables.transaction.createdAt})`.as(
+					"min_date",
+				),
+			})
+			.from(tables.transaction)
+			.where(eq(tables.transaction.type, "dev_plan_start"));
+		startDate = oldest?.minDate ? new Date(oldest.minDate) : now;
+		startDate.setUTCHours(0, 0, 0, 0);
+		endDate = new Date(now);
+		endDate.setUTCHours(23, 59, 59, 999);
+	}
+
+	if (endDate.getTime() < startDate.getTime()) {
+		endDate = new Date(startDate);
+		endDate.setUTCHours(23, 59, 59, 999);
+	}
+
+	// Revenue per day from completed DevPass transactions.
+	const revenuePerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<string>`COALESCE(SUM(CAST(${tables.transaction.creditAmount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.type, [...DEV_PLAN_TX_TYPES]),
+				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
+	// Provider cost per day for projects belonging to orgs that are or were
+	// ever on a DevPass plan (i.e. currently devPlan != 'none' OR have a
+	// historical dev_plan_start). This approximates "DevPass usage" without
+	// reconstructing daily plan membership.
+	const costPerDay = await db
+		.select({
+			date: sql<string>`DATE(${projectHourlyStats.hourTimestamp})`.as("date"),
+			total:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(projectHourlyStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyStats.projectId, tables.project.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.project.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				gte(projectHourlyStats.hourTimestamp, startDate),
+				lte(projectHourlyStats.hourTimestamp, endDate),
+				or(
+					ne(tables.organization.devPlan, "none"),
+					sql`EXISTS (
+						SELECT 1 FROM ${tables.transaction} t
+						WHERE t.organization_id = ${tables.organization.id}
+						AND t.type = 'dev_plan_start'
+					)`,
+				)!,
+			),
+		)
+		.groupBy(sql`DATE(${projectHourlyStats.hourTimestamp})`)
+		.orderBy(asc(sql`DATE(${projectHourlyStats.hourTimestamp})`));
+
+	const revenueMap = new Map<string, number>();
+	for (const row of revenuePerDay) {
+		revenueMap.set(row.date, Number(row.total));
+	}
+	const costMap = new Map<string, number>();
+	for (const row of costPerDay) {
+		costMap.set(row.date, Number(row.total));
+	}
+
+	const data: Array<{
+		date: string;
+		revenue: number;
+		cost: number;
+		margin: number;
+	}> = [];
+
+	const cursor = new Date(
+		Date.UTC(
+			startDate.getUTCFullYear(),
+			startDate.getUTCMonth(),
+			startDate.getUTCDate(),
+		),
+	);
+	const lastDay = Date.UTC(
+		endDate.getUTCFullYear(),
+		endDate.getUTCMonth(),
+		endDate.getUTCDate(),
+	);
+
+	let totalRevenue = 0;
+	let totalCost = 0;
+
+	while (cursor.getTime() <= lastDay) {
+		const iso = cursor.toISOString().slice(0, 10);
+		const revenue = revenueMap.get(iso) ?? 0;
+		const cost = costMap.get(iso) ?? 0;
+		const margin = revenue - cost;
+		data.push({ date: iso, revenue, cost, margin });
+		totalRevenue += revenue;
+		totalCost += cost;
+		cursor.setUTCDate(cursor.getUTCDate() + 1);
+	}
+
+	return c.json({
+		data,
+		totals: {
+			revenue: totalRevenue,
+			cost: totalCost,
+			margin: totalRevenue - totalCost,
+		},
+		range: {
+			from: startDate.toISOString().slice(0, 10),
+			to: endDate.toISOString().slice(0, 10),
+		},
 	});
 });
 

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4559,6 +4559,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4582,6 +4583,7 @@ export interface paths {
                                 totalRealCostCycle: number;
                                 totalMrrCycle: number;
                                 totalMargin: number;
+                                marginPct: number | null;
                             };
                             limit: number;
                             offset: number;
@@ -4646,6 +4648,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4679,6 +4682,60 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
                 };
             };
         };

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -20,7 +20,7 @@ import {
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { List, type RowComponentProps } from "react-window";
 import { toast } from "sonner";
 
@@ -89,19 +89,24 @@ type ChatHistoryRow =
 	| { type: "chat"; key: string; chat: Chat }
 	| { type: "spacer"; key: string };
 
+const ROW_HEIGHT_HEADER = 32;
+const ROW_HEIGHT_SPACER = 16;
+const ROW_HEIGHT_CHAT = 60;
+
 interface ChatHistoryRowProps {
 	rows: ChatHistoryRow[];
 	currentChatId?: string;
 	editingId: string | null;
 	editTitle: string;
+	pendingFocusChatId: string | null;
 	isPageLoading: boolean;
-	formatDate: (dateString: string) => string;
 	onChatSelect?: (chatId: string) => void;
 	onEditTitleChange: (value: string) => void;
 	onSaveTitle: (chatId: string) => void;
 	onCancelEdit: () => void;
 	onDeleteChat: (chatId: string) => void;
 	onStartEdit: (chat: Chat) => void;
+	onEditFocused: () => void;
 }
 
 function getChatHistoryRowHeight(
@@ -111,14 +116,69 @@ function getChatHistoryRowHeight(
 	const row = rows[index];
 
 	if (row?.type === "header") {
-		return 32;
+		return ROW_HEIGHT_HEADER;
 	}
 
 	if (row?.type === "spacer") {
-		return 16;
+		return ROW_HEIGHT_SPACER;
 	}
 
-	return 52;
+	return ROW_HEIGHT_CHAT;
+}
+
+function EditChatTitleInput({
+	chatId,
+	value,
+	shouldFocus,
+	onChange,
+	onSave,
+	onCancel,
+	onFocused,
+}: {
+	chatId: string;
+	value: string;
+	shouldFocus: boolean;
+	onChange: (value: string) => void;
+	onSave: (chatId: string) => void;
+	onCancel: () => void;
+	onFocused: () => void;
+}) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	useEffect(() => {
+		if (
+			!shouldFocus ||
+			!inputRef.current ||
+			document.activeElement === inputRef.current
+		) {
+			return;
+		}
+		const el = inputRef.current;
+		el.focus();
+		const len = el.value.length;
+		el.setSelectionRange(len, len);
+		onFocused();
+	}, [shouldFocus, onFocused]);
+
+	return (
+		<Input
+			ref={inputRef}
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			onBlur={() => onSave(chatId)}
+			onKeyDown={(e) => {
+				if (e.key === "Enter") {
+					e.preventDefault();
+					e.currentTarget.blur();
+				}
+				if (e.key === "Escape") {
+					e.preventDefault();
+					onCancel();
+				}
+			}}
+			className="h-7 text-sm border-none px-1 focus-visible:ring-0 bg-transparent"
+		/>
+	);
 }
 
 function ChatHistoryRowComponent({
@@ -129,14 +189,15 @@ function ChatHistoryRowComponent({
 	currentChatId,
 	editingId,
 	editTitle,
+	pendingFocusChatId,
 	isPageLoading,
-	formatDate,
 	onChatSelect,
 	onEditTitleChange,
 	onSaveTitle,
 	onCancelEdit,
 	onDeleteChat,
 	onStartEdit,
+	onEditFocused,
 }: RowComponentProps<ChatHistoryRowProps>) {
 	const row = rows[index];
 
@@ -159,37 +220,30 @@ function ChatHistoryRowComponent({
 	}
 
 	const { chat } = row;
+	const isEditing = editingId === chat.id;
 
 	return (
 		<div {...ariaAttributes} style={style}>
-			<div className="relative px-2">
-				<div className="relative">
-					{editingId === chat.id ? (
-						<div className="flex w-full items-center gap-3 rounded-md px-2 py-3 pr-10 text-left text-sm ring-sidebar-ring bg-sidebar-accent text-sidebar-accent-foreground">
+			<div className="relative h-full px-2">
+				<div className="relative h-full">
+					{isEditing ? (
+						<div className="flex h-full w-full items-center gap-3 rounded-md px-2 pr-10 text-left text-sm ring-sidebar-ring bg-sidebar-accent text-sidebar-accent-foreground">
 							<MessageSquare className="h-4 w-4 shrink-0 text-muted-foreground" />
-							<Input
+							<EditChatTitleInput
+								chatId={chat.id}
 								value={editTitle}
-								onChange={(e) => onEditTitleChange(e.target.value)}
-								onBlur={() => onSaveTitle(chat.id)}
-								onKeyDown={(e) => {
-									if (e.key === "Enter") {
-										e.preventDefault();
-										e.currentTarget.blur();
-									}
-									if (e.key === "Escape") {
-										e.preventDefault();
-										onCancelEdit();
-									}
-								}}
-								className="h-7 text-sm border-none px-1 focus-visible:ring-0 bg-transparent"
-								autoFocus
+								shouldFocus={pendingFocusChatId === chat.id}
+								onChange={onEditTitleChange}
+								onSave={onSaveTitle}
+								onCancel={onCancelEdit}
+								onFocused={onEditFocused}
 							/>
 						</div>
 					) : (
 						<SidebarMenuButton
 							isActive={currentChatId === chat.id}
 							onClick={() => onChatSelect?.(chat.id)}
-							className="w-full justify-start gap-3 group relative pr-10 py-6"
+							className="h-full! w-full justify-start gap-3 group relative pr-10"
 							type="button"
 							disabled={isPageLoading}
 						>
@@ -204,8 +258,8 @@ function ChatHistoryRowComponent({
 							</div>
 						</SidebarMenuButton>
 					)}
-					{currentChatId === chat.id && editingId !== chat.id && (
-						<div className="absolute right-0 top-2 bottom-0">
+					{currentChatId === chat.id && !isEditing && (
+						<div className="absolute right-0 top-1/2 -translate-y-1/2">
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>
 									<SidebarMenuAction
@@ -326,6 +380,11 @@ export function ChatSidebar({
 
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editTitle, setEditTitle] = useState("");
+	// chatId that needs initial focus. Cleared once the row delivers focus,
+	// so re-mounting the row on scroll never re-steals focus mid-edit.
+	const [pendingFocusChatId, setPendingFocusChatId] = useState<string | null>(
+		null,
+	);
 
 	const chats = chatsData?.chats ?? [];
 
@@ -353,40 +412,53 @@ export function ChatSidebar({
 		});
 	};
 
-	const handleEditTitle = (chat: Chat) => {
+	const handleEditTitle = useCallback((chat: Chat) => {
 		setEditingId(chat.id);
 		setEditTitle(chat.title);
-	};
+		setPendingFocusChatId(chat.id);
+	}, []);
 
-	const saveTitle = (chatId: string) => {
-		if (editTitle.trim()) {
-			updateChat.mutate({
+	const saveTitle = useCallback(
+		(chatId: string) => {
+			if (editTitle.trim()) {
+				updateChat.mutate({
+					params: {
+						path: { id: chatId },
+					},
+					body: { title: editTitle.trim() },
+				});
+			}
+			setEditingId(null);
+			setEditTitle("");
+			setPendingFocusChatId(null);
+		},
+		[editTitle, updateChat],
+	);
+
+	const cancelEditTitle = useCallback(() => {
+		setEditingId(null);
+		setEditTitle("");
+		setPendingFocusChatId(null);
+	}, []);
+
+	const handleDeleteChat = useCallback(
+		(chatId: string) => {
+			deleteChat.mutate({
 				params: {
 					path: { id: chatId },
 				},
-				body: { title: editTitle.trim() },
 			});
-		}
-		setEditingId(null);
-		setEditTitle("");
-	};
+			if (currentChatId === chatId) {
+				clearMessages();
+				onChatSelect?.("");
+			}
+		},
+		[deleteChat, currentChatId, clearMessages, onChatSelect],
+	);
 
-	const cancelEditTitle = () => {
-		setEditingId(null);
-		setEditTitle("");
-	};
-
-	const handleDeleteChat = (chatId: string) => {
-		deleteChat.mutate({
-			params: {
-				path: { id: chatId },
-			},
-		});
-		if (currentChatId === chatId) {
-			clearMessages();
-			onChatSelect?.("");
-		}
-	};
+	const onEditFocused = useCallback(() => {
+		setPendingFocusChatId(null);
+	}, []);
 
 	const chatGroups = useMemo(
 		() =>
@@ -430,6 +502,38 @@ export function ChatSidebar({
 
 		return rows;
 	}, [chatGroups]);
+
+	const rowProps = useMemo<ChatHistoryRowProps>(
+		() => ({
+			rows: historyRows,
+			currentChatId,
+			editingId,
+			editTitle,
+			pendingFocusChatId,
+			isPageLoading,
+			onChatSelect,
+			onEditTitleChange: setEditTitle,
+			onSaveTitle: saveTitle,
+			onCancelEdit: cancelEditTitle,
+			onDeleteChat: handleDeleteChat,
+			onStartEdit: handleEditTitle,
+			onEditFocused,
+		}),
+		[
+			historyRows,
+			currentChatId,
+			editingId,
+			editTitle,
+			pendingFocusChatId,
+			isPageLoading,
+			onChatSelect,
+			saveTitle,
+			cancelEditTitle,
+			handleDeleteChat,
+			handleEditTitle,
+			onEditFocused,
+		],
+	);
 
 	const isAuthenticated = !!user;
 
@@ -588,7 +692,7 @@ export function ChatSidebar({
 						)}
 					</SidebarMenuItem>
 				</SidebarMenu> */}
-				{chats.length === 0 && !isChatsLoading ? (
+				{chats.length === 0 ? (
 					<div className="flex flex-col items-center justify-center py-8 text-center group-data-[collapsible=icon]:hidden">
 						<MessageSquare className="h-12 w-12 text-muted-foreground/50 mb-4" />
 						<p className="text-sm text-muted-foreground mb-2">
@@ -605,20 +709,7 @@ export function ChatSidebar({
 						rowComponent={ChatHistoryRowComponent}
 						rowCount={historyRows.length}
 						rowHeight={getChatHistoryRowHeight}
-						rowProps={{
-							rows: historyRows,
-							currentChatId,
-							editingId,
-							editTitle,
-							isPageLoading,
-							formatDate,
-							onChatSelect,
-							onEditTitleChange: setEditTitle,
-							onSaveTitle: saveTitle,
-							onCancelEdit: cancelEditTitle,
-							onDeleteChat: handleDeleteChat,
-							onStartEdit: handleEditTitle,
-						}}
+						rowProps={rowProps}
 						overscanCount={8}
 					/>
 				)}

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4559,6 +4559,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4582,6 +4583,7 @@ export interface paths {
                                 totalRealCostCycle: number;
                                 totalMrrCycle: number;
                                 totalMargin: number;
+                                marginPct: number | null;
                             };
                             limit: number;
                             offset: number;
@@ -4646,6 +4648,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4679,6 +4682,60 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
                 };
             };
         };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4559,6 +4559,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4582,6 +4583,7 @@ export interface paths {
                                 totalRealCostCycle: number;
                                 totalMrrCycle: number;
                                 totalMargin: number;
+                                marginPct: number | null;
                             };
                             limit: number;
                             offset: number;
@@ -4646,6 +4648,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4679,6 +4682,60 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
                 };
             };
         };

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -8,6 +8,7 @@ import {
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { CopyableId } from "@/components/copyable-id";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -310,6 +311,7 @@ export default async function DevpassDetailPage({
 						<Table>
 							<TableHeader>
 								<TableRow>
+									<TableHead>ID</TableHead>
 									<TableHead>Date</TableHead>
 									<TableHead>Event</TableHead>
 									<TableHead>Amount</TableHead>
@@ -322,7 +324,7 @@ export default async function DevpassDetailPage({
 								{data.transactions.length === 0 ? (
 									<TableRow>
 										<TableCell
-											colSpan={6}
+											colSpan={7}
 											className="h-24 text-center text-muted-foreground"
 										>
 											No subscription events recorded
@@ -331,6 +333,9 @@ export default async function DevpassDetailPage({
 								) : (
 									data.transactions.map((t) => (
 										<TableRow key={t.id}>
+											<TableCell>
+												<CopyableId id={t.id} />
+											</TableCell>
 											<TableCell className="text-muted-foreground">
 												{formatDateTime(t.createdAt)}
 											</TableCell>
@@ -378,6 +383,7 @@ export default async function DevpassDetailPage({
 						<Table>
 							<TableHeader>
 								<TableRow>
+									<TableHead>ID</TableHead>
 									<TableHead>Date</TableHead>
 									<TableHead>Amount</TableHead>
 									<TableHead>Decline code</TableHead>
@@ -389,7 +395,7 @@ export default async function DevpassDetailPage({
 								{data.paymentFailures.length === 0 ? (
 									<TableRow>
 										<TableCell
-											colSpan={5}
+											colSpan={6}
 											className="h-24 text-center text-muted-foreground"
 										>
 											No payment failures
@@ -398,6 +404,9 @@ export default async function DevpassDetailPage({
 								) : (
 									data.paymentFailures.map((p) => (
 										<TableRow key={p.id}>
+											<TableCell>
+												<CopyableId id={p.id} />
+											</TableCell>
 											<TableCell className="text-muted-foreground">
 												{formatDateTime(p.createdAt)}
 											</TableCell>

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -383,6 +383,12 @@ export default async function DevpassPage({
 	if (showChurned) {
 		queryParams.set("showChurned", "true");
 	}
+	if (from) {
+		queryParams.set("from", from);
+	}
+	if (to) {
+		queryParams.set("to", to);
+	}
 	queryParams.set("sortBy", sortBy);
 	queryParams.set("sortOrder", sortOrder);
 	const queryString = queryParams.toString();
@@ -397,6 +403,8 @@ export default async function DevpassPage({
 		const utilValue = formData.get("utilization") as string;
 		const marginValue = formData.get("marginNegative") as string;
 		const churnValue = formData.get("showChurned") as string;
+		const fromValue = formData.get("from") as string;
+		const toValue = formData.get("to") as string;
 		const sp = new URLSearchParams();
 		if (searchValue) {
 			sp.set("search", searchValue);
@@ -415,6 +423,12 @@ export default async function DevpassPage({
 		}
 		if (churnValue) {
 			sp.set("showChurned", "true");
+		}
+		if (fromValue) {
+			sp.set("from", fromValue);
+		}
+		if (toValue) {
+			sp.set("to", toValue);
 		}
 		sp.set("sortBy", sortByValue);
 		sp.set("sortOrder", sortOrderValue);
@@ -551,6 +565,8 @@ export default async function DevpassPage({
 					name="showChurned"
 					value={showChurned ? "true" : ""}
 				/>
+				<input type="hidden" name="from" value={from ?? ""} />
+				<input type="hidden" name="to" value={to ?? ""} />
 				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
 					<div className="relative flex-1">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -13,7 +13,10 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 
+import { DateRangePicker } from "@/components/date-range-picker";
+import { DevpassTimeseriesChart } from "@/components/devpass-timeseries-chart";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -307,11 +310,15 @@ export default async function DevpassPage({
 		utilization?: string;
 		marginNegative?: string;
 		showChurned?: string;
+		from?: string;
+		to?: string;
 	}>;
 }) {
 	await requireSession();
 
 	const params = await searchParams;
+	const from = typeof params?.from === "string" ? params?.from : undefined;
+	const to = typeof params?.to === "string" ? params?.to : undefined;
 	const rawPage = parseInt(params?.page ?? "1", 10);
 	const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
 	const search = params?.search ?? "";
@@ -419,12 +426,17 @@ export default async function DevpassPage({
 
 	return (
 		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
-			<header className="space-y-2">
-				<h1 className="text-3xl font-semibold tracking-tight">DevPass</h1>
-				<p className="text-sm text-muted-foreground">
-					Subscribers across Lite, Pro and Max — current cycle utilization, real
-					provider cost, and margin.
-				</p>
+			<header className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
+				<div className="space-y-2">
+					<h1 className="text-3xl font-semibold tracking-tight">DevPass</h1>
+					<p className="text-sm text-muted-foreground">
+						Subscribers across Lite, Pro and Max — current cycle utilization,
+						real provider cost, and margin.
+					</p>
+				</div>
+				<Suspense>
+					<DateRangePicker />
+				</Suspense>
 			</header>
 
 			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -497,11 +509,28 @@ export default async function DevpassPage({
 						{currencyFormatter.format(kpis.totalMargin)}
 					</div>
 					<div className="mt-1 text-xs text-muted-foreground">
+						{kpis.marginPct !== null && kpis.marginPct !== undefined ? (
+							<>
+								<span
+									className={cn(
+										"font-medium tabular-nums",
+										kpis.marginPct < 0
+											? "text-rose-600 dark:text-rose-400"
+											: "text-emerald-600 dark:text-emerald-400",
+									)}
+								>
+									{kpis.marginPct.toFixed(1)}% margin
+								</span>{" "}
+								·{" "}
+							</>
+						) : null}
 						{currencyFormatter.format(kpis.totalRealCostCycle)} provider cost
 						this cycle
 					</div>
 				</div>
 			</section>
+
+			<DevpassTimeseriesChart from={from} to={to} />
 
 			<form
 				action={handleSearch}

--- a/ee/admin/src/components/copyable-id.tsx
+++ b/ee/admin/src/components/copyable-id.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
@@ -14,13 +14,28 @@ export function CopyableId({
 	className?: string;
 }) {
 	const [copied, setCopied] = useState(false);
+	const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (resetTimerRef.current !== null) {
+				clearTimeout(resetTimerRef.current);
+			}
+		};
+	}, []);
 
 	const handleCopy = async () => {
 		try {
 			await navigator.clipboard.writeText(id);
 			setCopied(true);
 			toast.success("ID copied");
-			setTimeout(() => setCopied(false), 1500);
+			if (resetTimerRef.current !== null) {
+				clearTimeout(resetTimerRef.current);
+			}
+			resetTimerRef.current = setTimeout(() => {
+				resetTimerRef.current = null;
+				setCopied(false);
+			}, 1500);
 		} catch {
 			toast.error("Failed to copy ID");
 		}

--- a/ee/admin/src/components/copyable-id.tsx
+++ b/ee/admin/src/components/copyable-id.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+
+export function CopyableId({
+	id,
+	className,
+}: {
+	id: string;
+	className?: string;
+}) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(id);
+			setCopied(true);
+			toast.success("ID copied");
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			toast.error("Failed to copy ID");
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			title={id}
+			className={cn(
+				"group inline-flex items-center gap-1.5 rounded font-mono text-xs text-muted-foreground hover:text-foreground transition-colors",
+				className,
+			)}
+		>
+			<span className="max-w-[120px] truncate">{id}</span>
+			{copied ? (
+				<Check className="h-3 w-3 shrink-0 text-emerald-500" />
+			) : (
+				<Copy className="h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+			)}
+		</button>
+	);
+}

--- a/ee/admin/src/components/devpass-timeseries-chart.tsx
+++ b/ee/admin/src/components/devpass-timeseries-chart.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { format, parseISO } from "date-fns";
+import { useState } from "react";
+import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "@/components/ui/chart";
+import { useApi } from "@/lib/fetch-client";
+import { cn } from "@/lib/utils";
+
+import type { ChartConfig } from "@/components/ui/chart";
+
+const chartConfig = {
+	revenue: {
+		label: "Revenue",
+		color: "hsl(142 71% 45%)",
+	},
+	cost: {
+		label: "Provider cost",
+		color: "hsl(32 95% 44%)",
+	},
+	margin: {
+		label: "Margin",
+		color: "hsl(221 83% 53%)",
+	},
+} satisfies ChartConfig;
+
+type ActiveSeries = keyof typeof chartConfig;
+
+const compactCurrency = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	notation: "compact",
+	compactDisplay: "short",
+	maximumFractionDigits: 1,
+});
+
+const fullCurrency = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+export function DevpassTimeseriesChart({
+	from,
+	to,
+}: {
+	from?: string;
+	to?: string;
+}) {
+	const [activeSeries, setActiveSeries] = useState<ActiveSeries>("revenue");
+	const $api = useApi();
+	const { data, isLoading, isError } = $api.useQuery(
+		"get",
+		"/admin/devpass/timeseries",
+		{
+			params: { query: { from, to } },
+		},
+	);
+
+	const chartData = data?.data ?? [];
+	const totals = data?.totals;
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
+				<div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
+					<CardTitle>DevPass revenue & usage</CardTitle>
+					<CardDescription>
+						Daily revenue from DevPass transactions, real provider cost across
+						current and former subscribers, and the resulting margin.
+					</CardDescription>
+				</div>
+				<div className="flex">
+					{(["revenue", "cost", "margin"] as const).map((key) => {
+						const value = totals?.[key] ?? 0;
+						return (
+							<button
+								key={key}
+								type="button"
+								data-active={activeSeries === key}
+								className={cn(
+									"relative z-30 flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6",
+								)}
+								onClick={() => setActiveSeries(key)}
+							>
+								<span className="text-xs text-muted-foreground">
+									{chartConfig[key].label}
+								</span>
+								<span
+									className={cn(
+										"text-lg font-bold leading-none sm:text-3xl",
+										key === "margin" && value < 0
+											? "text-rose-600 dark:text-rose-400"
+											: "",
+									)}
+								>
+									{compactCurrency.format(value)}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			</CardHeader>
+			<CardContent className="px-2 sm:p-6">
+				{isError ? (
+					<div className="flex h-[250px] items-center justify-center text-sm text-muted-foreground">
+						Failed to load DevPass timeseries.
+					</div>
+				) : isLoading ? (
+					<div className="flex h-[250px] items-center justify-center text-sm text-muted-foreground">
+						Loading…
+					</div>
+				) : chartData.length === 0 ? (
+					<div className="flex h-[250px] items-center justify-center text-sm text-muted-foreground">
+						No data for the selected range.
+					</div>
+				) : (
+					<ChartContainer
+						config={chartConfig}
+						className="aspect-auto h-[250px] w-full"
+					>
+						<LineChart data={chartData} margin={{ left: 12, right: 12 }}>
+							<CartesianGrid vertical={false} />
+							<XAxis
+								dataKey="date"
+								tickLine={false}
+								axisLine={false}
+								tickMargin={8}
+								minTickGap={32}
+								tickFormatter={(value: string) => {
+									const date = parseISO(value);
+									return format(date, "MMM d");
+								}}
+							/>
+							<ChartTooltip
+								content={
+									<ChartTooltipContent
+										className="w-[170px]"
+										nameKey={activeSeries}
+										labelFormatter={(value: string) => {
+											const date = parseISO(value);
+											return format(date, "MMM d, yyyy");
+										}}
+										formatter={(value) => fullCurrency.format(Number(value))}
+									/>
+								}
+							/>
+							<Line
+								dataKey={activeSeries}
+								type="monotone"
+								stroke={`var(--color-${activeSeries})`}
+								strokeWidth={2}
+								dot={false}
+							/>
+						</LineChart>
+					</ChartContainer>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/ee/admin/src/components/devpass-timeseries-chart.tsx
+++ b/ee/admin/src/components/devpass-timeseries-chart.tsx
@@ -89,6 +89,7 @@ export function DevpassTimeseriesChart({
 							<button
 								key={key}
 								type="button"
+								aria-pressed={activeSeries === key}
 								data-active={activeSeries === key}
 								className={cn(
 									"relative z-30 flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6",

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4559,6 +4559,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4582,6 +4583,7 @@ export interface paths {
                                 totalRealCostCycle: number;
                                 totalMrrCycle: number;
                                 totalMargin: number;
+                                marginPct: number | null;
                             };
                             limit: number;
                             offset: number;
@@ -4646,6 +4648,7 @@ export interface paths {
                                 mrr: number;
                                 realCost: number;
                                 margin: number;
+                                marginPct: number | null;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -4679,6 +4682,60 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
                 };
             };
         };


### PR DESCRIPTION
## Summary

Two related changes bundled into one PR.

### 1. Chat sidebar virtualization follow-ups (#2215)

- **Stop autoFocus stealing on scroll.** Inline rename Input no longer uses `autoFocus`. Parent state `pendingFocusChatId` flips on edit-start and is cleared once the input has actually delivered focus, so re-mounting the editing row on scroll never re-steals focus mid-edit.
- **Lock row heights.** Hard-coded `ROW_HEIGHT_HEADER` / `ROW_HEIGHT_SPACER` / `ROW_HEIGHT_CHAT` constants used by `getChatHistoryRowHeight`; row content stretches with `h-full!` and `top-1/2 -translate-y-1/2` so the menu action stays vertically centered regardless of slot height.
- **Memoize rowProps** so unrelated parent re-renders don't bust every visible row.
- **Drop unused `formatDate` prop** — already module-level, imported directly.
- Remove the redundant `!isChatsLoading` guard inside the empty-state branch (the early return already covers it).

### 2. DevPass admin dashboard

- **Profit margin %** added next to the dollar value in the *Cycle margin* KPI on `/devpass`. Formula: `totalMargin / totalMrrCycle`. Also surfaced per-subscriber on the detail response as `marginPct` (currently only KPI subtitle uses it; per-row UI can come later).
- **Click-to-copy IDs** on the *Subscription history* and *Payment failures* tables in `/devpass/[orgId]`, via a new tiny `CopyableId` client component (sonner toast on success, ✓ flicker confirmation).
- **Historical chart** on `/devpass`: new `DevpassTimeseriesChart` shows daily revenue, real provider cost, and margin. Uses the same `<DateRangePicker />` as the main admin dashboard (presets including `30d`, `90d`, `365d`, `All time`, plus custom).
- New API route `GET /admin/devpass/timeseries` — accepts `from`/`to`, defaults to all-time anchored on the earliest `dev_plan_start`. Revenue: completed `dev_plan_*` transactions. Cost: `project_hourly_stats.cost` for projects under orgs that are or were ever on a DevPass plan.

## Test plan

- [ ] On `/` (chat), rename a chat in a long history, scroll the sidebar so the editing row exits the viewport, scroll back — the input stays focused/active and does not re-steal focus.
- [ ] Rename a chat then click another chat — the rename saves correctly (blur path).
- [ ] Press Escape in rename — title resets, no save mutation fired.
- [ ] On `/devpass`, switch the date picker between 30d / 90d / 365d / All time — chart series and totals update; KPI strip reflects margin %.
- [ ] On `/devpass/[orgId]`, click a row ID in either table — clipboard contains the full id, toast shown.
- [ ] `pnpm format` clean; `pnpm --filter admin tsc --noEmit` clean; `pnpm --filter admin build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DevPass timeseries analytics endpoint with daily revenue, cost, and margin plus range totals
  * Interactive DevPass chart with metric toggle and date-range filtering
  * Copyable ID buttons added to DevPass admin tables

* **New Metrics**
  * Margin percentage (marginPct) surfaced in DevPass subscriber and KPI responses

* **Improvements**
  * Improved chat sidebar title editing and focus handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->