### PR TITLE
feat(admin): show IAM rules and provider keys

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -4,6 +4,7 @@ import Stripe from "stripe";
 import { z } from "zod";
 
 import { deleteResendContact } from "@/auth/config.js";
+import { maskToken } from "@/lib/maskToken.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
 
@@ -182,6 +183,29 @@ const projectsListSchema = z.object({
 	total: z.number(),
 });
 
+const iamRuleAdminSchema = z.object({
+	id: z.string(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	apiKeyId: z.string(),
+	ruleType: z.enum([
+		"allow_models",
+		"deny_models",
+		"allow_pricing",
+		"deny_pricing",
+		"allow_providers",
+		"deny_providers",
+	]),
+	ruleValue: z.object({
+		models: z.array(z.string()).optional(),
+		providers: z.array(z.string()).optional(),
+		pricingType: z.enum(["free", "paid"]).optional(),
+		maxInputPrice: z.number().optional(),
+		maxOutputPrice: z.number().optional(),
+	}),
+	status: z.enum(["active", "inactive"]),
+});
+
 const apiKeySchema = z.object({
 	id: z.string(),
 	token: z.string(),
@@ -192,6 +216,7 @@ const apiKeySchema = z.object({
 	projectId: z.string(),
 	projectName: z.string(),
 	createdAt: z.string(),
+	iamRules: z.array(iamRuleAdminSchema),
 });
 
 const apiKeysListSchema = z.object({
@@ -199,6 +224,22 @@ const apiKeysListSchema = z.object({
 	total: z.number(),
 	limit: z.number(),
 	offset: z.number(),
+});
+
+const providerKeyAdminSchema = z.object({
+	id: z.string(),
+	token: z.string(),
+	provider: z.string(),
+	name: z.string().nullable(),
+	baseUrl: z.string().nullable(),
+	status: z.string().nullable(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+});
+
+const providerKeysListSchema = z.object({
+	providerKeys: z.array(providerKeyAdminSchema),
+	total: z.number(),
 });
 
 const memberSchema = z.object({
@@ -375,6 +416,29 @@ const getOrganizationApiKeys = createRoute({
 				},
 			},
 			description: "Organization API keys.",
+		},
+		404: {
+			description: "Organization not found.",
+		},
+	},
+});
+
+const getOrganizationProviderKeys = createRoute({
+	method: "get",
+	path: "/organizations/{orgId}/provider-keys",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: providerKeysListSchema.openapi({}),
+				},
+			},
+			description: "Organization provider keys.",
 		},
 		404: {
 			description: "Organization not found.",
@@ -1690,16 +1754,82 @@ admin.openapi(getOrganizationApiKeys, async (c) => {
 		.limit(limit)
 		.offset(offset);
 
+	const apiKeyIds = apiKeys.map((k) => k.id);
+	const iamRules = apiKeyIds.length
+		? await db
+				.select()
+				.from(tables.apiKeyIamRule)
+				.where(inArray(tables.apiKeyIamRule.apiKeyId, apiKeyIds))
+				.orderBy(desc(tables.apiKeyIamRule.createdAt))
+		: [];
+
+	const rulesByKey = new Map<string, typeof iamRules>();
+	for (const rule of iamRules) {
+		const list = rulesByKey.get(rule.apiKeyId) ?? [];
+		list.push(rule);
+		rulesByKey.set(rule.apiKeyId, list);
+	}
+
 	return c.json({
 		apiKeys: apiKeys.map((k) => ({
 			...k,
 			usage: String(k.usage),
 			usageLimit: k.usageLimit ? String(k.usageLimit) : null,
 			createdAt: k.createdAt.toISOString(),
+			iamRules: (rulesByKey.get(k.id) ?? []).map((r) => ({
+				id: r.id,
+				createdAt: r.createdAt.toISOString(),
+				updatedAt: r.updatedAt.toISOString(),
+				apiKeyId: r.apiKeyId,
+				ruleType: r.ruleType,
+				ruleValue: r.ruleValue,
+				status: r.status,
+			})),
 		})),
 		total,
 		limit,
 		offset,
+	});
+});
+
+admin.openapi(getOrganizationProviderKeys, async (c) => {
+	const { orgId } = c.req.valid("param");
+
+	const org = await db.query.organization.findFirst({
+		where: {
+			id: { eq: orgId },
+		},
+	});
+
+	if (!org) {
+		throw new HTTPException(404, {
+			message: "Organization not found",
+		});
+	}
+
+	const providerKeys = await db
+		.select({
+			id: tables.providerKey.id,
+			token: tables.providerKey.token,
+			provider: tables.providerKey.provider,
+			name: tables.providerKey.name,
+			baseUrl: tables.providerKey.baseUrl,
+			status: tables.providerKey.status,
+			createdAt: tables.providerKey.createdAt,
+			updatedAt: tables.providerKey.updatedAt,
+		})
+		.from(tables.providerKey)
+		.where(eq(tables.providerKey.organizationId, orgId))
+		.orderBy(desc(tables.providerKey.createdAt));
+
+	return c.json({
+		providerKeys: providerKeys.map((k) => ({
+			...k,
+			token: maskToken(k.token, 6),
+			createdAt: k.createdAt.toISOString(),
+			updatedAt: k.updatedAt.toISOString(),
+		})),
+		total: providerKeys.length,
 	});
 });
 

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2690,10 +2690,84 @@ export interface paths {
                                 projectId: string;
                                 projectName: string;
                                 createdAt: string;
+                                iamRules: {
+                                    id: string;
+                                    createdAt: string;
+                                    updatedAt: string;
+                                    apiKeyId: string;
+                                    /** @enum {string} */
+                                    ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                    ruleValue: {
+                                        models?: string[];
+                                        providers?: string[];
+                                        /** @enum {string} */
+                                        pricingType?: "free" | "paid";
+                                        maxInputPrice?: number;
+                                        maxOutputPrice?: number;
+                                    };
+                                    /** @enum {string} */
+                                    status: "active" | "inactive";
+                                }[];
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/organizations/{orgId}/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization provider keys. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            providerKeys: {
+                                id: string;
+                                token: string;
+                                provider: string;
+                                name: string | null;
+                                baseUrl: string | null;
+                                status: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                            }[];
+                            total: number;
                         };
                     };
                 };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2690,10 +2690,84 @@ export interface paths {
                                 projectId: string;
                                 projectName: string;
                                 createdAt: string;
+                                iamRules: {
+                                    id: string;
+                                    createdAt: string;
+                                    updatedAt: string;
+                                    apiKeyId: string;
+                                    /** @enum {string} */
+                                    ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                    ruleValue: {
+                                        models?: string[];
+                                        providers?: string[];
+                                        /** @enum {string} */
+                                        pricingType?: "free" | "paid";
+                                        maxInputPrice?: number;
+                                        maxOutputPrice?: number;
+                                    };
+                                    /** @enum {string} */
+                                    status: "active" | "inactive";
+                                }[];
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/organizations/{orgId}/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization provider keys. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            providerKeys: {
+                                id: string;
+                                token: string;
+                                provider: string;
+                                name: string | null;
+                                baseUrl: string | null;
+                                status: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                            }[];
+                            total: number;
                         };
                     };
                 };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2690,10 +2690,84 @@ export interface paths {
                                 projectId: string;
                                 projectName: string;
                                 createdAt: string;
+                                iamRules: {
+                                    id: string;
+                                    createdAt: string;
+                                    updatedAt: string;
+                                    apiKeyId: string;
+                                    /** @enum {string} */
+                                    ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                    ruleValue: {
+                                        models?: string[];
+                                        providers?: string[];
+                                        /** @enum {string} */
+                                        pricingType?: "free" | "paid";
+                                        maxInputPrice?: number;
+                                        maxOutputPrice?: number;
+                                    };
+                                    /** @enum {string} */
+                                    status: "active" | "inactive";
+                                }[];
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/organizations/{orgId}/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization provider keys. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            providerKeys: {
+                                id: string;
+                                token: string;
+                                provider: string;
+                                name: string | null;
+                                baseUrl: string | null;
+                                status: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                            }[];
+                            total: number;
                         };
                     };
                 };

