### PR TITLE
feat(admin): layer processed/revenue/net in chart

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -819,7 +819,7 @@ admin.openapi(getTimeseries, async (c) => {
 		.groupBy(sql`DATE(${tables.user.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.user.createdAt})`));
 
-	// Revenue per day (creditAmount, post-fees; excludes gifts, refunds, devpass)
+	// Revenue per day (creditAmount, post-fees; matches /admin/metrics totalRevenue)
 	const revenuePerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
@@ -833,15 +833,15 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "credit_refund"),
 				notDevpassFilter,
 				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
 
-	// Processed per day (gross Stripe amount)
+	// Processed per day (gross Stripe amount; matches /admin/metrics totalProcessed)
 	const processedPerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
@@ -855,9 +855,9 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "credit_refund"),
 				notDevpassFilter,
 				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
@@ -878,6 +878,7 @@ admin.openapi(getTimeseries, async (c) => {
 				eq(tables.transaction.status, "completed"),
 				eq(tables.transaction.type, "credit_refund"),
 				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
@@ -896,7 +897,6 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "credit_refund"),
 				notDevpassFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),
@@ -915,7 +915,6 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "credit_refund"),
 				notDevpassFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7,6 +7,7 @@ import { deleteResendContact } from "@/auth/config.js";
 import { maskToken } from "@/lib/maskToken.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
+import { notDevpassFilter } from "@/utils/devpass-filter.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
@@ -579,30 +580,6 @@ admin.openapi(getMetrics, async (c) => {
 
 	const payingCustomers = Number(payingRow?.count ?? 0);
 
-	// DevPass-related transaction types: exclude these from credit-purchase
-	// metrics (revenue/processed/topped-up) because DevPass revenue lives in
-	// its own dashboard, and DevPass-granted credits are virtual (capped per
-	// cycle) rather than real top-up balance.
-	const devpassExcludedTypes = [
-		"dev_plan_start",
-		"dev_plan_upgrade",
-		"dev_plan_downgrade",
-		"dev_plan_renewal",
-		"dev_plan_cancel",
-		"dev_plan_end",
-		"subscription_start",
-		"subscription_cancel",
-		"subscription_end",
-		"subscription_upgrade",
-		"subscription_downgrade",
-		"subscription_renewal",
-	] as const;
-
-	const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
-		devpassExcludedTypes.map((t) => sql`${t}`),
-		sql`, `,
-	)})`;
-
 	// Total revenue (completed credit-purchase transactions, excluding gifts
 	// and all DevPass subscription rows, using creditAmount to exclude Stripe fees)
 	const [revenueRow] = await db
@@ -841,26 +818,6 @@ admin.openapi(getTimeseries, async (c) => {
 		.where(gte(tables.user.createdAt, startDate))
 		.groupBy(sql`DATE(${tables.user.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.user.createdAt})`));
-
-	const devpassExcludedTypes = [
-		"dev_plan_start",
-		"dev_plan_upgrade",
-		"dev_plan_downgrade",
-		"dev_plan_renewal",
-		"dev_plan_cancel",
-		"dev_plan_end",
-		"subscription_start",
-		"subscription_cancel",
-		"subscription_end",
-		"subscription_upgrade",
-		"subscription_downgrade",
-		"subscription_renewal",
-	] as const;
-
-	const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
-		devpassExcludedTypes.map((t) => sql`${t}`),
-		sql`, `,
-	)})`;
 
 	// Revenue per day (creditAmount, post-fees; excludes gifts, refunds, devpass)
 	const revenuePerDay = await db

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -82,6 +82,9 @@ const timeseriesDataPointSchema = z.object({
 	signups: z.number(),
 	paidCustomers: z.number(),
 	revenue: z.number(),
+	processed: z.number(),
+	refunds: z.number(),
+	net: z.number(),
 });
 
 const adminTimeseriesSchema = z.object({
@@ -91,6 +94,9 @@ const adminTimeseriesSchema = z.object({
 		signups: z.number(),
 		paidCustomers: z.number(),
 		revenue: z.number(),
+		processed: z.number(),
+		refunds: z.number(),
+		net: z.number(),
 	}),
 });
 
