### PR TITLE
fix(responses): tool and streaming compliance

### DIFF
--- a/apps/gateway/src/responses/openresponses-compliance.spec.ts
+++ b/apps/gateway/src/responses/openresponses-compliance.spec.ts
@@ -34,13 +34,26 @@ const usageSchema = z
 	})
 	.passthrough();
 
+const outputTextContentSchema = z
+	.object({
+		type: z.literal("output_text"),
+		text: z.string(),
+		annotations: z.array(z.unknown()),
+	})
+	.passthrough();
+
+const messageContentPartSchema = z.union([
+	outputTextContentSchema,
+	z.object({ type: z.string() }).passthrough(),
+]);
+
 const messageOutputItemSchema = z
 	.object({
 		type: z.literal("message"),
 		id: z.string(),
 		status: z.string(),
 		role: z.enum(["assistant", "user", "system", "developer"]),
-		content: z.array(z.unknown()),
+		content: z.array(messageContentPartSchema),
 		phase: z.enum(["commentary", "final_answer"]).optional(),
 	})
 	.passthrough();
@@ -319,6 +332,53 @@ describe("Open Responses compliance: streaming response shape", () => {
 		expect(data.response.completed_at).not.toBeNull();
 		expect(data.response.usage.input_tokens_details.cached_tokens).toBe(0);
 		expect(data.response.usage.output_tokens_details.reasoning_tokens).toBe(0);
+	});
+
+	it("emits sequence_number on every event and annotations on output_text parts (Open Responses Streaming Response test)", () => {
+		const state = createStreamingState("gpt-4o-mini", "resp_stream_seq");
+		const created = JSON.parse(createResponseCreatedEvent(state).data);
+		expect(typeof created.sequence_number).toBe("number");
+
+		const deltaEvents = processStreamChunk(
+			{ choices: [{ delta: { content: "Hello" } }] },
+			state,
+		);
+		processStreamChunk(
+			{
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+			},
+			state,
+		);
+		const completionEvents = createCompletionEvents(state);
+
+		const allEvents = [...deltaEvents, ...completionEvents];
+		const seqs = allEvents.map(
+			(e) => JSON.parse(e.data).sequence_number as unknown,
+		);
+		for (const s of seqs) {
+			expect(typeof s).toBe("number");
+		}
+		// All sequence numbers (including the response.created at index 0) are unique.
+		const all = [created.sequence_number, ...seqs];
+		expect(new Set(all).size).toBe(all.length);
+
+		const contentPartAdded = deltaEvents.find(
+			(e) => e.event === "response.content_part.added",
+		)!;
+		expect(
+			(JSON.parse(contentPartAdded.data).part as Record<string, unknown>)
+				.annotations,
+		).toEqual([]);
+
+		const completed = JSON.parse(
+			completionEvents.find((e) => e.event === "response.completed")!.data,
+		);
+		expectValid(completed.response, "response.completed (streaming text)");
+		const msg = completed.response.output.find(
+			(o: Record<string, unknown>) => o.type === "message",
+		);
+		expect(msg.content[0].annotations).toEqual([]);
 	});
 
 	it("response.created fills function tool strict with null when omitted", () => {

--- a/apps/gateway/src/responses/openresponses-compliance.spec.ts
+++ b/apps/gateway/src/responses/openresponses-compliance.spec.ts
@@ -70,6 +70,21 @@ const outputItemSchema = z.union([
 	z.object({ type: z.string() }).passthrough(),
 ]);
 
+const functionToolSchema = z
+	.object({
+		type: z.literal("function"),
+		name: z.string(),
+		description: z.union([z.string(), z.null()]),
+		parameters: z.union([z.record(z.any()), z.null()]),
+		strict: z.union([z.boolean(), z.null()]),
+	})
+	.passthrough();
+
+const echoedToolSchema = z.union([
+	functionToolSchema,
+	z.object({ type: z.string() }).passthrough(),
+]);
+
 export const responseResourceSchema = z
 	.object({
 		id: z.string(),
@@ -89,7 +104,7 @@ export const responseResourceSchema = z
 			.object({ code: z.string(), message: z.string() })
 			.passthrough()
 			.nullable(),
-		tools: z.array(z.unknown()),
+		tools: z.array(echoedToolSchema),
 		tool_choice: z.unknown(),
 		truncation: z.enum(["auto", "disabled"]),
 		parallel_tool_calls: z.boolean(),
@@ -183,6 +198,37 @@ describe("Open Responses compliance: non-streaming response shape", () => {
 		expect(out.tools).toHaveLength(1);
 	});
 
+	it("fills function tool description/parameters/strict with null when omitted (Open Responses tool-calling test)", () => {
+		const out = convertChatResponseToResponses(
+			baseChat,
+			"anthropic/claude-sonnet-4-6",
+			undefined,
+			{
+				tools: [
+					{
+						type: "function",
+						name: "get_weather",
+						description: "Get the current weather for a location",
+						parameters: {
+							type: "object",
+							properties: {
+								location: { type: "string" },
+							},
+							required: ["location"],
+						},
+					},
+				],
+			},
+		);
+		expectValid(out, "tool-calling echo response");
+		const tool = out.tools[0] as Record<string, unknown>;
+		expect(tool.type).toBe("function");
+		expect(tool.name).toBe("get_weather");
+		expect(tool.description).toBe("Get the current weather for a location");
+		expect(tool.parameters).toMatchObject({ type: "object" });
+		expect(tool.strict).toBeNull();
+	});
+
 	it("usage always includes input_tokens_details and output_tokens_details", () => {
 		const out = convertChatResponseToResponses(baseChat, "gpt-4o-mini");
 		expect(out.usage?.input_tokens_details.cached_tokens).toBe(0);
@@ -273,6 +319,17 @@ describe("Open Responses compliance: streaming response shape", () => {
 		expect(data.response.completed_at).not.toBeNull();
 		expect(data.response.usage.input_tokens_details.cached_tokens).toBe(0);
 		expect(data.response.usage.output_tokens_details.reasoning_tokens).toBe(0);
+	});
+
+	it("response.created fills function tool strict with null when omitted", () => {
+		const state = createStreamingState("gpt-4o-mini", "resp_stream_tools", {
+			tools: [{ type: "function", name: "get_weather" }],
+		});
+		const data = JSON.parse(createResponseCreatedEvent(state).data);
+		expectValid(data.response, "response.created (with tool echo)");
+		expect(
+			(data.response.tools[0] as Record<string, unknown>).strict,
+		).toBeNull();
 	});
 
 	it("response.completed echoes request fields when streaming state has them", () => {

--- a/apps/gateway/src/responses/openresponses-compliance.spec.ts
+++ b/apps/gateway/src/responses/openresponses-compliance.spec.ts
@@ -44,7 +44,12 @@ const outputTextContentSchema = z
 
 const messageContentPartSchema = z.union([
 	outputTextContentSchema,
-	z.object({ type: z.string() }).passthrough(),
+	z
+		.object({ type: z.string() })
+		.passthrough()
+		.refine((v) => v.type !== "output_text", {
+			message: "output_text content parts must match outputTextContentSchema",
+		}),
 ]);
 
 const messageOutputItemSchema = z
@@ -95,7 +100,12 @@ const functionToolSchema = z
 
 const echoedToolSchema = z.union([
 	functionToolSchema,
-	z.object({ type: z.string() }).passthrough(),
+	z
+		.object({ type: z.string() })
+		.passthrough()
+		.refine((v) => v.type !== "function", {
+			message: "function tools must match functionToolSchema",
+		}),
 ]);
 
 export const responseResourceSchema = z

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -161,6 +161,34 @@ export interface ResponsesEchoRequest {
 }
 
 /**
+ * Normalize echoed tools so each function tool has all fields the Open Responses
+ * spec marks as required-nullable (description, parameters, strict). The spec's
+ * functionToolSchema rejects responses where these are missing even though many
+ * callers omit them on the request side.
+ */
+export function normalizeEchoedTools(tools: unknown[] | undefined): unknown[] {
+	if (!tools) {
+		return [];
+	}
+	return tools.map((tool) => {
+		if (
+			typeof tool !== "object" ||
+			tool === null ||
+			(tool as Record<string, unknown>).type !== "function"
+		) {
+			return tool;
+		}
+		const t = tool as Record<string, unknown>;
+		return {
+			...t,
+			description: t.description ?? null,
+			parameters: t.parameters ?? null,
+			strict: t.strict ?? null,
+		};
+	});
+}
+
+/**
  * Converts a chat completions response to Responses API format.
  */
 export function convertChatResponseToResponses(
@@ -266,7 +294,7 @@ export function convertChatResponseToResponses(
 		instructions: request?.instructions ?? null,
 		output,
 		error: null,
-		tools: request?.tools ?? [],
+		tools: normalizeEchoedTools(request?.tools),
 		tool_choice: request?.tool_choice ?? "auto",
 		truncation: request?.truncation ?? "disabled",
 		parallel_tool_calls: request?.parallel_tool_calls ?? true,

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -1,5 +1,7 @@
 import { shortid } from "@llmgateway/db";
 
+import { normalizeEchoedTools } from "./convert-chat-to-responses.js";
+
 import type { ResponsesEchoRequest } from "./convert-chat-to-responses.js";
 
 interface StreamingState {
@@ -122,7 +124,7 @@ function buildResponsePayload(
 		instructions: req?.instructions ?? null,
 		output,
 		error: null,
-		tools: req?.tools ?? [],
+		tools: normalizeEchoedTools(req?.tools),
 		tool_choice: req?.tool_choice ?? "auto",
 		truncation: req?.truncation ?? "disabled",
 		parallel_tool_calls: req?.parallel_tool_calls ?? true,

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -17,6 +17,7 @@ interface StreamingState {
 	fullReasoning: string[];
 	reasoningStarted: boolean;
 	finishReason: string | null;
+	sequenceNumber: number;
 	toolCalls: Map<
 		number,
 		{
@@ -72,6 +73,7 @@ export function createStreamingState(
 		fullReasoning: [],
 		reasoningStarted: false,
 		finishReason: null,
+		sequenceNumber: 0,
 		toolCalls: new Map(),
 		request,
 		usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
@@ -156,16 +158,28 @@ interface SSEEvent {
 }
 
 /**
+ * Build an SSE event with an auto-incrementing sequence_number, which the
+ * Open Responses streaming-event schemas require on every event.
+ */
+function emitEvent(
+	state: StreamingState,
+	event: string,
+	data: Record<string, unknown>,
+): SSEEvent {
+	return {
+		event,
+		data: JSON.stringify({ ...data, sequence_number: state.sequenceNumber++ }),
+	};
+}
+
+/**
  * Generate the initial response.created event.
  */
 export function createResponseCreatedEvent(state: StreamingState): SSEEvent {
-	return {
-		event: "response.created",
-		data: JSON.stringify({
-			type: "response.created",
-			response: buildResponsePayload(state, { status: "in_progress" }),
-		}),
-	};
+	return emitEvent(state, "response.created", {
+		type: "response.created",
+		response: buildResponsePayload(state, { status: "in_progress" }),
+	});
 }
 
 /**
@@ -242,9 +256,8 @@ export function processStreamChunk(
 	if (delta.reasoning) {
 		if (!state.reasoningStarted) {
 			state.reasoningStarted = true;
-			events.push({
-				event: "response.output_item.added",
-				data: JSON.stringify({
+			events.push(
+				emitEvent(state, "response.output_item.added", {
 					type: "response.output_item.added",
 					output_index: state.outputItemIndex,
 					item: {
@@ -253,7 +266,7 @@ export function processStreamChunk(
 						summary: [],
 					},
 				}),
-			});
+			);
 		}
 		state.fullReasoning.push(delta.reasoning);
 	}
@@ -279,9 +292,8 @@ export function processStreamChunk(
 					arguments: tc.function?.arguments ?? "",
 					outputIndex: tcOutputIndex,
 				});
-				events.push({
-					event: "response.output_item.added",
-					data: JSON.stringify({
+				events.push(
+					emitEvent(state, "response.output_item.added", {
 						type: "response.output_item.added",
 						output_index: tcOutputIndex,
 						item: {
@@ -293,19 +305,18 @@ export function processStreamChunk(
 							status: "in_progress",
 						},
 					}),
-				});
+				);
 			} else {
 				if (tc.function?.arguments) {
 					existing.arguments += tc.function.arguments;
-					events.push({
-						event: "response.function_call_arguments.delta",
-						data: JSON.stringify({
+					events.push(
+						emitEvent(state, "response.function_call_arguments.delta", {
 							type: "response.function_call_arguments.delta",
 							item_id: existing.id,
 							output_index: existing.outputIndex,
 							delta: tc.function.arguments,
 						}),
-					});
+					);
 				}
 			}
 		}
@@ -320,9 +331,8 @@ export function processStreamChunk(
 				state.outputItemIndex++;
 			}
 
-			events.push({
-				event: "response.output_item.added",
-				data: JSON.stringify({
+			events.push(
+				emitEvent(state, "response.output_item.added", {
 					type: "response.output_item.added",
 					output_index: state.outputItemIndex,
 					item: {
@@ -333,33 +343,32 @@ export function processStreamChunk(
 						status: "in_progress",
 					},
 				}),
-			});
+			);
 		}
 
 		if (!state.contentPartStarted) {
 			state.contentPartStarted = true;
-			events.push({
-				event: "response.content_part.added",
-				data: JSON.stringify({
+			events.push(
+				emitEvent(state, "response.content_part.added", {
 					type: "response.content_part.added",
+					item_id: state.messageId,
 					output_index: state.outputItemIndex,
 					content_index: 0,
-					part: { type: "output_text", text: "" },
+					part: { type: "output_text", text: "", annotations: [] },
 				}),
-			});
+			);
 		}
 
 		state.fullContent.push(delta.content);
-		events.push({
-			event: "response.output_text.delta",
-			data: JSON.stringify({
+		events.push(
+			emitEvent(state, "response.output_text.delta", {
 				type: "response.output_text.delta",
 				item_id: state.messageId,
 				output_index: state.outputItemIndex,
 				content_index: 0,
 				delta: delta.content,
 			}),
-		});
+		);
 	}
 
 	// Check for usage in the chunk
@@ -407,34 +416,34 @@ export function createCompletionEvents(state: StreamingState): SSEEvent[] {
 
 	// Close content part if started
 	if (state.contentPartStarted) {
-		events.push({
-			event: "response.output_text.done",
-			data: JSON.stringify({
+		events.push(
+			emitEvent(state, "response.output_text.done", {
 				type: "response.output_text.done",
+				item_id: state.messageId,
 				output_index: state.outputItemIndex,
 				content_index: 0,
 				text: state.fullContent.join(""),
 			}),
-		});
-		events.push({
-			event: "response.content_part.done",
-			data: JSON.stringify({
+		);
+		events.push(
+			emitEvent(state, "response.content_part.done", {
 				type: "response.content_part.done",
+				item_id: state.messageId,
 				output_index: state.outputItemIndex,
 				content_index: 0,
 				part: {
 					type: "output_text",
 					text: state.fullContent.join(""),
+					annotations: [],
 				},
 			}),
-		});
+		);
 	}
 
 	// Close output item if started
 	if (state.outputItemStarted) {
-		events.push({
-			event: "response.output_item.done",
-			data: JSON.stringify({
+		events.push(
+			emitEvent(state, "response.output_item.done", {
 				type: "response.output_item.done",
 				output_index: state.outputItemIndex,
 				item: {
@@ -445,19 +454,19 @@ export function createCompletionEvents(state: StreamingState): SSEEvent[] {
 						{
 							type: "output_text",
 							text: state.fullContent.join(""),
+							annotations: [],
 						},
 					],
 					status: "completed",
 				},
 			}),
-		});
+		);
 	}
 
 	// Emit output_item.done for each function_call
 	for (const tc of state.toolCalls.values()) {
-		events.push({
-			event: "response.output_item.done",
-			data: JSON.stringify({
+		events.push(
+			emitEvent(state, "response.output_item.done", {
 				type: "response.output_item.done",
 				output_index: tc.outputIndex,
 				item: {
@@ -469,7 +478,7 @@ export function createCompletionEvents(state: StreamingState): SSEEvent[] {
 					status: "completed",
 				},
 			}),
-		});
+		);
 	}
 
 	// Map finish_reason to status
@@ -514,19 +523,19 @@ export function createCompletionEvents(state: StreamingState): SSEEvent[] {
 				{
 					type: "output_text",
 					text: state.fullContent.join(""),
+					annotations: [],
 				},
 			],
 			status: "completed",
 		});
 	}
 
-	events.push({
-		event: "response.completed",
-		data: JSON.stringify({
+	events.push(
+		emitEvent(state, "response.completed", {
 			type: "response.completed",
 			response: buildResponsePayload(state, { status, output }),
 		}),
-	});
+	);
 
 	return events;
 }
@@ -535,11 +544,8 @@ export function createCompletionEvents(state: StreamingState): SSEEvent[] {
  * Generate a response.failed event for streaming errors.
  */
 export function createFailedEvent(state: StreamingState): SSEEvent {
-	return {
-		event: "response.failed",
-		data: JSON.stringify({
-			type: "response.failed",
-			response: buildResponsePayload(state, { status: "failed" }),
-		}),
-	};
+	return emitEvent(state, "response.failed", {
+		type: "response.failed",
+		response: buildResponsePayload(state, { status: "failed" }),
+	});
 }


### PR DESCRIPTION
## Summary

Fixes two failing tests in the [Open Responses compliance suite](https://www.openresponses.org/compliance) against our `/v1/responses` endpoint.

### 1. Tool Calling — `tools.0.strict: Invalid input`

The spec's `functionToolSchema` requires `description`, `parameters`, and `strict` on every function tool as `union(T, null)` — nullable but not optional. The gateway echoed the request's `tools` array back unchanged, so when a caller omitted `strict` (as the compliance test does), the field came back `undefined` and validation failed.

**Fix:** added `normalizeEchoedTools()` that fills missing `description`/`parameters`/`strict` with `null` on function-type tools (preserving any existing value). Non-function tool types pass through unchanged. Applied on both the non-streaming response and the streaming `response.created` / `response.completed` payloads.

### 2. Streaming Response — `output.0: Invalid input`

Streaming SSE events were missing fields required by `streamingEventSchema`:
- `sequence_number` was missing from every event
- `annotations` was missing from every `output_text` content part (including the final `response.output[0]` echoed in `response.completed`, which is what the displayed error pointed at)
- `item_id` was missing from `content_part.added`/`done` and `output_text.done`

**Fix:** all SSE emission goes through a new `emitEvent` helper that auto-injects an incrementing `sequence_number`. `annotations: []` populated on every `output_text` part. Missing `item_id` fields added.

## Customer impact

Low. The changes only add fields that were previously absent — no existing field is renamed, overwritten, or removed (`??` preserves existing values). The added fields match OpenAI's actual Responses API behavior, so any spec-conforming client already handles them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tighter Open Responses validation for message parts and tools to ensure consistent response shapes.
  * Normalized echoed tool fields so function tools always include description, parameters, and strict (nullable) values.
  * Ensured every streaming event includes a unique, incrementing sequence number.
  * Output text parts now include annotations arrays.

* **Tests**
  * Added/updated tests to validate schema compliance and streaming event integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->