### PR TITLE
chore(codex): add invoice info notes

### DIFF
--- a/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
+++ b/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
@@ -115,21 +115,29 @@ export default function ActivePlanChangeTier({
 													: `Switch to ${plan.name}?`}
 											</AlertDialogTitle>
 											<AlertDialogDescription>
-												{isUpgrade ? (
-													<>
-														You&apos;ll be charged a prorated amount today for
-														the rest of your current billing period, then $
-														{plan.price}/mo going forward. Your usage allowance
-														increases to ${plan.usage} right away.
-													</>
-												) : (
-													<>
-														You&apos;ll keep your {currentName} allowance until
-														your next renewal, when you&apos;ll move to{" "}
-														{plan.name} (${plan.price}/mo, ${plan.usage} in
-														usage). No refund is issued for the current period.
-													</>
-												)}
+												<span>
+													{isUpgrade ? (
+														<>
+															You&apos;ll be charged a prorated amount today for
+															the rest of your current billing period, then $
+															{plan.price}/mo going forward. Your usage
+															allowance increases to ${plan.usage} right away.
+														</>
+													) : (
+														<>
+															You&apos;ll keep your {currentName} allowance
+															until your next renewal, when you&apos;ll move to{" "}
+															{plan.name} (${plan.price}/mo, ${plan.usage} in
+															usage). No refund is issued for the current
+															period.
+														</>
+													)}
+												</span>
+												<span className="mt-3 block">
+													Need company or address details on your invoice?{" "}
+													Update billing settings before confirming. An invoice
+													is emailed automatically after payment.
+												</span>
 											</AlertDialogDescription>
 										</AlertDialogHeader>
 										<AlertDialogFooter>

--- a/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
+++ b/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDown, ArrowRight, ArrowUp, Loader2 } from "lucide-react";
+import { ArrowDown, ArrowRight, ArrowUp, Info, Loader2 } from "lucide-react";
 
 import {
 	AlertDialog,
@@ -133,10 +133,13 @@ export default function ActivePlanChangeTier({
 														</>
 													)}
 												</span>
-												<span className="mt-3 block">
-													Need company or address details on your invoice?{" "}
-													Update billing settings before confirming. An invoice
-													is emailed automatically after payment.
+												<span className="mt-3 flex items-start gap-1.5 text-[11px] leading-relaxed">
+													<Info className="mt-0.5 h-3 w-3 shrink-0" />
+													<span>
+														Need company/address details on your invoice? Update
+														billing settings before confirming. We email the
+														invoice automatically after payment.
+													</span>
 												</span>
 											</AlertDialogDescription>
 										</AlertDialogHeader>

--- a/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
+++ b/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDown, ArrowRight, ArrowUp, Info, Loader2 } from "lucide-react";
+import { ArrowDown, ArrowRight, ArrowUp, Loader2 } from "lucide-react";
 
 import {
 	AlertDialog,
@@ -133,13 +133,10 @@ export default function ActivePlanChangeTier({
 														</>
 													)}
 												</span>
-												<span className="mt-3 flex items-start gap-1.5 text-[11px] leading-relaxed">
-													<Info className="mt-0.5 h-3 w-3 shrink-0" />
-													<span>
-														Need company/address details on your invoice? Update
-														billing settings before confirming. We email the
-														invoice automatically after payment.
-													</span>
+												<span className="mt-3 block text-center text-[11px] leading-relaxed">
+													Need company/address details on your invoice? Update
+													billing settings before confirming. We email the
+													invoice automatically after payment.
 												</span>
 											</AlertDialogDescription>
 										</AlertDialogHeader>

--- a/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
+++ b/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
@@ -80,18 +80,18 @@ export default function InactivePlanChooser({
 									"Subscribe"
 								)}
 							</Button>
-							<InvoiceInfoLabel />
 						</div>
 					);
 				})}
 			</div>
