### PR TITLE
fix(admin): hide virtual Alibaba root mappings

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -25,6 +25,7 @@ import {
 	lt,
 	lte,
 	ne,
+	notInArray,
 	or,
 	sql,
 	tables,
@@ -7249,12 +7250,43 @@ admin.openapi(getModelProviderMappings, async (c) => {
 	const search = query.search ?? "";
 	const { from, to } = query;
 
-	const whereClause = search
+	// Alibaba's region=null "root" mapping is virtual: the stats calculator
+	// aggregates all regional traffic up into it, so it duplicates the regional
+	// rows' stats and double-counts in the totals. Each Alibaba region is the
+	// relevant unit, so hide these virtual roots from the list and totals.
+	// Other providers (e.g. AWS Bedrock) keep their root mapping.
+	const alibabaMappings = await db
+		.select({
+			id: tables.modelProviderMapping.id,
+			modelId: tables.modelProviderMapping.modelId,
+			region: tables.modelProviderMapping.region,
+		})
+		.from(tables.modelProviderMapping)
+		.where(eq(tables.modelProviderMapping.providerId, "alibaba"));
+
+	const alibabaModelsWithRegions = new Set(
+		alibabaMappings.filter((m) => m.region).map((m) => m.modelId),
+	);
+	const virtualRootMappingIds = alibabaMappings
+		.filter((m) => !m.region && alibabaModelsWithRegions.has(m.modelId))
+		.map((m) => m.id);
+
+	const excludeVirtualRoots =
+		virtualRootMappingIds.length > 0
+			? notInArray(tables.modelProviderMapping.id, virtualRootMappingIds)
+			: undefined;
+
+	const searchClause = search
 		? or(
 				sql`${tables.modelProviderMapping.modelId} ILIKE ${"%" + search + "%"}`,
 				sql`${tables.modelProviderMapping.providerId} ILIKE ${"%" + search + "%"}`,
 			)
 		: undefined;
+
+	const whereClause =
+		searchClause && excludeVirtualRoots
+			? and(searchClause, excludeVirtualRoots)
+			: (searchClause ?? excludeVirtualRoots);
 
 	const dateRange = (() => {
 		if (!(from && to)) {
@@ -7368,6 +7400,12 @@ admin.openapi(getModelProviderMappings, async (c) => {
 				.where(
 					and(
 						historySearchClause,
+						virtualRootMappingIds.length > 0
+							? notInArray(
+									modelProviderMappingHistory.modelProviderMappingId,
+									virtualRootMappingIds,
+								)
+							: undefined,
 						gte(
 							modelProviderMappingHistory.minuteTimestamp,
 							dateRange.startDate,


### PR DESCRIPTION
## Problem

In the admin **Model-Provider Mappings** page, Alibaba models appear twice — once for each region (e.g. `singapore`) and once for the "global" version with `region = —`. The global row shows the *same* request/cost numbers as its region (e.g. both `212 / $30.9226`), and these get counted twice in the page totals.

That global `region=null` row is **virtual**: the stats calculator (`apps/worker/src/services/stats-calculator.ts`) aggregates all regional traffic up into the root mapping, so it is just a duplicate of the sum of its regions.

## Fix

In the `/admin/model-provider-mappings` endpoint, identify Alibaba `region=null` mappings that have regional siblings and exclude them from:

- the mappings list
- the total mappings count
- the total requests / tokens / cost (fixes the double-counting)

Scoped to Alibaba only — each region is the relevant unit there. Other providers (e.g. AWS Bedrock) keep their root mapping unchanged.

## Testing

- `pnpm format` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Corrected the model-provider mappings admin endpoint to exclude virtual aggregation entries, preventing duplicate regional traffic counts and ensuring historical totals accurately reflect the displayed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->