### PR TITLE
fix(logger): wrap unknown errors via toError helper

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -4,7 +4,7 @@ import { streamSSE } from "hono/streaming";
 
 import { app } from "@/app.js";
 
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -850,7 +850,7 @@ anthropic.openapi(messages, async (c) => {
 		openaiResponse = JSON.parse(openaiText);
 	} catch (error) {
 		logger.error("Failed to parse OpenAI response", {
-			err: error instanceof Error ? error : new Error(String(error)),
+			err: toError(error),
 			responseText: openaiText || "(empty)",
 		});
 		throw new HTTPException(500, {

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -15,7 +15,7 @@ import {
 	getMetrics,
 	getMetricsContentType,
 } from "@llmgateway/instrumentation";
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 import { HealthChecker } from "@llmgateway/shared";
 
 import { anthropic } from "./anthropic/anthropic.js";
@@ -169,10 +169,7 @@ app.onError((error, c) => {
 	}
 
 	// For any other errors (non-HTTPException), return 500 Internal Server Error
-	logger.error(
-		"Unhandled error",
-		error instanceof Error ? error : new Error(String(error)),
-	);
+	logger.error("Unhandled error", toError(error));
 	return c.json(
 		{
 			error: true,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -82,7 +82,7 @@ import {
 	checkGuardrails,
 	logViolation,
 } from "@llmgateway/guardrails";
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 import {
 	type BaseMessage,
 	getModelStreamingSupport,
@@ -7274,41 +7274,37 @@ chat.openapi(completions, async (c) => {
 							phase: "upstream_read",
 						});
 
-						logger.error(
-							"Error reading upstream stream",
-							error instanceof Error ? error : new Error(String(error)),
-							{
-								requestId,
+						logger.error("Error reading upstream stream", toError(error), {
+							requestId,
+							usedProvider,
+							requestedProvider,
+							usedModel,
+							initialRequestedModel,
+							upstreamStatus: res?.status ?? null,
+							upstreamStatusText: res?.statusText ?? null,
+							upstreamHeaders: res
+								? {
+										contentType: res.headers.get("content-type"),
+										contentLength: res.headers.get("content-length"),
+										transferEncoding: res.headers.get("transfer-encoding"),
+										requestId:
+											res.headers.get("x-request-id") ??
+											res.headers.get("request-id") ??
+											res.headers.get("openai-request-id"),
+									}
+								: null,
+							streamingDiagnostics: normalizedStreamingError.log.details,
+							timeToFirstToken,
+							timeToFirstReasoningToken,
+							firstTokenReceived,
+							firstReasoningTokenReceived,
+							unifiedFinishReason: getUnifiedFinishReason(
+								normalizedStreamingError.client.type === "gateway_error"
+									? "gateway_error"
+									: "upstream_error",
 								usedProvider,
-								requestedProvider,
-								usedModel,
-								initialRequestedModel,
-								upstreamStatus: res?.status ?? null,
-								upstreamStatusText: res?.statusText ?? null,
-								upstreamHeaders: res
-									? {
-											contentType: res.headers.get("content-type"),
-											contentLength: res.headers.get("content-length"),
-											transferEncoding: res.headers.get("transfer-encoding"),
-											requestId:
-												res.headers.get("x-request-id") ??
-												res.headers.get("request-id") ??
-												res.headers.get("openai-request-id"),
-										}
-									: null,
-								streamingDiagnostics: normalizedStreamingError.log.details,
-								timeToFirstToken,
-								timeToFirstReasoningToken,
-								firstTokenReceived,
-								firstReasoningTokenReceived,
-								unifiedFinishReason: getUnifiedFinishReason(
-									normalizedStreamingError.client.type === "gateway_error"
-										? "gateway_error"
-										: "upstream_error",
-									usedProvider,
-								),
-							},
-						);
+							),
+						});
 
 						// Forward the error to the client with the buffered content that caused the error
 						try {
@@ -7602,7 +7598,7 @@ chat.openapi(completions, async (c) => {
 							} catch (error) {
 								logger.error(
 									"Error sending synthesized finish chunk",
-									error instanceof Error ? error : new Error(String(error)),
+									toError(error),
 								);
 							}
 						}
@@ -7769,10 +7765,7 @@ chat.openapi(completions, async (c) => {
 								id: String(eventId++),
 							});
 						} catch (error) {
-							logger.error(
-								"Error sending final usage chunk",
-								error instanceof Error ? error : new Error(String(error)),
-							);
+							logger.error("Error sending final usage chunk", toError(error));
 						}
 
 						// Send healed content if buffering was enabled
@@ -7850,7 +7843,7 @@ chat.openapi(completions, async (c) => {
 							} catch (error) {
 								logger.error(
 									"Error sending healed content chunk",
-									error instanceof Error ? error : new Error(String(error)),
+									toError(error),
 								);
 							}
 						}
@@ -7887,7 +7880,7 @@ chat.openapi(completions, async (c) => {
 							} catch (error) {
 								logger.error(
 									"Error sending routing metadata chunk",
-									error instanceof Error ? error : new Error(String(error)),
+									toError(error),
 								);
 							}
 						}
@@ -7901,10 +7894,7 @@ chat.openapi(completions, async (c) => {
 									id: String(eventId++),
 								});
 							} catch (error) {
-								logger.error(
-									"Error sending [DONE] event",
-									error instanceof Error ? error : new Error(String(error)),
-								);
+								logger.error("Error sending [DONE] event", toError(error));
 							}
 						}
 					}
@@ -8221,10 +8211,7 @@ chat.openapi(completions, async (c) => {
 								cacheDuration,
 							);
 						} catch (error) {
-							logger.error(
-								"Error saving streaming cache",
-								error instanceof Error ? error : new Error(String(error)),
-							);
+							logger.error("Error saving streaming cache", toError(error));
 						}
 					}
 				}

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -4,7 +4,7 @@ import { HTTPException } from "hono/http-exception";
 import { app } from "@/app.js";
 
 import { processImageUrl } from "@llmgateway/actions";
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 
 import type { ServerTypes } from "@/vars.js";
 import type { Context } from "hono";
@@ -228,7 +228,7 @@ async function extractImagesFromChatResponse(
 						logger.warn("Images API - failed to fetch image from URL", {
 							model,
 							url: imageUrl.substring(0, 100),
-							err: error instanceof Error ? error : new Error(String(error)),
+							err: toError(error),
 						});
 					}
 				}
@@ -355,7 +355,7 @@ async function forwardToChatCompletions(
 		return JSON.parse(responseText);
 	} catch (error) {
 		logger.error("Images API - failed to parse chat completions response", {
-			err: error instanceof Error ? error : new Error(String(error)),
+			err: toError(error),
 		});
 		throw new HTTPException(500, {
 			message: "Failed to parse image generation response",

--- a/apps/gateway/src/mcp/mcp.ts
+++ b/apps/gateway/src/mcp/mcp.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 import { parseApiToken } from "@/lib/extract-api-token.js";
 
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 import {
 	models as modelsList,
 	type ModelDefinition,
@@ -210,10 +210,7 @@ function createMcpServer(apiKey: string): McpServer {
 					],
 				};
 			} catch (error) {
-				logger.error(
-					"MCP chat tool error",
-					error instanceof Error ? error : new Error(String(error)),
-				);
+				logger.error("MCP chat tool error", toError(error));
 				return {
 					content: [
 						{
@@ -394,10 +391,7 @@ function createMcpServer(apiKey: string): McpServer {
 					],
 				};
 			} catch (error) {
-				logger.error(
-					"MCP list-models tool error",
-					error instanceof Error ? error : new Error(String(error)),
-				);
+				logger.error("MCP list-models tool error", toError(error));
 				return {
 					content: [
 						{
@@ -538,10 +532,7 @@ function createMcpServer(apiKey: string): McpServer {
 					content: contentBlocks,
 				};
 			} catch (error) {
-				logger.error(
-					"MCP generate-image tool error",
-					error instanceof Error ? error : new Error(String(error)),
-				);
+				logger.error("MCP generate-image tool error", toError(error));
 				return {
 					content: [
 						{
@@ -768,10 +759,7 @@ function createMcpServer(apiKey: string): McpServer {
 					content: contentBlocks,
 				};
 			} catch (error) {
-				logger.error(
-					"MCP generate-nano-banana tool error",
-					error instanceof Error ? error : new Error(String(error)),
-				);
+				logger.error("MCP generate-nano-banana tool error", toError(error));
 				return {
 					content: [
 						{
@@ -869,10 +857,7 @@ function createMcpServer(apiKey: string): McpServer {
 					],
 				};
 			} catch (error) {
-				logger.error(
-					"MCP list-image-models tool error",
-					error instanceof Error ? error : new Error(String(error)),
-				);
+				logger.error("MCP list-image-models tool error", toError(error));
 				return {
 					content: [
 						{
@@ -1324,10 +1309,7 @@ export async function mcpHandler(c: Context): Promise<Response> {
 				);
 			}
 
-			logger.error(
-				"MCP request error",
-				error instanceof Error ? error : new Error(String(error)),
-			);
+			logger.error("MCP request error", toError(error));
 			return c.json(
 				{
 					jsonrpc: "2.0",
@@ -1864,10 +1846,7 @@ async function oauthRegisterHandler(c: Context): Promise<Response> {
 			201,
 		);
 	} catch (error) {
-		logger.error(
-			"OAuth registration error",
-			error instanceof Error ? error : new Error(String(error)),
-		);
+		logger.error("OAuth registration error", toError(error));
 		return c.json(
 			{
 				error: "invalid_request",

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -1,7 +1,7 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 import {
 	models as modelsList,
 	providers,
@@ -293,10 +293,7 @@ modelsApi.openapi(listModels, async (c) => {
 
 		return c.json({ data: modelData });
 	} catch (error) {
-		logger.error(
-			"Error in models endpoint",
-			error instanceof Error ? error : new Error(String(error)),
-		);
+		logger.error("Error in models endpoint", toError(error));
 		throw new HTTPException(500, { message: "Internal server error" });
 	}
 });

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -6,7 +6,7 @@ import {
 	initializeInstrumentation,
 	shutdownInstrumentation,
 } from "@llmgateway/instrumentation";
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 
 import { app } from "./app.js";
 
@@ -115,10 +115,7 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 		logger.info("Graceful shutdown completed");
 		process.exit(0);
 	} catch (error) {
-		logger.error(
-			"Error during graceful shutdown",
-			error instanceof Error ? error : new Error(String(error)),
-		);
+		logger.error("Error during graceful shutdown", toError(error));
 		process.exit(1);
 	}
 };

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -40,7 +40,7 @@ import {
 	tables,
 	type InferSelectModel,
 } from "@llmgateway/db";
-import { logger } from "@llmgateway/logger";
+import { logger, toError } from "@llmgateway/logger";
 import {
 	getProviderEnvValue,
 	getProviderEnvVar,
@@ -1842,7 +1842,7 @@ async function getExternalVideoContentUrl(
 		} catch (error) {
 			logger.error(
 				"Failed to create signed URL for video job",
-				error instanceof Error ? error : new Error(String(error)),
+				toError(error),
 				{
 					videoJobId: job.id,
 					storageUri: job.storageUri,

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -203,6 +203,48 @@ class LLMGatewayLogger {
 	}
 }
 
+export function toError(value: unknown): Error {
+	if (value instanceof Error) {
+		return value;
+	}
+
+	if (value === null || value === undefined) {
+		return new Error("Unknown error");
+	}
+
+	if (typeof value === "string") {
+		return new Error(value);
+	}
+
+	if (typeof value !== "object") {
+		return new Error(String(value));
+	}
+
+	const candidate = value as { message?: unknown; error?: unknown };
+	if (typeof candidate.message === "string" && candidate.message.length > 0) {
+		const err = new Error(candidate.message);
+		(err as Error & { cause?: unknown }).cause = value;
+		return err;
+	}
+	if (typeof candidate.error === "string" && candidate.error.length > 0) {
+		return new Error(candidate.error);
+	}
+
+	try {
+		const serialized = JSON.stringify(value);
+		if (serialized && serialized !== "{}") {
+			return new Error(serialized);
+		}
+	} catch {
+		// fall through to constructor name fallback
+	}
+
+	const ctorName =
+		(value as { constructor?: { name?: string } }).constructor?.name ??
+		"Object";
+	return new Error(`[unserializable ${ctorName}]`);
+}
+
 // Default logger instance
 export const logger = new LLMGatewayLogger();
 

--- a/packages/logger/src/logger.spec.ts
+++ b/packages/logger/src/logger.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { logger, createLogger } from "@/index.js";
+import { logger, createLogger, toError } from "@/index.js";
 
 describe("LLMGateway Logger", () => {
 	beforeEach(() => {
@@ -46,6 +46,50 @@ describe("LLMGateway Logger", () => {
 		const childLogger = logger.child({ component: "test" });
 		expect(childLogger).toBeDefined();
 		expect(typeof childLogger.info).toBe("function");
+	});
+
+	describe("toError", () => {
+		it("returns Error instances unchanged", () => {
+			const err = new Error("boom");
+			expect(toError(err)).toBe(err);
+		});
+
+		it("wraps string values", () => {
+			expect(toError("nope").message).toBe("nope");
+		});
+
+		it("uses message field for plain error-like objects", () => {
+			const result = toError({ message: "upstream failed", code: 500 });
+			expect(result.message).toBe("upstream failed");
+			expect((result as Error & { cause?: unknown }).cause).toEqual({
+				message: "upstream failed",
+				code: 500,
+			});
+		});
+
+		it("uses error field when message is missing", () => {
+			expect(toError({ error: "auth_failed" }).message).toBe("auth_failed");
+		});
+
+		it("JSON-serializes objects without message/error", () => {
+			expect(toError({ status: 502, retry: true }).message).toBe(
+				'{"status":502,"retry":true}',
+			);
+		});
+
+		it("falls back to constructor name for empty objects", () => {
+			expect(toError({}).message).toBe("[unserializable Object]");
+		});
+
+		it("handles null and undefined", () => {
+			expect(toError(null).message).toBe("Unknown error");
+			expect(toError(undefined).message).toBe("Unknown error");
+		});
+
+		it("avoids the [object Object] string for plain objects", () => {
+			const result = toError({ foo: "bar" });
+			expect(result.message).not.toBe("[object Object]");
+		});
 	});
 
 	it("should serialize Error instances passed to warn", () => {


### PR DESCRIPTION
## Summary
- Streaming/log paths in the gateway wrapped non-Error values with `new Error(String(error))`, producing `"[object Object]"` messages and stacks (observed today on `llmgateway-gateway` / `chat.ts:7279`).
- Adds a `toError(value: unknown): Error` helper to `@llmgateway/logger` that prefers `error.message`, then `error.error`, then JSON-serializes plain objects, and falls back to a `[unserializable <ConstructorName>]` marker.
- Replaces all 16 `error instanceof Error ? error : new Error(String(error))` sites across the gateway (`chat.ts`, `mcp.ts`, `videos.ts`, `images.ts`, `models.ts`, `app.ts`, `serve.ts`, `anthropic.ts`) with `toError(error)`.

## Test plan
- [x] `npx vitest run packages/logger` (14 tests, including 8 new cases covering Error passthrough, string, `{message}`/`{error}` extraction, JSON fallback, empty object, null/undefined, and explicit no-`[object Object]` regression)
- [x] `pnpm build` (full monorepo build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new error normalization utility to improve consistency and reliability in error logging across the application.

* **Refactor**
  * Updated error handling throughout the gateway application to use the new error normalization utility for more consistent error message formatting.

* **Tests**
  * Added comprehensive test coverage for the new error normalization utility across multiple input types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->