### PR TITLE
fix(gateway): reject image input for non-vision models

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1586,6 +1586,7 @@ chat.openapi(completions, async (c) => {
 		tools,
 		tool_choice,
 		webSearchTool,
+		hasImages,
 	});
 
 	let usedProvider = requestedProvider;

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -1,65 +1,29 @@
 import { HTTPException } from "hono/http-exception";
 import { describe, expect, it } from "vitest";
 
+import { models } from "@llmgateway/models";
+
 import { validateModelCapabilities } from "./validate-model-capabilities.js";
 
 import type { ModelDefinition } from "@llmgateway/models";
 
-const noVisionModel: ModelDefinition = {
-	id: "deepseek-v4-flash",
-	name: "DeepSeek V4 Flash",
-	family: "deepseek",
-	providers: [
-		{
-			providerId: "deepseek",
-			modelName: "deepseek-v4-flash",
-			inputPrice: 0,
-			outputPrice: 0,
-			contextSize: 1000,
-			streaming: true,
-			vision: false,
-			tools: true,
-		},
-		{
-			providerId: "novita",
-			modelName: "deepseek/deepseek-v4-flash",
-			inputPrice: 0,
-			outputPrice: 0,
-			contextSize: 1000,
-			streaming: true,
-			vision: false,
-			tools: true,
-		},
-	],
-} as ModelDefinition;
+function getModel(id: string): ModelDefinition {
+	const m = models.find((model) => model.id === id);
+	if (!m) {
+		throw new Error(
+			`Test fixture missing: model "${id}" not found in registry`,
+		);
+	}
+	return m as ModelDefinition;
+}
 
