### PR TITLE
fix(admin): exclude cancelling subs from gross MRR

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9026,10 +9026,12 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const [countRow] = await countSelect.where(whereClause);
 	const total = Number(countRow?.count ?? 0);
 
-	// KPI strip — always over the full active subscriber base, unfiltered.
-	// Matches Stripe's "active" filter, which includes cancel-at-period-end
-	// subscriptions until the period actually ends. The `cancelledPending`
-	// count below breaks out how many of these are flagged to cancel.
+	// KPI strip — counts committed subscribers only, excluding cancel-at-period-end.
+	// Once a subscription is flagged to cancel, Stripe still bills it until the
+	// period ends, but it should NOT count toward committed MRR / active subs in
+	// the dashboard — it's already churned in intent. The `cancelledPending`
+	// count below breaks out the to-be-churned subs as a separate KPI so admins
+	// can still see impending churn.
 	const activeRows = await db
 		.select({
 			tier: tables.organization.devPlan,
@@ -9039,6 +9041,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.where(
 			and(
 				ne(tables.organization.devPlan, "none"),
+				eq(tables.organization.devPlanCancelled, false),
 				or(
 					isNull(tables.organization.devPlanExpiresAt),
 					sql`${tables.organization.devPlanExpiresAt} > NOW()`,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8520,6 +8520,7 @@ const devpassKpisSchema = z.object({
 	cancelledPending: z.number(),
 	churned: z.number(),
 	grossMrr: z.number(),
+	committedMrr: z.number(),
 	startsThisMonth: z.number(),
 	endsThisMonth: z.number(),
 	netNewThisMonth: z.number(),
@@ -9026,35 +9027,39 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const [countRow] = await countSelect.where(whereClause);
 	const total = Number(countRow?.count ?? 0);
 
-	// KPI strip — counts committed subscribers only, excluding cancel-at-period-end.
-	// Once a subscription is flagged to cancel, Stripe still bills it until the
-	// period ends, but it should NOT count toward committed MRR / active subs in
-	// the dashboard — it's already churned in intent. The `cancelledPending`
-	// count below breaks out the to-be-churned subs as a separate KPI so admins
-	// can still see impending churn.
+	// KPI strip — counts the full active subscriber base, matching Stripe's
+	// "active" filter which includes cancel-at-period-end subs until the period
+	// actually ends. `grossMrr` is the Stripe-aligned figure (what will be
+	// invoiced this period). `committedMrr` excludes subs flagged to cancel,
+	// representing the forward-looking MRR after impending churn lands.
 	const activeRows = await db
 		.select({
 			tier: tables.organization.devPlan,
+			cancelled: tables.organization.devPlanCancelled,
 			count: sql<number>`COUNT(*)`,
 		})
 		.from(tables.organization)
 		.where(
 			and(
 				ne(tables.organization.devPlan, "none"),
-				eq(tables.organization.devPlanCancelled, false),
 				or(
 					isNull(tables.organization.devPlanExpiresAt),
 					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
 				)!,
 			),
 		)
-		.groupBy(tables.organization.devPlan);
+		.groupBy(tables.organization.devPlan, tables.organization.devPlanCancelled);
 
 	const activeByTier = { lite: 0, pro: 0, max: 0 };
+	const cancellingByTier = { lite: 0, pro: 0, max: 0 };
 	for (const r of activeRows) {
 		const tierKey = r.tier as keyof typeof activeByTier;
 		if (tierKey in activeByTier) {
-			activeByTier[tierKey] = Number(r.count);
+			const n = Number(r.count);
+			activeByTier[tierKey] += n;
+			if (r.cancelled) {
+				cancellingByTier[tierKey] += n;
+			}
 		}
 	}
 	const totalActive = activeByTier.lite + activeByTier.pro + activeByTier.max;
@@ -9062,21 +9067,13 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const proMrr = activeByTier.pro * DEV_PLAN_PRICES.pro;
 	const maxMrr = activeByTier.max * DEV_PLAN_PRICES.max;
 	const grossMrr = liteMrr + proMrr + maxMrr;
-
-	const [cancelledPendingRow] = await db
-		.select({ count: sql<number>`COUNT(*)` })
-		.from(tables.organization)
-		.where(
-			and(
-				ne(tables.organization.devPlan, "none"),
-				eq(tables.organization.devPlanCancelled, true),
-				or(
-					isNull(tables.organization.devPlanExpiresAt),
-					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
-				)!,
-			),
-		);
-	const cancelledPending = Number(cancelledPendingRow?.count ?? 0);
+	const cancellingLiteMrr = cancellingByTier.lite * DEV_PLAN_PRICES.lite;
+	const cancellingProMrr = cancellingByTier.pro * DEV_PLAN_PRICES.pro;
+	const cancellingMaxMrr = cancellingByTier.max * DEV_PLAN_PRICES.max;
+	const cancellingMrr = cancellingLiteMrr + cancellingProMrr + cancellingMaxMrr;
+	const committedMrr = grossMrr - cancellingMrr;
+	const cancelledPending =
+		cancellingByTier.lite + cancellingByTier.pro + cancellingByTier.max;
 
 	const [churnedRow] = await db
 		.select({
@@ -9228,6 +9225,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			cancelledPending,
 			churned,
 			grossMrr,
+			committedMrr,
 			startsThisMonth,
 			endsThisMonth,
 			netNewThisMonth: startsThisMonth - endsThisMonth,

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -5702,6 +5702,7 @@ export interface paths {
                                 cancelledPending: number;
                                 churned: number;
                                 grossMrr: number;
+                                committedMrr: number;
                                 startsThisMonth: number;
                                 endsThisMonth: number;
                                 netNewThisMonth: number;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -5702,6 +5702,7 @@ export interface paths {
                                 cancelledPending: number;
                                 churned: number;
                                 grossMrr: number;
+                                committedMrr: number;
                                 startsThisMonth: number;
                                 endsThisMonth: number;
                                 netNewThisMonth: number;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -5702,6 +5702,7 @@ export interface paths {
                                 cancelledPending: number;
                                 churned: number;
                                 grossMrr: number;
+                                committedMrr: number;
                                 startsThisMonth: number;
                                 endsThisMonth: number;
                                 netNewThisMonth: number;

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -486,14 +486,17 @@ export default async function DevpassPage({
 						<span className="text-2xl font-semibold tabular-nums">
 							{currencyFormatter.format(kpis.grossMrr)}
 						</span>
-						{kpis.committedMrr !== kpis.grossMrr ? (
-							<span
-								className="rounded-md border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-xs font-semibold tabular-nums text-amber-600 dark:text-amber-400"
-								title="Committed MRR — excludes subs flagged to cancel at period end"
-							>
-								{currencyFormatter.format(kpis.committedMrr)} committed
-							</span>
-						) : null}
+						<span
+							className={cn(
+								"rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+								kpis.committedMrr !== kpis.grossMrr
+									? "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+									: "border-border/60 bg-muted/40 text-muted-foreground",
+							)}
+							title="Committed MRR — excludes subs flagged to cancel at period end"
+						>
+							{currencyFormatter.format(kpis.committedMrr)} committed
+						</span>
 					</div>
 					<div className="mt-1 text-xs text-muted-foreground">
 						Net new this month:{" "}

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -5,6 +5,7 @@ import {
 	ArrowUpDown,
 	ChevronLeft,
 	ChevronRight,
+	Info,
 	Search,
 	TrendingDown,
 	TrendingUp,
@@ -28,6 +29,11 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
@@ -486,17 +492,26 @@ export default async function DevpassPage({
 						<span className="text-2xl font-semibold tabular-nums">
 							{currencyFormatter.format(kpis.grossMrr)}
 						</span>
-						<span
-							className={cn(
-								"rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
-								kpis.committedMrr !== kpis.grossMrr
-									? "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
-									: "border-border/60 bg-muted/40 text-muted-foreground",
-							)}
-							title="Committed MRR — excludes subs flagged to cancel at period end"
-						>
-							{currencyFormatter.format(kpis.committedMrr)} committed
-						</span>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span
+									className={cn(
+										"inline-flex cursor-help items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+										kpis.committedMrr !== kpis.grossMrr
+											? "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+											: "border-border/60 bg-muted/40 text-muted-foreground",
+									)}
+								>
+									<Info className="h-3 w-3" />
+									{currencyFormatter.format(kpis.committedMrr)} committed
+								</span>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-xs">
+								Forward-looking MRR after pending churn. Excludes subs flagged
+								to cancel at period end (still billed by Stripe this cycle, but
+								gone next cycle).
+							</TooltipContent>
+						</Tooltip>
 					</div>
 					<div className="mt-1 text-xs text-muted-foreground">
 						Net new this month:{" "}

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -482,8 +482,18 @@ export default async function DevpassPage({
 						<Wallet className="h-3.5 w-3.5" />
 						Gross MRR
 					</div>
-					<div className="mt-2 text-2xl font-semibold tabular-nums">
-						{currencyFormatter.format(kpis.grossMrr)}
+					<div className="mt-2 flex items-baseline gap-2">
+						<span className="text-2xl font-semibold tabular-nums">
+							{currencyFormatter.format(kpis.grossMrr)}
+						</span>
+						{kpis.committedMrr !== kpis.grossMrr ? (
+							<span
+								className="rounded-md border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-xs font-semibold tabular-nums text-amber-600 dark:text-amber-400"
+								title="Committed MRR — excludes subs flagged to cancel at period end"
+							>
+								{currencyFormatter.format(kpis.committedMrr)} committed
+							</span>
+						) : null}
 					</div>
 					<div className="mt-1 text-xs text-muted-foreground">
 						Net new this month:{" "}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -5702,6 +5702,7 @@ export interface paths {
                                 cancelledPending: number;
                                 churned: number;
                                 grossMrr: number;
+                                committedMrr: number;
                                 startsThisMonth: number;
                                 endsThisMonth: number;
                                 netNewThisMonth: number;


### PR DESCRIPTION
## Summary
- Adds `devPlanCancelled = false` to the active-subscribers query that feeds `activeByTier`, `totalActive`, and `grossMrr` on the `/admin/devpass` dashboard. Subs that are set to cancel-at-period-end are still billed by Stripe until the period ends, but they've churned in intent and shouldn't count toward committed MRR or active counts.
- Updates the comment to reflect the new "committed MRR" definition.
- The existing `cancelledPending` KPI continues to break out impending churn separately, so admins can still see how many subs are flagged to cancel.

## Test plan
- [x] SQL-level verification with a manually flagged cancel-pending Max org: `max` count drops from 4 → 3, Gross MRR drops by $179 (the cancelling tier's price).
- [x] `pnpm build` passes (17/17).

Follow-up to #2400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Committed MRR" KPI to the DevPass dashboard and included its value in the KPI response.
  * Added an info tooltip to the Gross MRR card to surface the Committed vs Gross distinction with contextual badge styling.

* **Bug Fixes**
  * Improved accuracy of DevPass subscriber metrics by refining active subscriber and pending-cancellation calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->