### PR TITLE
chore(models): deactivate gemini lite vertex preview

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -495,6 +495,7 @@ export const googleModels = [
 			},
 			{
 				providerId: "google-vertex",
+				deactivatedAt: new Date("2026-07-09"),
 				modelName: "gemini-2.5-flash-lite-preview-09-2025",
 				inputPrice: "0.1e-6",
 				outputPrice: "0.4e-6",


### PR DESCRIPTION
## Summary
- Google announced discontinuation of `gemini-2.5-flash-lite-preview-09-2025` on **2026-07-09**.
- The `google-ai-studio` mapping already had `deactivatedAt: 2026-03-31`; the `google-vertex` mapping had no date. Added `deactivatedAt: new Date("2026-07-09")` to match.
- The other three models in Google's notice (`gemini-2.5-flash-preview-05-20`, `gemini-2.5-flash-preview-09-2025`, `gemini-3.1-flash-lite-preview`) already have `deactivatedAt` dates in the past — no change needed.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gemini 2.5 Flash Lite preview model configuration to reflect a scheduled deactivation date of July 9, 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->