### PR TITLE
fix(admin): devpass chart uses paid amount, nets refunds

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7,6 +7,7 @@ import { adminMiddleware } from "@/middleware/admin.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
+	aliasedTable,
 	and,
 	asc,
 	db,
@@ -8151,11 +8152,15 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	// Revenue per day from completed DevPass transactions. Joins organization
 	// so legacy `subscription_*` rows can be counted only when the org is
 	// personal (where they are pre-rename dev plan rows, not org Pro).
+	// Sums `amount` (actual dollars paid) — `creditAmount` is the credits
+	// granted (price × DEV_PLAN_CREDITS_MULTIPLIER) and would over-report
+	// revenue, and is null on legacy `subscription_*` rows so they would
+	// otherwise contribute nothing.
 	const revenuePerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
 			total:
-				sql<string>`COALESCE(SUM(CAST(${tables.transaction.creditAmount} AS NUMERIC)), 0)`.as(
+				sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
 					"total",
 				),
 		})
@@ -8173,6 +8178,46 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 					inArray(tables.transaction.type, [...DEV_PLAN_TX_TYPES]),
 					and(
 						inArray(tables.transaction.type, [...LEGACY_DEV_PLAN_TX_TYPES]),
+						eq(tables.organization.isPersonal, true),
+					),
+				),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
+	// Refunds per day for DevPass transactions. `credit_refund` rows store the
+	// refunded amount as a positive `amount` and link back via
+	// `relatedTransactionId`. Net them out of revenue when the refunded
+	// transaction was a dev plan or (legacy + personal org) subscription row.
+	const originalTx = aliasedTable(tables.transaction, "original_tx");
+	const refundsPerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			originalTx,
+			eq(tables.transaction.relatedTransactionId, originalTx.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
+				or(
+					inArray(originalTx.type, [...DEV_PLAN_TX_TYPES]),
+					and(
+						inArray(originalTx.type, [...LEGACY_DEV_PLAN_TX_TYPES]),
 						eq(tables.organization.isPersonal, true),
 					),
 				),
@@ -8227,6 +8272,10 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	for (const row of revenuePerDay) {
 		revenueMap.set(row.date, Number(row.total));
 	}
+	const refundMap = new Map<string, number>();
+	for (const row of refundsPerDay) {
+		refundMap.set(row.date, Number(row.total));
+	}
 	const costMap = new Map<string, number>();
 	for (const row of costPerDay) {
 		costMap.set(row.date, Number(row.total));
@@ -8257,7 +8306,7 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 
 	while (cursor.getTime() <= lastDay) {
 		const iso = cursor.toISOString().slice(0, 10);
-		const revenue = revenueMap.get(iso) ?? 0;
+		const revenue = (revenueMap.get(iso) ?? 0) - (refundMap.get(iso) ?? 0);
 		const cost = costMap.get(iso) ?? 0;
 		const margin = revenue - cost;
 		data.push({ date: iso, revenue, cost, margin });


### PR DESCRIPTION
## Summary

The DevPass admin "revenue & usage" chart was over-reporting revenue and silently dropping all pre-rename history. Stripe MRR shows ~$500 from Aug→Nov 2025, dipping to ~$0 through April, then jumping to $1,762 in May, while the admin chart's "All time" line was flat for months and totaled ~3× the actual revenue.

Two bugs in the timeseries handler at `apps/api/src/routes/admin.ts`:

- **Sums the wrong column.** Revenue used `SUM(transaction.creditAmount)`, but `creditAmount` on `dev_plan_*` rows is the **credits limit** (price × `DEV_PLAN_CREDITS_MULTIPLIER`, default 3) — not dollars paid. Switched to `SUM(transaction.amount)`, which is set to `session.amount_total / 100` (or `invoice.amount_paid / 100`) on every revenue-bearing insert.
- **Legacy `subscription_*` rows had no `creditAmount`.** The pre-rename insert paths in `apps/api/src/stripe.ts` only set `amount`, so even though the legacy filter matches them, they contributed $0 to the chart. Switching to `amount` fixes this too — that's why the chart was flat through Jan/Feb/Mar despite Stripe showing real subscribers.

Also nets out refunds: `credit_refund` rows are joined to their original transaction via `relatedTransactionId`, scoped to dev plan / (legacy + personal-org) subscription rows, and subtracted from the matching day's revenue.

## Test plan

- [ ] Open `/devpass` in admin — confirm the "All time" range now extends back to the earliest legacy `subscription_start` (personal org) and chart shows non-zero revenue in Aug–Nov 2025
- [ ] Confirm "Revenue" total roughly matches Stripe's cumulative subscription revenue (was ~3× too high)
- [ ] Confirm a refunded dev plan transaction reduces that day's revenue rather than leaving the gross figure
- [ ] Apply `from`/`to` filters and verify the same numbers hold for narrower ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DevPass revenue reporting accuracy by using actual paid transaction amounts instead of credits.
  * Revenue calculations now properly account for refunds in timeseries data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2225)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->