### PR TITLE
chore(playground): seo improvements for chat product

### DIFF
--- a/apps/playground/src/app/canvas/page.tsx
+++ b/apps/playground/src/app/canvas/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import CanvasPageClient from "@/components/playground/canvas-page-client";
+import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -10,9 +11,10 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Canvas | LLM Gateway",
+	title: "Canvas — Build UIs from JSON Specs with Live Preview",
 	description:
-		"Build UIs from JSON specs with live preview, PDF and image export.",
+		"Build UIs from JSON specs with live preview, PDF and image export. Powered by LLM Gateway Playground.",
+	alternates: { canonical: "/canvas" },
 };
 
 export default async function CanvasPage({
@@ -107,6 +109,7 @@ export default async function CanvasPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
+			<PlaygroundSeoSection variant="canvas" />
 			<CanvasPageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import GroupChatClient from "@/components/playground/group-chat-client";
+import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -136,6 +137,7 @@ export default async function GroupPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
+			<PlaygroundSeoSection variant="group" />
 			<GroupChatClient
 				models={models.filter(
 					(m) =>

--- a/apps/playground/src/app/image/page.tsx
+++ b/apps/playground/src/app/image/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import ImagePageClient from "@/components/playground/image-page-client";
+import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -10,7 +11,7 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Image Generation",
+	title: "AI Image Generator — DALL·E, Flux, Stable Diffusion Side-by-Side",
 	description:
 		"Generate images with DALL-E, Stable Diffusion, Flux, and other AI models. Compare outputs across providers in one playground.",
 	alternates: { canonical: "/image" },
@@ -123,6 +124,7 @@ export default async function ImagePage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
+			<PlaygroundSeoSection variant="image" />
 			<ImagePageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -25,8 +25,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
 	metadataBase: new URL("https://chat.llmgateway.io"),
 	title: {
-		default:
-			"LLM Gateway Playground - Chat, Image & Video Generation with 210+ AI Models",
+		default: "Free AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
 		template: "%s | LLM Gateway Playground",
 	},
 	description:
@@ -46,7 +45,7 @@ export const metadata: Metadata = {
 		},
 	},
 	openGraph: {
-		title: "LLM Gateway Playground - Chat, Image & Video Generation",
+		title: "Free AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
 		description:
 			"Test and compare 210+ AI models in one playground. Chat, generate images and videos, and run multi-model group chats.",
 		images: ["/opengraph.png?v=1"],
@@ -57,7 +56,7 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "LLM Gateway Playground - Chat, Image & Video Generation",
+		title: "Free AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
 		description:
 			"Test and compare 210+ AI models in one playground. Chat, generate images and videos, and run multi-model group chats.",
 		images: ["/opengraph.png?v=1"],
@@ -79,6 +78,27 @@ const webSiteSchema = {
 	},
 };
 
+const softwareApplicationSchema = {
+	"@context": "https://schema.org",
+	"@type": "SoftwareApplication",
+	name: "LLM Gateway Playground",
+	url: "https://chat.llmgateway.io",
+	applicationCategory: "DeveloperApplication",
+	operatingSystem: "Web",
+	description:
+		"Free web playground to chat with 210+ AI models including GPT, Claude, Gemini, plus image and video generation.",
+	offers: {
+		"@type": "Offer",
+		price: "0",
+		priceCurrency: "USD",
+	},
+	publisher: {
+		"@type": "Organization",
+		name: "LLM Gateway",
+		url: "https://llmgateway.io",
+	},
+};
+
 export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
@@ -90,6 +110,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 					// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
 					dangerouslySetInnerHTML={{
 						__html: JSON.stringify(webSiteSchema),
+					}}
+				/>
+				<script
+					type="application/ld+json"
+					// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+					dangerouslySetInnerHTML={{
+						__html: JSON.stringify(softwareApplicationSchema),
 					}}
 				/>
 			</head>

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -25,11 +25,11 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
 	metadataBase: new URL("https://chat.llmgateway.io"),
 	title: {
-		default: "Free AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
+		default: "AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
 		template: "%s | LLM Gateway Playground",
 	},
 	description:
-		"Test and compare 210+ AI models in one playground. Chat with GPT-4, Claude, Gemini, generate images and videos, and run multi-model group chats.",
+		"Test and compare 210+ AI models from one account. Chat with GPT, Claude, Gemini, generate images and videos, and run multi-model group chats — pay-as-you-go with a single balance.",
 	icons: {
 		icon: "/favicon/favicon.ico?v=2",
 	},
@@ -45,9 +45,9 @@ export const metadata: Metadata = {
 		},
 	},
 	openGraph: {
-		title: "Free AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
+		title: "AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
 		description:
-			"Test and compare 210+ AI models in one playground. Chat, generate images and videos, and run multi-model group chats.",
+			"Test and compare 210+ AI models from one account. Chat, generate images and videos, and run multi-model group chats — pay-as-you-go.",
 		images: ["/opengraph.png?v=1"],
 		type: "website",
 		url: "https://chat.llmgateway.io",
@@ -56,9 +56,9 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "Free AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
+		title: "AI Playground — Chat with 210+ Models (GPT, Claude, Gemini)",
 		description:
-			"Test and compare 210+ AI models in one playground. Chat, generate images and videos, and run multi-model group chats.",
+			"Test and compare 210+ AI models from one account. Chat, generate images and videos, and run multi-model group chats — pay-as-you-go.",
 		images: ["/opengraph.png?v=1"],
 		creator: "@llmgateway",
 	},
