### PR TITLE
fix: handle DevPass payment actions

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -311,10 +311,16 @@ const finalize = createRoute({
 							status: z.literal("requires_action"),
 							subscriptionId: z.string(),
 							clientSecret: z.string(),
+							paymentMethodId: z.string().optional(),
 						}),
 						z.object({
 							status: z.literal("payment_pending"),
 							subscriptionId: z.string(),
+							subscriptionStatus: z.string().optional(),
+							invoiceId: z.string().optional(),
+							invoiceStatus: z.string().nullable().optional(),
+							paymentIntentStatus: z.string().optional(),
+							hasClientSecret: z.boolean().optional(),
 						}),
 					]),
 				},
@@ -382,6 +388,7 @@ devPlans.openapi(finalize, async (c) => {
 					status: result.status,
 					subscriptionId: result.subscriptionId,
 					clientSecret: result.clientSecret,
+					paymentMethodId: result.paymentMethodId,
 				},
 				200,
 			);
@@ -390,6 +397,11 @@ devPlans.openapi(finalize, async (c) => {
 				{
 					status: result.status,
 					subscriptionId: result.subscriptionId,
+					subscriptionStatus: result.subscriptionStatus,
+					invoiceId: result.invoiceId,
+					invoiceStatus: result.invoiceStatus,
+					paymentIntentStatus: result.paymentIntentStatus,
+					hasClientSecret: result.hasClientSecret,
 				},
 				200,
 			);

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -303,9 +303,20 @@ const finalize = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({
-						status: z.enum(["ok", "already_processed"]),
-					}),
+					schema: z.union([
+						z.object({
+							status: z.enum(["ok", "already_processed"]),
+						}),
+						z.object({
+							status: z.literal("requires_action"),
+							subscriptionId: z.string(),
+							clientSecret: z.string(),
+						}),
+						z.object({
+							status: z.literal("payment_pending"),
+							subscriptionId: z.string(),
+						}),
+					]),
 				},
 			},
 			description: "Dev plan subscription finalized",
