### PR TITLE
chore(gateway): raise default request timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,18 +43,18 @@ TIMEOUT_MS=5000
 # KEEP_ALIVE_TIMEOUT_S=620
 
 # Gateway request timeout in milliseconds - maximum time for end-to-end request
-# Defaults to 300000ms (5 minutes)
-# GATEWAY_TIMEOUT_MS=300000
+# Defaults to 1500000ms (25 minutes)
+# GATEWAY_TIMEOUT_MS=1500000
 
 # AI API request timeout in milliseconds for streaming requests
 # Should be shorter than GATEWAY_TIMEOUT_MS to allow for error handling
-# Defaults to 240000ms (4 minutes) or 80% of GATEWAY_TIMEOUT_MS, whichever is smaller
-# AI_STREAMING_TIMEOUT_MS=240000
+# Defaults to 1200000ms (20 minutes) or 80% of GATEWAY_TIMEOUT_MS, whichever is smaller
+# AI_STREAMING_TIMEOUT_MS=1200000
 
 # AI API request timeout in milliseconds for plain (non-streaming) requests
 # Non-streaming requests use a shorter timeout since they don't benefit from incremental responses
-# Defaults to 180000ms (3 minutes)
-# AI_TIMEOUT_MS=180000
+# Defaults to 600000ms (10 minutes)
+# AI_TIMEOUT_MS=600000
 
 # =============================================================================
 # WORKER CONFIGURATION

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4156,8 +4156,8 @@ chat.openapi(completions, async (c) => {
 	// requested. For image generation the upstream request is always non-streaming
 	// (effectiveStream is forced false above when faking streaming for the client),
 	// so partial_images=1 is needed in both cases to keep the connection alive past
-	// Azure's 122s synchronous wall and to use AI_STREAMING_TIMEOUT_MS (240s default)
-	// instead of AI_TIMEOUT_MS (180s). The SSE response is collapsed back into the
+	// Azure's 122s synchronous wall and to use AI_STREAMING_TIMEOUT_MS (1200s default)
+	// instead of AI_TIMEOUT_MS (600s). The SSE response is collapsed back into the
 	// regular non-streaming JSON shape before being returned (or re-wrapped as fake
 	// SSE for clients that requested streaming).
 	let forceImageStreamUpstream =

--- a/apps/gateway/src/lib/timeout-config.ts
+++ b/apps/gateway/src/lib/timeout-config.ts
@@ -8,11 +8,17 @@
  */
 
 /**
- * Gets the gateway request timeout - the maximum time a request can take end-to-end.
+ * Gets the gateway request budget used to derive the default streaming timeout cap.
+ * The streaming default is capped at 80% of this value so we still have headroom
+ * to surface upstream timeouts as proper errors before the overall budget elapses.
  * Default: 25 minutes (1500000ms)
  */
 export function getGatewayTimeoutMs(): number {
-	return Number(process.env.GATEWAY_TIMEOUT_MS) || 1500000;
+	const envValue = Number(process.env.GATEWAY_TIMEOUT_MS);
+	if (envValue > 0) {
+		return envValue;
+	}
+	return 1500000;
 }
 
 /**
@@ -85,7 +91,7 @@ export function createStreamingCombinedSignal(
 
 /**
  * Combines a plain (non-streaming) timeout signal with an optional cancellation signal.
- * Uses the shorter timeout (default 3min) for non-streaming requests.
+ * Uses the shorter timeout (default 10min) for non-streaming requests.
  */
 export function createCombinedSignal(
 	cancellationController?: AbortController,

--- a/apps/gateway/src/lib/timeout-config.ts
+++ b/apps/gateway/src/lib/timeout-config.ts
@@ -9,39 +9,39 @@
 
 /**
  * Gets the gateway request timeout - the maximum time a request can take end-to-end.
- * Default: 5 minutes (300000ms)
+ * Default: 25 minutes (1500000ms)
  */
 export function getGatewayTimeoutMs(): number {
-	return Number(process.env.GATEWAY_TIMEOUT_MS) || 300000;
+	return Number(process.env.GATEWAY_TIMEOUT_MS) || 1500000;
 }
 
 /**
  * Gets the AI API request timeout for streaming requests - the maximum time for upstream provider calls.
  * Should be shorter than gateway timeout to allow for error handling.
- * Default: 4 minutes (240000ms) or 80% of gateway timeout, whichever is smaller
+ * Default: 20 minutes (1200000ms) or 80% of gateway timeout, whichever is smaller
  */
 export function getStreamingTimeoutMs(): number {
 	const envValue = Number(process.env.AI_STREAMING_TIMEOUT_MS);
 	if (envValue > 0) {
 		return envValue;
 	}
-	// Default: 4 minutes or 80% of gateway timeout, whichever is smaller
-	return Math.min(240000, getGatewayTimeoutMs() * 0.8);
+	// Default: 20 minutes or 80% of gateway timeout, whichever is smaller
+	return Math.min(1200000, getGatewayTimeoutMs() * 0.8);
 }
 
 /**
  * Gets the AI API request timeout for non-streaming (plain) requests.
  * Non-streaming requests have a shorter default timeout since they don't benefit
  * from incremental responses and long waits are usually indicative of issues.
- * Default: 3 minutes (180000ms)
+ * Default: 10 minutes (600000ms)
  */
 export function getTimeoutMs(): number {
 	const envValue = Number(process.env.AI_TIMEOUT_MS);
 	if (envValue > 0) {
 		return envValue;
 	}
-	// Default: 3 minutes for non-streaming requests
-	return 180000;
+	// Default: 10 minutes for non-streaming requests
+	return 600000;
 }
 
 // Legacy exports for backwards compatibility (read at module load time)

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -45,9 +45,12 @@ async function startServer() {
 
 let isShuttingDown = false;
 
-// Grace period for in-flight requests to complete before force closing (default 120s)
+// Grace period for in-flight requests to complete before force closing.
+// Defaults to 20 minutes to match AI_STREAMING_TIMEOUT_MS so long-running streams
+// aren't force-killed mid-flight during rollouts. Should remain <= k8s
+// terminationGracePeriodSeconds (minus any preStop sleep).
 const shutdownGracePeriodMs =
-	Number(process.env.SHUTDOWN_GRACE_PERIOD_MS) || 120000;
+	Number(process.env.SHUTDOWN_GRACE_PERIOD_MS) || 1200000;
 
 const closeServer = (server: ServerType): Promise<void> => {
 	return new Promise((resolve, reject) => {

--- a/infra/helm/llmgateway/values.yaml
+++ b/infra/helm/llmgateway/values.yaml
@@ -128,7 +128,7 @@ gateway:
     aiStreamingTimeoutMs: 1200000
     aiTimeoutMs: 600000
     keepAliveTimeoutS: 620
-    shutdownGracePeriodMs: 120000
+    shutdownGracePeriodMs: 1200000
     healthCheckSkipDatabase: ""
     healthCheckTimeoutMs: 15000
     maxStreamingBufferMb: 50

--- a/infra/helm/llmgateway/values.yaml
+++ b/infra/helm/llmgateway/values.yaml
@@ -124,9 +124,9 @@ gateway:
       cpu: 200m
       memory: 256Mi
   config:
-    gatewayTimeoutMs: 300000
-    aiStreamingTimeoutMs: 240000
-    aiTimeoutMs: 180000
+    gatewayTimeoutMs: 1500000
+    aiStreamingTimeoutMs: 1200000
+    aiTimeoutMs: 600000
     keepAliveTimeoutS: 620
     shutdownGracePeriodMs: 120000
     healthCheckSkipDatabase: ""


### PR DESCRIPTION
## Summary
- Bump `AI_TIMEOUT_MS` (non-streaming upstream) default from 3min → **10min**
- Bump `AI_STREAMING_TIMEOUT_MS` default from 4min → **20min**
- Bump `GATEWAY_TIMEOUT_MS` end-to-end default from 5min → **25min** (keeps a buffer over the streaming timeout so upstream timeouts can still be caught and surfaced as proper errors before the gateway-level cutoff)
- Update Helm chart defaults (`infra/helm/llmgateway/values.yaml`) and `.env.example` to match

Long-running LLM calls (deep reasoning, image/video gen, large prompts) were getting cut off at the old 3min/4min limits. The matching infra-side bumps (GCP backend `timeoutSec`, draining, termination grace) are in a companion PR on the infra repo.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`
- [ ] Verify in staging that a request lasting >5min completes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased default timeouts for gateway, streaming, and general AI requests and raised the shutdown grace period to better support longer-running tasks.
* **Documentation**
  * Updated example configuration to reflect the new timeout recommendations and adjusted inline comments to match the revised defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->