### PR TITLE
feat(ui): add API key breakdown on model usage page

### DIFF
--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -195,6 +195,7 @@ const getActivity = createRoute({
 			projectId: z.string().optional(),
 			apiKeyId: z.string().optional(),
 			timeRange: z.enum(["1h", "4h", "24h", "7d", "30d"]).optional(),
+			groupBy: z.enum(["model", "apiKey"]).optional(),
 		}),
 	},
 	responses: {
@@ -222,8 +223,9 @@ activity.openapi(getActivity, async (c) => {
 	}
 
 	// Get the query parameters
-	const { days, from, to, projectId, apiKeyId, timeRange } =
+	const { days, from, to, projectId, apiKeyId, timeRange, groupBy } =
 		c.req.valid("query");
+	const breakdownByApiKey = groupBy === "apiKey";
 
 	// Calculate the date range and granularity
 	let startDate: Date;
@@ -721,142 +723,149 @@ activity.openapi(getActivity, async (c) => {
 				: sql`DATE(${projectHourlyStats.hourTimestamp}) ASC`,
 		);
 
-	// Query model breakdown from projectHourlyModelStats table
-	const modelBreakdowns = await db
-		.select({
-			date: isHourly
-				? sql<string>`to_char(${projectHourlyModelStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-						"date",
-					)
-				: sql<string>`DATE(${projectHourlyModelStats.hourTimestamp})`.as(
-						"date",
-					),
-			usedModel: projectHourlyModelStats.usedModel,
-			usedProvider: projectHourlyModelStats.usedProvider,
-			requestCount:
-				sql<number>`COALESCE(SUM(${projectHourlyModelStats.requestCount}), 0)`.as(
-					"requestCount",
-				),
-			inputTokens:
-				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.inputTokens} AS NUMERIC)), 0)`.as(
-					"inputTokens",
-				),
-			outputTokens:
-				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.outputTokens} AS NUMERIC)), 0)`.as(
-					"outputTokens",
-				),
-			totalTokens:
-				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
-					"totalTokens",
-				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
-				"cost",
-			),
-		})
-		.from(projectHourlyModelStats)
-		.where(
-			and(
-				inArray(projectHourlyModelStats.projectId, projectIds),
-				gte(projectHourlyModelStats.hourTimestamp, startDate),
-				lte(projectHourlyModelStats.hourTimestamp, endDate),
-			),
-		)
-		.groupBy(
-			isHourly
-				? sql`${projectHourlyModelStats.hourTimestamp}, ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`
-				: sql`DATE(${projectHourlyModelStats.hourTimestamp}), ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`,
-		)
-		.orderBy(
-			isHourly
-				? sql`${projectHourlyModelStats.hourTimestamp} ASC, ${projectHourlyModelStats.usedModel} ASC`
-				: sql`DATE(${projectHourlyModelStats.hourTimestamp}) ASC, ${projectHourlyModelStats.usedModel} ASC`,
-		);
-
-	// Create a map to organize model breakdowns by date
+	// Create a map to organize model breakdowns by date.
+	// Only query when not breaking down by api key — saves an aggregate scan
+	// for callers that opt into the api-key breakdown.
 	const modelBreakdownByDate = new Map<
 		string,
 		z.infer<typeof modelUsageSchema>[]
 	>();
-	for (const breakdown of modelBreakdowns) {
-		if (!modelBreakdownByDate.has(breakdown.date)) {
-			modelBreakdownByDate.set(breakdown.date, []);
+	if (!breakdownByApiKey) {
+		const modelBreakdowns = await db
+			.select({
+				date: isHourly
+					? sql<string>`to_char(${projectHourlyModelStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
+							"date",
+						)
+					: sql<string>`DATE(${projectHourlyModelStats.hourTimestamp})`.as(
+							"date",
+						),
+				usedModel: projectHourlyModelStats.usedModel,
+				usedProvider: projectHourlyModelStats.usedProvider,
+				requestCount:
+					sql<number>`COALESCE(SUM(${projectHourlyModelStats.requestCount}), 0)`.as(
+						"requestCount",
+					),
+				inputTokens:
+					sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.inputTokens} AS NUMERIC)), 0)`.as(
+						"inputTokens",
+					),
+				outputTokens:
+					sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.outputTokens} AS NUMERIC)), 0)`.as(
+						"outputTokens",
+					),
+				totalTokens:
+					sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
+						"totalTokens",
+					),
+				cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+					"cost",
+				),
+			})
+			.from(projectHourlyModelStats)
+			.where(
+				and(
+					inArray(projectHourlyModelStats.projectId, projectIds),
+					gte(projectHourlyModelStats.hourTimestamp, startDate),
+					lte(projectHourlyModelStats.hourTimestamp, endDate),
+				),
+			)
+			.groupBy(
+				isHourly
+					? sql`${projectHourlyModelStats.hourTimestamp}, ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`
+					: sql`DATE(${projectHourlyModelStats.hourTimestamp}), ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`,
+			)
+			.orderBy(
+				isHourly
+					? sql`${projectHourlyModelStats.hourTimestamp} ASC, ${projectHourlyModelStats.usedModel} ASC`
+					: sql`DATE(${projectHourlyModelStats.hourTimestamp}) ASC, ${projectHourlyModelStats.usedModel} ASC`,
+			);
+
+		for (const breakdown of modelBreakdowns) {
+			if (!modelBreakdownByDate.has(breakdown.date)) {
+				modelBreakdownByDate.set(breakdown.date, []);
+			}
+			modelBreakdownByDate.get(breakdown.date)!.push({
+				id: breakdown.usedModel || "unknown",
+				provider: breakdown.usedProvider || "unknown",
+				requestCount: Number(breakdown.requestCount),
+				inputTokens: Number(breakdown.inputTokens),
+				outputTokens: Number(breakdown.outputTokens),
+				totalTokens: Number(breakdown.totalTokens),
+				cost: Number(breakdown.cost),
+			});
 		}