--- a/ee/admin/src/app/organizations/[orgId]/api-keys-table.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/api-keys-table.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { ChevronDown, ChevronRight, Shield } from "lucide-react";
+import Link from "next/link";
+import { Fragment, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+import type { paths } from "@/lib/api/v1";
+
+type ApiKeysResponse =
+	paths["/admin/organizations/{orgId}/api-keys"]["get"]["responses"]["200"]["content"]["application/json"];
+type ApiKey = ApiKeysResponse["apiKeys"][number];
+type IamRule = ApiKey["iamRules"][number];
+
+const creditsFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+function formatDate(dateString: string) {
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function formatRuleType(type: string) {
+	return type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function ruleTypeBadgeVariant(
+	type: IamRule["ruleType"],
+): "default" | "secondary" | "outline" | "destructive" {
+	if (type.startsWith("deny_")) {
+		return "destructive";
+	}
+	return "secondary";
+}
+
+function formatRuleValue(rule: IamRule): string {
+	const v = rule.ruleValue;
+	if (v.models?.length) {
+		return `models: ${v.models.join(", ")}`;
+	}
+	if (v.providers?.length) {
+		return `providers: ${v.providers.join(", ")}`;
+	}
+	if (v.pricingType) {
+		const parts = [`pricing: ${v.pricingType}`];
+		if (typeof v.maxInputPrice === "number") {
+			parts.push(`maxInput: ${v.maxInputPrice}`);
+		}
+		if (typeof v.maxOutputPrice === "number") {
+			parts.push(`maxOutput: ${v.maxOutputPrice}`);
+		}
+		return parts.join(", ");
+	}
+	return "—";
+}
+
+interface ApiKeysTableProps {
+	apiKeys: ApiKey[];
+	orgId: string;
+	txPage: number;
+	akPage: number;
+	akOffset: number;
+	akLimit: number;
+	akTotal: number;
+	akTotalPages: number;
+}
+
+export function ApiKeysTable({
+	apiKeys,
+	orgId,
+	txPage,
+	akPage,
+	akOffset,
+	akLimit,
+	akTotal,
+	akTotalPages,
+}: ApiKeysTableProps) {
+	const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+	const toggle = (id: string) => {
+		setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+	};
+
+	return (
+		<div className="space-y-4">
+			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="w-10" />
+							<TableHead>Token</TableHead>
+							<TableHead>Description</TableHead>
+							<TableHead>Project</TableHead>
+							<TableHead>Usage</TableHead>
+							<TableHead>IAM Rules</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>Created</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{apiKeys.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={8}
+									className="h-24 text-center text-muted-foreground"
+								>
+									No API keys found
+								</TableCell>
+							</TableRow>
+						) : (
+							apiKeys.map((apiKey) => {
+								const isOpen = !!expanded[apiKey.id];
+								const ruleCount = apiKey.iamRules.length;
+								return (
+									<Fragment key={apiKey.id}>
+										<TableRow>
+											<TableCell>
+												<Button
+													variant="ghost"
+													size="sm"
+													className="h-8 w-8 p-0"
+													disabled={ruleCount === 0}
+													onClick={() => toggle(apiKey.id)}
+													aria-label={
+														isOpen ? "Collapse IAM rules" : "Expand IAM rules"
+													}
+												>
+													{ruleCount === 0 ? (
+														<ChevronRight className="h-4 w-4 opacity-30" />
+													) : isOpen ? (
+														<ChevronDown className="h-4 w-4" />
+													) : (
+														<ChevronRight className="h-4 w-4" />
+													)}
+												</Button>
+											</TableCell>
+											<TableCell className="font-mono text-xs">
+												{apiKey.token.slice(0, 12)}...
+											</TableCell>
+											<TableCell className="max-w-[200px] truncate">
+												{apiKey.description ?? "—"}
+											</TableCell>
+											<TableCell>
+												<span className="text-sm">{apiKey.projectName}</span>
+												<p className="text-xs text-muted-foreground">
+													{apiKey.projectId}
+												</p>
+											</TableCell>
+											<TableCell className="tabular-nums text-sm">
+												{creditsFormatter.format(parseFloat(apiKey.usage))}
+												{apiKey.usageLimit && (
+													<span className="text-muted-foreground">
+														{" "}
+														/{" "}
+														{creditsFormatter.format(
+															parseFloat(apiKey.usageLimit),
+														)}
+													</span>
+												)}
+											</TableCell>
+											<TableCell>
+												<Badge
+													variant={ruleCount > 0 ? "secondary" : "outline"}
+													className="gap-1"
+												>
+													<Shield className="h-3 w-3" />
+													{ruleCount}
+												</Badge>
+											</TableCell>
+											<TableCell>
+												<Badge
+													variant={
+														apiKey.status === "active" ? "secondary" : "outline"
+													}
+												>
+													{apiKey.status ?? "active"}
+												</Badge>
+											</TableCell>
+											<TableCell className="text-muted-foreground">
+												{formatDate(apiKey.createdAt)}
+											</TableCell>
+										</TableRow>
+										{isOpen && ruleCount > 0 && (
+											<TableRow className="bg-muted/30 hover:bg-muted/30">
+												<TableCell />
+												<TableCell colSpan={7} className="py-3">
+													<div className="space-y-2">
+														<div className="text-xs font-medium text-muted-foreground">
+															IAM Rules ({ruleCount})
+														</div>
+														<div className="overflow-hidden rounded-md border border-border/60 bg-background">
+															<Table>
+																<TableHeader>
+																	<TableRow>
+																		<TableHead>Type</TableHead>
+																		<TableHead>Value</TableHead>
+																		<TableHead>Status</TableHead>
+																		<TableHead>Created</TableHead>
+																	</TableRow>
+																</TableHeader>
+																<TableBody>
+																	{apiKey.iamRules.map((rule) => (
+																		<TableRow key={rule.id}>
+																			<TableCell>
+																				<Badge
+																					variant={ruleTypeBadgeVariant(
+																						rule.ruleType,
+																					)}
+																				>
+																					{formatRuleType(rule.ruleType)}
+																				</Badge>
+																			</TableCell>
+																			<TableCell className="text-xs text-muted-foreground">
+																				{formatRuleValue(rule)}
+																			</TableCell>
+																			<TableCell>
+																				<Badge
+																					variant={
+																						rule.status === "active"
+																							? "secondary"
+																							: "outline"
+																					}
+																				>
+																					{rule.status}
+																				</Badge>
+																			</TableCell>
+																			<TableCell className="text-xs text-muted-foreground">
+																				{formatDate(rule.createdAt)}
+																			</TableCell>
+																		</TableRow>
+																	))}
+																</TableBody>
+															</Table>
+														</div>
+													</div>
+												</TableCell>
+											</TableRow>
+										)}
+									</Fragment>
+								);
+							})
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{akTotalPages > 1 && (
+				<div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<p className="text-sm text-muted-foreground">
+						Showing {akOffset + 1} to {Math.min(akOffset + akLimit, akTotal)} of{" "}
+						{akTotal}
+					</p>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" size="sm" asChild disabled={akPage <= 1}>
+							<Link
+								href={`/organizations/${orgId}?tab=api-keys&txPage=${txPage}&akPage=${akPage - 1}`}
+								className={akPage <= 1 ? "pointer-events-none opacity-50" : ""}
+							>
+								Previous
+							</Link>
+						</Button>
+						<span className="text-sm text-muted-foreground">
+							Page {akPage} of {akTotalPages}
+						</span>
+						<Button
+							variant="outline"
+							size="sm"
+							asChild
+							disabled={akPage >= akTotalPages}
+						>
+							<Link
+								href={`/organizations/${orgId}?tab=api-keys&txPage=${txPage}&akPage=${akPage + 1}`}
+								className={
+									akPage >= akTotalPages ? "pointer-events-none opacity-50" : ""
+								}
+							>
+								Next
+							</Link>
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -5,6 +5,7 @@ import {
 	ChevronRight,
 	FolderOpen,
 	Key,
+	KeyRound,
 	Receipt,
 	Users,
 } from "lucide-react";
@@ -30,9 +31,11 @@ import {
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 
+import { ApiKeysTable } from "./api-keys-table";
 import { GiftCreditsDialog } from "./gift-credits-dialog";
 import { OrgCostByModel } from "./org-cost-by-model";
 import { OrgMetricsSection } from "./org-metrics";
+import { ProviderKeysTable } from "./provider-keys-table";
 import { SendEmailDialog } from "./send-email-dialog";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -144,30 +147,39 @@ export default async function OrganizationPage({
 	const akOffset = (akPage - 1) * akLimit;
 
 	const $api = await createServerApiClient();
-	const [transactionsRes, projectsRes, apiKeysRes, membersRes] =
-		await Promise.all([
-			$api.GET("/admin/organizations/{orgId}/transactions", {
-				params: {
-					path: { orgId },
-					query: { limit: txLimit, offset: txOffset },
-				},
-			}),
-			$api.GET("/admin/organizations/{orgId}/projects", {
-				params: { path: { orgId } },
-			}),
-			$api.GET("/admin/organizations/{orgId}/api-keys", {
-				params: {
-					path: { orgId },
-					query: { limit: akLimit, offset: akOffset },
-				},
-			}),
-			$api.GET("/admin/organizations/{orgId}/members", {
-				params: { path: { orgId } },
-			}),
-		]);
+	const [
+		transactionsRes,
+		projectsRes,
+		apiKeysRes,
+		providerKeysRes,
+		membersRes,
+	] = await Promise.all([
+		$api.GET("/admin/organizations/{orgId}/transactions", {
+			params: {
+				path: { orgId },
+				query: { limit: txLimit, offset: txOffset },
+			},
+		}),
+		$api.GET("/admin/organizations/{orgId}/projects", {
+			params: { path: { orgId } },
+		}),
+		$api.GET("/admin/organizations/{orgId}/api-keys", {
+			params: {
+				path: { orgId },
+				query: { limit: akLimit, offset: akOffset },
+			},
+		}),
+		$api.GET("/admin/organizations/{orgId}/provider-keys", {
+			params: { path: { orgId } },
+		}),
+		$api.GET("/admin/organizations/{orgId}/members", {
+			params: { path: { orgId } },
+		}),
+	]);
 	const transactionsData = transactionsRes.data;
 	const projectsData = projectsRes.data;
 	const apiKeysData = apiKeysRes.data;
+	const providerKeysData = providerKeysRes.data;
 	const membersData = membersRes.data;
 
 	if (transactionsData === null) {
@@ -187,6 +199,8 @@ export default async function OrganizationPage({
 	const apiKeys = apiKeysData?.apiKeys ?? [];
 	const akTotal = apiKeysData?.total ?? 0;
 	const akTotalPages = Math.ceil(akTotal / akLimit);
+	const providerKeys = providerKeysData?.providerKeys ?? [];
+	const providerKeysTotal = providerKeysData?.total ?? 0;
 	const members = membersData?.members ?? [];
 	const membersTotal = membersData?.total ?? 0;
 
@@ -324,6 +338,10 @@ export default async function OrganizationPage({
 						<Key className="mr-1.5 h-4 w-4" />
 						API Keys ({akTotal})
 					</TabsTrigger>
+					<TabsTrigger value="provider-keys">
+						<KeyRound className="mr-1.5 h-4 w-4" />
+						Provider Keys ({providerKeysTotal})
+					</TabsTrigger>
 					<TabsTrigger value="members">
 						<Users className="mr-1.5 h-4 w-4" />
 						Members ({membersTotal})
@@ -457,125 +475,20 @@ export default async function OrganizationPage({
 				</TabsContent>
 
 				<TabsContent value="api-keys">
-					<div className="space-y-4">
-						<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead>Token</TableHead>
-										<TableHead>Description</TableHead>
-										<TableHead>Project</TableHead>
-										<TableHead>Usage</TableHead>
-										<TableHead>Status</TableHead>
-										<TableHead>Created</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{apiKeys.length === 0 ? (
-										<TableRow>
-											<TableCell
-												colSpan={6}
-												className="h-24 text-center text-muted-foreground"
-											>
-												No API keys found
-											</TableCell>
-										</TableRow>
-									) : (
-										apiKeys.map((apiKey) => (
-											<TableRow key={apiKey.id}>
-												<TableCell className="font-mono text-xs">
-													{apiKey.token.slice(0, 12)}...
-												</TableCell>
-												<TableCell className="max-w-[200px] truncate">
-													{apiKey.description ?? "—"}
-												</TableCell>
-												<TableCell>
-													<span className="text-sm">{apiKey.projectName}</span>
-													<p className="text-xs text-muted-foreground">
-														{apiKey.projectId}
-													</p>
-												</TableCell>
-												<TableCell className="tabular-nums text-sm">
-													{creditsFormatter.format(parseFloat(apiKey.usage))}
-													{apiKey.usageLimit && (
-														<span className="text-muted-foreground">
-															{" "}
-															/{" "}
-															{creditsFormatter.format(
-																parseFloat(apiKey.usageLimit),
-															)}
-														</span>
-													)}
-												</TableCell>
-												<TableCell>
-													<Badge
-														variant={
-															apiKey.status === "active"
-																? "secondary"
-																: "outline"
-														}
-													>
-														{apiKey.status ?? "active"}
-													</Badge>
-												</TableCell>
-												<TableCell className="text-muted-foreground">
-													{formatDate(apiKey.createdAt)}
-												</TableCell>
-											</TableRow>
-										))
-									)}
-								</TableBody>
-							</Table>
-						</div>
+					<ApiKeysTable
+						apiKeys={apiKeys}
+						orgId={orgId}
+						txPage={txPage}
+						akPage={akPage}
+						akOffset={akOffset}
+						akLimit={akLimit}
+						akTotal={akTotal}
+						akTotalPages={akTotalPages}
+					/>
+				</TabsContent>
 
-						{akTotalPages > 1 && (
-							<div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-								<p className="text-sm text-muted-foreground">
-									Showing {akOffset + 1} to{" "}
-									{Math.min(akOffset + akLimit, akTotal)} of {akTotal}
-								</p>
-								<div className="flex items-center gap-2">
-									<Button
-										variant="outline"
-										size="sm"
-										asChild
-										disabled={akPage <= 1}
-									>
-										<Link
-											href={`/organizations/${orgId}?tab=api-keys&txPage=${txPage}&akPage=${akPage - 1}`}
-											className={
-												akPage <= 1 ? "pointer-events-none opacity-50" : ""
-											}
-										>
-											<ChevronLeft className="h-4 w-4" />
-											Previous
-										</Link>
-									</Button>
-									<span className="text-sm text-muted-foreground">
-										Page {akPage} of {akTotalPages}
-									</span>
-									<Button
-										variant="outline"
-										size="sm"
-										asChild
-										disabled={akPage >= akTotalPages}
-									>
-										<Link
-											href={`/organizations/${orgId}?tab=api-keys&txPage=${txPage}&akPage=${akPage + 1}`}
-											className={
-												akPage >= akTotalPages
-													? "pointer-events-none opacity-50"
-													: ""
-											}
-										>
-											Next
-											<ChevronRight className="h-4 w-4" />
-										</Link>
-									</Button>
-								</div>
-							</div>
-						)}
-					</div>
+				<TabsContent value="provider-keys">
+					<ProviderKeysTable providerKeys={providerKeys} />
 				</TabsContent>
 
 				<TabsContent value="members">

--- a/ee/admin/src/app/organizations/[orgId]/provider-keys-table.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/provider-keys-table.tsx
@@ -1,0 +1,80 @@
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+import type { paths } from "@/lib/api/v1";
+
+type ProviderKey =
+	paths["/admin/organizations/{orgId}/provider-keys"]["get"]["responses"]["200"]["content"]["application/json"]["providerKeys"][number];
+
+function formatDate(dateString: string) {
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export function ProviderKeysTable({
+	providerKeys,
+}: {
+	providerKeys: ProviderKey[];
+}) {
+	return (
+		<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Provider</TableHead>
+						<TableHead>Name</TableHead>
+						<TableHead>Token</TableHead>
+						<TableHead>Base URL</TableHead>
+						<TableHead>Status</TableHead>
+						<TableHead>Created</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{providerKeys.length === 0 ? (
+						<TableRow>
+							<TableCell
+								colSpan={6}
+								className="h-24 text-center text-muted-foreground"
+							>
+								No provider keys found
+							</TableCell>
+						</TableRow>
+					) : (
+						providerKeys.map((key) => (
+							<TableRow key={key.id}>
+								<TableCell>
+									<Badge variant="outline">{key.provider}</Badge>
+								</TableCell>
+								<TableCell className="text-sm">{key.name ?? "—"}</TableCell>
+								<TableCell className="font-mono text-xs">{key.token}</TableCell>
+								<TableCell className="max-w-[240px] truncate text-xs text-muted-foreground">
+									{key.baseUrl ?? "—"}
+								</TableCell>
+								<TableCell>
+									<Badge
+										variant={key.status === "active" ? "secondary" : "outline"}
+									>
+										{key.status ?? "active"}
+									</Badge>
+								</TableCell>
+								<TableCell className="text-muted-foreground">
+									{formatDate(key.createdAt)}
+								</TableCell>
+							</TableRow>
+						))
+					)}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2690,10 +2690,84 @@ export interface paths {
                                 projectId: string;
                                 projectName: string;
                                 createdAt: string;
+                                iamRules: {
+                                    id: string;
+                                    createdAt: string;
+                                    updatedAt: string;
+                                    apiKeyId: string;
+                                    /** @enum {string} */
+                                    ruleType: "allow_models" | "deny_models" | "allow_pricing" | "deny_pricing" | "allow_providers" | "deny_providers";
+                                    ruleValue: {
+                                        models?: string[];
+                                        providers?: string[];
+                                        /** @enum {string} */
+                                        pricingType?: "free" | "paid";
+                                        maxInputPrice?: number;
+                                        maxOutputPrice?: number;
+                                    };
+                                    /** @enum {string} */
+                                    status: "active" | "inactive";
+                                }[];
                             }[];
                             total: number;
                             limit: number;
                             offset: number;
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/organizations/{orgId}/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization provider keys. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            providerKeys: {
+                                id: string;
+                                token: string;
+                                provider: string;
+                                name: string | null;
+                                baseUrl: string | null;
+                                status: string | null;
+                                createdAt: string;
+                                updatedAt: string;
+                            }[];
+                            total: number;
                         };
                     };
                 };


### PR DESCRIPTION
## Summary

- Add IAM rule count column and expandable row to the API Keys table on the org detail page; expanding shows all IAM rules (type, value, status, created date) for that key.
- Add a new **Provider Keys** tab to the org detail page that lists all provider keys (provider, name, masked token, base URL, status, created).
- Backend: extend `GET /admin/organizations/{orgId}/api-keys` to include the `iamRules` array per key, and add a new `GET /admin/organizations/{orgId}/provider-keys` endpoint.

## Test plan

- [ ] Visit an org detail page in the admin dashboard
- [ ] API Keys tab shows the new **IAM Rules** column with a count badge
- [ ] Clicking the chevron on a row with rules expands an inline table of rules
- [ ] Provider Keys tab loads and lists provider keys for the org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API keys table now displays authorization rules with expandable details for each key, including associated projects, usage limits, and rule counts.
  * Provider keys management tab added to organization settings with secure token masking and provider information display.
  * Pagination controls added for browsing API and provider keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->