### PR TITLE
fix(gateway): serialize non-Error stream errors

### DIFF
--- a/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
@@ -53,4 +53,55 @@ describe("normalizeStreamingError", () => {
 		expect(normalized.log.details.name).toBe("SyntaxError");
 		expect(normalized.log.details.bufferSnapshot).toBe("data: {");
 	});
+
+	it("serializes non-Error object payloads instead of [object Object]", () => {
+		const error = {
+			status: 503,
+			body: { error: { type: "overloaded_error", message: "Try again" } },
+		};
+
+		const normalized = normalizeStreamingError({
+			error,
+			provider: "anthropic",
+			model: "claude-3-5-sonnet",
+			phase: "upstream_read",
+		});
+
+		expect(normalized.log.details.responseText).not.toContain(
+			"[object Object]",
+		);
+		expect(normalized.log.details.responseText).toContain("overloaded_error");
+		expect(normalized.client.message).not.toContain("[object Object]");
+		expect(normalized.client.message).toContain("overloaded_error");
+	});
+
+	it("uses message field when non-Error object provides one", () => {
+		const error = { message: "Connection reset by peer", code: "ECONNRESET" };
+
+		const normalized = normalizeStreamingError({
+			error,
+			provider: "openai",
+			model: "gpt-4.1-mini",
+			phase: "upstream_read",
+		});
+
+		expect(normalized.client.message).toBe(
+			"Streaming error: Connection reset by peer",
+		);
+		expect(normalized.log.details.responseText).toBe(
+			"Connection reset by peer",
+		);
+	});
+
+	it("falls back to a meaningful string for empty objects", () => {
+		const normalized = normalizeStreamingError({
+			error: {},
+			provider: "openai",
+			model: "gpt-4.1-mini",
+			phase: "upstream_read",
+		});
+
+		expect(normalized.log.details.responseText).not.toBe("[object Object]");
+		expect(normalized.client.message).not.toContain("[object Object]");
+	});
 });

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.ts
@@ -78,6 +78,46 @@ function getErrorCode(error: unknown): string | undefined {
 	return undefined;
 }
 
+function safeStringifyError(error: unknown): string {
+	if (error === null || error === undefined) {
+		return "Unknown error";
+	}
+
+	if (typeof error === "string") {
+		return error;
+	}
+
+	if (typeof error !== "object") {
+		return String(error);
+	}
+
+	if (error instanceof Error) {
+		return error.message || error.name || "Unknown error";
+	}
+
+	const candidate = error as { message?: unknown; error?: unknown };
+	if (typeof candidate.message === "string" && candidate.message.length > 0) {
+		return candidate.message;
+	}
+	if (typeof candidate.error === "string" && candidate.error.length > 0) {
+		return candidate.error;
+	}
+
+	try {
+		const serialized = JSON.stringify(error);
+		if (serialized && serialized !== "{}") {
+			return serialized;
+		}
+	} catch {
+		// fall through to constructor name fallback
+	}
+
+	const ctorName =
+		(error as { constructor?: { name?: string } }).constructor?.name ??
+		"Object";
+	return `[unserializable ${ctorName}]`;
+}
+
 function isUpstreamTermination(error: unknown, cause?: string): boolean {
 	if (!(error instanceof Error)) {
 		return false;
@@ -101,9 +141,14 @@ export function normalizeStreamingError(
 ): NormalizedStreamingError {
 	const { error, provider, model, bufferSnapshot, phase } = options;
 
-	const errorName = error instanceof Error ? error.name : "UnknownError";
-	const rawMessage =
-		error instanceof Error ? error.message : String(error ?? "Unknown error");
+	const errorName =
+		error instanceof Error
+			? error.name
+			: error && typeof error === "object"
+				? ((error as { constructor?: { name?: string } }).constructor?.name ??
+					"UnknownError")
+				: "UnknownError";
+	const rawMessage = safeStringifyError(error);
 	const cause = extractErrorCause(error);
 	const errorCode = getErrorCode(error);
 


### PR DESCRIPTION
## Summary
- Streaming errors that arrived as non-Error objects (e.g. provider error payloads) were stringified via `String(error)`, producing `"[object Object]"` as `errorDetails.responseText` in the logs table — useless for diagnosis.
- Added a `safeStringifyError` helper in `normalize-streaming-error.ts` that prefers `error.message`/`error.error`, JSON-serializes plain objects, and falls back to a constructor-name marker for unserializable values.
- `errorName` now uses the value's constructor name when no `Error` is present, so the log keeps a meaningful classifier.

## Test plan
- [x] `npx vitest run apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts` (5 tests, including 3 new cases covering plain object, `{message}`, and empty-object payloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for error normalization with non-Error objects

* **Bug Fixes**
  * Improved error serialization to prevent "[object Object]" messages and better surface nested error information
  * Enhanced error name and message derivation logic for more robust error handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2228)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->