### PR TITLE
fix(admin): correct aliased table in mapping subquery

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7272,7 +7272,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 					isNotNull(tables.modelProviderMapping.region),
 					sql`NOT EXISTS (
 						SELECT 1
-						FROM ${concreteRegionalMapping}
+						FROM ${tables.modelProviderMapping} ${concreteRegionalMapping}
 						WHERE ${concreteRegionalMapping.providerId} = ${tables.modelProviderMapping.providerId}
 							AND ${concreteRegionalMapping.modelId} = ${tables.modelProviderMapping.modelId}
 							AND ${concreteRegionalMapping.externalId} = ${tables.modelProviderMapping.externalId}


### PR DESCRIPTION
## What changed

Fixes the FROM clause of the `NOT EXISTS` predicate that hides virtual regional mappings in the admin model-provider mappings list (added in #2583).

## Why

The predicate interpolated an `aliasedTable` (`concrete_regional_mapping`) into a raw `sql` template. Inside raw SQL, Drizzle renders **only the alias name**, not the `"model_provider_mapping" "concrete_regional_mapping"` expansion it produces when an aliased table is passed to `.from()`. The generated SQL therefore read `FROM "concrete_regional_mapping"` — a relation that does not exist — and crashed every query using `visibleMappingClause` (count, list, and date-range totals).

It only surfaced in production because the bad branch runs only when `providersWithHiddenRootMappings` is non-empty (e.g. `alibaba`); locally that array is empty, so the subquery was never emitted.

The fix spells out the base table plus alias explicitly: `FROM ${tables.modelProviderMapping} ${concreteRegionalMapping}`.

## Validation

- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visibility logic for regional model provider mappings in the admin API to correctly determine when mappings should be hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->