### PR TITLE
fix(gateway): log guardrail blocks as client_error

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1493,15 +1493,90 @@ chat.openapi(completions, async (c) => {
 				}
 			}
 
+			const blockedViolations = guardrailResult.violations.map((v) => ({
+				rule: v.ruleName,
+				category: v.category,
+			}));
+
+			// Surface the block in the activity feed as a client_error so users
+			// can see that the gateway rejected their request before any provider
+			// was contacted.
+			try {
+				await insertLogEntry({
+					...createLogEntry(
+						requestId,
+						project,
+						apiKey,
+						undefined,
+						"",
+						undefined,
+						"llmgateway",
+						requestedModel,
+						requestedProvider,
+						messages as any[],
+						temperature,
+						max_tokens,
+						top_p,
+						frequency_penalty,
+						presence_penalty,
+						reasoning_effort,
+						reasoning_max_tokens,
+						effort as "low" | "medium" | "high" | undefined,
+						response_format,
+						tools,
+						tool_choice,
+						source,
+						customHeaders,
+						debugMode,
+						userAgent,
+					),
+					content: null,
+					responseSize: 0,
+					finishReason: "client_error",
+					promptTokens: null,
+					completionTokens: null,
+					totalTokens: null,
+					reasoningTokens: null,
+					cachedTokens: null,
+					hasError: true,
+					streamed: !!stream,
+					canceled: false,
+					errorDetails: {
+						statusCode: 400,
+						statusText: "Bad Request",
+						responseText: JSON.stringify({
+							message: "Request blocked by content policy",
+							violations: blockedViolations,
+						}),
+						cause: "guardrail_violation",
+					},
+					duration: 0,
+					timeToFirstToken: null,
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					webSearchCost: 0,
+					imageInputTokens: null,
+					imageOutputTokens: null,
+					imageInputCost: null,
+					imageOutputCost: null,
+					cost: 0,
+					estimatedCost: false,
+					discount: null,
+					pricingTier: null,
+					dataStorageCost: "0",
+				});
+			} catch {
+				// Silently ignore logging failures
+			}
+
 			throw new HTTPException(400, {
 				message: "Request blocked by content policy",
 				cause: {
 					type: "guardrail_violation",
 					code: "content_policy_violation",
-					violations: guardrailResult.violations.map((v) => ({
-						rule: v.ruleName,
-						category: v.category,
-					})),
+					violations: blockedViolations,
 				},
 			});
 		}

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1494,9 +1494,19 @@ chat.openapi(completions, async (c) => {
 			}
 
 			const blockedViolations = guardrailResult.violations.map((v) => ({
-				rule: v.ruleName,
+				rule_id: v.ruleId,
+				rule_name: v.ruleName,
 				category: v.category,
+				action: v.action,
 			}));
+			const blockedCategories = [
+				...new Set(guardrailResult.violations.map((v) => v.category)),
+			];
+			const blockedRuleIds = guardrailResult.violations.map((v) => v.ruleId);
+			const errorMessage =
+				guardrailResult.violations.length === 1 && guardrailResult.violations[0]
+					? `Request blocked by content policy: ${guardrailResult.violations[0].ruleName} (rule ${guardrailResult.violations[0].ruleId}, category ${guardrailResult.violations[0].category})`
+					: `Request blocked by content policy: ${guardrailResult.violations.length} violations (categories: ${blockedCategories.join(", ")}; rules: ${blockedRuleIds.join(", ")})`;
 
 			// Surface the block in the activity feed as a client_error so users
 			// can see that the gateway rejected their request before any provider
@@ -1545,7 +1555,7 @@ chat.openapi(completions, async (c) => {
 						statusCode: 400,
 						statusText: "Bad Request",
 						responseText: JSON.stringify({
-							message: "Request blocked by content policy",
+							message: errorMessage,
 							violations: blockedViolations,
 						}),
 						cause: "guardrail_violation",
@@ -1571,14 +1581,21 @@ chat.openapi(completions, async (c) => {
 				// Silently ignore logging failures
 			}
 
-			throw new HTTPException(400, {
-				message: "Request blocked by content policy",
-				cause: {
-					type: "guardrail_violation",
-					code: "content_policy_violation",
-					violations: blockedViolations,
+			// Return the structured violation details directly. HTTPException's
+			// `cause` is dropped by the global error handler, so callers would
+			// otherwise only see the generic message.
+			return c.json(
+				{
+					error: {
+						message: errorMessage,
+						type: "guardrail_violation",
+						param: null,
+						code: "content_policy_violation",
+						violations: blockedViolations,
+					},
 				},
-			});
+				400,
+			);
 		}
 
 		// Apply redactions if any


### PR DESCRIPTION
## Summary

- Guardrail blocks in `apps/gateway/src/chat/chat.ts` throw `HTTPException(400)` before any provider is contacted. The global `app.onError` handler returns the JSON response without calling `insertLog`, so blocked requests never appear in activity.
- Insert a `client_error` log entry at the guardrail-block site (modeled after the existing `llmgateway_content_filter` log path) before throwing, so each violation is surfaced in the activity feed with the violation details in `errorDetails`.

## Test plan

- [ ] Send a request to an enterprise org that trips a blocking guardrail and confirm a new log row appears with `finishReason = client_error` / `unifiedFinishReason = CLIENT_ERROR` and the violations stored in `errorDetails.responseText`.
- [ ] Confirm the same `HTTPException(400)` response shape is still returned to the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for requests blocked by content policy, now including detailed violation information in responses and improved audit logging for blocked requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->