### PR TITLE
fix(auth): downgrade malformed-JSON log noise from Better Auth

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -2,7 +2,52 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { db, tables } from "@llmgateway/db";
 
-import { apiAuth, redisClient } from "./config.js";
+import { apiAuth, isClientJsonError, redisClient } from "./config.js";
+
+describe("isClientJsonError", () => {
+	test("matches the real Better Auth malformed-JSON messages from production", () => {
+		const messages = [
+			"Expected ',' or '}' after property value in JSON at position 59 (line 1 column 60)",
+			"Expected ',' or '}' after property value in JSON at position 54 (line 1 column 55)",
+			"# SERVER_ERROR:  SyntaxError: Expected ',' or '}' after property value in JSON at position 49 (line 1 column 50)",
+		];
+		for (const message of messages) {
+			expect(isClientJsonError(message, [])).toBe(true);
+		}
+	});
+
+	test("matches other JSON.parse SyntaxError variants", () => {
+		expect(
+			isClientJsonError("Unexpected token o in JSON at position 1", []),
+		).toBe(true);
+		expect(isClientJsonError("Unexpected end of JSON input", [])).toBe(true);
+		expect(
+			isClientJsonError("Unexpected non-whitespace character after JSON", []),
+		).toBe(true);
+		expect(isClientJsonError('"[object Object]" is not valid JSON', [])).toBe(
+			true,
+		);
+	});
+
+	test("inspects Error args, not just the message string", () => {
+		const err = new SyntaxError(
+			"Expected ',' or '}' after property value in JSON at position 61",
+		);
+		expect(isClientJsonError("# SERVER_ERROR:", [err])).toBe(true);
+	});
+
+	test("does not match genuine server errors", () => {
+		expect(isClientJsonError("Database connection failed", [])).toBe(false);
+		expect(
+			isClientJsonError("Failed to send verification email", [
+				new Error("SMTP timeout"),
+			]),
+		).toBe(false);
+		expect(isClientJsonError("Redis pipeline execution failed", [])).toBe(
+			false,
+		);
+	});
+});
 
 describe("API auth configuration", () => {
 	test("should inherit basic auth configuration", () => {

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -507,9 +507,59 @@ export async function updateResendContact(
 	}
 }
 
+/**
+ * Malformed JSON request bodies (almost always bot/scanner traffic hitting the
+ * auth endpoints) make Better Auth throw a SyntaxError while parsing the body.
+ * These are client errors, not server faults, so they should not be logged at
+ * error severity where they trip production error alerting.
+ */
+export function isClientJsonError(message: string, args: unknown[]): boolean {
+	const haystack = [
+		message,
+		...args.map((arg) =>
+			arg instanceof Error ? `${arg.name}: ${arg.message}` : String(arg),
+		),
+	].join(" ");
+	return /in JSON at position|after property value|Unexpected (?:token|end of JSON|non-whitespace)|is not valid JSON/i.test(
+		haystack,
+	);
+}
+
+function extractLogExtra(args: unknown[]): object | undefined {
+	const errArg = args.find((arg) => arg instanceof Error);
+	if (errArg) {
+		return errArg as Error;
+	}
+	return args.find((arg) => arg && typeof arg === "object") as
+		| object
+		| undefined;
+}
+
 export const apiAuth: ReturnType<typeof instrumentBetterAuth> =
 	instrumentBetterAuth(
 		betterAuth({
+			logger: {
+				log: (level, message, ...args) => {
+					const text = `[Better Auth] ${message}`;
+					const effectiveLevel =
+						level === "error" && isClientJsonError(message, args)
+							? "warn"
+							: level;
+					switch (effectiveLevel) {
+						case "error":
+							logger.error(text, ...args);
+							break;
+						case "warn":
+							logger.warn(text, extractLogExtra(args));
+							break;
+						case "debug":
+							logger.debug(text, extractLogExtra(args));
+							break;
+						default:
+							logger.info(text, extractLogExtra(args));
+					}
+				},
+			},
 			advanced: {
 				crossSubDomainCookies: {
 					enabled: true,

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -539,7 +539,11 @@ export const apiAuth: ReturnType<typeof instrumentBetterAuth> =
 	instrumentBetterAuth(
 		betterAuth({
 			logger: {
-				log: (level, message, ...args) => {
+				log: (
+					level: "info" | "success" | "warn" | "error" | "debug",
+					message: string,
+					...args: unknown[]
+				) => {
 					const text = `[Better Auth] ${message}`;
 					const effectiveLevel =
 						level === "error" && isClientJsonError(message, args)


### PR DESCRIPTION
Production was flooding error alerts with `[Better Auth] Expected ',' or '}' after property value in JSON` and `# SERVER_ERROR: SyntaxError` lines — caused by bot/scanner traffic sending malformed JSON bodies to the `/auth/*` endpoints, which Better Auth logs at error severity. This routes Better Auth's logs through our own `logger` and adds an `isClientJsonError` classifier that downgrades these malformed-JSON parse failures from `error` to `warn`, so genuine client garbage stops tripping error alerting while real server faults still log at `error`. Added unit tests covering the exact production messages, other `JSON.parse` SyntaxError variants, error-arg inspection, and negative cases (DB/Redis/email failures stay at error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to treat malformed JSON client requests as client-originated, downgrading their log severity so monitoring better reflects true server issues and reduces noise.
  * Added structured context extraction for logs to improve readability of non-error entries.

* **Tests**
  * Added tests covering various malformed JSON/SyntaxError scenarios to ensure reliable detection and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->