### PR TITLE
fix: scope admin metrics + fix SEO canonicals

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -500,7 +500,32 @@ admin.openapi(getMetrics, async (c) => {
 
 	const payingCustomers = Number(payingRow?.count ?? 0);
 
-	// Total revenue (completed transactions, excluding gifts, using creditAmount to exclude Stripe fees)
+	// DevPass-related transaction types: exclude these from credit-purchase
+	// metrics (revenue/processed/topped-up) because DevPass revenue lives in
+	// its own dashboard, and DevPass-granted credits are virtual (capped per
+	// cycle) rather than real top-up balance.
+	const devpassExcludedTypes = [
+		"dev_plan_start",
+		"dev_plan_upgrade",
+		"dev_plan_downgrade",
+		"dev_plan_renewal",
+		"dev_plan_cancel",
+		"dev_plan_end",
+		"subscription_start",
+		"subscription_cancel",
+		"subscription_end",
+		"subscription_upgrade",
+		"subscription_downgrade",
+		"subscription_renewal",
+	] as const;
+
+	const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
+		devpassExcludedTypes.map((t) => sql`${t}`),
+		sql`, `,
+	)})`;
+
+	// Total revenue (completed credit-purchase transactions, excluding gifts
+	// and all DevPass subscription rows, using creditAmount to exclude Stripe fees)
 	const [revenueRow] = await db
 		.select({
 			value:
@@ -513,6 +538,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				notDevpassFilter,
 				transactionDateFilter,
 			),
 		);
@@ -529,7 +555,9 @@ admin.openapi(getMetrics, async (c) => {
 
 	const totalOrganizations = Number(orgsRow?.count ?? 0);
 
-	// Total topped up (credits from completed transactions)
+	// Total topped up (credits from completed credit-purchase transactions).
+	// Excludes DevPass virtual credits — those are granted per cycle and reset,
+	// so they would inflate the topped-up / unused-credits numbers.
 	const [toppedUpRow] = await db
 		.select({
 			value:
@@ -539,12 +567,19 @@ admin.openapi(getMetrics, async (c) => {
 		})
 		.from(tables.transaction)
 		.where(
-			and(eq(tables.transaction.status, "completed"), transactionDateFilter),
+			and(
+				eq(tables.transaction.status, "completed"),
+				notDevpassFilter,
+				transactionDateFilter,
+			),
 		);
 
 	const totalToppedUp = Number(toppedUpRow?.value ?? 0);
 
-	// Total spent (usage cost from hourly stats)
+	// Total spent (usage cost from hourly stats). Excludes spend from projects
+	// belonging to orgs whose usage is/was on a DevPass plan, so the
+	// unusedCredits derivation (toppedUp - spent) only reflects the
+	// credit-purchase economy.
 	const [spentRow] = await db
 		.select({
 			value:
@@ -553,11 +588,32 @@ admin.openapi(getMetrics, async (c) => {
 				),
 		})
 		.from(projectHourlyStats)
-		.where(projectStatsDateFilter);
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyStats.projectId, tables.project.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.project.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				projectStatsDateFilter,
+				eq(tables.organization.devPlan, "none"),
+				sql`NOT EXISTS (
+					SELECT 1 FROM ${tables.transaction} t
+					WHERE t.organization_id = ${tables.organization.id}
+					AND (
+						t.type IN ('dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal')
+						OR (t.type IN ('subscription_start', 'subscription_cancel', 'subscription_end') AND ${tables.organization.isPersonal} = true)
+					)
+				)`,
+			),
+		);
 
 	const totalSpent = Number(spentRow?.value ?? 0);
 
-	// Total processed (gross Stripe amounts from completed non-gift transactions)
+	// Total processed (gross Stripe amounts from completed non-gift, non-DevPass transactions)
 	const [processedRow] = await db
 		.select({
 			value:
@@ -570,6 +626,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				notDevpassFilter,
 				transactionDateFilter,
 			),
 		);
@@ -7875,7 +7932,11 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 
 	const conditions = [];
 
-	// DevPass scope: subscribers (devPlan != 'none') OR (showChurned && has past dev_plan_start)
+	// DevPass scope: subscribers (devPlan != 'none') OR (showChurned && has past dev_plan_start).
+	// Only personal orgs can hold a DevPass plan — restrict to isPersonal=true
+	// so the churned list doesn't surface non-personal "Default Organization"
+	// rows that happen to share legacy `subscription_*` history with org Pro.
+	conditions.push(eq(tables.organization.isPersonal, true));
 	if (showChurned) {
 		conditions.push(
 			or(

--- a/apps/api/src/routes/public-chat-shares.ts
+++ b/apps/api/src/routes/public-chat-shares.ts
@@ -1,6 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
-import { db, tables, eq, isNull, and } from "@llmgateway/db";
+import { db, tables, eq, isNull, and, desc } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -57,6 +57,59 @@ const getSharedChat = createRoute({
 			description: "Shared chat not found.",
 		},
 	},
+});
+
+const listSharedChats = createRoute({
+	method: "get",
+	path: "/",
+	request: {
+		query: z.object({
+			limit: z.coerce.number().int().min(1).max(50000).optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						shares: z.array(
+							z.object({
+								id: z.string(),
+								updatedAt: z.string().datetime(),
+							}),
+						),
+					}),
+				},
+			},
+			description: "Active public shared chats (id + updatedAt) for sitemaps.",
+		},
+	},
+});
+
+publicChatShares.openapi(listSharedChats, async (c) => {
+	const { limit } = c.req.valid("query");
+	const rows = await db
+		.select({
+			id: tables.chatShare.id,
+			updatedAt: tables.chatShare.updatedAt,
+		})
+		.from(tables.chatShare)
+		.innerJoin(tables.chat, eq(tables.chatShare.chatId, tables.chat.id))
+		.where(
+			and(isNull(tables.chatShare.deletedAt), eq(tables.chat.status, "active")),
+		)
+		.orderBy(desc(tables.chatShare.updatedAt))
+		.limit(limit ?? 5000);
+
+	return c.json(
+		{
+			shares: rows.map((r) => ({
+				id: r.id,
+				updatedAt: r.updatedAt.toISOString(),
+			})),
+		},
+		200,
+	);
 });
 
 publicChatShares.openapi(getSharedChat, async (c) => {

--- a/apps/code/src/app/coding-models/page.tsx
+++ b/apps/code/src/app/coding-models/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
 	title: "AI Models for Coding",
 	description:
 		"High-performance AI models optimized for coding tasks with tool support, JSON output, streaming, and prompt caching.",
+	alternates: { canonical: "/coding-models" },
 };
 
 export default function CodingModelsPage() {

--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -33,9 +33,6 @@ export const metadata: Metadata = {
 	icons: {
 		icon: "/favicon/favicon.ico?v=2",
 	},
-	alternates: {
-		canonical: "./",
-	},
 	robots: {
 		index: true,
 		follow: true,

--- a/apps/code/src/app/legal/privacy/page.tsx
+++ b/apps/code/src/app/legal/privacy/page.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
 	title: "Privacy Policy — DevPass",
 	description:
 		"How DevPass collects, uses, and protects your data — including request retention, AI provider routing, cookies, and your privacy rights.",
+	alternates: { canonical: "/legal/privacy" },
 };
 
 export default function PrivacyPage() {

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
 	title: "Terms of Use — DevPass",
 	description:
 		"Review the Terms of Use for DevPass. Learn about account eligibility, billing, fair-use limits, AI provider policies, and developer responsibilities when using our flat-rate AI coding subscription.",
+	alternates: { canonical: "/legal/terms" },
 };
 
 export default function TermsPage() {

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -22,6 +22,12 @@ import {
 	SoulForgeIcon,
 } from "@llmgateway/shared/components";
 
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+	alternates: { canonical: "/" },
+};
+
 const featuredTools = [
 	{
 		name: "Claude Code",

--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -30,6 +30,7 @@ export const metadata: Metadata = {
 	title: "Pricing — DevPass",
 	description:
 		"Flat-rate AI coding plans. Lite, Pro, and Max — every plan includes 200+ models. Pair with SoulForge to cut another ~50% of tokens.",
+	alternates: { canonical: "/pricing" },
 	openGraph: {
 		title: "Pricing — DevPass",
 		description:

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -490,6 +490,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/public/chats/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Active public shared chats (id + updatedAt) for sitemaps. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            shares: {
+                                id: string;
+                                /** Format: date-time */
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/chats/share/{shareId}": {
         parameters: {
             query?: never;

--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
 	title: "Group Chat - Compare AI Models Side by Side",
 	description:
 		"Send one prompt to multiple AI models simultaneously. Compare responses from GPT-4, Claude, Gemini, and more in real-time.",
+	alternates: { canonical: "/group" },
 };
 
 export interface GatewayModel {

--- a/apps/playground/src/app/image/page.tsx
+++ b/apps/playground/src/app/image/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
 	title: "AI Image Generation",
 	description:
 		"Generate images with DALL-E, Stable Diffusion, Flux, and other AI models. Compare outputs across providers in one playground.",
+	alternates: { canonical: "/image" },
 };
 
 export default async function ImagePage({

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -34,9 +34,6 @@ export const metadata: Metadata = {
 	icons: {
 		icon: "/favicon/favicon.ico?v=2",
 	},
-	alternates: {
-		canonical: "./",
-	},
 	robots: {
 		index: true,
 		follow: true,

--- a/apps/playground/src/app/page.tsx
+++ b/apps/playground/src/app/page.tsx
@@ -9,15 +9,14 @@ import { fetchServerData } from "@/lib/server-api";
 import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
-export async function generateMetadata({
-	searchParams,
-}: {
-	searchParams: Promise<{ model?: string }>;
-}): Promise<Metadata> {
-	const { model } = await searchParams;
+export async function generateMetadata(): Promise<Metadata> {
+	// All `?model=` variants of the homepage render the same page with a
+	// preselected model — they are not unique URLs from Google's perspective.
+	// Always canonicalize to "/" so the parameterized URLs don't trigger
+	// "Duplicate, Google chose different canonical than user" errors.
 	return {
 		alternates: {
-			canonical: model ? `/?model=${model}` : "/",
+			canonical: "/",
 		},
 	};
 }

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -1,32 +1,66 @@
+import { getConfig } from "@/lib/config-server";
+
 import type { MetadataRoute } from "next";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-	const baseUrl = "https://chat.llmgateway.io";
+interface ShareListResponse {
+	shares: Array<{ id: string; updatedAt: string }>;
+}
 
-	return [
+async function fetchPublicShares(): Promise<ShareListResponse["shares"]> {
+	const config = getConfig();
+	try {
+		const response = await fetch(
+			`${config.apiBackendUrl}/public/chats/share?limit=5000`,
+			{ cache: "no-store" },
+		);
+		if (!response.ok) {
+			return [];
+		}
+		const data = (await response.json()) as ShareListResponse;
+		return Array.isArray(data.shares) ? data.shares : [];
+	} catch {
+		return [];
+	}
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	const baseUrl = "https://chat.llmgateway.io";
+	const now = new Date();
+
+	const staticEntries: MetadataRoute.Sitemap = [
 		{
 			url: baseUrl,
-			lastModified: new Date(),
+			lastModified: now,
 			changeFrequency: "daily",
 			priority: 1,
 		},
 		{
 			url: `${baseUrl}/image`,
-			lastModified: new Date(),
+			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/video`,
-			lastModified: new Date(),
+			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/group`,
-			lastModified: new Date(),
+			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 	];
+
+	const shares = await fetchPublicShares();
+	const shareEntries: MetadataRoute.Sitemap = shares.map((share) => ({
+		url: `${baseUrl}/share/${share.id}`,
+		lastModified: new Date(share.updatedAt),
+		changeFrequency: "monthly",
+		priority: 0.6,
+	}));
+
+	return [...staticEntries, ...shareEntries];
 }

--- a/apps/playground/src/app/video/page.tsx
+++ b/apps/playground/src/app/video/page.tsx
@@ -13,6 +13,7 @@ export const metadata: Metadata = {
 	title: "AI Video Generation",
 	description:
 		"Generate videos with Veo, Wan, and other AI video models. Preview results and compare providers in one playground.",
+	alternates: { canonical: "/video" },
 };
 
 export default async function VideoPage({

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -490,6 +490,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/public/chats/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Active public shared chats (id + updatedAt) for sitemaps. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            shares: {
+                                id: string;
+                                /** Format: date-time */
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/chats/share/{shareId}": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -490,6 +490,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/public/chats/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Active public shared chats (id + updatedAt) for sitemaps. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            shares: {
+                                id: string;
+                                /** Format: date-time */
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/chats/share/{shareId}": {
         parameters: {
             query?: never;

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -523,30 +523,30 @@ export default async function DevpassPage({
 						)}
 						Cycle margin
 					</div>
-					<div
-						className={cn(
-							"mt-2 text-2xl font-semibold tabular-nums",
-							kpis.totalMargin < 0 ? "text-rose-600 dark:text-rose-400" : "",
-						)}
-					>
-						{currencyFormatter.format(kpis.totalMargin)}
+					<div className="mt-2 flex items-baseline gap-2">
+						<span
+							className={cn(
+								"text-2xl font-semibold tabular-nums",
+								kpis.totalMargin < 0 ? "text-rose-600 dark:text-rose-400" : "",
+							)}
+						>
+							{currencyFormatter.format(kpis.totalMargin)}
+						</span>
+						{kpis.marginPct !== null && kpis.marginPct !== undefined ? (
+							<span
+								className={cn(
+									"rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+									kpis.marginPct < 0
+										? "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400"
+										: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+								)}
+								title="Profit margin: cycle margin / gross MRR"
+							>
+								{kpis.marginPct.toFixed(1)}% profit
+							</span>
+						) : null}
 					</div>
 					<div className="mt-1 text-xs text-muted-foreground">
-						{kpis.marginPct !== null && kpis.marginPct !== undefined ? (
-							<>
-								<span
-									className={cn(
-										"font-medium tabular-nums",
-										kpis.marginPct < 0
-											? "text-rose-600 dark:text-rose-400"
-											: "text-emerald-600 dark:text-emerald-400",
-									)}
-								>
-									{kpis.marginPct.toFixed(1)}% margin
-								</span>{" "}
-								·{" "}
-							</>
-						) : null}
 						{currencyFormatter.format(kpis.totalRealCostCycle)} provider cost
 						this cycle
 					</div>

--- a/ee/admin/src/components/devpass-timeseries-chart.tsx
+++ b/ee/admin/src/components/devpass-timeseries-chart.tsx
@@ -79,7 +79,9 @@ export function DevpassTimeseriesChart({
 					<CardTitle>DevPass revenue & usage</CardTitle>
 					<CardDescription>
 						Daily revenue from DevPass transactions, real provider cost across
-						current and former subscribers, and the resulting margin.
+						current and former subscribers, and the resulting margin. Totals
+						aggregate the selected date range — note these will not match the
+						KPI cards above, which always reflect the current billing cycle.
 					</CardDescription>
 				</div>
 				<div className="flex">

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -490,6 +490,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/public/chats/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Active public shared chats (id + updatedAt) for sitemaps. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            shares: {
+                                id: string;
+                                /** Format: date-time */
+                                updatedAt: string;
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/public/chats/share/{shareId}": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

**Admin dashboard cards**
- `totalRevenue`, `totalProcessed`, `totalToppedUp`, and `totalSpent` (which feeds `unusedCredits`) now exclude `dev_plan_*` + legacy `subscription_*` transactions and DevPass-org spend. The credit-purchase cards stop double-counting DevPass revenue and virtual credits.
- DevPass subscriber list is restricted to `organization.isPersonal = true` so non-personal "Default Organization" rows no longer appear (only personal orgs can hold DevPass).
- Cycle margin card shows profit-margin % as a colored inline badge — visually distinct from utilization %.
- Chart description clarifies that its totals aggregate the *selected date range*, while the KPI cards always reflect the *current billing cycle* — this is the source of the apparent mismatch.

**SEO**
- New `GET /public/chats/share` endpoint returns active share IDs + `updatedAt` for sitemap consumption.
- Chat sitemap now emits `/share/{id}` URLs (up to 5000) so public chats are indexable.
- Removed broken relative `canonical: "./"` from chat and devpass root layouts — it resolved to the parent directory on subpages, causing Search Console's *"Duplicate, Google chose different canonical than user"* errors.
- Chat home always canonicalizes to `/` regardless of `?model=` (every `?model=foo` variant rendered the same page).
- Added explicit absolute canonicals to `/image`, `/video`, `/group` (chat) and `/`, `/pricing`, `/coding-models`, `/legal/terms`, `/legal/privacy` (devpass).

## Test plan

- [ ] Visit admin dashboard — confirm Total Revenue, Total Topped Up, Unused Credits drop by the DevPass revenue figure
- [ ] Open DevPass admin → enable "show churned" → confirm no "Default Organization" rows appear
- [ ] Inspect Cycle margin card — profit-margin % badge renders next to the dollar amount
- [ ] Read chart subtitle — wording about selected-range vs current-cycle is clear
- [ ] `curl https://chat.llmgateway.io/sitemap.xml` after deploy — public `/share/{id}` URLs appear
- [ ] `view-source:` on `https://chat.llmgateway.io/?model=anthropic/claude-opus-4-6` — canonical is `https://chat.llmgateway.io/`
- [ ] `view-source:` on `https://devpass.llmgateway.io/legal/terms` — canonical is `https://devpass.llmgateway.io/legal/terms` (not `/legal/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public endpoint for discovering shared content across the platform.
  * Implemented canonical URLs for key pages to improve search engine indexing.

* **Improvements**
  * Enhanced sitemap generation to dynamically include recently updated shared content.
  * Refined admin metrics to properly exclude specific plan activity from revenue KPIs.
  * Updated DevPass profitability display with clearer labeling and improved visual presentation.
  * Clarified timeseries chart data aggregation to reduce confusion with KPI metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2279)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->