### PR TITLE
feat: gate IP CIDR IAM rules to enterprise plan

### DIFF
--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -407,6 +407,23 @@ function isValidCidr(cidr: string): boolean {
 	}
 }
 
+export function isIpCidrRuleType(
+	ruleType?: z.infer<typeof iamRuleTypeEnum>,
+): boolean {
+	return ruleType === "allow_ip_cidrs" || ruleType === "deny_ip_cidrs";
+}
+
+export function assertEnterpriseForIpCidrRule(
+	ruleType: z.infer<typeof iamRuleTypeEnum> | undefined,
+	plan: string | null | undefined,
+): void {
+	if (isIpCidrRuleType(ruleType) && plan !== "enterprise") {
+		throw new HTTPException(403, {
+			message: "IP address IAM rules require an enterprise plan",
+		});
+	}
+}
+
 export function validateIamRuleInput(input: {
 	ruleType?: z.infer<typeof iamRuleTypeEnum>;
 	ruleValue?: z.infer<typeof iamRuleValueSchema>;
@@ -1347,7 +1364,11 @@ keysApi.openapi(createIamRule, async (c) => {
 			},
 		},
 		with: {
-			project: true,
+			project: {
+				with: {
+					organization: true,
+				},
+			},
 		},
 	});
 
@@ -1375,6 +1396,11 @@ keysApi.openapi(createIamRule, async (c) => {
 			message: "You don't have permission to manage IAM rules for this API key",
 		});
 	}
+
+	assertEnterpriseForIpCidrRule(
+		ruleData.ruleType,
+		apiKey.project.organization?.plan,
+	);
 
 	// Create the IAM rule
 	const [rule] = await db
@@ -1578,7 +1604,11 @@ keysApi.openapi(updateIamRule, async (c) => {
 			},
 		},
 		with: {
-			project: true,
+			project: {
+				with: {
+					organization: true,
+				},
+			},
 		},
 	});
 
@@ -1624,6 +1654,12 @@ keysApi.openapi(updateIamRule, async (c) => {
 			ruleValue: updateData.ruleValue ?? existingRule.ruleValue,
 		});
 	}
+
+	const effectiveRuleType = updateData.ruleType ?? existingRule?.ruleType;
+	assertEnterpriseForIpCidrRule(
+		effectiveRuleType,
+		apiKey.project.organization?.plan,
+	);
 
 	// Update the IAM rule
 	const [updatedRule] = await db

--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -110,6 +110,22 @@ Control access based on model pricing:
 - **Deny Pricing**: Block specific pricing tiers
 - **Free vs Paid**: Allow or deny access to free vs paid models
 
+#### IP Address Rules
+
+<Callout type="info">
+	IP address rules are available on the **Enterprise** plan only. Contact us at
+	contact@llmgateway.io to enable them for your organization.
+</Callout>
+
+Restrict where the API key can be used from by source IP, using CIDR ranges:
+
+- **Allow IP Ranges (CIDR)**: Only permit requests from the listed IPv4/IPv6 CIDRs
+- **Deny IP Ranges (CIDR)**: Block requests from the listed IPv4/IPv6 CIDRs
+
+Both IPv4 (e.g. `192.0.2.0/24`) and IPv6 (e.g. `2001:db8::/32`) ranges are supported, and you can mix both in a single rule. To restrict to a single address, use a `/32` (IPv4) or `/128` (IPv6) prefix.
+
+The gateway reads the client IP from the first entry in the `X-Forwarded-For` header (set by the GCP load balancer). When an `allow_ip_cidrs` rule is configured and the gateway cannot determine the client IP, the request is denied. Invalid CIDR syntax is rejected at rule-creation time with a `400` error.
+
 ## Error Handling
 
 When API keys encounter IAM rule violations, the API returns specific error messages:

--- a/apps/ui/src/components/api-keys/iam-rules-client.tsx
+++ b/apps/ui/src/components/api-keys/iam-rules-client.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 import {
@@ -95,6 +96,8 @@ export function IamRulesClient({ apiKey }: IamRulesClientProps) {
 		() => extractOrgAndProjectFromPath(pathname),
 		[pathname],
 	);
+	const { selectedOrganization } = useDashboardNavigation();
+	const isEnterprise = selectedOrganization?.plan === "enterprise";
 
 	const [newRule, setNewRule] = useState<{
 		ruleType: IamRule["ruleType"];
@@ -372,16 +375,32 @@ export function IamRulesClient({ apiKey }: IamRulesClientProps) {
 													Deny Pricing Constraints
 												</div>
 											</SelectItem>
-											<SelectItem value="allow_ip_cidrs">
+											<SelectItem
+												value="allow_ip_cidrs"
+												disabled={!isEnterprise}
+											>
 												<div className="flex items-center gap-2">
 													<Network className="h-4 w-4 text-blue-500" />
 													Allow IP Ranges (CIDR)
+													{!isEnterprise && (
+														<Badge variant="outline" className="text-[10px]">
+															Enterprise
+														</Badge>
+													)}
 												</div>
 											</SelectItem>
-											<SelectItem value="deny_ip_cidrs">
+											<SelectItem
+												value="deny_ip_cidrs"
+												disabled={!isEnterprise}
+											>
 												<div className="flex items-center gap-2">
 													<Network className="h-4 w-4 text-blue-500" />
 													Deny IP Ranges (CIDR)
+													{!isEnterprise && (
+														<Badge variant="outline" className="text-[10px]">
+															Enterprise
+														</Badge>
+													)}
 												</div>
 											</SelectItem>
 										</SelectContent>


### PR DESCRIPTION
## Summary

- Enforce on the API that creating or updating an IAM rule with `allow_ip_cidrs` / `deny_ip_cidrs` requires the org to be on the enterprise plan; non-enterprise calls now get a 403.
- In the dashboard IAM rules form, disable the IP-range options for non-enterprise orgs and label them with an "Enterprise" badge so the gating is visible before the user tries to submit.
- Master-key (`/v1/master/*`) IAM endpoints already require enterprise via the master-key middleware, so no extra check is needed there.

## Test plan

- [ ] On a non-enterprise org, open an API key's IAM rules page and verify the "Allow / Deny IP Ranges (CIDR)" options are disabled with an Enterprise badge.
- [ ] Attempt to create an `allow_ip_cidrs` rule against `/keys/api/{id}/iam` on a non-enterprise org — expect 403 with "IP address IAM rules require an enterprise plan".
- [ ] On an enterprise org, the dropdown options are enabled and rule creation/update still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * IP-CIDR rule types (Allow/Deny IP Ranges) are now restricted to enterprise plan subscriptions. Non-enterprise users will see these options disabled in the rule type selector with an "Enterprise" badge to indicate the requirement.
  * Backend API endpoints now enforce enterprise plan validation when creating or modifying IP-CIDR IAM rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->