### PR TITLE
feat: add deAPI as embeddings provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -218,6 +218,9 @@ LLM_AZURE_API_KEY=your_azure_key_here
 # DeepInfra
 LLM_DEEPINFRA_API_KEY=your_deepinfra_key_here
 
+# deAPI
+LLM_DEAPI_API_KEY=your_deapi_key_here
+
 # Azure AI Foundry (third-party models like Grok, Llama, Mistral)
 LLM_AZURE_AI_FOUNDRY_API_KEY=your_azure_ai_foundry_key_here
 LLM_AZURE_AI_FOUNDRY_RESOURCE=your_azure_ai_foundry_resource_here

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -603,6 +603,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		openai: "https://api.openai.com",
 		"google-ai-studio": "https://generativelanguage.googleapis.com",
 		"google-vertex": "https://aiplatform.googleapis.com",
+		deapi: "https://oai.deapi.ai",
 	};
 
 	interface EmbeddingAttempt {

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -36,6 +36,7 @@ export const providerLogoUrls: Partial<
 	xiaomi: ProviderIcons.xiaomi,
 	embercloud: ProviderIcons.embercloud,
 	deepinfra: ProviderIcons.deepinfra,
+	deapi: ProviderIcons.deapi,
 };
 
 export const getProviderLogoDarkModeClasses = () => {

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -330,6 +330,12 @@ export function getProviderEndpoint(
 			case "deepinfra":
 				url = "https://api.deepinfra.com/v1/openai";
 				break;
+			// deAPI is currently wired for embeddings only (the embeddings route
+			// resolves its own URL). This base-URL case keeps the provider
+			// resolvable for forward-compatibility with image/audio endpoints.
+			case "deapi":
+				url = "https://oai.deapi.ai";
+				break;
 			case "custom":
 				if (!baseUrl) {
 					throw new Error(`Custom provider requires a baseUrl`);

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -77,6 +77,7 @@ export function getProviderHeaders(
 		case "canopywave":
 		case "embercloud":
 		case "deepinfra":
+		case "deapi":
 		case "custom":
 		default:
 			return {

--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -133,6 +133,22 @@ export async function validateProviderKey(
 		validationModel =
 			getValidationModel(provider, providerKeyOptions) ?? undefined;
 		if (!validationModel) {
+			// Embeddings-only providers (e.g. deAPI) expose no chat/completions
+			// model, and getValidationModel deliberately excludes embeddings
+			// models. There is nothing to validate via a chat request, so skip
+			// live validation for them (mirroring the `custom` provider) instead
+			// of failing key creation. This only fires when EVERY model for the
+			// provider is embeddings-only, so chat-capable providers are never
+			// affected even if their chat models are temporarily unavailable.
+			const providerMappings = models.flatMap((model) =>
+				model.providers.filter((p) => p.providerId === provider),
+			) as ProviderModelMapping[];
+			const isEmbeddingsOnlyProvider =
+				providerMappings.length > 0 &&
+				providerMappings.every((p) => p.embeddings === true);
+			if (isEmbeddingsOnlyProvider) {
+				return { valid: true };
+			}
 			throw new Error(
 				`No suitable validation model found for provider ${provider}`,
 			);

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -1,6 +1,7 @@
 import { alibabaModels } from "./models/alibaba.js";
 import { anthropicModels } from "./models/anthropic.js";
 import { bytedanceModels } from "./models/bytedance.js";
+import { deapiModels } from "./models/deapi.js";
 import { deepseekModels } from "./models/deepseek.js";
 import { googleModels } from "./models/google.js";
 import { llmgatewayModels } from "./models/llmgateway.js";
@@ -529,6 +530,7 @@ export const models = [
 	...moonshotModels,
 	...alibabaModels,
 	...bytedanceModels,
+	...deapiModels,
 	...nousresearchModels,
 	...zaiModels,
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/deapi.ts
+++ b/packages/models/src/models/deapi.ts
@@ -13,7 +13,7 @@ export const deapiModels = [
 			{
 				providerId: "deapi",
 				externalId: "Bge_M3_FP16",
-				inputPrice: "0.13e-6",
+				inputPrice: "0.068e-6",
 				outputPrice: "0",
 				requestPrice: "0",
 				contextSize: 8192,

--- a/packages/models/src/models/deapi.ts
+++ b/packages/models/src/models/deapi.ts
@@ -1,0 +1,27 @@
+import type { ModelDefinition } from "@/models.js";
+
+export const deapiModels = [
+	{
+		id: "bge-m3",
+		name: "BGE-M3",
+		description:
+			"Multilingual BGE-M3 embedding model from BAAI (1024-dimensional output, 8192-token context). Served through deAPI's OpenAI-compatible /v1/embeddings endpoint.",
+		family: "deapi",
+		output: ["embedding"],
+		releasedAt: new Date("2024-01-30"),
+		providers: [
+			{
+				providerId: "deapi",
+				externalId: "Bge_M3_FP16",
+				inputPrice: "0.13e-6",
+				outputPrice: "0",
+				requestPrice: "0",
+				contextSize: 8192,
+				streaming: false,
+				tools: false,
+				jsonOutput: false,
+				embeddings: true,
+			},
+		],
+	},
+] as const satisfies ModelDefinition[];

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1142,6 +1142,13 @@ export const providers: ProviderDefinition[] = [
 		termsUrl: "https://deapi.ai/terms-of-service",
 		privacyPolicyUrl: "https://deapi.ai/privacy-policy",
 		headquarters: "PL",
+		dataPolicy: {
+			apiTraining: null,
+			consumerTraining: null,
+			promptLogging: true,
+			retentionPeriod: "90 days",
+			gdpr: true,
+		},
 	},
 ] as const satisfies ProviderDefinition[];
 

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1139,8 +1139,8 @@ export const providers: ProviderDefinition[] = [
 		color: "#FFBA00",
 		website: "https://deapi.ai",
 		announcement: null,
-		termsUrl: null,
-		privacyPolicyUrl: null,
+		termsUrl: "https://deapi.ai/terms-of-service",
+		privacyPolicyUrl: "https://deapi.ai/privacy-policy",
 		headquarters: "PL",
 	},
 ] as const satisfies ProviderDefinition[];

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1125,7 +1125,7 @@ export const providers: ProviderDefinition[] = [
 		id: "deapi",
 		name: "deAPI",
 		description:
-			"deAPI is an OpenAI-compatible inference platform for open-source models operated by GamerHash. This integration currently exposes deAPI's embedding models.",
+			"deAPI is an OpenAI-compatible inference platform for open-source models, operated by CoinAxe Ltd (Malta). This integration currently exposes deAPI's embedding models.",
 		env: {
 			required: {
 				apiKey: "LLM_DEAPI_API_KEY",
@@ -1141,7 +1141,7 @@ export const providers: ProviderDefinition[] = [
 		announcement: null,
 		termsUrl: "https://deapi.ai/terms-of-service",
 		privacyPolicyUrl: "https://deapi.ai/privacy-policy",
-		headquarters: "PL",
+		headquarters: "MT",
 		dataPolicy: {
 			apiTraining: null,
 			consumerTraining: null,

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1121,6 +1121,28 @@ export const providers: ProviderDefinition[] = [
 			gdpr: true,
 		},
 	},
+	{
+		id: "deapi",
+		name: "deAPI",
+		description:
+			"deAPI is an OpenAI-compatible inference platform for open-source models operated by GamerHash. This integration currently exposes deAPI's embedding models.",
+		env: {
+			required: {
+				apiKey: "LLM_DEAPI_API_KEY",
+			},
+			optional: {
+				baseUrl: "LLM_DEAPI_BASE_URL",
+			},
+		},
+		streaming: false,
+		cancellation: false,
+		color: "#FFBA00",
+		website: "https://deapi.ai",
+		announcement: null,
+		termsUrl: null,
+		privacyPolicyUrl: null,
+		headquarters: "PL",
+	},
 ] as const satisfies ProviderDefinition[];
 
 export type ProviderId = (typeof providers)[number]["id"];

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1285,6 +1285,23 @@ export const DeepInfraIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 	</svg>
 );
 
+// deAPI Icon
+export const DeAPIIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		fill="none"
+		viewBox="0 0 29.095 32"
+		className={props.className}
+	>
+		<path
+			fill="currentColor"
+			fillRule="nonzero"
+			d="M 23.899 26.311 L 25.051 25.18 L 25.051 22.246 L 29.095 22.246 L 29.095 19.984 L 25.051 19.984 L 25.051 17.131 L 29.095 17.131 L 29.095 14.87 L 25.051 14.87 L 25.051 12.017 L 29.095 12.017 L 29.095 9.755 L 25.051 9.755 L 25.051 6.821 L 23.899 5.69 L 20.91 5.69 L 20.91 3.116 L 18.606 1.81 L 18.606 5.689 L 15.699 5.689 L 15.699 0.163 L 15.412 0 L 13.684 0 L 13.396 0.163 L 13.396 5.689 L 10.489 5.689 L 10.489 1.81 L 8.186 3.116 L 8.186 5.69 L 5.196 5.69 L 4.044 6.821 L 4.044 9.755 L 0 9.755 L 0 12.017 L 4.044 12.017 L 4.044 14.87 L 0 14.87 L 0 17.131 L 4.044 17.131 L 4.044 19.984 L 0 19.984 L 0 22.246 L 4.044 22.246 L 4.044 25.18 L 5.196 26.311 L 8.186 26.311 L 8.186 28.884 L 10.489 30.19 L 10.489 26.311 L 13.396 26.311 L 13.396 31.837 L 13.684 32 L 15.412 32 L 15.699 31.837 L 15.699 26.311 L 18.606 26.311 L 18.606 30.19 L 20.91 28.884 L 20.91 26.311 L 23.899 26.311 Z M 6.348 24.049 L 6.348 7.951 L 22.747 7.951 L 22.747 24.048 L 6.348 24.049 Z M 17.986 9.729 L 20.889 9.729 L 11.105 22.27 L 8.202 22.27 L 17.986 9.729 Z"
+		/>
+	</svg>
+);
+
 export const ProviderIcons = {
 	anthropic: AnthropicIcon,
 	bytedance: BytedanceIcon,
@@ -1317,6 +1334,7 @@ export const ProviderIcons = {
 	xiaomi: XiaomiIcon,
 	embercloud: EmberCloudIcon,
 	deepinfra: DeepInfraIcon,
+	deapi: DeAPIIcon,
 } as const;
 
 // Type for provider icon keys
@@ -1356,6 +1374,7 @@ export const providerLogoUrls: Partial<
 	xiaomi: ProviderIcons.xiaomi,
 	embercloud: ProviderIcons.embercloud,
 	deepinfra: ProviderIcons.deepinfra,
+	deapi: ProviderIcons.deapi,
 };
 
 export const getProviderLogoDarkModeClasses = () => {

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1292,7 +1292,6 @@ export const DeAPIIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
 		xmlns="http://www.w3.org/2000/svg"
 		fill="none"
 		viewBox="0 0 29.095 32"
-		className={props.className}
 	>
 		<path
 			fill="currentColor"


### PR DESCRIPTION
## Summary

Adds **deAPI** ([deapi.ai](https://deapi.ai)) as a new OpenAI-compatible inference provider, exposing its multilingual **BGE-M3** embedding model as `deapi/bge-m3`.

> **Disclosure:** I'm contributing this on behalf of deAPI (operated by CoinAxe Ltd) — i.e. I'm affiliated with the provider.

deAPI serves a native `/v1/embeddings` endpoint and does **not** offer chat completions, so this PR is scoped to embeddings only. Image/audio modalities are intentionally left for follow-ups.

## Implementation

- Register `deapi` in `packages/models/src/providers.ts` + model definition in `packages/models/src/models/deapi.ts`, wired into the `models` aggregate.
- Base URL `https://oai.deapi.ai` resolved in the embeddings route (`providerBaseUrlDefaults`) and in `get-provider-endpoint.ts`.
- Bearer auth via the existing default group (`get-provider-headers.ts`).
- **Embeddings-only provider key validation:** `getValidationModel` deliberately excludes embedding models, so for an embeddings-only provider there is no chat model to validate against and key creation would throw `No suitable validation model found`. Added a minimal early-return mirroring the existing `custom` provider — it fires **only** when *every* model for the provider is embeddings-only, so chat-capable providers are never affected. deAPI is the first embeddings-only provider in the repo, hence this change.
- deAPI icon (`currentColor`, themeable) registered in the icon + provider-logo maps.

## Models

| Model | deAPI model id | Output | Dimensions | Price / 1M tokens | Context |
|---|---|---|---|---|---|
| `deapi/bge-m3` | `Bge_M3_FP16` | embedding | 1024 | ~$0.13 ¹ | 8192 |

¹ Derived from deAPI's price-calculation API; the exact configured rate will be confirmed/adjusted before merge.

## Test plan

- `pnpm build` — ✅ all core packages typecheck
- `pnpm test:unit` — ✅ 73/73 on the models + endpoint-resolution specs
- `pnpm format` — ✅
- **Live smoke test** against deAPI production: `POST https://oai.deapi.ai/v1/embeddings` with model `Bge_M3_FP16` → `HTTP 200`, returns a valid 1024-dimensional embedding vector. ✅

> **Note on usage accounting:** deAPI's `/v1/embeddings` response currently returns `usage.prompt_tokens: 0`, so gateway-side cost tracking will read `$0` until deAPI surfaces token usage (a fix is in progress on the deAPI side). The embedding output itself is correct and complete.

I'm happy to adjust naming, pricing, or scope to match your conventions — thanks for maintaining this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deAPI as a new LLM provider with support for the bge-m3 embedding model.
  * deAPI appears in the UI with its provider logo.
  * Users can configure deAPI via an API key and optional custom base URL; a sensible default endpoint is used.
  * Embeddings-only providers (like deAPI) are accepted during key validation without requiring chat-capable models.

* **Documentation**
  * Example environment configuration updated with deAPI placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->