### PR TITLE
fix(ui): show upstream error on provider key validation

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+[mcp_servers.figma-remote-mcp]
+url = "https://mcp.figma.com/mcp"
+
+[mcp_servers.playwright]
+args = [
+    "-y",
+    "@playwright/mcp@latest",
+]
+command = "npx"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,0 @@
-[mcp_servers.figma-remote-mcp]
-url = "https://mcp.figma.com/mcp"
-
-[mcp_servers.playwright]
-args = [
-    "-y",
-    "@playwright/mcp@latest",
-]
-command = "npx"

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -204,12 +204,25 @@ export function CreateProviderKeyDialog({
 					void queryClient.invalidateQueries({ queryKey });
 					setOpen(false);
 				},
-				onError: () => {
+				onError: (error: unknown) => {
 					setIsValidating(false);
+					let description =
+						"Failed to validate the API key. Please check your key and region.";
+					if (typeof error === "object" && error !== null) {
+						const err = error as Record<string, unknown>;
+						const nested =
+							err.error && typeof err.error === "object"
+								? (err.error as Record<string, unknown>)
+								: err;
+						if (typeof nested.message === "string") {
+							description = nested.message;
+						}
+					} else if (error instanceof Error) {
+						description = error.message;
+					}
 					toast({
 						title: "Validation Failed",
-						description:
-							"Failed to validate the API key. Please check your key and region.",
+						description,
 						variant: "destructive",
 					});
 				},


### PR DESCRIPTION
## Summary

- The provider key dialog's `onError` callback previously showed a hardcoded generic message regardless of what the API returned
- Now extracts and displays the actual error message from the API response (e.g. "Insufficient USD balance. Available 0.000000 USD, required 0.000601 USD.")
- Falls back to the generic message if no upstream message is available

## Test plan

- [ ] Add a NanoGPT provider key with zero balance — toast should show the upstream balance error instead of the generic message
- [ ] Add a key with an invalid token — should still show a meaningful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging in the provider key creation flow to display specific validation failure details instead of generic text.

* **Chores**
  * Configured additional development environment tools and services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->