### PR TITLE
feat(gateway): log upstream abort finish_reason

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -474,6 +474,15 @@ export function parseProviderResponse(
 			if (finishReason === "end_turn") {
 				finishReason = "stop";
 			} else if (finishReason === "abort") {
+				logger.warn("Upstream sent abort finish_reason", {
+					provider: usedProvider,
+					model: usedModel,
+					responseModel: json.model,
+					responseId: json.id,
+					finishReason: json.choices?.[0]?.finish_reason,
+					nativeFinishReason: json.choices?.[0]?.native_finish_reason,
+					usage: json.usage,
+				});
 				finishReason = "canceled";
 			} else if (finishReason === "tool_use") {
 				finishReason = "tool_calls";
@@ -755,6 +764,18 @@ export function parseProviderResponse(
 					) ??
 					null;
 				finishReason = json.choices?.[0]?.finish_reason ?? null;
+
+				if (finishReason === "abort") {
+					logger.warn("Upstream sent abort finish_reason", {
+						provider: usedProvider,
+						model: usedModel,
+						responseModel: json.model,
+						responseId: json.id,
+						finishReason: json.choices?.[0]?.finish_reason,
+						nativeFinishReason: json.choices?.[0]?.native_finish_reason,
+						usage: json.usage,
+					});
+				}
 
 				// ZAI-specific fix for incorrect finish_reason in tool response scenarios
 				// Only for models that were failing tests: glm-4.5-airx and glm-4.5-flash

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1333,6 +1333,11 @@ export function transformStreamingToOpenai(
 			if (transformedData?.choices?.[0]?.finish_reason === "end_turn") {
 				transformedData.choices[0].finish_reason = "stop";
 			} else if (transformedData?.choices?.[0]?.finish_reason === "abort") {
+				logger.warn("[streaming] Upstream sent abort finish_reason", {
+					provider: usedProvider,
+					model: usedModel,
+					chunk: data,
+				});
 				transformedData.choices[0].finish_reason = "canceled";
 			} else if (transformedData?.choices?.[0]?.finish_reason === "tool_use") {
 				transformedData.choices[0].finish_reason = "tool_calls";


### PR DESCRIPTION
## Summary
- Log a warning when an upstream provider emits a non-standard `abort` finish_reason, to help diagnose mysterious "canceled" requests (notably DeepSeek V4 / `deepseek-v4-flash`, also via Novita).
- Streaming path: logs the full chunk that carried the `abort` finish_reason (chunks at finish time don't include content deltas, only metadata).
- Non-streaming path: logs response metadata (provider, model, response model/id, finish_reason, native_finish_reason, usage) — no raw content.

## Test plan
- [ ] Trigger a deepseek/novita request that ends with upstream `abort` and verify the warning appears with useful metadata
- [ ] Confirm existing finish_reason mapping behavior is unchanged (`canceled` still emitted by mistral/novita case)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for provider response abort scenarios across multiple chat tools, capturing relevant metadata and upstream response details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2244)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->