### PR TITLE
feat(api): add IAM rule routes for v1 master keys

### DIFF
--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -371,48 +371,39 @@ const updateApiKeyUsageLimitSchema = z
 	})
 	.strict();
 
-// Schema for IAM rule
-const iamRuleSchema = z.object({
+export const iamRuleTypeEnum = z.enum([
+	"allow_models",
+	"deny_models",
+	"allow_pricing",
+	"deny_pricing",
+	"allow_providers",
+	"deny_providers",
+]);
+
+export const iamRuleValueSchema = z.object({
+	models: z.array(z.string()).optional(),
+	providers: z.array(z.string()).optional(),
+	pricingType: z.enum(["free", "paid"]).optional(),
+	maxInputPrice: z.number().optional(),
+	maxOutputPrice: z.number().optional(),
+});
+
+export const iamRuleStatusEnum = z.enum(["active", "inactive"]);
+
+export const iamRuleSchema = z.object({
 	id: z.string(),
 	createdAt: z.date(),
 	updatedAt: z.date(),
 	apiKeyId: z.string(),
-	ruleType: z.enum([
-		"allow_models",
-		"deny_models",
-		"allow_pricing",
-		"deny_pricing",
-		"allow_providers",
-		"deny_providers",
-	]),
-	ruleValue: z.object({
-		models: z.array(z.string()).optional(),
-		providers: z.array(z.string()).optional(),
-		pricingType: z.enum(["free", "paid"]).optional(),
-		maxInputPrice: z.number().optional(),
-		maxOutputPrice: z.number().optional(),
-	}),
-	status: z.enum(["active", "inactive"]),
+	ruleType: iamRuleTypeEnum,
+	ruleValue: iamRuleValueSchema,
+	status: iamRuleStatusEnum,
 });
 
-// Schema for creating/updating IAM rules
-const createIamRuleSchema = z.object({
-	ruleType: z.enum([
-		"allow_models",
-		"deny_models",
-		"allow_pricing",
-		"deny_pricing",
-		"allow_providers",
-		"deny_providers",
-	]),
-	ruleValue: z.object({
-		models: z.array(z.string()).optional(),
-		providers: z.array(z.string()).optional(),
-		pricingType: z.enum(["free", "paid"]).optional(),
-		maxInputPrice: z.number().optional(),
-		maxOutputPrice: z.number().optional(),
-	}),
-	status: z.enum(["active", "inactive"]).default("active"),
+export const createIamRuleSchema = z.object({
+	ruleType: iamRuleTypeEnum,
+	ruleValue: iamRuleValueSchema,
+	status: iamRuleStatusEnum.default("active"),
 });
 
 // Create a new API key

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -703,4 +703,295 @@ v1Master.openapi(deleteApiKey, async (c) => {
 	return c.json({ message: "API key deleted successfully" });
 });
 
+const iamRuleTypeEnum = z.enum([
+	"allow_models",
+	"deny_models",
+	"allow_pricing",
+	"deny_pricing",
+	"allow_providers",
+	"deny_providers",
+]);
+
+const iamRuleValueSchema = z.object({
+	models: z.array(z.string()).optional(),
+	providers: z.array(z.string()).optional(),
+	pricingType: z.enum(["free", "paid"]).optional(),
+	maxInputPrice: z.number().optional(),
+	maxOutputPrice: z.number().optional(),
+});
+
+const iamRuleSchema = z.object({
+	id: z.string(),
+	createdAt: z.date(),
+	updatedAt: z.date(),
+	apiKeyId: z.string(),
+	ruleType: iamRuleTypeEnum,
+	ruleValue: iamRuleValueSchema,
+	status: z.enum(["active", "inactive"]),
+});
+
+const createIamRuleBody = z.object({
+	ruleType: iamRuleTypeEnum,
+	ruleValue: iamRuleValueSchema,
+	status: z.enum(["active", "inactive"]).default("active"),
+});
+
+const updateIamRuleBody = z
+	.object({
+		ruleType: iamRuleTypeEnum.optional(),
+		ruleValue: iamRuleValueSchema.optional(),
+		status: z.enum(["active", "inactive"]).optional(),
+	})
+	.refine((v) => Object.keys(v).length > 0, {
+		message: "At least one field must be provided",
+	});
+
+async function loadApiKeyForOrg(apiKeyId: string, organizationId: string) {
+	const apiKey = await db.query.apiKey.findFirst({
+		where: { id: { eq: apiKeyId } },
+		with: { project: true },
+	});
+
+	if (
+		!apiKey ||
+		apiKey.status === "deleted" ||
+		!apiKey.project ||
+		apiKey.project.organizationId !== organizationId
+	) {
+		throw new HTTPException(404, {
+			message: "API key not found in this organization",
+		});
+	}
+
+	return apiKey;
+}
+
+const createIamRule = createRoute({
+	method: "post",
+	path: "/keys/{id}/iam",
+	request: {
+		params: z.object({ id: z.string() }),
+		body: {
+			content: {
+				"application/json": {
+					schema: createIamRuleBody,
+				},
+			},
+		},
+	},
+	responses: {
+		201: {
+			content: {
+				"application/json": {
+					schema: z.object({ rule: iamRuleSchema.openapi({}) }),
+				},
+			},
+			description: "IAM rule created successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(createIamRule, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+	const ruleData = c.req.valid("json");
+
+	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
+
+	const [rule] = await db
+		.insert(tables.apiKeyIamRule)
+		.values({
+			apiKeyId: apiKey.id,
+			...ruleData,
+		})
+		.returning();
+
+	await logAuditEvent({
+		organizationId: masterKey.organizationId,
+		userId: masterKey.createdBy,
+		action: "api_key.iam_rule.create",
+		resourceType: "iam_rule",
+		resourceId: rule.id,
+		metadata: {
+			apiKeyId: apiKey.id,
+			ruleType: ruleData.ruleType,
+			ruleValue: ruleData.ruleValue,
+		},
+	});
+
+	return c.json({ rule }, 201);
+});
+
+const listIamRules = createRoute({
+	method: "get",
+	path: "/keys/{id}/iam",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						rules: z.array(iamRuleSchema).openapi({}),
+					}),
+				},
+			},
+			description: "List IAM rules for an API key via master key.",
+		},
+	},
+});
+
+v1Master.openapi(listIamRules, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+
+	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
+
+	const rules = await db.query.apiKeyIamRule.findMany({
+		where: { apiKeyId: { eq: apiKey.id } },
+	});
+
+	return c.json({ rules });
+});
+
+const updateIamRule = createRoute({
+	method: "patch",
+	path: "/keys/{id}/iam/{ruleId}",
+	request: {
+		params: z.object({ id: z.string(), ruleId: z.string() }),
+		body: {
+			content: {
+				"application/json": {
+					schema: updateIamRuleBody,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ rule: iamRuleSchema.openapi({}) }),
+				},
+			},
+			description: "IAM rule updated successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(updateIamRule, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id, ruleId } = c.req.param();
+	const updates = c.req.valid("json");
+
+	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
+
+	const existingRule = await db.query.apiKeyIamRule.findFirst({
+		where: { id: { eq: ruleId }, apiKeyId: { eq: apiKey.id } },
+	});
+
+	if (!existingRule) {
+		throw new HTTPException(404, {
+			message: "IAM rule not found for this API key",
+		});
+	}
+
+	const [updated] = await db
+		.update(tables.apiKeyIamRule)
+		.set(updates)
+		.where(eq(tables.apiKeyIamRule.id, ruleId))
+		.returning();
+
+	const changes: Record<string, { old: unknown; new: unknown }> = {};
+	for (const [key, value] of Object.entries(updates)) {
+		const before = (existingRule as Record<string, unknown>)[key];
+		if (JSON.stringify(before) !== JSON.stringify(value)) {
+			changes[key] = { old: before, new: value };
+		}
+	}
+
+	if (Object.keys(changes).length > 0) {
+		await logAuditEvent({
+			organizationId: masterKey.organizationId,
+			userId: masterKey.createdBy,
+			action: "api_key.iam_rule.update",
+			resourceType: "iam_rule",
+			resourceId: ruleId,
+			metadata: { apiKeyId: apiKey.id, changes },
+		});
+	}
+
+	return c.json({ rule: updated });
+});
+
+const deleteIamRule = createRoute({
+	method: "delete",
+	path: "/keys/{id}/iam/{ruleId}",
+	request: {
+		params: z.object({ id: z.string(), ruleId: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description: "IAM rule deleted successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(deleteIamRule, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id, ruleId } = c.req.param();
+
+	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
+
+	const existingRule = await db.query.apiKeyIamRule.findFirst({
+		where: { id: { eq: ruleId }, apiKeyId: { eq: apiKey.id } },
+	});
+
+	if (!existingRule) {
+		throw new HTTPException(404, {
+			message: "IAM rule not found for this API key",
+		});
+	}
+
+	await db
+		.delete(tables.apiKeyIamRule)
+		.where(eq(tables.apiKeyIamRule.id, ruleId));
+
+	await logAuditEvent({
+		organizationId: masterKey.organizationId,
+		userId: masterKey.createdBy,
+		action: "api_key.iam_rule.delete",
+		resourceType: "iam_rule",
+		resourceId: ruleId,
+		metadata: {
+			apiKeyId: apiKey.id,
+			ruleType: existingRule.ruleType,
+		},
+	});
+
+	return c.json({ message: "IAM rule deleted successfully" });
+});
+
 export default v1Master;

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -5,7 +5,12 @@ import { z } from "zod";
 import {
 	buildApiKeyLimitAuditChanges,
 	createApiKeyForProject,
+	createIamRuleSchema,
 	hasPeriodConfigChanged,
+	iamRuleSchema,
+	iamRuleStatusEnum,
+	iamRuleTypeEnum,
+	iamRuleValueSchema,
 	isPlaygroundApiKey,
 	mergeApiKeyLimitConfig,
 	parseApiKeyPeriodConfig,
@@ -703,44 +708,11 @@ v1Master.openapi(deleteApiKey, async (c) => {
 	return c.json({ message: "API key deleted successfully" });
 });
 
-const iamRuleTypeEnum = z.enum([
-	"allow_models",
-	"deny_models",
-	"allow_pricing",
-	"deny_pricing",
-	"allow_providers",
-	"deny_providers",
-]);
-
-const iamRuleValueSchema = z.object({
-	models: z.array(z.string()).optional(),
-	providers: z.array(z.string()).optional(),
-	pricingType: z.enum(["free", "paid"]).optional(),
-	maxInputPrice: z.number().optional(),
-	maxOutputPrice: z.number().optional(),
-});
-
-const iamRuleSchema = z.object({
-	id: z.string(),
-	createdAt: z.date(),
-	updatedAt: z.date(),
-	apiKeyId: z.string(),
-	ruleType: iamRuleTypeEnum,
-	ruleValue: iamRuleValueSchema,
-	status: z.enum(["active", "inactive"]),
-});
-
-const createIamRuleBody = z.object({
-	ruleType: iamRuleTypeEnum,
-	ruleValue: iamRuleValueSchema,
-	status: z.enum(["active", "inactive"]).default("active"),
-});
-
 const updateIamRuleBody = z
 	.object({
 		ruleType: iamRuleTypeEnum.optional(),
 		ruleValue: iamRuleValueSchema.optional(),
-		status: z.enum(["active", "inactive"]).optional(),
+		status: iamRuleStatusEnum.optional(),
 	})
 	.refine((v) => Object.keys(v).length > 0, {
 		message: "At least one field must be provided",
@@ -774,7 +746,7 @@ const createIamRule = createRoute({
 		body: {
 			content: {
 				"application/json": {
-					schema: createIamRuleBody,
+					schema: createIamRuleSchema,
 				},
 			},
 		},

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -89,6 +89,28 @@ v1Master.use("*", async (c, next) => {
 	await next();
 });
 
+async function loadApiKeyForOrg(apiKeyId: string, organizationId: string) {
+	const apiKey = await db.query.apiKey.findFirst({
+		where: { id: { eq: apiKeyId } },
+		with: { project: true },
+	});
+
+	if (
+		!apiKey ||
+		apiKey.status === "deleted" ||
+		!apiKey.project ||
+		apiKey.project.organizationId !== organizationId
+	) {
+		throw new HTTPException(404, {
+			message: "API key not found in this organization",
+		});
+	}
+
+	return apiKey as typeof apiKey & {
+		project: NonNullable<typeof apiKey.project>;
+	};
+}
+
 const projectModeEnum = z.enum(["api-keys", "credits", "hybrid"]);
 
 const projectSchema = z.object({
@@ -510,21 +532,7 @@ v1Master.openapi(updateApiKey, async (c) => {
 	const { id } = c.req.param();
 	const updates = c.req.valid("json");
 
-	const existing = await db.query.apiKey.findFirst({
-		where: { id: { eq: id } },
-		with: { project: true },
-	});
-
-	if (
-		!existing ||
-		existing.status === "deleted" ||
-		!existing.project ||
-		existing.project.organizationId !== masterKey.organizationId
-	) {
-		throw new HTTPException(404, {
-			message: "API key not found in this organization",
-		});
-	}
+	const existing = await loadApiKeyForOrg(id, masterKey.organizationId);
 
 	if (isPlaygroundApiKey(existing)) {
 		if (
@@ -668,21 +676,7 @@ v1Master.openapi(deleteApiKey, async (c) => {
 
 	const { id } = c.req.param();
 
-	const existing = await db.query.apiKey.findFirst({
-		where: { id: { eq: id } },
-		with: { project: true },
-	});
-
-	if (
-		!existing ||
-		existing.status === "deleted" ||
-		!existing.project ||
-		existing.project.organizationId !== masterKey.organizationId
-	) {
-		throw new HTTPException(404, {
-			message: "API key not found in this organization",
-		});
-	}
+	const existing = await loadApiKeyForOrg(id, masterKey.organizationId);
 
 	if (isPlaygroundApiKey(existing)) {
 		throw new HTTPException(403, {
@@ -717,26 +711,6 @@ const updateIamRuleBody = z
 	.refine((v) => Object.keys(v).length > 0, {
 		message: "At least one field must be provided",
 	});
-
-async function loadApiKeyForOrg(apiKeyId: string, organizationId: string) {
-	const apiKey = await db.query.apiKey.findFirst({
-		where: { id: { eq: apiKeyId } },
-		with: { project: true },
-	});
-
-	if (
-		!apiKey ||
-		apiKey.status === "deleted" ||
-		!apiKey.project ||
-		apiKey.project.organizationId !== organizationId
-	) {
-		throw new HTTPException(404, {
-			message: "API key not found in this organization",
-		});
-	}
-
-	return apiKey;
-}
 
 const createIamRule = createRoute({
 	method: "post",

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -978,6 +978,220 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/master/keys/{id}/iam": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List IAM rules for an API key via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rules: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /**
+                         * @default active
+                         * @enum {string}
+                         */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule created successfully via master key. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/master/keys/{id}/iam/{ruleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description IAM rule deleted successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType?: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue?: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /** @enum {string} */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule updated successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/user/me": {
         parameters: {
             query?: never;

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -246,3 +246,127 @@ Response (200):
 <Callout type="info">
 	The auto-generated playground API key cannot be deleted via the master API.
 </Callout>
+
+## IAM rules
+
+Each gateway API key can have one or more IAM rules that restrict which models, providers, or pricing tiers it is allowed to use. Rules are evaluated at request time by the gateway. A key with no active rules has no IAM restrictions.
+
+Rule types:
+
+| `ruleType`        | Description                                               |
+| ----------------- | --------------------------------------------------------- |
+| `allow_models`    | Only the listed models are permitted                      |
+| `deny_models`     | The listed models are blocked                             |
+| `allow_providers` | Only the listed providers are permitted                   |
+| `deny_providers`  | The listed providers are blocked                          |
+| `allow_pricing`   | Only models matching the pricing constraint are permitted |
+| `deny_pricing`    | Models matching the pricing constraint are blocked        |
+
+The `ruleValue` JSON object holds the rule's parameters. The fields it accepts depend on the `ruleType`:
+
+| Field            | Type               | Used by                             |
+| ---------------- | ------------------ | ----------------------------------- |
+| `models`         | string[]           | `allow_models`, `deny_models`       |
+| `providers`      | string[]           | `allow_providers`, `deny_providers` |
+| `pricingType`    | `"free" \| "paid"` | `allow_pricing`, `deny_pricing`     |
+| `maxInputPrice`  | number             | `allow_pricing`, `deny_pricing`     |
+| `maxOutputPrice` | number             | `allow_pricing`, `deny_pricing`     |
+
+All endpoints scope by the master key's organization: a `404` is returned if the API key (or rule) is not part of the authenticated master key's organization.
+
+### List IAM rules
+
+`GET /v1/master/keys/{id}/iam`
+
+```bash
+curl https://internal.llmgateway.io/v1/master/keys/ak_.../iam \
+  -H "Authorization: Bearer $MASTER_KEY"
+```
+
+Response (200):
+
+```json
+{
+	"rules": [
+		{
+			"id": "iam_...",
+			"apiKeyId": "ak_...",
+			"ruleType": "allow_models",
+			"ruleValue": {
+				"models": ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]
+			},
+			"status": "active",
+			"createdAt": "...",
+			"updatedAt": "..."
+		}
+	]
+}
+```
+
+### Create an IAM rule
+
+`POST /v1/master/keys/{id}/iam`
+
+```bash
+curl -X POST https://internal.llmgateway.io/v1/master/keys/ak_.../iam \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ruleType": "allow_models",
+    "ruleValue": {
+      "models": ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]
+    }
+  }'
+```
+
+Body parameters:
+
+| Field       | Type                     | Description                                             |
+| ----------- | ------------------------ | ------------------------------------------------------- |
+| `ruleType`  | rule type enum (above)   | Required                                                |
+| `ruleValue` | object (see table above) | Must include the fields appropriate for the chosen type |
+| `status`    | `"active" \| "inactive"` | Optional, defaults to `"active"`                        |
+
+Response (201): the created IAM rule.
+
+### Update an IAM rule
+
+`PATCH /v1/master/keys/{id}/iam/{ruleId}`
+
+All body fields are optional; provide only the ones you want to change.
+
+```bash
+curl -X PATCH https://internal.llmgateway.io/v1/master/keys/ak_.../iam/iam_... \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "status": "inactive"
+  }'
+```
+
+Body parameters (all optional, at least one required):
+
+| Field       | Type                     | Description                             |
+| ----------- | ------------------------ | --------------------------------------- |
+| `ruleType`  | rule type enum (above)   | Change the rule type                    |
+| `ruleValue` | object (see table above) | Replace the rule value                  |
+| `status`    | `"active" \| "inactive"` | Activate or deactivate without deleting |
+
+Response (200): the updated IAM rule.
+
+### Delete an IAM rule
+
+`DELETE /v1/master/keys/{id}/iam/{ruleId}`
+
+Permanently removes an IAM rule from the API key.
+
+```bash
+curl -X DELETE https://internal.llmgateway.io/v1/master/keys/ak_.../iam/iam_... \
+  -H "Authorization: Bearer $MASTER_KEY"
+```
+
+Response (200):
+
+```json
+{ "message": "IAM rule deleted successfully" }
+```

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -978,6 +978,220 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/master/keys/{id}/iam": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List IAM rules for an API key via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rules: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /**
+                         * @default active
+                         * @enum {string}
+                         */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule created successfully via master key. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/master/keys/{id}/iam/{ruleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description IAM rule deleted successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType?: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue?: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /** @enum {string} */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule updated successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/user/me": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -978,6 +978,220 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/master/keys/{id}/iam": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List IAM rules for an API key via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rules: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /**
+                         * @default active
+                         * @enum {string}
+                         */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule created successfully via master key. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/master/keys/{id}/iam/{ruleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description IAM rule deleted successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType?: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue?: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /** @enum {string} */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule updated successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/user/me": {
         parameters: {
             query?: never;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -978,6 +978,220 @@ export interface paths {
         };
         trace?: never;
     };
+    "/v1/master/keys/{id}/iam": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description List IAM rules for an API key via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rules: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /**
+                         * @default active
+                         * @enum {string}
+                         */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule created successfully via master key. */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/master/keys/{id}/iam/{ruleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description IAM rule deleted successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    ruleId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        ruleType?: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                        ruleValue?: {
+                            models?: string[];
+                            providers?: string[];
+                            /** @enum {string} */
+                            pricingType?: "free" | "paid";
+                            maxInputPrice?: number;
+                            maxOutputPrice?: number;
+                        };
+                        /** @enum {string} */
+                        status?: "active" | "inactive";
+                    };
+                };
+            };
+            responses: {
+                /** @description IAM rule updated successfully via master key. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            rule: {
+                                id: string;
+                                createdAt: string;
+                                updatedAt: string;
+                                apiKeyId: string;
+                                /** @enum {string} */
+                                ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                ruleValue: {
+                                    models?: string[];
+                                    providers?: string[];
+                                    /** @enum {string} */
+                                    pricingType?: "free" | "paid";
+                                    maxInputPrice?: number;
+                                    maxOutputPrice?: number;
+                                };
+                                /** @enum {string} */
+                                status: "active" | "inactive";
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/user/me": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

Adds programmatic IAM rule management to the `/v1/master/*` API so master-key holders can configure model/provider/pricing allow & deny rules for their organization's API keys without going through the dashboard.

New endpoints under `/v1/master/keys/{id}/iam`:

- `POST /v1/master/keys/{id}/iam` — create an IAM rule
- `GET /v1/master/keys/{id}/iam` — list IAM rules
- `PATCH /v1/master/keys/{id}/iam/{ruleId}` — update an IAM rule
- `DELETE /v1/master/keys/{id}/iam/{ruleId}` — delete an IAM rule

Rule types supported: `allow_models`, `deny_models`, `allow_pricing`, `deny_pricing`, `allow_providers`, `deny_providers`.

## Access control

A shared `loadApiKeyForOrg` helper resolves the API key through its project and rejects with `404` unless `project.organizationId` matches the authenticated master key's organization. The same isolation already protects `PATCH/DELETE /v1/master/keys/{id}` and `/v1/master/projects/{id}`. Update/delete additionally verify the IAM rule actually belongs to the referenced API key.

All operations write audit log entries (`api_key.iam_rule.{create,update,delete}`) attributed to the master key issuer.

## Test plan

- [ ] Create, list, update, and delete IAM rules via `/v1/master/keys/{id}/iam` with a valid master key
- [ ] Confirm `404` is returned when targeting an API key in a different organization
- [ ] Confirm `404` is returned when targeting a rule that does not belong to the API key path param
- [ ] Verify audit log entries are produced for each operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added IAM rule management for master-key API keys: create, list, update, and delete rules at /v1/master/keys/{id}/iam.
  * Create/update validate inputs (update requires at least one updatable field); list returns { rules }.
  * Audit events emitted for creations, deletions, and updates (updates emit only when changes occur).
  * Rules support status (defaults to "active") and allow/deny-style rule values; all ops are scoped to the master key’s organization and out-of-scope requests return 404.

* **Documentation**
  * New docs detailing IAM rule formats, examples, CRUD endpoints, and scoping/404 behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->