### PR TITLE
docs: add video content JWT secret to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,10 @@ PASSKEY_RP_NAME=LLMGateway
 # Required in production. Generate with: openssl rand -base64 32
 GATEWAY_API_KEY_HASH_SECRET=your-api-key-hash-secret-here
 
+# Secret used to sign video content access tokens (JWT).
+# Required in production. Generate with: openssl rand -base64 32
+LLM_VIDEO_CONTENT_JWT_SECRET=your-video-content-jwt-secret-here
+
 # =============================================================================
 # FEATURE FLAGS
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add `LLM_VIDEO_CONTENT_JWT_SECRET` to `.env.example` with generation instructions

This env var is required in production for signing video content access tokens. Without it, the `/logs` endpoint throws a 500 when there are video logs.

## Test plan
- [x] Verify `.env.example` contains the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration support for video access token functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->