### PR TITLE
fix(admin): strip provider prefix in cost share labels

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1222,12 +1222,11 @@ admin.openapi(getGlobalStats, async (c) => {
 				)
 			: breakdownRows.map((row) => {
 					const isModel = "usedModel" in row;
-					const key = isModel
-						? `${row.usedProvider}/${row.usedModel}`
-						: row.source;
-					const label = isModel
-						? `${row.usedProvider}/${row.usedModel}`
-						: row.source;
+					const modelLabel = isModel
+						? formatProviderModelLabel(row.usedProvider, row.usedModel)
+						: null;
+					const key = isModel ? modelLabel! : row.source;
+					const label = isModel ? modelLabel! : row.source;
 					return {
 						key,
 						label,
@@ -1255,12 +1254,27 @@ admin.openapi(getGlobalStats, async (c) => {
 	});
 });
 
+function stripProviderPrefix(providerId: string, modelName: string): string {
+	const prefix = `${providerId}/`;
+	return modelName.startsWith(prefix)
+		? modelName.slice(prefix.length)
+		: modelName;
+}
+
+function formatProviderModelLabel(
+	providerId: string,
+	modelName: string,
+): string {
+	return `${providerId}/${stripProviderPrefix(providerId, modelName)}`;
+}
+
 const canonicalModelIdCache = new Map<string, string | null>();
 function lookupCanonicalModelId(
 	providerId: string,
 	modelName: string,
 ): string | null {
-	const cacheKey = `${providerId}/${modelName}`;
+	const bareModelName = stripProviderPrefix(providerId, modelName);
+	const cacheKey = `${providerId}/${bareModelName}`;
 	if (canonicalModelIdCache.has(cacheKey)) {
 		return canonicalModelIdCache.get(cacheKey) ?? null;
 	}
@@ -1268,7 +1282,7 @@ function lookupCanonicalModelId(
 	for (const m of models) {
 		if (
 			m.providers.some(
-				(p) => p.providerId === providerId && p.modelName === modelName,
+				(p) => p.providerId === providerId && p.modelName === bareModelName,
 			)
 		) {
 			canonical = m.id;
@@ -1302,8 +1316,10 @@ function aggregateModelRowsByCanonicalId(
 	>();
 	for (const row of rows) {
 		const canonical = lookupCanonicalModelId(row.usedProvider, row.usedModel);
-		const key = canonical ?? `${row.usedProvider}/${row.usedModel}`;
-		const label = canonical ?? row.usedModel;
+		const bareModel = stripProviderPrefix(row.usedProvider, row.usedModel);
+		const key =
+			canonical ?? formatProviderModelLabel(row.usedProvider, row.usedModel);
+		const label = canonical ?? bareModel;
 		const existing = aggregated.get(key);
 		if (existing) {
 			existing.requestCount += Number(row.requestCount);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1265,7 +1265,9 @@ function formatProviderModelLabel(
 	providerId: string,
 	modelName: string,
 ): string {
-	return `${providerId}/${stripProviderPrefix(providerId, modelName)}`;
+	return modelName.startsWith(`${providerId}/`)
+		? modelName
+		: `${providerId}/${modelName}`;
 }
 
 const canonicalModelIdCache = new Map<string, string | null>();


### PR DESCRIPTION
## Summary
- Some gateway endpoints (embeddings, image generation) store `usedModel` as `provider/model` (e.g. `google-ai-studio/gemini-3-pro-image-preview`), while chat stores just the bare model name.
- In the admin Cost share — models card, Mappings view was rendering `provider/provider/model` (e.g. `google-ai-studio/google-ai-studio/gemini-3-pro-image-preview`) because labels were built as `${usedProvider}/${usedModel}` without checking whether the prefix was already there.
- Canonical view fell back to `usedModel` for unresolved rows, leaving the provider prefix in place (e.g. `google-ai-studio/gemini-3-pro-image-preview`) and never aggregating because the lookup checked the prefixed string against model defs.
- Added a `stripProviderPrefix` helper used by both the Mappings label formatter and the canonical model lookup, so prefixed `usedModel` values are normalized consistently.

## Test plan
- [ ] `/global-stats?groupBy=model&modelView=mapping`: image/embedding rows render as `provider/model` (single prefix).
- [ ] `/global-stats?groupBy=model&modelView=canonical`: image/embedding rows aggregate under their canonical model id, summing across providers.
- [ ] Chat models (where `usedModel` has no prefix) still render unchanged in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-name normalization in the admin statistics endpoint by stripping redundant provider prefixes for clearer, more consistent labels.
  * Breakdown entries now prefer canonical model identifiers when available; otherwise use the normalized model name for keys and the bare model name for labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->