### PR TITLE
feat(gateway): routing metadata + key health for embeddings

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -119,6 +119,7 @@ import {
 } from "@llmgateway/models";
 
 import { completionsRequestSchema } from "./schemas/completions.js";
+import { buildRoutingAttempt } from "./tools/build-routing-attempt.js";
 import {
 	checkContentFilter,
 	getContentFilterMethod,
@@ -585,30 +586,6 @@ function withUsedApiKeyHash(
 	return {
 		...routingMetadata,
 		usedApiKeyHash,
-	};
-}
-
-function buildRoutingAttempt(
-	provider: string,
-	model: string,
-	statusCode: number,
-	errorType: string,
-	succeeded: boolean,
-	options?: {
-		region?: string;
-		apiKeyHash?: string;
-		logId?: string;
-	},
-): RoutingAttempt {
-	return {
-		provider,
-		model,
-		...(options?.region && { region: options.region }),
-		status_code: statusCode,
-		error_type: errorType,
-		succeeded,
-		...(options?.apiKeyHash && { apiKeyHash: options.apiKeyHash }),
-		...(options?.logId && { logId: options.logId }),
 	};
 }
 

--- a/apps/gateway/src/chat/tools/build-routing-attempt.ts
+++ b/apps/gateway/src/chat/tools/build-routing-attempt.ts
@@ -1,0 +1,25 @@
+import type { RoutingAttempt } from "./retry-with-fallback.js";
+
+export function buildRoutingAttempt(
+	provider: string,
+	model: string,
+	statusCode: number,
+	errorType: string,
+	succeeded: boolean,
+	options?: {
+		region?: string;
+		apiKeyHash?: string;
+		logId?: string;
+	},
+): RoutingAttempt {
+	return {
+		provider,
+		model,
+		...(options?.region && { region: options.region }),
+		status_code: statusCode,
+		error_type: errorType,
+		succeeded,
+		...(options?.apiKeyHash && { apiKeyHash: options.apiKeyHash }),
+		...(options?.logId && { logId: options.logId }),
+	};
+}

--- a/apps/gateway/src/embeddings/embeddings.spec.ts
+++ b/apps/gateway/src/embeddings/embeddings.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 
 import { app } from "@/app.js";
+import { getApiKeyFingerprint } from "@/lib/api-key-fingerprint.js";
+import { resetKeyHealth } from "@/lib/api-key-health.js";
 import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
 import { resetFailOnceCounter } from "@/test-utils/mock-openai-server.js";
 import { waitForLogs } from "@/test-utils/test-helpers.js";
@@ -169,5 +171,78 @@ describe("embeddings", () => {
 		expect(embeddingLog?.hasError).toBe(true);
 		expect(embeddingLog?.retried).toBe(false);
 		expect(embeddingLog?.retriedByLogId).toBeNull();
+	});
+
+	test("/v1/embeddings routes away from an unhealthy key on the next request", async () => {
+		resetKeyHealth();
+		resetFailOnceCounter();
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-embeddings-health",
+			token: "real-token-embeddings-health",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// The unhealthy key sorts first (id "...-a-...") so it is the primary
+		// candidate; its token contains EMBED_FAIL_KEY, so the mock fails every
+		// call made with it.
+		const unhealthyToken = "EMBED_FAIL_KEY-openai-unhealthy";
+		const healthyToken = "openai-healthy-secondary";
+		await db.insert(tables.providerKey).values([
+			{
+				id: "provider-key-openai-health-a-unhealthy",
+				token: unhealthyToken,
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: harness.mockServerUrl,
+			},
+			{
+				id: "provider-key-openai-health-b-healthy",
+				token: healthyToken,
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: harness.mockServerUrl,
+			},
+		]);
+
+		const makeRequest = (requestId: string) =>
+			app.request("/v1/embeddings", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-embeddings-health",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					model: "text-embedding-3-small",
+					input: "health-aware routing input",
+				}),
+			});
+
+		// Request 1 selects the (unhealthy) primary key first, fails, and retries
+		// onto the healthy key — recording the failure against the primary key's
+		// scoped health.
+		const res1 = await makeRequest("embed-health-req-1");
+		expect(res1.status).toBe(200);
+
+		// Request 2 must skip the now-unhealthy primary key on the FIRST attempt
+		// and go straight to the healthy key — a single log with no error.
+		const res2 = await makeRequest("embed-health-req-2");
+		expect(res2.status).toBe(200);
+
+		const logs = await waitForLogs(3);
+
+		const req1Logs = logs.filter((l) => l.requestId === "embed-health-req-1");
+		expect(req1Logs).toHaveLength(2);
+
+		const req2Logs = logs.filter((l) => l.requestId === "embed-health-req-2");
+		expect(req2Logs).toHaveLength(1);
+		expect(req2Logs[0].hasError).toBe(false);
+		expect(req2Logs[0].finishReason).toBe("stop");
+		expect(req2Logs[0].routingMetadata?.usedApiKeyHash).toBe(
+			getApiKeyFingerprint(healthyToken),
+		);
 	});
 });