@@ -836,7 +842,27 @@ admin.openapi(getTimeseries, async (c) => {
 		.groupBy(sql`DATE(${tables.user.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.user.createdAt})`));
 
-	// Revenue per day (completed transactions, excluding gifts, using creditAmount)
+	const devpassExcludedTypes = [
+		"dev_plan_start",
+		"dev_plan_upgrade",
+		"dev_plan_downgrade",
+		"dev_plan_renewal",
+		"dev_plan_cancel",
+		"dev_plan_end",
+		"subscription_start",
+		"subscription_cancel",
+		"subscription_end",
+		"subscription_upgrade",
+		"subscription_downgrade",
+		"subscription_renewal",
+	] as const;
+
+	const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
+		devpassExcludedTypes.map((t) => sql`${t}`),
+		sql`, `,
+	)})`;
+
+	// Revenue per day (creditAmount, post-fees; excludes gifts, refunds, devpass)
 	const revenuePerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
@@ -850,13 +876,57 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "credit_refund"),
+				notDevpassFilter,
 				gte(tables.transaction.createdAt, startDate),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
 
-	// Revenue earned before the range (for cumulative chart, excluding gifts, using creditAmount)
+	// Processed per day (gross Stripe amount)
+	const processedPerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "credit_refund"),
+				notDevpassFilter,
+				gte(tables.transaction.createdAt, startDate),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
+	// Refunds per day (positive amount on credit_refund rows)
+	const refundsPerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.transaction.type, "credit_refund"),
+				gte(tables.transaction.createdAt, startDate),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
+	// Pre-range totals for cumulative chart
 	const [preRangeRevenueRow] = await db
 		.select({
 			total:
@@ -869,10 +939,48 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "credit_refund"),
+				notDevpassFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),
 		);
 	const preRangeRevenue = Number(preRangeRevenueRow?.total ?? 0);
+
+	const [preRangeProcessedRow] = await db
+		.select({
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "credit_refund"),
+				notDevpassFilter,
+				sql`${tables.transaction.createdAt} < ${startDate}`,
+			),
+		);
+	const preRangeProcessed = Number(preRangeProcessedRow?.total ?? 0);
+
+	const [preRangeRefundsRow] = await db
+		.select({
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.transaction.type, "credit_refund"),
+				sql`${tables.transaction.createdAt} < ${startDate}`,
+			),
+		);
+	const preRangeRefunds = Number(preRangeRefundsRow?.total ?? 0);
 
 	// Count of orgs that became paying before the range (bounded SQL query)
 	const [preRangeRow] = await db
@@ -930,6 +1038,16 @@ admin.openapi(getTimeseries, async (c) => {
 		revenueMap.set(row.date, Number(row.total));
 	}
 
+	const processedMap = new Map<string, number>();
+	for (const row of processedPerDay) {
+		processedMap.set(row.date, Number(row.total));
+	}
+
+	const refundsMap = new Map<string, number>();
+	for (const row of refundsPerDay) {
+		refundsMap.set(row.date, Number(row.total));
+	}
+
 	const newPaidMap = new Map<string, number>();
 	for (const row of firstTransactionPerOrg) {
 		newPaidMap.set(row.date, Number(row.count));
@@ -941,10 +1059,15 @@ admin.openapi(getTimeseries, async (c) => {
 		signups: number;
 		paidCustomers: number;
 		revenue: number;
+		processed: number;
+		refunds: number;
+		net: number;
 	}> = [];
 	let cumulativePaid = preRangeCount;
 	let totalSignups = 0;
 	let totalRevenue = preRangeRevenue;
+	let totalProcessed = preRangeProcessed;
+	let totalRefunds = preRangeRefunds;
 
 	const totalDays = Math.ceil(
 		(endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000),
@@ -955,16 +1078,23 @@ admin.openapi(getTimeseries, async (c) => {
 		const dateStr = current.toISOString().split("T")[0];
 		const dailySignups = signupsMap.get(dateStr) ?? 0;
 		const dailyRevenue = revenueMap.get(dateStr) ?? 0;
+		const dailyProcessed = processedMap.get(dateStr) ?? 0;
+		const dailyRefunds = refundsMap.get(dateStr) ?? 0;
 		cumulativePaid += newPaidMap.get(dateStr) ?? 0;
 
 		totalSignups += dailySignups;
 		totalRevenue += dailyRevenue;
+		totalProcessed += dailyProcessed;
+		totalRefunds += dailyRefunds;
 
 		data.push({
 			date: dateStr,
 			signups: totalSignups,
 			paidCustomers: cumulativePaid,
 			revenue: totalRevenue,
+			processed: totalProcessed,
+			refunds: totalRefunds,
+			net: totalRevenue - totalRefunds,
 		});
 	}
 
@@ -975,6 +1105,9 @@ admin.openapi(getTimeseries, async (c) => {
 			signups: totalSignups,
 			paidCustomers: cumulativePaid,
 			revenue: totalRevenue,
+			processed: totalProcessed,
+			refunds: totalRefunds,
+			net: totalRevenue - totalRefunds,
 		},
 	});
 });

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -1,0 +1,21 @@
+import { sql, tables } from "@llmgateway/db";
+
+export const devpassExcludedTypes = [
+	"dev_plan_start",
+	"dev_plan_upgrade",
+	"dev_plan_downgrade",
+	"dev_plan_renewal",
+	"dev_plan_cancel",
+	"dev_plan_end",
+	"subscription_start",
+	"subscription_cancel",
+	"subscription_end",
+	"subscription_upgrade",
+	"subscription_downgrade",
+	"subscription_renewal",
+] as const;
+
+export const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
+	devpassExcludedTypes.map((t) => sql`${t}`),
+	sql`, `,
+)})`;

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2344,11 +2344,17 @@ export interface paths {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             }[];
                             totals: {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             };
                         };
                     };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2344,11 +2344,17 @@ export interface paths {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             }[];
                             totals: {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             };
                         };
                     };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2344,11 +2344,17 @@ export interface paths {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             }[];
                             totals: {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             };
                         };
                     };

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -261,7 +261,7 @@ export default async function Page({
 					/>
 					<RevenueChart
 						data={timeseries.data}
-						totalRevenue={timeseries.totals.revenue}
+						totalNet={timeseries.totals.net}
 					/>
 				</section>
 			) : null}

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -20,9 +20,17 @@ import type { ChartConfig } from "@/components/ui/chart";
 import type { TimeseriesDataPoint } from "@/lib/types";
 
 const chartConfig = {
+	processed: {
+		label: "Processed",
+		color: "hsl(217 91% 60%)",
+	},
 	revenue: {
 		label: "Revenue",
 		color: "hsl(142 71% 45%)",
+	},
+	net: {
+		label: "Net",
+		color: "hsl(38 92% 50%)",
 	},
 } satisfies ChartConfig;
 
