### PR TITLE
fix(google): strip unsupported JSON Schema metadata

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -799,6 +799,73 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		expect(params.properties.items.items.type).toBe("string");
 	});
 
+	test("should strip $id, examples, enumTitles, prefill from Google tool parameters", async () => {
+		const toolsWithMetaSchema = [
+			{
+				type: "function" as const,
+				function: {
+					name: "test_tool",
+					description: "Test tool",
+					parameters: {
+						$id: "https://example.com/schema.json",
+						$comment: "internal note",
+						type: "object",
+						properties: {
+							field_a: {
+								type: "string",
+								prefill: "hello",
+								examples: ["a", "b"],
+							},
+							field_b: {
+								type: "string",
+								examples: ["x"],
+							},
+							field_c: {
+								type: "array",
+								items: {
+									type: "string",
+									enum: ["one", "two"],
+									enumTitles: ["One", "Two"],
+								},
+								examples: [["one"]],
+							},
+						},
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithMetaSchema,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+
+		expect(params.$id).toBeUndefined();
+		expect(params.$comment).toBeUndefined();
+		expect(params.properties.field_a.prefill).toBeUndefined();
+		expect(params.properties.field_a.examples).toBeUndefined();
+		expect(params.properties.field_b.examples).toBeUndefined();
+		expect(params.properties.field_c.examples).toBeUndefined();
+		expect(params.properties.field_c.items.enumTitles).toBeUndefined();
+		expect(params.properties.field_a.type).toBe("string");
+		expect(params.properties.field_c.items.enum).toEqual(["one", "two"]);
+	});
+
 	test("should add additionalProperties: false to Cerebras tool parameters", async () => {
 		const toolsWithoutAdditionalProps = [
 			{

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -866,6 +866,84 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		expect(params.properties.field_c.items.enum).toEqual(["one", "two"]);
 	});
 
+	test("should preserve user-named fields that collide with stripped schema keywords", async () => {
+		const toolsWithCollidingNames = [
+			{
+				type: "function" as const,
+				function: {
+					name: "test_tool",
+					description: "Test tool",
+					parameters: {
+						type: "object",
+						properties: {
+							examples: {
+								type: "array",
+								items: { type: "string" },
+								description: "User-provided examples list",
+							},
+							prefill: {
+								type: "string",
+								description: "User-provided prefill text",
+							},
+							const: {
+								type: "string",
+								description: "A field literally named const",
+							},
+							nested: {
+								type: "object",
+								properties: {
+									examples: { type: "string" },
+								},
+								required: ["examples"],
+							},
+						},
+						required: ["examples", "prefill"],
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithCollidingNames,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+
+		// User-named fields must survive, even though they collide with stripped keywords
+		expect(params.properties.examples).toBeDefined();
+		expect(params.properties.examples.type).toBe("array");
+		expect(params.properties.examples.description).toBe(
+			"User-provided examples list",
+		);
+		expect(params.properties.prefill).toBeDefined();
+		expect(params.properties.prefill.type).toBe("string");
+		expect(params.properties.const).toBeDefined();
+		expect(params.properties.const.type).toBe("string");
+
+		// Nested properties map should also preserve user field names
+		expect(params.properties.nested.properties.examples).toBeDefined();
+		expect(params.properties.nested.properties.examples.type).toBe("string");
+		expect(params.properties.nested.required).toContain("examples");
+
+		// And `required` should still mention these user fields
+		expect(params.required).toContain("examples");
+		expect(params.required).toContain("prefill");
+	});
+
 	test("should add additionalProperties: false to Cerebras tool parameters", async () => {
 		const toolsWithoutAdditionalProps = [
 			{

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -337,6 +337,15 @@ function stripUnsupportedSchemaProperties(
 			key === "definitions" ||
 			key === "$ref" ||
 			key === "ref" ||
+			key === "$id" ||
+			key === "$comment" ||
+			key === "$anchor" ||
+			key === "$dynamicAnchor" ||
+			key === "$dynamicRef" ||
+			key === "$vocabulary" ||
+			key === "examples" ||
+			key === "enumTitles" ||
+			key === "prefill" ||
 			key === "maxLength" ||
 			key === "minLength" ||
 			key === "minimum" ||

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -378,6 +378,27 @@ function stripUnsupportedSchemaProperties(
 			continue;
 		}
 
+		// For `properties` (a map of user-named fields to schemas), recurse into
+		// each value but do not filter the field names themselves — otherwise a
+		// tool parameter legitimately named `examples`, `prefill`, `const`, etc.
+		// would be silently dropped.
+		if (
+			key === "properties" &&
+			value &&
+			typeof value === "object" &&
+			!Array.isArray(value)
+		) {
+			const cleanedProps: Record<string, any> = {};
+			for (const [propName, propSchema] of Object.entries(value)) {
+				cleanedProps[propName] = stripUnsupportedSchemaProperties(
+					propSchema,
+					defs,
+				);
+			}
+			cleaned[key] = cleanedProps;
+			continue;
+		}
+
 		// Recursively clean nested objects
 		if (value && typeof value === "object") {
 			cleaned[key] = stripUnsupportedSchemaProperties(value, defs);


### PR DESCRIPTION
## Summary

Google AI Studio (and Vertex) rejects tool parameter schemas containing JSON Schema metadata fields it doesn't understand, returning:

```
400 INVALID_ARGUMENT
Unknown name "prefill" / "examples" / "enumTitles" / "$id" ... Cannot find field.
```

This was observed in a real `google-ai-studio/gemini-3.5-flash` request (request id `DmWAZNBDO6vBJvwLgac9bv9vLJnCKrYI47BMA82M`) where one of the function declarations in `tools[0]` included those properties.

Extend `stripUnsupportedSchemaProperties` in `packages/actions/src/prepare-request-body.ts` to also remove:

- `$id`, `$comment`, `$anchor`, `$dynamicAnchor`, `$dynamicRef`, `$vocabulary`
- `examples`
- `enumTitles`
- `prefill`

These join the existing list (`$schema`, `$defs`, `$ref`, validation keywords, etc.) so any tool that ships richer JSON Schema metadata to Google models is sanitized before the request goes out.

## Test plan

- [x] `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts` — 80 tests pass, including the new case covering `$id`, `examples`, `enumTitles`, and `prefill` for `google-ai-studio`.
- [x] `pnpm build`
- [x] `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Google tool providers by removing unsupported JSON Schema metadata and presentation fields from forwarded tool parameters while preserving valid schema content.
  * Ensures user-provided fields that happen to share names with stripped keywords are retained.

* **Tests**
  * Added coverage verifying unsupported fields are stripped and user-named fields are preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->