### PR TITLE
fix(api): support refunds for devpass subscriptions

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1385,17 +1385,55 @@ async function handleChargeRefunded(event: Stripe.ChargeRefundedEvent) {
 		return;
 	}
 
-	// Find the original transaction by stripePaymentIntentId
-	const originalTransaction = await db.query.transaction.findFirst({
+	// Stripe v18 removed `invoice` from the typed Charge surface, but the
+	// field is still present on the underlying object for invoice-driven
+	// charges (subscriptions). Fall back to it to locate dev_plan_start /
+	// subscription_start transactions that only stored the invoice id.
+	const chargeInvoice = (
+		charge as unknown as { invoice?: string | { id?: string } | null }
+	).invoice;
+	const invoiceId =
+		typeof chargeInvoice === "string" ? chargeInvoice : chargeInvoice?.id;
+
+	const refundableTypes: (
+		| "credit_topup"
+		| "dev_plan_start"
+		| "dev_plan_renewal"
+		| "dev_plan_upgrade"
+		| "subscription_start"
+	)[] = [
+		"credit_topup",
+		"dev_plan_start",
+		"dev_plan_renewal",
+		"dev_plan_upgrade",
+		"subscription_start",
+	];
+
+	// Find the original transaction by stripePaymentIntentId first (covers
+	// credit_topup, dev_plan_renewal, subscription_start via invoice). Fall
+	// back to stripeInvoiceId since dev_plan_start (initial DevPass checkout)
+	// only records the invoice id, not the payment intent.
+	let originalTransaction = await db.query.transaction.findFirst({
 		where: {
 			stripePaymentIntentId: { eq: payment_intent as string },
-			type: { eq: "credit_topup" },
+			type: { in: refundableTypes },
 		},
 	});
 
+	if (!originalTransaction && invoiceId) {
+		originalTransaction = await db.query.transaction.findFirst({
+			where: {
+				stripeInvoiceId: { eq: invoiceId },
+				type: { in: refundableTypes },
+			},
+		});
+	}
+
 	if (!originalTransaction) {
 		logger.error(
-			`Original transaction not found for payment intent: ${payment_intent}`,
+			`Original transaction not found for payment intent: ${payment_intent}${
+				invoiceId ? ` (invoice: ${invoiceId})` : ""
+			}`,
 		);
 		return;
 	}
@@ -1435,10 +1473,18 @@ async function handleChargeRefunded(event: Stripe.ChargeRefundedEvent) {
 		originalTransaction.creditAmount ?? "0",
 	);
 
+	// Only credit_topup purchases add to organization.credits, so only those
+	// refunds should deduct credits back. Dev plan and subscription refunds
+	// are recorded for revenue reporting only — the subscription cancel/end
+	// webhooks handle the plan state changes separately.
+	const isCreditTopup = originalTransaction.type === "credit_topup";
+
 	// Calculate proportional credit refund
 	const refundRatio =
 		originalAmount > 0 ? refundAmountInDollars / originalAmount : 0;
-	const creditRefundAmount = originalCreditAmount * refundRatio;
+	const creditRefundAmount = isCreditTopup
+		? originalCreditAmount * refundRatio
+		: 0;
 
 	// Check if refund already exists (prevent duplicates)
 	const existingRefund = await db.query.transaction.findFirst({
@@ -1470,13 +1516,16 @@ async function handleChargeRefunded(event: Stripe.ChargeRefundedEvent) {
 		description: `Credit refund: $${refundAmountInDollars.toFixed(2)} (${(refundRatio * 100).toFixed(1)}% of original purchase)`,
 	});
 
-	// Deduct credits from organization (allow negative)
-	await db
-		.update(tables.organization)
-		.set({
-			credits: sql`${tables.organization.credits} - ${creditRefundAmount}`,
-		})
-		.where(eq(tables.organization.id, originalTransaction.organizationId));
+	// Deduct credits from organization (allow negative) — only for credit_topup
+	// refunds, since dev plan / subscription purchases don't add to credits.
+	if (isCreditTopup && creditRefundAmount !== 0) {
+		await db
+			.update(tables.organization)
+			.set({
+				credits: sql`${tables.organization.credits} - ${creditRefundAmount}`,
+			})
+			.where(eq(tables.organization.id, originalTransaction.organizationId));
+	}
 
 	// Track in PostHog
 	posthog.groupIdentify({
@@ -1503,8 +1552,9 @@ async function handleChargeRefunded(event: Stripe.ChargeRefundedEvent) {
 	});
 
 	logger.info(
-		`Processed refund for organization ${originalTransaction.organizationId}: ` +
-			`refunded $${refundAmountInDollars} (${creditRefundAmount} credits deducted)`,
+		`Processed refund for organization ${originalTransaction.organizationId} ` +
+			`(${originalTransaction.type}): refunded $${refundAmountInDollars}` +
+			(isCreditTopup ? ` (${creditRefundAmount} credits deducted)` : ""),
 	);
 }
 


### PR DESCRIPTION
## Summary
- DevPass subscription refunds were logging `Original transaction not found for payment intent: pi_...` and dropping the `charge.refunded` event because `handleChargeRefunded` only searched for `credit_topup` transactions matched by `stripePaymentIntentId`, but `dev_plan_start` rows only record `stripeInvoiceId`.
- Broaden the lookup to `credit_topup`, `dev_plan_start`, `dev_plan_renewal`, `dev_plan_upgrade`, and `subscription_start`, and fall back to `charge.invoice` when the payment intent isn't on the original transaction.
- Skip the `organization.credits` deduction for subscription-based refunds since those purchases don't add to that balance — plan state changes still flow through the subscription cancel/end webhooks.

## Test plan
- [ ] Refund a DevPass subscription charge in Stripe and confirm a `credit_refund` row is created linked to the `dev_plan_start` and revenue reporting nets it out.
- [ ] Refund a credit top-up and confirm credits are still deducted as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refund handling to accurately track original transactions across different refund types
  * Enhanced credit reversal logic to apply deductions only to applicable transaction types, ensuring subscription and plan refunds are processed correctly
  * Added fallback mechanisms for transaction identification to support the latest Stripe compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->