### PR TITLE
fix(codex): create org for devpass users

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
-import { db, tables } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 
 import { apiAuth, isClientJsonError, redisClient } from "./config.js";
 
@@ -230,6 +230,83 @@ describe("API auth hooks functionality", () => {
 
 		expect(project).not.toBeNull();
 		expect(project?.mode).toBe("credits");
+	});
+
+	test("should create default organization when DevPass user signs in to main app", async () => {
+		const codeUrl = process.env.CODE_URL ?? "http://localhost:3004";
+		const uiUrl = process.env.UI_URL ?? "http://localhost:3002";
+		const email = `test-devpass-main-${Date.now()}@example.com`;
+		const password = "Password123!";
+
+		const signUpResponse = await apiAuth.handler(
+			new Request("http://localhost:4002/auth/sign-up/email", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Origin: codeUrl,
+					"CF-Connecting-IP": `192.168.31.${Math.floor(Math.random() * 255)}`,
+				},
+				body: JSON.stringify({ email, password, name: "Dev User" }),
+			}),
+		);
+
+		expect(signUpResponse.status).toBe(200);
+
+		const user = await db.query.user.findFirst({
+			where: {
+				email: {
+					eq: email,
+				},
+			},
+		});
+
+		expect(user).not.toBeNull();
+
+		await db
+			.update(tables.user)
+			.set({ emailVerified: true })
+			.where(eq(tables.user.id, user!.id));
+
+		const signInResponse = await apiAuth.handler(
+			new Request("http://localhost:4002/auth/sign-in/email", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Origin: uiUrl,
+				},
+				body: JSON.stringify({ email, password }),
+			}),
+		);
+
+		expect(signInResponse.status).toBe(200);
+
+		const userOrganizations = await db.query.userOrganization.findMany({
+			where: {
+				userId: {
+					eq: user!.id,
+				},
+			},
+			with: {
+				organization: true,
+			},
+		});
+
+		const organizations = userOrganizations
+			.map((uo) => uo.organization)
+			.filter((org) => org?.status !== "deleted");
+
+		expect(organizations).toHaveLength(2);
+		expect(
+			organizations.some(
+				(org) => org?.name === "Personal" && org.isPersonal === true,
+			),
+		).toBe(true);
+		expect(
+			organizations.some(
+				(org) =>
+					org?.name === "Default Organization" && org.isPersonal === false,
+			),
+		).toBe(true);
 	});
 
 	test("should automatically verify email for self-hosted installations", async () => {

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -5,13 +5,14 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { createAuthMiddleware } from "better-auth/api";
 import { Redis } from "ioredis";
 
+import { getOrCreateDefaultOrganization } from "@/utils/default-org.js";
 import { notifyUserSignup } from "@/utils/discord.js";
 import { validateEmail } from "@/utils/email-validation.js";
 import { sendTransactionalEmail } from "@/utils/email.js";
 import { resolveSignupName } from "@/utils/infer-name.js";
 import { getOrCreatePersonalOrg } from "@/utils/personal-org.js";
 
-import { db, eq, tables, shortid } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import { getResendClient, resendAudienceId } from "@llmgateway/shared/email";
 
@@ -933,23 +934,12 @@ The LLM Gateway Team`.trim();
 					const activeOrganizations = userOrganizations.filter(
 						(uo) => uo.organization?.status !== "deleted",
 					);
-
-					if (activeOrganizations.length > 0) {
-						// User already has an organization, nothing to do
-						return;
-					}
-
-					// For self-hosted installations, automatically verify the user's email
-					if (!isHosted) {
-						await db
-							.update(tables.user)
-							.set({ emailVerified: true })
-							.where(eq(tables.user.id, userId));
-
-						logger.info("Automatically verified email for self-hosted user", {
-							userId,
-						});
-					}
+					const hasActiveDashboardOrganization = activeOrganizations.some(
+						(uo) => uo.organization && !uo.organization.isPersonal,
+					);
+					const hasActivePersonalOrganization = activeOrganizations.some(
+						(uo) => uo.organization?.isPersonal === true,
+					);
 
 					// DevPass (code app) signups get a personal organization instead of
 					// the shared "Default Organization" used by the main LLM Gateway
@@ -965,78 +955,46 @@ The LLM Gateway Team`.trim();
 							id: userId,
 							email: newSession.user.email,
 						});
