### PR TITLE
fix: removed the top border radius from chat OpenGraph card with image

### DIFF
--- a/apps/playground/src/app/share/[shareId]/opengraph-image.tsx
+++ b/apps/playground/src/app/share/[shareId]/opengraph-image.tsx
@@ -416,8 +416,6 @@ function ImagePreview({ preview }: { preview: SharePreview }) {
 					width: "100%",
 					height: 284,
 					overflow: "hidden",
-					borderTopLeftRadius: 24,
-					borderTopRightRadius: 24,
 				}}
 			>
 				<img
@@ -428,30 +426,6 @@ function ImagePreview({ preview }: { preview: SharePreview }) {
 						height: 568,
 						objectFit: "cover",
 						objectPosition: "center center",
-					}}
-				/>
-				<div
-					style={{
-						position: "absolute",
-						left: 0,
-						top: 0,
-						width: 24,
-						height: 24,
-						display: "flex",
-						background: "#09090b",
-						borderRadius: "0 0 24px 0",
-					}}
-				/>
-				<div
-					style={{
-						position: "absolute",
-						right: 0,
-						top: 0,
-						width: 24,
-						height: 24,
-						display: "flex",
-						background: "#09090b",
-						borderRadius: "0 0 0 24px",
 					}}
 				/>
 				<div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified image preview styling by removing top border-radius settings from the image container and removing decorative corner elements (top-left and top-right blocks). The bottom gradient overlay is preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->