### PR TITLE
feat(gateway): retry single-key direct provider once

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -196,6 +196,7 @@ import { extractTokenUsage } from "./tools/extract-token-usage.js";
 import { extractToolCalls } from "./tools/extract-tool-calls.js";
 import { getFinishReasonFromError } from "./tools/get-finish-reason-from-error.js";
 import {
+	getEnvKeyCount,
 	getProviderEnv,
 	getServiceTierIneligibleEnvIndices,
 	hasServiceTierEligibleEnvCredential,
@@ -235,6 +236,7 @@ import {
 	providerRetryKey,
 	selectNextProvider,
 	shouldRetryAlternateKey,
+	shouldRetrySameKey,
 	shouldRetryRequest,
 } from "./tools/retry-with-fallback.js";
 import {
@@ -6575,6 +6577,7 @@ chat.openapi(completions, async (c) => {
 				// --- Retry loop for provider fallback ---
 				const routingAttempts: RoutingAttempt[] = [];
 				const failedProviderIds = new Set<string>();
+				let sameKeyRetryCount = 0;
 				let res: Response | undefined;
 				for (
 					let retryAttempt = 0;
@@ -6775,8 +6778,23 @@ chat.openapi(completions, async (c) => {
 								maxRetries: routingCfg.retry.maxRetries,
 							});
 							const willRetrySameProvider = sameProviderRetryContext !== null;
+							const willRetrySameKey =
+								!willRetrySameProvider &&
+								!willRetryTimeout &&
+								shouldRetrySameKey({
+									usedProvider,
+									errorType: "upstream_timeout",
+									statusCode: 0,
+									envVarName,
+									envKeyCount: getEnvKeyCount(envVarName),
+									hasOtherProvider: (
+										routingMetadata?.providerScores ?? []
+									).some((s) => s.providerId !== usedProvider),
+									retryCount: sameKeyRetryCount,
+									maxRetries: routingCfg.retry.maxRetries,
+								});
 							const willRetryRequest =
-								willRetrySameProvider || willRetryTimeout;
+								willRetrySameProvider || willRetryTimeout || willRetrySameKey;
 
 							const baseLogEntry = createLogEntry(
 								requestId,
@@ -6870,6 +6888,30 @@ chat.openapi(completions, async (c) => {
 									),
 								);
 								applyResolvedProviderContext(sameProviderRetryContext);
+								retryAttempt--;
+								continue;
+							}
+
+							if (willRetrySameKey) {
+								sameKeyRetryCount++;
+								// Re-add abort listener (removed by catch/finally on the
+								// failed attempt) so a client disconnect during the
+								// retried upstream call still cancels.
+								c.req.raw.signal.addEventListener("abort", onAbort);
+								routingAttempts.push(
+									buildRoutingAttempt(
+										usedProvider,
+										usedInternalModel,
+										0,
+										getErrorType(0),
+										false,
+										{
+											region: usedRegion,
+											apiKeyHash: usedApiKeyHash,
+											logId: attemptLogId,
+										},
+									),
+								);
 								retryAttempt--;
 								continue;
 							}
@@ -7113,7 +7155,23 @@ chat.openapi(completions, async (c) => {
 								maxRetries: routingCfg.retry.maxRetries,
 							});
 							const willRetrySameProvider = sameProviderRetryContext !== null;
-							const willRetryRequest = willRetrySameProvider || willRetryFetch;
+							const willRetrySameKey =
+								!willRetrySameProvider &&
+								!willRetryFetch &&
+								shouldRetrySameKey({
+									usedProvider,
+									errorType: "network_error",
+									statusCode: 0,
+									envVarName,
+									envKeyCount: getEnvKeyCount(envVarName),
+									hasOtherProvider: (
+										routingMetadata?.providerScores ?? []
+									).some((s) => s.providerId !== usedProvider),
+									retryCount: sameKeyRetryCount,
+									maxRetries: routingCfg.retry.maxRetries,
+								});
+							const willRetryRequest =
+								willRetrySameProvider || willRetryFetch || willRetrySameKey;
 
 							const baseLogEntry = createLogEntry(
 								requestId,
@@ -7226,6 +7284,30 @@ chat.openapi(completions, async (c) => {
 									),
 								);
 								applyResolvedProviderContext(sameProviderRetryContext);
+								retryAttempt--;
+								continue;
+							}
+
+							if (willRetrySameKey) {
+								sameKeyRetryCount++;
+								// Re-add abort listener (removed by catch/finally on the
+								// failed attempt) so a client disconnect during the
+								// retried upstream call still cancels.
+								c.req.raw.signal.addEventListener("abort", onAbort);
+								routingAttempts.push(
+									buildRoutingAttempt(
+										usedProvider,
+										usedInternalModel,
+										0,
+										getErrorType(0),
+										false,
+										{
+											region: usedRegion,
+											apiKeyHash: usedApiKeyHash,
+											logId: attemptLogId,
+										},
+									),
+								);
 								retryAttempt--;
 								continue;
 							}
@@ -7355,8 +7437,23 @@ chat.openapi(completions, async (c) => {
 							maxRetries: routingCfg.retry.maxRetries,
 						});
 						const willRetrySameProvider = sameProviderRetryContext !== null;
+						const willRetrySameKey =
+							!willRetrySameProvider &&
+							!willRetryHttpError &&
+							shouldRetrySameKey({
+								usedProvider,
+								errorType: finishReason,
+								statusCode: res.status,
+								envVarName,
+								envKeyCount: getEnvKeyCount(envVarName),
+								hasOtherProvider: (routingMetadata?.providerScores ?? []).some(
+									(s) => s.providerId !== usedProvider,
+								),
+								retryCount: sameKeyRetryCount,
+								maxRetries: routingCfg.retry.maxRetries,
+							});
 						const willRetryRequest =
-							willRetrySameProvider || willRetryHttpError;
+							willRetrySameProvider || willRetryHttpError || willRetrySameKey;
 
 						const baseLogEntry = createLogEntry(
 							requestId,
@@ -7510,6 +7607,30 @@ chat.openapi(completions, async (c) => {
 								),
 							);
 							applyResolvedProviderContext(sameProviderRetryContext);
+							retryAttempt--;
+							continue;
+						}
+
+						if (willRetrySameKey) {
+							sameKeyRetryCount++;
+							// Re-add abort listener (removed by catch/finally on the
+							// failed attempt) so a client disconnect during the
+							// retried upstream call still cancels.
+							c.req.raw.signal.addEventListener("abort", onAbort);
+							routingAttempts.push(
+								buildRoutingAttempt(
+									usedProvider,
+									usedInternalModel,
+									res.status,
+									getErrorType(res.status),
+									false,
+									{
+										region: usedRegion,
+										apiKeyHash: usedApiKeyHash,
+										logId: attemptLogId,
+									},
+								),
+							);
 							retryAttempt--;
 							continue;
 						}
@@ -7675,8 +7796,25 @@ chat.openapi(completions, async (c) => {
 							maxRetries: routingCfg.retry.maxRetries,
 						});
 						const willRetrySameProvider = sameProviderRetryContext !== null;
+						const willRetrySameKey =
+							!willRetrySameProvider &&
+							!willRetryStreamingError &&
+							shouldRetrySameKey({
+								usedProvider,
+								errorType,
+								statusCode: inferredStatusCode,
+								envVarName,
+								envKeyCount: getEnvKeyCount(envVarName),
+								hasOtherProvider: (routingMetadata?.providerScores ?? []).some(
+									(s) => s.providerId !== usedProvider,
+								),
+								retryCount: sameKeyRetryCount,
+								maxRetries: routingCfg.retry.maxRetries,
+							});
 						const willRetryRequest =
-							willRetrySameProvider || willRetryStreamingError;
+							willRetrySameProvider ||
+							willRetryStreamingError ||
+							willRetrySameKey;
 
 						const baseLogEntry = createLogEntry(
 							requestId,
@@ -7790,6 +7928,30 @@ chat.openapi(completions, async (c) => {
 								),
 							);
 							applyResolvedProviderContext(sameProviderRetryContext);
+							retryAttempt--;
+							continue;
+						}
+
+						if (willRetrySameKey) {
+							sameKeyRetryCount++;
+							// Re-add abort listener (removed by catch/finally on the
+							// failed attempt) so a client disconnect during the
+							// retried upstream call still cancels.
+							c.req.raw.signal.addEventListener("abort", onAbort);
+							routingAttempts.push(
+								buildRoutingAttempt(
+									usedProvider,
+									usedInternalModel,
+									inferredStatusCode,
+									getErrorType(inferredStatusCode),
+									false,
+									{
+										region: usedRegion,
+										apiKeyHash: usedApiKeyHash,
+										logId: attemptLogId,
+									},
+								),
+							);
 							retryAttempt--;
 							continue;
 						}
@@ -10666,6 +10828,7 @@ chat.openapi(completions, async (c) => {
 	// --- Retry loop for provider fallback ---
 	const routingAttempts: RoutingAttempt[] = [];
 	const failedProviderIds = new Set<string>();
+	let sameKeyRetryCount = 0;
 	let canceled = false;
 	let fetchError: Error | null = null;
 	let isTimeoutFetchError = false;
@@ -10896,8 +11059,23 @@ chat.openapi(completions, async (c) => {
 				maxRetries: routingCfg.retry.maxRetries,
 			});
 			const willRetrySameProvider = sameProviderRetryContext !== null;
+			const willRetrySameKey =
+				!willRetrySameProvider &&
+				!willRetryFetchNonStreaming &&
+				shouldRetrySameKey({
+					usedProvider,
+					errorType: "network_error",
+					statusCode: 0,
+					envVarName,
+					envKeyCount: getEnvKeyCount(envVarName),
+					hasOtherProvider: (routingMetadata?.providerScores ?? []).some(
+						(s) => s.providerId !== usedProvider,
+					),
+					retryCount: sameKeyRetryCount,
+					maxRetries: routingCfg.retry.maxRetries,
+				});
 			const willRetryRequest =
-				willRetrySameProvider || willRetryFetchNonStreaming;
+				willRetrySameProvider || willRetryFetchNonStreaming || willRetrySameKey;
 
 			const baseLogEntry = createLogEntry(
 				requestId,
@@ -11011,6 +11189,30 @@ chat.openapi(completions, async (c) => {
 					),
 				);
 				applyResolvedProviderContext(sameProviderRetryContext);
+				retryAttempt--;
+				continue;
+			}
+
+			if (willRetrySameKey) {
+				sameKeyRetryCount++;
+				// Re-add abort listener (removed by the per-attempt finally) so
+				// a client disconnect during the retried upstream call still
+				// cancels.
+				c.req.raw.signal.addEventListener("abort", onAbort);
+				routingAttempts.push(
+					buildRoutingAttempt(
+						usedProvider,
+						usedInternalModel,
+						0,
+						getErrorType(0),
+						false,
+						{
+							region: usedRegion,
+							apiKeyHash: usedApiKeyHash,
+							logId: attemptLogId,
+						},
+					),
+				);
 				retryAttempt--;
 				continue;
 			}
@@ -11278,8 +11480,23 @@ chat.openapi(completions, async (c) => {
 				maxRetries: routingCfg.retry.maxRetries,
 			});
 			const willRetrySameProvider = sameProviderRetryContext !== null;
+			const willRetrySameKey =
+				!willRetrySameProvider &&
+				!willRetryHttpNonStreaming &&
+				shouldRetrySameKey({
+					usedProvider,
+					errorType: finishReason,
+					statusCode: res.status,
+					envVarName,
+					envKeyCount: getEnvKeyCount(envVarName),
+					hasOtherProvider: (routingMetadata?.providerScores ?? []).some(
+						(s) => s.providerId !== usedProvider,
+					),
+					retryCount: sameKeyRetryCount,
+					maxRetries: routingCfg.retry.maxRetries,
+				});
 			const willRetryRequest =
-				willRetrySameProvider || willRetryHttpNonStreaming;
+				willRetrySameProvider || willRetryHttpNonStreaming || willRetrySameKey;
 
 			const baseLogEntry = createLogEntry(
 				requestId,
@@ -11452,6 +11669,30 @@ chat.openapi(completions, async (c) => {
 					),
 				);
 				applyResolvedProviderContext(sameProviderRetryContext);
+				retryAttempt--;
+				continue;
+			}
+
+			if (willRetrySameKey) {
+				sameKeyRetryCount++;
+				// Re-add abort listener (removed by the per-attempt finally) so
+				// a client disconnect during the retried upstream call still
+				// cancels.
+				c.req.raw.signal.addEventListener("abort", onAbort);
+				routingAttempts.push(
+					buildRoutingAttempt(
+						usedProvider,
+						usedInternalModel,
+						res.status,
+						getErrorType(res.status),
+						false,
+						{
+							region: usedRegion,
+							apiKeyHash: usedApiKeyHash,
+							logId: attemptLogId,
+						},
+					),
+				);
 				retryAttempt--;
 				continue;
 			}

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -234,6 +234,7 @@ import {
 	getErrorType,
 	isRetryableErrorType,
 	providerRetryKey,
+	sameKeyRetryDelay,
 	selectNextProvider,
 	shouldRetryAlternateKey,
 	shouldRetrySameKey,
@@ -6898,6 +6899,7 @@ chat.openapi(completions, async (c) => {
 								// failed attempt) so a client disconnect during the
 								// retried upstream call still cancels.
 								c.req.raw.signal.addEventListener("abort", onAbort);
+								await sameKeyRetryDelay();
 								routingAttempts.push(
 									buildRoutingAttempt(
 										usedProvider,
@@ -7294,6 +7296,7 @@ chat.openapi(completions, async (c) => {
 								// failed attempt) so a client disconnect during the
 								// retried upstream call still cancels.
 								c.req.raw.signal.addEventListener("abort", onAbort);
+								await sameKeyRetryDelay();
 								routingAttempts.push(
 									buildRoutingAttempt(
 										usedProvider,
@@ -7617,6 +7620,7 @@ chat.openapi(completions, async (c) => {
 							// failed attempt) so a client disconnect during the
 							// retried upstream call still cancels.
 							c.req.raw.signal.addEventListener("abort", onAbort);
+							await sameKeyRetryDelay();
 							routingAttempts.push(
 								buildRoutingAttempt(
 									usedProvider,
@@ -7938,6 +7942,7 @@ chat.openapi(completions, async (c) => {
 							// failed attempt) so a client disconnect during the
 							// retried upstream call still cancels.
 							c.req.raw.signal.addEventListener("abort", onAbort);
+							await sameKeyRetryDelay();
 							routingAttempts.push(
 								buildRoutingAttempt(
 									usedProvider,
@@ -11199,6 +11204,7 @@ chat.openapi(completions, async (c) => {
 				// a client disconnect during the retried upstream call still
 				// cancels.
 				c.req.raw.signal.addEventListener("abort", onAbort);
+				await sameKeyRetryDelay();
 				routingAttempts.push(
 					buildRoutingAttempt(
 						usedProvider,
@@ -11679,6 +11685,7 @@ chat.openapi(completions, async (c) => {
 				// a client disconnect during the retried upstream call still
 				// cancels.
 				c.req.raw.signal.addEventListener("abort", onAbort);
+				await sameKeyRetryDelay();
 				routingAttempts.push(
 					buildRoutingAttempt(
 						usedProvider,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6793,7 +6793,16 @@ chat.openapi(completions, async (c) => {
 									).some((s) => s.providerId !== usedProvider),
 									retryCount: sameKeyRetryCount,
 									maxRetries: routingCfg.retry.maxRetries,
-								});
+								}) &&
+								// Same-key retries re-hit the provider, so consume a rate-limit
+								// slot like fallback retries do and skip the retry when limited.
+								!(
+									await checkProviderRateLimit(
+										project.organizationId,
+										usedProvider,
+										modelInfo.id,
+									)
+								).rateLimited;
 							const willRetryRequest =
 								willRetrySameProvider || willRetryTimeout || willRetrySameKey;
 
@@ -7171,7 +7180,16 @@ chat.openapi(completions, async (c) => {
 									).some((s) => s.providerId !== usedProvider),
 									retryCount: sameKeyRetryCount,
 									maxRetries: routingCfg.retry.maxRetries,
-								});
+								}) &&
+								// Same-key retries re-hit the provider, so consume a rate-limit
+								// slot like fallback retries do and skip the retry when limited.
+								!(
+									await checkProviderRateLimit(
+										project.organizationId,
+										usedProvider,
+										modelInfo.id,
+									)
+								).rateLimited;
 							const willRetryRequest =
 								willRetrySameProvider || willRetryFetch || willRetrySameKey;
 
@@ -7454,7 +7472,16 @@ chat.openapi(completions, async (c) => {
 								),
 								retryCount: sameKeyRetryCount,
 								maxRetries: routingCfg.retry.maxRetries,
-							});
+							}) &&
+							// Same-key retries re-hit the provider, so consume a rate-limit
+							// slot like fallback retries do and skip the retry when limited.
+							!(
+								await checkProviderRateLimit(
+									project.organizationId,
+									usedProvider,
+									modelInfo.id,
+								)
+							).rateLimited;
 						const willRetryRequest =
 							willRetrySameProvider || willRetryHttpError || willRetrySameKey;
 
@@ -7814,7 +7841,16 @@ chat.openapi(completions, async (c) => {
 								),
 								retryCount: sameKeyRetryCount,
 								maxRetries: routingCfg.retry.maxRetries,
-							});
+							}) &&
+							// Same-key retries re-hit the provider, so consume a rate-limit
+							// slot like fallback retries do and skip the retry when limited.
+							!(
+								await checkProviderRateLimit(
+									project.organizationId,
+									usedProvider,
+									modelInfo.id,
+								)
+							).rateLimited;
 						const willRetryRequest =
 							willRetrySameProvider ||
 							willRetryStreamingError ||
@@ -11078,7 +11114,16 @@ chat.openapi(completions, async (c) => {
 					),
 					retryCount: sameKeyRetryCount,
 					maxRetries: routingCfg.retry.maxRetries,
-				});
+				}) &&
+				// Same-key retries re-hit the provider, so consume a rate-limit
+				// slot like fallback retries do and skip the retry when limited.
+				!(
+					await checkProviderRateLimit(
+						project.organizationId,
+						usedProvider,
+						modelInfo.id,
+					)
+				).rateLimited;
 			const willRetryRequest =
 				willRetrySameProvider || willRetryFetchNonStreaming || willRetrySameKey;
 
@@ -11500,7 +11545,16 @@ chat.openapi(completions, async (c) => {
 					),
 					retryCount: sameKeyRetryCount,
 					maxRetries: routingCfg.retry.maxRetries,
-				});
+				}) &&
+				// Same-key retries re-hit the provider, so consume a rate-limit
+				// slot like fallback retries do and skip the retry when limited.
+				!(
+					await checkProviderRateLimit(
+						project.organizationId,
+						usedProvider,
+						modelInfo.id,
+					)
+				).rateLimited;
 			const willRetryRequest =
 				willRetrySameProvider || willRetryHttpNonStreaming || willRetrySameKey;
 

--- a/apps/gateway/src/chat/tools/get-provider-env.spec.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.spec.ts
@@ -4,6 +4,7 @@ import { reportKeyError, resetKeyHealth } from "@/lib/api-key-health.js";
 import { resetRoundRobinCounters } from "@/lib/round-robin-env.js";
 
 import {
+	getEnvKeyCount,
 	getProviderEnv,
 	getServiceTierIneligibleEnvIndices,
 	hasServiceTierEligibleEnvCredential,
@@ -76,6 +77,42 @@ describe("getProviderEnv", () => {
 
 		expect(gpt4Selection.configIndex).toBe(1);
 		expect(claudeSelection.configIndex).toBe(0);
+	});
+});
+
+describe("getEnvKeyCount", () => {
+	const envVar = "LLM_TEST_ENV_KEY_COUNT";
+
+	afterEach(() => {
+		delete process.env.LLM_TEST_ENV_KEY_COUNT;
+	});
+
+	it("returns 0 when the env var name is undefined", () => {
+		expect(getEnvKeyCount(undefined)).toBe(0);
+	});
+
+	it("returns 0 when the env var is unset or empty", () => {
+		delete process.env.LLM_TEST_ENV_KEY_COUNT;
+		expect(getEnvKeyCount(envVar)).toBe(0);
+		process.env.LLM_TEST_ENV_KEY_COUNT = "";
+		expect(getEnvKeyCount(envVar)).toBe(0);
+	});
+
+	it("counts a single key", () => {
+		process.env.LLM_TEST_ENV_KEY_COUNT = "sk-only";
+		expect(getEnvKeyCount(envVar)).toBe(1);
+	});
+
+	it("counts comma-separated keys", () => {
+		process.env.LLM_TEST_ENV_KEY_COUNT = "sk-a,sk-b,sk-c";
+		expect(getEnvKeyCount(envVar)).toBe(3);
+	});
+
+	it("ignores whitespace and empty segments from trailing commas", () => {
+		process.env.LLM_TEST_ENV_KEY_COUNT = " sk-a , sk-b ,";
+		expect(getEnvKeyCount(envVar)).toBe(2);
+		process.env.LLM_TEST_ENV_KEY_COUNT = ",,";
+		expect(getEnvKeyCount(envVar)).toBe(0);
 	});
 });
 

--- a/apps/gateway/src/chat/tools/get-provider-env.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.ts
@@ -2,6 +2,7 @@ import { HTTPException } from "hono/http-exception";
 
 import {
 	getRoundRobinValue,
+	parseCommaSeparatedEnv,
 	peekRoundRobinValue,
 } from "@/lib/round-robin-env.js";
 
@@ -146,4 +147,21 @@ export function getProviderEnv(
 		: peekRoundRobinValue(envVar, envValue, selectionScope, excludedIndices);
 
 	return { token: result.value, configIndex: result.index, envVarName: envVar };
+}
+
+/**
+ * Returns the number of comma-separated values configured in the named env
+ * var, or 0 if it's unset/empty. Pass the resolved `envVarName` from the
+ * provider context — it may be a regional override (e.g. `*__SINGAPORE`)
+ * rather than the provider's base var.
+ */
+export function getEnvKeyCount(envVarName: string | undefined): number {
+	if (!envVarName) {
+		return 0;
+	}
+	const value = process.env[envVarName];
+	if (!value) {
+		return 0;
+	}
+	return parseCommaSeparatedEnv(value).length;
 }

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
 	isRetryableErrorType,
 	shouldRetryAlternateKey,
+	shouldRetrySameKey,
 	shouldRetryRequest,
 	selectNextProvider,
 	getErrorType,
@@ -150,6 +151,113 @@ describe("shouldRetryAlternateKey", () => {
 	it("does not retry alternate keys for non-retryable failure types", () => {
 		expect(shouldRetryAlternateKey("client_error", 400)).toBe(false);
 		expect(shouldRetryAlternateKey("content_filter", 403)).toBe(false);
+	});
+});
+
+describe("shouldRetrySameKey", () => {
+	const defaultOpts = {
+		usedProvider: "openai",
+		errorType: "upstream_error",
+		statusCode: 500,
+		envVarName: "OPENAI_API_KEY",
+		envKeyCount: 1,
+		hasOtherProvider: false,
+		retryCount: 0,
+		maxRetries: 2,
+	};
+
+	it("retries with single env key on upstream error", () => {
+		expect(shouldRetrySameKey(defaultOpts)).toBe(true);
+	});
+
+	it("does not retry when another provider is available to fall back to", () => {
+		expect(shouldRetrySameKey({ ...defaultOpts, hasOtherProvider: true })).toBe(
+			false,
+		);
+	});
+
+	it("retries on upstream timeouts", () => {
+		expect(
+			shouldRetrySameKey({ ...defaultOpts, errorType: "upstream_timeout" }),
+		).toBe(true);
+	});
+
+	it("retries on network errors", () => {
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "network_error",
+				statusCode: 0,
+			}),
+		).toBe(true);
+	});
+
+	it("retries regardless of whether a specific provider was requested", () => {
+		// The "no other provider" gate lives at the call site (the
+		// provider-fallback check), so this helper no longer keys off
+		// requestedProvider — it fires for both direct and auto-routed requests.
+		expect(shouldRetrySameKey(defaultOpts)).toBe(true);
+	});
+
+	it("does not retry when env var has multiple keys (alternate-key path covers it)", () => {
+		expect(shouldRetrySameKey({ ...defaultOpts, envKeyCount: 2 })).toBe(false);
+	});
+
+	it("does not retry when no env var was used (BYOK)", () => {
+		expect(shouldRetrySameKey({ ...defaultOpts, envVarName: undefined })).toBe(
+			false,
+		);
+	});
+
+	it("does not retry on auth failures (same key will fail again)", () => {
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "gateway_error",
+				statusCode: 401,
+			}),
+		).toBe(false);
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "gateway_error",
+				statusCode: 403,
+			}),
+		).toBe(false);
+	});
+
+	it("does not retry on non-retryable error types", () => {
+		expect(
+			shouldRetrySameKey({ ...defaultOpts, errorType: "client_error" }),
+		).toBe(false);
+		expect(
+			shouldRetrySameKey({ ...defaultOpts, errorType: "content_filter" }),
+		).toBe(false);
+	});
+
+	it("retries up to maxRetries times then stops", () => {
+		expect(shouldRetrySameKey({ ...defaultOpts, retryCount: 1 })).toBe(true);
+		expect(shouldRetrySameKey({ ...defaultOpts, retryCount: 2 })).toBe(false);
+		expect(shouldRetrySameKey({ ...defaultOpts, retryCount: 3 })).toBe(false);
+	});
+
+	it("does not retry at all when maxRetries is 0", () => {
+		expect(
+			shouldRetrySameKey({ ...defaultOpts, retryCount: 0, maxRetries: 0 }),
+		).toBe(false);
+	});
+
+	it("does not retry for custom or llmgateway providers", () => {
+		expect(shouldRetrySameKey({ ...defaultOpts, usedProvider: "custom" })).toBe(
+			false,
+		);
+		expect(
+			shouldRetrySameKey({ ...defaultOpts, usedProvider: "llmgateway" }),
+		).toBe(false);
+	});
+
+	it("does not retry when env var is unset (envKeyCount=0)", () => {
+		expect(shouldRetrySameKey({ ...defaultOpts, envKeyCount: 0 })).toBe(false);
 	});
 });
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -238,21 +238,35 @@ describe("shouldRetrySameKey", () => {
 		).toBe(false);
 	});
 
-	it("does not retry deterministic upstream failures (402/404)", () => {
+	it("does not retry any 4xx (deterministic for the identical request/key)", () => {
+		for (const statusCode of [400, 402, 404, 408, 422, 499]) {
+			expect(
+				shouldRetrySameKey({
+					...defaultOpts,
+					errorType: "upstream_error",
+					statusCode,
+				}),
+			).toBe(false);
+		}
+	});
+
+	it("retries 5xx and network failures (statusCode 0)", () => {
+		for (const statusCode of [500, 502, 503, 529]) {
+			expect(
+				shouldRetrySameKey({
+					...defaultOpts,
+					errorType: "upstream_error",
+					statusCode,
+				}),
+			).toBe(true);
+		}
 		expect(
 			shouldRetrySameKey({
 				...defaultOpts,
-				errorType: "gateway_error",
-				statusCode: 402,
+				errorType: "network_error",
+				statusCode: 0,
 			}),
-		).toBe(false);
-		expect(
-			shouldRetrySameKey({
-				...defaultOpts,
-				errorType: "upstream_error",
-				statusCode: 404,
-			}),
-		).toBe(false);
+		).toBe(true);
 	});
 
 	it("does not retry gateway_error even without an auth status code (invalid key payloads)", () => {

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -226,6 +226,46 @@ describe("shouldRetrySameKey", () => {
 		).toBe(false);
 	});
 
+	it("does not retry on rate limits (would hammer the rate-limited key)", () => {
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "upstream_error",
+				statusCode: 429,
+			}),
+		).toBe(false);
+	});
+
+	it("does not retry deterministic upstream failures (402/404)", () => {
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "gateway_error",
+				statusCode: 402,
+			}),
+		).toBe(false);
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "upstream_error",
+				statusCode: 404,
+			}),
+		).toBe(false);
+	});
+
+	it("does not retry gateway_error even without an auth status code (invalid key payloads)", () => {
+		// e.g. providers returning 400 with "API key not valid" — the
+		// alternate-key path rotates keys for these, but the same key would
+		// fail identically.
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				errorType: "gateway_error",
+				statusCode: 400,
+			}),
+		).toBe(false);
+	});
+
 	it("does not retry on non-retryable error types", () => {
 		expect(
 			shouldRetrySameKey({ ...defaultOpts, errorType: "client_error" }),

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import {
 	isRetryableErrorType,
+	sameKeyRetryDelay,
+	SAME_KEY_RETRY_DELAY_MS,
 	shouldRetryAlternateKey,
 	shouldRetrySameKey,
 	shouldRetryRequest,
@@ -298,6 +300,27 @@ describe("shouldRetrySameKey", () => {
 
 	it("does not retry when env var is unset (envKeyCount=0)", () => {
 		expect(shouldRetrySameKey({ ...defaultOpts, envKeyCount: 0 })).toBe(false);
+	});
+});
+
+describe("sameKeyRetryDelay", () => {
+	it("resolves after the fixed delay", async () => {
+		vi.useFakeTimers();
+		try {
+			let resolved = false;
+			const pending = sameKeyRetryDelay().then(() => {
+				resolved = true;
+			});
+
+			await vi.advanceTimersByTimeAsync(SAME_KEY_RETRY_DELAY_MS - 1);
+			expect(resolved).toBe(false);
+
+			await vi.advanceTimersByTimeAsync(1);
+			await pending;
+			expect(resolved).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -71,8 +71,16 @@ export function shouldRetryAlternateKey(
  *
  * Bounded by `maxRetries` (the resolved routing-config retry budget): with the
  * default of 2 this allows up to 2 same-key retries (3 attempts total); 0
- * disables same-key retries. Auth failures (401/403) are excluded because the
- * same key will fail again, as are BYOK/custom providers (envVarName unset).
+ * disables same-key retries.
+ *
+ * Unlike cross-provider fallback — where a deterministic failure on one
+ * provider (bad credentials, unknown model, out of funds) can legitimately
+ * succeed on another — retrying the *same* key against the *same* provider
+ * only helps for transient faults. Deterministic failures are excluded:
+ * gateway_error (auth/config/payment), 402/404 (out of funds / unknown
+ * model), and 429 (immediately re-firing a rate-limited key would amplify
+ * the rate-limit pressure). BYOK/custom providers (envVarName unset) are
+ * also excluded.
  */
 export function shouldRetrySameKey(opts: {
 	usedProvider: string;
@@ -102,7 +110,17 @@ export function shouldRetrySameKey(opts: {
 	if (!isRetryableErrorType(opts.errorType)) {
 		return false;
 	}
-	if (opts.statusCode === 401 || opts.statusCode === 403) {
+	// Deterministic on the same key: auth/config/payment failures.
+	if (opts.errorType === "gateway_error") {
+		return false;
+	}
+	if (
+		opts.statusCode === 401 ||
+		opts.statusCode === 402 ||
+		opts.statusCode === 403 ||
+		opts.statusCode === 404 ||
+		opts.statusCode === 429
+	) {
 		return false;
 	}
 	return true;

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -60,6 +60,21 @@ export function shouldRetryAlternateKey(
 }
 
 /**
+ * Fixed delay before a same-key retry. Cross-provider fallback switches to a
+ * different upstream and retries immediately, but a same-key retry re-hits
+ * the upstream that just failed — a short pause gives transient faults a
+ * moment to clear instead of immediately adding pressure. The added latency
+ * is acceptable since the upstream is already slow or erroring.
+ */
+export const SAME_KEY_RETRY_DELAY_MS = 1000;
+
+export function sameKeyRetryDelay(): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, SAME_KEY_RETRY_DELAY_MS);
+	});
+}
+
+/**
  * Determines whether a failed request should be retried against the same
  * env-var key. This fires only when there is nowhere else to go: the model
  * resolves to a single provider (`hasOtherProvider` is false) and that

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -92,10 +92,10 @@ export function sameKeyRetryDelay(): Promise<void> {
  * provider (bad credentials, unknown model, out of funds) can legitimately
  * succeed on another — retrying the *same* key against the *same* provider
  * only helps for transient faults. Deterministic failures are excluded:
- * gateway_error (auth/config/payment), 402/404 (out of funds / unknown
- * model), and 429 (immediately re-firing a rate-limited key would amplify
- * the rate-limit pressure). BYOK/custom providers (envVarName unset) are
- * also excluded.
+ * gateway_error (auth/config/payment) and all 4xx responses — the identical
+ * request on the identical key will almost certainly fail the same way
+ * (and re-firing a 429 would amplify rate-limit pressure). BYOK/custom
+ * providers (envVarName unset) are also excluded.
  */
 export function shouldRetrySameKey(opts: {
 	usedProvider: string;
@@ -129,12 +129,12 @@ export function shouldRetrySameKey(opts: {
 	if (opts.errorType === "gateway_error") {
 		return false;
 	}
+	// Any 4xx is deterministic for the identical request on the identical
+	// key — it will almost certainly fail the same way on a retry.
 	if (
-		opts.statusCode === 401 ||
-		opts.statusCode === 402 ||
-		opts.statusCode === 403 ||
-		opts.statusCode === 404 ||
-		opts.statusCode === 429
+		opts.statusCode !== undefined &&
+		opts.statusCode >= 400 &&
+		opts.statusCode < 500
 	) {
 		return false;
 	}

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -60,6 +60,55 @@ export function shouldRetryAlternateKey(
 }
 
 /**
+ * Determines whether a failed request should be retried against the same
+ * env-var key. This fires only when there is nowhere else to go: the model
+ * resolves to a single provider (`hasOtherProvider` is false) and that
+ * provider has a single env-var key (so the alternate-key path yields
+ * nothing). It covers both direct-provider requests (`openai/gpt-4o`) and
+ * auto-routed requests where only one provider is available — in both the
+ * scored provider list contains just the one provider. When other providers
+ * exist, cross-provider fallback handles retries instead and this stays off.
+ *
+ * Bounded by `maxRetries` (the resolved routing-config retry budget): with the
+ * default of 2 this allows up to 2 same-key retries (3 attempts total); 0
+ * disables same-key retries. Auth failures (401/403) are excluded because the
+ * same key will fail again, as are BYOK/custom providers (envVarName unset).
+ */
+export function shouldRetrySameKey(opts: {
+	usedProvider: string;
+	errorType: string;
+	statusCode?: number;
+	envVarName: string | undefined;
+	envKeyCount: number;
+	hasOtherProvider: boolean;
+	retryCount: number;
+	maxRetries: number;
+}): boolean {
+	if (opts.retryCount >= opts.maxRetries) {
+		return false;
+	}
+	if (opts.hasOtherProvider) {
+		return false;
+	}
+	if (opts.usedProvider === "custom" || opts.usedProvider === "llmgateway") {
+		return false;
+	}
+	if (!opts.envVarName) {
+		return false;
+	}
+	if (opts.envKeyCount !== 1) {
+		return false;
+	}
+	if (!isRetryableErrorType(opts.errorType)) {
+		return false;
+	}
+	if (opts.statusCode === 401 || opts.statusCode === 403) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Determines whether a failed request should be retried with a different provider.
  * Only retries when no specific provider was requested, the error is retryable,
  * retry count hasn't been exceeded, and alternative providers are available.

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -13,6 +13,7 @@ import { db, eq, tables, type Log } from "@llmgateway/db";
 import { getProviderDefinition } from "@llmgateway/models";
 
 import { app } from "./app.js";
+import { SAME_KEY_RETRY_DELAY_MS } from "./chat/tools/retry-with-fallback.js";
 import { getApiKeyFingerprint } from "./lib/api-key-fingerprint.js";
 import {
 	isTrackedKeyHealthy,
@@ -2581,6 +2582,7 @@ describe("fallback and error status code handling", () => {
 					createdBy: "user-id",
 				});
 
+				const startedAt = Date.now();
 				const res = await app.request("/v1/chat/completions", {
 					method: "POST",
 					headers: {
@@ -2594,6 +2596,10 @@ describe("fallback and error status code handling", () => {
 				});
 
 				expect(res.status).toBe(200);
+				// One same-key retry → one fixed delay before the second attempt.
+				expect(Date.now() - startedAt).toBeGreaterThanOrEqual(
+					SAME_KEY_RETRY_DELAY_MS,
+				);
 				const json = await res.json();
 				expect(json.metadata.used_provider).toBe("google-ai-studio");
 				expect(json.metadata.routing).toHaveLength(2);
@@ -2655,6 +2661,7 @@ describe("fallback and error status code handling", () => {
 				// TRIGGER_ERROR fails on every call: initial attempt + 2 same-key
 				// retries (default retry.maxRetries = 2), then the error is
 				// returned to the client.
+				const startedAt = Date.now();
 				const res = await app.request("/v1/chat/completions", {
 					method: "POST",
 					headers: {
@@ -2668,6 +2675,10 @@ describe("fallback and error status code handling", () => {
 				});
 
 				expect(res.status).toBe(500);
+				// Two same-key retries → two fixed delays before giving up.
+				expect(Date.now() - startedAt).toBeGreaterThanOrEqual(
+					2 * SAME_KEY_RETRY_DELAY_MS,
+				);
 				const json = await res.json();
 				expect(json).toHaveProperty("error");
 

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -2559,6 +2559,139 @@ describe("fallback and error status code handling", () => {
 			);
 		});
 
+		test("non-streaming: retries the same env key when a single-key provider fails transiently", async () => {
+			const originalApiKey = process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+			const originalBaseUrl = process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+			// Single value → no alternate key to rotate to; the only recovery
+			// path is retrying the same key.
+			process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = "google-env-single-key";
+			process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = mockServerUrl;
+			try {
+				await ensureBaseFixtures();
+				await ensureProviders(["google-ai-studio"]);
+				await db
+					.update(tables.project)
+					.set({ mode: "credits" })
+					.where(eq(tables.project.id, "project-id"));
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
+
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify({
+						model: "google-ai-studio/gemini-2.5-flash",
+						messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				expect(json.metadata.used_provider).toBe("google-ai-studio");
+				expect(json.metadata.routing).toHaveLength(2);
+
+				// Both attempts used the same provider AND the same key.
+				const envKeyHash = getApiKeyFingerprint("google-env-single-key");
+				expect(json.metadata.routing[0]).toMatchObject({
+					provider: "google-ai-studio",
+					status_code: 500,
+					succeeded: false,
+					apiKeyHash: envKeyHash,
+				});
+				expect(json.metadata.routing[1]).toMatchObject({
+					provider: "google-ai-studio",
+					succeeded: true,
+					apiKeyHash: envKeyHash,
+				});
+
+				const logs = await waitForLogs(2);
+				const failedLog = logs.find((log: Log) => log.hasError);
+				const successLog = logs.find((log: Log) => !log.hasError);
+				expect(failedLog?.retried).toBe(true);
+				expect(failedLog?.retriedByLogId).toBeTruthy();
+				expect(successLog?.routingMetadata?.routing).toHaveLength(2);
+			} finally {
+				if (originalApiKey !== undefined) {
+					process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = originalApiKey;
+				} else {
+					delete process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+				}
+				if (originalBaseUrl !== undefined) {
+					process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = originalBaseUrl;
+				} else {
+					delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+				}
+			}
+		});
+
+		test("non-streaming: same-key retries stop after the retry budget is exhausted", async () => {
+			const originalApiKey = process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+			const originalBaseUrl = process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+			process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = "google-env-single-key";
+			process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = mockServerUrl;
+			try {
+				await ensureBaseFixtures();
+				await ensureProviders(["google-ai-studio"]);
+				await db
+					.update(tables.project)
+					.set({ mode: "credits" })
+					.where(eq(tables.project.id, "project-id"));
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
+
+				// TRIGGER_ERROR fails on every call: initial attempt + 2 same-key
+				// retries (default retry.maxRetries = 2), then the error is
+				// returned to the client.
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify({
+						model: "google-ai-studio/gemini-2.5-flash",
+						messages: [{ role: "user", content: "TRIGGER_ERROR" }],
+					}),
+				});
+
+				expect(res.status).toBe(500);
+				const json = await res.json();
+				expect(json).toHaveProperty("error");
+
+				const logs = await waitForLogs(3);
+				const errorLogs = logs.filter((log: Log) => log.hasError);
+				expect(errorLogs).toHaveLength(3);
+				// The first two attempts are marked as retried; the final one is
+				// returned to the client unretried.
+				expect(errorLogs.filter((log: Log) => log.retried)).toHaveLength(2);
+				expect(errorLogs.filter((log: Log) => !log.retried)).toHaveLength(1);
+			} finally {
+				if (originalApiKey !== undefined) {
+					process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = originalApiKey;
+				} else {
+					delete process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+				}
+				if (originalBaseUrl !== undefined) {
+					process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = originalBaseUrl;
+				} else {
+					delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+				}
+			}
+		});
+
 		test("streaming: retries on 500 and delivers response on fallback provider", async () => {
 			await setupMultiProviderKeys();
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1598,6 +1598,27 @@ async function handleGoogleGenerateContent(c: Context) {
 			},
 		});
 	}
+	// First call with TRIGGER_FAIL_ONCE fails with 500, subsequent calls
+	// succeed. Uses the shared failOnceCounter (reset via resetFailOnceCounter)
+	// so retry behavior can be exercised on the Gemini-format endpoint too.
+	const failOnce = body.contents?.some?.((content: any) =>
+		content.parts?.some?.((part: any) =>
+			part.text?.includes?.("TRIGGER_FAIL_ONCE"),
+		),
+	);
+	if (failOnce) {
+		failOnceCounter++;
+		if (failOnceCounter === 1) {
+			c.status(500);
+			return c.json({
+				error: {
+					code: 500,
+					message: "Internal server error (fail once)",
+					status: "INTERNAL",
+				},
+			});
+		}
+	}
 	// Speech generation: when the caller requests AUDIO output, return an
 	// inlineData audio part (base64-encoded PCM) like Gemini TTS models do.
 	const responseModalities: string[] =


### PR DESCRIPTION
## Summary

- For requests pinned to a specific provider where the env var contains only one key (so the existing alternate-key fallback yields nothing), do one same-key retry on transient upstream/gateway failures.
- Excludes 401/403 (futile to retry the same key on auth failures), `custom`/`llmgateway` providers, and BYOK paths (no env var).
- Adds `shouldRetryDirectProviderSameKey` helper + `getProviderEnvKeyCount`, wired into all six retry decision points (streaming timeout/fetch error/HTTP error/immediate-stream error + non-streaming fetch error/HTTP error).

## Test plan

- [x] `pnpm exec vitest run apps/gateway/src/chat/tools/retry-with-fallback.spec.ts` — 44 tests pass (11 new)
- [x] `pnpm --filter gateway build` — clean
- [x] `pnpm --filter gateway lint` — clean
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved chat reliability by adding a one-time same-provider-key retry before falling back to alternate keys, reducing transient failures for streaming and non-streaming requests.
* **New Features**
  * Added a helper to count configured API keys for a provider.
* **Tests**
  * Added unit tests verifying when same-key retries should and should not occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2229)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->