### PR TITLE
feat(gateway): same-provider key fallback for embeddings

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -720,6 +720,73 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/embeddings google-ai-studio honors LLM_*_BASE_URL env override in credits mode", async () => {
+		// Credits mode with no provider key forces the env-var token path. The
+		// only thing pointing the request at the mock server is the base-url
+		// env override — if it weren't applied, the request would go to the
+		// real generativelanguage.googleapis.com default and fail.
+		const originalApiKey = process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+		const originalBaseUrl = process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+		process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = "google-env-key";
+		process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = mockServerUrl;
+		try {
+			await harness.setProjectMode("credits");
+			await harness.setOrganizationCredits("100");
+			await db
+				.update(tables.organization)
+				.set({ retentionLevel: "none" })
+				.where(eq(tables.organization.id, "org-id"));
+
+			await db.insert(tables.apiKey).values({
+				id: "token-id-embeddings-google-env",
+				token: "real-token-embeddings-google-env",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const requestId = "embeddings-google-env-request-id";
+			const res = await app.request("/v1/embeddings", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-embeddings-google-env",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					input: "env base url routing",
+					model: "gemini-embedding-001",
+					dimensions: 768,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json).toHaveProperty("object", "list");
+			expect(json).toHaveProperty("model", "gemini-embedding-001");
+			expect(json.data).toHaveLength(1);
+			expect(json.data[0].embedding).toHaveLength(768);
+
+			const logs = await waitForLogs(1);
+			const embeddingLog = logs.find((log) => log.requestId === requestId);
+			expect(embeddingLog).toBeTruthy();
+			expect(embeddingLog?.usedProvider).toBe("google-ai-studio");
+			expect(embeddingLog?.finishReason).toBe("stop");
+			expect(embeddingLog?.hasError).toBe(false);
+		} finally {
+			if (originalApiKey !== undefined) {
+				process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = originalApiKey;
+			} else {
+				delete process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+			}
+			if (originalBaseUrl !== undefined) {
+				process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = originalBaseUrl;
+			} else {
+				delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+			}
+		}
+	});
+
 	test("/v1/embeddings google-ai-studio uses upstream usageMetadata when present", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-embeddings-google-v2",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -28,6 +28,7 @@ import {
 	providerSupportsCachedInput,
 } from "@/lib/coding-models.js";
 import { calculateCosts, shouldBillCancelledRequests } from "@/lib/costs.js";
