### PR TITLE
feat(claude): add session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) sessions, never locally.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+	exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+# 1. Install JS dependencies (fast no-op when already installed).
+pnpm install
+
+# 2. The web container boots without the Docker daemon running. Start it if
+#    needed and wait until it is reachable.
+if ! docker info >/dev/null 2>&1; then
+	dockerd >/tmp/dockerd.log 2>&1 &
+	for _ in $(seq 1 60); do
+		docker info >/dev/null 2>&1 && break
+		sleep 1
+	done
+fi
+
+# 3. Build core packages (required for the db seed) and start Postgres + Redis.
+pnpm build:core
+docker compose up -d
+
+# 4. Wait for Postgres to accept connections.
+for _ in $(seq 1 60); do
+	docker compose exec -T postgres pg_isready -U postgres >/dev/null 2>&1 && break
+	sleep 1
+done
+
+# 5. Sync schema + seed only when the database has not been initialized yet, so
+#    resuming an existing session does not wipe in-progress data.
+INITIALIZED=$(docker compose exec -T postgres \
+	psql -U postgres -d test -tAc \
+	"SELECT to_regclass('public.model_provider_mapping') IS NOT NULL" 2>/dev/null || echo "f")
+
+if [ "$INITIALIZED" != "t" ]; then
+	pnpm push-test
+	pnpm push-dev
+	pnpm seed
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -19,6 +19,11 @@ if ! docker info >/dev/null 2>&1; then
 		docker info >/dev/null 2>&1 && break
 		sleep 1
 	done
+	if ! docker info >/dev/null 2>&1; then
+		echo "ERROR: Docker daemon did not become ready within 60s" >&2
+		tail -n 50 /tmp/dockerd.log >&2 || true
+		exit 1
+	fi
 fi
 
 # 3. Build core packages (required for the db seed) and start Postgres + Redis.
@@ -30,14 +35,22 @@ for _ in $(seq 1 60); do
 	docker compose exec -T postgres pg_isready -U postgres >/dev/null 2>&1 && break
 	sleep 1
 done
+if ! docker compose exec -T postgres pg_isready -U postgres >/dev/null 2>&1; then
+	echo "ERROR: Postgres did not become ready within 60s" >&2
+	exit 1
+fi
 
-# 5. Sync schema + seed only when the database has not been initialized yet, so
-#    resuming an existing session does not wipe in-progress data.
-INITIALIZED=$(docker compose exec -T postgres \
-	psql -U postgres -d test -tAc \
-	"SELECT to_regclass('public.model_provider_mapping') IS NOT NULL" 2>/dev/null || echo "f")
+# 5. Sync schema + seed only when both databases are already initialized, so
+#    resuming an existing session does not redo setup. push-test targets the
+#    `test` database while push-dev/seed target `db`, so check both. The seed is
+#    idempotent (upserts), making a redundant run safe if either is missing.
+db_initialized() {
+	[ "$(docker compose exec -T postgres psql -U postgres -d "$1" -tAc \
+		"SELECT to_regclass('public.model_provider_mapping') IS NOT NULL" \
+		2>/dev/null || echo f)" = "t" ]
+}
 
-if [ "$INITIALIZED" != "t" ]; then
+if ! db_initialized test || ! db_initialized db; then
 	pnpm push-test
 	pnpm push-dev
 	pnpm seed

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,17 @@
 			"Read(.conductor/**)",
 			"Read(.turbo/**)"
 		]
+	},
+	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+					}
+				]
+			}
+		]
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds automatic session initialization for Claude Code web (remote) environments by introducing a session-start hook that sets up the development environment on session startup.

## Key Changes

- **New file**: `.claude/hooks/session-start.sh` - Bash script that runs automatically when a Claude Code web session starts
  - Installs JavaScript dependencies via `pnpm install`
  - Starts Docker daemon if not already running
  - Builds core packages and starts PostgreSQL + Redis services
  - Waits for database connectivity
  - Initializes database schema and seeds data only on first session (preserves data on session resume)

- **Updated**: `.claude/settings.json` - Configured the SessionStart hook to execute the initialization script in remote Claude Code environments

## Implementation Details

The hook is designed to:
- Only run in remote Claude Code sessions (checks `CLAUDE_CODE_REMOTE` environment variable)
- Be idempotent for dependency installation and service startup
- Preserve existing database state when resuming sessions by checking if the database is already initialized
- Include proper error handling with `set -euo pipefail` and retry logic with 60-second timeouts for service availability

https://claude.ai/code/session_01JyPzt96MTdvKTpW7fvCyUj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated initialization for remote coding sessions: automatically installs dependencies, builds core packages, starts required services (database and cache), waits for readiness, and applies test/dev schema and seed data to ensure a ready local workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->