+			<InvoiceInfoLabel />
 		</div>
 	);
 }
 
 function InvoiceInfoLabel() {
 	return (
-		<p className="mt-2 text-center text-[11px] leading-relaxed text-muted-foreground">
+		<p className="mx-auto mt-4 max-w-2xl text-center text-[11px] leading-relaxed text-muted-foreground">
 			Need company/address details on your invoice? Update billing settings
 			before purchase. We email the invoice automatically after payment.
 		</p>

--- a/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
+++ b/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
@@ -84,6 +84,10 @@ export default function InactivePlanChooser({
 					);
 				})}
 			</div>
+			<p className="mx-auto max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
+				Need company or address details on your invoice? Update billing settings
+				before purchase. An invoice is emailed automatically after payment.
+			</p>
 		</div>
 	);
 }

--- a/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
+++ b/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight, Check, Info, Loader2 } from "lucide-react";
+import { ArrowRight, Check, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
@@ -91,12 +91,9 @@ export default function InactivePlanChooser({
 
 function InvoiceInfoLabel() {
 	return (
-		<div className="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
-			<Info className="mt-0.5 h-3 w-3 shrink-0" />
-			<span>
-				Need company/address details on your invoice? Update billing settings
-				before purchase. We email the invoice automatically after payment.
-			</span>
-		</div>
+		<p className="mt-2 text-center text-[11px] leading-relaxed text-muted-foreground">
+			Need company/address details on your invoice? Update billing settings
+			before purchase. We email the invoice automatically after payment.
+		</p>
 	);
 }

--- a/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
+++ b/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight, Check, Loader2 } from "lucide-react";
+import { ArrowRight, Check, Info, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
@@ -80,14 +80,23 @@ export default function InactivePlanChooser({
 									"Subscribe"
 								)}
 							</Button>
+							<InvoiceInfoLabel />
 						</div>
 					);
 				})}
 			</div>
-			<p className="mx-auto max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
-				Need company or address details on your invoice? Update billing settings
-				before purchase. An invoice is emailed automatically after payment.
-			</p>
+		</div>
+	);
+}
+
+function InvoiceInfoLabel() {
+	return (
+		<div className="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
+			<Info className="mt-0.5 h-3 w-3 shrink-0" />
+			<span>
+				Need company/address details on your invoice? Update billing settings
+				before purchase. We email the invoice automatically after payment.
+			</span>
 		</div>
 	);
 }

--- a/apps/code/src/components/PricingPlans.tsx
+++ b/apps/code/src/components/PricingPlans.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Info, Sparkles } from "lucide-react";
+import { Check, Sparkles } from "lucide-react";
 import Link from "next/link";
 
 import { CodePlanTracker } from "@/components/LandingTracker";
@@ -215,12 +215,9 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 
 function InvoiceInfoLabel() {
 	return (
-		<div className="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
-			<Info className="mt-0.5 h-3 w-3 shrink-0" />
-			<span>
-				Need company/address details on your invoice? Update billing settings
-				before purchase. We email the invoice automatically after payment.
-			</span>
-		</div>
+		<p className="mt-2 text-center text-[11px] leading-relaxed text-muted-foreground">
+			Need company/address details on your invoice? Update billing settings
+			before purchase. We email the invoice automatically after payment.
+		</p>
 	);
 }

--- a/apps/code/src/components/PricingPlans.tsx
+++ b/apps/code/src/components/PricingPlans.tsx
@@ -208,6 +208,10 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 				Usage is metered at each provider&apos;s published per-token rate. Every
 				request shows its dollar value in your dashboard in real time.
 			</p>
+			<p className="mx-auto mt-2 max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
+				Need company or address details on your invoice? Update billing settings
+				before purchase. An invoice is emailed automatically after payment.
+			</p>
 		</div>
 	);
 }

--- a/apps/code/src/components/PricingPlans.tsx
+++ b/apps/code/src/components/PricingPlans.tsx
@@ -200,12 +200,12 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 									</Link>
 								</Button>
 							</CodePlanTracker>
