### PR TITLE
feat(ui): show cache write and audio cost/tokens in log

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -805,6 +805,14 @@ export function LogDetailClient({
 													muted
 												/>
 											)}
+										{!!log.cacheWriteInputCost &&
+											Number(log.cacheWriteInputCost) > 0 && (
+												<Field
+													label="Cache Write Cost"
+													value={`$${Number(log.cacheWriteInputCost).toFixed(8)}`}
+													muted
+												/>
+											)}
 										<Field
 											label="Request Cost"
 											value={
@@ -852,6 +860,13 @@ export function LogDetailClient({
 													muted
 												/>
 											)}
+										{!!log.audioInputCost && Number(log.audioInputCost) > 0 && (
+											<Field
+												label="Audio Input Cost"
+												value={`$${Number(log.audioInputCost).toFixed(8)}`}
+												muted
+											/>
+										)}
 										<Field
 											label="Inference Total"
 											value={log.cost ? `$${log.cost.toFixed(8)}` : "$0"}
@@ -899,6 +914,12 @@ export function LogDetailClient({
 								{log.cachedTokens && Number(log.cachedTokens) > 0 && (
 									<Field label="Cached Input Tokens" value={log.cachedTokens} />
 								)}
+								{log.cacheWriteTokens && Number(log.cacheWriteTokens) > 0 && (
+									<Field
+										label="Cache Write Tokens"
+										value={log.cacheWriteTokens}
+									/>
+								)}
 								{log.reasoningTokens && (
 									<Field label="Reasoning Tokens" value={log.reasoningTokens} />
 								)}
@@ -912,6 +933,12 @@ export function LogDetailClient({
 									<Field
 										label="Image Output Tokens"
 										value={log.imageOutputTokens}
+									/>
+								)}
+								{log.audioInputTokens && Number(log.audioInputTokens) > 0 && (
+									<Field
+										label="Audio Input Tokens"
+										value={log.audioInputTokens}
 									/>
 								)}
 								<Field

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -126,6 +126,8 @@ export interface LogCardData {
 	reasoningTokens?: string | number | null;
 	imageInputTokens?: string | number | null;
 	imageOutputTokens?: string | number | null;
+	audioInputTokens?: string | number | null;
+	cacheWriteTokens?: string | number | null;
 	duration?: number | null;
 	timeToFirstToken?: number | null;
 	timeToFirstReasoningToken?: number | null;
@@ -137,11 +139,14 @@ export interface LogCardData {
 	inputCost?: number | null;
 	outputCost?: number | null;
 	cachedInputCost?: number | string | null;
+	cacheWriteInputCost?: number | string | null;
 	requestCost?: number | null;
 	webSearchCost?: number | string | null;
+	contentFilterCost?: number | string | null;
 	imageInputCost?: number | string | null;
 	imageOutputCost?: number | string | null;
 	videoOutputCost?: number | string | null;
+	audioInputCost?: number | string | null;
 	discount?: number | null;
 	pricingTier?: string | null;
 	dataStorageCost?: number | string | null;
@@ -851,6 +856,14 @@ export function LogCard({
 										<div className="font-medium">{log.cachedTokens}</div>
 									</>
 								)}
+								{log.cacheWriteTokens && Number(log.cacheWriteTokens) > 0 && (
+									<>
+										<div className="text-muted-foreground">
+											Cache Write Tokens
+										</div>
+										<div className="font-medium">{log.cacheWriteTokens}</div>
+									</>
+								)}
 								{log.reasoningTokens && Number(log.reasoningTokens) > 0 && (
 									<>
 										<div className="text-muted-foreground">
@@ -873,6 +886,14 @@ export function LogCard({
 											Image Output Tokens
 										</div>
 										<div>{log.imageOutputTokens}</div>
+									</>
+								)}
+								{log.audioInputTokens && Number(log.audioInputTokens) > 0 && (
+									<>
+										<div className="text-muted-foreground">
+											Audio Input Tokens
+										</div>
+										<div>{log.audioInputTokens}</div>
 									</>
 								)}
 								<div className="text-muted-foreground">
@@ -949,6 +970,13 @@ export function LogCard({
 													<div>{`$${Number(log.cachedInputCost).toFixed(8)}`}</div>
 												</>
 											)}
+										{!!log.cacheWriteInputCost &&
+											Number(log.cacheWriteInputCost) > 0 && (
+												<>
+													<div>Cache Write Cost</div>
+													<div>{`$${Number(log.cacheWriteInputCost).toFixed(8)}`}</div>
+												</>
+											)}
 										<div>Request Cost</div>
 										<div>
 											{log.requestCost
@@ -961,6 +989,13 @@ export function LogCard({
 												<div>{`$${Number(log.webSearchCost).toFixed(8)}`}</div>
 											</>
 										)}
+										{!!log.contentFilterCost &&
+											Number(log.contentFilterCost) > 0 && (
+												<>
+													<div>Content Filter Cost</div>
+													<div>{`$${Number(log.contentFilterCost).toFixed(8)}`}</div>
+												</>
+											)}
 										{!!log.imageInputCost && Number(log.imageInputCost) > 0 && (
 											<>
 												<div>Image Input Cost</div>
@@ -981,6 +1016,12 @@ export function LogCard({
 													<div>{`$${Number(log.videoOutputCost).toFixed(8)}`}</div>
 												</>
 											)}
+										{!!log.audioInputCost && Number(log.audioInputCost) > 0 && (
+											<>
+												<div>Audio Input Cost</div>
+												<div>{`$${Number(log.audioInputCost).toFixed(8)}`}</div>
+											</>
+										)}
 										<div>Inference Total</div>
 										<div>{log.cost ? `$${log.cost.toFixed(8)}` : "$0"}</div>
 										{log.discount && log.discount !== 1 && (


### PR DESCRIPTION
## Summary
- Show cache write cost (and add missing content filter / audio input cost) in the activity log card and the log detail page
- Show cache write tokens and audio input tokens alongside existing token rows

## Test plan
- [ ] Open a log with non-zero cache write tokens/cost and verify the new rows appear
- [ ] Open a log with audio input usage and verify the new rows appear
- [ ] Open a log without these extras and verify rows stay hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility of additional cost and token telemetry metrics: Cache Write Cost, Audio Input Cost, Cache Write Tokens, and Audio Input Tokens
  * Metrics display conditionally based on data availability in activity logs and log cards
  * Enhanced cost and response metrics sections with comprehensive breakdown information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->