### PR TITLE
fix(admin): show cost per row in providers table

### DIFF
--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -98,6 +98,12 @@ function formatNumber(n: number) {
 	return new Intl.NumberFormat("en-US").format(n);
 }
 
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
 function formatDate(dateString: string) {
 	return new Date(dateString).toLocaleDateString("en-US", {
 		year: "numeric",
@@ -170,6 +176,9 @@ function ProviderRow({
 					{formatNumber(provider.cachedCount)}
 				</TableCell>
 				<TableCell className="tabular-nums">
+					{currencyFormatter.format(provider.totalCost)}
+				</TableCell>
+				<TableCell className="tabular-nums">
 					{provider.avgTimeToFirstToken !== null
 						? `${Math.round(provider.avgTimeToFirstToken)}ms`
 						: "\u2014"}
@@ -193,7 +202,7 @@ function ProviderRow({
 			</TableRow>
 			{expanded && (
 				<TableRow>
-					<TableCell colSpan={10} className="p-4">
+					<TableCell colSpan={11} className="p-4">
 						<HistoryChart
 							title={`${provider.name} — History`}
 							description="Request volume, errors, latency, and tokens over time"
@@ -243,6 +252,7 @@ export function ProvidersTable({
 					{sh("Errors", "errorsCount")}
 					<TableHead>Error Rate</TableHead>
 					{sh("Cached", "cachedCount")}
+					<TableHead>Cost</TableHead>
 					{sh("Avg TTFT", "avgTimeToFirstToken")}
 					{sh("Last Updated", "updatedAt")}
 					<TableHead></TableHead>
@@ -252,7 +262,7 @@ export function ProvidersTable({
 				{providers.length === 0 ? (
 					<TableRow>
 						<TableCell
-							colSpan={10}
+							colSpan={11}
 							className="h-24 text-center text-muted-foreground"
 						>
 							No providers found


### PR DESCRIPTION
## Problem

The admin Providers page table was not showing cost in each row, even though a "Total Cost" aggregate was displayed at the top.

## Cause

The `/admin/providers` endpoint already returns `totalCost` per provider (computed for the selected time window), but `providers-table.tsx` never rendered a cost column.

## Fix

Add a **Cost** column to the providers table, formatted as USD currency, so each row shows its cost for the selected window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cost column to the providers table, displaying per-provider costs formatted in USD currency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->