### PR TITLE
fix: improve organization switcher and share chat dialog responsiveness

### DIFF
--- a/apps/playground/src/components/playground/organization-switcher.tsx
+++ b/apps/playground/src/components/playground/organization-switcher.tsx
@@ -12,6 +12,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useSidebar } from "@/components/ui/sidebar";
 
 import type { Organization } from "@/lib/types";
 
@@ -27,10 +28,18 @@ export function OrganizationSwitcher({
 	onSelectOrganization,
 }: OrganizationSwitcherProps) {
 	const [mounted, setMounted] = useState(false);
+	const { isMobile, setOpenMobile } = useSidebar();
 
 	useEffect(() => {
 		setMounted(true);
 	}, []);
+
+	const handleSelectOrganization = (org: Organization | null) => {
+		if (isMobile) {
+			setOpenMobile(false);
+		}
+		onSelectOrganization(org);
+	};
 
 	const activeClass = selectedOrganization
 		? "bg-accent text-accent-foreground"
@@ -77,7 +86,7 @@ export function OrganizationSwitcher({
 				</DropdownMenuTrigger>
 				<DropdownMenuContent className="w-60 border-border bg-background text-foreground shadow-xl">
 					<DropdownMenuItem
-						onSelect={() => onSelectOrganization(null)}
+						onSelect={() => handleSelectOrganization(null)}
 						className="cursor-pointer px-2 py-1.5 text-sm hover:bg-accent focus:bg-accent data-[highlighted]:bg-accent"
 					>
 						<User className="mr-2 h-4 w-4 flex-shrink-0 text-muted-foreground" />
@@ -94,7 +103,7 @@ export function OrganizationSwitcher({
 					{organizations.map((org) => (
 						<DropdownMenuItem
 							key={org.id}
-							onSelect={() => onSelectOrganization(org)}
+							onSelect={() => handleSelectOrganization(org)}
 							className="cursor-pointer px-2 py-1.5 text-sm hover:bg-accent focus:bg-accent data-[highlighted]:bg-accent"
 						>
 							<Building2 className="mr-2 h-4 w-4 flex-shrink-0 text-muted-foreground" />

--- a/apps/playground/src/components/playground/share-chat-dialog.tsx
+++ b/apps/playground/src/components/playground/share-chat-dialog.tsx
@@ -94,12 +94,12 @@ function ShareSocialButton({ href, label, children }: ShareSocialButtonProps) {
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			className="group flex w-full flex-col items-center gap-1.5 sm:gap-2"
+			className="group flex min-w-0 w-full flex-col items-center gap-1.5 sm:gap-2"
 		>
-			<span className="bg-foreground text-background flex size-11 items-center justify-center rounded-full transition-transform group-hover:scale-105 sm:size-14">
+			<span className="bg-foreground text-background flex size-10 shrink-0 items-center justify-center rounded-full transition-transform group-hover:scale-105 sm:size-14">
 				{children}
 			</span>
-			<span className="text-foreground text-xs font-medium sm:text-sm">
+			<span className="text-foreground max-w-full truncate text-xs font-medium sm:text-sm">
 				{label}
 			</span>
 		</a>
@@ -346,18 +346,18 @@ export function ShareChatDialog({
 					<p>{tooltipText}</p>
 				</TooltipContent>
 			</Tooltip>
-			<DialogContent className="w-[calc(100vw-2rem)] max-w-[520px] min-w-0 gap-0 overflow-hidden p-0">
-				<DialogHeader className="px-5 pt-5 text-left sm:px-6 sm:pt-6">
+			<DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[520px] min-w-0 gap-0 overflow-hidden overflow-y-auto p-0 sm:w-[calc(100vw-2rem)]">
+				<DialogHeader className="min-w-0 px-4 pt-5 text-left sm:px-6 sm:pt-6">
 					<DialogTitle className="pb-2 pr-8 text-left text-lg font-semibold sm:text-xl">
 						{previewTitle}
 					</DialogTitle>
 				</DialogHeader>
-				<div className="px-5 py-4 sm:px-6">
+				<div className="min-w-0 px-4 py-4 sm:px-6">
 					<div className="border-border overflow-hidden rounded-lg border">
 						<button
 							type="button"
 							className={[
-								"flex w-full items-center gap-3 px-4 py-3 text-left transition-colors",
+								"flex w-full min-w-0 items-center gap-3 px-4 py-3 text-left transition-colors",
 								shareMode === "public" ? "bg-muted/60" : "hover:bg-muted/40",
 							].join(" ")}
 							onClick={() => setShareMode("public")}
@@ -375,7 +375,7 @@ export function ShareChatDialog({
 							type="button"
 							disabled={organizations.length === 0}
 							className={[
-								"flex w-full items-center gap-3 border-t px-4 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+								"flex w-full min-w-0 items-center gap-3 border-t px-4 py-3 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50",
 								shareMode === "organization"
 									? "bg-muted/60"
 									: "hover:bg-muted/40",
@@ -398,7 +398,7 @@ export function ShareChatDialog({
 					</div>
 				</div>
 				{shareMode === "public" && isPublicShared && activeShareUrl ? (
-					<div className="space-y-5 px-5 pb-5 sm:px-6 sm:pb-6">
+					<div className="min-w-0 space-y-5 px-4 pb-5 sm:px-6 sm:pb-6">
 						<div className="bg-muted/60 border-border/60 relative overflow-hidden rounded-2xl border p-4 sm:p-5">
 							{previewText ? (
 								<p className="text-foreground/90 line-clamp-4 text-sm leading-relaxed sm:text-[15px]">
@@ -411,12 +411,12 @@ export function ShareChatDialog({
 								</p>
 							)}
 						</div>
-						<div className="bg-muted/40 border-border/60 flex min-w-0 items-center gap-2 rounded-full border px-3 py-2">
+						<div className="bg-muted/40 border-border/60 flex min-w-0 items-center gap-2 rounded-full border py-2 pl-3 pr-2">
 							<a
 								href={activeShareUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="text-foreground min-w-0 flex-1 truncate text-sm"
+								className="text-foreground block min-w-0 flex-1 truncate text-sm"
 								title={activeShareUrl}
 							>
 								{activeShareUrl}
@@ -425,7 +425,7 @@ export function ShareChatDialog({
 								type="button"
 								size="sm"
 								variant="ghost"
-								className="h-8 shrink-0 rounded-full px-3"
+								className="h-8 min-w-8 shrink-0 rounded-full px-2"
 								onClick={() => copyLink(activeShareUrl)}
 								aria-label={copied ? "Link copied" : "Copy link"}
 							>
@@ -436,20 +436,20 @@ export function ShareChatDialog({
 								)}
 							</Button>
 						</div>
-						<div className="grid min-w-0 grid-cols-4 gap-2 sm:gap-3">
+						<div className="grid min-w-0 grid-cols-4 gap-1.5 sm:gap-3">
 							<button
 								type="button"
 								onClick={() => copyLink(activeShareUrl)}
-								className="group flex w-full flex-col items-center gap-1.5 sm:gap-2"
+								className="group flex min-w-0 w-full flex-col items-center gap-1.5 sm:gap-2"
 							>
-								<span className="bg-foreground text-background flex size-11 items-center justify-center rounded-full transition-transform group-hover:scale-105 sm:size-14">
+								<span className="bg-foreground text-background flex size-10 shrink-0 items-center justify-center rounded-full transition-transform group-hover:scale-105 sm:size-14">
 									{copied ? (
 										<Check className="size-5" />
 									) : (
 										<Copy className="size-5" />
 									)}
 								</span>
-								<span className="text-foreground text-xs font-medium sm:text-sm">
+								<span className="text-foreground max-w-full truncate text-xs font-medium sm:text-sm">
 									{copied ? "Copied" : "Copy link"}
 								</span>
 							</button>
@@ -490,8 +490,8 @@ export function ShareChatDialog({
 						</div>
 					</div>
 				) : shareMode === "organization" ? (
-					<div className="space-y-3 px-5 pb-5 sm:px-6 sm:pb-6">
-						<div className="flex gap-2">
+					<div className="min-w-0 space-y-3 px-4 pb-5 sm:px-6 sm:pb-6">
+						<div className="flex min-w-0 gap-2">
 							<Select value={selectedOrgId} onValueChange={setSelectedOrgId}>
 								<SelectTrigger className="min-w-0 flex-1">
 									<SelectValue placeholder="Select organization" />
@@ -531,11 +531,11 @@ export function ShareChatDialog({
 							</Button>
 						</div>
 						{sharedOrgEntries.length > 0 ? (
-							<div className="border-border overflow-hidden rounded-lg border">
+							<div className="border-border min-w-0 overflow-hidden rounded-lg border">
 								{sharedOrgEntries.map(({ orgId, shareId: sId, name }) => (
 									<div
 										key={orgId}
-										className="flex items-center gap-3 px-3 py-2 text-sm [&:not(:first-child)]:border-t"
+										className="flex min-w-0 items-center gap-3 px-3 py-2 text-sm [&:not(:first-child)]:border-t"
 									>
 										<span className="min-w-0 flex-1 truncate">{name}</span>
 										<Button


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style & UI Improvements**
  * Organization switcher now automatically closes the mobile sidebar when users select an organization, providing a smoother and more intuitive mobile navigation experience.
  * Share chat dialog UI has been refined with improved responsive design, better spacing and sizing adjustments for the social share section, improved icon sizing, and a more constrained layout for organization sharing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->