-		modelBreakdownByDate.get(breakdown.date)!.push({
-			id: breakdown.usedModel || "unknown",
-			provider: breakdown.usedProvider || "unknown",
-			requestCount: Number(breakdown.requestCount),
-			inputTokens: Number(breakdown.inputTokens),
-			outputTokens: Number(breakdown.outputTokens),
-			totalTokens: Number(breakdown.totalTokens),
-			cost: Number(breakdown.cost),
-		});
 	}
 
-	// Query api key breakdown from apiKeyHourlyStats table joined with apiKey
-	const apiKeyBreakdowns = await db
-		.select({
-			date: isHourly
-				? sql<string>`to_char(${apiKeyHourlyStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-						"date",
-					)
-				: sql<string>`DATE(${apiKeyHourlyStats.hourTimestamp})`.as("date"),
-			apiKeyId: apiKeyHourlyStats.apiKeyId,
-			description: apiKey.description,
-			requestCount:
-				sql<number>`COALESCE(SUM(${apiKeyHourlyStats.requestCount}), 0)`.as(
-					"requestCount",
-				),
-			inputTokens:
-				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.inputTokens} AS NUMERIC)), 0)`.as(
-					"inputTokens",
-				),
-			outputTokens:
-				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.outputTokens} AS NUMERIC)), 0)`.as(
-					"outputTokens",
-				),
-			totalTokens:
-				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
-					"totalTokens",
-				),
-			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
-		})
-		.from(apiKeyHourlyStats)
-		.leftJoin(apiKey, eq(apiKey.id, apiKeyHourlyStats.apiKeyId))
-		.where(
-			and(
-				inArray(apiKeyHourlyStats.projectId, projectIds),
-				gte(apiKeyHourlyStats.hourTimestamp, startDate),
-				lte(apiKeyHourlyStats.hourTimestamp, endDate),
-			),
-		)
-		.groupBy(
-			isHourly
-				? sql`${apiKeyHourlyStats.hourTimestamp}, ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`
-				: sql`DATE(${apiKeyHourlyStats.hourTimestamp}), ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`,
-		)
-		.orderBy(
-			isHourly
-				? sql`${apiKeyHourlyStats.hourTimestamp} ASC, ${apiKeyHourlyStats.apiKeyId} ASC`
-				: sql`DATE(${apiKeyHourlyStats.hourTimestamp}) ASC, ${apiKeyHourlyStats.apiKeyId} ASC`,
-		);
-
+	// Query api key breakdown only when the caller asks for it.
 	const apiKeyBreakdownByDate = new Map<
 		string,
 		z.infer<typeof apiKeyUsageSchema>[]
 	>();
-	for (const breakdown of apiKeyBreakdowns) {
-		if (!apiKeyBreakdownByDate.has(breakdown.date)) {
-			apiKeyBreakdownByDate.set(breakdown.date, []);
+	if (breakdownByApiKey) {
+		const apiKeyBreakdowns = await db
+			.select({
+				date: isHourly
+					? sql<string>`to_char(${apiKeyHourlyStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
+							"date",
+						)
+					: sql<string>`DATE(${apiKeyHourlyStats.hourTimestamp})`.as("date"),
+				apiKeyId: apiKeyHourlyStats.apiKeyId,
+				description: apiKey.description,
+				requestCount:
+					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.requestCount}), 0)`.as(
+						"requestCount",
+					),
+				inputTokens:
+					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.inputTokens} AS NUMERIC)), 0)`.as(
+						"inputTokens",
+					),
+				outputTokens:
+					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.outputTokens} AS NUMERIC)), 0)`.as(
+						"outputTokens",
+					),
+				totalTokens:
+					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
+						"totalTokens",
+					),
+				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
+					"cost",
+				),
+			})
+			.from(apiKeyHourlyStats)
+			.leftJoin(apiKey, eq(apiKey.id, apiKeyHourlyStats.apiKeyId))
+			.where(
+				and(
+					inArray(apiKeyHourlyStats.projectId, projectIds),
+					gte(apiKeyHourlyStats.hourTimestamp, startDate),
+					lte(apiKeyHourlyStats.hourTimestamp, endDate),
+				),
+			)
+			.groupBy(
+				isHourly
+					? sql`${apiKeyHourlyStats.hourTimestamp}, ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`
+					: sql`DATE(${apiKeyHourlyStats.hourTimestamp}), ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`,
+			)
+			.orderBy(
+				isHourly
+					? sql`${apiKeyHourlyStats.hourTimestamp} ASC, ${apiKeyHourlyStats.apiKeyId} ASC`
+					: sql`DATE(${apiKeyHourlyStats.hourTimestamp}) ASC, ${apiKeyHourlyStats.apiKeyId} ASC`,
+			);
+
+		for (const breakdown of apiKeyBreakdowns) {
+			if (!apiKeyBreakdownByDate.has(breakdown.date)) {
+				apiKeyBreakdownByDate.set(breakdown.date, []);
+			}
+			apiKeyBreakdownByDate.get(breakdown.date)!.push({
+				id: breakdown.apiKeyId,
+				description: breakdown.description ?? "Deleted key",
+				requestCount: Number(breakdown.requestCount),
+				inputTokens: Number(breakdown.inputTokens),
+				outputTokens: Number(breakdown.outputTokens),
+				totalTokens: Number(breakdown.totalTokens),
+				cost: Number(breakdown.cost),
+			});
 		}
-		apiKeyBreakdownByDate.get(breakdown.date)!.push({
-			id: breakdown.apiKeyId,
-			description: breakdown.description ?? "Deleted key",
-			requestCount: Number(breakdown.requestCount),
-			inputTokens: Number(breakdown.inputTokens),
-			outputTokens: Number(breakdown.outputTokens),
-			totalTokens: Number(breakdown.totalTokens),
-			cost: Number(breakdown.cost),
-		});
 	}
 
 	// Process hourly aggregates (summed to daily) and add calculated fields

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -12,6 +12,7 @@ import {
 	gte,
 	lte,
 	eq,
+	apiKey,
 	projectHourlyStats,
 	projectHourlyModelStats,
 	apiKeyHourlyStats,
@@ -26,6 +27,17 @@ export const activity = new OpenAPIHono<ServerTypes>();
 const modelUsageSchema = z.object({
 	id: z.string(),
 	provider: z.string(),
+	requestCount: z.number(),
+	inputTokens: z.number(),
+	outputTokens: z.number(),
+	totalTokens: z.number(),
+	cost: z.number(),
+});
+
+// Define the response schema for api-key-specific usage
+const apiKeyUsageSchema = z.object({
+	id: z.string(),
+	description: z.string(),
 	requestCount: z.number(),
 	inputTokens: z.number(),
 	outputTokens: z.number(),
@@ -65,6 +77,7 @@ const dailyActivitySchema = z.object({
 	creditsDataStorageCost: z.number(),
 	apiKeysDataStorageCost: z.number(),
 	modelBreakdown: z.array(modelUsageSchema),
+	apiKeyBreakdown: z.array(apiKeyUsageSchema),
 });
 
 type ActivityRow = z.infer<typeof dailyActivitySchema>;
@@ -151,6 +164,7 @@ function buildEmptyActivityRow(date: string): ActivityRow {
 		creditsDataStorageCost: 0,
 		apiKeysDataStorageCost: 0,
 		modelBreakdown: [],
+		apiKeyBreakdown: [],
 	};
 }
 
@@ -561,6 +575,7 @@ activity.openapi(getActivity, async (c) => {
 				creditsDataStorageCost,
 				apiKeysDataStorageCost,
 				modelBreakdown: modelBreakdownByDate.get(day.date) ?? [],
+				apiKeyBreakdown: [],
 			};
 		});
 
@@ -777,6 +792,73 @@ activity.openapi(getActivity, async (c) => {
 		});
 	}
 
+	// Query api key breakdown from apiKeyHourlyStats table joined with apiKey
+	const apiKeyBreakdowns = await db
+		.select({
+			date: isHourly
+				? sql<string>`to_char(${apiKeyHourlyStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
+						"date",
+					)
+				: sql<string>`DATE(${apiKeyHourlyStats.hourTimestamp})`.as("date"),
+			apiKeyId: apiKeyHourlyStats.apiKeyId,
+			description: apiKey.description,
+			requestCount:
+				sql<number>`COALESCE(SUM(${apiKeyHourlyStats.requestCount}), 0)`.as(
+					"requestCount",
+				),
+			inputTokens:
+				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.inputTokens} AS NUMERIC)), 0)`.as(
+					"inputTokens",
+				),
+			outputTokens:
+				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.outputTokens} AS NUMERIC)), 0)`.as(
+					"outputTokens",
+				),
+			totalTokens:
+				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
+					"totalTokens",
+				),
+			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
+		})
+		.from(apiKeyHourlyStats)
+		.leftJoin(apiKey, eq(apiKey.id, apiKeyHourlyStats.apiKeyId))
+		.where(
+			and(
+				inArray(apiKeyHourlyStats.projectId, projectIds),
+				gte(apiKeyHourlyStats.hourTimestamp, startDate),
+				lte(apiKeyHourlyStats.hourTimestamp, endDate),
+			),
+		)
+		.groupBy(
+			isHourly
+				? sql`${apiKeyHourlyStats.hourTimestamp}, ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`
+				: sql`DATE(${apiKeyHourlyStats.hourTimestamp}), ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`,
+		)
+		.orderBy(
+			isHourly
+				? sql`${apiKeyHourlyStats.hourTimestamp} ASC, ${apiKeyHourlyStats.apiKeyId} ASC`
+				: sql`DATE(${apiKeyHourlyStats.hourTimestamp}) ASC, ${apiKeyHourlyStats.apiKeyId} ASC`,
+		);
+
+	const apiKeyBreakdownByDate = new Map<
+		string,
+		z.infer<typeof apiKeyUsageSchema>[]
+	>();
+	for (const breakdown of apiKeyBreakdowns) {
+		if (!apiKeyBreakdownByDate.has(breakdown.date)) {
+			apiKeyBreakdownByDate.set(breakdown.date, []);
+		}
+		apiKeyBreakdownByDate.get(breakdown.date)!.push({
+			id: breakdown.apiKeyId,
+			description: breakdown.description ?? "Deleted key",
+			requestCount: Number(breakdown.requestCount),
+			inputTokens: Number(breakdown.inputTokens),
+			outputTokens: Number(breakdown.outputTokens),
+			totalTokens: Number(breakdown.totalTokens),
+			cost: Number(breakdown.cost),
+		});
+	}
+
 	// Process hourly aggregates (summed to daily) and add calculated fields
 	const activityData = hourlyAggregates.map((day) => {
 		// Convert database strings to numbers
@@ -842,6 +924,7 @@ activity.openapi(getActivity, async (c) => {
 			creditsDataStorageCost,
 			apiKeysDataStorageCost,
 			modelBreakdown: modelBreakdownByDate.get(day.date) ?? [],
+			apiKeyBreakdown: apiKeyBreakdownByDate.get(day.date) ?? [],
 		};
 	});
 

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2121,6 +2121,7 @@ export interface paths {
                     projectId?: string;
                     apiKeyId?: string;
                     timeRange?: "1h" | "4h" | "24h" | "7d" | "30d";
+                    groupBy?: "model" | "apiKey";
                 };
                 header?: never;
                 path?: never;

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2174,6 +2174,15 @@ export interface paths {
                                     totalTokens: number;
                                     cost: number;
                                 }[];
+                                apiKeyBreakdown: {
+                                    id: string;
+                                    description: string;
+                                    requestCount: number;
+                                    inputTokens: number;
+                                    outputTokens: number;
+                                    totalTokens: number;
+                                    cost: number;
+                                }[];
                             }[];
                             /** @enum {string} */
                             granularity?: "hourly" | "daily";

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2121,6 +2121,7 @@ export interface paths {
                     projectId?: string;
                     apiKeyId?: string;
                     timeRange?: "1h" | "4h" | "24h" | "7d" | "30d";
+                    groupBy?: "model" | "apiKey";
                 };
                 header?: never;
                 path?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2174,6 +2174,15 @@ export interface paths {
                                     totalTokens: number;
                                     cost: number;
                                 }[];