+						if (
+							hasActivePersonalOrganization ||
+							hasActiveDashboardOrganization
+						) {
+							return;
+						}
+					} else if (hasActiveDashboardOrganization) {
+						return;
 					} else {
-						// Perform all DB operations in a single transaction for atomicity
-						await db.transaction(async (tx) => {
-							// Create a default organization
-							const [organization] = await tx
-								.insert(tables.organization)
-								.values({
-									name: "Default Organization",
-									billingEmail: newSession.user.email,
-								})
-								.returning();
+						const cookieHeader = ctx.request?.headers.get("cookie") ?? "";
+						const referralMatch = cookieHeader.match(
+							/llmgateway_referral=([^;]+)/,
+						);
 
-							// Link user to organization
-							await tx.insert(tables.userOrganization).values({
-								userId,
-								organizationId: organization.id,
-							});
+						await getOrCreateDefaultOrganization(
+							{
+								id: userId,
+								email: newSession.user.email,
+							},
+							{
+								referralOrganizationId: referralMatch
+									? decodeURIComponent(referralMatch[1])
+									: null,
+							},
+						);
 
-							// Create a default project with hybrid mode
-							const [project] = await tx
-								.insert(tables.project)
-								.values({
-									name: "Default Project",
-									organizationId: organization.id,
-									mode: "hybrid",
-								})
-								.returning();
+						if (activeOrganizations.length > 0) {
+							return;
+						}
+					}
 
-							// Auto-create an API key for the playground to use
-							// Generate a token with a prefix for better identification
-							const prefix =
-								process.env.NODE_ENV === "development"
-									? `llmgdev_`
-									: "llmgtwy_";
-							const token = prefix + shortid(40);
+					// For self-hosted installations, automatically verify the user's email
+					if (!isHosted) {
+						await db
+							.update(tables.user)
+							.set({ emailVerified: true })
+							.where(eq(tables.user.id, userId));
 
-							await tx.insert(tables.apiKey).values({
-								projectId: project.id,
-								token: token,
-								description: "Auto-generated playground key",
-								usageLimit: null, // No limit for playground key
-								createdBy: userId,
-							});
-
-							// Handle referral if cookie is present
-							const cookieHeader = ctx.request?.headers.get("cookie") ?? "";
-							const referralMatch = cookieHeader.match(
-								/llmgateway_referral=([^;]+)/,
-							);
-							if (referralMatch) {
-								const referrerOrgId = decodeURIComponent(referralMatch[1]);
-								// Verify the referrer organization exists and is active
-								const referrerOrg = await tx.query.organization.findFirst({
-									where: {
-										id: { eq: referrerOrgId },
-										status: { eq: "active" },
-									},
-								});
-
-								if (referrerOrg) {
-									// Create the referral record
-									await tx.insert(tables.referral).values({
-										referrerOrganizationId: referrerOrgId,
-										referredOrganizationId: organization.id,
-									});
-
-									logger.info("Created referral record", {
-										referrerOrgId,
-										referredOrgId: organization.id,
-									});
-								}
-							}
+						logger.info("Automatically verified email for self-hosted user", {
+							userId,
 						});
 					}
 

--- a/apps/api/src/routes/organization.spec.ts
+++ b/apps/api/src/routes/organization.spec.ts
@@ -69,6 +69,70 @@ describe("organization route", () => {
 		});
 	});
 
