### PR TITLE
feat(gateway): seedance 2.0 reference video input

### DIFF
--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -56,15 +56,68 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 
 Requests return `400` when the selected provider cannot serve the requested `size` or `seconds`. Seedance derives `aspect_ratio` from the requested `size` (16:9 for landscape, 9:16 for portrait).
 
-### Seedance 2.0 omni-reference
+### Reference-guided generation (Seedance 2.0)
 
-Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`) supports reference-guided video generation. You can supply reference images, videos, and audio in the same request:
+Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`) can generate a video that is guided by reference **images**, **videos**, and **audio** — sometimes called omni-reference. You attach references as top-level fields in the same `POST /v1/videos` payload; the gateway forwards each one to the provider tagged with the correct role, so you don't set roles yourself.
 
-- `reference_images` (or `input_reference`) — one to three image inputs (HTTPS URLs or base64 data URLs)
-- `reference_videos` — one to three reference video **HTTPS URLs** (base64 data URLs are not supported for videos)
-- `reference_audios` — one to three reference audio **HTTPS URLs** (base64 data URLs are not supported for audio)
+| Reference type | Payload field                                | Count | Accepted input                   | Available on                                         |
+| -------------- | -------------------------------------------- | ----- | -------------------------------- | ---------------------------------------------------- |
+| Image          | `reference_images` (`input_reference` alias) | 1–3   | HTTPS URL **or** base64 data URL | Seedance 2.0, Veo 3.1 (`google-vertex`, `avalanche`) |
+| Video          | `reference_videos`                           | 1–3   | HTTPS URL only                   | Seedance 2.0                                         |
+| Audio          | `reference_audios`                           | 1–3   | HTTPS URL only                   | Seedance 2.0                                         |
 
-Reference inputs cannot be combined with the first/last frame inputs (`image`, `last_frame`). Reference videos and audio are only supported on Seedance 2.0 models.
+Each list item accepts either a bare URL string or an object form:
+
+- `reference_images`: `"https://…/subject.png"` or `{ "image_url": "https://…/subject.png" }`
+- `reference_videos`: `"https://…/motion.mp4"` or `{ "video_url": "https://…/motion.mp4" }`
+- `reference_audios`: `"https://…/track.mp3"` or `{ "audio_url": "https://…/track.mp3" }`
+
+You can mix all three reference types in one request. The `prompt` can be a light instruction (for example `"adapt this to show more detail"`) — the references drive the result.
+
+#### Rules and limits
+
+- **HTTPS only for video and audio.** `reference_videos` and `reference_audios` must be publicly reachable HTTPS URLs (the provider fetches them). base64 data URLs are rejected for video/audio; images may be HTTPS URLs or base64 data URLs.
+- **Reference video resolution.** Seedance requires reference video frames to be at least ~409,600 pixels (roughly 480p or larger). Low-resolution clips such as 360p are rejected with a `400`.
+- **Not combinable with frames.** Reference inputs (`reference_images`, `reference_videos`, `reference_audios`) cannot be combined with the first/last frame inputs (`image`, `last_frame`).
+- **Provider scope.** Reference videos and audio are only supported on Seedance 2.0 models; sending them to other models returns a `400`.
+- **Moderation still applies.** The output is subject to the provider's content moderation. Blocked generations finish as `failed` and are logged with a `content_filter` finish reason.
+
+#### Examples
+
+Reference images only (subjects / style):
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/videos" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0",
+    "prompt": "The subject walks through a neon-lit market at night",
+    "seconds": 5,
+    "size": "1280x720",
+    "reference_images": [
+      { "image_url": "https://example.com/subject.png" },
+      { "image_url": "https://example.com/style.png" }
+    ]
+  }'
+```
+
+Reference video only (motion / scene — let the clip drive the output):
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/videos" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0",
+    "prompt": "adapt this to show more detail",
+    "seconds": 5,
+    "size": "1280x720",
+    "reference_videos": ["https://example.com/reference-motion.mp4"]
+  }'
+```
+
+All three reference types combined:
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/videos" \

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -41,6 +41,7 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | `last_frame`       | object  | no       | Optional ending frame when `image` is provided                                                                             |
 | `reference_images` | array   | no       | One to three provider-specific image inputs                                                                                |
 | `input_reference`  | object  | no       | Alias for one or more `reference_images`                                                                                   |
+| `reference_videos` | array   | no       | One to three reference video HTTPS URLs (Seedance 2.0 only, see below)                                                     |
 | `callback_url`     | string  | no       | LLMGateway extension for completion webhooks                                                                               |
 | `callback_secret`  | string  | no       | LLMGateway extension used to sign webhook deliveries                                                                       |
 
@@ -53,6 +54,33 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | Seedance 2.0 / 2.0 Fast / 1.5 Pro | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `5`, `10`           |
 
 Requests return `400` when the selected provider cannot serve the requested `size` or `seconds`. Seedance derives `aspect_ratio` from the requested `size` (16:9 for landscape, 9:16 for portrait).
+
+### Seedance 2.0 omni-reference
+
+Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`) supports reference-guided video generation. You can supply reference images and reference videos in the same request:
+
+- `reference_images` (or `input_reference`) — one to three image inputs (HTTPS URLs or base64 data URLs)
+- `reference_videos` — one to three reference video **HTTPS URLs** (base64 data URLs are not supported for videos)
+
+Reference inputs cannot be combined with the first/last frame inputs (`image`, `last_frame`). Reference videos are only supported on Seedance 2.0 models.
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/videos" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0",
+    "prompt": "The subject performs the choreography from the reference video",
+    "seconds": 5,
+    "size": "1280x720",
+    "reference_images": [
+      { "image_url": "https://example.com/subject.png" }
+    ],
+    "reference_videos": [
+      "https://example.com/reference-motion.mp4"
+    ]
+  }'
+```
 
 ### Not supported yet
 

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -42,6 +42,7 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | `reference_images` | array   | no       | One to three provider-specific image inputs                                                                                |
 | `input_reference`  | object  | no       | Alias for one or more `reference_images`                                                                                   |
 | `reference_videos` | array   | no       | One to three reference video HTTPS URLs (Seedance 2.0 only, see below)                                                     |
+| `reference_audios` | array   | no       | One to three reference audio HTTPS URLs (Seedance 2.0 only, see below)                                                     |
 | `callback_url`     | string  | no       | LLMGateway extension for completion webhooks                                                                               |
 | `callback_secret`  | string  | no       | LLMGateway extension used to sign webhook deliveries                                                                       |
 
@@ -57,12 +58,13 @@ Requests return `400` when the selected provider cannot serve the requested `siz
 
 ### Seedance 2.0 omni-reference
 
-Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`) supports reference-guided video generation. You can supply reference images and reference videos in the same request:
+Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`) supports reference-guided video generation. You can supply reference images, videos, and audio in the same request:
 
 - `reference_images` (or `input_reference`) — one to three image inputs (HTTPS URLs or base64 data URLs)
 - `reference_videos` — one to three reference video **HTTPS URLs** (base64 data URLs are not supported for videos)
+- `reference_audios` — one to three reference audio **HTTPS URLs** (base64 data URLs are not supported for audio)
 
-Reference inputs cannot be combined with the first/last frame inputs (`image`, `last_frame`). Reference videos are only supported on Seedance 2.0 models.
+Reference inputs cannot be combined with the first/last frame inputs (`image`, `last_frame`). Reference videos and audio are only supported on Seedance 2.0 models.
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/videos" \
@@ -78,6 +80,9 @@ curl -X POST "https://api.llmgateway.io/v1/videos" \
     ],
     "reference_videos": [
       "https://example.com/reference-motion.mp4"
+    ],
+    "reference_audios": [
+      "https://example.com/reference-track.mp3"
     ]
   }'
 ```

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -1,5 +1,7 @@
 import { hasInvalidProviderCredentialError } from "@/lib/provider-auth-errors.js";
 
