### PR TITLE
feat(devpass): allow updating payment method

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2,7 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { ensureStripeCustomer, finalizeDevPlanSetupSession } from "@/stripe.js";
+import {
+	ensureStripeCustomer,
+	finalizeDevPlanPaymentUpdate,
+	finalizeDevPlanSetupSession,
+} from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import { db, tables, eq, shortid } from "@llmgateway/db";
@@ -414,6 +418,223 @@ devPlans.openapi(finalize, async (c) => {
 		case "no_payment_method":
 			throw new HTTPException(400, {
 				message: "No payment method found on the checkout session",
+			});
+		case "invalid_session":
+			throw new HTTPException(400, {
+				message: `Invalid checkout session: ${result.reason}`,
+			});
+	}
+});
+
+// Start updating the payment method for an active dev plan. Uses a setup-mode
+// Stripe Checkout session (no charge) to collect the new card; the resulting
+// session is finalized via /finalize-payment-update after the redirect.
+const updatePaymentMethod = createRoute({
+	method: "post",
+	path: "/update-payment-method",
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						checkoutUrl: z.string(),
+					}),
+				},
+			},
+			description: "Stripe Checkout session created successfully",
+		},
+	},
+});
+
+devPlans.openapi(updatePaymentMethod, async (c) => {
+	const user = c.get("user");
+
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: { userId: user.id },
+		with: { organization: true },
+	});
+	const personalOrg = userOrgs.find(
+		(uo) => uo.organization?.isPersonal === true,
+	)?.organization;
+
+	if (!personalOrg) {
+		throw new HTTPException(404, {
+			message: "Personal organization not found",
+		});
+	}
+
+	if (!personalOrg.devPlanStripeSubscriptionId) {
+		throw new HTTPException(400, {
+			message: "No active dev plan subscription found",
+		});
+	}
+
+	try {
+		const stripeCustomerId = await ensureStripeCustomer(personalOrg.id);
+
+		// Setup-mode collects the new card without charging. The fingerprint is
+		// validated against other DevPass orgs during finalize before the card
+		// becomes the subscription's default payment method.
+		const session = await getStripe().checkout.sessions.create({
+			customer: stripeCustomerId,
+			mode: "setup",
+			payment_method_types: ["card"],
+			success_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?payment_update_session_id={CHECKOUT_SESSION_ID}`,
+			cancel_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?payment_update_canceled=true`,
+			metadata: {
+				organizationId: personalOrg.id,
+				subscriptionType: "dev_plan_payment_update",
+				userEmail: user.email,
+			},
+			setup_intent_data: {
+				metadata: {
+					organizationId: personalOrg.id,
+					subscriptionType: "dev_plan_payment_update",
+					userEmail: user.email,
+				},
+			},
+		});
+
+		if (!session.url) {
+			throw new HTTPException(500, {
+				message: "Failed to generate checkout URL",
+			});
+		}
+
+		await logAuditEvent({
+			organizationId: personalOrg.id,
+			userId: user.id,
+			action: "dev_plan.update_payment_method",
+			resourceType: "dev_plan",
+			resourceId: personalOrg.devPlanStripeSubscriptionId,
+			metadata: {
+				tier: personalOrg.devPlan,
+			},
+		});
+
+		return c.json({
+			checkoutUrl: session.url,
+		});
+	} catch (error) {
+		if (error instanceof HTTPException) {
+			throw error;
+		}
+		logger.error(
+			"Stripe checkout session error for dev plan payment update",
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		throw new HTTPException(500, {
+			message: `Failed to create checkout session: ${error}`,
+		});
+	}
+});
+
+// Finalize a dev plan payment-method update — called by the dashboard after the
+// user returns from Stripe Checkout. Verifies the new card fingerprint and
+// points the existing subscription at the new card, or rejects with 409 if the
+// card is already used by another DevPass org.
+const finalizePaymentUpdate = createRoute({
+	method: "post",
+	path: "/finalize-payment-update",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						sessionId: z.string().min(1),
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						status: z.literal("ok"),
+					}),
+				},
+			},
+			description: "Dev plan payment method updated",
+		},
+		409: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						error: z.literal("duplicate_card"),
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Card already in use by another DevPass account",
+		},
+	},
+});
+
+devPlans.openapi(finalizePaymentUpdate, async (c) => {
+	const user = c.get("user");
+	const { sessionId } = c.req.valid("json");
+
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: { userId: user.id },
+		with: { organization: true },
+	});
+	const personalOrg = userOrgs.find(
+		(uo) => uo.organization?.isPersonal === true,
+	)?.organization;
+
+	if (!personalOrg) {
+		throw new HTTPException(404, {
+			message: "Personal organization not found",
+		});
+	}
+
+	let result;
+	try {
+		result = await finalizeDevPlanPaymentUpdate(sessionId);
+	} catch (error) {
+		logger.error(
+			`Failed to finalize dev plan payment update session ${sessionId}`,
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		throw new HTTPException(500, {
+			message: "Failed to update payment method",
+		});
+	}
+
+	switch (result.status) {
+		case "ok":
+			return c.json({ status: "ok" as const }, 200);
+		case "duplicate_card":
+			return c.json(
+				{
+					error: "duplicate_card" as const,
+					message:
+						"This card is already associated with another DevPass account. Please use a different payment method.",
+				},
+				409,
+			);
+		case "no_payment_method":
+			throw new HTTPException(400, {
+				message: "No payment method found on the checkout session",
+			});
+		case "no_subscription":
+			throw new HTTPException(400, {
+				message: "No active dev plan subscription found",
 			});
 		case "invalid_session":
 			throw new HTTPException(400, {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -626,6 +626,136 @@ export async function finalizeDevPlanSetupSession(
 	return { status: "ok", subscriptionId: subscription.id };
 }
 
+export type FinalizeDevPlanPaymentUpdateResult =
+	| { status: "ok" }
+	| { status: "duplicate_card"; conflictingOrgId: string }
+	| { status: "no_payment_method" }
+	| { status: "no_subscription" }
+	| { status: "invalid_session"; reason: string };
+
+/**
+ * Finalize a DevPass payment-method-update setup session: verify the new card
+ * is not already in use by another organization, then point the existing dev
+ * plan subscription (and the customer's default payment method) at the new
+ * card so future renewals are charged to it. Idempotent: safe to call from both
+ * the /dev-plans/finalize-payment-update endpoint and the
+ * checkout.session.completed webhook fallback.
+ */
+export async function finalizeDevPlanPaymentUpdate(
+	sessionId: string,
+): Promise<FinalizeDevPlanPaymentUpdateResult> {
+	const session = await getStripe().checkout.sessions.retrieve(sessionId);
+
+	if (session.mode !== "setup") {
+		return { status: "invalid_session", reason: "not_setup_mode" };
+	}
+
+	const metadata = session.metadata ?? {};
+	if (metadata.subscriptionType !== "dev_plan_payment_update") {
+		return { status: "invalid_session", reason: "not_payment_update" };
+	}
+
+	const organizationId = metadata.organizationId;
+	if (!organizationId) {
+		return { status: "invalid_session", reason: "missing_metadata" };
+	}
+
+	const organization = await db.query.organization.findFirst({
+		where: { id: organizationId },
+	});
+	if (!organization) {
+		return { status: "invalid_session", reason: "org_not_found" };
+	}
+
+	if (!organization.devPlanStripeSubscriptionId) {
+		return { status: "no_subscription" };
+	}
+
+	const paymentMethod = await resolvePaymentMethodFromSetupSession(session);
+	if (!paymentMethod) {
+		return { status: "no_payment_method" };
+	}
+
+	const fingerprint =
+		paymentMethod.type === "card"
+			? (paymentMethod.card?.fingerprint ?? null)
+			: null;
+
+	if (fingerprint) {
+		const conflictingOrg = await db.query.organization.findFirst({
+			where: {
+				devPlanCardFingerprint: { eq: fingerprint },
+				id: { ne: organizationId },
+			},
+		});
+		if (conflictingOrg) {
+			try {
+				await getStripe().paymentMethods.detach(paymentMethod.id);
+			} catch (err) {
+				logger.warn(
+					`Failed to detach duplicate dev plan card ${paymentMethod.id}`,
+					{
+						error: err instanceof Error ? err.message : String(err),
+					},
+				);
+			}
+
+			logger.warn(
+				`Rejecting dev plan payment update ${sessionId} for org ${organizationId}: card fingerprint already used by org ${conflictingOrg.id}`,
+			);
+
+			posthog.capture({
+				distinctId: "organization",
+				event: "dev_plan_blocked_duplicate_card",
+				groups: { organization: organizationId },
+				properties: {
+					organization: organizationId,
+					conflictingOrganization: conflictingOrg.id,
+					sessionId,
+					source: "payment_update",
+				},
+			});
+
+			return {
+				status: "duplicate_card",
+				conflictingOrgId: conflictingOrg.id,
+			};
+		}
+	}
+
+	const stripeCustomerId = await ensureStripeCustomer(organizationId);
+
+	await getStripe().customers.update(stripeCustomerId, {
+		invoice_settings: { default_payment_method: paymentMethod.id },
+	});
+
+	await getStripe().subscriptions.update(
+		organization.devPlanStripeSubscriptionId,
+		{ default_payment_method: paymentMethod.id },
+	);
+
+	await db
+		.update(tables.organization)
+		.set({ devPlanCardFingerprint: fingerprint })
+		.where(eq(tables.organization.id, organizationId));
+
+	logger.info(
+		`Updated dev plan payment method for organization ${organizationId} via setup-mode checkout`,
+	);
+
+	posthog.capture({
+		distinctId: "organization",
+		event: "dev_plan_payment_method_updated",
+		groups: { organization: organizationId },
+		properties: {
+			organization: organizationId,
+			subscriptionId: organization.devPlanStripeSubscriptionId,
+		},
+	});
+
+	return { status: "ok" };
+}
+
 async function handleCheckoutSessionCompleted(
 	event: Stripe.CheckoutSessionCompletedEvent,
 ) {
@@ -650,6 +780,29 @@ async function handleCheckoutSessionCompleted(
 		} catch (error) {
 			logger.error(
 				`Error finalizing dev plan setup session ${session.id}`,
+				error instanceof Error ? error : new Error(String(error)),
+			);
+		}
+		return;
+	}
+
+	// DevPass payment-method updates also use setup-mode checkout. We point the
+	// existing subscription at the new card via finalizeDevPlanPaymentUpdate.
+	// The /dev-plans/finalize-payment-update endpoint calls the same helper when
+	// the user lands back on the dashboard; this webhook is the fallback if the
+	// user closes the tab.
+	if (
+		session.mode === "setup" &&
+		metadata?.subscriptionType === "dev_plan_payment_update"
+	) {
+		try {
+			const result = await finalizeDevPlanPaymentUpdate(session.id);
+			logger.info(
+				`Dev plan payment update finalize result for session ${session.id}: ${result.status}`,
+			);
+		} catch (error) {
+			logger.error(
+				`Error finalizing dev plan payment update session ${session.id}`,
 				error instanceof Error ? error : new Error(String(error)),
 			);
 		}

--- a/apps/code/src/app/dashboard/DashboardClient.tsx
+++ b/apps/code/src/app/dashboard/DashboardClient.tsx
@@ -5,6 +5,7 @@ import {
 	ArrowRight,
 	Code,
 	Copy,
+	CreditCard,
 	Eye,
 	EyeOff,
 	Key,
@@ -207,6 +208,7 @@ export default function DashboardClient() {
 	const [subscribingTier, setSubscribingTier] = useState<PlanTier | null>(null);
 	const [isCancelling, setIsCancelling] = useState(false);
 	const [isResuming, setIsResuming] = useState(false);
+	const [isUpdatingPayment, setIsUpdatingPayment] = useState(false);
 
 	const { user, isLoading: userLoading } = useUser({
 		redirectTo: "/login?returnUrl=/dashboard",
@@ -228,6 +230,14 @@ export default function DashboardClient() {
 	const cancelMutation = api.useMutation("post", "/dev-plans/cancel");
 	const resumeMutation = api.useMutation("post", "/dev-plans/resume");
 	const changeTierMutation = api.useMutation("post", "/dev-plans/change-tier");
+	const updatePaymentMethodMutation = api.useMutation(
+		"post",
+		"/dev-plans/update-payment-method",
+	);
+	const finalizePaymentUpdateMutation = api.useMutation(
+		"post",
+		"/dev-plans/finalize-payment-update",
+	);
 	const rotateApiKeyMutation = api.useMutation(
 		"post",
 		"/dev-plans/rotate-api-key",
@@ -296,6 +306,65 @@ export default function DashboardClient() {
 				clearParam();
 			});
 	}, [searchParams, finalizeMutation, queryClient, router]);
+
+	useEffect(() => {
+		const sessionId = searchParams.get("payment_update_session_id");
+		if (!sessionId || finalizedSessions.current.has(sessionId)) {
+			return;
+		}
+		finalizedSessions.current.add(sessionId);
+
+		const clearParam = () => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.delete("payment_update_session_id");
+			const query = params.toString();
+			router.replace(query ? `/dashboard?${query}` : "/dashboard");
+		};
+
+		finalizePaymentUpdateMutation
+			.mutateAsync({ body: { sessionId } })
+			.then((result) => {
+				if (result?.status === "ok") {
+					toast.success("Payment method updated");
+					void queryClient.invalidateQueries({
+						predicate: (query) => {
+							const key = query.queryKey;
+							return Array.isArray(key) && key[1] === "/dev-plans/status";
+						},
+					});
+				}
+			})
+			.catch((error: unknown) => {
+				const errCode =
+					error && typeof error === "object" && "error" in error
+						? (error as { error?: unknown }).error
+						: undefined;
+				if (errCode === "duplicate_card") {
+					const msg =
+						error && typeof error === "object" && "message" in error
+							? (error as { message?: unknown }).message
+							: undefined;
+					setDuplicateCardError(
+						typeof msg === "string" && msg.length > 0
+							? msg
+							: "This card is already associated with another DevPass account. Please use a different payment method.",
+					);
+				} else {
+					const apiMessage =
+						error && typeof error === "object" && "message" in error
+							? (error as { message?: unknown }).message
+							: undefined;
+					toast.error(
+						typeof apiMessage === "string" && apiMessage.length > 0
+							? apiMessage
+							: "Failed to update payment method",
+					);
+				}
+			})
+			.finally(() => {
+				clearParam();
+			});
+	}, [searchParams, finalizePaymentUpdateMutation, queryClient, router]);
 
 	const handleSubscribe = async (
 		tier: PlanTier,
@@ -381,6 +450,35 @@ export default function DashboardClient() {
 			toast.error("Failed to change plan");
 		} finally {
 			setSubscribingTier(null);
+		}
+	};
+
+	const handleUpdatePaymentMethod = async (): Promise<void> => {
+		setIsUpdatingPayment(true);
+		try {
+			const result = await updatePaymentMethodMutation.mutateAsync({});
+
+			if (!result?.checkoutUrl) {
+				toast.error("Failed to start payment method update");
+				return;
+			}
+
+			if (posthogKey) {
+				posthog.capture("dev_plan_update_payment_started");
+			}
+			window.location.href = result.checkoutUrl;
+		} catch (error: unknown) {
+			const apiMessage =
+				error && typeof error === "object" && "message" in error
+					? (error as { message?: unknown }).message
+					: undefined;
+			toast.error(
+				typeof apiMessage === "string" && apiMessage.length > 0
+					? apiMessage
+					: "Failed to start payment method update",
+			);
+		} finally {
+			setIsUpdatingPayment(false);
 		}
 	};
 
@@ -565,8 +663,22 @@ export default function DashboardClient() {
 							onChangeTier={handleChangeTier}
 						/>
 
-						{/* Subscription controls (cancel/resume) */}
-						<div className="flex justify-end">
+						{/* Subscription controls (update payment, cancel/resume) */}
+						<div className="flex flex-wrap items-center justify-between gap-3">
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={handleUpdatePaymentMethod}
+								disabled={isUpdatingPayment}
+								className="gap-1.5"
+							>
+								{isUpdatingPayment ? (
+									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								) : (
+									<CreditCard className="h-3.5 w-3.5" />
+								)}
+								Update payment method
+							</Button>
 							{devPlanStatus?.devPlanCancelled ? (
 								<Button
 									variant="outline"

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -10549,6 +10549,100 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Stripe Checkout session created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            checkoutUrl: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/finalize-payment-update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan payment method updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;
@@ -10937,7 +11031,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -10549,6 +10549,100 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Stripe Checkout session created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            checkoutUrl: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/finalize-payment-update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan payment method updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;
@@ -10937,7 +11031,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -10549,6 +10549,100 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Stripe Checkout session created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            checkoutUrl: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/finalize-payment-update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan payment method updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;
@@ -10937,7 +11031,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -10549,6 +10549,100 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Stripe Checkout session created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            checkoutUrl: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/finalize-payment-update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        sessionId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Dev plan payment method updated */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            status: "ok";
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plans/cancel": {
         parameters: {
             query?: never;
@@ -10937,7 +11031,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1554,6 +1554,7 @@ export const auditLogActions = [
 	"dev_plan.change_tier",
 	"dev_plan.update_settings",
 	"dev_plan.rotate_api_key",
+	"dev_plan.update_payment_method",
 ] as const;
 
 export const auditLogResourceTypes = [


### PR DESCRIPTION
## What

Adds the ability to **change the card / payment details** for an active DevPass subscription. Previously the card was only collected once at subscribe time (via setup-mode Stripe Checkout) and there was no way to update it.

## How

Mirrors the existing DevPass subscribe → finalize flow:

**Backend (`apps/api`)**
- `POST /dev-plans/update-payment-method` — creates a setup-mode Stripe Checkout session (no charge) to collect a new card, returning a `checkoutUrl`. Requires an active dev plan subscription.
- `POST /dev-plans/finalize-payment-update` — called after the redirect. New `finalizeDevPlanPaymentUpdate()` helper in `stripe.ts`:
  - Resolves the new card's fingerprint and runs the **same duplicate-card check** used at subscribe (rejects with `409 duplicate_card` and detaches the card if it's already used by another DevPass org).
  - Sets the new card as the customer's default payment method **and** the subscription's `default_payment_method`, so renewals are charged to it.
  - Updates the stored `devPlanCardFingerprint`.
- `checkout.session.completed` webhook gains a fallback branch for `subscriptionType: "dev_plan_payment_update"` (handles the user closing the tab), reusing the same idempotent helper.
- New audit action `dev_plan.update_payment_method`.

**Frontend (`apps/code`)**
- "Update payment method" button in the DevPass dashboard subscription controls.
- `payment_update_session_id` redirect handler that finalizes the update, shows a toast, invalidates status, and surfaces the duplicate-card dialog (reuses the existing one).

## Notes
- The audit action is a `text` enum column (TS-level), so no DB migration is required.
- Generated API clients (code/ui/playground/admin) regenerated from the updated OpenAPI spec.

## Test plan
- `pnpm build` ✅
- `pnpm format` ✅
- `vitest run apps/api/src/stripe.spec.ts` ✅ (4 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now update their payment method for active DevPass plans directly from the dashboard.
  * New "Update payment method" button in subscription controls redirects to a secure checkout experience.
  * Handles duplicate card scenarios with appropriate error messaging and user feedback.
  * Audit logging added for payment method updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->