### PR TITLE
fix(ui): show OAuth sign-in errors in login/signup UI

### DIFF
--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -20,6 +20,7 @@ import { z } from "zod";
 
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
+import { getAuthErrorMessage } from "@/lib/auth-errors";
 import { Button } from "@/lib/components/button";
 import {
 	Form,
@@ -60,6 +61,20 @@ export default function Login() {
 	useEffect(() => {
 		posthog.capture("page_viewed_login");
 	}, [posthog]);
+
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		const error = params.get("error");
+		if (error) {
+			toast({
+				title: getAuthErrorMessage(error),
+				variant: "destructive",
+			});
+			params.delete("error");
+			const query = params.toString();
+			router.replace(window.location.pathname + (query ? `?${query}` : ""));
+		}
+	}, [router]);
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),
@@ -281,6 +296,8 @@ export default function Login() {
 										provider: "github",
 										callbackURL:
 											location.protocol + "//" + location.host + "/dashboard",
+										errorCallbackURL:
+											location.protocol + "//" + location.host + "/login",
 									});
 									if (res?.error) {
 										toast({
@@ -314,6 +331,8 @@ export default function Login() {
 										provider: "google",
 										callbackURL:
 											location.protocol + "//" + location.host + "/dashboard",
+										errorCallbackURL:
+											location.protocol + "//" + location.host + "/login",
 									});
 									if (res?.error) {
 										toast({

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -13,6 +13,7 @@ import { z } from "zod";
 
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
+import { getAuthErrorMessage } from "@/lib/auth-errors";
 import { Button } from "@/lib/components/button";
 import {
 	Form,
@@ -70,6 +71,20 @@ export default function Signup() {
 	useEffect(() => {
 		posthog.capture("page_viewed_signup");
 	}, [posthog]);
+
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		const error = params.get("error");
+		if (error) {
+			toast({
+				title: getAuthErrorMessage(error),
+				variant: "destructive",
+			});
+			params.delete("error");
+			const query = params.toString();
+			router.replace(window.location.pathname + (query ? `?${query}` : ""));
+		}
+	}, [router]);
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),
@@ -176,6 +191,8 @@ export default function Signup() {
 													"//" +
 													location.host +
 													"/dashboard",
+												errorCallbackURL:
+													location.protocol + "//" + location.host + "/signup",
 											});
 											if (res?.error) {
 												toast({
@@ -213,6 +230,8 @@ export default function Signup() {
 													"//" +
 													location.host +
 													"/dashboard",
+												errorCallbackURL:
+													location.protocol + "//" + location.host + "/signup",
 											});
 											if (res?.error) {
 												toast({

--- a/apps/ui/src/lib/auth-errors.ts
+++ b/apps/ui/src/lib/auth-errors.ts
@@ -1,0 +1,23 @@
+const authErrorMessages: Record<string, string> = {
+	account_not_linked:
+		"An account with this email already exists. Please sign in with your email and password, or use the provider you originally signed up with.",
+	signup_disabled: "Sign ups are currently disabled.",
+	unable_to_create_user: "We couldn't create your account. Please try again.",
+	email_not_verified:
+		"Please verify your email address before signing in. Check your inbox for the verification link.",
+	account_deactivated:
+		"Your account has been deactivated. Please contact support.",
+	state_mismatch: "Your sign-in session expired. Please try signing in again.",
+	please_restart_the_process:
+		"Something went wrong during sign-in. Please try again.",
+};
+
+export function getAuthErrorMessage(code: string | null | undefined): string {
+	if (!code) {
+		return "An unknown error occurred during sign-in. Please try again.";
+	}
+	return (
+		authErrorMessages[code] ??
+		"An error occurred during sign-in. Please try again."
+	);
+}

--- a/apps/ui/src/lib/auth-errors.ts
+++ b/apps/ui/src/lib/auth-errors.ts
@@ -1,15 +1,27 @@
+// Error codes emitted by better-auth's social OAuth callback as the `?error=`
+// query param. The callback derives them from `result.error.split(" ").join("_")`
+// (see better-auth dist/api/routes/callback.mjs and dist/oauth2/link-account.mjs).
 const authErrorMessages: Record<string, string> = {
 	account_not_linked:
 		"An account with this email already exists. Please sign in with your email and password, or use the provider you originally signed up with.",
+	account_already_linked_to_different_user:
+		"This provider account is already linked to a different user.",
+	unable_to_link_account:
+		"We couldn't link this account. Please try a different sign-in method.",
 	signup_disabled: "Sign ups are currently disabled.",
 	unable_to_create_user: "We couldn't create your account. Please try again.",
-	email_not_verified:
-		"Please verify your email address before signing in. Check your inbox for the verification link.",
-	account_deactivated:
-		"Your account has been deactivated. Please contact support.",
-	state_mismatch: "Your sign-in session expired. Please try signing in again.",
-	please_restart_the_process:
-		"Something went wrong during sign-in. Please try again.",
+	unable_to_create_session:
+		"We couldn't start your session. Please try signing in again.",
+	email_not_found:
+		"Your provider didn't share an email address, which is required to sign in.",
+	unable_to_get_user_info:
+		"We couldn't retrieve your account details from the provider. Please try again.",
+	oauth_provider_not_found: "This sign-in provider is not available.",
+	invalid_code: "Sign-in failed. Please try again.",
+	no_code: "Sign-in was interrupted. Please try again.",
+	no_callback_url:
+		"Sign-in failed due to a misconfiguration. Please try again.",
+	invalid_callback_request: "Sign-in failed. Please try again.",
 };
 
 export function getAuthErrorMessage(code: string | null | undefined): string {


### PR DESCRIPTION
## Problem

When a social sign-in fails — for example `account_not_linked`, which happens when a user signs in with Google but already has an account using that email with a password set — better-auth redirected the browser to the **API base URL** with an `?error=` query param (e.g. `https://internal.llmgateway.io/?error=account_not_linked`). The user was left staring at a raw JSON health response instead of a usable error.

## Fix

- Pass `errorCallbackURL` to every `signIn.social()` call so OAuth failures redirect back to the originating **login/signup page** instead of the API root.
- On the login and signup pages, read the `?error=` param on mount, show a friendly toast, and strip the param from the URL.
- Add `apps/ui/src/lib/auth-errors.ts` mapping better-auth error codes (`account_not_linked`, `signup_disabled`, etc.) to human-readable messages, with a sensible fallback.

## Testing

- `pnpm format` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-friendly mappings for authentication error codes so clearer messages are shown.

* **Bug Fixes**
  * Improved error handling on login and signup: OAuth failures now redirect back to the appropriate page, display a destructive toast, and remove error parameters from the URL after display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->