--- a/apps/gateway/src/embeddings/embeddings.spec.ts
+++ b/apps/gateway/src/embeddings/embeddings.spec.ts
@@ -100,6 +100,33 @@ describe("embeddings", () => {
 		expect(failedLog?.retriedByLogId).toBe(successLog?.id);
 		expect(successLog?.finishReason).toBe("stop");
 		expect(successLog?.retried).toBe(false);
+
+		// Routing metadata mirrors the chat path: the final log captures the full
+		// per-key attempt chain with cross-links to each attempt's log.
+		const routingMetadata = successLog?.routingMetadata;
+		expect(routingMetadata?.selectedProvider).toBe("openai");
+		expect(routingMetadata?.selectionReason).toBe("single-provider-available");
+		expect(routingMetadata?.availableProviders).toEqual(["openai"]);
+		expect(routingMetadata?.usedApiKeyHash).toBeTruthy();
+
+		const routing = routingMetadata?.routing;
+		expect(routing).toHaveLength(2);
+		expect(routing?.[0]).toMatchObject({
+			provider: "openai",
+			model: "text-embedding-3-small",
+			succeeded: false,
+			logId: failedLog?.id,
+		});
+		expect(routing?.[1]).toMatchObject({
+			provider: "openai",
+			model: "text-embedding-3-small",
+			succeeded: true,
+			logId: successLog?.id,
+		});
+		// The two attempts rotated across distinct BYOK keys.
+		expect(routing?.[0].apiKeyHash).toBeTruthy();
+		expect(routing?.[1].apiKeyHash).toBeTruthy();
+		expect(routing?.[0].apiKeyHash).not.toBe(routing?.[1].apiKeyHash);
 	});
 
 	test("/v1/embeddings returns upstream error when no alternate key is available", async () => {

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -938,10 +938,21 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 
 				const duration = Date.now() - startedAt;
 				if (attempt.envVarName !== undefined) {
-					reportKeyError(attempt.envVarName, attempt.configIndex, 0);
+					reportKeyError(
+						attempt.envVarName,
+						attempt.configIndex,
+						0,
+						undefined,
+						upstreamModel,
+					);
 				}
 				if (attempt.providerKey?.id) {
-					reportTrackedKeyError(attempt.providerKey.id, 0);
+					reportTrackedKeyError(
+						attempt.providerKey.id,
+						0,
+						undefined,
+						upstreamModel,
+					);
 				}
 
 				const networkErrorType = isTimeout
@@ -1076,10 +1087,16 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 						attempt.configIndex,
 						status,
 						upstreamText,
+						upstreamModel,
 					);
 				}
 				if (attempt.providerKey?.id) {
-					reportTrackedKeyError(attempt.providerKey.id, status, upstreamText);
+					reportTrackedKeyError(
+						attempt.providerKey.id,
+						status,
+						upstreamText,
+						upstreamModel,
+					);
 				}
 
 				const finishReason = getFinishReasonFromError(status, upstreamText);
