### PR TITLE
feat(devpass): change payment method in billing

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1358,6 +1358,17 @@ const updatePaymentMethod = createRoute({
 			},
 			description: "Card already in use by another DevPass account",
 		},
+		400: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						error: z.literal("invalid_payment_method"),
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Payment method is not a card with a fingerprint",
+		},
 	},
 });
 
@@ -1390,38 +1401,49 @@ devPlans.openapi(updatePaymentMethod, async (c) => {
 	const paymentMethod =
 		await getStripe().paymentMethods.retrieve(paymentMethodId);
 
+	// Only card payment methods carry the fingerprint we rely on to enforce the
+	// one-card-per-account rule. Reject anything else up front so we never store
+	// a null fingerprint or point the subscription at an unverifiable method.
 	const fingerprint =
 		paymentMethod.type === "card"
 			? (paymentMethod.card?.fingerprint ?? null)
 			: null;
 
+	if (!fingerprint) {
+		return c.json(
+			{
+				error: "invalid_payment_method" as const,
+				message: "Payment method must be a card with a fingerprint.",
+			},
+			400,
+		);
+	}
+
 	// Enforce one card per DevPass account: reject a card already linked to a
 	// different org and detach it so it isn't silently left on this customer.
-	if (fingerprint) {
-		const conflictingOrg = await db.query.organization.findFirst({
-			where: {
-				devPlanCardFingerprint: { eq: fingerprint },
-				id: { ne: personalOrg.id },
-			},
-		});
-		if (conflictingOrg) {
-			try {
-				await getStripe().paymentMethods.detach(paymentMethodId);
-			} catch (err) {
-				logger.warn(
-					`Failed to detach duplicate dev plan card ${paymentMethodId}`,
-					{ error: err instanceof Error ? err.message : String(err) },
-				);
-			}
-			return c.json(
-				{
-					error: "duplicate_card" as const,
-					message:
-						"This card is already associated with another DevPass account. Please use a different payment method.",
-				},
-				409,
+	const conflictingOrg = await db.query.organization.findFirst({
+		where: {
+			devPlanCardFingerprint: { eq: fingerprint },
+			id: { ne: personalOrg.id },
+		},
+	});
+	if (conflictingOrg) {
+		try {
+			await getStripe().paymentMethods.detach(paymentMethodId);
+		} catch (err) {
+			logger.warn(
+				`Failed to detach duplicate dev plan card ${paymentMethodId}`,
+				{ error: err instanceof Error ? err.message : String(err) },
 			);
 		}
+		return c.json(
+			{
+				error: "duplicate_card" as const,
+				message:
+					"This card is already associated with another DevPass account. Please use a different payment method.",
+			},
+			409,
+		);
 	}
 
 	// confirmCardSetup already attaches the card to the customer; attach again

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -111,6 +111,19 @@ async function getOrCreatePersonalOrgApiKey(
 	return token;
 }
 
+// Find the user's personal org without creating one. Used by the billing
+// payment-method routes, which only apply to users that already have a DevPass.
+async function findPersonalOrg(userId: string) {
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: { userId },
+		with: { organization: true },
+	});
+	return (
+		userOrgs.find((uo) => uo.organization?.isPersonal === true)?.organization ??
+		null
+	);
+}
+
 function getDevPlanPriceId(
 	tier: DevPlanTier,
 	cycle: DevPlanCycle = "monthly",
@@ -1167,4 +1180,295 @@ devPlans.openapi(rotateApiKey, async (c) => {
 	return c.json({
 		apiKey: newToken,
 	});
+});
+
+// Get the card currently backing the DevPass subscription
+const getPaymentMethod = createRoute({
+	method: "get",
+	path: "/payment-method",
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						card: z
+							.object({
+								brand: z.string(),
+								last4: z.string(),
+								expiryMonth: z.number(),
+								expiryYear: z.number(),
+							})
+							.nullable(),
+					}),
+				},
+			},
+			description: "Current DevPass payment method retrieved",
+		},
+	},
+});
+
+devPlans.openapi(getPaymentMethod, async (c) => {
+	const user = c.get("user");
+
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const personalOrg = await findPersonalOrg(user.id);
+
+	if (!personalOrg?.devPlanStripeSubscriptionId) {
+		return c.json({ card: null });
+	}
+
+	const subscription = await getStripe().subscriptions.retrieve(
+		personalOrg.devPlanStripeSubscriptionId,
+		{ expand: ["default_payment_method"] },
+	);
+
+	const defaultPaymentMethod = subscription.default_payment_method;
+	if (!defaultPaymentMethod) {
+		return c.json({ card: null });
+	}
+
+	const paymentMethod =
+		typeof defaultPaymentMethod === "string"
+			? await getStripe().paymentMethods.retrieve(defaultPaymentMethod)
+			: defaultPaymentMethod;
+
+	if (paymentMethod.type !== "card" || !paymentMethod.card) {
+		return c.json({ card: null });
+	}
+
+	return c.json({
+		card: {
+			brand: paymentMethod.card.brand,
+			last4: paymentMethod.card.last4,
+			expiryMonth: paymentMethod.card.exp_month,
+			expiryYear: paymentMethod.card.exp_year,
+		},
+	});
+});
+
+// Create a SetupIntent to collect a new card for the DevPass subscription. The
+// card is confirmed client-side via Stripe Elements, then attached to the
+// subscription through /dev-plans/update-payment-method.
+const createSetupIntent = createRoute({
+	method: "post",
+	path: "/create-setup-intent",
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						clientSecret: z.string(),
+					}),
+				},
+			},
+			description: "SetupIntent created successfully",
+		},
+	},
+});
+
+devPlans.openapi(createSetupIntent, async (c) => {
+	const user = c.get("user");
+
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const personalOrg = await findPersonalOrg(user.id);
+
+	if (!personalOrg) {
+		throw new HTTPException(404, {
+			message: "Personal organization not found",
+		});
+	}
+
+	if (personalOrg.devPlan === "none") {
+		throw new HTTPException(400, {
+			message: "No active dev plan subscription found",
+		});
+	}
+
+	const stripeCustomerId = await ensureStripeCustomer(personalOrg.id);
+
+	const setupIntent = await getStripe().setupIntents.create({
+		customer: stripeCustomerId,
+		payment_method_types: ["card"],
+		usage: "off_session",
+		metadata: {
+			organizationId: personalOrg.id,
+			subscriptionType: "dev_plan_update",
+		},
+	});
+
+	if (!setupIntent.client_secret) {
+		throw new HTTPException(500, {
+			message: "Failed to create setup intent",
+		});
+	}
+
+	return c.json({
+		clientSecret: setupIntent.client_secret,
+	});
+});
+
+// Attach a newly confirmed card as the DevPass subscription's payment method.
+// Rejects with 409 if the card is already used by another DevPass account, to
+// preserve the one-card-per-account guarantee enforced at signup.
+const updatePaymentMethod = createRoute({
+	method: "post",
+	path: "/update-payment-method",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						paymentMethodId: z.string().min(1),
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						success: z.boolean(),
+					}),
+				},
+			},
+			description: "Payment method updated successfully",
+		},
+		409: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						error: z.literal("duplicate_card"),
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Card already in use by another DevPass account",
+		},
+	},
+});
+
+devPlans.openapi(updatePaymentMethod, async (c) => {
+	const user = c.get("user");
+	const { paymentMethodId } = c.req.valid("json");
+
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const personalOrg = await findPersonalOrg(user.id);
+
+	if (!personalOrg) {
+		throw new HTTPException(404, {
+			message: "Personal organization not found",
+		});
+	}
+
+	if (!personalOrg.devPlanStripeSubscriptionId) {
+		throw new HTTPException(400, {
+			message: "No active dev plan subscription found",
+		});
+	}
+
+	const stripeCustomerId = await ensureStripeCustomer(personalOrg.id);
+
+	const paymentMethod =
+		await getStripe().paymentMethods.retrieve(paymentMethodId);
+
+	const fingerprint =
+		paymentMethod.type === "card"
+			? (paymentMethod.card?.fingerprint ?? null)
+			: null;
+
+	// Enforce one card per DevPass account: reject a card already linked to a
+	// different org and detach it so it isn't silently left on this customer.
+	if (fingerprint) {
+		const conflictingOrg = await db.query.organization.findFirst({
+			where: {
+				devPlanCardFingerprint: { eq: fingerprint },
+				id: { ne: personalOrg.id },
+			},
+		});
+		if (conflictingOrg) {
+			try {
+				await getStripe().paymentMethods.detach(paymentMethodId);
+			} catch (err) {
+				logger.warn(
+					`Failed to detach duplicate dev plan card ${paymentMethodId}`,
+					{ error: err instanceof Error ? err.message : String(err) },
+				);
+			}
+			return c.json(
+				{
+					error: "duplicate_card" as const,
+					message:
+						"This card is already associated with another DevPass account. Please use a different payment method.",
+				},
+				409,
+			);
+		}
+	}
+
+	// confirmCardSetup already attaches the card to the customer; attach again
+	// defensively in case it isn't, ignoring the already-attached error.
+	try {
+		await getStripe().paymentMethods.attach(paymentMethodId, {
+			customer: stripeCustomerId,
+		});
+	} catch (err) {
+		logger.warn(
+			`Attach dev plan card ${paymentMethodId} (likely already attached)`,
+			{
+				error: err instanceof Error ? err.message : String(err),
+			},
+		);
+	}
+
+	await getStripe().customers.update(stripeCustomerId, {
+		invoice_settings: { default_payment_method: paymentMethodId },
+	});
+
+	await getStripe().subscriptions.update(
+		personalOrg.devPlanStripeSubscriptionId,
+		{ default_payment_method: paymentMethodId },
+	);
+
+	await db
+		.update(tables.organization)
+		.set({ devPlanCardFingerprint: fingerprint })
+		.where(eq(tables.organization.id, personalOrg.id));
+
+	await logAuditEvent({
+		organizationId: personalOrg.id,
+		userId: user.id,
+		action: "dev_plan.update_payment_method",
+		resourceType: "dev_plan",
+		resourceId: personalOrg.devPlanStripeSubscriptionId,
+		metadata: {
+			cardLast4:
+				paymentMethod.type === "card" ? paymentMethod.card?.last4 : undefined,
+		},
+	});
+
+	return c.json(
+		{
+			success: true,
+		},
+		200,
+	);
 });

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1873,10 +1873,11 @@ async function handleSetupIntentSucceeded(
 	const { metadata, payment_method } = setupIntent;
 	const organizationId = metadata?.organizationId;
 
-	// DevPass setup intents are finalized via finalizeDevPlanSetupSession and
-	// must NOT be saved into the org's payment_method table (which is for the
-	// regular billing UI flow). Skip them here.
-	if (metadata?.subscriptionType === "dev_plan") {
+	// DevPass setup intents are finalized via finalizeDevPlanSetupSession (initial
+	// activation) or /dev-plans/update-payment-method (card change) and must NOT
+	// be saved into the org's payment_method table (which is for the regular
+	// billing UI flow). Skip both ("dev_plan" and "dev_plan_update") here.
+	if (metadata?.subscriptionType?.startsWith("dev_plan")) {
 		return;
 	}
 

--- a/apps/code/src/app/dashboard/(main)/billing/page.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/page.tsx
@@ -30,6 +30,10 @@ const ActivePlanChangeTier = dynamic(
 	() => import("@/app/dashboard/components/ActivePlanChangeTier"),
 );
 
+const DevPassPaymentMethod = dynamic(
+	() => import("@/app/dashboard/components/DevPassPaymentMethod"),
+);
+
 export default function BillingPage() {
 	const config = useAppConfig();
 	const { posthogKey } = config;
@@ -216,6 +220,9 @@ export default function BillingPage() {
 					</p>
 				</div>
 			</div>
+
+			{/* Payment method */}
+			<DevPassPaymentMethod />
 
 			{/* Change plan */}
 			<ActivePlanChangeTier

--- a/apps/code/src/app/dashboard/components/DevPassPaymentMethod.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassPaymentMethod.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import {
+	CardElement,
+	Elements,
+	useElements,
+	useStripe as useStripeElements,
+} from "@stripe/react-stripe-js";
+import { useQueryClient } from "@tanstack/react-query";
+import { CreditCard, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useApi } from "@/lib/fetch-client";
+import { useStripe } from "@/lib/stripe";
+
+import type React from "react";
+
+export default function DevPassPaymentMethod() {
+	const api = useApi();
+	const [editing, setEditing] = useState(false);
+
+	const { data, isLoading } = api.useQuery("get", "/dev-plans/payment-method");
+	const card = data?.card ?? null;
+
+	return (
+		<div className="rounded-xl border bg-card p-6">
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div>
+					<h2 className="font-semibold">Payment method</h2>
+					<p className="mt-1 text-sm text-muted-foreground">
+						The card used for your DevPass subscription.
+					</p>
+				</div>
+				{!editing && (
+					<Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+						{card ? "Update card" : "Add card"}
+					</Button>
+				)}
+			</div>
+
+			<div className="mt-5">
+				{isLoading ? (
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" />
+						Loading payment method…
+					</div>
+				) : editing ? (
+					<UpdateCardForm
+						onCancel={() => setEditing(false)}
+						onSuccess={() => setEditing(false)}
+					/>
+				) : card ? (
+					<div className="flex items-center gap-3 rounded-lg border bg-muted/40 p-3.5">
+						<CreditCard className="h-5 w-5 text-muted-foreground" />
+						<div>
+							<p className="text-sm font-medium capitalize">
+								{card.brand} •••• {card.last4}
+							</p>
+							<p className="text-xs text-muted-foreground">
+								Expires {String(card.expiryMonth).padStart(2, "0")}/
+								{card.expiryYear}
+							</p>
+						</div>
+					</div>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						No card on file for this subscription.
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function UpdateCardForm({
+	onCancel,
+	onSuccess,
+}: {
+	onCancel: () => void;
+	onSuccess: () => void;
+}) {
+	const { stripe, isLoading: stripeLoading } = useStripe();
+
+	if (stripeLoading) {
+		return (
+			<div className="flex items-center gap-2 text-sm text-muted-foreground">
+				<Loader2 className="h-4 w-4 animate-spin" />
+				Loading payment form…
+			</div>
+		);
+	}
+
+	return (
+		<Elements stripe={stripe}>
+			<UpdateCardFormInner onCancel={onCancel} onSuccess={onSuccess} />
+		</Elements>
+	);
+}
+
+function UpdateCardFormInner({
+	onCancel,
+	onSuccess,
+}: {
+	onCancel: () => void;
+	onSuccess: () => void;
+}) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const stripe = useStripeElements();
+	const elements = useElements();
+	const [loading, setLoading] = useState(false);
+
+	const paymentMethodQueryKey = api.queryOptions(
+		"get",
+		"/dev-plans/payment-method",
+	).queryKey;
+
+	const { mutateAsync: createSetupIntent } = api.useMutation(
+		"post",
+		"/dev-plans/create-setup-intent",
+	);
+	const { mutateAsync: updatePaymentMethod } = api.useMutation(
+		"post",
+		"/dev-plans/update-payment-method",
+	);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+
+		if (!stripe || !elements) {
+			return;
+		}
+
+		const cardElement = elements.getElement(CardElement);
+		if (!cardElement) {
+			return;
+		}
+
+		setLoading(true);
+
+		try {
+			const { clientSecret } = await createSetupIntent({});
+
+			const result = await stripe.confirmCardSetup(clientSecret, {
+				payment_method: { card: cardElement },
+			});
+
+			if (result.error) {
+				toast.error(result.error.message ?? "Failed to confirm card");
+				return;
+			}
+
+			const newPmId =
+				typeof result.setupIntent?.payment_method === "string"
+					? result.setupIntent.payment_method
+					: result.setupIntent?.payment_method?.id;
+
+			if (!newPmId) {
+				toast.error("Failed to confirm card");
+				return;
+			}
+
+			await updatePaymentMethod({ body: { paymentMethodId: newPmId } });
+
+			await queryClient.invalidateQueries({ queryKey: paymentMethodQueryKey });
+
+			toast.success("Payment method updated");
+			onSuccess();
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to update card";
+			// The update endpoint returns 409 for a card already linked to another
+			// DevPass account — surface its message when present.
+			const detail =
+				typeof error === "object" &&
+				error !== null &&
+				"message" in error &&
+				typeof (error as { message?: unknown }).message === "string"
+					? (error as { message: string }).message
+					: message;
+			toast.error(detail);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4">
+			<div className="rounded-md border bg-background p-3">
+				<CardElement
+					options={{
+						style: {
+							base: {
+								fontSize: "16px",
+								color: "#424770",
+								"::placeholder": { color: "#aab7c4" },
+							},
+							invalid: { color: "#9e2146" },
+						},
+					}}
+				/>
+			</div>
+			<div className="flex justify-end gap-2">
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					onClick={onCancel}
+					disabled={loading}
+				>
+					Cancel
+				</Button>
+				<Button type="submit" size="sm" disabled={!stripe || loading}>
+					{loading && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+					Save card
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -10935,6 +10935,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Payment method is not a card with a fingerprint */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "invalid_payment_method";
+                            message: string;
+                        };
+                    };
+                };
                 /** @description Card already in use by another DevPass account */
                 409: {
                     headers: {

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -10821,6 +10821,141 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current DevPass payment method retrieved */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            card: {
+                                brand: string;
+                                last4: string;
+                                expiryMonth: number;
+                                expiryYear: number;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/create-setup-intent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description SetupIntent created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            clientSecret: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        paymentMethodId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Payment method updated successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plan-cancellation-feedback/eligibility": {
         parameters: {
             query?: never;
@@ -10952,7 +11087,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/apps/code/src/lib/stripe.ts
+++ b/apps/code/src/lib/stripe.ts
@@ -1,0 +1,40 @@
+"use client";
+import { loadStripe } from "@stripe/stripe-js/pure";
+import { useEffect, useState } from "react";
+
+import type { Stripe } from "@stripe/stripe-js";
+
+let stripePromise: Promise<Stripe | null> | null = null;
+
+function getStripePromise() {
+	stripePromise ??= loadStripe(
+		process.env.NODE_ENV === "development"
+			? "pk_test_51RRXM1CYKGHizcWTfXxFSEzN8gsUQkg2efi2FN5KO2M2hxdV9QPCjeZMPaZQHSAatxpK9wDcSeilyYU14gz2qA2p00R4q5xU1R"
+			: "pk_live_51RRXLsEAkKxa3kRayCPr9oW8dUp7mIzwev1FVpM3jpKU3StLaaiKvXCEPkewabL5hRip4IXLzFlFTLC4RpFWRknN00lX2vgZHP",
+	);
+	return stripePromise;
+}
+
+export function useStripe() {
+	const [stripe, setStripe] = useState<Stripe | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<Error | null>(null);
+
+	useEffect(() => {
+		getStripePromise()
+			.then((stripeInstance) => {
+				setStripe(stripeInstance);
+				setIsLoading(false);
+			})
+			.catch((err) => {
+				setError(err);
+				setIsLoading(false);
+			});
+	}, []);
+
+	return { stripe, isLoading, error };
+}
+
+export function loadStripeNow() {
+	return getStripePromise();
+}

--- a/apps/code/src/lib/stripe.ts
+++ b/apps/code/src/lib/stripe.ts
@@ -2,26 +2,31 @@
 import { loadStripe } from "@stripe/stripe-js/pure";
 import { useEffect, useState } from "react";
 
+import { useAppConfig } from "@/lib/config";
+
 import type { Stripe } from "@stripe/stripe-js";
+
+// Test publishable key used as a safe fallback when no key is configured.
+// Falling back to the test key (never the live key) guarantees a misconfigured
+// staging/preview environment can't accidentally load live Stripe.
+const FALLBACK_TEST_PUBLISHABLE_KEY =
+	"pk_test_51RRXM1CYKGHizcWTfXxFSEzN8gsUQkg2efi2FN5KO2M2hxdV9QPCjeZMPaZQHSAatxpK9wDcSeilyYU14gz2qA2p00R4q5xU1R";
 
 let stripePromise: Promise<Stripe | null> | null = null;
 
-function getStripePromise() {
-	stripePromise ??= loadStripe(
-		process.env.NODE_ENV === "development"
-			? "pk_test_51RRXM1CYKGHizcWTfXxFSEzN8gsUQkg2efi2FN5KO2M2hxdV9QPCjeZMPaZQHSAatxpK9wDcSeilyYU14gz2qA2p00R4q5xU1R"
-			: "pk_live_51RRXLsEAkKxa3kRayCPr9oW8dUp7mIzwev1FVpM3jpKU3StLaaiKvXCEPkewabL5hRip4IXLzFlFTLC4RpFWRknN00lX2vgZHP",
-	);
+function getStripePromise(publishableKey: string) {
+	stripePromise ??= loadStripe(publishableKey);
 	return stripePromise;
 }
 
 export function useStripe() {
+	const { stripePublishableKey } = useAppConfig();
 	const [stripe, setStripe] = useState<Stripe | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
 
 	useEffect(() => {
-		getStripePromise()
+		getStripePromise(stripePublishableKey ?? FALLBACK_TEST_PUBLISHABLE_KEY)
 			.then((stripeInstance) => {
 				setStripe(stripeInstance);
 				setIsLoading(false);
@@ -30,11 +35,7 @@ export function useStripe() {
 				setError(err);
 				setIsLoading(false);
 			});
-	}, []);
+	}, [stripePublishableKey]);
 
 	return { stripe, isLoading, error };
-}
-
-export function loadStripeNow() {
-	return getStripePromise();
 }

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -10935,6 +10935,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Payment method is not a card with a fingerprint */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "invalid_payment_method";
+                            message: string;
+                        };
+                    };
+                };
                 /** @description Card already in use by another DevPass account */
                 409: {
                     headers: {

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -10821,6 +10821,141 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current DevPass payment method retrieved */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            card: {
+                                brand: string;
+                                last4: string;
+                                expiryMonth: number;
+                                expiryYear: number;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/create-setup-intent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description SetupIntent created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            clientSecret: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        paymentMethodId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Payment method updated successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plan-cancellation-feedback/eligibility": {
         parameters: {
             query?: never;
@@ -10952,7 +11087,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -10935,6 +10935,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Payment method is not a card with a fingerprint */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "invalid_payment_method";
+                            message: string;
+                        };
+                    };
+                };
                 /** @description Card already in use by another DevPass account */
                 409: {
                     headers: {

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -10821,6 +10821,141 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current DevPass payment method retrieved */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            card: {
+                                brand: string;
+                                last4: string;
+                                expiryMonth: number;
+                                expiryYear: number;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/create-setup-intent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description SetupIntent created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            clientSecret: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        paymentMethodId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Payment method updated successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plan-cancellation-feedback/eligibility": {
         parameters: {
             query?: never;
@@ -10952,7 +11087,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -10935,6 +10935,19 @@ export interface paths {
                         };
                     };
                 };
+                /** @description Payment method is not a card with a fingerprint */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "invalid_payment_method";
+                            message: string;
+                        };
+                    };
+                };
                 /** @description Card already in use by another DevPass account */
                 409: {
                     headers: {

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -10821,6 +10821,141 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dev-plans/payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Current DevPass payment method retrieved */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            card: {
+                                brand: string;
+                                last4: string;
+                                expiryMonth: number;
+                                expiryYear: number;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/create-setup-intent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description SetupIntent created successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            clientSecret: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dev-plans/update-payment-method": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        paymentMethodId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Payment method updated successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Card already in use by another DevPass account */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            error: "duplicate_card";
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dev-plan-cancellation-feedback/eligibility": {
         parameters: {
             query?: never;
@@ -10952,7 +11087,7 @@ export interface paths {
                                 organizationId: string;
                                 userId: string;
                                 /** @enum {string} */
-                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key";
+                                action: "organization.create" | "organization.update" | "organization.delete" | "organization.block" | "project.create" | "project.update" | "project.delete" | "team_member.add" | "team_member.update" | "team_member.remove" | "api_key.create" | "api_key.update_status" | "api_key.update_limit" | "api_key.update_description" | "api_key.delete" | "api_key.iam_rule.create" | "api_key.iam_rule.update" | "api_key.iam_rule.delete" | "master_key.create" | "master_key.update_status" | "master_key.delete" | "provider_key.create" | "provider_key.update" | "provider_key.delete" | "subscription.create" | "subscription.cancel" | "subscription.resume" | "subscription.upgrade_yearly" | "payment.method.set_default" | "payment.method.delete" | "payment.credit_topup" | "payment.auto_topup.update" | "payment.auto_topup.disable" | "credits.gift" | "referral_bonus.update" | "dev_plan.subscribe" | "dev_plan.cancel" | "dev_plan.resume" | "dev_plan.change_tier" | "dev_plan.update_settings" | "dev_plan.rotate_api_key" | "dev_plan.update_payment_method";
                                 /** @enum {string} */
                                 resourceType: "organization" | "project" | "team_member" | "api_key" | "master_key" | "iam_rule" | "provider_key" | "subscription" | "payment_method" | "payment" | "dev_plan";
                                 resourceId: string | null;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1554,6 +1554,7 @@ export const auditLogActions = [
 	"dev_plan.change_tier",
 	"dev_plan.update_settings",
 	"dev_plan.rotate_api_key",
+	"dev_plan.update_payment_method",
 ] as const;
 
 export const auditLogResourceTypes = [


### PR DESCRIPTION
## What

Adds the ability to view and change the credit card backing a **DevPass** subscription, directly from the DevPass billing page (`apps/code`). Reuses the Stripe Elements card-collection flow from `apps/ui`.

Previously the DevPass billing page only showed plan/subscription details — there was no way for a user to update their card after signup.

## Backend (`apps/api/src/routes/dev-plans.ts`)

Three new authenticated routes:

- **`GET /dev-plans/payment-method`** — returns the current card (`brand`, `last4`, `expiryMonth`, `expiryYear`) read from the subscription's `default_payment_method`, or `null`.
- **`POST /dev-plans/create-setup-intent`** — creates a Stripe `SetupIntent` (metadata `subscriptionType: "dev_plan_update"`) so the new card is confirmed client-side without a charge.
- **`POST /dev-plans/update-payment-method`** — takes the confirmed `paymentMethodId`, enforces the one-card-per-DevPass-account rule (rejects with **409 `duplicate_card`** and detaches the card if its fingerprint is already linked to another org), then sets it as the customer's default invoice method and the subscription's `default_payment_method`, updates `org.devPlanCardFingerprint`, and writes an audit log.

## Supporting changes

- `apps/api/src/stripe.ts` — the `setup_intent.succeeded` webhook now skips any `subscriptionType` starting with `dev_plan`, so the new `dev_plan_update` intents aren't written into the regular billing `payment_method` table.
- `packages/db/src/schema.ts` — added `dev_plan.update_payment_method` to `auditLogActions` (text enum, no DB migration needed).

## Frontend (`apps/code`)

- `src/lib/stripe.ts` — Stripe loader copied from `apps/ui`.
- `src/app/dashboard/components/DevPassPaymentMethod.tsx` — a card showing the current card with an "Update card" button that reveals an inline `CardElement` form (confirm setup → attach), with toast feedback including the duplicate-card error.
- Wired into the billing page between the subscription summary and change-plan sections.

## Notes

- Built as an inline expandable form rather than a dialog because `apps/code` has no `Dialog` component (only `AlertDialog`), and it matches the existing billing-page layout.
- No delete/remove-card action — a DevPass subscription always needs a card on file, so "change" is the only meaningful operation.

## Testing

- `pnpm build` (api + code) passes
- `pnpm format` / lint passes
- Regenerated the typed API client for `apps/code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View, add, and update DevPass payment methods from the billing page
  * Dedicated "Payment method" section on the billing page
  * One-card-per-account validation — duplicate card attempts return a clear error
  * Clear success and error feedback during card add/update flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->