### PR TITLE
fix(admin): devpass timeseries 404 + legacy sub history

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7633,7 +7633,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.groupBy(tables.project.organizationId)
 		.as("real_cost_sub");
 
-	// Subquery: first dev_plan_start (subscribedSince) and tier change count
+	// Subquery: first dev plan start (subscribedSince) and tier change count.
+	// Legacy rows used the generic "subscription_start" type before the
+	// dev_plan_* rename, so include both to anchor the correct first date.
 	const subscribedSinceSub = db
 		.select({
 			organizationId: tables.transaction.organizationId,
@@ -7642,7 +7644,12 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			),
 		})
 		.from(tables.transaction)
-		.where(eq(tables.transaction.type, "dev_plan_start"))
+		.where(
+			inArray(tables.transaction.type, [
+				"dev_plan_start",
+				"subscription_start",
+			]),
+		)
 		.groupBy(tables.transaction.organizationId)
 		.as("subscribed_since_sub");
 
@@ -8077,219 +8084,6 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	});
 });
 
-admin.openapi(getDevpassSubscriber, async (c) => {
-	const { orgId } = c.req.valid("param");
-	const now = new Date();
-
-	const org = await db.query.organization.findFirst({
-		where: { id: { eq: orgId } },
-	});
-
-	if (!org) {
-		throw new HTTPException(404, { message: "Subscriber not found" });
-	}
-
-	const owner = await db
-		.select({
-			userId: tables.user.id,
-			userName: tables.user.name,
-			userEmail: tables.user.email,
-		})
-		.from(tables.userOrganization)
-		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
-		.where(
-			and(
-				eq(tables.userOrganization.organizationId, orgId),
-				eq(tables.userOrganization.role, "owner"),
-			),
-		)
-		.limit(1);
-
-	const [firstStartRow] = await db
-		.select({
-			firstStart: sql<string>`MIN(${tables.transaction.createdAt})`,
-		})
-		.from(tables.transaction)
-		.where(
-			and(
-				eq(tables.transaction.organizationId, orgId),
-				eq(tables.transaction.type, "dev_plan_start"),
-			),
-		);
-
-	if (org.devPlan === "none" && !firstStartRow?.firstStart) {
-		throw new HTTPException(404, { message: "Subscriber not found" });
-	}
-
-	const [tierChangesRow] = await db
-		.select({
-			count: sql<number>`COUNT(*)`,
-		})
-		.from(tables.transaction)
-		.where(
-			and(
-				eq(tables.transaction.organizationId, orgId),
-				inArray(tables.transaction.type, [
-					"dev_plan_upgrade",
-					"dev_plan_downgrade",
-				]),
-			),
-		);
-
-	const [realCostRow] = org.devPlanBillingCycleStart
-		? await db
-				.select({
-					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
-				})
-				.from(projectHourlyStats)
-				.innerJoin(
-					tables.project,
-					eq(projectHourlyStats.projectId, tables.project.id),
-				)
-				.where(
-					and(
-						eq(tables.project.organizationId, orgId),
-						gte(projectHourlyStats.hourTimestamp, org.devPlanBillingCycleStart),
-					),
-				)
-		: [{ total: "0" }];
-
-	const realCost = Number(realCostRow?.total ?? 0);
-	const mrr = tierPriceOf(org.devPlan);
-	const margin = mrr - realCost;
-
-	const status = deriveStatus(
-		org.devPlan,
-		org.devPlanCancelled,
-		org.devPlanExpiresAt,
-		now,
-	);
-	const utilizationPct =
-		Number(org.devPlanCreditsLimit) > 0
-			? (Number(org.devPlanCreditsUsed) / Number(org.devPlanCreditsLimit)) * 100
-			: null;
-	const cycleDaysIn = org.devPlanBillingCycleStart
-		? Math.max(
-				0,
-				Math.floor(
-					(now.getTime() - org.devPlanBillingCycleStart.getTime()) /
-						(1000 * 60 * 60 * 24),
-				),
-			)
-		: null;
-
-	const [lastFailureRow] = await db
-		.select({
-			lastFailureAt: sql<string>`MAX(${tables.paymentFailure.createdAt})`,
-		})
-		.from(tables.paymentFailure)
-		.where(eq(tables.paymentFailure.organizationId, orgId));
-
-	const hasPaymentIssue = (org.paymentFailureCount ?? 0) > 0;
-
-	const marginPct = mrr > 0 ? (margin / mrr) * 100 : null;
-
-	const subscriber = {
-		id: org.id,
-		name: org.name,
-		billingEmail: org.billingEmail,
-		ownerUserId: owner[0]?.userId ?? null,
-		ownerName: owner[0]?.userName ?? null,
-		ownerEmail: owner[0]?.userEmail ?? null,
-		tier: org.devPlan,
-		status,
-		hasPaymentIssue,
-		creditsUsed: String(org.devPlanCreditsUsed),
-		creditsLimit: String(org.devPlanCreditsLimit),
-		utilizationPct,
-		cycleStart: org.devPlanBillingCycleStart
-			? org.devPlanBillingCycleStart.toISOString()
-			: null,
-		cycleDaysIn,
-		expiresAt: org.devPlanExpiresAt ? org.devPlanExpiresAt.toISOString() : null,
-		cancelled: org.devPlanCancelled,
-		allowAllModels: org.devPlanAllowAllModels,
-		mrr,
-		realCost,
-		margin,
-		marginPct,
-		subscribedSince: firstStartRow?.firstStart
-			? new Date(firstStartRow.firstStart).toISOString()
-			: null,
-		tierChanges: Number(tierChangesRow?.count ?? 0),
-		lastPaymentFailureAt: lastFailureRow?.lastFailureAt
-			? new Date(lastFailureRow.lastFailureAt).toISOString()
-			: null,
-		createdAt: org.createdAt.toISOString(),
-	};
-
-	const transactions = await db
-		.select({
-			id: tables.transaction.id,
-			createdAt: tables.transaction.createdAt,
-			type: tables.transaction.type,
-			amount: tables.transaction.amount,
-			creditAmount: tables.transaction.creditAmount,
-			currency: tables.transaction.currency,
-			status: tables.transaction.status,
-			description: tables.transaction.description,
-		})
-		.from(tables.transaction)
-		.where(
-			and(
-				eq(tables.transaction.organizationId, orgId),
-				inArray(tables.transaction.type, [
-					"dev_plan_start",
-					"dev_plan_upgrade",
-					"dev_plan_downgrade",
-					"dev_plan_cancel",
-					"dev_plan_end",
-					"dev_plan_renewal",
-				]),
-			),
-		)
-		.orderBy(desc(tables.transaction.createdAt))
-		.limit(100);
-
-	const paymentFailures = await db
-		.select({
-			id: tables.paymentFailure.id,
-			createdAt: tables.paymentFailure.createdAt,
-			amount: tables.paymentFailure.amount,
-			currency: tables.paymentFailure.currency,
-			declineCode: tables.paymentFailure.declineCode,
-			failureMessage: tables.paymentFailure.failureMessage,
-			source: tables.paymentFailure.source,
-		})
-		.from(tables.paymentFailure)
-		.where(eq(tables.paymentFailure.organizationId, orgId))
-		.orderBy(desc(tables.paymentFailure.createdAt))
-		.limit(50);
-
-	return c.json({
-		subscriber,
-		transactions: transactions.map((t) => ({
-			id: t.id,
-			createdAt: t.createdAt.toISOString(),
-			type: t.type,
-			amount: t.amount ?? null,
-			creditAmount: t.creditAmount ?? null,
-			currency: t.currency,
-			status: t.status,
-			description: t.description ?? null,
-		})),
-		paymentFailures: paymentFailures.map((p) => ({
-			id: p.id,
-			createdAt: p.createdAt.toISOString(),
-			amount: p.amount ?? null,
-			currency: p.currency,
-			declineCode: p.declineCode ?? null,
-			failureMessage: p.failureMessage ?? null,
-			source: p.source ?? null,
-		})),
-	});
-});
-
 const DEV_PLAN_TX_TYPES = [
 	"dev_plan_start",
 	"dev_plan_upgrade",
@@ -8297,6 +8091,9 @@ const DEV_PLAN_TX_TYPES = [
 	"dev_plan_renewal",
 ] as const;
 
+// Registered before the `/devpass/{orgId}` handler below: Hono matches routes
+// in registration order, so the literal `/devpass/timeseries` path must be
+// declared first or it would be captured as `orgId="timeseries"` and 404.
 admin.openapi(getDevpassTimeseries, async (c) => {
 	const query = c.req.valid("query");
 	const now = new Date();
@@ -8441,6 +8238,227 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 			from: startDate.toISOString().slice(0, 10),
 			to: endDate.toISOString().slice(0, 10),
 		},
+	});
+});
+
+admin.openapi(getDevpassSubscriber, async (c) => {
+	const { orgId } = c.req.valid("param");
+	const now = new Date();
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId } },
+	});
+
+	if (!org) {
+		throw new HTTPException(404, { message: "Subscriber not found" });
+	}
+
+	const owner = await db
+		.select({
+			userId: tables.user.id,
+			userName: tables.user.name,
+			userEmail: tables.user.email,
+		})
+		.from(tables.userOrganization)
+		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
+		.where(
+			and(
+				eq(tables.userOrganization.organizationId, orgId),
+				eq(tables.userOrganization.role, "owner"),
+			),
+		)
+		.limit(1);
+
+	const [firstStartRow] = await db
+		.select({
+			firstStart: sql<string>`MIN(${tables.transaction.createdAt})`,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				inArray(tables.transaction.type, [
+					"dev_plan_start",
+					"subscription_start",
+				]),
+			),
+		);
+
+	if (org.devPlan === "none" && !firstStartRow?.firstStart) {
+		throw new HTTPException(404, { message: "Subscriber not found" });
+	}
+
+	const [tierChangesRow] = await db
+		.select({
+			count: sql<number>`COUNT(*)`,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				inArray(tables.transaction.type, [
+					"dev_plan_upgrade",
+					"dev_plan_downgrade",
+				]),
+			),
+		);
+
+	const [realCostRow] = org.devPlanBillingCycleStart
+		? await db
+				.select({
+					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+				})
+				.from(projectHourlyStats)
+				.innerJoin(
+					tables.project,
+					eq(projectHourlyStats.projectId, tables.project.id),
+				)
+				.where(
+					and(
+						eq(tables.project.organizationId, orgId),
+						gte(projectHourlyStats.hourTimestamp, org.devPlanBillingCycleStart),
+					),
+				)
+		: [{ total: "0" }];
+
+	const realCost = Number(realCostRow?.total ?? 0);
+	const mrr = tierPriceOf(org.devPlan);
+	const margin = mrr - realCost;
+
+	const status = deriveStatus(
+		org.devPlan,
+		org.devPlanCancelled,
+		org.devPlanExpiresAt,
+		now,
+	);
+	const utilizationPct =
+		Number(org.devPlanCreditsLimit) > 0
+			? (Number(org.devPlanCreditsUsed) / Number(org.devPlanCreditsLimit)) * 100
+			: null;
+	const cycleDaysIn = org.devPlanBillingCycleStart
+		? Math.max(
+				0,
+				Math.floor(
+					(now.getTime() - org.devPlanBillingCycleStart.getTime()) /
+						(1000 * 60 * 60 * 24),
+				),
+			)
+		: null;
+
+	const [lastFailureRow] = await db
+		.select({
+			lastFailureAt: sql<string>`MAX(${tables.paymentFailure.createdAt})`,
+		})
+		.from(tables.paymentFailure)
+		.where(eq(tables.paymentFailure.organizationId, orgId));
+
+	const hasPaymentIssue = (org.paymentFailureCount ?? 0) > 0;
+
+	const marginPct = mrr > 0 ? (margin / mrr) * 100 : null;
+
+	const subscriber = {
+		id: org.id,
+		name: org.name,
+		billingEmail: org.billingEmail,
+		ownerUserId: owner[0]?.userId ?? null,
+		ownerName: owner[0]?.userName ?? null,
+		ownerEmail: owner[0]?.userEmail ?? null,
+		tier: org.devPlan,
+		status,
+		hasPaymentIssue,
+		creditsUsed: String(org.devPlanCreditsUsed),
+		creditsLimit: String(org.devPlanCreditsLimit),
+		utilizationPct,
+		cycleStart: org.devPlanBillingCycleStart
+			? org.devPlanBillingCycleStart.toISOString()
+			: null,
+		cycleDaysIn,
+		expiresAt: org.devPlanExpiresAt ? org.devPlanExpiresAt.toISOString() : null,
+		cancelled: org.devPlanCancelled,
+		allowAllModels: org.devPlanAllowAllModels,
+		mrr,
+		realCost,
+		margin,
+		marginPct,
+		subscribedSince: firstStartRow?.firstStart
+			? new Date(firstStartRow.firstStart).toISOString()
+			: null,
+		tierChanges: Number(tierChangesRow?.count ?? 0),
+		lastPaymentFailureAt: lastFailureRow?.lastFailureAt
+			? new Date(lastFailureRow.lastFailureAt).toISOString()
+			: null,
+		createdAt: org.createdAt.toISOString(),
+	};
+
+	const transactions = await db
+		.select({
+			id: tables.transaction.id,
+			createdAt: tables.transaction.createdAt,
+			type: tables.transaction.type,
+			amount: tables.transaction.amount,
+			creditAmount: tables.transaction.creditAmount,
+			currency: tables.transaction.currency,
+			status: tables.transaction.status,
+			description: tables.transaction.description,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				inArray(tables.transaction.type, [
+					"dev_plan_start",
+					"dev_plan_upgrade",
+					"dev_plan_downgrade",
+					"dev_plan_cancel",
+					"dev_plan_end",
+					"dev_plan_renewal",
+					// Legacy types — pre dev_plan_* rename, still in DB for older
+					// dev plan subscribers; without these their history reads as empty.
+					"subscription_start",
+					"subscription_cancel",
+					"subscription_end",
+				]),
+			),
+		)
+		.orderBy(desc(tables.transaction.createdAt))
+		.limit(100);
+
+	const paymentFailures = await db
+		.select({
+			id: tables.paymentFailure.id,
+			createdAt: tables.paymentFailure.createdAt,
+			amount: tables.paymentFailure.amount,
+			currency: tables.paymentFailure.currency,
+			declineCode: tables.paymentFailure.declineCode,
+			failureMessage: tables.paymentFailure.failureMessage,
+			source: tables.paymentFailure.source,
+		})
+		.from(tables.paymentFailure)
+		.where(eq(tables.paymentFailure.organizationId, orgId))
+		.orderBy(desc(tables.paymentFailure.createdAt))
+		.limit(50);
+
+	return c.json({
+		subscriber,
+		transactions: transactions.map((t) => ({
+			id: t.id,
+			createdAt: t.createdAt.toISOString(),
+			type: t.type,
+			amount: t.amount ?? null,
+			creditAmount: t.creditAmount ?? null,
+			currency: t.currency,
+			status: t.status,
+			description: t.description ?? null,
+		})),
+		paymentFailures: paymentFailures.map((p) => ({
+			id: p.id,
+			createdAt: p.createdAt.toISOString(),
+			amount: p.amount ?? null,
+			currency: p.currency,
+			declineCode: p.declineCode ?? null,
+			failureMessage: p.failureMessage ?? null,
+			source: p.source ?? null,
+		})),
 	});
 });
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8091,6 +8091,15 @@ const DEV_PLAN_TX_TYPES = [
 	"dev_plan_renewal",
 ] as const;
 
