### PR TITLE
docs: nest caching pages under caching

### DIFF
--- a/apps/docs/content/features/caching/gateway-caching.mdx
+++ b/apps/docs/content/features/caching/gateway-caching.mdx
@@ -13,10 +13,10 @@ Gateway caching serves a previously-seen, byte-identical request entirely from L
 <Callout type="info">
 	If you want to reduce the cost of long, partially-shared prompts in chat apps
 	or coding tools, you want [Provider Cache
-	Control](/features/provider-cache-control) instead. That discounts the cached
-	portion of your prompt on every call — it does not require byte-identical
-	requests. See the [Caching Overview](/features/caching) for a side-by-side
-	comparison.
+	Control](/features/caching/provider-cache-control) instead. That discounts the
+	cached portion of your prompt on every call — it does not require
+	byte-identical requests. See the [Caching Overview](/features/caching) for a
+	side-by-side comparison.
 </Callout>
 
 ## How It Works
@@ -201,7 +201,7 @@ Caching may not be suitable for:
 - Highly personalized responses
 - Time-sensitive information
 - Creative tasks requiring variety
-- Chat or coding tools where prompts overlap but are not byte-identical — use [Provider Cache Control](/features/provider-cache-control) instead
+- Chat or coding tools where prompts overlap but are not byte-identical — use [Provider Cache Control](/features/caching/provider-cache-control) instead
 
 ## Pricing
 

--- a/apps/docs/content/features/caching/index.mdx
+++ b/apps/docs/content/features/caching/index.mdx
@@ -18,7 +18,7 @@ This is the type of caching that powers efficient chat-based and assistant-based
 
 You see it in your usage as `prompt_tokens_details.cached_tokens`. For most providers it works automatically; some (notably Anthropic) also let you mark blocks explicitly with `cache_control` and choose a longer TTL.
 
-→ **[Read the Provider Cache Control docs](/features/provider-cache-control)**
+→ **[Read the Provider Cache Control docs](/features/caching/provider-cache-control)**
 
 ## Gateway Caching
 
@@ -26,17 +26,17 @@ LLM Gateway performs the caching. When a request is **byte-identical** to a prev
 
 This is most useful for deterministic API workloads — classification, batch jobs, FAQ lookups, retries — rather than free-form chat, because chat prompts almost always differ on the latest turn.
 
-→ **[Read the Gateway Caching docs](/features/gateway-caching)**
+→ **[Read the Gateway Caching docs](/features/caching/gateway-caching)**
 
 ## Which one do I want?
 
-| If you…                                                         | Use                                                                                   |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Build a chat app, assistant, or coding tool                     | [Provider Cache Control](/features/provider-cache-control)                            |
-| Send long system prompts or growing conversation history        | [Provider Cache Control](/features/provider-cache-control)                            |
-| Want longer cache lifetimes than the provider default           | [Provider Cache Control](/features/provider-cache-control) (explicit `cache_control`) |
-| Send the exact same request many times (batches, retries, FAQs) | [Gateway Caching](/features/gateway-caching)                                          |
-| Want $0 on repeated calls instead of a discount                 | [Gateway Caching](/features/gateway-caching)                                          |
+| If you…                                                         | Use                                                                                           |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Build a chat app, assistant, or coding tool                     | [Provider Cache Control](/features/caching/provider-cache-control)                            |
+| Send long system prompts or growing conversation history        | [Provider Cache Control](/features/caching/provider-cache-control)                            |
+| Want longer cache lifetimes than the provider default           | [Provider Cache Control](/features/caching/provider-cache-control) (explicit `cache_control`) |
+| Send the exact same request many times (batches, retries, FAQs) | [Gateway Caching](/features/caching/gateway-caching)                                          |
+| Want $0 on repeated calls instead of a discount                 | [Gateway Caching](/features/caching/gateway-caching)                                          |
 
 <Callout type="info">
 	The two are not mutually exclusive. A coding tool can rely on provider caching

