### PR TITLE
feat(admin): show cost column in mapping table

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7084,6 +7084,7 @@ const modelProviderMappingEntrySchema = z.object({
 	gatewayErrorsCount: z.number(),
 	upstreamErrorsCount: z.number(),
 	cachedCount: z.number(),
+	cost: z.number(),
 	avgTimeToFirstToken: z.number().nullable(),
 	inputPrice: z.string().nullable(),
 	outputPrice: z.string().nullable(),
@@ -7114,6 +7115,7 @@ const getModelProviderMappings = createRoute({
 					"clientErrorsCount",
 					"gatewayErrorsCount",
 					"upstreamErrorsCount",
+					"cost",
 					"avgTimeToFirstToken",
 					"updatedAt",
 				])
@@ -7209,6 +7211,9 @@ admin.openapi(getModelProviderMappings, async (c) => {
 						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
 							"cachedCount",
 						),
+					cost: sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalCost}), 0)`.as(
+						"cost",
+					),
 				})
 				.from(modelProviderMappingHistory)
 				.where(
@@ -7235,6 +7240,9 @@ admin.openapi(getModelProviderMappings, async (c) => {
 					gatewayErrorsCount: tables.modelProviderMapping.gatewayErrorsCount,
 					upstreamErrorsCount: tables.modelProviderMapping.upstreamErrorsCount,
 					cachedCount: tables.modelProviderMapping.cachedCount,
+					// Cost is only tracked in the history table, so it is only
+					// available when a date range is provided (mirrors the models list).
+					cost: sql<number>`0`.as("cost"),
 				})
 				.from(tables.modelProviderMapping)
 				.as("mapping_stats_sub");
@@ -7286,6 +7294,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 		clientErrorsCount: sql`COALESCE(${statsJoin.clientErrorsCount}, 0)`,
 		gatewayErrorsCount: sql`COALESCE(${statsJoin.gatewayErrorsCount}, 0)`,
 		upstreamErrorsCount: sql`COALESCE(${statsJoin.upstreamErrorsCount}, 0)`,
+		cost: sql`COALESCE(${statsJoin.cost}, 0)`,
 		avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
 		updatedAt: tables.modelProviderMapping.updatedAt,
 	} as const;
@@ -7328,6 +7337,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 				cachedCount: sql<number>`COALESCE(${statsJoin.cachedCount}, 0)`.as(
 					"cachedCount",
 				),
+				cost: sql<number>`COALESCE(${statsJoin.cost}, 0)`.as("cost"),
 				avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
 				inputPrice: tables.modelProviderMapping.inputPrice,
 				outputPrice: tables.modelProviderMapping.outputPrice,
@@ -7364,6 +7374,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 			gatewayErrorsCount: Number(r.gatewayErrorsCount ?? 0),
 			upstreamErrorsCount: Number(r.upstreamErrorsCount ?? 0),
 			cachedCount: Number(r.cachedCount ?? 0),
+			cost: Number(r.cost ?? 0),
 			avgTimeToFirstToken: r.avgTimeToFirstToken,
 			inputPrice: r.inputPrice,
 			outputPrice: r.outputPrice,

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -5018,7 +5018,7 @@ export interface paths {
             parameters: {
                 query?: {
                     search?: string;
-                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "avgTimeToFirstToken" | "updatedAt";
+                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "cost" | "avgTimeToFirstToken" | "updatedAt";
                     sortOrder?: "asc" | "desc";
                     limit?: number | null;
                     offset?: number | null;
@@ -5052,6 +5052,7 @@ export interface paths {
                                 gatewayErrorsCount: number;
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
+                                cost: number;
                                 avgTimeToFirstToken: number | null;
                                 inputPrice: string | null;
                                 outputPrice: string | null;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -5018,7 +5018,7 @@ export interface paths {
             parameters: {
                 query?: {
                     search?: string;
-                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "avgTimeToFirstToken" | "updatedAt";
+                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "cost" | "avgTimeToFirstToken" | "updatedAt";
                     sortOrder?: "asc" | "desc";
                     limit?: number | null;
                     offset?: number | null;
@@ -5052,6 +5052,7 @@ export interface paths {
                                 gatewayErrorsCount: number;
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
+                                cost: number;
                                 avgTimeToFirstToken: number | null;
                                 inputPrice: string | null;
                                 outputPrice: string | null;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -5018,7 +5018,7 @@ export interface paths {
             parameters: {
                 query?: {
                     search?: string;
-                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "avgTimeToFirstToken" | "updatedAt";
+                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "cost" | "avgTimeToFirstToken" | "updatedAt";
                     sortOrder?: "asc" | "desc";
                     limit?: number | null;
                     offset?: number | null;
@@ -5052,6 +5052,7 @@ export interface paths {
                                 gatewayErrorsCount: number;
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
+                                cost: number;
                                 avgTimeToFirstToken: number | null;
                                 inputPrice: string | null;
                                 outputPrice: string | null;

--- a/ee/admin/src/app/model-provider-mappings/page.tsx
+++ b/ee/admin/src/app/model-provider-mappings/page.tsx
@@ -22,6 +22,7 @@ type MappingSortBy =
 	| "clientErrorsCount"
 	| "gatewayErrorsCount"
 	| "upstreamErrorsCount"
+	| "cost"
 	| "avgTimeToFirstToken"
 	| "updatedAt";
 

--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -49,6 +49,7 @@ type MappingSortBy =
 	| "clientErrorsCount"
 	| "gatewayErrorsCount"
 	| "upstreamErrorsCount"
+	| "cost"
 	| "avgTimeToFirstToken"
 	| "updatedAt";
 
@@ -99,6 +100,10 @@ function SortableHeader({
 
 function formatNumber(n: number) {
 	return new Intl.NumberFormat("en-US").format(n);
+}
+
+function formatCost(n: number) {
+	return `$${n.toFixed(4)}`;
 }
 
 function formatPrice(price: string | null) {
@@ -199,6 +204,9 @@ function MappingRow({
 					{formatNumber(mapping.logsCount)}
 				</TableCell>
 				<TableCell className="tabular-nums">
+					{formatCost(mapping.cost)}
+				</TableCell>
+				<TableCell className="tabular-nums">
 					{formatNumber(mapping.errorsCount)}
 				</TableCell>
 				<TableCell className="tabular-nums">
@@ -246,7 +254,7 @@ function MappingRow({
 			{expanded && (
 				<TableRow>
 					<TableCell
-						colSpan={15}
+						colSpan={16}
 						className="p-4"
 						id={`mapping-history-${mapping.providerId}-${mapping.modelId}`}
 					>
@@ -300,6 +308,7 @@ export function MappingsTable({
 					<TableHead>Region</TableHead>
 					<TableHead>Status</TableHead>
 					{sh("Requests", "logsCount")}
+					{sh("Cost", "cost")}
 					{sh("Errors", "errorsCount")}
 					{sh("Client", "clientErrorsCount")}
 					{sh("Gateway", "gatewayErrorsCount")}
@@ -316,7 +325,7 @@ export function MappingsTable({
 				{mappings.length === 0 ? (
 					<TableRow>
 						<TableCell
-							colSpan={15}
+							colSpan={16}
 							className="h-24 text-center text-muted-foreground"
 						>
 							No mappings found

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -5018,7 +5018,7 @@ export interface paths {
             parameters: {
                 query?: {
                     search?: string;
-                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "avgTimeToFirstToken" | "updatedAt";
+                    sortBy?: "modelId" | "providerId" | "logsCount" | "errorsCount" | "clientErrorsCount" | "gatewayErrorsCount" | "upstreamErrorsCount" | "cost" | "avgTimeToFirstToken" | "updatedAt";
                     sortOrder?: "asc" | "desc";
                     limit?: number | null;
                     offset?: number | null;
@@ -5052,6 +5052,7 @@ export interface paths {
                                 gatewayErrorsCount: number;
                                 upstreamErrorsCount: number;
                                 cachedCount: number;
+                                cost: number;
                                 avgTimeToFirstToken: number | null;
                                 inputPrice: string | null;
                                 outputPrice: string | null;


### PR DESCRIPTION
## Summary

The model-provider-mappings admin table (`/model-provider-mappings`) was missing a **Cost** column that the `/models` page already shows. This adds it, placed right after **Requests**.

## How cost is sourced

Cost is only tracked in the `model_provider_mapping_history` table (the `modelProviderMapping` table has no cost column). This mirrors exactly how the `/models` list endpoint already works:

- **With a time window** (the page always sends `from`/`to`): cost is aggregated as `SUM(totalCost)` from history over the window, grouped per mapping.
- **Without a window**: cost is `0` — same fallback the models list endpoint uses.

Folded into the existing `statsJoin` rather than adding an extra join, so there's no additional history scan.

## Changes

- `apps/api/src/routes/admin.ts` — add `cost` to the mappings response schema, the sort enum (sortable like `/models`), and the aggregation.
- `ee/admin/src/components/mappings-table.tsx` — add sortable **Cost** column after **Requests**.
- `ee/admin/src/app/model-provider-mappings/page.tsx` — allow `cost` in `sortBy`.
- Regenerated OpenAPI spec + admin typed client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cost column to model provider mappings with currency formatting and four decimal place precision.
  * Administrators can now sort mappings by cost directly in the admin interface.
  * Cost metrics are calculated from aggregated historical data when date ranges are applied; defaults to zero otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->