### PR TITLE
chore: increase price weight in routing score

### DIFF
--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -22,8 +22,8 @@ interface ProviderScore<T extends AvailableModelProvider> {
 // With ratio-based scoring, throughput/latency differences are naturally amplified
 // (e.g., 6x faster = score of 5.0), so these weights are kept low to avoid
 // dominating price and uptime. Price/uptime differences are typically smaller ratios.
-const PRICE_WEIGHT = 0.3;
-const IMAGE_PRICE_WEIGHT = 0.5; // Higher weight for image generation models
+const PRICE_WEIGHT = 0.6;
+const IMAGE_PRICE_WEIGHT = 1.0; // Higher weight for image generation models
 const UPTIME_WEIGHT = 0.5;
 const THROUGHPUT_WEIGHT = 0.05;
 const LATENCY_WEIGHT = 0.025;


### PR DESCRIPTION
## Summary
- Bumps `PRICE_WEIGHT` from 0.3 → 0.6 and `IMAGE_PRICE_WEIGHT` from 0.5 → 1.0 in `packages/actions/src/get-cheapest-from-available-providers.ts`.
- Makes price the single largest weighted-score factor (0.6 vs uptime 0.5, cache 0.2, throughput 0.05, latency 0.025).
- Note: total non-price weights still sum to 0.775, so other signals retain meaningful influence — this is an intentional, conservative bump rather than fully price-dominant routing.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`
- [ ] Spot-check provider selection in staging for representative models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized provider selection algorithm to prioritize pricing more heavily when routing image generation requests, resulting in more cost-efficient provider selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->