### PR TITLE
fix(gateway): keep JSON credentials intact in env key split

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3564,13 +3564,11 @@ chat.openapi(completions, async (c) => {
 	// long-lived credential (kept in usedApiKeyHash above for health tracking)
 	// while the short-lived access token is what travels in the Authorization
 	// header — so swap usedToken here so downstream header builders just work.
-	// Read the env var directly to bypass round-robin comma-splitting (an SA
-	// JSON value contains commas and would otherwise be truncated).
+	// usedToken already holds the selected SA JSON: round-robin no longer
+	// splits a JSON credential on its inner commas, so the selected entry is
+	// used as-is (whether it came from a provider key or the env var).
 	if (usedProvider === "vertex-openai") {
-		const fullSaJson = providerKey
-			? usedToken
-			: (process.env.LLM_VERTEX_OPENAI_SERVICE_ACCOUNT_JSON ?? "");
-		usedToken = await getVertexOpenAIAccessToken(fullSaJson);
+		usedToken = await getVertexOpenAIAccessToken(usedToken);
 	}
 
 	const contentFilterBlocked =

--- a/apps/gateway/src/lib/round-robin-env.spec.ts
+++ b/apps/gateway/src/lib/round-robin-env.spec.ts
@@ -39,6 +39,44 @@ describe("round-robin-env", () => {
 			const result = parseCommaSeparatedEnv("value1,,value2,");
 			expect(result).toEqual(["value1", "value2"]);
 		});
+
+		it("should not split a JSON service-account value on its commas", () => {
+			const saJson =
+				'{"type":"service_account","project_id":"my-proj","private_key":"-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n","client_email":"sa@my-proj.iam.gserviceaccount.com"}';
+			const result = parseCommaSeparatedEnv(saJson);
+			expect(result).toEqual([saJson]);
+		});
+
+		it("should treat a whitespace-padded JSON value as a single entry", () => {
+			const saJson = '  {"type":"service_account","a":1,"b":2}  ';
+			const result = parseCommaSeparatedEnv(saJson);
+			expect(result).toEqual(['{"type":"service_account","a":1,"b":2}']);
+		});
+
+		it("should split multiple JSON credentials on top-level commas", () => {
+			const sa1 = '{"type":"service_account","project_id":"proj-a"}';
+			const sa2 = '{"type":"service_account","project_id":"proj-b"}';
+			const result = parseCommaSeparatedEnv(`${sa1},${sa2}`);
+			expect(result).toEqual([sa1, sa2]);
+		});
+
+		it("should split a mix of plain keys and JSON credentials", () => {
+			const saJson = '{"type":"service_account","a":1,"b":2}';
+			const result = parseCommaSeparatedEnv(`key1,${saJson},key2`);
+			expect(result).toEqual(["key1", saJson, "key2"]);
+		});
+
+		it("should preserve commas and braces inside JSON string values", () => {
+			const saJson = '{"client_email":"a,b@x.com","note":"has } and , inside"}';
+			const result = parseCommaSeparatedEnv(`${saJson},plainkey`);
+			expect(result).toEqual([saJson, "plainkey"]);
+		});
+
+		it("should preserve nested arrays/objects inside JSON", () => {
+			const saJson = '{"scopes":["a","b"],"meta":{"x":1,"y":2}}';
+			const result = parseCommaSeparatedEnv(saJson);
+			expect(result).toEqual([saJson]);
+		});
 	});
 
 	describe("getRoundRobinValue", () => {

--- a/apps/gateway/src/lib/round-robin-env.ts
+++ b/apps/gateway/src/lib/round-robin-env.ts
@@ -12,15 +12,72 @@ import {
 } from "./api-key-health.js";
 
 /**
- * Parse a comma-separated environment variable into an array of values
+ * Parse a comma-separated environment variable into an array of values.
+ *
+ * Splits on top-level commas only. Commas inside a JSON object (delimited by
+ * `{` / `}`, including those within JSON string values) are preserved, so
+ * service-account JSON credentials such as LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON
+ * and LLM_VERTEX_OPENAI_SERVICE_ACCOUNT_JSON are never mistaken for several keys.
+ * This still allows multiple comma-separated entries — including multiple JSON
+ * credentials (e.g. `{...},{...}`) or a mix of plain keys and JSON.
  * @param value The environment variable value (potentially comma-separated)
- * @returns Array of trimmed values
+ * @returns Array of trimmed, non-empty values
  */
 export function parseCommaSeparatedEnv(value: string): string[] {
-	return value
-		.split(",")
-		.map((v) => v.trim())
-		.filter((v) => v.length > 0);
+	const entries: string[] = [];
+	let current = "";
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+
+	for (const char of value) {
+		if (escaped) {
+			current += char;
+			escaped = false;
+			continue;
+		}
+
+		if (inString) {
+			current += char;
+			if (char === "\\") {
+				escaped = true;
+			} else if (char === '"') {
+				inString = false;
+			}
+			continue;
+		}
+
+		switch (char) {
+			case '"':
+				inString = true;
+				current += char;
+				break;
+			case "{":
+				depth++;
+				current += char;
+				break;
+			case "}":
+				if (depth > 0) {
+					depth--;
+				}
+				current += char;
+				break;
+			case ",":
+				if (depth === 0) {
+					entries.push(current);
+					current = "";
+				} else {
+					current += char;
+				}
+				break;
+			default:
+				current += char;
+		}
+	}
+
+	entries.push(current);
+
+	return entries.map((v) => v.trim()).filter((v) => v.length > 0);
 }
 
 export interface RoundRobinResult {


### PR DESCRIPTION
## Problem

`LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON` and `LLM_VERTEX_OPENAI_SERVICE_ACCOUNT_JSON` hold a service-account JSON object as the provider's `apiKey`. The round-robin env-key selector (`parseCommaSeparatedEnv`) split env values on **every** comma, which shredded these JSON blobs into meaningless fragments — the same commas that separate multiple keys also appear *inside* the JSON.

There were ad-hoc workarounds in `chat.ts` that read the env var directly to dodge the split, but the split still happened in `getProviderEnv` and corrupted the credential hash used for health tracking.

## Fix

`parseCommaSeparatedEnv` now splits on **top-level commas only**. It tracks `{`/`}` depth (and JSON string state, so braces/commas inside string values are ignored), so:

- A single JSON credential is one entry — commas inside it are preserved.
- Multiple comma-separated entries still work: plain keys (`k1,k2,k3`), multiple JSON creds (`{...},{...}`), or a mix (`key1,{...},key2`).

With selection now correct, the `vertex-openai` path uses the round-robin-selected token directly instead of re-reading the raw env var (which would have grabbed the entire comma-joined value when multiple creds were configured).

## Tests

Added coverage in `round-robin-env.spec.ts` for single JSON, whitespace-padded JSON, multiple JSON creds, mixed plain/JSON, commas/braces inside JSON string values, and nested arrays/objects. All 26 tests pass; full `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable parsing to properly handle complex credential configurations.

* **Tests**
  * Added comprehensive unit tests for environment variable parsing with various credential format scenarios, including JSON-embedded credentials and whitespace handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->