@@ -86,12 +86,7 @@ const softwareApplicationSchema = {
 	applicationCategory: "DeveloperApplication",
 	operatingSystem: "Web",
 	description:
-		"Free web playground to chat with 210+ AI models including GPT, Claude, Gemini, plus image and video generation.",
-	offers: {
-		"@type": "Offer",
-		price: "0",
-		priceCurrency: "USD",
-	},
+		"Web playground to chat with 210+ AI models including GPT, Claude, Gemini, plus image and video generation. Pay-as-you-go from a single credit balance.",
 	publisher: {
 		"@type": "Organization",
 		name: "LLM Gateway",

--- a/apps/playground/src/app/login/layout.tsx
+++ b/apps/playground/src/app/login/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Sign In",
+	robots: {
+		index: false,
+		follow: false,
+	},
+};
+
+export default function LoginLayout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/playground/src/app/manifest.ts
+++ b/apps/playground/src/app/manifest.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+	return {
+		name: "LLM Gateway Playground",
+		short_name: "LLM Gateway",
+		description:
+			"Test and compare 210+ AI models in one playground. Chat, image, video, and group-chat across providers.",
+		start_url: "/",
+		display: "standalone",
+		background_color: "#ffffff",
+		theme_color: "#ffffff",
+		icons: [
+			{
+				src: "/favicon/android-chrome-192x192.png",
+				sizes: "192x192",
+				type: "image/png",
+			},
+			{
+				src: "/favicon/android-chrome-512x512.png",
+				sizes: "512x512",
+				type: "image/png",
+			},
+		],
+	};
+}

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from "next/navigation";
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import ChatPageClient from "@/components/playground/chat-page-client";
 import OrgPageClient from "@/components/playground/org-page-client";
+import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -177,6 +178,7 @@ export async function renderPlaygroundShell({
 					projectId={selectedProject.id}
 				/>
 			) : null}
