### PR TITLE
feat(devpass): remove gateway caching from dev plans

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -724,8 +724,6 @@ const getStatus = createRoute({
 						projectId: z.string().nullable(),
 						apiKey: z.string().nullable(),
 						devPlanAllowAllModels: z.boolean(),
-						cachingEnabled: z.boolean(),
-						cacheDurationSeconds: z.number(),
 						retentionLevel: z.enum(["retain", "none"]),
 					}),
 				},
@@ -773,8 +771,6 @@ devPlans.openapi(getStatus, async (c) => {
 			projectId: null,
 			apiKey: null,
 			devPlanAllowAllModels: false,
-			cachingEnabled: false,
-			cacheDurationSeconds: 60,
 			retentionLevel: "none" as const,
 		});
 	}
@@ -786,8 +782,6 @@ devPlans.openapi(getStatus, async (c) => {
 	// Get API key and project if user has an active dev plan
 	let apiKey: string | null = null;
 	let projectId: string | null = null;
-	let cachingEnabled = false;
-	let cacheDurationSeconds = 60;
 	if (personalOrg.devPlan !== "none") {
 		// Find the default project for this org. Order by createdAt asc so we
 		// always return the original "Default Project" rather than whichever
@@ -805,8 +799,6 @@ devPlans.openapi(getStatus, async (c) => {
 
 		if (project) {
 			projectId = project.id;
-			cachingEnabled = project.cachingEnabled;
-			cacheDurationSeconds = project.cacheDurationSeconds;
 			apiKey = await getOrCreatePersonalOrgApiKey(
 				personalOrg.id,
 				project.id,
@@ -831,8 +823,6 @@ devPlans.openapi(getStatus, async (c) => {
 		projectId,
 		apiKey,
 		devPlanAllowAllModels: personalOrg.devPlanAllowAllModels,
-		cachingEnabled,
-		cacheDurationSeconds,
 		retentionLevel: personalOrg.retentionLevel,
 	});
 });
@@ -847,8 +837,6 @@ const updateSettings = createRoute({
 				"application/json": {
 					schema: z.object({
 						devPlanAllowAllModels: z.boolean().optional(),
-						cachingEnabled: z.boolean().optional(),
-						cacheDurationSeconds: z.number().min(10).max(31536000).optional(),
 						retentionLevel: z.enum(["retain", "none"]).optional(),
 					}),
 				},
@@ -862,8 +850,6 @@ const updateSettings = createRoute({
 					schema: z.object({
 						success: z.boolean(),
 						devPlanAllowAllModels: z.boolean(),
-						cachingEnabled: z.boolean(),
-						cacheDurationSeconds: z.number(),
 						retentionLevel: z.enum(["retain", "none"]),
 					}),
 				},
@@ -875,12 +861,7 @@ const updateSettings = createRoute({
 
 devPlans.openapi(updateSettings, async (c) => {
 	const user = c.get("user");
-	const {
-		devPlanAllowAllModels,
-		cachingEnabled,
-		cacheDurationSeconds,
-		retentionLevel,
-	} = c.req.valid("json");
+	const { devPlanAllowAllModels, retentionLevel } = c.req.valid("json");
 
 	if (!user) {
 		throw new HTTPException(401, {
@@ -954,54 +935,6 @@ devPlans.openapi(updateSettings, async (c) => {
 		}
 	}
 
-	const project = await db.query.project.findFirst({
-		where: {
-			organizationId: {
-				eq: personalOrg.id,
-			},
-		},
-		orderBy: {
-			createdAt: "asc",
-		},
-	});
-
-	const projectUpdate: {
-		cachingEnabled?: boolean;
-		cacheDurationSeconds?: number;
-	} = {};
-	if (cachingEnabled !== undefined) {
-		projectUpdate.cachingEnabled = cachingEnabled;
-	}
-	if (cacheDurationSeconds !== undefined) {
-		projectUpdate.cacheDurationSeconds = cacheDurationSeconds;
-	}
-
-	if (project && Object.keys(projectUpdate).length > 0) {
-		await db
-			.update(tables.project)
-			.set(projectUpdate)
-			.where(eq(tables.project.id, project.id));
-
-		if (
-			cachingEnabled !== undefined &&
-			cachingEnabled !== project.cachingEnabled
-		) {
-			changes.cachingEnabled = {
-				old: project.cachingEnabled,
-				new: cachingEnabled,
-			};
-		}
-		if (
-			cacheDurationSeconds !== undefined &&
-			cacheDurationSeconds !== project.cacheDurationSeconds
-		) {
-			changes.cacheDurationSeconds = {
-				old: project.cacheDurationSeconds,
-				new: cacheDurationSeconds,
-			};
-		}
-	}
-
 	if (Object.keys(changes).length > 0) {
 		await logAuditEvent({
 			organizationId: personalOrg.id,
@@ -1016,9 +949,6 @@ devPlans.openapi(updateSettings, async (c) => {
 		success: true,
 		devPlanAllowAllModels:
 			devPlanAllowAllModels ?? personalOrg.devPlanAllowAllModels,
-		cachingEnabled: cachingEnabled ?? project?.cachingEnabled ?? false,
-		cacheDurationSeconds:
-			cacheDurationSeconds ?? project?.cacheDurationSeconds ?? 60,
 		retentionLevel: retentionLevel ?? personalOrg.retentionLevel,
 	});
 });

--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -457,8 +457,6 @@ export default function DashboardClient() {
 							devPlanAllowAllModels={
 								devPlanStatus?.devPlanAllowAllModels ?? false
 							}
-							cachingEnabled={devPlanStatus?.cachingEnabled ?? false}
-							cacheDurationSeconds={devPlanStatus?.cacheDurationSeconds ?? 60}
 							retentionLevel={devPlanStatus?.retentionLevel ?? "none"}
 						/>
 

--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -1,43 +1,27 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ChevronDown, Loader2 } from "lucide-react";
+import { AlertTriangle, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useApi } from "@/lib/fetch-client";
 
 interface DevPlanSettingsProps {
 	devPlanAllowAllModels: boolean;
-	cachingEnabled: boolean;
-	cacheDurationSeconds: number;
 	retentionLevel: "retain" | "none";
 }
 
 export default function DevPlanSettings({
 	devPlanAllowAllModels: initialAllowAllModels,
-	cachingEnabled: initialCachingEnabled,
-	cacheDurationSeconds: initialCacheDurationSeconds,
 	retentionLevel: initialRetentionLevel,
 }: DevPlanSettingsProps) {
 	const api = useApi();
 	const queryClient = useQueryClient();
 	const [allowAllModels, setAllowAllModels] = useState(initialAllowAllModels);
 	const [isUpdatingAllowAll, setIsUpdatingAllowAll] = useState(false);
-
-	const [cachingEnabled, setCachingEnabled] = useState(initialCachingEnabled);
-	const [cacheDuration, setCacheDuration] = useState(
-		initialCacheDurationSeconds,
-	);
-	const [savedCacheDuration, setSavedCacheDuration] = useState(
-		initialCacheDurationSeconds,
-	);
-	const [isSavingCaching, setIsSavingCaching] = useState(false);
-	const [isTogglingCaching, setIsTogglingCaching] = useState(false);
 
 	const [retainData, setRetainData] = useState(
 		initialRetentionLevel === "retain",
@@ -76,46 +60,6 @@ export default function DevPlanSettings({
 		}
 	};
 
-	const handleCachingToggle = async (checked: boolean) => {
-		setIsTogglingCaching(true);
-		try {
-			await updateSettingsMutation.mutateAsync({
-				body: { cachingEnabled: checked },
-			});
-			setCachingEnabled(checked);
-			await invalidateStatus();
-			toast.success(checked ? "Caching enabled" : "Caching disabled");
-		} catch {
-			toast.error("Failed to update caching");
-		} finally {
-			setIsTogglingCaching(false);
-		}
-	};
-
-	const handleSaveCacheDuration = async () => {
-		if (
-			!Number.isFinite(cacheDuration) ||
-			cacheDuration < 10 ||
-			cacheDuration > 31536000
-		) {
-			toast.error("Cache duration must be between 10 and 31,536,000 seconds");
-			return;
-		}
-		setIsSavingCaching(true);
-		try {
-			await updateSettingsMutation.mutateAsync({
-				body: { cacheDurationSeconds: cacheDuration },
-			});
-			setSavedCacheDuration(cacheDuration);
-			await invalidateStatus();
-			toast.success("Cache duration updated");
-		} catch {
-			toast.error("Failed to update cache duration");
-		} finally {
-			setIsSavingCaching(false);
-		}
-	};
-
 	const handleRetentionToggle = async (checked: boolean) => {
 		setIsUpdatingRetention(true);
 		try {
@@ -138,68 +82,6 @@ export default function DevPlanSettings({
 		<div>
 			<h2 className="mb-4 font-semibold">Settings</h2>
 			<div className="space-y-4">
-				<div className="rounded-xl border p-5 space-y-4">
-					<div className="flex items-center justify-between gap-4">
-						<div className="space-y-0.5">
-							<Label htmlFor="enable-caching" className="text-sm font-medium">
-								Request caching
-							</Label>
-							<p className="text-xs text-muted-foreground">
-								Cache identical LLM requests to reduce cost and latency
-							</p>
-						</div>
-						<Switch
-							id="enable-caching"
-							checked={cachingEnabled}
-							onCheckedChange={handleCachingToggle}
-							disabled={isTogglingCaching}
-						/>
-					</div>
-
-					<div className="space-y-2">
-						<Label
-							htmlFor="cache-duration"
-							className={`text-sm font-medium ${
-								!cachingEnabled ? "text-muted-foreground" : ""
-							}`}
-						>
-							Cache duration (seconds)
-						</Label>
-						<div className="flex items-center gap-2">
-							<Input
-								id="cache-duration"
-								type="number"
-								min={10}
-								max={31536000}
-								className="w-40 h-9"
-								value={cacheDuration}
-								onChange={(e) => setCacheDuration(Number(e.target.value))}
-								disabled={!cachingEnabled}
-							/>
-							<Button
-								type="button"
-								size="sm"
-								variant="outline"
-								onClick={handleSaveCacheDuration}
-								disabled={
-									!cachingEnabled ||
-									isSavingCaching ||
-									cacheDuration === savedCacheDuration
-								}
-							>
-								{isSavingCaching && (
-									<Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-								)}
-								Save
-							</Button>
-						</div>
-						<p className="text-xs text-muted-foreground">
-							Min 10, max 31,536,000 (1 year). Changes may take up to 5 minutes
-							to take effect.
-						</p>
-					</div>
-				</div>
-
 				<div className="rounded-xl border p-5 space-y-4">
 					<div className="flex items-center justify-between gap-4">
 						<div className="space-y-0.5">

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -10430,8 +10430,6 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };
@@ -10471,8 +10469,6 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
-                        cachingEnabled?: boolean;
-                        cacheDurationSeconds?: number;
                         /** @enum {string} */
                         retentionLevel?: "retain" | "none";
                     };
@@ -10488,8 +10484,6 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3706,9 +3706,13 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	// Check if caching is enabled for this project
+	// Check if caching is enabled for this project. Dev plan orgs never get
+	// gateway-level response caching — the feature is offered only on regular
+	// (non-devpass) organizations.
 	const { enabled: cachingEnabled, duration: cacheDuration } =
-		await isCachingEnabled(project.id);
+		organization.devPlan !== "none"
+			? { enabled: false, duration: 0 }
+			: await isCachingEnabled(project.id);
 
 	let cacheKey: string | null = null;
 	let streamingCacheKey: string | null = null;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -10430,8 +10430,6 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };
@@ -10471,8 +10469,6 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
-                        cachingEnabled?: boolean;
-                        cacheDurationSeconds?: number;
                         /** @enum {string} */
                         retentionLevel?: "retain" | "none";
                     };
@@ -10488,8 +10484,6 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -10430,8 +10430,6 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };
@@ -10471,8 +10469,6 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
-                        cachingEnabled?: boolean;
-                        cacheDurationSeconds?: number;
                         /** @enum {string} */
                         retentionLevel?: "retain" | "none";
                     };
@@ -10488,8 +10484,6 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -10430,8 +10430,6 @@ export interface paths {
                             projectId: string | null;
                             apiKey: string | null;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };
@@ -10471,8 +10469,6 @@ export interface paths {
                 content: {
                     "application/json": {
                         devPlanAllowAllModels?: boolean;
-                        cachingEnabled?: boolean;
-                        cacheDurationSeconds?: number;
                         /** @enum {string} */
                         retentionLevel?: "retain" | "none";
                     };
@@ -10488,8 +10484,6 @@ export interface paths {
                         "application/json": {
                             success: boolean;
                             devPlanAllowAllModels: boolean;
-                            cachingEnabled: boolean;
-                            cacheDurationSeconds: number;
                             /** @enum {string} */
                             retentionLevel: "retain" | "none";
                         };


### PR DESCRIPTION
## Summary

- Gateway response caching is now offered only on regular (non-devpass) orgs. The gateway forces `cachingEnabled = false` whenever the owning organization has an active dev plan.
- Removes the Request caching toggle and duration input from the DevPass dashboard settings (`apps/code`).
- Drops `cachingEnabled` and `cacheDurationSeconds` from the `/dev-plans/status` and `/dev-plans/settings` API contracts (and regenerated the typed clients).

## Test plan

- [ ] Verify a non-devpass org still toggles caching on/off via the existing project settings and gets cache hits in the gateway.
- [ ] Verify a devpass org never gets gateway-level cache hits even if `project.cachingEnabled` is `true` in the DB.
- [ ] Confirm the DevPass dashboard no longer renders the Request caching section.
- [ ] `pnpm test:unit` still passes for the resilience SWR caching test (which uses a non-devpass org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Settings Interface Updates**
  * Simplified settings to remove request caching configuration options
  * Data retention level setting now primary focus for cache-related configuration
  * Model allowance feature continues to be configurable

* **Request Processing Changes**
  * Modified gateway request handling for development plan organizations regarding response caching behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->