### PR TITLE
feat(gateway): block non-inference for dev plans

### DIFF
--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -16,7 +16,7 @@ export default function TermsPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> May 13, 2026
+				<strong>Last Updated:</strong> May 26, 2026
 			</p>
 			<p>
 				Welcome to <strong>DevPass</strong>, a service operated by{" "}
@@ -41,14 +41,29 @@ export default function TermsPage() {
 			<ul>
 				<li>
 					Route AI requests to providers such as Anthropic, OpenAI, Google,
-					Mistral, DeepSeek, and others through coding tools like Claude Code,
-					Cursor, Cline, OpenCode, Codex, and Autohand
+					Mistral, DeepSeek, and others through approved coding and agent tools
+					like Claude Code, Codex, Cursor, Cline, OpenCode, OpenClaw, Hermes,
+					and Autohand
 				</li>
 				<li>
 					Track usage, costs, and per-agent activity in your DevPass dashboard
 				</li>
 				<li>Manage a single API key shared across every supported tool</li>
 			</ul>
+			<p>
+				DevPass is licensed solely for interactive use through approved coding
+				and agent tools. It is <strong>not</strong> a general-purpose API: you
+				may not use your DevPass API key to power your own applications,
+				products, services, backends, scripts, batch jobs, or any other direct
+				API integration. The flat-rate pricing assumes interactive,
+				human-in-the-loop usage from a whitelisted tool — any other usage breaks
+				the economics of the Service and is prohibited under Section&nbsp;7.
+				Embeddings, image generation, and video generation are not included in
+				DevPass and are blocked at the gateway. If you need API access for an
+				application or for non-inference workloads (such as embeddings, image
+				generation, or video generation), use a standard LLM Gateway credits
+				plan instead.
+			</p>
 			<hr />
 			<h2>2. Eligibility</h2>
 			<p>You must:</p>
@@ -208,6 +223,21 @@ export default function TermsPage() {
 				<li>
 					Open multiple DevPass accounts or otherwise abuse the included usage
 					allowance as described in Section&nbsp;5
+				</li>
+				<li>
+					Use your DevPass API key directly from your own applications,
+					backends, products, services, scripts, batch pipelines, or any other
+					integration outside of an approved coding or agent tool. DevPass is
+					only usable from whitelisted clients such as Claude Code, Codex,
+					Cursor, Cline, OpenCode, OpenClaw, Hermes, and Autohand. The list of
+					approved tools is maintained at our discretion and may change over
+					time
+				</li>
+				<li>
+					Use DevPass for non-inference workloads — embeddings, image
+					generation, and video generation are not included and are blocked at
+					the gateway. Use a standard LLM Gateway credits plan for those use
+					cases
 				</li>
 				<li>Probe, scan, or attack the platform or any connected provider</li>
 			</ul>

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -32,6 +32,72 @@ describe("api", () => {
 		expect(data.health).toHaveProperty("database");
 	});
 
+	test("/v1/chat/completions rejects image-output models for dev-plan orgs even with allowAllModels", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// Pro dev plan with allow-all-models on — the legacy coding-model
+		// restriction does NOT apply, so the only thing blocking image
+		// generation is the new image-output guard.
+		await harness.setDevPlan({ devPlan: "pro", allowAllModels: true });
+
+		// gemini-2.5-flash-image declares output: ["text", "image"] but
+		// has no imageGenerations: true mapping — exactly the case the
+		// guard needs to catch.
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "gemini-2.5-flash-image",
+				messages: [{ role: "user", content: "Draw a cat" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Image generation is not available for coding plans",
+		);
+	});
+
+	test("/v1/images/generations is blocked for dev-plan orgs via the chat-completions guard", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await harness.setDevPlan({ devPlan: "pro", allowAllModels: true });
+
+		const res = await app.request("/v1/images/generations", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "gemini-2.5-flash-image",
+				prompt: "A watercolor of a city skyline",
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Image generation is not available for coding plans",
+		);
+	});
+
 	test("/v1/chat/completions e2e success", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1622,6 +1622,21 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// Dev plans are inference-only — image generation is never allowed,
+	// regardless of devPlanAllowAllModels. Embeddings and video generation
+	// are blocked at their respective endpoints.
+	const isDevPlan = Boolean(
+		organization?.isPersonal && organization.devPlan !== "none",
+	);
+	if (
+		isDevPlan &&
+		modelInfo.providers.some((p) => p.imageGenerations === true)
+	) {
+		throw new HTTPException(403, {
+			message: `Image generation is not available for coding plans. Coding plans only include text-based inference.`,
+		});
+	}
+
 	// Coding plans only allow models/provider mappings with cached input pricing.
 	// The model-level check denies models with no cached mapping at all.
 	// The specific-provider check denies a request like `groq/gpt-oss-120b` where the

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1624,14 +1624,17 @@ chat.openapi(completions, async (c) => {
 
 	// Dev plans are inference-only — image generation is never allowed,
 	// regardless of devPlanAllowAllModels. Embeddings and video generation
-	// are blocked at their respective endpoints.
+	// are blocked at their respective endpoints. We check the model's
+	// declared output formats (and the legacy imageGenerations provider
+	// flag) so chat-completions models that emit images — e.g. Gemini
+	// *-flash-image with output: ["text", "image"] — are also blocked.
 	const isDevPlan = Boolean(
 		organization?.isPersonal && organization.devPlan !== "none",
 	);
-	if (
-		isDevPlan &&
-		modelInfo.providers.some((p) => p.imageGenerations === true)
-	) {
+	const modelEmitsImages =
+		modelInfo.output?.includes("image") === true ||
+		modelInfo.providers.some((p) => p.imageGenerations === true);
+	if (isDevPlan && modelEmitsImages) {
 		throw new HTTPException(403, {
 			message: `Image generation is not available for coding plans. Coding plans only include text-based inference.`,
 		});

--- a/apps/gateway/src/embeddings/embeddings.spec.ts
+++ b/apps/gateway/src/embeddings/embeddings.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
+
+import { db, tables } from "@llmgateway/db";
+
+describe("embeddings", () => {
+	const harness = createGatewayApiTestHarness();
+
+	test("/v1/embeddings rejects dev-plan personal orgs with 403", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await harness.setDevPlan({ devPlan: "pro", allowAllModels: true });
+
+		const res = await app.request("/v1/embeddings", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "text-embedding-3-small",
+				input: "The food was delicious",
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Embeddings are not available for coding plans",
+		);
+	});
+});

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -529,6 +529,13 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		});
 	}
 
+	if (organization.isPersonal && organization.devPlan !== "none") {
+		throw new HTTPException(403, {
+			message:
+				"Embeddings are not available for coding plans. Coding plans only include text-based inference.",
+		});
+	}
+
 	const retentionLevel = organization.retentionLevel ?? "none";
 	const iamValidation = await validateModelAccess(
 		apiKey.id,

--- a/apps/gateway/src/test-utils/gateway-api-test-harness.ts
+++ b/apps/gateway/src/test-utils/gateway-api-test-harness.ts
@@ -173,6 +173,23 @@ export function createGatewayApiTestHarness() {
 				.set({ credits })
 				.where(eq(tables.organization.id, TEST_ORGANIZATION_ID));
 		},
+		async setDevPlan(options: {
+			devPlan: "lite" | "pro" | "max";
+			allowAllModels?: boolean;
+			creditsUsed?: string;
+			creditsLimit?: string;
+		}) {
+			await db
+				.update(tables.organization)
+				.set({
+					isPersonal: true,
+					devPlan: options.devPlan,
+					devPlanAllowAllModels: options.allowAllModels ?? false,
+					devPlanCreditsUsed: options.creditsUsed ?? "0",
+					devPlanCreditsLimit: options.creditsLimit ?? "100",
+				})
+				.where(eq(tables.organization.id, TEST_ORGANIZATION_ID));
+		},
 		async setRoutingMetrics(
 			modelId: string,
 			providerId: string,

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -85,6 +85,49 @@ describe("videos", () => {
 		expect(JSON.stringify(json)).toContain("fixed 8s clips");
 	});
 
+	test("/v1/videos rejects dev-plan personal orgs with 403", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await harness.setDevPlan({ devPlan: "pro", allowAllModels: true });
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "veo-3.1-generate-preview",
+				prompt: "A neon city at night",
+				size: "1920x1080",
+				seconds: 8,
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Video generation is not available for coding plans",
+		);
+
+		// Existing video status/content endpoints must still be reachable.
+		// We don't have a job, but the endpoint should reach the project lookup
+		// (which is independent of devPlan) and return 404 rather than 403.
+		const statusRes = await app.request("/v1/videos/nonexistent", {
+			method: "GET",
+			headers: {
+				Authorization: "Bearer real-token",
+			},
+		});
+		expect(statusRes.status).toBe(404);
+	});
+
 	test("/v1/videos explains avalanche reference-image constraints clearly", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -3163,6 +3163,14 @@ videos.openapi(createVideo, async (c) => {
 	const { rawBody, request } = await parseJsonBody(c);
 	const { apiKey, project, organization, requestId } =
 		await requireRequestContext(c);
+
+	if (organization.isPersonal && organization.devPlan !== "none") {
+		throw new HTTPException(403, {
+			message:
+				"Video generation is not available for coding plans. Coding plans only include text-based inference.",
+		});
+	}
+
 	const { normalizedModel, requestedProvider } = getVideoModel(request.model);
 	const firstFrameInput = getVideoFirstFrameInput(request);
 	const lastFrameInput = getVideoLastFrameInput(request);


### PR DESCRIPTION
## Summary
- Coding (devpass) plans are inference-only: block image generation, embeddings, and video generation.
- Image generation block runs regardless of `devPlanAllowAllModels` (which previously would have allowed image-gen models through).
- Embeddings and video creation endpoints reject devpass orgs up front with a 403.

## Test plan
- [ ] Devpass org calling `/v1/embeddings` returns 403.
- [ ] Devpass org calling `/v1/videos` (create) returns 403; existing video status/content endpoints still work.
- [ ] Devpass org calling `/v1/chat/completions` with an image-generation model (e.g. `gemini-2.5-flash-image`) returns 403 even when `devPlanAllowAllModels = true`.
- [ ] Devpass org can still use regular text-inference models (subject to the existing coding-model restriction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image generation blocked for personal coding plans (including chat models that can emit images)
  * Embeddings blocked for personal coding plans
  * Video generation blocked for personal coding plans

* **Documentation**
  * Terms updated (effective May 26, 2026): clarified DevPass licensing for approved interactive tools; non-inference workloads (embeddings, images, video) disallowed for coding plans; guidance to use credits plans

* **Tests**
  * Added integration tests and test-harness support covering dev-plan restrictions for chat/images/embeddings/videos

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->