### PR TITLE
fix(gateway): classify client cancels as canceled, not gateway_error

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -126,6 +126,10 @@ import { extractErrorCause } from "./tools/extract-error-cause.js";
 import { extractReasoning } from "./tools/extract-reasoning.js";
 import { extractTokenUsage } from "./tools/extract-token-usage.js";
 import { extractToolCalls } from "./tools/extract-tool-calls.js";
+import {
+	CLIENT_DISCONNECT_REASON,
+	isSelfInitiatedClientDisconnect,
+} from "./tools/gateway-abort-reason.js";
 import { getFinishReasonFromError } from "./tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "./tools/get-provider-env.js";
 import { hasMeaningfulAssistantOutput } from "./tools/has-meaningful-assistant-output.js";
@@ -175,32 +179,6 @@ import { validateModelCapabilities } from "./tools/validate-model-capabilities.j
 
 import type { OriginalRequestParams } from "./tools/resolve-provider-context.js";
 import type { ServerTypes } from "@/vars.js";
-
-/**
- * Typed reasons we attach when the gateway aborts an upstream request via
- * `controller.abort(reason)`. AbortError on its own is ambiguous — undici can
- * surface upstream socket failures (HTTP/2 RST, ECONNRESET, etc.) as
- * AbortError, and a third-party fetch shim could in principle abort the
- * combined signal. By tagging our own aborts with a reason, the catches
- * below can distinguish "we aborted because the downstream client
- * disconnected" from "the runtime raised AbortError for some other cause."
- */
-interface GatewayAbortReason {
-	type: "client_disconnect";
-}
-
-const CLIENT_DISCONNECT_REASON: GatewayAbortReason = Object.freeze({
-	type: "client_disconnect",
-}) as GatewayAbortReason;
-
-function isGatewayAbortReason(reason: unknown): reason is GatewayAbortReason {
-	return (
-		typeof reason === "object" &&
-		reason !== null &&
-		"type" in reason &&
-		(reason as { type?: unknown }).type === "client_disconnect"
-	);
-}
 
 /**
  * Build an `errorDetails` payload from an AbortError so canceled requests
@@ -722,6 +700,7 @@ function inferStreamingErrorStatusCode(
 export async function inspectImmediateStreamingProviderError(
 	response: Response,
 	provider: Provider,
+	abortSignal?: AbortSignal,
 ): Promise<
 	| {
 			response: Response;
@@ -833,6 +812,13 @@ export async function inspectImmediateStreamingProviderError(
 			await reader.cancel();
 		} catch {
 			// Ignore cancellation errors - the response body is no longer needed.
+		}
+
+		// Self-initiated client disconnects must propagate to the caller —
+		// otherwise we mis-log canceled requests as upstream_error /
+		// stream_read_error.
+		if (abortSignal && isSelfInitiatedClientDisconnect(error, abortSignal)) {
+			throw error;
 		}
 
 		return {
@@ -4689,6 +4675,9 @@ chat.openapi(completions, async (c) => {
 						}
 					}
 
+					let inspectedStreamingResponse: Awaited<
+						ReturnType<typeof inspectImmediateStreamingProviderError>
+					> | null = null;
 					try {
 						const headers = getProviderHeaders(usedProvider, usedToken, {
 							requestId,
@@ -4726,6 +4715,21 @@ chat.openapi(completions, async (c) => {
 							body: JSON.stringify(requestBody),
 							signal: fetchSignal,
 						});
+
+						// Peek the upstream stream inside the same try so
+						// abort-during-peek surfaces through the fetch catch
+						// below instead of getting reported as a stream_read
+						// upstream_error. The actual error/replay handling
+						// runs after the catch (see below).
+						if (res.ok) {
+							inspectedStreamingResponse =
+								await inspectImmediateStreamingProviderError(
+									res,
+									usedProvider,
+									controller.signal,
+								);
+							res = inspectedStreamingResponse.response;
+						}
 					} catch (error) {
 						// Clean up the event listeners
 						c.req.raw.signal.removeEventListener("abort", onAbort);
@@ -4909,14 +4913,13 @@ chat.openapi(completions, async (c) => {
 							});
 							return;
 						} else if (
-							error instanceof Error &&
-							error.name === "AbortError" &&
-							isGatewayAbortReason(controller.signal.reason)
+							isSelfInitiatedClientDisconnect(error, controller.signal)
 						) {
 							// Self-initiated client disconnect; record as canceled.
 							// (Unlabeled AbortError falls through to the network-error
 							// branch below — undici surfaces upstream failures this way.)
-							const fetchAbortErrorDetails = buildAbortErrorDetails(error);
+							const fetchAbortErrorDetails =
+								error instanceof Error ? buildAbortErrorDetails(error) : null;
 							const canceledPluginIds = plugins?.map((p) => p.id) ?? [];
 
 							// Calculate costs for cancelled request if billing is enabled
@@ -5557,10 +5560,7 @@ chat.openapi(completions, async (c) => {
 						return;
 					}
 
-					const inspectedStreamingResponse =
-						await inspectImmediateStreamingProviderError(res, usedProvider);
-					res = inspectedStreamingResponse.response;
-					if (inspectedStreamingResponse.immediateError) {
+					if (inspectedStreamingResponse?.immediateError) {
 						const {
 							errorCode,
 							errorMessage,
@@ -7179,36 +7179,40 @@ chat.openapi(completions, async (c) => {
 						}
 					}
 				} catch (error) {
-					if (error instanceof Error && error.name === "AbortError") {
-						abortErrorDetails = buildAbortErrorDetails(error);
-						if (isGatewayAbortReason(controller.signal.reason)) {
-							// Self-initiated client disconnect (onAbort tagged the
-							// abort with our reason). canceled is already true; the
-							// log writer and recovery path will classify the row.
-						} else {
-							// Ambiguous AbortError — undici can surface upstream
-							// socket failures this way, and the runtime might raise
-							// AbortError without going through our controller. Log
-							// the cause for diagnostics; the streamEndedWithoutTerminalEvent
-							// recovery below will still classify the request as
-							// upstream_error.
-							const cause =
-								error.cause instanceof Error ? error.cause : undefined;
-							const causeCode = (error.cause as { code?: unknown } | undefined)
-								?.code;
-							logger.warn("Unexpected AbortError reading upstream stream", {
-								requestId,
-								usedProvider,
-								requestedProvider,
-								usedModel,
-								initialRequestedModel,
-								causeName: cause?.name,
-								causeMessage: cause?.message,
-								causeCode:
-									typeof causeCode === "string" ? causeCode : undefined,
-								signalAborted: controller.signal.aborted,
-							});
+					if (isSelfInitiatedClientDisconnect(error, controller.signal)) {
+						// Self-initiated client disconnect (onAbort tagged the
+						// abort with our reason). When the abort reason is a
+						// non-Error object, both fetch() and ReadableStream
+						// reject with the reason itself rather than wrapping it
+						// in an AbortError; recognize both shapes so the row
+						// isn't mislabeled as `gateway_error`. canceled is
+						// already true; the recovery path classifies the row.
+						if (error instanceof Error) {
+							abortErrorDetails = buildAbortErrorDetails(error);
 						}
+					} else if (error instanceof Error && error.name === "AbortError") {
+						abortErrorDetails = buildAbortErrorDetails(error);
+						// Ambiguous AbortError — undici can surface upstream
+						// socket failures this way, and the runtime might raise
+						// AbortError without going through our controller. Log
+						// the cause for diagnostics; the streamEndedWithoutTerminalEvent
+						// recovery below will still classify the request as
+						// upstream_error.
+						const cause =
+							error.cause instanceof Error ? error.cause : undefined;
+						const causeCode = (error.cause as { code?: unknown } | undefined)
+							?.code;
+						logger.warn("Unexpected AbortError reading upstream stream", {
+							requestId,
+							usedProvider,
+							requestedProvider,
+							usedModel,
+							initialRequestedModel,
+							causeName: cause?.name,
+							causeMessage: cause?.message,
+							causeCode: typeof causeCode === "string" ? causeCode : undefined,
+							signalAborted: controller.signal.aborted,
+						});
 					} else if (isTimeoutError(error)) {
 						const errorMessage =
 							error instanceof Error ? error.message : "Stream reading timeout";
@@ -8392,14 +8396,11 @@ chat.openapi(completions, async (c) => {
 				fetchError =
 					error instanceof Error ? error : new Error("Request timeout");
 				isTimeoutFetchError = true;
-			} else if (
-				error instanceof Error &&
-				error.name === "AbortError" &&
-				isGatewayAbortReason(controller.signal.reason)
-			) {
+			} else if (isSelfInitiatedClientDisconnect(error, controller.signal)) {
 				// Self-initiated client disconnect (onAbort tagged the abort).
 				canceled = true;
-				canceledErrorDetails = buildAbortErrorDetails(error);
+				canceledErrorDetails =
+					error instanceof Error ? buildAbortErrorDetails(error) : null;
 			} else if (error instanceof Error) {
 				// Captures fetch errors (connection failures, ECONNRESET, undici
 				// transport errors, and unlabeled AbortErrors that came from

--- a/apps/gateway/src/chat/tools/gateway-abort-reason.spec.ts
+++ b/apps/gateway/src/chat/tools/gateway-abort-reason.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	CLIENT_DISCONNECT_REASON,
+	ClientDisconnectError,
+	isGatewayAbortReason,
+	isSelfInitiatedClientDisconnect,
+} from "./gateway-abort-reason.js";
+
+describe("gateway-abort-reason", () => {
+	describe("CLIENT_DISCONNECT_REASON", () => {
+		it("is an Error instance with the disconnect type tag", () => {
+			// Error subclass keeps `instanceof Error` true at every catch site
+			// and lets undici's internal `.stack` annotation succeed (a frozen
+			// plain object reason produced "Cannot define property stack"
+			// TypeErrors that polluted logs as upstream_error).
+			expect(CLIENT_DISCONNECT_REASON).toBeInstanceOf(Error);
+			expect(CLIENT_DISCONNECT_REASON).toBeInstanceOf(ClientDisconnectError);
+			expect(CLIENT_DISCONNECT_REASON.type).toBe("client_disconnect");
+			expect(Object.isExtensible(CLIENT_DISCONNECT_REASON)).toBe(true);
+		});
+	});
+
+	describe("isGatewayAbortReason", () => {
+		it("recognizes the canonical reason instance", () => {
+			expect(isGatewayAbortReason(CLIENT_DISCONNECT_REASON)).toBe(true);
+		});
+
+		it("recognizes a structurally equivalent object", () => {
+			expect(isGatewayAbortReason({ type: "client_disconnect" })).toBe(true);
+		});
+
+		it("rejects unrelated values", () => {
+			expect(isGatewayAbortReason(null)).toBe(false);
+			expect(isGatewayAbortReason(undefined)).toBe(false);
+			expect(isGatewayAbortReason("client_disconnect")).toBe(false);
+			expect(isGatewayAbortReason({ type: "timeout" })).toBe(false);
+			expect(isGatewayAbortReason(new Error("boom"))).toBe(false);
+		});
+	});
+
+	describe("isSelfInitiatedClientDisconnect", () => {
+		it("returns true when the error IS the abort reason (ReadableStream path)", () => {
+			// Both fetch() and ReadableStream.read() reject with the abort
+			// reason itself rather than wrapping it. Recognize that shape.
+			const controller = new AbortController();
+			controller.abort(CLIENT_DISCONNECT_REASON);
+			expect(
+				isSelfInitiatedClientDisconnect(
+					CLIENT_DISCONNECT_REASON,
+					controller.signal,
+				),
+			).toBe(true);
+		});
+
+		it("returns true for an AbortError when the signal reason matches", () => {
+			const controller = new AbortController();
+			controller.abort(CLIENT_DISCONNECT_REASON);
+			const err = new Error("The operation was aborted.");
+			err.name = "AbortError";
+			expect(isSelfInitiatedClientDisconnect(err, controller.signal)).toBe(
+				true,
+			);
+		});
+
+		it("returns false for an AbortError when the signal reason is unrelated", () => {
+			const controller = new AbortController();
+			controller.abort(new Error("upstream socket closed"));
+			const err = new Error("The operation was aborted.");
+			err.name = "AbortError";
+			expect(isSelfInitiatedClientDisconnect(err, controller.signal)).toBe(
+				false,
+			);
+		});
+
+		it("returns false for a generic streaming error on a non-aborted signal", () => {
+			const controller = new AbortController();
+			const err = new TypeError("terminated");
+			expect(isSelfInitiatedClientDisconnect(err, controller.signal)).toBe(
+				false,
+			);
+		});
+
+		it("returns false for a generic upstream JSON error even after abort", () => {
+			// A late upstream-shaped error caught after we aborted ourselves
+			// should still be treated as self-initiated only when the error is
+			// our reason or a labeled AbortError. A SyntaxError mid-parse is
+			// real upstream noise.
+			const controller = new AbortController();
+			controller.abort(CLIENT_DISCONNECT_REASON);
+			const err = new SyntaxError("Unexpected end of JSON input");
+			expect(isSelfInitiatedClientDisconnect(err, controller.signal)).toBe(
+				false,
+			);
+		});
+	});
+});

--- a/apps/gateway/src/chat/tools/gateway-abort-reason.ts
+++ b/apps/gateway/src/chat/tools/gateway-abort-reason.ts
@@ -1,0 +1,65 @@
+/**
+ * Typed reason attached when the gateway aborts an upstream request via
+ * `controller.abort(reason)`. AbortError on its own is ambiguous — undici can
+ * surface upstream socket failures (HTTP/2 RST, ECONNRESET, etc.) as
+ * AbortError, and a third-party fetch shim could in principle abort the
+ * combined signal. Tagging our own aborts lets catch blocks distinguish "we
+ * aborted because the downstream client disconnected" from "the runtime
+ * raised AbortError for some other cause."
+ *
+ * Implemented as an Error subclass so:
+ *   - `error instanceof Error` is true at every catch site (a plain object
+ *     reason gets thrown bare by the WHATWG ReadableStream/fetch impls and
+ *     bypasses the standard Error-shaped catch arms).
+ *   - undici's internal `.stack` annotation doesn't blow up. A frozen plain
+ *     object reason produced "Cannot define property stack, object is not
+ *     extensible" TypeErrors that polluted logs as upstream_error.
+ */
+export class ClientDisconnectError extends Error {
+	readonly type = "client_disconnect" as const;
+
+	constructor() {
+		super("client_disconnect");
+		this.name = "ClientDisconnectError";
+	}
+}
+
+export const CLIENT_DISCONNECT_REASON: ClientDisconnectError =
+	new ClientDisconnectError();
+
+export function isGatewayAbortReason(
+	reason: unknown,
+): reason is ClientDisconnectError {
+	return (
+		typeof reason === "object" &&
+		reason !== null &&
+		"type" in reason &&
+		(reason as { type?: unknown }).type === "client_disconnect"
+	);
+}
+
+/**
+ * Recognize a self-initiated client disconnect from an upstream catch block.
+ *
+ * When `controller.abort(reason)` is called with a non-Error reason, both
+ * `fetch()` and `ReadableStream.read()` reject with the reason itself rather
+ * than wrapping it in an AbortError. We need to recognize both shapes:
+ *   - `error` IS our gateway abort reason (non-Error path), or
+ *   - `error` is an AbortError and `signal.reason` is our gateway abort reason.
+ *
+ * Without this, client cancels get mislabeled as `gateway_error` because the
+ * generic streaming-error handler runs on the bare reason object.
+ */
+export function isSelfInitiatedClientDisconnect(
+	error: unknown,
+	signal: AbortSignal,
+): boolean {
+	if (isGatewayAbortReason(error)) {
+		return true;
+	}
+	return (
+		error instanceof Error &&
+		error.name === "AbortError" &&
+		isGatewayAbortReason(signal.reason)
+	);
+}


