### PR TITLE
perf(admin): devpass usage reads from aggregator tables

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8857,7 +8857,7 @@ admin.openapi(getDevpassUsage, async (c) => {
 		endDate.setUTCHours(23, 59, 59, 999);
 	}
 
-	// Filter: only logs from orgs that are or were ever on a DevPass plan.
+	// Filter: only orgs that are or were ever on a DevPass plan.
 	// Mirrors the cost-per-day query in /devpass/timeseries.
 	const devpassOrgFilter = or(
 		ne(tables.organization.devPlan, "none"),
@@ -8871,67 +8871,113 @@ admin.openapi(getDevpassUsage, async (c) => {
 		)`,
 	)!;
 
-	const baseWhere = and(
-		gte(tables.log.createdAt, startDate),
-		lte(tables.log.createdAt, endDate),
+	// Models + providers: use the per-project hourly model aggregator so the
+	// dashboard reads from rollups instead of the raw `log` table. Joins
+	// project -> organization to restrict to DevPass orgs.
+	const projectModelWhere = and(
+		gte(projectHourlyModelStats.hourTimestamp, startDate),
+		lte(projectHourlyModelStats.hourTimestamp, endDate),
 		devpassOrgFilter,
 	);
 
 	const modelRows = await db
 		.select({
-			id: tables.log.usedModel,
-			requestCount: sql<number>`COUNT(*)`.as("request_count"),
-			totalTokens: sql<number>`COALESCE(SUM(${tables.log.totalTokens}), 0)`.as(
-				"total_tokens",
+			id: projectHourlyModelStats.usedModel,
+			requestCount:
+				sql<number>`COALESCE(SUM(${projectHourlyModelStats.requestCount}), 0)`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
+					"total_tokens",
+				),
+			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+				"cost",
 			),
-			cost: sql<number>`COALESCE(SUM(${tables.log.cost}), 0)`.as("cost"),
 		})
-		.from(tables.log)
+		.from(projectHourlyModelStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyModelStats.projectId, tables.project.id),
+		)
 		.innerJoin(
 			tables.organization,
-			eq(tables.log.organizationId, tables.organization.id),
+			eq(tables.project.organizationId, tables.organization.id),
 		)
-		.where(baseWhere)
-		.groupBy(tables.log.usedModel)
-		.orderBy(desc(sql`COALESCE(SUM(${tables.log.cost}), 0)`))
+		.where(projectModelWhere)
+		.groupBy(projectHourlyModelStats.usedModel)
+		.orderBy(desc(sql`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`))
 		.limit(limit);
 
 	const providerRows = await db
 		.select({
-			id: tables.log.usedProvider,
-			requestCount: sql<number>`COUNT(*)`.as("request_count"),
-			totalTokens: sql<number>`COALESCE(SUM(${tables.log.totalTokens}), 0)`.as(
-				"total_tokens",
+			id: projectHourlyModelStats.usedProvider,
+			requestCount:
+				sql<number>`COALESCE(SUM(${projectHourlyModelStats.requestCount}), 0)`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
+					"total_tokens",
+				),
+			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+				"cost",
 			),
-			cost: sql<number>`COALESCE(SUM(${tables.log.cost}), 0)`.as("cost"),
 		})
-		.from(tables.log)
+		.from(projectHourlyModelStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyModelStats.projectId, tables.project.id),
+		)
 		.innerJoin(
 			tables.organization,
-			eq(tables.log.organizationId, tables.organization.id),
+			eq(tables.project.organizationId, tables.organization.id),
 		)
-		.where(baseWhere)
-		.groupBy(tables.log.usedProvider)
-		.orderBy(desc(sql`COALESCE(SUM(${tables.log.cost}), 0)`))
+		.where(projectModelWhere)
+		.groupBy(projectHourlyModelStats.usedProvider)
+		.orderBy(desc(sql`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`))
 		.limit(limit);
+
+	// Sources: no per-org source aggregator exists, so use the same
+	// cross-org day-bucketed table the /global-stats endpoint reads.
+	// Snap range to UTC day boundaries to match the bucket grain.
+	const sourceStart = new Date(
+		Date.UTC(
+			startDate.getUTCFullYear(),
+			startDate.getUTCMonth(),
+			startDate.getUTCDate(),
+		),
+	);
+	const sourceEnd = new Date(
+		Date.UTC(
+			endDate.getUTCFullYear(),
+			endDate.getUTCMonth(),
+			endDate.getUTCDate(),
+		),
+	);
 
 	const sourceRows = await db
 		.select({
-			id: sql<string>`COALESCE(${tables.log.source}, 'unknown')`.as("id"),
-			requestCount: sql<number>`COUNT(*)`.as("request_count"),
-			totalTokens: sql<number>`COALESCE(SUM(${tables.log.totalTokens}), 0)`.as(
-				"total_tokens",
-			),
-			cost: sql<number>`COALESCE(SUM(${tables.log.cost}), 0)`.as("cost"),
+			id: globalSourceStats.source,
+			requestCount:
+				sql<number>`COALESCE(SUM(${globalSourceStats.requestCount}), 0)`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`COALESCE(SUM(CAST(${globalSourceStats.totalTokens} AS NUMERIC)), 0)`.as(
+					"total_tokens",
+				),
+			cost: sql<number>`COALESCE(SUM(${globalSourceStats.cost}), 0)`.as("cost"),
 		})
-		.from(tables.log)
-		.innerJoin(
-			tables.organization,
-			eq(tables.log.organizationId, tables.organization.id),
+		.from(globalSourceStats)
+		.where(
+			and(
+				gte(globalSourceStats.dayTimestamp, sourceStart),
+				lte(globalSourceStats.dayTimestamp, sourceEnd),
+			),
 		)
-		.where(baseWhere)
-		.groupBy(sql`COALESCE(${tables.log.source}, 'unknown')`)
-		.orderBy(desc(sql`COALESCE(SUM(${tables.log.cost}), 0)`))
+		.groupBy(globalSourceStats.source)
+		.orderBy(desc(sql`COALESCE(SUM(${globalSourceStats.cost}), 0)`))
 		.limit(limit);
 
 	const mapRow = (r: {

--- a/ee/admin/src/components/devpass-usage.tsx
+++ b/ee/admin/src/components/devpass-usage.tsx
@@ -131,7 +131,7 @@ export function DevpassUsage({ from, to }: { from?: string; to?: string }) {
 		<div className="grid gap-4 lg:grid-cols-3">
 			<UsageList
 				title="Top models"
-				description="By provider cost from DevPass subscribers."
+				description="DevPass spend from hourly project rollups."
 				icon={<Cpu className="h-4 w-4" />}
 				rows={models}
 				isLoading={isLoading}
@@ -140,7 +140,7 @@ export function DevpassUsage({ from, to }: { from?: string; to?: string }) {
 			/>
 			<UsageList
 				title="Top providers"
-				description="Real provider spend from DevPass orgs."
+				description="DevPass spend from hourly project rollups."
 				icon={<Server className="h-4 w-4" />}
 				rows={providers}
 				isLoading={isLoading}
@@ -148,7 +148,7 @@ export function DevpassUsage({ from, to }: { from?: string; to?: string }) {
 			/>
 			<UsageList
 				title="Top coding agents"
-				description="Inferred from request `source` header."
+				description="Global `source` header rollups (cross-org)."
 				icon={<Bot className="h-4 w-4" />}
 				rows={sources}
 				isLoading={isLoading}


### PR DESCRIPTION
Top models/providers panels now sum projectHourlyModelStats joined
to project -> organization with the DevPass filter, replacing the
expensive scan over the raw log table. Top coding agents reads from
globalSourceStats (cross-org), matching the global-stats endpoint
since no per-org source aggregator exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined DevPass usage reporting to correctly reflect organizations with active or past DevPass plans
  * Updated metric descriptions for model spend, provider usage, and coding agent data to improve clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->