-const mixedVisionModel: ModelDefinition = {
-	id: "mixed-model",
-	name: "Mixed",
-	family: "test",
-	providers: [
-		{
-			providerId: "deepseek",
-			modelName: "x",
-			inputPrice: 0,
-			outputPrice: 0,
-			contextSize: 1000,
-			streaming: true,
-			vision: false,
-			tools: true,
-		},
-		{
-			providerId: "openai",
-			modelName: "x",
-			inputPrice: 0,
-			outputPrice: 0,
-			contextSize: 1000,
-			streaming: true,
-			vision: true,
-			tools: true,
-		},
-	],
-} as ModelDefinition;
+// deepseek-v4-flash will not gain vision support upstream, so it's a stable
+// fixture for "no provider supports vision".
+const noVisionModel = getModel("deepseek-v4-flash");
+
+// qwen3-max has alibaba (vision: true) alongside novita/embercloud
+// (vision: false), giving us a mixed-capability fixture.
+const mixedVisionModel = getModel("qwen3-max");
 
 describe("validateModelCapabilities - vision", () => {
 	it("rejects when explicit provider does not support vision", () => {
@@ -83,7 +47,7 @@ describe("validateModelCapabilities - vision", () => {
 
 	it("allows when at least one provider supports vision and no explicit provider", () => {
 		expect(() =>
-			validateModelCapabilities(mixedVisionModel, "mixed-model", undefined, {
+			validateModelCapabilities(mixedVisionModel, "qwen3-max", undefined, {
 				hasImages: true,
 			}),
 		).not.toThrow();
@@ -91,7 +55,7 @@ describe("validateModelCapabilities - vision", () => {
 
 	it("allows when explicit provider supports vision", () => {
 		expect(() =>
-			validateModelCapabilities(mixedVisionModel, "mixed-model", "openai", {
+			validateModelCapabilities(mixedVisionModel, "qwen3-max", "alibaba", {
 				hasImages: true,
 			}),
 		).not.toThrow();
@@ -99,7 +63,7 @@ describe("validateModelCapabilities - vision", () => {
 
 	it("rejects when explicit non-vision provider is picked even if a sibling has vision", () => {
 		expect(() =>
-			validateModelCapabilities(mixedVisionModel, "mixed-model", "deepseek", {
+			validateModelCapabilities(mixedVisionModel, "qwen3-max", "novita", {
 				hasImages: true,
 			}),
 		).toThrow(HTTPException);

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -1,0 +1,133 @@
+import { HTTPException } from "hono/http-exception";
+import { describe, expect, it } from "vitest";
+
+import { validateModelCapabilities } from "./validate-model-capabilities.js";
+
+import type { ModelDefinition } from "@llmgateway/models";
+
+const noVisionModel: ModelDefinition = {
+	id: "deepseek-v4-flash",
+	name: "DeepSeek V4 Flash",
+	family: "deepseek",
+	providers: [
+		{
+			providerId: "deepseek",
+			modelName: "deepseek-v4-flash",
+			inputPrice: 0,
+			outputPrice: 0,
+			contextSize: 1000,
+			streaming: true,
+			vision: false,
+			tools: true,
+		},
+		{
+			providerId: "novita",
+			modelName: "deepseek/deepseek-v4-flash",
+			inputPrice: 0,
+			outputPrice: 0,
+			contextSize: 1000,
+			streaming: true,
+			vision: false,
+			tools: true,
+		},
+	],
+} as ModelDefinition;
+
+const mixedVisionModel: ModelDefinition = {
+	id: "mixed-model",
+	name: "Mixed",
+	family: "test",
+	providers: [
+		{
+			providerId: "deepseek",
+			modelName: "x",
+			inputPrice: 0,
+			outputPrice: 0,
+			contextSize: 1000,
+			streaming: true,
+			vision: false,
+			tools: true,
+		},
+		{
+			providerId: "openai",
+			modelName: "x",
+			inputPrice: 0,
+			outputPrice: 0,
+			contextSize: 1000,
+			streaming: true,
+			vision: true,
+			tools: true,
+		},
+	],
+} as ModelDefinition;
+
+describe("validateModelCapabilities - vision", () => {
+	it("rejects when explicit provider does not support vision", () => {
+		expect(() =>
+			validateModelCapabilities(
+				noVisionModel,
+				"deepseek-v4-flash",
+				"deepseek",
+				{ hasImages: true },
+			),
+		).toThrow(HTTPException);
+	});
+
+	it("rejects when no provider in the model supports vision", () => {
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "deepseek-v4-flash", undefined, {
+				hasImages: true,
+			}),
+		).toThrow(HTTPException);
+	});
+
+	it("allows when at least one provider supports vision and no explicit provider", () => {
+		expect(() =>
+			validateModelCapabilities(mixedVisionModel, "mixed-model", undefined, {
+				hasImages: true,
+			}),
+		).not.toThrow();
+	});
+
+	it("allows when explicit provider supports vision", () => {
+		expect(() =>
+			validateModelCapabilities(mixedVisionModel, "mixed-model", "openai", {
+				hasImages: true,
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects when explicit non-vision provider is picked even if a sibling has vision", () => {
+		expect(() =>
+			validateModelCapabilities(mixedVisionModel, "mixed-model", "deepseek", {
+				hasImages: true,
+			}),
+		).toThrow(HTTPException);
+	});
+
+	it("does not check vision when no images are present", () => {
+		expect(() =>
+			validateModelCapabilities(
+				noVisionModel,
+				"deepseek-v4-flash",
+				"deepseek",
+				{
+					hasImages: false,
+				},
+			),
+		).not.toThrow();
+	});
+
+	it("skips the vision check for auto and custom models", () => {
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "auto", undefined, {
+				hasImages: true,
+			}),
+		).not.toThrow();
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "custom", undefined, {
+				hasImages: true,
+			}),
+		).not.toThrow();
+	});
+});

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -18,6 +18,7 @@ export interface ValidateModelCapabilitiesOptions {
 	tools?: unknown[];
 	tool_choice?: unknown;
 	webSearchTool?: WebSearchTool;
+	hasImages?: boolean;
 }
 
 /**
@@ -41,7 +42,30 @@ export function validateModelCapabilities(
 		tools,
 		tool_choice,
 		webSearchTool,
+		hasImages,
 	} = options;
+
+	// Validate vision capability when the request contains images.
+	// Skip this check for "auto" and "custom" models as they will be resolved dynamically.
+	if (hasImages && requestedModel !== "auto" && requestedModel !== "custom") {
+		const providersToCheck = requestedProvider
+			? modelInfo.providers.filter(
+					(p) => (p as ProviderModelMapping).providerId === requestedProvider,
+				)
+			: modelInfo.providers;
+
+		const supportsVision = providersToCheck.some(
+			(provider) => (provider as ProviderModelMapping).vision === true,
+		);
+
+		if (!supportsVision) {
+			throw new HTTPException(400, {
+				message: requestedProvider
+					? `Provider ${requestedProvider} does not support image input for model ${requestedModel}. Remove the image content or use a vision-capable model.`
+					: `Model ${requestedModel} does not support image input. Remove the image content or use a vision-capable model.`,
+			});
+		}
+	}
 
 	// Validate JSON object output capability
 	if (response_format?.type === "json_object") {


### PR DESCRIPTION
## Summary
- A request with `image_url` content sent to a non-vision provider (e.g. `deepseek/deepseek-v4-flash`) was forwarded to the upstream, which then 400'd with a cryptic *"unknown variant \`image_url\`, expected \`text\`"*. The auto-router already filters non-vision providers, but explicit-provider requests bypassed that check.
- Add a vision check in `validateModelCapabilities` so we error upfront with a clear, actionable message ("Provider X does not support image input for model Y") instead of forwarding bad payloads to upstream.

## Verification (local `pnpm dev` against real DeepSeek upstream)
- `deepseek/deepseek-v4-flash` text-only → upstream 200, content returned
- `deepseek/deepseek-v4-flash` + `image_url` → gateway 400 with the new message, **no upstream call** (previously: upstream 400 with garbled error)
- `deepseek/deepseek-v4-flash` text-only without provider prefix still works

## Test plan
- [x] `pnpm exec vitest run apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts` — 7 new unit tests pass
- [x] Manual: text-only deepseek → 200, image deepseek → clean gateway 400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image content validation: the system now checks that chosen models/providers support vision when requests include images; incompatible selections return a clear error.

* **Tests**
  * Added tests covering vision-capability validation across selection scenarios (explicit provider, auto/custom selection, and mixed-provider setups).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2230)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->