### PR TITLE
fix(vertex): use ?key auth for all Gemini models

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4748,7 +4748,6 @@ chat.openapi(completions, async (c) => {
 						const headers = getProviderHeaders(usedProvider, usedToken, {
 							requestId,
 							webSearchEnabled: !!webSearchTool,
-							modelName: usedModelMapping,
 						});
 						headers["Content-Type"] = "application/json";
 
@@ -8398,7 +8397,6 @@ chat.openapi(completions, async (c) => {
 			const headers = getProviderHeaders(usedProvider, usedToken, {
 				requestId,
 				webSearchEnabled: !!webSearchTool,
-				modelName: usedModelMapping,
 			});
 			if (!(requestBody instanceof FormData)) {
 				headers["Content-Type"] = "application/json";

--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -139,8 +139,9 @@ describe("getProviderEndpoint", () => {
 		);
 	});
 
-	it("uses the Vertex base URL override for lite models", () => {
+	it("uses the Vertex base URL override", () => {
 		process.env.LLM_GOOGLE_VERTEX_BASE_URL = "https://vertex-override.example";
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "project-a";
 
 		const endpoint = getProviderEndpoint(
 			"google-vertex",
@@ -149,7 +150,7 @@ describe("getProviderEndpoint", () => {
 		);
 
 		expect(endpoint).toBe(
-			"https://vertex-override.example/v1/publishers/google/models/gemini-2.5-flash-lite:generateContent",
+			"https://vertex-override.example/v1/projects/project-a/locations/global/publishers/google/models/gemini-2.5-flash-lite:generateContent",
 		);
 	});
 
@@ -352,7 +353,7 @@ describe("getProviderEndpoint", () => {
 				undefined,
 				undefined,
 				undefined,
-				undefined,
+				{ google_vertex_project_id: "byok-project" },
 				undefined,
 				undefined,
 				undefined,
@@ -360,7 +361,7 @@ describe("getProviderEndpoint", () => {
 			);
 
 			expect(endpoint).toBe(
-				"https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash-lite:generateContent",
+				"https://aiplatform.googleapis.com/v1/projects/byok-project/locations/global/publishers/google/models/gemini-2.5-flash-lite:generateContent",
 			);
 		});
 

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -22,20 +22,6 @@ function buildVertexCompatibleEndpoint(
 	const endpoint = stream ? "streamGenerateContent" : "generateContent";
 	const model = modelName ?? "gemini-2.5-flash-lite";
 
-	if (model === "gemini-2.0-flash-lite" || model === "gemini-2.5-flash-lite") {
-		const baseEndpoint = `${url}/v1/publishers/google/models/${model}:${endpoint}`;
-		const queryParams = [];
-		if (token) {
-			queryParams.push(`key=${token}`);
-		}
-		if (stream) {
-			queryParams.push("alt=sse");
-		}
-		return queryParams.length > 0
-			? `${baseEndpoint}?${queryParams.join("&")}`
-			: baseEndpoint;
-	}
-
 	const projectId =
 		providerKeyOptions?.google_vertex_project_id ??
 		getProviderEnvValue(provider, "project", configIndex);

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -6,7 +6,6 @@ export interface ProviderHeaderOptions {
 	 */
 	webSearchEnabled?: boolean;
 	requestId?: string;
-	modelName?: string;
 }
 
 /**
@@ -39,18 +38,8 @@ export function getProviderHeaders(
 		case "glacier":
 			return requestIdHeader;
 		case "google-vertex":
-		case "quartz": {
-			const isLiteModel =
-				options?.modelName === "gemini-2.0-flash-lite" ||
-				options?.modelName === "gemini-2.5-flash-lite";
-			if (!isLiteModel) {
-				return {
-					...requestIdHeader,
-					Authorization: `Bearer ${token}`,
-				};
-			}
+		case "quartz":
 			return requestIdHeader;
-		}
 		case "vertex-anthropic":
 			return {
 				...requestIdHeader,


### PR DESCRIPTION
## Summary
- Drop the lite-model special case in `buildVertexCompatibleEndpoint` so every `google-vertex` request goes through the project/region URL with `?key=<token>`.
- Stop adding `Authorization: Bearer <token>` for `google-vertex` / `quartz` — sending both a Bearer header and `?key=` caused Google to reject Vertex API keys (which aren't OAuth access tokens) on non-lite Gemini models.
- Remove the now-dead `modelName` option from `ProviderHeaderOptions` and its remaining call sites.

## Test plan
- [ ] Send a chat request to `google-vertex/gemini-3.5-flash` (or any non-lite Gemini) with `LLM_GOOGLE_VERTEX_API_KEY` set to a Vertex API key; verify the call succeeds.
- [ ] Confirm `google-vertex/gemini-2.5-flash-lite` still works.
- [ ] `pnpm vitest run packages/actions/src/get-provider-endpoint.spec.ts` ✅
- [ ] `pnpm --filter @llmgateway/actions build` ✅
- [ ] `pnpm --filter gateway build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Google Vertex AI integration to properly construct API endpoints with correct project-based URL structure.

* **Configuration Changes**
  * Google Vertex AI provider now requires explicit project ID configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->