### PR TITLE
fix(api): non-blocking enterprise Discord notify

### DIFF
--- a/apps/api/src/routes/public-contact.ts
+++ b/apps/api/src/routes/public-contact.ts
@@ -378,13 +378,21 @@ publicContact.openapi(submitEnterpriseContact, async (c) => {
 		});
 	}
 
-	await notifyEnterpriseContact({
+	// Fire-and-forget: don't block the response on the Discord webhook.
+	// notifyEnterpriseContact already logs its own failures; the extra catch
+	// guards against an unexpected rejection becoming an unhandled rejection.
+	void notifyEnterpriseContact({
 		name: validatedData.name,
 		email: validatedData.email,
 		country: validatedData.country,
 		size: validatedData.size,
 		message: validatedData.message,
 		ipAddress,
+	}).catch((err) => {
+		logger.error(
+			"Failed to send enterprise Discord notification",
+			err instanceof Error ? err : new Error(String(err)),
+		);
 	});
 
 	return c.json({ success: true, message: "Email sent successfully" }, 200);

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -4,9 +4,6 @@ const discordWebhookUrl = process.env.DISCORD_NOTIFICATION_URL;
 const discordSupportWebhookUrl =
 	process.env.DISCORD_SUPPORT_NOTIFICATION_URL ??
 	process.env.DISCORD_NOTIFICATION_URL;
-const discordEnterpriseWebhookUrl =
-	process.env.DISCORD_ENTERPRISE_NOTIFICATION_URL ??
-	process.env.DISCORD_NOTIFICATION_URL;
 
 interface DiscordEmbed {
 	title: string;
@@ -285,7 +282,8 @@ export async function notifyEnterpriseContact(args: {
 				},
 			],
 		},
-		discordEnterpriseWebhookUrl,
+		process.env.DISCORD_ENTERPRISE_NOTIFICATION_URL ??
+			process.env.DISCORD_NOTIFICATION_URL,
 	);
 }
 


### PR DESCRIPTION
Follow-up to #2408 addressing two review findings. Both verified still valid against current `main`.

### 1. Don't block the HTTP response on the Discord webhook
`apps/api/src/routes/public-contact.ts` awaited `notifyEnterpriseContact(...)` before returning, so the enterprise contact request waited on an external Discord call before responding. Now it's fire-and-forget (`void … .catch(log)`) dispatched after core delivery is confirmed, so request latency no longer depends on Discord. `notifyEnterpriseContact` already logs its own failures; the added `.catch` guards against an unhandled rejection.

### 2. Resolve the enterprise webhook env at call time
`apps/api/src/utils/discord.ts` cached `DISCORD_ENTERPRISE_NOTIFICATION_URL` in a module-scope const. Removed it and resolve `process.env.DISCORD_ENTERPRISE_NOTIFICATION_URL ?? process.env.DISCORD_NOTIFICATION_URL` inside `notifyEnterpriseContact` instead — no module-load env read.

**Note:** left the pre-existing `discordSupportWebhookUrl` / `discordWebhookUrl` module-scope reads untouched to keep this change minimal and scoped to the findings.

## Testing
- `pnpm turbo run build --filter=api` ✅ (lint-staged eslint/prettier ran clean on commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for enterprise contact notifications to prevent form submission response delays.

* **Performance**
  * Optimized Discord notification delivery for enterprise contacts to process asynchronously, ensuring faster form submission responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->