### PR TITLE
feat(gateway): add no_training filter to /v1/models

### DIFF
--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "vitest";
 
 import { app } from "@/app.js";
 
+import { providers } from "@llmgateway/models";
+
 describe("Models API", () => {
 	test("GET /v1/models should return a list of models", async () => {
 		const res = await app.request("/v1/models");
@@ -132,6 +134,45 @@ describe("Models API", () => {
 				expect(isNaN(deprecatedAt.getTime())).toBe(false);
 			}
 		}
+	});
+
+	test("GET /v1/models?no_training=true should only return providers without API training", async () => {
+		const res = await app.request("/v1/models?no_training=true");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+		expect(json.data.length).toBeGreaterThan(0);
+
+		const noTrainingProviderIds = new Set(
+			providers
+				.filter((p) => p.dataPolicy?.apiTraining === false)
+				.map((p) => p.id),
+		);
+
+		for (const model of json.data) {
+			expect(model.providers.length).toBeGreaterThan(0);
+			for (const provider of model.providers) {
+				expect(noTrainingProviderIds.has(provider.providerId)).toBe(true);
+			}
+		}
+	});
+
+	test("GET /v1/models?no_training=true should return fewer providers than unfiltered", async () => {
+		const filteredRes = await app.request("/v1/models?no_training=true");
+		const unfilteredRes = await app.request("/v1/models");
+		expect(filteredRes.status).toBe(200);
+		expect(unfilteredRes.status).toBe(200);
+
+		const filtered = await filteredRes.json();
+		const unfiltered = await unfilteredRes.json();
+
+		const countProviders = (json: any) =>
+			json.data.reduce(
+				(sum: number, model: any) => sum + model.providers.length,
+				0,
+			);
+
+		expect(countProviders(filtered)).toBeLessThan(countProviders(unfiltered));
 	});
 
 	test("GET /v1/models should include proper output modalities for gemini-2.5-flash-image-preview", async () => {

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -101,6 +101,14 @@ const listModels = createRoute({
 				.transform((val) => val === "true")
 				.describe("Exclude deprecated models from the response")
 				.openapi({ example: "false" }),
+			no_training: z
+				.string()
+				.optional()
+				.transform((val) => val === "true")
+				.describe(
+					"Only return models and provider mappings whose provider does not train on API data",
+				)
+				.openapi({ example: "false" }),
 		}),
 	},
 	responses: {
@@ -120,36 +128,59 @@ modelsApi.openapi(listModels, async (c) => {
 		const query = c.req.valid("query");
 		const includeDeactivated = query.include_deactivated || false;
 		const excludeDeprecated = query.exclude_deprecated || false;
+		const noTraining = query.no_training || false;
 		const currentDate = new Date();
 
+		// Set of provider ids that do not train on API data
+		const noTrainingProviderIds = new Set(
+			providers
+				.filter((p) => p.dataPolicy?.apiTraining === false)
+				.map((p) => p.id),
+		);
+
 		// Filter models based on deactivation and deprecation status of their provider mappings
-		const filteredModels = modelsList.filter((model: ModelDefinition) => {
-			// Check if all provider mappings are deactivated
-			const allDeactivated = model.providers.every(
-				(provider) =>
-					(provider as ProviderModelMapping).deactivatedAt &&
-					currentDate > (provider as ProviderModelMapping).deactivatedAt!,
-			);
+		const deactivationFilteredModels = modelsList.filter(
+			(model: ModelDefinition) => {
+				// Check if all provider mappings are deactivated
+				const allDeactivated = model.providers.every(
+					(provider) =>
+						(provider as ProviderModelMapping).deactivatedAt &&
+						currentDate > (provider as ProviderModelMapping).deactivatedAt!,
+				);
 
-			// Filter out models where all providers are deactivated (unless explicitly included)
-			if (!includeDeactivated && allDeactivated) {
-				return false;
-			}
+				// Filter out models where all providers are deactivated (unless explicitly included)
+				if (!includeDeactivated && allDeactivated) {
+					return false;
+				}
 
-			// Check if all provider mappings are deprecated
-			const allDeprecated = model.providers.every(
-				(provider) =>
-					(provider as ProviderModelMapping).deprecatedAt &&
-					currentDate > (provider as ProviderModelMapping).deprecatedAt!,
-			);
+				// Check if all provider mappings are deprecated
+				const allDeprecated = model.providers.every(
+					(provider) =>
+						(provider as ProviderModelMapping).deprecatedAt &&
+						currentDate > (provider as ProviderModelMapping).deprecatedAt!,
+				);
 
-			// Filter out models where all providers are deprecated if requested
-			if (excludeDeprecated && allDeprecated) {
-				return false;
-			}
+				// Filter out models where all providers are deprecated if requested
+				if (excludeDeprecated && allDeprecated) {
+					return false;
+				}
 
-			return true;
-		});
+				return true;
+			},
+		);
+
+		// When requested, keep only provider mappings whose provider does not
+		// train on API data, and drop models left with no eligible mappings.
+		const filteredModels = noTraining
+			? deactivationFilteredModels
+					.map((model: ModelDefinition) => ({
+						...model,
+						providers: model.providers.filter((provider) =>
+							noTrainingProviderIds.has(provider.providerId),
+						),
+					}))
+					.filter((model) => model.providers.length > 0)
+			: deactivationFilteredModels;
 
 		const modelData = filteredModels.map((model: ModelDefinition) => {
 			// Determine input modalities (if model supports images)


### PR DESCRIPTION
## Summary

Adds a `no_training` query parameter to the `GET /v1/models` endpoint that returns only models and provider mappings whose provider does **not** train on API data.

When `no_training=true`:
- Provider mappings are filtered to only those whose provider has `dataPolicy.apiTraining === false` (the same semantic used by the "No training" badge in the UI providers grid).
- Models left with no eligible provider mappings are excluded from the response.

Defaults to `false`, so existing behavior is unchanged.

## Example

```bash
curl http://localhost:4001/v1/models?no_training=true
```

## Testing

- Added unit tests verifying that every returned provider has `apiTraining === false` and that the filtered set has strictly fewer provider mappings than the unfiltered one.
- `pnpm format`, `pnpm build`, and the `models.spec.ts` suite (15 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `no_training` query parameter to the models endpoint, allowing users to filter results to only include providers that don't train on API data.

* **Tests**
  * Added test cases verifying the filtering behavior of the `no_training` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->