### PR TITLE
feat: redesign share dialog, OG image, agent chart

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7874,7 +7874,10 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const [countRow] = await countSelect.where(whereClause);
 	const total = Number(countRow?.count ?? 0);
 
-	// KPI strip — always over the full active subscriber base, unfiltered
+	// KPI strip — always over the full active subscriber base, unfiltered.
+	// Matches Stripe's "active" filter, which includes cancel-at-period-end
+	// subscriptions until the period actually ends. The `cancelledPending`
+	// count below breaks out how many of these are flagged to cancel.
 	const activeRows = await db
 		.select({
 			tier: tables.organization.devPlan,
@@ -7884,7 +7887,6 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.where(
 			and(
 				ne(tables.organization.devPlan, "none"),
-				eq(tables.organization.devPlanCancelled, false),
 				or(
 					isNull(tables.organization.devPlanExpiresAt),
 					sql`${tables.organization.devPlanExpiresAt} > NOW()`,

--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import {
+	addDays,
+	addHours,
+	format,
+	parseISO,
+	startOfDay,
+	startOfHour,
+} from "date-fns";
+import { ChevronDown, Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+import { useApi } from "@/lib/fetch-client";
+
+import type { paths } from "@/lib/api/v1";
+import type { TooltipProps } from "recharts";
+
+type ApiLog =
+	paths["/logs"]["get"]["responses"][200]["content"]["application/json"]["logs"][number];
+
+export type AgentChartTimeRange = "1h" | "4h" | "24h" | "7d" | "30d";
+
+const TIME_RANGES: { value: AgentChartTimeRange; label: string }[] = [
+	{ value: "1h", label: "1h" },
+	{ value: "4h", label: "4h" },
+	{ value: "24h", label: "1d" },
+	{ value: "7d", label: "7d" },
+	{ value: "30d", label: "30d" },
+];
+
+type Metric = "requests" | "cost" | "tokens";
+
+const METRIC_OPTIONS: { value: Metric; label: string }[] = [
+	{ value: "requests", label: "Requests" },
+	{ value: "cost", label: "Cost" },
+	{ value: "tokens", label: "Tokens" },
+];
+
+const MODEL_COLORS = [
+	"#6366f1",
+	"#0ea5e9",
+	"#10b981",
+	"#f59e0b",
+	"#ef4444",
+	"#8b5cf6",
+	"#ec4899",
+	"#06b6d4",
+	"#84cc16",
+	"#f97316",
+];
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const RANGE_OFFSET_MS: Record<AgentChartTimeRange, number> = {
+	"1h": HOUR_MS,
+	"4h": 4 * HOUR_MS,
+	"24h": 24 * HOUR_MS,
+	"7d": 7 * DAY_MS,
+	"30d": 30 * DAY_MS,
+};
+
+function getRangeStart(range: AgentChartTimeRange): Date {
+	return new Date(Date.now() - RANGE_OFFSET_MS[range]);
+}
+
+function getGranularity(range: AgentChartTimeRange): "hourly" | "daily" {
+	if (range === "1h" || range === "4h" || range === "24h") {
+		return "hourly";
+	}
+	return "daily";
+}
+
+function getSlots(range: AgentChartTimeRange): Date[] {
+	const granularity = getGranularity(range);
+	const now = new Date();
+	const slots: Date[] = [];
+	if (granularity === "hourly") {
+		const totalHours = range === "1h" ? 1 : range === "4h" ? 4 : 24;
+		const end = startOfHour(now);
+		const start = addHours(end, -(totalHours - 1));
+		for (let i = 0; i < totalHours; i++) {
+			slots.push(addHours(start, i));
+		}
+	} else {
+		const totalDays = range === "7d" ? 7 : 30;
+		const end = startOfDay(now);
+		const start = addDays(end, -(totalDays - 1));
+		for (let i = 0; i < totalDays; i++) {
+			slots.push(addDays(start, i));
+		}
+	}
+	return slots;
+}
+
+function formatSlotKey(date: Date, granularity: "hourly" | "daily"): string {
+	if (granularity === "hourly") {
+		return format(date, "yyyy-MM-dd'T'HH:00:00");
+	}
+	return format(date, "yyyy-MM-dd");
+}
+
+function bucketLogToSlot(log: ApiLog, granularity: "hourly" | "daily"): string {
+	const date = new Date(log.createdAt);
+	if (granularity === "hourly") {
+		return formatSlotKey(startOfHour(date), granularity);
+	}
+	return formatSlotKey(startOfDay(date), granularity);
+}
+
+function formatTokens(n: number): string {
+	if (n >= 1_000_000) {
+		return `${(n / 1_000_000).toFixed(1)}M`;
+	}
+	if (n >= 1_000) {
+		return `${(n / 1_000).toFixed(1)}K`;
+	}
+	return n.toLocaleString();
+}
+
+interface AgentModelUsageChartProps {
+	sources: string[];
+}
+
+interface SlotData {
+	slot: string;
+	totalRequests: number;
+	totalCost: number;
+	totalTokens: number;
+	models: Record<string, { requests: number; cost: number; tokens: number }>;
+}
+
+function buildChartData(
+	logs: ApiLog[],
+	range: AgentChartTimeRange,
+): { rows: SlotData[]; models: string[] } {
+	const granularity = getGranularity(range);
+	const slots = getSlots(range);
+	const slotMap = new Map<string, SlotData>();
+	for (const date of slots) {
+		const key = formatSlotKey(date, granularity);
+		slotMap.set(key, {
+			slot: key,
+			totalRequests: 0,
+			totalCost: 0,
+			totalTokens: 0,
+			models: {},
+		});
+	}
+
+	const rangeStart = getRangeStart(range).getTime();
+	const modelTotals = new Map<string, number>();
+
+	for (const log of logs) {
+		const ts = new Date(log.createdAt).getTime();
+		if (ts < rangeStart) {
+			continue;
+		}
+		const key = bucketLogToSlot(log, granularity);
+		const slot = slotMap.get(key);
+		if (!slot) {
+			continue;
+		}
+		const modelId = log.usedModel || log.requestedModel || "unknown";
+		const cost = log.cost ?? 0;
+		const tokens = Number(log.totalTokens ?? 0);
+		slot.totalRequests += 1;
+		slot.totalCost += cost;
+		slot.totalTokens += tokens;
+		const entry = slot.models[modelId] ?? {
+			requests: 0,
+			cost: 0,
+			tokens: 0,
+		};
+		entry.requests += 1;
+		entry.cost += cost;
+		entry.tokens += tokens;
+		slot.models[modelId] = entry;
+		modelTotals.set(
+			modelId,
+			(modelTotals.get(modelId) ?? 0) + cost + tokens + 1,
+		);
+	}
+
+	const models = Array.from(modelTotals.entries())
+		.sort((a, b) => b[1] - a[1])
+		.map(([id]) => id);
+	const rows = Array.from(slotMap.values());
+	return { rows, models };
+}
+
+interface ChartRow {
+	slot: string;
+	formattedDate: string;
+	totalRequests: number;
+	totalCost: number;
+	totalTokens: number;
+	[key: string]: string | number;
+}
+
+interface ChartTooltipPayload {
+	dataKey?: string;
+	name?: string;
+	value?: number;
+	color?: string;
+	payload?: ChartRow;
+}
+
+function ChartTooltipContent({
+	active,
+	payload,
+	label,
+	metric,
+	hourly,
+}: TooltipProps<number, string> & {
+	metric: Metric;
+	hourly: boolean;
+}) {
+	if (!active || !payload || payload.length === 0) {
+		return null;
+	}
+	const typed = payload as unknown as ChartTooltipPayload[];
+	const first = typed[0]?.payload;
+	if (!first) {
+		return null;
+	}
+	const dateLabel = label
+		? format(parseISO(label), hourly ? "MMM d, HH:mm" : "MMM d, yyyy")
+		: "";
+	return (
+		<div className="rounded-lg border border-border/60 bg-popover p-2.5 text-xs text-popover-foreground shadow-md">
+			<div className="font-medium">{dateLabel}</div>
+			<div className="mt-1 space-y-0.5 text-[11px] text-muted-foreground">
+				<div>
+					<span className="font-medium text-foreground">
+						{first.totalRequests.toLocaleString()}
+					</span>{" "}
+					requests
+				</div>
+				<div>
+					<span className="font-medium text-foreground">
+						{formatTokens(first.totalTokens)}
+					</span>{" "}
+					tokens
+				</div>
+				<div>
+					<span className="font-medium text-foreground">
+						${first.totalCost.toFixed(4)}
+					</span>{" "}
+					cost
+				</div>
+			</div>
+			<div className="mt-2 space-y-0.5 border-t border-border/40 pt-2">
+				{typed
+					.filter((p) => typeof p.value === "number" && (p.value as number) > 0)
+					.map((p, i) => (
+						<div
+							key={`${p.dataKey ?? i}`}
+							className="flex items-center gap-1.5 text-[11px]"
+						>
+							<span
+								className="size-2 rounded-sm"
+								style={{ backgroundColor: p.color }}
+							/>
+							<span className="truncate text-muted-foreground">{p.name}</span>
+							<span className="ml-auto tabular-nums text-foreground">
+								{metric === "cost"
+									? `$${Number(p.value).toFixed(4)}`
+									: metric === "tokens"
+										? formatTokens(Number(p.value))
+										: Number(p.value).toLocaleString()}
+							</span>
+						</div>
+					))}
+			</div>
+		</div>
+	);
+}
+
+export function AgentModelUsageChart({ sources }: AgentModelUsageChartProps) {
+	const [range, setRange] = useState<AgentChartTimeRange>("24h");
+	const [metric, setMetric] = useState<Metric>("cost");
+	const api = useApi();
+	const startDate = useMemo(() => getRangeStart(range).toISOString(), [range]);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const endDate = useMemo(() => new Date().toISOString(), [range]);
+	const sourceParam = sources.join(",");
+
+	const { data, isLoading, isFetching } = api.useQuery(
+		"get",
+		"/logs",
+		{
+			params: {
+				query: {
+					orderBy: "createdAt_desc",
+					limit: "100",
+					source: sourceParam,
+					startDate,
+					endDate,
+				},
+			},
+		},
+		{
+			enabled: sources.length > 0,
+			refetchOnWindowFocus: false,
+			staleTime: 30_000,
+		},
+	);
+
+	const logs = useMemo(() => data?.logs ?? [], [data]);
+	const { rows, models } = useMemo(
+		() => buildChartData(logs, range),
+		[logs, range],
+	);
+
+	const granularity = getGranularity(range);
+	const hourly = granularity === "hourly";
+
+	const chartData: ChartRow[] = useMemo(
+		() =>
+			rows.map((row) => {
+				const base: ChartRow = {
+					slot: row.slot,
+					formattedDate: hourly
+						? format(parseISO(row.slot), "HH:mm")
+						: format(parseISO(row.slot), "MMM d"),
+					totalRequests: row.totalRequests,
+					totalCost: row.totalCost,
+					totalTokens: row.totalTokens,
+				};
+				for (const modelId of models) {
+					const m = row.models[modelId];
+					if (!m) {
+						base[modelId] = 0;
+						continue;
+					}
+					if (metric === "cost") {
+						base[modelId] = Number(m.cost.toFixed(6));
+					} else if (metric === "tokens") {
+						base[modelId] = m.tokens;
+					} else {
+						base[modelId] = m.requests;
+					}
+				}
+				return base;
+			}),
+		[rows, models, metric, hourly],
+	);
+
+	const visibleModels = models.slice(0, 10);
+
+	const subtitleLabel =
+		range === "1h"
+			? "last hour"
+			: range === "4h"
+				? "last 4 hours"
+				: range === "24h"
+					? "last 24 hours"
+					: range === "7d"
+						? "last 7 days"
+						: "last 30 days";
+
+	return (
+		<div className="overflow-hidden rounded-xl border bg-card">
+			<div className="flex flex-col gap-3 border-b p-4 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+				<div>
+					<div className="flex items-center gap-2">
+						<h3 className="text-sm font-semibold tracking-tight">
+							Model Usage Overview
+						</h3>
+						{isFetching && !isLoading ? (
+							<Loader2 className="size-3 animate-spin text-muted-foreground" />
+						) : null}
+					</div>
+					<p className="mt-0.5 text-xs text-muted-foreground">
+						Stacked model{" "}
+						{metric === "cost"
+							? "cost"
+							: metric === "tokens"
+								? "tokens"
+								: "requests"}{" "}
+						over {subtitleLabel}
+					</p>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<div className="inline-flex items-center rounded-md border bg-muted p-0.5">
+						{TIME_RANGES.map((r) => (
+							<button
+								key={r.value}
+								type="button"
+								onClick={() => setRange(r.value)}
+								className={`rounded-sm px-2.5 py-1 text-xs font-medium transition-colors ${
+									range === r.value
+										? "bg-background text-foreground shadow-sm"
+										: "text-muted-foreground hover:text-foreground"
+								}`}
+							>
+								{r.label}
+							</button>
+						))}
+					</div>
+					<div className="relative">
+						<select
+							value={metric}
+							onChange={(e) => setMetric(e.target.value as Metric)}
+							className="appearance-none rounded-md border bg-background px-3 py-1.5 pr-8 text-xs font-medium text-foreground transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+							aria-label="Metric"
+						>
+							{METRIC_OPTIONS.map((m) => (
+								<option key={m.value} value={m.value}>
+									{m.label}
+								</option>
+							))}
+						</select>
+						<ChevronDown className="pointer-events-none absolute right-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+					</div>
+				</div>
+			</div>
+			<div className="p-4">
+				{isLoading ? (
+					<div className="flex h-[280px] items-center justify-center text-xs text-muted-foreground">
+						<Loader2 className="mr-2 size-3.5 animate-spin" />
+						Loading…
+					</div>
+				) : models.length === 0 ? (
+					<div className="flex h-[280px] items-center justify-center text-xs text-muted-foreground">
+						No activity in this range.
+					</div>
+				) : (
+					<>
+						{visibleModels.length > 0 ? (
+							<div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-muted-foreground">
+								{visibleModels.map((model, i) => (
+									<div key={model} className="flex items-center gap-1.5">
+										<span
+											className="size-2 rounded-sm"
+											style={{
+												backgroundColor: MODEL_COLORS[i % MODEL_COLORS.length],
+											}}
+										/>
+										<span className="truncate max-w-[160px]">{model}</span>
+									</div>
+								))}
+								{models.length > visibleModels.length ? (
+									<span className="text-muted-foreground/70">
+										+{models.length - visibleModels.length} more
+									</span>
+								) : null}
+							</div>
+						) : null}
+						<ResponsiveContainer width="100%" height={280}>
+							<BarChart
+								data={chartData}
+								margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
+							>
+								<CartesianGrid
+									strokeDasharray="3 3"
+									vertical={false}
+									className="stroke-border/60"
+								/>
+								<XAxis
+									dataKey="slot"
+									tickFormatter={(value: string) => {
+										try {
+											return hourly
+												? format(parseISO(value), "HH:mm")
+												: format(parseISO(value), "MMM d");
+										} catch {
+											return value;
+										}
+									}}
+									stroke="currentColor"
+									className="text-muted-foreground"
+									fontSize={11}
+									tickLine={false}
+									axisLine={false}
+									minTickGap={hourly ? 24 : 16}
+								/>
+								<YAxis
+									stroke="currentColor"
+									className="text-muted-foreground"
+									fontSize={11}
+									tickLine={false}
+									axisLine={false}
+									tickFormatter={(value: number) => {
+										if (metric === "cost") {
+											return `$${value.toFixed(2)}`;
+										}
+										if (metric === "tokens") {
+											return formatTokens(value);
+										}
+										return value.toLocaleString();
+									}}
+								/>
+								<Tooltip
+									cursor={{
+										fill: "color-mix(in srgb, currentColor 8%, transparent)",
+									}}
+									content={
+										<ChartTooltipContent metric={metric} hourly={hourly} />
+									}
+								/>
+								{models.map((modelId, i) => (
+									<Bar
+										key={modelId}
+										dataKey={modelId}
+										name={modelId}
+										stackId="models"
+										fill={MODEL_COLORS[i % MODEL_COLORS.length]}
+										radius={
+											i === models.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]
+										}
+										maxBarSize={48}
+									/>
+								))}
+							</BarChart>
+						</ResponsiveContainer>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -8,7 +8,7 @@ import {
 	startOfDay,
 	startOfHour,
 } from "date-fns";
-import { ChevronDown, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
 	Bar,
@@ -20,6 +20,13 @@ import {
 	YAxis,
 } from "recharts";
 
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { useApi } from "@/lib/fetch-client";
 
 import type { paths } from "@/lib/api/v1";
@@ -288,9 +295,12 @@ export function AgentModelUsageChart({ sources }: AgentModelUsageChartProps) {
 	const [range, setRange] = useState<AgentChartTimeRange>("24h");
 	const [metric, setMetric] = useState<Metric>("cost");
 	const api = useApi();
-	const startDate = useMemo(() => getRangeStart(range).toISOString(), [range]);
-	const endDate = new Date().toISOString();
-	const sourceParam = sources.join(",");
+	const { startDate, endDate } = useMemo(() => {
+		const end = new Date();
+		const start = new Date(end.getTime() - RANGE_OFFSET_MS[range]);
+		return { startDate: start.toISOString(), endDate: end.toISOString() };
+	}, [range]);
+	const sourceParam = useMemo(() => sources.join(","), [sources]);
 
 	const { data, isLoading, isFetching } = api.useQuery(
 		"get",
@@ -405,21 +415,25 @@ export function AgentModelUsageChart({ sources }: AgentModelUsageChartProps) {
 							</button>
 						))}
 					</div>
-					<div className="relative">
-						<select
-							value={metric}
-							onChange={(e) => setMetric(e.target.value as Metric)}
-							className="appearance-none rounded-md border bg-background px-3 py-1.5 pr-8 text-xs font-medium text-foreground transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+					<Select
+						value={metric}
+						onValueChange={(value) => setMetric(value as Metric)}
+					>
+						<SelectTrigger
+							size="sm"
+							className="w-[110px] text-xs"
 							aria-label="Metric"
 						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
 							{METRIC_OPTIONS.map((m) => (
-								<option key={m.value} value={m.value}>
+								<SelectItem key={m.value} value={m.value} className="text-xs">
 									{m.label}
-								</option>
+								</SelectItem>
 							))}
-						</select>
-						<ChevronDown className="pointer-events-none absolute right-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-					</div>
+						</SelectContent>
+					</Select>
 				</div>
 			</div>
 			<div className="p-4">

--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -159,7 +159,7 @@ function buildChartData(
 	}
 
 	const rangeStart = getRangeStart(range).getTime();
-	const modelTotals = new Map<string, number>();
+	const modelCostTotals = new Map<string, number>();
 
 	for (const log of logs) {
 		const ts = new Date(log.createdAt).getTime();
@@ -186,13 +186,10 @@ function buildChartData(
 		entry.cost += cost;
 		entry.tokens += tokens;
 		slot.models[modelId] = entry;
-		modelTotals.set(
-			modelId,
-			(modelTotals.get(modelId) ?? 0) + cost + tokens + 1,
-		);
+		modelCostTotals.set(modelId, (modelCostTotals.get(modelId) ?? 0) + cost);
 	}
 
-	const models = Array.from(modelTotals.entries())
+	const models = Array.from(modelCostTotals.entries())
 		.sort((a, b) => b[1] - a[1])
 		.map(([id]) => id);
 	const rows = Array.from(slotMap.values());
@@ -292,8 +289,7 @@ export function AgentModelUsageChart({ sources }: AgentModelUsageChartProps) {
 	const [metric, setMetric] = useState<Metric>("cost");
 	const api = useApi();
 	const startDate = useMemo(() => getRangeStart(range).toISOString(), [range]);
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const endDate = useMemo(() => new Date().toISOString(), [range]);
+	const endDate = new Date().toISOString();
 	const sourceParam = sources.join(",");
 
 	const { data, isLoading, isFetching } = api.useQuery(

--- a/apps/code/src/app/dashboard/components/CodingAgents.tsx
+++ b/apps/code/src/app/dashboard/components/CodingAgents.tsx
@@ -26,6 +26,8 @@ import {
 	SoulForgeIcon,
 } from "@llmgateway/shared/components";
 
+import { AgentModelUsageChart } from "./AgentModelUsageChart";
+
 import type { paths } from "@/lib/api/v1";
 import type { ComponentType, SVGProps } from "react";
 
@@ -503,6 +505,7 @@ function AgentDetail({
 					</div>
 				</div>
 			</div>
+			<AgentModelUsageChart sources={stats.agent.sources} />
 			<ModelUsageBreakdown models={stats.modelBreakdown} />
 			<div className="overflow-hidden rounded-xl border">
 				<div className="border-b bg-muted/30 px-4 py-2.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">

--- a/apps/code/src/components/ui/select.tsx
+++ b/apps/code/src/components/ui/select.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+	return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+	return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+	return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+	className,
+	size = "default",
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+	size?: "sm" | "default";
+}) {
+	return (
+		<SelectPrimitive.Trigger
+			data-slot="select-trigger"
+			data-size={size}
+			className={cn(
+				"cursor-pointer border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<SelectPrimitive.Icon asChild>
+				<ChevronDownIcon className="size-4 opacity-50" />
+			</SelectPrimitive.Icon>
+		</SelectPrimitive.Trigger>
+	);
+}
+
+function SelectContent({
+	className,
+	children,
+	position = "popper",
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+	return (
+		<SelectPrimitive.Portal>
+			<SelectPrimitive.Content
+				data-slot="select-content"
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) relative z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border shadow-md",
+					position === "popper" &&
+						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+					className,
+				)}
+				position={position}
+				{...props}
+			>
+				<SelectScrollUpButton />
+				<SelectPrimitive.Viewport
+					className={cn(
+						"p-1",
+						position === "popper" &&
+							"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+					)}
+				>
+					{children}
+				</SelectPrimitive.Viewport>
+				<SelectScrollDownButton />
+			</SelectPrimitive.Content>
+		</SelectPrimitive.Portal>
+	);
+}
+
+function SelectLabel({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+	return (
+		<SelectPrimitive.Label
+			data-slot="select-label"
+			className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectItem({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+	return (
+		<SelectPrimitive.Item
+			data-slot="select-item"
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				className,
+			)}
+			{...props}
+		>
+			<span className="absolute right-2 flex size-3.5 items-center justify-center">
+				<SelectPrimitive.ItemIndicator>
+					<CheckIcon className="size-4" />
+				</SelectPrimitive.ItemIndicator>
+			</span>
+			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		</SelectPrimitive.Item>
+	);
+}
+
+function SelectSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+	return (
+		<SelectPrimitive.Separator
+			data-slot="select-separator"
+			className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectScrollUpButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+	return (
+		<SelectPrimitive.ScrollUpButton
+			data-slot="select-scroll-up-button"
+			className={cn(
+				"flex cursor-default items-center justify-center py-1",
+				className,
+			)}
+			{...props}
+		>
+			<ChevronUpIcon className="size-4" />
+		</SelectPrimitive.ScrollUpButton>
+	);
+}
+
+function SelectScrollDownButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+	return (
+		<SelectPrimitive.ScrollDownButton
+			data-slot="select-scroll-down-button"
+			className={cn(
+				"flex cursor-default items-center justify-center py-1",
+				className,
+			)}
+			{...props}
+		>
+			<ChevronDownIcon className="size-4" />
+		</SelectPrimitive.ScrollDownButton>
+	);
+}
+
+export {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectScrollDownButton,
+	SelectScrollUpButton,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+};

--- a/apps/playground/src/app/share/[shareId]/opengraph-image.tsx
+++ b/apps/playground/src/app/share/[shareId]/opengraph-image.tsx
@@ -1,0 +1,288 @@
+import { ImageResponse } from "next/og";
+
+import { getConfig } from "@/lib/config-server";
+
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+interface SharedMessage {
+	id: string;
+	role: "user" | "assistant" | "system";
+	content: string | null;
+	images: string | null;
+	reasoning: string | null;
+	tools: string | null;
+	sequence: number;
+	createdAt: string;
+}
+
+interface SharedChatResponse {
+	share: {
+		id: string;
+		title: string;
+		model: string;
+		createdAt: string;
+		messages: SharedMessage[];
+	};
+}
+
+interface OgImageProps {
+	params: Promise<{ shareId: string }>;
+}
+
+function flatten(text: string | null | undefined): string {
+	if (!text) {
+		return "";
+	}
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function clip(text: string, max: number): string {
+	if (text.length <= max) {
+		return text;
+	}
+	return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+function pickPromptAndResponse(messages: SharedMessage[]): {
+	prompt: string;
+	response: string;
+} {
+	const userMessage = messages.find((m) => m.role === "user");
+	const assistantMessage = messages.find((m) => m.role === "assistant");
+	return {
+		prompt: flatten(userMessage?.content),
+		response: flatten(assistantMessage?.content),
+	};
+}
+
+export default async function ShareOgImage({ params }: OgImageProps) {
+	try {
+		const { shareId } = await params;
+		const config = getConfig();
+		const response = await fetch(
+			`${config.apiBackendUrl}/public/chats/share/${shareId}`,
+			{ cache: "no-store" },
+		);
+
+		const data = response.ok
+			? ((await response.json()) as SharedChatResponse)
+			: null;
+
+		const title = clip(flatten(data?.share.title) || "Shared chat", 80);
+		const { prompt, response: responseText } = data
+			? pickPromptAndResponse(data.share.messages)
+			: { prompt: "", response: "" };
+		const promptText = clip(prompt || title, 180);
+		const previewResponse = clip(responseText, 220);
+		const model = flatten(data?.share.model);
+
+		return new ImageResponse(
+			(
+				<div
+					style={{
+						width: "100%",
+						height: "100%",
+						display: "flex",
+						flexDirection: "column",
+						justifyContent: "space-between",
+						background: "#0a0a0a",
+						backgroundImage:
+							"radial-gradient(circle at 15% 10%, rgba(99,102,241,0.18), transparent 45%), radial-gradient(circle at 95% 90%, rgba(56,189,248,0.16), transparent 50%)",
+						color: "white",
+						fontFamily:
+							"system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+						padding: 64,
+						boxSizing: "border-box",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							gap: 16,
+						}}
+					>
+						<svg
+							width={56}
+							height={56}
+							viewBox="0 0 218 232"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								d="M218 59.4686c0-4.1697-2.351-7.9813-6.071-9.8441L119.973 3.58361s2.926 3.32316 2.926 7.01529V218.833c0 4.081-2.926 7.016-2.926 7.016l15.24-7.468c2.964-2.232 7.187-7.443 7.438-16.006.293-9.976.61-84.847.732-121.0353.487-3.6678 4.096-11.0032 14.63-11.0032 10.535 0 29.262 5.1348 37.309 7.7022 2.439.7336 7.608 4.1812 8.779 12.1036 1.17 7.9223.975 59.0507.731 83.6247 0 2.445.137 7.069 6.653 7.069 6.515 0 6.515-7.069 6.515-7.069V59.4686Z"
+								fill="#ffffff"
+							/>
+							<path
+								d="M149.235 86.323c0-5.5921 5.132-9.7668 10.589-8.6132l31.457 6.6495c4.061.8585 6.967 4.4207 6.967 8.5824v81.9253c0 5.868 5.121 9.169 5.121 9.169l-51.9-12.658c-1.311-.32-2.234-1.498-2.234-2.852V86.323ZM99.7535 1.15076c7.2925-3.60996 15.8305 1.71119 15.8305 9.86634V220.983c0 8.155-8.538 13.476-15.8305 9.866L6.11596 184.496C2.37105 182.642 0 178.818 0 174.63v-17.868l49.7128 19.865c4.0474 1.617 8.4447-1.372 8.4449-5.741 0-2.66-1.6975-5.022-4.2142-5.863L0 146.992v-14.305l40.2756 7.708c3.9656.759 7.6405-2.289 7.6405-6.337 0-3.286-2.4628-6.048-5.7195-6.413L0 122.917V108.48l78.5181-3.014c4.1532-.16 7.4381-3.582 7.4383-7.7498 0-4.6256-4.0122-8.2229-8.5964-7.7073L0 98.7098V82.4399l53.447-17.8738c2.3764-.7948 3.9791-3.0254 3.9792-5.5374 0-4.0961-4.0978-6.9185-7.9106-5.4486L0 72.6695V57.3696c.0000304-4.1878 2.37107-8.0125 6.11596-9.8664L99.7535 1.15076Z"
+								fill="#ffffff"
+							/>
+						</svg>
+						<div
+							style={{
+								display: "flex",
+								flexDirection: "column",
+							}}
+						>
+							<span
+								style={{
+									fontSize: 30,
+									fontWeight: 700,
+									letterSpacing: "-0.02em",
+								}}
+							>
+								LLM Gateway
+							</span>
+							<span
+								style={{
+									fontSize: 18,
+									color: "#9CA3AF",
+									letterSpacing: "0.02em",
+								}}
+							>
+								Shared chat
+							</span>
+						</div>
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							gap: 28,
+							flex: 1,
+							justifyContent: "center",
+							marginTop: 28,
+						}}
+					>
+						<span
+							style={{
+								fontSize: 56,
+								fontWeight: 700,
+								color: "#F9FAFB",
+								letterSpacing: "-0.02em",
+								lineHeight: 1.05,
+								display: "flex",
+							}}
+						>
+							{promptText}
+						</span>
+						{previewResponse ? (
+							<div
+								style={{
+									display: "flex",
+									flexDirection: "column",
+									padding: "28px 32px",
+									borderRadius: 24,
+									background: "rgba(255,255,255,0.04)",
+									border: "1px solid rgba(255,255,255,0.08)",
+								}}
+							>
+								<span
+									style={{
+										fontSize: 14,
+										color: "#9CA3AF",
+										fontWeight: 600,
+										textTransform: "uppercase",
+										letterSpacing: "0.12em",
+										marginBottom: 12,
+									}}
+								>
+									Response preview
+								</span>
+								<span
+									style={{
+										fontSize: 26,
+										lineHeight: 1.4,
+										color: "#E5E7EB",
+										fontWeight: 400,
+										display: "flex",
+									}}
+								>
+									{previewResponse}
+								</span>
+							</div>
+						) : null}
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							justifyContent: "space-between",
+							marginTop: 28,
+						}}
+					>
+						<div
+							style={{
+								display: "flex",
+								flexDirection: "row",
+								alignItems: "center",
+								gap: 14,
+							}}
+						>
+							{model ? (
+								<span
+									style={{
+										display: "flex",
+										alignItems: "center",
+										padding: "8px 16px",
+										borderRadius: 999,
+										background: "rgba(255,255,255,0.06)",
+										border: "1px solid rgba(255,255,255,0.1)",
+										color: "#E5E7EB",
+										fontSize: 20,
+										fontFamily:
+											"ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+									}}
+								>
+									{clip(model, 40)}
+								</span>
+							) : null}
+						</div>
+						<span
+							style={{
+								color: "#9CA3AF",
+								fontSize: 22,
+								fontWeight: 500,
+							}}
+						>
+							chat.llmgateway.io
+						</span>
+					</div>
+				</div>
+			),
+			size,
+		);
+	} catch (error) {
+		console.error("Error generating share OpenGraph image:", error);
+		return new ImageResponse(
+			(
+				<div
+					style={{
+						width: "100%",
+						height: "100%",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						background: "#0a0a0a",
+						color: "white",
+						fontSize: 48,
+						fontWeight: 700,
+						fontFamily:
+							"system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+					}}
+				>
+					LLM Gateway · Shared chat
+				</div>
+			),
+			size,
+		);
+	}
+}

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -42,11 +42,54 @@ export async function generateMetadata({
 	params: Promise<{ shareId: string }>;
 }): Promise<Metadata> {
 	const { shareId } = await params;
+	const config = getConfig();
+
+	let title = "Shared Chat";
+	let description =
+		"A shared snapshot of an LLM Gateway chat — open it to see the full conversation.";
+
+	try {
+		const response = await fetch(
+			`${config.apiBackendUrl}/public/chats/share/${shareId}`,
+			{ cache: "no-store" },
+		);
+		if (response.ok) {
+			const data = (await response.json()) as SharedChatResponse;
+			const flatTitle = data.share.title?.replace(/\s+/g, " ").trim();
+			if (flatTitle) {
+				title =
+					flatTitle.length > 80 ? `${flatTitle.slice(0, 80)}…` : flatTitle;
+			}
+			const userMessage = data.share.messages.find((m) => m.role === "user");
+			const userText = userMessage?.content?.replace(/\s+/g, " ").trim();
+			if (userText) {
+				description =
+					userText.length > 160 ? `${userText.slice(0, 160)}…` : userText;
+			}
+		}
+	} catch {
+		// Fall back to defaults if the API call fails.
+	}
+
+	const url = `/share/${shareId}`;
 
 	return {
-		title: "Shared Chat - LLM Gateway",
+		title: `${title} · LLM Gateway`,
+		description,
 		alternates: {
-			canonical: `/share/${shareId}`,
+			canonical: url,
+		},
+		openGraph: {
+			title,
+			description,
+			url,
+			type: "article",
+			siteName: "LLM Gateway",
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
 		},
 	};
 }

--- a/apps/playground/src/components/playground/chat-header.tsx
+++ b/apps/playground/src/components/playground/chat-header.tsx
@@ -36,6 +36,8 @@ interface ChatHeaderProps {
 	hasTemporaryMessages: boolean;
 	currentChatId: string | null;
 	shareId: string | null;
+	chatTitle?: string | null;
+	previewPrompt?: string | null;
 }
 
 export const ChatHeader = ({
@@ -57,6 +59,8 @@ export const ChatHeader = ({
 	hasTemporaryMessages,
 	currentChatId,
 	shareId,
+	chatTitle,
+	previewPrompt,
 }: ChatHeaderProps) => {
 	return (
 		<header className="bg-background flex items-center border-b p-4">
@@ -82,7 +86,12 @@ export const ChatHeader = ({
 					hasTemporaryMessages={hasTemporaryMessages}
 				/>
 				{isTemporaryChat || !currentChatId ? null : (
-					<ShareChatDialog currentChatId={currentChatId} shareId={shareId} />
+					<ShareChatDialog
+						currentChatId={currentChatId}
+						shareId={shareId}
+						chatTitle={chatTitle}
+						previewPrompt={previewPrompt}
+					/>
 				)}
 				<TooltipProvider>
 					<McpServersDialog

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -59,6 +59,25 @@ function isToolPart(obj: unknown): obj is ToolPart {
 	);
 }
 
+function getFirstUserMessageText(
+	messages: { role: string; parts?: { type: string; text?: string }[] }[],
+): string | null {
+	for (const message of messages) {
+		if (message.role !== "user") {
+			continue;
+		}
+		const text = (message.parts ?? [])
+			.filter((p) => p.type === "text" && typeof p.text === "string")
+			.map((p) => p.text as string)
+			.join(" ")
+			.trim();
+		if (text) {
+			return text;
+		}
+	}
+	return null;
+}
+
 interface ChatPageClientProps {
 	models: ApiModel[];
 	providers: ApiProvider[];
@@ -1092,6 +1111,8 @@ export default function ChatPageClient({
 							hasTemporaryMessages={hasTemporaryMessages}
 							currentChatId={currentChatId}
 							shareId={currentChatData?.chat?.shareId ?? null}
+							chatTitle={currentChatData?.chat?.title ?? null}
+							previewPrompt={getFirstUserMessageText(messages)}
 						/>
 					</header>
 					{comparisonEnabled && !isTemporaryChat ? (

--- a/apps/playground/src/components/playground/share-chat-dialog.tsx
+++ b/apps/playground/src/components/playground/share-chat-dialog.tsx
@@ -44,13 +44,13 @@ function truncateShareUrl(url: string): string {
 		const parsed = new URL(url);
 		const segments = parsed.pathname.split("/").filter(Boolean);
 		const last = segments[segments.length - 1] ?? "";
-		const prefix = `${parsed.origin}/${segments.slice(0, -1).join("/")}/`;
-		const visiblePrefix =
-			prefix.length > URL_DISPLAY_PREFIX.length
-				? URL_DISPLAY_PREFIX
-				: prefix.replace(/\/+$/, "/");
 		const shortId = last.length > 8 ? `${last.slice(0, 6)}…` : last;
-		return `${visiblePrefix}${shortId}`;
+		const builtPrefix = `${parsed.origin}/${segments.slice(0, -1).join("/")}/`;
+		const displayPrefix =
+			builtPrefix.length > URL_DISPLAY_PREFIX.length
+				? URL_DISPLAY_PREFIX
+				: builtPrefix;
+		return `${displayPrefix}${shortId}`;
 	} catch {
 		return url.length > 40 ? `${url.slice(0, 37)}…` : url;
 	}

--- a/apps/playground/src/components/playground/share-chat-dialog.tsx
+++ b/apps/playground/src/components/playground/share-chat-dialog.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Check, Copy, Info, Loader2, Share, Trash2 } from "lucide-react";
+import {
+	Check,
+	Copy,
+	Info,
+	Linkedin,
+	Loader2,
+	Share,
+	Trash2,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -8,7 +16,6 @@ import { Button } from "@/components/ui/button";
 import {
 	Dialog,
 	DialogContent,
-	DialogFooter,
 	DialogHeader,
 	DialogTitle,
 	DialogTrigger,
@@ -23,11 +30,100 @@ import { useDeleteChatShare, useShareChat } from "@/hooks/useChats";
 interface ShareChatDialogProps {
 	currentChatId: string;
 	shareId: string | null;
+	chatTitle?: string | null;
+	previewPrompt?: string | null;
+}
+
+const URL_DISPLAY_PREFIX = "https://chat.llmgateway.io/share/";
+
+function truncateShareUrl(url: string): string {
+	if (!url) {
+		return "";
+	}
+	try {
+		const parsed = new URL(url);
+		const segments = parsed.pathname.split("/").filter(Boolean);
+		const last = segments[segments.length - 1] ?? "";
+		const prefix = `${parsed.origin}/${segments.slice(0, -1).join("/")}/`;
+		const visiblePrefix =
+			prefix.length > URL_DISPLAY_PREFIX.length
+				? URL_DISPLAY_PREFIX
+				: prefix.replace(/\/+$/, "/");
+		const shortId = last.length > 8 ? `${last.slice(0, 6)}…` : last;
+		return `${visiblePrefix}${shortId}`;
+	} catch {
+		return url.length > 40 ? `${url.slice(0, 37)}…` : url;
+	}
+}
+
+function XIcon(props: React.SVGProps<SVGSVGElement>) {
+	return (
+		<svg
+			viewBox="0 0 16 16"
+			fill="currentColor"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M1.60022 2H5.80022L8.78759 6.16842L12.4002 2H14.0002L9.5118 7.17895L14.4002 14H10.2002L7.21285 9.83158L3.60022 14H2.00022L6.48864 8.82105L1.60022 2ZM10.8166 12.8L3.93657 3.2H5.18387L12.0639 12.8H10.8166Z"
+			/>
+		</svg>
+	);
+}
+
+function RedditIcon(props: React.SVGProps<SVGSVGElement>) {
+	return (
+		<svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+			<path d="M14.238 15.348c.085.084.085.221 0 .306-.465.462-1.194.687-2.231.687l-.008-.002-.008.002c-1.036 0-1.766-.225-2.231-.688-.085-.084-.085-.221 0-.305.084-.084.222-.084.307 0 .379.377 1.008.561 1.924.561l.008.002.008-.002c.915 0 1.544-.184 1.924-.561.085-.084.223-.084.307 0zm-3.44-2.418c0-.507-.414-.918-.922-.918-.509 0-.923.411-.923.918 0 .506.414.918.923.918.508 0 .922-.412.922-.918zm4.434-.918c-.508 0-.922.411-.922.918 0 .506.414.918.922.918s.922-.412.922-.918c0-.507-.414-.918-.922-.918zM24 11.5c0 6.351-5.373 11.5-12 11.5S0 17.851 0 11.5 5.373 0 12 0s12 5.149 12 11.5zm-4.911-.793a1.643 1.643 0 0 0-1.643-1.64 1.62 1.62 0 0 0-1.092.42c-1.082-.711-2.495-1.158-4.038-1.213l.804-2.534 2.243.526a1.36 1.36 0 0 0 1.357 1.298c.752 0 1.364-.611 1.364-1.363a1.366 1.366 0 0 0-2.644-.464l-2.479-.581a.213.213 0 0 0-.253.144l-.95 2.994c-1.598.034-3.061.481-4.182 1.203a1.62 1.62 0 0 0-1.099-.43A1.643 1.643 0 0 0 4.91 10.707a1.65 1.65 0 0 0 .846 1.44c-.026.18-.038.363-.038.55 0 2.704 3.273 4.901 7.297 4.901 4.024 0 7.297-2.197 7.297-4.901 0-.184-.013-.367-.038-.546a1.65 1.65 0 0 0 .815-1.444z" />
+		</svg>
+	);
+}
+
+interface ShareSocialButtonProps {
+	href: string;
+	label: string;
+	children: React.ReactNode;
+}
+
+function ShareSocialButton({ href, label, children }: ShareSocialButtonProps) {
+	return (
+		<a
+			href={href}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="group flex flex-col items-center gap-2"
+		>
+			<span className="bg-foreground text-background flex size-12 items-center justify-center rounded-full transition-transform group-hover:scale-105 sm:size-14">
+				{children}
+			</span>
+			<span className="text-foreground text-xs font-medium sm:text-sm">
+				{label}
+			</span>
+		</a>
+	);
+}
+
+function clipPreview(
+	text: string | null | undefined,
+	max: number,
+): string | null {
+	if (!text) {
+		return null;
+	}
+	const flat = text.replace(/\s+/g, " ").trim();
+	if (!flat) {
+		return null;
+	}
+	return flat.length > max ? `${flat.slice(0, max)}…` : flat;
 }
 
 export function ShareChatDialog({
 	currentChatId,
 	shareId,
+	chatTitle,
+	previewPrompt,
 }: ShareChatDialogProps) {
 	const [open, setOpen] = useState(false);
 	const [copied, setCopied] = useState(false);
@@ -42,6 +138,39 @@ export function ShareChatDialog({
 		return `${window.location.origin}/share/${shareId}`;
 	}, [shareId]);
 	const activeShareUrl = createdShareUrl ?? shareUrl;
+	const truncatedDisplayUrl = useMemo(
+		() => truncateShareUrl(activeShareUrl),
+		[activeShareUrl],
+	);
+
+	const previewTitle = useMemo(() => {
+		const trimmed = chatTitle?.trim();
+		if (trimmed) {
+			return trimmed;
+		}
+		return clipPreview(previewPrompt, 80) ?? "Shared chat";
+	}, [chatTitle, previewPrompt]);
+
+	const previewText = useMemo(
+		() => clipPreview(previewPrompt, 160),
+		[previewPrompt],
+	);
+
+	const shareTitle = previewTitle;
+	const encodedShareUrl = activeShareUrl
+		? encodeURIComponent(activeShareUrl)
+		: "";
+	const encodedShareTitle = encodeURIComponent(shareTitle);
+
+	const xUrl = activeShareUrl
+		? `https://x.com/intent/tweet?url=${encodedShareUrl}&text=${encodedShareTitle}`
+		: "";
+	const linkedinUrl = activeShareUrl
+		? `https://www.linkedin.com/sharing/share-offsite/?url=${encodedShareUrl}`
+		: "";
+	const redditUrl = activeShareUrl
+		? `https://www.reddit.com/submit?url=${encodedShareUrl}&title=${encodedShareTitle}`
+		: "";
 
 	useEffect(() => {
 		if (shareUrl) {
@@ -107,27 +236,41 @@ export function ShareChatDialog({
 					<p>{isShared ? "Public link active" : "Share chat"}</p>
 				</TooltipContent>
 			</Tooltip>
-			<DialogContent className="gap-5 overflow-hidden p-0 sm:max-w-[560px]">
-				<DialogHeader>
-					<DialogTitle className="px-6 pt-6 pr-12 text-xl sm:text-2xl">
-						{isShared ? "Shareable public link" : "Share chat"}
+			<DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[520px]">
+				<DialogHeader className="px-5 pt-5 sm:px-6 sm:pt-6">
+					<DialogTitle className="pr-8 text-lg font-semibold sm:text-xl">
+						{previewTitle}
 					</DialogTitle>
 				</DialogHeader>
-				<div className="space-y-5 px-6">
-					{isShared && activeShareUrl ? (
-						<div className="bg-muted flex items-center gap-2 rounded-full px-3 py-2 sm:px-4">
+				{isShared && activeShareUrl ? (
+					<div className="space-y-5 px-5 pb-5 sm:px-6 sm:pb-6">
+						<div className="bg-muted/60 border-border/60 relative overflow-hidden rounded-2xl border p-4 sm:p-5">
+							{previewText ? (
+								<p className="text-foreground/90 line-clamp-4 text-sm leading-relaxed sm:text-[15px]">
+									{previewText}
+								</p>
+							) : (
+								<p className="text-muted-foreground text-sm">
+									A snapshot of this chat will be visible to anyone with the
+									link.
+								</p>
+							)}
+						</div>
+						<div className="bg-muted/40 border-border/60 flex items-center gap-2 rounded-full border px-3 py-2">
 							<a
 								href={activeShareUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="min-w-0 flex-1 truncate text-sm underline underline-offset-2"
+								className="text-foreground min-w-0 flex-1 truncate text-sm"
+								title={activeShareUrl}
 							>
-								{activeShareUrl}
+								{truncatedDisplayUrl}
 							</a>
 							<Button
 								type="button"
 								size="sm"
-								className="shrink-0 rounded-full"
+								variant="ghost"
+								className="h-8 shrink-0 rounded-full px-3"
 								onClick={() => copyLink(activeShareUrl)}
 								aria-label={copied ? "Link copied" : "Copy link"}
 							>
@@ -136,61 +279,88 @@ export function ShareChatDialog({
 								) : (
 									<Copy className="size-4" />
 								)}
-								<span className="hidden sm:inline">
-									{copied ? "Link copied" : "Copy link"}
-								</span>
 							</Button>
 						</div>
-					) : (
-						<p className="text-muted-foreground text-sm">
-							Only messages up to this point will be shared.
-						</p>
-					)}
-					<div className="text-muted-foreground flex gap-2 text-xs leading-relaxed">
-						<Info className="mt-0.5 size-3.5 shrink-0" />
-						<p>
-							Anyone with this link can open the snapshot. Avoid sharing private
-							details, and remove the link when it should no longer be
-							available.
-						</p>
+						<div className="flex items-center justify-around gap-2">
+							<button
+								type="button"
+								onClick={() => copyLink(activeShareUrl)}
+								className="group flex flex-col items-center gap-2"
+							>
+								<span className="bg-foreground text-background flex size-12 items-center justify-center rounded-full transition-transform group-hover:scale-105 sm:size-14">
+									{copied ? (
+										<Check className="size-5" />
+									) : (
+										<Copy className="size-5" />
+									)}
+								</span>
+								<span className="text-foreground text-xs font-medium sm:text-sm">
+									{copied ? "Copied" : "Copy link"}
+								</span>
+							</button>
+							<ShareSocialButton href={xUrl} label="X">
+								<XIcon className="size-5" />
+							</ShareSocialButton>
+							<ShareSocialButton href={linkedinUrl} label="LinkedIn">
+								<Linkedin className="size-5" />
+							</ShareSocialButton>
+							<ShareSocialButton href={redditUrl} label="Reddit">
+								<RedditIcon className="size-5" />
+							</ShareSocialButton>
+						</div>
+						<div className="text-muted-foreground flex gap-2 text-xs leading-relaxed">
+							<Info className="mt-0.5 size-3.5 shrink-0" />
+							<p>
+								Anyone with this link can open the snapshot. Avoid sharing
+								private details, and remove the link when it should no longer be
+								available.
+							</p>
+						</div>
+						<div className="flex justify-center">
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="text-destructive hover:text-destructive h-8"
+								disabled={deleteShare.isPending}
+								onClick={deleteSharedLink}
+							>
+								{deleteShare.isPending ? (
+									<Loader2 className="size-4 animate-spin" />
+								) : (
+									<Trash2 className="size-4" />
+								)}
+								{deleteShare.isPending ? "Deleting..." : "Delete shared link"}
+							</Button>
+						</div>
 					</div>
-				</div>
-				<DialogFooter
-					className={`items-center px-6 pb-6 ${
-						isShared ? "sm:justify-start" : "sm:justify-end"
-					}`}
-				>
-					{isShared ? (
-						<Button
-							type="button"
-							variant="ghost"
-							className="text-destructive hover:text-destructive"
-							disabled={deleteShare.isPending}
-							onClick={deleteSharedLink}
-						>
-							{deleteShare.isPending ? (
-								<Loader2 className="size-4 animate-spin" />
-							) : (
-								<Trash2 className="size-4" />
-							)}
-							{deleteShare.isPending ? "Deleting..." : "Delete shared link"}
-						</Button>
-					) : (
-						<span />
-					)}
-					{isShared ? null : (
-						<Button
-							type="button"
-							disabled={shareChat.isPending}
-							onClick={createShare}
-						>
-							{shareChat.isPending ? (
-								<Loader2 className="size-4 animate-spin" />
-							) : null}
-							{shareChat.isPending ? "Creating..." : "Create share link"}
-						</Button>
-					)}
-				</DialogFooter>
+				) : (
+					<div className="space-y-4 px-5 pb-5 sm:px-6 sm:pb-6">
+						<p className="text-muted-foreground text-sm">
+							Only messages up to this point will be shared. Anyone with the
+							link will be able to see the snapshot.
+						</p>
+						<div className="text-muted-foreground flex gap-2 text-xs leading-relaxed">
+							<Info className="mt-0.5 size-3.5 shrink-0" />
+							<p>
+								Avoid sharing private details — once the link is created you can
+								copy it and share it on X, LinkedIn, or Reddit.
+							</p>
+						</div>
+						<div className="flex justify-end">
+							<Button
+								type="button"
+								disabled={shareChat.isPending}
+								onClick={createShare}
+							>
+								{shareChat.isPending ? (
+									<Loader2 className="size-4 animate-spin" />
+								) : null}
+								{shareChat.isPending ? "Creating..." : "Create share link"}
+							</Button>
+						</div>
+					</div>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
@@ -1,6 +1,8 @@
 import { subDays, format } from "date-fns";
+import { cookies } from "next/headers";
 
 import { DashboardClient } from "@/components/dashboard/dashboard-client";
+import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { ActivitT } from "@/types/activity";
@@ -38,7 +40,14 @@ export default async function Dashboard({
 		},
 	);
 
+	const cookieStore = await cookies();
+	const devPassCollapsed =
+		cookieStore.get(DEVPASS_CARD_COLLAPSED_COOKIE)?.value === "1";
+
 	return (
-		<DashboardClient initialActivityData={initialActivityData ?? undefined} />
+		<DashboardClient
+			initialActivityData={initialActivityData ?? undefined}
+			initialDevPassCollapsed={devPassCollapsed}
+		/>
 	);
 }

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -62,9 +62,13 @@ import type { ActivitT } from "@/types/activity";
 
 interface DashboardClientProps {
 	initialActivityData?: ActivitT;
+	initialDevPassCollapsed?: boolean;
 }
 
-export function DashboardClient({ initialActivityData }: DashboardClientProps) {
+export function DashboardClient({
+	initialActivityData,
+	initialDevPassCollapsed,
+}: DashboardClientProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const { buildUrl, buildOrgUrl } = useDashboardNavigation();
@@ -323,7 +327,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 
 				<ReferralBanner />
 
-				<DevPassCard />
+				<DevPassCard defaultCollapsed={initialDevPassCollapsed} />
 
 				<DateRangePicker buildUrl={buildUrl} />
 

--- a/apps/ui/src/components/dashboard/devpass-card.tsx
+++ b/apps/ui/src/components/dashboard/devpass-card.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { ArrowUpRight, Terminal } from "lucide-react";
+import { ArrowUpRight, ChevronDown, ChevronUp, Terminal } from "lucide-react";
+import { useState } from "react";
+
+import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
 
 import { DEV_PLAN_PRICES } from "@llmgateway/shared";
 
@@ -15,69 +18,117 @@ const plans = [
 	{ name: "Max", price: `$${DEV_PLAN_PRICES.max}` },
 ] as const;
 
-export function DevPassCard() {
+interface DevPassCardProps {
+	defaultCollapsed?: boolean;
+}
+
+export function DevPassCard({ defaultCollapsed = false }: DevPassCardProps) {
+	const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+	const toggle = () => {
+		const next = !collapsed;
+		setCollapsed(next);
+		const maxAge = 60 * 60 * 24 * 365;
+		document.cookie = `${DEVPASS_CARD_COLLAPSED_COOKIE}=${next ? "1" : "0"}; path=/; max-age=${maxAge}; samesite=lax`;
+	};
+
 	return (
-		<a
-			href={DEVPASS_URL}
-			target="_blank"
-			rel="noopener noreferrer"
-			className="group relative block overflow-hidden rounded-xl border border-border/60 bg-gradient-to-br from-background via-background to-indigo-500/[0.04] transition-all duration-300 hover:border-indigo-500/40 hover:shadow-[0_0_40px_-12px_rgba(99,102,241,0.25)] dark:to-indigo-400/[0.06]"
-		>
+		<div className="group relative block overflow-hidden rounded-xl border border-border/60 bg-gradient-to-br from-background via-background to-indigo-500/[0.04] transition-all duration-300 hover:border-indigo-500/40 hover:shadow-[0_0_40px_-12px_rgba(99,102,241,0.25)] dark:to-indigo-400/[0.06]">
 			<div className="pointer-events-none absolute inset-y-0 right-0 w-2/3 bg-[radial-gradient(ellipse_at_right,_var(--tw-gradient-stops))] from-indigo-500/[0.06] via-transparent to-transparent dark:from-indigo-400/[0.08]" />
 			<div className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full bg-indigo-500/[0.08] blur-3xl dark:bg-indigo-400/[0.06]" />
 
-			<div className="relative flex flex-col gap-5 p-5 md:flex-row md:items-center md:justify-between md:gap-8 md:p-6">
-				<div className="flex items-start gap-4 md:flex-1">
-					<div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-foreground text-background shadow-sm">
-						<Terminal className="h-5 w-5" strokeWidth={1.75} />
+			{collapsed ? (
+				<div className="relative flex items-center gap-3 px-4 py-3">
+					<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-foreground text-background shadow-sm">
+						<Terminal className="h-4 w-4" strokeWidth={1.75} />
 					</div>
-					<div className="min-w-0 flex-1 space-y-2">
-						<div className="flex flex-wrap items-center gap-2">
-							<h3 className="text-base font-semibold tracking-tight">
-								DevPass
-							</h3>
-							<span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-indigo-600 dark:text-indigo-300">
-								Separate product
-							</span>
+					<div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+						<h3 className="text-sm font-semibold tracking-tight">DevPass</h3>
+						<span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-indigo-600 dark:text-indigo-300">
+							Separate product
+						</span>
+					</div>
+					<button
+						type="button"
+						onClick={toggle}
+						aria-label="Expand DevPass card"
+						aria-expanded={false}
+						className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					>
+						<ChevronDown className="h-4 w-4" />
+					</button>
+				</div>
+			) : (
+				<div className="relative flex flex-col gap-5 p-5 md:flex-row md:items-center md:justify-between md:gap-8 md:p-6">
+					<div className="flex items-start gap-4 md:flex-1">
+						<div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-foreground text-background shadow-sm">
+							<Terminal className="h-5 w-5" strokeWidth={1.75} />
 						</div>
-						<p className="text-sm leading-relaxed text-muted-foreground">
-							Fixed-price monthly plans for Claude Code, OpenCode, Cursor &
-							every coding tool.{" "}
-							<span className="font-medium text-foreground">
-								$1 turns into $3
-							</span>{" "}
-							of model usage at provider rates.
-						</p>
-						<div className="flex flex-wrap items-center gap-1.5 pt-1">
-							{plans.map((plan, i) => (
-								<span
-									key={plan.name}
-									className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-2 py-1 font-mono text-[11px] tabular-nums text-muted-foreground"
-								>
-									<span className="font-semibold text-foreground">
-										{plan.name}
-									</span>
-									<span aria-hidden="true" className="text-border">
-										·
-									</span>
-									<span>{plan.price}</span>
-									{i < plans.length - 1 && <span className="sr-only">, </span>}
+						<div className="min-w-0 flex-1 space-y-2">
+							<div className="flex flex-wrap items-center gap-2">
+								<h3 className="text-base font-semibold tracking-tight">
+									DevPass
+								</h3>
+								<span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-indigo-600 dark:text-indigo-300">
+									Separate product
 								</span>
-							))}
-							<span className="ml-1 text-[11px] text-muted-foreground/70">
-								/mo · cancel anytime
-							</span>
+							</div>
+							<p className="text-sm leading-relaxed text-muted-foreground">
+								Fixed-price monthly plans for Claude Code, OpenCode, Cursor &
+								every coding tool.{" "}
+								<span className="font-medium text-foreground">
+									$1 turns into $3
+								</span>{" "}
+								of model usage at provider rates.
+							</p>
+							<div className="flex flex-wrap items-center gap-1.5 pt-1">
+								{plans.map((plan, i) => (
+									<span
+										key={plan.name}
+										className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-2 py-1 font-mono text-[11px] tabular-nums text-muted-foreground"
+									>
+										<span className="font-semibold text-foreground">
+											{plan.name}
+										</span>
+										<span aria-hidden="true" className="text-border">
+											·
+										</span>
+										<span>{plan.price}</span>
+										{i < plans.length - 1 && (
+											<span className="sr-only">, </span>
+										)}
+									</span>
+								))}
+								<span className="ml-1 text-[11px] text-muted-foreground/70">
+									/mo · cancel anytime
+								</span>
+							</div>
 						</div>
 					</div>
-				</div>
 
-				<div className="flex shrink-0 items-center gap-2 self-start md:self-center">
-					<div className="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-transform duration-300 group-hover:translate-x-0.5">
-						Open DevPass
-						<ArrowUpRight className="h-4 w-4" />
+					<div className="flex shrink-0 items-center gap-2 self-start md:self-center">
+						<a
+							href={DEVPASS_URL}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-transform duration-300 hover:translate-x-0.5"
+						>
+							Open DevPass
+							<ArrowUpRight className="h-4 w-4" />
+						</a>
 					</div>
+
+					<button
+						type="button"
+						onClick={toggle}
+						aria-label="Collapse DevPass card"
+						aria-expanded={true}
+						className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+					>
+						<ChevronUp className="h-4 w-4" />
+					</button>
 				</div>
-			</div>
-		</a>
+			)}
+		</div>
 	);
 }

--- a/apps/ui/src/lib/cookies.ts
+++ b/apps/ui/src/lib/cookies.ts
@@ -1,0 +1,1 @@
+export const DEVPASS_CARD_COLLAPSED_COOKIE = "devpass_card_collapsed";

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -465,6 +465,15 @@ export default async function DevpassPage({
 					<div className="mt-1 text-xs text-muted-foreground">
 						Lite {kpis.activeByTier.lite} · Pro {kpis.activeByTier.pro} · Max{" "}
 						{kpis.activeByTier.max}
+						{kpis.cancelledPending > 0 ? (
+							<>
+								{" "}
+								·{" "}
+								<span className="text-amber-600 dark:text-amber-400">
+									{kpis.cancelledPending} cancelling
+								</span>
+							</>
+						) : null}
 					</div>
 				</div>
 				<div className="rounded-lg border border-border/60 bg-card p-4">

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1473,7 +1473,10 @@ async function seed() {
 			}) ?? DEVPASS_AGENTS[0];
 		const agentModel = weightedRandomChoice(agent.models);
 		const modelDef =
-			MODELS.find((m) => m.model === agentModel.model) ?? MODELS[0];
+			MODELS.find(
+				(m) =>
+					m.model === agentModel.model && m.provider === agentModel.provider,
+			) ?? MODELS[0];
 		const finishDef = weightedRandomChoice(FINISH_REASONS);
 		const isError =
 			finishDef.unified === "upstream_error" ||

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1275,106 +1275,185 @@ async function seed() {
 	});
 
 	// Realistic per-agent activity for the DevPass dashboard and the public
-	// /apps page. Weights are renormalized internally so it's safe to add or
-	// reorder entries here without recomputing the totals.
-	const DEVPASS_AGENTS = [
+	// /apps page. Each agent has its own mix of models so per-agent charts show
+	// a breakdown across multiple models. Weights are renormalized internally
+	// so it's safe to add or reorder entries.
+	interface DevpassAgentModel {
+		model: string;
+		provider: string;
+		weight: number;
+	}
+	const DEVPASS_AGENTS: Array<{
+		source: string;
+		weight: number;
+		models: DevpassAgentModel[];
+	}> = [
 		{
 			source: "claude.com/claude-code",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.22,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.7 },
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.2 },
+				{ model: "claude-3-opus", provider: "anthropic", weight: 0.1 },
+			],
 		},
-		{ source: "cursor", model: "gpt-4o", provider: "openai", weight: 0.14 },
+		{
+			source: "cursor",
+			weight: 0.14,
+			models: [
+				{ model: "gpt-4o", provider: "openai", weight: 0.45 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.35 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.15 },
+				{ model: "o1", provider: "openai", weight: 0.05 },
+			],
+		},
 		{
 			source: "cline",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.1,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.7 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.2 },
+				{ model: "deepseek-chat", provider: "deepseek", weight: 0.1 },
+			],
 		},
-		{ source: "codex", model: "o1", provider: "openai", weight: 0.08 },
+		{
+			source: "codex",
+			weight: 0.08,
+			models: [
+				{ model: "o1", provider: "openai", weight: 0.55 },
+				{ model: "o3-mini", provider: "openai", weight: 0.3 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.15 },
+			],
+		},
 		{
 			source: "opencode",
-			model: "claude-3-haiku",
-			provider: "anthropic",
 			weight: 0.07,
+			models: [
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.5 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.3 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.2 },
+			],
 		},
 		{
 			source: "aider",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.06,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.55 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.3 },
+				{ model: "deepseek-chat", provider: "deepseek", weight: 0.15 },
+			],
 		},
 		{
 			source: "continue.dev",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.05,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.5 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.3 },
+				{ model: "deepseek-chat", provider: "deepseek", weight: 0.2 },
+			],
 		},
 		{
 			source: "windsurf",
-			model: "gpt-4o",
-			provider: "openai",
 			weight: 0.05,
+			models: [
+				{ model: "gpt-4o", provider: "openai", weight: 0.5 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.35 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.15 },
+			],
 		},
 		{
 			source: "roo-cline",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.04,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.65 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.25 },
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.1 },
+			],
 		},
 		{
 			source: "kilo-code",
-			model: "deepseek-chat",
-			provider: "deepseek",
 			weight: 0.03,
+			models: [
+				{ model: "deepseek-chat", provider: "deepseek", weight: 0.6 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.25 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.15 },
+			],
 		},
 		{
 			source: "zed",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.03,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.6 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.25 },
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.15 },
+			],
 		},
 		{
 			source: "bolt.new",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.03,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.65 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.25 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.1 },
+			],
 		},
 		{
 			source: "v0.dev",
-			model: "gpt-4o",
-			provider: "openai",
 			weight: 0.025,
+			models: [
+				{ model: "gpt-4o", provider: "openai", weight: 0.55 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.35 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.1 },
+			],
 		},
 		{
 			source: "lovable.dev",
-			model: "claude-3.5-sonnet",
-			provider: "anthropic",
 			weight: 0.025,
+			models: [
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.6 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.3 },
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.1 },
+			],
 		},
 		{
 			source: "autohand",
-			model: "deepseek-chat",
-			provider: "deepseek",
 			weight: 0.02,
+			models: [
+				{ model: "deepseek-chat", provider: "deepseek", weight: 0.55 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.3 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.15 },
+			],
 		},
 		{
 			source: "soulforge",
-			model: "gemini-2.0-flash",
-			provider: "google-ai-studio",
 			weight: 0.02,
+			models: [
+				{
+					model: "gemini-2.0-flash",
+					provider: "google-ai-studio",
+					weight: 0.6,
+				},
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.25 },
+				{ model: "gemini-1.5-pro", provider: "google-ai-studio", weight: 0.15 },
+			],
 		},
 		{
 			source: "openclaw",
-			model: "claude-3-haiku",
-			provider: "anthropic",
 			weight: 0.015,
+			models: [
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.55 },
+				{ model: "claude-3.5-sonnet", provider: "anthropic", weight: 0.3 },
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.15 },
+			],
 		},
 		{
 			source: "n8n",
-			model: "gpt-4o-mini",
-			provider: "openai",
 			weight: 0.015,
+			models: [
+				{ model: "gpt-4o-mini", provider: "openai", weight: 0.55 },
+				{ model: "gpt-4o", provider: "openai", weight: 0.3 },
+				{ model: "claude-3-haiku", provider: "anthropic", weight: 0.15 },
+			],
 		},
 	];
 	const DEVPASS_LOG_COUNT = 1800;
@@ -1392,7 +1471,9 @@ async function seed() {
 				acc += a.weight;
 				return r <= acc;
 			}) ?? DEVPASS_AGENTS[0];
-		const modelDef = MODELS.find((m) => m.model === agent.model) ?? MODELS[0];
+		const agentModel = weightedRandomChoice(agent.models);
+		const modelDef =
+			MODELS.find((m) => m.model === agentModel.model) ?? MODELS[0];
 		const finishDef = weightedRandomChoice(FINISH_REASONS);
 		const isError =
 			finishDef.unified === "upstream_error" ||


### PR DESCRIPTION
## Summary

- **Playground share dialog**: redesigned to match the LLM Gateway theme — larger heading, prompt preview card, truncated `https://chat.llmgateway.io/share/…` URL pill, and a row of social share buttons (Copy / X / LinkedIn / Reddit) similar to ChatGPT's share modal. Mobile responsive.
- **Dynamic OG image** for `/share/[shareId]` (`opengraph-image.tsx`): uses the LLM Gateway logo, the shared chat title/prompt as the headline, and a small response preview card. `generateMetadata` now also fetches the share to set per-share `title` / `description` and `twitter:summary_large_image`.
- **DevPass agent detail**: new `AgentModelUsageChart` component shows a stacked Model Usage Overview chart (matching the apps/ui chart) with a metric switcher (Requests / Cost / Tokens) and a 1h / 4h / 1d / 7d / 30d range picker. Wired in above the existing model usage table on the agent detail view.

## Test plan

- [ ] Open a chat in the playground, share it, confirm the dialog renders correctly on mobile and desktop, and that the URL is visibly truncated.
- [ ] Verify Copy / X / LinkedIn / Reddit buttons open the correct share targets.
- [ ] Visit a `/share/[shareId]` URL and confirm the OG image loads with the prompt + response preview + LLM Gateway branding.
- [ ] In DevPass dashboard, open a Coding Agent's detail view and confirm the new chart renders with the time-range buttons and metric dropdown working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent model usage chart in agent details with selectable ranges/metrics and stacked model breakdown.
  * OpenGraph image generation for shared chats and enriched share dialog with social buttons (X, LinkedIn, Reddit) and copyable truncated URL.
  * New styled Select UI component.

* **Improvements**
  * Dynamic shared-chat metadata and preview prompt derived from chat content.
  * Collapsible DevPass card with persisted collapsed state and updated dashboard behavior.
  * Admin KPIs now include cancelling-but-still-active subscribers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2243)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->