### PR TITLE
chore: enable source maps for Next.js apps

### DIFF
--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
 	outputFileTracingRoot: join(__dirname, "../../"),
 	distDir: process.env.NODE_ENV === "development" ? ".next-dev" : ".next",
 	output: "standalone",
-	productionBrowserSourceMaps: false,
+	productionBrowserSourceMaps: true,
 	typedRoutes: true,
 	reactStrictMode: true,
 	reactCompiler: true,

--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -202,7 +202,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # Set working directory to where server.js is located in Docker build
 WORKDIR /app/apps/ui
-CMD ["node", "server.js"]
+CMD ["node", "--enable-source-maps", "server.js"]
 
 # Playground runtime stage
 FROM runtime AS playground
@@ -219,7 +219,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # Set working directory to where server.js is located in Docker build
 WORKDIR /app/apps/playground
-CMD ["node", "server.js"]
+CMD ["node", "--enable-source-maps", "server.js"]
 
 # Worker preparation stage
 FROM worker-builder AS worker-prep
@@ -249,7 +249,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # Set working directory to where server.js is located in Docker build
 WORKDIR /app/apps/docs
-CMD ["node", "server.js"]
+CMD ["node", "--enable-source-maps", "server.js"]
 
 # Admin runtime stage
 FROM runtime AS admin
@@ -266,7 +266,7 @@ ENV HOSTNAME="0.0.0.0"
 
 # Set working directory to where server.js is located in Docker build
 WORKDIR /app/ee/admin
-CMD ["node", "server.js"]
+CMD ["node", "--enable-source-maps", "server.js"]
 
 # Code runtime stage
 FROM runtime AS code
@@ -283,4 +283,4 @@ ENV HOSTNAME="0.0.0.0"
 
 # Set working directory to where server.js is located in Docker build
 WORKDIR /app/apps/code
-CMD ["node", "server.js"]
+CMD ["node", "--enable-source-maps", "server.js"]


### PR DESCRIPTION
## Summary

Production stack traces in the Next.js apps (UI, Playground, Docs, Admin, Code) showed minified positions like `.next/server/chunks/3755.js:1:1252` because Node doesn't consume `.map` files unless `--enable-source-maps` is passed.

- The webpack config in `apps/ui/next.config.ts` already sets `config.devtool = "source-map"` for the server build, so server source maps are generated and copied via the standalone output.
- Added `--enable-source-maps` to every Next.js standalone runtime `CMD` in `infra/split.dockerfile` (matches what API/Gateway/Worker already do).
- Flipped `productionBrowserSourceMaps` to `true` in `apps/ui/next.config.ts` for parity with the other Next apps (playground/code/docs/admin already had it on).

## Test plan

- [ ] Build the UI image and confirm `.next/server/chunks/*.js.map` are present in the standalone output.
- [ ] Trigger the failing render and verify the stack trace now references original source paths instead of minified chunk offsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled source maps in production for the web application and containerized services to improve error tracking and diagnostic visibility in production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->