### PR TITLE
feat(admin): add by-model time-series chart to org page

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6347,6 +6347,37 @@ function getBucketUnitForWindow(window: string): "hour" | "day" {
 	return "day";
 }
 
+function formatBucketTimestamp(date: Date): string {
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}Z`;
+}
+
+function truncateToBucket(date: Date, unit: "hour" | "day"): Date {
+	const truncated = new Date(date);
+	truncated.setUTCMilliseconds(0);
+	truncated.setUTCSeconds(0);
+	truncated.setUTCMinutes(0);
+	if (unit === "day") {
+		truncated.setUTCHours(0);
+	}
+	return truncated;
+}
+
+function generateBucketTimestamps(
+	start: Date,
+	end: Date,
+	unit: "hour" | "day",
+): string[] {
+	const buckets: string[] = [];
+	const stepMs = unit === "hour" ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+	const startBucket = truncateToBucket(start, unit);
+	const endBucket = truncateToBucket(end, unit);
+	for (let t = startBucket.getTime(); t <= endBucket.getTime(); t += stepMs) {
+		buckets.push(formatBucketTimestamp(new Date(t)));
+	}
+	return buckets;
+}
+
 const getOrgCostByModelTimeseries = createRoute({
 	method: "get",
 	path: "/organizations/{orgId}/cost-by-model-timeseries",
@@ -6472,17 +6503,23 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 		bucketMap.set(ts, entry);
 	}
 
-	const data = Array.from(bucketMap.entries())
-		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([timestamp, models]) => ({
-			timestamp,
-			entries: Array.from(models.entries()).map(([model, v]) => ({
+	const allBuckets = generateBucketTimestamps(
+		startDate,
+		new Date(),
+		bucketUnit,
+	);
+
+	const data = allBuckets.map((timestamp) => ({
+		timestamp,
+		entries: Array.from(bucketMap.get(timestamp)?.entries() ?? []).map(
+			([model, v]) => ({
 				model,
 				cost: v.cost,
 				requestCount: v.requestCount,
 				totalTokens: v.totalTokens,
-			})),
-		}));
+			}),
+		),
+	}));
 
 	return c.json({
 		window,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6429,7 +6429,7 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 		});
 	}
 
-	const bucketExpr = sql<string>`to_char(date_trunc(${bucketUnit}, ${projectHourlyModelStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
+	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${projectHourlyModelStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
 
 	const rows = await db
 		.select({

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6529,6 +6529,144 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 	});
 });
 
+const getProjectCostByModelTimeseries = createRoute({
+	method: "get",
+	path: "/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries",
+	request: {
+		params: z.object({ orgId: z.string(), projectId: z.string() }),
+		query: z.object({
+			window: tokenWindowSchema.default("7d").optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: costByModelTimeseriesResponseSchema.openapi({}),
+				},
+			},
+			description: "Project cost breakdown by model over time.",
+		},
+		404: {
+			description: "Project not found.",
+		},
+	},
+});
+
+admin.openapi(getProjectCostByModelTimeseries, async (c) => {
+	const { orgId, projectId } = c.req.valid("param");
+	const query = c.req.valid("query");
+	const window = query.window ?? "7d";
+	const startDate = getTokenWindowStartDate(window);
+	const bucketUnit = getBucketUnitForWindow(window);
+
+	const project = await db.query.project.findFirst({
+		where: {
+			id: { eq: projectId },
+			organizationId: { eq: orgId },
+		},
+	});
+
+	if (!project) {
+		throw new HTTPException(404, { message: "Project not found" });
+	}
+
+	const topModelsRows = await db
+		.select({
+			usedModel: projectHourlyModelStats.usedModel,
+			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+		})
+		.from(projectHourlyModelStats)
+		.where(
+			and(
+				eq(projectHourlyModelStats.projectId, projectId),
+				gte(projectHourlyModelStats.hourTimestamp, startDate),
+			),
+		)
+		.groupBy(projectHourlyModelStats.usedModel)
+		.orderBy(desc(sql`SUM(${projectHourlyModelStats.cost})`))
+		.limit(10);
+
+	const topModels = topModelsRows.map((r) => r.usedModel);
+
+	if (topModels.length === 0) {
+		return c.json({
+			window,
+			bucket: bucketUnit,
+			models: [],
+			data: [],
+		});
+	}
+
+	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${projectHourlyModelStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
+
+	const rows = await db
+		.select({
+			bucket: bucketExpr.as("bucket"),
+			usedModel: projectHourlyModelStats.usedModel,
+			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			requestCount:
+				sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
+					"total_tokens",
+				),
+		})
+		.from(projectHourlyModelStats)
+		.where(
+			and(
+				eq(projectHourlyModelStats.projectId, projectId),
+				gte(projectHourlyModelStats.hourTimestamp, startDate),
+				inArray(projectHourlyModelStats.usedModel, topModels),
+			),
+		)
+		.groupBy(bucketExpr, projectHourlyModelStats.usedModel)
+		.orderBy(asc(bucketExpr));
+
+	const bucketMap = new Map<
+		string,
+		Map<string, { cost: number; requestCount: number; totalTokens: number }>
+	>();
+
+	for (const row of rows) {
+		const ts = row.bucket;
+		const entry = bucketMap.get(ts) ?? new Map();
+		entry.set(row.usedModel, {
+			cost: Number(row.cost),
+			requestCount: Number(row.requestCount),
+			totalTokens: Number(row.totalTokens),
+		});
+		bucketMap.set(ts, entry);
+	}
+
+	const allBuckets = generateBucketTimestamps(
+		startDate,
+		new Date(),
+		bucketUnit,
+	);
+
+	const data = allBuckets.map((timestamp) => ({
+		timestamp,
+		entries: Array.from(bucketMap.get(timestamp)?.entries() ?? []).map(
+			([model, v]) => ({
+				model,
+				cost: v.cost,
+				requestCount: v.requestCount,
+				totalTokens: v.totalTokens,
+			}),
+		),
+	}));
+
+	return c.json({
+		window,
+		bucket: bucketUnit,
+		models: topModels,
+		data,
+	});
+});
+
 // --- Project Model-Provider Stats ---
 
 const projectModelProviderStatsEntrySchema = z.object({

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6314,6 +6314,184 @@ admin.openapi(getOrgCostByModel, async (c) => {
 	});
 });
 
+// --- Cost by model time-series endpoints ---
+
+const costByModelTimeseriesBucketSchema = z.object({
+	model: z.string(),
+	cost: z.number(),
+	requestCount: z.number(),
+	totalTokens: z.number(),
+});
+
+const costByModelTimeseriesPointSchema = z.object({
+	timestamp: z.string(),
+	entries: z.array(costByModelTimeseriesBucketSchema),
+});
+
+const costByModelTimeseriesResponseSchema = z.object({
+	window: tokenWindowSchema,
+	bucket: z.enum(["hour", "day"]),
+	models: z.array(z.string()),
+	data: z.array(costByModelTimeseriesPointSchema),
+});
+
+function getBucketUnitForWindow(window: string): "hour" | "day" {
+	if (
+		window === "1h" ||
+		window === "4h" ||
+		window === "12h" ||
+		window === "1d"
+	) {
+		return "hour";
+	}
+	return "day";
+}
+
+const getOrgCostByModelTimeseries = createRoute({
+	method: "get",
+	path: "/organizations/{orgId}/cost-by-model-timeseries",
+	request: {
+		params: z.object({ orgId: z.string() }),
+		query: z.object({
+			window: tokenWindowSchema.default("7d").optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: costByModelTimeseriesResponseSchema.openapi({}),
+				},
+			},
+			description: "Organization cost breakdown by model over time.",
+		},
+		404: {
+			description: "Organization not found.",
+		},
+	},
+});
+
+admin.openapi(getOrgCostByModelTimeseries, async (c) => {
+	const { orgId } = c.req.valid("param");
+	const query = c.req.valid("query");
+	const window = query.window ?? "7d";
+	const startDate = getTokenWindowStartDate(window);
+	const bucketUnit = getBucketUnitForWindow(window);
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId } },
+	});
+
+	if (!org || org.status === "deleted") {
+		throw new HTTPException(404, { message: "Organization not found" });
+	}
+
+	const projectIds = await db
+		.select({ id: tables.project.id })
+		.from(tables.project)
+		.where(eq(tables.project.organizationId, orgId));
+
+	const ids = projectIds.map((p) => p.id);
+
+	if (ids.length === 0) {
+		return c.json({
+			window,
+			bucket: bucketUnit,
+			models: [],
+			data: [],
+		});
+	}
+
+	const topModelsRows = await db
+		.select({
+			usedModel: projectHourlyModelStats.usedModel,
+			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+		})
+		.from(projectHourlyModelStats)
+		.where(
+			and(
+				inArray(projectHourlyModelStats.projectId, ids),
+				gte(projectHourlyModelStats.hourTimestamp, startDate),
+			),
+		)
+		.groupBy(projectHourlyModelStats.usedModel)
+		.orderBy(desc(sql`SUM(${projectHourlyModelStats.cost})`))
+		.limit(10);
+
+	const topModels = topModelsRows.map((r) => r.usedModel);
+
+	if (topModels.length === 0) {
+		return c.json({
+			window,
+			bucket: bucketUnit,
+			models: [],
+			data: [],
+		});
+	}
+
+	const bucketExpr = sql<string>`to_char(date_trunc(${bucketUnit}, ${projectHourlyModelStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
+
+	const rows = await db
+		.select({
+			bucket: bucketExpr.as("bucket"),
+			usedModel: projectHourlyModelStats.usedModel,
+			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			requestCount:
+				sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
+					"total_tokens",
+				),
+		})
+		.from(projectHourlyModelStats)
+		.where(
+			and(
+				inArray(projectHourlyModelStats.projectId, ids),
+				gte(projectHourlyModelStats.hourTimestamp, startDate),
+				inArray(projectHourlyModelStats.usedModel, topModels),
+			),
+		)
+		.groupBy(bucketExpr, projectHourlyModelStats.usedModel)
+		.orderBy(asc(bucketExpr));
+
+	const bucketMap = new Map<
+		string,
+		Map<string, { cost: number; requestCount: number; totalTokens: number }>
+	>();
+
+	for (const row of rows) {
+		const ts = row.bucket;
+		const entry = bucketMap.get(ts) ?? new Map();
+		entry.set(row.usedModel, {
+			cost: Number(row.cost),
+			requestCount: Number(row.requestCount),
+			totalTokens: Number(row.totalTokens),
+		});
+		bucketMap.set(ts, entry);
+	}
+
+	const data = Array.from(bucketMap.entries())
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([timestamp, models]) => ({
+			timestamp,
+			entries: Array.from(models.entries()).map(([model, v]) => ({
+				model,
+				cost: v.cost,
+				requestCount: v.requestCount,
+				totalTokens: v.totalTokens,
+			})),
+		}));
+
+	return c.json({
+		window,
+		bucket: bucketUnit,
+		models: topModels,
+		data,
+	});
+});
+
 // --- Project Model-Provider Stats ---
 
 const projectModelProviderStatsEntrySchema = z.object({

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4694,6 +4694,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                    projectId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Project cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Project not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4633,6 +4633,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4694,6 +4694,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                    projectId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Project cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Project not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4633,6 +4633,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4694,6 +4694,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                    projectId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Project cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Project not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4633,6 +4633,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/ee/admin/src/app/organizations/[orgId]/org-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-cost-by-model-timeseries.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { CostByModelTimeseriesChart } from "@/components/cost-by-model-timeseries-chart";
+import { getOrgCostByModelTimeseries } from "@/lib/admin-history";
+
+import type { TokenWindow } from "@/lib/types";
+
+const validWindows = new Set<TokenWindow>([
+	"1h",
+	"4h",
+	"12h",
+	"1d",
+	"7d",
+	"30d",
+	"90d",
+	"365d",
+]);
+
+function parseWindow(value: string | null): TokenWindow {
+	if (value && validWindows.has(value as TokenWindow)) {
+		return value as TokenWindow;
+	}
+	return "1d";
+}
+
+export function OrgCostByModelTimeseries({ orgId }: { orgId: string }) {
+	const searchParams = useSearchParams();
+	const window = parseWindow(searchParams.get("window"));
+
+	const fetchData = useCallback(
+		async (w: TokenWindow) => {
+			return await getOrgCostByModelTimeseries(orgId, w);
+		},
+		[orgId],
+	);
+
+	return (
+		<CostByModelTimeseriesChart
+			title="Cost by Model Over Time"
+			description="Stacked breakdown of top 10 models over the selected window"
+			fetchData={fetchData}
+			externalWindow={window}
+		/>
+	);
+}

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -34,6 +34,7 @@ import { createServerApiClient } from "@/lib/server-api";
 import { ApiKeysTable } from "./api-keys-table";
 import { GiftCreditsDialog } from "./gift-credits-dialog";
 import { OrgCostByModel } from "./org-cost-by-model";
+import { OrgCostByModelTimeseries } from "./org-cost-by-model-timeseries";
 import { OrgMetricsSection } from "./org-metrics";
 import { ProviderKeysTable } from "./provider-keys-table";
 import { SendEmailDialog } from "./send-email-dialog";
@@ -283,6 +284,8 @@ export default async function OrganizationPage({
 			<OrgMetricsSection orgId={orgId} />
 
 			<OrgCostByModel orgId={orgId} />
+
+			<OrgCostByModelTimeseries orgId={orgId} />
 
 			{projects.length > 0 && (
 				<section className="space-y-4">

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/page.tsx
@@ -13,6 +13,7 @@ import {
 	type ModelDefinition,
 } from "@llmgateway/models";
 
+import { ProjectCostByModelTimeseries } from "./project-cost-by-model-timeseries";
 import { ProjectLogsSection } from "./project-logs";
 import { ProjectMetricsSection } from "./project-metrics";
 
@@ -119,6 +120,8 @@ export default async function ProjectDetailPage({
 			</header>
 
 			<ProjectMetricsSection orgId={orgId} projectId={projectId} />
+
+			<ProjectCostByModelTimeseries orgId={orgId} projectId={projectId} />
 
 			<div>
 				<Button variant="outline" size="sm" asChild>

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { CostByModelTimeseriesChart } from "@/components/cost-by-model-timeseries-chart";
+import { getProjectCostByModelTimeseries } from "@/lib/admin-history";
+
+import type { TokenWindow } from "@/lib/types";
+
+const validWindows = new Set<TokenWindow>([
+	"1h",
+	"4h",
+	"12h",
+	"1d",
+	"7d",
+	"30d",
+	"90d",
+	"365d",
+]);
+
+function parseWindow(value: string | null): TokenWindow {
+	if (value && validWindows.has(value as TokenWindow)) {
+		return value as TokenWindow;
+	}
+	return "1d";
+}
+
+export function ProjectCostByModelTimeseries({
+	orgId,
+	projectId,
+}: {
+	orgId: string;
+	projectId: string;
+}) {
+	const searchParams = useSearchParams();
+	const window = parseWindow(searchParams.get("window"));
+
+	const fetchData = useCallback(
+		async (w: TokenWindow) => {
+			return await getProjectCostByModelTimeseries(orgId, projectId, w);
+		},
+		[orgId, projectId],
+	);
+
+	return (
+		<CostByModelTimeseriesChart
+			title="Cost by Model Over Time"
+			description="Stacked breakdown of top 10 models for this project"
+			fetchData={fetchData}
+			externalWindow={window}
+		/>
+	);
+}

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { format } from "date-fns";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+import type { ChartConfig } from "@/components/ui/chart";
+import type { CostByModelTimeseriesResponse, TokenWindow } from "@/lib/types";
+
+type ActiveMetric = "cost" | "requestCount" | "totalTokens";
+
+const metricTabs: { key: ActiveMetric; label: string }[] = [
+	{ key: "cost", label: "Cost" },
+	{ key: "requestCount", label: "Requests" },
+	{ key: "totalTokens", label: "Tokens" },
+];
+
+const seriesColors = [
+	"hsl(221 83% 53%)",
+	"hsl(142 71% 45%)",
+	"hsl(262 83% 58%)",
+	"hsl(32 95% 44%)",
+	"hsl(0 84% 60%)",
+	"hsl(199 89% 48%)",
+	"hsl(291 64% 42%)",
+	"hsl(48 96% 53%)",
+	"hsl(160 84% 39%)",
+	"hsl(340 82% 52%)",
+];
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
+function sanitizeKey(model: string): string {
+	return model.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+export function CostByModelTimeseriesChart({
+	title,
+	description,
+	fetchData,
+	externalWindow,
+}: {
+	title: string;
+	description?: string;
+	fetchData: (
+		window: TokenWindow,
+	) => Promise<CostByModelTimeseriesResponse | null>;
+	externalWindow: TokenWindow;
+}) {
+	const [data, setData] = useState<CostByModelTimeseriesResponse | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("cost");
+
+	const loadData = useCallback(async () => {
+		setLoading(true);
+		try {
+			const result = await fetchData(externalWindow);
+			setData(result);
+		} catch (error) {
+			console.error("Failed to load cost by model timeseries:", error);
+			setData(null);
+		} finally {
+			setLoading(false);
+		}
+	}, [fetchData, externalWindow]);
+
+	useEffect(() => {
+		void loadData();
+	}, [loadData]);
+
+	const { chartData, config, keyToModel } = useMemo(() => {
+		if (!data) {
+			return {
+				chartData: [],
+				config: {} as ChartConfig,
+				keyToModel: new Map<string, string>(),
+			};
+		}
+		const keyToModelLocal = new Map<string, string>();
+		const cfg: ChartConfig = {};
+		data.models.forEach((model, index) => {
+			const key = sanitizeKey(model);
+			keyToModelLocal.set(key, model);
+			cfg[key] = {
+				label: model,
+				color: seriesColors[index % seriesColors.length],
+			};
+		});
+		const rows = data.data.map((point) => {
+			const row: Record<string, number | string> = {
+				timestamp: point.timestamp,
+			};
+			for (const model of data.models) {
+				row[sanitizeKey(model)] = 0;
+			}
+			for (const entry of point.entries) {
+				const key = sanitizeKey(entry.model);
+				row[key] = Number(entry[activeMetric] ?? 0);
+			}
+			return row;
+		});
+		return { chartData: rows, config: cfg, keyToModel: keyToModelLocal };
+	}, [data, activeMetric]);
+
+	const bucket = data?.bucket ?? "day";
+
+	const formatTimestamp = useCallback(
+		(ts: string) => {
+			const date = new Date(ts);
+			if (bucket === "hour") {
+				return format(date, "MMM d HH:mm");
+			}
+			return format(date, "MMM d");
+		},
+		[bucket],
+	);
+
+	return (
+		<Card>
+			<CardHeader className="space-y-4 pb-2">
+				<div className="flex items-start justify-between gap-4">
+					<div>
+						<CardTitle className="text-base">{title}</CardTitle>
+						{description && <CardDescription>{description}</CardDescription>}
+					</div>
+				</div>
+				<div className="flex items-center gap-1 border-b pb-2">
+					{metricTabs.map((tab) => (
+						<button
+							key={tab.key}
+							className={cn(
+								"rounded-md px-3 py-1 text-xs font-medium transition-colors",
+								activeMetric === tab.key
+									? "bg-primary text-primary-foreground"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+							onClick={() => setActiveMetric(tab.key)}
+						>
+							{tab.label}
+						</button>
+					))}
+				</div>
+			</CardHeader>
+			<CardContent className="px-2 pb-4 sm:px-6">
+				{loading ? (
+					<div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
+						Loading...
+					</div>
+				) : !data || chartData.length === 0 ? (
+					<div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
+						No data for this time window
+					</div>
+				) : (
+					<>
+						<ChartContainer
+							config={config}
+							className="aspect-auto h-[300px] w-full"
+						>
+							<AreaChart
+								data={chartData}
+								margin={{ left: 0, right: 8, top: 4, bottom: 0 }}
+							>
+								<CartesianGrid vertical={false} strokeDasharray="3 3" />
+								<XAxis
+									dataKey="timestamp"
+									tickLine={false}
+									axisLine={false}
+									tickMargin={8}
+									minTickGap={40}
+									tickFormatter={(value: string) => formatTimestamp(value)}
+								/>
+								<YAxis
+									tickLine={false}
+									axisLine={false}
+									tickMargin={4}
+									width={60}
+									tickFormatter={(value: number) => {
+										if (activeMetric === "cost") {
+											return `$${value >= 1 ? value.toFixed(2) : value.toFixed(4)}`;
+										}
+										return value >= 1000
+											? `${(value / 1000).toFixed(1)}k`
+											: String(value);
+									}}
+								/>
+								<ChartTooltip
+									content={
+										<ChartTooltipContent
+											labelFormatter={(value: string) =>
+												format(
+													new Date(value),
+													bucket === "hour" ? "MMM d, HH:mm" : "MMM d, yyyy",
+												)
+											}
+											formatter={(value, name) => {
+												const label =
+													keyToModel.get(name as string) ?? String(name);
+												let formatted: string;
+												if (activeMetric === "cost") {
+													formatted = currencyFormatter.format(Number(value));
+												} else {
+													formatted = Number(value).toLocaleString();
+												}
+												return (
+													<span>
+														{label}: <strong>{formatted}</strong>
+													</span>
+												);
+											}}
+										/>
+									}
+								/>
+								{data.models.map((model) => {
+									const key = sanitizeKey(model);
+									return (
+										<Area
+											key={key}
+											dataKey={key}
+											type="monotone"
+											stackId="1"
+											stroke={`var(--color-${key})`}
+											fill={`var(--color-${key})`}
+											fillOpacity={0.5}
+											strokeWidth={1}
+										/>
+									);
+								})}
+							</AreaChart>
+						</ChartContainer>
+						<div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+							{data.models.map((model, i) => (
+								<div
+									key={model}
+									className="flex items-center gap-1.5 text-muted-foreground"
+								>
+									<span
+										className="inline-block h-2.5 w-2.5 rounded-sm"
+										style={{
+											backgroundColor: seriesColors[i % seriesColors.length],
+										}}
+									/>
+									<span className="truncate">{model}</span>
+								</div>
+							))}
+						</div>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -202,6 +202,7 @@ export function CostByModelTimeseriesChart({
 									}}
 								/>
 								<ChartTooltip
+									itemSorter={(item) => -Number(item.value ?? 0)}
 									content={
 										<ChartTooltipContent
 											labelFormatter={(value: string) =>

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -202,32 +202,41 @@ export function CostByModelTimeseriesChart({
 									}}
 								/>
 								<ChartTooltip
-									itemSorter={(item) => -Number(item.value ?? 0)}
-									content={
-										<ChartTooltipContent
-											labelFormatter={(value: string) =>
-												format(
-													new Date(value),
-													bucket === "hour" ? "MMM d, HH:mm" : "MMM d, yyyy",
-												)
-											}
-											formatter={(value, name) => {
-												const label =
-													keyToModel.get(name as string) ?? String(name);
-												let formatted: string;
-												if (activeMetric === "cost") {
-													formatted = currencyFormatter.format(Number(value));
-												} else {
-													formatted = Number(value).toLocaleString();
+									content={(props) => {
+										const sortedPayload = [...(props.payload ?? [])]
+											.filter((item) => Number(item.value ?? 0) > 0)
+											.sort(
+												(a, b) => Number(b.value ?? 0) - Number(a.value ?? 0),
+											);
+										return (
+											<ChartTooltipContent
+												active={props.active}
+												label={props.label}
+												payload={sortedPayload}
+												labelFormatter={(value: string) =>
+													format(
+														new Date(value),
+														bucket === "hour" ? "MMM d, HH:mm" : "MMM d, yyyy",
+													)
 												}
-												return (
-													<span>
-														{label}: <strong>{formatted}</strong>
-													</span>
-												);
-											}}
-										/>
-									}
+												formatter={(value, name) => {
+													const label =
+														keyToModel.get(name as string) ?? String(name);
+													let formatted: string;
+													if (activeMetric === "cost") {
+														formatted = currencyFormatter.format(Number(value));
+													} else {
+														formatted = Number(value).toLocaleString();
+													}
+													return (
+														<span>
+															{label}: <strong>{formatted}</strong>
+														</span>
+													);
+												}}
+											/>
+										);
+									}}
 								/>
 								{data.models.map((model) => {
 									const key = sanitizeKey(model);

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -121,3 +121,17 @@ export async function getOrgCostByModel(orgId: string, window: TokenWindow) {
 	);
 	return data ?? null;
 }
+
+export async function getOrgCostByModelTimeseries(
+	orgId: string,
+	window: TokenWindow,
+) {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET(
+		"/admin/organizations/{orgId}/cost-by-model-timeseries",
+		{
+			params: { path: { orgId }, query: { window } },
+		},
+	);
+	return data ?? null;
+}

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -135,3 +135,18 @@ export async function getOrgCostByModelTimeseries(
 	);
 	return data ?? null;
 }
+
+export async function getProjectCostByModelTimeseries(
+	orgId: string,
+	projectId: string,
+	window: TokenWindow,
+) {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET(
+		"/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries",
+		{
+			params: { path: { orgId, projectId }, query: { window } },
+		},
+	);
+	return data ?? null;
+}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4694,6 +4694,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                    projectId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Project cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Project not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4633,6 +4633,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/organizations/{orgId}/cost-by-model-timeseries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                };
+                header?: never;
+                path: {
+                    orgId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Organization cost breakdown by model over time. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                            /** @enum {string} */
+                            bucket: "hour" | "day";
+                            models: string[];
+                            data: {
+                                timestamp: string;
+                                entries: {
+                                    model: string;
+                                    cost: number;
+                                    requestCount: number;
+                                    totalTokens: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description Organization not found. */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/organizations/{orgId}/projects/{projectId}/model-provider-stats": {
         parameters: {
             query?: never;

--- a/ee/admin/src/lib/types.ts
+++ b/ee/admin/src/lib/types.ts
@@ -100,6 +100,8 @@ export type HistoryDataPoint = HistoryResponse["data"][number];
 // Cost by model
 export type CostByModelResponse =
 	GetJsonResponse<"/admin/metrics/cost-by-model">;
+export type CostByModelTimeseriesResponse =
+	GetJsonResponse<"/admin/organizations/{orgId}/cost-by-model-timeseries">;
 
 // Model-Provider Mappings
 export type ModelProviderMappingsResponse =


### PR DESCRIPTION
## Summary
- Adds a new admin endpoint `/admin/organizations/{orgId}/cost-by-model-timeseries` that returns hourly (≤1d window) or daily (>1d window) cost / requests / tokens bucketed by the top 10 models for the org.
- Adds a stacked area chart (`CostByModelTimeseriesChart`) on the admin organization detail page that visualises that breakdown over the currently selected window. Switch tabs between Cost, Requests, and Tokens.
- The chart respects the existing `?window=` query param used by the rest of the page, so adjusting the window updates the metrics, top-models bar chart, and this new time-series chart together.

## Test plan
- [ ] Visit `/organizations/<orgId>?window=7d` in the admin app and verify the new "Cost by Model Over Time" card shows a stacked area chart with up to 10 models.
- [ ] Switch the tabs to Requests and Tokens and verify the y-axis & tooltip formatting update.
- [ ] Change `?window=` between `1h`, `1d`, `7d`, `30d` and confirm bucket granularity flips between hour-level and day-level labels.
- [ ] Confirm an org with no traffic in the selected window renders the empty state without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added org- and project-scoped cost-by-model time-series endpoints and admin dashboard views.
  * Dashboard: selectable time window, metrics (cost, request count, tokens), stacked-area chart of top models, interactive tooltip, legend, loading and “No data” states.
  * Client-side fetch helpers and typed response shape for consuming the timeseries data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->