@@ -365,6 +376,23 @@ devPlans.openapi(finalize, async (c) => {
 		case "ok":
 		case "already_processed":
 			return c.json({ status: result.status }, 200);
+		case "requires_action":
+			return c.json(
+				{
+					status: result.status,
+					subscriptionId: result.subscriptionId,
+					clientSecret: result.clientSecret,
+				},
+				200,
+			);
+		case "payment_pending":
+			return c.json(
+				{
+					status: result.status,
+					subscriptionId: result.subscriptionId,
+				},
+				200,
+			);
 		case "duplicate_card":
 			return c.json(
 				{

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -413,6 +413,62 @@ function getSubscriptionPaymentIntent(
 	return isStripePaymentIntent(paymentIntent) ? paymentIntent : null;
 }
 
+function getInvoiceConfirmationClientSecret(
+	invoice: Stripe.Invoice,
+): string | null {
+	const confirmationSecret = invoice.confirmation_secret;
+	return confirmationSecret?.client_secret ?? null;
+}
+
+async function getSubscriptionInvoice(
+	subscription: Stripe.Subscription,
+): Promise<Stripe.Invoice | null> {
+	const latestInvoice = subscription.latest_invoice;
+	if (!latestInvoice) {
+		return null;
+	}
+	if (typeof latestInvoice !== "string") {
+		return latestInvoice;
+	}
+
+	return await getStripe().invoices.retrieve(latestInvoice, {
+		expand: ["payment_intent"],
+	});
+}
+
+async function getSubscriptionPaymentConfirmation(
+	subscription: Stripe.Subscription,
+): Promise<{
+	paymentIntent: Stripe.PaymentIntent | null;
+	clientSecret: string | null;
+}> {
+	const invoice = await getSubscriptionInvoice(subscription);
+	if (!invoice) {
+		return { paymentIntent: null, clientSecret: null };
+	}
+
+	let paymentIntent = getSubscriptionPaymentIntent(subscription);
+	if (!paymentIntent) {
+		const { payment_intent: invoicePaymentIntent } = invoice as {
+			payment_intent?: unknown;
+		};
+		if (
+			invoicePaymentIntent &&
+			typeof invoicePaymentIntent !== "string" &&
+			isStripePaymentIntent(invoicePaymentIntent)
+		) {
+			paymentIntent = invoicePaymentIntent;
+		}
+	}
+
+	return {
+		paymentIntent,
+		clientSecret:
+			paymentIntent?.client_secret ??
+			getInvoiceConfirmationClientSecret(invoice),
+	};
+}
+
 async function findDevPlanSubscriptionForSetupSession(
 	customerId: string,
 	sessionId: string,
@@ -632,16 +688,21 @@ export async function finalizeDevPlanSetupSession(
 			{ idempotencyKey: stripeIdempotencyKey },
 		));
 
-	const paymentIntent = getSubscriptionPaymentIntent(subscription);
+	const { paymentIntent, clientSecret } =
+		await getSubscriptionPaymentConfirmation(subscription);
 	if (
-		paymentIntent?.client_secret &&
-		(paymentIntent.status === "requires_action" ||
-			paymentIntent.status === "requires_confirmation")
+		clientSecret &&
+		((paymentIntent &&
+			(paymentIntent.status === "requires_action" ||
+				paymentIntent.status === "requires_confirmation")) ||
+			(!paymentIntent &&
+				(subscription.status === "incomplete" ||
+					subscription.status === "past_due")))
 	) {
 		return {
 			status: "requires_action",
 			subscriptionId: subscription.id,
-			clientSecret: paymentIntent.client_secret,
+			clientSecret,
 		};
 	}
 	if (paymentIntent && paymentIntent.status !== "succeeded") {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -377,8 +377,17 @@ export type FinalizeDevPlanResult =
 			status: "requires_action";
 			subscriptionId: string;
 			clientSecret: string;
+			paymentMethodId?: string;
 	  }
-	| { status: "payment_pending"; subscriptionId: string }
+	| {
+			status: "payment_pending";
+			subscriptionId: string;
+			subscriptionStatus?: string;
+			invoiceId?: string;
+			invoiceStatus?: string | null;
+			paymentIntentStatus?: string;
+			hasClientSecret?: boolean;
+	  }
 	| { status: "duplicate_card"; conflictingOrgId: string }
 	| { status: "already_processed"; subscriptionId: string | null }
 	| { status: "no_payment_method" }
@@ -420,6 +429,36 @@ function getInvoiceConfirmationClientSecret(
 	return confirmationSecret?.client_secret ?? null;
 }
 
+async function getPaymentIntentFromInvoicePayments(
+	invoice: Stripe.Invoice,
+): Promise<Stripe.PaymentIntent | null> {
+	let invoicePayments = invoice.payments?.data ?? [];
+	if (invoicePayments.length === 0) {
+		const listedPayments = await getStripe().invoicePayments.list({
+			invoice: invoice.id,
+			limit: 10,
+		});
+		invoicePayments = listedPayments.data;
+	}
+
+	for (const invoicePayment of invoicePayments) {
+		const paymentIntent = invoicePayment.payment.payment_intent;
+		if (!paymentIntent) {
+			continue;
+		}
+		if (typeof paymentIntent !== "string") {
+			if (isStripePaymentIntent(paymentIntent)) {
+				return paymentIntent;
+			}
+			continue;
+		}
+		const retrieved = await getStripe().paymentIntents.retrieve(paymentIntent);
+		return isStripePaymentIntent(retrieved) ? retrieved : null;
+	}
+
+	return null;
+}
+
 async function getSubscriptionInvoice(
 	subscription: Stripe.Subscription,
 ): Promise<Stripe.Invoice | null> {
@@ -441,10 +480,11 @@ async function getSubscriptionPaymentConfirmation(
 ): Promise<{
 	paymentIntent: Stripe.PaymentIntent | null;
 	clientSecret: string | null;
+	invoice: Stripe.Invoice | null;
 }> {
 	const invoice = await getSubscriptionInvoice(subscription);
 	if (!invoice) {
-		return { paymentIntent: null, clientSecret: null };
+		return { paymentIntent: null, clientSecret: null, invoice: null };
 	}
 
 	let paymentIntent = getSubscriptionPaymentIntent(subscription);
@@ -460,12 +500,46 @@ async function getSubscriptionPaymentConfirmation(
 			paymentIntent = invoicePaymentIntent;
 		}
 	}
+	paymentIntent ??= await getPaymentIntentFromInvoicePayments(invoice);
 
 	return {
 		paymentIntent,
 		clientSecret:
 			paymentIntent?.client_secret ??
 			getInvoiceConfirmationClientSecret(invoice),
+		invoice,
+	};
+}
+
+function getPaymentPendingResult({
+	subscription,
+	invoice,
+	paymentIntent,
+	clientSecret,
+}: {
+	subscription: Stripe.Subscription;
+	invoice: Stripe.Invoice | null;
+	paymentIntent: Stripe.PaymentIntent | null;
+	clientSecret: string | null;
+}): FinalizeDevPlanResult {
+	logger.info("Dev plan subscription payment is pending", {
+		subscriptionId: subscription.id,
+		subscriptionStatus: subscription.status,
+		invoiceId: invoice?.id,
+		invoiceStatus: invoice?.status,
+		paymentIntentId: paymentIntent?.id,
+		paymentIntentStatus: paymentIntent?.status,
+		hasClientSecret: Boolean(clientSecret),
+	});
+
+	return {
+		status: "payment_pending",
+		subscriptionId: subscription.id,
+		subscriptionStatus: subscription.status,
+		invoiceId: invoice?.id,
+		invoiceStatus: invoice?.status,
+		paymentIntentStatus: paymentIntent?.status,
+		hasClientSecret: Boolean(clientSecret),
 	};
 }
 
@@ -688,13 +762,14 @@ export async function finalizeDevPlanSetupSession(
 			{ idempotencyKey: stripeIdempotencyKey },
 		));
 
-	const { paymentIntent, clientSecret } =
+	const { paymentIntent, clientSecret, invoice } =
 		await getSubscriptionPaymentConfirmation(subscription);
 	if (
 		clientSecret &&
 		((paymentIntent &&
 			(paymentIntent.status === "requires_action" ||
-				paymentIntent.status === "requires_confirmation")) ||
+				paymentIntent.status === "requires_confirmation" ||
+				paymentIntent.status === "requires_payment_method")) ||
 			(!paymentIntent &&
 				(subscription.status === "incomplete" ||
 					subscription.status === "past_due")))
@@ -703,22 +778,27 @@ export async function finalizeDevPlanSetupSession(
 			status: "requires_action",
 			subscriptionId: subscription.id,
 			clientSecret,
+			paymentMethodId: paymentMethod.id,
 		};
 	}
 	if (paymentIntent && paymentIntent.status !== "succeeded") {
-		return {
-			status: "payment_pending",
-			subscriptionId: subscription.id,
-		};
+		return getPaymentPendingResult({
+			subscription,
+			invoice,
+			paymentIntent,
+			clientSecret,
+		});
 	}
 	if (
 		!paymentIntent &&
 		(subscription.status === "incomplete" || subscription.status === "past_due")
 	) {
-		return {
-			status: "payment_pending",
-			subscriptionId: subscription.id,
-		};
+		return getPaymentPendingResult({
+			subscription,
+			invoice,
+			paymentIntent,
+			clientSecret,
+		});
 	}
 
 	const creditsLimit = getDevPlanCreditsLimit(devPlanTier);
@@ -2534,9 +2614,16 @@ export async function handleInvoicePaymentSucceeded(event: {
 	const isDevPlanSubscription =
 		organization.devPlanStripeSubscriptionId === subscriptionId &&
 		organization.devPlan !== "none";
-	const stripeSubscription =
-		await getStripe().subscriptions.retrieve(subscriptionId);
-	const subscriptionMetadata = stripeSubscription.metadata ?? {};
+	let subscriptionMetadata: Stripe.Metadata | undefined;
+	if (
+		organization.devPlan === "none" &&
+		organization.devPlanStripeSubscriptionId !== subscriptionId
+	) {
+		const stripeSubscription =
+			await getStripe().subscriptions.retrieve(subscriptionId);
+		subscriptionMetadata = stripeSubscription.metadata;
+	}
+	subscriptionMetadata ??= {};
 	const initialDevPlanTier = subscriptionMetadata.devPlan as
 		| DevPlanTier
 		| undefined;

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -277,6 +277,9 @@ stripeRoutes.openapi(webhookHandler, async (c) => {
 			case "invoice.payment_succeeded":
 				await handleInvoicePaymentSucceeded(event);
 				break;
+			case "invoice.paid":
+				await handleInvoicePaymentSucceeded(event);
+				break;
 			case "invoice.payment_failed":
 				await handleInvoicePaymentFailed(event);
 				break;
@@ -429,6 +432,10 @@ async function findDevPlanSubscriptionForSetupSession(
 	return await getStripe().subscriptions.retrieve(existing.id, {
 		expand: ["latest_invoice.payment_intent"],
 	});
+}
+
+function shouldForceDevPlan3dsChallenge(): boolean {
+	return process.env.STRIPE_DEV_PLAN_FORCE_3DS === "true";
 }
 
 async function resolvePaymentMethodFromSetupSession(
@@ -601,6 +608,17 @@ export async function finalizeDevPlanSetupSession(
 				items: [{ price: priceId }],
 				default_payment_method: paymentMethod.id,
 				payment_behavior: "default_incomplete",
+				...(shouldForceDevPlan3dsChallenge()
+					? {
+							payment_settings: {
+								payment_method_options: {
+									card: {
+										request_three_d_secure: "challenge" as const,
+									},
+								},
+							},
+						}
+					: {}),
 				metadata: {
 					organizationId,
 					subscriptionType: "dev_plan",
@@ -2381,9 +2399,9 @@ async function handleSetupIntentSucceeded(
 	});
 }
 
-export async function handleInvoicePaymentSucceeded(
-	event: Stripe.InvoicePaymentSucceededEvent,
-) {
+export async function handleInvoicePaymentSucceeded(event: {
+	data: { object: Stripe.Invoice };
+}) {
 	const invoice = event.data.object;
 	const { customer, metadata } = invoice;
 	const subscription = (invoice as any).subscription;

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -370,10 +370,66 @@ async function getSubscriptionCardFingerprint(
 
 export type FinalizeDevPlanResult =
 	| { status: "ok"; subscriptionId: string }
+	| {
+			status: "requires_action";
+			subscriptionId: string;
+			clientSecret: string;
+	  }
+	| { status: "payment_pending"; subscriptionId: string }
 	| { status: "duplicate_card"; conflictingOrgId: string }
 	| { status: "already_processed"; subscriptionId: string | null }
 	| { status: "no_payment_method" }
 	| { status: "invalid_session"; reason: string };
+
+function isStripePaymentIntent(value: unknown): value is Stripe.PaymentIntent {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+	return (value as { object?: unknown }).object === "payment_intent";
+}
+
+function getSubscriptionPaymentIntent(
+	subscription: Stripe.Subscription,
+): Stripe.PaymentIntent | null {
+	const latestInvoice = subscription.latest_invoice;
+	if (
+		!latestInvoice ||
+		typeof latestInvoice === "string" ||
+		!("payment_intent" in latestInvoice)
+	) {
+		return null;
+	}
+
+	const { payment_intent: paymentIntent } = latestInvoice as {
+		payment_intent?: unknown;
+	};
+	if (!paymentIntent || typeof paymentIntent === "string") {
+		return null;
+	}
+
+	return isStripePaymentIntent(paymentIntent) ? paymentIntent : null;
+}
+
+async function findDevPlanSubscriptionForSetupSession(
+	customerId: string,
+	sessionId: string,
+): Promise<Stripe.Subscription | null> {
+	const subscriptions = await getStripe().subscriptions.list({
+		customer: customerId,
+		status: "all",
+		limit: 100,
+	});
+	const existing = subscriptions.data.find(
+		(subscription) => subscription.metadata?.setupSessionId === sessionId,
+	);
+	if (!existing) {
+		return null;
+	}
+
+	return await getStripe().subscriptions.retrieve(existing.id, {
+		expand: ["latest_invoice.payment_intent"],
+	});
+}
 
 async function resolvePaymentMethodFromSetupSession(
 	session: Stripe.Checkout.Session,
@@ -532,24 +588,59 @@ export async function finalizeDevPlanSetupSession(
 	// writer has filled in devPlanStripeSubscriptionId yet — the loser then
 	// reports already_processed so it doesn't double-insert the transaction
 	// row or re-send notifications.
-	const stripeIdempotencyKey = `devpass-sub:${organizationId}:${sessionId}`;
-	const subscription = await getStripe().subscriptions.create(
-		{
-			customer: stripeCustomerId,
-			items: [{ price: priceId }],
-			default_payment_method: paymentMethod.id,
-			payment_behavior: "error_if_incomplete",
-			metadata: {
-				organizationId,
-				subscriptionType: "dev_plan",
-				devPlan: devPlanTier,
-				devPlanCycle,
-				userEmail: userEmail ?? "",
-			},
-			expand: ["latest_invoice"],
-		},
-		{ idempotencyKey: stripeIdempotencyKey },
+	const existingSubscription = await findDevPlanSubscriptionForSetupSession(
+		stripeCustomerId,
+		sessionId,
 	);
+	const stripeIdempotencyKey = `devpass-sub:${organizationId}:${sessionId}`;
+	const subscription =
+		existingSubscription ??
+		(await getStripe().subscriptions.create(
+			{
+				customer: stripeCustomerId,
+				items: [{ price: priceId }],
+				default_payment_method: paymentMethod.id,
+				payment_behavior: "default_incomplete",
+				metadata: {
+					organizationId,
+					subscriptionType: "dev_plan",
+					devPlan: devPlanTier,
+					devPlanCycle,
+					setupSessionId: sessionId,
+					userEmail: userEmail ?? "",
+				},
+				expand: ["latest_invoice.payment_intent"],
+			},
+			{ idempotencyKey: stripeIdempotencyKey },
+		));
+
+	const paymentIntent = getSubscriptionPaymentIntent(subscription);
+	if (
+		paymentIntent?.client_secret &&
+		(paymentIntent.status === "requires_action" ||
+			paymentIntent.status === "requires_confirmation")
+	) {
+		return {
+			status: "requires_action",
+			subscriptionId: subscription.id,
+			clientSecret: paymentIntent.client_secret,
+		};
+	}
+	if (paymentIntent && paymentIntent.status !== "succeeded") {
+		return {
+			status: "payment_pending",
+			subscriptionId: subscription.id,
+		};
+	}
+	if (
+		!paymentIntent &&
+		(subscription.status === "incomplete" || subscription.status === "past_due")
+	) {
+		return {
+			status: "payment_pending",
+			subscriptionId: subscription.id,
+		};
+	}
 
 	const creditsLimit = getDevPlanCreditsLimit(devPlanTier);
 
@@ -2364,6 +2455,19 @@ export async function handleInvoicePaymentSucceeded(
 	const isDevPlanSubscription =
 		organization.devPlanStripeSubscriptionId === subscriptionId &&
 		organization.devPlan !== "none";
+	const stripeSubscription =
+		await getStripe().subscriptions.retrieve(subscriptionId);
+	const subscriptionMetadata = stripeSubscription.metadata ?? {};
+	const initialDevPlanTier = subscriptionMetadata.devPlan as
+		| DevPlanTier
+		| undefined;
+	const initialDevPlanCycle: DevPlanCycle =
+		subscriptionMetadata.devPlanCycle === "annual" ? "annual" : "monthly";
+	const isInitialDevPlanSubscription =
+		subscriptionMetadata.subscriptionType === "dev_plan" &&
+		!!initialDevPlanTier &&
+		organization.devPlan === "none" &&
+		organization.devPlanStripeSubscriptionId !== subscriptionId;
 
 	// Stripe fires `invoice.payment_succeeded` both for true period renewals
 	// (`subscription_cycle`) and for the proration invoice generated when a
@@ -2379,7 +2483,114 @@ export async function handleInvoicePaymentSucceeded(
 		`Found organization: ${organization.name} (${organization.id}), current plan: ${organization.plan}, billingReason: ${invoice.billing_reason}, isDevPlanRenewal: ${isDevPlanRenewal}`,
 	);
 
-	if (isDevPlanRenewal) {
+	if (isInitialDevPlanSubscription && initialDevPlanTier) {
+		const creditsLimit = getDevPlanCreditsLimit(initialDevPlanTier);
+		const fingerprint = await getSubscriptionCardFingerprint(subscriptionId);
+
+		const claimed = await db
+			.update(tables.organization)
+			.set({
+				devPlan: initialDevPlanTier,
+				devPlanCreditsLimit: creditsLimit.toString(),
+				devPlanCreditsUsed: "0",
+				devPlanBillingCycleStart: new Date(),
+				devPlanStripeSubscriptionId: subscriptionId,
+				devPlanCancelled: false,
+				devPlanCycle: initialDevPlanCycle,
+				devPlanCardFingerprint: fingerprint,
+			})
+			.where(
+				and(
+					eq(tables.organization.id, organizationId),
+					isNull(tables.organization.devPlanStripeSubscriptionId),
+				),
+			)
+			.returning({ id: tables.organization.id });
+
+		if (claimed.length === 0) {
+			logger.info(
+				`Skipping initial DevPass invoice ${invoice.id}: subscription ${subscriptionId} was already activated`,
+			);
+			return;
+		}
+
+		const [transaction] = await db
+			.insert(tables.transaction)
+			.values({
+				organizationId,
+				type: "dev_plan_start",
+				amount: (invoice.amount_paid / 100).toString(),
+				creditAmount: creditsLimit.toString(),
+				currency: invoice.currency.toUpperCase(),
+				status: "completed",
+				stripePaymentIntentId: (invoice as { payment_intent?: string | null })
+					.payment_intent,
+				stripeInvoiceId: invoice.id,
+				description: `Dev Plan ${initialDevPlanTier.toUpperCase()} started via Stripe Checkout`,
+			})
+			.returning();
+
+		try {
+			await generateAndEmailInvoice({
+				invoiceNumber: transaction.id,
+				invoiceDate: new Date(),
+				organizationName: organization.name,
+				billingEmail: organization.billingEmail,
+				billingCompany: organization.billingCompany,
+				billingAddress: organization.billingAddress,
+				billingTaxId: organization.billingTaxId,
+				billingNotes: organization.billingNotes,
+				lineItems: [
+					{
+						description: `Dev Plan ${initialDevPlanTier.toUpperCase()} ($${creditsLimit} credits included)`,
+						amount: invoice.amount_paid / 100,
+					},
+				],
+				currency: invoice.currency.toUpperCase(),
+			});
+		} catch (e) {
+			logger.error(
+				"Invoice email failed (initial DevPass invoice); suppressing failure",
+				e as Error,
+			);
+		}
+
+		posthog.groupIdentify({
+			groupType: "organization",
+			groupKey: organizationId,
+			properties: { name: organization.name },
+		});
+		posthog.capture({
+			distinctId: "organization",
+			event: "dev_plan_started",
+			groups: { organization: organizationId },
+			properties: {
+				devPlan: initialDevPlanTier,
+				creditsLimit,
+				organization: organizationId,
+				subscriptionId,
+				source: "stripe_invoice",
+			},
+		});
+
+		const subscribedEmail =
+			subscriptionMetadata.userEmail || organization.billingEmail;
+		if (subscribedEmail) {
+			const subscribedUser = await db.query.user.findFirst({
+				where: { email: { eq: subscribedEmail } },
+			});
+			await notifyDevPlanSubscribed(
+				subscribedEmail,
+				subscribedUser?.name,
+				initialDevPlanTier,
+				initialDevPlanCycle,
+			);
+		}
+
+		logger.info(
+			`Activated initial DevPass subscription ${subscriptionId} for organization ${organizationId} from invoice ${invoice.id}`,
+		);
+	} else if (isDevPlanRenewal) {
 		// Handle dev plan renewal - reset credits
 		const creditsLimit = getDevPlanCreditsLimit(
 			organization.devPlan as DevPlanTier,

--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -109,18 +109,23 @@ export default function DashboardShell({
 	const [duplicateCardError, setDuplicateCardError] = useState<string | null>(
 		null,
 	);
-	const finalizedSessions = useRef<Set<string>>(new Set());
+	const activeSetupSession = useRef<string | null>(null);
+	const finalizeDevPlanRef = useRef(finalizeMutation.mutateAsync);
+
+	useEffect(() => {
+		finalizeDevPlanRef.current = finalizeMutation.mutateAsync;
+	}, [finalizeMutation.mutateAsync]);
 
 	useEffect(() => {
 		const sessionId = searchParams.get("setup_session_id");
 		if (
 			!sessionId ||
 			stripeLoading ||
-			finalizedSessions.current.has(sessionId)
+			activeSetupSession.current === sessionId
 		) {
 			return;
 		}
-		finalizedSessions.current.add(sessionId);
+		activeSetupSession.current = sessionId;
 		const abortController = new AbortController();
 		const { signal } = abortController;
 
@@ -132,7 +137,7 @@ export default function DashboardShell({
 		};
 
 		const finalizeOnce = async () => {
-			return await finalizeMutation.mutateAsync({
+			return await finalizeDevPlanRef.current({
 				body: { sessionId },
 			});
 		};
@@ -222,19 +227,18 @@ export default function DashboardShell({
 				if (!signal.aborted) {
 					clearParam();
 				}
+				if (activeSetupSession.current === sessionId) {
+					activeSetupSession.current = null;
+				}
 			});
 
 		return () => {
 			abortController.abort();
+			if (activeSetupSession.current === sessionId) {
+				activeSetupSession.current = null;
+			}
 		};
-	}, [
-		searchParams,
-		finalizeMutation,
-		queryClient,
-		router,
-		stripe,
-		stripeLoading,
-	]);
+	}, [searchParams, queryClient, router, stripe, stripeLoading]);
 
 	const handleSubscribe = async (tier: PlanTier): Promise<void> => {
 		setSubscribingTier(tier);

--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -5,6 +5,7 @@ import {
 	BarChart3,
 	Code,
 	CreditCard,
+	Loader2,
 	LogOut,
 	Settings,
 	UserRound,
@@ -55,6 +56,45 @@ const navItems: Array<{ label: string; href: Route; icon: typeof BarChart3 }> =
 		{ label: "Settings", href: "/dashboard/settings" as Route, icon: Settings },
 	];
 
+type SetupActivationStatus =
+	| "loading_stripe"
+	| "finalizing"
+	| "authenticating"
+	| "processing"
+	| "success"
+	| "error";
+
+const setupActivationCopy: Record<
+	SetupActivationStatus,
+	{ title: string; description: string }
+> = {
+	loading_stripe: {
+		title: "Preparing payment",
+		description: "Loading secure payment confirmation.",
+	},
+	finalizing: {
+		title: "Activating DevPass",
+		description: "Creating your subscription and checking payment status.",
+	},
+	authenticating: {
+		title: "Confirming payment",
+		description: "Complete the secure authentication prompt to continue.",
+	},
+	processing: {
+		title: "Payment is processing",
+		description:
+			"DevPass will activate as soon as Stripe confirms the payment.",
+	},
+	success: {
+		title: "DevPass activated",
+		description: "Refreshing your dashboard.",
+	},
+	error: {
+		title: "Activation failed",
+		description: "Refresh this page to retry DevPass activation.",
+	},
+};
+
 const wait = async (ms: number, signal: AbortSignal) => {
 	if (signal.aborted) {
 		throw new DOMException("Aborted", "AbortError");
@@ -104,11 +144,14 @@ export default function DashboardShell({
 
 	const subscribeMutation = api.useMutation("post", "/dev-plans/subscribe");
 	const finalizeMutation = api.useMutation("post", "/dev-plans/finalize");
+	const setupSessionId = searchParams.get("setup_session_id");
 
 	const [subscribingTier, setSubscribingTier] = useState<PlanTier | null>(null);
 	const [duplicateCardError, setDuplicateCardError] = useState<string | null>(
 		null,
 	);
+	const [setupActivationStatus, setSetupActivationStatus] =
+		useState<SetupActivationStatus | null>(null);
 	const activeSetupSession = useRef<string | null>(null);
 	const finalizeDevPlanRef = useRef(finalizeMutation.mutateAsync);
 
@@ -117,17 +160,23 @@ export default function DashboardShell({
 	}, [finalizeMutation.mutateAsync]);
 
 	useEffect(() => {
-		const sessionId = searchParams.get("setup_session_id");
-		if (
-			!sessionId ||
-			stripeLoading ||
-			activeSetupSession.current === sessionId
-		) {
+		const sessionId = setupSessionId;
+		if (!sessionId) {
+			setSetupActivationStatus(null);
+			return;
+		}
+		if (stripeLoading) {
+			setSetupActivationStatus("loading_stripe");
+			return;
+		}
+		if (activeSetupSession.current === sessionId) {
 			return;
 		}
 		activeSetupSession.current = sessionId;
+		setSetupActivationStatus("finalizing");
 		const abortController = new AbortController();
 		const { signal } = abortController;
+		let shouldClearSetupParam = true;
 
 		const clearParam = () => {
 			const params = new URLSearchParams(searchParams.toString());
@@ -146,10 +195,11 @@ export default function DashboardShell({
 			initialResult: Awaited<ReturnType<typeof finalizeOnce>>,
 		) => {
 			let result = initialResult;
-			for (let attempt = 0; attempt < 10; attempt++) {
+			for (let attempt = 0; attempt < 60; attempt++) {
 				if (result?.status !== "payment_pending") {
 					return result;
 				}
+				setSetupActivationStatus("processing");
 				await wait(2000, signal);
 				result = await finalizeOnce();
 			}
@@ -162,8 +212,12 @@ export default function DashboardShell({
 				if (!stripe) {
 					throw new Error("Stripe is not ready. Please refresh and try again.");
 				}
+				setSetupActivationStatus("authenticating");
 				const confirmation = await stripe.confirmCardPayment(
 					result.clientSecret,
+					result.paymentMethodId
+						? { payment_method: result.paymentMethodId }
+						: undefined,
 				);
 				if (confirmation.error) {
 					throw new Error(
@@ -171,6 +225,7 @@ export default function DashboardShell({
 					);
 				}
 
+				setSetupActivationStatus("processing");
 				return await waitForFinalization(await finalizeOnce());
 			}
 			return await waitForFinalization(result);
@@ -182,6 +237,7 @@ export default function DashboardShell({
 					return;
 				}
 				if (result?.status === "ok" || result?.status === "already_processed") {
+					setSetupActivationStatus("success");
 					toast.success("DevPass activated");
 					void queryClient.invalidateQueries({
 						predicate: (query) => {
@@ -190,6 +246,8 @@ export default function DashboardShell({
 						},
 					});
 				} else if (result?.status === "payment_pending") {
+					shouldClearSetupParam = false;
+					setSetupActivationStatus("processing");
 					toast.info("Payment is processing. DevPass will activate shortly.");
 				}
 			})
@@ -212,6 +270,8 @@ export default function DashboardShell({
 							: "This card is already associated with another DevPass account. Please use a different payment method.",
 					);
 				} else {
+					shouldClearSetupParam = false;
+					setSetupActivationStatus("error");
 					const apiMessage =
 						error && typeof error === "object" && "message" in error
 							? (error as { message?: unknown }).message
@@ -224,7 +284,7 @@ export default function DashboardShell({
 				}
 			})
 			.finally(() => {
-				if (!signal.aborted) {
+				if (!signal.aborted && shouldClearSetupParam) {
 					clearParam();
 				}
 				if (activeSetupSession.current === sessionId) {
@@ -238,7 +298,14 @@ export default function DashboardShell({
 				activeSetupSession.current = null;
 			}
 		};
-	}, [searchParams, queryClient, router, stripe, stripeLoading]);
+	}, [
+		setupSessionId,
+		searchParams,
+		queryClient,
+		router,
+		stripe,
+		stripeLoading,
+	]);
 
 	const handleSubscribe = async (tier: PlanTier): Promise<void> => {
 		setSubscribingTier(tier);
@@ -279,6 +346,11 @@ export default function DashboardShell({
 	const hasActivePlan =
 		devPlanStatus?.devPlan && devPlanStatus.devPlan !== "none";
 	const currentPlanName = devPlanStatus?.devPlan?.toUpperCase() ?? "";
+	const activeSetupActivationStatus =
+		setupActivationStatus ?? (setupSessionId ? "finalizing" : null);
+	const activeSetupActivationCopy = activeSetupActivationStatus
+		? setupActivationCopy[activeSetupActivationStatus]
+		: null;
 
 	return (
 		<div className="min-h-screen bg-background">
@@ -343,7 +415,26 @@ export default function DashboardShell({
 
 			<EmailVerificationBanner />
 
-			{statusLoading ? (
+			{activeSetupActivationCopy ? (
+				<main className="container mx-auto flex min-h-[calc(100vh-120px)] max-w-3xl items-center justify-center px-4 py-12">
+					<div className="w-full rounded-xl border bg-background p-8 text-center shadow-sm sm:p-12">
+						<div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
+							<Loader2
+								className={cn(
+									"h-10 w-10 text-foreground",
+									activeSetupActivationStatus !== "error" && "animate-spin",
+								)}
+							/>
+						</div>
+						<h1 className="text-2xl font-semibold sm:text-3xl">
+							{activeSetupActivationCopy.title}
+						</h1>
+						<p className="mx-auto mt-3 max-w-md text-sm leading-6 text-muted-foreground sm:text-base">
+							{activeSetupActivationCopy.description}
+						</p>
+					</div>
+				</main>
+			) : statusLoading ? (
 				<div className="container mx-auto flex flex-col gap-8 px-4 py-8 lg:flex-row">
 					<aside className="lg:w-56 lg:shrink-0">
 						<div className="flex gap-1 lg:flex-col">

--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -55,6 +55,24 @@ const navItems: Array<{ label: string; href: Route; icon: typeof BarChart3 }> =
 		{ label: "Settings", href: "/dashboard/settings" as Route, icon: Settings },
 	];
 
+const wait = async (ms: number, signal: AbortSignal) => {
+	if (signal.aborted) {
+		throw new DOMException("Aborted", "AbortError");
+	}
+
+	await new Promise<void>((resolve, reject) => {
+		const timeoutId = window.setTimeout(() => {
+			signal.removeEventListener("abort", handleAbort);
+			resolve();
+		}, ms);
+		function handleAbort() {
+			window.clearTimeout(timeoutId);
+			reject(new DOMException("Aborted", "AbortError"));
+		}
+		signal.addEventListener("abort", handleAbort, { once: true });
+	});
+};
+
 export default function DashboardShell({
 	children,
 	initialUser,
@@ -103,6 +121,8 @@ export default function DashboardShell({
 			return;
 		}
 		finalizedSessions.current.add(sessionId);
+		const abortController = new AbortController();
+		const { signal } = abortController;
 
 		const clearParam = () => {
 			const params = new URLSearchParams(searchParams.toString());
@@ -111,10 +131,28 @@ export default function DashboardShell({
 			router.replace(query ? `/dashboard?${query}` : "/dashboard");
 		};
 
-		const finalizeDevPlan = async () => {
-			const result = await finalizeMutation.mutateAsync({
+		const finalizeOnce = async () => {
+			return await finalizeMutation.mutateAsync({
 				body: { sessionId },
 			});
+		};
+
+		const waitForFinalization = async (
+			initialResult: Awaited<ReturnType<typeof finalizeOnce>>,
+		) => {
+			let result = initialResult;
+			for (let attempt = 0; attempt < 10; attempt++) {
+				if (result?.status !== "payment_pending") {
+					return result;
+				}
+				await wait(2000, signal);
+				result = await finalizeOnce();
+			}
+			return result;
+		};
+
+		const finalizeDevPlan = async () => {
+			const result = await finalizeOnce();
 			if (result?.status === "requires_action") {
 				if (!stripe) {
 					throw new Error("Stripe is not ready. Please refresh and try again.");
@@ -127,18 +165,17 @@ export default function DashboardShell({
 						confirmation.error.message ?? "Payment authentication failed",
 					);
 				}
-				if (confirmation.paymentIntent?.status !== "succeeded") {
-					toast.info("Payment is processing. DevPass will activate shortly.");
-					return;
-				}
 
-				return await finalizeMutation.mutateAsync({ body: { sessionId } });
+				return await waitForFinalization(await finalizeOnce());
 			}
-			return result;
+			return await waitForFinalization(result);
 		};
 
 		finalizeDevPlan()
 			.then((result) => {
+				if (signal.aborted) {
+					return;
+				}
 				if (result?.status === "ok" || result?.status === "already_processed") {
 					toast.success("DevPass activated");
 					void queryClient.invalidateQueries({
@@ -152,6 +189,9 @@ export default function DashboardShell({
 				}
 			})
 			.catch((error: unknown) => {
+				if (signal.aborted) {
+					return;
+				}
 				const errCode =
 					error && typeof error === "object" && "error" in error
 						? (error as { error?: unknown }).error
@@ -179,8 +219,14 @@ export default function DashboardShell({
 				}
 			})
 			.finally(() => {
-				clearParam();
+				if (!signal.aborted) {
+					clearParam();
+				}
 			});
+
+		return () => {
+			abortController.abort();
+		};
 	}, [
 		searchParams,
 		finalizeMutation,

--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -32,6 +32,7 @@ import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
+import { useStripe } from "@/lib/stripe";
 import { cn } from "@/lib/utils";
 
 import { plans } from "./plans";
@@ -71,6 +72,7 @@ export default function DashboardShell({
 	const config = useAppConfig();
 	const { posthogKey } = config;
 	const api = useApi();
+	const { stripe, isLoading: stripeLoading } = useStripe();
 	const queryClient = useQueryClient();
 
 	const { user } = useUser({
@@ -93,7 +95,11 @@ export default function DashboardShell({
 
 	useEffect(() => {
 		const sessionId = searchParams.get("setup_session_id");
-		if (!sessionId || finalizedSessions.current.has(sessionId)) {
+		if (
+			!sessionId ||
+			stripeLoading ||
+			finalizedSessions.current.has(sessionId)
+		) {
 			return;
 		}
 		finalizedSessions.current.add(sessionId);
@@ -105,8 +111,33 @@ export default function DashboardShell({
 			router.replace(query ? `/dashboard?${query}` : "/dashboard");
 		};
 
-		finalizeMutation
-			.mutateAsync({ body: { sessionId } })
+		const finalizeDevPlan = async () => {
+			const result = await finalizeMutation.mutateAsync({
+				body: { sessionId },
+			});
+			if (result?.status === "requires_action") {
+				if (!stripe) {
+					throw new Error("Stripe is not ready. Please refresh and try again.");
+				}
+				const confirmation = await stripe.confirmCardPayment(
+					result.clientSecret,
+				);
+				if (confirmation.error) {
+					throw new Error(
+						confirmation.error.message ?? "Payment authentication failed",
+					);
+				}
+				if (confirmation.paymentIntent?.status !== "succeeded") {
+					toast.info("Payment is processing. DevPass will activate shortly.");
+					return;
+				}
+
+				return await finalizeMutation.mutateAsync({ body: { sessionId } });
+			}
+			return result;
+		};
+
+		finalizeDevPlan()
 			.then((result) => {
 				if (result?.status === "ok" || result?.status === "already_processed") {
 					toast.success("DevPass activated");
@@ -116,6 +147,8 @@ export default function DashboardShell({
 							return Array.isArray(key) && key[1] === "/dev-plans/status";
 						},
 					});
+				} else if (result?.status === "payment_pending") {
+					toast.info("Payment is processing. DevPass will activate shortly.");
 				}
 			})
 			.catch((error: unknown) => {
@@ -148,7 +181,14 @@ export default function DashboardShell({
 			.finally(() => {
 				clearParam();
 			});
-	}, [searchParams, finalizeMutation, queryClient, router]);
+	}, [
+		searchParams,
+		finalizeMutation,
+		queryClient,
+		router,
+		stripe,
+		stripeLoading,
+	]);
 
 	const handleSubscribe = async (tier: PlanTier): Promise<void> => {
 		setSubscribingTier(tier);


### PR DESCRIPTION
## Summary

- Handle Stripe `subscription_payment_intent_requires_action` during DevPass finalization as a normal payment-action state instead of a 500.
- Create DevPass subscriptions with `default_incomplete`, return a client secret when SCA/3DS is required, and have the Code dashboard confirm it with Stripe.js after the Checkout redirect.
- Resolve Stripe PaymentIntents through invoice payments and `invoice.confirmation_secret` when `latest_invoice.payment_intent` is not present.
- Return pending-payment diagnostics from `/dev-plans/finalize` so stuck local or sandbox flows expose subscription, invoice, PaymentIntent, and client-secret state.
- Keep `setup_session_id` on the dashboard while activation is pending and show a full-page DevPass activation/loading state instead of falling back to the plan chooser.
- Accept both `invoice.payment_succeeded` and `invoice.paid` as successful DevPass activation webhooks, and activate initial DevPass subscriptions from the first successful invoice webhook.
- Add `STRIPE_DEV_PLAN_FORCE_3DS=true` as a sandbox-only way to request a 3DS challenge on the server-created subscription PaymentIntent.
- Regenerate typed API clients for Code, UI, Playground, and Admin.

## Root Cause

DevPass setup-mode checkout collected a payment method, then the API created the subscription server-side. When Stripe required authentication for the first invoice, the subscription could remain incomplete and the dashboard had too little state to re-confirm the invoice payment after Checkout redirected back.

Stripe's newer invoice shape can expose the confirmation secret or PaymentIntent through invoice payment records rather than `latest_invoice.payment_intent`, so the finalize endpoint sometimes returned permanent `payment_pending` instead of a confirmable `requires_action` result.

## Validation

- `pnpm format`
- `pnpm build`
- `pnpm vitest run apps/api/src/stripe.spec.ts --no-file-parallelism`
- `pnpm vitest run apps/gateway/src/graceful-shutdown.spec.ts --no-file-parallelism`
- `pnpm test:unit` was run before the final Stripe guard fix; it found the Stripe regression fixed here and one timing-sensitive graceful-shutdown failure that passed on focused rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced payment setup flow with support for 3D Secure authentication
  * Automatic retry logic for pending payment states
  * Improved real-time status messaging during plan activation
  * Better differentiation between payment scenarios (requires action vs. processing)

* **Bug Fixes**
  * Dev plans now properly activate when initial payments succeed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->