### PR TITLE
feat(admin): custom date range on global stats

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1074,6 +1074,7 @@ admin.openapi(getTimeseries, async (c) => {
 const globalStatsRangeSchema = z.enum(["7d", "30d", "90d", "365d"]);
 const globalStatsGroupBySchema = z.enum(["model", "source"]);
 const globalStatsModelViewSchema = z.enum(["mapping", "canonical", "provider"]);
+const globalStatsDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
 
 const globalStatsMetricsSchema = z.object({
 	requestCount: z.number(),
@@ -1103,7 +1104,8 @@ const globalStatsBreakdownItemSchema = globalStatsMetricsSchema
 	.openapi({});
 
 const globalStatsResponseSchema = z.object({
-	range: globalStatsRangeSchema,
+	start: z.string(),
+	end: z.string(),
 	groupBy: globalStatsGroupBySchema,
 	modelView: globalStatsModelViewSchema,
 	totals: globalStatsMetricsSchema,
@@ -1117,6 +1119,8 @@ const getGlobalStats = createRoute({
 	request: {
 		query: z.object({
 			range: globalStatsRangeSchema.default("30d").optional(),
+			from: globalStatsDateSchema.optional(),
+			to: globalStatsDateSchema.optional(),
 			groupBy: globalStatsGroupBySchema.default("model").optional(),
 			modelView: globalStatsModelViewSchema.default("mapping").optional(),
 		}),
@@ -1135,23 +1139,45 @@ const getGlobalStats = createRoute({
 
 admin.openapi(getGlobalStats, async (c) => {
 	const query = c.req.valid("query");
-	const range = query.range ?? "30d";
 	const groupBy = query.groupBy ?? "model";
 	const modelView = query.modelView ?? "mapping";
 
-	const rangeDays: Record<typeof range, number> = {
-		"7d": 7,
-		"30d": 30,
-		"90d": 90,
-		"365d": 365,
-	};
-	const days = rangeDays[range];
-
 	const dayMs = 24 * 60 * 60 * 1000;
-	const startDate = new Date();
-	startDate.setUTCHours(0, 0, 0, 0);
-	const startMs = startDate.getTime() - (days - 1) * dayMs; // eslint-disable-line no-mixed-operators
-	startDate.setTime(startMs);
+	const MAX_GLOBAL_STATS_DAYS = 731;
+
+	let startDate: Date;
+	let endDate: Date;
+	if (query.from && query.to) {
+		startDate = new Date(query.from + "T00:00:00Z");
+		startDate.setUTCHours(0, 0, 0, 0);
+		endDate = new Date(query.to + "T00:00:00Z");
+		endDate.setUTCHours(0, 0, 0, 0);
+		if (endDate.getTime() < startDate.getTime()) {
+			const tmp = startDate;
+			startDate = endDate;
+			endDate = tmp;
+		}
+	} else {
+		const range = query.range ?? "30d";
+		const rangeDays: Record<typeof range, number> = {
+			"7d": 7,
+			"30d": 30,
+			"90d": 90,
+			"365d": 365,
+		};
+		endDate = new Date();
+		endDate.setUTCHours(0, 0, 0, 0);
+		startDate = new Date(endDate.getTime() - (rangeDays[range] - 1) * dayMs); // eslint-disable-line no-mixed-operators
+	}
+
+	let days = Math.floor((endDate.getTime() - startDate.getTime()) / dayMs) + 1;
+	if (days < 1) {
+		days = 1;
+	}
+	if (days > MAX_GLOBAL_STATS_DAYS) {
+		days = MAX_GLOBAL_STATS_DAYS;
+		startDate = new Date(endDate.getTime() - (days - 1) * dayMs); // eslint-disable-line no-mixed-operators
+	}
 
 	const sourceTable =
 		groupBy === "model" ? globalModelStats : globalSourceStats;
@@ -1209,7 +1235,12 @@ admin.openapi(getGlobalStats, async (c) => {
 			...metricSums,
 		})
 		.from(sourceTable)
-		.where(gte(sourceTable.dayTimestamp, startDate))
+		.where(
+			and(
+				gte(sourceTable.dayTimestamp, startDate),
+				lte(sourceTable.dayTimestamp, endDate),
+			),
+		)
 		.groupBy(sourceTable.dayTimestamp)
 		.orderBy(asc(sourceTable.dayTimestamp));
 
@@ -1289,7 +1320,12 @@ admin.openapi(getGlobalStats, async (c) => {
 						...metricSums,
 					})
 					.from(globalModelStats)
-					.where(gte(globalModelStats.dayTimestamp, startDate))
+					.where(
+						and(
+							gte(globalModelStats.dayTimestamp, startDate),
+							lte(globalModelStats.dayTimestamp, endDate),
+						),
+					)
 					.groupBy(globalModelStats.usedModel, globalModelStats.usedProvider)
 					.orderBy(desc(metricSums.requestCount))
 			: await db
@@ -1298,7 +1334,12 @@ admin.openapi(getGlobalStats, async (c) => {
 						...metricSums,
 					})
 					.from(globalSourceStats)
-					.where(gte(globalSourceStats.dayTimestamp, startDate))
+					.where(
+						and(
+							gte(globalSourceStats.dayTimestamp, startDate),
+							lte(globalSourceStats.dayTimestamp, endDate),
+						),
+					)
 					.groupBy(globalSourceStats.source)
 					.orderBy(desc(metricSums.requestCount));
 
@@ -1341,7 +1382,8 @@ admin.openapi(getGlobalStats, async (c) => {
 					});
 
 	return c.json({
-		range,
+		start: startDate.toISOString().split("T")[0],
+		end: endDate.toISOString().split("T")[0],
 		groupBy,
 		modelView,
 		totals,

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2491,6 +2491,8 @@ export interface paths {
             parameters: {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
+                    from?: string;
+                    to?: string;
                     groupBy?: "model" | "source";
                     modelView?: "mapping" | "canonical" | "provider";
                 };
@@ -2507,8 +2509,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            /** @enum {string} */
-                            range: "7d" | "30d" | "90d" | "365d";
+                            start: string;
+                            end: string;
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2491,6 +2491,8 @@ export interface paths {
             parameters: {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
+                    from?: string;
+                    to?: string;
                     groupBy?: "model" | "source";
                     modelView?: "mapping" | "canonical" | "provider";
                 };
@@ -2507,8 +2509,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            /** @enum {string} */
-                            range: "7d" | "30d" | "90d" | "365d";
+                            start: string;
+                            end: string;
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2491,6 +2491,8 @@ export interface paths {
             parameters: {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
+                    from?: string;
+                    to?: string;
                     groupBy?: "model" | "source";
                     modelView?: "mapping" | "canonical" | "provider";
                 };
@@ -2507,8 +2509,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            /** @enum {string} */
-                            range: "7d" | "30d" | "90d" | "365d";
+                            start: string;
+                            end: string;
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */

--- a/ee/admin/package.json
+++ b/ee/admin/package.json
@@ -57,6 +57,7 @@
 		"openapi-react-query": "0.5.1",
 		"pretty-bytes": "7.1.0",
 		"react": "19.2.6",
+		"react-day-picker": "9.13.2",
 		"react-dom": "19.2.6",
 		"react-hook-form": "7.65.0",
 		"recharts": "^2.15.4",

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -16,6 +16,10 @@ import {
 	YAxis,
 } from "recharts";
 
+import {
+	GlobalStatsRangePicker,
+	resolveGlobalStatsRange,
+} from "@/components/global-stats-range-picker";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -34,16 +38,8 @@ import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
 
-type Range = "7d" | "30d" | "90d" | "365d";
 type GroupBy = "model" | "source";
 type ModelView = "mapping" | "canonical" | "provider";
-
-const RANGE_OPTIONS: { value: Range; label: string }[] = [
-	{ value: "7d", label: "Last 7 days" },
-	{ value: "30d", label: "Last 30 days" },
-	{ value: "90d", label: "Last 90 days" },
-	{ value: "365d", label: "Last 365 days" },
-];
 
 const GROUP_OPTIONS: { value: GroupBy; label: string; icon: typeof Cpu }[] = [
 	{ value: "model", label: "By model", icon: Cpu },
@@ -108,7 +104,6 @@ const timeseriesChartConfig = {
 
 type TimeseriesMetric = keyof typeof timeseriesChartConfig;
 
-const VALID_RANGES: Range[] = ["7d", "30d", "90d", "365d"];
 const VALID_GROUPS: GroupBy[] = ["model", "source"];
 const VALID_METRICS: TimeseriesMetric[] = [
 	"requestCount",
@@ -118,10 +113,6 @@ const VALID_METRICS: TimeseriesMetric[] = [
 const VALID_MODEL_VIEWS: ModelView[] = ["mapping", "canonical", "provider"];
 
 const BREAKDOWN_PAGE_SIZE = 25;
-
-function parseRange(value: string | null): Range {
-	return VALID_RANGES.includes(value as Range) ? (value as Range) : "30d";
-}
 
 function parseGroupBy(value: string | null): GroupBy {
 	return VALID_GROUPS.includes(value as GroupBy) ? (value as GroupBy) : "model";
@@ -216,10 +207,19 @@ export function GlobalStatsClient() {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 
-	const range = parseRange(searchParams.get("range"));
+	const { from, to } = resolveGlobalStatsRange(searchParams);
 	const groupBy = parseGroupBy(searchParams.get("groupBy"));
 	const chartMetric = parseMetric(searchParams.get("metric"));
 	const modelView = parseModelView(searchParams.get("modelView"));
+
+	const rangeLabel = useMemo(() => {
+		const fromDate = parseISO(from);
+		const toDate = parseISO(to);
+		if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+			return "selected range";
+		}
+		return `${format(fromDate, "MMM d, yyyy")} – ${format(toDate, "MMM d, yyyy")}`;
+	}, [from, to]);
 
 	const updateParam = useCallback(
 		(key: string, value: string) => {
@@ -232,13 +232,15 @@ export function GlobalStatsClient() {
 
 	const [breakdownPage, setBreakdownPage] = useState(1);
 
-	const setRange = useCallback(
-		(value: Range) => {
-			setBreakdownPage(1);
-			updateParam("range", value);
-		},
-		[updateParam],
-	);
+	// The range picker writes from/to directly to the URL, so reset pagination
+	// during render when the selected window changes.
+	const rangeKey = `${from}|${to}`;
+	const [lastRangeKey, setLastRangeKey] = useState(rangeKey);
+	if (rangeKey !== lastRangeKey) {
+		setLastRangeKey(rangeKey);
+		setBreakdownPage(1);
+	}
+
 	const setGroupBy = useCallback(
 		(value: GroupBy) => {
 			setBreakdownPage(1);
@@ -266,7 +268,7 @@ export function GlobalStatsClient() {
 		"get",
 		"/admin/global-stats",
 		{
-			params: { query: { range, groupBy, modelView } },
+			params: { query: { from, to, groupBy, modelView } },
 		},
 	);
 
@@ -374,18 +376,7 @@ export function GlobalStatsClient() {
 							);
 						})}
 					</div>
-					<div className="flex items-center gap-1">
-						{RANGE_OPTIONS.map((opt) => (
-							<Button
-								key={opt.value}
-								variant={range === opt.value ? "default" : "outline"}
-								size="sm"
-								onClick={() => setRange(opt.value)}
-							>
-								{opt.label}
-							</Button>
-						))}
-					</div>
+					<GlobalStatsRangePicker />
 				</div>
 			</header>
 
@@ -555,8 +546,8 @@ export function GlobalStatsClient() {
 						</CardTitle>
 						<CardDescription>
 							{breakdown.length > 10
-								? `Top 10 + Other across the ${range} window.`
-								: `All ${breakdown.length} ${breakdownNoun} in the ${range} window.`}
+								? `Top 10 + Other across ${rangeLabel}.`
+								: `All ${breakdown.length} ${breakdownNoun} across ${rangeLabel}.`}
 						</CardDescription>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">

--- a/ee/admin/src/components/global-stats-range-picker.tsx
+++ b/ee/admin/src/components/global-stats-range-picker.tsx
@@ -6,6 +6,7 @@ import {
 	format,
 	startOfMonth,
 	startOfYear,
+	subDays,
 	subMonths,
 	subYears,
 } from "date-fns";
@@ -34,6 +35,21 @@ export const DEFAULT_GLOBAL_STATS_PRESET = "last_3_months";
 
 function buildPresets(today: Date): DatePreset[] {
 	return [
+		{
+			label: "Last 7 days",
+			value: "last_7_days",
+			getRange: () => ({ from: subDays(today, 6), to: today }),
+		},
+		{
+			label: "Last 30 days",
+			value: "last_30_days",
+			getRange: () => ({ from: subDays(today, 29), to: today }),
+		},
+		{
+			label: "Last 90 days",
+			value: "last_90_days",
+			getRange: () => ({ from: subDays(today, 89), to: today }),
+		},
 		{
 			label: "This month",
 			value: "this_month",

--- a/ee/admin/src/components/global-stats-range-picker.tsx
+++ b/ee/admin/src/components/global-stats-range-picker.tsx
@@ -31,7 +31,7 @@ interface DatePreset {
 	getRange: () => { from: Date; to: Date };
 }
 
-export const DEFAULT_GLOBAL_STATS_PRESET = "last_3_months";
+export const DEFAULT_GLOBAL_STATS_PRESET = "last_7_days";
 
 function buildPresets(today: Date): DatePreset[] {
 	return [

--- a/ee/admin/src/components/global-stats-range-picker.tsx
+++ b/ee/admin/src/components/global-stats-range-picker.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import {
+	endOfMonth,
+	endOfYear,
+	format,
+	startOfMonth,
+	startOfYear,
+	subMonths,
+	subYears,
+} from "date-fns";
+import { CalendarIcon, ChevronDownIcon } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { DateRange } from "react-day-picker";
+
+interface DatePreset {
+	label: string;
+	value: string;
+	getRange: () => { from: Date; to: Date };
+}
+
+export const DEFAULT_GLOBAL_STATS_PRESET = "last_3_months";
+
+function buildPresets(today: Date): DatePreset[] {
+	return [
+		{
+			label: "This month",
+			value: "this_month",
+			getRange: () => ({ from: startOfMonth(today), to: today }),
+		},
+		{
+			label: "Last month",
+			value: "last_month",
+			getRange: () => {
+				const lm = subMonths(today, 1);
+				return { from: startOfMonth(lm), to: endOfMonth(lm) };
+			},
+		},
+		{
+			label: "Last 3 months",
+			value: "last_3_months",
+			getRange: () => ({ from: subMonths(today, 3), to: today }),
+		},
+		{
+			label: "Last 12 months",
+			value: "last_12_months",
+			getRange: () => ({ from: subMonths(today, 12), to: today }),
+		},
+		{
+			label: "This year",
+			value: "this_year",
+			getRange: () => ({ from: startOfYear(today), to: today }),
+		},
+		{
+			label: "Last year",
+			value: "last_year",
+			getRange: () => {
+				const ly = subYears(today, 1);
+				return { from: startOfYear(ly), to: endOfYear(ly) };
+			},
+		},
+	];
+}
+
+export function resolveGlobalStatsRange(searchParams: URLSearchParams): {
+	from: string;
+	to: string;
+} {
+	const fromParam = searchParams.get("from");
+	const toParam = searchParams.get("to");
+	if (fromParam && toParam) {
+		return { from: fromParam, to: toParam };
+	}
+	const today = new Date();
+	const presets = buildPresets(today);
+	const preset =
+		presets.find((p) => p.value === DEFAULT_GLOBAL_STATS_PRESET) ?? presets[0];
+	const range = preset.getRange();
+	return {
+		from: format(range.from, "yyyy-MM-dd"),
+		to: format(range.to, "yyyy-MM-dd"),
+	};
+}
+
+export function GlobalStatsRangePicker() {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const [open, setOpen] = useState(false);
+	const [showCalendar, setShowCalendar] = useState(false);
+	const [calendarRange, setCalendarRange] = useState<DateRange | undefined>();
+
+	const today = useMemo(() => new Date(), []);
+	const presets = useMemo(() => buildPresets(today), [today]);
+
+	const { from, to } = resolveGlobalStatsRange(searchParams);
+	const fromDate = useMemo(() => new Date(`${from}T00:00:00`), [from]);
+	const toDate = useMemo(() => new Date(`${to}T00:00:00`), [to]);
+
+	const activePreset = useMemo(() => {
+		for (const preset of presets) {
+			const r = preset.getRange();
+			if (
+				format(r.from, "yyyy-MM-dd") === from &&
+				format(r.to, "yyyy-MM-dd") === to
+			) {
+				return preset.value;
+			}
+		}
+		return "custom";
+	}, [presets, from, to]);
+
+	const updateRange = (newFrom: Date, newTo: Date) => {
+		const params = new URLSearchParams(searchParams.toString());
+		params.delete("range");
+		params.set("from", format(newFrom, "yyyy-MM-dd"));
+		params.set("to", format(newTo, "yyyy-MM-dd"));
+		router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+	};
+
+	const handlePresetSelect = (preset: DatePreset) => {
+		const r = preset.getRange();
+		updateRange(r.from, r.to);
+		setOpen(false);
+	};
+
+	const openCalendar = () => {
+		setCalendarRange({ from: fromDate, to: toDate });
+		setShowCalendar(true);
+	};
+
+	const applyCalendar = () => {
+		if (calendarRange?.from && calendarRange?.to) {
+			updateRange(calendarRange.from, calendarRange.to);
+			setOpen(false);
+			setShowCalendar(false);
+		}
+	};
+
+	const triggerLabel = useMemo(() => {
+		const preset = presets.find((p) => p.value === activePreset);
+		if (preset) {
+			return preset.label;
+		}
+		return `${format(fromDate, "MMM d, yyyy")} – ${format(toDate, "MMM d, yyyy")}`;
+	}, [activePreset, presets, fromDate, toDate]);
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(isOpen) => {
+				setOpen(isOpen);
+				if (!isOpen) {
+					setShowCalendar(false);
+				}
+			}}
+		>
+			<PopoverTrigger asChild>
+				<Button variant="outline" size="sm" className="gap-2">
+					<CalendarIcon className="h-4 w-4" />
+					{triggerLabel}
+					<ChevronDownIcon className="h-4 w-4 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				className={cn("p-0", showCalendar ? "w-auto" : "w-56")}
+				align="end"
+			>
+				{!showCalendar ? (
+					<div className="py-1">
+						{presets.map((preset) => (
+							<button
+								key={preset.value}
+								type="button"
+								onClick={() => handlePresetSelect(preset)}
+								className={cn(
+									"w-full px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
+									activePreset === preset.value && "bg-accent/50",
+								)}
+							>
+								{preset.label}
+							</button>
+						))}
+						<div className="my-1 border-t border-border/60" />
+						<button
+							type="button"
+							onClick={openCalendar}
+							className={cn(
+								"w-full px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
+								activePreset === "custom" && "bg-accent/50",
+							)}
+						>
+							Custom range…
+						</button>
+					</div>
+				) : (
+					<div className="p-3">
+						<Calendar
+							mode="range"
+							numberOfMonths={2}
+							defaultMonth={subMonths(toDate, 1)}
+							selected={calendarRange}
+							onSelect={setCalendarRange}
+							disabled={{ after: today }}
+						/>
+						<div className="flex items-center justify-between gap-2 border-t border-border/60 px-1 pt-3">
+							<button
+								type="button"
+								onClick={() => setShowCalendar(false)}
+								className="text-xs text-muted-foreground hover:text-foreground"
+							>
+								← Back to presets
+							</button>
+							<div className="flex items-center gap-3">
+								<span className="text-xs text-muted-foreground tabular-nums">
+									{calendarRange?.from
+										? format(calendarRange.from, "MMM d, yyyy")
+										: "Start"}{" "}
+									–{" "}
+									{calendarRange?.to
+										? format(calendarRange.to, "MMM d, yyyy")
+										: "End"}
+								</span>
+								<Button
+									size="sm"
+									className="h-7"
+									disabled={!calendarRange?.from || !calendarRange?.to}
+									onClick={applyCalendar}
+								>
+									Apply
+								</Button>
+							</div>
+						</div>
+					</div>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/ee/admin/src/components/ui/calendar.tsx
+++ b/ee/admin/src/components/ui/calendar.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function CalendarChevron({ orientation }: { orientation?: string }) {
+	const Icon = orientation === "left" ? ChevronLeft : ChevronRight;
+	return <Icon className="h-4 w-4" />;
+}
+
+function Calendar({
+	className,
+	classNames,
+	showOutsideDays = true,
+	...props
+}: React.ComponentProps<typeof DayPicker>) {
+	return (
+		<DayPicker
+			showOutsideDays={showOutsideDays}
+			className={cn("p-3", className)}
+			classNames={{
+				months: "flex flex-col sm:flex-row gap-2",
+				month: "flex flex-col gap-4",
+				month_caption: "flex justify-center pt-1 relative items-center w-full",
+				caption_label: "text-sm font-medium",
+				nav: "flex items-center gap-1",
+				button_previous: cn(
+					buttonVariants({ variant: "outline" }),
+					"absolute left-1 top-0 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 z-10",
+				),
+				button_next: cn(
+					buttonVariants({ variant: "outline" }),
+					"absolute right-1 top-0 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 z-10",
+				),
+				month_grid: "w-full border-collapse space-x-1",
+				weekdays: "flex",
+				weekday:
+					"text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
+				week: "flex w-full mt-2",
+				day: cn(
+					"relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50",
+					props.mode === "range"
+						? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+						: "[&:has([aria-selected])]:rounded-md",
+				),
+				day_button: cn(
+					buttonVariants({ variant: "ghost" }),
+					"h-8 w-8 p-0 font-normal aria-selected:opacity-100",
+				),
+				range_start: "day-range-start rounded-l-md",
+				range_end: "day-range-end rounded-r-md",
+				selected:
+					"bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+				today: "bg-accent text-accent-foreground",
+				outside:
+					"day-outside text-muted-foreground aria-selected:text-muted-foreground",
+				disabled: "text-muted-foreground opacity-50",
+				range_middle:
+					"aria-selected:bg-accent aria-selected:text-accent-foreground",
+				hidden: "invisible",
+				...classNames,
+			}}
+			components={{
+				Chevron: CalendarChevron,
+			}}
+			{...props}
+		/>
+	);
+}
+
+export { Calendar };

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2491,6 +2491,8 @@ export interface paths {
             parameters: {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
+                    from?: string;
+                    to?: string;
                     groupBy?: "model" | "source";
                     modelView?: "mapping" | "canonical" | "provider";
                 };
@@ -2507,8 +2509,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            /** @enum {string} */
-                            range: "7d" | "30d" | "90d" | "365d";
+                            start: string;
+                            end: string;
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,7 +258,7 @@ importers:
         version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.6))(zod@3.25.76)
@@ -891,10 +891,10 @@ importers:
         version: 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(@opentelemetry/api@1.9.0)(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.16.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(vite@7.3.5(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))))(better-call@1.3.5(zod@3.25.75))(nanostores@1.3.0)
       '@content-collections/core':
         specifier: 0.15.0
-        version: 0.15.0(typescript@5.9.2)
+        version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.2))(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.6))(zod@3.25.75)
@@ -1117,7 +1117,7 @@ importers:
         version: 10.4.21(postcss@8.5.10)
       openapi-typescript:
         specifier: 7.10.1
-        version: 7.10.1(typescript@5.9.2)
+        version: 7.10.1(typescript@5.9.3)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -1280,6 +1280,9 @@ importers:
       react:
         specifier: 19.2.6
         version: 19.2.6
+      react-day-picker:
+        specifier: 9.13.2
+        version: 9.13.2(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -2841,105 +2844,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3087,28 +3074,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -4713,157 +4696,131 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -5221,56 +5178,48 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
     resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.16':
     resolution: {integrity: sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.16':
     resolution: {integrity: sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.16':
     resolution: {integrity: sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.16':
     resolution: {integrity: sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==}
@@ -5820,49 +5769,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -8906,56 +8847,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -12818,21 +12751,6 @@ snapshots:
       conventional-commits-parser: 6.4.0
       picocolors: 1.1.1
 
-  '@content-collections/core@0.15.0(typescript@5.9.2)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      camelcase: 8.0.0
-      chokidar: 4.0.3
-      esbuild: 0.25.12
-      gray-matter: 4.0.3
-      p-limit: 6.2.0
-      picomatch: 4.0.4
-      pluralize: 8.0.0
-      serialize-javascript: 7.0.5
-      tinyglobby: 0.2.16
-      typescript: 5.9.2
-      yaml: 2.8.3
-
   '@content-collections/core@0.15.0(typescript@5.9.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -12848,21 +12766,11 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.3
 
-  '@content-collections/integrations@0.5.0(@content-collections/core@0.15.0(typescript@5.9.2))':
-    dependencies:
-      '@content-collections/core': 0.15.0(typescript@5.9.2)
-
   '@content-collections/integrations@0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
 
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.2))(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
-    dependencies:
-      '@content-collections/core': 0.15.0(typescript@5.9.2)
-      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.2))
-      next: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))
@@ -21397,16 +21305,6 @@ snapshots:
   openapi-types@12.1.3: {}
 
   openapi-typescript-helpers@0.0.15: {}
-
-  openapi-typescript@7.10.1(typescript@5.9.2):
-    dependencies:
-      '@redocly/openapi-core': 1.34.5(supports-color@10.2.2)
-      ansi-colors: 4.1.3
-      change-case: 5.4.4
-      parse-json: 8.3.0
-      supports-color: 10.2.2
-      typescript: 5.9.2
-      yargs-parser: 21.1.1
 
   openapi-typescript@7.10.1(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## What

Replaces the fixed "Last N days" range buttons on the **Global Stats** admin page with a richer date range picker.

### Presets
- This month
- Last month
- Last 3 months (default)
- Last 12 months
- This year
- Last year

### Custom range
A "Custom range…" option opens a two-month, day-level calendar (`react-day-picker`) so admins can pick an exact `from`–`to` window. Future days are disabled. The selected window is stored in the URL as `from`/`to` (matching the existing admin dashboard convention), so it's shareable and survives refresh.

## Backend

`GET /admin/global-stats` now accepts `from`/`to` (`YYYY-MM-DD`) and bounds the aggregation window on **both** ends (previously only a lower bound, since "last N days" always ended today). The legacy `range` param is kept for backward compatibility. The window is capped at 731 days to bound the timeseries fill loop. The response now echoes `start`/`end` instead of `range`.

## Notes
- Added a `Calendar` UI component to `ee/admin` (copied from the existing one in `apps/ui`) and the `react-day-picker` dependency.
- Regenerated the typed API clients across apps from the updated OpenAPI spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global statistics now accept absolute from/to dates and return explicit resolved start/end dates.
  * New interactive date-range picker with presets (defaulting to last 7 days) and a custom calendar; selecting dates updates the view and resets breakdown pagination.
  * Timeseries, totals, and breakdowns are consistently bounded to the selected inclusive date window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->