### PR TITLE
feat(og): add static Google AI Studio icon

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -12,6 +12,7 @@ import {
 import {
 	AWSBedrockIconStatic,
 	getProviderIcon,
+	GoogleStudioAIIconStatic,
 	MinimaxIconStatic,
 } from "@llmgateway/shared/components";
 
@@ -104,7 +105,9 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 				? MinimaxIconStatic
 				: selectedMapping.providerId === "aws-bedrock"
 					? AWSBedrockIconStatic
-					: getProviderIcon(selectedMapping.providerId)
+					: selectedMapping.providerId === "google-ai-studio"
+						? GoogleStudioAIIconStatic
+						: getProviderIcon(selectedMapping.providerId)
 			: null;
 		const pricing = getEffectivePricePerMillion(selectedMapping);
 		const requestPrice =
@@ -140,7 +143,9 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 						? AWSBedrockIconStatic
 						: providerId === "minimax"
 							? MinimaxIconStatic
-							: getProviderIcon(providerId);
+							: providerId === "google-ai-studio"
+								? GoogleStudioAIIconStatic
+								: getProviderIcon(providerId);
 				const info = providerDefinitions.find((p) => p.id === providerId);
 				return {
 					id: providerId,

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -104,6 +104,48 @@ export const GoogleStudioAIIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({
 	/>
 );
 
+export const GoogleStudioAIIconStatic: React.FC<
+	React.SVGProps<SVGSVGElement>
+> = (props) => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" {...props}>
+		<defs>
+			<linearGradient
+				id="googleAiStudioStaticTop"
+				x1="21"
+				y1="60"
+				x2="171"
+				y2="60"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop offset="0%" stopColor="#22a05a" />
+				<stop offset="45%" stopColor="#1e88e5" />
+				<stop offset="100%" stopColor="#2f7df5" />
+			</linearGradient>
+			<linearGradient
+				id="googleAiStudioStaticBottom"
+				x1="21"
+				y1="132"
+				x2="171"
+				y2="132"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop offset="0%" stopColor="#2f7df5" />
+				<stop offset="55%" stopColor="#5d8df0" />
+				<stop offset="80%" stopColor="#f4a72b" />
+				<stop offset="100%" stopColor="#ea3a2d" />
+			</linearGradient>
+		</defs>
+		<path
+			fill="url(#googleAiStudioStaticTop)"
+			d="M161.23 55.76 79.92 98.11C53.06 112.1 21.01 92.5 21.01 62.08c0-22.42 18.08-40.59 40.37-40.58l91.57.04c18.88 0 25.04 25.5 8.28 34.22"
+		/>
+		<path
+			fill="url(#googleAiStudioStaticBottom)"
+			d="m30.77 136.24 81.31-42.35c26.86-13.99 58.91 5.61 58.91 36.03 0 22.42-18.08 40.59-40.37 40.58l-91.57-.04c-18.88 0-25.04-25.5-8.28-34.22"
+		/>
+	</svg>
+);
+
 // Google Vertex Icon
 export const GoogleVertexIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 	props,


### PR DESCRIPTION
## Summary
Added a static version of the Google AI Studio icon component and integrated it into the OG image generation logic for model provider pages.

## Changes
- **New Component**: Added `GoogleStudioAIIconStatic` export in `provider-icons.tsx`
  - Static SVG icon with two linear gradients (top and bottom)
  - Matches the visual style of other static provider icons (AWS Bedrock, Minimax)
  
- **OG Image Integration**: Updated `opengraph-image.tsx` to use the static icon
  - Imported `GoogleStudioAIIconStatic` from shared components
  - Added conditional logic to select the static icon when `providerId === "google-ai-studio"`
  - Applied the same pattern used for AWS Bedrock and Minimax providers in two locations (selected mapping and provider list rendering)

## Implementation Details
The static icon uses SVG gradients with specific color stops to create a visually appealing design with green, blue, and orange/red tones. The implementation follows the existing pattern for other static provider icons in the codebase.

https://claude.ai/code/session_01TsNdTdNShRFRa9EPSEM8NE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google AI Studio provider icon support to OpenGraph image generation for improved model preview sharing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->