### PR TITLE
fix: make sticky session routing cost-aware

### DIFF
--- a/apps/api/src/routes/routing-config.ts
+++ b/apps/api/src/routes/routing-config.ts
@@ -167,6 +167,8 @@ const stickySchema = z
 const sessionSchema = z
 	.object({
 		enabled: z.boolean().optional(),
+		ttlSeconds: z.number().int().min(1).max(86_400).optional(),
+		uptimeThreshold: z.number().min(0).max(100).optional(),
 	})
 	.strict();
 
@@ -242,6 +244,8 @@ const resolvedConfigSchema = z.object({
 	}),
 	session: z.object({
 		enabled: z.boolean(),
+		ttlSeconds: z.number(),
+		uptimeThreshold: z.number(),
 	}),
 	providerPriorities: z.record(z.string(), z.number()),
 });
@@ -503,6 +507,8 @@ const getDefaults = createRoute({
 						}),
 						session: z.object({
 							enabled: z.boolean(),
+							ttlSeconds: z.number(),
+							uptimeThreshold: z.number(),
 						}),
 						providerPriorities: z.record(z.string(), z.number()),
 					}),

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -178,27 +178,29 @@ For the Anthropic Messages endpoint (`/v1/messages`), the session key is derived
 
 #### How pinning works
 
-When a session id is present, the provider (and region) is chosen **deterministically** using [rendezvous hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing) over the available providers, rather than the weighted score. The same session always maps to the same provider as long as that provider remains available.
+On a session's **first** request the provider is chosen by the normal weighted smart-routing score — the same price-, priority-, uptime-, and throughput-aware algorithm used for non-sticky requests. That choice is then **persisted for the session** and reused on every subsequent request, so the upstream prompt cache stays warm without bouncing the conversation between providers.
 
-Because the choice is deterministic per session, sticky requests **bypass both the weighted scoring and the epsilon-greedy exploration** — a session is never randomly bounced to a different provider mid-conversation.
+Because the pinned provider is replayed directly, sticky requests **skip the epsilon-greedy exploration** — a session is never randomly bounced to a different provider mid-conversation.
 
 #### Falling back when a provider is down
 
-Stickiness yields only when the pinned provider is effectively unavailable. A session is re-pinned to another provider when its provider:
+An established pin yields only when its provider can no longer serve the session well. A session is re-scored and re-pinned to the current weighted-best provider when its provider:
 
