### PR TITLE
fix(gateway): strict project alignment for vertex video keys

### DIFF
--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -42,6 +42,7 @@ import {
 } from "@llmgateway/db";
 import { logger, toError } from "@llmgateway/logger";
 import {
+	getProviderEnvConfig,
 	getProviderEnvValue,
 	getProviderEnvVar,
 	hasProviderEnvironmentToken,
@@ -1008,27 +1009,38 @@ function getVideoExcludedConfigIndices(
 	if (!apiKeyValue) {
 		return undefined;
 	}
-	const valueCount = apiKeyValue
+	const apiKeys = apiKeyValue
 		.split(",")
 		.map((value) => value.trim())
-		.filter((value) => value.length > 0).length;
-	if (valueCount === 0) {
+		.filter((value) => value.length > 0);
+	if (apiKeys.length === 0) {
 		return undefined;
 	}
 	const defaultBaseUrl = getDefaultVideoProviderBaseUrl(providerId);
 	const storageProjectId = process.env.GOOGLE_CLOUD_PROJECT?.trim();
+	// Parse the project env directly (no last-value fallback) so that an index
+	// without an explicit project entry is treated as a mismatch — otherwise an
+	// extra API key would silently inherit the previous index's project and be
+	// kept by the filter even though it isn't actually for that project.
+	const projectEnvVar = getProviderEnvConfig(providerId)?.required?.project;
+	const projectEnvValue = projectEnvVar
+		? process.env[projectEnvVar]
+		: undefined;
+	const projects = projectEnvValue
+		? projectEnvValue
+				.split(",")
+				.map((value) => value.trim())
+				.filter((value) => value.length > 0)
+		: [];
 	const excluded = new Set<number>();
-	for (let index = 0; index < valueCount; index += 1) {
+	for (let index = 0; index < apiKeys.length; index += 1) {
 		const baseUrl = getProviderEnvValue(providerId, "baseUrl", index);
 		if (baseUrl && baseUrl !== defaultBaseUrl) {
 			excluded.add(index);
 			continue;
 		}
-		if (storageProjectId) {
-			const indexProjectId = getProviderEnvValue(providerId, "project", index);
-			if (indexProjectId && indexProjectId !== storageProjectId) {
-				excluded.add(index);
-			}
+		if (storageProjectId && projects[index] !== storageProjectId) {
+			excluded.add(index);
 		}
 	}
 	return excluded.size > 0 ? excluded : undefined;


### PR DESCRIPTION
## Summary

Follow-up to #2246. The previous filter used \`getProviderEnvValue\` to look up the per-index project, which falls back to the **last** value when \`LLM_GOOGLE_CLOUD_PROJECT\` has fewer entries than \`LLM_GOOGLE_VERTEX_API_KEY\`. Result: any API key at an index without an explicit project entry inherited the previous index's project, satisfied the match, and stayed eligible — but the actual key at that position isn't for that project, so Vertex AI rejects it with \"invalid authentication credentials.\"

Fix: parse \`LLM_GOOGLE_CLOUD_PROJECT\` directly (no last-value fallback) and only keep an index when \`projects[index] === GOOGLE_CLOUD_PROJECT\` exactly. Indices without an explicit project entry are excluded.

Example — before this fix, with \`LLM_GOOGLE_VERTEX_API_KEY=keyA,keyB,keyC\`, \`LLM_GOOGLE_CLOUD_PROJECT=projA,llmgatewayio\`, \`GOOGLE_CLOUD_PROJECT=llmgatewayio\`:
- index 0 → projA ≠ llmgatewayio → excluded
- index 1 → llmgatewayio → kept ✓
- index 2 → \`getProviderEnvValue\` fallback returned llmgatewayio → kept ✗ (this was the bug)

After this fix, only index 1 is kept.

## Test plan

- [x] \`pnpm format\`
- [x] \`pnpm build\`
- [ ] Verify on production that veo-3.1-fast-generate-001 calls succeed (single matching index now picked deterministically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes Google Vertex video provider selection when multiple API keys are configured—now correctly detects per-entry base URL overrides and per-entry project values so the app uses the intended provider configuration and avoids misrouted video requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2250)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->