### PR TITLE
fix(gateway): align vertex video keys with storage project

### DIFF
--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -1016,11 +1016,19 @@ function getVideoExcludedConfigIndices(
 		return undefined;
 	}
 	const defaultBaseUrl = getDefaultVideoProviderBaseUrl(providerId);
+	const storageProjectId = process.env.GOOGLE_CLOUD_PROJECT?.trim();
 	const excluded = new Set<number>();
 	for (let index = 0; index < valueCount; index += 1) {
 		const baseUrl = getProviderEnvValue(providerId, "baseUrl", index);
 		if (baseUrl && baseUrl !== defaultBaseUrl) {
 			excluded.add(index);
+			continue;
+		}
+		if (storageProjectId) {
+			const indexProjectId = getProviderEnvValue(providerId, "project", index);
+			if (indexProjectId && indexProjectId !== storageProjectId) {
+				excluded.add(index);
+			}
 		}
 	}
 	return excluded.size > 0 ? excluded : undefined;


### PR DESCRIPTION
## Summary

When `LLM_GOOGLE_VERTEX_API_KEY` is configured with multiple comma-separated values targeting different GCP projects (e.g. one for the real Vertex AI project and one for a Google-compatible provider on a different base URL/project), the env-based round-robin could pick a key whose per-index project doesn't match `GOOGLE_CLOUD_PROJECT`. The upstream Vertex URL is built from `GOOGLE_CLOUD_PROJECT` when GCS output is configured, so the wrong key gets sent to the right project's URL — `aiplatform.endpoints.predict` denied / 403, exactly as we saw on `veo-3.1-fast-generate-001`.

`getVideoExcludedConfigIndices` already excluded indices with a non-default `baseUrl`. This extends it to also exclude indices whose per-index `LLM_GOOGLE_CLOUD_PROJECT` doesn't equal `GOOGLE_CLOUD_PROJECT` (when set). Result: only keys whose project matches the storage/URL project are eligible — so the gateway can't pick a stray non-vertex key for video generation.

## Test plan

- [x] `pnpm format`
- [x] `pnpm build`
- [x] `pnpm test:unit` — pre-existing `videos.spec.ts` failures (mock URL routing) are identical with/without this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced video provider configuration selection logic to better match project environment settings, ensuring the appropriate configuration is applied for video operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2246)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->