### PR TITLE
fix(playground): show chat plan across studios + prefetch nav

### DIFF
--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -93,14 +93,15 @@ export default async function GroupPage({
 	const organizations = allOrganizations.filter(
 		(o) => !o.isChat && !o.isPersonal,
 	);
+	// Mirror the chat page: in the personal context no dashboard org is selected
+	// (selectedOrganization === null) so the "Chat plan" billing context shows,
+	// while generation, billing, and projects all run under the dedicated Chat org.
 	const selectedOrganization =
-		(orgId ? organizations.find((o) => o.id === orgId) : null) ??
-		chatOrg ??
-		organizations[0] ??
-		null;
+		(orgId ? organizations.find((o) => o.id === orgId) : null) ?? null;
+	const projectOrgId = selectedOrganization?.id ?? chatOrg?.id ?? null;
 
-	// Ensure we have projects for the selected organization (when orgId not provided)
-	if (!initialProjectsData && selectedOrganization?.id) {
+	// Ensure we have projects for the resolved billing org (when orgId not provided)
+	if (!initialProjectsData && projectOrgId) {
 		try {
 			initialProjectsData = (await fetchServerData(
 				"GET",
@@ -108,7 +109,7 @@ export default async function GroupPage({
 				{
 					params: {
 						path: {
-							id: selectedOrganization.id,
+							id: projectOrgId,
 						},
 					},
 				},
@@ -116,7 +117,7 @@ export default async function GroupPage({
 		} catch (error) {
 			console.warn(
 				"Failed to fetch projects for organization:",
-				selectedOrganization?.id,
+				projectOrgId,
 				error,
 			);
 		}
@@ -131,9 +132,9 @@ export default async function GroupPage({
 		if (projectId && !selectedProject && projectId.length > 0) {
 			notFound();
 		}
-	} else if (selectedOrganization?.id) {
+	} else if (projectOrgId) {
 		const cookieStore = await cookies();
-		const cookieName = `llmgateway-last-used-project-${selectedOrganization.id}`;
+		const cookieName = `llmgateway-last-used-project-${projectOrgId}`;
 		const lastUsed = cookieStore.get(cookieName)?.value;
 		if (lastUsed) {
 			selectedProject = projects.find((p) => p.id === lastUsed) ?? null;
@@ -143,9 +144,9 @@ export default async function GroupPage({
 
 	return (
 		<>
-			{selectedOrganization?.id && selectedProject?.id ? (
+			{projectOrgId && selectedProject?.id ? (
 				<LastUsedProjectTracker
-					orgId={selectedOrganization.id}
+					orgId={projectOrgId}
 					projectId={selectedProject.id}
 				/>
 			) : null}

--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -93,15 +93,14 @@ export default async function GroupPage({
 	const organizations = allOrganizations.filter(
 		(o) => !o.isChat && !o.isPersonal,
 	);
-	// Mirror the chat page: in the personal context no dashboard org is selected
-	// (selectedOrganization === null) so the "Chat plan" billing context shows,
-	// while generation, billing, and projects all run under the dedicated Chat org.
 	const selectedOrganization =
-		(orgId ? organizations.find((o) => o.id === orgId) : null) ?? null;
-	const projectOrgId = selectedOrganization?.id ?? chatOrg?.id ?? null;
+		(orgId ? organizations.find((o) => o.id === orgId) : null) ??
+		chatOrg ??
+		organizations[0] ??
+		null;
 
-	// Ensure we have projects for the resolved billing org (when orgId not provided)
-	if (!initialProjectsData && projectOrgId) {
+	// Ensure we have projects for the selected organization (when orgId not provided)
+	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
 				"GET",
@@ -109,7 +108,7 @@ export default async function GroupPage({
 				{
 					params: {
 						path: {
-							id: projectOrgId,
+							id: selectedOrganization.id,
 						},
 					},
 				},
@@ -117,7 +116,7 @@ export default async function GroupPage({
 		} catch (error) {
 			console.warn(
 				"Failed to fetch projects for organization:",
-				projectOrgId,
+				selectedOrganization?.id,
 				error,
 			);
 		}
@@ -132,9 +131,9 @@ export default async function GroupPage({
 		if (projectId && !selectedProject && projectId.length > 0) {
 			notFound();
 		}
-	} else if (projectOrgId) {
+	} else if (selectedOrganization?.id) {
 		const cookieStore = await cookies();
-		const cookieName = `llmgateway-last-used-project-${projectOrgId}`;
+		const cookieName = `llmgateway-last-used-project-${selectedOrganization.id}`;
 		const lastUsed = cookieStore.get(cookieName)?.value;
 		if (lastUsed) {
 			selectedProject = projects.find((p) => p.id === lastUsed) ?? null;
@@ -144,9 +143,9 @@ export default async function GroupPage({
 
 	return (
 		<>
-			{projectOrgId && selectedProject?.id ? (
+			{selectedOrganization?.id && selectedProject?.id ? (
 				<LastUsedProjectTracker
-					orgId={projectOrgId}
+					orgId={selectedOrganization.id}
 					projectId={selectedProject.id}
 				/>
 			) : null}

--- a/apps/playground/src/components/playground/canvas-sidebar.tsx
+++ b/apps/playground/src/components/playground/canvas-sidebar.tsx
@@ -198,7 +198,7 @@ export function CanvasSidebar({
 							tooltip="Chat"
 							isActive={pathname === "/"}
 						>
-							<Link href="/">
+							<Link href="/" prefetch={true}>
 								<MessageSquare className="h-4 w-4" />
 								<span>Chat</span>
 							</Link>
@@ -210,7 +210,7 @@ export function CanvasSidebar({
 							tooltip="Group Chat"
 							isActive={pathname === "/group"}
 						>
-							<Link href="/group">
+							<Link href="/group" prefetch={true}>
 								<Users className="h-4 w-4" />
 								<span>Group Chat</span>
 							</Link>
@@ -222,7 +222,7 @@ export function CanvasSidebar({
 							tooltip="Image Studio"
 							isActive={pathname === "/image"}
 						>
-							<Link href="/image">
+							<Link href="/image" prefetch={true}>
 								<ImageIcon className="h-4 w-4" />
 								<span>Image Studio</span>
 							</Link>
@@ -234,7 +234,7 @@ export function CanvasSidebar({
 							tooltip="Video Studio"
 							isActive={pathname === "/video"}
 						>
-							<Link href="/video">
+							<Link href="/video" prefetch={true}>
 								<Film className="h-4 w-4" />
 								<span>Video Studio</span>
 							</Link>
@@ -246,7 +246,7 @@ export function CanvasSidebar({
 							tooltip="Canvas"
 							isActive={pathname === "/canvas"}
 						>
-							<Link href="/canvas">
+							<Link href="/canvas" prefetch={true}>
 								<PenTool className="h-4 w-4" />
 								<span>Canvas</span>
 							</Link>
@@ -272,8 +272,9 @@ export function CanvasSidebar({
 			<SidebarFooter>
 				<div className="group-data-[collapsible=icon]:hidden">
 					<CreditsDisplay
-						organization={organization}
+						organization={switcherSelectedOrganization ?? organization}
 						isLoading={isOrgLoading}
+						isChatPlanOrg={!switcherSelectedOrganization}
 					/>
 				</div>
 				<SidebarMenu>

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -932,9 +932,13 @@ export const ChatSidebar = function ChatSidebar({
 			<SidebarFooter>
 				<div className="group-data-[collapsible=icon]:hidden">
 					<CreditsDisplay
-						organization={selectedOrganization ?? organization}
+						organization={
+							!selectedOrganization || selectedOrganization.isChat
+								? organization
+								: selectedOrganization
+						}
 						isLoading={isOrgLoading}
-						isChatPlanOrg={!selectedOrganization}
+						isChatPlanOrg={!selectedOrganization || selectedOrganization.isChat}
 					/>
 				</div>
 				<SidebarMenu>

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -788,7 +788,7 @@ export const ChatSidebar = function ChatSidebar({
 							tooltip="Chat"
 							isActive={pathname === "/"}
 						>
-							<Link href="/">
+							<Link href="/" prefetch={true}>
 								<MessageSquare className="h-4 w-4" />
 								<span>Chat</span>
 							</Link>
@@ -800,7 +800,7 @@ export const ChatSidebar = function ChatSidebar({
 							tooltip="Group Chat"
 							isActive={pathname === "/group"}
 						>
-							<Link href="/group">
+							<Link href="/group" prefetch={true}>
 								<Users className="h-4 w-4" />
 								<span>Group Chat</span>
 							</Link>
@@ -812,7 +812,7 @@ export const ChatSidebar = function ChatSidebar({
 							tooltip="Image Studio"
 							isActive={pathname === "/image"}
 						>
-							<Link href="/image">
+							<Link href="/image" prefetch={true}>
 								<ImagePlus className="h-4 w-4" />
 								<span>Image Studio</span>
 							</Link>
@@ -824,7 +824,7 @@ export const ChatSidebar = function ChatSidebar({
 							tooltip="Video Studio"
 							isActive={pathname === "/video"}
 						>
-							<Link href="/video">
+							<Link href="/video" prefetch={true}>
 								<Film className="h-4 w-4" />
 								<span>Video Studio</span>
 							</Link>
@@ -836,7 +836,7 @@ export const ChatSidebar = function ChatSidebar({
 							tooltip="Canvas"
 							isActive={pathname === "/canvas"}
 						>
-							<Link href="/canvas">
+							<Link href="/canvas" prefetch={true}>
 								<PenTool className="h-4 w-4" />
 								<span>Canvas</span>
 							</Link>

--- a/apps/playground/src/components/playground/image-sidebar.tsx
+++ b/apps/playground/src/components/playground/image-sidebar.tsx
@@ -603,7 +603,7 @@ export function ImageSidebar({
 							tooltip="Chat"
 							isActive={pathname === "/"}
 						>
-							<Link href="/">
+							<Link href="/" prefetch={true}>
 								<MessageSquare className="h-4 w-4" />
 								<span>Chat</span>
 							</Link>
@@ -615,7 +615,7 @@ export function ImageSidebar({
 							tooltip="Group Chat"
 							isActive={pathname === "/group"}
 						>
-							<Link href="/group">
+							<Link href="/group" prefetch={true}>
 								<Users className="h-4 w-4" />
 								<span>Group Chat</span>
 							</Link>
@@ -627,7 +627,7 @@ export function ImageSidebar({
 							tooltip="Image Studio"
 							isActive={pathname === "/image"}
 						>
-							<Link href="/image">
+							<Link href="/image" prefetch={true}>
 								<ImageIcon className="h-4 w-4" />
 								<span>Image Studio</span>
 							</Link>
@@ -639,7 +639,7 @@ export function ImageSidebar({
 							tooltip="Video Studio"
 							isActive={pathname === "/video"}
 						>
-							<Link href="/video">
+							<Link href="/video" prefetch={true}>
 								<Film className="h-4 w-4" />
 								<span>Video Studio</span>
 							</Link>
@@ -651,7 +651,7 @@ export function ImageSidebar({
 							tooltip="Canvas"
 							isActive={pathname === "/canvas"}
 						>
-							<Link href="/canvas">
+							<Link href="/canvas" prefetch={true}>
 								<PenTool className="h-4 w-4" />
 								<span>Canvas</span>
 							</Link>
@@ -707,8 +707,9 @@ export function ImageSidebar({
 			<SidebarFooter>
 				<div className="group-data-[collapsible=icon]:hidden">
 					<CreditsDisplay
-						organization={organization}
+						organization={switcherSelectedOrganization ?? organization}
 						isLoading={isOrgLoading}
+						isChatPlanOrg={!switcherSelectedOrganization}
 					/>
 				</div>
 				<SidebarMenu>

--- a/apps/playground/src/components/playground/org-sidebar.tsx
+++ b/apps/playground/src/components/playground/org-sidebar.tsx
@@ -421,7 +421,7 @@ export function OrgSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Chat">
-							<Link href="/">
+							<Link href="/" prefetch={true}>
 								<MessageSquare className="h-4 w-4" />
 								<span>Chat</span>
 							</Link>
@@ -429,7 +429,7 @@ export function OrgSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Group Chat">
-							<Link href="/group">
+							<Link href="/group" prefetch={true}>
 								<Users className="h-4 w-4" />
 								<span>Group Chat</span>
 							</Link>
@@ -437,7 +437,7 @@ export function OrgSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Image Studio">
-							<Link href="/image">
+							<Link href="/image" prefetch={true}>
 								<ImagePlus className="h-4 w-4" />
 								<span>Image Studio</span>
 							</Link>
@@ -445,7 +445,7 @@ export function OrgSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Video Studio">
-							<Link href="/video">
+							<Link href="/video" prefetch={true}>
 								<Film className="h-4 w-4" />
 								<span>Video Studio</span>
 							</Link>
@@ -453,7 +453,7 @@ export function OrgSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Canvas">
-							<Link href="/canvas">
+							<Link href="/canvas" prefetch={true}>
 								<PenTool className="h-4 w-4" />
 								<span>Canvas</span>
 							</Link>

--- a/apps/playground/src/components/playground/skills-sidebar.tsx
+++ b/apps/playground/src/components/playground/skills-sidebar.tsx
@@ -183,7 +183,7 @@ export function SkillsSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Chat">
-							<Link href="/">
+							<Link href="/" prefetch={true}>
 								<MessageSquare className="h-4 w-4" />
 								<span>Chat</span>
 							</Link>
@@ -191,7 +191,7 @@ export function SkillsSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Group Chat">
-							<Link href="/group">
+							<Link href="/group" prefetch={true}>
 								<Users className="h-4 w-4" />
 								<span>Group Chat</span>
 							</Link>
@@ -199,7 +199,7 @@ export function SkillsSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Image Studio">
-							<Link href="/image">
+							<Link href="/image" prefetch={true}>
 								<ImagePlus className="h-4 w-4" />
 								<span>Image Studio</span>
 							</Link>
@@ -207,7 +207,7 @@ export function SkillsSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Video Studio">
-							<Link href="/video">
+							<Link href="/video" prefetch={true}>
 								<Film className="h-4 w-4" />
 								<span>Video Studio</span>
 							</Link>
@@ -215,7 +215,7 @@ export function SkillsSidebar({
 					</SidebarMenuItem>
 					<SidebarMenuItem>
 						<SidebarMenuButton asChild tooltip="Canvas">
-							<Link href="/canvas">
+							<Link href="/canvas" prefetch={true}>
 								<PenTool className="h-4 w-4" />
 								<span>Canvas</span>
 							</Link>

--- a/apps/playground/src/components/playground/video-sidebar.tsx
+++ b/apps/playground/src/components/playground/video-sidebar.tsx
@@ -627,7 +627,7 @@ export function VideoSidebar({
 							tooltip="Chat"
 							isActive={pathname === "/"}
 						>
-							<Link href="/">
+							<Link href="/" prefetch={true}>
 								<MessageSquare className="h-4 w-4" />
 								<span>Chat</span>
 							</Link>
@@ -639,7 +639,7 @@ export function VideoSidebar({
 							tooltip="Group Chat"
 							isActive={pathname === "/group"}
 						>
-							<Link href="/group">
+							<Link href="/group" prefetch={true}>
 								<Users className="h-4 w-4" />
 								<span>Group Chat</span>
 							</Link>
@@ -651,7 +651,7 @@ export function VideoSidebar({
 							tooltip="Image Studio"
 							isActive={pathname === "/image"}
 						>
-							<Link href="/image">
+							<Link href="/image" prefetch={true}>
 								<ImageIcon className="h-4 w-4" />
 								<span>Image Studio</span>
 							</Link>
@@ -663,7 +663,7 @@ export function VideoSidebar({
 							tooltip="Video Studio"
 							isActive={pathname === "/video"}
 						>
-							<Link href="/video">
+							<Link href="/video" prefetch={true}>
 								<Film className="h-4 w-4" />
 								<span>Video Studio</span>
 							</Link>
@@ -675,7 +675,7 @@ export function VideoSidebar({
 							tooltip="Canvas"
 							isActive={pathname === "/canvas"}
 						>
-							<Link href="/canvas">
+							<Link href="/canvas" prefetch={true}>
 								<PenTool className="h-4 w-4" />
 								<span>Canvas</span>
 							</Link>
@@ -731,8 +731,9 @@ export function VideoSidebar({
 			<SidebarFooter>
 				<div className="group-data-[collapsible=icon]:hidden">
 					<CreditsDisplay
-						organization={organization}
+						organization={switcherSelectedOrganization ?? organization}
 						isLoading={isOrgLoading}
+						isChatPlanOrg={!switcherSelectedOrganization}
 					/>
 				</div>
 				<SidebarMenu>


### PR DESCRIPTION
## What

The Starter/Plus/Pro **Chat plan** badge (e.g. _"Starter plan · \$17.98 of \$18.00 left"_) only rendered on the **Chat** page. On **Image Studio**, **Video Studio**, **Canvas**, and **Group Chat** the sidebar footer fell back to plain "Credits / No credits remaining".

### Root cause
`CreditsDisplay` only enables the `/chat-plans/status` query (and renders the plan + "Pay-as-you-go" split) when it receives `isChatPlanOrg`. Whether that flag is true depends on detecting the personal **Chat org** context:

- **Image/Video/Canvas sidebars** never passed `isChatPlanOrg` at all → query disabled → only credits showed.
- **Group Chat** uses `ChatSidebar`, which derived `isChatPlanOrg` from `!selectedOrganization`. But the studio/group pages default `selectedOrganization` to the **Chat org** (a real object, not `null`) so the playground key / billing works (their clients early-return from `ensureKey` on a null org). A non-null Chat org made `!selectedOrganization` false → plan hidden.

### Fix
- `image-sidebar`, `video-sidebar`, `canvas-sidebar`: pass `organization={switcherSelectedOrganization ?? organization}` and `isChatPlanOrg={!switcherSelectedOrganization}`. `switcherSelectedOrganization` already filters out the Chat org, so the Chat context is detected correctly.
- `chat-sidebar`: treat a selected **Chat org** (`selectedOrganization.isChat`) the same as the `null` personal context, so the badge renders on Group Chat without changing its billing context.

> Note: an earlier iteration changed `app/group/page.tsx` to use `selectedOrganization = null`; that was reverted because `group-chat-client` early-returns from `ensureKey` on a null org, which would break group-chat billing. The fix now lives entirely in the sidebars and preserves the Chat org as the billing context.

### Prefetch
Added `prefetch={true}` to the Chat / Group Chat / Image / Video / Canvas links in every sidebar (chat, image, video, canvas, org, skills) so switching studios is instant instead of waiting on a cold dynamic-route fetch.

## Test
- `tsc` clean for all touched files (pre-existing, unrelated `shiki` version-mismatch errors in `ai-elements/{reasoning,response}.tsx` remain).
- `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation link handling across sidebar components for improved performance.
  * Enhanced organization data management in credits display functionality across multiple sidebar views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->