-							<InvoiceInfoLabel />
 						</div>
 					);
 				})}
 			</div>
-			<p className="mt-6 text-center text-xs text-muted-foreground">
+			<InvoiceInfoLabel />
+			<p className="mt-3 text-center text-xs text-muted-foreground">
 				Usage is metered at each provider&apos;s published per-token rate. Every
 				request shows its dollar value in your dashboard in real time.
 			</p>
@@ -215,7 +215,7 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 
 function InvoiceInfoLabel() {
 	return (
-		<p className="mt-2 text-center text-[11px] leading-relaxed text-muted-foreground">
+		<p className="mx-auto mt-4 max-w-2xl text-center text-[11px] leading-relaxed text-muted-foreground">
 			Need company/address details on your invoice? Update billing settings
 			before purchase. We email the invoice automatically after payment.
 		</p>

--- a/apps/code/src/components/PricingPlans.tsx
+++ b/apps/code/src/components/PricingPlans.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Sparkles } from "lucide-react";
+import { Check, Info, Sparkles } from "lucide-react";
 import Link from "next/link";
 
 import { CodePlanTracker } from "@/components/LandingTracker";
@@ -200,6 +200,7 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 									</Link>
 								</Button>
 							</CodePlanTracker>
+							<InvoiceInfoLabel />
 						</div>
 					);
 				})}
@@ -208,10 +209,18 @@ export function PricingPlans({ credits }: PricingPlansProps) {
 				Usage is metered at each provider&apos;s published per-token rate. Every
 				request shows its dollar value in your dashboard in real time.
 			</p>
-			<p className="mx-auto mt-2 max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
-				Need company or address details on your invoice? Update billing settings
-				before purchase. An invoice is emailed automatically after payment.
-			</p>
+		</div>
+	);
+}
+
+function InvoiceInfoLabel() {
+	return (
+		<div className="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
+			<Info className="mt-0.5 h-3 w-3 shrink-0" />
+			<span>
+				Need company/address details on your invoice? Update billing settings
+				before purchase. We email the invoice automatically after payment.
+			</span>
 		</div>
 	);
 }

--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -5,7 +5,7 @@ import {
 	useStripe as useStripeElements,
 } from "@stripe/react-stripe-js";
 import { useQueryClient } from "@tanstack/react-query";
-import { CreditCard, ExternalLink, Plus } from "lucide-react";
+import { CreditCard, ExternalLink, Info, Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -323,7 +323,6 @@ function AmountStep({
 						) : null}
 					</div>
 				)}
-				<InvoiceSettingsNote />
 			</div>
 			<DialogFooter className="flex flex-col gap-3 sm:flex-col">
 				<div className="flex justify-end gap-2">
