### PR TITLE
feat(models): discontinue gemini-2.5-flash-image

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -1343,6 +1343,7 @@ export const googleModels = [
 				tools: false,
 				jsonOutput: true,
 				jsonOutputSchema: true,
+				deactivatedAt: new Date("2026-10-02"),
 			},
 			{
 				test: "skip",
@@ -1359,6 +1360,7 @@ export const googleModels = [
 				tools: false,
 				jsonOutput: true,
 				jsonOutputSchema: true,
+				deactivatedAt: new Date("2026-10-02"),
 			},
 			{
 				test: "skip",


### PR DESCRIPTION
## Summary

Google's model card for `gemini-2.5-flash-image` lists a discontinuation date of **October 2, 2026** (Launch stage GA, released October 2, 2025).

This sets `deactivatedAt: new Date("2026-10-02")` on the `google-ai-studio` and `google-vertex` provider mappings so requests return an error once Google retires the model. The `glacier` mapping is left untouched since its lifecycle isn't governed by Google's model card.

## Testing

- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google AI provider configurations with planned deactivation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->