### PR TITLE
refactor(chat): enhance Reasoning component behavior

### DIFF
--- a/apps/playground/src/components/ai-elements/reasoning.tsx
+++ b/apps/playground/src/components/ai-elements/reasoning.tsx
@@ -2,7 +2,7 @@
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
-import { createContext, memo, use, useEffect, useState } from "react";
+import { createContext, memo, use, useEffect, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
 
 import { Shimmer } from "@/components/ai-elements/shimmer";
@@ -72,6 +72,7 @@ export const Reasoning = memo(
 
 		const [hasAutoClosed, setHasAutoClosed] = useState(false);
 		const [startTime, setStartTime] = useState<number | null>(null);
+		const wasInitiallyOpen = useRef(defaultOpen);
 
 		// Track duration when streaming starts and ends
 		useEffect(() => {
@@ -85,10 +86,14 @@ export const Reasoning = memo(
 			}
 		}, [isStreaming, startTime, setDuration]);
 
-		// Auto-open when streaming starts, auto-close when streaming ends (once only)
+		// Auto-close when streaming ends (once only), if initially opened
 		useEffect(() => {
-			if (defaultOpen && !isStreaming && isOpen && !hasAutoClosed) {
-				// Add a small delay before closing to allow user to see the content
+			if (
+				wasInitiallyOpen.current &&
+				!isStreaming &&
+				isOpen &&
+				!hasAutoClosed
+			) {
 				const timer = setTimeout(() => {
 					setIsOpen(false);
 					setHasAutoClosed(true);
@@ -97,7 +102,7 @@ export const Reasoning = memo(
 				return () => clearTimeout(timer);
 			}
 			return undefined;
-		}, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
+		}, [isStreaming, isOpen, setIsOpen, hasAutoClosed]);
 
 		const handleOpenChange = (newOpen: boolean) => {
 			setIsOpen(newOpen);

--- a/apps/playground/src/components/playground/chat-ui.tsx
+++ b/apps/playground/src/components/playground/chat-ui.tsx
@@ -524,8 +524,12 @@ const AssistantMessage = memo(
 				{reasoningContent ? (
 					<Reasoning
 						className="w-full"
-						defaultOpen={false}
-						isStreaming={status === "streaming" && isLastMessage}
+						defaultOpen={
+							status === "streaming" && isLastMessage && textContent === ""
+						}
+						isStreaming={
+							status === "streaming" && isLastMessage && textContent === ""
+						}
 					>
 						<ReasoningTrigger />
 						<ReasoningContent>{reasoningContent}</ReasoningContent>
@@ -598,10 +602,10 @@ const AssistantMessage = memo(
 					</div>
 				)}
 
-				{(metadata || isLastMessage) && (
+				{(metadata || (isLastMessage && status !== "streaming")) && (
 					<Actions className="mt-2">
 						{metadata ? <MessageMetadataPopover metadata={metadata} /> : null}
-						{isLastMessage ? (
+						{isLastMessage && status !== "streaming" ? (
 							<>
 								<Action
 									onClick={() => regenerate()}
@@ -816,14 +820,30 @@ const UserMessage = memo(
 							</div>
 						)}
 					</MessageContent>
-					{canEdit && !isEditing ? (
+					{!isEditing ? (
 						<Actions className="mt-2 opacity-0 transition-opacity group-hover/user-message:opacity-100 focus-within:opacity-100">
+							{canEdit ? (
+								<Action
+									onClick={onEditStart}
+									label="Edit and retry"
+									tooltip="Edit and retry from here"
+								>
+									<Undo2 className="size-3" />
+								</Action>
+							) : null}
 							<Action
-								onClick={onEditStart}
-								label="Edit and retry"
-								tooltip="Edit and retry from here"
+								onClick={async () => {
+									try {
+										await navigator.clipboard.writeText(initialText);
+										toast.success("Copied to clipboard");
+									} catch {
+										toast.error("Failed to copy to clipboard");
+									}
+								}}
+								label="Copy"
+								tooltip="Copy to clipboard"
 							>
-								<Undo2 className="size-3" />
+								<Copy className="size-3" />
 							</Action>
 						</Actions>
 					) : null}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reasoning component auto-close behavior to only trigger once when streaming ends and was initially open
  * Assistant reasoning now auto-opens during active streaming with empty content

* **Improvements**
  * Refined action toolbar visibility logic for assistant and user messages
  * Copy message action now always available for user messages, regardless of edit permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->