### PR TITLE
fix(gateway): map bare 'Not Found' as gateway error

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -169,6 +169,13 @@ describe("getFinishReasonFromError", () => {
 		expect(getFinishReasonFromError(422)).toBe("client_error");
 	});
 
+	it("returns gateway_error for bare 'Not Found' body", () => {
+		expect(getFinishReasonFromError(400, "Not Found")).toBe("gateway_error");
+		expect(getFinishReasonFromError(400, "  Not Found  ")).toBe(
+			"gateway_error",
+		);
+	});
+
 	it("returns gateway_error for upstream 'Unknown model' messages", () => {
 		expect(
 			getFinishReasonFromError(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -85,6 +85,13 @@ export function getFinishReasonFromError(
 		return "gateway_error";
 	}
 
+	// Some providers return a bare "Not Found" body on non-404 status codes when
+	// the model/endpoint mapping is wrong on our side. Treat as gateway_error so
+	// the request can be retried with another provider.
+	if (errorText?.trim() === "Not Found") {
+		return "gateway_error";
+	}
+
 	// zai content filter
 	if (
 		errorText?.includes(

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 
 import { createLogEntry } from "@/chat/tools/create-log-entry.js";
 import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
+import { getFinishReasonFromError } from "@/chat/tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "@/chat/tools/get-provider-env.js";
 import { validateSource } from "@/chat/tools/validate-source.js";
 import {
@@ -175,10 +176,6 @@ function getResponseContent(responseJson: unknown): string | null {
 		}
 	}
 	return JSON.stringify(summary);
-}
-
-function getErrorFinishReason(status: number): string {
-	return status >= 500 ? "upstream_error" : "client_error";
 }
 
 function packFloat32Base64(values: number[]): string {
@@ -925,7 +922,10 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			responseSize,
 			content: getResponseContent(upstreamJson),
 			reasoningContent: null,
-			finishReason: getErrorFinishReason(upstreamResponse.status),
+			finishReason: getFinishReasonFromError(
+				upstreamResponse.status,
+				upstreamText,
+			),
 			promptTokens: null,
 			completionTokens: null,
 			totalTokens: null,

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 
 import { createLogEntry } from "@/chat/tools/create-log-entry.js";
 import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
+import { getFinishReasonFromError } from "@/chat/tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "@/chat/tools/get-provider-env.js";
 import { validateSource } from "@/chat/tools/validate-source.js";
 import {
@@ -167,10 +168,6 @@ function getResponseContent(responseJson: unknown): string | null {
 	}
 
 	return JSON.stringify(responseJson);
-}
-
-function getErrorFinishReason(status: number): string {
-	return status >= 500 ? "upstream_error" : "client_error";
 }
 
 export const moderations = new OpenAPIHono<ServerTypes>();
@@ -611,7 +608,10 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 			responseSize,
 			content: getResponseContent(upstreamJson),
 			reasoningContent: null,
-			finishReason: getErrorFinishReason(upstreamResponse.status),
+			finishReason: getFinishReasonFromError(
+				upstreamResponse.status,
+				upstreamText,
+			),
 			promptTokens: null,
 			completionTokens: null,
 			totalTokens: null,


### PR DESCRIPTION
## Summary
- In `getFinishReasonFromError`, classify a bare `Not Found` error body as `gateway_error` instead of `client_error`, so it gets retried via another provider rather than being attributed to the client.

## Test plan
- [x] `pnpm exec vitest run apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts`
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to treat bare "Not Found" responses as gateway-side errors, yielding more accurate upstream error categorization and more consistent logging/handling across moderation and embeddings flows.

* **Tests**
  * Added a unit test covering the trimmed "Not Found" response case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->