### PR TITLE
fix(gateway): map novita 'sensitive' to content_filter

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -205,6 +205,24 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps novita finish reasons correctly", () => {
+		expect(getUnifiedFinishReason("stop", "novita")).toBe(
+			UnifiedFinishReason.COMPLETED,
+		);
+		expect(getUnifiedFinishReason("length", "novita")).toBe(
+			UnifiedFinishReason.LENGTH_LIMIT,
+		);
+		expect(getUnifiedFinishReason("tool_calls", "novita")).toBe(
+			UnifiedFinishReason.TOOL_CALLS,
+		);
+		expect(getUnifiedFinishReason("sensitive", "novita")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+		expect(getUnifiedFinishReason("content_filter", "novita")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+	});
+
 	it("maps llmgateway_content_filter to CONTENT_FILTER", () => {
 		expect(
 			getUnifiedFinishReason("llmgateway_content_filter", "any-provider"),

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -143,6 +143,7 @@ export function getUnifiedFinishReason(
 			}
 			break;
 		case "zai":
+		case "novita":
 			if (finishReason === "stop") {
 				return UnifiedFinishReason.COMPLETED;
 			}


### PR DESCRIPTION
## Summary
- Novita's GLM models return `sensitive` as a finish reason for safety-filtered output, which was previously logged as an `Unknown finish reason encountered` error.
- Map `sensitive` (and `content_filter`) under provider `novita` to `UnifiedFinishReason.CONTENT_FILTER`, mirroring the existing `zai` handling.

## Test plan
- [x] `pnpm test:unit` passes (added novita finish-reason mapping tests)
- [x] `pnpm build` passes
- [x] `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added novita provider support for finish reason mapping to ensure consistent logging and metrics tracking across providers.

* **Tests**
  * Added test coverage for novita provider finish reason mappings including various completion scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->