### PR TITLE
feat(code): auth-aware Get your DevPass CTA

### DIFF
--- a/apps/code/src/app/coding-models/page.tsx
+++ b/apps/code/src/app/coding-models/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import { CodingModelsShowcase } from "@/components/CodingModelsShowcase";
 import { Footer } from "@/components/Footer";
+import { GetDevPassButton } from "@/components/GetDevPassButton";
 import { Header } from "@/components/Header";
 import { Button } from "@/components/ui/button";
 import { getConfig } from "@/lib/config-server";
@@ -116,9 +117,10 @@ export default function CodingModelsPage() {
 							key.
 						</p>
 						<div className="flex gap-4 justify-center">
-							<Button size="lg" asChild>
-								<Link href="/signup">Get your DevPass</Link>
-							</Button>
+							<GetDevPassButton
+								cta="get_started"
+								location="coding_models_cta"
+							/>
 						</div>
 					</div>
 				</section>

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { CodingModelsShowcase } from "@/components/CodingModelsShowcase";
 import { Faq } from "@/components/Faq";
 import { Footer } from "@/components/Footer";
+import { GetDevPassButton } from "@/components/GetDevPassButton";
 import { Header } from "@/components/Header";
 import {
 	CodeCTATracker,
@@ -96,14 +97,12 @@ export default function LandingPage() {
 								every OpenAI-compatible tool — no SDK changes.
 							</p>
 							<div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-								<CodeCTATracker cta="start_coding" location="hero">
-									<Button size="lg" className="gap-2 px-8" asChild>
-										<Link href="/signup">
-											Get your DevPass
-											<ArrowRight className="h-4 w-4" />
-										</Link>
-									</Button>
-								</CodeCTATracker>
+								<GetDevPassButton
+									cta="start_coding"
+									location="hero"
+									showArrow
+									className="gap-2 px-8"
+								/>
 								<CodeCTATracker cta="view_plans" location="hero">
 									<Button size="lg" variant="outline" asChild>
 										<Link href="/pricing">See pricing</Link>
@@ -279,14 +278,12 @@ export default function LandingPage() {
 							Pick a plan, set two env vars, get back to building.
 						</p>
 						<div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-							<CodeCTATracker cta="get_started" location="bottom_cta">
-								<Button size="lg" className="gap-2 px-8" asChild>
-									<Link href="/signup">
-										Get your DevPass
-										<ArrowRight className="h-4 w-4" />
-									</Link>
-								</Button>
-							</CodeCTATracker>
+							<GetDevPassButton
+								cta="get_started"
+								location="bottom_cta"
+								showArrow
+								className="gap-2 px-8"
+							/>
 							<CodeCTATracker cta="browse_models" location="bottom_cta">
 								<Button size="lg" variant="ghost" asChild>
 									<Link href="/coding-models">Browse all models</Link>

--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -6,10 +6,10 @@ import {
 	Minus,
 	Sparkles,
 } from "lucide-react";
-import Link from "next/link";
 
 import { Faq } from "@/components/Faq";
 import { Footer } from "@/components/Footer";
+import { GetDevPassButton } from "@/components/GetDevPassButton";
 import { Header } from "@/components/Header";
 import { CodeCTATracker } from "@/components/LandingTracker";
 import { PricingPlans } from "@/components/PricingPlans";
@@ -481,14 +481,13 @@ export default function PricingPage() {
 							time, prorated.
 						</p>
 						<div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-							<CodeCTATracker cta="get_started" location="pricing_bottom_cta">
-								<Button size="lg" className="gap-2 px-8" asChild>
-									<Link href="/signup?plan=pro">
-										Get your DevPass
-										<ArrowRight className="h-4 w-4" />
-									</Link>
-								</Button>
-							</CodeCTATracker>
+							<GetDevPassButton
+								cta="get_started"
+								location="pricing_bottom_cta"
+								signupHref="/signup?plan=pro"
+								showArrow
+								className="gap-2 px-8"
+							/>
 							<Button size="lg" variant="ghost" asChild>
 								<a href="mailto:contact@llmgateway.io">Talk to us</a>
 							</Button>

--- a/apps/code/src/components/GetDevPassButton.tsx
+++ b/apps/code/src/components/GetDevPassButton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+import { CodeCTATracker } from "@/components/LandingTracker";
+import { Button } from "@/components/ui/button";
+import { useUser } from "@/hooks/useUser";
+
+export function GetDevPassButton({
+	signupHref = "/signup",
+	cta,
+	location,
+	showArrow = false,
+	className,
+}: {
+	signupHref?: string;
+	cta: string;
+	location: string;
+	showArrow?: boolean;
+	className?: string;
+}) {
+	const { user, isLoading } = useUser();
+	const isAuthenticated = !!user && !isLoading;
+
+	return (
+		<CodeCTATracker cta={cta} location={location}>
+			<Button size="lg" className={className} asChild>
+				<Link href={isAuthenticated ? "/dashboard" : signupHref}>
+					{isAuthenticated ? "Go to Dashboard" : "Get your DevPass"}
+					{showArrow && <ArrowRight className="h-4 w-4" />}
+				</Link>
+			</Button>
+		</CodeCTATracker>
+	);
+}


### PR DESCRIPTION
## Summary
The "Get your DevPass" CTA buttons across the DevPass site now render **"Go to Dashboard"** and link to `/dashboard` when the user is logged in — mirroring the existing login/dashboard button behavior in the header menu.

Extracted a reusable `GetDevPassButton` client component (uses `useUser`) and applied it to the landing page (hero + bottom CTA), pricing page, and coding-models page so all primary CTAs behave consistently. Existing PostHog CTA tracking is preserved.

## Test plan
- [x] `pnpm format`
- [x] `pnpm build --filter=code`
- Logged out: button reads "Get your DevPass" → `/signup`
- Logged in: button reads "Go to Dashboard" → `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Call-to-action buttons now intelligently display "Go to Dashboard" for logged-in users and "Get your DevPass" for others across multiple pages.

* **Refactor**
  * Unified call-to-action button implementation for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->