### PR TITLE
test(gateway): use ephemeral port for mock server

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -13,9 +13,7 @@ import { createGatewayApiTestHarness } from "./test-utils/gateway-api-test-harne
 import { readAll, waitForLogs } from "./test-utils/test-helpers.js";
 
 describe("api", () => {
-	const harness = createGatewayApiTestHarness({
-		mockServerPort: 3001,
-	});
+	const harness = createGatewayApiTestHarness();
 	let mockServerUrl = "";
 
 	beforeAll(() => {

--- a/apps/gateway/src/chat/chat-resilience.spec.ts
+++ b/apps/gateway/src/chat/chat-resilience.spec.ts
@@ -7,9 +7,7 @@ import { redisClient } from "@llmgateway/cache";
 import { cdb, db, eq, tables } from "@llmgateway/db";
 
 describe("chat resilience under DB outage", () => {
-	const harness = createGatewayApiTestHarness({
-		mockServerPort: 3010,
-	});
+	const harness = createGatewayApiTestHarness();
 	let mockServerUrl = "";
 
 	beforeAll(() => {

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -124,8 +124,8 @@ describe("fallback and error status code handling", () => {
 		]);
 	}
 
-	beforeAll(() => {
-		mockServerUrl = startMockServer(3001);
+	beforeAll(async () => {
+		mockServerUrl = await startMockServer();
 	});
 
 	afterAll(() => {

--- a/apps/gateway/src/test-utils/gateway-api-test-harness.ts
+++ b/apps/gateway/src/test-utils/gateway-api-test-harness.ts
@@ -12,9 +12,6 @@ import {
 import { clearCache } from "./test-helpers.js";
 
 type ProjectMode = "api-keys" | "credits" | "hybrid";
-interface GatewayApiTestHarnessOptions {
-	mockServerPort: number;
-}
 interface LockClient {
 	query: (text: string, values?: unknown[]) => Promise<unknown>;
 	release: () => void;
@@ -121,14 +118,12 @@ async function ensureRoutingMetricMapping(modelId: string, providerId: string) {
 		.onConflictDoNothing();
 }
 
-export function createGatewayApiTestHarness(
-	options: GatewayApiTestHarnessOptions,
-) {
+export function createGatewayApiTestHarness() {
 	let mockServerUrl = "";
 	let lockClient: LockClient | null = null;
 
-	beforeAll(() => {
-		mockServerUrl = startMockServer(options.mockServerPort);
+	beforeAll(async () => {
+		mockServerUrl = await startMockServer();
 	});
 
 	afterAll(() => {

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -329,7 +329,7 @@ function hasUserMessageTrigger(
 // Each test that relies on TRIGGER_FAIL_ONCE must call resetFailOnceCounter()
 // in its beforeEach to avoid cross-test interference.
 let failOnceCounter = 0;
-let currentMockServerUrl = "http://localhost:3001";
+let currentMockServerUrl = "";
 let videoCounter = 0;
 
 interface MockVideoJobState {
@@ -2220,20 +2220,25 @@ mockOpenAIServer.post("/model/:model/converse-stream", async (c) => {
 
 let server: any = null;
 
-export function startMockServer(port = 3001): string {
-	if (server) {
-		return `http://localhost:${port}`;
-	}
+export function startMockServer(port = 0): Promise<string> {
+	return new Promise((resolve) => {
+		if (server) {
+			resolve(currentMockServerUrl);
+			return;
+		}
 
-	currentMockServerUrl = `http://localhost:${port}`;
-
-	server = serve({
-		fetch: mockOpenAIServer.fetch,
-		port,
+		server = serve(
+			{
+				fetch: mockOpenAIServer.fetch,
+				port,
+			},
+			(info) => {
+				currentMockServerUrl = `http://localhost:${info.port}`;
+				console.log(`Mock OpenAI server started on port ${info.port}`);
+				resolve(currentMockServerUrl);
+			},
+		);
 	});
-
-	console.log(`Mock OpenAI server started on port ${port}`);
-	return `http://localhost:${port}`;
 }
 
 export function stopMockServer() {

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -11,9 +11,7 @@ import {
 import { db, eq, tables } from "@llmgateway/db";
 
 describe("videos", () => {
-	const harness = createGatewayApiTestHarness({
-		mockServerPort: 3002,
-	});
+	const harness = createGatewayApiTestHarness();
 	let mockServerUrl: string;
 	let originalGoogleVertexBaseUrl: string | undefined;
 


### PR DESCRIPTION
## Summary
- Mock OpenAI/Vertex test server now binds to an ephemeral port and reports the actual port back to the harness, so tests stop colliding with the UI dev server (3002) and can run in parallel on the same machine.
- Drops the `mockServerPort` option from `createGatewayApiTestHarness` and removes the hardcoded `3001`/`3002`/`3010` defaults from the four gateway spec files that used it.

## Test plan
- [x] `pnpm vitest run --no-file-parallelism apps/gateway/src/videos/videos.spec.ts` — 21/21 pass with ephemeral port
- [x] `pnpm build`
- [x] `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use dynamic mock server port allocation instead of fixed ports, improving test reliability and reducing port conflicts during concurrent test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->