### PR TITLE
fix(gateway): normalize function tool parameters

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -886,6 +886,112 @@ describe("prepareRequestBody - MiniMax", () => {
 	});
 });
 
+describe("prepareRequestBody - function tool parameter normalization", () => {
+	test("should default missing parameters to a JSON Schema object for DeepSeek", async () => {
+		const requestBody = (await prepareRequestBody(
+			"deepseek",
+			"deepseek-chat",
+			[{ role: "user", content: "hi" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			[
+				{
+					type: "function" as const,
+					function: {
+						name: "web_search",
+						description: "Search the web",
+					},
+				},
+			],
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as { tools?: any[] };
+
+		expect(requestBody.tools).toBeDefined();
+		expect(requestBody.tools?.[0].function.parameters).toEqual({
+			type: "object",
+			properties: {},
+		});
+	});
+
+	test("should rewrite parameters with type: null to type: object", async () => {
+		const requestBody = (await prepareRequestBody(
+			"deepseek",
+			"deepseek-chat",
+			[{ role: "user", content: "hi" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			[
+				{
+					type: "function" as const,
+					function: {
+						name: "web_search",
+						description: "Search the web",
+						parameters: { type: null as unknown as string },
+					},
+				},
+			],
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as { tools?: any[] };
+
+		expect(requestBody.tools?.[0].function.parameters).toEqual({
+			type: "object",
+			properties: {},
+		});
+	});
+
+	test("should preserve valid object parameters as-is", async () => {
+		const params = {
+			type: "object",
+			properties: { query: { type: "string" } },
+			required: ["query"],
+		};
+		const requestBody = (await prepareRequestBody(
+			"deepseek",
+			"deepseek-chat",
+			[{ role: "user", content: "hi" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			[
+				{
+					type: "function" as const,
+					function: {
+						name: "web_search",
+						description: "Search the web",
+						parameters: params,
+					},
+				},
+			],
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as { tools?: any[] };
+
+		expect(requestBody.tools?.[0].function.parameters).toEqual(params);
+	});
+});
+
 describe("prepareRequestBody - AWS Bedrock", () => {
 	test("should preserve explicit cache_control ttl as Bedrock cachePoint ttl", async () => {
 		const requestBody = (await prepareRequestBody(

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -104,6 +104,48 @@ function isFunctionTool(
 }
 
 /**
+ * Ensures function-tool parameters form a valid JSON Schema object. Some
+ * upstreams (e.g. DeepSeek) reject tools whose parameters omit `type` or set
+ * it to null, which happens when SDKs serialize parameter-less tools.
+ */
+function normalizeToolParameters(tools?: OpenAIToolInput[]): typeof tools {
+	if (!tools) {
+		return tools;
+	}
+	return tools.map((tool) => {
+		if (!isFunctionTool(tool)) {
+			return tool;
+		}
+		const params = tool.function.parameters as
+			| Record<string, unknown>
+			| null
+			| undefined;
+		if (
+			params &&
+			typeof params === "object" &&
+			"type" in params &&
+			params.type !== null &&
+			params.type !== undefined
+		) {
+			return tool;
+		}
+		const baseParams =
+			params && typeof params === "object" ? { ...params } : {};
+		return {
+			...tool,
+			function: {
+				...tool.function,
+				parameters: {
+					...baseParams,
+					type: "object",
+					properties: (baseParams as { properties?: unknown }).properties ?? {},
+				} as FunctionParameter,
+			},
+		};
+	});
+}
+
+/**
  * Converts OpenAI JSON schema format to Google's schema format
  * Google uses uppercase type names (STRING, OBJECT, ARRAY) vs OpenAI's lowercase (string, object, array)
  */
@@ -658,6 +700,8 @@ export async function prepareRequestBody(
 	prompt_cache_key?: string,
 	prompt_cache_retention?: PromptCacheRetention,
 ): Promise<ProviderRequestBody | FormData> {
+	tools = normalizeToolParameters(tools);
+
 	// Handle OpenAI / Azure image generation models (e.g. gpt-image-2)
 	if (
 		imageGenerations &&


### PR DESCRIPTION
## Summary
- Some OpenAI-compatible upstreams (DeepSeek confirmed in the wild) reject tools whose `function.parameters` is missing or has `type: null`, returning `Invalid schema for function 'web_search': schema must be a JSON Schema of 'type: "object"', got 'type: null'`.
- Normalize function tool parameters once at the top of `prepareRequestBody` so every provider path receives a valid JSON Schema object (`{ type: "object", properties: {} }`) when none is supplied.

## Test plan
- [x] `pnpm exec vitest run packages/actions/src/prepare-request-body.spec.ts -t "function tool parameter normalization"` (3 new tests pass)
- [x] `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tool parameter validation to ensure consistent handling across all provider integrations, with improved support for edge cases where parameters may be missing or improperly formatted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->