### PR TITLE
feat(admin): all-time devpass cost and margin

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8644,6 +8644,9 @@ const devpassSubscriberSchema = z.object({
 	realCost: z.number(),
 	margin: z.number(),
 	marginPct: z.number().nullable(),
+	allTimeRevenue: z.number(),
+	allTimeCost: z.number(),
+	allTimeMargin: z.number(),
 	subscribedSince: z.string().nullable(),
 	tierChanges: z.number(),
 	lastPaymentFailureAt: z.string().nullable(),
@@ -8692,6 +8695,9 @@ const devpassSortBySchema = z.enum([
 	"margin",
 	"mrr",
 	"creditsUsed",
+	"allTimeRevenue",
+	"allTimeCost",
+	"allTimeMargin",
 ]);
 
 const devpassUtilizationSchema = z.enum(["low", "healthy", "high", "over"]);
@@ -8855,6 +8861,22 @@ const getDevpassUsage = createRoute({
 	},
 });
 
+const DEV_PLAN_TX_TYPES = [
+	"dev_plan_start",
+	"dev_plan_upgrade",
+	"dev_plan_downgrade",
+	"dev_plan_renewal",
+] as const;
+
+// Pre-rename rows for what is now a dev plan. The same `subscription_*` types
+// are STILL written today for non-personal org Pro subs, so always pair them
+// with `organization.isPersonal = true` to avoid counting org Pro revenue.
+const LEGACY_DEV_PLAN_TX_TYPES = [
+	"subscription_start",
+	"subscription_cancel",
+	"subscription_end",
+] as const;
+
 function tierPriceOf(tier: string): number {
 	if (tier === "lite" || tier === "pro" || tier === "max") {
 		return DEV_PLAN_PRICES[tier];
@@ -8981,6 +9003,101 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.where(eq(tables.userOrganization.role, "owner"))
 		.as("owner_sub");
 
+	// All-time provider cost per org: every project, every cycle, no status or
+	// billing-cycle window. Unlike `realCostSub` (current cycle only) this never
+	// collapses to 0 when a renewal advances `devPlanBillingCycleStart` or when
+	// the org is blocked/expired, so the admin always sees the true spend.
+	const allTimeCostSub = db
+		.select({
+			organizationId: tables.project.organizationId,
+			cost: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+				"all_time_cost",
+			),
+		})
+		.from(projectHourlyStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyStats.projectId, tables.project.id),
+		)
+		.groupBy(tables.project.organizationId)
+		.as("all_time_cost_sub");
+
+	// All-time DevPass revenue per org: sum of completed dev plan payments
+	// (`amount` = actual dollars paid). Deduplicated by invoice with the same
+	// NOT EXISTS guard as the timeseries endpoint — the first invoice of a
+	// subscription inserts BOTH a `dev_plan_start` and a `dev_plan_renewal` row,
+	// which would otherwise double-count. The list is already scoped to personal
+	// orgs, so legacy `subscription_*` rows are safe to include unconditionally
+	// (the left join discards any non-personal org's revenue).
+	const allTimeRevenueSub = db
+		.select({
+			organizationId: tables.transaction.organizationId,
+			revenue:
+				sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"all_time_revenue",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				sql`NOT EXISTS (
+					SELECT 1 FROM ${tables.transaction} dup
+					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
+						AND dup.stripe_invoice_id IS NOT NULL
+						AND dup.organization_id = ${tables.transaction.organizationId}
+						AND dup.id <> ${tables.transaction.id}
+						AND dup.status = 'completed'
+						AND dup.amount IS NOT NULL
+						AND dup.type IN (
+							'dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal',
+							'subscription_start', 'subscription_cancel', 'subscription_end'
+						)
+						AND (
+							dup.created_at < ${tables.transaction.createdAt}
+							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
+						)
+				)`,
+			),
+		)
+		.groupBy(tables.transaction.organizationId)
+		.as("all_time_revenue_sub");
+
+	// Refunds against DevPass payments per org, netted out of revenue.
+	const allTimeRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"all_time_refund_original_tx",
+	);
+	const allTimeRefundSub = db
+		.select({
+			organizationId: tables.transaction.organizationId,
+			refund:
+				sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"all_time_refund",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			allTimeRefundOriginalTx,
+			eq(tables.transaction.relatedTransactionId, allTimeRefundOriginalTx.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				inArray(allTimeRefundOriginalTx.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+			),
+		)
+		.groupBy(tables.transaction.organizationId)
+		.as("all_time_refund_sub");
+
 	const tierPriceExpr = sql<number>`CASE
 		WHEN ${tables.organization.devPlan} = 'lite' THEN ${DEV_PLAN_PRICES.lite}
 		WHEN ${tables.organization.devPlan} = 'pro' THEN ${DEV_PLAN_PRICES.pro}
@@ -8997,6 +9114,10 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 
 	const realCostExpr = sql<number>`COALESCE(CAST(${realCostSub.realCost} AS NUMERIC), 0)`;
 	const marginExpr = sql<number>`(${tierPriceExpr}) - COALESCE(CAST(${realCostSub.realCost} AS NUMERIC), 0)`;
+
+	const allTimeCostExpr = sql<number>`COALESCE(CAST(${allTimeCostSub.cost} AS NUMERIC), 0)`;
+	const allTimeRevenueExpr = sql<number>`(COALESCE(CAST(${allTimeRevenueSub.revenue} AS NUMERIC), 0) - COALESCE(CAST(${allTimeRefundSub.refund} AS NUMERIC), 0))`;
+	const allTimeMarginExpr = sql<number>`(${allTimeRevenueExpr}) - (${allTimeCostExpr})`;
 
 	const conditions = [];
 
@@ -9089,6 +9210,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		margin: sql`${marginExpr}`,
 		mrr: sql`${tierPriceExpr}`,
 		creditsUsed: sql`CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC)`,
+		allTimeRevenue: sql`${allTimeRevenueExpr}`,
+		allTimeCost: sql`${allTimeCostExpr}`,
+		allTimeMargin: sql`${allTimeMarginExpr}`,
 	} as const;
 	const sortColumn = sortColumnMap[sortBy];
 
@@ -9110,6 +9234,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			mrr: tierPriceExpr,
 			realCost: realCostExpr,
 			margin: marginExpr,
+			allTimeRevenue: allTimeRevenueExpr,
+			allTimeCost: allTimeCostExpr,
+			allTimeMargin: allTimeMarginExpr,
 			subscribedSince: subscribedSinceSub.firstStart,
 			tierChanges: sql<number>`COALESCE(${tierChangesSub.count}, 0)`,
 			lastPaymentFailureAt: lastPaymentFailureSub.lastFailureAt,
@@ -9134,7 +9261,19 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			lastPaymentFailureSub,
 			eq(tables.organization.id, lastPaymentFailureSub.organizationId),
 		)
-		.leftJoin(ownerSub, eq(tables.organization.id, ownerSub.organizationId));
+		.leftJoin(ownerSub, eq(tables.organization.id, ownerSub.organizationId))
+		.leftJoin(
+			allTimeCostSub,
+			eq(tables.organization.id, allTimeCostSub.organizationId),
+		)
+		.leftJoin(
+			allTimeRevenueSub,
+			eq(tables.organization.id, allTimeRevenueSub.organizationId),
+		)
+		.leftJoin(
+			allTimeRefundSub,
+			eq(tables.organization.id, allTimeRefundSub.organizationId),
+		);
 
 	const rows = await baseSelect
 		.where(whereClause)
@@ -9344,6 +9483,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			realCost: Number(row.realCost ?? 0),
 			margin: marginNum,
 			marginPct,
+			allTimeRevenue: Number(row.allTimeRevenue ?? 0),
+			allTimeCost: Number(row.allTimeCost ?? 0),
+			allTimeMargin: Number(row.allTimeMargin ?? 0),
 			subscribedSince: row.subscribedSince
 				? new Date(row.subscribedSince).toISOString()
 				: null,
@@ -9379,22 +9521,6 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		offset,
 	});
 });
-
-const DEV_PLAN_TX_TYPES = [
-	"dev_plan_start",
-	"dev_plan_upgrade",
-	"dev_plan_downgrade",
-	"dev_plan_renewal",
-] as const;
-
-// Pre-rename rows for what is now a dev plan. The same `subscription_*` types
-// are STILL written today for non-personal org Pro subs, so always pair them
-// with `organization.isPersonal = true` to avoid counting org Pro revenue.
-const LEGACY_DEV_PLAN_TX_TYPES = [
-	"subscription_start",
-	"subscription_cancel",
-	"subscription_end",
-] as const;
 
 // Registered before the `/devpass/{orgId}` handler below: Hono matches routes
 // in registration order, so the literal `/devpass/timeseries` path must be
@@ -9899,6 +10025,86 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 	const mrr = tierPriceOf(org.devPlan);
 	const margin = mrr - realCost;
 
+	// All-time figures: never windowed on the (resettable) billing cycle and
+	// never gated on plan status, so a blocked/expired/renewed org still shows
+	// its true lifetime spend and margin. Mirrors the timeseries definitions —
+	// revenue is the sum of completed dev plan payments (deduped by invoice,
+	// refunds netted), cost is every project's provider cost.
+	const [allTimeCostRow] = await db
+		.select({
+			total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+		})
+		.from(projectHourlyStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyStats.projectId, tables.project.id),
+		)
+		.where(eq(tables.project.organizationId, orgId));
+	const allTimeCost = Number(allTimeCostRow?.total ?? 0);
+
+	const [allTimeRevenueRow] = await db
+		.select({
+			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				sql`NOT EXISTS (
+					SELECT 1 FROM ${tables.transaction} dup
+					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
+						AND dup.stripe_invoice_id IS NOT NULL
+						AND dup.organization_id = ${tables.transaction.organizationId}
+						AND dup.id <> ${tables.transaction.id}
+						AND dup.status = 'completed'
+						AND dup.amount IS NOT NULL
+						AND dup.type IN (
+							'dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal',
+							'subscription_start', 'subscription_cancel', 'subscription_end'
+						)
+						AND (
+							dup.created_at < ${tables.transaction.createdAt}
+							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
+						)
+				)`,
+			),
+		);
+
+	const detailRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"detail_refund_original_tx",
+	);
+	const [allTimeRefundRow] = await db
+		.select({
+			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			detailRefundOriginalTx,
+			eq(tables.transaction.relatedTransactionId, detailRefundOriginalTx.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, orgId),
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				inArray(detailRefundOriginalTx.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+			),
+		);
+
+	const allTimeRevenue =
+		Number(allTimeRevenueRow?.total ?? 0) -
+		Number(allTimeRefundRow?.total ?? 0);
+	const allTimeMargin = allTimeRevenue - allTimeCost;
+
 	const status = deriveStatus(
 		org.devPlan,
 		org.devPlanCancelled,
@@ -9954,6 +10160,9 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 		realCost,
 		margin,
 		marginPct,
+		allTimeRevenue,
+		allTimeCost,
+		allTimeMargin,
 		subscribedSince: firstStartRow?.firstStart
 			? new Date(firstStartRow.firstStart).toISOString()
 			: null,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9007,6 +9007,8 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	// billing-cycle window. Unlike `realCostSub` (current cycle only) this never
 	// collapses to 0 when a renewal advances `devPlanBillingCycleStart` or when
 	// the org is blocked/expired, so the admin always sees the true spend.
+	// Scoped to personal orgs (DevPass is personal-only) so the aggregation
+	// doesn't scan every org's hourly stats.
 	const allTimeCostSub = db
 		.select({
 			organizationId: tables.project.organizationId,
@@ -9019,6 +9021,13 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			tables.project,
 			eq(projectHourlyStats.projectId, tables.project.id),
 		)
+		.innerJoin(
+			tables.organization,
+			and(
+				eq(tables.project.organizationId, tables.organization.id),
+				eq(tables.organization.isPersonal, true),
+			),
+		)
 		.groupBy(tables.project.organizationId)
 		.as("all_time_cost_sub");
 
@@ -9026,9 +9035,9 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	// (`amount` = actual dollars paid). Deduplicated by invoice with the same
 	// NOT EXISTS guard as the timeseries endpoint — the first invoice of a
 	// subscription inserts BOTH a `dev_plan_start` and a `dev_plan_renewal` row,
-	// which would otherwise double-count. The list is already scoped to personal
-	// orgs, so legacy `subscription_*` rows are safe to include unconditionally
-	// (the left join discards any non-personal org's revenue).
+	// which would otherwise double-count. Scoped to personal orgs so legacy
+	// `subscription_*` rows (still written for non-personal org Pro subs) can't
+	// be misattributed as DevPass revenue.
 	const allTimeRevenueSub = db
 		.select({
 			organizationId: tables.transaction.organizationId,
@@ -9038,6 +9047,13 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 				),
 		})
 		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			and(
+				eq(tables.transaction.organizationId, tables.organization.id),
+				eq(tables.organization.isPersonal, true),
+			),
+		)
 		.where(
 			and(
 				eq(tables.transaction.status, "completed"),
@@ -9067,7 +9083,8 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.groupBy(tables.transaction.organizationId)
 		.as("all_time_revenue_sub");
 
-	// Refunds against DevPass payments per org, netted out of revenue.
+	// Refunds against DevPass payments per org, netted out of revenue. Scoped to
+	// personal orgs for the same reason as the revenue subquery.
 	const allTimeRefundOriginalTx = aliasedTable(
 		tables.transaction,
 		"all_time_refund_original_tx",
@@ -9084,6 +9101,13 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.innerJoin(
 			allTimeRefundOriginalTx,
 			eq(tables.transaction.relatedTransactionId, allTimeRefundOriginalTx.id),
+		)
+		.innerJoin(
+			tables.organization,
+			and(
+				eq(tables.transaction.organizationId, tables.organization.id),
+				eq(tables.organization.isPersonal, true),
+			),
 		)
 		.where(
 			and(
@@ -10029,7 +10053,12 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 	// never gated on plan status, so a blocked/expired/renewed org still shows
 	// its true lifetime spend and margin. Mirrors the timeseries definitions —
 	// revenue is the sum of completed dev plan payments (deduped by invoice,
-	// refunds netted), cost is every project's provider cost.
+	// refunds netted), cost is every project's provider cost. Legacy
+	// `subscription_*` rows are only DevPass revenue on personal orgs (they are
+	// org Pro subs otherwise), so only count them when the org is personal.
+	const allTimeRevenueTypes = org.isPersonal
+		? [...DEV_PLAN_TX_TYPES, ...LEGACY_DEV_PLAN_TX_TYPES]
+		: [...DEV_PLAN_TX_TYPES];
 	const [allTimeCostRow] = await db
 		.select({
 			total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
@@ -10051,10 +10080,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 			and(
 				eq(tables.transaction.organizationId, orgId),
 				eq(tables.transaction.status, "completed"),
-				inArray(tables.transaction.type, [
-					...DEV_PLAN_TX_TYPES,
-					...LEGACY_DEV_PLAN_TX_TYPES,
-				]),
+				inArray(tables.transaction.type, allTimeRevenueTypes),
 				sql`NOT EXISTS (
 					SELECT 1 FROM ${tables.transaction} dup
 					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
@@ -10093,10 +10119,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 				eq(tables.transaction.organizationId, orgId),
 				eq(tables.transaction.type, "credit_refund"),
 				eq(tables.transaction.status, "completed"),
-				inArray(detailRefundOriginalTx.type, [
-					...DEV_PLAN_TX_TYPES,
-					...LEGACY_DEV_PLAN_TX_TYPES,
-				]),
+				inArray(detailRefundOriginalTx.type, allTimeRevenueTypes),
 			),
 		);
 

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -5832,7 +5832,7 @@ export interface paths {
                     utilization?: "low" | "healthy" | "high" | "over";
                     marginNegative?: boolean | null;
                     showChurned?: boolean | null;
-                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed" | "allTimeRevenue" | "allTimeCost" | "allTimeMargin";
                     sortOrder?: "asc" | "desc";
                 };
                 header?: never;
