### PR TITLE
fix(code): point integration guide links to ui domain

### DIFF
--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -444,7 +444,7 @@ export default function DashboardClient() {
 						)}
 
 						{/* Integrations */}
-						<DashboardIntegrations />
+						<DashboardIntegrations uiUrl={config.uiUrl} />
 
 						{/* Models */}
 						<div>

--- a/apps/code/src/app/dashboard/components/DashboardIntegrations.tsx
+++ b/apps/code/src/app/dashboard/components/DashboardIntegrations.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ArrowRight, ArrowUpRight } from "lucide-react";
-import Link from "next/link";
 
 import {
 	AnthropicIcon,
@@ -16,61 +15,67 @@ type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
 interface Integration {
 	name: string;
+	path: string;
 	description: string;
-	href: string;
 	icon: IconComponent;
-	external: boolean;
+	external?: string;
 }
 
 const integrations: Integration[] = [
 	{
 		name: "OpenCode",
 		description: "AI dev workflows",
-		href: "/guides/opencode",
+		path: "/guides/opencode",
 		icon: OpenCodeIcon,
-		external: false,
 	},
 	{
 		name: "Claude Code",
 		description: "Terminal AI assistant",
-		href: "/guides/claude-code",
+		path: "/guides/claude-code",
 		icon: AnthropicIcon,
-		external: false,
 	},
 	{
 		name: "SoulForge",
 		description: "Soul AI coding agent",
-		href: "https://soulforge.proxysoul.com/",
+		path: "",
+		external: "https://soulforge.proxysoul.com/",
 		icon: SoulForgeIcon,
-		external: true,
 	},
 	{
 		name: "Kilo Code",
 		description: "VS Code autonomous agent",
-		href: "/guides/kilo-code",
+		path: "/guides/kilo-code",
 		icon: KiloCodeIcon,
-		external: false,
 	},
 ];
 
-export default function DashboardIntegrations() {
+export default function DashboardIntegrations({ uiUrl }: { uiUrl: string }) {
 	return (
 		<div>
 			<div className="mb-4 flex items-end justify-between gap-3">
 				<h2 className="font-semibold tracking-tight">Integrations</h2>
-				<Link
-					href="/guides"
+				<a
+					href={`${uiUrl}/guides`}
+					target="_blank"
+					rel="noopener noreferrer"
 					className="group inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
 				>
 					See more guides
 					<ArrowRight className="h-3 w-3 transition-transform duration-300 group-hover:translate-x-0.5" />
-				</Link>
+				</a>
 			</div>
 			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
 				{integrations.map((integration) => {
 					const Icon = integration.icon;
-					const content = (
-						<>
+					const href = integration.external ?? `${uiUrl}${integration.path}`;
+					return (
+						<a
+							key={integration.name}
+							href={href}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="group relative flex items-center gap-3 overflow-hidden rounded-xl border border-border/50 bg-card p-4 transition-all duration-500 ease-out hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-[0_8px_30px_-12px_rgba(0,0,0,0.12)] dark:hover:shadow-[0_8px_30px_-12px_rgba(255,255,255,0.06)]"
+						>
 							<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-gradient-to-br from-muted/40 to-muted/10 transition-all duration-500 group-hover:border-foreground/20 group-hover:from-muted/60">
 								<Icon className="h-4.5 w-4.5" />
 							</div>
@@ -85,28 +90,7 @@ export default function DashboardIntegrations() {
 									{integration.description}
 								</p>
 							</div>
-						</>
-					);
-					const className =
-						"group relative flex items-center gap-3 overflow-hidden rounded-xl border border-border/50 bg-card p-4 transition-all duration-500 ease-out hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-[0_8px_30px_-12px_rgba(0,0,0,0.12)] dark:hover:shadow-[0_8px_30px_-12px_rgba(255,255,255,0.06)]";
-					return integration.external ? (
-						<a
-							key={integration.name}
-							href={integration.href}
-							target="_blank"
-							rel="noopener noreferrer"
-							className={className}
-						>
-							{content}
 						</a>
-					) : (
-						<Link
-							key={integration.name}
-							href={integration.href as never}
-							className={className}
-						>
-							{content}
-						</Link>
 					);
 				})}
 			</div>


### PR DESCRIPTION
## Summary
- Dashboard Integrations cards (OpenCode, Claude Code, SoulForge, Kilo Code) and the "See more guides" link rendered on `devpass.llmgateway.io/dashboard` were resolving against the devpass subdomain and 404'ing — the guides live on the main UI (`llmgateway.io`).
- Pass `config.uiUrl` through to `DashboardIntegrations` and prefix the internal guide links with it so they target the correct host.

## Test plan
- [ ] Visit `/dashboard` and confirm the four integration cards and "See more guides" link open `llmgateway.io/guides/...` in a new tab
- [ ] SoulForge card still opens its external URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated integrations section to use centralized URL configuration for improved link management and navigation consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->