### PR TITLE
fix(gateway): only rotate keys on credential errors

### DIFF
--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -151,6 +151,16 @@ describe("shouldRetryAlternateKey", () => {
 		expect(shouldRetryAlternateKey("client_error", 400)).toBe(false);
 		expect(shouldRetryAlternateKey("content_filter", 403)).toBe(false);
 	});
+
+	it("does not rotate keys for non-credential gateway errors", () => {
+		expect(
+			shouldRetryAlternateKey("gateway_error", 400, "Unknown model: foo"),
+		).toBe(false);
+		expect(shouldRetryAlternateKey("gateway_error", 400, "Not Found")).toBe(
+			false,
+		);
+		expect(shouldRetryAlternateKey("gateway_error", undefined)).toBe(false);
+	});
 });
 
 describe("selectNextProvider", () => {

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -50,13 +50,19 @@ export function shouldRetryAlternateKey(
 	statusCode?: number,
 	errorText?: string,
 ): boolean {
-	return (
-		isRetryableErrorType(errorType) ||
-		(errorType === "gateway_error" &&
-			((statusCode !== undefined &&
+	// Transient upstream/network failures warrant another attempt regardless of
+	// which key is used. A gateway_error, however, is only worth rotating keys
+	// for when it stems from a bad credential (401/403 or an invalid-key
+	// payload) — other gateway_error causes such as model-mapping gaps would
+	// fail identically with a different key for the same provider.
+	if (errorType === "gateway_error") {
+		return (
+			(statusCode !== undefined &&
 				(statusCode === 401 || statusCode === 403)) ||
-				hasInvalidProviderCredentialError(errorText)))
-	);
+			hasInvalidProviderCredentialError(errorText)
+		);
+	}
+	return isRetryableErrorType(errorType);
 }
 
 /**


### PR DESCRIPTION
## Problem

`shouldRetryAlternateKey` decides whether a failed request should be retried against a **different API key for the same provider**. It was written as:

```ts
return (
  isRetryableErrorType(errorType) ||
  (errorType === "gateway_error" &&
    ((statusCode === 401 || statusCode === 403) || hasInvalidProviderCredentialError(errorText)))
);
```

`isRetryableErrorType()` already includes `"gateway_error"`, so the first clause short-circuits to `true` for **every** gateway error. The second clause — the 401/403 / invalid-credential guard — and its `statusCode`/`errorText` parameters were **dead code**.

## Why it matters

`getFinishReasonFromError` classifies several **non-credential** failures as `gateway_error`:

- unknown-model on a 400 (`"Unknown model: ..."`)
- bare `"Not Found"` body (model/endpoint mapping gap)
- the catch-all fallthrough

For these, rotating to another key on the *same provider* fails identically (the credential is fine — the model mapping is wrong) and wastes a request. The function's docstring already states the intent: rotate keys only when the failure is isolated to a single credential.

## Fix

Gate alternate-key retry so `gateway_error` only rotates keys on genuine credential failures (401/403 or invalid-key payload). Transient upstream/network error types are unchanged. Cross-provider fallback (`shouldRetryRequest`) is untouched — `gateway_error` correctly stays retryable there.

## Tests

Added a regression test proving non-credential gateway errors no longer rotate keys. The pre-existing "invalid API key payload" test had been passing for the wrong reason (the guard it exercised was never reached). All 34 tests in the suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication errors—the system now correctly distinguishes between credential-related failures and other gateway errors for more reliable error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->