### PR TITLE
feat(guardrails): add redact action for custom rules

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/org/guardrails/guardrails-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/guardrails/guardrails-client.tsx
@@ -616,12 +616,18 @@ export function GuardrailsClient() {
 											<Label>Rule Type</Label>
 											<Select
 												value={newRule.type}
-												onValueChange={(value) =>
+												onValueChange={(value) => {
+													const type = value as typeof newRule.type;
 													setNewRule({
 														...newRule,
-														type: value as typeof newRule.type,
-													})
-												}
+														type,
+														action:
+															type === "topic_restriction" &&
+															newRule.action === "redact"
+																? "block"
+																: newRule.action,
+													});
+												}}
 											>
 												<SelectTrigger>
 													<SelectValue />
@@ -656,6 +662,10 @@ export function GuardrailsClient() {
 											</SelectTrigger>
 											<SelectContent>
 												<SelectItem value="block">Block</SelectItem>
+												{(newRule.type === "blocked_terms" ||
+													newRule.type === "custom_regex") && (
+													<SelectItem value="redact">Redact</SelectItem>
+												)}
 												<SelectItem value="warn">Warn</SelectItem>
 												<SelectItem value="allow">Allow (Log Only)</SelectItem>
 											</SelectContent>

--- a/apps/ui/src/app/dashboard/[orgId]/org/guardrails/guardrails-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/guardrails/guardrails-client.tsx
@@ -478,7 +478,8 @@ export function GuardrailsClient() {
 												</SelectTrigger>
 												<SelectContent>
 													<SelectItem value="block">Block</SelectItem>
-													{rule.id === "pii_detection" && (
+													{(rule.id === "pii_detection" ||
+														rule.id === "secrets") && (
 														<SelectItem value="redact">Redact</SelectItem>
 													)}
 													<SelectItem value="warn">Warn</SelectItem>

--- a/ee/guardrails/src/engine.ts
+++ b/ee/guardrails/src/engine.ts
@@ -15,6 +15,7 @@ import {
 import {
 	systemRules,
 	redactPii,
+	redactSecrets,
 	checkBlockedTerms,
 	checkCustomRegex,
 	checkTopicRestriction,
@@ -107,40 +108,44 @@ export async function checkGuardrails(
 			const result = rule.check(content, ruleConfig);
 
 			if (!result.passed) {
-				// Handle PII redaction specially
-				if (
-					rule.id === "system:pii_detection" &&
-					ruleConfig.action === "redact"
-				) {
-					const { patterns } = redactPii(content);
-					if (patterns.length > 0) {
-						redactions.push({
-							ruleId: rule.id,
-							messageIndex,
-							kind: "pii",
-							matches: [],
-							pattern: patterns.join(", "),
-						});
+				let matchedPattern = result.matches.join(", ");
+
+				if (ruleConfig.action === "redact") {
+					if (rule.id === "system:pii_detection") {
+						const { patterns } = redactPii(content);
+						if (patterns.length > 0) {
+							redactions.push({
+								ruleId: rule.id,
+								messageIndex,
+								kind: "pii",
+								matches: [],
+								pattern: patterns.join(", "),
+							});
+						}
+						// Avoid logging the raw PII; log the detected types instead
+						matchedPattern = patterns.join(", ");
+					} else if (rule.id === "system:secrets") {
+						const { patterns } = redactSecrets(content);
+						if (patterns.length > 0) {
+							redactions.push({
+								ruleId: rule.id,
+								messageIndex,
+								kind: "secrets",
+								matches: [],
+								pattern: patterns.join(", "),
+							});
+						}
 					}
-					// Also add as violation for logging
-					violations.push({
-						ruleId: rule.id,
-						ruleName: rule.name,
-						category: rule.category,
-						action: ruleConfig.action,
-						matchedPattern: patterns.join(", "),
-						matchedContent: content.substring(0, 100),
-					});
-				} else {
-					violations.push({
-						ruleId: rule.id,
-						ruleName: rule.name,
-						category: rule.category,
-						action: ruleConfig.action,
-						matchedPattern: result.matches.join(", "),
-						matchedContent: content.substring(0, 100),
-					});
 				}
+
+				violations.push({
+					ruleId: rule.id,
+					ruleName: rule.name,
+					category: rule.category,
+					action: ruleConfig.action,
+					matchedPattern,
+					matchedContent: content.substring(0, 100),
+				});
 			}
 		}
 	}
@@ -279,6 +284,7 @@ export function applyRedactions(
 		}
 
 		const hasPii = messageRedactions.some((r) => r.kind === "pii");
+		const hasSecrets = messageRedactions.some((r) => r.kind === "secrets");
 		const maskMatches = messageRedactions
 			.filter((r) => r.kind === "mask")
 			.flatMap((r) => r.matches);
@@ -287,6 +293,9 @@ export function applyRedactions(
 			let result = text;
 			if (hasPii) {
 				result = redactPii(result).redacted;
+			}
+			if (hasSecrets) {
+				result = redactSecrets(result).redacted;
 			}
 			for (const match of maskMatches) {
 				result = maskMatch(result, match);

--- a/ee/guardrails/src/engine.ts
+++ b/ee/guardrails/src/engine.ts
@@ -113,13 +113,13 @@ export async function checkGuardrails(
 					ruleConfig.action === "redact"
 				) {
 					const { patterns } = redactPii(content);
-					for (const pattern of patterns) {
+					if (patterns.length > 0) {
 						redactions.push({
 							ruleId: rule.id,
-							pattern,
-							replacement: `[${pattern.toUpperCase()}_REDACTED]`,
 							messageIndex,
-							originalContent: content,
+							kind: "pii",
+							matches: [],
+							pattern: patterns.join(", "),
 						});
 					}
 					// Also add as violation for logging
@@ -164,7 +164,7 @@ export async function checkGuardrails(
 
 		rulesChecked++;
 
-		for (const { content } of textContents) {
+		for (const { content, messageIndex } of textContents) {
 			let result: {
 				passed: boolean;
 				matches: string[];
@@ -206,6 +206,16 @@ export async function checkGuardrails(
 					matchedPattern: result.matches.join(", "),
 					matchedContent: content.substring(0, 100),
 				});
+
+				if (result.action === "redact" && result.matches.length > 0) {
+					redactions.push({
+						ruleId: rule.id,
+						messageIndex,
+						kind: "mask",
+						matches: result.matches,
+						pattern: result.matches.join(", "),
+					});
+				}
 			}
 		}
 	}
@@ -268,25 +278,48 @@ export function applyRedactions(
 			return message;
 		}
 
+		const hasPii = messageRedactions.some((r) => r.kind === "pii");
+		const maskMatches = messageRedactions
+			.filter((r) => r.kind === "mask")
+			.flatMap((r) => r.matches);
+
+		const redactText = (text: string): string => {
+			let result = text;
+			if (hasPii) {
+				result = redactPii(result).redacted;
+			}
+			for (const match of maskMatches) {
+				result = maskMatch(result, match);
+			}
+			return result;
+		};
+
 		if (typeof message.content === "string") {
-			let content = message.content;
-			// Apply PII redaction
-			const { redacted } = redactPii(content);
-			content = redacted;
-			return { ...message, content };
+			return { ...message, content: redactText(message.content) };
 		}
 
 		// Handle array content (multimodal)
 		const content = message.content.map((part) => {
 			if (part.type === "text" && part.text) {
-				const { redacted } = redactPii(part.text);
-				return { ...part, text: redacted };
+				return { ...part, text: redactText(part.text) };
 			}
 			return part;
 		});
 
 		return { ...message, content };
 	});
+}
+
+function escapeRegex(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function maskMatch(content: string, match: string): string {
+	if (!match || !match.trim()) {
+		return content;
+	}
+	const regex = new RegExp(escapeRegex(match), "gi");
+	return content.replace(regex, (m) => "*".repeat(m.length));
 }
 
 function extractTextContent(

--- a/ee/guardrails/src/redaction.spec.ts
+++ b/ee/guardrails/src/redaction.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { applyRedactions } from "./engine.js";
+
+import type { Message, RedactionInfo } from "./types.js";
+
+describe("applyRedactions", () => {
+	it("returns messages unchanged when there are no redactions", () => {
+		const messages: Message[] = [{ role: "user", content: "hello world" }];
+		expect(applyRedactions(messages, [])).toEqual(messages);
+	});
+
+	it("masks literal matches with asterisks of the same length", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "Our competitor is Acme Corp." },
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "rule_1",
+				messageIndex: 0,
+				kind: "mask",
+				matches: ["competitor"],
+				pattern: "competitor",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		expect(result[0].content).toBe("Our ********** is Acme Corp.");
+	});
+
+	it("masks matches case-insensitively while preserving original length", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "SECRET and secret and Secret" },
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "rule_1",
+				messageIndex: 0,
+				kind: "mask",
+				matches: ["secret"],
+				pattern: "secret",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		expect(result[0].content).toBe("****** and ****** and ******");
+	});
+
+	it("only applies redactions to the targeted message index", () => {
+		const messages: Message[] = [
+			{ role: "system", content: "secret instructions" },
+			{ role: "user", content: "secret request" },
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "rule_1",
+				messageIndex: 1,
+				kind: "mask",
+				matches: ["secret"],
+				pattern: "secret",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		expect(result[0].content).toBe("secret instructions");
+		expect(result[1].content).toBe("****** request");
+	});
+
+	it("masks matches inside multimodal text parts", () => {
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "block competitor talk" },
+					{ type: "image_url", image_url: { url: "https://example.com" } },
+				],
+			},
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "rule_1",
+				messageIndex: 0,
+				kind: "mask",
+				matches: ["competitor"],
+				pattern: "competitor",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		const content = result[0].content as { type: string; text?: string }[];
+		expect(content[0].text).toBe("block ********** talk");
+		expect(content[1]).toEqual({
+			type: "image_url",
+			image_url: { url: "https://example.com" },
+		});
+	});
+
+	it("applies built-in PII redaction for pii redactions", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "email me at john@example.com please" },
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "system:pii_detection",
+				messageIndex: 0,
+				kind: "pii",
+				matches: [],
+				pattern: "Email",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		expect(result[0].content).toBe("email me at [EMAIL_REDACTED] please");
+	});
+
+	it("escapes regex metacharacters in literal matches", () => {
+		const messages: Message[] = [
+			{ role: "user", content: "value is a.b.c and axbxc" },
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "rule_1",
+				messageIndex: 0,
+				kind: "mask",
+				matches: ["a.b.c"],
+				pattern: "a.b.c",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		expect(result[0].content).toBe("value is ***** and axbxc");
+	});
+});

--- a/ee/guardrails/src/redaction.spec.ts
+++ b/ee/guardrails/src/redaction.spec.ts
@@ -130,4 +130,26 @@ describe("applyRedactions", () => {
 		const result = applyRedactions(messages, redactions);
 		expect(result[0].content).toBe("value is ***** and axbxc");
 	});
+
+	it("applies built-in secrets redaction for secrets redactions", () => {
+		const messages: Message[] = [
+			{
+				role: "user",
+				content:
+					"use key sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL now",
+			},
+		];
+		const redactions: RedactionInfo[] = [
+			{
+				ruleId: "system:secrets",
+				messageIndex: 0,
+				kind: "secrets",
+				matches: [],
+				pattern: "Secret",
+			},
+		];
+
+		const result = applyRedactions(messages, redactions);
+		expect(result[0].content).toBe("use key [SECRET_REDACTED] now");
+	});
 });

--- a/ee/guardrails/src/rules/index.ts
+++ b/ee/guardrails/src/rules/index.ts
@@ -10,7 +10,7 @@ import type { SystemRule } from "@/types.js";
 export { injectionRule } from "./system/injection.js";
 export { jailbreakRule } from "./system/jailbreak.js";
 export { piiRule, redactPii } from "./system/pii.js";
-export { secretsRule } from "./system/secrets.js";
+export { secretsRule, redactSecrets } from "./system/secrets.js";
 export { fileTypesRule, checkFileType, checkFileSize } from "./system/files.js";
 export { documentLeakageRule } from "./system/document-leakage.js";
 

--- a/ee/guardrails/src/rules/system/secrets.ts
+++ b/ee/guardrails/src/rules/system/secrets.ts
@@ -27,6 +27,28 @@ const SECRET_PATTERNS = [
 	/\b(password|passwd|pwd)[=:]\s*['"]?[^\s'"]{8,}['"]?\b/i,
 ];
 
+export function redactSecrets(content: string): {
+	redacted: string;
+	patterns: string[];
+} {
+	let redacted = content;
+	const patterns: string[] = [];
+
+	for (const pattern of SECRET_PATTERNS) {
+		const globalPattern = new RegExp(
+			pattern.source,
+			pattern.global ? pattern.flags : pattern.flags + "g",
+		);
+		const matches = redacted.match(globalPattern);
+		if (matches) {
+			patterns.push(...matches.map(() => "Secret"));
+			redacted = redacted.replace(globalPattern, "[SECRET_REDACTED]");
+		}
+	}
+
+	return { redacted, patterns };
+}
+
 export const secretsRule: SystemRule = {
 	id: "system:secrets",
 	name: "Secrets Detection",

--- a/ee/guardrails/src/types.ts
+++ b/ee/guardrails/src/types.ts
@@ -32,8 +32,8 @@ export interface RuleViolation {
 export interface RedactionInfo {
 	ruleId: string;
 	messageIndex: number;
-	// "pii" applies the built-in PII redaction; "mask" replaces literal matches with asterisks
-	kind: "pii" | "mask";
+	// "pii"/"secrets" apply the built-in detectors' redaction; "mask" replaces literal matches with asterisks
+	kind: "pii" | "secrets" | "mask";
 	// Literal substrings to mask out (used when kind is "mask")
 	matches: string[];
 	// Matched patterns, for reference/logging

--- a/ee/guardrails/src/types.ts
+++ b/ee/guardrails/src/types.ts
@@ -31,10 +31,13 @@ export interface RuleViolation {
 
 export interface RedactionInfo {
 	ruleId: string;
-	pattern: string;
-	replacement: string;
 	messageIndex: number;
-	originalContent: string;
+	// "pii" applies the built-in PII redaction; "mask" replaces literal matches with asterisks
+	kind: "pii" | "mask";
+	// Literal substrings to mask out (used when kind is "mask")
+	matches: string[];
+	// Matched patterns, for reference/logging
+	pattern: string;
 }
 
 export interface GuardrailResult {


### PR DESCRIPTION
## Summary

Adds a **redact** action for guardrail custom rules. Previously only PII detection could redact; custom rules could only `block`, `warn`, or `allow`. With `redact`, detected matches are replaced with asterisks (`*****`) and the request is **still forwarded upstream**, while the violation is logged (as `redacted`) like a warn.

## Changes

- **`ee/guardrails/src/engine.ts`**: custom rules whose action is `redact` now emit mask redactions for the matched message. `applyRedactions` was reworked to handle two redaction kinds — built-in PII redaction and literal-match masking (case-insensitive, regex-escaped, same-length asterisks).
- **`ee/guardrails/src/types.ts`**: `RedactionInfo` now carries a `kind` (`"pii" | "mask"`) and the literal `matches` to mask.
- **`apps/ui/.../guardrails/guardrails-client.tsx`**: the custom-rule action dropdown now offers **Redact** for `blocked_terms` and `custom_regex` rule types (topic restriction has no literal span to mask, so it's excluded; switching to it resets a stale `redact` selection).
- **`ee/guardrails/src/redaction.spec.ts`**: unit tests for the masking behavior.

The DB schema and API already accepted `redact` for rules, and the gateway already applies redactions + logs non-blocking violations, so no changes were needed there.

## Testing

- `pnpm test:unit` (new `redaction.spec.ts` — 7 tests pass)
- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - UI: Action options now show "Redact" only where applicable and auto-adjusts actions when changing custom rule types.

* **Improvements**
  - Redaction engine rewritten to aggregate detections, apply targeted redactions per message, and perform safe substring masking across content types.
  - Redaction metadata model updated for clearer kinds and matches.

* **Tests**
  - Expanded tests covering secrets redaction, PII redaction, multimodal masking, and regex-safe masking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->