### PR TITLE
feat(analytics): add cache cost metrics and indicators

### DIFF
--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -34,6 +34,7 @@ const modelUsageSchema = z.object({
 	outputTokens: z.number(),
 	totalTokens: z.number(),
 	cost: z.number(),
+	cachedInputCost: z.number(),
 });
 
 // Define the response schema for api-key-specific usage
@@ -473,6 +474,10 @@ activity.openapi(getActivity, async (c) => {
 				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cost}), 0)`.as(
 					"cost",
 				),
+				cachedInputCost:
+					sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cachedInputCost}), 0)`.as(
+						"cachedInputCost",
+					),
 			})
 			.from(apiKeyHourlyModelStats)
 			.where(
@@ -510,6 +515,7 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens: Number(breakdown.outputTokens),
 				totalTokens: Number(breakdown.totalTokens),
 				cost: Number(breakdown.cost),
+				cachedInputCost: Number(breakdown.cachedInputCost),
 			});
 		}
 
@@ -763,6 +769,10 @@ activity.openapi(getActivity, async (c) => {
 				cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
 					"cost",
 				),
+				cachedInputCost:
+					sql<number>`COALESCE(SUM(${projectHourlyModelStats.cachedInputCost}), 0)`.as(
+						"cachedInputCost",
+					),
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -795,6 +805,7 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens: Number(breakdown.outputTokens),
 				totalTokens: Number(breakdown.totalTokens),
 				cost: Number(breakdown.cost),
+				cachedInputCost: Number(breakdown.cachedInputCost),
 			});
 		}
 	}

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2179,6 +2179,7 @@ export interface paths {
                                     outputTokens: number;
                                     totalTokens: number;
                                     cost: number;
+                                    cachedInputCost: number;
                                 }[];
                                 apiKeyBreakdown: {
                                     id: string;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2179,6 +2179,7 @@ export interface paths {
                                     outputTokens: number;
                                     totalTokens: number;
                                     cost: number;
+                                    cachedInputCost: number;
                                 }[];
                                 apiKeyBreakdown: {
                                     id: string;

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -174,6 +174,9 @@ export function DashboardClient({
 		activityData.reduce((sum, day) => sum + day.cachedTokens, 0) ?? 0;
 	const totalCachedInputCost =
 		activityData.reduce((sum, day) => sum + day.cachedInputCost, 0) ?? 0;
+	const totalCacheWriteInputCost =
+		activityData.reduce((sum, day) => sum + day.cacheWriteInputCost, 0) ?? 0;
+	const totalCacheCost = totalCachedInputCost + totalCacheWriteInputCost;
 
 	const { mostUsedModel, mostUsedProvider } = (() => {
 		const modelCostMap = new Map<string, { cost: number; provider: string }>();
@@ -433,6 +436,18 @@ export function DashboardClient({
 							icon={<Server className="h-4 w-4" />}
 							accent="green"
 							tooltip="Cached input tokens are already included in the Input Tokens & Cost total above. This card breaks them out so you can see how much of the input was served from cache."
+						/>
+						<MetricCard
+							label="Total Cache Cost"
+							value={isLoading ? "Loading..." : `$${totalCacheCost.toFixed(4)}`}
+							subtitle={
+								isLoading
+									? "–"
+									: `$${totalCachedInputCost.toFixed(4)} read • $${totalCacheWriteInputCost.toFixed(4)} write`
+							}
+							icon={<Server className="h-4 w-4" />}
+							accent="green"
+							tooltip="Total cost related to prompt caching: cache reads (cached input tokens) plus cache writes (tokens written to the cache)."
 						/>
 						<MetricCard
 							label="Most Used Model"

--- a/apps/ui/src/components/usage/model-usage-table.tsx
+++ b/apps/ui/src/components/usage/model-usage-table.tsx
@@ -20,7 +20,12 @@ import { useApi } from "@/lib/fetch-client";
 
 import type { ActivityModelUsage, ActivitT } from "@/types/activity";
 
-type SortColumn = "id" | "provider" | "requestCount" | "totalTokens";
+type SortColumn =
+	| "id"
+	| "provider"
+	| "requestCount"
+	| "totalTokens"
+	| "cachedInputCost";
 type SortDirection = "asc" | "desc";
 
 interface ModelUsageTableProps {
@@ -138,6 +143,7 @@ export function ModelUsageTable({
 				existing.outputTokens += model.outputTokens;
 				existing.totalTokens += model.totalTokens;
 				existing.cost += model.cost;
+				existing.cachedInputCost += model.cachedInputCost;
 			} else {
 				modelMap.set(key, { ...model });
 			}
@@ -209,6 +215,16 @@ export function ModelUsageTable({
 								{getSortIcon("totalTokens")}
 							</Button>
 						</TableHead>
+						<TableHead>
+							<Button
+								variant="ghost"
+								onClick={() => handleSort("cachedInputCost")}
+								className="flex items-center p-0 h-auto font-semibold"
+							>
+								Cache Cost
+								{getSortIcon("cachedInputCost")}
+							</Button>
+						</TableHead>
 						<TableHead>Usage</TableHead>
 					</TableRow>
 				</TableHeader>
@@ -224,6 +240,11 @@ export function ModelUsageTable({
 								<TableCell>{model.provider}</TableCell>
 								<TableCell>{model.requestCount.toLocaleString()}</TableCell>
 								<TableCell>{model.totalTokens.toLocaleString()}</TableCell>
+								<TableCell>
+									{model.cachedInputCost > 0
+										? `$${model.cachedInputCost.toFixed(6)}`
+										: "—"}
+								</TableCell>
 								<TableCell className="w-[200px]">
 									<div className="flex items-center gap-2">
 										<Progress value={percentage} className="h-2" />

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2179,6 +2179,7 @@ export interface paths {
                                     outputTokens: number;
                                     totalTokens: number;
                                     cost: number;
+                                    cachedInputCost: number;
                                 }[];
                                 apiKeyBreakdown: {
                                     id: string;

--- a/apps/ui/src/types/activity.ts
+++ b/apps/ui/src/types/activity.ts
@@ -8,6 +8,7 @@ export interface ActivityModelUsage {
 	outputTokens: number;
 	totalTokens: number;
 	cost: number;
+	cachedInputCost: number;
 }
 
 export interface ActivityApiKeyUsage {

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2179,6 +2179,7 @@ export interface paths {
                                     outputTokens: number;
                                     totalTokens: number;
                                     cost: number;
+                                    cachedInputCost: number;
                                 }[];
                                 apiKeyBreakdown: {
                                     id: string;

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -474,6 +474,16 @@ export function LogCard({
 									Retried
 								</Badge>
 							)}
+							{(log.cached ||
+								(log.cachedTokens && Number(log.cachedTokens) > 0)) && (
+								<Badge
+									variant="outline"
+									className="gap-1 text-blue-600 dark:text-blue-400 border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30"
+								>
+									<Zap className="h-3 w-3" />
+									{log.cached ? "Cached" : "Partially cached"}
+								</Badge>
+							)}
 							<Badge
 								variant={
 									log.hasError


### PR DESCRIPTION
## Summary

Surfaces prompt-caching costs across the dashboard analytics, building on the existing cache token tracking.

- **Dashboard**: new **Total Cache Cost** metric card showing the combined cache read (`cachedInputCost`) + cache write (`cacheWriteInputCost`) cost, with a read/write breakdown in the subtitle.
- **Model usage table**: new sortable **Cache Cost** column. Threaded `cachedInputCost` through the `/activity` model breakdown (both project- and api-key-scoped queries) so per-model cache cost is available.
- **Recent requests**: added a visible **Cached** / **Partially cached** badge on each log card header so cache status is scannable without expanding the row.

## Changes

- `apps/api/src/routes/activity.ts` — add `cachedInputCost` to `modelUsageSchema` and aggregate it in both model-breakdown queries.
- `apps/ui/src/types/activity.ts` — add `cachedInputCost` to `ActivityModelUsage`.
- `apps/ui/src/components/usage/model-usage-table.tsx` — render + sort the Cache Cost column.
- `apps/ui/src/components/dashboard/dashboard-client.tsx` — add Total Cache Cost card.
- `packages/shared/src/components/log-card.tsx` — add cached badge.
- Regenerated typed API clients (`ui`, `code`, `playground`, `admin`).

## Testing

- `pnpm format` ✅
- `pnpm build` ✅ (17/17 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Extended usage analytics with per-model cache cost visibility and sortable cache cost columns
* Introduced a new 'Total Cache Cost' metric card on the dashboard that aggregates both cache read and write costs
* Enhanced activity logs with visual cache status badges to highlight when requests have been cached

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->