### PR TITLE
fix(gateway): handle empty input_json_delta chunks

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -91,6 +91,45 @@ describe("transformStreamingToOpenai", () => {
 		expect(warn).not.toHaveBeenCalled();
 	});
 
+	it.each([{ partial_json: "" }, { partial_json: '{"foo":' }])(
+		"maps Anthropic input_json_delta (%o) to tool_call arguments without warning",
+		({ partial_json }) => {
+			warn.mockClear();
+
+			const result = transformStreamingToOpenai(
+				"anthropic",
+				"claude-opus-4-8",
+				{
+					type: "content_block_delta",
+					index: 1,
+					delta: { type: "input_json_delta", partial_json },
+				},
+				[],
+			);
+
+			expect(result).toMatchObject({
+				object: "chat.completion.chunk",
+				model: "claude-opus-4-8",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 1,
+									function: { arguments: partial_json },
+								},
+							],
+							role: "assistant",
+						},
+						finish_reason: null,
+					},
+				],
+			});
+			expect(warn).not.toHaveBeenCalled();
+		},
+	);
+
 	it("ignores OpenAI keepalive events without warning", () => {
 		warn.mockClear();
 

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -207,8 +207,13 @@ export function transformStreamingToOpenai(
 				};
 			} else if (
 				data.type === "content_block_delta" &&
-				data.delta?.partial_json
+				(data.delta?.type === "input_json_delta" ||
+					data.delta?.partial_json !== undefined)
 			) {
+				// input_json_delta carries the tool-call arguments. The first delta
+				// of a tool_use block often has an empty partial_json (""), so match
+				// on the delta type rather than the truthiness of partial_json.
+				const partialJson = data.delta.partial_json ?? "";
 				// Skip partial_json deltas for server_tool_use blocks (e.g. web search)
 				if (
 					serverToolUseIndices &&
@@ -245,7 +250,7 @@ export function transformStreamingToOpenai(
 										{
 											index: data.index ?? 0,
 											function: {
-												arguments: data.delta.partial_json,
+												arguments: partialJson,
 											},
 										},
 									],


### PR DESCRIPTION
## Summary

Streaming Anthropic responses logged `[streaming] Unrecognized Anthropic chunk` for `content_block_delta` events with `deltaType: "input_json_delta"`.

The branch in `transform-streaming-to-openai.ts` matched these chunks only when `data.delta.partial_json` was **truthy**. But the first `input_json_delta` of a tool_use block carries an empty `partial_json` (`""`), which is falsy — so it fell through to the catch-all "Unrecognized" warning branch and emitted a spurious empty assistant delta.

## Fix

Match on `data.delta.type === "input_json_delta"` (or `partial_json !== undefined`) instead of truthiness, and forward `partial_json ?? ""` as the tool-call arguments.

## Testing

- Added parameterized spec cases for `input_json_delta` with both empty (`""`) and non-empty `partial_json`, asserting correct `tool_calls` mapping and no warning.
- `pnpm vitest run apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts` — 18 passing
- `pnpm build` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Anthropic `input_json_delta` streaming event conversion to OpenAI-compatible format with tool calls.

* **Bug Fixes**
  * Improved streaming tool call handling for Anthropic/Vertex Anthropic models to properly process partial JSON values, including empty strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->