+import { isContentFilterErrorText } from "@llmgateway/shared";
+
 /**
  * Determines the appropriate finish reason based on HTTP status code and error message
  * 5xx status codes indicate upstream provider errors
@@ -31,21 +33,10 @@ export function getFinishReasonFromError(
 		return "upstream_error";
 	}
 
-	// Azure OpenAI content filter (ResponsibleAIPolicyViolation)
-	if (errorText?.includes("ResponsibleAIPolicyViolation")) {
-		return "content_filter";
-	}
-
-	// ByteDance / DeepSeek provider moderation block
-	if (errorText?.includes("SensitiveContentDetected")) {
-		return "content_filter";
-	}
-
-	// Alibaba / DashScope moderation block
-	if (
-		errorText?.includes("data_inspection_failed") ||
-		errorText?.includes("Input data may contain inappropriate content")
-	) {
+	// Provider content-moderation / safety blocks (Azure ResponsibleAIPolicyViolation,
+	// ByteDance/DeepSeek SensitiveContentDetected, Alibaba data_inspection_failed,
+	// Azure content management policy, OpenAI safety system rejection, etc.)
+	if (isContentFilterErrorText(errorText)) {
 		return "content_filter";
 	}
 
@@ -54,17 +45,6 @@ export function getFinishReasonFromError(
 		statusCode === 403 &&
 		errorText?.includes("Content violates usage guidelines")
 	) {
-		return "content_filter";
-	}
-
-	// Azure OpenAI prompt-side content filter (distinct from ResponsibleAIPolicyViolation,
-	// which fires on the response side and includes inner_error details)
-	if (errorText?.includes("Microsoft's content management policy")) {
-		return "content_filter";
-	}
-
-	// OpenAI safety system rejection (e.g. gpt-image-2 image generation)
-	if (errorText?.includes("Your request was rejected by the safety system")) {
 		return "content_filter";
 	}
 

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -269,6 +269,74 @@ describe("videos", () => {
 		);
 	});
 
+	test("/v1/videos rejects non-https reference audios", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0",
+				prompt: "Align the motion to the reference track",
+				size: "1280x720",
+				seconds: 5,
+				reference_audios: ["http://example.com/reference-track.mp3"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("reference_audios");
+	});
+
+	test("/v1/videos rejects reference audio on non-bytedance models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "avalanche",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "avalanche/veo-3.1-fast-generate-preview",
+				prompt: "Align this motion",
+				size: "1920x1080",
+				seconds: 8,
+				reference_audios: ["https://example.com/reference-track.mp3"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"reference audio is currently only supported on bytedance",
+		);
+	});
+
 	test("/v1/videos restricts reference inputs to Seedance 2.0 models", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -171,6 +171,133 @@ describe("videos", () => {
 		);
 	});
 
+	test("/v1/videos rejects non-https reference videos", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0",
+				prompt: "Reproduce the camera move from the reference clip",
+				size: "1280x720",
+				seconds: 5,
+				reference_videos: ["http://example.com/reference-motion.mp4"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("reference_videos");
+	});
+
+	test("/v1/videos rejects combining frames with reference videos", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0",
+				prompt: "Blend these inputs",
+				size: "1280x720",
+				seconds: 5,
+				image: { image_url: "data:image/png;base64,aGVsbG8=" },
+				reference_videos: ["https://example.com/reference-motion.mp4"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("Frame inputs");
+	});
+
+	test("/v1/videos rejects reference videos on non-bytedance models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "avalanche",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "avalanche/veo-3.1-fast-generate-preview",
+				prompt: "Reproduce this motion",
+				size: "1920x1080",
+				seconds: 8,
+				reference_videos: ["https://example.com/reference-motion.mp4"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"reference videos are currently only supported on bytedance",
+		);
+	});
+
+	test("/v1/videos restricts reference inputs to Seedance 2.0 models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "bytedance/seedance-1-5-pro",
+				prompt: "Reproduce this motion",
+				size: "1280x720",
+				seconds: 5,
+				reference_videos: ["https://example.com/reference-motion.mp4"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("Seedance 2.0");
+	});
+
 	test("/v1/videos uses routing metrics to pick the best eligible provider", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
 		const originalRuntimeGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -161,6 +161,33 @@ const videoImageInputSchema = z
 
 const videoReferenceImagesSchema = z.array(videoImageInputSchema).min(1).max(3);
 
+const referenceVideoUrlSchema = z
+	.string()
+	.url()
+	.refine((value) => /^https:\/\//i.test(value), {
+		message: "Reference video URL must be an HTTPS URL",
+	});
+
+const videoReferenceVideoInputSchema = z
+	.union([
+		referenceVideoUrlSchema,
+		z.object({
+			video_url: referenceVideoUrlSchema,
+		}),
+	])
+	.openapi({
+		description:
+			"Reference video input for omni-reference video generation. Must be a publicly reachable HTTPS URL; base64 data URLs are not supported for videos.",
+		example: {
+			video_url: "https://example.com/reference-motion.mp4",
+		},
+	});
+
+const videoReferenceVideosSchema = z
+	.array(videoReferenceVideoInputSchema)
+	.min(1)
+	.max(3);
+
 const createVideoRequestSchema = z
 	.object({
 		model: z.string().default("veo-3.1-generate-preview").openapi({
@@ -223,6 +250,15 @@ const createVideoRequestSchema = z
 				},
 			],
 		}),
+		reference_videos: videoReferenceVideosSchema.optional().openapi({
+			description:
+				"One to three reference videos (HTTPS URLs) for omni-reference video generation. Currently only supported on ByteDance Seedance 2.0 models and can be combined with reference_images.",
+			example: [
+				{
+					video_url: "https://example.com/reference-motion.mp4",
+				},
+			],
+		}),
 	})
 	.superRefine((value, ctx) => {
 		const hasCallbackUrl = value.callback_url !== undefined;
@@ -258,7 +294,8 @@ const createVideoRequestSchema = z
 			value.image !== undefined || value.last_frame !== undefined;
 		const hasReferenceInput =
 			value.reference_images !== undefined ||
-			value.input_reference !== undefined;
+			value.input_reference !== undefined ||
+			value.reference_videos !== undefined;
 
 		if (value.last_frame !== undefined && value.image === undefined) {
 			ctx.addIssue({
@@ -700,6 +737,13 @@ function isSoraVideoModelName(externalId: string): boolean {
 	return externalId === "sora-2" || externalId === "sora-2-pro";
 }
 
+function isBytedanceReferenceVideoModel(externalId: string): boolean {
+	return (
+		externalId === "dreamina-seedance-2-0-260128" ||
+		externalId === "dreamina-seedance-2-0-fast-260128"
+	);
+}
+
 function isGoogleVertexVideoProvider(providerId: string): boolean {
 	return providerId === "google-vertex";
 }
@@ -710,6 +754,7 @@ function getVideoProviderConstraintReasons(
 	videoDurationSeconds: number,
 	inputMode: VideoInputMode,
 	inputImageCount: number,
+	referenceVideoCount: number,
 	includeAudio: boolean,
 ): string[] {
 	const reasons: string[] = [];
@@ -783,6 +828,11 @@ function getVideoProviderConstraintReasons(
 
 	if (inputMode === "reference") {
 		if (isSoraVideoModelName(provider.externalId)) {
+			if (referenceVideoCount > 0) {
+				reasons.push(
+					"Sora models do not support reference videos. Use reference_images with exactly one image.",
+				);
+			}
 			if (inputImageCount !== 1) {
 				reasons.push(
 					"Sora reference-image video generation supports exactly 1 input image",
@@ -790,6 +840,22 @@ function getVideoProviderConstraintReasons(
 			}
 
 			return reasons;
+		}
+
+		if (provider.providerId === "bytedance") {
+			if (!isBytedanceReferenceVideoModel(provider.externalId)) {
+				reasons.push(
+					"reference inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast)",
+				);
+			}
+
+			return reasons;
+		}
+
+		if (referenceVideoCount > 0) {
+			reasons.push(
+				"reference videos are currently only supported on bytedance Seedance 2.0 models",
+			);
 		}
 
 		if (isGoogleVertexVideoProvider(provider.providerId)) {
@@ -827,6 +893,7 @@ function formatVideoProviderConstraintSummary(
 	videoDurationSeconds: number,
 	inputMode: VideoInputMode,
 	inputImageCount: number,
+	referenceVideoCount: number,
 	includeAudio: boolean,
 ): string {
 	const providerSummaries = providers.map((provider) => {
@@ -836,6 +903,7 @@ function formatVideoProviderConstraintSummary(
 			videoDurationSeconds,
 			inputMode,
 			inputImageCount,
+			referenceVideoCount,
 			includeAudio,
 		);
 		return `${provider.providerId}: ${reasons.join("; ")}`;
@@ -856,6 +924,7 @@ function getEligibleVideoProviderMappings(
 	videoDurationSeconds: number,
 	inputMode: VideoInputMode,
 	inputImageCount: number,
+	referenceVideoCount: number,
 	includeAudio: boolean,
 ): ProviderModelMapping[] {
 	const now = new Date();
@@ -886,6 +955,7 @@ function getEligibleVideoProviderMappings(
 				videoDurationSeconds,
 				inputMode,
 				inputImageCount,
+				referenceVideoCount,
 				includeAudio,
 			).length === 0
 		);
@@ -900,6 +970,7 @@ function getEligibleVideoProviderMappings(
 				videoDurationSeconds,
 				inputMode,
 				inputImageCount,
+				referenceVideoCount,
 				includeAudio,
 			),
 		});
@@ -1370,6 +1441,7 @@ async function resolveVideoExecution(
 	videoDurationSeconds: number,
 	inputMode: VideoInputMode,
 	inputImageCount: number,
+	referenceVideoCount: number,
 	includeAudio: boolean,
 	project: InferSelectModel<typeof tables.project>,
 	organizationId: string,
@@ -1397,6 +1469,7 @@ async function resolveVideoExecution(
 		videoDurationSeconds,
 		inputMode,
 		inputImageCount,
+		referenceVideoCount,
 		includeAudio,
 	);
 	const configuredEligibleMappings: ProviderModelMapping[] = [];
@@ -1446,6 +1519,7 @@ async function resolveVideoExecution(
 						videoDurationSeconds,
 						inputMode,
 						inputImageCount,
+						referenceVideoCount,
 						includeAudio,
 					),
 				});
@@ -2840,6 +2914,7 @@ async function createBytedanceVideoJob(
 	firstFrameInput: VideoImageInput | undefined,
 	processedFirstFrame: ProcessedVideoImageInput | null,
 	processedReferenceImages: ProcessedVideoImageInput[],
+	referenceVideoUrls: string[],
 ): Promise<{
 	upstreamId: string;
 	upstreamRequest: Record<string, unknown>;
@@ -2859,6 +2934,7 @@ async function createBytedanceVideoJob(
 			image_url: {
 				url: `data:${processedFirstFrame.mimeType};base64,${processedFirstFrame.bytesBase64Encoded}`,
 			},
+			role: "first_frame",
 		});
 	}
 
@@ -2869,8 +2945,19 @@ async function createBytedanceVideoJob(
 				image_url: {
 					url: `data:${image.mimeType};base64,${image.bytesBase64Encoded}`,
 				},
+				role: "reference_image",
 			});
 		}
+	}
+
+	for (const referenceVideoUrl of referenceVideoUrls) {
+		content.push({
+			type: "video_url",
+			video_url: {
+				url: referenceVideoUrl,
+			},
+			role: "reference_video",
+		});
 	}
 
 	const isDreaminaModel = upstreamModelName.startsWith("dreamina-");
@@ -2934,6 +3021,7 @@ async function createUpstreamVideoJob(
 	firstFrameInput: VideoImageInput | undefined,
 	lastFrameInput: VideoImageInput | undefined,
 	referenceImageInputs: VideoImageInput[],
+	referenceVideoUrls: string[],
 	processedFirstFrame: ProcessedVideoImageInput | null,
 	processedLastFrame: ProcessedVideoImageInput | null,
 	processedReferenceImages: ProcessedVideoImageInput[],
@@ -2986,6 +3074,7 @@ async function createUpstreamVideoJob(
 				firstFrameInput,
 				processedFirstFrame,
 				processedReferenceImages,
+				referenceVideoUrls,
 			);
 		case "google-vertex":
 			return await createGoogleVertexVideoJob(
@@ -3048,12 +3137,27 @@ function getVideoInputMode(
 
 	if (
 		request.reference_images !== undefined ||
-		request.input_reference !== undefined
+		request.input_reference !== undefined ||
+		request.reference_videos !== undefined
 	) {
 		return "reference";
 	}
 
 	return "none";
+}
+
+function getVideoReferenceVideoInputs(
+	request: z.infer<typeof createVideoRequestSchema>,
+): string[] {
+	if (!request.reference_videos) {
+		return [];
+	}
+
+	return request.reference_videos.map((referenceVideo) =>
+		typeof referenceVideo === "string"
+			? referenceVideo
+			: referenceVideo.video_url,
+	);
 }
 
 function getVideoInputImageCount(
@@ -3199,6 +3303,7 @@ videos.openapi(createVideo, async (c) => {
 	const firstFrameInput = getVideoFirstFrameInput(request);
 	const lastFrameInput = getVideoLastFrameInput(request);
 	const referenceImageInputs = getVideoReferenceImageInputs(request);
+	const referenceVideoInputs = getVideoReferenceVideoInputs(request);
 	const inputMode = getVideoInputMode(request);
 	const inputImageCount = getVideoInputImageCount(
 		inputMode,
@@ -3251,6 +3356,7 @@ videos.openapi(createVideo, async (c) => {
 		videoDurationSeconds,
 		inputMode,
 		inputImageCount,
+		referenceVideoInputs.length,
 		request.audio,
 		project,
 		organization.id,
@@ -3399,6 +3505,7 @@ videos.openapi(createVideo, async (c) => {
 				firstFrameInput,
 				lastFrameInput,
 				referenceImageInputs,
+				referenceVideoInputs,
 				processedFirstFrame,
 				processedLastFrameInput,
 				processedReferenceImages,

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -188,6 +188,33 @@ const videoReferenceVideosSchema = z
 	.min(1)
 	.max(3);
 
+const referenceAudioUrlSchema = z
+	.string()
+	.url()
+	.refine((value) => /^https:\/\//i.test(value), {
+		message: "Reference audio URL must be an HTTPS URL",
+	});
+
+const videoReferenceAudioInputSchema = z
+	.union([
+		referenceAudioUrlSchema,
+		z.object({
+			audio_url: referenceAudioUrlSchema,
+		}),
+	])
+	.openapi({
+		description:
+			"Reference audio input for omni-reference video generation. Must be a publicly reachable HTTPS URL; base64 data URLs are not supported for audio.",
+		example: {
+			audio_url: "https://example.com/reference-track.mp3",
+		},
+	});
+
+const videoReferenceAudiosSchema = z
+	.array(videoReferenceAudioInputSchema)
+	.min(1)
+	.max(3);
+
 const createVideoRequestSchema = z
 	.object({
 		model: z.string().default("veo-3.1-generate-preview").openapi({
@@ -259,6 +286,15 @@ const createVideoRequestSchema = z
 				},
 			],
 		}),
+		reference_audios: videoReferenceAudiosSchema.optional().openapi({
+			description:
+				"One to three reference audio clips (HTTPS URLs) for omni-reference video generation. Currently only supported on ByteDance Seedance 2.0 models and can be combined with reference_images and reference_videos.",
+			example: [
+				{
+					audio_url: "https://example.com/reference-track.mp3",
+				},
+			],
+		}),
 	})
 	.superRefine((value, ctx) => {
 		const hasCallbackUrl = value.callback_url !== undefined;
@@ -295,7 +331,8 @@ const createVideoRequestSchema = z
 		const hasReferenceInput =
 			value.reference_images !== undefined ||
 			value.input_reference !== undefined ||
-			value.reference_videos !== undefined;
+			value.reference_videos !== undefined ||
+			value.reference_audios !== undefined;
 
 		if (value.last_frame !== undefined && value.image === undefined) {
 			ctx.addIssue({
@@ -737,7 +774,7 @@ function isSoraVideoModelName(externalId: string): boolean {
 	return externalId === "sora-2" || externalId === "sora-2-pro";
 }
 
-function isBytedanceReferenceVideoModel(externalId: string): boolean {
+function isBytedanceReferenceModel(externalId: string): boolean {
 	return (
 		externalId === "dreamina-seedance-2-0-260128" ||
 		externalId === "dreamina-seedance-2-0-fast-260128"
@@ -755,6 +792,7 @@ function getVideoProviderConstraintReasons(
 	inputMode: VideoInputMode,
 	inputImageCount: number,
 	referenceVideoCount: number,
+	referenceAudioCount: number,
 	includeAudio: boolean,
 ): string[] {
 	const reasons: string[] = [];
@@ -833,6 +871,11 @@ function getVideoProviderConstraintReasons(
 					"Sora models do not support reference videos. Use reference_images with exactly one image.",
 				);
 			}
+			if (referenceAudioCount > 0) {
+				reasons.push(
+					"Sora models do not support reference audio. Use reference_images with exactly one image.",
+				);
+			}
 			if (inputImageCount !== 1) {
 				reasons.push(
 					"Sora reference-image video generation supports exactly 1 input image",
@@ -843,7 +886,7 @@ function getVideoProviderConstraintReasons(
 		}
 
 		if (provider.providerId === "bytedance") {
-			if (!isBytedanceReferenceVideoModel(provider.externalId)) {
+			if (!isBytedanceReferenceModel(provider.externalId)) {
 				reasons.push(
 					"reference inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast)",
 				);
@@ -855,6 +898,12 @@ function getVideoProviderConstraintReasons(
 		if (referenceVideoCount > 0) {
 			reasons.push(
 				"reference videos are currently only supported on bytedance Seedance 2.0 models",
+			);
+		}
+
+		if (referenceAudioCount > 0) {
+			reasons.push(
+				"reference audio is currently only supported on bytedance Seedance 2.0 models",
 			);
 		}
 
@@ -894,6 +943,7 @@ function formatVideoProviderConstraintSummary(
 	inputMode: VideoInputMode,
 	inputImageCount: number,
 	referenceVideoCount: number,
+	referenceAudioCount: number,
 	includeAudio: boolean,
 ): string {
 	const providerSummaries = providers.map((provider) => {
@@ -904,6 +954,7 @@ function formatVideoProviderConstraintSummary(
 			inputMode,
 			inputImageCount,
 			referenceVideoCount,
+			referenceAudioCount,
 			includeAudio,
 		);
 		return `${provider.providerId}: ${reasons.join("; ")}`;
@@ -925,6 +976,7 @@ function getEligibleVideoProviderMappings(
 	inputMode: VideoInputMode,
 	inputImageCount: number,
 	referenceVideoCount: number,
+	referenceAudioCount: number,
 	includeAudio: boolean,
 ): ProviderModelMapping[] {
 	const now = new Date();
@@ -956,6 +1008,7 @@ function getEligibleVideoProviderMappings(
 				inputMode,
 				inputImageCount,
 				referenceVideoCount,
+				referenceAudioCount,
 				includeAudio,
 			).length === 0
 		);
@@ -971,6 +1024,7 @@ function getEligibleVideoProviderMappings(
 				inputMode,
 				inputImageCount,
 				referenceVideoCount,
+				referenceAudioCount,
 				includeAudio,
 			),
 		});
@@ -1442,6 +1496,7 @@ async function resolveVideoExecution(
 	inputMode: VideoInputMode,
 	inputImageCount: number,
 	referenceVideoCount: number,
+	referenceAudioCount: number,
 	includeAudio: boolean,
 	project: InferSelectModel<typeof tables.project>,
 	organizationId: string,
@@ -1470,6 +1525,7 @@ async function resolveVideoExecution(
 		inputMode,
 		inputImageCount,
 		referenceVideoCount,
+		referenceAudioCount,
 		includeAudio,
 	);
 	const configuredEligibleMappings: ProviderModelMapping[] = [];
@@ -1520,6 +1576,7 @@ async function resolveVideoExecution(
 						inputMode,
 						inputImageCount,
 						referenceVideoCount,
+						referenceAudioCount,
 						includeAudio,
 					),
 				});
@@ -2915,6 +2972,7 @@ async function createBytedanceVideoJob(
 	processedFirstFrame: ProcessedVideoImageInput | null,
 	processedReferenceImages: ProcessedVideoImageInput[],
 	referenceVideoUrls: string[],
+	referenceAudioUrls: string[],
 ): Promise<{
 	upstreamId: string;
 	upstreamRequest: Record<string, unknown>;
@@ -2957,6 +3015,16 @@ async function createBytedanceVideoJob(
 				url: referenceVideoUrl,
 			},
 			role: "reference_video",
+		});
+	}
+
+	for (const referenceAudioUrl of referenceAudioUrls) {
+		content.push({
+			type: "audio_url",
+			audio_url: {
+				url: referenceAudioUrl,
+			},
+			role: "reference_audio",
 		});
 	}
 
@@ -3022,6 +3090,7 @@ async function createUpstreamVideoJob(
 	lastFrameInput: VideoImageInput | undefined,
 	referenceImageInputs: VideoImageInput[],
 	referenceVideoUrls: string[],
+	referenceAudioUrls: string[],
 	processedFirstFrame: ProcessedVideoImageInput | null,
 	processedLastFrame: ProcessedVideoImageInput | null,
 	processedReferenceImages: ProcessedVideoImageInput[],
@@ -3075,6 +3144,7 @@ async function createUpstreamVideoJob(
 				processedFirstFrame,
 				processedReferenceImages,
 				referenceVideoUrls,
+				referenceAudioUrls,
 			);
 		case "google-vertex":
 			return await createGoogleVertexVideoJob(
@@ -3138,7 +3208,8 @@ function getVideoInputMode(
 	if (
 		request.reference_images !== undefined ||
 		request.input_reference !== undefined ||
-		request.reference_videos !== undefined
+		request.reference_videos !== undefined ||
+		request.reference_audios !== undefined
 	) {
 		return "reference";
 	}
@@ -3157,6 +3228,20 @@ function getVideoReferenceVideoInputs(
 		typeof referenceVideo === "string"
 			? referenceVideo
 			: referenceVideo.video_url,
+	);
+}
+
+function getVideoReferenceAudioInputs(
+	request: z.infer<typeof createVideoRequestSchema>,
+): string[] {
+	if (!request.reference_audios) {
+		return [];
+	}
+
+	return request.reference_audios.map((referenceAudio) =>
+		typeof referenceAudio === "string"
+			? referenceAudio
+			: referenceAudio.audio_url,
 	);
 }
 
@@ -3304,6 +3389,7 @@ videos.openapi(createVideo, async (c) => {
 	const lastFrameInput = getVideoLastFrameInput(request);
 	const referenceImageInputs = getVideoReferenceImageInputs(request);
 	const referenceVideoInputs = getVideoReferenceVideoInputs(request);
+	const referenceAudioInputs = getVideoReferenceAudioInputs(request);
 	const inputMode = getVideoInputMode(request);
 	const inputImageCount = getVideoInputImageCount(
 		inputMode,
@@ -3357,6 +3443,7 @@ videos.openapi(createVideo, async (c) => {
 		inputMode,
 		inputImageCount,
 		referenceVideoInputs.length,
+		referenceAudioInputs.length,
 		request.audio,
 		project,
 		organization.id,
@@ -3506,6 +3593,7 @@ videos.openapi(createVideo, async (c) => {
 				lastFrameInput,
 				referenceImageInputs,
 				referenceVideoInputs,
+				referenceAudioInputs,
 				processedFirstFrame,
 				processedLastFrameInput,
 				processedReferenceImages,

--- a/apps/playground/src/components/playground/video-controls.tsx
+++ b/apps/playground/src/components/playground/video-controls.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Film, ImagePlus, Loader2, Plus, Sparkles, X } from "lucide-react";
+import {
+	Film,
+	ImagePlus,
+	Loader2,
+	Music,
+	Plus,
+	Sparkles,
+	X,
+} from "lucide-react";
 import {
 	type Dispatch,
 	type SetStateAction,
@@ -45,12 +53,15 @@ interface VideoControlsProps {
 	canUseFrameInputs: boolean;
 	canUseReferenceInputs: boolean;
 	canUseReferenceVideoInputs: boolean;
+	canUseReferenceAudioInputs: boolean;
 	frameInputs: VideoFrameInputs;
 	setFrameInputs: Dispatch<SetStateAction<VideoFrameInputs>>;
 	referenceImages: VideoInputImage[];
 	setReferenceImages: Dispatch<SetStateAction<VideoInputImage[]>>;
 	referenceVideos: string[];
 	setReferenceVideos: Dispatch<SetStateAction<string[]>>;
+	referenceAudios: string[];
+	setReferenceAudios: Dispatch<SetStateAction<string[]>>;
 	supportedVideoSizes: VideoSize[];
 	supportedVideoDurations: VideoDuration[];
 	isGenerating: boolean;
@@ -73,12 +84,15 @@ export function VideoControls({
 	canUseFrameInputs,
 	canUseReferenceInputs,
 	canUseReferenceVideoInputs,
+	canUseReferenceAudioInputs,
 	frameInputs,
 	setFrameInputs,
 	referenceImages,
 	setReferenceImages,
 	referenceVideos,
 	setReferenceVideos,
+	referenceAudios,
+	setReferenceAudios,
 	supportedVideoSizes,
 	supportedVideoDurations,
 	isGenerating,
@@ -108,6 +122,27 @@ export function VideoControls({
 			setReferenceVideos((prev) => prev.filter((_, i) => i !== index));
 		},
 		[setReferenceVideos],
+	);
+
+	const [referenceAudioDraft, setReferenceAudioDraft] = useState("");
+
+	const addReferenceAudio = useCallback(() => {
+		const url = referenceAudioDraft.trim();
+		if (!url || !/^https:\/\//i.test(url)) {
+			return;
+		}
+		setFrameInputs({ start: null, end: null });
+		setReferenceAudios((prev) =>
+			prev.length >= 3 || prev.includes(url) ? prev : [...prev, url],
+		);
+		setReferenceAudioDraft("");
+	}, [referenceAudioDraft, setFrameInputs, setReferenceAudios]);
+
+	const removeReferenceAudio = useCallback(
+		(index: number) => {
+			setReferenceAudios((prev) => prev.filter((_, i) => i !== index));
+		},
+		[setReferenceAudios],
 	);
 
 	const canGenerate = prompt.trim().length > 0 && selectedModels.length > 0;
@@ -153,6 +188,7 @@ export function VideoControls({
 				if (target === "frame-start") {
 					setReferenceImages([]);
 					setReferenceVideos([]);
+					setReferenceAudios([]);
 					setFrameInputs((prev) => ({
 						...prev,
 						start: nextImage,
@@ -163,6 +199,7 @@ export function VideoControls({
 				if (target === "frame-end") {
 					setReferenceImages([]);
 					setReferenceVideos([]);
+					setReferenceAudios([]);
 					setFrameInputs((prev) => ({
 						...prev,
 						end: nextImage,
@@ -192,6 +229,7 @@ export function VideoControls({
 			setFrameInputs,
 			setReferenceImages,
 			setReferenceVideos,
+			setReferenceAudios,
 		],
 	);
 
@@ -417,6 +455,28 @@ export function VideoControls({
 							))}
 						</div>
 					)}
+					{referenceAudios.length > 0 && (
+						<div className="flex flex-wrap gap-2 px-3 pt-3">
+							{referenceAudios.map((url, index) => (
+								<div
+									key={`${url}-${index}`}
+									className="group relative flex max-w-[220px] items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2 pr-6 text-xs"
+									title={url}
+								>
+									<Music className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+									<span className="truncate">Reference audio {index + 1}</span>
+									<button
+										type="button"
+										aria-label="Remove reference audio"
+										onClick={() => removeReferenceAudio(index)}
+										className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border bg-background text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground"
+									>
+										<X className="h-3 w-3" />
+									</button>
+								</div>
+							))}
+						</div>
+					)}
 					<Textarea
 						ref={textareaRef}
 						value={prompt}
@@ -514,6 +574,39 @@ export function VideoControls({
 								{referenceVideos.length === 0
 									? "Video"
 									: `${referenceVideos.length}/3 videos`}
+							</Button>
+						</div>
+					)}
+					{canUseReferenceAudioInputs && (
+						<div className="flex items-center gap-1.5">
+							<Input
+								value={referenceAudioDraft}
+								onChange={(e) => setReferenceAudioDraft(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										addReferenceAudio();
+									}
+								}}
+								placeholder="Reference audio URL (https://)"
+								disabled={isGenerating || referenceAudios.length >= 3}
+								className="h-8 w-[220px] text-sm"
+							/>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={addReferenceAudio}
+								disabled={
+									isGenerating ||
+									referenceAudios.length >= 3 ||
+									!/^https:\/\//i.test(referenceAudioDraft.trim())
+								}
+								title="Add an HTTPS reference audio URL"
+							>
+								<Plus className="mr-1.5 h-4 w-4" />
+								{referenceAudios.length === 0
+									? "Audio ref"
+									: `${referenceAudios.length}/3 audio`}
 							</Button>
 						</div>
 					)}

--- a/apps/playground/src/components/playground/video-controls.tsx
+++ b/apps/playground/src/components/playground/video-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ImagePlus, Loader2, Sparkles, X } from "lucide-react";
+import { Film, ImagePlus, Loader2, Plus, Sparkles, X } from "lucide-react";
 import {
 	type Dispatch,
 	type SetStateAction,
@@ -11,6 +11,7 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -43,10 +44,13 @@ interface VideoControlsProps {
 	audioToggleDisabled: boolean;
 	canUseFrameInputs: boolean;
 	canUseReferenceInputs: boolean;
+	canUseReferenceVideoInputs: boolean;
 	frameInputs: VideoFrameInputs;
 	setFrameInputs: Dispatch<SetStateAction<VideoFrameInputs>>;
 	referenceImages: VideoInputImage[];
 	setReferenceImages: Dispatch<SetStateAction<VideoInputImage[]>>;
+	referenceVideos: string[];
+	setReferenceVideos: Dispatch<SetStateAction<string[]>>;
 	supportedVideoSizes: VideoSize[];
 	supportedVideoDurations: VideoDuration[];
 	isGenerating: boolean;
@@ -68,10 +72,13 @@ export function VideoControls({
 	audioToggleDisabled,
 	canUseFrameInputs,
 	canUseReferenceInputs,
+	canUseReferenceVideoInputs,
 	frameInputs,
 	setFrameInputs,
 	referenceImages,
 	setReferenceImages,
+	referenceVideos,
+	setReferenceVideos,
 	supportedVideoSizes,
 	supportedVideoDurations,
 	isGenerating,
@@ -82,6 +89,26 @@ export function VideoControls({
 	const dropZoneRef = useRef<HTMLDivElement>(null);
 	const [isDragging, setIsDragging] = useState(false);
 	const [uploadTarget, setUploadTarget] = useState<UploadTarget>("frame-start");
+	const [referenceVideoDraft, setReferenceVideoDraft] = useState("");
+
+	const addReferenceVideo = useCallback(() => {
+		const url = referenceVideoDraft.trim();
+		if (!url || !/^https:\/\//i.test(url)) {
+			return;
+		}
+		setFrameInputs({ start: null, end: null });
+		setReferenceVideos((prev) =>
+			prev.length >= 3 || prev.includes(url) ? prev : [...prev, url],
+		);
+		setReferenceVideoDraft("");
+	}, [referenceVideoDraft, setFrameInputs, setReferenceVideos]);
+
+	const removeReferenceVideo = useCallback(
+		(index: number) => {
+			setReferenceVideos((prev) => prev.filter((_, i) => i !== index));
+		},
+		[setReferenceVideos],
+	);
 
 	const canGenerate = prompt.trim().length > 0 && selectedModels.length > 0;
 	const canAcceptInput = canUseFrameInputs || canUseReferenceInputs;
@@ -125,6 +152,7 @@ export function VideoControls({
 
 				if (target === "frame-start") {
 					setReferenceImages([]);
+					setReferenceVideos([]);
 					setFrameInputs((prev) => ({
 						...prev,
 						start: nextImage,
@@ -134,6 +162,7 @@ export function VideoControls({
 
 				if (target === "frame-end") {
 					setReferenceImages([]);
+					setReferenceVideos([]);
 					setFrameInputs((prev) => ({
 						...prev,
 						end: nextImage,
@@ -162,6 +191,7 @@ export function VideoControls({
 			defaultUploadTarget,
 			setFrameInputs,
 			setReferenceImages,
+			setReferenceVideos,
 		],
 	);
 
@@ -365,6 +395,28 @@ export function VideoControls({
 							))}
 						</div>
 					)}
+					{referenceVideos.length > 0 && (
+						<div className="flex flex-wrap gap-2 px-3 pt-3">
+							{referenceVideos.map((url, index) => (
+								<div
+									key={`${url}-${index}`}
+									className="group relative flex max-w-[220px] items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2 pr-6 text-xs"
+									title={url}
+								>
+									<Film className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+									<span className="truncate">Reference video {index + 1}</span>
+									<button
+										type="button"
+										aria-label="Remove reference video"
+										onClick={() => removeReferenceVideo(index)}
+										className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border bg-background text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground"
+									>
+										<X className="h-3 w-3" />
+									</button>
+								</div>
+							))}
+						</div>
+					)}
 					<Textarea
 						ref={textareaRef}
 						value={prompt}
@@ -432,6 +484,39 @@ export function VideoControls({
 							? "Reference"
 							: `${referenceImages.length}/3 refs`}
 					</Button>
+					{canUseReferenceVideoInputs && (
+						<div className="flex items-center gap-1.5">
+							<Input
+								value={referenceVideoDraft}
+								onChange={(e) => setReferenceVideoDraft(e.target.value)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										addReferenceVideo();
+									}
+								}}
+								placeholder="Reference video URL (https://)"
+								disabled={isGenerating || referenceVideos.length >= 3}
+								className="h-8 w-[220px] text-sm"
+							/>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={addReferenceVideo}
+								disabled={
+									isGenerating ||
+									referenceVideos.length >= 3 ||
+									!/^https:\/\//i.test(referenceVideoDraft.trim())
+								}
+								title="Add an HTTPS reference video URL"
+							>
+								<Plus className="mr-1.5 h-4 w-4" />
+								{referenceVideos.length === 0
+									? "Video"
+									: `${referenceVideos.length}/3 videos`}
+							</Button>
+						</div>
+					)}
 					<Select
 						value={videoSize}
 						onValueChange={(val) => setVideoSize(val as VideoSize)}

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -33,6 +33,7 @@ import {
 	supportsVideoFrameInput,
 	supportsVideoReferenceInput,
 	supportsVideoReferenceVideoInput,
+	supportsVideoReferenceAudioInput,
 } from "@/lib/video-gen";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
@@ -131,6 +132,7 @@ export default function VideoPageClient({
 	});
 	const [referenceImages, setReferenceImages] = useState<VideoInputImage[]>([]);
 	const [referenceVideos, setReferenceVideos] = useState<string[]>([]);
+	const [referenceAudios, setReferenceAudios] = useState<string[]>([]);
 	const availableModelsById = useMemo(
 		() => new Map(availableModels.map((model) => [model.id, model])),
 		[availableModels],
@@ -259,6 +261,14 @@ export default function VideoPageClient({
 			selectedModels.length > 0 &&
 			selectedModels.every((modelId) =>
 				supportsVideoReferenceVideoInput(modelId),
+			),
+		[selectedModels],
+	);
+	const canUseReferenceAudioInputs = useMemo(
+		() =>
+			selectedModels.length > 0 &&
+			selectedModels.every((modelId) =>
+				supportsVideoReferenceAudioInput(modelId),
 			),
 		[selectedModels],
 	);
@@ -404,10 +414,22 @@ export default function VideoPageClient({
 		if (!canUseReferenceVideoInputs) {
 			setReferenceVideos([]);
 		}
-	}, [canUseFrameInputs, canUseReferenceInputs, canUseReferenceVideoInputs]);
+		if (!canUseReferenceAudioInputs) {
+			setReferenceAudios([]);
+		}
+	}, [
+		canUseFrameInputs,
+		canUseReferenceInputs,
+		canUseReferenceVideoInputs,
+		canUseReferenceAudioInputs,
+	]);
 
 	const videoInputMode = useMemo(() => {
-		if (referenceImages.length > 0 || referenceVideos.length > 0) {
+		if (
+			referenceImages.length > 0 ||
+			referenceVideos.length > 0 ||
+			referenceAudios.length > 0
+		) {
 			return "reference" as const;
 		}
 
@@ -421,6 +443,7 @@ export default function VideoPageClient({
 		frameInputs.start,
 		referenceImages.length,
 		referenceVideos.length,
+		referenceAudios.length,
 	]);
 
 	const supportedVideoRequestOptions = useMemo(
@@ -559,6 +582,7 @@ export default function VideoPageClient({
 				has_frame_inputs: !!(frameInputs.start ?? frameInputs.end),
 				has_reference_images: referenceImages.length > 0,
 				has_reference_videos: referenceVideos.length > 0,
+				has_reference_audios: referenceAudios.length > 0,
 			});
 
 			const itemId = crypto.randomUUID();
@@ -593,6 +617,7 @@ export default function VideoPageClient({
 			});
 			setReferenceImages([]);
 			setReferenceVideos([]);
+			setReferenceAudios([]);
 
 			pendingRef.current = modelsToGenerate.length;
 
@@ -618,6 +643,7 @@ export default function VideoPageClient({
 								audio: effectiveAudioEnabled,
 								...(referenceImages.length === 0 &&
 								referenceVideos.length === 0 &&
+								referenceAudios.length === 0 &&
 								frameInputs.start
 									? {
 											image: {
@@ -627,6 +653,7 @@ export default function VideoPageClient({
 									: {}),
 								...(referenceImages.length === 0 &&
 								referenceVideos.length === 0 &&
+								referenceAudios.length === 0 &&
 								frameInputs.end
 									? {
 											last_frame: {
@@ -644,6 +671,11 @@ export default function VideoPageClient({
 								...(referenceVideos.length > 0
 									? {
 											reference_videos: referenceVideos,
+										}
+									: {}),
+								...(referenceAudios.length > 0
+									? {
+											reference_audios: referenceAudios,
 										}
 									: {}),
 							}),
@@ -731,6 +763,7 @@ export default function VideoPageClient({
 			posthog,
 			referenceImages,
 			referenceVideos,
+			referenceAudios,
 			updateGalleryModel,
 			pathname,
 			router,
@@ -791,6 +824,7 @@ export default function VideoPageClient({
 		setFrameInputs({ start: null, end: null });
 		setReferenceImages([]);
 		setReferenceVideos([]);
+		setReferenceAudios([]);
 		setIsGenerating(false);
 		setComparisonMode(false);
 		pendingRef.current = 0;
@@ -883,12 +917,15 @@ export default function VideoPageClient({
 						canUseFrameInputs={canUseFrameInputs}
 						canUseReferenceInputs={canUseReferenceInputs}
 						canUseReferenceVideoInputs={canUseReferenceVideoInputs}
+						canUseReferenceAudioInputs={canUseReferenceAudioInputs}
 						frameInputs={frameInputs}
 						setFrameInputs={setFrameInputs}
 						referenceImages={referenceImages}
 						setReferenceImages={setReferenceImages}
 						referenceVideos={referenceVideos}
 						setReferenceVideos={setReferenceVideos}
+						referenceAudios={referenceAudios}
+						setReferenceAudios={setReferenceAudios}
 						supportedVideoSizes={supportedVideoRequestOptions.sizes}
 						supportedVideoDurations={supportedVideoRequestOptions.durations}
 						isGenerating={isGenerating}

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -32,6 +32,7 @@ import {
 	pollVideoJob,
 	supportsVideoFrameInput,
 	supportsVideoReferenceInput,
+	supportsVideoReferenceVideoInput,
 } from "@/lib/video-gen";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
@@ -129,6 +130,7 @@ export default function VideoPageClient({
 		end: null,
 	});
 	const [referenceImages, setReferenceImages] = useState<VideoInputImage[]>([]);
+	const [referenceVideos, setReferenceVideos] = useState<string[]>([]);
 	const availableModelsById = useMemo(
 		() => new Map(availableModels.map((model) => [model.id, model])),
 		[availableModels],
@@ -250,6 +252,14 @@ export default function VideoPageClient({
 		() =>
 			selectedModels.length > 0 &&
 			selectedModels.every((modelId) => supportsVideoReferenceInput(modelId)),
+		[selectedModels],
+	);
+	const canUseReferenceVideoInputs = useMemo(
+		() =>
+			selectedModels.length > 0 &&
+			selectedModels.every((modelId) =>
+				supportsVideoReferenceVideoInput(modelId),
+			),
 		[selectedModels],
 	);
 	const requiresAudioSelection = useMemo(
@@ -391,10 +401,13 @@ export default function VideoPageClient({
 		if (!canUseReferenceInputs) {
 			setReferenceImages([]);
 		}
-	}, [canUseFrameInputs, canUseReferenceInputs]);
+		if (!canUseReferenceVideoInputs) {
+			setReferenceVideos([]);
+		}
+	}, [canUseFrameInputs, canUseReferenceInputs, canUseReferenceVideoInputs]);
 
 	const videoInputMode = useMemo(() => {
-		if (referenceImages.length > 0) {
+		if (referenceImages.length > 0 || referenceVideos.length > 0) {
 			return "reference" as const;
 		}
 
@@ -403,7 +416,12 @@ export default function VideoPageClient({
 		}
 
 		return "none" as const;
-	}, [frameInputs.end, frameInputs.start, referenceImages.length]);
+	}, [
+		frameInputs.end,
+		frameInputs.start,
+		referenceImages.length,
+		referenceVideos.length,
+	]);
 
 	const supportedVideoRequestOptions = useMemo(
 		() =>
@@ -540,6 +558,7 @@ export default function VideoPageClient({
 				audio_enabled: effectiveAudioEnabled,
 				has_frame_inputs: !!(frameInputs.start ?? frameInputs.end),
 				has_reference_images: referenceImages.length > 0,
+				has_reference_videos: referenceVideos.length > 0,
 			});
 
 			const itemId = crypto.randomUUID();
@@ -573,6 +592,7 @@ export default function VideoPageClient({
 				end: null,
 			});
 			setReferenceImages([]);
+			setReferenceVideos([]);
 
 			pendingRef.current = modelsToGenerate.length;
 
@@ -596,14 +616,18 @@ export default function VideoPageClient({
 								size: videoSize,
 								seconds: videoDuration,
 								audio: effectiveAudioEnabled,
-								...(referenceImages.length === 0 && frameInputs.start
+								...(referenceImages.length === 0 &&
+								referenceVideos.length === 0 &&
+								frameInputs.start
 									? {
 											image: {
 												image_url: frameInputs.start.dataUrl,
 											},
 										}
 									: {}),
-								...(referenceImages.length === 0 && frameInputs.end
+								...(referenceImages.length === 0 &&
+								referenceVideos.length === 0 &&
+								frameInputs.end
 									? {
 											last_frame: {
 												image_url: frameInputs.end.dataUrl,
@@ -615,6 +639,11 @@ export default function VideoPageClient({
 											reference_images: referenceImages.map((image) => ({
 												image_url: image.dataUrl,
 											})),
+										}
+									: {}),
+								...(referenceVideos.length > 0
+									? {
+											reference_videos: referenceVideos,
 										}
 									: {}),
 							}),
@@ -701,6 +730,7 @@ export default function VideoPageClient({
 			frameInputs,
 			posthog,
 			referenceImages,
+			referenceVideos,
 			updateGalleryModel,
 			pathname,
 			router,
@@ -760,6 +790,7 @@ export default function VideoPageClient({
 		setPrompt("");
 		setFrameInputs({ start: null, end: null });
 		setReferenceImages([]);
+		setReferenceVideos([]);
 		setIsGenerating(false);
 		setComparisonMode(false);
 		pendingRef.current = 0;
@@ -851,10 +882,13 @@ export default function VideoPageClient({
 						audioToggleDisabled={isGenerating || requiresAudioSelection}
 						canUseFrameInputs={canUseFrameInputs}
 						canUseReferenceInputs={canUseReferenceInputs}
+						canUseReferenceVideoInputs={canUseReferenceVideoInputs}
 						frameInputs={frameInputs}
 						setFrameInputs={setFrameInputs}
 						referenceImages={referenceImages}
 						setReferenceImages={setReferenceImages}
+						referenceVideos={referenceVideos}
+						setReferenceVideos={setReferenceVideos}
 						supportedVideoSizes={supportedVideoRequestOptions.sizes}
 						supportedVideoDurations={supportedVideoRequestOptions.durations}
 						isGenerating={isGenerating}

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -5,6 +5,8 @@ import {
 	getSupportedVideoRequestOptions,
 	getSupportedVideoSizesForSelection,
 	getNormalizedVideoRequestSelection,
+	supportsVideoReferenceInput,
+	supportsVideoReferenceVideoInput,
 } from "./video-gen";
 
 import type { ApiModel, ApiModelProviderMapping } from "./fetch-models";
@@ -202,5 +204,73 @@ describe("getSupportedVideoSizesForSelection", () => {
 		);
 
 		expect(frameSizes).toEqual(textSizes);
+	});
+});
+
+describe("Seedance 2.0 reference capabilities", () => {
+	function makeSeedanceMapping(
+		overrides: Partial<ApiModelProviderMapping> = {},
+	): ApiModelProviderMapping {
+		return makeMapping({
+			modelId: "seedance-2-0",
+			providerId: "bytedance",
+			externalId: "dreamina-seedance-2-0-260128",
+			supportedVideoSizes: ["1280x720", "720x1280", "1920x1080", "1080x1920"],
+			supportedVideoDurationsSeconds: [5, 10],
+			supportedVideoDurationsSecondsImageToVideo: null,
+			...overrides,
+		});
+	}
+
+	test("supportsVideoReferenceInput is true for Seedance 2.0", () => {
+		expect(supportsVideoReferenceInput("seedance-2-0")).toBe(true);
+		expect(supportsVideoReferenceInput("seedance-2-0-fast")).toBe(true);
+		expect(supportsVideoReferenceInput("bytedance/seedance-2-0")).toBe(true);
+		expect(supportsVideoReferenceInput("bytedance/seedance-1-5-pro")).toBe(
+			false,
+		);
+	});
+
+	test("supportsVideoReferenceVideoInput is restricted to Seedance 2.0 bytedance", () => {
+		expect(supportsVideoReferenceVideoInput("seedance-2-0")).toBe(true);
+		expect(
+			supportsVideoReferenceVideoInput("bytedance/seedance-2-0-fast"),
+		).toBe(true);
+		expect(supportsVideoReferenceVideoInput("google-vertex/seedance-2-0")).toBe(
+			false,
+		);
+		expect(supportsVideoReferenceVideoInput("veo-3.1-generate-preview")).toBe(
+			false,
+		);
+	});
+
+	test("reference mode is supported for Seedance 2.0 mappings", () => {
+		const model = makeModel([makeSeedanceMapping()], "seedance-2-0");
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["seedance-2-0"],
+			"reference",
+			true,
+		);
+
+		expect(options.sizes).toContain("1280x720");
+		expect(options.sizes).toContain("1920x1080");
+		expect(options.durations).toContain(10);
+	});
+
+	test("reference mode is rejected for non-2.0 bytedance models", () => {
+		const model = makeModel(
+			[makeSeedanceMapping({ modelId: "seedance-1-5-pro" })],
+			"seedance-1-5-pro",
+		);
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["seedance-1-5-pro"],
+			"reference",
+			true,
+		);
+
+		expect(options.sizes).toHaveLength(0);
+		expect(options.durations).toHaveLength(0);
 	});
 });

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -7,6 +7,7 @@ import {
 	getNormalizedVideoRequestSelection,
 	supportsVideoReferenceInput,
 	supportsVideoReferenceVideoInput,
+	supportsVideoReferenceAudioInput,
 } from "./video-gen";
 
 import type { ApiModel, ApiModelProviderMapping } from "./fetch-models";
@@ -240,6 +241,19 @@ describe("Seedance 2.0 reference capabilities", () => {
 			false,
 		);
 		expect(supportsVideoReferenceVideoInput("veo-3.1-generate-preview")).toBe(
+			false,
+		);
+	});
+
+	test("supportsVideoReferenceAudioInput is restricted to Seedance 2.0 bytedance", () => {
+		expect(supportsVideoReferenceAudioInput("seedance-2-0")).toBe(true);
+		expect(
+			supportsVideoReferenceAudioInput("bytedance/seedance-2-0-fast"),
+		).toBe(true);
+		expect(supportsVideoReferenceAudioInput("google-vertex/seedance-2-0")).toBe(
+			false,
+		);
+		expect(supportsVideoReferenceAudioInput("veo-3.1-generate-preview")).toBe(
 			false,
 		);
 	});

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -104,10 +104,18 @@ export function supportsVideoFrameInput(modelId: string): boolean {
 	);
 }
 
+function isSeedance2ReferenceModel(rootModelId: string): boolean {
+	return rootModelId === "seedance-2-0" || rootModelId === "seedance-2-0-fast";
+}
+
 export function supportsVideoReferenceInput(modelId: string): boolean {
 	const [providerId, rootModelId] = modelId.includes("/")
 		? modelId.split("/", 2)
 		: [undefined, modelId];
+
+	if (providerId === "bytedance") {
+		return isSeedance2ReferenceModel(rootModelId);
+	}
 
 	if (providerId === "google-vertex") {
 		return rootModelId === "veo-3.1-generate-preview";
@@ -119,8 +127,21 @@ export function supportsVideoReferenceInput(modelId: string): boolean {
 
 	return (
 		rootModelId === "veo-3.1-generate-preview" ||
-		rootModelId === "veo-3.1-fast-generate-preview"
+		rootModelId === "veo-3.1-fast-generate-preview" ||
+		isSeedance2ReferenceModel(rootModelId)
 	);
+}
+
+export function supportsVideoReferenceVideoInput(modelId: string): boolean {
+	const [providerId, rootModelId] = modelId.includes("/")
+		? modelId.split("/", 2)
+		: [undefined, modelId];
+
+	if (providerId !== undefined && providerId !== "bytedance") {
+		return false;
+	}
+
+	return isSeedance2ReferenceModel(rootModelId);
 }
 
 function getSelectedVideoMappings(
@@ -180,8 +201,15 @@ function mappingSupportsVideoRequest(
 	}
 
 	if (inputMode === "reference") {
-		// Reference images are only supported on the veo-3.1 family. Match by
-		// canonical root model id — never by the upstream externalId.
+		// Match by canonical root model id — never by the upstream externalId.
+		if (mapping.providerId === "bytedance") {
+			return (
+				mapping.modelId === "seedance-2-0" ||
+				mapping.modelId === "seedance-2-0-fast"
+			);
+		}
+
+		// Veo reference images are only supported on the veo-3.1 family.
 		if (mapping.modelId !== "veo-3.1-generate-preview") {
 			return false;
 		}

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -144,6 +144,18 @@ export function supportsVideoReferenceVideoInput(modelId: string): boolean {
 	return isSeedance2ReferenceModel(rootModelId);
 }
 
+export function supportsVideoReferenceAudioInput(modelId: string): boolean {
+	const [providerId, rootModelId] = modelId.includes("/")
+		? modelId.split("/", 2)
+		: [undefined, modelId];
+
+	if (providerId !== undefined && providerId !== "bytedance") {
+		return false;
+	}
+
+	return isSeedance2ReferenceModel(rootModelId);
+}
+
 function getSelectedVideoMappings(
 	models: ApiModel[],
 	modelId: string,

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -31,6 +31,7 @@ import {
 	getAvalancheApiBaseUrl,
 	getAvalancheJobsApiBaseUrl,
 	getVideoProxyRedisKey,
+	isContentFilterErrorText,
 	VIDEO_PROXY_REDIS_TTL_SECONDS,
 } from "@llmgateway/shared";
 import {
@@ -1691,6 +1692,20 @@ async function finalizeVideoJob(job: VideoJobRecord): Promise<void> {
 						]
 					: null;
 
+			const isContentFilterFailure =
+				jobToLog.status === "failed" &&
+				isContentFilterErrorText(
+					[jobToLog.error?.code, jobToLog.error?.message]
+						.filter(Boolean)
+						.join(" "),
+				);
+			const failureFinishReason = isContentFilterFailure
+				? "content_filter"
+				: "upstream_error";
+			const failureUnifiedFinishReason = isContentFilterFailure
+				? UnifiedFinishReason.CONTENT_FILTER
+				: UnifiedFinishReason.UPSTREAM_ERROR;
+
 			await tx.insert(tables.log).values({
 				id: logId,
 				requestId: jobToLog.requestId,
@@ -1709,11 +1724,11 @@ async function finalizeVideoJob(job: VideoJobRecord): Promise<void> {
 						? buildGatewayVideoLogContentUrl(logId)
 						: null,
 				finishReason:
-					jobToLog.status === "completed" ? "completed" : "upstream_error",
+					jobToLog.status === "completed" ? "completed" : failureFinishReason,
 				unifiedFinishReason:
 					jobToLog.status === "completed"
 						? UnifiedFinishReason.COMPLETED
-						: UnifiedFinishReason.UPSTREAM_ERROR,
+						: failureUnifiedFinishReason,
 				hasError: jobToLog.status !== "completed",
 				errorDetails: jobToLog.error
 					? {

--- a/packages/shared/src/content-filter.spec.ts
+++ b/packages/shared/src/content-filter.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import { isContentFilterErrorText } from "./content-filter.js";
+
+describe("isContentFilterErrorText", () => {
+	test("detects ByteDance Seedance video output moderation", () => {
+		expect(
+			isContentFilterErrorText("OutputVideoSensitiveContentDetected"),
+		).toBe(true);
+		expect(
+			isContentFilterErrorText(
+				"OutputVideoSensitiveContentDetected.PolicyViolation: the output video may be related to copyright restrictions",
+			),
+		).toBe(true);
+	});
+
+	test("detects other provider moderation signals", () => {
+		expect(isContentFilterErrorText("ResponsibleAIPolicyViolation")).toBe(true);
+		expect(isContentFilterErrorText("data_inspection_failed")).toBe(true);
+		expect(
+			isContentFilterErrorText(
+				"Your request was rejected by the safety system",
+			),
+		).toBe(true);
+		expect(
+			isContentFilterErrorText(
+				"Blocked by Microsoft's content management policy",
+			),
+		).toBe(true);
+	});
+
+	test("returns false for generic upstream errors and empty input", () => {
+		expect(isContentFilterErrorText("Internal server error")).toBe(false);
+		expect(isContentFilterErrorText("the task id was not found")).toBe(false);
+		expect(isContentFilterErrorText(null)).toBe(false);
+		expect(isContentFilterErrorText(undefined)).toBe(false);
+		expect(isContentFilterErrorText("")).toBe(false);
+	});
+});

--- a/packages/shared/src/content-filter.ts
+++ b/packages/shared/src/content-filter.ts
@@ -1,0 +1,36 @@
+/**
+ * Text fragments that uniquely identify a provider content-moderation / safety
+ * block in an upstream error payload. Used to classify a request's finish reason
+ * as `content_filter` rather than a generic upstream error.
+ *
+ * Covers chat, image, and video generation providers:
+ * - Azure OpenAI: `ResponsibleAIPolicyViolation`, `Microsoft's content management policy`
+ * - ByteDance / DeepSeek (incl. Seedance video moderation, e.g.
+ *   `OutputVideoSensitiveContentDetected`): `SensitiveContentDetected`
+ * - Alibaba / DashScope: `data_inspection_failed`
+ * - OpenAI safety system (e.g. Sora / gpt-image): `rejected by the safety system`
+ */
+const CONTENT_FILTER_ERROR_SIGNALS = [
+	"ResponsibleAIPolicyViolation",
+	"SensitiveContentDetected",
+	"data_inspection_failed",
+	"Input data may contain inappropriate content",
+	"Microsoft's content management policy",
+	"Your request was rejected by the safety system",
+];
+
+/**
+ * Returns true when the provided upstream error text indicates a provider
+ * content-moderation / safety block. Status-code-dependent cases (e.g. xAI's
+ * 403 "Content violates usage guidelines") are intentionally excluded and must
+ * be handled by the caller alongside the relevant status code.
+ */
+export function isContentFilterErrorText(
+	text: string | null | undefined,
+): boolean {
+	if (!text) {
+		return false;
+	}
+
+	return CONTENT_FILTER_ERROR_SIGNALS.some((signal) => text.includes(signal));
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -62,6 +62,8 @@ export {
 
 export { selectLoadBalancedItem } from "./load-balance.js";
 
+export { isContentFilterErrorText } from "./content-filter.js";
+
 export {
 	estimateChatMessageTokens,
 	estimateTokensFromText,


### PR DESCRIPTION
## Summary

Adds support for **reference-guided video generation on ByteDance Seedance 2.0** (`seedance-2-0`, `seedance-2-0-fast`) — the model's "omni / all-round reference" feature.

- New request field **`reference_videos`**: 1–3 reference video **HTTPS URLs** (base64 data URLs are rejected for videos; URLs are passed straight through to ByteDance per the chosen design).
- Enables the existing **reference image** path (`reference_images` / `input_reference`) for Seedance 2.0, which was previously blocked for the `bytedance` provider.
- Reference inputs are sent to ModelArk's `/contents/generations/tasks` `content` array with the correct **roles**: `first_frame`, `reference_image`, and `reference_video` (`type: "video_url"`).
- Reference videos and images can be combined in a single request; reference inputs still cannot be combined with `image`/`last_frame` frame inputs.
- Reference videos are restricted to Seedance 2.0 models — other providers (Sora/Veo) return a clear `400`.

## Validation / constraints

- `reference_videos` must be HTTPS (zod refine).
- Frame inputs + reference inputs → `400` (existing rule extended to `reference_videos`).
- Reference videos on non-ByteDance models → `400` ("reference videos are currently only supported on bytedance Seedance 2.0 models").
- Reference inputs on non-2.0 ByteDance models (e.g. Seedance 1.5 Pro) → `400`.

## Tests

Added 4 unit tests in `videos.spec.ts` covering the validation/constraint paths above (no upstream mock required). Full `videos.spec.ts` suite passes (26 tests).

## Docs

Updated `video-generation.mdx` with the `reference_videos` field and a Seedance 2.0 omni-reference section with an example request.

## Notes

The official BytePlus ModelArk docs are a JS-rendered SPA that couldn't be scraped directly; model IDs (`dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`), the endpoint, and the `content`-array `role` shape were cross-checked against the IDs already present in `packages/models` and ByteDance developer references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reference video and reference audio input support for video generation (HTTPS URLs only)
  * Ability to combine reference videos/audios with reference images in the same request
  * Supported for Seedance 2.0 ByteDance models only

* **Documentation**
  * Updated video generation guide with combined reference inputs and examples

* **UI**
  * Playground controls now allow adding/removing reference video and audio URLs with validation

* **Tests**
  * Added validation tests for reference video and reference audio constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->