### PR TITLE
fix(ui): isolate tweet card failures from page

### DIFF
--- a/apps/ui/src/lib/components/error-boundary.tsx
+++ b/apps/ui/src/lib/components/error-boundary.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+	children: ReactNode;
+	fallback: ReactNode;
+}
+
+interface ErrorBoundaryState {
+	hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<
+	ErrorBoundaryProps,
+	ErrorBoundaryState
+> {
+	state: ErrorBoundaryState = { hasError: false };
+
+	static getDerivedStateFromError(): ErrorBoundaryState {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: Error) {
+		console.error("ErrorBoundary caught:", error);
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return this.props.fallback;
+		}
+		return this.props.children;
+	}
+}

--- a/apps/ui/src/lib/components/tweet-card.tsx
+++ b/apps/ui/src/lib/components/tweet-card.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-tweet";
 import { fetchTweet, type Tweet } from "react-tweet/api";
 
+import { ErrorBoundary } from "@/lib/components/error-boundary";
 import { cn } from "@/lib/utils";
 
 interface TwitterIconProps {
@@ -283,30 +284,24 @@ export const MagicTweet = ({
 	);
 };
 
-/**
- * TweetCard (Server Side Only)
- */
-export const TweetCard = async ({
+const TweetCardInner = async ({
 	id,
 	components,
-	fallback = <TweetSkeleton />,
 	onError,
 	...props
 }: TweetProps & {
 	className?: string;
 }) => {
-	let tweet: Tweet | undefined;
+	const NotFound = components?.TweetNotFound ?? TweetNotFound;
 
 	if (!id) {
-		const NotFound = components?.TweetNotFound ?? TweetNotFound;
 		return <NotFound {...props} />;
 	}
 
+	let tweet: Tweet | undefined;
 	try {
 		const result = await fetchTweet(id);
-		if (result.tombstone || result.notFound || !result.data?.user) {
-			tweet = undefined;
-		} else {
+		if (!result.tombstone && !result.notFound && result.data?.user) {
 			tweet = normalizeTweetEntities(result.data);
 		}
 	} catch (err) {
@@ -315,17 +310,33 @@ export const TweetCard = async ({
 		} else {
 			console.error("Failed to fetch tweet:", err);
 		}
-		tweet = undefined;
 	}
 
 	if (!tweet) {
-		const NotFound = components?.TweetNotFound ?? TweetNotFound;
 		return <NotFound {...props} />;
 	}
 
+	return <MagicTweet tweet={tweet} {...props} />;
+};
+
+/**
+ * TweetCard (Server Side Only)
+ *
+ * Wraps the async inner component in an ErrorBoundary so a failed tweet
+ * fetch or render falls back to TweetNotFound instead of crashing the page.
+ */
+export const TweetCard = ({
+	fallback = <TweetSkeleton />,
+	...props
+}: TweetProps & {
+	className?: string;
+}) => {
+	const NotFound = props.components?.TweetNotFound ?? TweetNotFound;
 	return (
-		<Suspense fallback={fallback}>
-			<MagicTweet tweet={tweet} {...props} />
-		</Suspense>
+		<ErrorBoundary fallback={<NotFound className={props.className} />}>
+			<Suspense fallback={fallback}>
+				<TweetCardInner {...props} />
+			</Suspense>
+		</ErrorBoundary>
 	);
 };


### PR DESCRIPTION
## Summary
- Wrap each `TweetCard` in a client `ErrorBoundary` so a failed tweet fetch or render falls back to `TweetNotFound` instead of crashing the entire page (`This page couldn't load`).
- Split the async fetching into a `TweetCardInner` server component; the outer `TweetCard` only mounts the boundary + suspense fallback.

## Test plan
- [ ] Visit landing page (testimonials) and auth panels with network blocked to Twitter — confirm individual cards show `Tweet not found` and the rest of the page still renders.
- [ ] Normal load: tweets still render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling and resilience to gracefully manage content loading failures
  * Implemented fallback UI that displays user-friendly messages when content is unavailable or encounters issues
  * Improved application stability with better error boundary protection to prevent cascading failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->