@@ -1182,10 +1199,14 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			}
 
 			if (attempt.envVarName !== undefined) {
-				reportKeySuccess(attempt.envVarName, attempt.configIndex);
+				reportKeySuccess(
+					attempt.envVarName,
+					attempt.configIndex,
+					upstreamModel,
+				);
 			}
 			if (attempt.providerKey?.id) {
-				reportTrackedKeySuccess(attempt.providerKey.id);
+				reportTrackedKeySuccess(attempt.providerKey.id, upstreamModel);
 			}
 
 			let normalizedResponse: Record<string, unknown> = (upstreamJson ??

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -1,15 +1,18 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 
+import { buildRoutingAttempt } from "@/chat/tools/build-routing-attempt.js";
 import { createLogEntry } from "@/chat/tools/create-log-entry.js";
 import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
 import { getFinishReasonFromError } from "@/chat/tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "@/chat/tools/get-provider-env.js";
 import {
+	getErrorType,
 	isRetryableErrorType,
 	shouldRetryAlternateKey,
 } from "@/chat/tools/retry-with-fallback.js";
 import { validateSource } from "@/chat/tools/validate-source.js";
+import { getApiKeyFingerprint } from "@/lib/api-key-fingerprint.js";
 import {
 	reportKeyError,
 	reportKeySuccess,
@@ -38,7 +41,9 @@ import {
 	models as modelDefinitions,
 } from "@llmgateway/models";
 
+import type { RoutingAttempt } from "@/chat/tools/retry-with-fallback.js";
 import type { ServerTypes } from "@/vars.js";
+import type { RoutingMetadata } from "@llmgateway/actions";
 import type { InferSelectModel, tables } from "@llmgateway/db";
 import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
 
@@ -196,6 +201,7 @@ function findEmbeddingMapping(modelId: string): {
 	mapping: ProviderModelMapping;
 	modelDef: ModelDefinition;
 	modelDefId: string;
+	explicitProvider: boolean;
 } | null {
 	// Split an optional "<provider>/<model>" prefix. When present, only
 	// mappings on that provider are considered — this lets callers pick
@@ -218,7 +224,12 @@ function findEmbeddingMapping(modelId: string): {
 				continue;
 			}
 			if (model.id === modelKey || candidate.externalId === modelKey) {
-				return { mapping: candidate, modelDef: model, modelDefId: model.id };
+				return {
+					mapping: candidate,
+					modelDef: model,
+					modelDefId: model.id,
+					explicitProvider: requestedProvider !== undefined,
+				};
 			}
 		}
 	}
@@ -448,7 +459,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		);
 	}
 
-	const { mapping, modelDef, modelDefId } = match;
+	const { mapping, modelDef, modelDefId, explicitProvider } = match;
 	const upstreamModel = mapping.externalId;
 	const providerId = mapping.providerId;
 
@@ -552,6 +563,25 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 
 	const finalLogId = shortid();
 	const failedKeys = createFailedKeyTracker();
