### PR TITLE
feat(admin): break down errors by source in history

### DIFF
--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -163,6 +163,18 @@ export function HistoryChart({
 	const summaryStats = {
 		totalRequests: data.reduce((sum, d) => sum + d.logsCount, 0),
 		totalErrors: data.reduce((sum, d) => sum + d.errorsCount, 0),
+		totalClientErrors: data.reduce(
+			(sum, d) => sum + (d.clientErrorsCount ?? 0),
+			0,
+		),
+		totalGatewayErrors: data.reduce(
+			(sum, d) => sum + (d.gatewayErrorsCount ?? 0),
+			0,
+		),
+		totalUpstreamErrors: data.reduce(
+			(sum, d) => sum + (d.upstreamErrorsCount ?? 0),
+			0,
+		),
 		totalTokens: data.reduce((sum, d) => sum + d.totalTokens, 0),
 		totalCost: data.reduce((sum, d) => sum + d.totalCost, 0),
 		avgTtft:
@@ -242,7 +254,18 @@ export function HistoryChart({
 						<strong className="text-foreground">
 							{summaryStats.totalErrors.toLocaleString()}
 						</strong>{" "}
-						({summaryStats.errorRate}%)
+						({summaryStats.errorRate}%) — client:{" "}
+						<strong className="text-foreground">
+							{summaryStats.totalClientErrors.toLocaleString()}
+						</strong>
+						, gateway:{" "}
+						<strong className="text-foreground">
+							{summaryStats.totalGatewayErrors.toLocaleString()}
+						</strong>
+						, upstream:{" "}
+						<strong className="text-foreground">
+							{summaryStats.totalUpstreamErrors.toLocaleString()}
+						</strong>
 					</span>
 					<span>
 						Tokens:{" "}


### PR DESCRIPTION
## Summary
- Show client / gateway / upstream error counts alongside the total error count and rate in the history chart summary line (used on provider/model detail pages in the admin dashboard).

## Test plan
- [ ] Open admin dashboard → any provider (e.g. Azure) → History card shows the new breakdown
- [ ] Verify counts match the Errors metric tab and detail stat cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error reporting to display a detailed breakdown of client, gateway, and upstream errors alongside the overall error rate percentage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->