### PR TITLE
docs: refresh LLM SDK docs and blog article

### DIFF
--- a/apps/docs/content/features/llm-sdk.mdx
+++ b/apps/docs/content/features/llm-sdk.mdx
@@ -39,21 +39,18 @@ Your backend ──(secret key sk_)──▶ POST /v1/sessions ──▶ ephemer
 - The **browser** only ever holds the `es_…` token (and a publishable Stripe key). It calls the gateway directly; usage is billed to that user's wallet.
 - **Markup is applied at top-up time**: if you set a 20% markup and a user buys $10, their wallet is credited the net spend power and your **margin accrues to your organization** for later payout.
 
-## Prerequisites
+## Set up in the dashboard
 
-1. In the dashboard, open your project and **enable end-user sessions** (sets `endUserEnabled` on the project). Optionally set a **markup percent** and an **allowed-origins** list.
-2. Create a **platform secret key** (`sk_…`, an API key of type `platform_secret`) for that project. Keep it server-side.
+Before you write any code, configure the project you want to embed:
 
-## Create an SDK platform secret key
-
-LLM SDK sessions use a project-scoped **platform secret key** that starts with `sk_`. This is different from a regular gateway API key (`llmgtwy_…`) and must only be used from your backend.
-
-1. Open the LLM Gateway dashboard and select the project you want to embed.
-2. Go to **Settings → SDK**.
-3. Enable **End-user sessions**.
-4. Add any allowed browser origins, such as `https://app.example.com`.
-5. Click **Create Secret Key** and copy the `sk_…` value immediately.
+1. Open the LLM Gateway dashboard and select your project.
+2. Go to **Settings → SDK** and turn on **End-user sessions**.
+3. _(Optional)_ Set a **markup percent** — the margin you earn on every top-up.
+4. Add the browser origins allowed to call the gateway, one per line (e.g. `https://app.example.com`), then click **Save Settings**.
+5. Under **Platform Secret Keys**, click **Create Secret Key** and copy the `sk_…` value immediately.
 6. Store it as a server-side environment variable, for example `LLMGATEWAY_SECRET_KEY`.
+
+The platform secret key (`sk_…`) is different from a regular gateway API key (`llmgtwy_…`): it mints end-user sessions and must only ever be used from your backend.
 
 <Callout type="warn">
 	The platform secret key is shown only once. Do not put it in frontend code,

--- a/apps/ui/src/content/blog/2026-06-07-embeddable-ai-credits.md
+++ b/apps/ui/src/content/blog/2026-06-07-embeddable-ai-credits.md
@@ -56,7 +56,7 @@ export async function POST() {
     customer: { externalId: "user_123" }, // your signed-in user
     scope: { models: ["openai/gpt-4o-mini"] }, // lock down what they can call
   });
-  return Response.json(session); // { sessionToken, walletId, expiresAt }
+  return Response.json(session); // { sessionToken, walletId, endCustomerId, expiresAt, publishableKey }
 }
 ```
 
@@ -93,11 +93,12 @@ export default function App({ session }) {
 
 That's the whole integration. The session token auto-refreshes before it expires, `<BuyCredits>` loads LLM Gateway's bundled Stripe publishable key, confirms the payment, and the balance updates once the webhook credits the wallet. Pass `test` while developing to use Stripe test mode; you don't need to ship a Stripe publishable key of your own for LLM Gateway payments.
 
-## A few engineering details we cared about
+## Safe by default
 
-- **The hot path stays low-cardinality.** Browser sessions live in a dedicated session table, while logs and API-key aggregates use one hidden project-level embedded-session key so end-user traffic does not create one API key per user.
-- **Idempotent top-ups.** Wallet credits are written in a single transaction guarded by a unique index on the payment intent, so a re-delivered Stripe webhook can never double-credit.
-- **Safe by default.** Tokens are short-lived and revocable, scoped to an allow-list of models, bounded by per-session spend caps, and constrained by a per-project origin allowlist. Webhook URLs are validated against SSRF (no private/internal targets), and developer margin payouts reserve funds before transferring so they can't overpay under concurrency.
+- **Your secret key never leaves your server.** The browser only ever holds a short-lived, revocable session token scoped to a single wallet.
+- **Sessions are scoped.** Lock each one to an allow-list of models and an optional per-session spend cap, and restrict which browser origins can reach the gateway.
+- **Top-ups can't double-credit.** A wallet is credited exactly once per payment, even if Stripe re-delivers the webhook.
+- **Webhooks are signed and SSRF-safe.** Events are signed so you can verify them, and only public HTTPS endpoints can be registered.
 
 ## Try it
 

--- a/apps/ui/src/content/blog/2026-06-07-embeddable-ai-credits.md
+++ b/apps/ui/src/content/blog/2026-06-07-embeddable-ai-credits.md
@@ -106,4 +106,4 @@ There's a complete, runnable Next.js example — backend session route, provider
 
 ➡️ **[theopenco/llmgateway-templates → templates/embeddable-credits](https://github.com/theopenco/llmgateway-templates/tree/main/templates/embeddable-credits)**
 
-Full reference is in the [LLM SDK docs](https://docs.llmgateway.io/features/llm-sdk). Enable end-user sessions on your project, create a platform secret key, and you can be live in an afternoon.
+Full reference is in the [LLM SDK docs](https://docs.llmgateway.io/features/llm-sdk). In the dashboard, open your project's **Settings → SDK** to enable end-user sessions and create a platform secret key — and you can be live in an afternoon.


### PR DESCRIPTION
## What

Refreshes the LLM SDK documentation page and the embeddable-credits blog article so they match the current implementation and focus on how to set the SDK up in a project — without leaking internal mechanics that don't help a reader.

## Why

The pages referenced internal storage details and database field names, and the setup section duplicated itself. The blog's session-response example also omitted fields the API actually returns.

## Changes

**`apps/docs/content/features/llm-sdk.mdx`**
- Merged the duplicate **Prerequisites** + **Create an SDK platform secret key** sections into a single **Set up in the dashboard** walkthrough.
- Dropped internal references (the `endUserEnabled` field name, "an API key of type `platform_secret`") in favor of the user-facing dashboard flow.
- Kept the user-facing token prefixes (`sk_…`, `es_…`, `llmgtwy_…`) and the secret-key warning.

**`apps/ui/src/content/blog/2026-06-07-embeddable-ai-credits.md`**
- Replaced the "engineering details" section (dedicated session tables, hidden project-level aggregate keys, unique-index internals) with a concise **Safe by default** section covering user-facing guarantees.
- Updated the backend snippet's response comment to match the fields the session endpoint actually returns (`sessionToken, walletId, endCustomerId, expiresAt, publishableKey`).

## Verification

Cross-checked every documented setup step and example against the backend implementation (`apps/api/src/routes/platform-*.ts`, project settings PATCH, webhook signing) — session create fields/response, platform secret keys, wallets, customers, webhooks, Stripe Connect payouts, and project settings all match.

Note: `pnpm format` could not run in this fresh container (dependencies not installed); changes are prose/list edits that follow the existing Markdown/MDX style.

https://claude.ai/code/session_01FqddC4uHnUHzfoSeFrab3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqddC4uHnUHzfoSeFrab3V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized LLM SDK setup into a concise "Set up in the dashboard" numbered checklist; clarifies platform secret key setup and that it differs from a gateway API key.
  * Updated embeddable AI guide: session-route example documents additional returned fields (endCustomerId, expiresAt, publishableKey) and replaced prior details with a "Safe by default" section emphasizing secret-key locality, scoped sessions, idempotent top-ups, and signed/SSRF-safe webhooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->