### PR TITLE
feat(ui): add blog category pages to sitemap

### DIFF
--- a/apps/ui/src/app/sitemap.ts
+++ b/apps/ui/src/app/sitemap.ts
@@ -8,6 +8,13 @@ import {
 
 import type { MetadataRoute } from "next";
 
+function slugify(label: string) {
+	return label
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/(^-|-$)/g, "");
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = "https://llmgateway.io";
 
@@ -305,6 +312,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.6,
 		}));
 
+	// Blog category pages
+	const blogCategorySlugs = new Set<string>();
+	for (const blog of allBlogs) {
+		if (blog.draft) {
+			continue;
+		}
+		for (const category of blog.categories ?? []) {
+			blogCategorySlugs.add(slugify(category));
+		}
+	}
+	const blogCategoryPages: MetadataRoute.Sitemap = Array.from(
+		blogCategorySlugs,
+	).map((category) => ({
+		url: `${baseUrl}/blog/category/${encodeURIComponent(category)}`,
+		lastModified: new Date(),
+		changeFrequency: "weekly" as const,
+		priority: 0.5,
+	}));
+
 	// Guide pages
 	const guidePages: MetadataRoute.Sitemap = allGuides.map((guide) => ({
 		url: `${baseUrl}/guides/${guide.slug}`,
@@ -348,6 +374,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		...featurePages,
 		...enterpriseFeaturePages,
 		...blogPages,
+		...blogCategoryPages,
 		...guidePages,
 		...changelogPages,
 		...legalPages,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog category pages are now included in the sitemap with search-engine-optimized URLs. Categories are automatically processed and added with optimized update frequency settings for efficient search engine crawling. This enhancement improves search visibility and enables better user discovery of blog content organized by category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->