### PR TITLE
feat(seo): enrich llms.txt and add sitemap page

### DIFF
--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -4,9 +4,21 @@ import { source } from "@/lib/source";
 // cached forever
 export const revalidate = false;
 
+const HEADER = `# LLM Gateway — Full Documentation
+
+> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 20+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
+
+API base URL: https://api.llmgateway.io/v1 · Docs: https://docs.llmgateway.io · Site: https://llmgateway.io
+
+This file concatenates the full text of every documentation page below.`;
+
 export async function GET() {
 	const scan = source.getPages().map(getLLMText);
 	const scanned = await Promise.all(scan);
 
-	return new Response(scanned.join("\n\n"));
+	return new Response([HEADER, ...scanned].join("\n\n"), {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
+	});
 }

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,22 +1,85 @@
 import { source } from "@/lib/source";
 
+import type { InferPageType } from "fumadocs-core/source";
+
 // cached forever
 export const revalidate = false;
+
+const SITE_URL = "https://llmgateway.io";
+const DOCS_URL = "https://docs.llmgateway.io";
+
+type Page = InferPageType<typeof source>;
+
+// Section headings keyed by the first URL segment, in the order they should
+// appear. Pages whose first segment isn't listed fall back to "Getting Started",
+// and OpenAPI reference pages (v1_*, health) are grouped under "API Reference".
+const SECTIONS: { key: string; title: string }[] = [
+	{ key: "", title: "Getting Started" },
+	{ key: "features", title: "Features" },
+	{ key: "guides", title: "Guides & AI Tooling" },
+	{ key: "integrations", title: "Provider Integrations" },
+	{ key: "learn", title: "Platform & Dashboard" },
+	{ key: "migrations", title: "Migration Guides" },
+	{ key: "resources", title: "Resources" },
+	{ key: "api", title: "API Reference" },
+];
+
+function sectionKey(page: Page): string {
+	const first = page.url.split("/").filter(Boolean)[0] ?? "";
+	if (first.startsWith("v1") || first === "health") {
+		return "api";
+	}
+	return SECTIONS.some((s) => s.key === first) ? first : "";
+}
 
 export async function GET() {
 	const pages = source.getPages();
 
-	const lines = pages.map((page) => {
-		return `- [${page.data.title}](${page.url})${page.data.description ? `: ${page.data.description}` : ""}`;
+	const grouped = new Map<string, string[]>();
+	for (const page of pages) {
+		const key = sectionKey(page);
+		const line = `- [${page.data.title}](${DOCS_URL}${page.url})${page.data.description ? `: ${page.data.description}` : ""}`;
+		const existing = grouped.get(key);
+		if (existing) {
+			existing.push(line);
+		} else {
+			grouped.set(key, [line]);
+		}
+	}
+
+	const docSections = SECTIONS.filter((s) => grouped.has(s.key))
+		.map((s) => `## ${s.title}\n\n${grouped.get(s.key)!.join("\n")}`)
+		.join("\n\n");
+
+	const content = `# LLM Gateway
+
+> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 20+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
+
+## Key facts
+
+- One OpenAI-compatible API for 20+ providers and 200+ models.
+- Migrate by changing only the base URL (\`https://api.llmgateway.io/v1\`) and your API key — no code rewrites.
+- Open source (AGPLv3 core) with a managed cloud option; self-hosting supported via Docker.
+- Built-in usage analytics, per-model/provider cost breakdowns, automatic routing, fallbacks, caching, and guardrails.
+- API base URL: \`https://api.llmgateway.io/v1\` · Docs: ${DOCS_URL} · Site: ${SITE_URL}
+
+## Product pages
+
+- [Home](${SITE_URL}): Unified API for multiple LLM providers.
+- [Models](${SITE_URL}/models): Browse 200+ supported models with pricing and capabilities.
+- [Providers](${SITE_URL}/providers): All supported LLM providers.
+- [Pricing](${SITE_URL}/pricing): Plans and pricing.
+- [Enterprise](${SITE_URL}/enterprise): Self-hosting, SSO, and team features.
+- [Token Cost Calculator](${SITE_URL}/token-cost-calculator): Estimate and compare LLM costs across models.
+- [LLM Gateway vs LiteLLM](${SITE_URL}/compare/litellm)
+- [LLM Gateway vs OpenRouter](${SITE_URL}/compare/open-router)
+- [LLM Gateway vs Portkey](${SITE_URL}/compare/portkey)
+
+${docSections}`;
+
+	return new Response(content, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+		},
 	});
-
-	const content = `# LLM Gateway Documentation
-
-> Documentation for LLM Gateway - a full-stack LLM API gateway
-
-## Docs
-
-${lines.join("\n")}`;
-
-	return new Response(content);
 }

