### PR TITLE
fix(ui): apply global discounts on model detail page

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og";
 
+import { discountFraction, getEffectiveProviderDiscount } from "@/lib/discount";
+import { fetchModelDiscounts } from "@/lib/fetch-models";
 import Logo from "@/lib/icons/Logo";
 import { formatContextSize } from "@/lib/utils";
 
@@ -21,6 +23,7 @@ export const size = {
 	height: 630,
 };
 export const contentType = "image/png";
+export const revalidate = 60;
 
 interface ImageProps {
 	params: Promise<{ name: string; provider: string }>;
@@ -28,6 +31,7 @@ interface ImageProps {
 
 function getEffectivePricePerMillion(
 	mapping: ProviderModelMapping | undefined,
+	discount: number,
 ) {
 	if (
 		!mapping?.inputPrice &&
@@ -42,7 +46,6 @@ function getEffectivePricePerMillion(
 			return undefined;
 		}
 		const base = Number(price) * 1e6;
-		const discount = Number(mapping?.discount ?? "0");
 		if (!discount) {
 			return { original: base, discounted: base };
 		}
@@ -109,7 +112,17 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 						? GoogleStudioAIIconStatic
 						: getProviderIcon(selectedMapping.providerId)
 			: null;
-		const pricing = getEffectivePricePerMillion(selectedMapping);
+		const discounts = await fetchModelDiscounts(decodedName);
+		const effectiveDiscount = selectedMapping
+			? (getEffectiveProviderDiscount(
+					discounts,
+					selectedMapping.providerId,
+					decodedName,
+				) ?? selectedMapping.discount)
+			: undefined;
+		const discountNum = discountFraction(effectiveDiscount);
+
+		const pricing = getEffectivePricePerMillion(selectedMapping, discountNum);
 		const requestPrice =
 			selectedMapping?.requestPrice !== undefined
 				? Number(selectedMapping.requestPrice)
@@ -122,10 +135,6 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 					]),
 				)
 			: undefined;
-		const discountNum =
-			selectedMapping?.discount !== undefined
-				? Number(selectedMapping.discount)
-				: undefined;
 		const isVideoGen = selectedMapping?.videoGenerations === true;
 		const isImageGen = selectedMapping?.imageGenerations === true;
 		const hasTokenPricing =

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -19,16 +19,19 @@ import { Navbar } from "@/components/landing/navbar";
 import { adaptModel } from "@/components/models/adapt-model";
 import { CopyModelName } from "@/components/models/copy-model-name";
 import { DetailProviderCards } from "@/components/models/detail-provider-cards";
-import {
-	GlobalDiscountBanner,
-	type DiscountData,
-} from "@/components/models/global-discount-banner";
+import { GlobalDiscountBanner } from "@/components/models/global-discount-banner";
 import { ModelBenchmarks } from "@/components/models/model-benchmarks";
 import { ModelCtaButton } from "@/components/models/model-cta-button";
 import { ModelStatusBadgeAuto } from "@/components/models/model-status-badge-auto";
 import { ProviderTabs } from "@/components/models/provider-tabs";
 import { Badge } from "@/lib/components/badge";
-import { fetchServerData } from "@/lib/server-api";
+import {
+	applyDiscount,
+	getBestDiscount,
+	getEffectiveProviderDiscount,
+	perMillion,
+} from "@/lib/discount";
+import { fetchModelDiscounts } from "@/lib/fetch-models";
 
 import {
 	models as modelDefinitions,
@@ -44,76 +47,9 @@ interface PageProps {
 	params: Promise<{ name: string }>;
 }
 
-async function getModelDiscounts(modelId: string): Promise<DiscountData[]> {
-	const data = await fetchServerData<{ discounts: DiscountData[] }>(
-		"GET",
-		"/public/discounts/model/{modelId}",
-		{
-			params: {
-				path: { modelId },
-			},
-		},
-	);
-
-	return data?.discounts ?? [];
-}
-
-function getBestDiscount(
-	discounts: DiscountData[],
-	modelId: string,
-): DiscountData | null {
-	// Precedence: model-specific > fully global
-	const modelSpecific = discounts.find((d) => d.model === modelId);
-	if (modelSpecific) {
-		return modelSpecific;
-	}
-
-	const fullyGlobal = discounts.find(
-		(d) => d.provider === null && d.model === null,
-	);
-	if (fullyGlobal) {
-		return fullyGlobal;
-	}
-
-	return null;
-}
-
-function getEffectiveProviderDiscount(
-	discounts: DiscountData[],
-	providerId: string,
-	modelId: string,
-): string | undefined {
-	// Precedence: provider+model > provider > model > fully global
-	const providerModel = discounts.find(
-		(d) => d.provider === providerId && d.model === modelId,
-	);
-	if (providerModel) {
-		return providerModel.discountPercent;
-	}
-
-	const providerOnly = discounts.find(
-		(d) => d.provider === providerId && d.model === null,
-	);
-	if (providerOnly) {
-		return providerOnly.discountPercent;
-	}
-
-	const modelOnly = discounts.find(
-		(d) => d.provider === null && d.model === modelId,
-	);
-	if (modelOnly) {
-		return modelOnly.discountPercent;
-	}
-
-	const fullyGlobal = discounts.find(
-		(d) => d.provider === null && d.model === null,
-	);
-	if (fullyGlobal) {
-		return fullyGlobal.discountPercent;
-	}
-
-	return undefined;
-}
+// Revalidate so admin-configured global discounts propagate to this
+// statically-generated page within a minute.
+export const revalidate = 60;
 
 export default async function ModelPage({ params }: PageProps) {
 	const { name } = await params;
@@ -156,7 +92,7 @@ export default async function ModelPage({ params }: PageProps) {
 		return stability && ["unstable", "experimental"].includes(stability);
 	};
 
-	const allDiscounts = await getModelDiscounts(decodedName);
+	const allDiscounts = await fetchModelDiscounts(decodedName);
 	const expandedProviders = expandAllProviderRegions(modelDef.providers);
 	const modelProviders = expandedProviders.map((provider) => {
 		const providerInfo = providerDefinitions.find(
@@ -205,10 +141,7 @@ export default async function ModelPage({ params }: PageProps) {
 
 	const providerPrices = modelProviders
 		.filter((p) => p.inputPrice)
-		.map(
-			(p) =>
-				Number(p.inputPrice!) * 1e6 * (p.discount ? 1 - Number(p.discount) : 1),
-		);
+		.map((p) => applyDiscount(perMillion(p.inputPrice)!, p.discount));
 	const lowestInputPrice = Math.min(...providerPrices);
 	const highestInputPrice = Math.max(...providerPrices);
 
@@ -348,11 +281,11 @@ export default async function ModelPage({ params }: PageProps) {
 									const inputPrices = modelProviders
 										.filter((p) => p.inputPrice)
 										.map((p) => ({
-											price:
-												Number(p.inputPrice!) *
-												1e6 *
-												(p.discount ? 1 - Number(p.discount) : 1),
-											originalPrice: Number(p.inputPrice!) * 1e6,
+											price: applyDiscount(
+												perMillion(p.inputPrice)!,
+												p.discount,
+											),
+											originalPrice: perMillion(p.inputPrice)!,
 											discount: p.discount,
 										}));
 									if (inputPrices.length === 0) {
@@ -374,11 +307,11 @@ export default async function ModelPage({ params }: PageProps) {
 									const outputPrices = modelProviders
 										.filter((p) => p.outputPrice)
 										.map((p) => ({
-											price:
-												Number(p.outputPrice!) *
-												1e6 *
-												(p.discount ? 1 - Number(p.discount) : 1),
-											originalPrice: Number(p.outputPrice!) * 1e6,
+											price: applyDiscount(
+												perMillion(p.outputPrice)!,
+												p.discount,
+											),
+											originalPrice: perMillion(p.outputPrice)!,
 											discount: p.discount,
 										}));
 									if (outputPrices.length === 0) {
@@ -403,10 +336,10 @@ export default async function ModelPage({ params }: PageProps) {
 										const imageOutputPrices = modelProviders
 											.filter((p) => p.imageOutputPrice !== undefined)
 											.map((p) => ({
-												price:
-													Number(p.imageOutputPrice!) *
-													1e6 *
-													(p.discount ? 1 - Number(p.discount) : 1),
+												price: applyDiscount(
+													perMillion(p.imageOutputPrice)!,
+													p.discount,
+												),
 												discount:
 													p.discount && Number(p.discount) !== 0
 														? p.discount

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -47,8 +47,6 @@ interface PageProps {
 	params: Promise<{ name: string }>;
 }
 
-// Revalidate so admin-configured global discounts propagate to this
-// statically-generated page within a minute.
 export const revalidate = 60;
 
 export default async function ModelPage({ params }: PageProps) {

--- a/apps/ui/src/components/models/detail-provider-cards.tsx
+++ b/apps/ui/src/components/models/detail-provider-cards.tsx
@@ -49,7 +49,7 @@ export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 				(priceNum * 1e6 * (1 - discountNum)).toFixed(4),
 			);
 			return (
-				<div className="flex flex-col justify-items-center">
+				<div className="flex flex-col items-center gap-0.5">
 					<div className="flex items-center gap-1">
 						<span className="line-through text-muted-foreground text-xs">
 							${originalPrice}
@@ -58,6 +58,9 @@ export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 							${discountedPrice}
 						</span>
 					</div>
+					<span className="text-[9px] font-semibold leading-none rounded px-1 py-0.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20">
+						{Math.round(discountNum * 100)}% off
+					</span>
 				</div>
 			);
 		}

--- a/apps/ui/src/components/models/global-discount-banner.tsx
+++ b/apps/ui/src/components/models/global-discount-banner.tsx
@@ -1,6 +1,7 @@
 import { Percent } from "lucide-react";
 
 import { Countdown } from "@/components/countdown";
+import { discountFraction } from "@/lib/discount";
 
 import type { DiscountData } from "@/lib/discount";
 
@@ -15,7 +16,7 @@ export function GlobalDiscountBanner({ discount }: GlobalDiscountBannerProps) {
 		return null;
 	}
 
-	const percent = (parseFloat(discount.discountPercent) * 100).toFixed(0);
+	const percent = (discountFraction(discount.discountPercent) * 100).toFixed(0);
 
 	return (
 		<div className="rounded-lg bg-linear-to-r from-green-500/10 via-emerald-500/10 to-teal-500/10 border border-green-500/20 p-4 flex items-center gap-3 flex-wrap">

--- a/apps/ui/src/components/models/global-discount-banner.tsx
+++ b/apps/ui/src/components/models/global-discount-banner.tsx
@@ -2,15 +2,9 @@ import { Percent } from "lucide-react";
 
 import { Countdown } from "@/components/countdown";
 
-export interface DiscountData {
-	id: string;
-	provider: string | null;
-	model: string | null;
-	discountPercent: string;
-	reason: string | null;
-	expiresAt: string | null;
-	createdAt: string;
-}
+import type { DiscountData } from "@/lib/discount";
+
+export type { DiscountData };
 
 interface GlobalDiscountBannerProps {
 	discount: DiscountData | null;

--- a/apps/ui/src/components/models/model-card.tsx
+++ b/apps/ui/src/components/models/model-card.tsx
@@ -938,20 +938,64 @@ export function ProviderSection({
 						{!isImageGen &&
 							activeMapping.requestPrice !== null &&
 							activeMapping.requestPrice !== undefined &&
-							parseFloat(activeMapping.requestPrice) > 0 && (
-								<span>
-									+ ${parseFloat(activeMapping.requestPrice).toFixed(3)}
-									<span className="text-muted-foreground/60"> per request</span>
-								</span>
-							)}
+							parseFloat(activeMapping.requestPrice) > 0 &&
+							(() => {
+								const original = parseFloat(activeMapping.requestPrice);
+								const discountNum = activeMapping.discount
+									? parseFloat(activeMapping.discount)
+									: 0;
+								return (
+									<span>
+										+{" "}
+										{discountNum > 0 ? (
+											<>
+												<span className="line-through text-muted-foreground/60 mr-1">
+													${original.toFixed(3)}
+												</span>
+												<span className="text-green-600 font-semibold">
+													${(original * (1 - discountNum)).toFixed(3)}
+												</span>
+											</>
+										) : (
+											`$${original.toFixed(3)}`
+										)}
+										<span className="text-muted-foreground/60">
+											{" "}
+											per request
+										</span>
+									</span>
+								);
+							})()}
 						{activeMapping.webSearchPrice !== null &&
 							activeMapping.webSearchPrice !== undefined &&
-							parseFloat(activeMapping.webSearchPrice) > 0 && (
-								<span>
-									+ ${parseFloat(activeMapping.webSearchPrice).toFixed(3)}
-									<span className="text-muted-foreground/60"> per search</span>
-								</span>
-							)}
+							parseFloat(activeMapping.webSearchPrice) > 0 &&
+							(() => {
+								const original = parseFloat(activeMapping.webSearchPrice);
+								const discountNum = activeMapping.discount
+									? parseFloat(activeMapping.discount)
+									: 0;
+								return (
+									<span>
+										+{" "}
+										{discountNum > 0 ? (
+											<>
+												<span className="line-through text-muted-foreground/60 mr-1">
+													${original.toFixed(3)}
+												</span>
+												<span className="text-green-600 font-semibold">
+													${(original * (1 - discountNum)).toFixed(3)}
+												</span>
+											</>
+										) : (
+											`$${original.toFixed(3)}`
+										)}
+										<span className="text-muted-foreground/60">
+											{" "}
+											per search
+										</span>
+									</span>
+								);
+							})()}
 					</div>
 				) : null}
 

--- a/apps/ui/src/lib/discount.spec.ts
+++ b/apps/ui/src/lib/discount.spec.ts
@@ -78,7 +78,7 @@ describe("model-detail discounts", () => {
 		).toBeCloseTo(2.5);
 	});
 
-	it.each(["1.5", "-0.2", "abc"])(
+	it.each(["1.5", "-0.2", "abc", "0.5abc"])(
 		"ignores the invalid discount %s and keeps base prices",
 		(discountPercent) => {
 			const discounts: DiscountData[] = [

--- a/apps/ui/src/lib/discount.spec.ts
+++ b/apps/ui/src/lib/discount.spec.ts
@@ -77,4 +77,25 @@ describe("model-detail discounts", () => {
 			applyDiscount(perMillion(alibaba.inputPrice)!, discount),
 		).toBeCloseTo(2.5);
 	});
+
+	it.each(["1.5", "-0.2", "abc"])(
+		"ignores the invalid discount %s and keeps base prices",
+		(discountPercent) => {
+			const discounts: DiscountData[] = [
+				{ ...fiftyPercentOff, discountPercent },
+			];
+
+			expect(
+				getEffectiveProviderDiscount(discounts, "alibaba", "qwen37-max"),
+			).toBeUndefined();
+			expect(getBestDiscount(discounts, "qwen37-max")).toBeNull();
+
+			expect(
+				applyDiscount(perMillion(alibaba.inputPrice)!, discountPercent),
+			).toBeCloseTo(2.5);
+			expect(
+				applyDiscount(Number(alibaba.webSearchPrice), discountPercent),
+			).toBeCloseTo(0.01);
+		},
+	);
 });

--- a/apps/ui/src/lib/discount.spec.ts
+++ b/apps/ui/src/lib/discount.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { models } from "@llmgateway/models";
+
+import {
+	applyDiscount,
+	getBestDiscount,
+	getEffectiveProviderDiscount,
+	perMillion,
+	type DiscountData,
+} from "./discount";
+
+const qwen = models.find((m) => m.id === "qwen37-max")!;
+const alibaba = qwen.providers.find((p) => p.providerId === "alibaba")!;
+
+// Mocked global 50% discount on qwen37-max, as configured in the admin
+// dashboard (stored as a 0-1 fraction).
+const fiftyPercentOff: DiscountData = {
+	id: "test-discount",
+	provider: null,
+	model: "qwen37-max",
+	discountPercent: "0.5",
+	reason: "Launch promo",
+	expiresAt: null,
+	createdAt: new Date().toISOString(),
+};
+
+describe("model-detail discounts", () => {
+	it("model definition has the expected base prices", () => {
+		expect(alibaba.inputPrice).toBe("2.5e-6");
+		expect(alibaba.outputPrice).toBe("7.5e-6");
+		expect(alibaba.cachedInputPrice).toBe("0.5e-6");
+		expect(alibaba.webSearchPrice).toBe("0.01");
+	});
+
+	it("selects the global model discount for the provider", () => {
+		const discounts = [fiftyPercentOff];
+		expect(
+			getEffectiveProviderDiscount(discounts, "alibaba", "qwen37-max"),
+		).toBe("0.5");
+		expect(getBestDiscount(discounts, "qwen37-max")).toEqual(fiftyPercentOff);
+	});
+
+	it("applies the 50% discount to all per-million token prices", () => {
+		const discount = getEffectiveProviderDiscount(
+			[fiftyPercentOff],
+			"alibaba",
+			"qwen37-max",
+		);
+
+		expect(
+			applyDiscount(perMillion(alibaba.inputPrice)!, discount),
+		).toBeCloseTo(1.25);
+		expect(
+			applyDiscount(perMillion(alibaba.outputPrice)!, discount),
+		).toBeCloseTo(3.75);
+		expect(
+			applyDiscount(perMillion(alibaba.cachedInputPrice)!, discount),
+		).toBeCloseTo(0.25);
+	});
+
+	it("applies the 50% discount to the per-search price", () => {
+		const discount = getEffectiveProviderDiscount(
+			[fiftyPercentOff],
+			"alibaba",
+			"qwen37-max",
+		);
+		expect(applyDiscount(Number(alibaba.webSearchPrice), discount)).toBeCloseTo(
+			0.005,
+		);
+	});
+
+	it("returns base prices when no discount is active", () => {
+		const discount = getEffectiveProviderDiscount([], "alibaba", "qwen37-max");
+		expect(discount).toBeUndefined();
+		expect(
+			applyDiscount(perMillion(alibaba.inputPrice)!, discount),
+		).toBeCloseTo(2.5);
+	});
+});

--- a/apps/ui/src/lib/discount.ts
+++ b/apps/ui/src/lib/discount.ts
@@ -1,0 +1,90 @@
+export interface DiscountData {
+	id: string;
+	provider: string | null;
+	model: string | null;
+	discountPercent: string;
+	reason: string | null;
+	expiresAt: string | null;
+	createdAt: string;
+}
+
+export function getBestDiscount(
+	discounts: DiscountData[],
+	modelId: string,
+): DiscountData | null {
+	// Precedence: model-specific > fully global
+	const modelSpecific = discounts.find((d) => d.model === modelId);
+	if (modelSpecific) {
+		return modelSpecific;
+	}
+
+	const fullyGlobal = discounts.find(
+		(d) => d.provider === null && d.model === null,
+	);
+	if (fullyGlobal) {
+		return fullyGlobal;
+	}
+
+	return null;
+}
+
+export function getEffectiveProviderDiscount(
+	discounts: DiscountData[],
+	providerId: string,
+	modelId: string,
+): string | undefined {
+	// Precedence: provider+model > provider > model > fully global
+	const providerModel = discounts.find(
+		(d) => d.provider === providerId && d.model === modelId,
+	);
+	if (providerModel) {
+		return providerModel.discountPercent;
+	}
+
+	const providerOnly = discounts.find(
+		(d) => d.provider === providerId && d.model === null,
+	);
+	if (providerOnly) {
+		return providerOnly.discountPercent;
+	}
+
+	const modelOnly = discounts.find(
+		(d) => d.provider === null && d.model === modelId,
+	);
+	if (modelOnly) {
+		return modelOnly.discountPercent;
+	}
+
+	const fullyGlobal = discounts.find(
+		(d) => d.provider === null && d.model === null,
+	);
+	if (fullyGlobal) {
+		return fullyGlobal.discountPercent;
+	}
+
+	return undefined;
+}
+
+// Discounts are stored as a 0-1 fraction (e.g. "0.5" = 50% off).
+export function discountFraction(discount?: string | null): number {
+	if (!discount) {
+		return 0;
+	}
+	const n = parseFloat(discount);
+	return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+export function applyDiscount(value: number, discount?: string | null): number {
+	return value * (1 - discountFraction(discount));
+}
+
+// Converts a per-token price (e.g. "2.5e-6") to a per-million-token price.
+export function perMillion(
+	price: string | number | null | undefined,
+): number | null {
+	if (price === null || price === undefined || price === "") {
+		return null;
+	}
+	const n = typeof price === "number" ? price : parseFloat(price);
+	return Number.isFinite(n) ? n * 1e6 : null;
+}

--- a/apps/ui/src/lib/discount.ts
+++ b/apps/ui/src/lib/discount.ts
@@ -15,7 +15,7 @@ function isValidDiscount(discount?: string | null): boolean {
 	if (!discount) {
 		return false;
 	}
-	const n = parseFloat(discount);
+	const n = Number(discount);
 	return Number.isFinite(n) && n > 0 && n <= 1;
 }
 
@@ -79,7 +79,7 @@ export function getEffectiveProviderDiscount(
 }
 
 export function discountFraction(discount?: string | null): number {
-	return isValidDiscount(discount) ? parseFloat(discount!) : 0;
+	return isValidDiscount(discount) ? Number(discount) : 0;
 }
 
 export function applyDiscount(value: number, discount?: string | null): number {

--- a/apps/ui/src/lib/discount.ts
+++ b/apps/ui/src/lib/discount.ts
@@ -8,17 +8,29 @@ export interface DiscountData {
 	createdAt: string;
 }
 
+// Discounts are stored as a 0-1 fraction (e.g. "0.5" = 50% off). Values outside
+// (0, 1] are treated as invalid data and ignored to avoid negative or inflated
+// prices.
+function isValidDiscount(discount?: string | null): boolean {
+	if (!discount) {
+		return false;
+	}
+	const n = parseFloat(discount);
+	return Number.isFinite(n) && n > 0 && n <= 1;
+}
+
 export function getBestDiscount(
 	discounts: DiscountData[],
 	modelId: string,
 ): DiscountData | null {
+	const valid = discounts.filter((d) => isValidDiscount(d.discountPercent));
 	// Precedence: model-specific > fully global
-	const modelSpecific = discounts.find((d) => d.model === modelId);
+	const modelSpecific = valid.find((d) => d.model === modelId);
 	if (modelSpecific) {
 		return modelSpecific;
 	}
 
-	const fullyGlobal = discounts.find(
+	const fullyGlobal = valid.find(
 		(d) => d.provider === null && d.model === null,
 	);
 	if (fullyGlobal) {
@@ -33,29 +45,30 @@ export function getEffectiveProviderDiscount(
 	providerId: string,
 	modelId: string,
 ): string | undefined {
+	const valid = discounts.filter((d) => isValidDiscount(d.discountPercent));
 	// Precedence: provider+model > provider > model > fully global
-	const providerModel = discounts.find(
+	const providerModel = valid.find(
 		(d) => d.provider === providerId && d.model === modelId,
 	);
 	if (providerModel) {
 		return providerModel.discountPercent;
 	}
 
-	const providerOnly = discounts.find(
+	const providerOnly = valid.find(
 		(d) => d.provider === providerId && d.model === null,
 	);
 	if (providerOnly) {
 		return providerOnly.discountPercent;
 	}
 
-	const modelOnly = discounts.find(
+	const modelOnly = valid.find(
 		(d) => d.provider === null && d.model === modelId,
 	);
 	if (modelOnly) {
 		return modelOnly.discountPercent;
 	}
 
-	const fullyGlobal = discounts.find(
+	const fullyGlobal = valid.find(
 		(d) => d.provider === null && d.model === null,
 	);
 	if (fullyGlobal) {
@@ -65,13 +78,8 @@ export function getEffectiveProviderDiscount(
 	return undefined;
 }
 
-// Discounts are stored as a 0-1 fraction (e.g. "0.5" = 50% off).
 export function discountFraction(discount?: string | null): number {
-	if (!discount) {
-		return 0;
-	}
-	const n = parseFloat(discount);
-	return Number.isFinite(n) && n > 0 ? n : 0;
+	return isValidDiscount(discount) ? parseFloat(discount!) : 0;
 }
 
 export function applyDiscount(value: number, discount?: string | null): number {

--- a/apps/ui/src/lib/fetch-models.ts
+++ b/apps/ui/src/lib/fetch-models.ts
@@ -2,6 +2,8 @@ import { cache } from "react";
 
 import { getConfig } from "./config-server";
 
+import type { DiscountData } from "./discount";
+
 export interface ApiProvider {
 	id: string;
 	createdAt: string;
@@ -89,6 +91,27 @@ export const fetchModels = cache(async (): Promise<ApiModel[]> => {
 		return [];
 	}
 });
+
+export const fetchModelDiscounts = cache(
+	async (modelId: string): Promise<DiscountData[]> => {
+		const config = getConfig();
+		try {
+			const response = await fetch(
+				`${config.apiBackendUrl}/public/discounts/model/${encodeURIComponent(modelId)}`,
+				{ next: { revalidate: 60 } },
+			);
+			if (!response.ok) {
+				console.error("Failed to fetch discounts:", response.statusText);
+				return [];
+			}
+			const data = await response.json();
+			return data.discounts ?? [];
+		} catch (error) {
+			console.error("Error fetching discounts:", error);
+			return [];
+		}
+	},
+);
 
 export const fetchProviders = cache(async (): Promise<ApiProvider[]> => {
 	const config = getConfig();


### PR DESCRIPTION
Load active discounts via a cookie-free, ISR-cached fetch and add
revalidate=60 so admin-configured global discounts propagate to the
statically-generated model detail page. Apply the discount to per-search
and per-request prices and surface a "% off" badge next to discounted
prices.

https://claude.ai/code/session_018uhD7xtdxbAj9GcFPUvQ7Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized discount utilities for consistent pricing across the UI
  * Visible "% off" badges and discounted pricing on provider cards and model listings
  * Model-specific discounts fetched and applied automatically; global discounts refresh every 60s

* **Refactor**
  * Unified pricing calculations so all displayed prices (including "Starting at" token amounts and image previews) apply discounts consistently
  * Consolidated discount precedence between provider/model/global

* **Tests**
  * Added test suite validating discount selection and price calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->