+			<PlaygroundSeoSection variant="chat" />
 			<ChatPageClient
 				models={models.filter(
 					(m) =>

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -231,12 +231,12 @@ export default async function SharedChatPage({
 			<script
 				type="application/ld+json"
 				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+				dangerouslySetInnerHTML={{ __html: serializeJsonLd(articleSchema) }}
 			/>
 			<script
 				type="application/ld+json"
 				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+				dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbSchema) }}
 			/>
 			<div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 py-8">
 				<header className="mx-auto w-full max-w-4xl pb-4">
@@ -343,6 +343,13 @@ function toUiMessage(message: SharedMessage): UIMessage {
 		metadata: parsePlaygroundMessageMetadata(message.metadata),
 		parts,
 	} satisfies UIMessage;
+}
+
+function serializeJsonLd(value: unknown): string {
+	return JSON.stringify(value)
+		.replace(/</g, "\\u003c")
+		.replace(/>/g, "\\u003e")
+		.replace(/&/g, "\\u0026");
 }
 
 function isStoredImagePart(value: unknown): value is StoredImagePart {

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -46,6 +46,63 @@ interface StoredImagePart {
 	};
 }
 
+const MIN_USER_PROMPT_CHARS = 30;
+const MIN_ASSISTANT_RESPONSE_CHARS = 80;
+
+function deriveShareDescription(messages: SharedMessage[]): {
+	description: string;
+	source: "user" | "assistant" | "fallback";
+} {
+	const userMessage = messages.find((m) => m.role === "user");
+	const assistantMessage = messages.find((m) => m.role === "assistant");
+	const userText = userMessage?.content?.replace(/\s+/g, " ").trim() ?? "";
+	const assistantText =
+		assistantMessage?.content?.replace(/\s+/g, " ").trim() ?? "";
+
+	if (userText.length >= MIN_USER_PROMPT_CHARS) {
+		return {
+			description:
+				userText.length > 160 ? `${userText.slice(0, 160)}…` : userText,
+			source: "user",
+		};
+	}
+	if (assistantText.length >= MIN_ASSISTANT_RESPONSE_CHARS) {
+		const prefix = userText ? `“${userText}” — ` : "";
+		const remaining = Math.max(40, 160 - prefix.length - 1);
+		const trimmedAssistant =
+			assistantText.length > remaining
+				? `${assistantText.slice(0, remaining)}…`
+				: assistantText;
+		return {
+			description: `${prefix}${trimmedAssistant}`,
+			source: "assistant",
+		};
+	}
+	return {
+		description:
+			"A shared snapshot of an LLM Gateway chat — open it to see the full conversation.",
+		source: "fallback",
+	};
+}
+
+function meetsIndexThreshold(messages: SharedMessage[]): boolean {
+	const userMessage = messages.find((m) => m.role === "user");
+	const assistantMessage = messages.find((m) => m.role === "assistant");
+	if (!userMessage || !assistantMessage) {
+		return false;
+	}
+	const userText = userMessage.content?.replace(/\s+/g, " ").trim() ?? "";
+	const assistantText =
+		assistantMessage.content?.replace(/\s+/g, " ").trim() ?? "";
+	if (userText.length < MIN_USER_PROMPT_CHARS) {
+		return false;
+	}
+	if (assistantText.length < MIN_ASSISTANT_RESPONSE_CHARS) {
+		return false;
+	}
+	return true;
+}
+
 export async function generateMetadata({
 	params,
 }: {
@@ -57,6 +114,7 @@ export async function generateMetadata({
 	let title = "Shared Chat";
 	let description =
 		"A shared snapshot of an LLM Gateway chat — open it to see the full conversation.";
+	let indexable = true;
 
 	try {
 		const response = await fetch(
@@ -70,12 +128,9 @@ export async function generateMetadata({
 				title =
 					flatTitle.length > 80 ? `${flatTitle.slice(0, 80)}…` : flatTitle;
 			}
-			const userMessage = data.share.messages.find((m) => m.role === "user");
-			const userText = userMessage?.content?.replace(/\s+/g, " ").trim();
-			if (userText) {
-				description =
-					userText.length > 160 ? `${userText.slice(0, 160)}…` : userText;
-			}
+			const derived = deriveShareDescription(data.share.messages);
+			description = derived.description;
+			indexable = meetsIndexThreshold(data.share.messages);
 		}
 	} catch {
 		// Fall back to defaults if the API call fails.
@@ -84,17 +139,23 @@ export async function generateMetadata({
 	const url = `/share/${shareId}`;
 
 	return {
-		title: `${title} · LLM Gateway`,
+		title: `${title} | LLM Gateway Playground`,
 		description,
 		alternates: {
 			canonical: url,
 		},
+		robots: indexable
+			? undefined
+			: {
+					index: false,
+					follow: true,
+				},
 		openGraph: {
 			title,
 			description,
 			url,
 			type: "article",
-			siteName: "LLM Gateway",
+			siteName: "LLM Gateway Playground",
 		},
 		twitter: {
 			card: "summary_large_image",
@@ -125,8 +186,58 @@ export default async function SharedChatPage({
 	const data = (await response.json()) as SharedChatResponse;
 	const messages = data.share.messages.map(toUiMessage);
 
+	const shareUrl = `https://chat.llmgateway.io/share/${data.share.id}`;
+	const { description: articleDescription } = deriveShareDescription(
+		data.share.messages,
+	);
+
+	const articleSchema = {
+		"@context": "https://schema.org",
+		"@type": "Article",
+		headline: data.share.title,
+		description: articleDescription,
+		datePublished: data.share.createdAt,
+		dateModified: data.share.createdAt,
+		mainEntityOfPage: shareUrl,
+		url: shareUrl,
+		publisher: {
+			"@type": "Organization",
+			name: "LLM Gateway",
+			url: "https://llmgateway.io",
+		},
+	};
+
+	const breadcrumbSchema = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: "https://chat.llmgateway.io",
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: data.share.title,
+				item: shareUrl,
+			},
+		],
+	};
+
 	return (
 		<main className="bg-background min-h-screen">
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+			/>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+			/>
 			<div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-4 py-8">
 				<header className="mx-auto w-full max-w-4xl pb-4">
 					<Link href="/" className="flex w-fit items-center gap-2">

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -86,21 +86,28 @@ function deriveShareDescription(messages: SharedMessage[]): {
 }
 
 function meetsIndexThreshold(messages: SharedMessage[]): boolean {
-	const userMessage = messages.find((m) => m.role === "user");
-	const assistantMessage = messages.find((m) => m.role === "assistant");
-	if (!userMessage || !assistantMessage) {
-		return false;
+	let hasValidUserTurn = false;
+	let hasValidAssistantTurn = false;
+	for (const message of messages) {
+		const text = message.content?.replace(/\s+/g, " ").trim() ?? "";
+		if (
+			!hasValidUserTurn &&
+			message.role === "user" &&
+			text.length >= MIN_USER_PROMPT_CHARS
+		) {
+			hasValidUserTurn = true;
+		} else if (
+			!hasValidAssistantTurn &&
+			message.role === "assistant" &&
+			text.length >= MIN_ASSISTANT_RESPONSE_CHARS
+		) {
+			hasValidAssistantTurn = true;
+		}
+		if (hasValidUserTurn && hasValidAssistantTurn) {
+			return true;
+		}
 	}
-	const userText = userMessage.content?.replace(/\s+/g, " ").trim() ?? "";
-	const assistantText =
-		assistantMessage.content?.replace(/\s+/g, " ").trim() ?? "";
-	if (userText.length < MIN_USER_PROMPT_CHARS) {
-		return false;
-	}
-	if (assistantText.length < MIN_ASSISTANT_RESPONSE_CHARS) {
-		return false;
-	}
-	return true;
+	return hasValidUserTurn && hasValidAssistantTurn;
 }
 
 export async function generateMetadata({

--- a/apps/playground/src/app/signup/layout.tsx
+++ b/apps/playground/src/app/signup/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Sign Up",
+	robots: {
+		index: false,
+		follow: false,
+	},
+};
+
+export default function SignupLayout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -6,12 +6,14 @@ interface ShareListResponse {
 	shares: Array<{ id: string; updatedAt: string }>;
 }
 
+export const revalidate = 3600;
+
 async function fetchPublicShares(): Promise<ShareListResponse["shares"]> {
 	const config = getConfig();
 	try {
 		const response = await fetch(
 			`${config.apiBackendUrl}/public/chats/share?limit=5000`,
-			{ cache: "no-store" },
+			{ next: { revalidate: 3600 } },
 		);
 		if (!response.ok) {
 			return [];
@@ -48,6 +50,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		},
 		{
 			url: `${baseUrl}/group`,
+			lastModified: now,
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
+		{
+			url: `${baseUrl}/canvas`,
 			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -1,25 +1,28 @@
+import createFetchClient from "openapi-fetch";
+
 import { getConfig } from "@/lib/config-server";
 
+import type { paths } from "@/lib/api/v1";
 import type { MetadataRoute } from "next";
 
-interface ShareListResponse {
-	shares: Array<{ id: string; updatedAt: string }>;
+interface ShareListItem {
+	id: string;
+	updatedAt: string;
 }
 
 export const revalidate = 3600;
 
-async function fetchPublicShares(): Promise<ShareListResponse["shares"]> {
+async function fetchPublicShares(): Promise<ShareListItem[]> {
 	const config = getConfig();
+	const client = createFetchClient<paths>({
+		baseUrl: config.apiBackendUrl,
+	});
 	try {
-		const response = await fetch(
-			`${config.apiBackendUrl}/public/chats/share?limit=5000`,
-			{ next: { revalidate: 3600 } },
-		);
-		if (!response.ok) {
-			return [];
-		}
-		const data = (await response.json()) as ShareListResponse;
-		return Array.isArray(data.shares) ? data.shares : [];
+		const { data } = await client.GET("/public/chats/share", {
+			params: { query: { limit: 5000 } },
+			next: { revalidate: 3600 },
+		});
+		return data?.shares ?? [];
 	} catch {
 		return [];
 	}

--- a/apps/playground/src/app/video/page.tsx
+++ b/apps/playground/src/app/video/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import VideoPageClient from "@/components/playground/video-page-client";
+import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -10,7 +11,7 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Video Generation",
+	title: "AI Video Generator — Compare Veo, Wan & More in One Playground",
 	description:
 		"Generate videos with Veo, Wan, and other AI video models. Preview results and compare providers in one playground.",
 	alternates: { canonical: "/video" },
@@ -123,6 +124,7 @@ export default async function VideoPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
+			<PlaygroundSeoSection variant="video" />
 			<VideoPageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/components/seo/playground-seo-section.tsx
+++ b/apps/playground/src/components/seo/playground-seo-section.tsx
@@ -11,13 +11,13 @@ interface VariantContent {
 
 const variants: Record<SeoVariant, VariantContent> = {
 	chat: {
-		h1: "Free AI chat playground — talk to 210+ models in one place",
+		h1: "AI chat playground — talk to 210+ models in one place",
 		intro:
-			"Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time. No API key required for the free tier.",
+			"Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time. Pay-as-you-go from a single credit balance — no per-provider billing setup.",
 		bullets: [
 			"Supports 210+ models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers.",
 			"Stream responses, fork past conversations, and share read-only chat snapshots via public links.",
-			"Bring your own API key or use included credits — the playground routes through LLM Gateway for usage tracking and cost analytics.",
+			"One credit balance covers every provider — top up once, route requests anywhere, get unified usage and cost analytics through LLM Gateway.",
 		],
 		related: [
 			{ href: "/image", label: "AI image generation" },

--- a/apps/playground/src/components/seo/playground-seo-section.tsx
+++ b/apps/playground/src/components/seo/playground-seo-section.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+
+export type SeoVariant = "chat" | "image" | "video" | "group" | "canvas";
+
+interface VariantContent {
+	h1: string;
+	intro: string;
+	bullets: string[];
+	related: Array<{ href: string; label: string }>;
+}
+
+const variants: Record<SeoVariant, VariantContent> = {
+	chat: {
+		h1: "Free AI chat playground — talk to 210+ models in one place",
+		intro:
+			"Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time. No API key required for the free tier.",
+		bullets: [
+			"Supports 210+ models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers.",
+			"Stream responses, fork past conversations, and share read-only chat snapshots via public links.",
+			"Bring your own API key or use included credits — the playground routes through LLM Gateway for usage tracking and cost analytics.",
+		],
+		related: [
+			{ href: "/image", label: "AI image generation" },
+			{ href: "/video", label: "AI video generation" },
+			{ href: "/group", label: "Compare models side by side" },
+			{ href: "/canvas", label: "Canvas — UI from JSON" },
+		],
+	},
+	image: {
+		h1: "AI image generation — DALL·E, Flux, Stable Diffusion side by side",
+		intro:
+			"Generate images from text prompts using the latest AI image models. Compare outputs across providers, request multiple variants per prompt, and save or share the results.",
+		bullets: [
+			"Models include DALL·E 3, Flux Pro, Flux Schnell, Stable Diffusion 3, Seedream, and more.",
+			"Request 1, 2, or 4 images per prompt and compare them in a grid.",
+			"All requests route through LLM Gateway for unified billing and usage tracking.",
+		],
+		related: [
+			{ href: "/", label: "AI chat playground" },
+			{ href: "/video", label: "AI video generation" },
+			{ href: "/group", label: "Compare models side by side" },
+			{ href: "/canvas", label: "Canvas — UI from JSON" },
+		],
+	},
+	video: {
+		h1: "AI video generation — compare Veo, Wan, and more in one playground",
+		intro:
+			"Generate short videos from text prompts using the newest AI video models. Preview results inline, compare providers, and download the output.",
+		bullets: [
+			"Models include Google Veo, Alibaba Wan, and other text-to-video providers.",
+			"Preview generated videos in the browser without leaving the playground.",
+			"Routes through LLM Gateway for cost tracking across providers.",
+		],
+		related: [
+			{ href: "/", label: "AI chat playground" },
+			{ href: "/image", label: "AI image generation" },
+			{ href: "/group", label: "Compare models side by side" },
+			{ href: "/canvas", label: "Canvas — UI from JSON" },
+		],
+	},
+	group: {
+		h1: "Group chat — compare AI models side by side on the same prompt",
+		intro:
+			"Send one prompt to multiple AI models simultaneously and compare their responses. Useful for evaluating quality, speed, and cost across GPT, Claude, Gemini, Grok, and other models.",
+		bullets: [
+			"Run the same prompt against any combination of 210+ supported models.",
+			"See streamed responses side by side in real time.",
+			"Compare latency, token counts, and cost per response in a single view.",
+		],
+		related: [
+			{ href: "/", label: "AI chat playground" },
+			{ href: "/image", label: "AI image generation" },
+			{ href: "/video", label: "AI video generation" },
+			{ href: "/canvas", label: "Canvas — UI from JSON" },
+		],
+	},
+	canvas: {
+		h1: "Canvas — build UIs from JSON specs with live preview",
+		intro:
+			"Generate, edit, and export interactive UI specs as JSON with live preview. Export the result as a PDF or image. Powered by LLM Gateway.",
+		bullets: [
+			"Iterate on UI layouts by editing a JSON spec with live preview.",
+			"Use any of 210+ supported models to generate or modify canvas specs.",
+			"Export the canvas to PDF or PNG for sharing.",
+		],
+		related: [
+			{ href: "/", label: "AI chat playground" },
+			{ href: "/image", label: "AI image generation" },
+			{ href: "/video", label: "AI video generation" },
+			{ href: "/group", label: "Compare models side by side" },
+		],
+	},
+};
+
+export function PlaygroundSeoSection({ variant }: { variant: SeoVariant }) {
+	const content = variants[variant];
+	return (
+		<section className="sr-only">
+			<h1>{content.h1}</h1>
+			<p>{content.intro}</p>
+			<ul>
+				{content.bullets.map((bullet) => (
+					<li key={bullet}>{bullet}</li>
+				))}
+			</ul>
+			<nav aria-label="Related tools">
+				<ul>
+					{content.related.map((link) => (
+						<li key={link.href}>
+							<Link href={link.href}>{link.label}</Link>
+						</li>
+					))}
+				</ul>
+			</nav>
+		</section>
+	);
+}


### PR DESCRIPTION
## Summary

Implements SEO recommendations from a `/seo-audit` of `apps/playground` (chat.llmgateway.io). Skips the recommendation to remove `force-dynamic` from the root layout since that's needed.

### Metadata & titles
- Shortened root title to fit SERP (was 84 chars, now ~62) and rewrote `/image`, `/video`, `/canvas` titles to be keyword-led
- Standardized `siteName` to `"LLM Gateway Playground"` everywhere (was inconsistent across layout and share pages)
- Added missing `alternates.canonical: "/canvas"`

### Sitemap & robots
- Added `/canvas` to the sitemap
- Replaced `cache: "no-store"` with `revalidate: 3600` so we don't refetch 5,000 shares on every Googlebot hit
- Added explicit `robots: { index: false, follow: false }` to `/login` and `/signup` via layout.tsx files (defense in depth beyond robots.txt)

### Share pages (`/share/[shareId]`)
- Added `Article` + `BreadcrumbList` JSON-LD
- Description fallback: when the user prompt is too short to be a useful meta description, fall back to a quoted-prompt + assistant-response excerpt
- Quality gate: shares without both a meaningful user prompt (≥30 chars) and assistant response (≥80 chars) get `noindex` so low-quality user content doesn't pollute the index

### Structured data
- Added `SoftwareApplication` JSON-LD to the homepage (free DeveloperApplication offer)

### Server-rendered content for crawlers
- Added `PlaygroundSeoSection` component rendered on each public page (`/`, `/image`, `/video`, `/group`, `/canvas`)
- Each variant has an `<h1>`, value-prop paragraph, feature bullets, and a related-tools nav linking between the public pages — addresses the audit finding that the homepage was a JS chat shell with no crawlable content and no `<h1>`
- Uses `sr-only` because the chat clients lock the viewport with `h-svh` + `overflow-hidden` (visible footer wouldn't be reachable). Content is honest, real, and helpful to both bots and screen-reader users — not keyword stuffing.

### Other
- Added `manifest.ts` (PWA manifest at `/manifest.webmanifest`)

## Notes

- Did NOT remove `export const dynamic = "force-dynamic"` from the root layout (per request).
- The local `pnpm build` failure is pre-existing on `main` (missing `html-to-image`, `jspdf`, `@json-render/*` packages and unrelated type drift in chat/org share files). None of the files I touched introduce TypeScript errors.

## Test plan

- [ ] Verify `/robots.txt` still serves correctly
- [ ] Verify `/sitemap.xml` includes `/canvas` and is cached
- [ ] Verify `/manifest.webmanifest` resolves
- [ ] View-source on `/`, `/image`, `/video`, `/group`, `/canvas` and confirm the `sr-only` `<h1>` + value-prop + related-links are present in the server HTML
- [ ] View-source on a `/share/[id]` page with a short prompt → confirm description falls back to assistant excerpt
- [ ] View-source on a low-quality share (short prompt + short response) → confirm `<meta name="robots" content="noindex,follow">`
- [ ] Visit `/login` and `/signup` → confirm `<meta name="robots" content="noindex,nofollow">`
- [ ] Validate share JSON-LD via [Google Rich Results Test](https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web app manifest for installability and branding.
  * Introduced a reusable SEO section used across playground tools (chat, image, video, group, canvas).
  * Added Sign In and Sign Up page layouts with page-level metadata and robots directives.

* **Chores**
  * Updated site titles, descriptions, canonical URLs, and switched structured-data to reflect new branding.
  * Improved sitemap revalidation and entries; refined shared-chat metadata, indexing rules, and JSON‑LD output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->