### PR TITLE
fix(billing): credit top-up targets active org

### DIFF
--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -48,6 +48,25 @@ const creditTopUpAmountSchema = z
 	)
 	.max(CREDIT_TOP_UP_MAX_AMOUNT, "Maximum top-up amount is $5000.");
 
+/**
+ * Resolves the organization a payment operation should target.
+ *
+ * When an `organizationId` is provided (e.g. the user is acting within a
+ * non-default organization they switched to in the dashboard), it is looked up
+ * scoped to the user's memberships so a user can only ever target an org they
+ * belong to. When omitted, it falls back to the user's first organization for
+ * backward compatibility.
+ */
+async function findUserOrganization(userId: string, organizationId?: string) {
+	return await db.query.userOrganization.findFirst({
+		where: organizationId ? { userId, organizationId } : { userId },
+		with: {
+			organization: true,
+			user: true,
+		},
+	});
+}
+
 export async function isInternationalPaymentMethod(
 	stripePaymentMethodId: string,
 ): Promise<boolean> {
@@ -68,6 +87,7 @@ const createPaymentIntent = createRoute({
 					schema: z.object({
 						amount: creditTopUpAmountSchema,
 						stripePaymentMethodId: z.string().optional(),
+						organizationId: z.string().optional(),
 					}),
 				},
 			},
@@ -106,16 +126,16 @@ payments.openapi(createPaymentIntent, async (c) => {
 		});
 	}
 
