### PR TITLE
fix(admin): derive cost share labels from used_model

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1216,17 +1216,13 @@ admin.openapi(getGlobalStats, async (c) => {
 					breakdownRows as Array<
 						(typeof breakdownRows)[number] & {
 							usedModel: string;
-							usedProvider: string;
 						}
 					>,
 				)
 			: breakdownRows.map((row) => {
 					const isModel = "usedModel" in row;
-					const modelLabel = isModel
-						? formatProviderModelLabel(row.usedProvider, row.usedModel)
-						: null;
-					const key = isModel ? modelLabel! : row.source;
-					const label = isModel ? modelLabel! : row.source;
+					const key = isModel ? row.usedModel : row.source;
+					const label = isModel ? row.usedModel : row.source;
 					return {
 						key,
 						label,
@@ -1254,50 +1250,19 @@ admin.openapi(getGlobalStats, async (c) => {
 	});
 });
 
-function stripProviderPrefix(providerId: string, modelName: string): string {
-	const prefix = `${providerId}/`;
-	return modelName.startsWith(prefix)
-		? modelName.slice(prefix.length)
-		: modelName;
-}
-
-function formatProviderModelLabel(
-	providerId: string,
-	modelName: string,
-): string {
-	return modelName.startsWith(`${providerId}/`)
-		? modelName
-		: `${providerId}/${modelName}`;
-}
-
-const canonicalModelIdCache = new Map<string, string | null>();
-function lookupCanonicalModelId(
-	providerId: string,
-	modelName: string,
-): string | null {
-	const bareModelName = stripProviderPrefix(providerId, modelName);
-	const cacheKey = `${providerId}/${bareModelName}`;
-	if (canonicalModelIdCache.has(cacheKey)) {
-		return canonicalModelIdCache.get(cacheKey) ?? null;
-	}
-	let canonical: string | null = null;
-	for (const m of models) {
-		if (
-			m.providers.some(
-				(p) => p.providerId === providerId && p.modelName === bareModelName,
-			)
-		) {
-			canonical = m.id;
-			break;
-		}
-	}
-	canonicalModelIdCache.set(cacheKey, canonical);
-	return canonical;
+// `used_model` in global_model_stats is stored as `<provider>/<canonical-model>[:<region>]`
+// (e.g. `google-ai-studio/gemini-embedding-2`, `alibaba/deepseek-v4-flash:singapore`).
+// The canonical id is the segment between the first `/` and the optional `:`.
+function extractCanonicalModelId(usedModel: string): string {
+	const slashIdx = usedModel.indexOf("/");
+	const withoutProvider =
+		slashIdx === -1 ? usedModel : usedModel.slice(slashIdx + 1);
+	const colonIdx = withoutProvider.indexOf(":");
+	return colonIdx === -1 ? withoutProvider : withoutProvider.slice(0, colonIdx);
 }
 
 function aggregateModelRowsByCanonicalId(
 	rows: Array<{
-		usedProvider: string;
 		usedModel: string;
 		requestCount: number;
 		errorCount: number;
@@ -1317,12 +1282,8 @@ function aggregateModelRowsByCanonicalId(
 		z.infer<typeof globalStatsBreakdownItemSchema>
 	>();
 	for (const row of rows) {
-		const canonical = lookupCanonicalModelId(row.usedProvider, row.usedModel);
-		const bareModel = stripProviderPrefix(row.usedProvider, row.usedModel);
-		const key =
-			canonical ?? formatProviderModelLabel(row.usedProvider, row.usedModel);
-		const label = canonical ?? bareModel;
-		const existing = aggregated.get(key);
+		const canonical = extractCanonicalModelId(row.usedModel);
+		const existing = aggregated.get(canonical);
 		if (existing) {
 			existing.requestCount += Number(row.requestCount);
 			existing.errorCount += Number(row.errorCount);
@@ -1336,9 +1297,9 @@ function aggregateModelRowsByCanonicalId(
 			existing.cachedInputCost += Number(row.cachedInputCost);
 			existing.outputCost += Number(row.outputCost);
 		} else {
-			aggregated.set(key, {
-				key,
-				label,
+			aggregated.set(canonical, {
+				key: canonical,
+				label: canonical,
 				requestCount: Number(row.requestCount),
 				errorCount: Number(row.errorCount),
 				cacheCount: Number(row.cacheCount),


### PR DESCRIPTION
## Summary
- `global_model_stats.used_model` is already stored as `<provider>/<canonical-model>[:<region>]` (e.g. `google-ai-studio/gemini-embedding-2`, `alibaba/deepseek-v4-flash:singapore`), so the admin Cost share — models card can derive both labels directly from that string.
- Mappings mode now uses `used_model` verbatim — no more provider re-concatenation.
- Canonical mode strips the provider prefix and optional `:region` suffix to group rows. Removes the `@llmgateway/models` lookup that produced duplicate canonical rows whenever a `(providerId, modelName)` pair wasn't declared (e.g. `claude-sonnet-4-6` showing up twice with different costs).

## Test plan
- [ ] `/global-stats?groupBy=model&modelView=mapping`: rows render exactly as stored in `used_model` (single provider prefix, region suffix preserved).
- [ ] `/global-stats?groupBy=model&modelView=canonical`: `claude-sonnet-4-6` and `claude-opus-4-6` each appear once, summing all provider variants. Regional variants (e.g. `:singapore`, `:us-virginia`) roll up into the same canonical row.
- [ ] By-source view unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated model identification logic in global statistics aggregation. Changed how canonical model IDs are derived and how model labels are constructed for statistics breakdowns, improving the efficiency of the admin statistics endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->