### PR TITLE
feat(gateway): restrict devpass to root model routing

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1643,19 +1643,15 @@ chat.openapi(completions, async (c) => {
 			requestedProvider !== "llmgateway" &&
 			requestedProvider !== "custom"
 		) {
-			const requestedProviderMappings = modelInfo.providers.filter(
-				(p) =>
-					p.providerId === requestedProvider &&
-					(requestedRegion === undefined || p.region === requestedRegion),
-			);
-			if (
-				requestedProviderMappings.length > 0 &&
-				!requestedProviderMappings.some(providerSupportsCachedInput)
-			) {
-				throw new HTTPException(403, {
-					message: `Provider ${requestedProvider} does not offer cached input pricing for model ${modelInfo.id}. Coding plans require providers with prompt caching support; choose another provider or enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
-				});
-			}
+			throw new HTTPException(403, {
+				message: `Direct provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+			});
+		}
+
+		if (requestedProvider === "custom") {
+			throw new HTTPException(403, {
+				message: `Custom provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+			});
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Coding plan users on personal orgs can no longer request a specific `provider/model` mapping; only root model ids are accepted, and gateway routing decides the provider.
- Custom provider prefixes are likewise rejected for devpass requests so users cannot bypass routing via a configured custom provider.
- Non-devpass users keep the existing behavior (direct provider mappings, custom providers, region pinning all still work).

## Test plan
- [ ] Devpass org: `POST /v1/chat/completions` with `model: "openai/gpt-5"` returns 403 explaining to use the root model id.
- [ ] Devpass org: `POST /v1/chat/completions` with `model: "mycustom/gpt-5"` (custom provider) returns 403 with the same guidance.
- [ ] Devpass org: `POST /v1/chat/completions` with `model: "gpt-5"` (root id) and `model: "auto"` continue to route normally through the gateway.
- [ ] Non-devpass org: `provider/model`, `provider/model:region`, and custom providers continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway enforces stricter validation for routing requests: direct provider routing and custom provider routing are now rejected with explicit error responses (use root model IDs so the gateway can route).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->