### PR TITLE
fix(gateway): quantise costs and routing prices

### DIFF
--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -891,4 +891,29 @@ describe("calculateCosts", () => {
 		// 1.05e-6 + 1.8e-6 = 2.85e-6
 		expect(result.totalCost).toBe(2.85e-6);
 	});
+
+	it("should quantise costs from prices whose JS-number form is inexact", async () => {
+		// novita/deepseek-v3.2 has inputPrice 0.269/1e6 — `0.269 / 1e6` is not a
+		// clean IEEE-754 double, so `new Decimal(0.269 / 1e6)` preserves the
+		// noise and `.toNumber()` would emit values like `2.6900000000000003e-7`.
+		// The quantise step at the boundary must clean these up.
+		const result = await calculateCosts("deepseek-v3.2", "novita", 1, 0, null);
+
+		const fields: Array<number | null> = [
+			result.inputCost,
+			result.outputCost,
+			result.cachedInputCost,
+			result.cacheWriteInputCost,
+			result.requestCost,
+			result.webSearchCost,
+			result.totalCost,
+		];
+		for (const value of fields) {
+			expect(value).not.toBeNull();
+			const n = value as number;
+			expect(Math.round(n * 1e10) / 1e10).toBe(n);
+		}
+		// Confirm the input cost is the clean float (not the noisy `0.269 / 1e6`)
+		expect(result.inputCost).toBe(2.69e-7);
+	});
 });

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -20,6 +20,17 @@ interface ChatMessage {
 }
 
 /**
+ * Round a Decimal cost to 10 decimal places (~picoUSD) before converting to a
+ * JS number. Without this, values like `0.269 / 1e6` carry IEEE-754 noise that
+ * the Decimal constructor preserves, so the final `.toNumber()` produces things
+ * like `2.6900000000000003e-7`. 10dp is finer than any realistic per-token rate
+ * and below PG `real`'s ~7 significant-digit precision.
+ */
+function quantiseCost(value: Decimal): number {
+	return value.toDecimalPlaces(10).toNumber();
+}
+
+/**
  * Check if billing for cancelled requests is enabled via environment variable.
  * Defaults to false if not set.
  */
@@ -520,17 +531,19 @@ export async function calculateCosts(
 		.plus(webSearchCost);
 
 	return {
-		inputCost: inputCost.toNumber(),
-		outputCost: outputCost.toNumber(),
-		cachedInputCost: cachedInputCost.toNumber(),
-		cacheWriteInputCost: cacheWriteInputCost.toNumber(),
-		requestCost: requestCost.toNumber(),
-		webSearchCost: webSearchCost.toNumber(),
+		inputCost: quantiseCost(inputCost),
+		outputCost: quantiseCost(outputCost),
+		cachedInputCost: quantiseCost(cachedInputCost),
+		cacheWriteInputCost: quantiseCost(cacheWriteInputCost),
+		requestCost: quantiseCost(requestCost),
+		webSearchCost: quantiseCost(webSearchCost),
 		imageInputTokens,
 		imageOutputTokens,
-		imageInputCost: imageInputCost?.toNumber() ?? null,
-		imageOutputCost: imageOutputCost?.toNumber() ?? null,
-		totalCost: totalCost.toNumber(),
+		imageInputCost:
+			imageInputCost === null ? null : quantiseCost(imageInputCost),
+		imageOutputCost:
+			imageOutputCost === null ? null : quantiseCost(imageOutputCost),
+		totalCost: quantiseCost(totalCost),
 		dataStorageCost: null as number | null,
 		// Only add image input tokens to promptTokens for providers whose upstream
 		// usage excludes them (Google). Other providers (OpenAI, xAI) already

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -37,6 +37,17 @@ interface ProviderScore<T extends AvailableModelProvider> {
 	cacheSupported?: boolean;
 }
 
+/**
+ * Round a Decimal price to 10 decimal places before converting to a JS number.
+ * Source pricing is stored as JS numbers like `0.269 / 1e6`, which already
+ * carry IEEE-754 noise that the Decimal constructor preserves verbatim, so the
+ * final `.toNumber()` would emit values like `3.3450000000000004e-7` to the UI.
+ * 10dp is far finer than any realistic per-token rate.
+ */
+function quantisePrice(value: Decimal): number {
+	return value.toDecimalPlaces(10).toNumber();
+}
+
 // Scoring weights
 // With ratio-based scoring, throughput/latency differences are naturally amplified
 // (e.g., 6x faster = score of 5.0), so these weights are kept low to avoid
@@ -411,10 +422,9 @@ export function getCheapestFromAvailableProviders<
 						uptime: metrics?.uptime,
 						latency: metrics?.averageLatency,
 						throughput: metrics?.throughput,
-						price: getProviderSelectionPrice(
-							providerInfo,
-							videoPricing,
-						).toNumber(),
+						price: quantisePrice(
+							getProviderSelectionPrice(providerInfo, videoPricing),
+						),
 						priority,
 						cacheSupported: providerSupportsCaching(
 							providerInfo as ProviderModelMapping | undefined,
@@ -582,7 +592,7 @@ export function getCheapestFromAvailableProviders<
 				uptime: p.uptime,
 				latency: p.latency,
 				throughput: p.throughput,
-				price: p.price.toNumber(), // Keep full precision for very small prices
+				price: quantisePrice(p.price),
 				priority,
 				cacheSupported: p.cacheSupported,
 			};
@@ -651,7 +661,7 @@ function selectByPriceOnly<T extends AvailableModelProvider>(
 			providerId: p.providerId,
 			region: p.region,
 			score: 0,
-			price: p.price.toNumber(),
+			price: quantisePrice(p.price),
 			priority: p.priority,
 		})),
 	};

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1269,6 +1269,49 @@ describe("getCheapestFromAvailableProviders", () => {
 		).toBe(0.018);
 	});
 
