### PR TITLE
feat(gateway): reject n>1 in chat completions

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -2624,6 +2624,45 @@ describe("api", () => {
 		expect(res.status).toBe(400);
 	});
 
+	test("/v1/chat/completions rejects n greater than 1", async () => {
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer fake`,
+			},
+			body: JSON.stringify({
+				model: "gpt-4o-mini",
+				messages: [{ role: "user", content: "Hello!" }],
+				n: 5,
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error?.code).toBe("unsupported_parameter");
+		expect(json.error?.param).toBe("n");
+	});
+
+	test("/v1/chat/completions accepts n equal to 1", async () => {
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer fake`,
+			},
+			body: JSON.stringify({
+				model: "invalid",
+				messages: [{ role: "user", content: "Hello!" }],
+				n: 1,
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error?.code).not.toBe("unsupported_parameter");
+	});
+
 	test("/v1/chat/completions rejects embedding models", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-chat-embed-reject",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1045,6 +1045,28 @@ chat.openapi(completions, async (c) => {
 		);
 	}
 
+	if (
+		typeof rawBody === "object" &&
+		rawBody !== null &&
+		"n" in rawBody &&
+		rawBody.n !== null &&
+		rawBody.n !== undefined &&
+		rawBody.n !== 1
+	) {
+		return c.json(
+			{
+				error: {
+					message:
+						"The 'n' parameter is not supported with values other than 1. Only n=1 (or omitting n) is currently supported. To generate multiple completions, send parallel requests.",
+					type: "invalid_request_error",
+					param: "n",
+					code: "unsupported_parameter",
+				},
+			},
+			400,
+		);
+	}
+
 	// Validate against schema
 	const validationResult = completionsRequestSchema.safeParse(rawBody);
 	if (!validationResult.success) {

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -159,6 +159,17 @@ export const completionsRequestSchema = z.object({
 		])
 		.optional(),
 	stream: z.boolean().optional().default(false),
+	n: z
+		.number()
+		.int()
+		.nullable()
+		.optional()
+		.transform((val) => (val === null ? undefined : val))
+		.openapi({
+			description:
+				"Number of completions to generate for each prompt. Only n=1 is currently supported; values greater than 1 will return a 400 error.",
+			example: 1,
+		}),
 	prompt_cache_key: z
 		.string()
 		.nullable()


### PR DESCRIPTION
## Summary
- The `n` parameter was being silently stripped by the chat completions request schema, so callers requesting `n=5` would get a single choice back with no indication anything was wrong.
- Add `n` to the schema (typed and documented in OpenAPI) and return a clear `400 invalid_request_error` with `code: "unsupported_parameter"` / `param: "n"` whenever a value other than `1` is sent.
- `n=1` and omitting `n` continue to work exactly as before.

This is intentionally a "phase 1" — native pass-through for OpenAI/Gemini and proper fan-out for Anthropic/Bedrock/etc. can come later if there is demand. For now we fail loudly instead of silently returning the wrong number of choices.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`
- [x] `pnpm exec vitest run apps/gateway/src/api.spec.ts -t "rejects n greater than 1"`
- [x] `pnpm exec vitest run apps/gateway/src/api.spec.ts -t "accepts n equal to 1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `n` parameter for the `/v1/chat/completions` API endpoint.

* **Validation & Error Handling**
  * Implemented request validation to reject `n` values greater than 1 with error guidance, directing users to submit parallel requests for generating multiple completions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->