### PR TITLE
fix(support): unarchive chat on new user message

### DIFF
--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -253,7 +253,10 @@ async function persistMessages(
 
 		await db
 			.update(t)
-			.set({ messageCount: existingCount + newMessages.length })
+			.set({
+				messageCount: existingCount + newMessages.length,
+				archivedAt: null,
+			})
 			.where(eq(t.id, conversationId));
 	} catch (error) {
 		logger.error("Failed to persist chat support messages", { error });


### PR DESCRIPTION
## Summary
- When admin archives a chat support conversation, sending a new user message now clears `archivedAt` so the thread reappears in the active list.
- Previously the new message was appended to the same row but `archivedAt` was untouched, leaving the conversation hidden in the archived view.

## Test plan
- [ ] Archive a chat support conversation in admin
- [ ] Send a follow-up message from the widget for that client
- [ ] Verify the conversation is no longer archived and the new message is persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where archived chat conversations would remain archived when new messages were sent to them. Conversations are now automatically unarchived upon receiving new messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->