### PR TITLE
test: fix routing tests broken by provider priority

### DIFF
--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -1138,6 +1138,20 @@ describe("fallback and error status code handling", () => {
 		test("auto routing ignores synthetic root region mappings", async () => {
 			await ensureProviders(["zai", "alibaba", "novita"]);
 
+			// zai carries a default provider-priority bonus that would otherwise win
+			// auto-routing outright. Neutralize provider priorities via an enterprise
+			// routing config so this test exercises pure metric-based selection of
+			// the regional mapping.
+			await db
+				.update(tables.organization)
+				.set({ plan: "enterprise" })
+				.where(eq(tables.organization.id, "org-id"));
+			await db.insert(tables.routingConfig).values({
+				projectId: "project-id",
+				enabled: true,
+				providerPriorities: { zai: 1, alibaba: 1, novita: 1 },
+			});
+
 			await db.insert(tables.providerKey).values([
 				{
 					id: "provider-key-zai",

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1135,11 +1135,22 @@ describe("getCheapestFromAvailableProviders", () => {
 			],
 		]);
 
+		// Neutralize provider priority defaults so these tests isolate cache
+		// support weighting from any per-provider priority bias.
+		const equalPriorityConfig = resolveRoutingConfig(
+			{ providerPriorities: { openai: 1, deepseek: 1 } },
+			buildProviderPriorityDefaults(),
+		);
+
 		it("does not factor cache support when prompt is below the threshold", () => {
 			const result = getCheapestFromAvailableProviders(
 				cacheTestModel.providers,
 				cacheTestModel,
-				{ metricsMap: equalMetrics, promptTokens: 1000 },
+				{
+					metricsMap: equalMetrics,
+					promptTokens: 1000,
+					routingConfig: equalPriorityConfig,
+				},
 			);
 
 			const openai = result?.metadata.providerScores.find(
@@ -1156,7 +1167,11 @@ describe("getCheapestFromAvailableProviders", () => {
 			const result = getCheapestFromAvailableProviders(
 				cacheTestModel.providers,
 				cacheTestModel,
-				{ metricsMap: equalMetrics, promptTokens: 8000 },
+				{
+					metricsMap: equalMetrics,
+					promptTokens: 8000,
+					routingConfig: equalPriorityConfig,
+				},
 			);
 
 			expect(result?.provider.providerId).toBe("openai");
@@ -1198,7 +1213,11 @@ describe("getCheapestFromAvailableProviders", () => {
 			const result = getCheapestFromAvailableProviders(
 				cheapNoCacheModel.providers,
 				cheapNoCacheModel,
-				{ metricsMap: equalMetrics, promptTokens: 10_000 },
+				{
+					metricsMap: equalMetrics,
+					promptTokens: 10_000,
+					routingConfig: equalPriorityConfig,
+				},
 			);
 
 			expect(result?.provider.providerId).toBe("deepseek");


### PR DESCRIPTION
## Why

CI on `main` has been red since `78f96ba4e` (`feat(providers): add priority field to provider configurations`). That commit added `priority: 1.5` to `zai`, `deepseek`, `moonshot`, and `minimax`, which **activated the pre-existing provider-priority scoring logic** (`getCheapestFromAvailableProviders`). Three routing tests assumed all providers had neutral priority and broke:

```
FAIL packages/actions/src/models.spec.ts > cache support weighting > does not factor cache support when prompt is below the threshold
FAIL packages/actions/src/models.spec.ts > cache support weighting > prefers a cache-supporting provider when prompt is large
FAIL apps/gateway/src/fallback.spec.ts > ... > auto routing ignores synthetic root region mappings
```

The first green build before this was `2647378b9`; every run from `78f96ba4e` onward failed.

## Root cause

In the weighted-score path, priority is applied as `priorityPenalty = 1 - priority`, so `priority: 1.5` gives a provider a `-0.5` score bonus. That is large relative to the normalized score, so:

- **cache tests** — `deepseek` (now 1.5) got a `-0.5` bonus, so it no longer tied/lost to `openai` as the tests expected.
- **fallback auto-routing test** — `zai` (now 1.5) won outright over `alibaba`, and since the mock server has no `zai` endpoint (`/api/paas/v4/chat/completions`) the request 502'd with `all_providers_failed`. The test needs `alibaba` to win to verify that its synthetic region-less root mapping is excluded in favor of the `cn-beijing` regional mapping.

## Fix

These tests are about cache-support scoring and synthetic-root-region exclusion — not provider priority — so they should run with neutral priorities:

- **models.spec.ts**: pass a routing config with equal priorities (`resolveRoutingConfig({ providerPriorities: { openai: 1, deepseek: 1 } }, …)`) to the cache-weighting cases.
- **fallback.spec.ts**: set the test org to `enterprise` and insert a routing config with `providerPriorities: { zai: 1, alibaba: 1, novita: 1 }`, so metric-based selection of the regional mapping is exercised as originally intended. Redis is flushed per-test and the project (and its cascaded routing config) is reset each `beforeEach`, so there's no cross-test leakage.

No production code changed — the priority feature behaves exactly as committed.

## Testing

- `pnpm vitest run packages/actions/src/models.spec.ts` → 38 passed
- `pnpm vitest run apps/gateway/src/fallback.spec.ts` → 49 passed
- `pnpm format` and `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to validate routing behavior with neutralized provider priorities, ensuring region selection is based on routing metrics rather than priority defaults.
  * Enhanced cache support testing to verify correct provider selection under various cache threshold scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->