### PR TITLE
fix(gateway): log unsupported reasoning_max_tokens as warn

### DIFF
--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -175,7 +175,7 @@ export function validateModelCapabilities(
 		);
 
 		if (!reasoningMaxTokens) {
-			logger.error(
+			logger.warn(
 				`reasoning.max_tokens specified for model that doesn't support it: ${requestedModel}`,
 				{
 					requestedModel,


### PR DESCRIPTION
## Summary
- `reasoning.max_tokens` on a model that doesn't support it results in a 400 client error, so logging it at `error` (level 50) was noisy and triggered error alerts.
- Switched to `logger.warn` to match the sibling `reasoning_effort` validation branch.

## Test plan
- [ ] Send a chat request with `reasoning.max_tokens` to a model lacking `reasoningMaxTokens` support; confirm the 400 response is unchanged and the log is emitted at warn level instead of error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined diagnostic logging for model capability validation to better reflect error severity levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->