### PR TITLE
fix(ui): only show top-up prompt for free model usage

### DIFF
--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -343,10 +343,13 @@ export function RecentLogs({
 		data?.pages.flatMap((page) => page?.logs ?? []) ?? []
 	).filter((log) => !log.retriedByLogId);
 
+	const successfulLogs = allLogs.filter(
+		(log) => !log.hasError && !log.canceled,
+	);
 	const showTopUpPrompt =
-		allLogs.length > 0 &&
 		allLogs.length <= 5 &&
-		allLogs.every((log) => !log.cost || log.cost === 0);
+		successfulLogs.length > 0 &&
+		successfulLogs.every((log) => log.cost === 0);
 
 	const selectedModelOption = useMemo(
 		() => modelOptions.find((option) => option.id === model),

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -343,6 +343,11 @@ export function RecentLogs({
 		data?.pages.flatMap((page) => page?.logs ?? []) ?? []
 	).filter((log) => !log.retriedByLogId);
 
+	const showTopUpPrompt =
+		allLogs.length > 0 &&
+		allLogs.length <= 5 &&
+		allLogs.every((log) => !log.cost || log.cost === 0);
+
 	const selectedModelOption = useMemo(
 		() => modelOptions.find((option) => option.id === model),
 		[model, modelOptions],
@@ -589,7 +594,7 @@ export function RecentLogs({
 								orgId={orgId ?? undefined}
 								projectId={projectId || undefined}
 							/>
-							{index === 0 && allLogs.length <= 5 && <FirstLogTopUpPrompt />}
+							{index === 0 && showTopUpPrompt && <FirstLogTopUpPrompt />}
 						</div>
 					))}
 


### PR DESCRIPTION
## Summary
- Limit the "Your first API call worked!" top-up prompt to users whose recent logs are all free / \$0 cost
- Previously it appeared after any first call (even paid usage with non-zero cost), which made the "unlock paid models" pitch incoherent

## Test plan
- [ ] Make a request with a free model — prompt appears
- [ ] Make a request with a paid model — prompt does not appear
- [ ] After making 6+ requests, prompt no longer appears (existing behavior preserved)
- [ ] Dismissing the prompt continues to persist via cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined activity log top-up prompt visibility: the prompt now appears only when there are five or fewer logs, at least one successful run exists, and every successful run reports zero cost. The prompt is also restricted to the first log entry when those conditions are met, preventing inappropriate or misleading prompts that previously appeared based solely on position and log count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->