### PR TITLE
fix(minimax): fix m2.5 tool calls and broken embercloud route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ When running curl commands against the local API, you can use `test-token` as au
 
 To test a specific provider in isolation (e.g. to reproduce a provider-specific failure without the gateway silently falling back to a healthy provider), pin the provider with the `provider/model` model string and disable fallback with the `x-no-fallback: true` header:
 
-```
+```bash
 curl -N http://localhost:4001/v1/chat/completions \
   -H "Authorization: Bearer test-token" -H "x-no-fallback: true" \
   -d '{"model":"embercloud/minimax-m2.5","stream":true,"messages":[{"role":"user","content":"hi"}]}'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,18 @@ Do not run test files or suites in parallel unless the repository instructions f
 
 When running curl commands against the local API, you can use `test-token` as authentication.
 
+To test a specific provider in isolation (e.g. to reproduce a provider-specific failure without the gateway silently falling back to a healthy provider), pin the provider with the `provider/model` model string and disable fallback with the `x-no-fallback: true` header:
+
+```
+curl -N http://localhost:4001/v1/chat/completions \
+  -H "Authorization: Bearer test-token" -H "x-no-fallback: true" \
+  -d '{"model":"embercloud/minimax-m2.5","stream":true,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+Without `x-no-fallback`, a failing pinned provider falls back to the next healthy provider, masking the error. Also note that the gateway caches responses (including errors) in Redis keyed on the request body, so vary the prompt when re-testing the same failure.
+
+Caveat: if you run multiple git worktrees (e.g. conductor workspaces), only one `pnpm dev` can own port :4001 — confirm which working tree is actually serving it (`lsof -a -p <pid> -d cwd -Fn`) before assuming your local edits are live, or launch your own build on a different `PORT`.
+
 #### E2E Test Options
 
 - `TEST_MODELS` - Run tests only for specific models (comma-separated list of `provider/model-id` pairs)

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -7426,6 +7426,27 @@ chat.openapi(completions, async (c) => {
 									continue;
 								}
 
+								// A chunk whose finish_reason signals an upstream failure (e.g.
+								// Embercloud's "error") is not a valid OpenAI completion chunk —
+								// "error" is not a valid OpenAI finish_reason. Capture the
+								// terminal finish reason and raw payload for the error event and
+								// logging, but skip this chunk entirely otherwise: it is not
+								// forwarded to the client and must not feed content/token/cost
+								// accumulation, since the client never receives it.
+								const isUpstreamErrorChunk =
+									transformedData.choices?.some(
+										(choice: { finish_reason?: string | null }) =>
+											choice?.finish_reason === "error",
+									) ?? false;
+								if (isUpstreamErrorChunk) {
+									finishReason = "error";
+									sawProviderTerminalEvent = true;
+									upstreamErrorChunkRaw = JSON.stringify(data);
+									processedLength = eventEnd;
+									searchStart = eventEnd;
+									continue;
+								}
+
 								if (splitTaggedReasoning) {
 									const deltaContent =
 										transformedData.choices?.[0]?.delta?.content;
@@ -7574,23 +7595,9 @@ chat.openapi(completions, async (c) => {
 									}
 								}
 
-								// A chunk whose finish_reason signals an upstream failure (e.g.
-								// Embercloud's "error") is not a valid OpenAI completion chunk —
-								// "error" is not a valid OpenAI finish_reason. Don't forward it to
-								// the client; the terminal error event emitted later is the only
-								// signal the client should see. We still fall through below so the
-								// finish reason / raw chunk is captured for logging.
-								const isUpstreamErrorChunk =
-									transformedData.choices?.some(
-										(choice: { finish_reason?: string | null }) =>
-											choice?.finish_reason === "error",
-									) ?? false;
-
 								// When buffering for healing, strip content from chunks and buffer it
 								// We still send metadata (usage, finish_reason, tool_calls) but buffer text content
-								if (isUpstreamErrorChunk) {
-									// Intentionally not forwarded — see comment above.
-								} else if (shouldBufferForHealing) {
+								if (shouldBufferForHealing) {
 									const deltaContent =
 										transformedData.choices?.[0]?.delta?.content;
 									if (deltaContent) {
@@ -7670,12 +7677,6 @@ chat.openapi(completions, async (c) => {
 											finishReason = choice.finish_reason;
 											sawProviderTerminalEvent = true;
 											sentDownstreamFinishReasonChunk = true;
-											// Preserve the raw upstream chunk when it signals a
-											// hard error, so the logged error reflects the actual
-											// provider payload (which may carry no message at all).
-											if (choice.finish_reason === "error") {
-												upstreamErrorChunkRaw = JSON.stringify(data);
-											}
 										}
 									}
 								}

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6610,6 +6610,10 @@ chat.openapi(completions, async (c) => {
 				let buffer = ""; // Buffer for accumulating partial data across chunks (string for SSE)
 				let binaryBuffer = new Uint8Array(0); // Buffer for binary event streams (AWS Bedrock)
 				let rawUpstreamData = ""; // Raw data received from upstream provider
+				// Raw upstream chunk that carried a finish_reason signalling an upstream
+				// failure (e.g. "error"), preserved so the log shows the actual provider
+				// payload rather than only our synthesized error message.
+				let upstreamErrorChunkRaw: string | null = null;
 				const isAwsBedrock = usedProvider === "aws-bedrock";
 				const taggedReasoningStreamState = {
 					inReasoning: false,
@@ -7652,6 +7656,12 @@ chat.openapi(completions, async (c) => {
 											finishReason = choice.finish_reason;
 											sawProviderTerminalEvent = true;
 											sentDownstreamFinishReasonChunk = true;
+											// Preserve the raw upstream chunk when it signals a
+											// hard error, so the logged error reflects the actual
+											// provider payload (which may carry no message at all).
+											if (choice.finish_reason === "error") {
+												upstreamErrorChunkRaw = JSON.stringify(data);
+											}
 										}
 									}
 								}
@@ -8254,7 +8264,24 @@ chat.openapi(completions, async (c) => {
 								),
 							},
 						);
-						streamingError = errorMessage;
+						// For an explicit upstream error finish_reason, preserve the raw
+						// provider chunk as responseText so the log reflects what the
+						// upstream actually sent, not just our synthesized message.
+						streamingError = hasUpstreamErrorFinishReason
+							? {
+									message: errorMessage,
+									type: "upstream_error",
+									code: "upstream_finish_reason_error",
+									details: {
+										statusCode: 502,
+										statusText: "Upstream Stream Error",
+										responseText: upstreamErrorChunkRaw ?? errorMessage,
+										timestamp: new Date().toISOString(),
+										provider: usedProvider,
+										model: usedInternalModel,
+									},
+								}
+							: errorMessage;
 						finishReason = "upstream_error";
 
 						// Send error event to client using writeSSEAndCache to cache the error

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -8237,8 +8237,15 @@ chat.openapi(completions, async (c) => {
 								usedProvider,
 							),
 						});
+						// Some providers (e.g. Embercloud) signal an upstream failure by
+						// terminating the stream with finish_reason "error" and a null
+						// content delta, rather than an HTTP error or error event. Surface
+						// that explicitly instead of the misleading "finished successfully"
+						// message, since the stream did not complete successfully.
 						const errorMessage =
-							"Response finished successfully but returned no content or tool calls";
+							finishReason === "error"
+								? 'Upstream provider terminated the stream with finish_reason "error" and returned no content'
+								: "Response finished successfully but returned no content or tool calls";
 						streamingError = errorMessage;
 						finishReason = "upstream_error";
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -8196,6 +8196,14 @@ chat.openapi(completions, async (c) => {
 						}
 					}
 
+					// A finish_reason that itself signals an upstream failure (e.g.
+					// Embercloud emits finish_reason "error" with a null content delta and
+					// no error event/HTTP error) is a hard error in its own right. Treat it
+					// as an upstream error regardless of whether any partial content
+					// arrived, instead of inferring failure from an empty response.
+					const hasUpstreamErrorFinishReason =
+						!streamingError && finishReason === "error";
+
 					// Check if the response finished successfully but has no content, tokens, or tool calls
 					// This indicates an empty response which should be marked as an error
 					// Do this check BEFORE sending usage chunks to ensure proper event ordering
@@ -8206,6 +8214,7 @@ chat.openapi(completions, async (c) => {
 					);
 					const hasEmptyResponse =
 						!streamingError &&
+						!hasUpstreamErrorFinishReason &&
 						finishReason &&
 						finishReason !== "incomplete" &&
 						!isContentFilterStreamingResponse &&
@@ -8218,34 +8227,33 @@ chat.openapi(completions, async (c) => {
 						| Awaited<ReturnType<typeof calculateCosts>>
 						| undefined;
 
-					if (hasEmptyResponse) {
-						logger.warn("[streaming] Empty response detected", {
-							provider: usedProvider,
-							model: usedInternalModel,
-							finishReason,
-							calculatedCompletionTokens,
-							calculatedReasoningTokens,
-							fullContentLength: fullContent?.length ?? 0,
-							fullContentTrimmed: fullContent?.trim()?.length ?? 0,
-							streamingToolCallsCount: streamingToolCalls?.length ?? 0,
-							promptTokens,
-							completionTokens,
-							totalTokens,
-							reasoningTokens,
-							unifiedFinishReason: getUnifiedFinishReason(
-								"upstream_error",
-								usedProvider,
-							),
-						});
-						// Some providers (e.g. Embercloud) signal an upstream failure by
-						// terminating the stream with finish_reason "error" and a null
-						// content delta, rather than an HTTP error or error event. Surface
-						// that explicitly instead of the misleading "finished successfully"
-						// message, since the stream did not complete successfully.
-						const errorMessage =
-							finishReason === "error"
-								? 'Upstream provider terminated the stream with finish_reason "error" and returned no content'
-								: "Response finished successfully but returned no content or tool calls";
+					if (hasUpstreamErrorFinishReason || hasEmptyResponse) {
+						const errorMessage = hasUpstreamErrorFinishReason
+							? `Upstream provider terminated the stream with finish_reason "${finishReason}"`
+							: "Response finished successfully but returned no content or tool calls";
+						logger.warn(
+							hasUpstreamErrorFinishReason
+								? "[streaming] Upstream error finish_reason"
+								: "[streaming] Empty response detected",
+							{
+								provider: usedProvider,
+								model: usedInternalModel,
+								finishReason,
+								calculatedCompletionTokens,
+								calculatedReasoningTokens,
+								fullContentLength: fullContent?.length ?? 0,
+								fullContentTrimmed: fullContent?.trim()?.length ?? 0,
+								streamingToolCallsCount: streamingToolCalls?.length ?? 0,
+								promptTokens,
+								completionTokens,
+								totalTokens,
+								reasoningTokens,
+								unifiedFinishReason: getUnifiedFinishReason(
+									"upstream_error",
+									usedProvider,
+								),
+							},
+						);
 						streamingError = errorMessage;
 						finishReason = "upstream_error";
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -7574,9 +7574,23 @@ chat.openapi(completions, async (c) => {
 									}
 								}
 
+								// A chunk whose finish_reason signals an upstream failure (e.g.
+								// Embercloud's "error") is not a valid OpenAI completion chunk —
+								// "error" is not a valid OpenAI finish_reason. Don't forward it to
+								// the client; the terminal error event emitted later is the only
+								// signal the client should see. We still fall through below so the
+								// finish reason / raw chunk is captured for logging.
+								const isUpstreamErrorChunk =
+									transformedData.choices?.some(
+										(choice: { finish_reason?: string | null }) =>
+											choice?.finish_reason === "error",
+									) ?? false;
+
 								// When buffering for healing, strip content from chunks and buffer it
 								// We still send metadata (usage, finish_reason, tool_calls) but buffer text content
-								if (shouldBufferForHealing) {
+								if (isUpstreamErrorChunk) {
+									// Intentionally not forwarded — see comment above.
+								} else if (shouldBufferForHealing) {
 									const deltaContent =
 										transformedData.choices?.[0]?.delta?.content;
 									if (deltaContent) {

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -128,7 +128,7 @@ export const minimaxModels = [
 				reasoning: true,
 				splitTaggedReasoning: true,
 				vision: false,
-				tools: false,
+				tools: true,
 				jsonOutput: false,
 			},
 			{
@@ -163,6 +163,10 @@ export const minimaxModels = [
 				jsonOutputSchema: true,
 			},
 			{
+				// Embercloud's upstream routing for this model is broken: streaming
+				// returns finish_reason "error" with null content, and non-streaming
+				// returns "Temporary routing error (400)". Deactivated until fixed.
+				deactivatedAt: new Date("2026-06-03"),
 				providerId: "embercloud",
 				externalId: "minimax-m2.5",
 				inputPrice: "0.2e-6",
@@ -233,7 +237,7 @@ export const minimaxModels = [
 				reasoning: true,
 				splitTaggedReasoning: true,
 				vision: false,
-				tools: false,
+				tools: true,
 				jsonOutput: false,
 			},
 		],
@@ -258,7 +262,7 @@ export const minimaxModels = [
 				reasoning: true,
 				splitTaggedReasoning: true,
 				vision: false,
-				tools: false,
+				tools: true,
 				jsonOutput: false,
 			},
 		],
@@ -283,7 +287,7 @@ export const minimaxModels = [
 				reasoning: true,
 				splitTaggedReasoning: true,
 				vision: false,
-				tools: false,
+				tools: true,
 				jsonOutput: false,
 			},
 			{
@@ -325,7 +329,7 @@ export const minimaxModels = [
 				reasoning: true,
 				splitTaggedReasoning: true,
 				vision: false,
-				tools: false,
+				tools: true,
 				jsonOutput: false,
 			},
 		],
@@ -351,7 +355,7 @@ export const minimaxModels = [
 				splitTaggedReasoning: true,
 				reasoningOutput: "omit",
 				vision: false,
-				tools: false,
+				tools: true,
 				jsonOutput: false,
 			},
 		],


### PR DESCRIPTION
## Summary

Investigated a reported streaming error with `minimax/minimax-m2.5` and found two distinct provider-config bugs plus a misleading gateway error message.

### 1. Tool calls rejected despite being supported
MiniMax's API supports tool calls on all M2/M2.5/Text-01 models (verified directly against `https://api.minimax.io` — each returns a proper `tool_calls` delta with `finish_reason: "tool_calls"`). But several models were configured with `tools: false` on the `minimax` provider, so the gateway rejected any tool request with a 400 (`Model … does not support tool calls`).

