### PR TITLE
feat(devpass): reject duplicate cards before charging

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2,7 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { ensureStripeCustomer } from "@/stripe.js";
+import { ensureStripeCustomer, finalizeDevPlanSetupSession } from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import { db, tables, eq, shortid } from "@llmgateway/db";
@@ -255,31 +255,33 @@ devPlans.openapi(subscribe, async (c) => {
 	try {
 		const stripeCustomerId = await ensureStripeCustomer(personalOrg.id);
 
+		// We use `mode: "setup"` (not "subscription") so the card is collected
+		// but the customer is NOT charged at checkout. After redirect we check
+		// the card fingerprint against existing DevPass orgs; if it conflicts
+		// we reject the activation without ever creating a Stripe subscription
+		// or charging the user. The shared metadata carries everything the
+		// finalize step needs to create the subscription server-side.
 		const session = await getStripe().checkout.sessions.create({
 			customer: stripeCustomerId,
-			mode: "subscription",
-			line_items: [
-				{
-					price: priceId,
-					quantity: 1,
-				},
-			],
-			allow_promotion_codes: true,
-			success_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?success=true`,
+			mode: "setup",
+			payment_method_types: ["card"],
+			success_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?setup_session_id={CHECKOUT_SESSION_ID}`,
 			cancel_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?canceled=true`,
 			metadata: {
 				organizationId: personalOrg.id,
 				subscriptionType: "dev_plan",
 				devPlan: tier,
 				devPlanCycle: cycle,
+				priceId,
 				userEmail: user.email,
 			},
-			subscription_data: {
+			setup_intent_data: {
 				metadata: {
 					organizationId: personalOrg.id,
 					subscriptionType: "dev_plan",
 					devPlan: tier,
 					devPlanCycle: cycle,
+					priceId,
 					userEmail: user.email,
 				},
 			},
@@ -313,6 +315,110 @@ devPlans.openapi(subscribe, async (c) => {
 		throw new HTTPException(500, {
 			message: `Failed to create checkout session: ${error}`,
 		});
+	}
+});
+
+// Finalize a dev plan setup session — called by the dashboard after the user
+// returns from Stripe Checkout. Verifies the card fingerprint and creates the
+// subscription server-side, or rejects with 409 if the card is already used
+// by another DevPass org (no charge is made in that case).
+const finalize = createRoute({
+	method: "post",
+	path: "/finalize",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						sessionId: z.string().min(1),
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						status: z.enum(["ok", "already_processed"]),
+					}),
+				},
+			},
+			description: "Dev plan subscription finalized",
+		},
+		409: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						error: z.literal("duplicate_card"),
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Card already in use by another DevPass account",
+		},
+	},
+});
+
+devPlans.openapi(finalize, async (c) => {
+	const user = c.get("user");
+	const { sessionId } = c.req.valid("json");
+
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: { userId: user.id },
+		with: { organization: true },
+	});
+	const personalOrg = userOrgs.find(
+		(uo) => uo.organization?.isPersonal === true,
+	)?.organization;
+
+	if (!personalOrg) {
+		throw new HTTPException(404, {
+			message: "Personal organization not found",
+		});
+	}
+
+	let result;
+	try {
+		result = await finalizeDevPlanSetupSession(sessionId);
+	} catch (error) {
+		logger.error(
+			`Failed to finalize dev plan session ${sessionId}`,
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		throw new HTTPException(500, {
+			message: "Failed to finalize subscription",
+		});
+	}
+
+	switch (result.status) {
+		case "ok":
+		case "already_processed":
+			return c.json({ status: result.status }, 200);
+		case "duplicate_card":
+			return c.json(
+				{
+					error: "duplicate_card" as const,
+					message:
+						"This card is already associated with another DevPass account. Please use a different payment method.",
+				},
+				409,
+			);
+		case "no_payment_method":
+			throw new HTTPException(400, {
+				message: "No payment method found on the checkout session",
+			});
+		case "invalid_session":
+			throw new HTTPException(400, {
+				message: `Invalid checkout session: ${result.reason}`,
+			});
 	}
 });
 

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -20,6 +20,7 @@ import {
 } from "./utils/discord.js";
 import {
 	generateDevPlanCancellationFeedbackEmailHtml,
+	generateDevPlanDuplicateCardEmailHtml,
 	generatePaymentFailureEmailHtml,
 	generateSubscriptionCancelledEmailHtml,
 	sendTransactionalEmail,
@@ -312,27 +313,290 @@ async function getSubscriptionCardFingerprint(
 	}
 }
 
+export type FinalizeDevPlanResult =
+	| { status: "ok"; subscriptionId: string }
+	| { status: "duplicate_card"; conflictingOrgId: string }
+	| { status: "already_processed"; subscriptionId: string | null }
+	| { status: "no_payment_method" }
+	| { status: "invalid_session"; reason: string };
+
+async function resolvePaymentMethodFromSetupSession(
+	session: Stripe.Checkout.Session,
+): Promise<Stripe.PaymentMethod | null> {
+	let setupIntent: Stripe.SetupIntent | null = null;
+	const rawSetupIntent = session.setup_intent;
+	if (typeof rawSetupIntent === "string") {
+		setupIntent = await getStripe().setupIntents.retrieve(rawSetupIntent);
+	} else if (rawSetupIntent) {
+		setupIntent = rawSetupIntent;
+	}
+
+	if (!setupIntent?.payment_method) {
+		return null;
+	}
+
+	const pm = setupIntent.payment_method;
+	if (typeof pm === "string") {
+		return await getStripe().paymentMethods.retrieve(pm);
+	}
+	return pm;
+}
+
 /**
- * Cancel a Stripe dev plan subscription that was rejected because the card
- * was already used by another organization. This only cancels the
- * subscription — no refund or invoice void is issued here. Stripe's normal
- * dispute / refund flow is the path for fee recovery.
+ * Finalize a DevPass setup-mode checkout session: verify the card fingerprint
+ * is not already in use by another organization, then create the Stripe
+ * subscription server-side. Idempotent: safe to call from both the
+ * /dev-plans/finalize endpoint (user-triggered after redirect) and the
+ * checkout.session.completed webhook (fallback if the user closes the tab).
+ *
+ * Critically, no Stripe subscription is created — and no charge is issued —
+ * when the card is a duplicate. The duplicate payment method is detached
+ * from the customer so it isn't accidentally reused later.
  */
-async function rejectDuplicateDevPlanSubscription(
-	subscriptionId: string,
-	reason: string,
-) {
-	try {
-		await getStripe().subscriptions.cancel(subscriptionId, {
-			invoice_now: false,
-			prorate: false,
+export async function finalizeDevPlanSetupSession(
+	sessionId: string,
+): Promise<FinalizeDevPlanResult> {
+	const session = await getStripe().checkout.sessions.retrieve(sessionId);
+
+	if (session.mode !== "setup") {
+		return { status: "invalid_session", reason: "not_setup_mode" };
+	}
+
+	const metadata = session.metadata ?? {};
+	if (metadata.subscriptionType !== "dev_plan") {
+		return { status: "invalid_session", reason: "not_dev_plan" };
+	}
+
+	const organizationId = metadata.organizationId;
+	const devPlanTier = metadata.devPlan as DevPlanTier | undefined;
+	const devPlanCycle: DevPlanCycle =
+		metadata.devPlanCycle === "annual" ? "annual" : "monthly";
+	const priceId = metadata.priceId;
+	const userEmail = metadata.userEmail;
+
+	if (!organizationId || !devPlanTier || !priceId) {
+		return { status: "invalid_session", reason: "missing_metadata" };
+	}
+
+	const organization = await db.query.organization.findFirst({
+		where: { id: organizationId },
+	});
+	if (!organization) {
+		return { status: "invalid_session", reason: "org_not_found" };
+	}
+
+	if (
+		organization.devPlan !== "none" &&
+		organization.devPlanStripeSubscriptionId
+	) {
+		return {
+			status: "already_processed",
+			subscriptionId: organization.devPlanStripeSubscriptionId,
+		};
+	}
+
+	const paymentMethod = await resolvePaymentMethodFromSetupSession(session);
+	if (!paymentMethod) {
+		return { status: "no_payment_method" };
+	}
+
+	const fingerprint =
+		paymentMethod.type === "card"
+			? (paymentMethod.card?.fingerprint ?? null)
+			: null;
+
+	if (fingerprint) {
+		const conflictingOrg = await db.query.organization.findFirst({
+			where: {
+				devPlanCardFingerprint: { eq: fingerprint },
+				id: { ne: organizationId },
+			},
 		});
-	} catch (error) {
-		logger.error(
-			`Failed to cancel duplicate dev plan subscription ${subscriptionId}: ${reason}`,
-			error instanceof Error ? error : new Error(String(error)),
+		if (conflictingOrg) {
+			try {
+				await getStripe().paymentMethods.detach(paymentMethod.id);
+			} catch (err) {
+				logger.warn(
+					`Failed to detach duplicate dev plan card ${paymentMethod.id}`,
+					{
+						error: err instanceof Error ? err.message : String(err),
+					},
+				);
+			}
+
+			logger.warn(
+				`Rejecting dev plan setup ${sessionId} for org ${organizationId}: card fingerprint already used by org ${conflictingOrg.id}`,
+			);
+
+			posthog.capture({
+				distinctId: "organization",
+				event: "dev_plan_blocked_duplicate_card",
+				groups: { organization: organizationId },
+				properties: {
+					organization: organizationId,
+					conflictingOrganization: conflictingOrg.id,
+					sessionId,
+				},
+			});
+
+			const notifyEmail = userEmail ?? organization.billingEmail;
+			if (notifyEmail) {
+				try {
+					await sendTransactionalEmail({
+						to: notifyEmail,
+						subject: "DevPass activation failed — card already in use",
+						html: generateDevPlanDuplicateCardEmailHtml(organization.name),
+					});
+				} catch (err) {
+					logger.error(
+						"Failed to send dev plan duplicate-card email",
+						err instanceof Error ? err : new Error(String(err)),
+					);
+				}
+			}
+
+			return {
+				status: "duplicate_card",
+				conflictingOrgId: conflictingOrg.id,
+			};
+		}
+	}
+
+	const stripeCustomerId = await ensureStripeCustomer(organizationId);
+
+	await getStripe().customers.update(stripeCustomerId, {
+		invoice_settings: { default_payment_method: paymentMethod.id },
+	});
+
+	const subscription = await getStripe().subscriptions.create({
+		customer: stripeCustomerId,
+		items: [{ price: priceId }],
+		default_payment_method: paymentMethod.id,
+		payment_behavior: "error_if_incomplete",
+		metadata: {
+			organizationId,
+			subscriptionType: "dev_plan",
+			devPlan: devPlanTier,
+			devPlanCycle,
+			userEmail: userEmail ?? "",
+		},
+		expand: ["latest_invoice"],
+	});
+
+	const creditsLimit = getDevPlanCreditsLimit(devPlanTier);
+
+	await db
+		.update(tables.organization)
+		.set({
+			devPlan: devPlanTier,
+			devPlanCreditsLimit: creditsLimit.toString(),
+			devPlanCreditsUsed: "0",
+			devPlanBillingCycleStart: new Date(),
+			devPlanStripeSubscriptionId: subscription.id,
+			devPlanCancelled: false,
+			devPlanCycle,
+			devPlanCardFingerprint: fingerprint,
+		})
+		.where(eq(tables.organization.id, organizationId));
+
+	logger.info(
+		`Successfully activated dev plan ${devPlanTier} for organization ${organizationId} with ${creditsLimit} credits via setup-mode checkout`,
+	);
+
+	const latestInvoice = subscription.latest_invoice;
+	const stripeInvoiceId =
+		typeof latestInvoice === "string"
+			? latestInvoice
+			: (latestInvoice?.id ?? undefined);
+	const invoiceAmount =
+		typeof latestInvoice === "object" && latestInvoice
+			? (latestInvoice.amount_paid / 100).toString()
+			: "0";
+	const invoiceCurrency = (
+		typeof latestInvoice === "object" && latestInvoice
+			? latestInvoice.currency
+			: "usd"
+	).toUpperCase();
+
+	const existing = stripeInvoiceId
+		? await db.query.transaction.findFirst({
+				where: { stripeInvoiceId: { eq: stripeInvoiceId } },
+			})
+		: null;
+
+	if (!existing) {
+		const [transaction] = await db
+			.insert(tables.transaction)
+			.values({
+				organizationId,
+				type: "dev_plan_start",
+				amount: invoiceAmount,
+				creditAmount: creditsLimit.toString(),
+				currency: invoiceCurrency,
+				status: "completed",
+				stripeInvoiceId,
+				description: `Dev Plan ${devPlanTier.toUpperCase()} started via Stripe Checkout`,
+			})
+			.returning();
+
+		try {
+			await generateAndEmailInvoice({
+				invoiceNumber: transaction.id,
+				invoiceDate: new Date(),
+				organizationName: organization.name,
+				billingEmail: organization.billingEmail,
+				billingCompany: organization.billingCompany,
+				billingAddress: organization.billingAddress,
+				billingTaxId: organization.billingTaxId,
+				billingNotes: organization.billingNotes,
+				lineItems: [
+					{
+						description: `Dev Plan ${devPlanTier.toUpperCase()} ($${creditsLimit} credits included)`,
+						amount: parseFloat(invoiceAmount),
+					},
+				],
+				currency: invoiceCurrency,
+			});
+		} catch (e) {
+			logger.error(
+				"Invoice email failed (dev plan finalize); suppressing failure",
+				e as Error,
+			);
+		}
+	}
+
+	posthog.groupIdentify({
+		groupType: "organization",
+		groupKey: organizationId,
+		properties: { name: organization.name },
+	});
+	posthog.capture({
+		distinctId: "organization",
+		event: "dev_plan_started",
+		groups: { organization: organizationId },
+		properties: {
+			devPlan: devPlanTier,
+			creditsLimit,
+			organization: organizationId,
+			subscriptionId: subscription.id,
+			source: "stripe_checkout_setup",
+		},
+	});
+
+	const subscribedEmail = userEmail ?? organization.billingEmail;
+	if (subscribedEmail) {
+		const subscribedUser = await db.query.user.findFirst({
+			where: { email: { eq: subscribedEmail } },
+		});
+		await notifyDevPlanSubscribed(
+			subscribedEmail,
+			subscribedUser?.name,
+			devPlanTier,
+			devPlanCycle,
 		);
 	}
+
+	return { status: "ok", subscriptionId: subscription.id };
 }
 
 async function handleCheckoutSessionCompleted(
@@ -342,8 +606,28 @@ async function handleCheckoutSessionCompleted(
 	const { customer, metadata, subscription } = session;
 
 	logger.info(
-		`Processing checkout session completed for customer: ${customer}, subscription: ${subscription}`,
+		`Processing checkout session completed for customer: ${customer}, subscription: ${subscription}, mode: ${session.mode}`,
 	);
+
+	// DevPass uses setup-mode checkout so the card is collected without
+	// charging. We verify the card fingerprint and create the subscription
+	// server-side via finalizeDevPlanSetupSession. The /dev-plans/finalize
+	// endpoint also calls the same helper when the user lands back on the
+	// dashboard; this webhook is the fallback if the user closes the tab.
+	if (session.mode === "setup" && metadata?.subscriptionType === "dev_plan") {
+		try {
+			const result = await finalizeDevPlanSetupSession(session.id);
+			logger.info(
+				`Dev plan setup-mode finalize result for session ${session.id}: ${result.status}`,
+			);
+		} catch (error) {
+			logger.error(
+				`Error finalizing dev plan setup session ${session.id}`,
+				error instanceof Error ? error : new Error(String(error)),
+			);
+		}
+		return;
+	}
 
 	if (!subscription && metadata?.type === "credit_topup") {
 		await handleCreditTopUpCheckout(session);
@@ -385,46 +669,14 @@ async function handleCheckoutSessionCompleted(
 
 	try {
 		if (isDevPlan && devPlanTier) {
-			// Reject any DevPass subscription paid for with a card that already
-			// activated DevPass on another organization. Without this, a user
-			// can rotate accounts to multiply the included usage allowance.
+			// DevPass activations are now finalized via the setup-mode branch
+			// above (see finalizeDevPlanSetupSession). This subscription-mode
+			// branch only runs for legacy in-flight sessions created before
+			// that switch landed and is kept as a safety net.
 			const fingerprint = subscriptionId
 				? await getSubscriptionCardFingerprint(subscriptionId)
 				: null;
 
-			if (fingerprint) {
-				const conflictingOrg = await db.query.organization.findFirst({
-					where: {
-						devPlanCardFingerprint: { eq: fingerprint },
-						id: { ne: organizationId },
-					},
-				});
-
-				if (conflictingOrg) {
-					logger.warn(
-						`Rejecting duplicate dev plan subscription ${subscriptionId} for organization ${organizationId}: card fingerprint already claimed by organization ${conflictingOrg.id}`,
-					);
-					await rejectDuplicateDevPlanSubscription(
-						subscriptionId!,
-						"duplicate_card_fingerprint",
-					);
-					posthog.capture({
-						distinctId: "organization",
-						event: "dev_plan_blocked_duplicate_card",
-						groups: {
-							organization: organizationId,
-						},
-						properties: {
-							organization: organizationId,
-							conflictingOrganization: conflictingOrg.id,
-							subscriptionId,
-						},
-					});
-					return;
-				}
-			}
-
-			// Handle dev plan subscription
 			const creditsLimit = getDevPlanCreditsLimit(devPlanTier);
 
 			await db
@@ -1565,6 +1817,13 @@ async function handleSetupIntentSucceeded(
 	const { metadata, payment_method } = setupIntent;
 	const organizationId = metadata?.organizationId;
 
+	// DevPass setup intents are finalized via finalizeDevPlanSetupSession and
+	// must NOT be saved into the org's payment_method table (which is for the
+	// regular billing UI flow). Skip them here.
+	if (metadata?.subscriptionType === "dev_plan") {
+		return;
+	}
+
 	if (!organizationId || !payment_method) {
 		logger.warn(
 			`Missing organizationId or payment_method in setupIntent: ${event.id} ${setupIntent.id}`,
@@ -2379,6 +2638,16 @@ async function handleSubscriptionCreated(
 	logger.info(
 		`Found organization: ${organization.name} (${organization.id}) for subscription creation`,
 	);
+
+	// DevPass subscriptions (personal orgs) use the devPlan field — they must
+	// not be coerced to plan="pro" or have stripeSubscriptionId set, which is
+	// reserved for regular Pro subscriptions on team orgs.
+	if (metadata?.subscriptionType === "dev_plan" || organization.isPersonal) {
+		logger.info(
+			`Skipping plan: "pro" for dev plan / personal org ${organizationId}`,
+		);
+		return;
+	}
 
 	try {
 		await db

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -2,7 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { and, db, eq, inArray, sql, tables } from "@llmgateway/db";
+import { and, db, eq, inArray, isNull, sql, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
 	getDevPlanCreditsLimit,
@@ -468,24 +468,37 @@ export async function finalizeDevPlanSetupSession(
 		invoice_settings: { default_payment_method: paymentMethod.id },
 	});
 
-	const subscription = await getStripe().subscriptions.create({
-		customer: stripeCustomerId,
-		items: [{ price: priceId }],
-		default_payment_method: paymentMethod.id,
-		payment_behavior: "error_if_incomplete",
-		metadata: {
-			organizationId,
-			subscriptionType: "dev_plan",
-			devPlan: devPlanTier,
-			devPlanCycle,
-			userEmail: userEmail ?? "",
+	// The /finalize endpoint and the checkout.session.completed webhook can
+	// race for the same setup session. We guard against duplicate subscription
+	// creation on two levels: (1) a deterministic Stripe idempotency key
+	// derived from org+session so a second `subscriptions.create()` call
+	// returns the same subscription instead of a new one; (2) an atomic
+	// conditional UPDATE that only writes the dev plan state if no other
+	// writer has filled in devPlanStripeSubscriptionId yet — the loser then
+	// reports already_processed so it doesn't double-insert the transaction
+	// row or re-send notifications.
+	const stripeIdempotencyKey = `devpass-sub:${organizationId}:${sessionId}`;
+	const subscription = await getStripe().subscriptions.create(
+		{
+			customer: stripeCustomerId,
+			items: [{ price: priceId }],
+			default_payment_method: paymentMethod.id,
+			payment_behavior: "error_if_incomplete",
+			metadata: {
+				organizationId,
+				subscriptionType: "dev_plan",
+				devPlan: devPlanTier,
+				devPlanCycle,
+				userEmail: userEmail ?? "",
+			},
+			expand: ["latest_invoice"],
 		},
-		expand: ["latest_invoice"],
-	});
+		{ idempotencyKey: stripeIdempotencyKey },
+	);
 
 	const creditsLimit = getDevPlanCreditsLimit(devPlanTier);
 
-	await db
+	const claimed = await db
 		.update(tables.organization)
 		.set({
 			devPlan: devPlanTier,
@@ -497,7 +510,20 @@ export async function finalizeDevPlanSetupSession(
 			devPlanCycle,
 			devPlanCardFingerprint: fingerprint,
 		})
-		.where(eq(tables.organization.id, organizationId));
+		.where(
+			and(
+				eq(tables.organization.id, organizationId),
+				isNull(tables.organization.devPlanStripeSubscriptionId),
+			),
+		)
+		.returning({ id: tables.organization.id });
+
+	if (claimed.length === 0) {
+		logger.info(
+			`Dev plan finalize lost the race for org ${organizationId} session ${sessionId}; another path already activated subscription ${subscription.id}`,
+		);
+		return { status: "already_processed", subscriptionId: subscription.id };
+	}
 
 	logger.info(
 		`Successfully activated dev plan ${devPlanTier} for organization ${organizationId} with ${creditsLimit} credits via setup-mode checkout`,

--- a/apps/api/src/utils/email.ts
+++ b/apps/api/src/utils/email.ts
@@ -263,6 +263,90 @@ export function generatePaymentFailureEmailHtml(
 	`.trim();
 }
 
+export function generateDevPlanDuplicateCardEmailHtml(
+	organizationName: string,
+): string {
+	const escapedOrgName = escapeHtml(organizationName);
+	const codeUrl = process.env.CODE_URL ?? "https://code.llmgateway.io";
+	const dashboardUrl = `${codeUrl}/dashboard`;
+
+	return `
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>DevPass activation failed - LLMGateway</title>
+	</head>
+	<body
+		style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #ffffff;"
+	>
+		<table role="presentation" style="width: 100%; border-collapse: collapse;">
+			<tr>
+				<td align="center" style="padding: 40px 20px;">
+					<table role="presentation" style="max-width: 600px; width: 100%; border-collapse: collapse;">
+						<tr>
+							<td
+								style="background-color: #dc2626; padding: 40px 30px; text-align: center; border-radius: 8px 8px 0 0;"
+							>
+								<h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">Activation Failed</h1>
+							</td>
+						</tr>
+
+						<tr>
+							<td style="background-color: #f8f9fa; padding: 40px 30px; border-radius: 0 0 8px 8px;">
+								<p style="margin: 0 0 20px 0; font-size: 16px; line-height: 1.6; color: #333333;">
+									Hi there,
+								</p>
+
+								<p style="margin: 0 0 20px 0; font-size: 16px; line-height: 1.6; color: #333333;">
+									We couldn't activate DevPass for <strong>${escapedOrgName}</strong>. The card you provided is already linked to another DevPass account, so it can't be used a second time. <strong>You were not charged.</strong>
+								</p>
+
+								<p style="margin: 0 0 20px 0; font-size: 16px; line-height: 1.6; color: #333333;">
+									To activate DevPass on this account, please try again with a different payment method.
+								</p>
+
+								<table role="presentation" style="width: 100%; border-collapse: collapse;">
+									<tr>
+										<td align="center" style="padding: 10px 0;">
+											<a
+												href="${dashboardUrl}"
+												style="display: inline-block; background-color: #000000; color: #ffffff; padding: 14px 40px; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px;"
+											>Try again</a>
+										</td>
+									</tr>
+								</table>
+
+								<p style="margin: 30px 0 0 0; font-size: 14px; line-height: 1.6; color: #666666;">
+									If you think this is a mistake, just reply to this email and we'll take a look.
+								</p>
+							</td>
+						</tr>
+
+						<tr>
+							<td
+								style="padding: 30px 40px; background-color: #f8f9fa; border-radius: 0 0 8px 8px; border-top: 1px solid #e9ecef;"
+							>
+								<p style="margin: 0 0 12px; color: #666666; font-size: 14px; line-height: 1.6;">
+									Need help? Check out our <a
+									href="https://docs.llmgateway.io" style="color: #000000; text-decoration: none;"
+								>documentation</a> or reply to this email for any questions.
+								</p>
+								<p style="margin: 0; color: #999999; font-size: 12px;">
+									© 2025 LLM Gateway. All rights reserved. This is a transactional email and it can't be unsubscribed from.
+								</p>
+							</td>
+						</tr>
+					</table>
+				</td>
+			</tr>
+		</table>
+	</body>
+</html>
+	`.trim();
+}
+
 export function generateDevPlanCancellationFeedbackEmailHtml(
 	organizationName: string,
 ): string {

--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -16,7 +16,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { CodingModelsShowcase } from "@/components/CodingModelsShowcase";
@@ -223,6 +223,7 @@ export default function DashboardClient() {
 	);
 
 	const subscribeMutation = api.useMutation("post", "/dev-plans/subscribe");
+	const finalizeMutation = api.useMutation("post", "/dev-plans/finalize");
 	const cancelMutation = api.useMutation("post", "/dev-plans/cancel");
 	const resumeMutation = api.useMutation("post", "/dev-plans/resume");
 	const changeTierMutation = api.useMutation("post", "/dev-plans/change-tier");
@@ -230,6 +231,70 @@ export default function DashboardClient() {
 		"post",
 		"/dev-plans/rotate-api-key",
 	);
+
+	const [duplicateCardError, setDuplicateCardError] = useState<string | null>(
+		null,
+	);
+	const finalizedSessions = useRef<Set<string>>(new Set());
+
+	useEffect(() => {
+		const sessionId = searchParams.get("setup_session_id");
+		if (!sessionId || finalizedSessions.current.has(sessionId)) {
+			return;
+		}
+		finalizedSessions.current.add(sessionId);
+
+		const clearParam = () => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.delete("setup_session_id");
+			const query = params.toString();
+			router.replace(query ? `/dashboard?${query}` : "/dashboard");
+		};
+
+		finalizeMutation
+			.mutateAsync({ body: { sessionId } })
+			.then((result) => {
+				if (result?.status === "ok" || result?.status === "already_processed") {
+					toast.success("DevPass activated");
+					void queryClient.invalidateQueries({
+						predicate: (query) => {
+							const key = query.queryKey;
+							return Array.isArray(key) && key[1] === "/dev-plans/status";
+						},
+					});
+				}
+			})
+			.catch((error: unknown) => {
+				const errCode =
+					error && typeof error === "object" && "error" in error
+						? (error as { error?: unknown }).error
+						: undefined;
+				if (errCode === "duplicate_card") {
+					const msg =
+						error && typeof error === "object" && "message" in error
+							? (error as { message?: unknown }).message
+							: undefined;
+					setDuplicateCardError(
+						typeof msg === "string" && msg.length > 0
+							? msg
+							: "This card is already associated with another DevPass account. Please use a different payment method.",
+					);
+				} else {
+					const apiMessage =
+						error && typeof error === "object" && "message" in error
+							? (error as { message?: unknown }).message
+							: undefined;
+					toast.error(
+						typeof apiMessage === "string" && apiMessage.length > 0
+							? apiMessage
+							: "Failed to activate DevPass",
+					);
+				}
+			})
+			.finally(() => {
+				clearParam();
+			});
+	}, [searchParams, finalizeMutation, queryClient, router]);
 
 	const handleSubscribe = async (
 		tier: PlanTier,
@@ -362,6 +427,34 @@ export default function DashboardClient() {
 
 	return (
 		<div className="min-h-screen bg-background">
+			<AlertDialog
+				open={duplicateCardError !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setDuplicateCardError(null);
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Card already in use</AlertDialogTitle>
+						<AlertDialogDescription>
+							{duplicateCardError ??
+								"This card is already associated with another DevPass account."}
+							<br />
+							<br />
+							You were not charged. Please try again with a different payment
+							method.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogAction onClick={() => setDuplicateCardError(null)}>
+							Got it
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
 			{/* Header */}
 			<header className="border-b border-border/50">
 				<div className="container mx-auto flex items-center justify-between px-4 py-3">

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -10273,6 +10273,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/finalize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan subscription finalized */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok" | "already_processed";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -10273,6 +10273,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/finalize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan subscription finalized */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok" | "already_processed";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -10273,6 +10273,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/finalize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan subscription finalized */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok" | "already_processed";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -10273,6 +10273,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/finalize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan subscription finalized */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok" | "already_processed";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## Summary

- Switch DevPass subscribe to Stripe Checkout `setup` mode so the card is collected without an immediate charge.
- Verify the card fingerprint server-side, then either create the subscription via `subscriptions.create()` or reject the activation (detaches the duplicate card, no charge).
- Add `/dev-plans/finalize` for the post-redirect path, with `checkout.session.completed` webhook as fallback if the user closes the tab. Both paths share an idempotent helper.
- Show a duplicate-card dialog on the dashboard and send a rejection email so the user knows what happened and that they weren't charged.

Before this change, the fingerprint check ran in `checkout.session.completed` _after_ the first invoice had already been paid; rejection cancelled the subscription but left the charge intact, requiring a manual refund.

## Test plan
- [ ] Subscribe to DevPass with a fresh card → checkout flows through, dashboard lands with `setup_session_id`, finalize creates the subscription, plan activates.
- [ ] Subscribe to DevPass with a card already used by another DevPass org → no Stripe subscription is created, no charge is made, the dashboard shows the "card already in use" dialog and an email is sent.
- [ ] Close the browser before returning to the dashboard with a duplicate card → webhook fallback detaches the card and sends the email; org stays on the free plan.
- [ ] Existing Pro (non-personal) subscriptions still flow through `mode: "subscription"` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side finalization for DevPlan setup sessions with clearer activation outcomes.
  * Client-side finalize flow that auto-processes setup links, shows toasts, and displays a duplicate-card alert dialog.
  * Transactional duplicate-card notification email sent when activation is blocked.

* **Bug Fixes**
  * Robust duplicate payment-method detection and handling to avoid conflicted activations.
  * Safer webhook/finalization logic to prevent double-processing and incorrect subscription state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->