### PR TITLE
feat(admin): add provider cost share view

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1073,7 +1073,7 @@ admin.openapi(getTimeseries, async (c) => {
 
 const globalStatsRangeSchema = z.enum(["7d", "30d", "90d", "365d"]);
 const globalStatsGroupBySchema = z.enum(["model", "source"]);
-const globalStatsModelViewSchema = z.enum(["mapping", "canonical"]);
+const globalStatsModelViewSchema = z.enum(["mapping", "canonical", "provider"]);
 
 const globalStatsMetricsSchema = z.object({
 	requestCount: z.number(),
@@ -1311,26 +1311,34 @@ admin.openapi(getGlobalStats, async (c) => {
 						}
 					>,
 				)
-			: breakdownRows.map((row) => {
-					const isModel = "usedModel" in row;
-					const key = isModel ? row.usedModel : row.source;
-					const label = isModel ? row.usedModel : row.source;
-					return {
-						key,
-						label,
-						requestCount: Number(row.requestCount),
-						errorCount: Number(row.errorCount),
-						cacheCount: Number(row.cacheCount),
-						inputTokens: Number(row.inputTokens),
-						cachedTokens: Number(row.cachedTokens),
-						outputTokens: Number(row.outputTokens),
-						totalTokens: Number(row.totalTokens),
-						cost: Number(row.cost),
-						inputCost: Number(row.inputCost),
-						cachedInputCost: Number(row.cachedInputCost),
-						outputCost: Number(row.outputCost),
-					};
-				});
+			: groupBy === "model" && modelView === "provider"
+				? aggregateModelRowsByProvider(
+						breakdownRows as Array<
+							(typeof breakdownRows)[number] & {
+								usedProvider: string;
+							}
+						>,
+					)
+				: breakdownRows.map((row) => {
+						const isModel = "usedModel" in row;
+						const key = isModel ? row.usedModel : row.source;
+						const label = isModel ? row.usedModel : row.source;
+						return {
+							key,
+							label,
+							requestCount: Number(row.requestCount),
+							errorCount: Number(row.errorCount),
+							cacheCount: Number(row.cacheCount),
+							inputTokens: Number(row.inputTokens),
+							cachedTokens: Number(row.cachedTokens),
+							outputTokens: Number(row.outputTokens),
+							totalTokens: Number(row.totalTokens),
+							cost: Number(row.cost),
+							inputCost: Number(row.inputCost),
+							cachedInputCost: Number(row.cachedInputCost),
+							outputCost: Number(row.outputCost),
+						};
+					});
 
 	return c.json({
 		range,
@@ -1392,6 +1400,64 @@ function aggregateModelRowsByCanonicalId(
 			aggregated.set(canonical, {
 				key: canonical,
 				label: canonical,
+				requestCount: Number(row.requestCount),
+				errorCount: Number(row.errorCount),
+				cacheCount: Number(row.cacheCount),
+				inputTokens: Number(row.inputTokens),
+				cachedTokens: Number(row.cachedTokens),
+				outputTokens: Number(row.outputTokens),
+				totalTokens: Number(row.totalTokens),
+				cost: Number(row.cost),
+				inputCost: Number(row.inputCost),
+				cachedInputCost: Number(row.cachedInputCost),
+				outputCost: Number(row.outputCost),
+			});
+		}
+	}
+	return Array.from(aggregated.values()).sort(
+		(a, b) => b.requestCount - a.requestCount,
+	);
+}
+
+function aggregateModelRowsByProvider(
+	rows: Array<{
+		usedProvider: string;
+		requestCount: number;
+		errorCount: number;
+		cacheCount: number;
+		inputTokens: number;
+		cachedTokens: number;
+		outputTokens: number;
+		totalTokens: number;
+		cost: number;
+		inputCost: number;
+		cachedInputCost: number;
+		outputCost: number;
+	}>,
+): z.infer<typeof globalStatsBreakdownItemSchema>[] {
+	const aggregated = new Map<
+		string,
+		z.infer<typeof globalStatsBreakdownItemSchema>
+	>();
+	for (const row of rows) {
+		const provider = row.usedProvider || "unknown";
+		const existing = aggregated.get(provider);
+		if (existing) {
+			existing.requestCount += Number(row.requestCount);
+			existing.errorCount += Number(row.errorCount);
+			existing.cacheCount += Number(row.cacheCount);
+			existing.inputTokens += Number(row.inputTokens);
+			existing.cachedTokens += Number(row.cachedTokens);
+			existing.outputTokens += Number(row.outputTokens);
+			existing.totalTokens += Number(row.totalTokens);
+			existing.cost += Number(row.cost);
+			existing.inputCost += Number(row.inputCost);
+			existing.cachedInputCost += Number(row.cachedInputCost);
+			existing.outputCost += Number(row.outputCost);
+		} else {
+			aggregated.set(provider, {
+				key: provider,
+				label: provider,
 				requestCount: Number(row.requestCount),
 				errorCount: Number(row.errorCount),
 				cacheCount: Number(row.cacheCount),

--- a/apps/code/src/lib/api/v1.d.ts
+++ b/apps/code/src/lib/api/v1.d.ts
@@ -2492,7 +2492,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
-                    modelView?: "mapping" | "canonical";
+                    modelView?: "mapping" | "canonical" | "provider";
                 };
                 header?: never;
                 path?: never;
@@ -2512,7 +2512,7 @@ export interface paths {
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */
-                            modelView: "mapping" | "canonical";
+                            modelView: "mapping" | "canonical" | "provider";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;

--- a/apps/playground/src/lib/api/v1.d.ts
+++ b/apps/playground/src/lib/api/v1.d.ts
@@ -2492,7 +2492,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
-                    modelView?: "mapping" | "canonical";
+                    modelView?: "mapping" | "canonical" | "provider";
                 };
                 header?: never;
                 path?: never;
@@ -2512,7 +2512,7 @@ export interface paths {
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */
-                            modelView: "mapping" | "canonical";
+                            modelView: "mapping" | "canonical" | "provider";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;

--- a/apps/ui/src/lib/api/v1.d.ts
+++ b/apps/ui/src/lib/api/v1.d.ts
@@ -2492,7 +2492,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
-                    modelView?: "mapping" | "canonical";
+                    modelView?: "mapping" | "canonical" | "provider";
                 };
                 header?: never;
                 path?: never;
@@ -2512,7 +2512,7 @@ export interface paths {
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */
-                            modelView: "mapping" | "canonical";
+                            modelView: "mapping" | "canonical" | "provider";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { format, parseISO } from "date-fns";
-import { BarChart3, Coins, Cpu, Layers } from "lucide-react";
+import { BarChart3, Coins, Cpu, Layers, Server } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import {
@@ -36,7 +36,7 @@ import type { ChartConfig } from "@/components/ui/chart";
 
 type Range = "7d" | "30d" | "90d" | "365d";
 type GroupBy = "model" | "source";
-type ModelView = "mapping" | "canonical";
+type ModelView = "mapping" | "canonical" | "provider";
 
 const RANGE_OPTIONS: { value: Range; label: string }[] = [
 	{ value: "7d", label: "Last 7 days" },
@@ -57,6 +57,7 @@ const MODEL_VIEW_OPTIONS: {
 }[] = [
 	{ value: "mapping", label: "Mappings", icon: Layers },
 	{ value: "canonical", label: "Canonical", icon: Cpu },
+	{ value: "provider", label: "Providers", icon: Server },
 ];
 
 // Distinct, color-blind-friendly hues. Repeat for >12 series.
@@ -114,7 +115,7 @@ const VALID_METRICS: TimeseriesMetric[] = [
 	"cost",
 	"totalTokens",
 ];
-const VALID_MODEL_VIEWS: ModelView[] = ["mapping", "canonical"];
+const VALID_MODEL_VIEWS: ModelView[] = ["mapping", "canonical", "provider"];
 
 const BREAKDOWN_PAGE_SIZE = 25;
 
@@ -319,6 +320,19 @@ export function GlobalStatsClient() {
 		[breakdown, chartMetric],
 	);
 
+	const breakdownNoun =
+		groupBy === "model"
+			? modelView === "provider"
+				? "providers"
+				: "models"
+			: "sources";
+	const breakdownNounSingular =
+		groupBy === "model"
+			? modelView === "provider"
+				? "Provider"
+				: "Model"
+			: "Source";
+
 	const breakdownTotalPages = Math.max(
 		1,
 		Math.ceil(sortedBreakdown.length / BREAKDOWN_PAGE_SIZE),
@@ -412,7 +426,7 @@ export function GlobalStatsClient() {
 					accent="orange"
 				/>
 				<StatCard
-					label={groupBy === "model" ? "Distinct models" : "Distinct sources"}
+					label={`Distinct ${breakdownNoun}`}
 					value={numberFormatter.format(breakdown.length)}
 					subtitle={
 						totals
@@ -421,7 +435,11 @@ export function GlobalStatsClient() {
 					}
 					icon={
 						groupBy === "model" ? (
-							<Cpu className="h-4 w-4" />
+							modelView === "provider" ? (
+								<Server className="h-4 w-4" />
+							) : (
+								<Cpu className="h-4 w-4" />
+							)
 						) : (
 							<Layers className="h-4 w-4" />
 						)
@@ -533,12 +551,12 @@ export function GlobalStatsClient() {
 					<div>
 						<CardTitle>
 							{timeseriesChartConfig[chartMetric].label as string} share —{" "}
-							{groupBy === "model" ? "models" : "sources"}
+							{breakdownNoun}
 						</CardTitle>
 						<CardDescription>
 							{breakdown.length > 10
 								? `Top 10 + Other across the ${range} window.`
-								: `All ${breakdown.length} ${groupBy === "model" ? "models" : "sources"} in the ${range} window.`}
+								: `All ${breakdown.length} ${breakdownNoun} in the ${range} window.`}
 						</CardDescription>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">
@@ -640,7 +658,7 @@ export function GlobalStatsClient() {
 								<thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
 									<tr>
 										<th className="px-3 py-2 text-left">
-											{groupBy === "model" ? "Model" : "Source"}
+											{breakdownNounSingular}
 										</th>
 										<th className="px-3 py-2 text-right">
 											{timeseriesChartConfig[chartMetric].label as string}

--- a/ee/admin/src/lib/api/v1.d.ts
+++ b/ee/admin/src/lib/api/v1.d.ts
@@ -2492,7 +2492,7 @@ export interface paths {
                 query?: {
                     range?: "7d" | "30d" | "90d" | "365d";
                     groupBy?: "model" | "source";
-                    modelView?: "mapping" | "canonical";
+                    modelView?: "mapping" | "canonical" | "provider";
                 };
                 header?: never;
                 path?: never;
@@ -2512,7 +2512,7 @@ export interface paths {
                             /** @enum {string} */
                             groupBy: "model" | "source";
                             /** @enum {string} */
-                            modelView: "mapping" | "canonical";
+                            modelView: "mapping" | "canonical" | "provider";
                             totals: {
                                 requestCount: number;
                                 errorCount: number;


### PR DESCRIPTION
## Summary

Adds a third **Providers** option to the model-view toggle on the admin Global Stats "Cost share — models" card, alongside the existing **Mappings** and **Canonical** views. The new view aggregates the cost/request/token breakdown by upstream provider.

## Changes

- **API** (`apps/api/src/routes/admin.ts`): extend `globalStatsModelViewSchema` with `"provider"` and add `aggregateModelRowsByProvider` to group the model breakdown rows by `usedProvider`. Only affects the `/admin/global-stats` breakdown when `groupBy === "model"`; the timeseries and totals are unchanged.
- **Admin UI** (`ee/admin/src/app/global-stats/client.tsx`): add the `Providers` toggle button (Server icon), accept `provider` as a valid `modelView` URL param, and make the card title, "Distinct …" stat card, and breakdown table header read "providers"/"Provider" in that view.
- Regenerated the typed OpenAPI clients for `admin`, `code`, `playground`, and `ui`.

## Testing

- `pnpm build`, `pnpm format`, and `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)