### PR TITLE
fix(gateway): handle Anthropic content_block start/stop

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -77,7 +77,7 @@ describe("transformStreamingToOpenai", () => {
 			content_block: { type: "thinking", thinking: "" },
 		},
 		{ type: "content_block_stop" },
-	])("treats Anthropic %s as a handled non-renderable chunk", (chunk) => {
+	])("drops Anthropic %s without warning", (chunk) => {
 		warn.mockClear();
 
 		const result = transformStreamingToOpenai(
@@ -87,17 +87,7 @@ describe("transformStreamingToOpenai", () => {
 			[],
 		);
 
-		expect(result).toMatchObject({
-			object: "chat.completion.chunk",
-			model: "claude-opus-4-8",
-			choices: [
-				{
-					index: 0,
-					delta: { role: "assistant" },
-					finish_reason: null,
-				},
-			],
-		});
+		expect(result).toBeNull();
 		expect(warn).not.toHaveBeenCalled();
 	});
 

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -70,6 +70,37 @@ describe("transformStreamingToOpenai", () => {
 		expect(warn).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		{ type: "content_block_start", content_block: { type: "text", text: "" } },
+		{
+			type: "content_block_start",
+			content_block: { type: "thinking", thinking: "" },
+		},
+		{ type: "content_block_stop" },
+	])("treats Anthropic %s as a handled non-renderable chunk", (chunk) => {
+		warn.mockClear();
+
+		const result = transformStreamingToOpenai(
+			"anthropic",
+			"claude-opus-4-8",
+			{ index: 0, ...chunk },
+			[],
+		);
+
+		expect(result).toMatchObject({
+			object: "chat.completion.chunk",
+			model: "claude-opus-4-8",
+			choices: [
+				{
+					index: 0,
+					delta: { role: "assistant" },
+					finish_reason: null,
+				},
+			],
+		});
+		expect(warn).not.toHaveBeenCalled();
+	});
+
 	it("ignores OpenAI keepalive events without warning", () => {
 		warn.mockClear();
 

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -292,6 +292,31 @@ export function transformStreamingToOpenai(
 					],
 					usage: normalizeAnthropicUsage(usage),
 				};
+			} else if (
+				data.type === "content_block_start" ||
+				data.type === "content_block_stop"
+			) {
+				// Text/thinking/redacted_thinking blocks open with a
+				// content_block_start that carries no renderable delta (the actual
+				// content arrives in subsequent content_block_delta chunks), and
+				// every block closes with a content_block_stop. Neither has an
+				// OpenAI-chunk equivalent, so emit an empty assistant delta.
+				transformedData = {
+					id: data.id ?? `chatcmpl-${Date.now()}`,
+					object: "chat.completion.chunk",
+					created: data.created ?? Math.floor(Date.now() / 1000),
+					model: data.model ?? usedModel,
+					choices: [
+						{
+							index: 0,
+							delta: {
+								role: "assistant",
+							},
+							finish_reason: null,
+						},
+					],
+					usage: normalizeAnthropicUsage(usage),
+				};
 			} else if (data.type === "message_delta" && data.delta?.stop_reason) {
 				const stopReason = data.delta.stop_reason;
 				transformedData = {

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -297,26 +297,11 @@ export function transformStreamingToOpenai(
 				data.type === "content_block_stop"
 			) {
 				// Text/thinking/redacted_thinking blocks open with a
-				// content_block_start that carries no renderable delta (the actual
-				// content arrives in subsequent content_block_delta chunks), and
-				// every block closes with a content_block_stop. Neither has an
-				// OpenAI-chunk equivalent, so emit an empty assistant delta.
-				transformedData = {
-					id: data.id ?? `chatcmpl-${Date.now()}`,
-					object: "chat.completion.chunk",
-					created: data.created ?? Math.floor(Date.now() / 1000),
-					model: data.model ?? usedModel,
-					choices: [
-						{
-							index: 0,
-							delta: {
-								role: "assistant",
-							},
-							finish_reason: null,
-						},
-					],
-					usage: normalizeAnthropicUsage(usage),
-				};
+				// content_block_start and close with a content_block_stop. Neither
+				// carries renderable content or usage (that arrives in the
+				// content_block_delta and message_delta chunks), so drop them
+				// instead of forwarding an empty assistant delta.
+				return null;
 			} else if (data.type === "message_delta" && data.delta?.stop_reason) {
 				const stopReason = data.delta.stop_reason;
 				transformedData = {


### PR DESCRIPTION
## Problem

Production logs were filling with `[streaming] Unrecognized Anthropic chunk` warnings on every streamed completion:

```
"msg": "[streaming] Unrecognized Anthropic chunk",
"model": "claude-opus-4-8",
"type": "content_block_start",
"dataKeys": ["type", "index", "content_block"]
```

Anthropic emits a `content_block_start` for **every** content block — including plain `text`, `thinking`, and `redacted_thinking` — and a `content_block_stop` when each block closes. The streaming transform only had explicit branches for the `server_tool_use`, `tool_use`, and `web_search_tool_result` start variants, so the common text/thinking block boundaries fell through to the catch-all "Unrecognized" warning.

The output was still correct (the fallback emitted an empty assistant delta), but it logged a WARNING for the most common case on every request.

## Fix

Treat `content_block_start` (any remaining type) and `content_block_stop` as handled non-renderable chunks that emit an empty assistant delta — the actual content arrives in subsequent `content_block_delta` chunks, which already have dedicated handling.

## Testing

- Added a parametrized unit test covering `content_block_start` (text/thinking) and `content_block_stop`, asserting no warning is logged.
- `pnpm vitest run apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts` — 16 passed.
- `pnpm --filter gateway build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming chunk handling so non-renderable start/stop blocks are dropped and do not produce empty assistant chunks, improving OpenAI-format compatibility.

* **Tests**
  * Added parameterized tests to verify correct handling of Anthropic streaming start/stop content blocks (ensuring no warnings and expected drop behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->