### PR TITLE
fix(gateway): single-newline SSE keepalive

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4487,11 +4487,14 @@ chat.openapi(completions, async (c) => {
 				}> = [];
 				const streamStartTime = Date.now();
 
-				// SSE keepalive to prevent proxy/load balancer timeouts
-				// Sends SSE comments (ignored by clients) every 15 seconds to keep connection alive
+				// SSE keepalive to prevent proxy/load balancer timeouts.
+				// Sends a single-newline comment (no trailing blank line) so buggy
+				// SSE parsers (e.g. openai-python <=2.37.0, openai/openai-python#2722)
+				// don't dispatch an empty-data event from a `\n\n` sequence when
+				// last_event_id is already set.
 				const KEEPALIVE_INTERVAL_MS = 15000;
 				const keepaliveInterval = setInterval(() => {
-					stream.write(": ping\n\n").catch(() => {
+					stream.write(": ping\n").catch(() => {
 						// Stream likely closed, cleanup will happen via abort handler or finally
 					});
 				}, KEEPALIVE_INTERVAL_MS);


### PR DESCRIPTION
## Summary

The chat-streaming keepalive emits `: ping\n\n` every 15s. The trailing `\n\n` is a comment followed by a blank line — and the [openai-python SSE decoder](https://github.com/openai/openai-python/issues/2722) dispatches an event on any blank line as long as `last_event_id` was set by an earlier real event (which it always is, since the gateway sets `id:` on every chunk). The dispatched event has `event=None, data=''`, and `sse.json()` then raises `JSONDecodeError`.

This explains the report at openai/openai-python#2722 and matches the observed timing: Claude generations slow enough to still be streaming when the first 15s keepalive fires crash ~16-17s in; faster generations (DeepSeek) finish before any keepalive and never trip it.

Fix: drop the trailing newline. `: ping\n` is still a valid SSE comment line and still flushes bytes for proxy keepalive, but no blank line follows, so no buggy parser dispatches an empty-data event. Spec-compliant parsers behave identically.

## Test plan

- [ ] Run a slow Anthropic stream (sonnet/haiku via direct or Bedrock) through the gateway with openai-python ≤ 2.37.0; confirm no `JSONDecodeError` after 15s
- [ ] Verify GCP LB / Cloudflare connections still stay open across long idle gaps (keepalive bytes still flush)
- [ ] `pnpm test:unit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability in chat responses by fixing SSE keepalive message format to prevent unintended empty events from being dispatched by some SSE parsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->