### PR TITLE
feat(ui): show DevPass card on agents page

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
@@ -1,4 +1,8 @@
+import { cookies } from "next/headers";
+
 import { AgentsView } from "@/components/activity/agents-view";
+import { DevPassCard } from "@/components/dashboard/devpass-card";
+import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { SourceActivityData } from "@/types/activity";
@@ -28,9 +32,14 @@ export default async function AgentsPage({
 		},
 	);
 
+	const cookieStore = await cookies();
+	const devPassCollapsed =
+		cookieStore.get(DEVPASS_CARD_COLLAPSED_COOKIE)?.value === "1";
+
 	return (
 		<div className="flex flex-col">
 			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
+				<DevPassCard defaultCollapsed={devPassCollapsed} />
 				<div>
 					<h2 className="text-3xl font-bold tracking-tight">Agents</h2>
 					<p className="text-muted-foreground">


### PR DESCRIPTION
Shows the DevPass card at the top of the dashboard Agents page, matching the existing placement on the main dashboard.

- Reuses the existing `DevPassCard` component
- Respects the shared collapsed cookie (`DEVPASS_CARD_COLLAPSED_COOKIE`) so collapse state stays in sync with the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The DevPassCard on the agents page now remembers its collapsed or expanded state across sessions, restoring the user's preference on subsequent visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->