### PR TITLE
feat(playground): org switcher in studios + Chat badge

### DIFF
--- a/apps/playground/src/components/playground/canvas-page-client.tsx
+++ b/apps/playground/src/components/playground/canvas-page-client.tsx
@@ -13,7 +13,7 @@ import {
 	Play,
 	Square,
 } from "lucide-react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
 	memo,
 	type RefObject,
@@ -240,6 +240,7 @@ const CanvasPromptInput = memo(function CanvasPromptInput({
 export default function CanvasPageClient({
 	models,
 	providers,
+	organizations,
 	selectedOrganization,
 	selectedProject,
 	initialModelPreference,
@@ -274,6 +275,23 @@ export default function CanvasPageClient({
 
 	const { user, isLoading: isUserLoading } = useUser();
 	const pathname = usePathname();
+	const router = useRouter();
+	const searchParams = useSearchParams();
+	const handleSelectOrganization = useCallback(
+		(org: Organization | null) => {
+			const params = new URLSearchParams(Array.from(searchParams.entries()));
+			if (org?.id) {
+				params.set("orgId", org.id);
+			} else {
+				params.delete("orgId");
+			}
+			params.delete("projectId");
+			router.push(
+				params.toString() ? `/canvas?${params.toString()}` : "/canvas",
+			);
+		},
+		[router, searchParams],
+	);
 	const isAuthenticated = !isUserLoading && !!user;
 	const showAuthDialog = !isAuthenticated && !isUserLoading && !user;
 	const ensuredProjectRef = useRef<string | null>(null);
@@ -583,7 +601,9 @@ export default function CanvasPageClient({
 			<SidebarProvider>
 				<div className="flex h-dvh w-full">
 					<CanvasSidebar
+						organizations={organizations}
 						selectedOrganization={selectedOrganization}
+						onSelectOrganization={handleSelectOrganization}
 						onNewCanvas={handleNewCanvas}
 					/>
 					<div className="flex min-w-0 flex-1 flex-col">

--- a/apps/playground/src/components/playground/canvas-sidebar.tsx
+++ b/apps/playground/src/components/playground/canvas-sidebar.tsx
@@ -43,19 +43,31 @@ import { useUser } from "@/hooks/useUser";
 import { clearLastUsedProjectCookiesAction } from "@/lib/actions/project";
 import { useAuth } from "@/lib/auth-client";
 
+import { OrganizationSwitcher } from "./organization-switcher";
+
 import type { Organization } from "@/lib/types";
 
 interface CanvasSidebarProps {
+	organizations: Organization[];
 	selectedOrganization: Organization | null;
+	onSelectOrganization: (organization: Organization | null) => void;
 	className?: string;
 	onNewCanvas?: () => void;
 }
 
 export function CanvasSidebar({
+	organizations,
 	selectedOrganization,
+	onSelectOrganization,
 	className,
 	onNewCanvas,
 }: CanvasSidebarProps) {
+	const switcherOrganizations = organizations.filter(
+		(org) => !org.isPersonal && !org.isChat,
+	);
+	const switcherSelectedOrganization =
+		switcherOrganizations.find((org) => org.id === selectedOrganization?.id) ??
+		null;
 	const router = useRouter();
 	const posthog = usePostHog();
 	const { user, isLoading: isUserLoading } = useUser();
@@ -161,6 +173,12 @@ export function CanvasSidebar({
 								<span className="text-lg font-bold tracking-tight">
 									LLM Gateway
 								</span>
+								<Badge
+									variant="secondary"
+									className="group-data-[collapsible=icon]:hidden"
+								>
+									Chat
+								</Badge>
 							</Link>
 						</SidebarMenuButton>
 					</SidebarMenuItem>
@@ -237,7 +255,19 @@ export function CanvasSidebar({
 				</SidebarMenu>
 			</SidebarHeader>
 
-			<SidebarContent className="px-2 py-4" />
+			<SidebarContent className="px-2 py-4">
+				{switcherOrganizations.length > 0 ? (
+					<SidebarMenu className="group-data-[collapsible=icon]:hidden">
+						<SidebarMenuItem>
+							<OrganizationSwitcher
+								organizations={switcherOrganizations}
+								selectedOrganization={switcherSelectedOrganization}
+								onSelectOrganization={onSelectOrganization}
+							/>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				) : null}
+			</SidebarContent>
 
 			<SidebarFooter>
 				<div className="group-data-[collapsible=icon]:hidden">

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -444,7 +444,7 @@ export const ChatSidebar = function ChatSidebar({
 	const pathname = usePathname();
 	const posthog = usePostHog();
 	const { state: sidebarState, isMobile, setOpenMobile } = useSidebar();
-	const showOrganizationSwitcher = pathname === "/";
+	const showOrganizationSwitcher = pathname === "/" || pathname === "/group";
 	const { user, isLoading: isUserLoading } = useUser();
 	const { signOut } = useAuth();
 	const { organization, isLoading: isOrgLoading } = useOrganization();
@@ -758,6 +758,12 @@ export const ChatSidebar = function ChatSidebar({
 								<span className="text-lg font-bold tracking-tight">
 									LLM Gateway
 								</span>
+								<Badge
+									variant="secondary"
+									className="group-data-[collapsible=icon]:hidden"
+								>
+									Chat
+								</Badge>
 							</Link>
 						</SidebarMenuButton>
 					</SidebarMenuItem>

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -44,7 +44,7 @@ interface ImagePageClientProps {
 export default function ImagePageClient({
 	models,
 	providers,
-	organizations: _organizations,
+	organizations,
 	selectedOrganization,
 	projects: _projects,
 	selectedProject,
@@ -718,6 +718,20 @@ export default function ImagePageClient({
 		? Number(selectedOrganization.credits) < 1 && chatPlanCreditsRemaining <= 0
 		: false;
 
+	const handleSelectOrganization = useCallback(
+		(org: Organization | null) => {
+			const params = new URLSearchParams(Array.from(searchParams.entries()));
+			if (org?.id) {
+				params.set("orgId", org.id);
+			} else {
+				params.delete("orgId");
+			}
+			params.delete("projectId");
+			router.push(params.toString() ? `/image?${params.toString()}` : "/image");
+		},
+		[router, searchParams],
+	);
+
 	return (
 		<SidebarProvider>
 			<div className="flex h-dvh w-full">
@@ -725,7 +739,9 @@ export default function ImagePageClient({
 					galleryItems={galleryItems}
 					onNewChat={handleNewChat}
 					onItemClick={handleItemClick}
+					organizations={organizations}
 					selectedOrganization={selectedOrganization}
+					onSelectOrganization={handleSelectOrganization}
 					currentItemId={selectedItemId}
 				/>
 				<div className="flex flex-1 flex-col min-w-0">

--- a/apps/playground/src/components/playground/image-sidebar.tsx
+++ b/apps/playground/src/components/playground/image-sidebar.tsx
@@ -54,6 +54,8 @@ import { useUser } from "@/hooks/useUser";
 import { clearLastUsedProjectCookiesAction } from "@/lib/actions/project";
 import { useAuth } from "@/lib/auth-client";
 
+import { OrganizationSwitcher } from "./organization-switcher";
+
 import type { GalleryItem } from "@/lib/image-gen";
 import type { Organization } from "@/lib/types";
 
@@ -61,7 +63,9 @@ interface ImageSidebarProps {
 	galleryItems: GalleryItem[];
 	onNewChat: () => void;
 	onItemClick: (itemId: string) => void;
+	organizations: Organization[];
 	selectedOrganization: Organization | null;
+	onSelectOrganization: (organization: Organization | null) => void;
 	currentItemId?: string | null;
 	className?: string;
 }
@@ -335,10 +339,18 @@ export function ImageSidebar({
 	galleryItems,
 	onNewChat,
 	onItemClick,
-	selectedOrganization: _selectedOrganization,
+	organizations,
+	selectedOrganization,
+	onSelectOrganization,
 	currentItemId,
 	className,
 }: ImageSidebarProps) {
+	const switcherOrganizations = organizations.filter(
+		(org) => !org.isPersonal && !org.isChat,
+	);
+	const switcherSelectedOrganization =
+		switcherOrganizations.find((org) => org.id === selectedOrganization?.id) ??
+		null;
 	const listContainerRef = useRef<HTMLDivElement | null>(null);
 	const router = useRouter();
 	const pathname = usePathname();
@@ -566,6 +578,12 @@ export function ImageSidebar({
 								<span className="text-lg font-bold tracking-tight">
 									LLM Gateway
 								</span>
+								<Badge
+									variant="secondary"
+									className="group-data-[collapsible=icon]:hidden"
+								>
+									Chat
+								</Badge>
 							</Link>
 						</SidebarMenuButton>
 					</SidebarMenuItem>
@@ -645,6 +663,17 @@ export function ImageSidebar({
 			<SidebarContent className="overflow-hidden pb-2">
 				<div>
 					<div className="mx-2 mb-2 border-t border-sidebar-border" />
+					{switcherOrganizations.length > 0 ? (
+						<SidebarMenu className="px-2 pb-2 group-data-[collapsible=icon]:hidden">
+							<SidebarMenuItem>
+								<OrganizationSwitcher
+									organizations={switcherOrganizations}
+									selectedOrganization={switcherSelectedOrganization}
+									onSelectOrganization={onSelectOrganization}
+								/>
+							</SidebarMenuItem>
+						</SidebarMenu>
+					) : null}
 				</div>
 				<div
 					ref={listContainerRef}

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -60,7 +60,7 @@ interface VideoPageClientProps {
 export default function VideoPageClient({
 	models,
 	providers,
-	organizations: _organizations,
+	organizations,
 	selectedOrganization,
 	projects: _projects,
 	selectedProject,
@@ -870,6 +870,20 @@ export default function VideoPageClient({
 		? Number(selectedOrganization.credits) < 1 && chatPlanCreditsRemaining <= 0
 		: false;
 
+	const handleSelectOrganization = useCallback(
+		(org: Organization | null) => {
+			const params = new URLSearchParams(Array.from(searchParams.entries()));
+			if (org?.id) {
+				params.set("orgId", org.id);
+			} else {
+				params.delete("orgId");
+			}
+			params.delete("projectId");
+			router.push(params.toString() ? `/video?${params.toString()}` : "/video");
+		},
+		[router, searchParams],
+	);
+
 	return (
 		<SidebarProvider>
 			<div className="flex h-dvh w-full">
@@ -877,7 +891,9 @@ export default function VideoPageClient({
 					galleryItems={galleryItems}
 					onNewChat={handleNewChat}
 					onItemClick={handleItemClick}
+					organizations={organizations}
 					selectedOrganization={selectedOrganization}
+					onSelectOrganization={handleSelectOrganization}
 					currentItemId={selectedItemId}
 				/>
 				<div className="flex flex-1 flex-col min-w-0">

--- a/apps/playground/src/components/playground/video-sidebar.tsx
+++ b/apps/playground/src/components/playground/video-sidebar.tsx
@@ -54,6 +54,8 @@ import { useUser } from "@/hooks/useUser";
 import { clearLastUsedProjectCookiesAction } from "@/lib/actions/project";
 import { useAuth } from "@/lib/auth-client";
 
+import { OrganizationSwitcher } from "./organization-switcher";
+
 import type { Organization } from "@/lib/types";
 import type { VideoGalleryItem } from "@/lib/video-gen";
 
@@ -61,7 +63,9 @@ interface VideoSidebarProps {
 	galleryItems: VideoGalleryItem[];
 	onNewChat: () => void;
 	onItemClick: (itemId: string) => void;
+	organizations: Organization[];
 	selectedOrganization: Organization | null;
+	onSelectOrganization: (organization: Organization | null) => void;
 	currentItemId?: string | null;
 	className?: string;
 }
@@ -359,10 +363,18 @@ export function VideoSidebar({
 	galleryItems,
 	onNewChat,
 	onItemClick,
-	selectedOrganization: _selectedOrganization,
+	organizations,
+	selectedOrganization,
+	onSelectOrganization,
 	currentItemId,
 	className,
 }: VideoSidebarProps) {
+	const switcherOrganizations = organizations.filter(
+		(org) => !org.isPersonal && !org.isChat,
+	);
+	const switcherSelectedOrganization =
+		switcherOrganizations.find((org) => org.id === selectedOrganization?.id) ??
+		null;
 	const listContainerRef = useRef<HTMLDivElement | null>(null);
 	const router = useRouter();
 	const pathname = usePathname();
@@ -590,6 +602,12 @@ export function VideoSidebar({
 								<span className="text-lg font-bold tracking-tight">
 									LLM Gateway
 								</span>
+								<Badge
+									variant="secondary"
+									className="group-data-[collapsible=icon]:hidden"
+								>
+									Chat
+								</Badge>
 							</Link>
 						</SidebarMenuButton>
 					</SidebarMenuItem>
@@ -669,6 +687,17 @@ export function VideoSidebar({
 			<SidebarContent className="overflow-hidden pb-2">
 				<div>
 					<div className="mx-2 mb-2 border-t border-sidebar-border" />
+					{switcherOrganizations.length > 0 ? (
+						<SidebarMenu className="px-2 pb-2 group-data-[collapsible=icon]:hidden">
+							<SidebarMenuItem>
+								<OrganizationSwitcher
+									organizations={switcherOrganizations}
+									selectedOrganization={switcherSelectedOrganization}
+									onSelectOrganization={onSelectOrganization}
+								/>
+							</SidebarMenuItem>
+						</SidebarMenu>
+					) : null}
 				</div>
 				<div
 					ref={listContainerRef}


### PR DESCRIPTION
## What

Brings the organization switcher (already present in the Chat sidebar) to the **Image Studio**, **Video Studio**, **Canvas**, and **Group Chat** views, and adds a **Chat** badge next to the **LLM Gateway** logo across the playground sidebars.

## Changes

- **Group Chat** reuses `ChatSidebar`, so its switcher was simply gated to `pathname === "/"`. Extended `showOrganizationSwitcher` to also include `/group`.
- **Image / Video / Canvas** sidebars now accept `organizations` + `onSelectOrganization` props and render the same `OrganizationSwitcher` component in their sidebar content.
  - The switcher filters out personal/chat orgs and resolves the active selection against that list, so the dedicated Chat billing org shows as **"Chat plan"** (matching Chat's behavior).
  - Each page client got a `handleSelectOrganization` that navigates to the same route with the `orgId` param (dropping it for the Chat plan).
- Added a `secondary` **Chat** badge beside the **LLM Gateway** wordmark in the chat, image, video, and canvas sidebar headers (hidden when the sidebar is collapsed to icon mode).

## Notes

- `pnpm format` run; the changed files pass `eslint` (0 errors) and `tsc` (the only `tsc` errors present are a pre-existing shiki version-mismatch in `ai-elements/*`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization switcher to Canvas, Image, and Video playgrounds for seamless organization switching.
  * Switching organizations automatically clears the current project selection.
  * Added Chat badge indicator to sidebar headers for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->