### PR TITLE
fix(gateway): stream v1/messages usage tokens

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -601,6 +601,83 @@ anthropic.openapi(messages, async (c) => {
 				let currentTextBlockIndex: number | null = null;
 				const toolCallBlockIndex = new Map<number, number>();
 				let currentEventType: string | null = null;
+				let stopReason: string | null = null;
+				let contentBlockStopsSent = false;
+				let messageDeltaSent = false;
+
+				const extractUsage = (chunk: any) => {
+					if (!chunk?.usage) {
+						return;
+					}
+					const promptDetails = chunk.usage.prompt_tokens_details ?? {};
+					const cacheRead: number = promptDetails.cached_tokens ?? 0;
+					const cacheCreation: number =
+						promptDetails.cache_write_tokens ??
+						promptDetails.cache_creation_tokens ??
+						0;
+					const totalPrompt: number = chunk.usage.prompt_tokens ?? 0;
+					const nonCachedInput = Math.max(
+						0,
+						totalPrompt - cacheRead - cacheCreation,
+					);
+					const breakdown = promptDetails.cache_creation as
+						| {
+								ephemeral_5m_input_tokens?: number;
+								ephemeral_1h_input_tokens?: number;
+						  }
+						| undefined;
+					usage = {
+						input_tokens: nonCachedInput,
+						output_tokens: chunk.usage.completion_tokens ?? 0,
+						// Match Anthropic's API and always emit both fields
+						// (set to 0 when inapplicable).
+						cache_creation_input_tokens: cacheCreation,
+						cache_read_input_tokens: cacheRead,
+						...(breakdown &&
+							cacheCreation > 0 && {
+								cache_creation: {
+									ephemeral_5m_input_tokens:
+										breakdown.ephemeral_5m_input_tokens ?? 0,
+									ephemeral_1h_input_tokens:
+										breakdown.ephemeral_1h_input_tokens ?? 0,
+								},
+							}),
+					};
+				};
+
+				const sendContentBlockStops = async () => {
+					if (contentBlockStopsSent) {
+						return;
+					}
+					contentBlockStopsSent = true;
+					for (let i = 0; i < contentBlocks.length; i++) {
+						await stream.writeSSE({
+							data: JSON.stringify({
+								type: "content_block_stop",
+								index: i,
+							}),
+							event: "content_block_stop",
+						});
+					}
+				};
+
+				const sendMessageDelta = async () => {
+					if (messageDeltaSent || stopReason === null) {
+						return;
+					}
+					messageDeltaSent = true;
+					await stream.writeSSE({
+						data: JSON.stringify({
+							type: "message_delta",
+							delta: {
+								stop_reason: stopReason,
+								stop_sequence: null,
+							},
+							usage: usage,
+						}),
+						event: "message_delta",
+					});
+				};
 
 				try {
 					while (true) {
@@ -631,6 +708,8 @@ anthropic.openapi(messages, async (c) => {
 							if (line.startsWith("data: ")) {
 								const data = line.slice(6).trim();
 								if (data === "[DONE]") {
+									await sendContentBlockStops();
+									await sendMessageDelta();
 									// Send final Anthropic streaming event
 									await stream.writeSSE({
 										data: JSON.stringify({
@@ -703,6 +782,12 @@ anthropic.openapi(messages, async (c) => {
 										event: "message_start",
 									});
 								}
+
+								// Extract usage from any chunk that carries it. The
+								// upstream chat completions endpoint emits usage in a
+								// separate final chunk (no finish_reason), so we must not
+								// gate this on choices/delta/finish_reason.
+								extractUsage(chunk);
 
 								const choice = chunk.choices?.[0];
 								if (!choice) {
@@ -820,73 +905,27 @@ anthropic.openapi(messages, async (c) => {
 									}
 								}
 
-								// Handle finish_reason
+								// Capture the stop reason and flush content_block_stops,
+								// but defer message_delta until the final usage chunk
+								// (or stream end) so usage is included.
 								if (choice.finish_reason) {
-									// Send content_block_stop events
-									for (let i = 0; i < contentBlocks.length; i++) {
-										await stream.writeSSE({
-											data: JSON.stringify({
-												type: "content_block_stop",
-												index: i,
-											}),
-											event: "content_block_stop",
-										});
-									}
-
-									// Update usage if available
-									if (chunk.usage) {
-										const promptDetails =
-											chunk.usage.prompt_tokens_details ?? {};
-										const cacheRead: number = promptDetails.cached_tokens ?? 0;
-										const cacheCreation: number =
-											promptDetails.cache_write_tokens ??
-											promptDetails.cache_creation_tokens ??
-											0;
-										const totalPrompt: number = chunk.usage.prompt_tokens ?? 0;
-										const nonCachedInput = Math.max(
-											0,
-											totalPrompt - cacheRead - cacheCreation,
-										);
-										const breakdown = promptDetails.cache_creation as
-											| {
-													ephemeral_5m_input_tokens?: number;
-													ephemeral_1h_input_tokens?: number;
-											  }
-											| undefined;
-										usage = {
-											input_tokens: nonCachedInput,
-											output_tokens: chunk.usage.completion_tokens ?? 0,
-											// Match Anthropic's API and always emit both fields
-											// (set to 0 when inapplicable).
-											cache_creation_input_tokens: cacheCreation,
-											cache_read_input_tokens: cacheRead,
-											...(breakdown &&
-												cacheCreation > 0 && {
-													cache_creation: {
-														ephemeral_5m_input_tokens:
-															breakdown.ephemeral_5m_input_tokens ?? 0,
-														ephemeral_1h_input_tokens:
-															breakdown.ephemeral_1h_input_tokens ?? 0,
-													},
-												}),
-										};
-									}
-
-									// Send message_delta with usage
-									await stream.writeSSE({
-										data: JSON.stringify({
-											type: "message_delta",
-											delta: {
-												stop_reason: determineStopReason(choice.finish_reason),
-												stop_sequence: null,
-											},
-											usage: usage,
-										}),
-										event: "message_delta",
-									});
+									stopReason = determineStopReason(choice.finish_reason);
+									await sendContentBlockStops();
 								}
 							}
 						}
+					}
+
+					// Stream ended without an explicit [DONE]. Emit any deferred
+					// terminator events so downstream clients see a well-formed
+					// Anthropic stream.
+					await sendContentBlockStops();
+					await sendMessageDelta();
+					if (stopReason !== null) {
+						await stream.writeSSE({
+							data: JSON.stringify({ type: "message_stop" }),
+							event: "message_stop",
+						});
 					}
 				} catch (error) {
 					throw new HTTPException(500, {

--- a/apps/gateway/src/native-anthropic-cache.e2e.ts
+++ b/apps/gateway/src/native-anthropic-cache.e2e.ts
@@ -667,4 +667,79 @@ describe("e2e native /v1/messages cache", getConcurrentTestOptions(), () => {
 			}
 		},
 	);
+
+	// Streaming /v1/messages must surface non-zero usage tokens in the final
+	// message_delta event. The upstream /v1/chat/completions endpoint emits
+	// `finish_reason` and the `usage` payload in *separate* chunks (the usage
+	// chunk has finish_reason: null). Before the fix, the Anthropic translator
+	// only read usage when it saw finish_reason, so message_delta carried
+	// zeros for input_tokens/output_tokens. Run for each provider since the
+	// chunk ordering depends on the upstream.
+	const streamingUsageBody = (model: string) => ({
+		model,
+		max_tokens: 50,
+		stream: true,
+		messages: [{ role: "user" as const, content: "What is 2+2?" }],
+	});
+
+	const assertStreamingUsage = async (model: string, label: string) => {
+		const requestId = generateTestRequestId();
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-request-id": requestId,
+				"anthropic-version": "2023-06-01",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify(streamingUsageBody(model)),
+		});
+		expect(res.status).toBe(200);
+
+		const chunks = await readSseChunks(res.body);
+		const messageDelta = chunks.find((c) => c?.type === "message_delta");
+		const messageStop = chunks.find((c) => c?.type === "message_stop");
+		const messageDeltaCount = chunks.filter(
+			(c) => c?.type === "message_delta",
+		).length;
+
+		if (logMode) {
+			console.log(
+				label,
+				requestId,
+				"message_delta usage",
+				JSON.stringify(messageDelta?.usage),
+				"count",
+				messageDeltaCount,
+			);
+		}
+
+		expect(messageDelta, "missing message_delta event").toBeDefined();
+		expect(messageStop, "missing message_stop event").toBeDefined();
+		expect(messageDeltaCount).toBe(1);
+		expect(messageDelta.usage.input_tokens).toBeGreaterThan(0);
+		expect(messageDelta.usage.output_tokens).toBeGreaterThan(0);
+	};
+
+	(hasAnthropicKey ? test : test.skip)(
+		"streaming /v1/messages surfaces non-zero usage tokens for anthropic",
+		getTestOptions(),
+		async () => {
+			await assertStreamingUsage(
+				"anthropic/claude-haiku-4-5",
+				"streaming /v1/messages anthropic usage",
+			);
+		},
+	);
+
+	(hasBedrockKey ? test : test.skip)(
+		"streaming /v1/messages surfaces non-zero usage tokens for bedrock",
+		getTestOptions(),
+		async () => {
+			await assertStreamingUsage(
+				"aws-bedrock/claude-haiku-4-5",
+				"streaming /v1/messages bedrock usage",
+			);
+		},
+	);
 });


### PR DESCRIPTION
## Summary

The Anthropic Messages translator at `/v1/messages` was reporting `input_tokens: 0, output_tokens: 0` in the streamed `message_delta` event. The upstream `/v1/chat/completions` endpoint emits `finish_reason` and `usage` in **separate** chunks (the usage chunk has `finish_reason: null`), so gating usage extraction on `finish_reason` always missed it. The fix defers `message_delta` until `[DONE]` (or stream end), extracts usage from any chunk that carries it, and makes the terminator events idempotent. Added paired Anthropic/Bedrock e2e tests in `native-anthropic-cache.e2e.ts` that fail on the old code (zero usage on bedrock, duplicate `message_delta` on anthropic) and pass with the fix.

## Test plan

- [x] Verified zero-token repro against local gateway with stashed fix
- [x] Verified correct tokens (14/14 matching non-streaming) with fix applied
- [x] New e2e tests fail on reverted code, pass with fix restored
- [ ] Verify on prod (`api.llmgateway.io`) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed streaming message events to eliminate duplicates and ensure proper sequencing
  * Corrected token usage data reporting in streaming API responses, including cache metrics

* **Tests**
  * Added end-to-end test coverage for streaming message token usage validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->