### PR TITLE
fix: mark Qwen3.7 Plus as vision model

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1325,7 +1325,7 @@ export const alibabaModels = [
 				reasoning: true,
 				reasoningOutput: "omit",
 				streaming: true,
-				vision: false,
+				vision: true,
 				tools: true,
 				jsonOutput: true,
 				// Qwen thinking models reject tool_choice "required" or object


### PR DESCRIPTION
https://claude.ai/code/session_01TKyHsYgQJ6E5uWrn91GTZ4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled vision capability for the Qwen 3.7-plus model through the Alibaba provider, allowing image processing and visual understanding features for this model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->