+// Pre-rename rows for what is now a dev plan. The same `subscription_*` types
+// are STILL written today for non-personal org Pro subs, so always pair them
+// with `organization.isPersonal = true` to avoid counting org Pro revenue.
+const LEGACY_DEV_PLAN_TX_TYPES = [
+	"subscription_start",
+	"subscription_cancel",
+	"subscription_end",
+] as const;
+
 // Registered before the `/devpass/{orgId}` handler below: Hono matches routes
 // in registration order, so the literal `/devpass/timeseries` path must be
 // declared first or it would be captured as `orgId="timeseries"` and 404.
@@ -8099,7 +8108,9 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	const now = new Date();
 
 	// Resolve range. When no from/to is provided, default to all-time
-	// (anchored to the earliest dev_plan_start, falling back to today).
+	// (anchored to the earliest dev plan start, falling back to today).
+	// Includes legacy `subscription_start` rows for personal orgs so subscribers
+	// from before the dev_plan_* rename also extend the chart range.
 	let startDate: Date;
 	let endDate: Date;
 	if (query.from && query.to) {
@@ -8113,7 +8124,19 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 				),
 			})
 			.from(tables.transaction)
-			.where(eq(tables.transaction.type, "dev_plan_start"));
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				or(
+					eq(tables.transaction.type, "dev_plan_start"),
+					and(
+						eq(tables.transaction.type, "subscription_start"),
+						eq(tables.organization.isPersonal, true),
+					),
+				),
+			);
 		startDate = oldest?.minDate ? new Date(oldest.minDate) : now;
 		startDate.setUTCHours(0, 0, 0, 0);
 		endDate = new Date(now);
