### PR TITLE
fix(ui): security events stat cards show zero

### DIFF
--- a/apps/api/src/routes/guardrails.ts
+++ b/apps/api/src/routes/guardrails.ts
@@ -681,10 +681,15 @@ const getStats = createRoute({
 			content: {
 				"application/json": {
 					schema: z.object({
-						blocked: z.number(),
-						redacted: z.number(),
-						warned: z.number(),
-						total: z.number(),
+						totalViolations: z.number(),
+						last24Hours: z.number(),
+						last7Days: z.number(),
+						byAction: z.object({
+							blocked: z.number(),
+							redacted: z.number(),
+							warned: z.number(),
+						}),
+						byCategory: z.record(z.string(), z.number()),
 					}),
 				},
 			},
@@ -703,32 +708,53 @@ guardrails.openapi(getStats, async (c) => {
 	await checkEnterpriseAccess(user.id, organizationId);
 
 	const { days } = c.req.valid("query");
-	const startDate = new Date();
-	startDate.setDate(startDate.getDate() - days);
+	const windowStart = new Date();
+	windowStart.setDate(windowStart.getDate() - days);
 
 	const violations = await db.query.guardrailViolation.findMany({
 		where: {
 			organizationId: { eq: organizationId },
-			createdAt: { gte: startDate },
+			createdAt: { gte: windowStart },
 		},
-		columns: { actionTaken: true },
+		columns: { actionTaken: true, category: true, createdAt: true },
 	});
 
+	const now = Date.now();
+	const dayMs = 24 * 60 * 60 * 1000;
+	const weekMs = 7 * dayMs;
+	const last24HoursStart = now - dayMs;
+	const last7DaysStart = now - weekMs;
+
 	const stats = {
-		blocked: 0,
-		redacted: 0,
-		warned: 0,
-		total: violations.length,
+		totalViolations: violations.length,
+		last24Hours: 0,
+		last7Days: 0,
+		byAction: {
+			blocked: 0,
+			redacted: 0,
+			warned: 0,
+		},
+		byCategory: {} as Record<string, number>,
 	};
 
 	for (const v of violations) {
-		if (v.actionTaken === "blocked") {
-			stats.blocked++;
-		} else if (v.actionTaken === "redacted") {
-			stats.redacted++;
-		} else if (v.actionTaken === "warned") {
-			stats.warned++;
+		const createdAtMs = v.createdAt.getTime();
+		if (createdAtMs >= last24HoursStart) {
+			stats.last24Hours++;
 		}
+		if (createdAtMs >= last7DaysStart) {
+			stats.last7Days++;
+		}
+
+		if (v.actionTaken === "blocked") {
+			stats.byAction.blocked++;
+		} else if (v.actionTaken === "redacted") {
+			stats.byAction.redacted++;
+		} else if (v.actionTaken === "warned") {
+			stats.byAction.warned++;
+		}
+
+		stats.byCategory[v.category] = (stats.byCategory[v.category] ?? 0) + 1;
 	}
 
 	return c.json(stats);

--- a/apps/api/src/routes/guardrails.ts
+++ b/apps/api/src/routes/guardrails.ts
@@ -551,6 +551,7 @@ const listViolations = createRoute({
 			startDate: z.string().datetime({ offset: true }).optional(),
 			endDate: z.string().datetime({ offset: true }).optional(),
 			actionTaken: z.string().optional(),
+			category: z.string().optional(),
 			ruleId: z.string().optional(),
 		}),
 	},
@@ -589,6 +590,7 @@ guardrails.openapi(listViolations, async (c) => {
 		startDate,
 		endDate,
 		actionTaken,
+		category,
 		ruleId,
 	} = query;
 
@@ -620,6 +622,9 @@ guardrails.openapi(listViolations, async (c) => {
 				actionTaken as (typeof guardrailActionsTaken)[number],
 			),
 		);
+	}
+	if (category) {
+		whereConditions.push(eq(tables.guardrailViolation.category, category));
 	}
 	if (ruleId) {
 		whereConditions.push(eq(tables.guardrailViolation.ruleId, ruleId));

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -11724,6 +11724,7 @@ export interface paths {
                     startDate?: string;
                     endDate?: string;
                     actionTaken?: string;
+                    category?: string;
                     ruleId?: string;
                 };
                 header?: never;

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -11802,10 +11802,17 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            blocked: number;
-                            redacted: number;
-                            warned: number;
-                            total: number;
+                            totalViolations: number;
+                            last24Hours: number;
+                            last7Days: number;
+                            byAction: {
+                                blocked: number;
+                                redacted: number;
+                                warned: number;
+                            };
+                            byCategory: {
+                                [key: string]: number;
+                            };
                         };
                     };
                 };

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -11724,6 +11724,7 @@ export interface paths {
                     startDate?: string;
                     endDate?: string;
                     actionTaken?: string;
+                    category?: string;
                     ruleId?: string;
                 };
                 header?: never;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -11802,10 +11802,17 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            blocked: number;
-                            redacted: number;
-                            warned: number;
-                            total: number;
+                            totalViolations: number;
+                            last24Hours: number;
+                            last7Days: number;
+                            byAction: {
+                                blocked: number;
+                                redacted: number;
+                                warned: number;
+                            };
+                            byCategory: {
+                                [key: string]: number;
+                            };
                         };
                     };
                 };

