### PR TITLE
fix(ui): calendly height + prominent share bar

### DIFF
--- a/apps/ui/src/components/enterprise/calendly-inline.tsx
+++ b/apps/ui/src/components/enterprise/calendly-inline.tsx
@@ -27,18 +27,35 @@ export function CalendlyInline({
 	email?: string;
 }) {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const initializedRef = useRef(false);
 	const [scriptLoaded, setScriptLoaded] = useState(
 		typeof window !== "undefined" && Boolean(window.Calendly),
 	);
 
 	useEffect(() => {
 		const container = containerRef.current;
-		if (!scriptLoaded || !container || !window.Calendly) {
+		if (
+			!scriptLoaded ||
+			!container ||
+			!window.Calendly ||
+			initializedRef.current
+		) {
 			return;
 		}
-		container.innerHTML = "";
+		// Init exactly once per mount; re-initializing into the same node leaves
+		// Calendly stuck on its loading spinner.
+		initializedRef.current = true;
+
+		const widgetUrl = new URL(url);
+		widgetUrl.searchParams.set("hide_gdpr_banner", "1");
+		widgetUrl.searchParams.set("primary_color", "2563eb");
+		if (document.documentElement.classList.contains("dark")) {
+			widgetUrl.searchParams.set("background_color", "0a0a0a");
+			widgetUrl.searchParams.set("text_color", "e4e4e7");
+		}
+
 		window.Calendly.initInlineWidget({
-			url,
+			url: widgetUrl.toString(),
 			parentElement: container,
 			prefill: { name, email },
 		});
@@ -55,10 +72,23 @@ export function CalendlyInline({
 				strategy="afterInteractive"
 				onLoad={() => setScriptLoaded(true)}
 			/>
+			{/* Calendly injects an iframe with height:100%, so the parent needs an
+			    explicit (not just min) height for it to render at full size. */}
 			<div
 				ref={containerRef}
-				className="min-h-[700px] w-full overflow-hidden rounded-xl"
+				className="h-[1040px] w-full overflow-hidden rounded-xl border border-border bg-card sm:h-[720px]"
 			/>
+			<p className="mt-3 text-center text-sm text-muted-foreground">
+				Prefer a new tab?{" "}
+				<a
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="font-medium text-blue-600 underline-offset-4 hover:underline dark:text-blue-400"
+				>
+					Open the scheduler
+				</a>
+			</p>
 		</>
 	);
 }

--- a/apps/ui/src/components/token-cost-calculator/token-cost-calculator-client.tsx
+++ b/apps/ui/src/components/token-cost-calculator/token-cost-calculator-client.tsx
@@ -16,12 +16,6 @@ import { useCallback, useMemo, useState } from "react";
 import { ModelSelector } from "@/components/models/playground-model-selector";
 import { Button } from "@/lib/components/button";
 import { Card } from "@/lib/components/card";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/lib/components/dropdown-menu";
 import { Input } from "@/lib/components/input";
 import { XIcon } from "@/lib/icons/XIcon";
 
@@ -742,42 +736,54 @@ function ResultsPanel({
 				</Card>
 			</div>
 
-			{/* Share button */}
-			<div className="flex justify-end">
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button variant="outline" size="sm" className="gap-2">
-							<Share2 className="h-4 w-4" />
-							Share Results
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
-						<DropdownMenuItem onClick={handleCopy} className="cursor-pointer">
-							{copied ? (
-								<Check className="h-4 w-4 mr-2 text-green-500" />
-							) : (
-								<Copy className="h-4 w-4 mr-2" />
-							)}
-							{copied ? "Copied!" : "Copy to clipboard"}
-						</DropdownMenuItem>
-						<DropdownMenuItem asChild className="cursor-pointer">
-							<a href={xShareUrl} target="_blank" rel="noopener noreferrer">
-								<XIcon className="h-4 w-4 mr-2" />
-								Share on X
-							</a>
-						</DropdownMenuItem>
-						<DropdownMenuItem asChild className="cursor-pointer">
-							<a
-								href={linkedinShareUrl}
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								<Linkedin className="h-4 w-4 mr-2" />
-								Share on LinkedIn
-							</a>
-						</DropdownMenuItem>
-					</DropdownMenuContent>
-				</DropdownMenu>
+			{/* Share bar */}
+			<div className="flex flex-col gap-4 rounded-xl border border-blue-500/30 bg-gradient-to-br from-blue-500/10 to-blue-600/5 p-5 sm:flex-row sm:items-center sm:justify-between">
+				<div className="flex items-start gap-3">
+					<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500/15 text-blue-600 dark:text-blue-400">
+						<Share2 className="h-4 w-4" />
+					</div>
+					<div>
+						<p className="text-sm font-semibold">
+							{savings > 0
+								? `Share your ${savingsPercent}% savings`
+								: "Share these results"}
+						</p>
+						<p className="text-xs text-muted-foreground">
+							Send this breakdown to your team or post it in one click.
+						</p>
+					</div>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						onClick={handleCopy}
+						variant={copied ? "outline" : "default"}
+						size="sm"
+						className="gap-2"
+					>
+						{copied ? (
+							<Check className="h-4 w-4 text-green-500" />
+						) : (
+							<Copy className="h-4 w-4" />
+						)}
+						{copied ? "Copied!" : "Copy link"}
+					</Button>
+					<Button variant="outline" size="sm" className="gap-2" asChild>
+						<a href={xShareUrl} target="_blank" rel="noopener noreferrer">
+							<XIcon className="h-4 w-4" />
+							Post on X
+						</a>
+					</Button>
+					<Button variant="outline" size="sm" className="gap-2" asChild>
+						<a
+							href={linkedinShareUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<Linkedin className="h-4 w-4" />
+							LinkedIn
+						</a>
+					</Button>
+				</div>
 			</div>
 
 			{/* Breakdown table */}


### PR DESCRIPTION
Branched off latest `main`. Two `apps/ui` fixes.

### 1. Enterprise Calendly widget rendered as a sliver / loaded forever
The inline embed container had only `min-h-[700px]`. Calendly injects an iframe with `height:100%`, and a percentage height needs a **definite** parent height, so it collapsed to a thin strip with a perpetual loading spinner below it (per the reported screenshot).

Fixes in `calendly-inline.tsx`:
- Explicit responsive height on the container (`h-[1040px]` mobile / `sm:h-[720px]`) so the iframe fills it.
- Guard against double-initialization (re-initializing into the same node leaves Calendly stuck on its spinner).
- Theme the widget for dark mode (`background_color` / `text_color`) and `hide_gdpr_banner`, so the white panel no longer clashes with the dark page.
- Added an "Open the scheduler in a new tab" fallback link.

### 2. Token cost calculator share button was easy to miss
Replaced the small, right-aligned **"Share Results"** dropdown with a prominent share bar.

- **frontend-design:** branded blue gradient panel, icon badge, clear hierarchy — it now reads as a deliberate moment, not an afterthought.
- **marketing psychology:** IKEA effect + social proof (the visitor built the comparison, so the CTA frames it as *"Share your X% savings"* — a flex worth posting), and EAST / Hick's Law (Copy, X, and LinkedIn are now one-click visible actions instead of buried in a dropdown), lowering friction to drive organic/referral sharing.

## Testing
- `pnpm format` ✅
- `pnpm turbo run build --filter=ui` ✅ (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced social sharing with direct copy link, X, and LinkedIn buttons in the token cost calculator.
  * Improved Calendly widget with dark mode support and direct scheduler link in text prompt.

* **Style**
  * Updated Calendly container with improved border and background styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->