### PR TITLE
feat(admin): add cost column + sortable provider models

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -5497,6 +5497,7 @@ const providerModelStatsSchema = z.object({
 	upstreamErrorsCount: z.number(),
 	cachedCount: z.number(),
 	avgTimeToFirstToken: z.number().nullable(),
+	totalCost: z.number(),
 	updatedAt: z.string(),
 });
 
@@ -5598,6 +5599,10 @@ admin.openapi(getProviderDetail, async (c) => {
 					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`.as(
 						"total_ttft",
 					),
+				totalCost:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalCost}), 0)`.as(
+						"total_cost",
+					),
 			})
 			.from(modelProviderMappingHistory)
 			.where(
@@ -5631,6 +5636,7 @@ admin.openapi(getProviderDetail, async (c) => {
 			upstreamErrorsCount: Number(s?.upstreamErrorsCount ?? 0),
 			cachedCount,
 			avgTimeToFirstToken: avgTtft ?? m.avgTimeToFirstToken,
+			totalCost: Number(s?.totalCost ?? 0),
 			updatedAt: m.updatedAt.toISOString(),
 		};
 	});

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4080,6 +4080,7 @@ export interface paths {
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                         };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4080,6 +4080,7 @@ export interface paths {
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                         };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4080,6 +4080,7 @@ export interface paths {
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                         };