@@ -36,10 +44,10 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 
 export function RevenueChart({
 	data,
-	totalRevenue,
+	totalNet,
 }: {
 	data: TimeseriesDataPoint[];
-	totalRevenue: number;
+	totalNet: number;
 }) {
 	return (
 		<Card>
@@ -47,14 +55,15 @@ export function RevenueChart({
 				<div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
 					<CardTitle>Revenue</CardTitle>
 					<CardDescription>
-						Cumulative revenue from completed transactions
+						Cumulative processed, revenue (after fees), and net (after fees &
+						refunds)
 					</CardDescription>
 				</div>
 				<div className="flex">
 					<div className="flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left sm:border-l sm:border-t-0 sm:px-8 sm:py-6">
 						<span className="text-xs text-muted-foreground">Total Revenue</span>
 						<span className="text-lg font-bold leading-none sm:text-3xl">
-							{currencyFormatter.format(totalRevenue)}
+							{currencyFormatter.format(totalNet)}
 						</span>
 					</div>
 				</div>
@@ -80,20 +89,43 @@ export function RevenueChart({
 						<ChartTooltip
 							content={
 								<ChartTooltipContent
-									className="w-[150px]"
-									nameKey="revenue"
+									className="w-[180px]"
 									labelFormatter={(value: string) => {
 										const date = parseISO(value);
 										return format(date, "MMM d, yyyy");
 									}}
-									formatter={(value) => currencyFormatter.format(Number(value))}
+									formatter={(value, name) => (
+										<>
+											<span className="text-muted-foreground">
+												{chartConfig[name as keyof typeof chartConfig]?.label ??
+													name}
+											</span>
+											<span className="ml-auto font-mono font-medium tabular-nums">
+												{currencyFormatter.format(Number(value))}
+											</span>
+										</>
+									)}
 								/>
 							}
+						/>
+						<Line
+							dataKey="processed"
+							type="monotone"
+							stroke="var(--color-processed)"
+							strokeWidth={2}
+							dot={false}
 						/>
 						<Line
 							dataKey="revenue"
 							type="monotone"
 							stroke="var(--color-revenue)"
+							strokeWidth={2}
+							dot={false}
+						/>
+						<Line
+							dataKey="net"
+							type="monotone"
+							stroke="var(--color-net)"
 							strokeWidth={2}
 							dot={false}
 						/>

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2344,11 +2344,17 @@ export interface paths {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             }[];
                             totals: {
                                 signups: number;
                                 paidCustomers: number;
                                 revenue: number;
+                                processed: number;
+                                refunds: number;
+                                net: number;
                             };
                         };
                     };


### PR DESCRIPTION
## Summary
- Revenue chart on `https://admin.llmgateway.io/` now shows three layered lines: cumulative Processed (gross), Revenue (after Stripe fees), and Net (after fees & refunds).
- The big "Total Revenue" stat now displays Net (= revenue − refunds), matching the Revenue metric card's headline.
- `/admin/metrics/timeseries` returns per-day cumulative `processed`, `refunds`, and `net` alongside `revenue`, with the same DevPass/refund exclusions used by `/admin/metrics`.

## Test plan
- [ ] Open `/admin` and verify the Revenue chart shows three lines (Processed > Revenue > Net) and tooltip shows all three values.
- [ ] Confirm "Total Revenue" matches the Revenue card's Net value (`totalRevenue − totalRefunds`).
- [ ] Toggle the date range picker and confirm chart + totals update consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin metrics API now returns per-day and total values for processed, refunds, and net amounts (net = revenue − refunds).
  * Admin revenue dashboard chart updated to show processed, refunds, and net series and uses net totals in summaries.
* **Bug Fixes / Accuracy**
  * Timeseries calculations refined to better separate gross, refunds, and net values and exclude DevPass-related transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->