@@ -5872,6 +5872,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -6078,6 +6081,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -5832,7 +5832,7 @@ export interface paths {
                     utilization?: "low" | "healthy" | "high" | "over";
                     marginNegative?: boolean | null;
                     showChurned?: boolean | null;
-                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed" | "allTimeRevenue" | "allTimeCost" | "allTimeMargin";
                     sortOrder?: "asc" | "desc";
                 };
                 header?: never;
@@ -5872,6 +5872,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -6078,6 +6081,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -5832,7 +5832,7 @@ export interface paths {
                     utilization?: "low" | "healthy" | "high" | "over";
                     marginNegative?: boolean | null;
                     showChurned?: boolean | null;
-                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed" | "allTimeRevenue" | "allTimeCost" | "allTimeMargin";
                     sortOrder?: "asc" | "desc";
                 };
                 header?: never;
@@ -5872,6 +5872,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -6078,6 +6081,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -294,6 +294,57 @@ export default async function DevpassDetailPage({
 				</div>
 			</section>
 
+			<section className="space-y-3">
+				<div className="flex items-center gap-2">
+					<h2 className="text-sm font-semibold tracking-tight">All-time</h2>
+					<span className="text-xs text-muted-foreground">
+						Lifetime totals — unaffected by cycle resets or block/disable
+					</span>
+				</div>
+				<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+					<div className="rounded-lg border border-border/60 bg-card p-4">
+						<div className="text-xs uppercase tracking-wide text-muted-foreground">
+							Revenue (all-time)
+						</div>
+						<div className="mt-2 text-2xl font-semibold tabular-nums">
+							{currencyFormatter.format(sub.allTimeRevenue)}
+						</div>
+						<div className="mt-1 text-xs text-muted-foreground">
+							Net of refunds, across all cycles
+						</div>
+					</div>
+					<div className="rounded-lg border border-border/60 bg-card p-4">
+						<div className="text-xs uppercase tracking-wide text-muted-foreground">
+							Real provider cost (all-time)
+						</div>
+						<div className="mt-2 text-2xl font-semibold tabular-nums">
+							{currencyFormatterPrecise.format(sub.allTimeCost)}
+						</div>
+						<div className="mt-1 text-xs text-muted-foreground">
+							From hourly project stats
+						</div>
+					</div>
+					<div className="rounded-lg border border-border/60 bg-card p-4">
+						<div className="text-xs uppercase tracking-wide text-muted-foreground">
+							Margin (all-time)
+						</div>
+						<div
+							className={cn(
+								"mt-2 text-2xl font-semibold tabular-nums",
+								sub.allTimeMargin < 0
+									? "text-rose-600 dark:text-rose-400"
+									: "text-emerald-600 dark:text-emerald-400",
+							)}
+						>
+							{currencyFormatter.format(sub.allTimeMargin)}
+						</div>
+						<div className="mt-1 text-xs text-muted-foreground">
+							Revenue − provider cost
+						</div>
+					</div>
+				</div>
+			</section>
+
 			<Tabs defaultValue="transactions">
 				<TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
 					<TabsTrigger value="transactions">

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -51,6 +51,9 @@ const SORT_BY_VALUES = [
 	"margin",
 	"mrr",
 	"creditsUsed",
+	"allTimeRevenue",
+	"allTimeCost",
+	"allTimeMargin",
 ] as const;
 type SortBy = (typeof SORT_BY_VALUES)[number];
 
@@ -816,6 +819,24 @@ export default async function DevpassPage({
 							</TableHead>
 							<TableHead>
 								<SortableHeader
+									label="Cost (all-time)"
+									sortKey="allTimeCost"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Margin (all-time)"
+									sortKey="allTimeMargin"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
 									label="Since"
 									sortKey="subscribedSince"
 									currentSortBy={sortBy}
@@ -831,7 +852,7 @@ export default async function DevpassPage({
 						{data.subscribers.length === 0 ? (
 							<TableRow>
 								<TableCell
-									colSpan={12}
+									colSpan={14}
 									className="h-24 text-center text-muted-foreground"
 								>
 									No subscribers match
@@ -889,6 +910,22 @@ export default async function DevpassPage({
 										)}
 									>
 										{currencyFormatter.format(sub.margin)}
+									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground">
+										{currencyFormatterPrecise.format(sub.allTimeCost)}
+									</TableCell>
+									<TableCell
+										className={cn(
+											"tabular-nums",
+											sub.allTimeMargin < 0
+												? "text-rose-600 dark:text-rose-400"
+												: "text-emerald-600 dark:text-emerald-400",
+										)}
+										title={`Revenue ${currencyFormatter.format(
+											sub.allTimeRevenue,
+										)} − cost ${currencyFormatterPrecise.format(sub.allTimeCost)}`}
+									>
+										{currencyFormatter.format(sub.allTimeMargin)}
 									</TableCell>
 									<TableCell className="text-muted-foreground text-xs">
 										{formatDate(sub.subscribedSince)}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -5832,7 +5832,7 @@ export interface paths {
                     utilization?: "low" | "healthy" | "high" | "over";
                     marginNegative?: boolean | null;
                     showChurned?: boolean | null;
-                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed";
+                    sortBy?: "name" | "billingEmail" | "tier" | "createdAt" | "cycleStart" | "expiresAt" | "subscribedSince" | "utilizationPct" | "realCost" | "margin" | "mrr" | "creditsUsed" | "allTimeRevenue" | "allTimeCost" | "allTimeMargin";
                     sortOrder?: "asc" | "desc";
                 };
                 header?: never;
@@ -5872,6 +5872,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;
@@ -6078,6 +6081,9 @@ export interface paths {
                                 realCost: number;
                                 margin: number;
                                 marginPct: number | null;
+                                allTimeRevenue: number;
+                                allTimeCost: number;
+                                allTimeMargin: number;
                                 subscribedSince: string | null;
                                 tierChanges: number;
                                 lastPaymentFailureAt: string | null;


### PR DESCRIPTION
## Problem

The admin DevPass list and detail views computed **real cost** and **margin** only over the *current billing cycle* (cost summed from `project_hourly_stats` since `devPlanBillingCycleStart`; margin = MRR − cycle cost).

That number collapses to zero whenever the cycle pointer moves or the plan is torn down:
- A **renewal** resets `devPlanCreditsUsed → 0` and advances `devPlanBillingCycleStart` (`apps/api/src/stripe.ts`), so the prior cycle's heavy usage falls outside the window.
- **Blocking / cancelling** an org tears down the dev plan fields.

Result: a heavily-used org (e.g. 99% of credits consumed) showed **0% utilization** and an inflated **~100% margin** — its real spend was no longer visible to admins.

## Change

Add **all-time revenue, cost, and margin** that are never windowed on the resettable billing cycle and never gated on plan status, so a blocked/expired/renewed org still shows its true lifetime spend and margin.

Definitions mirror the existing `/admin/devpass/timeseries` endpoint so the numbers reconcile:
- **Revenue** = completed dev plan payments (`amount`), deduped by invoice (the first invoice emits both `dev_plan_start` and `dev_plan_renewal`), refunds netted out.
- **Cost** = every project's provider cost from `project_hourly_stats`, no cycle window.
- **Margin** = revenue − cost.

Surfaced in:
- **List table** (`/devpass`) — new sortable `Cost (all-time)` and `Margin (all-time)` columns.
- **Detail page** (`/devpass/{orgId}`) — new "All-time" section with revenue / provider cost / margin cards.

The existing current-cycle metrics are left in place alongside the new all-time figures.

## Validation

- `pnpm format`, `pnpm turbo run build --filter=api --filter=admin` pass; generated API clients regenerated.
- Ran the per-org all-time SQL against the seeded local DB — produces correct non-zero lifetime values (e.g. a `max` org: revenue \$299, cost \$9.35, margin \$289.65) where the current-cycle figure was \$0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DevPass admin endpoints now expose all-time revenue, cost, and margin metrics per organization
  * Added ability to sort DevPass subscribers by all-time financial metrics
  * New "All-time" metrics summary section displays lifetime totals on DevPass organization detail page
  * DevPass subscribers table now shows all-time cost and margin columns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->