### PR TITLE
fix(playground): don't persist model from chat loads

### DIFF
--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -1336,24 +1336,23 @@ export default function ChatPageClient({
 		status,
 	]);
 
-	// keep URL in sync with selected model
-	useEffect(() => {
-		// Read current URL params directly to avoid stale searchParams closure
-		const currentParams = new URLSearchParams(window.location.search);
-		if (selectedModel) {
-			currentParams.set("model", selectedModel);
-		} else {
-			currentParams.delete("model");
-		}
-		const qs = currentParams.toString();
-		router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
-	}, [selectedModel, pathname, router]);
-
-	useEffect(() => {
-		if (selectedModel) {
-			setModelPreferenceCookie(CHAT_MODEL_COOKIE, selectedModel);
-		}
-	}, [selectedModel]);
+	const handleSelectModel = useCallback(
+		(model: string) => {
+			setSelectedModel(model);
+			if (model) {
+				setModelPreferenceCookie(CHAT_MODEL_COOKIE, model);
+			}
+			const currentParams = new URLSearchParams(window.location.search);
+			if (model) {
+				currentParams.set("model", model);
+			} else {
+				currentParams.delete("model");
+			}
+			const qs = currentParams.toString();
+			router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+		},
+		[pathname, router],
+	);
 
 	const [text, setText] = useState(initialPrompt ?? "");
 	const primaryText = syncInput ? syncedText : text;
@@ -1457,7 +1456,7 @@ export default function ChatPageClient({
 							models={models}
 							providers={providers}
 							selectedModel={selectedModel}
-							setSelectedModel={setSelectedModel}
+							setSelectedModel={handleSelectModel}
 							comparisonEnabled={comparisonEnabled}
 							onComparisonEnabledChange={(enabled) => {
 								setComparisonEnabled(enabled);
@@ -1576,7 +1575,7 @@ export default function ChatPageClient({
 												models={models}
 												providers={providers}
 												value={selectedModel}
-												onValueChange={setSelectedModel}
+												onValueChange={handleSelectModel}
 												placeholder="Select a model..."
 											/>
 										</div>


### PR DESCRIPTION
## Summary

Opening an old chat called `setSelectedModel(chat.model)` (chat-page-client.tsx:803), which then triggered the cookie + URL sync `useEffect`s, overwriting the user's saved preference and URL with whatever model that chat happened to use. So just *viewing* an old chat that used (say) `openai/gpt-5` would silently clobber the cookie and make gpt-5 the default for every future session — even though the user never picked it.

This consolidates the cookie + URL writes into a single `handleSelectModel` callback wired into the dropdowns (`ChatHeader`, `ModelSelector`). Programmatic updates from chat loads no longer touch the persisted preference.

- Last-used-model behavior is preserved — explicit picks still persist.
- `?model=` URL param from CTA links still seeds the initial selection (via `getInitialModel`), and is no longer auto-overwritten by chat loads.

## Test plan

- [ ] Pick a model in the dropdown → cookie + URL update.
- [ ] Open an old chat whose stored model differs from your preference → selector shows that chat's model, but cookie and URL stay as your last explicit pick.
- [ ] Click "New Chat" → selection persists from current state.
- [ ] Open `/chat` in a fresh tab → defaults to last explicitly-picked model (or `auto` if none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal model selection handling to enhance stability and consistency across the chat interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->