### PR TITLE
fix(ui): start passkey autofill once to fix button login

### DIFF
--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -15,7 +15,7 @@ import { motion } from "motion/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod/v3";
@@ -82,29 +82,39 @@ function LoginForm() {
 		},
 	});
 
+	const passkeyAutofillStarted = useRef(false);
 	useEffect(() => {
-		if (window.PublicKeyCredential) {
-			void signIn.passkey({ autoFill: true }).then((res) => {
-				if (res?.data) {
-					queryClient.clear();
-					if (posthogKey) {
-						posthog.capture("user_logged_in", { method: "passkey" });
-					}
-					router.push(returnUrl);
-				} else if (res?.error) {
-					if (res.error.message?.toLowerCase().includes("cancelled")) {
-						return;
-					}
-					toast.error(res.error.message ?? "Failed to sign in with passkey", {
-						style: {
-							backgroundColor: "var(--destructive)",
-							color: "var(--destructive-foreground)",
-						},
-					});
-				}
-			});
+		// Start the conditional (autofill) passkey ceremony exactly once. Re-running
+		// it restarts the WebAuthn request, which flickers the browser/password
+		// manager prompt and aborts an in-progress manual passkey button click.
+		if (passkeyAutofillStarted.current) {
+			return;
 		}
-	}, [signIn, queryClient, posthogKey, posthog, router, returnUrl]);
+		if (typeof window === "undefined" || !window.PublicKeyCredential) {
+			return;
+		}
+		passkeyAutofillStarted.current = true;
+		void signIn.passkey({ autoFill: true }).then((res) => {
+			if (res?.data) {
+				queryClient.clear();
+				if (posthogKey) {
+					posthog.capture("user_logged_in", { method: "passkey" });
+				}
+				router.push(returnUrl);
+			} else if (res?.error) {
+				if (res.error.message?.toLowerCase().includes("cancelled")) {
+					return;
+				}
+				toast.error(res.error.message ?? "Failed to sign in with passkey", {
+					style: {
+						backgroundColor: "var(--destructive)",
+						color: "var(--destructive-foreground)",
+					},
+				});
+			}
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	async function onSubmit(values: z.infer<typeof formSchema>) {
 		setIsLoading(true);

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -15,7 +15,7 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -85,25 +85,35 @@ export default function Login() {
 		},
 	});
 
+	const passkeyAutofillStarted = useRef(false);
 	useEffect(() => {
-		if (window.PublicKeyCredential) {
-			void signIn.passkey({ autoFill: true }).then((res) => {
-				if (res?.data) {
-					queryClient.clear();
-					posthog.capture("user_logged_in", { method: "passkey" });
-					router.push("/dashboard");
-				} else if (res?.error) {
-					if (res.error.message?.toLowerCase().includes("cancelled")) {
-						return;
-					}
-					toast({
-						title: res.error.message ?? "Failed to sign in with passkey",
-						variant: "destructive",
-					});
-				}
-			});
+		// Start the conditional (autofill) passkey ceremony exactly once. Re-running
+		// it restarts the WebAuthn request, which flickers the browser/password
+		// manager prompt and aborts an in-progress manual passkey button click.
+		if (passkeyAutofillStarted.current) {
+			return;
 		}
-	}, [signIn, queryClient, posthog, router]);
+		if (typeof window === "undefined" || !window.PublicKeyCredential) {
+			return;
+		}
+		passkeyAutofillStarted.current = true;
+		void signIn.passkey({ autoFill: true }).then((res) => {
+			if (res?.data) {
+				queryClient.clear();
+				posthog.capture("user_logged_in", { method: "passkey" });
+				router.push("/dashboard");
+			} else if (res?.error) {
+				if (res.error.message?.toLowerCase().includes("cancelled")) {
+					return;
+				}
+				toast({
+					title: res.error.message ?? "Failed to sign in with passkey",
+					variant: "destructive",
+				});
+			}
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	async function onSubmit(values: z.infer<typeof formSchema>) {
 		setIsLoading(true);


### PR DESCRIPTION
Follow-up to #2517.

## Problem

On the main UI (`llmgateway.io`):
- The password-manager passkey suggestion **flickers 2-3 times** on page load.
- The autofill/inline passkey sign-in works, but clicking the **"Sign in with passkey"** button fails ("Auth cancelled").
- DevPass (`devpass.llmgateway.io`) works perfectly.

## Root cause

The login pages start the conditional (autofill) passkey ceremony inside a `useEffect` keyed on `[signIn, queryClient, posthog, router]`. On the main UI, `posthog`'s identity churns during PostHog init/hydration (the shared `useUser` hook also calls `posthog.identify()` during render), so the effect **re-runs several times**:

- Each re-run calls `signIn.passkey({ autoFill: true })` again, which restarts the WebAuthn request → the password-manager prompt flickers 2-3 times.
- When the user clicks the button, the re-render re-runs the effect, and SimpleWebAuthn's `createNewAbortSignal()` from the restarted autofill **aborts the button's in-flight modal ceremony** → "Auth cancelled".

DevPass's deps happen not to churn, so it never manifested there.

## Fix

Start the conditional autofill ceremony **exactly once on mount** via a `useRef` guard, so dependency churn can no longer restart or abort it. Applied to both the main UI and DevPass login pages for consistency.

## Verification

- `pnpm format` and full `pnpm build` (incl. `tsc`) pass.

> The timing-sensitive autofill path can't be exercised headlessly — please confirm on a real Chrome session: the prompt should no longer flicker and the "Sign in with passkey" button should log in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed passkey auto-fill behavior on login pages to run once on page load instead of repeatedly, improving reliability and user experience.
  * Enhanced error handling for cancelled passkey sign-in attempts with improved toast notifications.
  * Optimized login flow with proper cache management and analytics tracking on successful sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->