### PR TITLE
fix(admin): default column sort to desc

### DIFF
--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -71,7 +71,7 @@ function SortableHeader({
 	pageWindow?: PageWindow;
 }) {
 	const isActive = currentSortBy === sortKey;
-	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
+	const nextOrder = isActive && currentSortOrder === "desc" ? "asc" : "desc";
 	const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
 	const windowParam = pageWindow ? `&window=${pageWindow}` : "";
 	const href = `/model-provider-mappings?sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}${windowParam}`;

--- a/ee/admin/src/components/models-table.tsx
+++ b/ee/admin/src/components/models-table.tsx
@@ -73,7 +73,7 @@ function SortableHeader({
 	pageWindow?: PageWindow;
 }) {
 	const isActive = currentSortBy === sortKey;
-	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
+	const nextOrder = isActive && currentSortOrder === "desc" ? "asc" : "desc";
 
 	const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
 	const windowParam = pageWindow ? `&window=${pageWindow}` : "";

--- a/ee/admin/src/components/project-mappings-table.tsx
+++ b/ee/admin/src/components/project-mappings-table.tsx
@@ -81,7 +81,7 @@ function SortableHeader({
 	basePath: string;
 }) {
 	const isActive = currentSortBy === sortKey;
-	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
+	const nextOrder = isActive && currentSortOrder === "desc" ? "asc" : "desc";
 	const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
 	const href = `${basePath}?sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}&window=${pageWindow}`;
 

--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -67,7 +67,7 @@ function SortableHeader({
 	pageWindow?: PageWindow;
 }) {
 	const isActive = currentSortBy === sortKey;
-	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
+	const nextOrder = isActive && currentSortOrder === "desc" ? "asc" : "desc";
 
 	const windowParam = pageWindow ? `&window=${pageWindow}` : "";
 	const href = `/providers?sortBy=${sortKey}&sortOrder=${nextOrder}${windowParam}`;


### PR DESCRIPTION
## Summary

In the admin dashboard's **providers**, **models**, and **mappings** tables, clicking an inactive sortable column header previously sorted ascending first. Since descending is what we want ~99% of the time, this flips the default so the first click on a column sorts **descending**, and clicking again toggles to ascending.

## Changes

- `providers-table.tsx`, `models-table.tsx`, `mappings-table.tsx`, `project-mappings-table.tsx`: invert the `nextOrder` logic so an inactive column defaults to `desc`.

`provider-models-table.tsx` already defaulted to `desc` on a fresh column, so it was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)