### PR TITLE
fix(gateway): accept reasoning_effort=none for OpenAI

### DIFF
--- a/apps/docs/content/features/reasoning.mdx
+++ b/apps/docs/content/features/reasoning.mdx
@@ -34,11 +34,19 @@ There are two ways to control reasoning effort:
 
 Add the `reasoning_effort` parameter directly to your request:
 
+- `none` - Disable reasoning. Supported by OpenAI's newer reasoning models (e.g. `gpt-5.4-mini` and later, which accept `none` instead of `minimal`). For other providers this turns reasoning off.
 - `minimal` - Fastest reasoning with minimal thought process (only for GPT-5 models)
 - `low` - Light reasoning for simpler tasks
 - `medium` - Balanced reasoning for most tasks
 - `high` - Deep reasoning for complex problems
 - `xhigh` - Maximum reasoning depth for the most complex problems
+
+<Callout type="info">
+	OpenAI's reasoning models do not all accept the same effort values. The
+	original GPT-5 models support `minimal`, while newer models (e.g.
+	`gpt-5.4-mini` and later) replace it with `none`. If you send an effort value
+	the target model doesn't support, OpenAI returns an `unsupported_value` error.
+</Callout>
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/chat/completions" \

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1150,16 +1150,12 @@ chat.openapi(completions, async (c) => {
 	}
 
 	// Extract reasoning_effort as mutable variable for auto-routing modification
-	// Use reasoning.effort if provided, otherwise use top-level reasoning_effort
-	// Map "none" to undefined for internal processing
-	let reasoning_effort = (() => {
-		const effort =
-			reasoning_object_effort ?? validationResult.data.reasoning_effort;
-		if (effort === "none") {
-			return undefined;
-		}
-		return effort;
-	})();
+	// Use reasoning.effort if provided, otherwise use top-level reasoning_effort.
+	// "none" is preserved and forwarded to OpenAI (its newer reasoning models
+	// accept it); for other providers it is normalized to "off" downstream in
+	// prepareRequestBody.
+	let reasoning_effort =
+		reasoning_object_effort ?? validationResult.data.reasoning_effort;
 
 	// Check if messages contain images for vision capability filtering
 	const hasImages = messagesContainImages(messages as BaseMessage[]);
@@ -1881,8 +1877,14 @@ chat.openapi(completions, async (c) => {
 					return false;
 				}
 
-				// Check reasoning capability if reasoning_effort is specified
-				if (reasoning_effort !== undefined && provider.reasoning !== true) {
+				// Check reasoning capability if reasoning_effort is specified.
+				// "none" means "no reasoning", so it doesn't require a
+				// reasoning-capable provider.
+				if (
+					reasoning_effort !== undefined &&
+					reasoning_effort !== "none" &&
+					provider.reasoning !== true
+				) {
 					return false;
 				}
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -429,7 +429,12 @@ function filterEligibleModelProviders(
 			return false;
 		}
 
-		if (options.reasoningEffort !== undefined) {
+		// "none" means "no reasoning", so it doesn't require a reasoning-capable
+		// provider. Let it fall through so non-reasoning variants stay eligible.
+		if (
+			options.reasoningEffort !== undefined &&
+			options.reasoningEffort !== "none"
+		) {
 			return provider.reasoning === true;
 		}
 

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -220,12 +220,13 @@ export const completionsRequestSchema = z.object({
 		])
 		.optional(),
 	reasoning_effort: z
-		.enum(["minimal", "low", "medium", "high", "xhigh"])
+		.enum(["none", "minimal", "low", "medium", "high", "xhigh"])
 		.nullable()
 		.optional()
 		.transform((val) => (val === null ? undefined : val))
 		.openapi({
-			description: "Controls the reasoning effort for reasoning-capable models",
+			description:
+				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning.",
 			example: "medium",
 		}),
 	reasoning: z

--- a/apps/gateway/src/chat/tools/create-log-entry.ts
+++ b/apps/gateway/src/chat/tools/create-log-entry.ts
@@ -31,7 +31,7 @@ export interface CreateLogEntryOptions {
 	top_p?: number;
 	frequency_penalty?: number;
 	presence_penalty?: number;
-	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningMaxTokens?: number;
 	effort?: "low" | "medium" | "high";
 	responseFormat?: any;
@@ -146,7 +146,14 @@ export function createLogEntry(
 	top_p: number | undefined,
 	frequency_penalty: number | undefined,
 	presence_penalty: number | undefined,
-	reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | undefined,
+	reasoningEffort:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| undefined,
 	reasoningMaxTokens: number | undefined,
 	effort: "low" | "medium" | "high" | undefined,
 	responseFormat: any | undefined,
@@ -188,7 +195,7 @@ export function createLogEntry(
 	top_p?: number,
 	frequency_penalty?: number,
 	presence_penalty?: number,
-	reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh",
+	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh",
 	reasoningMaxTokens?: number,
 	effort?: "low" | "medium" | "high",
 	responseFormat?: any,

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -83,7 +83,14 @@ export interface ProviderContextOptions {
 	response_format: OpenAIRequestBody["response_format"];
 	tools: OpenAIToolInput[] | undefined;
 	tool_choice: ToolChoiceType | undefined;
-	reasoning_effort: "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+	reasoning_effort:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| undefined;
 	reasoning_max_tokens: number | undefined;
 	prompt_cache_key: string | undefined;
 	prompt_cache_retention: PromptCacheRetention | undefined;

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -169,7 +169,9 @@ export const responsesRequestSchema = z.object({
 		.optional(),
 	reasoning: z
 		.object({
-			effort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).optional(),
+			effort: z
+				.enum(["none", "minimal", "low", "medium", "high", "xhigh"])
+				.optional(),
 			summary: z.enum(["detailed", "auto"]).optional(),
 		})
 		.nullable()

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -386,11 +386,14 @@ describe("prepareRequestBody - reasoning_effort none", () => {
 		expect(requestBody.reasoning.effort).toBe("none");
 	});
 
-	test("normalizes none to off for Google (no thinkingBudget)", async () => {
+	test("disables thinking for Google on none", async () => {
 		const requestBody = await prepare({
 			provider: "google-ai-studio",
 			model: "gemini-2.5-pro",
 		});
+		expect(requestBody.generationConfig.thinkingConfig.includeThoughts).toBe(
+			false,
+		);
 		expect(
 			requestBody.generationConfig.thinkingConfig.thinkingBudget,
 		).toBeUndefined();

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -338,6 +338,73 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 	});
 });
 
+describe("prepareRequestBody - reasoning_effort none", () => {
+	async function prepare(options: {
+		provider: Parameters<typeof prepareRequestBody>[0];
+		model: string;
+		useResponsesApi?: boolean;
+	}) {
+		return (await prepareRequestBody(
+			options.provider,
+			options.model,
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"none", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+			20,
+			null,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			options.useResponsesApi ?? false,
+		)) as any;
+	}
+
+	test("forwards none to OpenAI chat completions", async () => {
+		const requestBody = await prepare({ provider: "openai", model: "gpt-5.5" });
+		expect(requestBody.reasoning_effort).toBe("none");
+	});
+
+	test("forwards none to OpenAI Responses API", async () => {
+		const requestBody = await prepare({
+			provider: "openai",
+			model: "gpt-5.5",
+			useResponsesApi: true,
+		});
+		expect(requestBody.reasoning.effort).toBe("none");
+	});
+
+	test("normalizes none to off for Google (no thinkingBudget)", async () => {
+		const requestBody = await prepare({
+			provider: "google-ai-studio",
+			model: "gemini-2.5-pro",
+		});
+		expect(
+			requestBody.generationConfig.thinkingConfig.thinkingBudget,
+		).toBeUndefined();
+	});
+
+	test("normalizes none to off for Anthropic (thinking not enabled)", async () => {
+		const requestBody = (await prepare({
+			provider: "anthropic",
+			model: "claude-sonnet-4-20250514",
+		})) as AnthropicRequestBody;
+		expect(requestBody.thinking).toBeUndefined();
+	});
+});
+
 describe("prepareRequestBody - Google AI Studio", () => {
 	test("should map gateway 0.5K image size to Google 512", async () => {
 		const requestBody = (await prepareRequestBody(

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -679,7 +679,7 @@ export async function prepareRequestBody(
 	response_format: OpenAIRequestBody["response_format"],
 	tools?: OpenAIToolInput[],
 	tool_choice?: ToolChoiceType,
-	reasoning_effort?: "minimal" | "low" | "medium" | "high" | "xhigh",
+	reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh",
 	supportsReasoning?: boolean,
 	isProd = false,
 	maxImageSizeMB = 20,
@@ -701,6 +701,18 @@ export async function prepareRequestBody(
 	prompt_cache_retention?: PromptCacheRetention,
 ): Promise<ProviderRequestBody | FormData> {
 	tools = normalizeToolParameters(tools);
+
+	// `none` reasoning effort is an OpenAI-specific value: its newer reasoning
+	// models (gpt-5.4 and later) accept it to turn reasoning off. Every other
+	// provider treats the absence of reasoning_effort as "off", so normalize
+	// `none` away for them to avoid forwarding an unsupported enum value.
+	if (
+		reasoning_effort === "none" &&
+		usedProvider !== "openai" &&
+		usedProvider !== "azure"
+	) {
+		reasoning_effort = undefined;
+	}
 
 	// Handle OpenAI / Azure image generation models (e.g. gpt-image-2)
 	if (

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -702,15 +702,20 @@ export async function prepareRequestBody(
 ): Promise<ProviderRequestBody | FormData> {
 	tools = normalizeToolParameters(tools);
 
-	// `none` reasoning effort is an OpenAI-specific value: its newer reasoning
-	// models (gpt-5.4 and later) accept it to turn reasoning off. Every other
-	// provider treats the absence of reasoning_effort as "off", so normalize
-	// `none` away for them to avoid forwarding an unsupported enum value.
-	if (
-		reasoning_effort === "none" &&
-		usedProvider !== "openai" &&
-		usedProvider !== "azure"
-	) {
+	// `none` reasoning effort is handled natively by a few providers:
+	// OpenAI/Azure forward it (their newer models accept it to turn reasoning
+	// off), and Google reasons by default so it must explicitly disable thinking
+	// when asked. Every other provider treats the absence of reasoning_effort as
+	// "off" already, so normalize `none` away for them to avoid forwarding an
+	// unsupported enum value.
+	const handlesNoneNatively =
+		usedProvider === "openai" ||
+		usedProvider === "azure" ||
+		usedProvider === "google-ai-studio" ||
+		usedProvider === "glacier" ||
+		usedProvider === "google-vertex" ||
+		usedProvider === "quartz";
+	if (reasoning_effort === "none" && !handlesNoneNatively) {
 		reasoning_effort = undefined;
 	}
 
@@ -2296,33 +2301,42 @@ export async function prepareRequestBody(
 
 			// Enable thinking/reasoning content exposure for Google models that support reasoning
 			if (supportsReasoning) {
-				requestBody.generationConfig.thinkingConfig = {
-					includeThoughts: true,
-				};
-
-				if (reasoning_max_tokens !== undefined) {
-					// Google's thinkingBudget: just use the provided value directly
-					// Google maps this internally to thinkingLevel, so exact token control isn't guaranteed
-					requestBody.generationConfig.thinkingConfig.thinkingBudget =
-						reasoning_max_tokens;
-				} else if (reasoning_effort !== undefined) {
-					const getThinkingBudget = (effort: string) => {
-						switch (effort) {
-							case "minimal":
-								return 512; // Minimum supported by most models
-							case "low":
-								return 2048;
-							case "high":
-								return 24576;
-							case "xhigh":
-								return 65536;
-							case "medium":
-							default:
-								return 8192; // Balanced default
-						}
+				if (reasoning_effort === "none") {
+					// Google reasons by default, so `none` must explicitly turn
+					// thinking off (mirrors Anthropic dropping thinking when reasoning
+					// is disabled). Leave thinkingBudget unset.
+					requestBody.generationConfig.thinkingConfig = {
+						includeThoughts: false,
 					};
-					requestBody.generationConfig.thinkingConfig.thinkingBudget =
-						getThinkingBudget(reasoning_effort);
+				} else {
+					requestBody.generationConfig.thinkingConfig = {
+						includeThoughts: true,
+					};
+
+					if (reasoning_max_tokens !== undefined) {
+						// Google's thinkingBudget: just use the provided value directly
+						// Google maps this internally to thinkingLevel, so exact token control isn't guaranteed
+						requestBody.generationConfig.thinkingConfig.thinkingBudget =
+							reasoning_max_tokens;
+					} else if (reasoning_effort !== undefined) {
+						const getThinkingBudget = (effort: string) => {
+							switch (effort) {
+								case "minimal":
+									return 512; // Minimum supported by most models
+								case "low":
+									return 2048;
+								case "high":
+									return 24576;
+								case "xhigh":
+									return 65536;
+								case "medium":
+								default:
+									return 8192; // Balanced default
+							}
+						};
+						requestBody.generationConfig.thinkingConfig.thinkingBudget =
+							getThinkingBudget(reasoning_effort);
+					}
 				}
 			}
 

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -236,7 +236,7 @@ export interface OpenAIRequestBody extends BaseRequestBody {
 	stream_options?: {
 		include_usage: boolean;
 	};
-	reasoning_effort?: "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	extra_body?: Record<string, unknown>;
 }
 
@@ -264,7 +264,7 @@ export interface OpenAIResponsesRequestBody {
 	prompt_cache_key?: string;
 	prompt_cache_retention?: PromptCacheRetention;
 	reasoning: {
-		effort: "minimal" | "low" | "medium" | "high" | "xhigh";
+		effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 		summary: "detailed";
 	};
 	tools?: Array<{
@@ -397,7 +397,7 @@ export type RequestBodyPreparer = (
 	response_format?: OpenAIRequestBody["response_format"],
 	tools?: OpenAIToolInput[],
 	tool_choice?: ToolChoiceType,
-	reasoning_effort?: "minimal" | "low" | "medium" | "high" | "xhigh",
+	reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh",
 	supportsReasoning?: boolean,
 	isProd?: boolean,
 	maxImageSizeMB?: number,


### PR DESCRIPTION
## Problem

OpenAI's newer reasoning models (`gpt-5.4-mini` and later) accept `none` instead of `minimal` to disable reasoning. But the gateway's `reasoning_effort` enum only allowed `minimal | low | medium | high | xhigh`, so a request like:

```json
{ "model": "openai/gpt-5.4-mini", "reasoning_effort": "none" }
```

was rejected at validation time with a `ZodError` (`invalid_enum_value`) — before it ever reached OpenAI.

(The separate `minimal` → `unsupported_value` error in the report comes from OpenAI itself: the original GPT-5 models accept `minimal`, the newer ones accept `none`. That's a per-model OpenAI constraint, not a gateway bug.)

## Fix

- Add `none` to the `reasoning_effort` enum (both top-level and the `reasoning.effort` object) in the chat completions and responses schemas, plus the corresponding type unions.
- **Forward `none` directly to OpenAI/Azure** — their newer reasoning models support it.
- **Normalize `none` → off (`undefined`) for every other provider** in `prepareRequestBody`, since they have no equivalent value and treat the absence of `reasoning_effort` as "reasoning off". This avoids forwarding an unsupported enum value to Anthropic/Google/etc.
- Treat `none` as "no reasoning required" in provider capability filtering (so it doesn't force routing to reasoning-only providers).
- Update the reasoning docs to document `none` and the OpenAI model-specific behavior.

## Tests

Added unit tests in `prepare-request-body.spec.ts`:
- `none` is forwarded to OpenAI chat completions and the Responses API
- `none` is normalized to off for Google (no `thinkingBudget`) and Anthropic (thinking not enabled)

All 79 tests in the suite pass. `pnpm build` and `pnpm format` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a reasoning-effort value "none" to explicitly disable reasoning where supported.
  * Routing/provider selection now treats "none" as disabling reasoning and no longer excludes providers based on reasoning capability.

* **Documentation**
  * Updated guidance clarifying which models support "none" vs. legacy effort values and error behavior for unsupported values.

* **Tests**
  * Added tests verifying "none" is propagated and normalized across providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->