### PR TITLE
fix(gateway): don't drop reasoning effort on the Anthropic endpoint

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -12,6 +12,7 @@ import { extractAnthropicSessionId } from "@/lib/session-id.js";
 import { logger, toError } from "@llmgateway/logger";
 
 import { buildAnthropicErrorEvent } from "./streaming-error-translation.js";
+import { mapAnthropicThinkingToReasoning } from "./thinking-to-reasoning.js";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -145,6 +146,33 @@ const anthropicRequestSchema = z.object({
 		.openapi({
 			description:
 				"Anthropic request metadata. Claude Code embeds the session id in user_id, which the gateway uses for sticky routing.",
+		}),
+	thinking: z
+		.object({
+			// Tolerant string (not an enum) so a future Anthropic thinking type
+			// doesn't 400 the request; unknown types simply map to no reasoning.
+			type: z.string(),
+			budget_tokens: z.number().int().positive().optional(),
+		})
+		.optional()
+		.openapi({
+			description:
+				"Anthropic extended-thinking configuration. Mapped onto the gateway's unified reasoning controls so the requested effort reaches the provider.",
+		}),
+	output_config: z
+		.object({
+			// Matches the chat completions reasoning-effort enum. Claude Code emits
+			// the full range (including `xhigh` and `max`), so accept all of them;
+			// `max` is normalized to `high` downstream for client compatibility.
+			effort: z
+				.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
+				.optional(),
+		})
+		.passthrough()
+		.optional()
+		.openapi({
+			description:
+				"Anthropic output configuration. `effort` controls adaptive reasoning depth on Opus 4.7+ models.",
 		}),
 });
 
