### PR TITLE
feat(ui): products nav, calendly, calculator SEO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -286,3 +286,9 @@ INVOICE_FROM=Fake Company\nUnited States
 # Discord webhook for notifications (signups, credit purchases)
 
 DISCORD_NOTIFICATION_URL=
+# Discord webhook for chat support escalations (#customer-support channel).
+# Falls back to DISCORD_NOTIFICATION_URL when unset.
+DISCORD_SUPPORT_NOTIFICATION_URL=
+# Discord webhook for enterprise contact requests (#enterprise channel).
+# Falls back to DISCORD_NOTIFICATION_URL when unset.
+DISCORD_ENTERPRISE_NOTIFICATION_URL=

--- a/apps/api/src/routes/public-contact.ts
+++ b/apps/api/src/routes/public-contact.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
 import { redisClient } from "@/auth/config.js";
+import { notifyEnterpriseContact } from "@/utils/discord.js";
 
 import { db, eq, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
@@ -376,5 +377,15 @@ publicContact.openapi(submitEnterpriseContact, async (c) => {
 			error: err,
 		});
 	}
+
+	await notifyEnterpriseContact({
+		name: validatedData.name,
+		email: validatedData.email,
+		country: validatedData.country,
+		size: validatedData.size,
+		message: validatedData.message,
+		ipAddress,
+	});
+
 	return c.json({ success: true, message: "Email sent successfully" }, 200);
 });

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -4,6 +4,9 @@ const discordWebhookUrl = process.env.DISCORD_NOTIFICATION_URL;
 const discordSupportWebhookUrl =
 	process.env.DISCORD_SUPPORT_NOTIFICATION_URL ??
 	process.env.DISCORD_NOTIFICATION_URL;
+const discordEnterpriseWebhookUrl =
+	process.env.DISCORD_ENTERPRISE_NOTIFICATION_URL ??
+	process.env.DISCORD_NOTIFICATION_URL;
 
 interface DiscordEmbed {
 	title: string;
@@ -246,6 +249,43 @@ export async function notifyChatSupportEscalation(args: {
 			],
 		},
 		discordSupportWebhookUrl,
+	);
+}
+
+export async function notifyEnterpriseContact(args: {
+	name: string;
+	email: string;
+	country: string;
+	size: string;
+	message: string;
+	ipAddress?: string | null;
+}): Promise<void> {
+	const { name, email, country, size, message, ipAddress } = args;
+	const truncatedMessage =
+		message.length > 1000 ? `${message.slice(0, 1000)}…` : message;
+
+	await sendDiscordNotification(
+		{
+			content: "📨 New enterprise contact request.",
+			embeds: [
+				{
+					title: "Enterprise Contact Request",
+					color: 0x2563eb, // Blue
+					fields: [
+						{ name: "Name", value: name, inline: true },
+						{ name: "Email", value: email, inline: true },
+						{ name: "Country", value: country, inline: true },
+						{ name: "Company Size", value: size, inline: true },
+						...(ipAddress
+							? [{ name: "IP Address", value: ipAddress, inline: true }]
+							: []),
+						{ name: "Message", value: truncatedMessage, inline: false },
+					],
+					timestamp: new Date().toISOString(),
+				},
+			],
+		},
+		discordEnterpriseWebhookUrl,
 	);
 }
 

