### PR TITLE
fix: require email signup

### DIFF
--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { WebAuthnAbortService } from "@simplewebauthn/browser";
 import { useQueryClient } from "@tanstack/react-query";
-import { Loader2, Terminal, Code2, Cpu, KeySquare } from "lucide-react";
+import { Loader2, Terminal, Code2, Cpu } from "lucide-react";
 import { motion } from "motion/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -13,7 +12,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod/v3";
 
-import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { Button } from "@/components/ui/button";
 import {
 	Form,
@@ -53,7 +51,7 @@ function SignupForm() {
 	const posthog = usePostHog();
 	const { posthogKey } = useAppConfig();
 	const [isLoading, setIsLoading] = useState(false);
-	const { signIn, signUp } = useAuth();
+	const { signUp } = useAuth();
 	const returnUrl = getSafeRedirectUrl(searchParams.get("returnUrl"));
 	const selectedPlan = searchParams.get("plan");
 
@@ -128,43 +126,6 @@ function SignupForm() {
 		}
 
 		setIsLoading(false);
-	}
-
-	async function handlePasskeySignIn() {
-		setIsLoading(true);
-		try {
-			// Cancel any pending conditional (autofill) ceremony so it doesn't
-			// collide with this modal request and abort it as "cancelled".
-			WebAuthnAbortService.cancelCeremony();
-			const res = await signIn.passkey();
-			if (res?.error) {
-				toast.error(res.error.message ?? "Failed to sign in with passkey", {
-					style: {
-						backgroundColor: "var(--destructive)",
-						color: "var(--destructive-foreground)",
-					},
-				});
-				return;
-			}
-			queryClient.clear();
-			if (posthogKey) {
-				posthog.capture("user_logged_in", { method: "passkey" });
-			}
-			toast.success("Login successful");
-			router.push(returnUrl);
-		} catch (error: unknown) {
-			toast.error(
-				(error as Error)?.message || "Failed to sign in with passkey",
-				{
-					style: {
-						backgroundColor: "var(--destructive)",
-						color: "var(--destructive-foreground)",
-					},
-				},
-			);
-		} finally {
-			setIsLoading(false);
-		}
 	}
 
 	return (
@@ -354,40 +315,6 @@ function SignupForm() {
 								</Button>
 							</form>
 						</Form>
-
-						<div className="mt-4 space-y-4">
-							<div className="relative">
-								<div className="absolute inset-0 flex items-center">
-									<span className="w-full border-t" />
-								</div>
-								<div className="relative flex justify-center text-xs uppercase">
-									<span className="bg-background px-2 text-muted-foreground">
-										Or
-									</span>
-								</div>
-							</div>
-
-							<SocialAuthButtons
-								isLoading={isLoading}
-								setIsLoading={setIsLoading}
-								callbackPath={returnUrl}
-								errorCallbackPath="/signup"
-							/>
-
-							<Button
-								onClick={handlePasskeySignIn}
-								variant="outline"
-								className="w-full"
-								disabled={isLoading}
-							>
-								{isLoading ? (
-									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-								) : (
-									<KeySquare className="mr-2 h-4 w-4" />
-								)}
-								Sign in with passkey
-							</Button>
-						</div>
 					</div>
 
 					<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
-import { Loader2, Github, Eye, EyeOff } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
@@ -56,7 +56,7 @@ export default function Signup() {
 	const posthog = usePostHog();
 	const [isLoading, setIsLoading] = useState(false);
 	const [showPassword, setShowPassword] = useState(false);
-	const { signUp, signIn } = useAuth();
+	const { signUp } = useAuth();
 	const config = useAppConfig();
 	const fetchClient = useFetchClient();
 
@@ -175,121 +175,6 @@ export default function Signup() {
 			</div>
 
 			<div className="mt-8 space-y-4">
-				{/* Social auth buttons */}
-				{(config.githubAuth || config.googleAuth) && (
-					<>
-						<div className="grid gap-3 sm:grid-cols-2">
-							{config.githubAuth && (
-								<Button
-									onClick={async () => {
-										setIsLoading(true);
-										try {
-											const res = await signIn.social({
-												provider: "github",
-												callbackURL:
-													location.protocol +
-													"//" +
-													location.host +
-													"/dashboard",
-												errorCallbackURL:
-													location.protocol + "//" + location.host + "/signup",
-											});
-											if (res?.error) {
-												toast({
-													title:
-														res.error.message ??
-														"Failed to sign up with GitHub",
-													variant: "destructive",
-												});
-											}
-										} finally {
-											setIsLoading(false);
-										}
-									}}
-									variant="outline"
-									className="w-full"
-									disabled={isLoading}
-								>
-									{isLoading ? (
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-									) : (
-										<Github className="mr-2 h-4 w-4" />
-									)}
-									GitHub
-								</Button>
-							)}
-							{config.googleAuth && (
-								<Button
-									onClick={async () => {
-										setIsLoading(true);
-										try {
-											const res = await signIn.social({
-												provider: "google",
-												callbackURL:
-													location.protocol +
-													"//" +
-													location.host +
-													"/dashboard",
-												errorCallbackURL:
-													location.protocol + "//" + location.host + "/signup",
-											});
-											if (res?.error) {
-												toast({
-													title:
-														res.error.message ??
-														"Failed to sign up with Google",
-													variant: "destructive",
-												});
-											}
-										} finally {
-											setIsLoading(false);
-										}
-									}}
-									variant="outline"
-									className="w-full"
-									disabled={isLoading}
-								>
-									{isLoading ? (
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-									) : (
-										<svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-											<path
-												d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-												fill="#4285F4"
-											/>
-											<path
-												d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-												fill="#34A853"
-											/>
-											<path
-												d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-												fill="#FBBC05"
-											/>
-											<path
-												d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-												fill="#EA4335"
-											/>
-										</svg>
-									)}
-									Google
-								</Button>
-							)}
-						</div>
-
-						<div className="relative">
-							<div className="absolute inset-0 flex items-center">
-								<span className="w-full border-t" />
-							</div>
-							<div className="relative flex justify-center text-xs uppercase">
-								<span className="bg-background px-2 text-muted-foreground">
-									Or continue with email
-								</span>
-							</div>
-						</div>
-					</>
-				)}
-
-				{/* Email form */}
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
 						<FormField


### PR DESCRIPTION
## Summary

- Remove passkey sign-in from the DevPass signup page.
- Remove social auth buttons from signup pages so account creation starts with email and password.
- Leave passkey/social auth available on login and existing account security flows.

## Validation

- `pnpm format`
- `pnpm build`

## Notes

Playground signup was checked and was already email/password-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed passkey-based authentication from signup flow
  * Removed social authentication options (GitHub, Google) from signup
  * Email and password signup remains available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->