--- a/ee/admin/src/components/provider-models-table.tsx
+++ b/ee/admin/src/components/provider-models-table.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import Link from "next/link";
+import { useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -11,11 +13,81 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
 import type { ProviderModelStats } from "@/lib/types";
 
+type SortKey =
+	| "logsCount"
+	| "errorsCount"
+	| "clientErrorsCount"
+	| "gatewayErrorsCount"
+	| "upstreamErrorsCount"
+	| "errorRate"
+	| "cachedCount"
+	| "avgTimeToFirstToken"
+	| "totalCost";
+
+type SortOrder = "asc" | "desc";
+
 function formatNumber(n: number) {
 	return new Intl.NumberFormat("en-US").format(n);
+}
+
+function formatCost(n: number) {
+	return `$${n.toFixed(4)}`;
+}
+
+function errorRateOf(m: ProviderModelStats) {
+	return m.logsCount > 0 ? (m.errorsCount / m.logsCount) * 100 : 0;
+}
+
+function getValue(m: ProviderModelStats, key: SortKey): number {
+	switch (key) {
+		case "errorRate":
+			return errorRateOf(m);
+		case "avgTimeToFirstToken":
+			return m.avgTimeToFirstToken ?? -1;
+		default:
+			return m[key] ?? 0;
+	}
+}
+
+function SortableHeader({
+	label,
+	sortKey,
+	currentSortBy,
+	currentSortOrder,
+	onSort,
+}: {
+	label: string;
+	sortKey: SortKey;
+	currentSortBy: SortKey | null;
+	currentSortOrder: SortOrder;
+	onSort: (key: SortKey) => void;
+}) {
+	const isActive = currentSortBy === sortKey;
+	return (
+		<button
+			type="button"
+			onClick={() => onSort(sortKey)}
+			className={cn(
+				"flex items-center gap-1 hover:text-foreground transition-colors",
+				isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+		>
+			{label}
+			{isActive ? (
+				currentSortOrder === "asc" ? (
+					<ArrowUp className="h-3.5 w-3.5" />
+				) : (
+					<ArrowDown className="h-3.5 w-3.5" />
+				)
+			) : (
+				<ArrowUpDown className="h-3.5 w-3.5 opacity-50" />
+			)}
+		</button>
+	);
 }
 
 export function ProviderModelsTable({
@@ -25,6 +97,33 @@ export function ProviderModelsTable({
 	providerId: string;
 	models: ProviderModelStats[];
 }) {
+	const [sortBy, setSortBy] = useState<SortKey | null>("logsCount");
+	const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+
+	const handleSort = (key: SortKey) => {
+		if (sortBy === key) {
+			setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
+		} else {
+			setSortBy(key);
+			setSortOrder("desc");
+		}
+	};
+
+	const sortedModels = useMemo(() => {
+		if (!sortBy) {
+			return models;
+		}
+		const dir = sortOrder === "asc" ? 1 : -1;
+		return [...models].sort((a, b) => {
+			const av = getValue(a, sortBy);
+			const bv = getValue(b, sortBy);
+			if (av === bv) {
+				return 0;
+			}
+			return av < bv ? -1 * dir : 1 * dir;
+		});
+	}, [models, sortBy, sortOrder]);
+
 	if (models.length === 0) {
 		return (
 			<div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
@@ -33,6 +132,18 @@ export function ProviderModelsTable({
 		);
 	}
 
+	const sh = (label: string, key: SortKey) => (
+		<TableHead>
+			<SortableHeader
+				label={label}
+				sortKey={key}
+				currentSortBy={sortBy}
+				currentSortOrder={sortOrder}
+				onSort={handleSort}
+			/>
+		</TableHead>
+	);
+
 	return (
 		<Table>
 			<TableHeader>
@@ -40,18 +151,19 @@ export function ProviderModelsTable({
 					<TableHead>Model</TableHead>
 					<TableHead>Region</TableHead>
 					<TableHead>Status</TableHead>
-					<TableHead>Requests</TableHead>
-					<TableHead>Errors</TableHead>
-					<TableHead>Client</TableHead>
-					<TableHead>Gateway</TableHead>
-					<TableHead>Upstream</TableHead>
-					<TableHead>Error Rate</TableHead>
-					<TableHead>Cached</TableHead>
-					<TableHead>Avg TTFT</TableHead>
+					{sh("Requests", "logsCount")}
+					{sh("Cost", "totalCost")}
+					{sh("Errors", "errorsCount")}
+					{sh("Client", "clientErrorsCount")}
+					{sh("Gateway", "gatewayErrorsCount")}
+					{sh("Upstream", "upstreamErrorsCount")}
+					{sh("Error Rate", "errorRate")}
+					{sh("Cached", "cachedCount")}
+					{sh("Avg TTFT", "avgTimeToFirstToken")}
 				</TableRow>
 			</TableHeader>
 			<TableBody>
-				{models.map((m) => {
+				{sortedModels.map((m) => {
 					const errorRate =
 						m.logsCount > 0
 							? ((m.errorsCount / m.logsCount) * 100).toFixed(1)
@@ -70,7 +182,7 @@ export function ProviderModelsTable({
 								)}
 							</TableCell>
 							<TableCell className="text-xs text-muted-foreground">
-								{m.region ?? "\u2014"}
+								{m.region ?? "—"}
 							</TableCell>
 							<TableCell>
 								<Badge
@@ -81,6 +193,9 @@ export function ProviderModelsTable({
 							</TableCell>
 							<TableCell className="tabular-nums">
 								{formatNumber(m.logsCount)}
+							</TableCell>
+							<TableCell className="tabular-nums">
+								{formatCost(m.totalCost)}
 							</TableCell>
 							<TableCell className="tabular-nums">
 								{formatNumber(m.errorsCount)}
@@ -101,7 +216,7 @@ export function ProviderModelsTable({
 							<TableCell className="tabular-nums">
 								{m.avgTimeToFirstToken !== null
 									? `${Math.round(m.avgTimeToFirstToken)}ms`
-									: "\u2014"}
+									: "—"}
 							</TableCell>
 						</TableRow>
 					);

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4080,6 +4080,7 @@ export interface paths {
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
                                 avgTimeToFirstToken: number | null;
+                                totalCost: number;
                                 updatedAt: string;
                             }[];
                         };


### PR DESCRIPTION
## Summary
- Add a USD **Cost** column to the per-provider models table at `/providers/[providerId]`, aggregating `totalCost` from `model_provider_mapping_history` over the selected window.
- Make all value columns (Requests, Cost, Errors, Client/Gateway/Upstream errors, Error Rate, Cached, Avg TTFT) sortable client-side. Click a header to toggle asc/desc; defaults to Requests desc.

## Test plan
- [ ] Open `/providers/openai` — verify the new **Cost** column shows `$0.0000`-style values matching `totalCost` from the API.
- [ ] Click each value-column header — verify sort indicator flips and rows reorder.
- [ ] Switch time window — verify cost values update accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider models table now supports column sorting via clickable headers
  * Added cost column displaying total costs per model-provider mapping
  * Provider detail views now include aggregated cost metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->