### PR TITLE
fix(gateway): guard streaming SSE to JSON-only payloads

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4481,6 +4481,32 @@ chat.openapi(completions, async (c) => {
 					event?: string;
 					id?: string;
 				}) => {
+					// Guard: every SSE payload must be either the [DONE] sentinel or
+					// a JSON-parseable string. An empty or non-JSON `data:` line breaks
+					// OpenAI-compatible clients (they raise JSONDecodeError on the chunk).
+					if (sseData.data !== "[DONE]") {
+						if (!sseData.data || sseData.data.trim().length === 0) {
+							logger.warn("[streaming] Dropping empty SSE payload", {
+								provider: usedProvider,
+								model: usedModel,
+								event: sseData.event,
+							});
+							return;
+						}
+						try {
+							JSON.parse(sseData.data);
+						} catch (e) {
+							logger.warn("[streaming] Dropping non-JSON SSE payload", {
+								provider: usedProvider,
+								model: usedModel,
+								event: sseData.event,
+								error: e instanceof Error ? e.message : String(e),
+								preview: sseData.data.substring(0, 200),
+							});
+							return;
+						}
+					}
+
 					await stream.writeSSE(sseData);
 
 					// Collect raw response data for logging only in debug mode and within size limit


### PR DESCRIPTION
## Summary

- Add a defensive guard in `writeSSEAndCache` so every streamed SSE `data:` payload is either the literal `[DONE]` sentinel or a JSON-parseable string. Empty or non-JSON payloads are dropped with a warn log instead of being flushed to the client.
- Motivation: OpenAI-compatible clients (e.g. the OpenAI Python SDK used by Hermes Agent) raise `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` if any SSE chunk's data is empty or not valid JSON. The central `writeSSEAndCache` helper is the choke point for all per-chunk emissions in the chat streaming path, so guarding here covers every provider — including DeepSeek V3.2 tool-call streaming — without per-provider patches.
- The remaining direct `stream.writeSSE` callsites in chat.ts and responses.ts already pass literal `JSON.stringify({...})` or `"[DONE]"`, so they are safe by construction and unchanged.

## Test plan

- [ ] Existing `streaming tool calls $model` e2e (apps/gateway/src/chat-toolcalls.e2e.ts) still passes for the DeepSeek V3.2 provider fan-out
- [ ] Manual `curl -N` against /v1/chat/completions with `stream:true` + tools shows no empty `data:` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streaming response validation to automatically filter out malformed or unparseable data chunks, preventing errors and improving reliability
  * Added diagnostic logging to help identify and troubleshoot streaming payload issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2282)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->