### PR TITLE
fix(gateway): map zai sensitive finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -169,6 +169,24 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps zai finish reasons correctly", () => {
+		expect(getUnifiedFinishReason("stop", "zai")).toBe(
+			UnifiedFinishReason.COMPLETED,
+		);
+		expect(getUnifiedFinishReason("length", "zai")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(getUnifiedFinishReason("tool_calls", "zai")).toBe(
+			UnifiedFinishReason.TOOL_CALLS,
+		);
+		expect(getUnifiedFinishReason("sensitive", "zai")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+		expect(getUnifiedFinishReason("content_filter", "zai")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+	});
+
 	it("maps llmgateway_content_filter to CONTENT_FILTER", () => {
 		expect(
 			getUnifiedFinishReason("llmgateway_content_filter", "any-provider"),

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -141,6 +141,20 @@ export function getUnifiedFinishReason(
 				return UnifiedFinishReason.UPSTREAM_ERROR;
 			}
 			break;
+		case "zai":
+			if (finishReason === "stop") {
+				return UnifiedFinishReason.COMPLETED;
+			}
+			if (finishReason === "length" || finishReason === "incomplete") {
+				return UnifiedFinishReason.LENGTH_LIMIT;
+			}
+			if (finishReason === "tool_calls") {
+				return UnifiedFinishReason.TOOL_CALLS;
+			}
+			if (finishReason === "sensitive" || finishReason === "content_filter") {
+				return UnifiedFinishReason.CONTENT_FILTER;
+			}
+			break;
 		default: // OpenAI format (also used by inference.net and other providers)
 			if (finishReason === "stop") {
 				return UnifiedFinishReason.COMPLETED;


### PR DESCRIPTION
## Summary
- Map zai's `sensitive` finish reason to `CONTENT_FILTER` so blocked completions are no longer logged as unknown.
- Add a dedicated `zai` case mapping `stop`, `length`/`incomplete`, `tool_calls`, and `content_filter` to their unified equivalents.

## Test plan
- [x] `pnpm test:unit` covering the new zai mappings in `logs.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `zai` provider with proper finish-reason mapping.

* **Tests**
  * Added test coverage for `zai` provider finish-reason mappings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->