### PR TITLE
fix(gateway): guard undefined toolResult in cost calc

### DIFF
--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -221,10 +221,10 @@ export async function calculateCosts(
 			// Include tool results if available
 			if (fullOutput.toolResults && Array.isArray(fullOutput.toolResults)) {
 				for (const toolResult of fullOutput.toolResults) {
-					if (toolResult.function?.name) {
+					if (toolResult?.function?.name) {
 						completionText += toolResult.function.name;
 					}
-					if (toolResult.function?.arguments) {
+					if (toolResult?.function?.arguments) {
 						completionText += JSON.stringify(toolResult.function.arguments);
 					}
 				}


### PR DESCRIPTION
## Problem

Production error in the gateway:

```
TypeError: Cannot read properties of undefined (reading 'function')
    at calculateCosts (/app/src/lib/costs.ts:224:21)
```

When estimating completion tokens from `fullOutput.toolResults`, the loop accessed `toolResult.function?.name`. If an element of the `toolResults` array was itself `undefined`/`null`, reading `.function` threw before the optional chain could help.

## Fix

Guard the array element with optional chaining (`toolResult?.function?.name`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made cost/token-estimation text construction more robust so missing or incomplete tool result data no longer causes errors; pricing and overall cost calculations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->