### PR TITLE
fix: enable summarized thinking for Opus 4.7/4.8

### DIFF
--- a/packages/actions/src/prepare-request-body.adaptive.spec.ts
+++ b/packages/actions/src/prepare-request-body.adaptive.spec.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "vitest";
 import { prepareRequestBody } from "./prepare-request-body.js";
 
 interface AdaptiveThinkingBody {
-	thinking?: { type: "adaptive" | "enabled"; budget_tokens?: number };
+	thinking?: {
+		type: "adaptive" | "enabled";
+		budget_tokens?: number;
+		display?: "summarized" | "omitted";
+	};
 	output_config?: {
 		effort?: "low" | "medium" | "high" | "xhigh" | "max";
 	};
@@ -66,7 +70,10 @@ describe("prepareRequestBody - adaptive thinking (Opus 4.6/4.7/4.8)", () => {
 			const body = await buildAnthropicBody(model, {
 				reasoning_effort: "high",
 			});
-			expect(body.thinking).toEqual({ type: "adaptive" });
+			expect(body.thinking).toEqual({
+				type: "adaptive",
+				display: "summarized",
+			});
 			expect(body.output_config?.effort).toBe("high");
 		});
 	}
@@ -75,6 +82,9 @@ describe("prepareRequestBody - adaptive thinking (Opus 4.6/4.7/4.8)", () => {
 		const body = await buildAnthropicBody("claude-opus-4-6", {
 			reasoning_max_tokens: 8000,
 		});
-		expect(body.thinking).toEqual({ type: "adaptive" });
+		expect(body.thinking).toEqual({
+			type: "adaptive",
+			display: "summarized",
+		});
 	});
 });

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -713,7 +713,10 @@ describe("prepareRequestBody - Google AI Studio", () => {
 			false, // isProd
 		)) as any;
 
-		expect(requestBody.thinking).toEqual({ type: "adaptive" });
+		expect(requestBody.thinking).toEqual({
+			type: "adaptive",
+			display: "summarized",
+		});
 		expect(requestBody.output_config.effort).toBe("max");
 	});
 
@@ -740,10 +743,65 @@ describe("prepareRequestBody - Google AI Studio", () => {
 
 		expect(requestBody.additionalModelRequestFields.thinking).toEqual({
 			type: "adaptive",
+			display: "summarized",
 		});
 		expect(requestBody.additionalModelRequestFields.output_config.effort).toBe(
 			"max",
 		);
+	});
+
+	test('sets display "summarized" for adaptive thinking on Bedrock', async () => {
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-opus-4-7",
+			null,
+			"claude-opus-4-7",
+			[{ role: "user", content: "test" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"high", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.additionalModelRequestFields.thinking).toEqual({
+			type: "adaptive",
+			display: "summarized",
+		});
+	});
+
+	test('sets display "summarized" for adaptive thinking on Anthropic', async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-opus-4-7",
+			null,
+			"claude-opus-4-7",
+			[{ role: "user", content: "test" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"high", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.thinking).toEqual({
+			type: "adaptive",
+			display: "summarized",
+		});
 	});
 
 	test('aliases "max" effort to "high" for providers without a max tier', async () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1774,7 +1774,10 @@ export async function prepareRequestBody(
 					// Opus 4.7+ uses adaptive thinking: `thinking: { type: "adaptive" }` with
 					// `output_config.effort` controlling depth. `budget_tokens` is rejected.
 					// The model decides whether to engage thinking based on prompt complexity.
-					requestBody.thinking = { type: "adaptive" };
+					// `display: "summarized"` is required on Opus 4.7/4.8 to receive readable
+					// thinking text — their default flipped to "omitted" (empty thinking,
+					// signature only), unlike Opus 4.6 which defaults to "summarized".
+					requestBody.thinking = { type: "adaptive", display: "summarized" };
 					if (effort === undefined && reasoning_effort) {
 						const mapEffort = (
 							e: typeof reasoning_effort,
@@ -2190,8 +2193,12 @@ export async function prepareRequestBody(
 					// Opus 4.7+ uses adaptive thinking: `thinking: { type: "adaptive" }` with
 					// `output_config.effort` controlling depth. `budget_tokens` is rejected.
 					requestBody.additionalModelRequestFields ??= {};
+					// `display: "summarized"` is required on Opus 4.7/4.8 to receive
+					// readable thinking text — their default flipped to "omitted"
+					// (empty thinking, signature only), unlike Opus 4.6.
 					requestBody.additionalModelRequestFields.thinking = {
 						type: "adaptive",
+						display: "summarized",
 					};
 					const mapEffort = (
 						e: typeof reasoning_effort,

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -321,9 +321,11 @@ export interface AnthropicRequestBody extends BaseRequestBody {
 		| {
 				type: "enabled";
 				budget_tokens: number;
+				display?: "summarized" | "omitted";
 		  }
 		| {
 				type: "adaptive";
+				display?: "summarized" | "omitted";
 		  };
 	output_config?: {
 		effort?: "low" | "medium" | "high" | "xhigh" | "max";


### PR DESCRIPTION
Adaptive Claude models (Opus 4.7/4.8) default `thinking.display` to `"omitted"`, so the response returns an empty thinking field (signature only) and the gateway captured no reasoning content — unlike Opus 4.6, which defaults to `"summarized"`. This sets `display: "summarized"` on the adaptive thinking config for both the Anthropic and AWS Bedrock paths so readable summarized reasoning is returned and logged again. Verified live against Bedrock Opus 4.7 (reasoning now appears in the activity log) and covered by unit tests; no beta header is required per Anthropic's docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