+	test("GET /orgs creates a dashboard org for DevPass-only users", async () => {
+		await deleteAll();
+
+		const codeUrl = process.env.CODE_URL ?? "http://localhost:3004";
+		const email = `test-devpass-orgs-${Date.now()}@example.com`;
+		const password = "Password123!";
+
+		const signUpResponse = await app.request("/auth/sign-up/email", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Origin: codeUrl,
+				"CF-Connecting-IP": `192.168.32.${Math.floor(Math.random() * 255)}`,
+			},
+			body: JSON.stringify({ email, password, name: "Dev User" }),
+		});
+
+		expect(signUpResponse.status).toBe(200);
+
+		const cookie = signUpResponse.headers.get("set-cookie");
+		expect(cookie).not.toBeNull();
+
+		const beforeOrganizations = await db.query.userOrganization.findMany({
+			with: {
+				organization: true,
+			},
+		});
+
+		expect(beforeOrganizations).toHaveLength(1);
+		expect(beforeOrganizations[0]?.organization?.isPersonal).toBe(true);
+
+		const response = await app.request("/orgs", {
+			headers: {
+				Cookie: cookie!,
+			},
+		});
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			organizations: Array<{ name: string; isPersonal: boolean }>;
+		};
+
+		expect(body.organizations).toHaveLength(1);
+		expect(body.organizations[0]?.name).toBe("Default Organization");
+		expect(body.organizations[0]?.isPersonal).toBe(false);
+
+		const afterOrganizations = await db.query.userOrganization.findMany({
+			with: {
+				organization: true,
+			},
+		});
+
+		expect(afterOrganizations).toHaveLength(2);
+		expect(
+			afterOrganizations.some((uo) => uo.organization?.isPersonal === true),
+		).toBe(true);
+		expect(
+			afterOrganizations.some(
+				(uo) => uo.organization?.name === "Default Organization",
+			),
+		).toBe(true);
+	});
+
 	test("PATCH /orgs/{id} logs top-up setting changes separately from organization updates", async () => {
 		const response = await app.request("/orgs/test-org-id", {
 			method: "PATCH",

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { userHasOrganizationAccess } from "@/utils/authorization.js";
+import { getOrCreateDefaultOrganization } from "@/utils/default-org.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
@@ -162,11 +163,25 @@ organization.openapi(getOrganizations, async (c) => {
 		},
 	});
 
-	const organizations = userOrganizations
+	let organizations = userOrganizations
 		.map((uo) => uo.organization!)
 		.filter((org) => org.status !== "deleted")
 		// Hide personal orgs from regular UI - they are only visible on devpass.llmgateway.io
 		.filter((org) => !org.isPersonal);
+
+	if (organizations.length === 0) {
+		const defaultOrganization = await getOrCreateDefaultOrganization({
+			id: user.id,
+			email: user.email,
+		});
+
+		if (
+			defaultOrganization.status !== "deleted" &&
+			!defaultOrganization.isPersonal
+		) {
+			organizations = [defaultOrganization];
+		}
+	}
 
 	return c.json({
 		organizations,

--- a/apps/api/src/utils/default-org.ts
+++ b/apps/api/src/utils/default-org.ts
@@ -1,0 +1,122 @@
+import { db, shortid, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
+
+interface DefaultOrganizationUser {
+	id: string;
+	email: string;
+}
+
+interface DefaultOrganizationOptions {
+	referralOrganizationId?: string | null;
+}
+
+function isActiveDashboardOrganization(userOrganization: {
+	organization: typeof tables.organization.$inferSelect | null;
+}): userOrganization is {
+	organization: typeof tables.organization.$inferSelect;
+} {
+	return (
+		userOrganization.organization !== null &&
+		userOrganization.organization.status !== "deleted" &&
+		!userOrganization.organization.isPersonal
+	);
+}
+
+export async function getOrCreateDefaultOrganization(
+	user: DefaultOrganizationUser,
+	options: DefaultOrganizationOptions = {},
+) {
+	const userOrganizations = await db.query.userOrganization.findMany({
+		where: {
+			userId: user.id,
+		},
+		with: {
+			organization: true,
+		},
+	});
+
+	const existingOrganization = userOrganizations.find(
+		isActiveDashboardOrganization,
+	)?.organization;
+
+	if (existingOrganization) {
+		return existingOrganization;
+	}
+
+	return await db.transaction(async (tx) => {
+		const currentUserOrganizations = await tx.query.userOrganization.findMany({
+			where: {
+				userId: user.id,
+			},
+			with: {
+				organization: true,
+			},
+		});
+
+		const currentOrganization = currentUserOrganizations.find(
+			isActiveDashboardOrganization,
+		)?.organization;
+
+		if (currentOrganization) {
+			return currentOrganization;
+		}
+
+		const [organization] = await tx
+			.insert(tables.organization)
+			.values({
+				name: "Default Organization",
+				billingEmail: user.email,
+			})
+			.returning();
+
+		await tx.insert(tables.userOrganization).values({
+			userId: user.id,
+			organizationId: organization.id,
+			role: "owner",
+		});
+
+		const [project] = await tx
+			.insert(tables.project)
+			.values({
+				name: "Default Project",
+				organizationId: organization.id,
+				mode: "hybrid",
+			})
+			.returning();
+
+		const prefix =
+			process.env.NODE_ENV === "development" ? `llmgdev_` : "llmgtwy_";
+		const token = prefix + shortid(40);
+
+		await tx.insert(tables.apiKey).values({
+			projectId: project.id,
+			token,
+			description: "Auto-generated playground key",
+			usageLimit: null,
+			createdBy: user.id,
+		});
+
+		if (options.referralOrganizationId) {
+			const referrerOrg = await tx.query.organization.findFirst({
+				where: {
+					id: { eq: options.referralOrganizationId },
+					status: { eq: "active" },
+				},
+			});
+
+			if (referrerOrg) {
+				await tx.insert(tables.referral).values({
+					referrerOrganizationId: options.referralOrganizationId,
+					referredOrganizationId: organization.id,
+				});
+
+				logger.info("Created referral record", {
+					referrerOrgId: options.referralOrganizationId,
+					referredOrgId: organization.id,
+				});
+			}
+		}
+
+		return organization;
+	});
+}


### PR DESCRIPTION
## What changed

- Added shared default dashboard organization provisioning for users who do not have a non-personal organization.
- Reused that provisioning in the auth hook and in `GET /orgs`.
- Added regressions for DevPass signup followed by main-app sign-in, and for same-session `/orgs` access by DevPass-only users.

## Why

DevPass signups create a personal organization. The main dashboard hides personal organizations, but the auth hook previously treated the personal org as enough and skipped creating the regular "Default Organization". Users arriving from DevPass could therefore end up in onboarding with no visible main org.

## Validation

- `pnpm format`
- `pnpm build`
- `pnpm vitest run apps/api/src/auth/config.spec.ts apps/api/src/routes/organization.spec.ts --no-file-parallelism`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced organization provisioning: users signing up now automatically receive both a Personal organization and a Default Organization to support improved workspace management.

* **Tests**
  * Added integration tests for authentication flows and organization endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->