### PR TITLE
fix(admin): key discounts by root model id only

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2425,30 +2425,21 @@ admin.openapi(getProjectLogs, async (c) => {
 // Get valid provider IDs as a Set for O(1) lookup
 const validProviderIds = new Set<string>(providers.map((p) => p.id));
 
-// Build a map of provider -> Set of valid model names for that provider
-// This includes both root model IDs and provider-specific modelNames
+// Build a map of provider -> Set of valid root model IDs served by that provider.
+// Only root model IDs are accepted as discount/rate-limit targets — the
+// provider-specific modelName is reserved for upstream requests only.
 const providerModelMappings = new Map<string, Set<string>>();
 for (const model of models) {
 	for (const mapping of model.providers) {
 		if (!providerModelMappings.has(mapping.providerId)) {
 			providerModelMappings.set(mapping.providerId, new Set<string>());
 		}
-		const modelSet = providerModelMappings.get(mapping.providerId)!;
-		// Add the provider-specific model name
-		modelSet.add(mapping.modelName);
-		// Also add the root model ID for backwards compatibility
-		modelSet.add(model.id);
+		providerModelMappings.get(mapping.providerId)!.add(model.id);
 	}
 }
 
-// Get all valid model names (union of all provider model names + root IDs)
-const validModelIds = new Set<string>();
-for (const model of models) {
-	validModelIds.add(model.id);
-	for (const mapping of model.providers) {
-		validModelIds.add(mapping.modelName);
-	}
-}
+// All valid root model IDs.
+const validModelIds = new Set<string>(models.map((m) => m.id));
 
 const discountSchema = z.object({
 	id: z.string(),
@@ -2659,7 +2650,6 @@ const getAvailableProvidersAndModels = createRoute({
 									providerId: z.string(),
 									providerName: z.string(),
 									modelId: z.string(),
-									modelName: z.string(),
 									rootModelId: z.string(),
 									rootModelName: z.string(),
 									family: z.string(),
@@ -2934,12 +2924,14 @@ admin.openapi(deleteOrganizationDiscount, async (c) => {
 // --- Available Options Handler ---
 
 admin.openapi(getAvailableProvidersAndModels, async (c) => {
-	// Build mappings from all models and their providers
+	// Build mappings from all models and their providers. modelId is always the
+	// root model id — the provider-specific modelName is only used for upstream
+	// requests and must never be exposed in the discount selector or stored as a
+	// discount target.
 	const mappings: Array<{
 		providerId: string;
 		providerName: string;
 		modelId: string;
-		modelName: string;
 		rootModelId: string;
 		rootModelName: string;
 		family: string;
@@ -2952,9 +2944,8 @@ admin.openapi(getAvailableProvidersAndModels, async (c) => {
 				mappings.push({
 					providerId: mapping.providerId,
 					providerName: provider.name,
-					modelId: mapping.modelName, // The provider-specific model name
-					modelName: mapping.modelName,
-					rootModelId: model.id, // The root model ID
+					modelId: model.id,
+					rootModelId: model.id,
 					rootModelName: (model as { name?: string }).name ?? model.id,
 					family: model.family,
 				});

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -158,18 +158,15 @@ internalModels.openapi(getModelsRoute, async (c) => {
 			),
 	]);
 
-	// Helper to find the best global discount for a given provider+model
+	// Find the best global discount for a given provider+model. Discounts are
+	// always keyed by the root model ID.
 	const getGlobalDiscount = (
 		providerId: string,
 		modelId: string,
-		modelName: string,
 	): string | null => {
-		const modelMatches = (dm: string | null) =>
-			dm === modelId || dm === modelName;
-
 		// Precedence: provider+model > provider > model
 		const providerModel = globalDiscounts.find(
-			(d) => d.provider === providerId && modelMatches(d.model),
+			(d) => d.provider === providerId && d.model === modelId,
 		);
 		if (providerModel) {
 			return providerModel.discountPercent;
@@ -183,7 +180,7 @@ internalModels.openapi(getModelsRoute, async (c) => {
 		}
 
 		const modelOnly = globalDiscounts.find(
-			(d) => d.provider === null && modelMatches(d.model),
+			(d) => d.provider === null && d.model === modelId,
 		);
 		if (modelOnly) {
 			return modelOnly.discountPercent;
@@ -210,11 +207,7 @@ internalModels.openapi(getModelsRoute, async (c) => {
 					?.providers.find(
 						(provider) => provider.providerId === mapping.providerId,
 					) ?? null;
-			const globalDiscount = getGlobalDiscount(
-				mapping.providerId,
-				model.id,
-				mapping.modelName,
-			);
+			const globalDiscount = getGlobalDiscount(mapping.providerId, model.id);
 			// Global discount takes precedence over hardcoded mapping discount
 			const effectiveDiscount = globalDiscount ?? mapping.discount;
 			return {

--- a/apps/api/src/routes/public-discounts.ts
+++ b/apps/api/src/routes/public-discounts.ts
@@ -1,17 +1,7 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
-import {
-	and,
-	db,
-	desc,
-	gte,
-	inArray,
-	isNull,
-	or,
-	tables,
-} from "@llmgateway/db";
-import { models as modelDefinitions } from "@llmgateway/models";
+import { and, db, desc, eq, gte, isNull, or, tables } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -52,14 +42,6 @@ const getModelDiscounts = createRoute({
 publicDiscounts.openapi(getModelDiscounts, async (c) => {
 	const { modelId } = c.req.param();
 
-	// Discounts may be keyed by the root model ID or by any of the model's
-	// provider-specific model names (the admin UI submits the latter), so match
-	// against all of them.
-	const modelDef = modelDefinitions.find((m) => m.id === modelId);
-	const modelValues = Array.from(
-		new Set([modelId, ...(modelDef?.providers.map((p) => p.modelName) ?? [])]),
-	);
-
 	const now = new Date();
 	const notExpired = or(
 		isNull(tables.discount.expiresAt),
@@ -72,10 +54,7 @@ publicDiscounts.openapi(getModelDiscounts, async (c) => {
 		.where(
 			and(
 				isNull(tables.discount.organizationId),
-				or(
-					isNull(tables.discount.model),
-					inArray(tables.discount.model, modelValues),
-				),
+				or(isNull(tables.discount.model), eq(tables.discount.model, modelId)),
 				notExpired,
 			),
 		)

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -3462,7 +3462,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -328,7 +328,6 @@ describe("calculateCosts", () => {
 			"openai",
 			"gpt-4",
 			"0",
-			"gpt-4",
 		);
 	});
 

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -343,15 +343,14 @@ export async function calculateCosts(
 			: cacheWriteInputPrice;
 	const requestPrice = new Decimal(providerInfo.requestPrice ?? "0");
 
-	// Get effective discount (checks org-specific, global, then hardcoded)
-	// Pass both the root model ID and the provider-specific model name for matching
+	// Get effective discount (checks org-specific, global, then hardcoded).
+	// Discounts are keyed by the root model ID only.
 	const hardcodedDiscount = providerInfo.discount ?? "0";
 	const effectiveDiscountResult = await getEffectiveDiscount(
 		organizationId,
 		provider,
 		model,
 		hardcodedDiscount,
-		providerInfo.modelName, // Provider-specific model name for discount matching
 	);
 	const discount = effectiveDiscountResult.discount;
 	const discountMultiplier = new Decimal(1).minus(discount);

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -344,12 +344,13 @@ export async function calculateCosts(
 	const requestPrice = new Decimal(providerInfo.requestPrice ?? "0");
 
 	// Get effective discount (checks org-specific, global, then hardcoded).
-	// Discounts are keyed by the root model ID only.
+	// Discounts are keyed by the root model ID only — `model` may be a
+	// provider-specific alias, so use the resolved root id from modelInfo.
 	const hardcodedDiscount = providerInfo.discount ?? "0";
 	const effectiveDiscountResult = await getEffectiveDiscount(
 		organizationId,
 		provider,
-		model,
+		modelInfo.id,
 		hardcodedDiscount,
 	);
 	const discount = effectiveDiscountResult.discount;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -3462,7 +3462,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -3462,7 +3462,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/ee/admin/src/components/discount-form.tsx
+++ b/ee/admin/src/components/discount-form.tsx
@@ -64,13 +64,12 @@ export function DiscountForm({
 		return mappings.filter((m) => m.providerId === provider);
 	}, [provider, mappings]);
 
-	// Get unique models for the filtered mappings (deduplicate by modelId)
+	// Get unique models for the filtered mappings (deduplicate by root modelId)
 	const availableModels = useMemo(() => {
 		const uniqueModels = new Map<
 			string,
 			{
 				modelId: string;
-				modelName: string;
 				rootModelName: string;
 				family: string;
 			}
@@ -79,7 +78,6 @@ export function DiscountForm({
 			if (!uniqueModels.has(mapping.modelId)) {
 				uniqueModels.set(mapping.modelId, {
 					modelId: mapping.modelId,
-					modelName: mapping.modelName,
 					rootModelName: mapping.rootModelName,
 					family: mapping.family,
 				});

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -3462,7 +3462,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/packages/db/src/discount-helpers.ts
+++ b/packages/db/src/discount-helpers.ts
@@ -30,19 +30,22 @@ export interface EffectiveDiscount {
  * Uses the cached database client (cdb) which has Drizzle's cache layer.
  *
  * Precedence (highest to lowest):
- * 1. Org + Provider + Model discount (checks both root model ID and provider model name)
+ * 1. Org + Provider + Model discount
  * 2. Org + Provider discount (all models)
  * 3. Org + Model discount (all providers)
- * 4. Global + Provider + Model discount (checks both root model ID and provider model name)
+ * 4. Global + Provider + Model discount
  * 5. Global + Provider discount
  * 6. Global + Model discount
  * 7. Hardcoded model discount (fallback)
+ *
+ * Discounts are always keyed by the root model ID — provider-specific model
+ * names are reserved for upstream requests and are never persisted as a
+ * discount target.
  *
  * @param organizationId - The organization ID (null for global only)
  * @param provider - The provider ID
  * @param model - The root model ID (e.g., "gpt-4o-mini")
  * @param hardcodedDiscount - The hardcoded discount from model definition (0-1)
- * @param providerModelName - The provider-specific model name (e.g., "gpt-4o-mini-2024-07-18")
  * @returns The effective discount to apply
  */
 export async function getEffectiveDiscount(
@@ -50,25 +53,15 @@ export async function getEffectiveDiscount(
 	provider: string,
 	model: string,
 	hardcodedDiscount: string = "0",
-	providerModelName?: string,
 ): Promise<EffectiveDiscount> {
 	try {
 		const now = new Date();
 
-		// Build conditions for non-expired discounts
 		const notExpiredCondition = or(
 			isNull(discountTable.expiresAt),
 			gte(discountTable.expiresAt, now),
 		);
 
-		// Build model matching condition - match either root model ID or provider model name
-		const modelConditions = [eq(discountTable.model, model)];
-		if (providerModelName && providerModelName !== model) {
-			modelConditions.push(eq(discountTable.model, providerModelName));
-		}
-
-		// Query all potentially matching discounts
-		// We'll filter in code to determine precedence
 		const discounts = await cdb
 			.select({
 				id: discountTable.id,
@@ -81,36 +74,22 @@ export async function getEffectiveDiscount(
 			.where(
 				and(
 					notExpiredCondition,
-					// Either global (null org) or specific org
 					or(
 						isNull(discountTable.organizationId),
 						organizationId
 							? eq(discountTable.organizationId, organizationId)
 							: isNull(discountTable.organizationId),
 					),
-					// Either matches provider or is null (all providers)
 					or(
 						eq(discountTable.provider, provider),
 						isNull(discountTable.provider),
 					),
-					// Either matches model (root ID or provider model name) or is null (all models)
-					or(...modelConditions, isNull(discountTable.model)),
+					or(eq(discountTable.model, model), isNull(discountTable.model)),
 				),
 			);
 
-		// Helper to check if a discount's model matches (root ID or provider model name)
-		const modelMatches = (discountModel: string | null): boolean => {
-			if (discountModel === null) {
-				return false;
-			}
-			if (discountModel === model) {
-				return true;
-			}
-			if (providerModelName && discountModel === providerModelName) {
-				return true;
-			}
-			return false;
-		};
+		const modelMatches = (discountModel: string | null): boolean =>
+			discountModel !== null && discountModel === model;
 
 		// Find highest precedence discount
 		// Order: org-specific > global, more specific > less specific


### PR DESCRIPTION
## Summary
- The global discounts selector in the admin dashboard was showing and submitting provider-specific `modelName` values (the upstream API model name) instead of the canonical root model id.
- The `/admin/discounts/options` endpoint now returns the root model id as `modelId`, the form deduplicates and submits root ids, validation only accepts root ids, and the lookup helpers (`getEffectiveDiscount`, `public-discounts`, `internal-models`) match strictly by root id.
- `providerModelName` is no longer threaded through `getEffectiveDiscount`; callers (`apps/gateway/src/lib/costs.ts`) updated accordingly.

`modelName` is now reserved exclusively for upstream provider requests and is never persisted or matched against discount targets.

## Test plan
- [ ] Open admin → Global Discounts → "Add Discount": dropdown shows root model ids (e.g. `gpt-4o-mini`), not provider-specific names (e.g. `gpt-4o-mini-2024-07-18`).
- [ ] Create a discount for a provider + model, confirm the stored `discount.model` value is the root id.
- [ ] Confirm an in-flight request to that provider/model applies the discount in cost calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Discount matching now targets root model IDs only (no provider-specific model names), unifying discount behavior across admin UI, public APIs, and billing.
  * Admin discount form and options now show deduplicated root-model choices.
  * Cost calculations and discount queries updated to use root-model-based lookups, preserving existing precedence and outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->