### PR TITLE
fix(gateway): don't log forwarded upstream errors as errors

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -30,6 +30,7 @@ import { imagesRoute } from "./images/route.js";
 import {
 	buildAnthropicErrorBody,
 	buildOpenAIErrorBody,
+	getUpstreamErrorCause,
 } from "./lib/error-response.js";
 import { mcpHandler, registerMcpOAuthRoutes } from "./mcp/mcp.js";
 import { tracingMiddleware } from "./middleware/tracing.js";
@@ -165,8 +166,19 @@ app.onError((error, c) => {
 
 	if (error instanceof HTTPException) {
 		const status = error.status;
+		const upstreamCause = getUpstreamErrorCause(error.cause);
 
-		if (status >= 500) {
+		if (upstreamCause) {
+			// Expected upstream/gateway provider error (e.g. a provider 429)
+			// forwarded from an internal chat-completions call. It is already
+			// recorded in the log table with its unifiedFinishReason, so surface
+			// it as a warning rather than an ERROR-level log.
+			logger.warn("Provider error", {
+				status,
+				message: error.message,
+				unifiedFinishReason: upstreamCause.unifiedFinishReason,
+			});
+		} else if (status >= 500) {
 			logger.error("HTTP 500 exception", error);
 		} else {
 			logger.warn("HTTP client error", { status, message: error.message });

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -2,12 +2,14 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 
 import { app } from "@/app.js";
+import { upstreamErrorCause } from "@/lib/error-response.js";
 
 import { parseDataUrl, processImageUrl } from "@llmgateway/actions";
 import { logger, toError } from "@llmgateway/logger";
 
 import type { ServerTypes } from "@/vars.js";
 import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 const imageGenerationsRequestSchema = z.object({
 	prompt: z.string().min(1).openapi({
@@ -338,15 +340,23 @@ async function forwardToChatCompletions(
 		});
 		const errorData = await response.text();
 		let errorMessage = `Image generation failed with status ${response.status}`;
+		let upstreamFinishReason: string | undefined;
 		try {
 			const parsed = JSON.parse(errorData);
 			errorMessage = parsed?.error?.message ?? parsed?.message ?? errorMessage;
+			const errorType = parsed?.error?.type ?? parsed?.error?.code;
+			if (errorType === "upstream_error" || errorType === "gateway_error") {
+				upstreamFinishReason = errorType;
+			}
 		} catch {
 			// use default message
 		}
 
-		throw new HTTPException(response.status as any, {
+		throw new HTTPException(response.status as ContentfulStatusCode, {
 			message: errorMessage,
+			...(upstreamFinishReason
+				? { cause: upstreamErrorCause(upstreamFinishReason) }
+				: {}),
 		});
 	}
 

--- a/apps/gateway/src/lib/error-response.spec.ts
+++ b/apps/gateway/src/lib/error-response.spec.ts
@@ -5,6 +5,8 @@ import {
 	buildOpenAIErrorBody,
 	getAnthropicErrorType,
 	getOpenAIErrorMeta,
+	getUpstreamErrorCause,
+	upstreamErrorCause,
 } from "./error-response.js";
 
 describe("error-response", () => {
@@ -69,5 +71,28 @@ describe("error-response", () => {
 		);
 		expect(getAnthropicErrorType(429)).toBe("rate_limit_error");
 		expect(getAnthropicErrorType(500)).toBe("api_error");
+	});
+
+	test("round-trips the upstream error cause marker", () => {
+		const cause = upstreamErrorCause("upstream_error");
+		expect(cause).toEqual({
+			upstreamError: true,
+			unifiedFinishReason: "upstream_error",
+		});
+		expect(getUpstreamErrorCause(cause)).toBe(cause);
+		expect(getUpstreamErrorCause(upstreamErrorCause("gateway_error"))).toEqual({
+			upstreamError: true,
+			unifiedFinishReason: "gateway_error",
+		});
+	});
+
+	test("rejects non-marker causes", () => {
+		expect(getUpstreamErrorCause(undefined)).toBeNull();
+		expect(getUpstreamErrorCause(null)).toBeNull();
+		expect(getUpstreamErrorCause(new Error("boom"))).toBeNull();
+		expect(getUpstreamErrorCause({ upstreamError: true })).toBeNull();
+		expect(
+			getUpstreamErrorCause({ unifiedFinishReason: "upstream_error" }),
+		).toBeNull();
 	});
 });

--- a/apps/gateway/src/lib/error-response.ts
+++ b/apps/gateway/src/lib/error-response.ts
@@ -128,6 +128,37 @@ export function buildOpenAIErrorBody(opts: {
 	};
 }
 
+// Marker attached as the `cause` of an HTTPException when an internal
+// chat-completions call surfaces an expected upstream/gateway provider error
+// (e.g. a provider 429). These are already recorded in the log table with their
+// unifiedFinishReason, so the global error handler should surface them as
+// warnings rather than ERROR-level logs that trip error alerting.
+export interface UpstreamErrorCause {
+	upstreamError: true;
+	unifiedFinishReason: string;
+}
+
+export function upstreamErrorCause(
+	unifiedFinishReason: string,
+): UpstreamErrorCause {
+	return { upstreamError: true, unifiedFinishReason };
+}
+
+export function getUpstreamErrorCause(
+	cause: unknown,
+): UpstreamErrorCause | null {
+	if (
+		cause &&
+		typeof cause === "object" &&
+		(cause as Partial<UpstreamErrorCause>).upstreamError === true &&
+		typeof (cause as Partial<UpstreamErrorCause>).unifiedFinishReason ===
+			"string"
+	) {
+		return cause as UpstreamErrorCause;
+	}
+	return null;
+}
+
 export function buildAnthropicErrorBody(opts: {
 	message: string;
 	status: number;


### PR DESCRIPTION
## Problem

A google-vertex `429 Too Many Requests` (an expected, transient upstream rate limit) was being surfaced in logs at **ERROR** severity, tripping error alerting:

```
ERROR {"err":{"message":"Error from provider google-vertex: 429 Too Many Requests {...RESOURCE_EXHAUSTED...}","stack":"Error: Error from provider google-vertex: 429 ..."}}
```

These are expected upstream errors and should not be reported as logger errors — they just need to be marked as `upstream_error` / `gateway_error` in the log table (which already happens).

## Root cause

The `"Error from provider ..."` string is only ever built as a **response body** in `chat.ts` (returned via `c.json`/SSE, never thrown). The image-generation endpoint forwards to `/v1/chat/completions` (`images.ts:forwardToChatCompletions`); on an upstream error `chat.ts` wraps it as HTTP **500**, and `images.ts` re-threw it as `HTTPException(500)`. The global handler `app.onError` logs **all** `HTTPException` with status ≥ 500 at ERROR (`app.ts:170`), so the forwarded provider 429 became an ERROR log.

The sibling forwarders (`responses.ts`, `anthropic.ts`) return the upstream error via `c.json` and never hit this path — `images.ts` was the outlier.

## Fix

- `images.ts` now tags forwarded upstream/gateway provider errors (`error.type`/`code` of `upstream_error` or `gateway_error`) via the `HTTPException` `cause`.
- `app.onError` recognizes that marker and logs at **warn** (`"Provider error"`, with the `unifiedFinishReason`) instead of ERROR, while still returning the same error response to the client.
- New `upstreamErrorCause` / `getUpstreamErrorCause` helpers in `error-response.ts`, with unit tests.

No DB change needed: the internal chat-completions call already inserts the log row with the correct `unifiedFinishReason` (429 → `upstream_error`). The client-facing response is unchanged.

## Testing

- `pnpm build` — full monorepo build passes (17/17).
- `pnpm exec vitest run apps/gateway/src/lib/error-response.spec.ts` — 6/6 pass.
- `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error logging and message extraction for upstream provider failures
  * Enhanced error cause tracking to distinguish provider errors from internal issues

* **Tests**
  * Added test coverage for upstream error detection and handling utilities

* **Chores**
  * Refined error response handling and categorization system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->