### PR TITLE
feat(admin): toggle canonical model id grouping on cost share

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1225,7 +1225,9 @@ admin.openapi(getGlobalStats, async (c) => {
 					const key = isModel
 						? `${row.usedProvider}/${row.usedModel}`
 						: row.source;
-					const label = isModel ? row.usedModel : row.source;
+					const label = isModel
+						? `${row.usedProvider}/${row.usedModel}`
+						: row.source;
 					return {
 						key,
 						label,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -981,6 +981,7 @@ admin.openapi(getTimeseries, async (c) => {
 
 const globalStatsRangeSchema = z.enum(["7d", "30d", "90d", "365d"]);
 const globalStatsGroupBySchema = z.enum(["model", "source"]);
+const globalStatsModelViewSchema = z.enum(["mapping", "canonical"]);
 
 const globalStatsMetricsSchema = z.object({
 	requestCount: z.number(),
@@ -1012,6 +1013,7 @@ const globalStatsBreakdownItemSchema = globalStatsMetricsSchema
 const globalStatsResponseSchema = z.object({
 	range: globalStatsRangeSchema,
 	groupBy: globalStatsGroupBySchema,
+	modelView: globalStatsModelViewSchema,
 	totals: globalStatsMetricsSchema,
 	timeseries: z.array(globalStatsTimeseriesPointSchema),
 	breakdown: z.array(globalStatsBreakdownItemSchema),
@@ -1024,6 +1026,7 @@ const getGlobalStats = createRoute({
 		query: z.object({
 			range: globalStatsRangeSchema.default("30d").optional(),
 			groupBy: globalStatsGroupBySchema.default("model").optional(),
+			modelView: globalStatsModelViewSchema.default("mapping").optional(),
 		}),
 	},
 	responses: {
@@ -1042,6 +1045,7 @@ admin.openapi(getGlobalStats, async (c) => {
 	const query = c.req.valid("query");
 	const range = query.range ?? "30d";
 	const groupBy = query.groupBy ?? "model";
+	const modelView = query.modelView ?? "mapping";
 
 	const rangeDays: Record<typeof range, number> = {
 		"7d": 7,
@@ -1207,11 +1211,112 @@ admin.openapi(getGlobalStats, async (c) => {
 					.orderBy(desc(metricSums.requestCount));
 
 	const breakdown: z.infer<typeof globalStatsBreakdownItemSchema>[] =
-		breakdownRows.map((row) => {
-			const isModel = "usedModel" in row;
-			const key = isModel ? `${row.usedProvider}/${row.usedModel}` : row.source;
-			const label = isModel ? row.usedModel : row.source;
-			return {
+		groupBy === "model" && modelView === "canonical"
+			? aggregateModelRowsByCanonicalId(
+					breakdownRows as Array<
+						(typeof breakdownRows)[number] & {
+							usedModel: string;
+							usedProvider: string;
+						}
+					>,
+				)
+			: breakdownRows.map((row) => {
+					const isModel = "usedModel" in row;
+					const key = isModel
+						? `${row.usedProvider}/${row.usedModel}`
+						: row.source;
+					const label = isModel ? row.usedModel : row.source;
+					return {
+						key,
+						label,
+						requestCount: Number(row.requestCount),
+						errorCount: Number(row.errorCount),
+						cacheCount: Number(row.cacheCount),
+						inputTokens: Number(row.inputTokens),
+						cachedTokens: Number(row.cachedTokens),
+						outputTokens: Number(row.outputTokens),
+						totalTokens: Number(row.totalTokens),
+						cost: Number(row.cost),
+						inputCost: Number(row.inputCost),
+						cachedInputCost: Number(row.cachedInputCost),
+						outputCost: Number(row.outputCost),
+					};
+				});
+
+	return c.json({
+		range,
+		groupBy,
+		modelView,
+		totals,
+		timeseries,
+		breakdown,
+	});
+});
+
+const canonicalModelIdCache = new Map<string, string | null>();
+function lookupCanonicalModelId(
+	providerId: string,
+	modelName: string,
+): string | null {
+	const cacheKey = `${providerId}/${modelName}`;
+	if (canonicalModelIdCache.has(cacheKey)) {
+		return canonicalModelIdCache.get(cacheKey) ?? null;
+	}
+	let canonical: string | null = null;
+	for (const m of models) {
+		if (
+			m.providers.some(
+				(p) => p.providerId === providerId && p.modelName === modelName,
+			)
+		) {
+			canonical = m.id;
+			break;
+		}
+	}
+	canonicalModelIdCache.set(cacheKey, canonical);
+	return canonical;
+}
+
+function aggregateModelRowsByCanonicalId(
+	rows: Array<{
+		usedProvider: string;
+		usedModel: string;
+		requestCount: number;
+		errorCount: number;
+		cacheCount: number;
+		inputTokens: number;
+		cachedTokens: number;
+		outputTokens: number;
+		totalTokens: number;
+		cost: number;
+		inputCost: number;
+		cachedInputCost: number;
+		outputCost: number;
+	}>,
+): z.infer<typeof globalStatsBreakdownItemSchema>[] {
+	const aggregated = new Map<
+		string,
+		z.infer<typeof globalStatsBreakdownItemSchema>
+	>();
+	for (const row of rows) {
+		const canonical = lookupCanonicalModelId(row.usedProvider, row.usedModel);
+		const key = canonical ?? `${row.usedProvider}/${row.usedModel}`;
+		const label = canonical ?? row.usedModel;
+		const existing = aggregated.get(key);
+		if (existing) {
+			existing.requestCount += Number(row.requestCount);
+			existing.errorCount += Number(row.errorCount);
+			existing.cacheCount += Number(row.cacheCount);
+			existing.inputTokens += Number(row.inputTokens);
+			existing.cachedTokens += Number(row.cachedTokens);
+			existing.outputTokens += Number(row.outputTokens);
+			existing.totalTokens += Number(row.totalTokens);
+			existing.cost += Number(row.cost);
+			existing.inputCost += Number(row.inputCost);
+			existing.cachedInputCost += Number(row.cachedInputCost);
+			existing.outputCost += Number(row.outputCost);
+		} else {
+			aggregated.set(key, {
 				key,
 				label,
 				requestCount: Number(row.requestCount),
@@ -1225,17 +1330,13 @@ admin.openapi(getGlobalStats, async (c) => {
 				inputCost: Number(row.inputCost),
 				cachedInputCost: Number(row.cachedInputCost),
 				outputCost: Number(row.outputCost),
-			};
-		});
-
-	return c.json({
-		range,
-		groupBy,
-		totals,
-		timeseries,
-		breakdown,
-	});
-});
+			});
+		}
+	}
+	return Array.from(aggregated.values()).sort(
+		(a, b) => b.requestCount - a.requestCount,
+	);
+}
 
 admin.openapi(getOrganizations, async (c) => {
 	const query = c.req.valid("query");

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2375,6 +2375,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path?: never;
@@ -2393,6 +2394,8 @@ export interface paths {
                             range: "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             groupBy: "model" | "source";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2375,6 +2375,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path?: never;
@@ -2393,6 +2394,8 @@ export interface paths {
                             range: "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             groupBy: "model" | "source";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2375,6 +2375,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path?: never;
@@ -2393,6 +2394,8 @@ export interface paths {
                             range: "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             groupBy: "model" | "source";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -446,8 +446,14 @@ export function GlobalStatsClient() {
 									axisLine={false}
 									tickMargin={8}
 									minTickGap={32}
-									tickFormatter={(value: string) => {
+									tickFormatter={(value) => {
+										if (typeof value !== "string" || !value) {
+											return "";
+										}
 										const date = parseISO(value);
+										if (Number.isNaN(date.getTime())) {
+											return value;
+										}
 										return format(date, "MMM d");
 									}}
 								/>
@@ -461,8 +467,14 @@ export function GlobalStatsClient() {
 									content={
 										<ChartTooltipContent
 											className="w-[180px]"
-											labelFormatter={(value: string) => {
+											labelFormatter={(value) => {
+												if (typeof value !== "string" || !value) {
+													return "";
+												}
 												const date = parseISO(value);
+												if (Number.isNaN(date.getTime())) {
+													return value;
+												}
 												return format(date, "MMM d, yyyy");
 											}}
 											formatter={(value) =>

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -32,10 +32,13 @@ import {
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
+import { models } from "@llmgateway/models";
+
 import type { ChartConfig } from "@/components/ui/chart";
 
 type Range = "7d" | "30d" | "90d" | "365d";
 type GroupBy = "model" | "source";
+type ModelView = "mapping" | "canonical";
 
 const RANGE_OPTIONS: { value: Range; label: string }[] = [
 	{ value: "7d", label: "Last 7 days" },
@@ -47,6 +50,15 @@ const RANGE_OPTIONS: { value: Range; label: string }[] = [
 const GROUP_OPTIONS: { value: GroupBy; label: string; icon: typeof Cpu }[] = [
 	{ value: "model", label: "By model", icon: Cpu },
 	{ value: "source", label: "By x-source", icon: Layers },
+];
+
+const MODEL_VIEW_OPTIONS: {
+	value: ModelView;
+	label: string;
+	icon: typeof Cpu;
+}[] = [
+	{ value: "mapping", label: "Mappings", icon: Layers },
+	{ value: "canonical", label: "Canonical", icon: Cpu },
 ];
 
 // Distinct, color-blind-friendly hues. Repeat for >12 series.
@@ -104,6 +116,7 @@ const VALID_METRICS: TimeseriesMetric[] = [
 	"cost",
 	"totalTokens",
 ];
+const VALID_MODEL_VIEWS: ModelView[] = ["mapping", "canonical"];
 
 function parseRange(value: string | null): Range {
 	return VALID_RANGES.includes(value as Range) ? (value as Range) : "30d";
@@ -117,6 +130,44 @@ function parseMetric(value: string | null): TimeseriesMetric {
 	return VALID_METRICS.includes(value as TimeseriesMetric)
 		? (value as TimeseriesMetric)
 		: "cost";
+}
+
+function parseModelView(value: string | null): ModelView {
+	return VALID_MODEL_VIEWS.includes(value as ModelView)
+		? (value as ModelView)
+		: "mapping";
+}
+
+const mappingToCanonicalCache = new Map<string, string>();
+function findCanonicalModelId(
+	providerId: string,
+	modelName: string,
+): string | null {
+	const cacheKey = `${providerId}/${modelName}`;
+	const cached = mappingToCanonicalCache.get(cacheKey);
+	if (cached !== undefined) {
+		return cached || null;
+	}
+	for (const m of models) {
+		if (
+			m.providers.some(
+				(p) => p.providerId === providerId && p.modelName === modelName,
+			)
+		) {
+			mappingToCanonicalCache.set(cacheKey, m.id);
+			return m.id;
+		}
+	}
+	// Fall back to a provider-agnostic match on modelName so renames/typos still
+	// collapse into the most plausible canonical id.
+	for (const m of models) {
+		if (m.providers.some((p) => p.modelName === modelName)) {
+			mappingToCanonicalCache.set(cacheKey, m.id);
+			return m.id;
+		}
+	}
+	mappingToCanonicalCache.set(cacheKey, "");
+	return null;
 }
 
 function StatCard({
@@ -199,6 +250,7 @@ export function GlobalStatsClient() {
 	const range = parseRange(searchParams.get("range"));
 	const groupBy = parseGroupBy(searchParams.get("groupBy"));
 	const chartMetric = parseMetric(searchParams.get("metric"));
+	const modelView = parseModelView(searchParams.get("modelView"));
 
 	const updateParam = useCallback(
 		(key: string, value: string) => {
@@ -221,6 +273,10 @@ export function GlobalStatsClient() {
 		(value: TimeseriesMetric) => updateParam("metric", value),
 		[updateParam],
 	);
+	const setModelView = useCallback(
+		(value: ModelView) => updateParam("modelView", value),
+		[updateParam],
+	);
 
 	const $api = useApi();
 	const { data, isLoading, isError } = $api.useQuery(
@@ -233,7 +289,40 @@ export function GlobalStatsClient() {
 
 	const totals = data?.totals;
 	const timeseries = data?.timeseries ?? [];
-	const breakdown = data?.breakdown ?? [];
+	const rawBreakdown = data?.breakdown ?? [];
+
+	const breakdown = useMemo(() => {
+		if (groupBy !== "model" || modelView !== "canonical") {
+			return rawBreakdown;
+		}
+		const aggregated = new Map<string, (typeof rawBreakdown)[number]>();
+		for (const item of rawBreakdown) {
+			const [providerId, ...rest] = item.key.split("/");
+			const modelName = rest.join("/");
+			const canonical = findCanonicalModelId(providerId, modelName);
+			const key = canonical ?? item.key;
+			const label = canonical ?? item.label;
+			const existing = aggregated.get(key);
+			if (existing) {
+				existing.requestCount += item.requestCount;
+				existing.errorCount += item.errorCount;
+				existing.cacheCount += item.cacheCount;
+				existing.inputTokens += item.inputTokens;
+				existing.cachedTokens += item.cachedTokens;
+				existing.outputTokens += item.outputTokens;
+				existing.totalTokens += item.totalTokens;
+				existing.cost += item.cost;
+				existing.inputCost += item.inputCost;
+				existing.cachedInputCost += item.cachedInputCost;
+				existing.outputCost += item.outputCost;
+			} else {
+				aggregated.set(key, { ...item, key, label });
+			}
+		}
+		return Array.from(aggregated.values()).sort(
+			(a, b) => b.requestCount - a.requestCount,
+		);
+	}, [rawBreakdown, groupBy, modelView]);
 
 	// Pie data: top 10 by the selected metric, the rest collapsed into "Other".
 	const pieData = useMemo(() => {
@@ -359,7 +448,7 @@ export function GlobalStatsClient() {
 				/>
 				<StatCard
 					label={groupBy === "model" ? "Distinct models" : "Distinct sources"}
-					value={numberFormatter.format(breakdown.length)}
+					value={numberFormatter.format(rawBreakdown.length)}
 					subtitle={
 						totals
 							? `Errors: ${numberFormatter.format(totals.errorCount)} · Cached: ${numberFormatter.format(totals.cacheCount)}`
@@ -475,20 +564,41 @@ export function GlobalStatsClient() {
 								: `All ${breakdown.length} ${groupBy === "model" ? "models" : "sources"} in the ${range} window.`}
 						</CardDescription>
 					</div>
-					<div className="flex items-center gap-1">
-						{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
-							(m) => (
-								<Button
-									key={m}
-									variant={chartMetric === m ? "default" : "outline"}
-									size="sm"
-									className="h-7 px-3 text-xs"
-									onClick={() => setChartMetric(m)}
-								>
-									{timeseriesChartConfig[m].label as string}
-								</Button>
-							),
-						)}
+					<div className="flex flex-wrap items-center gap-3">
+						{groupBy === "model" ? (
+							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
+								{MODEL_VIEW_OPTIONS.map((opt) => {
+									const Icon = opt.icon;
+									return (
+										<Button
+											key={opt.value}
+											variant={modelView === opt.value ? "default" : "ghost"}
+											size="sm"
+											className="h-7 gap-1.5 px-3 text-xs"
+											onClick={() => setModelView(opt.value)}
+										>
+											<Icon className="h-3.5 w-3.5" />
+											{opt.label}
+										</Button>
+									);
+								})}
+							</div>
+						) : null}
+						<div className="flex items-center gap-1">
+							{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
+								(m) => (
+									<Button
+										key={m}
+										variant={chartMetric === m ? "default" : "outline"}
+										size="sm"
+										className="h-7 px-3 text-xs"
+										onClick={() => setChartMetric(m)}
+									>
+										{timeseriesChartConfig[m].label as string}
+									</Button>
+								),
+							)}
+						</div>
 					</div>
 				</CardHeader>
 				<CardContent className="grid gap-6 p-4 sm:p-6 lg:grid-cols-2">

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -158,14 +158,6 @@ function findCanonicalModelId(
 			return m.id;
 		}
 	}
-	// Fall back to a provider-agnostic match on modelName so renames/typos still
-	// collapse into the most plausible canonical id.
-	for (const m of models) {
-		if (m.providers.some((p) => p.modelName === modelName)) {
-			mappingToCanonicalCache.set(cacheKey, m.id);
-			return m.id;
-		}
-	}
 	mappingToCanonicalCache.set(cacheKey, "");
 	return null;
 }

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -32,8 +32,6 @@ import {
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
-import { models } from "@llmgateway/models";
-
 import type { ChartConfig } from "@/components/ui/chart";
 
 type Range = "7d" | "30d" | "90d" | "365d";
@@ -136,30 +134,6 @@ function parseModelView(value: string | null): ModelView {
 	return VALID_MODEL_VIEWS.includes(value as ModelView)
 		? (value as ModelView)
 		: "mapping";
-}
-
-const mappingToCanonicalCache = new Map<string, string>();
-function findCanonicalModelId(
-	providerId: string,
-	modelName: string,
-): string | null {
-	const cacheKey = `${providerId}/${modelName}`;
-	const cached = mappingToCanonicalCache.get(cacheKey);
-	if (cached !== undefined) {
-		return cached || null;
-	}
-	for (const m of models) {
-		if (
-			m.providers.some(
-				(p) => p.providerId === providerId && p.modelName === modelName,
-			)
-		) {
-			mappingToCanonicalCache.set(cacheKey, m.id);
-			return m.id;
-		}
-	}
-	mappingToCanonicalCache.set(cacheKey, "");
-	return null;
 }
 
 function StatCard({
@@ -275,46 +249,13 @@ export function GlobalStatsClient() {
 		"get",
 		"/admin/global-stats",
 		{
-			params: { query: { range, groupBy } },
+			params: { query: { range, groupBy, modelView } },
 		},
 	);
 
 	const totals = data?.totals;
 	const timeseries = data?.timeseries ?? [];
-	const rawBreakdown = data?.breakdown ?? [];
-
-	const breakdown = useMemo(() => {
-		if (groupBy !== "model" || modelView !== "canonical") {
-			return rawBreakdown;
-		}
-		const aggregated = new Map<string, (typeof rawBreakdown)[number]>();
-		for (const item of rawBreakdown) {
-			const [providerId, ...rest] = item.key.split("/");
-			const modelName = rest.join("/");
-			const canonical = findCanonicalModelId(providerId, modelName);
-			const key = canonical ?? item.key;
-			const label = canonical ?? item.label;
-			const existing = aggregated.get(key);
-			if (existing) {
-				existing.requestCount += item.requestCount;
-				existing.errorCount += item.errorCount;
-				existing.cacheCount += item.cacheCount;
-				existing.inputTokens += item.inputTokens;
-				existing.cachedTokens += item.cachedTokens;
-				existing.outputTokens += item.outputTokens;
-				existing.totalTokens += item.totalTokens;
-				existing.cost += item.cost;
-				existing.inputCost += item.inputCost;
-				existing.cachedInputCost += item.cachedInputCost;
-				existing.outputCost += item.outputCost;
-			} else {
-				aggregated.set(key, { ...item, key, label });
-			}
-		}
-		return Array.from(aggregated.values()).sort(
-			(a, b) => b.requestCount - a.requestCount,
-		);
-	}, [rawBreakdown, groupBy, modelView]);
+	const breakdown = data?.breakdown ?? [];
 
 	// Pie data: top 10 by the selected metric, the rest collapsed into "Other".
 	const pieData = useMemo(() => {
@@ -440,7 +381,7 @@ export function GlobalStatsClient() {
 				/>
 				<StatCard
 					label={groupBy === "model" ? "Distinct models" : "Distinct sources"}
-					value={numberFormatter.format(rawBreakdown.length)}
+					value={numberFormatter.format(breakdown.length)}
 					subtitle={
 						totals
 							? `Errors: ${numberFormatter.format(totals.errorCount)} · Cached: ${numberFormatter.format(totals.cacheCount)}`

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2375,6 +2375,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path?: never;
@@ -2393,6 +2394,8 @@ export interface paths {
                             range: "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             groupBy: "model" | "source";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;


### PR DESCRIPTION
## Summary
- Adds a Mappings/Canonical selector to the Cost share — models card on /global-stats.
- Canonical mode collapses provider mapping rows (e.g. `openai/gpt-4o-2024-08-06`) into their canonical model id (e.g. `gpt-4o`), summing all metrics.
- Selection is persisted in the URL (`?modelView=canonical`) and only renders when grouping by model.

## Test plan
- [ ] Visit `/global-stats?groupBy=model`, confirm new Mappings/Canonical toggle on the Cost share — models card.
- [ ] Switch to Canonical: pie chart, legend, and breakdown table aggregate provider variants under canonical ids.
- [ ] Switch back to Mappings: original `provider/modelName` rows return.
- [ ] Switch `groupBy` to x-source: toggle is hidden, source breakdown unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "model view" option to control how model-grouped statistics are displayed and requested.
  * Introduced a canonical aggregation mode that consolidates provider-specific model entries into canonical model IDs for rollups.
  * Added a UI toggle to switch model view modes when viewing stats grouped by model.
  * Adjusted distinct-model/source counts to reflect unaggregated breakdowns where applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->