### PR TITLE
docs: add migrations skill

### DIFF
--- a/.agents/skills/migrations/SKILL.md
+++ b/.agents/skills/migrations/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: migrations
+description: Generate, review, edit, apply, or resolve conflicts for Drizzle database migrations in this repo. Use when changing packages/db/src/schema.ts, running pnpm migrations or pnpm migrate, touching packages/db/migrations, reviewing migration diffs, or handling migration merge conflicts.
+---
+
+# Migrations
+
+Use this workflow for database schema changes and migration conflicts.
+
+## Generate migrations
+
+- Run all commands from the repository root.
+- Make schema changes in `packages/db/src/schema.ts`.
+- Generate Drizzle migration artifacts with `pnpm migrations`.
+- Review the generated diff under `packages/db/migrations/`.
+- Drizzle may generate:
+  - `packages/db/migrations/<timestamp>_<name>.sql`
+  - `packages/db/migrations/meta/<timestamp>_snapshot.json`
+  - `packages/db/migrations/meta/_journal.json`
+
+## Editing generated migrations
+
+- Do not write a migration by hand from scratch. Generate it first with `pnpm migrations`.
+- If the generated migration needs adaptation, edit only the generated `.sql` file.
+- Never manually edit any `*_snapshot.json` file.
+- Never manually edit `packages/db/migrations/meta/_journal.json`.
+- If the TypeScript schema is wrong, fix `packages/db/src/schema.ts` and regenerate instead of patching snapshot or journal metadata.
+- Use snake_case column names in SQL because Drizzle maps camelCase TypeScript fields to snake_case database columns.
+
+Appropriate `.sql`-only edits include adding safe data backfills, adjusting a generated type cast, adding a `USING` clause, splitting statements for safer execution, or preserving data during a rename. Keep the generated snapshot and journal exactly as Drizzle wrote them.
+
+## Conflict resolution
+
+Never resolve merge conflicts in migration SQL, snapshot JSON, or journal files manually.
+
+When merging with `main` and migration conflicts appear:
+
+1. Reset migrations to `origin/main`:
+
+```bash
+git restore --source=origin/main packages/db/migrations/
+```
+
+2. Re-run generation from the repository root:
+
+```bash
+pnpm migrations
+```
+
+3. Review the regenerated SQL. If needed, adapt only the generated `.sql` file.
+
+## Validation
+
+- Inspect `git diff packages/db/src/schema.ts packages/db/migrations/`.
+- Confirm any snapshot JSON and journal changes came from `pnpm migrations`, not manual edits.
+- Run `pnpm format` after changes.
+- Run `pnpm build` after schema or migration changes.

--- a/.claude/skills/migrations
+++ b/.claude/skills/migrations
@@ -1,0 +1,1 @@
+../../.agents/skills/migrations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,12 +134,14 @@ NOTE: these commands can only be run in the root directory of the repository, no
 
 ### Database Operations
 
+- Use the local `migrations` skill for database migration generation, review, edits, and merge conflicts.
 - Use Drizzle ORM with latest object syntax
 - The schema uses camelCase in TypeScript but the actual database columns are snake_case (configured via Drizzle's `casing: "snake_case"`). When writing raw SQL, always use snake_case column names (e.g. `user_id`, not `userId`).
 - For reads: Use `db().query.<table>.findMany()` or `db().query.<table>.findFirst()`
-- For schema changes: Use `pnpm run setup` instead of writing migrations which will generate .sql files
-- Always sync schema with `pnpm run setup` after table/column changes
-- Never write migrations manually, only edit generated migration files if specifically asked
+- For schema changes: edit `packages/db/src/schema.ts`, then generate migration artifacts with `pnpm migrations`
+- If generated migration SQL needs adaptation, edit only the generated `.sql` file. Never manually edit snapshot JSON or journal files.
+- Always sync schema with `pnpm run setup` after table/column changes when local database state needs to be refreshed
+- Never write migrations manually from scratch
 - **NEVER resolve merge conflicts in migration files, journal files, or snapshot files manually.** When merging with main and migration conflicts occur, ALWAYS follow this exact procedure:
   1. **Before merging**, reset migrations: `git restore --source=origin/main packages/db/migrations/`
   2. **After merging**, regenerate migrations: `pnpm migrations`


### PR DESCRIPTION
## Summary

- add a repo-local `migrations` skill for Drizzle migration workflows
- expose the same skill to Claude via `.claude/skills/migrations`
- update agent instructions to generate migrations with `pnpm migrations` and only edit generated SQL when adaptation is needed

## Validation

- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines for database migration workflows.

**Note:** This release contains only developer-facing documentation updates with no changes visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->