### PR TITLE
fix(gateway): map vertex-anthropic finish reasons

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -37,6 +37,24 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps Vertex Anthropic finish reasons correctly", () => {
+		expect(getUnifiedFinishReason("end_turn", "vertex-anthropic")).toBe(
+			UnifiedFinishReason.COMPLETED,
+		);
+		expect(getUnifiedFinishReason("stop_sequence", "vertex-anthropic")).toBe(
+			UnifiedFinishReason.COMPLETED,
+		);
+		expect(getUnifiedFinishReason("max_tokens", "vertex-anthropic")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(getUnifiedFinishReason("tool_use", "vertex-anthropic")).toBe(
+			UnifiedFinishReason.TOOL_CALLS,
+		);
+		expect(getUnifiedFinishReason("refusal", "vertex-anthropic")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+	});
+
 	it("maps Google AI Studio finish reasons correctly (original Google format)", () => {
 		expect(getUnifiedFinishReason("STOP", "google-ai-studio")).toBe(
 			UnifiedFinishReason.COMPLETED,

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -66,6 +66,7 @@ export function getUnifiedFinishReason(
 
 	switch (provider) {
 		case "anthropic":
+		case "vertex-anthropic":
 			if (finishReason === "stop_sequence") {
 				return UnifiedFinishReason.COMPLETED;
 			}


### PR DESCRIPTION
## Summary
- `getUnifiedFinishReason` had no case for `vertex-anthropic`, so finish reasons like `end_turn`/`max_tokens`/`tool_use` fell through to `UNKNOWN`, triggering noisy `Unknown finish reason encountered` error logs in prod.
- Reuse the existing `anthropic` mapping for `vertex-anthropic` (same wire format).
- Added unit tests covering the vertex-anthropic mappings.

## Test plan
- [x] `npx vitest run apps/gateway/src/lib/logs.spec.ts`
- [x] `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Vertex Anthropic provider in finish reason mapping, enabling the system to properly handle and convert all Vertex Anthropic finish reasons (stop_sequence, end_turn, max_tokens, tool_use, refusal) to a unified format for consistent processing.

* **Tests**
  * Extended test coverage to validate finish reason mapping for Vertex Anthropic provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->