@@ -519,6 +547,19 @@ anthropic.openapi(messages, async (c) => {
 	if (openaiTools) {
 		openaiRequest.tools = openaiTools;
 	}
+
+	// Translate Anthropic reasoning controls (extended `thinking` and adaptive
+	// `output_config.effort`) onto the unified reasoning fields the inner
+	// /v1/chat/completions endpoint understands. Without this, native-Anthropic
+	// clients like Claude Code lose reasoning entirely — the field is otherwise
+	// dropped here and never reaches the provider.
+	Object.assign(
+		openaiRequest,
+		mapAnthropicThinkingToReasoning(
+			anthropicRequest.thinking,
+			anthropicRequest.output_config?.effort,
+		),
+	);
 
 	// Get user-agent for forwarding
 	const userAgent = c.req.header("User-Agent") ?? "";

--- a/apps/gateway/src/anthropic/thinking-to-reasoning.spec.ts
+++ b/apps/gateway/src/anthropic/thinking-to-reasoning.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { mapAnthropicThinkingToReasoning } from "./thinking-to-reasoning.js";
+
+describe("mapAnthropicThinkingToReasoning", () => {
+	it("forwards budget-based thinking as reasoning.max_tokens (Claude Code's path)", () => {
+		expect(
+			mapAnthropicThinkingToReasoning(
+				{ type: "enabled", budget_tokens: 8000 },
+				undefined,
+			),
+		).toEqual({ reasoning: { max_tokens: 8000 } });
+	});
+
+	it("maps adaptive thinking with output_config.effort to reasoning.effort", () => {
+		expect(
+			mapAnthropicThinkingToReasoning({ type: "adaptive" }, "high"),
+		).toEqual({ reasoning: { effort: "high" } });
+	});
+
+	it("defaults adaptive thinking without effort to high (Anthropic's default)", () => {
+		expect(
+			mapAnthropicThinkingToReasoning({ type: "adaptive" }, undefined),
+		).toEqual({ reasoning: { effort: "high" } });
+	});
+
+	it("passes through the higher effort tiers Claude Code emits (xhigh, max)", () => {
+		expect(
+			mapAnthropicThinkingToReasoning({ type: "adaptive" }, "xhigh"),
+		).toEqual({ reasoning: { effort: "xhigh" } });
+		expect(mapAnthropicThinkingToReasoning(undefined, "max")).toEqual({
+			reasoning: { effort: "max" },
+		});
+	});
+
+	it("maps a bare output_config.effort (no thinking field) to reasoning.effort", () => {
+		expect(mapAnthropicThinkingToReasoning(undefined, "low")).toEqual({
+			reasoning: { effort: "low" },
+		});
+	});
+
+	it("prefers an explicit budget over effort when both are present", () => {
+		expect(
+			mapAnthropicThinkingToReasoning(
+				{ type: "enabled", budget_tokens: 4000 },
+				"high",
+			),
+		).toEqual({ reasoning: { max_tokens: 4000 } });
+	});
+
+	it("defaults enabled-without-budget to high effort (Anthropic's default)", () => {
+		expect(
+			mapAnthropicThinkingToReasoning({ type: "enabled" }, undefined),
+		).toEqual({ reasoning: { effort: "high" } });
+	});
+
+	it("disables reasoning when thinking is disabled", () => {
+		expect(
+			mapAnthropicThinkingToReasoning({ type: "disabled" }, undefined),
+		).toEqual({ reasoning_effort: "none" });
+	});
+
+	it("returns nothing when no reasoning controls are present", () => {
+		expect(mapAnthropicThinkingToReasoning(undefined, undefined)).toEqual({});
+	});
+});

--- a/apps/gateway/src/anthropic/thinking-to-reasoning.ts
+++ b/apps/gateway/src/anthropic/thinking-to-reasoning.ts
@@ -1,0 +1,65 @@
+/**
+ * Native-Anthropic clients (e.g. Claude Code) express reasoning through the
+ * Messages API `thinking` field (extended thinking) and, on Opus 4.7+, through
+ * `output_config.effort` (adaptive thinking). The gateway's `/v1/messages`
+ * endpoint translates Anthropic requests into an internal `/v1/chat/completions`
+ * call, which speaks the unified reasoning controls (`reasoning.max_tokens`,
+ * `reasoning.effort`, `reasoning_effort`). This maps the former onto the latter
+ * so the requested effort actually reaches the provider instead of being
+ * silently dropped during the Anthropic -> OpenAI transformation.
+ */
+
+export interface AnthropicThinkingConfig {
+	type: string;
+	budget_tokens?: number;
+}
+
+/**
+ * Mirrors the reasoning-effort enum accepted by the chat completions endpoint
+ * (`reasoning.effort` / `reasoning_effort`). Claude Code's effort selector emits
+ * the full range, including `xhigh` and `max`, so the Anthropic path must accept
+ * them too rather than capping at `low | medium | high`.
+ */
+export type ReasoningEffort =
+	| "none"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
+
+export interface MappedReasoningFields {
+	reasoning?: {
+		effort?: ReasoningEffort;
+		max_tokens?: number;
+	};
+	reasoning_effort?: "none";
+}
+
+export function mapAnthropicThinkingToReasoning(
+	thinking: AnthropicThinkingConfig | undefined,
+	effort: ReasoningEffort | undefined,
+): MappedReasoningFields {
+	// Budget-based extended thinking — what Claude Code sends. Forward the exact
+	// token budget so reasoning depth is preserved end to end.
+	if (thinking?.type === "enabled" && thinking.budget_tokens !== undefined) {
+		return { reasoning: { max_tokens: thinking.budget_tokens } };
+	}
+	// Adaptive/effort-based reasoning (Opus 4.7+), or a bare `output_config.effort`.
+	// When no effort is given, fall back to `high`: it is Anthropic's documented
+	// default and is equivalent to omitting the parameter, so this matches what a
+	// request sent straight to Anthropic would do instead of under-powering it.
+	if (thinking?.type === "adaptive" || effort !== undefined) {
+		return { reasoning: { effort: effort ?? "high" } };
+	}
+	// Thinking enabled without a budget — reason at `high`, Anthropic's default depth.
+	if (thinking?.type === "enabled") {
+		return { reasoning: { effort: "high" } };
+	}
+	// Explicitly disabled — turn reasoning off downstream.
+	if (thinking?.type === "disabled") {
+		return { reasoning_effort: "none" };
+	}
+	return {};
+}

--- a/apps/gateway/src/chat/schemas/completions.spec.ts
+++ b/apps/gateway/src/chat/schemas/completions.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { completionsRequestSchema } from "./completions.js";
 
 describe("completionsRequestSchema reasoning_effort", () => {
-	it('accepts top-level reasoning_effort "max" and normalizes it to "high"', () => {
+	it('preserves top-level reasoning_effort "max" (Anthropic honors it natively; providers without a max tier alias it to high downstream)', () => {
 		const result = completionsRequestSchema.safeParse({
 			model: "deepseek-v4",
 			messages: [{ role: "user", content: "hi" }],
@@ -11,10 +11,10 @@ describe("completionsRequestSchema reasoning_effort", () => {
 		});
 
 		expect(result.success).toBe(true);
-		expect(result.data?.reasoning_effort).toBe("high");
+		expect(result.data?.reasoning_effort).toBe("max");
 	});
 
-	it('normalizes nested reasoning.effort "max" to "high"', () => {
+	it('preserves nested reasoning.effort "max"', () => {
 		const result = completionsRequestSchema.safeParse({
 			model: "deepseek-v4",
 			messages: [{ role: "user", content: "hi" }],
@@ -22,7 +22,7 @@ describe("completionsRequestSchema reasoning_effort", () => {
 		});
 
 		expect(result.success).toBe(true);
-		expect(result.data?.reasoning?.effort).toBe("high");
+		expect(result.data?.reasoning?.effort).toBe("max");
 	});
 
 	it("leaves other effort levels unchanged", () => {

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -265,17 +265,10 @@ export const completionsRequestSchema = z.object({
 		.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 		.nullable()
 		.optional()
-		.transform((val) => {
-			if (val === null) {
-				return undefined;
-			}
-			// "max" is accepted for client compatibility (e.g. opencode/DeepSeek)
-			// and normalized to "high".
-			return val === "max" ? "high" : val;
-		})
+		.transform((val) => (val === null ? undefined : val))
 		.openapi({
 			description:
-				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning. `max` is accepted as an alias for `high`.",
+				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning. `max` is the highest tier and is honored natively by Anthropic models (above `xhigh`); providers without a `max` tier treat it as `high`.",
 			example: "medium",
 		}),
 	reasoning: z
@@ -283,10 +276,9 @@ export const completionsRequestSchema = z.object({
 			effort: z
 				.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 				.optional()
-				.transform((val) => (val === "max" ? "high" : val))
 				.openapi({
 					description:
-						"Controls the reasoning effort. Alternative to top-level reasoning_effort. Cannot be used together with reasoning_effort. `max` is accepted as an alias for `high`.",
+						"Controls the reasoning effort. Alternative to top-level reasoning_effort. Cannot be used together with reasoning_effort. `max` is the highest tier (honored natively by Anthropic, above `xhigh`); providers without a `max` tier treat it as `high`.",
 					example: "medium",
 				}),
 			max_tokens: z.number().int().positive().optional().openapi({

--- a/apps/gateway/src/chat/tools/create-log-entry.ts
+++ b/apps/gateway/src/chat/tools/create-log-entry.ts
@@ -31,7 +31,14 @@ export interface CreateLogEntryOptions {
 	top_p?: number;
 	frequency_penalty?: number;
 	presence_penalty?: number;
-	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	reasoningEffort?:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| "max";
 	reasoningMaxTokens?: number;
 	effort?: "low" | "medium" | "high";
 	responseFormat?: any;
@@ -153,6 +160,7 @@ export function createLogEntry(
 		| "medium"
 		| "high"
 		| "xhigh"
+		| "max"
 		| undefined,
 	reasoningMaxTokens: number | undefined,
 	effort: "low" | "medium" | "high" | undefined,
@@ -195,7 +203,14 @@ export function createLogEntry(
 	top_p?: number,
 	frequency_penalty?: number,
 	presence_penalty?: number,
-	reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh",
+	reasoningEffort?:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| "max",
 	reasoningMaxTokens?: number,
 	effort?: "low" | "medium" | "high",
 	responseFormat?: any,

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -98,6 +98,7 @@ export interface ProviderContextOptions {
 		| "medium"
 		| "high"
 		| "xhigh"
+		| "max"
 		| undefined;
 	reasoning_max_tokens: number | undefined;
 	prompt_cache_key: string | undefined;

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -651,6 +651,88 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		}
 	});
 
+	test('preserves "max" effort natively for adaptive Anthropic models', async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-opus-4-7",
+			null,
+			"claude-opus-4-7",
+			[{ role: "user", content: "test" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"max", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.thinking).toEqual({ type: "adaptive" });
+		expect(requestBody.output_config.effort).toBe("max");
+	});
+
+	test('preserves "max" effort natively for adaptive Anthropic models on Bedrock', async () => {
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-opus-4-7",
+			null,
+			"claude-opus-4-7",
+			[{ role: "user", content: "test" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"max", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.additionalModelRequestFields.thinking).toEqual({
+			type: "adaptive",
+		});
+		expect(requestBody.additionalModelRequestFields.output_config.effort).toBe(
+			"max",
+		);
+	});
+
+	test('aliases "max" effort to "high" for providers without a max tier', async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.5-pro",
+			null,
+			"gemini-2.5-pro",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"max", // reasoning_effort
+			true,
+			false,
+		)) as any;
+
+		// "max" has no Google tier, so it aliases to "high" (24576) rather than
+		// falling through to the medium default (8192).
+		expect(requestBody.generationConfig.thinkingConfig.thinkingBudget).toBe(
+			24576,
+		);
+	});
+
 	test("should not set thinkingBudget when reasoning_effort is not provided", async () => {
 		const requestBody = (await prepareRequestBody(
 			"google-ai-studio",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -709,7 +709,14 @@ export async function prepareRequestBody(
 	response_format: OpenAIRequestBody["response_format"],
 	tools?: OpenAIToolInput[],
 	tool_choice?: ToolChoiceType,
-	reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh",
+	reasoning_effort?:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| "max",
 	supportsReasoning?: boolean,
 	isProd = false,
 	maxImageSizeMB = 20,
@@ -750,6 +757,19 @@ export async function prepareRequestBody(
 	if (reasoning_effort === "none" && !handlesNoneNatively) {
 		reasoning_effort = undefined;
 	}
+
+	// `max` is Anthropic's top effort tier (above `xhigh`). Providers without a
+	// native `max` level treat it as an alias for `high` (e.g. OpenAI, Google,
+	// DeepSeek). Anthropic-family branches use `reasoning_effort` directly and
+	// handle `max` natively, so they intentionally do not use this alias.
+	const genericReasoningEffort:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| undefined = reasoning_effort === "max" ? "high" : reasoning_effort;
 
 	// Handle OpenAI / Azure image generation models (e.g. gpt-image-2)
 	if (
@@ -1265,7 +1285,7 @@ export async function prepareRequestBody(
 					model: usedExternalId,
 					input: transformedMessages,
 					reasoning: {
-						effort: reasoning_effort ?? defaultEffort,
+						effort: genericReasoningEffort ?? defaultEffort,
 						summary: "detailed",
 					},
 				};
@@ -1435,7 +1455,7 @@ export async function prepareRequestBody(
 					requestBody.presence_penalty = presence_penalty;
 				}
 				if (reasoning_effort !== undefined) {
-					requestBody.reasoning_effort = reasoning_effort;
+					requestBody.reasoning_effort = genericReasoningEffort;
 				}
 				if (n !== undefined && n > 1) {
 					requestBody.n = n;
@@ -1524,6 +1544,8 @@ export async function prepareRequestBody(
 						return 4000;
 					case "xhigh":
 						return 16000;
+					case "max":
+						return 32000;
 					default:
 						return 2000; // medium or undefined
 				}
@@ -1749,6 +1771,8 @@ export async function prepareRequestBody(
 									return "high";
 								case "xhigh":
 									return "xhigh";
+								case "max":
+									return "max";
 								default:
 									return "high";
 							}
@@ -2164,6 +2188,8 @@ export async function prepareRequestBody(
 								return "high";
 							case "xhigh":
 								return "xhigh";
+							case "max":
+								return "max";
 							default:
 								return "high";
 						}
@@ -2191,6 +2217,8 @@ export async function prepareRequestBody(
 								return 4000;
 							case "xhigh":
 								return 16000;
+							case "max":
+								return 32000;
 							default:
 								return 2000;
 						}
@@ -2361,7 +2389,7 @@ export async function prepareRequestBody(
 						// Google maps this internally to thinkingLevel, so exact token control isn't guaranteed
 						requestBody.generationConfig.thinkingConfig.thinkingBudget =
 							reasoning_max_tokens;
-					} else if (reasoning_effort !== undefined) {
+					} else if (genericReasoningEffort !== undefined) {
 						const getThinkingBudget = (effort: string) => {
 							switch (effort) {
 								case "minimal":
@@ -2378,7 +2406,7 @@ export async function prepareRequestBody(
 							}
 						};
 						requestBody.generationConfig.thinkingConfig.thinkingBudget =
-							getThinkingBudget(reasoning_effort);
+							getThinkingBudget(genericReasoningEffort);
 					}
 				}
 			}
@@ -2501,7 +2529,7 @@ export async function prepareRequestBody(
 				requestBody.presence_penalty = presence_penalty;
 			}
 			if (reasoning_effort !== undefined) {
-				requestBody.reasoning_effort = reasoning_effort;
+				requestBody.reasoning_effort = genericReasoningEffort;
 			}
 			break;
 		}
@@ -2609,7 +2637,7 @@ export async function prepareRequestBody(
 					supported.length === 0 ||
 					supported.includes("reasoning_effort")
 				) {
-					requestBody.reasoning_effort = reasoning_effort;
+					requestBody.reasoning_effort = genericReasoningEffort;
 				}
 			}
 			if (usedProvider === "minimax" && supportsReasoning) {

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -408,7 +408,14 @@ export type RequestBodyPreparer = (
 	response_format?: OpenAIRequestBody["response_format"],
 	tools?: OpenAIToolInput[],
 	tool_choice?: ToolChoiceType,
-	reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh",
+	reasoning_effort?:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| "max",
 	supportsReasoning?: boolean,
 	isProd?: boolean,
 	maxImageSizeMB?: number,


### PR DESCRIPTION
The native Anthropic `/v1/messages` endpoint (used by Claude Code) parsed neither `thinking` nor `output_config.effort`, so the requested reasoning effort was silently dropped before reaching the provider; it now translates both onto the unified `reasoning.effort`/`reasoning.max_tokens` fields the chat-completions path already understands. `max` is also promoted to a first-class effort tier — preserved natively for Anthropic models (the top tier, above `xhigh`) instead of being normalized to `high`, and aliased to `high` only at non-Anthropic provider boundaries that lack a max tier. This adds a pure, unit-tested `mapAnthropicThinkingToReasoning` helper and threads the widened effort enum through the provider request builder, shared types, and request logging. Verified live end-to-end (the full `low`→`max` ladder now reaches the provider) with 100+ passing unit tests and a green `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `"max"` reasoning effort tier alongside existing effort levels
  * Enabled Anthropic extended reasoning controls including thinking type and budget token configuration
  
* **Improvements**
  * Gateway now properly preserves and maps reasoning controls across supported providers instead of normalizing values
  * Enhanced schema validation to accept and maintain new reasoning configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->