### PR TITLE
test: add gated context-size e2e suite

### DIFF
--- a/apps/gateway/src/chat-context-size.e2e.ts
+++ b/apps/gateway/src/chat-context-size.e2e.ts
@@ -1,0 +1,127 @@
+import "dotenv/config";
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import {
+	beforeAllHook,
+	beforeEachHook,
+	generateTestRequestId,
+	logMode,
+	testModels,
+	validateLogByRequestId,
+	validateResponse,
+} from "@/chat-helpers.e2e.js";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+const contextSizeTest = process.env.CONTEXT_SIZE_TEST === "true";
+
+const describeContextSize = contextSizeTest ? describe : describe.skip;
+
+// Approximate characters per token for synthetic English filler text.
+// Real tokenization varies by tokenizer; 4 chars/token is a conservative
+// average across the providers we test so the request stays under the
+// advertised context window after expansion.
+const CHARS_PER_TOKEN = 4;
+
+// Fraction of the advertised context window to fill with input.
+const CONTEXT_FILL_RATIO = 0.7;
+
+function getProviderContextSize(
+	provider: ProviderModelMapping,
+): number | undefined {
+	return provider.contextSize;
+}
+
+const contextSizeModels = testModels
+	.map((m) => {
+		const provider = m.providers[0];
+		const contextSize = getProviderContextSize(provider);
+		return { ...m, contextSize };
+	})
+	.filter(
+		(m): m is typeof m & { contextSize: number } =>
+			typeof m.contextSize === "number" && m.contextSize > 0,
+	);
+
+function buildFillerContent(targetTokens: number): string {
+	const targetChars = targetTokens * CHARS_PER_TOKEN;
+	// Use a varied sentence so providers don't trivially compress repeated tokens.
+	const sentence =
+		"The quick brown fox jumps over the lazy dog while reciting the alphabet ABCDEFGHIJKLMNOPQRSTUVWXYZ and counting 0123456789. ";
+	const repeats = Math.ceil(targetChars / sentence.length);
+	return sentence.repeat(repeats).slice(0, targetChars);
+}
+
+describeContextSize("e2e context size", () => {
+	beforeAll(beforeAllHook);
+
+	beforeEach(beforeEachHook);
+
+	test("empty", () => {
+		expect(true).toBe(true);
+	});
+
+	test.each(contextSizeModels)(
+		"context size $model ($contextSize tokens)",
+		{ timeout: 900000, retry: 1 },
+		async ({ model, contextSize }) => {
+			const targetInputTokens = Math.floor(contextSize * CONTEXT_FILL_RATIO);
+			const filler = buildFillerContent(targetInputTokens);
+
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model,
+					messages: [
+						{
+							role: "system",
+							content:
+								"You are a helpful assistant. After reading the provided text, reply with exactly the word 'OK' and nothing else.",
+						},
+						{
+							role: "user",
+							content: `Here is a long passage of text:\n\n${filler}\n\nNow reply with 'OK'.`,
+						},
+					],
+					max_tokens: 32,
+				}),
+			});
+
+			const json = await res.json();
+			if (logMode) {
+				console.log(
+					"context-size response:",
+					JSON.stringify({ ...json, choices: json?.choices }, null, 2),
+				);
+			}
+
+			expect(res.status).toBe(200);
+			validateResponse(json);
+
+			const content = json.choices?.[0]?.message?.content;
+			expect(typeof content).toBe("string");
+			expect(content.length).toBeGreaterThan(0);
+
+			expect(json).toHaveProperty("usage.prompt_tokens");
+			expect(typeof json.usage.prompt_tokens).toBe("number");
+			expect(json.usage.prompt_tokens).toBeGreaterThan(0);
+			// The provider should have actually processed a large input; verify it
+			// is at least within a reasonable fraction of our target. Tokenizers
+			// vary, so allow a wide lower bound (50% of target).
+			expect(json.usage.prompt_tokens).toBeGreaterThan(
+				Math.floor(targetInputTokens * 0.5),
+			);
+
+			const log = await validateLogByRequestId(requestId);
+			expect(log.streamed).toBe(false);
+		},
+	);
+});

--- a/apps/gateway/src/chat-context-size.e2e.ts
+++ b/apps/gateway/src/chat-context-size.e2e.ts
@@ -18,11 +18,13 @@ const contextSizeTest = process.env.CONTEXT_SIZE_TEST === "true";
 
 const describeContextSize = contextSizeTest ? describe : describe.skip;
 
-// Approximate characters per token for synthetic English filler text.
-// Real tokenization varies by tokenizer; 4 chars/token is a conservative
-// average across the providers we test so the request stays under the
-// advertised context window after expansion.
-const CHARS_PER_TOKEN = 4;
+// Approximate characters per token for the natural-English filler below.
+// Empirically the Anthropic tokenizer hits ~2 chars/token on dense content
+// (alphabet/digit listings) and ~4 chars/token on plain prose. Using a
+// conservative 3 keeps the resulting prompt under the advertised window
+// across the providers we test even when their tokenizer is denser than
+// the OpenAI/Anthropic BPE average.
+const CHARS_PER_TOKEN = 3;
 
 // Fraction of the advertised context window to fill with input.
 const CONTEXT_FILL_RATIO = 0.7;
@@ -48,7 +50,7 @@ function buildFillerContent(targetTokens: number): string {
 	const targetChars = targetTokens * CHARS_PER_TOKEN;
 	// Use a varied sentence so providers don't trivially compress repeated tokens.
 	const sentence =
-		"The quick brown fox jumps over the lazy dog while reciting the alphabet ABCDEFGHIJKLMNOPQRSTUVWXYZ and counting 0123456789. ";
+		"The quick brown fox jumps over the lazy dog near the riverbank, while curious sparrows watched from the old oak tree branches above. ";
 	const repeats = Math.ceil(targetChars / sentence.length);
 	return sentence.repeat(repeats).slice(0, targetChars);
 }
@@ -96,10 +98,10 @@ describeContextSize("e2e context size", () => {
 			});
 
 			const json = await res.json();
-			if (logMode) {
+			if (logMode || res.status !== 200) {
 				console.log(
-					"context-size response:",
-					JSON.stringify({ ...json, choices: json?.choices }, null, 2),
+					`context-size response (status ${res.status}):`,
+					JSON.stringify(json, null, 2),
 				);
 			}
 


### PR DESCRIPTION
## Summary

- Adds `apps/gateway/src/chat-context-size.e2e.ts`, a new e2e suite that only runs when `CONTEXT_SIZE_TEST=true` so it doesn't burn money on every CI run.
- For each model in `TEST_MODELS` that exposes a provider-level `contextSize` (e.g. claude-opus-4-7 at 1M), it sends a chat completion filled with synthetic text targeting ~70% of the advertised context window (700k tokens for opus 4.7) and asks for a tiny reply.
- Verifies the request succeeds (200), the response is well-formed, the log entry is recorded, and `usage.prompt_tokens` is at least roughly the target — confirming the provider actually accepted the large input.

## Test plan

- [ ] `CONTEXT_SIZE_TEST=true TEST_MODELS="anthropic/claude-opus-4-7" pnpm --filter gateway exec vitest run src/chat-context-size.e2e.ts`
- [ ] Confirm suite is skipped by default (no `CONTEXT_SIZE_TEST` env)
- [ ] Spot-check with another large-context model (e.g. `google/gemini-2.5-pro`) via `TEST_MODELS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for chat context-size handling, verifying long-system/user messages, accurate token usage reporting, non-empty responses, and persisted request log status. Includes a basic empty-case test and optional test logging for debug visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->