+- Drops below the session uptime threshold (default 85%),
 - Is filtered out by health checks (e.g. excluded for low uptime), or
 - Fails the request and is dropped by the [automatic retry & fallback](#automatic-retry--fallback) loop.
 
-Rendezvous hashing guarantees a **minimal-disruption** reshuffle: when one provider drops out, only the sessions pinned to that provider move — every other session keeps its provider. When the provider recovers and re-enters the available pool, affected sessions pin back to it.
+Re-pinning runs the same weighted algorithm again, so the replacement is the best currently available provider — not an arbitrary one.
 
 The selection reason in routing metadata shows `session-sticky` when a request was pinned via a session id.
 
 <Callout type="info">
-	Sticky routing optimizes for cache locality over per-request price. A session
-	stays on its provider even if a cheaper or faster alternative is momentarily
-	available, since the prompt-cache savings typically outweigh the difference.
-	Requests without a session id are unaffected and continue to use the weighted
-	smart-routing algorithm.
+	Sticky routing optimizes for cache locality over per-request churn. Once a
+	session is pinned it stays on its provider even if a cheaper or faster
+	alternative becomes momentarily available, since the prompt-cache savings
+	typically outweigh the difference — but the initial pick still respects price
+	and priority. Requests without a session id are unaffected and continue to use
+	the weighted smart-routing algorithm.
 </Callout>
 
 ### Provider-Specific Routing

--- a/apps/docs/content/features/sessions.mdx
+++ b/apps/docs/content/features/sessions.mdx
@@ -42,7 +42,7 @@ For the [Anthropic Messages endpoint](/features/anthropic-endpoint) (`/v1/messag
 
 When a model is served by multiple providers, requests are normally scored independently, so a multi-turn conversation can bounce between providers. That defeats provider-side **prompt caching**, which only pays off when consecutive requests with a shared prefix reach the **same** provider.
 
-With a session id set, LLMGateway pins all requests for that session to a single provider (and region) using deterministic [rendezvous hashing](https://en.wikipedia.org/wiki/Rendezvous_hashing). The session stays on that provider — bypassing the weighted score and the epsilon-greedy exploration — and only moves when its provider leaves the available pool (health filtering or a failed request dropped by retry/fallback). Rendezvous hashing keeps the reshuffle minimal: only sessions pinned to the departed provider move.
+With a session id set, LLMGateway scores the session's first request with the normal weighted smart-routing algorithm (price, priority, uptime, throughput) and then **pins that provider for the session**, reusing it on every subsequent request to keep the prompt cache warm. The session stays on that provider — skipping the epsilon-greedy exploration — and only moves when its provider drops below the session uptime threshold or leaves the available pool (health filtering or a failed request dropped by retry/fallback), at which point the session is re-scored and re-pinned to the current best provider.
 
 See [Routing → Sticky Session Routing](/features/routing) for the full algorithm, fallback behavior, and the `session-sticky` routing-metadata reason.
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -48,6 +48,7 @@ import {
 	insertLog as _insertLog,
 } from "@/lib/logs.js";
 import {
+	createSessionProviderStore,
 	getPreferredProvider,
 	resolvePreferredProvider,
 	setPreferredProvider,
@@ -365,7 +366,6 @@ async function collapseProvidersToBestRegionPerProvider(
 		metricsMap: Map<string, ProviderMetrics>;
 		isStreaming: boolean;
 		promptTokens?: number;
-		sessionId?: string;
 		routingConfig?: ResolvedRoutingConfig;
 		organizationId: string;
 	},
@@ -1963,6 +1963,22 @@ chat.openapi(completions, async (c) => {
 		organization.plan,
 	);
 
+	// Sticky-session routing: when the request carries a session id and the
+	// project has session stickiness enabled, provider selection is scored
+	// normally and then pinned for the session via this store. The store is
+	// keyed per (org, model, session); creating it lazily per model id keeps the
+	// final routing decision pinned without affecting region sub-selection.
+	const sessionStickyEnabled = Boolean(sessionId) && routingCfg.session.enabled;
+	const createSessionStore = (modelId: string) =>
+		sessionStickyEnabled && sessionId
+			? createSessionProviderStore(
+					project.organizationId,
+					modelId,
+					sessionId,
+					routingCfg.session.ttlSeconds,
+				)
+			: undefined;
+
 	const retryProjectContext = {
 		mode: project.mode,
 		organizationId: project.organizationId,
@@ -2617,7 +2633,6 @@ chat.openapi(completions, async (c) => {
 						metricsMap,
 						isStreaming: stream,
 						promptTokens: routingPromptTokens,
-						sessionId,
 						routingConfig: routingCfg,
 						organizationId: project.organizationId,
 					},
@@ -2630,7 +2645,7 @@ chat.openapi(completions, async (c) => {
 					metricsMap,
 					isStreaming: stream,
 					promptTokens: routingPromptTokens,
-					sessionId,
+					sessionProviderStore: createSessionStore(selectedModel.id),
 					routingConfig: routingCfg,
 					organizationId: project.organizationId,
 					providerDiscountResolver,
@@ -2855,7 +2870,7 @@ chat.openapi(completions, async (c) => {
 							metricsMap,
 							isStreaming: stream,
 							promptTokens: routingPromptTokens,
-							sessionId,
+							sessionProviderStore: createSessionStore(modelInfo.id),
 							routingConfig: routingCfg,
 							organizationId: project.organizationId,
 							providerDiscountResolver,
@@ -3054,7 +3069,7 @@ chat.openapi(completions, async (c) => {
 								metricsMap: allMetricsMap,
 								isStreaming: stream,
 								promptTokens: routingPromptTokens,
-								sessionId,
+								sessionProviderStore: createSessionStore(modelWithPricing.id),
 								routingConfig: routingCfg,
 								organizationId: project.organizationId,
 								providerDiscountResolver,
@@ -3236,7 +3251,6 @@ chat.openapi(completions, async (c) => {
 									metricsMap: allMetricsMap,
 									isStreaming: stream,
 									promptTokens: routingPromptTokens,
-									sessionId,
 									routingConfig: routingCfg,
 									organizationId: project.organizationId,
 								},
@@ -3268,7 +3282,7 @@ chat.openapi(completions, async (c) => {
 									metricsMap: allMetricsMap,
 									isStreaming: stream,
 									promptTokens: routingPromptTokens,
-									sessionId,
+									sessionProviderStore: createSessionStore(modelWithPricing.id),
 									routingConfig: routingCfg,
 									organizationId: project.organizationId,
 									providerDiscountResolver,
@@ -3462,7 +3476,6 @@ chat.openapi(completions, async (c) => {
 							metricsMap,
 							isStreaming: stream,
 							promptTokens: routingPromptTokens,
-							sessionId,
 							routingConfig: routingCfg,
 							organizationId: project.organizationId,
 						},
@@ -3475,7 +3488,7 @@ chat.openapi(completions, async (c) => {
 						metricsMap,
 						isStreaming: stream,
 						promptTokens: routingPromptTokens,
-						sessionId,
+						sessionProviderStore: createSessionStore(modelWithPricing.id),
 						routingConfig: routingCfg,
 						organizationId: project.organizationId,
 						providerDiscountResolver,
@@ -3484,14 +3497,17 @@ chat.openapi(completions, async (c) => {
 
 				if (cheapestResult) {
 					// Apply provider preference hysteresis to reduce unnecessary switching.
-					// Skip for exploration requests — they exist to refresh per-provider metrics.
+					// Skip for exploration requests — they exist to refresh per-provider
+					// metrics — and for sticky sessions, which already pin the provider
+					// per-session via the session store inside provider selection.
 					let selectedProvider = cheapestResult.provider;
 					let hysteresisSelectionReason =
 						cheapestResult.metadata.selectionReason;
 
 					if (
 						hysteresisSelectionReason !== "random-exploration" &&
-						routingCfg.sticky.enabled
+						routingCfg.sticky.enabled &&
+						!sessionStickyEnabled
 					) {
 						const preferred = await getPreferredProvider(
 							project.organizationId,
@@ -3713,10 +3729,11 @@ chat.openapi(completions, async (c) => {
 							output?: string[];
 						},
 						{
+							// No session store here: this call only computes scores for
+							// routing metadata and must not re-pin the session.
 							metricsMap,
 							isStreaming: stream,
 							promptTokens: routingPromptTokens,
-							sessionId,
 							routingConfig: routingCfg,
 							organizationId: project.organizationId,
 							providerDiscountResolver,

--- a/apps/gateway/src/lib/preferred-provider-session.spec.ts
+++ b/apps/gateway/src/lib/preferred-provider-session.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createSessionProviderStore } from "./preferred-provider.js";
+
+vi.mock("@llmgateway/cache", () => ({
+	redisClient: {
+		get: vi.fn(),
+		set: vi.fn(),
+	},
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+const mockCache = await import("@llmgateway/cache");
+const redis = mockCache.redisClient;
+
+describe("createSessionProviderStore", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("reads the pinned provider from the per-session redis key", async () => {
+		vi.mocked(redis.get).mockResolvedValue(
+			JSON.stringify({ providerId: "deepseek", region: "singapore" }),
+		);
+		const store = createSessionProviderStore(
+			"org1",
+			"model1",
+			"session-abc",
+			3600,
+		);
+
+		const entry = await store.get();
+
+		expect(redis.get).toHaveBeenCalledWith(
+			"session_provider:org1:model1:session-abc",
+		);
+		expect(entry).toEqual({ providerId: "deepseek", region: "singapore" });
+	});
+
+	it("returns null when no pin is stored", async () => {
+		vi.mocked(redis.get).mockResolvedValue(null);
+		const store = createSessionProviderStore(
+			"org1",
+			"model1",
+			"session-abc",
+			3600,
+		);
+
+		expect(await store.get()).toBeNull();
+	});
+
+	it("returns null and swallows redis errors on read", async () => {
+		vi.mocked(redis.get).mockRejectedValue(new Error("boom"));
+		const store = createSessionProviderStore(
+			"org1",
+			"model1",
+			"session-abc",
+			3600,
+		);
+
+		expect(await store.get()).toBeNull();
+	});
+
+	it("writes the pinned provider with the configured ttl", async () => {
+		const store = createSessionProviderStore(
+			"org1",
+			"model1",
+			"session-abc",
+			1800,
+		);
+
+		await store.set("deepseek", "singapore");
+
+		expect(redis.set).toHaveBeenCalledWith(
+			"session_provider:org1:model1:session-abc",
+			JSON.stringify({ providerId: "deepseek", region: "singapore" }),
+			"EX",
+			1800,
+		);
+	});
+
+	it("persists a region-less pin", async () => {
+		const store = createSessionProviderStore(
+			"org1",
+			"model1",
+			"session-abc",
+			1800,
+		);
+
+		await store.set("openai");
+
+		expect(redis.set).toHaveBeenCalledWith(
+			"session_provider:org1:model1:session-abc",
+			JSON.stringify({ providerId: "openai", region: undefined }),
+			"EX",
+			1800,
+		);
+	});
+
+	it("scopes the redis key per org, model, and session", async () => {
+		vi.mocked(redis.get).mockResolvedValue(null);
+
+		await createSessionProviderStore("orgA", "modelX", "s1", 60).get();
+		await createSessionProviderStore("orgB", "modelY", "s2", 60).get();
+
+		expect(redis.get).toHaveBeenNthCalledWith(
+			1,
+			"session_provider:orgA:modelX:s1",
+		);
+		expect(redis.get).toHaveBeenNthCalledWith(
+			2,
+			"session_provider:orgB:modelY:s2",
+		);
+	});
+});

--- a/apps/gateway/src/lib/preferred-provider.ts
+++ b/apps/gateway/src/lib/preferred-provider.ts
@@ -5,6 +5,8 @@ import {
 	type RoutingStickyConfig,
 } from "@llmgateway/shared/routing-config";
 
+import type { SessionProviderStore } from "@llmgateway/actions";
+
 type StickyCfg = Required<RoutingStickyConfig>;
 
 function getTtl(cfg?: StickyCfg): number {
@@ -90,6 +92,79 @@ export async function setPreferredProvider(
 	} catch (error) {
 		logger.error("Error setting preferred provider in Redis:", error as Error);
 	}
+}
+
+function sessionRedisKey(
+	orgId: string,
+	modelId: string,
+	sessionId: string,
+): string {
+	return `session_provider:${orgId}:${modelId}:${sessionId}`;
+}
+
+async function getSessionProvider(
+	orgId: string,
+	modelId: string,
+	sessionId: string,
+): Promise<PreferredProviderEntry | null> {
+	try {
+		const value = await redisClient.get(
+			sessionRedisKey(orgId, modelId, sessionId),
+		);
+		if (!value) {
+			return null;
+		}
+		return JSON.parse(value) as PreferredProviderEntry;
+	} catch (error) {
+		logger.error("Error getting session provider from Redis:", error as Error);
+		return null;
+	}
+}
+
+async function setSessionProvider(
+	orgId: string,
+	modelId: string,
+	sessionId: string,
+	providerId: string,
+	region: string | undefined,
+	ttlSeconds: number,
+): Promise<void> {
+	try {
+		await redisClient.set(
+			sessionRedisKey(orgId, modelId, sessionId),
+			JSON.stringify({ providerId, region }),
+			"EX",
+			ttlSeconds,
+		);
+	} catch (error) {
+		logger.error("Error setting session provider in Redis:", error as Error);
+	}
+}
+
+/**
+ * Build a session-scoped provider store for sticky routing. The selection logic
+ * in @llmgateway/actions reads/writes the pinned provider through this so the
+ * same session reuses its provider across requests (keeping upstream prompt
+ * caches warm), re-scoring only when the pin is no longer viable.
+ */
+export function createSessionProviderStore(
+	orgId: string,
+	modelId: string,
+	sessionId: string,
+	ttlSeconds: number,
+): SessionProviderStore {
+	return {
+		get: () => getSessionProvider(orgId, modelId, sessionId),
+		set: (providerId, region) =>
+			setSessionProvider(
+				orgId,
+				modelId,
+				sessionId,
+				providerId,
+				region,
+				ttlSeconds,
+			),
+	};
 }
 
 export interface ProviderScoreForHysteresis {

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -136,6 +136,21 @@ export interface ProviderSelectionResult<T extends AvailableModelProvider> {
 	metadata: RoutingMetadata;
 }
 
+export interface SessionProviderEntry {
+	providerId: string;
+	region?: string;
+}
+
+/**
+ * Persistence backend for sticky-session routing. The gateway implements this
+ * with a Redis-backed per-session entry; selection logic stays pure by reading
+ * and writing through these callbacks.
+ */
+export interface SessionProviderStore {
+	get: () => Promise<SessionProviderEntry | null>;
+	set: (providerId: string, region?: string) => Promise<void>;
+}
+
 export interface ProviderSelectionOptions {
 	metricsMap?: Map<string, ProviderMetrics>;
 	isStreaming?: boolean;
@@ -147,58 +162,21 @@ export interface ProviderSelectionOptions {
 	 */
 	promptTokens?: number;
 	/**
-	 * Sticky-routing session identifier. When provided, the provider (and
-	 * region) is chosen deterministically via rendezvous hashing so that all
-	 * requests for the same session pin to the same provider, maximizing
-	 * upstream prompt-cache hits. Price/uptime scoring is bypassed; the session
-	 * only moves to another provider when its pinned provider is no longer in
-	 * the available list (e.g. excluded by health filtering or removed by the
-	 * retry-fallback loop after the provider failed).
+	 * Sticky-routing session store. When provided (and session stickiness is
+	 * enabled), the provider is selected with the normal weighted-score
+	 * algorithm and then persisted for the session: subsequent requests reuse
+	 * the saved provider so the upstream prompt cache stays warm. The pin only
+	 * breaks when the saved provider leaves the available list or its uptime
+	 * drops below the session uptime threshold, at which point the session is
+	 * re-scored and re-pinned to the new best provider.
 	 */
-	sessionId?: string;
+	sessionProviderStore?: SessionProviderStore;
 	routingConfig?: ResolvedRoutingConfig;
 	organizationId?: string | null;
 	providerDiscountResolver?: (
 		provider: AvailableModelProvider,
 		modelId: string,
 	) => Promise<string | null | undefined> | string | null | undefined;
-}
-
-/**
- * FNV-1a 32-bit hash mapped to the unit interval [0, 1). Deterministic across
- * processes, no crypto needed.
- */
-function hashToUnitInterval(input: string): number {
-	let hash = 0x811c9dc5;
-	for (let i = 0; i < input.length; i++) {
-		hash ^= input.charCodeAt(i);
-		hash = Math.imul(hash, 0x01000193);
-	}
-	return (hash >>> 0) / 0xffffffff;
-}
-
-/**
- * Rendezvous (highest-random-weight) hashing: deterministically pick one
- * provider for a session. Unlike modulo hashing, removing a provider only
- * reassigns the sessions that were pinned to it — every other session keeps
- * its provider.
- */
-function selectStickyProvider<T extends AvailableModelProvider>(
-	providers: T[],
-	sessionId: string,
-): T {
-	let best = providers[0];
-	let bestWeight = -1;
-	for (const provider of providers) {
-		const weight = hashToUnitInterval(
-			`${sessionId}|${provider.providerId}|${provider.region ?? ""}`,
-		);
-		if (weight > bestWeight) {
-			bestWeight = weight;
-			best = provider;
-		}
-	}
-	return best;
 }
 
 function findProviderMapping<P extends ModelWithPricing["providers"][number]>(
@@ -424,6 +402,63 @@ async function getProviderSelectionPrices<T extends AvailableModelProvider>(
 }
 
 /**
+ * Apply sticky-session routing on top of a freshly computed selection.
+ *
+ * If the session already has a pinned provider that is still available and
+ * healthy (uptime at or above the session threshold), reuse it so the upstream
+ * prompt cache stays warm. Otherwise persist the just-scored best provider so
+ * subsequent requests in this session reuse it. The pin only moves when its
+ * provider leaves the candidate list or its uptime drops too low.
+ */
+async function applySessionSticky<T extends AvailableModelProvider>(
+	naturalResult: ProviderSelectionResult<T>,
+	candidates: T[],
+	store: SessionProviderStore,
+	cfg: ResolvedRoutingConfig,
+	modelId: string,
+	metricsMap: Map<string, ProviderMetrics> | undefined,
+): Promise<ProviderSelectionResult<T>> {
+	const saved = await store.get();
+	if (saved) {
+		const candidate = candidates.find(
+			(c) =>
+				c.providerId === saved.providerId &&
+				(saved.region === undefined || c.region === saved.region),
+		);
+		if (candidate) {
+			const uptime = metricsMap?.get(
+				metricsKey(modelId, candidate.providerId, candidate.region),
+			)?.uptime;
+			if (uptime === undefined || uptime >= cfg.session.uptimeThreshold) {
+				// Re-persist so the pin's TTL keeps refreshing while the session
+				// stays active.
+				await store.set(candidate.providerId, candidate.region);
+				return {
+					provider: candidate,
+					metadata: {
+						...naturalResult.metadata,
+						selectedProvider: candidate.providerId,
+						selectionReason: "session-sticky",
+					},
+				};
+			}
+		}
+	}
+
+	await store.set(
+		naturalResult.provider.providerId,
+		naturalResult.provider.region,
+	);
+	return {
+		provider: naturalResult.provider,
+		metadata: {
+			...naturalResult.metadata,
+			selectionReason: "session-sticky",
+		},
+	};
+}
+
+/**
  * Get the best provider from a list of available model providers.
  * Considers price, uptime, throughput, and latency metrics.
  *
@@ -489,63 +524,22 @@ export async function getCheapestFromAvailableProviders<
 		options,
 	);
 
-	// Sticky routing: when a session id is provided (and session stickiness is
-	// enabled for the project), pin the session to a single provider via
-	// rendezvous hashing. Bypasses scoring and exploration so the upstream
-	// prompt cache stays warm; the session only moves if its provider leaves
-	// the available list (health filtering or retry-fallback exclusion).
-	const sessionId = options?.sessionId?.trim();
-	if (sessionId && cfg.session.enabled) {
-		const stickyProvider = selectStickyProvider(stableProviders, sessionId);
-		return {
-			provider: stickyProvider,
-			metadata: {
-				availableProviders: stableProviders.map((p) => p.providerId),
-				selectedProvider: stickyProvider.providerId,
-				selectionReason: "session-sticky",
-				providerScores: stableProviders.map((provider) => {
-					const providerInfo = findProviderMapping(
-						modelWithPricing.providers,
-						provider,
-					);
-					const providerDef = getProviderDefinition(provider.providerId);
-					const priority = providerDef?.priority ?? 1;
-					const metrics = metricsMap?.get(
-						metricsKey(
-							modelWithPricing.id,
-							provider.providerId,
-							provider.region,
-						),
-					);
-
-					return {
-						providerId: provider.providerId,
-						region: provider.region,
-						score: 0,
-						uptime: metrics?.uptime,
-						latency: metrics?.averageLatency,
-						throughput: metrics?.throughput,
-						price: (
-							providerSelectionPrices.get(providerSelectionKey(provider))
-								?.price ?? getProviderSelectionPrice(providerInfo, videoPricing)
-						).toNumber(),
-						priority,
-						cacheSupported: providerSupportsCaching(
-							providerInfo as ProviderModelMapping | undefined,
-						),
-						discount: providerSelectionPrices
-							.get(providerSelectionKey(provider))
-							?.discount.toNumber(),
-					};
-				}),
-			},
-		};
-	}
+	// Sticky routing: when a session store is provided (and session stickiness
+	// is enabled for the project), the provider is scored with the normal
+	// weighted algorithm below and then pinned for the session via the store.
+	// Exploration is skipped so the deterministic best is what gets persisted.
+	const sessionStore = options?.sessionProviderStore;
+	const sessionSticky = sessionStore !== undefined && cfg.session.enabled;
 
 	// Epsilon-greedy exploration: randomly select a provider some % of the time
 	// (configurable per project via thresholds.explorationRate). Skip during tests
-	// to keep behavior deterministic.
-	if (!isTestProcess() && Math.random() < getExplorationRate(cfg)) {
+	// to keep behavior deterministic, and for sticky sessions where we want the
+	// scored best provider to be the one we pin.
+	if (
+		!sessionSticky &&
+		!isTestProcess() &&
+		Math.random() < getExplorationRate(cfg)
+	) {
 		const randomProvider =
 			stableProviders[Math.floor(Math.random() * stableProviders.length)];
 		return {
@@ -594,13 +588,23 @@ export async function getCheapestFromAvailableProviders<
 
 	// If no metrics provided, fall back to price-only selection
 	if (!metricsMap || metricsMap.size === 0) {
-		return selectByPriceOnly(
+		const priceOnlyResult = selectByPriceOnly(
 			stableProviders,
 			modelWithPricing,
 			videoPricing,
 			cfg,
 			providerSelectionPrices,
 		);
+		return sessionSticky
+			? await applySessionSticky(
+					priceOnlyResult,
+					stableProviders,
+					sessionStore,
+					cfg,
+					modelWithPricing.id,
+					metricsMap,
+				)
+			: priceOnlyResult;
 	}
 
 	// If the project zeroed out every scoring weight, the weighted-score path
@@ -615,13 +619,23 @@ export async function getCheapestFromAvailableProviders<
 		effectiveLatencyWeight +
 		effectiveCacheWeight;
 	if (totalWeight <= 0) {
-		return selectByPriceOnly(
+		const priceOnlyResult = selectByPriceOnly(
 			stableProviders,
 			modelWithPricing,
 			videoPricing,
 			cfg,
 			providerSelectionPrices,
 		);
+		return sessionSticky
+			? await applySessionSticky(
+					priceOnlyResult,
+					stableProviders,
+					sessionStore,
+					cfg,
+					modelWithPricing.id,
+					metricsMap,
+				)
+			: priceOnlyResult;
 	}
 
 	// Calculate scores for each provider
@@ -789,10 +803,21 @@ export async function getCheapestFromAvailableProviders<
 		}),
 	};
 
-	return {
+	const weightedResult = {
 		provider: bestProvider.provider,
 		metadata,
 	};
+
+	return sessionSticky
+		? await applySessionSticky(
+				weightedResult,
+				stableProviders,
+				sessionStore,
+				cfg,
+				modelWithPricing.id,
+				metricsMap,
+			)
+		: weightedResult;
 }
 
 /**

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -15,6 +15,8 @@ import {
 import {
 	getCheapestFromAvailableProviders,
 	getProviderSelectionPrice,
+	type SessionProviderEntry,
+	type SessionProviderStore,
 } from "./get-cheapest-from-available-providers.js";
 import { getCheapestModelForProvider } from "./get-cheapest-model-for-provider.js";
 import { prepareRequestBody } from "./prepare-request-body.js";
@@ -476,7 +478,20 @@ describe("getCheapestFromAvailableProviders", () => {
 				),
 		);
 
-		it("pins the same session to the same provider deterministically", async () => {
+		function createMemoryStore(
+			initial: SessionProviderEntry | null = null,
+		): SessionProviderStore & { value: SessionProviderEntry | null } {
+			const store = {
+				value: initial,
+				get: async () => store.value,
+				set: async (providerId: string, region?: string) => {
+					store.value = { providerId, region };
+				},
+			};
+			return store;
+		}
+
+		it("scores the best provider, pins it, and reuses it on the next request", async () => {
 			if (!modelWithMultipleProviders) {
 				return;
 			}
@@ -487,23 +502,54 @@ describe("getCheapestFromAvailableProviders", () => {
 				return;
 			}
 
+			const store = createMemoryStore();
 			const first = await getCheapestFromAvailableProviders(
 				availableProviders,
 				modelWithMultipleProviders,
-				{ sessionId: "session_abc-123" },
+				{ sessionProviderStore: store },
 			);
 			const second = await getCheapestFromAvailableProviders(
 				availableProviders,
 				modelWithMultipleProviders,
-				{ sessionId: "session_abc-123" },
+				{ sessionProviderStore: store },
 			);
 
 			const regionOf = (p: unknown) =>
 				(p as { region?: string } | undefined)?.region;
 
 			expect(first?.metadata.selectionReason).toBe("session-sticky");
+			// The freshly scored best is persisted to the store.
+			expect(store.value?.providerId).toBe(first?.provider.providerId);
+			// The next request for the same session reuses the pinned provider.
 			expect(second?.provider.providerId).toBe(first?.provider.providerId);
 			expect(regionOf(second?.provider)).toBe(regionOf(first?.provider));
+		});
+
+		it("pins the same provider the weighted algorithm would pick without a session", async () => {
+			if (!modelWithMultipleProviders) {
+				return;
+			}
+			const availableProviders = modelWithMultipleProviders.providers.filter(
+				(p) => p.inputPrice !== undefined && p.outputPrice !== undefined,
+			);
+			if (availableProviders.length <= 1) {
+				return;
+			}
+
+			const withoutSession = await getCheapestFromAvailableProviders(
+				availableProviders,
+				modelWithMultipleProviders,
+			);
+			const store = createMemoryStore();
+			const withSession = await getCheapestFromAvailableProviders(
+				availableProviders,
+				modelWithMultipleProviders,
+				{ sessionProviderStore: store },
+			);
+
+			expect(withSession?.provider.providerId).toBe(
+				withoutSession?.provider.providerId,
+			);
 		});
 
 		it("does not pin a session when session stickiness is disabled", async () => {
@@ -521,50 +567,44 @@ describe("getCheapestFromAvailableProviders", () => {
 				{ session: { enabled: false } },
 				buildProviderPriorityDefaults(),
 			);
+			const store = createMemoryStore();
 			const result = await getCheapestFromAvailableProviders(
 				availableProviders,
 				modelWithMultipleProviders,
-				{ sessionId: "session_abc-123", routingConfig: overrides },
+				{ sessionProviderStore: store, routingConfig: overrides },
 			);
 
 			expect(result?.metadata.selectionReason).not.toBe("session-sticky");
+			expect(store.value).toBeNull();
 		});
 
-		it("keeps unrelated sessions on their provider when one provider is removed", async () => {
+		it("re-pins to the current best when the saved provider is gone", async () => {
 			if (!modelWithMultipleProviders) {
 				return;
 			}
 			const availableProviders = modelWithMultipleProviders.providers.filter(
 				(p) => p.inputPrice !== undefined && p.outputPrice !== undefined,
 			);
-			if (availableProviders.length <= 2) {
+			if (availableProviders.length <= 1) {
 				return;
 			}
 
-			// Find a session pinned to a provider, then drop a *different* provider
-			// and confirm the session stays put (rendezvous hashing property).
-			const sessionId = "session_stable";
-			const pinned = await getCheapestFromAvailableProviders(
+			// Saved provider is not in the available list (e.g. health-filtered),
+			// so the session is re-scored and re-pinned to the current best.
+			const store = createMemoryStore({
+				providerId: "definitely-not-a-real-provider",
+			});
+			const result = await getCheapestFromAvailableProviders(
 				availableProviders,
 				modelWithMultipleProviders,
-				{ sessionId },
-			);
-			const removable = availableProviders.find(
-				(p) => p.providerId !== pinned?.provider.providerId,
-			);
-			const reduced = availableProviders.filter(
-				(p) => p.providerId !== removable?.providerId,
+				{ sessionProviderStore: store },
 			);
 
-			const afterRemoval = await getCheapestFromAvailableProviders(
-				reduced,
-				modelWithMultipleProviders,
-				{ sessionId },
+			expect(result?.metadata.selectionReason).toBe("session-sticky");
+			expect(result?.provider.providerId).not.toBe(
+				"definitely-not-a-real-provider",
 			);
-
-			expect(afterRemoval?.provider.providerId).toBe(
-				pinned?.provider.providerId,
-			);
+			expect(store.value?.providerId).toBe(result?.provider.providerId);
 		});
 	});
 

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -480,15 +480,80 @@ describe("getCheapestFromAvailableProviders", () => {
 
 		function createMemoryStore(
 			initial: SessionProviderEntry | null = null,
-		): SessionProviderStore & { value: SessionProviderEntry | null } {
+		): SessionProviderStore & {
+			value: SessionProviderEntry | null;
+			setCalls: SessionProviderEntry[];
+		} {
 			const store = {
 				value: initial,
+				setCalls: [] as SessionProviderEntry[],
 				get: async () => store.value,
 				set: async (providerId: string, region?: string) => {
 					store.value = { providerId, region };
+					store.setCalls.push({ providerId, region });
 				},
 			};
 			return store;
+		}
+
+		// openai is priced ~5x cheaper than deepseek, so with equal priority and
+		// equal metrics the weighted-score winner is always openai. This lets the
+		// tests assert that stickiness keeps a session on a *more expensive*
+		// provider once pinned.
+		const stickyModel = {
+			id: "sticky-routing-model",
+			name: "Sticky Routing Model",
+			family: "openai" as const,
+			providers: [
+				{
+					providerId: "openai" as const,
+					externalId: "sticky-openai",
+					inputPrice: "1.0e-6",
+					outputPrice: "2.0e-6",
+					streaming: true as const,
+				},
+				{
+					providerId: "deepseek" as const,
+					externalId: "sticky-deepseek",
+					inputPrice: "5.0e-6",
+					outputPrice: "10.0e-6",
+					streaming: true as const,
+				},
+			],
+		};
+
+		// Neutralize per-provider priority defaults (deepseek ships with priority 2)
+		// so these tests isolate price + uptime behavior from priority bias.
+		const equalPriority = resolveRoutingConfig(
+			{ providerPriorities: { openai: 1, deepseek: 1 } },
+			buildProviderPriorityDefaults(),
+		);
+
+		function stickyMetrics(openaiUptime: number, deepseekUptime: number) {
+			return new Map([
+				[
+					metricsKey(stickyModel.id, "openai", undefined),
+					{
+						modelId: stickyModel.id,
+						providerId: "openai",
+						uptime: openaiUptime,
+						averageLatency: 200,
+						throughput: 100,
+						totalRequests: 100,
+					},
+				],
+				[
+					metricsKey(stickyModel.id, "deepseek", undefined),
+					{
+						modelId: stickyModel.id,
+						providerId: "deepseek",
+						uptime: deepseekUptime,
+						averageLatency: 200,
+						throughput: 100,
+						totalRequests: 100,
+					},
+				],
+			]);
 		}
 
 		it("scores the best provider, pins it, and reuses it on the next request", async () => {
@@ -605,6 +670,219 @@ describe("getCheapestFromAvailableProviders", () => {
 				"definitely-not-a-real-provider",
 			);
 			expect(store.value?.providerId).toBe(result?.provider.providerId);
+		});
+
+		it("uses the weighted-score winner for a new session and persists it", async () => {
+			const store = createMemoryStore();
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 99),
+					routingConfig: equalPriority,
+					sessionProviderStore: store,
+				},
+			);
+
+			expect(result?.provider.providerId).toBe("openai");
+			expect(result?.metadata.selectionReason).toBe("session-sticky");
+			expect(store.value).toEqual({ providerId: "openai", region: undefined });
+		});
+
+		it("keeps the session on its pinned provider even when a cheaper one is available", async () => {
+			// Previously pinned to the more expensive deepseek.
+			const store = createMemoryStore({ providerId: "deepseek" });
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 99),
+					routingConfig: equalPriority,
+					sessionProviderStore: store,
+				},
+			);
+
+			// Cheaper openai exists, but stickiness keeps the cache warm on deepseek.
+			expect(result?.provider.providerId).toBe("deepseek");
+			expect(result?.metadata.selectionReason).toBe("session-sticky");
+		});
+
+		it("refreshes the pin (its TTL) on reuse", async () => {
+			const store = createMemoryStore({ providerId: "deepseek" });
+			await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 99),
+					routingConfig: equalPriority,
+					sessionProviderStore: store,
+				},
+			);
+
+			expect(store.setCalls).toEqual([
+				{ providerId: "deepseek", region: undefined },
+			]);
+		});
+
+		it("re-pins to the best provider when the pinned one's uptime is too low", async () => {
+			// deepseek is pinned but its uptime fell below the 85% session threshold.
+			const store = createMemoryStore({ providerId: "deepseek" });
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 50),
+					routingConfig: equalPriority,
+					sessionProviderStore: store,
+				},
+			);
+
+			expect(result?.provider.providerId).toBe("openai");
+			expect(result?.metadata.selectionReason).toBe("session-sticky");
+			expect(store.value).toEqual({ providerId: "openai", region: undefined });
+		});
+
+		it("keeps the pin when uptime is exactly at the threshold", async () => {
+			const store = createMemoryStore({ providerId: "deepseek" });
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 85),
+					routingConfig: equalPriority,
+					sessionProviderStore: store,
+				},
+			);
+
+			expect(result?.provider.providerId).toBe("deepseek");
+		});
+
+		it("honors a custom session uptime threshold", async () => {
+			const strictThreshold = resolveRoutingConfig(
+				{
+					providerPriorities: { openai: 1, deepseek: 1 },
+					session: { uptimeThreshold: 95 },
+				},
+				buildProviderPriorityDefaults(),
+			);
+			const store = createMemoryStore({ providerId: "deepseek" });
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 90), // 90 < 95 → re-pin
+					routingConfig: strictThreshold,
+					sessionProviderStore: store,
+				},
+			);
+
+			expect(result?.provider.providerId).toBe("openai");
+		});
+
+		it("ignores the saved provider and the store when stickiness is disabled", async () => {
+			const disabled = resolveRoutingConfig(
+				{
+					providerPriorities: { openai: 1, deepseek: 1 },
+					session: { enabled: false },
+				},
+				buildProviderPriorityDefaults(),
+			);
+			const store = createMemoryStore({ providerId: "deepseek" });
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(99, 99),
+					routingConfig: disabled,
+					sessionProviderStore: store,
+				},
+			);
+
+			// Falls back to the weighted winner and never touches the store.
+			expect(result?.provider.providerId).toBe("openai");
+			expect(result?.metadata.selectionReason).not.toBe("session-sticky");
+			expect(store.setCalls).toEqual([]);
+			expect(store.value).toEqual({ providerId: "deepseek" });
+		});
+
+		it("reuses the pinned region and re-pins when the saved region is gone", async () => {
+			// Same provider, two regions; r1 is cheaper than r2.
+			const regionModel = {
+				id: "sticky-region-model",
+				name: "Sticky Region Model",
+				family: "openai" as const,
+				providers: [
+					{
+						providerId: "openai" as const,
+						externalId: "sticky-r1",
+						region: "r1",
+						inputPrice: "1.0e-6",
+						outputPrice: "2.0e-6",
+						streaming: true as const,
+					},
+					{
+						providerId: "openai" as const,
+						externalId: "sticky-r2",
+						region: "r2",
+						inputPrice: "5.0e-6",
+						outputPrice: "10.0e-6",
+						streaming: true as const,
+					},
+				],
+			};
+			const regionMetrics = new Map([
+				[
+					metricsKey(regionModel.id, "openai", "r1"),
+					{
+						modelId: regionModel.id,
+						providerId: "openai",
+						region: "r1",
+						uptime: 99,
+						averageLatency: 200,
+						throughput: 100,
+						totalRequests: 100,
+					},
+				],
+				[
+					metricsKey(regionModel.id, "openai", "r2"),
+					{
+						modelId: regionModel.id,
+						providerId: "openai",
+						region: "r2",
+						uptime: 99,
+						averageLatency: 200,
+						throughput: 100,
+						totalRequests: 100,
+					},
+				],
+			]);
+
+			// Pinned to the pricier r2 → stays on r2.
+			const pinned = createMemoryStore({ providerId: "openai", region: "r2" });
+			const reused = await getCheapestFromAvailableProviders(
+				regionModel.providers,
+				regionModel,
+				{
+					metricsMap: regionMetrics,
+					routingConfig: equalPriority,
+					sessionProviderStore: pinned,
+				},
+			);
+			expect(reused?.provider.region).toBe("r2");
+
+			// Saved region no longer offered → re-pin to the best region (r1).
+			const stale = createMemoryStore({ providerId: "openai", region: "gone" });
+			const repinned = await getCheapestFromAvailableProviders(
+				regionModel.providers,
+				regionModel,
+				{
+					metricsMap: regionMetrics,
+					routingConfig: equalPriority,
+					sessionProviderStore: stale,
+				},
+			);
+			expect(repinned?.provider.region).toBe("r1");
+			expect(stale.value).toEqual({ providerId: "openai", region: "r1" });
 		});
 	});
 

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -689,6 +689,28 @@ describe("getCheapestFromAvailableProviders", () => {
 			expect(store.value).toEqual({ providerId: "openai", region: undefined });
 		});
 
+		it("pins the full weighted-score winner, not merely the cheapest provider", async () => {
+			// openai is ~5x cheaper, but its uptime is poor. The full weighted
+			// score (price + uptime + throughput + priority, not price alone) makes
+			// the more expensive deepseek the winner — and that is what gets pinned.
+			const store = createMemoryStore();
+			const result = await getCheapestFromAvailableProviders(
+				stickyModel.providers,
+				stickyModel,
+				{
+					metricsMap: stickyMetrics(50, 100),
+					routingConfig: equalPriority,
+					sessionProviderStore: store,
+				},
+			);
+
+			expect(result?.provider.providerId).toBe("deepseek");
+			expect(store.value).toEqual({
+				providerId: "deepseek",
+				region: undefined,
+			});
+		});
+
 		it("keeps the session on its pinned provider even when a cheaper one is available", async () => {
 			// Previously pinned to the more expensive deepseek.
 			const store = createMemoryStore({ providerId: "deepseek" });

--- a/packages/shared/src/routing-config.spec.ts
+++ b/packages/shared/src/routing-config.spec.ts
@@ -122,6 +122,21 @@ describe("resolveRoutingConfig", () => {
 		expect(resolved.session.enabled).toBe(false);
 	});
 
+	it("defaults session ttl and uptime threshold", () => {
+		const resolved = resolveRoutingConfig(null, providerDefaults);
+		expect(resolved.session.ttlSeconds).toBe(3600);
+		expect(resolved.session.uptimeThreshold).toBe(85);
+	});
+
+	it("clamps session overrides into valid ranges", () => {
+		const resolved = resolveRoutingConfig(
+			{ session: { ttlSeconds: 0, uptimeThreshold: 150 } },
+			providerDefaults,
+		);
+		expect(resolved.session.ttlSeconds).toBe(1);
+		expect(resolved.session.uptimeThreshold).toBe(100);
+	});
+
 	it("clamps timeout overrides down to the infra ceiling", () => {
 		const resolved = resolveRoutingConfig(
 			{

--- a/packages/shared/src/routing-config.ts
+++ b/packages/shared/src/routing-config.ts
@@ -56,6 +56,18 @@ export interface RoutingSessionConfig {
 	 * provider. Defaults to true.
 	 */
 	enabled?: boolean;
+	/**
+	 * How long (seconds) a session stays pinned to its provider. Refreshed on
+	 * every request, so the pin lives as long as the session keeps making
+	 * requests within this window.
+	 */
+	ttlSeconds?: number;
+	/**
+	 * When the pinned provider's uptime drops below this percentage the session
+	 * is re-scored and pinned to the current best provider instead. This is the
+	 * only thing that breaks an established pin.
+	 */
+	uptimeThreshold?: number;
 }
 
 export type ProviderPriorityOverrides = Record<string, number>;
@@ -132,6 +144,8 @@ export const DEFAULT_ROUTING_STICKY: Required<RoutingStickyConfig> = {
 
 export const DEFAULT_ROUTING_SESSION: Required<RoutingSessionConfig> = {
 	enabled: true,
+	ttlSeconds: 3600,
+	uptimeThreshold: 85,
 };
 
 /**
@@ -168,6 +182,16 @@ function clampSticky(
 		ttlSeconds: Math.max(1, Math.floor(cfg.ttlSeconds)),
 		uptimeThreshold: Math.max(0, Math.min(100, cfg.uptimeThreshold)),
 		scoreMargin: Math.max(0, cfg.scoreMargin),
+	};
+}
+
+function clampSession(
+	cfg: Required<RoutingSessionConfig>,
+): Required<RoutingSessionConfig> {
+	return {
+		enabled: Boolean(cfg.enabled),
+		ttlSeconds: Math.max(1, Math.floor(cfg.ttlSeconds)),
+		uptimeThreshold: Math.max(0, Math.min(100, cfg.uptimeThreshold)),
 	};
 }
 
@@ -285,7 +309,9 @@ export function resolveRoutingConfig(
 		sticky: clampSticky(
 			mergeGroup(DEFAULT_ROUTING_STICKY, effectiveOverrides?.sticky),
 		),
-		session: mergeGroup(DEFAULT_ROUTING_SESSION, effectiveOverrides?.session),
+		session: clampSession(
+			mergeGroup(DEFAULT_ROUTING_SESSION, effectiveOverrides?.session),
+		),
 		providerPriorities,
 	};
 }


### PR DESCRIPTION
## Problem

Sticky session routing pinned each session to a provider via **rendezvous hashing**, which ignored the weighted-score routing algorithm entirely. Roughly 1/N of all sessions got pinned (for the session's life) to whichever provider won the hash — including the most expensive one — and the cheaper, higher-priority provider lost those sessions outright. The weighted-score path's price weight and provider priority only applied when there was *no* session id; they were completely bypassed once a session id was present.

## Fix

Sticky routing now uses **the exact same weighted-score algorithm** (price, priority, uptime, throughput) to pick the best provider, and only the *result* is made sticky:

1. On a session's first request the provider is scored normally and the choice is **persisted per session** (Redis, keyed per org/model/session).
2. Subsequent requests for the same session **reuse the saved provider** so the upstream prompt cache stays warm.
3. The pin only moves when the provider leaves the candidate list (health filtering / retry-fallback) or its uptime drops below the session uptime threshold (default 85%) — at which point the session is re-scored and re-pinned to the current best.

## Changes

- **`packages/actions`** — Replace the rendezvous hash (`selectStickyProvider` / `hashToUnitInterval`) in `getCheapestFromAvailableProviders` with an injected `SessionProviderStore` (`get`/`set`), matching the existing `providerDiscountResolver` injection pattern. Exploration is skipped while sticky so the deterministic best is what gets pinned. TTL is refreshed on reuse.
- **`apps/gateway`** — Add `createSessionProviderStore` (Redis-backed, per org/model/session) in `preferred-provider.ts` and wire it into the real routing decision points in `chat.ts`. The org+model preferred-provider hysteresis is skipped while a session is pinned (session stickiness takes precedence); region sub-selection and the metadata-only scoring call do **not** persist.
- **`packages/shared`** — Add `session.ttlSeconds` (default 3600) and `session.uptimeThreshold` (default 85) to the routing config, with clamping.
- **`apps/api`** — Extend the routing-config Zod schemas (override + resolved + defaults) for the new session fields.
- **docs** — Update the sticky-routing sections to describe weighted-pick-then-persist instead of rendezvous hashing.

## Testing

- `packages/actions/src/models.spec.ts` — rewritten sticky-session tests: pins the weighted best, reuses it on the next request, matches the non-session weighted pick, no-pin when disabled, re-pins when the saved provider is gone.
- `packages/shared/src/routing-config.spec.ts` — new tests for session ttl/uptime defaults and clamping.
- `pnpm build`, `pnpm format`, `pnpm lint`, and the affected unit suites (64 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable session TTL and uptime-threshold for session-based provider routing; session pinning now persists provider (including region) across requests.
  * First request uses weighted smart-routing and then pins that provider; pinned sessions skip exploration.

* **Documentation**
  * Clarified sticky-session behavior, re-evaluation conditions (uptime threshold or provider unavailability), and exploration rules.

* **Tests**
  * Expanded coverage for session pinning, TTL/threshold clamping, re-pinning, and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->