+                                apiKeyBreakdown: {
+                                    id: string;
+                                    description: string;
+                                    requestCount: number;
+                                    inputTokens: number;
+                                    outputTokens: number;
+                                    totalTokens: number;
+                                    cost: number;
+                                }[];
                             }[];
                             /** @enum {string} */
                             granularity?: "hourly" | "daily";

--- a/apps/ui/src/components/dashboard/activity-chart.tsx
+++ b/apps/ui/src/components/dashboard/activity-chart.tsx
@@ -38,31 +38,43 @@ import {
 import { useApi } from "@/lib/fetch-client";
 
 import type { TimeRangeValue } from "@/components/time-range-picker";
-import type { ActivitT, ActivityModelUsage } from "@/types/activity";
+import type {
+	ActivitT,
+	ActivityApiKeyUsage,
+	ActivityModelUsage,
+} from "@/types/activity";
 import type { TooltipProps } from "recharts";
 
-// Helper function to get all unique models from the data
-function getUniqueModels(
-	data: { modelBreakdown: { id: string }[] }[],
+type GroupBy = "model" | "apiKey";
+
+// Helper function to get all unique series (model ids or api key ids) from the data
+function getUniqueSeries(
+	data: {
+		modelBreakdown: { id: string }[];
+		apiKeyBreakdown: { id: string }[];
+	}[],
+	groupBy: GroupBy,
 ): string[] {
 	if (!data || data.length === 0) {
 		return [];
 	}
 
-	const allModels = new Set<string>();
+	const all = new Set<string>();
 	data.forEach((day) => {
-		if (day.modelBreakdown && day.modelBreakdown.length > 0) {
-			day.modelBreakdown.forEach((model) => {
-				allModels.add(model.id);
+		const items =
+			groupBy === "apiKey" ? day.apiKeyBreakdown : day.modelBreakdown;
+		if (items && items.length > 0) {
+			items.forEach((item) => {
+				all.add(item.id);
 			});
 		}
 	});
 
-	return Array.from(allModels);
+	return Array.from(all);
 }
 
-// Helper function to generate colors for each model
-function getModelColor(model: string, index: number): string {
+// Helper function to generate colors for each series
+function getSeriesColor(_series: string, index: number): string {
 	// Define a set of colors for the bars
 	const colors = [
 		"#4f46e5", // indigo
@@ -112,6 +124,7 @@ interface TooltipPayload {
 		totalTokens: number;
 		cost: number;
 		modelBreakdown: ActivityModelUsage[];
+		apiKeyBreakdown: ActivityApiKeyUsage[];
 	};
 }
 
@@ -121,6 +134,7 @@ interface CustomTooltipProps extends TooltipProps<number, string> {
 	label?: string;
 	breakdownField?: "requests" | "cost" | "tokens";
 	hourly?: boolean;
+	groupBy?: GroupBy;
 }
 
 const CustomTooltip = ({
@@ -129,6 +143,7 @@ const CustomTooltip = ({
 	label,
 	breakdownField = "requests",
 	hourly = false,
+	groupBy = "model",
 }: CustomTooltipProps) => {
 	if (active && payload && payload.length) {
 		const data = payload[0].payload;
@@ -154,16 +169,29 @@ const CustomTooltip = ({
 					<span className="font-medium">${data.cost.toFixed(4)}</span> estimated
 					cost
 				</p>
-				{Array.isArray(data.modelBreakdown) &&
+				{groupBy === "model" &&
+					Array.isArray(data.modelBreakdown) &&
 					data.modelBreakdown.length === 1 && (
 						<p className="mt-1 text-xs text-muted-foreground">
 							Model:{" "}
 							<span className="font-medium">{data.modelBreakdown[0]?.id}</span>
 						</p>
 					)}
+				{groupBy === "apiKey" &&
+					Array.isArray(data.apiKeyBreakdown) &&
+					data.apiKeyBreakdown.length === 1 && (
+						<p className="mt-1 text-xs text-muted-foreground">
+							API key:{" "}
+							<span className="font-medium">
+								{data.apiKeyBreakdown[0]?.description}
+							</span>
+						</p>
+					)}
 				{payload.length > 1 && (
 					<div className="mt-2 pt-2 border-t">
-						<p className="text-sm font-medium">Model Breakdown:</p>
+						<p className="text-sm font-medium">
+							{groupBy === "apiKey" ? "API Key Breakdown:" : "Model Breakdown:"}
+						</p>
 						{payload.map((entry, index) => {
 							// Skip the entry if it's not a model (e.g., it's the total requestCount)
 							if (entry.dataKey === "requestCount") {
@@ -216,12 +244,14 @@ interface ActivityChartProps {
 	initialData?: ActivitT;
 	apiKeyId?: string;
 	timeRange?: TimeRangeValue;
+	groupBy?: GroupBy;
 }
 
 export function ActivityChart({
 	initialData,
 	apiKeyId,
 	timeRange,
+	groupBy = "model",
 }: ActivityChartProps) {
 	const searchParams = useSearchParams();
 	const [breakdownField, setBreakdownField] = useState<
@@ -399,17 +429,10 @@ export function ActivityChart({
 		if (dataByDate.has(slot)) {
 			const dayData = dataByDate.get(slot)!;
 
-			// Process model breakdown data for stacked bars
+			// Process breakdown data for stacked bars
 			const result: Record<
 				string,
-				| string
-				| number
-				| {
-						id: string;
-						requestCount: number;
-						cost: number;
-						totalTokens: number;
-				  }[]
+				string | number | ActivityModelUsage[] | ActivityApiKeyUsage[]
 			> = {
 				...dayData,
 				formattedDate: hourly
@@ -417,18 +440,20 @@ export function ActivityChart({
 					: format(parseISO(slot), "MMM d"),
 			};
 
-			// Add each model's selected metric as a separate property for stacking
-			dayData.modelBreakdown.forEach((model) => {
+			// Add each series' selected metric as a separate property for stacking
+			const items =
+				groupBy === "apiKey" ? dayData.apiKeyBreakdown : dayData.modelBreakdown;
+			items.forEach((item) => {
 				switch (breakdownField) {
 					case "cost":
-						result[model.id] = model.cost;
+						result[item.id] = item.cost;
 						break;
 					case "tokens":
-						result[model.id] = model.totalTokens;
+						result[item.id] = item.totalTokens;
 						break;
 					case "requests":
 					default:
-						result[model.id] = model.requestCount;
+						result[item.id] = item.requestCount;
 						break;
 				}
 			});
@@ -446,19 +471,37 @@ export function ActivityChart({
 			totalTokens: 0,
 			cost: 0,
 			modelBreakdown: [],
+			apiKeyBreakdown: [],
 		};
 	});
 
-	const uniqueModels = getUniqueModels(data.activity);
-	const visibleModels = showAllModels ? uniqueModels : uniqueModels.slice(0, 7);
+	const uniqueSeries = getUniqueSeries(data.activity, groupBy);
+	const visibleSeries = showAllModels ? uniqueSeries : uniqueSeries.slice(0, 7);
+
+	const seriesLabelById = new Map<string, string>();
+	if (groupBy === "apiKey") {
+		data.activity.forEach((day) => {
+			day.apiKeyBreakdown.forEach((item) => {
+				if (!seriesLabelById.has(item.id)) {
+					seriesLabelById.set(item.id, item.description || item.id);
+				}
+			});
+		});
+	}
+	const getSeriesLabel = (id: string) => seriesLabelById.get(id) ?? id;
+	const seriesNoun = groupBy === "apiKey" ? "API key" : "model";
 
 	return (
 		<Card>
 			<CardHeader className="flex flex-col space-y-4 md:flex-row items-center justify-between pb-2">
 				<div>
-					<CardTitle>Model Usage Overview</CardTitle>
+					<CardTitle>
+						{groupBy === "apiKey"
+							? "API Key Usage Overview"
+							: "Model Usage Overview"}
+					</CardTitle>
 					<CardDescription>
-						Stacked model {breakdownField} over {periodLabel}
+						Stacked {seriesNoun} {breakdownField} over {periodLabel}
 						{selectedProject && (
 							<span className="block mt-1 text-sm">
 								Project: {selectedProject.name}
@@ -485,23 +528,25 @@ export function ActivityChart({
 				</div>
 			</CardHeader>
 			<CardContent>
-				{uniqueModels.length > 0 && (
+				{uniqueSeries.length > 0 && (
 					<div className="mb-4 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-						{visibleModels.map((model) => (
-							<div key={model} className="flex items-center gap-2">
+						{visibleSeries.map((id) => (
+							<div key={id} className="flex items-center gap-2">
 								<span
 									className="h-2 w-2 rounded-sm"
 									style={{
-										backgroundColor: getModelColor(
-											model,
-											uniqueModels.indexOf(model),
+										backgroundColor: getSeriesColor(
+											id,
+											uniqueSeries.indexOf(id),
 										),
 									}}
 								/>
-								<span className="truncate max-w-[140px]">{model}</span>
+								<span className="truncate max-w-[140px]">
+									{getSeriesLabel(id)}
+								</span>
 							</div>
 						))}
-						{uniqueModels.length > 7 && (
+						{uniqueSeries.length > 7 && (
 							<button
 								type="button"
 								onClick={() => setShowAllModels((prev) => !prev)}
@@ -509,7 +554,7 @@ export function ActivityChart({
 							>
 								{showAllModels
 									? "Show less"
-									: `+${uniqueModels.length - 7} more`}
+									: `+${uniqueSeries.length - 7} more`}
 							</button>
 						)}
 					</div>
@@ -551,6 +596,7 @@ export function ActivityChart({
 								<CustomTooltip
 									breakdownField={breakdownField}
 									hourly={hourly}
+									groupBy={groupBy}
 								/>
 							}
 							cursor={{
@@ -558,17 +604,17 @@ export function ActivityChart({
 							}}
 						/>
 
-						{/* Generate a Bar for each unique model in the dataset */}
-						{getUniqueModels(data.activity).length > 0 ? (
-							getUniqueModels(data.activity).map((model, index) => (
+						{/* Generate a Bar for each unique series in the dataset */}
+						{uniqueSeries.length > 0 ? (
+							uniqueSeries.map((id, index) => (
 								<Bar
-									key={`${model}-${index}`}
-									dataKey={model}
-									name={model}
-									stackId="models"
-									fill={getModelColor(model, index)}
+									key={`${id}-${index}`}
+									dataKey={id}
+									name={getSeriesLabel(id)}
+									stackId="series"
+									fill={getSeriesColor(id, index)}
 									radius={
-										index === getUniqueModels(data.activity).length - 1
+										index === uniqueSeries.length - 1
 											? [4, 4, 0, 0]
 											: [0, 0, 0, 0]
 									}

--- a/apps/ui/src/components/dashboard/activity-chart.tsx
+++ b/apps/ui/src/components/dashboard/activity-chart.tsx
@@ -265,11 +265,13 @@ export function ActivityChart({
 
 	// Build query params based on whether we're using timeRange or date range
 	const queryParams = useMemo(() => {
+		const breakdownParam = groupBy === "apiKey" ? { groupBy } : {};
 		if (timeRange) {
 			return {
 				timeRange,
 				...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
 				...(apiKeyId ? { apiKeyId } : {}),
+				...breakdownParam,
 			};
 		}
 		const { from, to } = getDateRangeFromParams(searchParams);
@@ -278,8 +280,9 @@ export function ActivityChart({
 			to: format(to, "yyyy-MM-dd"),
 			...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
 			...(apiKeyId ? { apiKeyId } : {}),
+			...breakdownParam,
 		};
-	}, [timeRange, searchParams, selectedProject?.id, apiKeyId]);
+	}, [timeRange, searchParams, selectedProject?.id, apiKeyId, groupBy]);
 
 	const { data, isLoading, error } = api.useQuery(
 		"get",

--- a/apps/ui/src/components/dashboard/activity-chart.tsx
+++ b/apps/ui/src/components/dashboard/activity-chart.tsx
@@ -311,11 +311,15 @@ export function ActivityChart({
 		return `${days} days`;
 	}, [timeRange, searchParams]);
 
+	const seriesNoun = groupBy === "apiKey" ? "API key" : "model";
+	const cardTitle =
+		groupBy === "apiKey" ? "API Key Usage Overview" : "Model Usage Overview";
+
 	if (!selectedProject) {
 		return (
 			<Card>
 				<CardHeader>
-					<CardTitle>Model Usage Overview</CardTitle>
+					<CardTitle>{cardTitle}</CardTitle>
 					<CardDescription>
 						Please select a project to view activity data
 					</CardDescription>
@@ -333,9 +337,9 @@ export function ActivityChart({
 		return (
 			<Card>
 				<CardHeader>
-					<CardTitle>Model Usage Overview</CardTitle>
+					<CardTitle>{cardTitle}</CardTitle>
 					<CardDescription>
-						Stacked model {breakdownField} over {periodLabel}
+						Stacked {seriesNoun} {breakdownField} over {periodLabel}
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -351,9 +355,9 @@ export function ActivityChart({
 		return (
 			<Card>
 				<CardHeader>
-					<CardTitle>Model Usage Overview</CardTitle>
+					<CardTitle>{cardTitle}</CardTitle>
 					<CardDescription>
-						Stacked model {breakdownField} over {periodLabel}
+						Stacked {seriesNoun} {breakdownField} over {periodLabel}
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -369,9 +373,9 @@ export function ActivityChart({
 		return (
 			<Card>
 				<CardHeader>
-					<CardTitle>Model Usage Overview</CardTitle>
+					<CardTitle>{cardTitle}</CardTitle>
 					<CardDescription>
-						Stacked model {breakdownField} over {periodLabel}
+						Stacked {seriesNoun} {breakdownField} over {periodLabel}
 						{selectedProject && (
 							<span className="block mt-1 text-sm">
 								Project: {selectedProject.name}
@@ -489,17 +493,12 @@ export function ActivityChart({
 		});
 	}
 	const getSeriesLabel = (id: string) => seriesLabelById.get(id) ?? id;
-	const seriesNoun = groupBy === "apiKey" ? "API key" : "model";
 
 	return (
 		<Card>
 			<CardHeader className="flex flex-col space-y-4 md:flex-row items-center justify-between pb-2">
 				<div>
-					<CardTitle>
-						{groupBy === "apiKey"
-							? "API Key Usage Overview"
-							: "Model Usage Overview"}
-					</CardTitle>
+					<CardTitle>{cardTitle}</CardTitle>
 					<CardDescription>
 						Stacked {seriesNoun} {breakdownField} over {periodLabel}
 						{selectedProject && (

--- a/apps/ui/src/components/usage/model-usage-client.tsx
+++ b/apps/ui/src/components/usage/model-usage-client.tsx
@@ -21,6 +21,8 @@ interface ModelUsageClientProps {
 	projectId: string;
 }
 
+type GroupBy = "model" | "apiKey";
+
 export function ModelUsageClient({ projectId }: ModelUsageClientProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
@@ -46,7 +48,9 @@ export function ModelUsageClient({ projectId }: ModelUsageClientProps) {
 	const apiKeys =
 		apiKeysData?.apiKeys.filter((key) => key.status !== "deleted") ?? [];
 
-	// Get apiKeyId and timeRange from URL
+	// Get groupBy, apiKeyId and timeRange from URL
+	const groupBy: GroupBy =
+		searchParams.get("groupBy") === "apiKey" ? "apiKey" : "model";
 	const apiKeyId = searchParams.get("apiKeyId") ?? undefined;
 	const timeRange = (searchParams.get("timeRange") as TimeRangeValue) ?? "24h";
 
@@ -72,14 +76,44 @@ export function ModelUsageClient({ projectId }: ModelUsageClientProps) {
 		router.push(`${buildUrl("model-usage")}?${params.toString()}`);
 	};
 
+	const updateGroupBy = (newGroupBy: GroupBy) => {
+		const params = new URLSearchParams(searchParams);
+		if (newGroupBy === "apiKey") {
+			params.set("groupBy", "apiKey");
+			// Clear api key filter when grouping by api key
+			params.delete("apiKeyId");
+		} else {
+			params.delete("groupBy");
+		}
+		router.push(`${buildUrl("model-usage")}?${params.toString()}`);
+	};
+
+	const apiKeyFilterDisabled = groupBy === "apiKey";
+	const effectiveApiKeyId = apiKeyFilterDisabled ? undefined : apiKeyId;
+
 	return (
 		<div className="flex flex-col">
 			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
 				<div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-					<h2 className="text-3xl font-bold tracking-tight">Usage by model</h2>
+					<h2 className="text-3xl font-bold tracking-tight">
+						{groupBy === "apiKey" ? "Usage by API key" : "Usage by model"}
+					</h2>
 					<div className="flex items-center space-x-2">
 						<Select
-							value={apiKeyId ?? "all"}
+							value={groupBy}
+							onValueChange={(v) => updateGroupBy(v as GroupBy)}
+						>
+							<SelectTrigger size="sm" className="w-[180px]">
+								<SelectValue placeholder="Group by" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="model">Breakdown by model</SelectItem>
+								<SelectItem value="apiKey">Breakdown by API key</SelectItem>
+							</SelectContent>
+						</Select>
+						<Select
+							value={effectiveApiKeyId ?? "all"}
+							disabled={apiKeyFilterDisabled}
 							onValueChange={(value) =>
 								updateApiKeyIdInUrl(value === "all" ? undefined : value)
 							}
@@ -100,7 +134,11 @@ export function ModelUsageClient({ projectId }: ModelUsageClientProps) {
 					</div>
 				</div>
 				<div className="space-y-4">
-					<ActivityChart apiKeyId={apiKeyId} timeRange={timeRange} />
+					<ActivityChart
+						apiKeyId={effectiveApiKeyId}
+						timeRange={timeRange}
+						groupBy={groupBy}
+					/>
 				</div>
 			</div>
 		</div>

--- a/apps/ui/src/components/usage/model-usage-client.tsx
+++ b/apps/ui/src/components/usage/model-usage-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
 
 import { ActivityChart } from "@/components/dashboard/activity-chart";
 import {
@@ -90,6 +91,15 @@ export function ModelUsageClient({ projectId }: ModelUsageClientProps) {
 
 	const apiKeyFilterDisabled = groupBy === "apiKey";
 	const effectiveApiKeyId = apiKeyFilterDisabled ? undefined : apiKeyId;
+
+	// Normalize stale URLs: groupBy=apiKey should never coexist with apiKeyId
+	useEffect(() => {
+		if (groupBy === "apiKey" && searchParams.has("apiKeyId")) {
+			const params = new URLSearchParams(searchParams);
+			params.delete("apiKeyId");
+			router.replace(`${buildUrl("model-usage")}?${params.toString()}`);
+		}
+	}, [groupBy, searchParams, router, buildUrl]);
 
 	return (
 		<div className="flex flex-col">

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2121,6 +2121,7 @@ export interface paths {
                     projectId?: string;
                     apiKeyId?: string;
                     timeRange?: "1h" | "4h" | "24h" | "7d" | "30d";
+                    groupBy?: "model" | "apiKey";
                 };
                 header?: never;
                 path?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2174,6 +2174,15 @@ export interface paths {
                                     totalTokens: number;
                                     cost: number;
                                 }[];
+                                apiKeyBreakdown: {
+                                    id: string;
+                                    description: string;
+                                    requestCount: number;
+                                    inputTokens: number;
+                                    outputTokens: number;
+                                    totalTokens: number;
+                                    cost: number;
+                                }[];
                             }[];
                             /** @enum {string} */
                             granularity?: "hourly" | "daily";

--- a/apps/ui/src/types/activity.ts
+++ b/apps/ui/src/types/activity.ts
@@ -10,6 +10,16 @@ export interface ActivityModelUsage {
 	cost: number;
 }
 
+export interface ActivityApiKeyUsage {
+	id: string;
+	description: string;
+	requestCount: number;
+	inputTokens: number;
+	outputTokens: number;
+	totalTokens: number;
+	cost: number;
+}
+
 export interface DailyActivity {
 	date: string;
 	requestCount: number;
@@ -41,6 +51,7 @@ export interface DailyActivity {
 	creditsDataStorageCost: number;
 	apiKeysDataStorageCost: number;
 	modelBreakdown: ActivityModelUsage[];
+	apiKeyBreakdown: ActivityApiKeyUsage[];
 }
 
 export interface ActivityResponse {
@@ -80,6 +91,7 @@ export type ActivitT =
 				creditsDataStorageCost: number;
 				apiKeysDataStorageCost: number;
 				modelBreakdown: ActivityModelUsage[];
+				apiKeyBreakdown: ActivityApiKeyUsage[];
 			}[];
 	  }
 	| undefined;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2121,6 +2121,7 @@ export interface paths {
                     projectId?: string;
                     apiKeyId?: string;
                     timeRange?: "1h" | "4h" | "24h" | "7d" | "30d";
+                    groupBy?: "model" | "apiKey";
                 };
                 header?: never;
                 path?: never;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2174,6 +2174,15 @@ export interface paths {
                                     totalTokens: number;
                                     cost: number;
                                 }[];
+                                apiKeyBreakdown: {
+                                    id: string;
+                                    description: string;
+                                    requestCount: number;
+                                    inputTokens: number;
+                                    outputTokens: number;
+                                    totalTokens: number;
+                                    cost: number;
+                                }[];
                             }[];
                             /** @enum {string} */
                             granularity?: "hourly" | "daily";


### PR DESCRIPTION
## Summary
- Adds a "Group By" selector on the model usage dashboard so the stacked chart can be broken down by API key in addition to model
- When breakdown by API key is selected, the API key filter is disabled and cleared
- Backend `/activity` now returns an `apiKeyBreakdown` alongside `modelBreakdown` (queried from `api_key_hourly_stats` joined with `api_key` for the human-readable description)

## Test plan
- [ ] Open the dashboard model-usage page, switch "Group By" between Model and API key — stacked bars and legend update accordingly
- [ ] When "API key" is selected, the API key filter dropdown is disabled and any prior selection is cleared from the URL
- [ ] When "Model" is selected, the API key filter works as before
- [ ] Activity unit tests still pass (`vitest run apps/api/src/routes/activity.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to group activity metrics by API key in addition to model-based grouping.
  * New "Group by" control in the activity dashboard to switch visualization between API key and model; choosing API key clears the individual API key filter.
  * Daily activity responses and charts now include a per‑API‑key usage breakdown (missing slots appear as empty arrays) for richer tooltips and legends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->