+	it("emits clean prices in providerScores even when source rates carry IEEE-754 noise", () => {
+		// `0.269 / 1e6` is not exactly representable as an IEEE-754 double, so
+		// `new Decimal(0.269 / 1e6)` carries that noise into the average. Without
+		// quantising at the metadata boundary, the price field surfaces as
+		// `3.3450000000000004e-7` in the UI / activity log.
+		const result = getCheapestFromAvailableProviders(
+			[
+				{
+					providerId: "novita",
+					modelName: "deepseek/deepseek-v3.2",
+				} as never,
+				{
+					providerId: "alibaba",
+					modelName: "deepseek-v3.2",
+				} as never,
+			],
+			{
+				id: "deepseek-v3.2",
+				providers: [
+					{
+						providerId: "novita",
+						modelName: "deepseek/deepseek-v3.2",
+						inputPrice: 0.269 / 1e6,
+						outputPrice: 0.4 / 1e6,
+					},
+					{
+						providerId: "alibaba",
+						modelName: "deepseek-v3.2",
+						discount: 0.2,
+						inputPrice: 0.57 / 1e6,
+						outputPrice: 1.71 / 1e6,
+					},
+				],
+			} as never,
+		);
+
+		expect(result).not.toBeNull();
+		const noisy = result!.metadata.providerScores.filter(
+			(p) => Math.round(p.price * 1e10) / 1e10 !== p.price,
+		);
+		expect(noisy).toEqual([]);
+	});
+
 	describe("cache support weighting", () => {
 		const cacheTestModel = {
 			id: "cache-test-model",


### PR DESCRIPTION
## Summary

PR #2238 declared `quantiseCost` / `quantisePrice` helpers to round `Decimal` values before `.toNumber()`, but the helpers never actually landed in the code — only the Decimal-arithmetic refactor did. Source rates are stored as JS numbers like `0.269 / 1e6`, whose IEEE-754 form already carries noise; `new Decimal(...)` preserves that noise verbatim, so the final `.toNumber()` continues to surface values like `3.3450000000000004e-7` and `9.119999999999999e-7` in activity-log routing scores and costs.

Add the missing helpers and apply them at every Decimal→Number boundary:

- `apps/gateway/src/lib/costs.ts` — `quantiseCost(value)` rounds to 10dp before `.toNumber()`, applied to `inputCost`, `outputCost`, `cachedInputCost`, `cacheWriteInputCost`, `requestCost`, `webSearchCost`, `imageInputCost`, `imageOutputCost`, `totalCost`.
- `packages/actions/src/get-cheapest-from-available-providers.ts` — `quantisePrice(value)` applied to all three sites that emit `providerScores[].price` (random-exploration, weighted-score, price-only).

10dp is comfortably finer than the cheapest realistic per-token rates and well below PG `real`'s ~7-significant-digit precision, so no schema change is needed. Selection logic still operates on the unrounded `Decimal`, so the routing decision is unchanged.

## Why the previous fix didn't catch this

The existing regression tests (`models.spec.ts` and `costs.spec.ts`) used cleanly-representable rates like `0.15/1e6` (which round-trips to `1.5e-7` exactly), so the broken pipeline passed them. The new tests use the actual problematic rates from novita/deepseek-v3.2 (`0.269/1e6`) and alibaba's discounted rates, and assert `Math.round(n * 1e10) / 1e10 === n`.

## Test plan

- [x] `npx vitest run packages/actions/src/models.spec.ts apps/gateway/src/lib/costs.spec.ts` (80 tests pass, including the new `0.269/1e6` regression cases that fail without the quantise step)
- [x] `pnpm format`
- [x] `pnpm build`
- [ ] Manual: load an activity log for novita/deepseek-v3.2 and confirm routing scores show `$3.345e-7` / `$9.12e-7` instead of `$3.3450000000000004e-7` / `$9.119999999999999e-7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in cost and price calculations by fixing floating-point arithmetic inconsistencies that could affect displayed billing amounts and provider pricing in routing decisions.

* **Tests**
  * Added validation tests for cost calculations and provider pricing accuracy under edge-case numeric conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->