### PR TITLE
feat(models): add cn-beijing region for qwen3.7-max

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1218,6 +1218,15 @@ export const alibabaModels = [
 				cachedInputPrice: "0.5e-6",
 				cacheReadInputPrice: "0.25e-6",
 				cacheWriteInputPrice: "3.125e-6",
+				regions: [
+					{ id: "singapore" },
+					{
+						id: "cn-beijing",
+						inputPrice: "1.7232e-6",
+						outputPrice: "5.169e-6",
+						cachedInputPrice: "0.3446e-6",
+					},
+				],
 				requestPrice: "0",
 				contextSize: 1000000,
 				maxOutput: 65536,

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1225,6 +1225,8 @@ export const alibabaModels = [
 						inputPrice: "1.7232e-6",
 						outputPrice: "5.169e-6",
 						cachedInputPrice: "0.3446e-6",
+						cacheReadInputPrice: "0.17232e-6",
+						cacheWriteInputPrice: "2.154e-6",
 					},
 				],
 				requestPrice: "0",


### PR DESCRIPTION
## Summary

- Add `cn-beijing` region mapping for `qwen3.7-max` alongside the existing default (`singapore`).
- Pricing for `cn-beijing` derived from [Alibaba Bailian's official CN price page](https://help.aliyun.com/zh/model-studio/model-pricing) (12元/M input, 36元/M output, flat 0-1M; context cache discount), converted at the same CNY→USD ratio used by `qwen3-max-2026-01-23` in this file (~6.964):
  - `inputPrice`: `1.7232e-6`
  - `outputPrice`: `5.169e-6`
  - `cachedInputPrice`: `0.3446e-6` (input × 0.2, matching the cache-hit discount used by other Alibaba models in this file)

`us-virginia` is omitted: the endpoint returns `access_denied` for this account (model exists, but allowlist gated).

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm format` — clean
- [x] `TEST_MODELS="alibaba/qwen37-max:singapore,alibaba/qwen37-max:cn-beijing" pnpm test:e2e` — all qwen3.7-max tests pass for both regions (basic, basic+reasoning, streaming, tool calls, streaming tool calls, tool call results, responses single/multi-turn, responses tool calls). The 3 failures in `native-anthropic-cache.e2e.ts` are pre-existing bedrock cache flakes unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added regional support for the Qwen 3.7B Max model in Singapore and Beijing, with region-specific pricing and optimized cost settings for input, output, and cached operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->