### PR TITLE
fix: hide virtual regional mappings

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -25,6 +25,7 @@ import {
 	lt,
 	lte,
 	ne,
+	notInArray,
 	or,
 	sql,
 	tables,
@@ -7201,6 +7202,13 @@ const modelProviderMappingsListSchema = z.object({
 	totalCost: z.number(),
 });
 
+const providersWithHiddenRootMappings = providers
+	.filter(
+		(provider) =>
+			provider.regionConfig && !provider.regionConfig.pinDefaultRegion,
+	)
+	.map((provider) => provider.id);
+
 const getModelProviderMappings = createRoute({
 	method: "get",
 	path: "/model-provider-mappings",
@@ -7249,22 +7257,28 @@ admin.openapi(getModelProviderMappings, async (c) => {
 	const search = query.search ?? "";
 	const { from, to } = query;
 
-	const alibabaRegionalMapping = aliasedTable(
+	const concreteRegionalMapping = aliasedTable(
 		tables.modelProviderMapping,
-		"alibaba_regional_mapping",
+		"concrete_regional_mapping",
 	);
-	const visibleMappingClause = or(
-		ne(tables.modelProviderMapping.providerId, "alibaba"),
-		isNotNull(tables.modelProviderMapping.region),
-		sql`NOT EXISTS (
-			SELECT 1
-			FROM ${alibabaRegionalMapping}
-			WHERE ${alibabaRegionalMapping.providerId} = ${tables.modelProviderMapping.providerId}
-				AND ${alibabaRegionalMapping.modelId} = ${tables.modelProviderMapping.modelId}
-				AND ${alibabaRegionalMapping.externalId} = ${tables.modelProviderMapping.externalId}
-				AND ${alibabaRegionalMapping.region} IS NOT NULL
-		)`,
-	);
+	const visibleMappingClause =
+		providersWithHiddenRootMappings.length === 0
+			? undefined
+			: or(
+					notInArray(
+						tables.modelProviderMapping.providerId,
+						providersWithHiddenRootMappings,
+					),
+					isNotNull(tables.modelProviderMapping.region),
+					sql`NOT EXISTS (
+						SELECT 1
+						FROM ${concreteRegionalMapping}
+						WHERE ${concreteRegionalMapping.providerId} = ${tables.modelProviderMapping.providerId}
+							AND ${concreteRegionalMapping.modelId} = ${tables.modelProviderMapping.modelId}
+							AND ${concreteRegionalMapping.externalId} = ${tables.modelProviderMapping.externalId}
+							AND ${concreteRegionalMapping.region} IS NOT NULL
+					)`,
+				);
 	const searchClause = search
 		? or(
 				sql`${tables.modelProviderMapping.modelId} ILIKE ${"%" + search + "%"}`,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7249,12 +7249,29 @@ admin.openapi(getModelProviderMappings, async (c) => {
 	const search = query.search ?? "";
 	const { from, to } = query;
 
-	const whereClause = search
+	const alibabaRegionalMapping = aliasedTable(
+		tables.modelProviderMapping,
+		"alibaba_regional_mapping",
+	);
+	const visibleMappingClause = or(
+		ne(tables.modelProviderMapping.providerId, "alibaba"),
+		isNotNull(tables.modelProviderMapping.region),
+		sql`NOT EXISTS (
+			SELECT 1
+			FROM ${alibabaRegionalMapping}
+			WHERE ${alibabaRegionalMapping.providerId} = ${tables.modelProviderMapping.providerId}
+				AND ${alibabaRegionalMapping.modelId} = ${tables.modelProviderMapping.modelId}
+				AND ${alibabaRegionalMapping.externalId} = ${tables.modelProviderMapping.externalId}
+				AND ${alibabaRegionalMapping.region} IS NOT NULL
+		)`,
+	);
+	const searchClause = search
 		? or(
 				sql`${tables.modelProviderMapping.modelId} ILIKE ${"%" + search + "%"}`,
 				sql`${tables.modelProviderMapping.providerId} ILIKE ${"%" + search + "%"}`,
 			)
 		: undefined;
+	const whereClause = and(visibleMappingClause, searchClause);
 
 	const dateRange = (() => {
 		if (!(from && to)) {
@@ -7276,13 +7293,6 @@ admin.openapi(getModelProviderMappings, async (c) => {
 
 		return { startDate, endDateExclusive };
 	})();
-
-	const historySearchClause = search
-		? or(
-				sql`${modelProviderMappingHistory.modelId} ILIKE ${"%" + search + "%"}`,
-				sql`${modelProviderMappingHistory.providerId} ILIKE ${"%" + search + "%"}`,
-			)
-		: undefined;
 
 	const statsJoin = dateRange
 		? db
@@ -7319,7 +7329,6 @@ admin.openapi(getModelProviderMappings, async (c) => {
 				.from(modelProviderMappingHistory)
 				.where(
 					and(
-						historySearchClause,
 						gte(
 							modelProviderMappingHistory.minuteTimestamp,
 							dateRange.startDate,
@@ -7365,9 +7374,16 @@ admin.openapi(getModelProviderMappings, async (c) => {
 						),
 				})
 				.from(modelProviderMappingHistory)
+				.innerJoin(
+					tables.modelProviderMapping,
+					eq(
+						modelProviderMappingHistory.modelProviderMappingId,
+						tables.modelProviderMapping.id,
+					),
+				)
 				.where(
 					and(
-						historySearchClause,
+						whereClause,
 						gte(
 							modelProviderMappingHistory.minuteTimestamp,
 							dateRange.startDate,


### PR DESCRIPTION
## What changed

- Hide synthetic root/global model-provider mapping rows in the admin model-provider mappings list for regional providers whose metadata does not pin a true default/global region.
- Apply the same visible-row predicate to the list count and date-ranged totals so requests, tokens, and cost are not double-counted by virtual rows.
- Preserve AWS Bedrock global/default mappings because AWS has `regionConfig.pinDefaultRegion: true`.

## Why

Alibaba regional mappings are the actionable rows in this admin view. The synthetic null-region root row can duplicate regional usage and make the page-level totals look double-counted. The implementation now derives this from provider region metadata instead of hardcoding a provider id.

## Validation

- `pnpm format`
- `pnpm build`
- `pnpm test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filtering of model provider mappings to properly exclude hidden default region mappings for specific providers in the admin interface.
  * Corrected aggregation calculations in date-range history queries to align with filtered mapping results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->