+import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
 import {
 	getGcpAccessToken,
 	getVertexAnthropicProjectId,
@@ -4562,8 +4563,7 @@ chat.openapi(completions, async (c) => {
 	}
 
 	const startTime = Date.now();
-	const failedEnvKeyIndicesByProvider = new Map<string, Set<number>>();
-	const failedTrackedKeyIdsByProvider = new Map<string, Set<string>>();
+	const failedKeys = createFailedKeyTracker();
 
 	function rememberFailedKey(
 		providerId: string,
@@ -4574,21 +4574,7 @@ chat.openapi(completions, async (c) => {
 			providerKeyId?: string;
 		},
 	): void {
-		const retryKey = providerRetryKey(providerId, region);
-
-		if (options.envVarName !== undefined && options.configIndex !== undefined) {
-			const failedIndices =
-				failedEnvKeyIndicesByProvider.get(retryKey) ?? new Set<number>();
-			failedIndices.add(options.configIndex);
-			failedEnvKeyIndicesByProvider.set(retryKey, failedIndices);
-		}
-
-		if (options.providerKeyId) {
-			const failedKeyIds =
-				failedTrackedKeyIdsByProvider.get(retryKey) ?? new Set<string>();
-			failedKeyIds.add(options.providerKeyId);
-			failedTrackedKeyIdsByProvider.set(retryKey, failedKeyIds);
-		}
+		failedKeys.remember(providerId, region, options);
 	}
 
 	async function resolveProviderContextForRetry(
@@ -4599,10 +4585,6 @@ chat.openapi(completions, async (c) => {
 		},
 		streamValue: boolean,
 	) {
-		const retryKey = providerRetryKey(
-			providerMapping.providerId,
-			providerMapping.region,
-		);
 		return await resolveProviderContext(
 			providerMapping,
 			retryProjectContext,
@@ -4630,8 +4612,14 @@ chat.openapi(completions, async (c) => {
 				hasExistingToolCalls,
 				customProviderName,
 				webSearchEnabled: !!webSearchTool,
-				excludedEnvKeyIndices: failedEnvKeyIndicesByProvider.get(retryKey),
-				excludedProviderKeyIds: failedTrackedKeyIdsByProvider.get(retryKey),
+				excludedEnvKeyIndices: failedKeys.envKeyIndicesFor(
+					providerMapping.providerId,
+					providerMapping.region,
+				),
+				excludedProviderKeyIds: failedKeys.providerKeyIdsFor(
+					providerMapping.providerId,
+					providerMapping.region,
+				),
 				providerCacheControlEnabled,
 			},
 		);

--- a/apps/gateway/src/embeddings/embeddings.spec.ts
+++ b/apps/gateway/src/embeddings/embeddings.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "vitest";
 
 import { app } from "@/app.js";
 import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
+import { resetFailOnceCounter } from "@/test-utils/mock-openai-server.js";
+import { waitForLogs } from "@/test-utils/test-helpers.js";
 
 import { db, tables } from "@llmgateway/db";
 
@@ -36,5 +38,109 @@ describe("embeddings", () => {
 		expect(JSON.stringify(json)).toContain(
 			"Embeddings are not available for coding plans",
 		);
+	});
+
+	test("/v1/embeddings retries with another BYOK key after upstream 500", async () => {
+		resetFailOnceCounter();
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-embeddings-retry",
+			token: "real-token-embeddings-retry",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values([
+			{
+				id: "provider-key-openai-primary",
+				token: "openai-primary-token",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: harness.mockServerUrl,
+			},
+			{
+				id: "provider-key-openai-secondary",
+				token: "openai-secondary-token",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: harness.mockServerUrl,
+			},
+		]);
+
+		const res = await app.request("/v1/embeddings", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-embeddings-retry",
+			},
+			body: JSON.stringify({
+				model: "text-embedding-3-small",
+				input: "TRIGGER_FAIL_ONCE first call should fail",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json).toHaveProperty("object", "list");
+		expect(Array.isArray(json.data)).toBe(true);
+
+		const logs = await waitForLogs(2);
+		const embeddingLogs = logs.filter(
+			(l) => l.usedModel === "openai/text-embedding-3-small",
+		);
+		expect(embeddingLogs).toHaveLength(2);
+
+		const failedLog = embeddingLogs.find((l) => l.hasError);
+		const successLog = embeddingLogs.find((l) => !l.hasError);
+		expect(failedLog).toBeDefined();
+		expect(successLog).toBeDefined();
+		expect(failedLog?.finishReason).toBe("upstream_error");
+		expect(failedLog?.retried).toBe(true);
+		expect(failedLog?.retriedByLogId).toBe(successLog?.id);
+		expect(successLog?.finishReason).toBe("stop");
+		expect(successLog?.retried).toBe(false);
+	});
+
+	test("/v1/embeddings returns upstream error when no alternate key is available", async () => {
+		resetFailOnceCounter();
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-embeddings-no-retry",
+			token: "real-token-embeddings-no-retry",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-openai-only",
+			token: "openai-only-token",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: harness.mockServerUrl,
+		});
+
+		const res = await app.request("/v1/embeddings", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-embeddings-no-retry",
+			},
+			body: JSON.stringify({
+				model: "text-embedding-3-small",
+				input: "TRIGGER_FAIL_ONCE no alternate key configured",
+			}),
+		});
+
+		expect(res.status).toBe(500);
+		const logs = await waitForLogs(1);
+		const embeddingLog = logs.find(
+			(l) => l.usedModel === "openai/text-embedding-3-small",
+		);
+		expect(embeddingLog).toBeDefined();
+		expect(embeddingLog?.hasError).toBe(true);
+		expect(embeddingLog?.retried).toBe(false);
+		expect(embeddingLog?.retriedByLogId).toBeNull();
 	});
 });

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -5,6 +5,10 @@ import { createLogEntry } from "@/chat/tools/create-log-entry.js";
 import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
 import { getFinishReasonFromError } from "@/chat/tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "@/chat/tools/get-provider-env.js";
+import {
+	isRetryableErrorType,
+	shouldRetryAlternateKey,
+} from "@/chat/tools/retry-with-fallback.js";
 import { validateSource } from "@/chat/tools/validate-source.js";
 import {
 	reportKeyError,
@@ -21,6 +25,7 @@ import {
 } from "@/lib/cached-queries.js";
 import { getClientIpFromRequest } from "@/lib/client-ip.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
+import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
 import { throwIamException, validateModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
@@ -545,102 +550,17 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		throwIamException(iamValidation.reason ?? "Model access denied");
 	}
 
-	let providerKey: InferSelectModel<typeof tables.providerKey> | undefined;
-	let usedToken: string | undefined;
-	let configIndex = 0;
-	let envVarName: string | undefined;
+	const finalLogId = shortid();
+	const failedKeys = createFailedKeyTracker();
 
-	if (project.mode === "api-keys") {
-		providerKey = await findProviderKey(
-			project.organizationId,
-			providerId,
-			upstreamModel,
-		);
-		if (!providerKey) {
-			throw new HTTPException(400, {
-				message: `No API key set for provider: ${providerId}. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.`,
-			});
-		}
-		usedToken = providerKey.token;
-	} else if (project.mode === "credits") {
-		assertCreditsAvailableForEmbedding(
-			organization,
-			modelDef,
-			`Organization ${organization.id} has insufficient credits`,
-			(renewalDate) =>
-				`Dev Plan credit limit reached. Upgrade your plan or wait for renewal on ${renewalDate}.`,
-		);
-
-		const envResult = getProviderEnv(providerId, {
-			selectionScope: upstreamModel,
-		});
-		usedToken = envResult.token;
-		configIndex = envResult.configIndex;
-		envVarName = envResult.envVarName;
-	} else if (project.mode === "hybrid") {
-		providerKey = await findProviderKey(
-			project.organizationId,
-			providerId,
-			upstreamModel,
-		);
-		if (providerKey) {
-			usedToken = providerKey.token;
-		} else {
-			assertCreditsAvailableForEmbedding(
-				organization,
-				modelDef,
-				"No API key set for provider and organization has insufficient credits",
-				(renewalDate) =>
-					`No API key set for provider. Dev Plan credit limit reached. Upgrade your plan or wait for renewal on ${renewalDate}.`,
-			);
-
-			const envResult = getProviderEnv(providerId, {
-				selectionScope: upstreamModel,
-			});
-			usedToken = envResult.token;
-			configIndex = envResult.configIndex;
-			envVarName = envResult.envVarName;
-		}
-	} else {
-		throw new HTTPException(400, {
-			message: `Invalid project mode: ${project.mode}`,
-		});
-	}
-
-	if (retentionLevel === "retain") {
-		const { totalAvailableCredits } = getAvailableCredits(organization);
-
-		if (totalAvailableCredits <= 0) {
-			throw new HTTPException(402, {
-				message:
-					"Organization has insufficient credits for data retention. Data retention requires credits for storage costs ($0.01 per 1M tokens). Please add credits or disable data retention in organization settings.",
-			});
-		}
-	}
-
-	if (!usedToken) {
-		throw new HTTPException(500, {
-			message: "No token",
-		});
-	}
-
-	const providerBaseUrlDefaults: Partial<Record<string, string>> = {
-		openai: "https://api.openai.com",
-		"google-ai-studio": "https://generativelanguage.googleapis.com",
-		"google-vertex": "https://aiplatform.googleapis.com",
+	// Snapshot narrowed fields so the resolveAttempt closure (defined later) sees
+	// them as definitely-present without leaning on TS's flow narrowing across
+	// closure boundaries.
+	const retryProject = {
+		mode: project.mode,
+		organizationId: project.organizationId,
 	};
-	// Env baseUrl override: LLM_<PROVIDER>_BASE_URL can redirect upstream
-	// traffic to proxies, regional endpoints, or test mocks. Applies to
-	// any provider — getProviderEnvValue returns undefined for providers
-	// that don't declare a baseUrl env in packages/models/src/providers.ts,
-	// so the ?? chain falls through safely. providerKey.baseUrl still wins
-	// when set, so BYOK callers can opt out by configuring their own.
-	const envBaseUrl = getProviderEnvValue(providerId, "baseUrl", configIndex);
-	const resolvedBaseUrl =
-		providerKey?.baseUrl ??
-		envBaseUrl ??
-		providerBaseUrlDefaults[providerId] ??
-		"https://api.openai.com";
+	const retryOrganization = organization;
 
 	const isGoogleAiStudio = providerId === "google-ai-studio";
 	const isGoogleVertex = providerId === "google-vertex";
@@ -651,117 +571,288 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				: [input as string]
 			: [];
 
-	let upstreamUrl: string;
-	let requestBody: Record<string, unknown>;
+	const providerBaseUrlDefaults: Partial<Record<string, string>> = {
+		openai: "https://api.openai.com",
+		"google-ai-studio": "https://generativelanguage.googleapis.com",
+		"google-vertex": "https://aiplatform.googleapis.com",
+	};
 
-	if (isGoogleAiStudio) {
-		const endpoint =
-			googleInputs.length > 1 ? "batchEmbedContents" : "embedContent";
-		upstreamUrl = `${resolvedBaseUrl}/v1beta/models/${upstreamModel}:${endpoint}?key=${encodeURIComponent(usedToken)}`;
-		const buildSingleRequest = (text: string) => {
-			const single: Record<string, unknown> = {
-				content: { parts: [{ text }] },
+	interface EmbeddingAttempt {
+		providerKey: InferSelectModel<typeof tables.providerKey> | undefined;
+		usedToken: string;
+		configIndex: number;
+		envVarName: string | undefined;
+		upstreamUrl: string;
+		requestBody: Record<string, unknown>;
+	}
+
+	type ResolveResult =
+		| { kind: "ok"; attempt: EmbeddingAttempt }
+		| {
+				kind: "json_error";
+				status: 400 | 500;
+				body: z.infer<typeof embeddingErrorSchema>;
+		  };
+
+	// Resolves the per-attempt context: which token to use plus the upstream URL
+	// and request body. Called once per attempt so same-provider retries can
+	// rotate to the next configured key via `failedKeys`. Credit / no-key / bad
+	// project-mode failures propagate as HTTPException (same shape as before).
+	// Provider-shape validation errors (Vertex project id, batch_not_supported)
+	// come back as `json_error` so the caller can `c.json` them directly with
+	// the OpenAI-compatible `{ error: { code, ... } }` envelope.
+	async function resolveAttempt(): Promise<ResolveResult> {
+		let providerKey: InferSelectModel<typeof tables.providerKey> | undefined;
+		let usedToken: string | undefined;
+		let configIndex = 0;
+		let envVarName: string | undefined;
+
+		const excludedProviderKeyIds = failedKeys.providerKeyIdsFor(
+			providerId,
+			undefined,
+		);
+		const excludedEnvKeyIndices = failedKeys.envKeyIndicesFor(
+			providerId,
+			undefined,
+		);
+
+		if (retryProject.mode === "api-keys") {
+			providerKey = await findProviderKey(
+				retryProject.organizationId,
+				providerId,
+				upstreamModel,
+				excludedProviderKeyIds,
+			);
+			if (!providerKey) {
+				throw new HTTPException(400, {
+					message: `No API key set for provider: ${providerId}. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.`,
+				});
+			}
+			usedToken = providerKey.token;
+		} else if (retryProject.mode === "credits") {
+			assertCreditsAvailableForEmbedding(
+				retryOrganization,
+				modelDef,
+				`Organization ${retryOrganization.id} has insufficient credits`,
+				(renewalDate) =>
+					`Dev Plan credit limit reached. Upgrade your plan or wait for renewal on ${renewalDate}.`,
+			);
+
+			const envResult = getProviderEnv(providerId, {
+				selectionScope: upstreamModel,
+				excludedIndices: excludedEnvKeyIndices,
+			});
+			usedToken = envResult.token;
+			configIndex = envResult.configIndex;
+			envVarName = envResult.envVarName;
+		} else if (retryProject.mode === "hybrid") {
+			providerKey = await findProviderKey(
+				retryProject.organizationId,
+				providerId,
+				upstreamModel,
+				excludedProviderKeyIds,
+			);
+			if (providerKey) {
+				usedToken = providerKey.token;
+			} else {
+				assertCreditsAvailableForEmbedding(
+					retryOrganization,
+					modelDef,
+					"No API key set for provider and organization has insufficient credits",
+					(renewalDate) =>
+						`No API key set for provider. Dev Plan credit limit reached. Upgrade your plan or wait for renewal on ${renewalDate}.`,
+				);
+
+				const envResult = getProviderEnv(providerId, {
+					selectionScope: upstreamModel,
+					excludedIndices: excludedEnvKeyIndices,
+				});
+				usedToken = envResult.token;
+				configIndex = envResult.configIndex;
+				envVarName = envResult.envVarName;
+			}
+		} else {
+			throw new HTTPException(400, {
+				message: `Invalid project mode: ${retryProject.mode}`,
+			});
+		}
+
+		if (retentionLevel === "retain") {
+			const { totalAvailableCredits } = getAvailableCredits(retryOrganization);
+
+			if (totalAvailableCredits <= 0) {
+				throw new HTTPException(402, {
+					message:
+						"Organization has insufficient credits for data retention. Data retention requires credits for storage costs ($0.01 per 1M tokens). Please add credits or disable data retention in organization settings.",
+				});
+			}
+		}
+
+		if (!usedToken) {
+			throw new HTTPException(500, {
+				message: "No token",
+			});
+		}
+
+		// Env baseUrl override: LLM_<PROVIDER>_BASE_URL can redirect upstream
+		// traffic to proxies, regional endpoints, or test mocks. Applies to
+		// any provider — getProviderEnvValue returns undefined for providers
+		// that don't declare a baseUrl env in packages/models/src/providers.ts,
+		// so the ?? chain falls through safely. providerKey.baseUrl still wins
+		// when set, so BYOK callers can opt out by configuring their own.
+		const envBaseUrl = getProviderEnvValue(providerId, "baseUrl", configIndex);
+		const resolvedBaseUrl =
+			providerKey?.baseUrl ??
+			envBaseUrl ??
+			providerBaseUrlDefaults[providerId] ??
+			"https://api.openai.com";
+
+		let upstreamUrl: string;
+		let requestBody: Record<string, unknown>;
+
+		if (isGoogleAiStudio) {
+			const endpoint =
+				googleInputs.length > 1 ? "batchEmbedContents" : "embedContent";
+			upstreamUrl = `${resolvedBaseUrl}/v1beta/models/${upstreamModel}:${endpoint}?key=${encodeURIComponent(usedToken)}`;
+			const buildSingleRequest = (text: string) => {
+				const single: Record<string, unknown> = {
+					content: { parts: [{ text }] },
+				};
+				if (dimensions !== undefined) {
+					single.outputDimensionality = dimensions;
+				}
+				return single;
+			};
+
+			if (endpoint === "batchEmbedContents") {
+				requestBody = {
+					requests: googleInputs.map((text) => ({
+						model: `models/${upstreamModel}`,
+						...buildSingleRequest(text),
+					})),
+				};
+			} else {
+				requestBody = buildSingleRequest(googleInputs[0]);
+			}
+		} else if (isGoogleVertex) {
+			// All exposed google-vertex embedding models go through PredictionService's
+			// :predict endpoint, which accepts API-key auth via ?key= just like the
+			// chat path. The text-embedding-* family natively batches up to 250
+			// inputs per request; gemini-embedding-001 is the one model that only
+			// accepts a single input per call, so we reject batches for it upfront
+			// rather than fanning out silently (which would hide cost/quota/latency).
+			const singleInputOnlyModels = new Set(["gemini-embedding-001"]);
+			if (singleInputOnlyModels.has(upstreamModel) && googleInputs.length > 1) {
+				return {
+					kind: "json_error",
+					status: 400,
+					body: {
+						error: {
+							message: `Model ${upstreamModel} accepts only one input per request on google-vertex. Pass a single string instead of an array, loop client-side, or use the same model via the google-ai-studio provider which supports native batching via batchEmbedContents.`,
+							type: "invalid_request_error",
+							param: "input",
+							code: "batch_not_supported",
+						},
+					},
+				};
+			}
+			const vertexProjectId =
+				providerKey?.options?.google_vertex_project_id ??
+				getProviderEnvValue("google-vertex", "project", configIndex);
+			if (!vertexProjectId) {
+				return {
+					kind: "json_error",
+					status: 500,
+					body: {
+						error: {
+							message:
+								"Google Vertex requires a project ID. Set LLM_GOOGLE_CLOUD_PROJECT or configure google_vertex_project_id on the provider key.",
+							type: "invalid_request_error",
+							param: null,
+							code: "missing_project_id",
+						},
+					},
+				};
+			}
+			const vertexRegion =
+				getProviderEnvValue("google-vertex", "region", configIndex, "global") ??
+				"global";
+
+			upstreamUrl = `${resolvedBaseUrl}/v1/projects/${vertexProjectId}/locations/${vertexRegion}/publishers/google/models/${upstreamModel}:predict?key=${encodeURIComponent(usedToken)}`;
+			requestBody = {
+				instances: googleInputs.map((text) => ({ content: text })),
 			};
 			if (dimensions !== undefined) {
-				single.outputDimensionality = dimensions;
+				requestBody.parameters = { outputDimensionality: dimensions };
 			}
-			return single;
-		};
-
-		if (endpoint === "batchEmbedContents") {
-			requestBody = {
-				requests: googleInputs.map((text) => ({
-					model: `models/${upstreamModel}`,
-					...buildSingleRequest(text),
-				})),
-			};
 		} else {
-			requestBody = buildSingleRequest(googleInputs[0]);
+			upstreamUrl = `${resolvedBaseUrl}/v1/embeddings`;
+			requestBody = {
+				input,
+				model: upstreamModel,
+			};
+			if (encoding_format !== undefined) {
+				requestBody.encoding_format = encoding_format;
+			}
+			if (dimensions !== undefined) {
+				requestBody.dimensions = dimensions;
+			}
+			if (user !== undefined) {
+				requestBody.user = user;
+			}
 		}
-	} else if (isGoogleVertex) {
-		// All exposed google-vertex embedding models go through PredictionService's
-		// :predict endpoint, which accepts API-key auth via ?key= just like the
-		// chat path. The text-embedding-* family natively batches up to 250
-		// inputs per request; gemini-embedding-001 is the one model that only
-		// accepts a single input per call, so we reject batches for it upfront
-		// rather than fanning out silently (which would hide cost/quota/latency).
-		const singleInputOnlyModels = new Set(["gemini-embedding-001"]);
-		if (singleInputOnlyModels.has(upstreamModel) && googleInputs.length > 1) {
-			return c.json(
-				{
-					error: {
-						message: `Model ${upstreamModel} accepts only one input per request on google-vertex. Pass a single string instead of an array, loop client-side, or use the same model via the google-ai-studio provider which supports native batching via batchEmbedContents.`,
-						type: "invalid_request_error",
-						param: "input",
-						code: "batch_not_supported",
-					},
-				},
-				400,
-			);
-		}
-		const vertexProjectId =
-			providerKey?.options?.google_vertex_project_id ??
-			getProviderEnvValue("google-vertex", "project", configIndex);
-		if (!vertexProjectId) {
-			return c.json(
-				{
-					error: {
-						message:
-							"Google Vertex requires a project ID. Set LLM_GOOGLE_CLOUD_PROJECT or configure google_vertex_project_id on the provider key.",
-						type: "invalid_request_error",
-						param: null,
-						code: "missing_project_id",
-					},
-				},
-				500,
-			);
-		}
-		const vertexRegion =
-			getProviderEnvValue("google-vertex", "region", configIndex, "global") ??
-			"global";
 
-		upstreamUrl = `${resolvedBaseUrl}/v1/projects/${vertexProjectId}/locations/${vertexRegion}/publishers/google/models/${upstreamModel}:predict?key=${encodeURIComponent(usedToken)}`;
-		requestBody = {
-			instances: googleInputs.map((text) => ({ content: text })),
+		return {
+			kind: "ok",
+			attempt: {
+				providerKey,
+				usedToken,
+				configIndex,
+				envVarName,
+				upstreamUrl,
+				requestBody,
+			},
 		};
-		if (dimensions !== undefined) {
-			requestBody.parameters = { outputDimensionality: dimensions };
-		}
-	} else {
-		upstreamUrl = `${resolvedBaseUrl}/v1/embeddings`;
-		requestBody = {
-			input,
-			model: upstreamModel,
-		};
-		if (encoding_format !== undefined) {
-			requestBody.encoding_format = encoding_format;
-		}
-		if (dimensions !== undefined) {
-			requestBody.dimensions = dimensions;
-		}
-		if (user !== undefined) {
-			requestBody.user = user;
+	}
+
+	// Mark the failed key, then resolve a new attempt context. Returns null when
+	// no eligible alternate key remains (tracker exhausted, getProviderEnv throws
+	// "no eligible values remain", findProviderKey returns undefined, or the
+	// resolver hits a configuration error we shouldn't retry on).
+	async function resolveNextAttempt(
+		failedAttempt: EmbeddingAttempt,
+	): Promise<EmbeddingAttempt | null> {
+		failedKeys.remember(providerId, undefined, {
+			envVarName: failedAttempt.envVarName,
+			configIndex: failedAttempt.configIndex,
+			providerKeyId: failedAttempt.providerKey?.id,
+		});
+		try {
+			const next = await resolveAttempt();
+			if (next.kind !== "ok") {
+				return null;
+			}
+			// Guard against the rare case where the selector hands back the same
+			// credential (e.g. health failover collapsed back to the only key).
+			if (
+				next.attempt.usedToken === failedAttempt.usedToken &&
+				next.attempt.envVarName === failedAttempt.envVarName &&
+				next.attempt.configIndex === failedAttempt.configIndex &&
+				next.attempt.providerKey?.id === failedAttempt.providerKey?.id
+			) {
+				return null;
+			}
+			return next.attempt;
+		} catch {
+			return null;
 		}
 	}
 
-	const baseLogEntry = createLogEntry({
-		requestId,
-		project,
-		apiKey,
-		providerKeyId: providerKey?.id,
-		usedModel: `${providerId}/${modelDefId}`,
-		usedModelMapping: upstreamModel,
-		usedProvider: providerId,
-		requestedModel,
-		requestedProvider: providerId,
-		messages: normalizedMessages,
-		source,
-		customHeaders,
-		debugMode,
-		userAgent,
-		rawRequest: rawBody,
-		upstreamRequest: requestBody,
-	});
+	const initialResult = await resolveAttempt();
+	if (initialResult.kind === "json_error") {
+		return c.json(initialResult.body, initialResult.status);
+	}
+	let attempt: EmbeddingAttempt = initialResult.attempt;
 
 	const controller = new AbortController();
 	const onAbort = () => {
@@ -769,421 +860,465 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 	};
 	c.req.raw.signal.addEventListener("abort", onAbort);
 
-	let upstreamResponse: Response;
-	let duration: number;
-
 	try {
-		const fetchSignal = createCombinedSignal(controller);
-		upstreamResponse = await fetch(upstreamUrl, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				...getProviderHeaders(providerId, usedToken, { requestId }),
-			},
-			body: JSON.stringify(requestBody),
-			signal: fetchSignal,
-		});
-	} catch (error) {
-		const isCanceled = error instanceof Error && error.name === "AbortError";
-		const isTimeout = isTimeoutError(error);
-		const isNetworkError = error instanceof TypeError;
+		while (true) {
+			const attemptLogId = shortid();
+			const baseLogEntry = createLogEntry({
+				requestId,
+				project,
+				apiKey,
+				providerKeyId: attempt.providerKey?.id,
+				usedModel: `${providerId}/${modelDefId}`,
+				usedModelMapping: upstreamModel,
+				usedProvider: providerId,
+				requestedModel,
+				requestedProvider: providerId,
+				messages: normalizedMessages,
+				source,
+				customHeaders,
+				debugMode,
+				userAgent,
+				rawRequest: rawBody,
+				upstreamRequest: attempt.requestBody,
+			});
 
-		if (!isCanceled && !isTimeout && !isNetworkError) {
-			throw error;
-		}
-
-		duration = Date.now() - startedAt;
-		if (envVarName !== undefined) {
-			reportKeyError(envVarName, configIndex, 0);
-		}
-		if (providerKey?.id) {
-			reportTrackedKeyError(providerKey.id, 0);
-		}
-
-		await insertLog({
-			...baseLogEntry,
-			duration,
-			timeToFirstToken: null,
-			timeToFirstReasoningToken: null,
-			responseSize: 0,
-			content: null,
-			reasoningContent: null,
-			finishReason: isCanceled ? "canceled" : "upstream_error",
-			promptTokens: null,
-			completionTokens: null,
-			totalTokens: null,
-			reasoningTokens: null,
-			cachedTokens: null,
-			hasError: !isCanceled,
-			streamed: false,
-			canceled: isCanceled,
-			errorDetails: isCanceled
-				? null
-				: {
-						statusCode: 0,
-						statusText: error instanceof Error ? error.name : "FetchError",
-						responseText:
-							error instanceof Error ? error.message : String(error),
+			let upstreamResponse: Response;
+			let fetchError: Error | null = null;
+			try {
+				const fetchSignal = createCombinedSignal(controller);
+				upstreamResponse = await fetch(attempt.upstreamUrl, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						...getProviderHeaders(providerId, attempt.usedToken, { requestId }),
 					},
-			inputCost: 0,
-			outputCost: 0,
-			cachedInputCost: 0,
-			requestCost: 0,
-			webSearchCost: 0,
-			imageInputTokens: null,
-			imageOutputTokens: null,
-			imageInputCost: null,
-			imageOutputCost: null,
-			cost: 0,
-			estimatedCost: false,
-			discount: null,
-			pricingTier: null,
-			dataStorageCost: calculateDataStorageCost(
-				null,
-				null,
-				null,
-				null,
-				retentionLevel,
-			),
-			cached: false,
-			toolResults: null,
-		});
+					body: JSON.stringify(attempt.requestBody),
+					signal: fetchSignal,
+				});
+			} catch (error) {
+				const isCanceled =
+					error instanceof Error && error.name === "AbortError";
+				const isTimeout = isTimeoutError(error);
+				const isNetworkError = error instanceof TypeError;
+				if (!isCanceled && !isTimeout && !isNetworkError) {
+					throw error;
+				}
+				fetchError = error instanceof Error ? error : new Error(String(error));
+				upstreamResponse = undefined as unknown as Response;
+			}
 
-		if (isCanceled) {
-			return c.json(
-				{
+			if (fetchError !== null) {
+				const isCanceled = fetchError.name === "AbortError";
+				const isTimeout = isTimeoutError(fetchError);
+
+				const duration = Date.now() - startedAt;
+				if (attempt.envVarName !== undefined) {
+					reportKeyError(attempt.envVarName, attempt.configIndex, 0);
+				}
+				if (attempt.providerKey?.id) {
+					reportTrackedKeyError(attempt.providerKey.id, 0);
+				}
+
+				const nextAttempt =
+					!isCanceled && isRetryableErrorType("network_error")
+						? await resolveNextAttempt(attempt)
+						: null;
+				const willRetry = nextAttempt !== null;
+
+				await insertLog({
+					...baseLogEntry,
+					id: willRetry ? attemptLogId : finalLogId,
+					duration,
+					timeToFirstToken: null,
+					timeToFirstReasoningToken: null,
+					responseSize: 0,
+					content: null,
+					reasoningContent: null,
+					finishReason: isCanceled ? "canceled" : "upstream_error",
+					promptTokens: null,
+					completionTokens: null,
+					totalTokens: null,
+					reasoningTokens: null,
+					cachedTokens: null,
+					hasError: !isCanceled,
+					streamed: false,
+					canceled: isCanceled,
+					errorDetails: isCanceled
+						? null
+						: {
+								statusCode: 0,
+								statusText: fetchError.name,
+								responseText: fetchError.message,
+							},
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					webSearchCost: 0,
+					imageInputTokens: null,
+					imageOutputTokens: null,
+					imageInputCost: null,
+					imageOutputCost: null,
+					cost: 0,
+					estimatedCost: false,
+					discount: null,
+					pricingTier: null,
+					dataStorageCost: calculateDataStorageCost(
+						null,
+						null,
+						null,
+						null,
+						retentionLevel,
+					),
+					cached: false,
+					toolResults: null,
+					retried: willRetry,
+					retriedByLogId: willRetry ? finalLogId : null,
+				});
+
+				if (willRetry && nextAttempt) {
+					attempt = nextAttempt;
+					continue;
+				}
+
+				if (isCanceled) {
+					return c.json(
+						{
+							error: {
+								message: "Request canceled by client",
+								type: "canceled",
+								param: null,
+								code: "request_canceled",
+							},
+						},
+						400,
+					);
+				}
+
+				return c.json(
+					{
+						error: {
+							message: isTimeout
+								? `Upstream provider timeout: ${fetchError.message}`
+								: `Failed to connect to provider: ${fetchError.message}`,
+							type: isTimeout ? "upstream_timeout" : "upstream_error",
+							param: null,
+							code: isTimeout ? "timeout" : "fetch_failed",
+						},
+					},
+					isTimeout ? 504 : 502,
+				);
+			}
+
+			const upstreamText = await upstreamResponse.text();
+			const duration = Date.now() - startedAt;
+			const responseSize = upstreamText.length;
+
+			let upstreamJson: unknown = null;
+			if (upstreamText) {
+				try {
+					upstreamJson = JSON.parse(upstreamText);
+				} catch {
+					upstreamJson = upstreamText;
+				}
+			}
+
+			if (!upstreamResponse.ok) {
+				const status = upstreamResponse.status;
+				if (attempt.envVarName !== undefined) {
+					reportKeyError(
+						attempt.envVarName,
+						attempt.configIndex,
+						status,
+						upstreamText,
+					);
+				}
+				if (attempt.providerKey?.id) {
+					reportTrackedKeyError(attempt.providerKey.id, status, upstreamText);
+				}
+
+				const finishReason = getFinishReasonFromError(status, upstreamText);
+				const nextAttempt = shouldRetryAlternateKey(
+					finishReason,
+					status,
+					upstreamText,
+				)
+					? await resolveNextAttempt(attempt)
+					: null;
+				const willRetry = nextAttempt !== null;
+
+				await insertLog({
+					...baseLogEntry,
+					id: willRetry ? attemptLogId : finalLogId,
+					duration,
+					timeToFirstToken: null,
+					timeToFirstReasoningToken: null,
+					responseSize,
+					content: getResponseContent(upstreamJson),
+					reasoningContent: null,
+					finishReason,
+					promptTokens: null,
+					completionTokens: null,
+					totalTokens: null,
+					reasoningTokens: null,
+					cachedTokens: null,
+					hasError: true,
+					streamed: false,
+					canceled: false,
+					errorDetails: {
+						statusCode: status,
+						statusText: upstreamResponse.statusText,
+						responseText: upstreamText,
+					},
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					webSearchCost: 0,
+					imageInputTokens: null,
+					imageOutputTokens: null,
+					imageInputCost: null,
+					imageOutputCost: null,
+					cost: 0,
+					estimatedCost: false,
+					discount: null,
+					pricingTier: null,
+					dataStorageCost: calculateDataStorageCost(
+						null,
+						null,
+						null,
+						null,
+						retentionLevel,
+					),
+					cached: false,
+					toolResults: null,
+					retried: willRetry,
+					retriedByLogId: willRetry ? finalLogId : null,
+				});
+
+				if (willRetry && nextAttempt) {
+					attempt = nextAttempt;
+					continue;
+				}
+
+				const normalizedUpstreamError: z.infer<typeof embeddingErrorSchema> = {
 					error: {
-						message: "Request canceled by client",
-						type: "canceled",
+						message:
+							typeof upstreamJson === "string"
+								? upstreamJson
+								: (upstreamResponse.statusText ?? "Upstream error"),
+						type: "upstream_error",
 						param: null,
-						code: "request_canceled",
+						code: "upstream_error",
 					},
-				},
-				400,
-			);
-		}
+				};
 
-		return c.json(
-			{
-				error: {
-					message: isTimeout
-						? `Upstream provider timeout: ${
-								error instanceof Error ? error.message : String(error)
-							}`
-						: `Failed to connect to provider: ${
-								error instanceof Error ? error.message : String(error)
-							}`,
-					type: isTimeout ? "upstream_timeout" : "upstream_error",
-					param: null,
-					code: isTimeout ? "timeout" : "fetch_failed",
-				},
-			},
-			isTimeout ? 504 : 502,
-		);
+				return c.json(
+					upstreamJson && typeof upstreamJson === "object"
+						? upstreamJson
+						: normalizedUpstreamError,
+					status as 400 | 401 | 403 | 404 | 410 | 429 | 500 | 502 | 503 | 504,
+				);
+			}
+
+			if (attempt.envVarName !== undefined) {
+				reportKeySuccess(attempt.envVarName, attempt.configIndex);
+			}
+			if (attempt.providerKey?.id) {
+				reportTrackedKeySuccess(attempt.providerKey.id);
+			}
+
+			let normalizedResponse: Record<string, unknown> = (upstreamJson ??
+				{}) as Record<string, unknown>;
+			let promptTokens: number | null = null;
+			let totalTokens: number | null = null;
+			let estimatedUsage = false;
+
+			if (isGoogleAiStudio) {
+				const upstream =
+					upstreamJson && typeof upstreamJson === "object"
+						? (upstreamJson as Record<string, unknown>)
+						: {};
+				const rawEmbeddings: Array<Record<string, unknown>> = (() => {
+					if (Array.isArray(upstream.embeddings)) {
+						return upstream.embeddings as Array<Record<string, unknown>>;
+					}
+					if (upstream.embedding && typeof upstream.embedding === "object") {
+						return [upstream.embedding as Record<string, unknown>];
+					}
+					return [];
+				})();
+				const wantsBase64 = encoding_format === "base64";
+				const data = rawEmbeddings.map((item, index) => {
+					const values = Array.isArray(item.values)
+						? (item.values as number[])
+						: [];
+					return {
+						object: "embedding" as const,
+						index,
+						embedding: wantsBase64 ? packFloat32Base64(values) : values,
+					};
+				});
+				const upstreamUsage =
+					upstream.usageMetadata && typeof upstream.usageMetadata === "object"
+						? (upstream.usageMetadata as Record<string, unknown>)
+						: undefined;
+				const upstreamPromptTokens =
+					typeof upstreamUsage?.promptTokenCount === "number"
+						? upstreamUsage.promptTokenCount
+						: null;
+				const estimatedTokens = googleInputs.reduce(
+					(sum, text) => sum + Math.max(1, Math.ceil(text.length / 4)),
+					0,
+				);
+				if (upstreamPromptTokens !== null) {
+					promptTokens = upstreamPromptTokens;
+				} else {
+					promptTokens = estimatedTokens;
+					estimatedUsage = true;
+				}
+				totalTokens = promptTokens;
+				normalizedResponse = {
+					object: "list",
+					data,
+					model: requestedModel,
+					usage: {
+						prompt_tokens: promptTokens,
+						total_tokens: totalTokens,
+					},
+				};
+			} else if (isGoogleVertex) {
+				const upstream =
+					upstreamJson && typeof upstreamJson === "object"
+						? (upstreamJson as Record<string, unknown>)
+						: {};
+				// Vertex :predict response: { predictions: [{embeddings: {values, statistics: {token_count}}}, ...] }
+				// One prediction per instance. text-embedding-* models return multiple
+				// when batched; gemini-embedding-001 always returns one.
+				const predictions = Array.isArray(upstream.predictions)
+					? (upstream.predictions as Array<Record<string, unknown>>)
+					: [];
+				const wantsBase64 = encoding_format === "base64";
+				let upstreamTokenSum = 0;
+				let anyTokenStatMissing = false;
+				const data = predictions.map((prediction, index) => {
+					const embeddingsObj =
+						prediction.embeddings && typeof prediction.embeddings === "object"
+							? (prediction.embeddings as Record<string, unknown>)
+							: {};
+					const values = Array.isArray(embeddingsObj.values)
+						? (embeddingsObj.values as number[])
+						: [];
+					const stats =
+						embeddingsObj.statistics &&
+						typeof embeddingsObj.statistics === "object"
+							? (embeddingsObj.statistics as Record<string, unknown>)
+							: undefined;
+					if (typeof stats?.token_count === "number") {
+						upstreamTokenSum += stats.token_count;
+					} else {
+						anyTokenStatMissing = true;
+					}
+					return {
+						object: "embedding" as const,
+						index,
+						embedding: wantsBase64 ? packFloat32Base64(values) : values,
+					};
+				});
+				if (predictions.length === 0 || anyTokenStatMissing) {
+					promptTokens = googleInputs.reduce(
+						(sum, text) => sum + Math.max(1, Math.ceil(text.length / 4)),
+						0,
+					);
+					estimatedUsage = true;
+				} else {
+					promptTokens = upstreamTokenSum;
+				}
+				totalTokens = promptTokens;
+				normalizedResponse = {
+					object: "list",
+					data,
+					model: requestedModel,
+					usage: {
+						prompt_tokens: promptTokens,
+						total_tokens: totalTokens,
+					},
+				};
+			} else {
+				const usage =
+					upstreamJson &&
+					typeof upstreamJson === "object" &&
+					"usage" in (upstreamJson as Record<string, unknown>)
+						? ((upstreamJson as Record<string, unknown>).usage as
+								| Record<string, unknown>
+								| undefined)
+						: undefined;
+				const promptTokensRaw = usage?.prompt_tokens;
+				const totalTokensRaw = usage?.total_tokens;
+				promptTokens =
+					typeof promptTokensRaw === "number" ? promptTokensRaw : null;
+				totalTokens =
+					typeof totalTokensRaw === "number" ? totalTokensRaw : promptTokens;
+				if (promptTokens === null) {
+					logger.warn("Embeddings response missing usage.prompt_tokens", {
+						requestId,
+						provider: providerId,
+						model: upstreamModel,
+					});
+				}
+			}
+
+			const inputPrice = Number(mapping.inputPrice ?? "0");
+			const inputCost = promptTokens !== null ? promptTokens * inputPrice : 0;
+			const requestCost = Number(mapping.requestPrice ?? "0");
+			const cost = inputCost + requestCost;
+
+			await insertLog({
+				...baseLogEntry,
+				id: finalLogId,
+				duration,
+				timeToFirstToken: null,
+				timeToFirstReasoningToken: null,
+				responseSize,
+				content: getResponseContent(normalizedResponse),
+				reasoningContent: null,
+				finishReason: "stop",
+				promptTokens: promptTokens !== null ? promptTokens.toString() : null,
+				completionTokens: null,
+				totalTokens: totalTokens !== null ? totalTokens.toString() : null,
+				reasoningTokens: null,
+				cachedTokens: null,
+				hasError: false,
+				streamed: false,
+				canceled: false,
+				errorDetails: null,
+				inputCost,
+				outputCost: 0,
+				cachedInputCost: 0,
+				requestCost,
+				webSearchCost: 0,
+				imageInputTokens: null,
+				imageOutputTokens: null,
+				imageInputCost: null,
+				imageOutputCost: null,
+				cost,
+				estimatedCost: estimatedUsage,
+				discount: null,
+				pricingTier: null,
+				dataStorageCost: calculateDataStorageCost(
+					promptTokens,
+					null,
+					null,
+					null,
+					retentionLevel,
+				),
+				cached: false,
+				toolResults: null,
+			});
+
+			return c.json(normalizedResponse);
+		}
 	} finally {
 		c.req.raw.signal.removeEventListener("abort", onAbort);
 	}
-
-	const upstreamText = await upstreamResponse.text();
-	duration = Date.now() - startedAt;
-	const responseSize = upstreamText.length;
-
-	let upstreamJson: unknown = null;
-	if (upstreamText) {
-		try {
-			upstreamJson = JSON.parse(upstreamText);
-		} catch {
-			upstreamJson = upstreamText;
-		}
-	}
-
-	if (!upstreamResponse.ok) {
-		if (envVarName !== undefined) {
-			reportKeyError(
-				envVarName,
-				configIndex,
-				upstreamResponse.status,
-				upstreamText,
-			);
-		}
-		if (providerKey?.id) {
-			reportTrackedKeyError(
-				providerKey.id,
-				upstreamResponse.status,
-				upstreamText,
-			);
-		}
-
-		await insertLog({
-			...baseLogEntry,
-			duration,
-			timeToFirstToken: null,
-			timeToFirstReasoningToken: null,
-			responseSize,
-			content: getResponseContent(upstreamJson),
-			reasoningContent: null,
-			finishReason: getFinishReasonFromError(
-				upstreamResponse.status,
-				upstreamText,
-			),
-			promptTokens: null,
-			completionTokens: null,
-			totalTokens: null,
-			reasoningTokens: null,
-			cachedTokens: null,
-			hasError: true,
-			streamed: false,
-			canceled: false,
-			errorDetails: {
-				statusCode: upstreamResponse.status,
-				statusText: upstreamResponse.statusText,
-				responseText: upstreamText,
-			},
-			inputCost: 0,
-			outputCost: 0,
-			cachedInputCost: 0,
-			requestCost: 0,
-			webSearchCost: 0,
-			imageInputTokens: null,
-			imageOutputTokens: null,
-			imageInputCost: null,
-			imageOutputCost: null,
-			cost: 0,
-			estimatedCost: false,
-			discount: null,
-			pricingTier: null,
-			dataStorageCost: calculateDataStorageCost(
-				null,
-				null,
-				null,
-				null,
-				retentionLevel,
-			),
-			cached: false,
-			toolResults: null,
-		});
-
-		const normalizedUpstreamError: z.infer<typeof embeddingErrorSchema> = {
-			error: {
-				message:
-					typeof upstreamJson === "string"
-						? upstreamJson
-						: (upstreamResponse.statusText ?? "Upstream error"),
-				type: "upstream_error",
-				param: null,
-				code: "upstream_error",
-			},
-		};
-
-		return c.json(
-			upstreamJson && typeof upstreamJson === "object"
-				? upstreamJson
-				: normalizedUpstreamError,
-			upstreamResponse.status as
-				| 400
-				| 401
-				| 403
-				| 404
-				| 410
-				| 429
-				| 500
-				| 502
-				| 503
-				| 504,
-		);
-	}
-
-	if (envVarName !== undefined) {
-		reportKeySuccess(envVarName, configIndex);
-	}
-	if (providerKey?.id) {
-		reportTrackedKeySuccess(providerKey.id);
-	}
-
-	let normalizedResponse: Record<string, unknown> = (upstreamJson ??
-		{}) as Record<string, unknown>;
-	let promptTokens: number | null = null;
-	let totalTokens: number | null = null;
-	let estimatedUsage = false;
-
-	if (isGoogleAiStudio) {
-		const upstream =
-			upstreamJson && typeof upstreamJson === "object"
-				? (upstreamJson as Record<string, unknown>)
-				: {};
-		const rawEmbeddings: Array<Record<string, unknown>> = (() => {
-			if (Array.isArray(upstream.embeddings)) {
-				return upstream.embeddings as Array<Record<string, unknown>>;
-			}
-			if (upstream.embedding && typeof upstream.embedding === "object") {
-				return [upstream.embedding as Record<string, unknown>];
-			}
-			return [];
-		})();
-		const wantsBase64 = encoding_format === "base64";
-		const data = rawEmbeddings.map((item, index) => {
-			const values = Array.isArray(item.values)
-				? (item.values as number[])
-				: [];
-			return {
-				object: "embedding" as const,
-				index,
-				embedding: wantsBase64 ? packFloat32Base64(values) : values,
-			};
-		});
-		const upstreamUsage =
-			upstream.usageMetadata && typeof upstream.usageMetadata === "object"
-				? (upstream.usageMetadata as Record<string, unknown>)
-				: undefined;
-		const upstreamPromptTokens =
-			typeof upstreamUsage?.promptTokenCount === "number"
-				? upstreamUsage.promptTokenCount
-				: null;
-		const estimatedTokens = googleInputs.reduce(
-			(sum, text) => sum + Math.max(1, Math.ceil(text.length / 4)),
-			0,
-		);
-		if (upstreamPromptTokens !== null) {
-			promptTokens = upstreamPromptTokens;
-		} else {
-			promptTokens = estimatedTokens;
-			estimatedUsage = true;
-		}
-		totalTokens = promptTokens;
-		normalizedResponse = {
-			object: "list",
-			data,
-			model: requestedModel,
-			usage: {
-				prompt_tokens: promptTokens,
-				total_tokens: totalTokens,
-			},
-		};
-	} else if (isGoogleVertex) {
-		const upstream =
-			upstreamJson && typeof upstreamJson === "object"
-				? (upstreamJson as Record<string, unknown>)
-				: {};
-		// Vertex :predict response: { predictions: [{embeddings: {values, statistics: {token_count}}}, ...] }
-		// One prediction per instance. text-embedding-* models return multiple
-		// when batched; gemini-embedding-001 always returns one.
-		const predictions = Array.isArray(upstream.predictions)
-			? (upstream.predictions as Array<Record<string, unknown>>)
-			: [];
-		const wantsBase64 = encoding_format === "base64";
-		let upstreamTokenSum = 0;
-		let anyTokenStatMissing = false;
-		const data = predictions.map((prediction, index) => {
-			const embeddingsObj =
-				prediction.embeddings && typeof prediction.embeddings === "object"
-					? (prediction.embeddings as Record<string, unknown>)
-					: {};
-			const values = Array.isArray(embeddingsObj.values)
-				? (embeddingsObj.values as number[])
-				: [];
-			const stats =
-				embeddingsObj.statistics && typeof embeddingsObj.statistics === "object"
-					? (embeddingsObj.statistics as Record<string, unknown>)
-					: undefined;
-			if (typeof stats?.token_count === "number") {
-				upstreamTokenSum += stats.token_count;
-			} else {
-				anyTokenStatMissing = true;
-			}
-			return {
-				object: "embedding" as const,
-				index,
-				embedding: wantsBase64 ? packFloat32Base64(values) : values,
-			};
-		});
-		if (predictions.length === 0 || anyTokenStatMissing) {
-			promptTokens = googleInputs.reduce(
-				(sum, text) => sum + Math.max(1, Math.ceil(text.length / 4)),
-				0,
-			);
-			estimatedUsage = true;
-		} else {
-			promptTokens = upstreamTokenSum;
-		}
-		totalTokens = promptTokens;
-		normalizedResponse = {
-			object: "list",
-			data,
-			model: requestedModel,
-			usage: {
-				prompt_tokens: promptTokens,
-				total_tokens: totalTokens,
-			},
-		};
-	} else {
-		const usage =
-			upstreamJson &&
-			typeof upstreamJson === "object" &&
-			"usage" in (upstreamJson as Record<string, unknown>)
-				? ((upstreamJson as Record<string, unknown>).usage as
-						| Record<string, unknown>
-						| undefined)
-				: undefined;
-		const promptTokensRaw = usage?.prompt_tokens;
-		const totalTokensRaw = usage?.total_tokens;
-		promptTokens = typeof promptTokensRaw === "number" ? promptTokensRaw : null;
-		totalTokens =
-			typeof totalTokensRaw === "number" ? totalTokensRaw : promptTokens;
-		if (promptTokens === null) {
-			logger.warn("Embeddings response missing usage.prompt_tokens", {
-				requestId,
-				provider: providerId,
-				model: upstreamModel,
-			});
-		}
-	}
-
-	const inputPrice = Number(mapping.inputPrice ?? "0");
-	const inputCost = promptTokens !== null ? promptTokens * inputPrice : 0;
-	const requestCost = Number(mapping.requestPrice ?? "0");
-	const cost = inputCost + requestCost;
-
-	await insertLog({
-		...baseLogEntry,
-		duration,
-		timeToFirstToken: null,
-		timeToFirstReasoningToken: null,
-		responseSize,
-		content: getResponseContent(normalizedResponse),
-		reasoningContent: null,
-		finishReason: "stop",
-		promptTokens: promptTokens !== null ? promptTokens.toString() : null,
-		completionTokens: null,
-		totalTokens: totalTokens !== null ? totalTokens.toString() : null,
-		reasoningTokens: null,
-		cachedTokens: null,
-		hasError: false,
-		streamed: false,
-		canceled: false,
-		errorDetails: null,
-		inputCost,
-		outputCost: 0,
-		cachedInputCost: 0,
-		requestCost,
-		webSearchCost: 0,
-		imageInputTokens: null,
-		imageOutputTokens: null,
-		imageInputCost: null,
-		imageOutputCost: null,
-		cost,
-		estimatedCost: estimatedUsage,
-		discount: null,
-		pricingTier: null,
-		dataStorageCost: calculateDataStorageCost(
-			promptTokens,
-			null,
-			null,
-			null,
-			retentionLevel,
-		),
-		cached: false,
-		toolResults: null,
-	});
-
-	return c.json(normalizedResponse);
 });

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -553,9 +553,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 	const finalLogId = shortid();
 	const failedKeys = createFailedKeyTracker();
 
-	// Snapshot narrowed fields so the resolveAttempt closure (defined later) sees
-	// them as definitely-present without leaning on TS's flow narrowing across
-	// closure boundaries.
+	// Snapshot narrowed fields so the resolveAttempt closure keeps them non-null.
 	const retryProject = {
 		mode: project.mode,
 		organizationId: project.organizationId,
@@ -594,13 +592,10 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				body: z.infer<typeof embeddingErrorSchema>;
 		  };
 
-	// Resolves the per-attempt context: which token to use plus the upstream URL
-	// and request body. Called once per attempt so same-provider retries can
-	// rotate to the next configured key via `failedKeys`. Credit / no-key / bad
-	// project-mode failures propagate as HTTPException (same shape as before).
-	// Provider-shape validation errors (Vertex project id, batch_not_supported)
-	// come back as `json_error` so the caller can `c.json` them directly with
-	// the OpenAI-compatible `{ error: { code, ... } }` envelope.
+	// Resolves the token, upstream URL, and request body for one attempt,
+	// excluding keys already tried via `failedKeys` so retries rotate. Credit /
+	// no-key failures throw HTTPException; provider-shape errors (Vertex project
+	// id, batch_not_supported) return as `json_error` for direct `c.json`.
 	async function resolveAttempt(): Promise<ResolveResult> {
 		let providerKey: InferSelectModel<typeof tables.providerKey> | undefined;
 		let usedToken: string | undefined;
@@ -815,10 +810,10 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		};
 	}
 
-	// Mark the failed key, then resolve a new attempt context. Returns null when
-	// no eligible alternate key remains (tracker exhausted, getProviderEnv throws
-	// "no eligible values remain", findProviderKey returns undefined, or the
-	// resolver hits a configuration error we shouldn't retry on).
+	// Marks the failed key and resolves the next attempt, or null when no eligible
+	// alternate key remains. Mirrors chat's tryResolveAlternateKeyForCurrentProvider:
+	// resolution failures (no key / json_error) collapse to null so the original
+	// upstream error stays the terminal response.
 	async function resolveNextAttempt(
 		failedAttempt: EmbeddingAttempt,
 	): Promise<EmbeddingAttempt | null> {
@@ -832,8 +827,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			if (next.kind !== "ok") {
 				return null;
 			}
-			// Guard against the rare case where the selector hands back the same
-			// credential (e.g. health failover collapsed back to the only key).
+			// Selector may hand back the same credential (single key, health collapse).
 			if (
 				next.attempt.usedToken === failedAttempt.usedToken &&
 				next.attempt.envVarName === failedAttempt.envVarName &&
@@ -919,8 +913,11 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					reportTrackedKeyError(attempt.providerKey.id, 0);
 				}
 
+				const networkErrorType = isTimeout
+					? "upstream_timeout"
+					: "network_error";
 				const nextAttempt =
-					!isCanceled && isRetryableErrorType("network_error")
+					!isCanceled && isRetryableErrorType(networkErrorType)
 						? await resolveNextAttempt(attempt)
 						: null;
 				const willRetry = nextAttempt !== null;

--- a/apps/gateway/src/lib/failed-key-tracker.spec.ts
+++ b/apps/gateway/src/lib/failed-key-tracker.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import { createFailedKeyTracker } from "./failed-key-tracker.js";
+
+describe("createFailedKeyTracker", () => {
+	test("tracks env-var indices separately per provider+region", () => {
+		const tracker = createFailedKeyTracker();
+
+		tracker.remember("openai", undefined, {
+			envVarName: "LLM_OPENAI_API_KEY",
+			configIndex: 0,
+		});
+		tracker.remember("openai", undefined, {
+			envVarName: "LLM_OPENAI_API_KEY",
+			configIndex: 2,
+		});
+		tracker.remember("alibaba", "cn-beijing", {
+			envVarName: "LLM_ALIBABA_API_KEY",
+			configIndex: 1,
+		});
+
+		expect(
+			Array.from(tracker.envKeyIndicesFor("openai", undefined) ?? []),
+		).toEqual([0, 2]);
+		expect(
+			Array.from(tracker.envKeyIndicesFor("alibaba", "cn-beijing") ?? []),
+		).toEqual([1]);
+		expect(tracker.envKeyIndicesFor("alibaba", "singapore")).toBeUndefined();
+	});
+
+	test("tracks BYOK provider-key ids separately from env indices", () => {
+		const tracker = createFailedKeyTracker();
+
+		tracker.remember("together-ai", undefined, {
+			providerKeyId: "key-primary",
+		});
+		tracker.remember("together-ai", undefined, {
+			providerKeyId: "key-secondary",
+		});
+
+		expect(
+			Array.from(tracker.providerKeyIdsFor("together-ai", undefined) ?? []),
+		).toEqual(["key-primary", "key-secondary"]);
+		expect(tracker.envKeyIndicesFor("together-ai", undefined)).toBeUndefined();
+	});
+
+	test("ignores incomplete env-var entries (missing configIndex or envVarName)", () => {
+		const tracker = createFailedKeyTracker();
+
+		// envVarName without configIndex — not enough to identify the slot
+		tracker.remember("openai", undefined, { envVarName: "LLM_OPENAI_API_KEY" });
+		// configIndex without envVarName — same
+		tracker.remember("openai", undefined, { configIndex: 0 });
+
+		expect(tracker.envKeyIndicesFor("openai", undefined)).toBeUndefined();
+	});
+});

--- a/apps/gateway/src/lib/failed-key-tracker.ts
+++ b/apps/gateway/src/lib/failed-key-tracker.ts
@@ -1,0 +1,60 @@
+import { providerRetryKey } from "@/chat/tools/retry-with-fallback.js";
+
+export interface FailedKeyOptions {
+	envVarName?: string;
+	configIndex?: number;
+	providerKeyId?: string;
+}
+
+export interface FailedKeyTracker {
+	remember: (
+		providerId: string,
+		region: string | undefined,
+		options: FailedKeyOptions,
+	) => void;
+	envKeyIndicesFor: (
+		providerId: string,
+		region: string | undefined,
+	) => ReadonlySet<number> | undefined;
+	providerKeyIdsFor: (
+		providerId: string,
+		region: string | undefined,
+	) => ReadonlySet<string> | undefined;
+}
+
+/**
+ * Tracks env-var indices and BYOK provider-key ids that have already failed
+ * during a single request, so the same key isn't retried twice. Shared by the
+ * chat and embedding paths to drive same-provider key rotation.
+ */
+export function createFailedKeyTracker(): FailedKeyTracker {
+	const envIndices = new Map<string, Set<number>>();
+	const providerKeyIds = new Map<string, Set<string>>();
+
+	return {
+		remember(providerId, region, options) {
+			const key = providerRetryKey(providerId, region);
+
+			if (
+				options.envVarName !== undefined &&
+				options.configIndex !== undefined
+			) {
+				const set = envIndices.get(key) ?? new Set<number>();
+				set.add(options.configIndex);
+				envIndices.set(key, set);
+			}
+
+			if (options.providerKeyId) {
+				const set = providerKeyIds.get(key) ?? new Set<string>();
+				set.add(options.providerKeyId);
+				providerKeyIds.set(key, set);
+			}
+		},
+		envKeyIndicesFor(providerId, region) {
+			return envIndices.get(providerRetryKey(providerId, region));
+		},
+		providerKeyIdsFor(providerId, region) {
+			return providerKeyIds.get(providerRetryKey(providerId, region));
+		},
+	};
+}

--- a/apps/gateway/src/lib/failed-key-tracker.ts
+++ b/apps/gateway/src/lib/failed-key-tracker.ts
@@ -51,10 +51,12 @@ export function createFailedKeyTracker(): FailedKeyTracker {
 			}
 		},
 		envKeyIndicesFor(providerId, region) {
-			return envIndices.get(providerRetryKey(providerId, region));
+			const set = envIndices.get(providerRetryKey(providerId, region));
+			return set ? new Set(set) : undefined;
 		},
 		providerKeyIdsFor(providerId, region) {
-			return providerKeyIds.get(providerRetryKey(providerId, region));
+			const set = providerKeyIds.get(providerRetryKey(providerId, region));
+			return set ? new Set(set) : undefined;
 		},
 	};
 }

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1104,6 +1104,17 @@ mockOpenAIServer.post("/v1/embeddings", async (c) => {
 		return c.json(sampleErrorResponse);
 	}
 
+	// First call with TRIGGER_FAIL_ONCE fails with 500, subsequent calls fall
+	// through to the success path. Lets embedding key-rotation tests verify
+	// that the gateway retries with another key after an upstream failure.
+	if (combinedInput.includes("TRIGGER_FAIL_ONCE")) {
+		failOnceCounter++;
+		if (failOnceCounter === 1) {
+			c.status(500);
+			return c.json(sampleErrorResponse);
+		}
+	}
+
 	const requestedDimensions =
 		typeof body.dimensions === "number" && body.dimensions > 0
 			? body.dimensions


### PR DESCRIPTION
## Summary

`/v1/embeddings` previously made a single upstream fetch and surfaced any failure straight to the client, even when other configured keys (BYOK provider rows or extra comma-separated values in `LLM_<PROVIDER>_API_KEY`) could have served the request. The chat path has had same-provider key rotation for a while; embeddings now mirrors it.

- On a retryable upstream failure, the failed key is recorded and excluded, the per-attempt context (token, baseUrl, Google `?key=` URL) is re-resolved, and the request retries against the next eligible key.
- Each attempt writes its own log entry: failed attempts get a fresh id with `retried=true` + `retriedByLogId` pointing at the final log id; the terminal attempt (success or final error) keeps the pre-allocated `finalLogId`. Same shape chat uses.
- All three project modes participate: `api-keys` and `hybrid` rotate BYOK rows via `findProviderKey(... excludedProviderKeyIds)`; `credits` and `hybrid` fallback rotate env-var indices via `getProviderEnv(... excludedIndices)`.
- Retry decision uses the same `shouldRetryAlternateKey` / `isRetryableErrorType` helpers from `chat/tools/retry-with-fallback`, so 5xx, network errors, timeouts, and credential-shaped 401/403 all rotate consistently with chat.

## Reuse

Extracts `chat.ts`'s inline `rememberFailedKey` closure into a shared `createFailedKeyTracker()` helper (`apps/gateway/src/lib/failed-key-tracker.ts`). Chat is refactored to use it; embeddings uses it directly. No behavior change for chat — just the closure became a tiny module.

## Test plan

- [x] `pnpm format`
- [x] `pnpm build` (17/17 succeed)
- [x] `pnpm test:unit apps/gateway/src/embeddings` — 3/3 pass (existing + 2 new: retry success and no-alternate-key cases)
- [x] `pnpm test:unit apps/gateway/src/lib/failed-key-tracker.spec.ts` — 3/3 pass
- [x] `pnpm test:unit apps/gateway/src/chat` — 357/357 pass (no chat regressions from the closure refactor)
- [x] `pnpm test:unit apps/gateway/src/api.spec.ts -t embeddings` — 17/17 pass (all pre-existing embeddings api.spec coverage still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embeddings now support multi-attempt retries that rotate across alternate provider credentials and respect per-attempt exclusion of previously-failed keys; Google AI Studio and Vertex responses are normalized and batched as needed.
* **Bug Fixes**
  * Improved retry decisioning, error normalization, and timeout/cancel classification with clearer per-attempt logging.
* **Tests**
  * Added tests and mocks for fail-once retry behavior, failed-key tracking, and Google AI Studio routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->