@@ -362,6 +361,7 @@ function AmountStep({
 					Stripe Checkout supports additional payment methods like Google Pay,
 					Apple Pay, and more.
 				</p>
+				<InvoiceSettingsNote />
 			</DialogFooter>
 		</>
 	);
@@ -544,7 +544,6 @@ function PaymentStep({
 				<p className="text-xs text-muted-foreground">
 					International cards are subject to an additional 1.5% processing fee.
 				</p>
-				<InvoiceSettingsNote />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -566,6 +565,7 @@ function PaymentStep({
 						{loading ? "Processing..." : `Continue`}
 					</Button>
 				</DialogFooter>
+				<InvoiceSettingsNote />
 			</form>
 		</>
 	);
@@ -764,7 +764,6 @@ function ConfirmPaymentStep({
 						<p className="text-sm text-muted-foreground">Amount: ${amount}</p>
 					)}
 				</div>
-				<InvoiceSettingsNote />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -788,6 +787,7 @@ function ConfirmPaymentStep({
 							: `Pay ${feeData ? `$${feeData.totalAmount.toFixed(2)}` : `$${amount}`}`}
 					</Button>
 				</DialogFooter>
+				<InvoiceSettingsNote />
 			</form>
 		</>
 	);
@@ -795,9 +795,12 @@ function ConfirmPaymentStep({
 
 function InvoiceSettingsNote() {
 	return (
-		<p className="rounded-lg bg-muted/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-			Need company or address details on your invoice? Update billing settings
-			before purchase. An invoice is emailed automatically after payment.
-		</p>
+		<div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
+			<Info className="mt-0.5 h-3 w-3 shrink-0" />
+			<span>
+				Need company/address details on your invoice? Update billing settings
+				before purchase. We email the invoice automatically after payment.
+			</span>
+		</div>
 	);
 }

--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -323,6 +323,7 @@ function AmountStep({
 						) : null}
 					</div>
 				)}
+				<InvoiceSettingsNote />
 			</div>
 			<DialogFooter className="flex flex-col gap-3 sm:flex-col">
 				<div className="flex justify-end gap-2">
@@ -543,6 +544,7 @@ function PaymentStep({
 				<p className="text-xs text-muted-foreground">
 					International cards are subject to an additional 1.5% processing fee.
 				</p>
+				<InvoiceSettingsNote />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -762,6 +764,7 @@ function ConfirmPaymentStep({
 						<p className="text-sm text-muted-foreground">Amount: ${amount}</p>
 					)}
 				</div>
+				<InvoiceSettingsNote />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -787,5 +790,14 @@ function ConfirmPaymentStep({
 				</DialogFooter>
 			</form>
 		</>
+	);
+}
+
+function InvoiceSettingsNote() {
+	return (
+		<p className="rounded-lg bg-muted/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+			Need company or address details on your invoice? Update billing settings
+			before purchase. An invoice is emailed automatically after payment.
+		</p>
 	);
 }

--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -5,7 +5,7 @@ import {
 	useStripe as useStripeElements,
 } from "@stripe/react-stripe-js";
 import { useQueryClient } from "@tanstack/react-query";
-import { CreditCard, ExternalLink, Info, Plus } from "lucide-react";
+import { CreditCard, ExternalLink, Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -795,12 +795,9 @@ function ConfirmPaymentStep({
 
 function InvoiceSettingsNote() {
 	return (
-		<div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
-			<Info className="mt-0.5 h-3 w-3 shrink-0" />
-			<span>
-				Need company/address details on your invoice? Update billing settings
-				before purchase. We email the invoice automatically after payment.
-			</span>
-		</div>
+		<p className="text-center text-[11px] leading-relaxed text-muted-foreground">
+			Need company/address details on your invoice? Update billing settings
+			before purchase. We email the invoice automatically after payment.
+		</p>
 	);
 }

--- a/apps/playground/src/components/pricing/chat-pricing-plans.tsx
+++ b/apps/playground/src/components/pricing/chat-pricing-plans.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Info, Loader2 } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -389,12 +389,9 @@ export function ChatPricingPlans({
 
 function InvoiceInfoLabel() {
 	return (
-		<div className="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
-			<Info className="mt-0.5 h-3 w-3 shrink-0" />
-			<span>
-				Need company/address details on your invoice? Update billing settings
-				before purchase. We email the invoice automatically after payment.
-			</span>
-		</div>
+		<p className="mt-2 text-center text-[11px] leading-relaxed text-muted-foreground">
+			Need company/address details on your invoice? Update billing settings
+			before purchase. We email the invoice automatically after payment.
+		</p>
 	);
 }

--- a/apps/playground/src/components/pricing/chat-pricing-plans.tsx
+++ b/apps/playground/src/components/pricing/chat-pricing-plans.tsx
@@ -382,6 +382,10 @@ export function ChatPricingPlans({
 				Pay-as-you-go credits stay available — chat plan credits drain first on
 				requests from the chat app.
 			</p>
+			<p className="mx-auto mt-2 max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
+				Need company or address details on your invoice? Update billing settings
+				before purchase. An invoice is emailed automatically after payment.
+			</p>
 		</div>
 	);
 }

--- a/apps/playground/src/components/pricing/chat-pricing-plans.tsx
+++ b/apps/playground/src/components/pricing/chat-pricing-plans.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Loader2 } from "lucide-react";
+import { Check, Info, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -373,6 +373,7 @@ export function ChatPricingPlans({
 									`Get ${plan.name}`
 								)}
 							</Button>
+							<InvoiceInfoLabel />
 						</div>
 					);
 				})}
@@ -382,10 +383,18 @@ export function ChatPricingPlans({
 				Pay-as-you-go credits stay available — chat plan credits drain first on
 				requests from the chat app.
 			</p>
-			<p className="mx-auto mt-2 max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
-				Need company or address details on your invoice? Update billing settings
-				before purchase. An invoice is emailed automatically after payment.
-			</p>
+		</div>
+	);
+}
+
+function InvoiceInfoLabel() {
+	return (
+		<div className="mt-2 flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
+			<Info className="mt-0.5 h-3 w-3 shrink-0" />
+			<span>
+				Need company/address details on your invoice? Update billing settings
+				before purchase. We email the invoice automatically after payment.
+			</span>
 		</div>
 	);
 }

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -9,6 +9,7 @@ import {
 import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
 import { ChevronDown, CreditCard, Lock, Plus } from "lucide-react";
+import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 
@@ -482,6 +483,8 @@ function AmountStep({
 						/>
 					</div>
 				) : null}
+
+				<InvoiceSettingsNote organizationId={organizationId} />
 			</div>
 
 			<DialogFooter className="flex flex-col gap-3 sm:flex-col">
@@ -752,6 +755,7 @@ function PaymentStep({
 				<p className="text-xs text-muted-foreground">
 					International cards are subject to an additional 1.5% processing fee.
 				</p>
+				<InvoiceSettingsNote organizationId={organizationId} />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -1195,6 +1199,7 @@ function ConfirmPaymentStep({
 						<p className="text-sm text-muted-foreground">Amount: ${amount}</p>
 					)}
 				</div>
+				<InvoiceSettingsNote organizationId={organizationId} />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -1220,6 +1225,29 @@ function ConfirmPaymentStep({
 				</DialogFooter>
 			</form>
 		</>
+	);
+}
+
+function InvoiceSettingsNote({
+	organizationId,
+}: {
+	organizationId: string | undefined;
+}) {
+	return (
+		<p className="rounded-lg bg-muted/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+			Need company or address details on your invoice?{" "}
+			{organizationId ? (
+				<Link
+					href={`/dashboard/${organizationId}/org/preferences`}
+					className="font-medium underline underline-offset-2 hover:text-foreground"
+				>
+					Update billing settings
+				</Link>
+			) : (
+				"Update billing settings"
+			)}{" "}
+			before purchase. An invoice is emailed automatically after payment.
+		</p>
 	);
 }
 

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@stripe/react-stripe-js";
 import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
-import { ChevronDown, CreditCard, Info, Lock, Plus } from "lucide-react";
+import { ChevronDown, CreditCard, Lock, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
@@ -1234,23 +1234,20 @@ function InvoiceSettingsNote({
 	organizationId: string | undefined;
 }) {
 	return (
-		<div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
-			<Info className="mt-0.5 h-3 w-3 shrink-0" />
-			<span>
-				Need company/address details on your invoice?{" "}
-				{organizationId ? (
-					<Link
-						href={`/dashboard/${organizationId}/org/preferences`}
-						className="font-medium underline underline-offset-2 hover:text-foreground"
-					>
-						Update billing settings
-					</Link>
-				) : (
-					"Update billing settings"
-				)}{" "}
-				before purchase. We email the invoice automatically after payment.
-			</span>
-		</div>
+		<p className="text-center text-[11px] leading-relaxed text-muted-foreground">
+			Need company/address details on your invoice?{" "}
+			{organizationId ? (
+				<Link
+					href={`/dashboard/${organizationId}/org/preferences`}
+					className="font-medium underline underline-offset-2 hover:text-foreground"
+				>
+					Update billing settings
+				</Link>
+			) : (
+				"Update billing settings"
+			)}{" "}
+			before purchase. We email the invoice automatically after payment.
+		</p>
 	);
 }
 

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@stripe/react-stripe-js";
 import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
-import { ChevronDown, CreditCard, Lock, Plus } from "lucide-react";
+import { ChevronDown, CreditCard, Info, Lock, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
@@ -483,8 +483,6 @@ function AmountStep({
 						/>
 					</div>
 				) : null}
-
-				<InvoiceSettingsNote organizationId={organizationId} />
 			</div>
 
 			<DialogFooter className="flex flex-col gap-3 sm:flex-col">
@@ -541,6 +539,8 @@ function AmountStep({
 					<span aria-hidden="true">·</span>
 					<span>Visa · Mastercard · Amex</span>
 				</div>
+
+				<InvoiceSettingsNote organizationId={organizationId} />
 			</DialogFooter>
 		</>
 	);
@@ -755,7 +755,6 @@ function PaymentStep({
 				<p className="text-xs text-muted-foreground">
 					International cards are subject to an additional 1.5% processing fee.
 				</p>
-				<InvoiceSettingsNote organizationId={organizationId} />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -777,6 +776,7 @@ function PaymentStep({
 						{loading ? "Processing..." : `Continue`}
 					</Button>
 				</DialogFooter>
+				<InvoiceSettingsNote organizationId={organizationId} />
 			</form>
 		</>
 	);
@@ -1199,7 +1199,6 @@ function ConfirmPaymentStep({
 						<p className="text-sm text-muted-foreground">Amount: ${amount}</p>
 					)}
 				</div>
-				<InvoiceSettingsNote organizationId={organizationId} />
 				<DialogFooter className="flex space-x-2 justify-end">
 					<Button
 						type="button"
@@ -1223,6 +1222,7 @@ function ConfirmPaymentStep({
 							: `Pay ${feeData ? `$${feeData.totalAmount.toFixed(2)}` : `$${amount}`}`}
 					</Button>
 				</DialogFooter>
+				<InvoiceSettingsNote organizationId={organizationId} />
 			</form>
 		</>
 	);
@@ -1234,20 +1234,23 @@ function InvoiceSettingsNote({
 	organizationId: string | undefined;
 }) {
 	return (
-		<p className="rounded-lg bg-muted/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-			Need company or address details on your invoice?{" "}
-			{organizationId ? (
-				<Link
-					href={`/dashboard/${organizationId}/org/preferences`}
-					className="font-medium underline underline-offset-2 hover:text-foreground"
-				>
-					Update billing settings
-				</Link>
-			) : (
-				"Update billing settings"
-			)}{" "}
-			before purchase. An invoice is emailed automatically after payment.
-		</p>
+		<div className="flex items-start gap-1.5 text-[11px] leading-relaxed text-muted-foreground">
+			<Info className="mt-0.5 h-3 w-3 shrink-0" />
+			<span>
+				Need company/address details on your invoice?{" "}
+				{organizationId ? (
+					<Link
+						href={`/dashboard/${organizationId}/org/preferences`}
+						className="font-medium underline underline-offset-2 hover:text-foreground"
+					>
+						Update billing settings
+					</Link>
+				) : (
+					"Update billing settings"
+				)}{" "}
+				before purchase. We email the invoice automatically after payment.
+			</span>
+		</div>
 	);
 }
 


### PR DESCRIPTION
## Summary
- add invoice settings reminders to dashboard and playground credit top-up dialogs
- add the same reminder to chat plan and DevPass purchase surfaces
- mention invoice email delivery before checkout or plan confirmation

## Validation
- pnpm format
- pnpm build
- pnpm test:unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Experience**
  * Enhanced billing guidance across pricing and payment flows with clearer reminders to update billing/company details before purchase.
  * Added consistent messaging confirming invoices are emailed after payment.
  * Improved access to billing settings with direct links in applicable payment dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->