### PR TITLE
feat(code): show cache cost in DevPass agent details

### DIFF
--- a/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
+++ b/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
@@ -9,6 +9,7 @@ import {
 	Cpu,
 	Loader2,
 	Terminal,
+	Zap,
 } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -30,7 +31,8 @@ type ModelSortColumn =
 	| "provider"
 	| "requestCount"
 	| "totalTokens"
-	| "cost";
+	| "cost"
+	| "cachedInputCost";
 type SortDirection = "asc" | "desc";
 
 function ModelUsageBreakdown({ models }: { models: ModelUsage[] }) {
@@ -142,6 +144,16 @@ function ModelUsageBreakdown({ models }: { models: ModelUsage[] }) {
 										{sortIcon("cost")}
 									</button>
 								</th>
+								<th className="px-4 py-2 text-right font-medium">
+									<button
+										type="button"
+										onClick={() => handleSort("cachedInputCost")}
+										className="inline-flex items-center hover:text-foreground"
+									>
+										Cache cost
+										{sortIcon("cachedInputCost")}
+									</button>
+								</th>
 								<th className="hidden w-[180px] px-4 py-2 text-left font-medium sm:table-cell">
 									Usage
 								</th>
@@ -169,6 +181,11 @@ function ModelUsageBreakdown({ models }: { models: ModelUsage[] }) {
 										</td>
 										<td className="px-4 py-2.5 text-right font-medium tabular-nums">
 											${model.cost.toFixed(4)}
+										</td>
+										<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
+											{model.cachedInputCost > 0
+												? `$${model.cachedInputCost.toFixed(4)}`
+												: "—"}
 										</td>
 										<td className="hidden px-4 py-2.5 sm:table-cell">
 											<div className="flex items-center gap-2">
@@ -255,6 +272,23 @@ function AgentDetailBody({
 									</p>
 								</div>
 								<div className="flex items-center gap-3 text-xs text-muted-foreground tabular-nums">
+									<span
+										title="Cache status"
+										className={
+											log.cached
+												? "text-blue-500"
+												: Number(log.cachedInputCost ?? 0) > 0
+													? "text-blue-400"
+													: "text-muted-foreground/50"
+										}
+									>
+										<Zap className="mr-1 inline h-3 w-3" />
+										{log.cached
+											? "Cached"
+											: Number(log.cachedInputCost ?? 0) > 0
+												? "Partially cached"
+												: "Not cached"}
+									</span>
 									<span title="Tokens">
 										<Cpu className="mr-1 inline h-3 w-3" />
 										{Number(log.totalTokens ?? 0).toLocaleString()}

--- a/apps/code/src/app/dashboard/components/coding-agents-shared.ts
+++ b/apps/code/src/app/dashboard/components/coding-agents-shared.ts
@@ -102,6 +102,7 @@ export interface ModelUsage {
 	completionTokens: number;
 	totalTokens: number;
 	cost: number;
+	cachedInputCost: number;
 }
 
 export interface AgentStats {
@@ -164,6 +165,7 @@ export function computeModelBreakdown(logs: ApiLog[]): ModelUsage[] {
 				completionTokens: 0,
 				totalTokens: 0,
 				cost: 0,
+				cachedInputCost: 0,
 			};
 			map.set(key, entry);
 		}
@@ -172,6 +174,7 @@ export function computeModelBreakdown(logs: ApiLog[]): ModelUsage[] {
 		entry.completionTokens += Number(log.completionTokens ?? 0);
 		entry.totalTokens += Number(log.totalTokens ?? 0);
 		entry.cost += log.cost ?? 0;
+		entry.cachedInputCost += Number(log.cachedInputCost ?? 0);
 	}
 	return Array.from(map.values()).sort((a, b) => b.cost - a.cost);
 }


### PR DESCRIPTION
## Summary

Adds cache cost visibility to the DevPass coding-agent detail pages (`apps/code`, route `/dashboard/agents/[agentId]`).

- **Model usage table** — new sortable **Cache cost** column showing per-model cached input cost. Aggregated client-side from the existing `/logs` data (`cachedInputCost`), alongside the existing Cost column.
- **Recent requests** — each request now shows its cache status: **Cached** (full cache hit), **Partially cached** (some input served from cache), or **Not cached**.

No API or schema changes — both use fields already returned by `/logs` (`cached`, `cachedInputCost`).

## Files

- `apps/code/src/app/dashboard/components/coding-agents-shared.ts` — add `cachedInputCost` to `ModelUsage` and aggregate it in `computeModelBreakdown`.
- `apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx` — render/sort the Cache cost column and the per-request cache indicator.

## Testing

- `pnpm format` ✅
- `pnpm --filter code build` ✅ and `tsc --noEmit` ✅ for `apps/code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added cache cost column to the Model usage table displaying cached input costs with sorting capability
* Added cache status badges to recent requests showing cached, partially cached, or not cached status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->