### PR DESCRIPTION
## Summary

When a client disconnects mid-stream, the gateway aborts the upstream via `controller.abort(CLIENT_DISCONNECT_REASON)`. The reason was a frozen plain object, which both `fetch()` and `ReadableStream` reject with directly instead of wrapping in an AbortError — bypassing the existing `error.name === "AbortError"` catches and landing in the generic streaming-error handler.

Visible symptoms in production logs (provider-agnostic, hit on deepseek-v4-flash via alibaba/novita first because of how its routing fans out):

- `finish_reason = gateway_error`, `unified_finish_reason = gateway_error` for what were really client cancels
- `error_details.responseText = {"type":"client_disconnect"}`
- A second class of `upstream_error` rows with `{"statusCode":0,"statusText":"TypeError","responseText":"Cannot define property stack, object is not extensible"}` — undici trying to annotate `.stack` on the frozen reason

## Fix

- Move `CLIENT_DISCONNECT_REASON` / `isGatewayAbortReason` into a new `tools/gateway-abort-reason.ts`
- Make the reason a `ClientDisconnectError` (Error subclass): `instanceof Error` is true at every catch, undici's `.stack` annotation succeeds
- Add `isSelfInitiatedClientDisconnect(error, signal)` that recognizes both shapes — the error being our reason, or an AbortError whose `signal.reason` is — and wire it through the three catch sites (streaming fetch, streaming read, non-streaming fetch)
- Wire the immediate-error peek into the fetch `try` block so abort-during-peek surfaces through the existing cancel handler instead of being reported as `stream_read_error` / `upstream_error`

## Test plan

- [x] New unit suite `gateway-abort-reason.spec.ts` covers the canonical + structurally-equivalent reason shapes and the AbortError + signal-reason path
- [x] Replayed the exact incident payload (1500ms abort hits the peek path; 4000ms hits stream-read; 8000ms hits mid-stream): all rows now log as `canceled`, `has_error=false`, `errorDetails.statusCode=499`. Repeated against alibaba and novita to confirm provider-agnostic.
- [x] `pnpm format`, `pnpm build`, `pnpm vitest run --no-file-parallelism apps/gateway/src/chat` (all 314 tests pass; pre-existing `videos.spec.ts` failures on main are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error classification to accurately distinguish between client-initiated cancellations and upstream service errors during streaming requests.

* **Refactor**
  * Centralized client disconnect detection logic for consistent error handling across all request types.

* **Tests**
  * Added comprehensive test coverage for disconnect detection and error classification mechanisms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->