+
+	// Routing metadata mirrors the chat path so the activity log UI can render
+	// the selected provider, key fingerprint, and per-key request attempts.
+	// Embeddings resolve to a single provider/model mapping, so there is no
+	// cross-provider scoring — only the key-rotation retries are tracked.
+	const selectionReason = explicitProvider
+		? "direct-provider-specified"
+		: "single-provider-available";
+	const routingAttempts: RoutingAttempt[] = [];
+	const buildEmbeddingRoutingMetadata = (
+		usedApiKeyHash: string | undefined,
+	): RoutingMetadata => ({
+		availableProviders: [providerId],
+		selectedProvider: providerId,
+		selectionReason,
+		...(usedApiKeyHash ? { usedApiKeyHash } : {}),
+		providerScores: [],
+		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
+	});
 
 	// Snapshot narrowed fields so the resolveAttempt closure keeps them non-null.
 	const retryProject = {
@@ -857,6 +887,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 	try {
 		while (true) {
 			const attemptLogId = shortid();
+			const usedApiKeyHash = getApiKeyFingerprint(attempt.usedToken);
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -922,9 +953,26 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 						: null;
 				const willRetry = nextAttempt !== null;
 
+				if (!isCanceled) {
+					routingAttempts.push(
+						buildRoutingAttempt(
+							providerId,
+							modelDefId,
+							0,
+							networkErrorType,
+							false,
+							{
+								apiKeyHash: usedApiKeyHash,
+								logId: willRetry ? attemptLogId : finalLogId,
+							},
+						),
+					);
+				}
+
 				await insertLog({
 					...baseLogEntry,
 					id: willRetry ? attemptLogId : finalLogId,
+					routingMetadata: buildEmbeddingRoutingMetadata(usedApiKeyHash),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1044,9 +1092,24 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					: null;
 				const willRetry = nextAttempt !== null;
 
+				routingAttempts.push(
+					buildRoutingAttempt(
+						providerId,
+						modelDefId,
+						status,
+						getErrorType(status),
+						false,
+						{
+							apiKeyHash: usedApiKeyHash,
+							logId: willRetry ? attemptLogId : finalLogId,
+						},
+					),
+				);
+
 				await insertLog({
 					...baseLogEntry,
 					id: willRetry ? attemptLogId : finalLogId,
+					routingMetadata: buildEmbeddingRoutingMetadata(usedApiKeyHash),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1270,9 +1333,24 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			const requestCost = Number(mapping.requestPrice ?? "0");
 			const cost = inputCost + requestCost;
 
+			routingAttempts.push(
+				buildRoutingAttempt(
+					providerId,
+					modelDefId,
+					upstreamResponse.status,
+					"none",
+					true,
+					{
+						apiKeyHash: usedApiKeyHash,
+						logId: finalLogId,
+					},
+				),
+			);
+
 			await insertLog({
 				...baseLogEntry,
 				id: finalLogId,
+				routingMetadata: buildEmbeddingRoutingMetadata(usedApiKeyHash),
 				duration,
 				timeToFirstToken: null,
 				timeToFirstReasoningToken: null,

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1104,6 +1104,17 @@ mockOpenAIServer.post("/v1/embeddings", async (c) => {
 		return c.json(sampleErrorResponse);
 	}
 
+	// Any request authenticated with a key whose token contains EMBED_FAIL_KEY
+	// fails with 500 on every call. Unlike the global TRIGGER_FAIL_ONCE counter,
+	// this is keyed on the credential, so tests can mark one specific provider
+	// key as persistently unhealthy and verify health-aware key selection routes
+	// subsequent requests onto the other key.
+	const embeddingsAuthHeader = c.req.header("authorization") ?? "";
+	if (embeddingsAuthHeader.includes("EMBED_FAIL_KEY")) {
+		c.status(500);
+		return c.json(sampleErrorResponse);
+	}
+
 	// First call with TRIGGER_FAIL_ONCE fails with 500, subsequent calls fall
 	// through to the success path. Lets embedding key-rotation tests verify
 	// that the gateway retries with another key after an upstream failure.


### PR DESCRIPTION
## Summary

The embeddings endpoint logged requests but never populated `routingMetadata`, so the activity log UI's **Routing** section was empty for embeddings — unlike chat completions. This wires the same routing-metadata tracking into the embeddings path.

Each embedding log now records:
- **Selected provider** and **selection reason** (`direct-provider-specified` when a `provider/model` prefix is used, otherwise `single-provider-available`)
- **Available providers** and the **used API key fingerprint**
- The full **per-key request attempt chain** (`routing[]`) — each key-rotation retry and the final outcome, with `apiKeyHash`, status, error type, and a cross-link to that attempt's own log

Since embeddings resolve to a single fixed provider/model mapping, there is no cross-provider scoring (`providerScores` is empty) — only the key-rotation retries within the provider are tracked.

The activity log UI already renders this exact shape, so embedding logs gain a populated Routing section with no UI changes.

## Changes
- Extract `buildRoutingAttempt` out of `chat.ts` into a shared `chat/tools/build-routing-attempt.ts`, reused by both chat and embeddings (DRY).
- Build and attach `routingMetadata` at every `insertLog` call in `embeddings.ts` (network error, upstream non-OK, and success branches).
- `findEmbeddingMapping` now reports whether a provider was explicitly requested, to derive the selection reason.
- Add assertions to `embeddings.spec.ts` covering the persisted routing metadata and the two-attempt key-rotation chain.

## Testing
- `pnpm build` ✅
- `pnpm format` ✅
- Gateway unit tests: `embeddings.spec.ts` (3), `fallback.spec.ts` (49), `chat-resilience.spec.ts` (8) all pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Routing construction moved into a shared tool to centralize behavior across services.

* **Improvements**
  * Embeddings requests now include routing attempt metadata in logs and skip unhealthy API keys, improving retry behavior and observability.

* **Tests**
  * Expanded tests to validate routing metadata, provider selection, and API-key-specific failure/retry scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/theopenco/llmgateway/pull/2453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->