### PR TITLE
fix: use root model id for rate limits and UI lookups

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2753,8 +2753,7 @@ const getAvailableProvidersAndModels = createRoute({
 									providerId: z.string(),
 									providerName: z.string(),
 									modelId: z.string(),
-									rootModelId: z.string(),
-									rootModelName: z.string(),
+									modelName: z.string(),
 									family: z.string(),
 								}),
 							),
@@ -3027,16 +3026,14 @@ admin.openapi(deleteOrganizationDiscount, async (c) => {
 // --- Available Options Handler ---
 
 admin.openapi(getAvailableProvidersAndModels, async (c) => {
-	// Build mappings from all models and their providers. modelId is always the
-	// root model id — the provider-specific modelName is only used for upstream
-	// requests and must never be exposed in the discount selector or stored as a
-	// discount target.
+	// modelId is the canonical root model id — the provider-specific upstream
+	// modelName is never exposed here or stored as a discount target. modelName
+	// in this response is the root model's human-readable display name.
 	const mappings: Array<{
 		providerId: string;
 		providerName: string;
 		modelId: string;
-		rootModelId: string;
-		rootModelName: string;
+		modelName: string;
 		family: string;
 	}> = [];
 
@@ -3048,8 +3045,7 @@ admin.openapi(getAvailableProvidersAndModels, async (c) => {
 					providerId: mapping.providerId,
 					providerName: provider.name,
 					modelId: model.id,
-					rootModelId: model.id,
-					rootModelName: (model as { name?: string }).name ?? model.id,
+					modelName: (model as { name?: string }).name ?? model.id,
 					family: model.family,
 				});
 			}
@@ -3460,8 +3456,7 @@ const getAvailableRateLimitOptions = createRoute({
 									providerId: z.string(),
 									providerName: z.string(),
 									modelId: z.string(),
-									rootModelId: z.string(),
-									rootModelName: z.string(),
+									modelName: z.string(),
 									family: z.string(),
 								}),
 							),
@@ -3476,15 +3471,15 @@ const getAvailableRateLimitOptions = createRoute({
 });
 
 admin.openapi(getAvailableRateLimitOptions, async (c) => {
-	// Rate limits are always keyed by the root model id — the provider-specific
-	// modelName is reserved for upstream requests and must never be exposed in
-	// the rate-limit selector or stored as a rate-limit target.
+	// modelId is the canonical root model id — the provider-specific upstream
+	// modelName is never exposed here or stored as a rate-limit target.
+	// modelName in this response is the root model's human-readable display
+	// name.
 	const mappings: Array<{
 		providerId: string;
 		providerName: string;
 		modelId: string;
-		rootModelId: string;
-		rootModelName: string;
+		modelName: string;
 		family: string;
 	}> = [];
 
@@ -3496,8 +3491,7 @@ admin.openapi(getAvailableRateLimitOptions, async (c) => {
 					providerId: mapping.providerId,
 					providerName: provider.name,
 					modelId: model.id,
-					rootModelId: model.id,
-					rootModelName: (model as { name?: string }).name ?? model.id,
+					modelName: (model as { name?: string }).name ?? model.id,
 					family: model.family,
 				});
 			}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3460,7 +3460,6 @@ const getAvailableRateLimitOptions = createRoute({
 									providerId: z.string(),
 									providerName: z.string(),
 									modelId: z.string(),
-									modelName: z.string(),
 									rootModelId: z.string(),
 									rootModelName: z.string(),
 									family: z.string(),
@@ -3477,12 +3476,13 @@ const getAvailableRateLimitOptions = createRoute({
 });
 
 admin.openapi(getAvailableRateLimitOptions, async (c) => {
-	// Build mappings from all models and their providers
+	// Rate limits are always keyed by the root model id — the provider-specific
+	// modelName is reserved for upstream requests and must never be exposed in
+	// the rate-limit selector or stored as a rate-limit target.
 	const mappings: Array<{
 		providerId: string;
 		providerName: string;
 		modelId: string;
-		modelName: string;
 		rootModelId: string;
 		rootModelName: string;
 		family: string;
@@ -3496,7 +3496,6 @@ admin.openapi(getAvailableRateLimitOptions, async (c) => {
 					providerId: mapping.providerId,
 					providerName: provider.name,
 					modelId: model.id,
-					modelName: mapping.modelName,
 					rootModelId: model.id,
 					rootModelName: (model as { name?: string }).name ?? model.id,
 					family: model.family,

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -3465,8 +3465,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };
@@ -3832,8 +3831,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -3832,7 +3832,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2279,7 +2279,6 @@ chat.openapi(completions, async (c) => {
 			project.organizationId,
 			usedProvider,
 			baseModelId,
-			usedModel,
 		);
 
 		if (rateLimitPeek.rateLimited) {
@@ -3342,7 +3341,6 @@ chat.openapi(completions, async (c) => {
 			project.organizationId,
 			usedProvider,
 			modelInfo.id,
-			usedModel,
 		);
 
 		const providerRateLimitEntries = Object.entries(
@@ -4819,7 +4817,6 @@ chat.openapi(completions, async (c) => {
 							project.organizationId,
 							nextProvider.providerId,
 							modelInfo.id,
-							nextProvider.modelName,
 						);
 						if (retryRateLimitResult.rateLimited) {
 							failedProviderIds.add(
@@ -8477,7 +8474,6 @@ chat.openapi(completions, async (c) => {
 				project.organizationId,
 				nextProvider.providerId,
 				modelInfo.id,
-				nextProvider.modelName,
 			);
 			if (retryRateLimitResult.rateLimited) {
 				failedProviderIds.add(

--- a/apps/gateway/src/lib/provider-rate-limit.ts
+++ b/apps/gateway/src/lib/provider-rate-limit.ts
@@ -159,7 +159,6 @@ async function getProviderRateLimitStates(
 	organizationId: string,
 	provider: string,
 	model: string,
-	providerModelName?: string,
 ): Promise<{
 	keys: Record<ProviderRateLimitWindow, string>;
 	limits: Record<ProviderRateLimitWindow, ProviderRateLimitWindowState>;
@@ -168,7 +167,6 @@ async function getProviderRateLimitStates(
 		organizationId,
 		provider,
 		model,
-		providerModelName,
 	);
 	const now = Date.now();
 
@@ -212,14 +210,12 @@ export async function peekProviderRateLimit(
 	organizationId: string,
 	provider: string,
 	model: string,
-	providerModelName?: string,
 ): Promise<ProviderRateLimitResult> {
 	try {
 		const { limits } = await getProviderRateLimitStates(
 			organizationId,
 			provider,
 			model,
-			providerModelName,
 		);
 		const blockedBy = (
 			Object.entries(limits) as Array<
@@ -251,7 +247,6 @@ export async function filterRateLimitedProviders(
 	candidates: Array<{
 		providerId: string;
 		model: string;
-		providerModelName?: string;
 	}>,
 ): Promise<Set<string>> {
 	const results = await Promise.all(
@@ -261,7 +256,6 @@ export async function filterRateLimitedProviders(
 				organizationId,
 				candidate.providerId,
 				candidate.model,
-				candidate.providerModelName,
 			)),
 		})),
 	);
@@ -275,12 +269,13 @@ export async function filterRateLimitedProviders(
 
 /**
  * Pick fallback candidates that are not at their RPM/RPD cap.
- * Dedupes peeks by providerId+modelName since region-expanded variants share
- * the same rate-limit window. Falls open to the original candidates if every
- * one is capped, so callers always get a non-empty list when input was non-empty.
+ * Dedupes peeks by providerId since rate limits are keyed by org+provider+root
+ * model id, so region-expanded variants share the same window. Falls open to
+ * the original candidates if every one is capped, so callers always get a
+ * non-empty list when input was non-empty.
  */
 export async function pickNonRateLimitedCandidates<
-	T extends { providerId: string; modelName: string },
+	T extends { providerId: string },
 >(organizationId: string, baseModelId: string, candidates: T[]): Promise<T[]> {
 	if (candidates.length === 0) {
 		return candidates;
@@ -289,11 +284,10 @@ export async function pickNonRateLimitedCandidates<
 	const uniquePeekCandidates = Array.from(
 		new Map(
 			candidates.map((p) => [
-				`${p.providerId}:${p.modelName}`,
+				p.providerId,
 				{
 					providerId: p.providerId,
 					model: baseModelId,
-					providerModelName: p.modelName,
 				},
 			]),
 		).values(),
@@ -319,14 +313,12 @@ export async function checkProviderRateLimit(
 	organizationId: string,
 	provider: string,
 	model: string,
-	providerModelName?: string,
 ): Promise<ProviderRateLimitResult> {
 	try {
 		const { keys, limits } = await getProviderRateLimitStates(
 			organizationId,
 			provider,
 			model,
-			providerModelName,
 		);
 		const blockedBy = (
 			Object.entries(limits) as Array<
@@ -343,7 +335,6 @@ export async function checkProviderRateLimit(
 				organizationId,
 				provider,
 				model,
-				providerModelName,
 				blockedBy,
 				limits,
 				retryAfter,
@@ -391,7 +382,6 @@ export async function checkProviderRateLimit(
 			organizationId,
 			provider,
 			model,
-			providerModelName,
 			limits: updatedLimits,
 		});
 

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -3465,8 +3465,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };
@@ -3832,8 +3831,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -3832,7 +3832,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -113,15 +113,11 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 						: getProviderIcon(selectedMapping.providerId)
 			: null;
 		const discounts = await fetchModelDiscounts(decodedName);
-		const modelNames = Array.from(
-			new Set(model.providers.map((p) => p.modelName)),
-		);
 		const effectiveDiscount = selectedMapping
 			? (getEffectiveProviderDiscount(
 					discounts,
 					selectedMapping.providerId,
 					decodedName,
-					modelNames,
 				) ?? selectedMapping.discount)
 			: undefined;
 		const discountNum = discountFraction(effectiveDiscount);

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -91,9 +91,6 @@ export default async function ModelPage({ params }: PageProps) {
 	};
 
 	const allDiscounts = await fetchModelDiscounts(decodedName);
-	const modelNames = Array.from(
-		new Set(modelDef.providers.map((p) => p.modelName)),
-	);
 	const expandedProviders = expandAllProviderRegions(modelDef.providers);
 	const modelProviders = expandedProviders.map((provider) => {
 		const providerInfo = providerDefinitions.find(
@@ -103,7 +100,6 @@ export default async function ModelPage({ params }: PageProps) {
 			allDiscounts,
 			provider.providerId,
 			decodedName,
-			modelNames,
 		);
 		return {
 			...provider,
@@ -112,11 +108,7 @@ export default async function ModelPage({ params }: PageProps) {
 			discount: globalDiscount ?? provider.discount,
 		};
 	});
-	const currentModelDiscount = getBestDiscount(
-		allDiscounts,
-		decodedName,
-		modelNames,
-	);
+	const currentModelDiscount = getBestDiscount(allDiscounts, decodedName);
 
 	const adaptedModel = adaptModel(modelDef, modelProviders);
 

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -3465,8 +3465,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };
@@ -3832,8 +3831,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -3832,7 +3832,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/apps/ui/src/lib/discount.spec.ts
+++ b/apps/ui/src/lib/discount.spec.ts
@@ -70,31 +70,16 @@ describe("model-detail discounts", () => {
 		);
 	});
 
-	it("matches a discount keyed by the provider model name", () => {
-		// The admin UI stores discounts keyed by the provider-specific model name
-		// (e.g. "qwen3.7-max") rather than the root model id ("qwen37-max").
-		const modelNames = [alibaba.modelName];
+	it("ignores discounts keyed by a provider-specific model name rather than the root id", () => {
 		const byModelName: DiscountData = {
 			...fiftyPercentOff,
-			model: "qwen3.7-max",
+			model: alibaba.modelName,
 		};
 
 		expect(
-			getEffectiveProviderDiscount(
-				[byModelName],
-				"alibaba",
-				"qwen37-max",
-				modelNames,
-			),
-		).toBe("0.5");
-		expect(getBestDiscount([byModelName], "qwen37-max", modelNames)).toEqual(
-			byModelName,
-		);
-
-		// Without the model-name list it would not be found (the original bug).
-		expect(
 			getEffectiveProviderDiscount([byModelName], "alibaba", "qwen37-max"),
 		).toBeUndefined();
+		expect(getBestDiscount([byModelName], "qwen37-max")).toBeNull();
 	});
 
 	it("returns base prices when no discount is active", () => {

--- a/apps/ui/src/lib/discount.ts
+++ b/apps/ui/src/lib/discount.ts
@@ -19,23 +19,16 @@ function isValidDiscount(discount?: string | null): boolean {
 	return Number.isFinite(n) && n > 0 && n <= 1;
 }
 
-// A discount can be keyed by the root model ID or by any of the model's
-// provider-specific model names (the admin UI submits the latter).
-function makeModelMatcher(modelId: string, modelNames: string[]) {
-	return (discountModel: string | null): boolean =>
-		discountModel !== null &&
-		(discountModel === modelId || modelNames.includes(discountModel));
-}
-
+// Discounts are always keyed by the root model id — the provider-specific
+// modelName is reserved for upstream requests and is never persisted as a
+// discount target.
 export function getBestDiscount(
 	discounts: DiscountData[],
 	modelId: string,
-	modelNames: string[] = [],
 ): DiscountData | null {
 	const valid = discounts.filter((d) => isValidDiscount(d.discountPercent));
-	const modelMatches = makeModelMatcher(modelId, modelNames);
 	// Precedence: model-specific > fully global
-	const modelSpecific = valid.find((d) => modelMatches(d.model));
+	const modelSpecific = valid.find((d) => d.model === modelId);
 	if (modelSpecific) {
 		return modelSpecific;
 	}
@@ -54,13 +47,11 @@ export function getEffectiveProviderDiscount(
 	discounts: DiscountData[],
 	providerId: string,
 	modelId: string,
-	modelNames: string[] = [],
 ): string | undefined {
 	const valid = discounts.filter((d) => isValidDiscount(d.discountPercent));
-	const modelMatches = makeModelMatcher(modelId, modelNames);
 	// Precedence: provider+model > provider > model > fully global
 	const providerModel = valid.find(
-		(d) => d.provider === providerId && modelMatches(d.model),
+		(d) => d.provider === providerId && d.model === modelId,
 	);
 	if (providerModel) {
 		return providerModel.discountPercent;
@@ -74,7 +65,7 @@ export function getEffectiveProviderDiscount(
 	}
 
 	const modelOnly = valid.find(
-		(d) => d.provider === null && modelMatches(d.model),
+		(d) => d.provider === null && d.model === modelId,
 	);
 	if (modelOnly) {
 		return modelOnly.discountPercent;

--- a/ee/admin/src/components/discount-form.tsx
+++ b/ee/admin/src/components/discount-form.tsx
@@ -70,7 +70,7 @@ export function DiscountForm({
 			string,
 			{
 				modelId: string;
-				rootModelName: string;
+				modelName: string;
 				family: string;
 			}
 		>();
@@ -78,13 +78,13 @@ export function DiscountForm({
 			if (!uniqueModels.has(mapping.modelId)) {
 				uniqueModels.set(mapping.modelId, {
 					modelId: mapping.modelId,
-					rootModelName: mapping.rootModelName,
+					modelName: mapping.modelName,
 					family: mapping.family,
 				});
 			}
 		}
 		return Array.from(uniqueModels.values()).sort((a, b) =>
-			a.rootModelName.localeCompare(b.rootModelName),
+			a.modelName.localeCompare(b.modelName),
 		);
 	}, [filteredMappings]);
 
@@ -206,7 +206,7 @@ export function DiscountForm({
 							<SelectTrigger className="w-full">
 								<SelectValue>
 									{selectedModel
-										? `${selectedModel.rootModelName} (${selectedModel.modelId})`
+										? `${selectedModel.modelName} (${selectedModel.modelId})`
 										: "All Models"}
 								</SelectValue>
 							</SelectTrigger>
@@ -215,7 +215,7 @@ export function DiscountForm({
 								{availableModels.map((m) => (
 									<SelectItem key={m.modelId} value={m.modelId}>
 										<span className="truncate">
-											{m.rootModelName}{" "}
+											{m.modelName}{" "}
 											<span className="text-muted-foreground">
 												({m.modelId})
 											</span>

--- a/ee/admin/src/components/rate-limit-form.tsx
+++ b/ee/admin/src/components/rate-limit-form.tsx
@@ -72,7 +72,6 @@ export function RateLimitForm({
 			string,
 			{
 				modelId: string;
-				modelName: string;
 				rootModelName: string;
 				family: string;
 			}
@@ -81,7 +80,6 @@ export function RateLimitForm({
 			if (!uniqueModels.has(mapping.modelId)) {
 				uniqueModels.set(mapping.modelId, {
 					modelId: mapping.modelId,
-					modelName: mapping.modelName,
 					rootModelName: mapping.rootModelName,
 					family: mapping.family,
 				});

--- a/ee/admin/src/components/rate-limit-form.tsx
+++ b/ee/admin/src/components/rate-limit-form.tsx
@@ -72,7 +72,7 @@ export function RateLimitForm({
 			string,
 			{
 				modelId: string;
-				rootModelName: string;
+				modelName: string;
 				family: string;
 			}
 		>();
@@ -80,13 +80,13 @@ export function RateLimitForm({
 			if (!uniqueModels.has(mapping.modelId)) {
 				uniqueModels.set(mapping.modelId, {
 					modelId: mapping.modelId,
-					rootModelName: mapping.rootModelName,
+					modelName: mapping.modelName,
 					family: mapping.family,
 				});
 			}
 		}
 		return Array.from(uniqueModels.values()).sort((a, b) =>
-			a.rootModelName.localeCompare(b.rootModelName),
+			a.modelName.localeCompare(b.modelName),
 		);
 	}, [filteredMappings]);
 
@@ -225,7 +225,7 @@ export function RateLimitForm({
 							<SelectTrigger className="w-full">
 								<SelectValue>
 									{selectedModel
-										? `${selectedModel.rootModelName} (${selectedModel.modelId})`
+										? `${selectedModel.modelName} (${selectedModel.modelId})`
 										: "All Models"}
 								</SelectValue>
 							</SelectTrigger>
@@ -234,7 +234,7 @@ export function RateLimitForm({
 								{availableModels.map((m) => (
 									<SelectItem key={m.modelId} value={m.modelId}>
 										<span className="truncate">
-											{m.rootModelName}{" "}
+											{m.modelName}{" "}
 											<span className="text-muted-foreground">
 												({m.modelId})
 											</span>

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -3465,8 +3465,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };
@@ -3832,8 +3831,7 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                rootModelId: string;
-                                rootModelName: string;
+                                modelName: string;
                                 family: string;
                             }[];
                         };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -3832,7 +3832,6 @@ export interface paths {
                                 providerId: string;
                                 providerName: string;
                                 modelId: string;
-                                modelName: string;
                                 rootModelId: string;
                                 rootModelName: string;
                                 family: string;

--- a/packages/db/src/rate-limit-helpers.spec.ts
+++ b/packages/db/src/rate-limit-helpers.spec.ts
@@ -115,7 +115,7 @@ describe("getEffectiveRateLimit", () => {
 		});
 	});
 
-	it("matches provider-specific model names", async () => {
+	it("ignores rows whose model is a provider-specific alias rather than the root model id", async () => {
 		createQueryMock([
 			{
 				id: "rl-rpd",
@@ -127,19 +127,13 @@ describe("getEffectiveRateLimit", () => {
 			},
 		]);
 
-		const result = await getEffectiveRateLimit(
-			"org-1",
-			"openai",
-			"gpt-4o",
-			"gpt-4o-2024-08-06",
-		);
+		const result = await getEffectiveRateLimit("org-1", "openai", "gpt-4o");
 
 		expect(result).toEqual({
 			maxRpm: 0,
-			maxRpd: 1200,
+			maxRpd: 0,
 			rpmSource: "none",
-			rpdSource: "global_provider_model",
-			rpdRateLimitId: "rl-rpd",
+			rpdSource: "none",
 		});
 	});
 

--- a/packages/db/src/rate-limit-helpers.ts
+++ b/packages/db/src/rate-limit-helpers.ts
@@ -41,16 +41,16 @@ const rateLimitPrecedence: Array<{
 		rateLimit: RateLimitMatch,
 		organizationId: string | null,
 		provider: string,
-		modelMatches: (rateLimitModel: string | null) => boolean,
+		model: string,
 	) => boolean;
 }> = [
 	{
 		source: "org_provider_model",
-		matches: (rateLimit, organizationId, provider, modelMatches) =>
+		matches: (rateLimit, organizationId, provider, model) =>
 			organizationId !== null &&
 			rateLimit.organizationId === organizationId &&
 			rateLimit.provider === provider &&
-			modelMatches(rateLimit.model),
+			rateLimit.model === model,
 	},
 	{
 		source: "org_provider",
@@ -62,18 +62,18 @@ const rateLimitPrecedence: Array<{
 	},
 	{
 		source: "org_model",
-		matches: (rateLimit, organizationId, _provider, modelMatches) =>
+		matches: (rateLimit, organizationId, _provider, model) =>
 			organizationId !== null &&
 			rateLimit.organizationId === organizationId &&
 			rateLimit.provider === null &&
-			modelMatches(rateLimit.model),
+			rateLimit.model === model,
 	},
 	{
 		source: "global_provider_model",
-		matches: (rateLimit, _organizationId, provider, modelMatches) =>
+		matches: (rateLimit, _organizationId, provider, model) =>
 			rateLimit.organizationId === null &&
 			rateLimit.provider === provider &&
-			modelMatches(rateLimit.model),
+			rateLimit.model === model,
 	},
 	{
 		source: "global_provider",
@@ -84,10 +84,10 @@ const rateLimitPrecedence: Array<{
 	},
 	{
 		source: "global_model",
-		matches: (rateLimit, _organizationId, _provider, modelMatches) =>
+		matches: (rateLimit, _organizationId, _provider, model) =>
 			rateLimit.organizationId === null &&
 			rateLimit.provider === null &&
-			modelMatches(rateLimit.model),
+			rateLimit.model === model,
 	},
 ];
 
@@ -95,14 +95,14 @@ function pickRateLimitByPrecedence(
 	rateLimits: RateLimitMatch[],
 	organizationId: string | null,
 	provider: string,
-	modelMatches: (rateLimitModel: string | null) => boolean,
+	model: string,
 	getLimitValue: (rateLimit: RateLimitMatch) => number | null,
 ): { limit: number; source: RateLimitSource; rateLimitId?: string } {
 	for (const precedence of rateLimitPrecedence) {
 		const match = rateLimits.find(
 			(rateLimit) =>
 				getLimitValue(rateLimit) !== null &&
-				precedence.matches(rateLimit, organizationId, provider, modelMatches),
+				precedence.matches(rateLimit, organizationId, provider, model),
 		);
 		if (match) {
 			return {
@@ -123,26 +123,24 @@ function pickRateLimitByPrecedence(
  * Get the effective rate limits for a given organization, provider, and model.
  * Uses the uncached database client so admin changes take effect immediately.
  *
+ * Rate limits are always keyed by the root model ID — provider-specific model
+ * names are reserved for upstream requests and are never persisted as a
+ * rate-limit target.
+ *
  * Precedence (highest to lowest):
- * 1. Org + Provider + Model rate limit (checks both root model ID and provider model name)
- * 2. Org + Provider rate limit (all models)
- * 3. Org + Model rate limit (all providers)
- * 4. Global + Provider + Model rate limit (checks both root model ID and provider model name)
- * 5. Global + Provider rate limit
- * 6. Global + Model rate limit
+ * 1. Org + Provider + Model
+ * 2. Org + Provider (all models)
+ * 3. Org + Model (all providers)
+ * 4. Global + Provider + Model
+ * 5. Global + Provider
+ * 6. Global + Model
  */
 export async function getEffectiveRateLimit(
 	organizationId: string | null,
 	provider: string,
 	model: string,
-	providerModelName?: string,
 ): Promise<EffectiveRateLimit> {
 	try {
-		const modelConditions = [eq(rateLimitTable.model, model)];
-		if (providerModelName && providerModelName !== model) {
-			modelConditions.push(eq(rateLimitTable.model, providerModelName));
-		}
-
 		const rateLimits = await db
 			.select({
 				id: rateLimitTable.id,
@@ -165,34 +163,22 @@ export async function getEffectiveRateLimit(
 						eq(rateLimitTable.provider, provider),
 						isNull(rateLimitTable.provider),
 					),
-					or(...modelConditions, isNull(rateLimitTable.model)),
+					or(eq(rateLimitTable.model, model), isNull(rateLimitTable.model)),
 				),
 			);
-
-		const modelMatches = (rateLimitModel: string | null): boolean => {
-			if (rateLimitModel === null) {
-				return false;
-			}
-			if (rateLimitModel === model) {
-				return true;
-			}
-			return (
-				providerModelName !== undefined && rateLimitModel === providerModelName
-			);
-		};
 
 		const rpm = pickRateLimitByPrecedence(
 			rateLimits,
 			organizationId,
 			provider,
-			modelMatches,
+			model,
 			(rateLimit) => rateLimit.maxRpm,
 		);
 		const rpd = pickRateLimitByPrecedence(
 			rateLimits,
 			organizationId,
 			provider,
-			modelMatches,
+			model,
 			(rateLimit) => rateLimit.maxRpd,
 		);
 


### PR DESCRIPTION
## Summary

Follow-up to #2402. Extends the canonical-root-model-id rule to the rate-limit stack and the remaining UI discount helpers. The provider-specific `modelName` is reserved for upstream provider requests only; everything else — admin selectors, persisted keys, in-memory lookups — keys on the root model id.

### Backend
- `packages/db/src/rate-limit-helpers.ts` — `getEffectiveRateLimit` drops the `providerModelName` parameter and matches by root model id only (same pattern the discount helper landed on).
- `apps/gateway/src/lib/provider-rate-limit.ts` — `peek` / `check` / `filter` / `pickNonRateLimited` no longer take or forward `providerModelName`; dedupe key for region-expanded variants is now just `providerId`. Log fields cleaned up.
- `apps/gateway/src/chat/chat.ts` — call sites no longer pass `usedModel` / `nextProvider.modelName` to rate-limit calls.
- `apps/api/src/routes/admin.ts` — `/rate-limits/options` schema and handler drop the `modelName` field (only the root id is needed for selection/storage).

### Frontend
- `apps/ui/src/lib/discount.ts` — `getBestDiscount` and `getEffectiveProviderDiscount` drop the `modelNames` fuzzy-match fallback that existed for the old admin behavior. Spec updated.
- `apps/ui/src/app/models/[name]/page.tsx` and `…/[provider]/opengraph-image.tsx` — call sites drop the now-removed `modelNames` argument.
- `ee/admin/src/components/rate-limit-form.tsx` — drops the unused `modelName` from the local model map.

### Generated
- `apps/{ui,playground,code}/src/lib/api/v1.d.ts` and `ee/admin/src/lib/api/v1.d.ts` regenerated from the updated OpenAPI spec.

## Test plan
- [x] `pnpm test:unit` — 1601/1601 passing (includes updated rate-limit and discount spec assertions confirming provider-modelName-keyed rows are now ignored).
- [x] `pnpm format`
- [x] `pnpm build` — all core packages and apps compile; the `code` app's font fetch failure is a sandbox network issue, unrelated to these changes (verified via `tsc --noEmit` on each affected app).
- [ ] Smoke test in admin: confirm the rate-limit selector shows only root model ids and that an existing rate limit keyed by a provider modelName no longer matches (needs to be recreated by root id — same migration story as the discount PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized model identification across discount and rate-limit systems to use canonical root model IDs instead of provider-specific variant names.

* **Bug Fixes**
  * Fixed discount and rate-limit matching to correctly exclude provider-specific model variants, ensuring consistent behavior across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->