### PR TITLE
fix(chat): bill chats under selected org

### DIFF
--- a/apps/playground/src/components/credits/credits-display.tsx
+++ b/apps/playground/src/components/credits/credits-display.tsx
@@ -19,20 +19,24 @@ interface Organization {
 interface CreditsDisplayProps {
 	organization: Organization | null;
 	isLoading?: boolean;
+	// True when showing the dedicated chat-plan ("Chat plan") context rather than a
+	// real dashboard org. The chat plan and its upgrade nudge only apply here.
+	isChatPlanOrg?: boolean;
 }
 
 export function CreditsDisplay({
 	organization,
 	isLoading,
+	isChatPlanOrg = false,
 }: CreditsDisplayProps) {
 	const api = useApi();
 	const planQuery = useQuery({
 		...api.queryOptions("get", "/chat-plans/status"),
-		enabled: Boolean(organization),
+		enabled: Boolean(organization) && isChatPlanOrg,
 		staleTime: 30_000,
 	});
 	const plan = planQuery.data;
-	const hasActivePlan = plan && plan.chatPlan !== "none";
+	const hasActivePlan = isChatPlanOrg && plan && plan.chatPlan !== "none";
 
 	if (isLoading) {
 		return (
@@ -105,7 +109,7 @@ export function CreditsDisplay({
 					<span className="text-xs text-muted-foreground">Add</span>
 				</button>
 			</TopUpCreditsDialog>
-			{!hasActivePlan && (
+			{isChatPlanOrg && !hasActivePlan && (
 				<Link
 					href="/pricing"
 					className="group mt-1 flex items-center gap-2.5 rounded-md border border-indigo-500/20 bg-indigo-500/5 px-2 py-2 transition-colors hover:bg-indigo-500/10"
@@ -124,12 +128,12 @@ export function CreditsDisplay({
 					<ChevronRight className="ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
 				</Link>
 			)}
-			{hasNoCredits && !hasActivePlan && (
+			{!isChatPlanOrg && hasNoCredits && (
 				<div className="mt-1 px-2">
 					<p className="text-xs text-destructive">⚠️ No credits remaining</p>
 				</div>
 			)}
-			{isLowCredits && !hasNoCredits && !hasActivePlan && (
+			{!isChatPlanOrg && isLowCredits && !hasNoCredits && (
 				<div className="mt-1 px-2">
 					<p className="text-xs text-yellow-600">⚡ Low credits remaining</p>
 				</div>

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -1636,11 +1636,15 @@ export default function ChatPageClient({
 	}, [selectedModel]);
 
 	const handleSelectOrganization = (org: Organization | null) => {
+		// Switching org changes the billing context: chats run under the selected
+		// org's project key. Route to the full chat experience (not the read-only
+		// shared-chats view) so New Chat works and credits resolve to that org.
+		const params = new URLSearchParams();
+		params.set("model", selectedModel);
 		if (org?.id) {
-			router.push(`/org/${org.id}`);
-			return;
+			params.set("orgId", org.id);
 		}
-		router.push("/");
+		router.push(`/?${params.toString()}`);
 	};
 
 	const handleOrganizationCreated = (org: Organization) => {

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -926,8 +926,9 @@ export const ChatSidebar = function ChatSidebar({
 			<SidebarFooter>
 				<div className="group-data-[collapsible=icon]:hidden">
 					<CreditsDisplay
-						organization={organization}
+						organization={selectedOrganization ?? organization}
 						isLoading={isOrgLoading}
+						isChatPlanOrg={!selectedOrganization}
 					/>
 				</div>
 				<SidebarMenu>

--- a/apps/playground/src/components/playground/organization-switcher.tsx
+++ b/apps/playground/src/components/playground/organization-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronsUpDown, Check, User, Building2 } from "lucide-react";
+import { ChevronsUpDown, Check, Sparkles, Building2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -55,10 +55,10 @@ export function OrganizationSwitcher({
 				{selectedOrganization ? (
 					<Building2 className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
 				) : (
-					<User className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+					<Sparkles className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
 				)}
 				<span className="truncate">
-					{selectedOrganization ? selectedOrganization.name : "Personal"}
+					{selectedOrganization ? selectedOrganization.name : "Chat plan"}
 				</span>
 				<ChevronsUpDown className="ml-auto h-4 w-4 flex-shrink-0 opacity-50" />
 			</Button>
@@ -76,10 +76,10 @@ export function OrganizationSwitcher({
 						{selectedOrganization ? (
 							<Building2 className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
 						) : (
-							<User className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+							<Sparkles className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
 						)}
 						<span className="truncate">
-							{selectedOrganization ? selectedOrganization.name : "Personal"}
+							{selectedOrganization ? selectedOrganization.name : "Chat plan"}
 						</span>
 						<ChevronsUpDown className="ml-auto h-4 w-4 flex-shrink-0 opacity-50" />
 					</Button>
@@ -89,8 +89,8 @@ export function OrganizationSwitcher({
 						onSelect={() => handleSelectOrganization(null)}
 						className="cursor-pointer px-2 py-1.5 text-sm hover:bg-accent focus:bg-accent data-[highlighted]:bg-accent"
 					>
-						<User className="mr-2 h-4 w-4 flex-shrink-0 text-muted-foreground" />
-						<span className="truncate">Personal</span>
+						<Sparkles className="mr-2 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+						<span className="truncate">Chat plan</span>
 						{!selectedOrganization ? (
 							<Check className="ml-auto h-4 w-4 flex-shrink-0" />
 						) : null}


### PR DESCRIPTION
## Problem

In the playground chat, switching organizations was broken:

- The sidebar org switcher routed to `/org/{id}` — the **read-only shared-chats view** — so **New Chat didn't work** and you couldn't actually chat under the selected org.
- The credits widget always read the dedicated **chat org**, so it showed `$0` even when the selected org (e.g. Default org) had a balance.
- The unsubscribed **Chat plan** org showed a misleading **"No credits remaining"** warning.

## Changes

- **Switch orgs and chat under them** — org selection now routes to the full chat experience (`/?orgId={id}`) instead of the read-only view. Chats run and bill under the selected org's project key, and New Chat works. `pathname` stays `/`, so the switcher stays visible.
- **Credits reflect the selected org** — the sidebar passes `selectedOrganization ?? organization` and an `isChatPlanOrg` flag to `CreditsDisplay`.
- **Gate chat-plan UI** — the chat-plan banner, upgrade nudge, and no-/low-credits warnings are gated on `isChatPlanOrg`. The unsubscribed Chat plan org no longer shows "No credits remaining" (the "Get up to 3× the credits" nudge stays). Real orgs still show the warning when actually at $0.
- **Rename** the "Personal" switcher entry to **"Chat plan"** (with a Sparkles icon).

## Notes

- Chats are user-scoped (`GET /chats`), so the chat list is the same across orgs — switching only changes billing context, not which chats are listed.
- The read-only `/org/{id}` shared-chats browser is no longer linked from the chat sidebar switcher (still reachable via direct/shared links).

## Testing

- `tsc` compiles all four edited files cleanly.
- Full `pnpm build` currently fails only on a pre-existing `shiki` version duplication in untouched `ai-elements/*` files (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced chat plan organization context for differentiated credit display behavior.

* **UI/UX Updates**
  * Organization switcher now displays "Chat plan" label with updated icon when no organization is selected.
  * Credit status messages now display contextually based on whether the org is a chat plan or regular dashboard org.
  * Organization switching now seamlessly maintains the chat experience with query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->