### PR TITLE
feat(admin): add canonical model view to cost chart

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6471,6 +6471,8 @@ admin.openapi(getOrgCostByModel, async (c) => {
 
 // --- Cost by model time-series endpoints ---
 
+const costByModelTimeseriesModelViewSchema = z.enum(["mapping", "canonical"]);
+
 const costByModelTimeseriesBucketSchema = z.object({
 	model: z.string(),
 	cost: z.number(),
@@ -6486,6 +6488,7 @@ const costByModelTimeseriesPointSchema = z.object({
 const costByModelTimeseriesResponseSchema = z.object({
 	window: tokenWindowSchema,
 	bucket: z.enum(["hour", "day"]),
+	modelView: costByModelTimeseriesModelViewSchema,
 	models: z.array(z.string()),
 	data: z.array(costByModelTimeseriesPointSchema),
 });
@@ -6540,6 +6543,9 @@ const getOrgCostByModelTimeseries = createRoute({
 		params: z.object({ orgId: z.string() }),
 		query: z.object({
 			window: tokenWindowSchema.default("7d").optional(),
+			modelView: costByModelTimeseriesModelViewSchema
+				.default("mapping")
+				.optional(),
 		}),
 	},
 	responses: {
@@ -6561,6 +6567,7 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 	const { orgId } = c.req.valid("param");
 	const query = c.req.valid("query");
 	const window = query.window ?? "7d";
+	const modelView = query.modelView ?? "mapping";
 	const startDate = getTokenWindowStartDate(window);
 	const bucketUnit = getBucketUnitForWindow(window);
 
@@ -6583,104 +6590,28 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 		return c.json({
 			window,
 			bucket: bucketUnit,
+			modelView,
 			models: [],
 			data: [],
 		});
 	}
 
-	const topModelsRows = await db
-		.select({
-			usedModel: projectHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
-		})
-		.from(projectHourlyModelStats)
-		.where(
-			and(
-				inArray(projectHourlyModelStats.projectId, ids),
-				gte(projectHourlyModelStats.hourTimestamp, startDate),
-			),
-		)
-		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(desc(sql`SUM(${projectHourlyModelStats.cost})`))
-		.limit(10);
-
-	const topModels = topModelsRows.map((r) => r.usedModel);
-
-	if (topModels.length === 0) {
-		return c.json({
-			window,
-			bucket: bucketUnit,
-			models: [],
-			data: [],
-		});
-	}
-
-	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${projectHourlyModelStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
-
-	const rows = await db
-		.select({
-			bucket: bucketExpr.as("bucket"),
-			usedModel: projectHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
-			requestCount:
-				sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
-					"request_count",
-				),
-			totalTokens:
-				sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
-					"total_tokens",
-				),
-		})
-		.from(projectHourlyModelStats)
-		.where(
-			and(
-				inArray(projectHourlyModelStats.projectId, ids),
-				gte(projectHourlyModelStats.hourTimestamp, startDate),
-				inArray(projectHourlyModelStats.usedModel, topModels),
-			),
-		)
-		.groupBy(bucketExpr, projectHourlyModelStats.usedModel)
-		.orderBy(asc(bucketExpr));
-
-	const bucketMap = new Map<
-		string,
-		Map<string, { cost: number; requestCount: number; totalTokens: number }>
-	>();
-
-	for (const row of rows) {
-		const ts = row.bucket;
-		const entry = bucketMap.get(ts) ?? new Map();
-		entry.set(row.usedModel, {
-			cost: Number(row.cost),
-			requestCount: Number(row.requestCount),
-			totalTokens: Number(row.totalTokens),
-		});
-		bucketMap.set(ts, entry);
-	}
-
-	const allBuckets = generateBucketTimestamps(
-		startDate,
-		new Date(),
+	const result = await buildCostByModelTimeseries({
+		modelView,
 		bucketUnit,
-	);
-
-	const data = allBuckets.map((timestamp) => ({
-		timestamp,
-		entries: Array.from(bucketMap.get(timestamp)?.entries() ?? []).map(
-			([model, v]) => ({
-				model,
-				cost: v.cost,
-				requestCount: v.requestCount,
-				totalTokens: v.totalTokens,
-			}),
+		startDate,
+		baseFilter: and(
+			inArray(projectHourlyModelStats.projectId, ids),
+			gte(projectHourlyModelStats.hourTimestamp, startDate),
 		),
-	}));
+	});
 
 	return c.json({
 		window,
 		bucket: bucketUnit,
-		models: topModels,
-		data,
+		modelView,
+		models: result.models,
+		data: result.data,
 	});
 });
 
@@ -6691,6 +6622,9 @@ const getProjectCostByModelTimeseries = createRoute({
 		params: z.object({ orgId: z.string(), projectId: z.string() }),
 		query: z.object({
 			window: tokenWindowSchema.default("7d").optional(),
+			modelView: costByModelTimeseriesModelViewSchema
+				.default("mapping")
+				.optional(),
 		}),
 	},
 	responses: {
@@ -6712,6 +6646,7 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 	const { orgId, projectId } = c.req.valid("param");
 	const query = c.req.valid("query");
 	const window = query.window ?? "7d";
+	const modelView = query.modelView ?? "mapping";
 	const startDate = getTokenWindowStartDate(window);
 	const bucketUnit = getBucketUnitForWindow(window);
 
@@ -6726,32 +6661,78 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 		throw new HTTPException(404, { message: "Project not found" });
 	}
 
-	const topModelsRows = await db
+	const result = await buildCostByModelTimeseries({
+		modelView,
+		bucketUnit,
+		startDate,
+		baseFilter: and(
+			eq(projectHourlyModelStats.projectId, projectId),
+			gte(projectHourlyModelStats.hourTimestamp, startDate),
+		),
+	});
+
+	return c.json({
+		window,
+		bucket: bucketUnit,
+		modelView,
+		models: result.models,
+		data: result.data,
+	});
+});
+
+async function buildCostByModelTimeseries({
+	modelView,
+	bucketUnit,
+	startDate,
+	baseFilter,
+}: {
+	modelView: z.infer<typeof costByModelTimeseriesModelViewSchema>;
+	bucketUnit: "hour" | "day";
+	startDate: Date;
+	baseFilter: ReturnType<typeof and>;
+}): Promise<{
+	models: string[];
+	data: z.infer<typeof costByModelTimeseriesPointSchema>[];
+}> {
+	const keyOf = (usedModel: string) =>
+		modelView === "canonical" ? extractCanonicalModelId(usedModel) : usedModel;
+
+	const modelTotals = await db
 		.select({
 			usedModel: projectHourlyModelStats.usedModel,
 			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
 		})
 		.from(projectHourlyModelStats)
-		.where(
-			and(
-				eq(projectHourlyModelStats.projectId, projectId),
-				gte(projectHourlyModelStats.hourTimestamp, startDate),
-			),
-		)
-		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(desc(sql`SUM(${projectHourlyModelStats.cost})`))
-		.limit(10);
+		.where(baseFilter)
+		.groupBy(projectHourlyModelStats.usedModel);
 
-	const topModels = topModelsRows.map((r) => r.usedModel);
-
-	if (topModels.length === 0) {
-		return c.json({
-			window,
-			bucket: bucketUnit,
-			models: [],
-			data: [],
-		});
+	const totalByKey = new Map<string, number>();
+	const usedModelsByKey = new Map<string, string[]>();
+	for (const row of modelTotals) {
+		const key = keyOf(row.usedModel);
+		totalByKey.set(key, (totalByKey.get(key) ?? 0) + Number(row.cost));
+		const list = usedModelsByKey.get(key) ?? [];
+		list.push(row.usedModel);
+		usedModelsByKey.set(key, list);
 	}
+
+	const topKeys = [...totalByKey.entries()]
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 10)
+		.map(([k]) => k);
+
+	if (topKeys.length === 0) {
+		return { models: [], data: [] };
+	}
+
+	const allBuckets = generateBucketTimestamps(
+		startDate,
+		new Date(),
+		bucketUnit,
+	);
+	const usedModelsToFetch = topKeys.flatMap(
+		(k) => usedModelsByKey.get(k) ?? [],
+	);
 
 	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${projectHourlyModelStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
 
@@ -6772,9 +6753,8 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 		.from(projectHourlyModelStats)
 		.where(
 			and(
-				eq(projectHourlyModelStats.projectId, projectId),
-				gte(projectHourlyModelStats.hourTimestamp, startDate),
-				inArray(projectHourlyModelStats.usedModel, topModels),
+				baseFilter,
+				inArray(projectHourlyModelStats.usedModel, usedModelsToFetch),
 			),
 		)
 		.groupBy(bucketExpr, projectHourlyModelStats.usedModel)
@@ -6787,20 +6767,19 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 
 	for (const row of rows) {
 		const ts = row.bucket;
+		const key = keyOf(row.usedModel);
 		const entry = bucketMap.get(ts) ?? new Map();
-		entry.set(row.usedModel, {
-			cost: Number(row.cost),
-			requestCount: Number(row.requestCount),
-			totalTokens: Number(row.totalTokens),
-		});
+		const existing = entry.get(key) ?? {
+			cost: 0,
+			requestCount: 0,
+			totalTokens: 0,
+		};
+		existing.cost += Number(row.cost);
+		existing.requestCount += Number(row.requestCount);
+		existing.totalTokens += Number(row.totalTokens);
+		entry.set(key, existing);
 		bucketMap.set(ts, entry);
 	}
-
-	const allBuckets = generateBucketTimestamps(
-		startDate,
-		new Date(),
-		bucketUnit,
-	);
 
 	const data = allBuckets.map((timestamp) => ({
 		timestamp,
@@ -6814,13 +6793,8 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 		),
 	}));
 
-	return c.json({
-		window,
-		bucket: bucketUnit,
-		models: topModels,
-		data,
-	});
-});
+	return { models: topKeys, data };
+}
 
 // --- Project Model-Provider Stats ---
 

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -4652,6 +4652,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4672,6 +4673,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;
@@ -4713,6 +4716,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4734,6 +4738,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -4652,6 +4652,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4672,6 +4673,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;
@@ -4713,6 +4716,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4734,6 +4738,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -4652,6 +4652,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4672,6 +4673,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;
@@ -4713,6 +4716,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4734,6 +4738,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;

--- a/ee/admin/src/app/organizations/[orgId]/org-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-cost-by-model-timeseries.tsx
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 import { CostByModelTimeseriesChart } from "@/components/cost-by-model-timeseries-chart";
 import { getOrgCostByModelTimeseries } from "@/lib/admin-history";
 
-import type { TokenWindow } from "@/lib/types";
+import type { ModelView, TokenWindow } from "@/lib/types";
 
 const validWindows = new Set<TokenWindow>([
 	"1h",
@@ -31,8 +31,8 @@ export function OrgCostByModelTimeseries({ orgId }: { orgId: string }) {
 	const window = parseWindow(searchParams.get("window"));
 
 	const fetchData = useCallback(
-		async (w: TokenWindow) => {
-			return await getOrgCostByModelTimeseries(orgId, w);
+		async (w: TokenWindow, modelView: ModelView) => {
+			return await getOrgCostByModelTimeseries(orgId, w, modelView);
 		},
 		[orgId],
 	);

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 import { CostByModelTimeseriesChart } from "@/components/cost-by-model-timeseries-chart";
 import { getProjectCostByModelTimeseries } from "@/lib/admin-history";
 
-import type { TokenWindow } from "@/lib/types";
+import type { ModelView, TokenWindow } from "@/lib/types";
 
 const validWindows = new Set<TokenWindow>([
 	"1h",
@@ -37,8 +37,13 @@ export function ProjectCostByModelTimeseries({
 	const window = parseWindow(searchParams.get("window"));
 
 	const fetchData = useCallback(
-		async (w: TokenWindow) => {
-			return await getProjectCostByModelTimeseries(orgId, projectId, w);
+		async (w: TokenWindow, modelView: ModelView) => {
+			return await getProjectCostByModelTimeseries(
+				orgId,
+				projectId,
+				w,
+				modelView,
+			);
 		},
 		[orgId, projectId],
 	);

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { format } from "date-fns";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import {
@@ -79,17 +79,27 @@ export function CostByModelTimeseriesChart({
 	const [loading, setLoading] = useState(true);
 	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("cost");
 	const [modelView, setModelView] = useState<ModelView>("mapping");
+	const latestRequestRef = useRef(0);
 
 	const loadData = useCallback(async () => {
+		const requestId = ++latestRequestRef.current;
 		setLoading(true);
 		try {
 			const result = await fetchData(externalWindow, modelView);
+			if (requestId !== latestRequestRef.current) {
+				return;
+			}
 			setData(result);
 		} catch (error) {
+			if (requestId !== latestRequestRef.current) {
+				return;
+			}
 			console.error("Failed to load cost by model timeseries:", error);
 			setData(null);
 		} finally {
-			setLoading(false);
+			if (requestId === latestRequestRef.current) {
+				setLoading(false);
+			}
 		}
 	}, [fetchData, externalWindow, modelView]);
 

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -19,7 +19,11 @@ import {
 import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
-import type { CostByModelTimeseriesResponse, TokenWindow } from "@/lib/types";
+import type {
+	CostByModelTimeseriesResponse,
+	ModelView,
+	TokenWindow,
+} from "@/lib/types";
 
 type ActiveMetric = "cost" | "requestCount" | "totalTokens";
 
@@ -27,6 +31,11 @@ const metricTabs: { key: ActiveMetric; label: string }[] = [
 	{ key: "cost", label: "Cost" },
 	{ key: "requestCount", label: "Requests" },
 	{ key: "totalTokens", label: "Tokens" },
+];
+
+const modelViewTabs: { key: ModelView; label: string }[] = [
+	{ key: "mapping", label: "Mappings" },
+	{ key: "canonical", label: "Canonical" },
 ];
 
 const seriesColors = [
@@ -62,17 +71,19 @@ export function CostByModelTimeseriesChart({
 	description?: string;
 	fetchData: (
 		window: TokenWindow,
+		modelView: ModelView,
 	) => Promise<CostByModelTimeseriesResponse | null>;
 	externalWindow: TokenWindow;
 }) {
 	const [data, setData] = useState<CostByModelTimeseriesResponse | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("cost");
+	const [modelView, setModelView] = useState<ModelView>("mapping");
 
 	const loadData = useCallback(async () => {
 		setLoading(true);
 		try {
-			const result = await fetchData(externalWindow);
+			const result = await fetchData(externalWindow, modelView);
 			setData(result);
 		} catch (error) {
 			console.error("Failed to load cost by model timeseries:", error);
@@ -80,7 +91,7 @@ export function CostByModelTimeseriesChart({
 		} finally {
 			setLoading(false);
 		}
-	}, [fetchData, externalWindow]);
+	}, [fetchData, externalWindow, modelView]);
 
 	useEffect(() => {
 		void loadData();
@@ -142,21 +153,39 @@ export function CostByModelTimeseriesChart({
 						{description && <CardDescription>{description}</CardDescription>}
 					</div>
 				</div>
-				<div className="flex items-center gap-1 border-b pb-2">
-					{metricTabs.map((tab) => (
-						<button
-							key={tab.key}
-							className={cn(
-								"rounded-md px-3 py-1 text-xs font-medium transition-colors",
-								activeMetric === tab.key
-									? "bg-primary text-primary-foreground"
-									: "text-muted-foreground hover:text-foreground",
-							)}
-							onClick={() => setActiveMetric(tab.key)}
-						>
-							{tab.label}
-						</button>
-					))}
+				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
+					<div className="flex items-center gap-1">
+						{metricTabs.map((tab) => (
+							<button
+								key={tab.key}
+								className={cn(
+									"rounded-md px-3 py-1 text-xs font-medium transition-colors",
+									activeMetric === tab.key
+										? "bg-primary text-primary-foreground"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+								onClick={() => setActiveMetric(tab.key)}
+							>
+								{tab.label}
+							</button>
+						))}
+					</div>
+					<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
+						{modelViewTabs.map((tab) => (
+							<button
+								key={tab.key}
+								className={cn(
+									"rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
+									modelView === tab.key
+										? "bg-primary text-primary-foreground"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+								onClick={() => setModelView(tab.key)}
+							>
+								{tab.label}
+							</button>
+						))}
+					</div>
 				</div>
 			</CardHeader>
 			<CardContent className="px-2 pb-4 sm:px-6">

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -2,7 +2,7 @@
 
 import { createServerApiClient } from "./server-api";
 
-import type { TokenWindow } from "./types";
+import type { ModelView, TokenWindow } from "./types";
 import type { HistoryWindow } from "@/components/history-chart";
 
 export async function getProviderHistory(
@@ -125,12 +125,13 @@ export async function getOrgCostByModel(orgId: string, window: TokenWindow) {
 export async function getOrgCostByModelTimeseries(
 	orgId: string,
 	window: TokenWindow,
+	modelView: ModelView = "mapping",
 ) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET(
 		"/admin/organizations/{orgId}/cost-by-model-timeseries",
 		{
-			params: { path: { orgId }, query: { window } },
+			params: { path: { orgId }, query: { window, modelView } },
 		},
 	);
 	return data ?? null;
@@ -140,12 +141,13 @@ export async function getProjectCostByModelTimeseries(
 	orgId: string,
 	projectId: string,
 	window: TokenWindow,
+	modelView: ModelView = "mapping",
 ) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET(
 		"/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries",
 		{
-			params: { path: { orgId, projectId }, query: { window } },
+			params: { path: { orgId, projectId }, query: { window, modelView } },
 		},
 	);
 	return data ?? null;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -4652,6 +4652,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4672,6 +4673,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;
@@ -4713,6 +4716,7 @@ export interface paths {
             parameters: {
                 query?: {
                     window?: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
+                    modelView?: "mapping" | "canonical";
                 };
                 header?: never;
                 path: {
@@ -4734,6 +4738,8 @@ export interface paths {
                             window: "1h" | "4h" | "12h" | "1d" | "7d" | "30d" | "90d" | "365d";
                             /** @enum {string} */
                             bucket: "hour" | "day";
+                            /** @enum {string} */
+                            modelView: "mapping" | "canonical";
                             models: string[];
                             data: {
                                 timestamp: string;

--- a/ee/admin/src/lib/types.ts
+++ b/ee/admin/src/lib/types.ts
@@ -102,6 +102,7 @@ export type CostByModelResponse =
 	GetJsonResponse<"/admin/metrics/cost-by-model">;
 export type CostByModelTimeseriesResponse =
 	GetJsonResponse<"/admin/organizations/{orgId}/cost-by-model-timeseries">;
+export type ModelView = CostByModelTimeseriesResponse["modelView"];
 
 // Model-Provider Mappings
 export type ModelProviderMappingsResponse =


### PR DESCRIPTION
## Summary
- Adds a "Mappings" / "Canonical" toggle to the admin "Cost by Model Over Time" chart (org + project views), mirroring the existing selector on the global stats page.
- Backend timeseries endpoints (`/admin/organizations/{orgId}/cost-by-model-timeseries` and the project equivalent) now accept a `modelView` query param. In `canonical` mode, rows are aggregated by canonical model id (the segment between the first `/` and an optional `:region` suffix of `usedModel`), so different provider mappings for the same root model are combined.
- Top-10 selection is also done by the chosen key, so the canonical view returns the top 10 canonical models (with their mappings rolled up) rather than the top 10 raw mappings.

## Test plan
- [ ] Open an organization in the admin dashboard and verify the "Cost by Model Over Time" chart has Mappings / Canonical buttons that switch between the two aggregations.
- [ ] Same on the project drilldown view.
- [ ] Switch the metric tab (Cost / Requests / Tokens) and confirm the canonical aggregation respects the active metric.
- [ ] Confirm the org global stats page is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model view selector (mapping vs canonical) to cost-by-model analytics for organizations and projects.
  * Timeseries charts and APIs now support toggling aggregation mode; charts re-fetch data when the view changes and show results consistent with the selected mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->