--- a/apps/ui/src/app/sitemap.ts
+++ b/apps/ui/src/app/sitemap.ts
@@ -108,8 +108,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		{
 			url: `${baseUrl}/token-cost-calculator`,
 			lastModified: new Date(),
-			changeFrequency: "monthly",
-			priority: 0.8,
+			changeFrequency: "weekly",
+			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/blog/category`,

--- a/apps/ui/src/app/token-cost-calculator/page.tsx
+++ b/apps/ui/src/app/token-cost-calculator/page.tsx
@@ -1,25 +1,121 @@
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
+import { CALCULATOR_FAQ } from "@/components/token-cost-calculator/faq-data";
 import { TokenCostCalculatorClient } from "@/components/token-cost-calculator/token-cost-calculator-client";
+import { TokenCostCalculatorContent } from "@/components/token-cost-calculator/token-cost-calculator-content";
 
 import type { Metadata } from "next";
 
+const PAGE_URL = "https://llmgateway.io/token-cost-calculator";
+
 export const metadata: Metadata = {
-	title: "Token Cost Calculator — Compare LLM Pricing",
+	title: "LLM Token Cost Calculator — Compare AI API Pricing",
 	description:
-		"Calculate your LLM token costs across models and providers. Compare official pricing vs LLM Gateway's cheapest provider rates with volume discounts.",
-	openGraph: {
-		title: "Token Cost Calculator — Compare LLM Pricing",
-		description:
-			"Calculate your LLM token costs across models and providers. Compare official pricing vs LLM Gateway's cheapest provider rates with volume discounts.",
+		"Free LLM token cost calculator. Estimate and compare API pricing for GPT-4o, Claude, Gemini, and 200+ models, then see how much you save with LLM Gateway's cheapest-provider routing and zero platform markup.",
+	keywords: [
+		"LLM token cost calculator",
+		"AI API pricing calculator",
+		"token cost calculator",
+		"GPT-4o pricing",
+		"Claude API cost",
+		"Gemini API pricing",
+		"LLM pricing comparison",
+		"cheapest LLM API",
+	],
+	alternates: {
+		canonical: "/token-cost-calculator",
 	},
+	openGraph: {
+		type: "website",
+		url: PAGE_URL,
+		title: "LLM Token Cost Calculator — Compare AI API Pricing",
+		description:
+			"Estimate token costs across GPT-4o, Claude, Gemini, and 200+ models and compare official pricing against LLM Gateway's cheapest-provider routing.",
+		images: [{ url: "/opengraph.png?v=1" }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "LLM Token Cost Calculator — Compare AI API Pricing",
+		description:
+			"Estimate and compare token costs across 200+ LLMs, then see how much you save with LLM Gateway.",
+		images: ["/opengraph.png?v=1"],
+	},
+};
+
+const breadcrumbSchema = {
+	"@context": "https://schema.org",
+	"@type": "BreadcrumbList",
+	itemListElement: [
+		{
+			"@type": "ListItem",
+			position: 1,
+			name: "Home",
+			item: "https://llmgateway.io",
+		},
+		{
+			"@type": "ListItem",
+			position: 2,
+			name: "Token Cost Calculator",
+			item: PAGE_URL,
+		},
+	],
+};
+
+const appSchema = {
+	"@context": "https://schema.org",
+	"@type": "SoftwareApplication",
+	name: "LLM Token Cost Calculator",
+	applicationCategory: "FinanceApplication",
+	operatingSystem: "Web",
+	url: PAGE_URL,
+	description:
+		"Free calculator to estimate and compare LLM token costs across GPT-4o, Claude, Gemini, and 200+ models, with cheapest-provider routing from LLM Gateway.",
+	offers: {
+		"@type": "Offer",
+		price: "0",
+		priceCurrency: "USD",
+	},
+	publisher: {
+		"@type": "Organization",
+		name: "LLM Gateway",
+		url: "https://llmgateway.io",
+	},
+};
+
+const faqSchema = {
+	"@context": "https://schema.org",
+	"@type": "FAQPage",
+	mainEntity: CALCULATOR_FAQ.map((item) => ({
+		"@type": "Question",
+		name: item.question,
+		acceptedAnswer: {
+			"@type": "Answer",
+			text: item.answer,
+		},
+	})),
 };
 
 export default function TokenCostCalculatorPage() {
 	return (
 		<div>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+			/>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(appSchema) }}
+			/>
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+			/>
 			<HeroRSC navbarOnly />
 			<TokenCostCalculatorClient />
+			<TokenCostCalculatorContent />
 			<Footer />
 		</div>
 	);

--- a/apps/ui/src/components/enterprise/calendly-inline.tsx
+++ b/apps/ui/src/components/enterprise/calendly-inline.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Script from "next/script";
+import { useEffect, useRef, useState } from "react";
+
+interface CalendlyApi {
+	initInlineWidget: (options: {
+		url: string;
+		parentElement: HTMLElement;
+		prefill?: { name?: string; email?: string };
+	}) => void;
+}
+
+declare global {
+	interface Window {
+		Calendly?: CalendlyApi;
+	}
+}
+
+export function CalendlyInline({
+	url,
+	name,
+	email,
+}: {
+	url: string;
+	name?: string;
+	email?: string;
+}) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [scriptLoaded, setScriptLoaded] = useState(
+		typeof window !== "undefined" && Boolean(window.Calendly),
+	);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!scriptLoaded || !container || !window.Calendly) {
+			return;
+		}
+		container.innerHTML = "";
+		window.Calendly.initInlineWidget({
+			url,
+			parentElement: container,
+			prefill: { name, email },
+		});
+	}, [scriptLoaded, url, name, email]);
+
+	return (
+		<>
+			<link
+				rel="stylesheet"
+				href="https://assets.calendly.com/assets/external/widget.css"
+			/>
+			<Script
+				src="https://assets.calendly.com/assets/external/widget.js"
+				strategy="afterInteractive"
+				onLoad={() => setScriptLoaded(true)}
+			/>
+			<div
+				ref={containerRef}
+				className="min-h-[700px] w-full overflow-hidden rounded-xl"
+			/>
+		</>
+	);
+}

--- a/apps/ui/src/components/enterprise/contact.tsx
+++ b/apps/ui/src/components/enterprise/contact.tsx
@@ -29,6 +29,11 @@ import { Textarea } from "@/lib/components/textarea";
 import { useAppConfig } from "@/lib/config";
 import { countries } from "@/lib/countries";
 
+import { CalendlyInline } from "./calendly-inline";
+
+const CALENDLY_ENTERPRISE_URL =
+	"https://calendly.com/llmgateway/llmgateway-enterprise";
+
 const contactFormSchema = z.object({
 	name: z.string().min(2, "Name must be at least 2 characters"),
 	email: z.string().email("Invalid email address"),
@@ -46,6 +51,10 @@ export function ContactFormEnterprise() {
 	const posthog = usePostHog();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isSuccess, setIsSuccess] = useState(false);
+	const [scheduled, setScheduled] = useState<{ name: string; email: string }>({
+		name: "",
+		email: "",
+	});
 	const [formLoadTime] = useState(() => Date.now());
 
 	const form = useForm<ContactFormData>({
@@ -93,6 +102,7 @@ export function ContactFormEnterprise() {
 					country: data.country,
 					companySize: data.size,
 				});
+				setScheduled({ name: data.name, email: data.email });
 				setIsSuccess(true);
 				form.reset();
 				toast.success("Message sent successfully!", {
@@ -128,24 +138,37 @@ export function ContactFormEnterprise() {
 
 					<div className="rounded-2xl border border-border bg-card/50 backdrop-blur-sm p-8 sm:p-10 shadow-lg">
 						{isSuccess ? (
-							<div className="text-center py-12">
-								<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/20 mb-6">
-									<CheckCircle2 className="w-8 h-8 text-green-600 dark:text-green-400" />
+							<div className="py-4">
+								<div className="text-center">
+									<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/20 mb-6">
+										<CheckCircle2 className="w-8 h-8 text-green-600 dark:text-green-400" />
+									</div>
+									<h3 className="text-2xl font-semibold mb-2">
+										Thank you for reaching out!
+									</h3>
+									<p className="text-muted-foreground">
+										We've received your message. Book a time below and our team
+										will meet you then — otherwise we'll reply within 24 hours.
+									</p>
 								</div>
-								<h3 className="text-2xl font-semibold mb-2">
-									Thank you for reaching out!
-								</h3>
-								<p className="text-muted-foreground mb-6">
-									We've received your message and will get back to you within 24
-									hours.
-								</p>
-								<Button
-									onClick={() => setIsSuccess(false)}
-									variant="outline"
-									size="lg"
-								>
-									Send Another Message
-								</Button>
+
+								<div className="mt-8">
+									<CalendlyInline
+										url={CALENDLY_ENTERPRISE_URL}
+										name={scheduled.name}
+										email={scheduled.email}
+									/>
+								</div>
+
+								<div className="mt-6 text-center">
+									<Button
+										onClick={() => setIsSuccess(false)}
+										variant="outline"
+										size="lg"
+									>
+										Send Another Message
+									</Button>
+								</div>
 							</div>
 						) : (
 							<Form {...form}>

--- a/apps/ui/src/components/landing/navbar.tsx
+++ b/apps/ui/src/components/landing/navbar.tsx
@@ -10,9 +10,7 @@ import {
 	Menu,
 	MessagesSquare,
 	Network,
-	Puzzle,
 	Server,
-	ShieldCheck,
 	Sparkles,
 	Wrench,
 	X,
@@ -98,7 +96,7 @@ export const Navbar = ({
 }) => {
 	const config = useAppConfig();
 
-	const featuresLinks: Array<{
+	const productsLinks: Array<{
 		title: string;
 		href: string;
 		description: string;
@@ -116,13 +114,14 @@ export const Navbar = ({
 				"hover:from-violet-500/20 hover:to-purple-600/30 hover:shadow-violet-500/10 group-hover/product:text-violet-500 dark:group-hover/product:text-violet-400",
 		},
 		{
-			title: "Observability",
-			href: "/features/performance-monitoring",
+			title: "DevPass",
+			href: "https://devpass.llmgateway.io",
 			description:
-				"Monitor usage, costs, and latency with real-time analytics dashboards.",
-			icon: Activity,
+				"Fixed-price monthly plans for Claude Code, Cursor, and every coding tool.",
+			icon: Code,
 			gradient:
-				"hover:from-emerald-500/20 hover:to-teal-600/30 hover:shadow-emerald-500/10 group-hover/product:text-emerald-500 dark:group-hover/product:text-emerald-400",
+				"hover:from-indigo-500/20 hover:to-blue-600/30 hover:shadow-indigo-500/10 group-hover/product:text-indigo-500 dark:group-hover/product:text-indigo-400",
+			external: true,
 		},
 		{
 			title: "Chat Playground",
@@ -135,41 +134,13 @@ export const Navbar = ({
 			external: true,
 		},
 		{
-			title: "Guardrails",
-			href: "/features/guardrails",
+			title: "Observability",
+			href: "/features/performance-monitoring",
 			description:
-				"Protect your AI with content moderation and safety filters.",
-			icon: ShieldCheck,
+				"Monitor usage, costs, and latency with real-time analytics dashboards.",
+			icon: Activity,
 			gradient:
-				"hover:from-amber-500/20 hover:to-orange-600/30 hover:shadow-amber-500/10 group-hover/product:text-amber-500 dark:group-hover/product:text-amber-400",
-		},
-		{
-			title: "Integrations",
-			href: "/guides",
-			description:
-				"Connect seamlessly with popular frameworks, SDKs, and tools.",
-			icon: Puzzle,
-			gradient:
-				"hover:from-pink-500/20 hover:to-rose-600/30 hover:shadow-pink-500/10 group-hover/product:text-pink-500 dark:group-hover/product:text-pink-400",
-		},
-		{
-			title: "DevPass",
-			href: "https://devpass.llmgateway.io",
-			description:
-				"Fixed-price monthly plans for Claude Code, Cursor, and every coding tool.",
-			icon: Code,
-			gradient:
-				"hover:from-indigo-500/20 hover:to-blue-600/30 hover:shadow-indigo-500/10 group-hover/product:text-indigo-500 dark:group-hover/product:text-indigo-400",
-			external: true,
-		},
-		{
-			title: "Reliability",
-			href: "/reliability",
-			description:
-				"Automatic failover and 99.9999% effective uptime across providers.",
-			icon: ShieldCheck,
-			gradient:
-				"hover:from-emerald-500/20 hover:to-green-600/30 hover:shadow-emerald-500/10 group-hover/product:text-emerald-500 dark:group-hover/product:text-emerald-400",
+				"hover:from-emerald-500/20 hover:to-teal-600/30 hover:shadow-emerald-500/10 group-hover/product:text-emerald-500 dark:group-hover/product:text-emerald-400",
 		},
 	];
 
@@ -188,6 +159,24 @@ export const Navbar = ({
 			title: "Changelog",
 			href: "/changelog",
 			description: "What's new in LLM Gateway across releases.",
+		},
+		{
+			title: "Integrations",
+			href: "/guides",
+			description:
+				"Connect seamlessly with popular frameworks, SDKs, and tools.",
+		},
+		{
+			title: "Reliability",
+			href: "/reliability",
+			description:
+				"Automatic failover and 99.9999% effective uptime across providers.",
+		},
+		{
+			title: "Guardrails",
+			href: "/features/guardrails",
+			description:
+				"Protect your AI with content moderation and safety filters.",
 		},
 		{
 			title: "Providers",
@@ -288,8 +277,8 @@ export const Navbar = ({
 
 	const mobileSections = [
 		{
-			label: "Features",
-			items: featuresLinks.map((i) => ({
+			label: "Products",
+			items: productsLinks.map((i) => ({
 				name: i.title,
 				href: i.href,
 				external: i.external,
@@ -372,14 +361,14 @@ export const Navbar = ({
 							</div>
 							<NavigationMenu viewport={false} delayDuration={300}>
 								<NavigationMenuList className="flex gap-1 text-sm">
-									{/* Features dropdown */}
+									{/* Products dropdown */}
 									<NavigationMenuItem>
 										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-4 py-2">
-											Features
+											Products
 										</NavigationMenuTrigger>
 										<NavigationMenuContent>
 											<ul className="grid grid-cols-2 gap-2 p-4 md:w-[520px] lg:w-[580px]">
-												{featuresLinks.map((product) => {
+												{productsLinks.map((product) => {
 													const IconComponent = product.icon;
 													const linkClassName = cn(
 														"group/product flex items-start gap-3 select-none rounded-lg p-3 no-underline outline-none transition-all duration-300 bg-linear-to-br from-transparent to-transparent",

--- a/apps/ui/src/components/token-cost-calculator/faq-data.ts
+++ b/apps/ui/src/components/token-cost-calculator/faq-data.ts
@@ -1,0 +1,48 @@
+export interface CalculatorFaqItem {
+	question: string;
+	answer: string;
+}
+
+/**
+ * Shared FAQ source of truth for the token cost calculator page.
+ * Used both to render the on-page FAQ and to generate FAQPage JSON-LD,
+ * so the two never drift apart.
+ */
+export const CALCULATOR_FAQ: CalculatorFaqItem[] = [
+	{
+		question: "How is the cost of LLM tokens calculated?",
+		answer:
+			"Providers bill separately for input tokens (your prompt) and output tokens (the model's response), priced per million tokens. Your total cost is (input tokens × input price) + (output tokens × output price). This calculator runs that math for every model you add and sums the result.",
+	},
+	{
+		question: "What is the difference between input and output tokens?",
+		answer:
+			"Input tokens are everything you send to the model, including your prompt, system message, and conversation history. Output tokens are what the model generates back. Output tokens almost always cost more than input tokens, which is why the split matters when you estimate spend.",
+	},
+	{
+		question: "Why do the same model's prices differ between providers?",
+		answer:
+			"Popular models are often served by several providers at different rates, and prices change as providers compete. LLM Gateway routes each request to the cheapest available provider for that model, so you pay the lowest live rate without changing any code.",
+	},
+	{
+		question: "Does LLM Gateway add a markup or platform fee?",
+		answer:
+			"No. LLM Gateway passes through provider pricing with zero platform markup, so you pay exactly what the provider charges (and less when a cheaper provider or volume discount is available). You only add a payment method once you start sending real traffic.",
+	},
+	{
+		question: "How accurate are these cost estimates?",
+		answer:
+			"Estimates use current published per-token prices for each model and provider. Real-world cost depends on your exact token counts, caching, and any negotiated rates, so treat the numbers as a close planning estimate rather than a final invoice.",
+	},
+	{
+		question:
+			"What is the cheapest way to call LLMs like GPT-4o, Claude, and Gemini?",
+		answer:
+			"Route through a gateway that compares providers and picks the lowest price per request. Because LLM Gateway supports 200+ models behind one OpenAI-compatible API, you can switch models or providers based on cost without rewriting your integration.",
+	},
+	{
+		question: "Is the token cost calculator free to use?",
+		answer:
+			"Yes, the calculator is completely free and requires no signup. You can compare as many models and token volumes as you like, then create a free LLM Gateway account when you are ready to start sending requests.",
+	},
+];

--- a/apps/ui/src/components/token-cost-calculator/token-cost-calculator-client.tsx
+++ b/apps/ui/src/components/token-cost-calculator/token-cost-calculator-client.tsx
@@ -296,24 +296,46 @@ export function TokenCostCalculatorClient() {
 	}, [rows]);
 
 	return (
-		<div className="pt-32 pb-20 sm:pt-40 sm:pb-28">
+		<div className="relative overflow-hidden pt-32 pb-20 sm:pt-40 sm:pb-28">
+			{/* Decorative backdrop */}
+			<div
+				aria-hidden="true"
+				className="pointer-events-none absolute inset-0 -z-10"
+			>
+				<div className="absolute left-1/2 top-0 h-[420px] w-full max-w-[820px] -translate-x-1/2 rounded-full bg-blue-500/10 blur-3xl" />
+				<div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-blue-500/40 to-transparent" />
+			</div>
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 				{/* Header */}
-				<div className="mx-auto max-w-3xl text-center mb-16">
+				<div className="mx-auto max-w-3xl text-center mb-12 sm:mb-16">
 					<div className="mb-6 inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1.5">
 						<Calculator className="h-3.5 w-3.5 text-blue-500" />
 						<span className="text-xs font-medium text-blue-600 dark:text-blue-400">
-							Token Cost Calculator
+							Free LLM Token Cost Calculator
 						</span>
 					</div>
 					<h1 className="mb-6 text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-6xl">
-						Calculate your true LLM costs
+						Calculate your true LLM token costs
 					</h1>
 					<p className="text-lg text-muted-foreground text-balance leading-relaxed max-w-2xl mx-auto">
-						Add the models you use, set your token volumes, and instantly see
-						how much you&apos;d pay at official rates vs. LLM Gateway&apos;s
-						cheapest provider for each model.
+						See exactly what GPT-4o, Claude, Gemini, and 200+ models cost at
+						official rates, then how much less you&apos;d pay routing each
+						request through LLM Gateway&apos;s cheapest provider.
 					</p>
+					<div className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
+						<span className="flex items-center gap-1.5">
+							<Check className="h-4 w-4 text-green-500" />
+							200+ models
+						</span>
+						<span className="flex items-center gap-1.5">
+							<Check className="h-4 w-4 text-green-500" />
+							Zero platform markup
+						</span>
+						<span className="flex items-center gap-1.5">
+							<Check className="h-4 w-4 text-green-500" />
+							Free, no signup
+						</span>
+					</div>
 				</div>
 
 				<div className="mx-auto max-w-5xl space-y-6">
@@ -849,17 +871,23 @@ function ResultsPanel({
 			{savings > 0 && (
 				<Card className="border-2 border-green-500/30 bg-gradient-to-br from-green-500/10 to-green-600/5 p-8 text-center">
 					<p className="text-sm text-muted-foreground mb-2">
-						Total savings with LLM Gateway
+						At official rates you&apos;re overpaying by
 					</p>
 					<p className="text-5xl sm:text-6xl font-bold text-green-600 dark:text-green-400 tracking-tight">
 						{formatUsd(savings)}
 					</p>
 					<p className="text-lg text-green-600/80 dark:text-green-400/80 mt-2 font-medium">
-						{savingsPercent}% less than official provider pricing
+						{savingsPercent}% less with LLM Gateway, same models
 					</p>
 					<p className="text-sm text-muted-foreground mt-4">
 						Based on the token volumes entered above
 					</p>
+					<Button size="lg" className="mt-6" asChild>
+						<Link href="/signup">
+							Start saving for free
+							<ArrowRight className="ml-2 h-4 w-4" />
+						</Link>
+					</Button>
 				</Card>
 			)}
 

--- a/apps/ui/src/components/token-cost-calculator/token-cost-calculator-content.tsx
+++ b/apps/ui/src/components/token-cost-calculator/token-cost-calculator-content.tsx
@@ -1,0 +1,172 @@
+import { ChevronDown, Coins, Route, SlidersHorizontal } from "lucide-react";
+import Link from "next/link";
+
+import { CALCULATOR_FAQ } from "./faq-data";
+
+const STEPS = [
+	{
+		icon: SlidersHorizontal,
+		title: "Add the models you use",
+		description:
+			"Pick from 200+ LLMs across OpenAI, Anthropic, Google, Mistral, Meta, and more. Stack as many models as you want to compare side by side.",
+	},
+	{
+		icon: Coins,
+		title: "Enter your token volumes",
+		description:
+			"Set the input and output tokens you expect to process, or start from a Light, Medium, Heavy, or Intensive preset and adjust from there.",
+	},
+	{
+		icon: Route,
+		title: "Compare and start saving",
+		description:
+			"Instantly see official provider pricing next to LLM Gateway's cheapest routed provider, plus the exact amount you would save each cycle.",
+	},
+];
+
+export function TokenCostCalculatorContent() {
+	return (
+		<>
+			{/* How it works */}
+			<section
+				className="border-t border-border bg-muted/30 py-20 sm:py-28"
+				aria-labelledby="how-it-works-heading"
+			>
+				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+					<div className="mx-auto max-w-3xl text-center">
+						<h2
+							id="how-it-works-heading"
+							className="text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+						>
+							How the LLM cost calculator works
+						</h2>
+						<p className="mt-4 text-lg text-muted-foreground text-balance leading-relaxed">
+							Estimate your monthly spend across any model in three steps, then
+							see how much routing through LLM Gateway saves you.
+						</p>
+					</div>
+
+					<ol className="mx-auto mt-14 grid max-w-5xl gap-6 sm:grid-cols-3">
+						{STEPS.map((step, index) => {
+							const Icon = step.icon;
+							return (
+								<li
+									key={step.title}
+									className="relative rounded-2xl border border-border bg-card/60 p-6"
+								>
+									<div className="flex items-center gap-3">
+										<div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/10 text-blue-500">
+											<Icon className="h-5 w-5" />
+										</div>
+										<span className="font-mono text-sm font-semibold text-muted-foreground">
+											Step {index + 1}
+										</span>
+									</div>
+									<h3 className="mt-4 text-lg font-semibold">{step.title}</h3>
+									<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+										{step.description}
+									</p>
+								</li>
+							);
+						})}
+					</ol>
+				</div>
+			</section>
+
+			{/* Explainer / keyword-rich content */}
+			<section className="py-20 sm:py-28" aria-labelledby="explainer-heading">
+				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+					<div className="mx-auto max-w-3xl">
+						<h2
+							id="explainer-heading"
+							className="text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+						>
+							Understanding LLM token costs
+						</h2>
+						<div className="mt-6 space-y-5 text-base leading-relaxed text-muted-foreground">
+							<p>
+								Every large language model bills by the token, the small chunks
+								of text a model reads and writes. Roughly speaking, one token is
+								about four characters of English, so 1,000 tokens is around 750
+								words. Providers quote prices per million tokens, and they
+								charge separately for the tokens you send (input) and the tokens
+								the model generates (output).
+							</p>
+							<p>
+								Output tokens are usually two to four times more expensive than
+								input tokens, so the ratio between your prompt size and response
+								size has a big impact on your bill. A summarization workload
+								that reads a lot and writes a little costs very differently from
+								a code-generation workload that writes long responses. The
+								calculator above keeps the two separate so your estimate
+								reflects how you actually use each model.
+							</p>
+							<p>
+								Prices also vary by provider. A single popular model is often
+								hosted by several providers at different rates, and those rates
+								change as providers compete on price. Instead of locking
+								yourself into one provider, LLM Gateway routes each request to
+								the cheapest available provider for that model through one
+								OpenAI-compatible API, with no platform markup. That is the gap
+								the calculator shows: the official list price versus the lowest
+								live price you would actually pay.
+							</p>
+							<p>
+								Use it to budget a new feature, compare GPT-4o against Claude or
+								Gemini before you commit, or build the business case for
+								switching providers. When the numbers look good, you can{" "}
+								<Link
+									href="/signup"
+									className="font-medium text-blue-600 underline-offset-4 hover:underline dark:text-blue-400"
+								>
+									start for free
+								</Link>{" "}
+								and keep the same estimate in production.
+							</p>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			{/* FAQ — rendered with native <details> so answers stay in the HTML */}
+			<section
+				className="border-t border-border bg-muted/30 py-20 sm:py-28"
+				aria-labelledby="faq-heading"
+			>
+				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+					<div className="mx-auto max-w-3xl">
+						<div className="text-center">
+							<h2
+								id="faq-heading"
+								className="text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+							>
+								Frequently asked questions
+							</h2>
+							<p className="mt-4 text-lg text-muted-foreground text-balance leading-relaxed">
+								Everything you need to know about estimating and lowering your
+								LLM token costs.
+							</p>
+						</div>
+
+						<div className="mt-12 space-y-3">
+							{CALCULATOR_FAQ.map((item) => (
+								<details
+									key={item.question}
+									className="group rounded-xl border border-border bg-card/60 px-5 [&_summary::-webkit-details-marker]:hidden"
+								>
+									<summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left text-base font-medium">
+										{item.question}
+										<ChevronDown className="h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
+									</summary>
+									<p className="pb-5 text-sm leading-relaxed text-muted-foreground">
+										{item.answer}
+									</p>
+								</details>
+							))}
+						</div>
+					</div>
+				</div>
+			</section>
+		</>
+	);
+}


### PR DESCRIPTION
## Summary

Four UI/marketing changes for `apps/ui` (plus a backend hook in `apps/api`):

### 1. Navbar: "Features" → "Products"
- Renamed the dropdown to **Products**, limited to **AI Gateway, DevPass, Chat Playground, Observability**.
- Moved **Integrations** and **Reliability** into **Resources**. **Guardrails** was also moved to Resources since it's no longer one of the four products (preserves the existing `/features/guardrails` link).
- Removed now-unused icon imports.

### 2. Enterprise page: Calendly after submit
- After a successful contact-form submission, the enterprise page now shows an inline **Calendly scheduler** (`https://calendly.com/llmgateway/llmgateway-enterprise`) prefilled with the submitter's name/email.
- Uses Calendly's official inline embed via `next/script` — **no new dependency** (avoids React 19 peer-dep friction with `react-calendly`).

### 3. Discord notifications
- Enterprise contact requests now also post to Discord (intended **#enterprise** channel) via a new `DISCORD_ENTERPRISE_NOTIFICATION_URL` webhook (`notifyEnterpriseContact`).
- Documented `DISCORD_SUPPORT_NOTIFICATION_URL` (chat support escalations, intended **#customer-support** channel) in `.env.example`. The chat-support channel switch is purely a config change — the code already reads this var; no code change was required.
- Both fall back to `DISCORD_NOTIFICATION_URL` when unset.

> ⚠️ **Action required (secrets):** The actual webhook URLs contain tokens and were **not** committed (this is a public repo). Set these in deployment secrets:
> - `DISCORD_SUPPORT_NOTIFICATION_URL` → the **#customer-support** webhook
> - `DISCORD_ENTERPRISE_NOTIFICATION_URL` → the **#enterprise** webhook

### 4. Token Cost Calculator redesign + SEO (target: #7 → #1)
**Design / conversion** (`token-cost-calculator-client.tsx`):
- Stronger hero with decorative backdrop and a trust strip (200+ models · zero markup · free).
- Anchoring + loss-aversion framing on results ("At official rates you're overpaying by …") with a CTA at the savings peak.

**SEO** — the page was a thin interactive widget with little crawlable text. Added:
- Server-rendered **How it works**, **Understanding LLM token costs** explainer, and an **FAQ** (native `<details>` so answers stay in the HTML).
- Three JSON-LD blocks: **BreadcrumbList**, **SoftwareApplication**, **FAQPage** (FAQ schema shares a single source of truth with the rendered FAQ).
- Per-page **canonical**, richer title/description/keywords/OG/Twitter metadata, and bumped sitemap priority (0.8 → 0.9, weekly).

## Testing
- `pnpm format` ✅ / `pnpm lint` ✅
- `pnpm turbo run build --filter=api --filter=ui` ✅ (13/13 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enterprise contact form now displays an embedded Calendly scheduling widget after successful submission, with name and email pre-filled.
  * Token cost calculator page now includes an FAQ accordion section and step-by-step "How it works" guide.

* **Improvements**
  * Token cost calculator messaging updated to emphasize the free offering.
  * Navigation menu: "Features" dropdown renamed to "Products" with refreshed content.
  * Enhanced SEO metadata and structured data for the token cost calculator page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->