### PR TITLE
chore(models): deactivate deepseek v3.2 upstream

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -119,6 +119,7 @@ export const deepseekModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				deactivatedAt: new Date("2026-05-01"),
 			},
 			{
 				providerId: "novita",


### PR DESCRIPTION
Set `deactivatedAt` to `2026-05-01` for the DeepSeek V3.2 model on the DeepSeek upstream provider (`providerId: "deepseek"`, `externalId: "deepseek-chat"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model configuration for Deepseek v3.2 to mark the Bytedance provider as deactivated starting May 1, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->