--- a/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
@@ -148,7 +148,7 @@ export function SecurityEventsClient() {
 					queryParams.cursor = cursor;
 				}
 				if (actionFilter !== "all") {
-					queryParams.action = actionFilter;
+					queryParams.actionTaken = actionFilter;
 				}
 				if (categoryFilter !== "all") {
 					queryParams.category = categoryFilter;

--- a/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
@@ -220,12 +220,14 @@ export function SecurityEventsClient() {
 							<CardTitle className="text-3xl">
 								{stats.totalViolations}
 							</CardTitle>
+							<p className="text-xs text-muted-foreground">Last 7 days</p>
 						</CardHeader>
 					</Card>
 					<Card>
 						<CardHeader className="pb-2">
 							<CardDescription>Last 24 Hours</CardDescription>
 							<CardTitle className="text-3xl">{stats.last24Hours}</CardTitle>
+							<p className="text-xs text-muted-foreground">&nbsp;</p>
 						</CardHeader>
 					</Card>
 					<Card>
@@ -234,6 +236,7 @@ export function SecurityEventsClient() {
 							<CardTitle className="text-3xl text-destructive">
 								{stats.byAction?.blocked ?? 0}
 							</CardTitle>
+							<p className="text-xs text-muted-foreground">Last 7 days</p>
 						</CardHeader>
 					</Card>
 					<Card>
@@ -242,6 +245,7 @@ export function SecurityEventsClient() {
 							<CardTitle className="text-3xl text-orange-500">
 								{stats.byAction?.redacted ?? 0}
 							</CardTitle>
+							<p className="text-xs text-muted-foreground">Last 7 days</p>
 						</CardHeader>
 					</Card>
 				</div>

--- a/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
@@ -29,40 +29,16 @@ import { useFetchClient } from "@/lib/fetch-client";
 
 import { ContactSalesCard } from "./contact-sales-card";
 
-interface Violation {
-	id: string;
-	createdAt: string;
-	ruleId: string;
-	ruleName: string;
-	category: string;
-	actionTaken: "blocked" | "redacted" | "warned";
-	matchedPattern: string | null;
-	matchedContent: string | null;
-	logId: string | null;
-	apiKeyId: string | null;
-	model: string | null;
-}
+import type { paths } from "@/lib/api/v1";
 
-interface ViolationsResponse {
-	violations: Violation[];
-	pagination: {
-		nextCursor: string | null;
-		hasMore: boolean;
-		limit: number;
-	};
-}
-
-interface Stats {
-	totalViolations: number;
-	last24Hours: number;
-	last7Days: number;
-	byAction: {
-		blocked: number;
-		redacted: number;
-		warned: number;
-	};
-	byCategory: Record<string, number>;
-}
+type ViolationsResponse =
+	paths["/guardrails/violations/{organizationId}"]["get"]["responses"][200]["content"]["application/json"];
+type Violation = ViolationsResponse["violations"][number];
+type ViolationsQuery = NonNullable<
+	paths["/guardrails/violations/{organizationId}"]["get"]["parameters"]["query"]
+>;
+type Stats =
+	paths["/guardrails/stats/{organizationId}"]["get"]["responses"][200]["content"]["application/json"];
 
 function getActionBadgeVariant(
 	action: string,
@@ -126,7 +102,7 @@ export function SecurityEventsClient() {
 			);
 
 			if (response.data) {
-				setStats(response.data as unknown as Stats);
+				setStats(response.data);
 			}
 		} catch {
 			// Silently fail for stats
@@ -143,7 +119,7 @@ export function SecurityEventsClient() {
 					setIsLoadingMore(true);
 				}
 
-				const queryParams: Record<string, string> = {};
+				const queryParams: ViolationsQuery = {};
 				if (cursor) {
 					queryParams.cursor = cursor;
 				}
@@ -169,7 +145,7 @@ export function SecurityEventsClient() {
 					return;
 				}
 
-				const data = response.data as unknown as ViolationsResponse;
+				const data = response.data;
 
 				if (isInitialLoad) {
 					setViolations(data.violations);
@@ -314,12 +290,14 @@ export function SecurityEventsClient() {
 								</SelectTrigger>
 								<SelectContent>
 									<SelectItem value="all">All categories</SelectItem>
-									<SelectItem value="prompt_injection">
-										Prompt Injection
-									</SelectItem>
+									<SelectItem value="injection">Prompt Injection</SelectItem>
 									<SelectItem value="jailbreak">Jailbreak</SelectItem>
-									<SelectItem value="pii_detection">PII Detection</SelectItem>
+									<SelectItem value="pii">PII Detection</SelectItem>
 									<SelectItem value="secrets">Secrets</SelectItem>
+									<SelectItem value="files">File Types</SelectItem>
+									<SelectItem value="document_leakage">
+										Document Leakage
+									</SelectItem>
 									<SelectItem value="blocked_terms">Blocked Terms</SelectItem>
 									<SelectItem value="custom_regex">Custom Regex</SelectItem>
 									<SelectItem value="topic_restriction">

--- a/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
@@ -87,6 +87,7 @@ export function SecurityEventsClient() {
 	// Filters
 	const [actionFilter, setActionFilter] = useState<string>("all");
 	const [categoryFilter, setCategoryFilter] = useState<string>("all");
+	const [statsDays, setStatsDays] = useState<string>("7");
 
 	const canViewEvents =
 		selectedOrganization?.plan === "enterprise" &&
@@ -97,7 +98,10 @@ export function SecurityEventsClient() {
 			const response = await fetchClient.GET(
 				"/guardrails/stats/{organizationId}",
 				{
-					params: { path: { organizationId } },
+					params: {
+						path: { organizationId },
+						query: { days: statsDays },
+					},
 				},
 			);
 
@@ -107,7 +111,7 @@ export function SecurityEventsClient() {
 		} catch {
 			// Silently fail for stats
 		}
-	}, [fetchClient, organizationId]);
+	}, [fetchClient, organizationId, statsDays]);
 
 	const fetchViolations = useCallback(
 		async (cursor?: string) => {
@@ -166,23 +170,23 @@ export function SecurityEventsClient() {
 		[fetchClient, organizationId, actionFilter, categoryFilter],
 	);
 
-	// Reset and refetch when filters or view permissions change
+	// Reset and refetch the violations list when filters or permissions change
 	useEffect(() => {
 		if (canViewEvents) {
 			setViolations([]);
 			setNextCursor(null);
-			void fetchStats();
 			void fetchViolations();
 		} else {
 			setIsLoading(false);
 		}
-	}, [
-		canViewEvents,
-		fetchStats,
-		fetchViolations,
-		actionFilter,
-		categoryFilter,
-	]);
+	}, [canViewEvents, fetchViolations, actionFilter, categoryFilter]);
+
+	// Refetch stats when the time window or permissions change
+	useEffect(() => {
+		if (canViewEvents) {
+			void fetchStats();
+		}
+	}, [canViewEvents, fetchStats]);
 
 	if (selectedOrganization?.plan !== "enterprise") {
 		return <ContactSalesCard />;
@@ -211,45 +215,66 @@ export function SecurityEventsClient() {
 
 	return (
 		<div className="space-y-6">
-			{/* Stats Cards */}
-			{stats && (
-				<div className="grid gap-4 md:grid-cols-4">
-					<Card>
-						<CardHeader className="pb-2">
-							<CardDescription>Total Violations</CardDescription>
-							<CardTitle className="text-3xl">
-								{stats.totalViolations}
-							</CardTitle>
-							<p className="text-xs text-muted-foreground">Last 7 days</p>
-						</CardHeader>
-					</Card>
-					<Card>
-						<CardHeader className="pb-2">
-							<CardDescription>Last 24 Hours</CardDescription>
-							<CardTitle className="text-3xl">{stats.last24Hours}</CardTitle>
-							<p className="text-xs text-muted-foreground">&nbsp;</p>
-						</CardHeader>
-					</Card>
-					<Card>
-						<CardHeader className="pb-2">
-							<CardDescription>Blocked</CardDescription>
-							<CardTitle className="text-3xl text-destructive">
-								{stats.byAction?.blocked ?? 0}
-							</CardTitle>
-							<p className="text-xs text-muted-foreground">Last 7 days</p>
-						</CardHeader>
-					</Card>
-					<Card>
-						<CardHeader className="pb-2">
-							<CardDescription>Redacted</CardDescription>
-							<CardTitle className="text-3xl text-orange-500">
-								{stats.byAction?.redacted ?? 0}
-							</CardTitle>
-							<p className="text-xs text-muted-foreground">Last 7 days</p>
-						</CardHeader>
-					</Card>
+			{/* Stats overview */}
+			<div className="space-y-4">
+				<div className="flex items-center justify-between gap-2">
+					<h2 className="text-lg font-semibold">Overview</h2>
+					<Select value={statsDays} onValueChange={setStatsDays}>
+						<SelectTrigger className="w-[160px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="7">Last 7 days</SelectItem>
+							<SelectItem value="30">Last 30 days</SelectItem>
+							<SelectItem value="90">Last 90 days</SelectItem>
+						</SelectContent>
+					</Select>
 				</div>
-			)}
+				{stats && (
+					<div className="grid gap-4 md:grid-cols-4">
+						<Card>
+							<CardHeader className="pb-2">
+								<CardDescription>Total Violations</CardDescription>
+								<CardTitle className="text-3xl">
+									{stats.totalViolations}
+								</CardTitle>
+								<p className="text-xs text-muted-foreground">
+									Last {statsDays} days
+								</p>
+							</CardHeader>
+						</Card>
+						<Card>
+							<CardHeader className="pb-2">
+								<CardDescription>Last 24 Hours</CardDescription>
+								<CardTitle className="text-3xl">{stats.last24Hours}</CardTitle>
+								<p className="text-xs text-muted-foreground">&nbsp;</p>
+							</CardHeader>
+						</Card>
+						<Card>
+							<CardHeader className="pb-2">
+								<CardDescription>Blocked</CardDescription>
+								<CardTitle className="text-3xl text-destructive">
+									{stats.byAction?.blocked ?? 0}
+								</CardTitle>
+								<p className="text-xs text-muted-foreground">
+									Last {statsDays} days
+								</p>
+							</CardHeader>
+						</Card>
+						<Card>
+							<CardHeader className="pb-2">
+								<CardDescription>Redacted</CardDescription>
+								<CardTitle className="text-3xl text-orange-500">
+									{stats.byAction?.redacted ?? 0}
+								</CardTitle>
+								<p className="text-xs text-muted-foreground">
+									Last {statsDays} days
+								</p>
+							</CardHeader>
+						</Card>
+					</div>
+				)}
+			</div>
 
 			{/* Violations List */}
 			<Card>

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -11724,6 +11724,7 @@ export interface paths {
                     startDate?: string;
                     endDate?: string;
                     actionTaken?: string;
+                    category?: string;
                     ruleId?: string;
                 };
                 header?: never;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -11802,10 +11802,17 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            blocked: number;
-                            redacted: number;
-                            warned: number;
-                            total: number;
+                            totalViolations: number;
+                            last24Hours: number;
+                            last7Days: number;
+                            byAction: {
+                                blocked: number;
+                                redacted: number;
+                                warned: number;
+                            };
+                            byCategory: {
+                                [key: string]: number;
+                            };
                         };
                     };
                 };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -11724,6 +11724,7 @@ export interface paths {
                     startDate?: string;
                     endDate?: string;
                     actionTaken?: string;
+                    category?: string;
                     ruleId?: string;
                 };
                 header?: never;

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -11802,10 +11802,17 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            blocked: number;
-                            redacted: number;
-                            warned: number;
-                            total: number;
+                            totalViolations: number;
+                            last24Hours: number;
+                            last7Days: number;
+                            byAction: {
+                                blocked: number;
+                                redacted: number;
+                                warned: number;
+                            };
+                            byCategory: {
+                                [key: string]: number;
+                            };
                         };
                     };
                 };


### PR DESCRIPTION
## Problem

On the **Security Events** dashboard, the stat cards (Total Violations, Last 24 Hours, Blocked, Redacted) always showed `0` even when guardrail violations were present in the table below.

## Root cause

Two contract mismatches between the frontend and the `/guardrails/stats` API:

1. **Stats shape.** The API returned a flat `{ blocked, redacted, warned, total }`, but the client reads `stats.totalViolations`, `stats.last24Hours`, and `stats.byAction.{blocked,redacted}`. All of those were `undefined`, so every card rendered `0`.

2. **Filter param.** The violations filter sent `?action=<value>`, but the list endpoint expects `?actionTaken=<value>`, so the Action dropdown was silently ignored.

## Fix

- Align the `getStats` endpoint with the frontend contract: return `totalViolations`, `last24Hours`, `last7Days`, `byAction: { blocked, redacted, warned }`, and `byCategory`. Windowed counts are computed from each violation's `createdAt`.
- Send `actionTaken` instead of `action` from the violations filter.
- Regenerated the typed API clients.

## Testing

- `pnpm format` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guardrails stats now return totalViolations, last24Hours, last7Days and breakdowns by action and category; stats respect a configurable time window.
  * UI adds a "Last N days" selector (7/30/90) and updates stats card labels to show "Last {N} days".

* **Bug Fixes**
  * Violations list accepts an optional category filter.
  * Security events filter now sends the correct actionTaken parameter.
  * Category dropdown values normalized (e.g., injection, pii, document_leakage); 24-hour card placeholder adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->