### PR TITLE
refactor(gateway): centralize provider/model formatting

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2946,8 +2946,9 @@ chat.openapi(completions, async (c) => {
 	let usedModelMapping = usedModel; // Store the original provider model name
 	let usedModelFormatted = formatUsedModelForDisplay(
 		usedProvider,
-		usedRegion ? `${baseModelName}:${usedRegion}` : baseModelName,
+		baseModelName,
 		customProviderName,
+		usedRegion,
 	); // Store in LLMGateway format
 
 	// Auto-set reasoning_effort for auto-routing when model supports reasoning
@@ -3564,8 +3565,9 @@ chat.openapi(completions, async (c) => {
 		if (usedRegion) {
 			usedModelFormatted = formatUsedModelForDisplay(
 				usedProvider,
-				`${baseModelName}:${usedRegion}`,
+				baseModelName,
 				customProviderName,
+				usedRegion,
 			);
 		}
 	} catch (error) {
@@ -5581,7 +5583,12 @@ chat.openapi(completions, async (c) => {
 							await writeStreamingContentFilterResponse({
 								billingModel: usedModel,
 								billingProvider: usedProvider,
-								responseModel: `${usedProvider}/${baseModelName}`,
+								responseModel: formatUsedModelForDisplay(
+									usedProvider,
+									baseModelName,
+									customProviderName,
+									usedRegion,
+								),
 								metadata: {
 									requested_model: initialRequestedModel,
 									requested_provider: requestedProvider,
@@ -7926,7 +7933,12 @@ chat.openapi(completions, async (c) => {
 									id: `chatcmpl-${Date.now()}`,
 									object: "chat.completion.chunk",
 									created: Math.floor(Date.now() / 1000),
-									model: usedModel,
+									model: formatUsedModelForDisplay(
+										usedProvider,
+										baseModelName,
+										customProviderName,
+										usedRegion,
+									),
 									choices: [
 										{
 											index: 0,
@@ -9211,7 +9223,12 @@ chat.openapi(completions, async (c) => {
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						customProviderName,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -9509,7 +9526,12 @@ chat.openapi(completions, async (c) => {
 						id: `chatcmpl-${Date.now()}`,
 						object: "chat.completion",
 						created: Math.floor(Date.now() / 1000),
-						model: `${usedProvider}/${baseModelName}`,
+						model: formatUsedModelForDisplay(
+							usedProvider,
+							baseModelName,
+							customProviderName,
+							usedRegion,
+						),
 						choices: [
 							{
 								index: 0,

--- a/apps/gateway/src/chat/tools/resolve-provider-context.spec.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.spec.ts
@@ -14,4 +14,16 @@ describe("formatUsedModelForDisplay", () => {
 			"stuff/gpt-5.4-nano",
 		);
 	});
+
+	it("appends the region suffix when provided", () => {
+		expect(
+			formatUsedModelForDisplay("alibaba", "glm-4.6", undefined, "cn-beijing"),
+		).toBe("alibaba/glm-4.6:cn-beijing");
+	});
+
+	it("omits the region suffix when undefined", () => {
+		expect(
+			formatUsedModelForDisplay("alibaba", "glm-4.6", undefined, undefined),
+		).toBe("alibaba/glm-4.6");
+	});
 });

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -160,13 +160,15 @@ export function formatUsedModelForDisplay(
 	usedProvider: string,
 	baseModelName: string,
 	customProviderName?: string,
+	usedRegion?: string,
 ): string {
 	const usedModelProviderPrefix =
 		usedProvider === "custom" && customProviderName
 			? customProviderName
 			: usedProvider;
 
-	return `${usedModelProviderPrefix}/${baseModelName}`;
+	const base = `${usedModelProviderPrefix}/${baseModelName}`;
+	return usedRegion ? `${base}:${usedRegion}` : base;
 }
 
 /**
@@ -199,6 +201,7 @@ export async function resolveProviderContext(
 		usedProvider,
 		baseModelName,
 		options.customProviderName,
+		providerMapping.region,
 	);
 
 	// --- Token resolution ---

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -1,4 +1,5 @@
 import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
+import { formatUsedModelForDisplay } from "./resolve-provider-context.js";
 
 import type { RoutingAttempt } from "./retry-with-fallback.js";
 import type { Annotation, ImageObject } from "./types.js";
@@ -340,7 +341,12 @@ export function transformResponseToOpenai(
 				id: `chatcmpl-${Date.now()}`,
 				object: "chat.completion",
 				created: Math.floor(Date.now() / 1000),
-				model: `${usedProvider}/${baseModelName}`,
+				model: formatUsedModelForDisplay(
+					usedProvider,
+					baseModelName,
+					undefined,
+					usedRegion,
+				),
 				choices: [
 					{
 						index: 0,
@@ -395,7 +401,12 @@ export function transformResponseToOpenai(
 				id: `chatcmpl-${Date.now()}`,
 				object: "chat.completion",
 				created: Math.floor(Date.now() / 1000),
-				model: `${usedProvider}/${baseModelName}`,
+				model: formatUsedModelForDisplay(
+					usedProvider,
+					baseModelName,
+					undefined,
+					usedRegion,
+				),
 				choices: [
 					{
 						index: 0,
@@ -451,7 +462,12 @@ export function transformResponseToOpenai(
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -509,7 +525,12 @@ export function transformResponseToOpenai(
 					transformedResponse.choices[0].finish_reason = finishReason;
 				}
 				// Add metadata and usage with costs to existing response
-				transformedResponse.model = `${usedProvider}/${baseModelName}`;
+				transformedResponse.model = formatUsedModelForDisplay(
+					usedProvider,
+					baseModelName,
+					undefined,
+					usedRegion,
+				);
 				transformedResponse.metadata = buildMetadata(
 					requestedModel,
 					requestedProvider,
@@ -542,7 +563,12 @@ export function transformResponseToOpenai(
 				id: `chatcmpl-${Date.now()}`,
 				object: "chat.completion",
 				created: Math.floor(Date.now() / 1000),
-				model: `${usedProvider}/${baseModelName}`,
+				model: formatUsedModelForDisplay(
+					usedProvider,
+					baseModelName,
+					undefined,
+					usedRegion,
+				),
 				choices: [
 					{
 						index: 0,
@@ -594,7 +620,12 @@ export function transformResponseToOpenai(
 					id: json.request_id ?? `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -647,7 +678,12 @@ export function transformResponseToOpenai(
 					if (transformedResponse.choices?.[0] && finishReason !== null) {
 						transformedResponse.choices[0].finish_reason = finishReason;
 					}
-					transformedResponse.model = `${usedProvider}/${baseModelName}`;
+					transformedResponse.model = formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					);
 					transformedResponse.metadata = buildMetadata(
 						requestedModel,
 						requestedProvider,
@@ -693,7 +729,12 @@ export function transformResponseToOpenai(
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: json.created ?? Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -739,7 +780,12 @@ export function transformResponseToOpenai(
 					id: json.id ?? `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: json.created_at ?? Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -804,7 +850,12 @@ export function transformResponseToOpenai(
 						transformedResponse.choices[0].finish_reason = finishReason;
 					}
 
-					transformedResponse.model = `${usedProvider}/${baseModelName}`;
+					transformedResponse.model = formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					);
 					transformedResponse.metadata = buildMetadata(
 						requestedModel,
 						requestedProvider,
@@ -841,7 +892,12 @@ export function transformResponseToOpenai(
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: json.created ?? Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -893,7 +949,12 @@ export function transformResponseToOpenai(
 					if (transformedResponse.choices?.[0] && finishReason !== null) {
 						transformedResponse.choices[0].finish_reason = finishReason;
 					}
-					transformedResponse.model = `${usedProvider}/${baseModelName}`;
+					transformedResponse.model = formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					);
 					transformedResponse.metadata = buildMetadata(
 						requestedModel,
 						requestedProvider,
@@ -930,7 +991,12 @@ export function transformResponseToOpenai(
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: json.created ?? Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -982,7 +1048,12 @@ export function transformResponseToOpenai(
 					if (transformedResponse.choices?.[0] && finishReason !== null) {
 						transformedResponse.choices[0].finish_reason = finishReason;
 					}
-					transformedResponse.model = `${usedProvider}/${baseModelName}`;
+					transformedResponse.model = formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					);
 					transformedResponse.metadata = buildMetadata(
 						requestedModel,
 						requestedProvider,
@@ -1020,7 +1091,12 @@ export function transformResponseToOpenai(
 					id: `chatcmpl-${Date.now()}`,
 					object: "chat.completion",
 					created: json.created ?? Math.floor(Date.now() / 1000),
-					model: `${usedProvider}/${baseModelName}`,
+					model: formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					),
 					choices: [
 						{
 							index: 0,
@@ -1072,7 +1148,12 @@ export function transformResponseToOpenai(
 					if (transformedResponse.choices?.[0] && finishReason !== null) {
 						transformedResponse.choices[0].finish_reason = finishReason;
 					}
-					transformedResponse.model = `${usedProvider}/${baseModelName}`;
+					transformedResponse.model = formatUsedModelForDisplay(
+						usedProvider,
+						baseModelName,
+						undefined,
+						usedRegion,
+					);
 					transformedResponse.metadata = buildMetadata(
 						requestedModel,
 						requestedProvider,
@@ -1121,7 +1202,12 @@ export function transformResponseToOpenai(
 						message.annotations = annotations;
 					}
 				}
-				transformedResponse.model = `${usedProvider}/${baseModelName}`;
+				transformedResponse.model = formatUsedModelForDisplay(
+					usedProvider,
+					baseModelName,
+					undefined,
+					usedRegion,
+				);
 				transformedResponse.metadata = buildMetadata(
 					requestedModel,
 					requestedProvider,


### PR DESCRIPTION
## Summary

Extend the existing `formatUsedModelForDisplay` helper to also accept an optional `usedRegion` and append it as a `:region` suffix when defined, then replace every inline `${usedProvider}/${baseModelName}` concatenation in the chat pipeline with a call to the helper.

This fixes the playground's response-metadata popover, which previously showed the internal model id (e.g. `claude-haiku-4-5`) because the streaming routing-metadata chunk emitted `model: usedModel` while the non-streaming response already used `provider/model`. Now every code path — including the routing chunk picked up by the AI SDK as `response.modelId` — goes through the same helper and yields `provider/model[:region]`.

Touched call sites:
- Routing-metadata chunk in `chat.ts` (the source of the playground regression)
- Two existing `usedModelFormatted` computations in `chat.ts` that previously inlined the `:region` suffix on the model name
- The streaming content-filter `responseModel` and the two non-streaming content-filter responses in `chat.ts`
- All 17 `model: ${usedProvider}/${baseModelName}` / `transformedResponse.model = …` occurrences in `transform-response-to-openai.ts`
- The shared helper in `resolve-provider-context.ts` and its unit tests

## Test plan

- [ ] Playground response metadata shows `provider/model` (or `provider/model:region` for regional models) for chat completions, including `auto` routing
- [ ] Non-streaming `model` field on chat completions now matches the streaming routing-chunk format (regional requests gain `:region`)
- [ ] `pnpm test:unit` passes for `resolve-provider-context.spec.ts` and `transform-response-to-openai.spec.ts`
- [ ] Existing fallback/routing e2e tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently format the model identifier shown in chat responses, content-filter events, and streaming routing metadata to include provider, base model, and optional region for clearer display.
* **Tests**
  * Added unit tests to verify region-suffix behavior for the formatted model display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->