-	const { amount, stripePaymentMethodId } = c.req.valid("json");
+	const {
+		amount,
+		stripePaymentMethodId,
+		organizationId: requestedOrganizationId,
+	} = c.req.valid("json");
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {
@@ -183,7 +203,18 @@ payments.openapi(createPaymentIntent, async (c) => {
 const createSetupIntent = createRoute({
 	method: "post",
 	path: "/create-setup-intent",
-	request: {},
+	request: {
+		body: {
+			required: false,
+			content: {
+				"application/json": {
+					schema: z.object({
+						organizationId: z.string().optional(),
+					}),
+				},
+			},
+		},
+	},
 	responses: {
 		200: {
 			content: {
@@ -215,14 +246,12 @@ payments.openapi(createSetupIntent, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const { organizationId: requestedOrganizationId } = c.req.valid("json") ?? {};
+
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {
@@ -247,7 +276,11 @@ payments.openapi(createSetupIntent, async (c) => {
 const getPaymentMethods = createRoute({
 	method: "get",
 	path: "/payment-methods",
-	request: {},
+	request: {
+		query: z.object({
+			organizationId: z.string().optional(),
+		}),
+	},
 	responses: {
 		200: {
 			content: {
@@ -282,14 +315,12 @@ payments.openapi(getPaymentMethods, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const { organizationId: requestedOrganizationId } = c.req.valid("query");
+
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {
@@ -342,6 +373,7 @@ const setDefaultPaymentMethod = createRoute({
 				"application/json": {
 					schema: z.object({
 						paymentMethodId: z.string(),
+						organizationId: z.string().optional(),
 					}),
 				},
 			},
@@ -370,16 +402,13 @@ payments.openapi(setDefaultPaymentMethod, async (c) => {
 		});
 	}
 
-	const { paymentMethodId } = c.req.valid("json");
+	const { paymentMethodId, organizationId: requestedOrganizationId } =
+		c.req.valid("json");
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {
@@ -436,6 +465,9 @@ const deletePaymentMethod = createRoute({
 		params: z.object({
 			id: z.string(),
 		}),
+		query: z.object({
+			organizationId: z.string().optional(),
+		}),
 	},
 	responses: {
 		200: {
@@ -460,16 +492,13 @@ payments.openapi(deletePaymentMethod, async (c) => {
 		});
 	}
 
-	const { id } = c.req.param();
+	const { id } = c.req.valid("param");
+	const { organizationId: requestedOrganizationId } = c.req.valid("query");
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {
@@ -543,6 +572,7 @@ const topUpWithSavedMethod = createRoute({
 					schema: z.object({
 						amount: creditTopUpAmountSchema,
 						paymentMethodId: z.string(),
+						organizationId: z.string().optional(),
 					}),
 				},
 			},
@@ -582,7 +612,12 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 	const {
 		amount,
 		paymentMethodId,
-	}: { amount: number; paymentMethodId: string } = c.req.valid("json");
+		organizationId: requestedOrganizationId,
+	}: {
+		amount: number;
+		paymentMethodId: string;
+		organizationId?: string;
+	} = c.req.valid("json");
 
 	const paymentMethod = await db.query.paymentMethod.findFirst({
 		where: {
@@ -596,14 +631,10 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (
 		!userOrganization ||
@@ -738,6 +769,7 @@ const createCheckoutSession = createRoute({
 					schema: z.object({
 						amount: creditTopUpAmountSchema,
 						returnUrl: z.string().url().optional(),
+						organizationId: z.string().optional(),
 					}),
 				},
 			},
@@ -773,16 +805,16 @@ payments.openapi(createCheckoutSession, async (c) => {
 		});
 	}
 
-	const { amount, returnUrl } = c.req.valid("json");
+	const {
+		amount,
+		returnUrl,
+		organizationId: requestedOrganizationId,
+	} = c.req.valid("json");
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {
@@ -880,6 +912,7 @@ const calculateFeesRoute = createRoute({
 					schema: z.object({
 						amount: creditTopUpAmountSchema,
 						paymentMethodId: z.string().optional(),
+						organizationId: z.string().optional(),
 					}),
 				},
 			},
@@ -924,17 +957,17 @@ payments.openapi(calculateFeesRoute, async (c) => {
 	const {
 		amount,
 		paymentMethodId,
-	}: { amount: number; paymentMethodId?: string } = c.req.valid("json");
+		organizationId: requestedOrganizationId,
+	}: {
+		amount: number;
+		paymentMethodId?: string;
+		organizationId?: string;
+	} = c.req.valid("json");
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-			user: true,
-		},
-	});
+	const userOrganization = await findUserOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
 
 	if (!userOrganization || !userOrganization.organization) {
 		throw new HTTPException(404, {

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -8793,6 +8793,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         stripePaymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8834,7 +8835,13 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        organizationId?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Setup intent created successfully */
                 200: {
@@ -8864,7 +8871,9 @@ export interface paths {
         };
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -8921,6 +8930,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8956,7 +8966,9 @@ export interface paths {
         post?: never;
         delete: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path: {
                     id: string;
@@ -9004,6 +9016,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9049,6 +9062,7 @@ export interface paths {
                         amount: number;
                         /** Format: uri */
                         returnUrl?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9093,6 +9107,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -8793,6 +8793,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         stripePaymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8834,7 +8835,13 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        organizationId?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Setup intent created successfully */
                 200: {
@@ -8864,7 +8871,9 @@ export interface paths {
         };
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -8921,6 +8930,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8956,7 +8966,9 @@ export interface paths {
         post?: never;
         delete: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path: {
                     id: string;
@@ -9004,6 +9016,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9049,6 +9062,7 @@ export interface paths {
                         amount: number;
                         /** Format: uri */
                         returnUrl?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9093,6 +9107,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };

--- a/apps/ui/src/components/billing/auto-topup-settings.tsx
+++ b/apps/ui/src/components/billing/auto-topup-settings.tsx
@@ -27,9 +27,13 @@ function AutoTopUpSettings() {
 	const api = useApi();
 
 	const { selectedOrganization } = useDashboardState();
+	const organizationId = selectedOrganization?.id;
 	const { data: paymentMethods } = api.useQuery(
 		"get",
 		"/payments/payment-methods",
+		{
+			params: { query: { organizationId } },
+		},
 	);
 
 	const [enabled, setEnabled] = useState(false);
@@ -51,6 +55,7 @@ function AutoTopUpSettings() {
 			body: {
 				amount,
 				paymentMethodId: defaultPaymentMethod?.id,
+				organizationId,
 			},
 		},
 		{

--- a/apps/ui/src/components/credits/payment-methods-management.tsx
+++ b/apps/ui/src/components/credits/payment-methods-management.tsx
@@ -21,6 +21,7 @@ import {
 	DialogTrigger,
 } from "@/lib/components/dialog";
 import { toast } from "@/lib/components/use-toast";
+import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
 import { useStripe } from "@/lib/stripe";
 
@@ -29,17 +30,23 @@ import type React from "react";
 export function PaymentMethodsManagement() {
 	const queryClient = useQueryClient();
 	const api = useApi();
+	const { selectedOrganization } = useDashboardState();
+	const organizationId = selectedOrganization?.id;
 
 	// Use regular query instead of suspense query to prevent infinite re-rendering
 	const { data, isLoading, error } = api.useQuery(
 		"get",
 		"/payments/payment-methods",
+		{
+			params: { query: { organizationId } },
+		},
 	);
 
 	// Generate query key once and reuse it
 	const paymentMethodsQueryKey = api.queryOptions(
 		"get",
 		"/payments/payment-methods",
+		{ params: { query: { organizationId } } },
 	).queryKey;
 
 	const { mutate: setDefaultMutation, isPending: isDefaultMethodPending } =
@@ -73,7 +80,7 @@ export function PaymentMethodsManagement() {
 
 	const handleSetDefault = async (paymentMethodId: string) => {
 		setDefaultMutation(
-			{ body: { paymentMethodId } },
+			{ body: { paymentMethodId, organizationId } },
 			{
 				onSuccess: () => {
 					void queryClient.invalidateQueries({
@@ -100,6 +107,7 @@ export function PaymentMethodsManagement() {
 					path: {
 						id: paymentMethodId,
 					},
+					query: { organizationId },
 				},
 			},
 			{
@@ -174,12 +182,16 @@ export function PaymentMethodsManagement() {
 					))}
 				</div>
 			)}
-			<AddPaymentMethodDialog />
+			<AddPaymentMethodDialog organizationId={organizationId} />
 		</div>
 	);
 }
 
-function AddPaymentMethodDialog() {
+function AddPaymentMethodDialog({
+	organizationId,
+}: {
+	organizationId: string | undefined;
+}) {
 	const [open, setOpen] = useState(false);
 	const { stripe, isLoading: stripeLoading } = useStripe();
 
@@ -196,7 +208,10 @@ function AddPaymentMethodDialog() {
 					<div className="p-6 text-center">Loading payment form...</div>
 				) : (
 					<Elements stripe={stripe}>
-						<AddPaymentMethodForm onSuccess={() => setOpen(false)} />
+						<AddPaymentMethodForm
+							organizationId={organizationId}
+							onSuccess={() => setOpen(false)}
+						/>
 					</Elements>
 				)}
 			</DialogContent>
@@ -204,7 +219,13 @@ function AddPaymentMethodDialog() {
 	);
 }
 
-function AddPaymentMethodForm({ onSuccess }: { onSuccess: () => void }) {
+function AddPaymentMethodForm({
+	organizationId,
+	onSuccess,
+}: {
+	organizationId: string | undefined;
+	onSuccess: () => void;
+}) {
 	const queryClient = useQueryClient();
 	const stripe = useStripeElements();
 	const elements = useElements();
@@ -214,6 +235,7 @@ function AddPaymentMethodForm({ onSuccess }: { onSuccess: () => void }) {
 	const paymentMethodsQueryOptions = api.queryOptions(
 		"get",
 		"/payments/payment-methods",
+		{ params: { query: { organizationId } } },
 	);
 
 	const { mutateAsync: setupIntentMutation } = api.useMutation(
@@ -231,7 +253,9 @@ function AddPaymentMethodForm({ onSuccess }: { onSuccess: () => void }) {
 		setLoading(true);
 
 		try {
-			const { clientSecret } = await setupIntentMutation({});
+			const { clientSecret } = await setupIntentMutation({
+				body: { organizationId },
+			});
 
 			const result = await stripe.confirmCardSetup(clientSecret, {
 				payment_method: {

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -68,6 +68,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 	>(null);
 	const [autoTopUpIntent, setAutoTopUpIntent] = useState(false);
 	const { selectedOrganization } = useDashboardState();
+	const organizationId = selectedOrganization?.id;
 	const alreadyHasAutoTopUp = selectedOrganization?.autoTopUpEnabled ?? false;
 	const { stripe, isLoading: stripeLoading } = useStripe();
 	const api = useApi();
@@ -77,7 +78,9 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 		api.useQuery(
 			"get",
 			"/payments/payment-methods",
-			{},
+			{
+				params: { query: { organizationId } },
+			},
 			{
 				enabled: open, // Only fetch when dialog is open
 			},
@@ -126,6 +129,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 					<AmountStep
 						amount={amount}
 						setAmount={setAmount}
+						organizationId={organizationId}
 						autoTopUpIntent={autoTopUpIntent}
 						setAutoTopUpIntent={setAutoTopUpIntent}
 						alreadyHasAutoTopUp={alreadyHasAutoTopUp}
@@ -156,6 +160,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 					<ConfirmPaymentStep
 						amount={amount}
 						paymentMethodId={selectedPaymentMethod!}
+						organizationId={organizationId}
 						onSuccess={() => setStep("success")}
 						onBack={() => setStep("select-payment")}
 						onCancel={handleClose}
@@ -169,6 +174,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 						<Elements stripe={stripe}>
 							<PaymentStep
 								amount={amount}
+								organizationId={organizationId}
 								onBack={() => setStep("amount")}
 								onSuccess={() => setStep("success")}
 								onCancel={handleClose}
@@ -195,6 +201,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 function AmountStep({
 	amount,
 	setAmount,
+	organizationId,
 	autoTopUpIntent,
 	setAutoTopUpIntent,
 	alreadyHasAutoTopUp,
@@ -202,6 +209,7 @@ function AmountStep({
 }: {
 	amount: number;
 	setAmount: (amount: number) => void;
+	organizationId: string | undefined;
 	autoTopUpIntent: boolean;
 	setAutoTopUpIntent: (v: boolean) => void;
 	alreadyHasAutoTopUp: boolean;
@@ -239,7 +247,7 @@ function AmountStep({
 		"post",
 		"/payments/calculate-fees",
 		{
-			body: { amount },
+			body: { amount, organizationId },
 		},
 		{
 			enabled: isAmountValid,
@@ -262,7 +270,11 @@ function AmountStep({
 		setCheckoutLoading(true);
 		try {
 			const { checkoutUrl } = await createCheckoutSession({
-				body: { amount, returnUrl: window.location.href.split("?")[0] },
+				body: {
+					amount,
+					returnUrl: window.location.href.split("?")[0],
+					organizationId,
+				},
 			});
 			window.location.href = checkoutUrl;
 		} catch (error: unknown) {
@@ -513,6 +525,7 @@ function AmountStep({
 
 function PaymentStep({
 	amount,
+	organizationId,
 	onBack,
 	onSuccess,
 	onCancel,
@@ -520,6 +533,7 @@ function PaymentStep({
 	setLoading,
 }: {
 	amount: number;
+	organizationId: string | undefined;
 	onBack: () => void;
 	onSuccess: () => void;
 	onCancel: () => void;
@@ -544,6 +558,7 @@ function PaymentStep({
 	const paymentMethodsQueryKey = api.queryOptions(
 		"get",
 		"/payments/payment-methods",
+		{ params: { query: { organizationId } } },
 	).queryKey;
 
 	const [saveCard, setSaveCard] = useState(true);
@@ -561,7 +576,9 @@ function PaymentStep({
 			let stripePaymentMethodId: string | undefined;
 
 			if (saveCard) {
-				const { clientSecret: setupSecret } = await setupIntentMutation({});
+				const { clientSecret: setupSecret } = await setupIntentMutation({
+					body: { organizationId },
+				});
 
 				const setupResult = await stripe.confirmCardSetup(setupSecret, {
 					payment_method: {
@@ -610,6 +627,7 @@ function PaymentStep({
 				body: {
 					amount,
 					stripePaymentMethodId,
+					organizationId,
 				},
 			});
 
@@ -629,16 +647,21 @@ function PaymentStep({
 				// so the UI reflects the change immediately, then invalidate
 				// in the background to sync with the server.
 				queryClient.setQueryData<{
-					organizations: { credits: string }[];
+					organizations: { id: string; credits: string }[];
 				}>(orgsQueryKey, (old) => {
-					if (!old?.organizations?.[0]) {
+					if (!old?.organizations?.length) {
 						return old;
 					}
-					const current = Number(old.organizations[0].credits ?? 0);
+					const targetId = organizationId ?? old.organizations[0]?.id;
 					return {
 						...old,
-						organizations: old.organizations.map((org, i) =>
-							i === 0 ? { ...org, credits: String(current + amount) } : org,
+						organizations: old.organizations.map((org) =>
+							org.id === targetId
+								? {
+										...org,
+										credits: String(Number(org.credits ?? 0) + amount),
+									}
+								: org,
 						),
 					};
 				});
@@ -988,6 +1011,7 @@ function SelectPaymentStep({
 function ConfirmPaymentStep({
 	amount,
 	paymentMethodId,
+	organizationId,
 	onSuccess,
 	onBack,
 	onCancel,
@@ -996,6 +1020,7 @@ function ConfirmPaymentStep({
 }: {
 	amount: number;
 	paymentMethodId: string;
+	organizationId: string | undefined;
 	onSuccess: () => void;
 	onBack: () => void;
 	onCancel: () => void;
@@ -1016,7 +1041,7 @@ function ConfirmPaymentStep({
 		"post",
 		"/payments/calculate-fees",
 		{
-			body: { amount, paymentMethodId },
+			body: { amount, paymentMethodId, organizationId },
 		},
 	);
 
@@ -1047,23 +1072,28 @@ function ConfirmPaymentStep({
 
 		try {
 			await topUpMutation({
-				body: { amount, paymentMethodId },
+				body: { amount, paymentMethodId, organizationId },
 			});
 
 			// Payment succeeded — optimistically update cached credits
 			// so the UI reflects the change immediately, then invalidate
 			// in the background to sync with the server.
 			queryClient.setQueryData<{
-				organizations: { credits: string }[];
+				organizations: { id: string; credits: string }[];
 			}>(orgsQueryKey, (old) => {
-				if (!old?.organizations?.[0]) {
+				if (!old?.organizations?.length) {
 					return old;
 				}
-				const current = Number(old.organizations[0].credits ?? 0);
+				const targetId = organizationId ?? old.organizations[0]?.id;
 				return {
 					...old,
-					organizations: old.organizations.map((org, i) =>
-						i === 0 ? { ...org, credits: String(current + amount) } : org,
+					organizations: old.organizations.map((org) =>
+						org.id === targetId
+							? {
+									...org,
+									credits: String(Number(org.credits ?? 0) + amount),
+								}
+							: org,
 					),
 				};
 			});

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -8793,6 +8793,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         stripePaymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8834,7 +8835,13 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        organizationId?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Setup intent created successfully */
                 200: {
@@ -8864,7 +8871,9 @@ export interface paths {
         };
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -8921,6 +8930,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8956,7 +8966,9 @@ export interface paths {
         post?: never;
         delete: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path: {
                     id: string;
@@ -9004,6 +9016,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9049,6 +9062,7 @@ export interface paths {
                         amount: number;
                         /** Format: uri */
                         returnUrl?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9093,6 +9107,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };

--- a/apps/ui/src/lib/dashboard-state.ts
+++ b/apps/ui/src/lib/dashboard-state.ts
@@ -45,13 +45,29 @@ export function useDashboardState({
 		[organizationsData?.organizations],
 	);
 
-	// Derive selected organization from props or default to first
-	const selectedOrganization = useMemo(() => {
+	// Resolve the active org id: prefer the explicit prop, otherwise fall back
+	// to the org segment in the URL (/dashboard/[orgId]/...). The URL is the
+	// source of truth for which org the user switched to, so components that
+	// call useDashboardState() without a prop (e.g. the top-up dialog) still
+	// target the org currently being viewed rather than the first/default one.
+	const resolvedOrgId = useMemo(() => {
 		if (selectedOrgId) {
-			return organizations.find((org) => org.id === selectedOrgId) ?? null;
+			return selectedOrgId;
+		}
+		const parts = pathname.split("/");
+		if (parts[1] === "dashboard" && parts[2]) {
+			return parts[2];
+		}
+		return undefined;
+	}, [selectedOrgId, pathname]);
+
+	// Derive selected organization from the resolved id or default to first
+	const selectedOrganization = useMemo(() => {
+		if (resolvedOrgId) {
+			return organizations.find((org) => org.id === resolvedOrgId) ?? null;
 		}
 		return organizations[0] ?? null;
-	}, [selectedOrgId, organizations]);
+	}, [resolvedOrgId, organizations]);
 
 	// Fetch projects for selected organization
 	const { data: projectsData } = api.useQuery(

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -8793,6 +8793,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         stripePaymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8834,7 +8835,13 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        organizationId?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Setup intent created successfully */
                 200: {
@@ -8864,7 +8871,9 @@ export interface paths {
         };
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -8921,6 +8930,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -8956,7 +8966,9 @@ export interface paths {
         post?: never;
         delete: {
             parameters: {
-                query?: never;
+                query?: {
+                    organizationId?: string;
+                };
                 header?: never;
                 path: {
                     id: string;
@@ -9004,6 +9016,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9049,6 +9062,7 @@ export interface paths {
                         amount: number;
                         /** Format: uri */
                         returnUrl?: string;
+                        organizationId?: string;
                     };
                 };
             };
@@ -9093,6 +9107,7 @@ export interface paths {
                     "application/json": {
                         amount: number;
                         paymentMethodId?: string;
+                        organizationId?: string;
                     };
                 };
             };


### PR DESCRIPTION
## Problem

When a user switches to a non-default organization and buys credits from the top-up dialog, the credits are added to the **default** organization instead of the one currently selected.

## Root cause

1. **Frontend** — the billing/credits components (`top-up-credits-dialog`, `payment-methods-management`, `auto-topup-settings`, etc.) call `useDashboardState()` with no arguments, so `selectedOrganization` always falls back to `organizations[0]`. They also never sent an org id to the payment API.
2. **Backend** — every `/payments/*` handler resolved the org via `userOrganization.findFirst({ where: { userId } })`, which returns the user's first/default org regardless of context. The Stripe webhook then correctly credits whatever org id is in the metadata — which was the wrong one.

## Fix

- `useDashboardState` now derives the active org from the `/dashboard/[orgId]` URL segment when no explicit prop is passed. The URL is the source of truth for which org the user is viewing, so all bare consumers (top-up dialog, credits balance, auto top-up, etc.) now target the correct org.
- All `/payments/*` endpoints accept an optional `organizationId`, resolved **scoped to the user's memberships** (`findUserOrganization`) so a user can only ever target an org they belong to. Falls back to the first org when omitted (backward compatible).
- The top-up dialog, payment-methods management, and auto top-up settings pass the active `organizationId` to every payments call, and scope payment-method queries per org.
- Optimistic credit-cache updates now target the org **by id** instead of index `0`.

## Testing

- `pnpm format`
- `pnpm --filter api... --filter ui... build` ✅
- Regenerated the OpenAPI spec + typed UI client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing operations to properly scope payment methods, top-up credits, and fee calculations to the selected organization instead of defaulting to a single organization.

* **Improvements**
  * Enhanced organization context resolution in the dashboard to better reflect the currently selected organization across billing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->