@@ -8125,7 +8148,9 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 		endDate.setUTCHours(23, 59, 59, 999);
 	}
 
-	// Revenue per day from completed DevPass transactions.
+	// Revenue per day from completed DevPass transactions. Joins organization
+	// so legacy `subscription_*` rows can be counted only when the org is
+	// personal (where they are pre-rename dev plan rows, not org Pro).
 	const revenuePerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
@@ -8135,12 +8160,22 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 				),
 		})
 		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
 		.where(
 			and(
 				eq(tables.transaction.status, "completed"),
-				inArray(tables.transaction.type, [...DEV_PLAN_TX_TYPES]),
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
+				or(
+					inArray(tables.transaction.type, [...DEV_PLAN_TX_TYPES]),
+					and(
+						inArray(tables.transaction.type, [...LEGACY_DEV_PLAN_TX_TYPES]),
+						eq(tables.organization.isPersonal, true),
+					),
+				),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
@@ -8148,8 +8183,9 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 
 	// Provider cost per day for projects belonging to orgs that are or were
 	// ever on a DevPass plan (i.e. currently devPlan != 'none' OR have a
-	// historical dev_plan_start). This approximates "DevPass usage" without
-	// reconstructing daily plan membership.
+	// historical dev_plan_start, OR a legacy subscription_start while personal).
+	// This approximates "DevPass usage" without reconstructing daily plan
+	// membership.
 	const costPerDay = await db
 		.select({
 			date: sql<string>`DATE(${projectHourlyStats.hourTimestamp})`.as("date"),
@@ -8176,7 +8212,10 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 					sql`EXISTS (
 						SELECT 1 FROM ${tables.transaction} t
 						WHERE t.organization_id = ${tables.organization.id}
-						AND t.type = 'dev_plan_start'
+						AND (
+							t.type = 'dev_plan_start'
+							OR (t.type = 'subscription_start' AND ${tables.organization.isPersonal} = true)
+						)
 					)`,
 				)!,
 			),

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4600,6 +4600,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/devpass/{orgId}": {
         parameters: {
             query?: never;
@@ -4682,60 +4736,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/devpass/timeseries": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    from?: string;
-                    to?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description DevPass revenue/cost/margin per day. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            data: {
-                                date: string;
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            }[];
-                            totals: {
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            };
-                            range: {
-                                from: string;
-                                to: string;
-                            };
-                        };
-                    };
                 };
             };
         };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4600,6 +4600,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/devpass/{orgId}": {
         parameters: {
             query?: never;
@@ -4682,60 +4736,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/devpass/timeseries": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    from?: string;
-                    to?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description DevPass revenue/cost/margin per day. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            data: {
-                                date: string;
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            }[];
-                            totals: {
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            };
-                            range: {
-                                from: string;
-                                to: string;
-                            };
-                        };
-                    };
                 };
             };
         };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4600,6 +4600,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/devpass/{orgId}": {
         parameters: {
             query?: never;
@@ -4682,60 +4736,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/devpass/timeseries": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    from?: string;
-                    to?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description DevPass revenue/cost/margin per day. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            data: {
-                                date: string;
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            }[];
-                            totals: {
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            };
-                            range: {
-                                from: string;
-                                to: string;
-                            };
-                        };
-                    };
                 };
             };
         };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4600,6 +4600,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/devpass/timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    from?: string;
