### PR TITLE
fix(gateway): treat 'Unknown model' as gateway error

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -168,4 +168,16 @@ describe("getFinishReasonFromError", () => {
 		expect(getFinishReasonFromError(400)).toBe("client_error");
 		expect(getFinishReasonFromError(422)).toBe("client_error");
 	});
+
+	it("returns gateway_error for upstream 'Unknown model' messages", () => {
+		expect(
+			getFinishReasonFromError(
+				400,
+				'{"object":"error","message":"Unknown model: foo","type":"invalid_model"}',
+			),
+		).toBe("gateway_error");
+		expect(getFinishReasonFromError(400, "unknown model: bar")).toBe(
+			"gateway_error",
+		);
+	});
 });

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -77,6 +77,14 @@ export function getFinishReasonFromError(
 		return "gateway_error";
 	}
 
+	// Upstream reports the model id as unknown (e.g. Mistral / Together / Fireworks
+	// returning `Unknown model: <name>` on a 400). This is a gateway-side mapping
+	// gap rather than a client problem, so classify as gateway_error so the
+	// request can be retried with another provider.
+	if (errorText && /unknown model/i.test(errorText)) {
+		return "gateway_error";
+	}
+
 	// zai content filter
 	if (
 		errorText?.includes(


### PR DESCRIPTION
## Summary
- Detect upstream "Unknown model" error payloads (e.g. Mistral / Together / Fireworks 400 responses like `Unknown model: <name>`) in `getFinishReasonFromError` and classify them as `gateway_error` so the request becomes retryable against another provider through the existing fallback flow.
- Add unit coverage for both the JSON payload form and a plain-text variant.

The match is intentionally narrow to the literal phrase "unknown model" (case-insensitive), and only impacts the finish-reason classification — it doesn't add the message to the invalid-credential patterns, so it won't permanently blacklist the API key or affect uptime-tracking (400 errors are already excluded from key-health accounting unless they look like auth failures).

## Test plan
- [x] `pnpm vitest run apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts`
- [x] `pnpm format`
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced gateway error detection for unknown model scenarios. Unknown model errors are now properly identified and classified, preventing incorrect categorization as client errors or content filter violations.

* **Tests**
  * Expanded test coverage for unknown model error handling, including both JSON-formatted and plain-text error message variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->