### PR TITLE
feat: add social and passkey auth to DevPass

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -174,6 +174,64 @@ describe("API auth hooks functionality", () => {
 		expect(project?.name).toBe("Default Project");
 	});
 
+	test("should create personal organization for DevPass (code app) signup", async () => {
+		const codeUrl = process.env.CODE_URL ?? "http://localhost:3004";
+		const email = `test-devpass-${Date.now()}@example.com`;
+		const password = "Password123!";
+
+		// Sign up a new user with the code app as the request origin
+		const signUpResponse = await apiAuth.handler(
+			new Request("http://localhost:4002/auth/sign-up/email", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Origin: codeUrl,
+					"CF-Connecting-IP": `192.168.30.${Math.floor(Math.random() * 255)}`,
+				},
+				body: JSON.stringify({ email, password, name: "Dev User" }),
+			}),
+		);
+
+		expect(signUpResponse.status).toBe(200);
+
+		const user = await db.query.user.findFirst({
+			where: {
+				email: {
+					eq: email,
+				},
+			},
+		});
+
+		expect(user).not.toBeNull();
+
+		const userOrganization = await db.query.userOrganization.findFirst({
+			where: {
+				userId: {
+					eq: user!.id,
+				},
+			},
+			with: {
+				organization: true,
+			},
+		});
+
+		expect(userOrganization).not.toBeNull();
+		// DevPass signups get a "Personal" org, not the shared "Default Organization"
+		expect(userOrganization?.organization?.name).toBe("Personal");
+		expect(userOrganization?.organization?.isPersonal).toBe(true);
+
+		const project = await db.query.project.findFirst({
+			where: {
+				organizationId: {
+					eq: userOrganization!.organization?.id,
+				},
+			},
+		});
+
+		expect(project).not.toBeNull();
+		expect(project?.mode).toBe("credits");
+	});
+
 	test("should automatically verify email for self-hosted installations", async () => {
 		const isHosted = process.env.HOSTED === "true";
 

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -9,6 +9,7 @@ import { notifyUserSignup } from "@/utils/discord.js";
 import { validateEmail } from "@/utils/email-validation.js";
 import { sendTransactionalEmail } from "@/utils/email.js";
 import { resolveSignupName } from "@/utils/infer-name.js";
+import { getOrCreatePersonalOrg } from "@/utils/personal-org.js";
 
 import { db, eq, tables, shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
@@ -23,21 +24,21 @@ const originUrls =
 	"http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:4002,http://localhost:3006";
 const isHosted = process.env.HOSTED === "true";
 
+function isCodeAppOrigin(url: string | null | undefined): boolean {
+	if (!url) {
+		return false;
+	}
+	try {
+		return new URL(url).origin === new URL(codeUrl).origin;
+	} catch {
+		return false;
+	}
+}
+
 function resolveCallbackBaseUrl(request?: Request): string {
 	const originHeader =
 		request?.headers.get("origin") ?? request?.headers.get("referer");
-	if (!originHeader) {
-		return uiUrl;
-	}
-	try {
-		const requestOrigin = new URL(originHeader).origin;
-		if (requestOrigin === new URL(codeUrl).origin) {
-			return codeUrl;
-		}
-	} catch {
-		// fall through to default
-	}
-	return uiUrl;
+	return isCodeAppOrigin(originHeader) ? codeUrl : uiUrl;
 }
 
 export const redisClient = new Redis({
@@ -936,88 +937,106 @@ The LLM Gateway Team`.trim();
 						return;
 					}
 
-					// Perform all DB operations in a single transaction for atomicity
-					await db.transaction(async (tx) => {
-						// For self-hosted installations, automatically verify the user's email
-						if (!isHosted) {
-							await tx
-								.update(tables.user)
-								.set({ emailVerified: true })
-								.where(eq(tables.user.id, userId));
+					// For self-hosted installations, automatically verify the user's email
+					if (!isHosted) {
+						await db
+							.update(tables.user)
+							.set({ emailVerified: true })
+							.where(eq(tables.user.id, userId));
 
-							logger.info("Automatically verified email for self-hosted user", {
-								userId,
-							});
-						}
-
-						// Create a default organization
-						const [organization] = await tx
-							.insert(tables.organization)
-							.values({
-								name: "Default Organization",
-								billingEmail: newSession.user.email,
-							})
-							.returning();
-
-						// Link user to organization
-						await tx.insert(tables.userOrganization).values({
+						logger.info("Automatically verified email for self-hosted user", {
 							userId,
-							organizationId: organization.id,
 						});
+					}
 
-						// Create a default project with hybrid mode
-						const [project] = await tx
-							.insert(tables.project)
-							.values({
-								name: "Default Project",
+					// DevPass (code app) signups get a personal organization instead of
+					// the shared "Default Organization" used by the main LLM Gateway
+					// dashboard. For social sign-in the request hits the OAuth callback
+					// (no app origin header), so fall back to the redirect target.
+					const isCodeAppSignup =
+						isCodeAppOrigin(ctx.headers?.get("origin")) ||
+						isCodeAppOrigin(ctx.headers?.get("referer")) ||
+						isCodeAppOrigin(ctx.context.responseHeaders?.get("location"));
+
+					if (isCodeAppSignup) {
+						await getOrCreatePersonalOrg({
+							id: userId,
+							email: newSession.user.email,
+						});
+					} else {
+						// Perform all DB operations in a single transaction for atomicity
+						await db.transaction(async (tx) => {
+							// Create a default organization
+							const [organization] = await tx
+								.insert(tables.organization)
+								.values({
+									name: "Default Organization",
+									billingEmail: newSession.user.email,
+								})
+								.returning();
+
+							// Link user to organization
+							await tx.insert(tables.userOrganization).values({
+								userId,
 								organizationId: organization.id,
-								mode: "hybrid",
-							})
-							.returning();
-
-						// Auto-create an API key for the playground to use
-						// Generate a token with a prefix for better identification
-						const prefix =
-							process.env.NODE_ENV === "development" ? `llmgdev_` : "llmgtwy_";
-						const token = prefix + shortid(40);
-
-						await tx.insert(tables.apiKey).values({
-							projectId: project.id,
-							token: token,
-							description: "Auto-generated playground key",
-							usageLimit: null, // No limit for playground key
-							createdBy: userId,
-						});
-
-						// Handle referral if cookie is present
-						const cookieHeader = ctx.request?.headers.get("cookie") ?? "";
-						const referralMatch = cookieHeader.match(
-							/llmgateway_referral=([^;]+)/,
-						);
-						if (referralMatch) {
-							const referrerOrgId = decodeURIComponent(referralMatch[1]);
-							// Verify the referrer organization exists and is active
-							const referrerOrg = await tx.query.organization.findFirst({
-								where: {
-									id: { eq: referrerOrgId },
-									status: { eq: "active" },
-								},
 							});
 
-							if (referrerOrg) {
-								// Create the referral record
-								await tx.insert(tables.referral).values({
-									referrerOrganizationId: referrerOrgId,
-									referredOrganizationId: organization.id,
+							// Create a default project with hybrid mode
+							const [project] = await tx
+								.insert(tables.project)
+								.values({
+									name: "Default Project",
+									organizationId: organization.id,
+									mode: "hybrid",
+								})
+								.returning();
+
+							// Auto-create an API key for the playground to use
+							// Generate a token with a prefix for better identification
+							const prefix =
+								process.env.NODE_ENV === "development"
+									? `llmgdev_`
+									: "llmgtwy_";
+							const token = prefix + shortid(40);
+
+							await tx.insert(tables.apiKey).values({
+								projectId: project.id,
+								token: token,
+								description: "Auto-generated playground key",
+								usageLimit: null, // No limit for playground key
+								createdBy: userId,
+							});
+
+							// Handle referral if cookie is present
+							const cookieHeader = ctx.request?.headers.get("cookie") ?? "";
+							const referralMatch = cookieHeader.match(
+								/llmgateway_referral=([^;]+)/,
+							);
+							if (referralMatch) {
+								const referrerOrgId = decodeURIComponent(referralMatch[1]);
+								// Verify the referrer organization exists and is active
+								const referrerOrg = await tx.query.organization.findFirst({
+									where: {
+										id: { eq: referrerOrgId },
+										status: { eq: "active" },
+									},
 								});
 
-								logger.info("Created referral record", {
-									referrerOrgId,
-									referredOrgId: organization.id,
-								});
+								if (referrerOrg) {
+									// Create the referral record
+									await tx.insert(tables.referral).values({
+										referrerOrganizationId: referrerOrgId,
+										referredOrganizationId: organization.id,
+									});
+
+									logger.info("Created referral record", {
+										referrerOrgId,
+										referredOrgId: organization.id,
+									});
+								}
 							}
-						}
-					});
+						});
+					}
 
 					// Check if this is a social login by querying the account table
 					// For OAuth signups, we need to send notifications and create Resend contacts

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { ensureStripeCustomer, finalizeDevPlanSetupSession } from "@/stripe.js";
+import { getOrCreatePersonalOrg } from "@/utils/personal-org.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import { db, tables, eq, shortid } from "@llmgateway/db";
@@ -19,63 +20,6 @@ import { getStripe } from "./payments.js";
 import type { ServerTypes } from "@/vars.js";
 
 export const devPlans = new OpenAPIHono<ServerTypes>();
-
-interface User {
-	id: string;
-	email: string;
-	emailVerified?: boolean;
-}
-
-// Helper to get or create personal organization for a user
-// Uses a transaction to ensure atomicity when creating org, membership, and project
-async function getOrCreatePersonalOrg(user: User) {
-	// Find existing personal org for user
-	const userOrgs = await db.query.userOrganization.findMany({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	const existingPersonalOrg = userOrgs.find(
-		(uo) => uo.organization?.isPersonal === true,
-	);
-
-	if (existingPersonalOrg?.organization) {
-		return existingPersonalOrg.organization;
-	}
-
-	// Create new personal org with transaction for atomicity
-	return await db.transaction(async (tx) => {
-		const [newOrg] = await tx
-			.insert(tables.organization)
-			.values({
-				name: "Personal",
-				isPersonal: true,
-				billingEmail: user.email,
-				// DevPass orgs retain request/response data by default; users can
-				// disable this from the data retention settings.
-				retentionLevel: "retain",
-			})
-			.returning();
-
-		await tx.insert(tables.userOrganization).values({
-			userId: user.id,
-			organizationId: newOrg.id,
-			role: "owner",
-		});
-
-		await tx.insert(tables.project).values({
-			name: "Default Project",
-			organizationId: newOrg.id,
-			mode: "credits",
-		});
-
-		return newOrg;
-	});
-}
 
 // Helper to get or create API key for personal org
 async function getOrCreatePersonalOrgApiKey(

--- a/apps/api/src/utils/personal-org.ts
+++ b/apps/api/src/utils/personal-org.ts
@@ -1,0 +1,55 @@
+import { db, tables } from "@llmgateway/db";
+
+interface PersonalOrgUser {
+	id: string;
+	email: string;
+}
+
+// Get or create the personal organization for a user (DevPass).
+// Uses a transaction to ensure atomicity when creating org, membership, and project.
+export async function getOrCreatePersonalOrg(user: PersonalOrgUser) {
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: {
+			userId: user.id,
+		},
+		with: {
+			organization: true,
+		},
+	});
+
+	const existingPersonalOrg = userOrgs.find(
+		(uo) => uo.organization?.isPersonal === true,
+	);
+
+	if (existingPersonalOrg?.organization) {
+		return existingPersonalOrg.organization;
+	}
+
+	return await db.transaction(async (tx) => {
+		const [newOrg] = await tx
+			.insert(tables.organization)
+			.values({
+				name: "Personal",
+				isPersonal: true,
+				billingEmail: user.email,
+				// DevPass orgs retain request/response data by default; users can
+				// disable this from the data retention settings.
+				retentionLevel: "retain",
+			})
+			.returning();
+
+		await tx.insert(tables.userOrganization).values({
+			userId: user.id,
+			organizationId: newOrg.id,
+			role: "owner",
+		});
+
+		await tx.insert(tables.project).values({
+			name: "Default Project",
+			organizationId: newOrg.id,
+			mode: "credits",
+		});
+
+		return newOrg;
+	});
+}

--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -19,6 +19,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod/v3";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { Button } from "@/components/ui/button";
 import {
 	Form,
@@ -370,6 +371,13 @@ function LoginForm() {
 								</span>
 							</div>
 						</div>
+
+						<SocialAuthButtons
+							isLoading={isLoading}
+							setIsLoading={setIsLoading}
+							callbackPath={returnUrl}
+							errorCallbackPath="/login"
+						/>
 
 						<Button
 							onClick={handlePasskeySignIn}

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import { Loader2, Terminal, Code2, Cpu } from "lucide-react";
+import { Loader2, Terminal, Code2, Cpu, KeySquare } from "lucide-react";
 import { motion } from "motion/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -12,6 +12,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod/v3";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { Button } from "@/components/ui/button";
 import {
 	Form,
@@ -51,7 +52,7 @@ function SignupForm() {
 	const posthog = usePostHog();
 	const { posthogKey } = useAppConfig();
 	const [isLoading, setIsLoading] = useState(false);
-	const { signUp } = useAuth();
+	const { signIn, signUp } = useAuth();
 	const baseReturnUrl = getSafeRedirectUrl(searchParams.get("returnUrl"));
 	const selectedPlan = searchParams.get("plan");
 	const selectedCycle = searchParams.get("cycle");
@@ -133,6 +134,40 @@ function SignupForm() {
 		}
 
 		setIsLoading(false);
+	}
+
+	async function handlePasskeySignIn() {
+		setIsLoading(true);
+		try {
+			const res = await signIn.passkey();
+			if (res?.error) {
+				toast.error(res.error.message ?? "Failed to sign in with passkey", {
+					style: {
+						backgroundColor: "var(--destructive)",
+						color: "var(--destructive-foreground)",
+					},
+				});
+				return;
+			}
+			queryClient.clear();
+			if (posthogKey) {
+				posthog.capture("user_logged_in", { method: "passkey" });
+			}
+			toast.success("Login successful");
+			router.push(returnUrl);
+		} catch (error: unknown) {
+			toast.error(
+				(error as Error)?.message || "Failed to sign in with passkey",
+				{
+					style: {
+						backgroundColor: "var(--destructive)",
+						color: "var(--destructive-foreground)",
+					},
+				},
+			);
+		} finally {
+			setIsLoading(false);
+		}
 	}
 
 	return (
@@ -322,6 +357,40 @@ function SignupForm() {
 								</Button>
 							</form>
 						</Form>
+
+						<div className="mt-4 space-y-4">
+							<div className="relative">
+								<div className="absolute inset-0 flex items-center">
+									<span className="w-full border-t" />
+								</div>
+								<div className="relative flex justify-center text-xs uppercase">
+									<span className="bg-background px-2 text-muted-foreground">
+										Or
+									</span>
+								</div>
+							</div>
+
+							<SocialAuthButtons
+								isLoading={isLoading}
+								setIsLoading={setIsLoading}
+								callbackPath={returnUrl}
+								errorCallbackPath="/signup"
+							/>
+
+							<Button
+								onClick={handlePasskeySignIn}
+								variant="outline"
+								className="w-full"
+								disabled={isLoading}
+							>
+								{isLoading ? (
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								) : (
+									<KeySquare className="mr-2 h-4 w-4" />
+								)}
+								Sign in with passkey
+							</Button>
+						</div>
 					</div>
 
 					<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/code/src/components/social-auth-buttons.tsx
+++ b/apps/code/src/components/social-auth-buttons.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Github, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/auth-client";
+import { useAppConfig } from "@/lib/config";
+
+interface SocialAuthButtonsProps {
+	isLoading: boolean;
+	setIsLoading: (loading: boolean) => void;
+	callbackPath: string;
+	errorCallbackPath: string;
+}
+
+export function SocialAuthButtons({
+	isLoading,
+	setIsLoading,
+	callbackPath,
+	errorCallbackPath,
+}: SocialAuthButtonsProps) {
+	const { signIn } = useAuth();
+	const { githubAuth, googleAuth } = useAppConfig();
+
+	if (!githubAuth && !googleAuth) {
+		return null;
+	}
+
+	async function handleSocialSignIn(provider: "github" | "google") {
+		setIsLoading(true);
+		try {
+			const res = await signIn.social({
+				provider,
+				callbackURL: location.protocol + "//" + location.host + callbackPath,
+				errorCallbackURL:
+					location.protocol + "//" + location.host + errorCallbackPath,
+			});
+			if (res?.error) {
+				toast.error(res.error.message ?? `Failed to sign in with ${provider}`, {
+					style: {
+						backgroundColor: "var(--destructive)",
+						color: "var(--destructive-foreground)",
+					},
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="grid gap-3 sm:grid-cols-2">
+			{githubAuth && (
+				<Button
+					onClick={() => handleSocialSignIn("github")}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<Github className="mr-2 h-4 w-4" />
+					)}
+					GitHub
+				</Button>
+			)}
+			{googleAuth && (
+				<Button
+					onClick={() => handleSocialSignIn("google")}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+							<path
+								d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+								fill="#4285F4"
+							/>
+							<path
+								d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+								fill="#34A853"
+							/>
+							<path
+								d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+								fill="#FBBC05"
+							/>
+							<path
+								d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+								fill="#EA4335"
+							/>
+						</svg>
+					)}
+					Google
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/code/src/lib/config-server.ts
+++ b/apps/code/src/lib/config-server.ts
@@ -11,6 +11,8 @@ export interface AppConfig {
 	posthogKey?: string;
 	posthogHost?: string;
 	stripePublishableKey?: string;
+	githubAuth: boolean;
+	googleAuth: boolean;
 }
 
 export function getConfig(): AppConfig {
@@ -29,5 +31,7 @@ export function getConfig(): AppConfig {
 		posthogKey: process.env.POSTHOG_KEY,
 		posthogHost: process.env.POSTHOG_HOST,
 		stripePublishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
+		githubAuth: !!process.env.GITHUB_CLIENT_ID,
+		googleAuth: !!process.env.GOOGLE_CLIENT_ID,
 	};
 }


### PR DESCRIPTION
Add GitHub and Google OAuth plus passkey to the DevPass (code app)
sign-in and sign-up pages, matching the LLM Gateway auth pages.

DevPass-originated signups (detected via the request origin for
email/passkey and the OAuth redirect target for social sign-in) now
create the personal organization used by DevPass instead of the
shared "Default Organization" created for the main dashboard.

- Expose githubAuth/googleAuth config flags in the code app
- Add a shared SocialAuthButtons component for the code app
- Extract getOrCreatePersonalOrg into a shared util reused by the
  auth after-hook and the dev-plans route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal organizations are now automatically created for DevPass code app signups.
  * GitHub and Google social authentication options added to login and signup flows.
  * Passkey-based sign-in support now available on the signup page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->