### PR TITLE
fix(ui): render google-ai-studio icon in provider OG image

### DIFF
--- a/apps/ui/src/app/providers/[id]/opengraph-image.tsx
+++ b/apps/ui/src/app/providers/[id]/opengraph-image.tsx
@@ -7,6 +7,7 @@ import {
 import {
 	AWSBedrockIconStatic,
 	getProviderIcon,
+	GoogleStudioAIIconStatic,
 	MinimaxIconStatic,
 } from "@llmgateway/shared/components";
 
@@ -58,7 +59,9 @@ export default async function ProviderOgImage({ params }: ImageProps) {
 				? MinimaxIconStatic
 				: provider.id === "aws-bedrock"
 					? AWSBedrockIconStatic
-					: getProviderIcon(provider.id);
+					: provider.id === "google-ai-studio"
+						? GoogleStudioAIIconStatic
+						: getProviderIcon(provider.id);
 
 		// Count how many models this provider offers
 		const supportedModels = modelDefinitions.filter((model) =>


### PR DESCRIPTION
## Summary

- The `/providers/[id]/opengraph-image` route had the same bug as the model OG route fixed in #2337: `GoogleStudioAIIcon` uses `dangerouslySetInnerHTML` with an SVG containing clip-paths + `<image xlink:href="data:image/png;base64,...">`, neither of which Satori (`next/og`) can render — so `https://llmgateway.io/providers/google-ai-studio/opengraph-image` showed an empty icon box.
- Route the `google-ai-studio` case to `GoogleStudioAIIconStatic` (the pure-JSX SVG added in #2337), matching the existing `minimax` / `aws-bedrock` pattern.

## Test plan

- [ ] Verify `https://llmgateway.io/providers/google-ai-studio/opengraph-image` renders the proper two-swoosh S mark with gradients after deploy.
- [ ] Spot-check other providers (`openai`, `anthropic`, `minimax`, `aws-bedrock`) still render correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsNdTdNShRFRa9EPSEM8NE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenGraph preview image icon display for Google AI Studio provider to use the correct static icon asset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->