### PR TITLE
feat(ui): add Python tab to quick start snippet

### DIFF
--- a/apps/ui/src/components/shared/quick-start-snippet.tsx
+++ b/apps/ui/src/components/shared/quick-start-snippet.tsx
@@ -14,9 +14,9 @@ export function QuickStartSection({
 	apiKey?: string;
 	onCopy?: () => void;
 }) {
-	const [activeTab, setActiveTab] = useState<"curl" | "typescript" | "ai-sdk">(
-		"curl",
-	);
+	const [activeTab, setActiveTab] = useState<
+		"curl" | "typescript" | "python" | "ai-sdk"
+	>("curl");
 
 	const keyPlaceholder = apiKey ?? "YOUR_API_KEY";
 
@@ -45,6 +45,19 @@ const response = await client.chat.completions.create({
   free_models_only: true,
 });`;
 
+	const pythonExample = `from openai import OpenAI
+
+client = OpenAI(
+    api_key="${keyPlaceholder}",
+    base_url="https://api.llmgateway.io/v1/",
+)
+
+response = client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Hello!"}],
+    extra_body={"free_models_only": True},
+)`;
+
 	const aiSdkExample = `import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 import { generateText } from "ai";
 
@@ -62,7 +75,9 @@ const { text } = await generateText({
 			? curlExample
 			: activeTab === "typescript"
 				? tsExample
-				: aiSdkExample;
+				: activeTab === "python"
+					? pythonExample
+					: aiSdkExample;
 
 	function copyCode() {
 		void navigator.clipboard.writeText(code);
@@ -102,6 +117,14 @@ const { text } = await generateText({
 							type="button"
 						>
 							TypeScript
+						</Button>
+						<Button
+							variant={activeTab === "python" ? "default" : "outline"}
+							size="sm"
+							onClick={() => setActiveTab("python")}
+							type="button"
+						>
+							Python
 						</Button>
 						<Button
 							variant={activeTab === "ai-sdk" ? "default" : "outline"}


### PR DESCRIPTION
## Summary

Adds a **Python** tab to the Quick Start snippet (shown on the dashboard and onboarding wizard), using the `openai` library. Previously only cURL, TypeScript (OpenAI SDK), and AI SDK examples were available — Python is the most common `openai` lib usage and was missing.

The example mirrors the existing TypeScript one: changes the base URL to the gateway and uses the `auto` model with `free_models_only`.

```python
from openai import OpenAI

client = OpenAI(
    api_key="YOUR_API_KEY",
    base_url="https://api.llmgateway.io/v1/",
)

response = client.chat.completions.create(
    model="auto",
    messages=[{"role": "user", "content": "Hello!"}],
    extra_body={"free_models_only": True},
)
```

## Testing

- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Python language support to the quick-start snippet selector, enabling users to view and copy code examples in Python alongside other available languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->