### PR TITLE
feat(admin): sync selected chat to URL query state

### DIFF
--- a/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
+++ b/ee/admin/src/app/chat-support-logs/chat-support-logs-client.tsx
@@ -20,6 +20,7 @@ import {
 	Trash2,
 	User,
 } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -148,7 +149,25 @@ function StarRating({
 export function ChatSupportLogsClient() {
 	const $api = useApi();
 	const queryClient = useQueryClient();
-	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
+	const selectedId = searchParams.get("chat");
+	const setSelectedId = useCallback(
+		(id: string | null) => {
+			const params = new URLSearchParams(searchParams.toString());
+			if (id) {
+				params.set("chat", id);
+			} else {
+				params.delete("chat");
+			}
+			const query = params.toString();
+			router.replace(query ? `${pathname}?${query}` : pathname, {
+				scroll: false,
+			});
+		},
+		[searchParams, router, pathname],
+	);
 	const [search, setSearch] = useState("");
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [replyText, setReplyText] = useState("");
@@ -303,7 +322,7 @@ export function ChatSupportLogsClient() {
 				});
 			}
 		},
-		[conversations, markRead],
+		[conversations, markRead, setSelectedId],
 	);
 
 	const handleReplySubmit = (e: React.FormEvent) => {

--- a/ee/admin/src/app/chat-support-logs/page.tsx
+++ b/ee/admin/src/app/chat-support-logs/page.tsx
@@ -1,8 +1,14 @@
+import { Suspense } from "react";
+
 import { requireSession } from "@/lib/require-session";
 
 import { ChatSupportLogsClient } from "./chat-support-logs-client";
 
 export default async function ChatSupportLogsPage() {
 	await requireSession();
-	return <ChatSupportLogsClient />;
+	return (
+		<Suspense>
+			<ChatSupportLogsClient />
+		</Suspense>
+	);
 }


### PR DESCRIPTION
## What

In the admin **chat-support-logs** page, clicking a conversation now writes the chat id to a `?chat=<id>` query param in the URL. This makes the selected conversation shareable — sending the link opens that specific chat directly.

## How

- Replaced the local `selectedId` `useState` with URL-backed state derived from `useSearchParams().get("chat")`, and a `setSelectedId` helper that updates the query param via `router.replace` (matching the existing `project-logs` pattern). All existing call sites (select, back, archive, delete) keep their `string | null` signature.
- Wrapped the client in `<Suspense>` in `page.tsx`, required for `useSearchParams` in the App Router.

## Test

- `pnpm format`, `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Conversation selection in chat support logs now synchronizes with the URL, enabling browser back/forward navigation and shareable links
  * Enhanced page loading experience with improved async component handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->