### PR TITLE
fix(admin): stop double-counting devpass first-invoice revenue

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8158,6 +8158,15 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	// granted (price × DEV_PLAN_CREDITS_MULTIPLIER) and would over-report
 	// revenue, and is null on legacy `subscription_*` rows so they would
 	// otherwise contribute nothing.
+	//
+	// Deduplicated by (stripe_invoice_id, organization_id): the FIRST invoice
+	// of every subscription triggers BOTH `checkout.session.completed` (which
+	// inserts `dev_plan_start`) AND `invoice.payment_succeeded` (which then
+	// inserts `dev_plan_renewal`) for the same invoice. Without this NOT
+	// EXISTS guard the initial payment is counted twice. Race orderings can
+	// also produce a `subscription_start` paired with a `dev_plan_start` for
+	// the same invoice on personal orgs. We keep the earliest row per invoice
+	// (tie-broken by id) so each Stripe invoice contributes exactly once.
 	const revenuePerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
@@ -8183,6 +8192,23 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 						eq(tables.organization.isPersonal, true),
 					),
 				),
+				sql`NOT EXISTS (
+					SELECT 1 FROM ${tables.transaction} dup
+					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
+						AND dup.stripe_invoice_id IS NOT NULL
+						AND dup.organization_id = ${tables.transaction.organizationId}
+						AND dup.id <> ${tables.transaction.id}
+						AND dup.status = 'completed'
+						AND dup.amount IS NOT NULL
+						AND dup.type IN (
+							'dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal',
+							'subscription_start', 'subscription_cancel', 'subscription_end'
+						)
+						AND (
+							dup.created_at < ${tables.transaction.createdAt}
+							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
+						)
+				)`,
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1497,6 +1497,26 @@ async function handleInvoicePaymentSucceeded(
 
 	const { organizationId, organization } = result;
 
+	// Stripe fires both `checkout.session.completed` and
+	// `invoice.payment_succeeded` for the FIRST invoice of every new
+	// subscription. The checkout handler already inserts the
+	// `dev_plan_start` (or `subscription_start`) row and does the
+	// idempotent state setup, so re-running this handler for the same
+	// invoice would double-insert (and inflate admin revenue reporting)
+	// and also reset the just-set billing cycle. Bail out if a row for
+	// this invoice already exists, regardless of type.
+	if (invoice.id) {
+		const existingForInvoice = await db.query.transaction.findFirst({
+			where: { stripeInvoiceId: { eq: invoice.id } },
+		});
+		if (existingForInvoice) {
+			logger.info(
+				`Skipping invoice.payment_succeeded for ${invoice.id}: transaction ${existingForInvoice.id} (type=${existingForInvoice.type}) already recorded`,
+			);
+			return;
+		}
+	}
+
 	// Check if this is a dev plan subscription renewal
 	const isDevPlanRenewal =
 		organization.devPlanStripeSubscriptionId === subscriptionId &&


### PR DESCRIPTION
## Summary

The DevPass admin dashboard's all-time revenue was inflated

**Root cause**: every DevPass signup triggers two Stripe webhooks for the same first invoice:
1. `checkout.session.completed` → inserts `dev_plan_start` (with the full price as `amount`)
2. `invoice.payment_succeeded` → enters the `isDevPlanRenewal` branch (because checkout already set `devPlanStripeSubscriptionId` + `devPlan`) and inserts a **second** row of type `dev_plan_renewal` for the same invoice with the same `amount`

Both rows are summed by the admin timeseries → every signup is counted twice. With ~X active subs averaging ~$X plus historical churned subs, the over-count adds up to roughly the reported delta. Race orderings can also produce a `subscription_start` paired with a `dev_plan_start` for the same invoice on personal orgs.

## Fixes

1. **`handleInvoicePaymentSucceeded` (`apps/api/src/stripe.ts`)** — bail out early if a transaction already exists for the invoice ID, so future first-invoice webhooks no longer double-write. Also makes the handler idempotent against Stripe webhook retries.

2. **DevPass admin timeseries (`apps/api/src/routes/admin.ts`)** — add a `NOT EXISTS` guard that keeps the earliest row per `(stripe_invoice_id, organization_id)`, correcting **historical** duplicates already in the DB without a destructive migration.

Legacy `subscription_*` rows remain scoped to personal orgs (so non-personal LLMGateway Pro renewals stay excluded), per existing behavior. The user explicitly asked that the old LLMGateway Pro plan not be counted — that's already the case via the `isPersonal = true` clause.

## Test plan

- [ ] Open `/admin/devpass` — the "DevPass revenue & usage" total should now match (within rounding) the sum of paid Stripe invoices on the Code Lite/Pro/Max prices.
- [ ] Daily chart shape should still resemble Stripe's daily revenue chart.
- [ ] KPIs that don't depend on `transaction.amount` (active subscribers, gross MRR, starts/ends this month, utilization, real cost, margin) should be unchanged.
- [ ] New DevPass signup creates exactly **one** revenue-bearing transaction (`dev_plan_start`), not two.
- [ ] DevPass renewal (second cycle onward) still creates a `dev_plan_renewal` row and resets credits / billing-cycle start.
- [ ] Stripe webhook retry for the same invoice no longer double-inserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)