--- a/apps/docs/content/features/caching/meta.json
+++ b/apps/docs/content/features/caching/meta.json
@@ -1,0 +1,5 @@
+{
+	"title": "Caching",
+	"icon": "Zap",
+	"pages": ["index", "provider-cache-control", "gateway-caching"]
+}

--- a/apps/docs/content/features/caching/meta.json
+++ b/apps/docs/content/features/caching/meta.json
@@ -1,5 +1,5 @@
 {
 	"title": "Caching",
 	"icon": "Zap",
-	"pages": ["index", "provider-cache-control", "gateway-caching"]
+	"pages": ["[Overview](index)", "provider-cache-control", "gateway-caching"]
 }

--- a/apps/docs/content/features/caching/meta.json
+++ b/apps/docs/content/features/caching/meta.json
@@ -1,5 +1,6 @@
 {
 	"title": "Caching",
 	"icon": "Zap",
-	"pages": ["[Overview](index)", "provider-cache-control", "gateway-caching"]
+	"defaultOpen": true,
+	"pages": ["provider-cache-control", "gateway-caching"]
 }

--- a/apps/docs/content/features/caching/provider-cache-control.mdx
+++ b/apps/docs/content/features/caching/provider-cache-control.mdx
@@ -14,7 +14,7 @@ This is the behavior you see surfaced as `cached_tokens` in your usage payloads,
 
 <Callout type="info">
 	Looking for $0 on repeated calls instead of a discount on the cached portion?
-	That is [Gateway Caching](/features/gateway-caching), which serves
+	That is [Gateway Caching](/features/caching/gateway-caching), which serves
 	byte-identical requests entirely from LLM Gateway without hitting the
 	provider. It is a better fit for deterministic API workloads than for chat.
 	See the [Caching Overview](/features/caching) for a side-by-side comparison.
@@ -122,7 +122,7 @@ For providers that publish a separate explicit-cache read rate (for example, Ali
 
 ## Related
 
-- [Gateway Caching](/features/gateway-caching) — serve byte-identical requests entirely from LLM Gateway at $0 cost
+- [Gateway Caching](/features/caching/gateway-caching) — serve byte-identical requests entirely from LLM Gateway at $0 cost
 - [Caching Overview](/features/caching) — side-by-side comparison of provider caching vs. gateway caching
 - [Cost Breakdown](/features/cost-breakdown) — full reference for the usage and cost fields on every response
 - [Smart Routing](/features/routing) — how cache support influences provider selection for large prompts

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -23,6 +23,20 @@ const nextConfig: NextConfig = {
 			},
 		];
 	},
+	redirects() {
+		return [
+			{
+				source: "/features/gateway-caching",
+				destination: "/features/caching/gateway-caching",
+				permanent: true,
+			},
+			{
+				source: "/features/provider-cache-control",
+				destination: "/features/caching/provider-cache-control",
+				permanent: true,
+			},
+		];
+	},
 };
 
 export default withMDX(nextConfig);


### PR DESCRIPTION
## Summary
- Move `gateway-caching.mdx` and `provider-cache-control.mdx` under `features/caching/` so they appear as children of the Caching section in the docs sidebar
- Convert `features/caching.mdx` into `features/caching/index.mdx` with a `meta.json` defining child order
- Update all internal cross-links to the new paths and add permanent redirects from the old URLs

## Test plan
- [x] \`pnpm format\`
- [x] \`pnpm build\`
- [ ] Visually confirm sidebar nests Provider Cache Control and Gateway Caching under Caching
- [ ] Confirm old URLs (\`/features/gateway-caching\`, \`/features/provider-cache-control\`) redirect to new paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized caching docs into a single "Caching" section with consolidated pages for Provider Cache Control and Gateway Caching.
  * Updated internal links to use the new caching routes.
  * Added metadata to surface the new section in navigation.
  * Implemented permanent URL redirects to preserve existing external links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->