### PR TITLE
chore(models): mark together-ai kimi-k2.5 deprecated

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -227,7 +227,7 @@ export const moonshotModels = [
 				vision: true,
 				tools: false,
 				jsonOutput: false,
-				deactivatedAt: new Date("2026-05-21"),
+				deprecatedAt: new Date("2026-05-21"),
 			},
 			{
 				providerId: "nebius",

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -227,6 +227,7 @@ export const moonshotModels = [
 				vision: true,
 				tools: false,
 				jsonOutput: false,
+				deactivatedAt: new Date("2026-05-21"),
 			},
 			{
 				providerId: "nebius",


### PR DESCRIPTION
## Summary
- Together AI announced deprecation of `moonshotai/Kimi-K2.5` effective 2026-05-21, with `Kimi-K2.6` as the recommended replacement.
- Adds `deactivatedAt: new Date("2026-05-21")` to the `together-ai` provider entry for the `kimi-k2.5` model.
- Other providers for this model (moonshot, nebius, alibaba, embercloud, deepinfra) remain active.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked the together‑ai provider entry for the kimi‑k2.5 model as deprecated effective May 21, 2026.
  * Interfaces and tooling will reflect the provider’s deprecated status from that date (informational only).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->