### PR TITLE
fix(playground): clear auto-generated key on logout

### DIFF
--- a/apps/playground/src/app/api/canvas/generate/route.ts
+++ b/apps/playground/src/app/api/canvas/generate/route.ts
@@ -2,6 +2,7 @@ import { streamText } from "ai";
 import { cookies } from "next/headers";
 
 import { catalog } from "@/lib/canvas/catalog";
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
@@ -44,8 +45,8 @@ export async function POST(req: Request) {
 
 	const cookieStore = await cookies();
 	const cookieApiKey =
-		cookieStore.get("llmgateway_playground_key")?.value.trim() ||
-		cookieStore.get("__Host-llmgateway_playground_key")?.value.trim();
+		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value.trim() ||
+		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value.trim();
 	const finalApiKey = headerApiKey || cookieApiKey;
 
 	if (!finalApiKey) {

--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -13,6 +13,7 @@ import {
 import { cookies } from "next/headers";
 import { z } from "zod";
 
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 import { getModelImageConfig } from "@/lib/image-gen";
 import {
@@ -446,8 +447,8 @@ export async function POST(req: Request) {
 
 	const cookieStore = await cookies();
 	const cookieApiKey =
-		cookieStore.get("llmgateway_playground_key")?.value ??
-		cookieStore.get("__Host-llmgateway_playground_key")?.value;
+		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value ??
+		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value;
 	const finalApiKey = apiKey ?? headerApiKey ?? cookieApiKey;
 	if (!finalApiKey) {
 		return new Response(JSON.stringify({ error: "Missing API key" }), {

--- a/apps/playground/src/app/api/ensure-playground-key/route.ts
+++ b/apps/playground/src/app/api/ensure-playground-key/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { getConfig } from "@/lib/config-server";
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import type { NextRequest } from "next/server";
@@ -45,7 +46,7 @@ export async function POST(req: NextRequest) {
 	const data = (await res.json()) as { ok: boolean; token?: string };
 	const response = NextResponse.json({ ok: true });
 	if (data?.token) {
-		response.cookies.set("llmgateway_playground_key", data.token, {
+		response.cookies.set(PLAYGROUND_KEY_COOKIE_NAME, data.token, {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === "production",
 			sameSite: "lax",

--- a/apps/playground/src/app/api/image/route.ts
+++ b/apps/playground/src/app/api/image/route.ts
@@ -1,6 +1,7 @@
 import { generateImage } from "ai";
 import { cookies } from "next/headers";
 
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
@@ -67,8 +68,8 @@ export async function POST(req: Request) {
 
 	const cookieStore = await cookies();
 	const cookieApiKey =
-		cookieStore.get("llmgateway_playground_key")?.value ??
-		cookieStore.get("__Host-llmgateway_playground_key")?.value;
+		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value ??
+		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value;
 	const finalApiKey = apiKey ?? headerApiKey ?? cookieApiKey;
 	if (!finalApiKey) {
 		return new Response(JSON.stringify({ error: "Missing API key" }), {

--- a/apps/playground/src/app/api/video/[videoId]/content/route.ts
+++ b/apps/playground/src/app/api/video/[videoId]/content/route.ts
@@ -5,6 +5,7 @@ import {
 	getGatewayErrorMessage,
 	readGatewayResponseBody,
 } from "@/app/api/video/utils";
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 export const dynamic = "force-dynamic";
@@ -22,8 +23,8 @@ export async function GET(
 
 	const cookieStore = await cookies();
 	const apiKey =
-		cookieStore.get("llmgateway_playground_key")?.value ??
-		cookieStore.get("__Host-llmgateway_playground_key")?.value;
+		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value ??
+		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value;
 
 	if (!apiKey) {
 		return NextResponse.json({ error: "Missing API key" }, { status: 400 });

--- a/apps/playground/src/app/api/video/[videoId]/route.ts
+++ b/apps/playground/src/app/api/video/[videoId]/route.ts
@@ -5,6 +5,7 @@ import {
 	getGatewayErrorMessage,
 	readGatewayResponseBody,
 } from "@/app/api/video/utils";
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 export const dynamic = "force-dynamic";
@@ -44,8 +45,8 @@ export async function GET(
 
 	const cookieStore = await cookies();
 	const apiKey =
-		cookieStore.get("llmgateway_playground_key")?.value ??
-		cookieStore.get("__Host-llmgateway_playground_key")?.value;
+		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value ??
+		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value;
 
 	if (!apiKey) {
 		return NextResponse.json({ error: "Missing API key" }, { status: 400 });

--- a/apps/playground/src/app/api/video/route.ts
+++ b/apps/playground/src/app/api/video/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
+import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import { getGatewayErrorMessage, readGatewayResponseBody } from "./utils";
@@ -15,8 +16,8 @@ export async function POST(req: Request) {
 
 	const cookieStore = await cookies();
 	const apiKey =
-		cookieStore.get("llmgateway_playground_key")?.value ??
-		cookieStore.get("__Host-llmgateway_playground_key")?.value;
+		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value ??
+		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value;
 
 	if (!apiKey) {
 		return NextResponse.json({ error: "Missing API key" }, { status: 400 });

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -121,7 +121,8 @@ export async function renderPlaygroundShell({
 	}
 
 	const selectedOrganization =
-		(orgId ? organizations.find((o) => o.id === orgId) : null) ?? null;
+		(orgId ? organizations.find((o) => o.id === orgId) : organizations[0]) ??
+		null;
 
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {

--- a/apps/playground/src/lib/actions/project.ts
+++ b/apps/playground/src/lib/actions/project.ts
@@ -4,6 +4,11 @@ import { cookies } from "next/headers";
 
 const COOKIE_NAME = "llmgateway-last-used-project";
 
+const PLAYGROUND_KEY_COOKIE_NAMES = [
+	"llmgateway_playground_key",
+	"__Host-llmgateway_playground_key",
+];
+
 /**
  * Server Action to set the last used project ID in cookies
  */
@@ -22,17 +27,21 @@ export async function setLastUsedProjectAction(
 }
 
 /**
- * Server Action to clear all last used project cookies on logout
+ * Server Action to clear cookies that should not persist across users on logout:
+ * last-used-project cookies and the auto-generated playground API key cookie.
  */
 export async function clearLastUsedProjectCookiesAction(): Promise<void> {
 	const cookieStore = await cookies();
 
-	// Get all cookies to find and delete the last-used-project ones
 	const allCookies = cookieStore.getAll();
 
 	for (const cookie of allCookies) {
 		if (cookie.name.startsWith(COOKIE_NAME)) {
 			cookieStore.delete(cookie.name);
 		}
+	}
+
+	for (const name of PLAYGROUND_KEY_COOKIE_NAMES) {
+		cookieStore.delete(name);
 	}
 }

--- a/apps/playground/src/lib/actions/project.ts
+++ b/apps/playground/src/lib/actions/project.ts
@@ -2,12 +2,9 @@
 
 import { cookies } from "next/headers";
 
-const COOKIE_NAME = "llmgateway-last-used-project";
+import { PLAYGROUND_KEY_COOKIE_NAMES } from "@/lib/constants";
 
-const PLAYGROUND_KEY_COOKIE_NAMES = [
-	"llmgateway_playground_key",
-	"__Host-llmgateway_playground_key",
-];
+const COOKIE_NAME = "llmgateway-last-used-project";
 
 /**
  * Server Action to set the last used project ID in cookies

--- a/apps/playground/src/lib/constants.ts
+++ b/apps/playground/src/lib/constants.ts
@@ -1,0 +1,5 @@
+export const PLAYGROUND_KEY_COOKIE_NAME = "llmgateway_playground_key";
+export const PLAYGROUND_KEY_COOKIE_NAMES = [
+	PLAYGROUND_KEY_COOKIE_NAME,
+	`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`,
+] as const;


### PR DESCRIPTION
## Summary
- The `llmgateway_playground_key` httpOnly cookie (set by `/api/ensure-playground-key`) was not cleared on logout, so the next user on the same browser inherited the previous user's auto-generated playground API key. Extended `clearLastUsedProjectCookiesAction` to also delete `llmgateway_playground_key` and its `__Host-` variant.
- After the cookie cleared, logging back in still didn't re-provision the key: the chat page (`playground-shell.tsx`) was the only playground route that defaulted `selectedOrganization` to `null` when no `orgId` was in the URL, so the `ensure-playground-key` effect short-circuited. Aligned with the other pages (image/video/canvas/group) which default to `organizations[0]`.
- Refactored the duplicated `"llmgateway_playground_key"` / `"__Host-llmgateway_playground_key"` string literals across 7 playground API routes to import a single `PLAYGROUND_KEY_COOKIE_NAME` constant from `@/lib/constants`.

## Test plan
- [ ] Log in, open playground, confirm `llmgateway_playground_key` cookie is set.
- [ ] Log out and confirm the cookie is deleted from the browser.
- [ ] Log in as a different user and confirm a fresh playground key is provisioned automatically (no manual org selection needed).
- [ ] Verify chat/image/video/canvas routes still authenticate against the gateway using the cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playground now defaults to the first available organization when a requested organization is missing, preventing an unselected state and ensuring downstream features render reliably.
  * Clearing or switching the last-used project now also removes additional playground API-key cookies, improving session cleanup and reducing leftover credentials.
  * Playground API endpoints now read and set the playground key using a single consistent cookie name, improving authentication reliability across features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->