### PR TITLE
fix(ui): backfill tweet entity arrays to prevent SSR crash

### DIFF
--- a/apps/ui/src/lib/components/tweet-card.tsx
+++ b/apps/ui/src/lib/components/tweet-card.tsx
@@ -44,6 +44,31 @@ const Verified = ({ className, ...props }: TwitterIconProps) => (
 	</svg>
 );
 
+// react-tweet's enrichTweet iterates entities.{hashtags,user_mentions,urls,symbols}
+// without null checks; the syndication API sometimes omits these arrays, which
+// crashes server rendering. Backfill missing arrays before passing into enrichTweet.
+function normalizeEntities<T extends { entities: Tweet["entities"] }>(t: T): T {
+	const entities = t.entities ?? ({} as Tweet["entities"]);
+	return {
+		...t,
+		entities: {
+			...entities,
+			hashtags: entities.hashtags ?? [],
+			user_mentions: entities.user_mentions ?? [],
+			urls: entities.urls ?? [],
+			symbols: entities.symbols ?? [],
+		},
+	};
+}
+
+function normalizeTweetEntities(tweet: Tweet): Tweet {
+	const normalized = normalizeEntities(tweet);
+	if (normalized.quoted_tweet) {
+		normalized.quoted_tweet = normalizeEntities(normalized.quoted_tweet);
+	}
+	return normalized;
+}
+
 export const truncate = (str: string | null, length: number) => {
 	if (!str || str.length <= length) {
 		return str;
@@ -282,7 +307,7 @@ export const TweetCard = async ({
 		if (result.tombstone || result.notFound || !result.data?.user) {
 			tweet = undefined;
 		} else {
-			tweet = result.data;
+			tweet = normalizeTweetEntities(result.data);
 		}
 	} catch (err) {
 		if (onError) {


### PR DESCRIPTION
## Summary

- Root URL (`/`) was crashing in production with `TypeError: c is not iterable` during Next.js Flight serialization of the testimonials section.
- Traced to `react-tweet`'s `enrichTweet`, which iterates `entities.hashtags`, `entities.user_mentions`, `entities.urls`, and `entities.symbols` without null checks. Twitter's syndication API occasionally returns tweets where one or more of those arrays is omitted, so the inner `for…of` blows up.
- Normalize the fetched tweet (and any `quoted_tweet`) in `TweetCard` before handing it to `MagicTweet` / `enrichTweet`.

## Why only `/`

`/` is the only route that renders `<Testimonials />`, which is the only consumer of `TweetCard`. Every other landing page uses `<HeroRSC navbarOnly />` without testimonials, so the bad data path never executes there.

## Test plan

- [ ] Load `/` in prod build — testimonials render, no SSR crash
- [ ] If Twitter API returns a tweet missing entity arrays, fallback renders instead of 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when rendering tweets with incomplete entity data from API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->