### PR TITLE
fix(moonshot): deactivate dead kimi-k2 mappings

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -24,6 +24,8 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				// 404 model_not_found: moonshotai/kimi-k2-instruct no longer served
+				deactivatedAt: new Date("2026-06-05"),
 			},
 			{
 				providerId: "novita",
@@ -53,6 +55,8 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				// 404 resource_not_found: kimi-k2-0905-preview no longer served
+				deactivatedAt: new Date("2026-06-05"),
 			},
 			{
 				providerId: "nebius",
@@ -81,6 +85,8 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: false,
+				// 404 InvalidEndpointOrModel.NotFound: kimi-k2-250905 no longer served
+				deactivatedAt: new Date("2026-06-05"),
 			},
 			{
 				test: "skip",


### PR DESCRIPTION
## Summary

Ran the gateway e2e suite against every base `kimi-k2` provider mapping (only `kimi-k2`, excluding `kimi-k2.6`). Three providers now return `404 model_not_found` upstream and are deactivated; the one that still works is left active.

| Mapping | e2e result | Action |
|---|---|---|
| `moonshot/kimi-k2` (`kimi-k2-0905-preview`) | 404 `resource_not_found_error` | deactivated |
| `groq/kimi-k2` (`moonshotai/kimi-k2-instruct`) | 404 `model_not_found` | deactivated |
| `bytedance/kimi-k2` (`kimi-k2-250905`) | 404 `InvalidEndpointOrModel.NotFound` | deactivated |
| `novita/kimi-k2` | 200 ✓ | kept active |
| `nebius/kimi-k2` | — | already deactivated (2026-04-25) |
| `alibaba/kimi-k2` | — | `test: "skip"` (cn-beijing, untestable) |

## Test plan

- `TEST_MODELS="<provider>/kimi-k2" pnpm test:e2e` per provider, confirming the 404 upstream errors above
- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deactivated three Kimi-K2 model variants (Groq provider, preview version, and 250905 version) as of June 5, 2026. These model combinations are no longer available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->