+                    to?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DevPass revenue/cost/margin per day. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            data: {
+                                date: string;
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            }[];
+                            totals: {
+                                revenue: number;
+                                cost: number;
+                                margin: number;
+                            };
+                            range: {
+                                from: string;
+                                to: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/devpass/{orgId}": {
         parameters: {
             query?: never;
@@ -4682,60 +4736,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/devpass/timeseries": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    from?: string;
-                    to?: string;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description DevPass revenue/cost/margin per day. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            data: {
-                                date: string;
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            }[];
-                            totals: {
-                                revenue: number;
-                                cost: number;
-                                margin: number;
-                            };
-                            range: {
-                                from: string;
-                                to: string;
-                            };
-                        };
-                    };
                 };
             };
         };


### PR DESCRIPTION
## Summary

Two bugs in the admin DevPass page:

- **Timeseries chart 404'd** with `Subscriber not found`. Hono matches routes in registration order, so `/devpass/{orgId}` (registered first) was capturing `/devpass/timeseries` as `orgId="timeseries"` and the org lookup returned 404. Moved the timeseries handler registration above the `{orgId}` handler.
- **Subscribers from before the `subscription_*` → `dev_plan_*` rename** showed `Subscription history (0)` even when active (e.g. `subscription_start` row with `$29` / `Pro subscription started`). The detail and listing queries only matched `dev_plan_*` types. Now also include legacy `subscription_start/cancel/end` rows so the history populates and `subscribedSince` anchors to the correct first start.

## Test plan

- [ ] Open `/devpass` in admin — chart loads (no `Failed to load DevPass timeseries` banner).
- [ ] Click into a subscriber whose only DB row is `subscription_start` (e.g. `hxJxePnwiH0kXHoVZMKb`) — Subscription history shows that row, "Subscribed" date populated.
- [ ] Click into a modern subscriber with `dev_plan_*` rows — history still shows them; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DevPass timeseries routing to prevent request conflicts.
  * Admin DevPass metrics now recognize legacy and current subscription transactions for accurate subscriber counts.
  * Subscriber history queries expanded to include legacy transaction types for complete activity visibility.
  * Timeseries revenue/cost/margin calculations updated to avoid counting legacy org Pro records as DevPass revenue.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2223)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->