--- a/apps/docs/lib/get-llm-text.ts
+++ b/apps/docs/lib/get-llm-text.ts
@@ -1,9 +1,11 @@
 import type { source } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
 
+const DOCS_URL = "https://docs.llmgateway.io";
+
 export async function getLLMText(page: InferPageType<typeof source>) {
 	const processed = await page.data.getText("processed");
 	return `# ${page.data.title}
-URL: ${page.url}
+URL: ${DOCS_URL}${page.url}
 ${processed}`;
 }

--- a/apps/ui/src/app/sitemap.ts
+++ b/apps/ui/src/app/sitemap.ts
@@ -112,6 +112,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.9,
 		},
 		{
+			url: `${baseUrl}/nano-banana-simulator/20`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.6,
+		},
+		{
 			url: `${baseUrl}/blog/category`,
 			lastModified: new Date(),
 			changeFrequency: "weekly",


### PR DESCRIPTION
## What & why

Applies the **seo-audit** and **ai-seo** skills to our AI-discovery and sitemap files so AI systems (ChatGPT, Perplexity, Google AI Overviews, Claude) can better understand and cite LLM Gateway.

The canonical `llms.txt` / `llms-full.txt` live in `apps/docs` (Fumadocs); `apps/ui` already redirects `/llms.txt` and `/llms-full.txt` there.

## Changes

**`apps/docs` — `llms.txt`**
- Replace the thin one-line summary with a proper product overview blockquote + a **Key facts** section (OpenAI-compatible, 20+ providers / 200+ models, API base URL, open source / self-host).
- Add a **Product pages** section linking to the main site (models, pricing, enterprise, token calculator, vs LiteLLM/OpenRouter/Portkey) so AI discovers the whole product, not just docs.
- Group doc pages into sections (Getting Started, Features, Guides & AI Tooling, Provider Integrations, Platform & Dashboard, Migration Guides, Resources, API Reference) instead of one flat list — matches the [llmstxt.org](https://llmstxt.org) format.
- Use **absolute URLs** (`https://docs.llmgateway.io/...`) so links are citable when the file is consumed off-domain.
- Set `text/plain; charset=utf-8` content-type.

**`apps/docs` — `llms-full.txt`**
- Prepend a product summary header.
- Absolute page URLs (via `lib/get-llm-text.ts`).
- Set `text/plain; charset=utf-8` content-type.

**`apps/ui` — `sitemap.ts`**
- Add the `/nano-banana-simulator/20` landing page (was missing despite having indexable metadata).

## Notes
- Both `llms.txt` routes remain dynamically generated from docs content — no manual upkeep.
- Verified: ESLint clean, `tsc --noEmit` clean, Prettier clean.
- Out of scope (flagging for later): the docs site (docs.llmgateway.io) has no `sitemap.ts` / `robots.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM Gateway documentation now includes a comprehensive overview header.
  * Documentation pages are organized into categorized sections for improved navigation.
  * Documentation entries now display explicit URLs for reference.

* **Chores**
  * Updated sitemap with new route entry.
  * Set explicit content-type headers on documentation responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->