### PR TITLE
fix: keep public pages from redirecting

### DIFF
--- a/apps/ui/src/hooks/useUser.ts
+++ b/apps/ui/src/hooks/useUser.ts
@@ -1,6 +1,6 @@
 "use client";
 import { useQueryClient } from "@tanstack/react-query";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
 
@@ -28,7 +28,6 @@ export function useUser(options?: UseUserOptions) {
 	const posthog = usePostHog();
 	const router = useRouter();
 	const api = useApi();
-	const pathname = usePathname();
 
 	const { data, isLoading, error } = api.useQuery(
 		"get",
@@ -48,29 +47,6 @@ export function useUser(options?: UseUserOptions) {
 			onboarding_completed: data.user.onboardingCompleted,
 		});
 	}
-
-	// Check for onboarding completion for all authenticated users
-	useEffect(() => {
-		if (!data?.user || isLoading) {
-			return;
-		}
-
-		const currentPath = pathname;
-		const isAuthPage = ["/login", "/signup", "/onboarding"].includes(
-			currentPath,
-		);
-		const isLandingPage = currentPath === "/";
-
-		// Don't redirect if already on auth pages
-		if (isAuthPage || isLandingPage) {
-			return;
-		}
-
-		// Redirect to onboarding if user hasn't completed it
-		if (!data.user.onboardingCompleted) {
-			router.push("/onboarding");
-		}
-	}, [data?.user, isLoading, router, pathname]);
 
 	// Handle existing redirect logic
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- remove the global onboarding redirect side effect from the shared `useUser` hook
- keep redirects opt-in for callers that explicitly pass `redirectTo`/`redirectWhen`, so public pages can read auth state without navigating away
- fix public model pages like `/models/gpt-5.5` being redirected away after client hydration

## Why this was intermittent
This only happened after client hydration when a public component mounted `useUser()` and `/user/me` successfully returned a real user. Whether it reproduced depended on runtime state, including:

- whether the browser had a valid session cookie
- whether `/user/me` returned before navigation or page teardown
- whether the signed-in user had `onboardingCompleted === false`
- whether the environment was serving the latest build versus an older/cached build
- whether the auth query errored or lagged

So prod might not show it for a logged-out browser, a completed-onboarding user, an older deployed build, or a slow/failed auth query. The code was still wrong because public components like the navbar/model CTA/chat support only needed auth state, but inherited global navigation behavior from the hook.

## Auth protection still works
This does not remove protected-route redirects. It only removes the implicit redirect that ran for every `useUser()` caller.

Protected dashboard routes still redirect unauthenticated users through server-side checks:

- `apps/ui/src/app/dashboard/layout.tsx` calls `getUser()` and redirects unauthenticated users to `/login`
- `apps/ui/src/app/dashboard/page.tsx` also redirects unauthenticated users to `/login`
- client-only callers that explicitly pass `redirectTo`/`redirectWhen` still keep their redirect behavior because that opt-in block remains unchanged

## Verification
- `pnpm format`
- `pnpm build`
- `curl -I http://localhost:3012/models/gpt-5.5` returned `200 OK`
- `curl -I http://localhost:3012/dashboard` returned `307` to `/login` when unauthenticated

Note: Browser-level fallback check was blocked because the available Playwright browser profile was already in use; route-level verification passed against the built UI server.