Enabled `tools: true` for the `minimax` provider on:
- `minimax-m2.5`
- `minimax-m2.5-highspeed`
- `minimax-m2`
- `minimax-m2.1`
- `minimax-m2.1-lightning`
- `minimax-text-01`

Verified the full streaming tool-call path through the local gateway: returns a correct `get_weather` call with `finish_reason: "tool_calls"`, and reasoning is correctly split into the `reasoning` field (no `<think>` leakage).

### 2. Broken Embercloud route (the actual streaming error)
The reported 500 was caused by the request routing to **Embercloud**, whose upstream routing for `minimax-m2.5` is currently broken:
- **Streaming:** returns `data: {"choices":[{"delta":{"content":null},"finish_reason":"error"}]}` then `[DONE]`, over **HTTP 200** — no error object, no message.
- **Non-streaming:** returns `{"error":{"message":"Temporary routing error (400).","type":"upstream_error","code":400}}`.

The gateway tries Embercloud, gets the empty/errored stream, and (when fallback is available) recovers via Novita — but when fallback is unavailable it surfaces a confusing 500. Deactivated the Embercloud route for `minimax-m2.5` until it is fixed. The `minimax`, `novita`, and `nebius` routes all work.

### 3. Clearer error message for `finish_reason: "error"`
Since Embercloud's streaming failure carries no error message — only `finish_reason: "error"` — the gateway previously labeled it *"Response finished successfully but returned no content or tool calls"*, which is misleading (it did **not** finish successfully). The streaming empty-response handler now reports the actual `finish_reason "error"` condition.

## Testing
- Verified each MiniMax model supports tool calls directly against the upstream API.
- Verified streaming + streaming tool calls work through the local gateway for `minimax-m2.5`.
- Confirmed Embercloud's exact broken SSE payload (HTTP 200, `finish_reason: "error"`, null content).
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling: gateway now treats upstream finish-with-error as a distinct upstream failure, emits a synthesized upstream_error (with preserved upstream payload in diagnostics) and updates empty-response detection and warning logs.

* **New Features**
  * Enabled tools support for multiple MiniMax model variants.
  * Deactivated a problematic provider entry to avoid unstable routing.

* **Documentation**
  * Added guidance for testing providers, disabling fallbacks, caching notes, and local port considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->