### PR TITLE
fix(gateway): preserve Alibaba thinking default

### DIFF
--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1197,13 +1197,15 @@ export async function prepareRequestBody(
 		}
 	}
 
-	// Alibaba's API defaults `enable_thinking` to ON for thinking models.
-	// Mirror the OpenAI/Anthropic/Google/ZAI contract: thinking is opt-in via
-	// `reasoning_effort`. Unset or `minimal` => off, anything else => on.
+	// Only override Alibaba's `enable_thinking` default when the caller
+	// explicitly opted in or out via `reasoning_effort`. Leaving it unset
+	// preserves the provider's default behavior.
 	if (usedProvider === "alibaba" && supportsReasoning) {
-		const wantsThinking =
-			reasoning_effort !== undefined && reasoning_effort !== "minimal";
-		requestBody.enable_thinking = wantsThinking;
+		if (reasoning_effort === "minimal") {
+			requestBody.enable_thinking = false;
+		} else if (reasoning_effort !== undefined) {
+			requestBody.enable_thinking = true;
+		}
 	}
 
 	if (forcesToolUse && usedProvider === "moonshot") {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1197,17 +1197,6 @@ export async function prepareRequestBody(
 		}
 	}
 
-	// Only override Alibaba's `enable_thinking` default when the caller
-	// explicitly opted in or out via `reasoning_effort`. Leaving it unset
-	// preserves the provider's default behavior.
-	if (usedProvider === "alibaba" && supportsReasoning) {
-		if (reasoning_effort === "minimal") {
-			requestBody.enable_thinking = false;
-		} else if (reasoning_effort !== undefined) {
-			requestBody.enable_thinking = true;
-		}
-	}
-
 	if (forcesToolUse && usedProvider === "moonshot") {
 		const providerMapping = modelDef?.providers.find(
 			(p) =>


### PR DESCRIPTION
## Summary
- Stop overriding Alibaba's `enable_thinking` default when `reasoning_effort` is not provided
- `reasoning_effort=minimal` → `enable_thinking: false`; any other explicit value → `enable_thinking: true`; unset → omit the flag entirely so Alibaba uses its native default

## Why
Previously the gateway always sent `enable_thinking: false` for Alibaba reasoning models unless `reasoning_effort` was explicitly elevated. That silently disabled thinking for callers who never asked us to change provider defaults, producing very different responses (and latencies) versus hitting Alibaba directly.

## Test plan
- [ ] Call an Alibaba reasoning model through the gateway with no `reasoning_effort` and confirm `enable_thinking` is not in the upstream body
- [ ] Call with `reasoning_effort: "minimal"` and confirm `enable_thinking: false`
- [ ] Call with `reasoning_effort: "high"` and confirm `enable_thinking: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alibaba provider now respects its own default reasoning behavior when no reasoning level is specified.
  * Existing configurations for minimal and other reasoning effort settings continue to apply correctly.
  * Behavior when tool usage is forced remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->