### PR TITLE
feat: add ByteDance AI terms

### DIFF
--- a/apps/ui/src/components/providers/hero.tsx
+++ b/apps/ui/src/components/providers/hero.tsx
@@ -221,6 +221,23 @@ export function Hero({ providerId }: HeroProps) {
 									</>
 								)}
 							</div>
+							{provider.additionalLinks &&
+								provider.additionalLinks.length > 0 && (
+									<div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t pt-3 text-sm text-muted-foreground">
+										{provider.additionalLinks.map((additionalLink) => (
+											<a
+												key={additionalLink.link}
+												href={additionalLink.link}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
+											>
+												{additionalLink.desc}
+												<ExternalLink className="h-3 w-3" />
+											</a>
+										))}
+									</div>
+								)}
 						</div>
 					)}
 

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -56,6 +56,11 @@ export interface ProviderDataPolicy {
 	gdpr?: boolean | null;
 }
 
+export interface ProviderAdditionalLink {
+	desc: string;
+	link: string;
+}
+
 export interface ProviderDefinition {
 	id: string;
 	name: string;
@@ -90,6 +95,8 @@ export interface ProviderDefinition {
 	headquarters?: string | null;
 	/** Data usage and privacy policy details */
 	dataPolicy?: ProviderDataPolicy | null;
+	/** Additional provider policy links shown in the Data & Privacy card */
+	additionalLinks?: ProviderAdditionalLink[];
 }
 
 export const providers: ProviderDefinition[] = [
@@ -990,9 +997,15 @@ export const providers: ProviderDefinition[] = [
 			apiTraining: false,
 			consumerTraining: null,
 			promptLogging: false,
-			retentionPeriod: "0 days",
+			retentionPeriod: "24 hours",
 			soc2: true,
 		},
+		additionalLinks: [
+			{
+				desc: "AI Terms",
+				link: "https://docs.byteplus.com/en/docs/legal/docs-service-specific-terms",
+			},
+		],
 	},
 	{
 		id: "minimax",


### PR DESCRIPTION
## Summary

- Add typed provider `additionalLinks` metadata for provider-specific policy links in the Data & Privacy card.
- Update ByteDance retention metadata to `24 hours` and add the BytePlus Service Specific Terms link labeled `AI Terms`.
- Render additional provider policy links below the existing Data & Privacy details without changing the general Terms of Service / Privacy Policy links.

## Validation

- `pnpm format` passed.
- `pnpm build` passed.
- `pnpm test:unit` failed because the connected local Postgres test schema is stale: the `user` table is missing the `username` column expected by the current Drizzle schema. The suite reported 335 failures with errors like `column "username" of relation "user" does not exist` / `column "username" does not exist` across DB-backed specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Providers can now display additional links within the "Data & Privacy" section for relevant documentation and policies
  
* **Updates**
  * Updated ByteDance provider with clarified data retention policy ("24 hours") and added "AI Terms" reference link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->