### PR TITLE
fix: show inferred scores for sticky session logs

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -205,16 +205,19 @@ function formatDuration(ms: number) {
 
 // Selection reasons where the weighted-score formula is bypassed entirely, so
 // every provider's score is a hardcoded 0 placeholder rather than a real value.
+// "session-sticky" is intentionally excluded: it scores providers with the
+// normal weighted algorithm and pins the result for the session, so the logged
+// scores are real values worth surfacing. The all-zero fallback below hides
+// those scores when they couldn't be computed (no metrics available).
 const SCORE_BYPASSED_SELECTION_REASONS = new Set([
-	"session-sticky",
 	"random-exploration",
 	"price-only-no-metrics",
 ]);
 
 // The per-provider score only carries information when scoring actually ran.
-// Sticky/exploration/price-only paths emit 0 for every provider, and
-// "stable-preferred" can layer on top of a sticky pick (also all zeros), so
-// treat an all-zero set as "scoring did not run" regardless of the reason.
+// Exploration/price-only paths emit 0 for every provider, and "stable-preferred"
+// can layer on top of a sticky pick, so treat an all-zero set as "scoring did
+// not run" regardless of the reason.
 function isProviderScoreMeaningful(
 	selectionReason: string | null | undefined,
 	providerScores: { score: number }[],


### PR DESCRIPTION
## Problem

The activity-log "Routing Info" panel hides the per-provider scores for
sticky-session requests. As of #2596, sticky-session routing scores
providers with the normal weighted algorithm and only pins the *result*
for the session — so the log already carries the real inferred scores
under `selectionReason: "session-sticky"`. The dashboard still listed
`session-sticky` in `SCORE_BYPASSED_SELECTION_REASONS`, a leftover from
when sticky picks used rendezvous hashing and emitted hardcoded `0`
placeholders, so those real scores were never displayed.

## Fix

Remove `session-sticky` from `SCORE_BYPASSED_SELECTION_REASONS` so the
inferred weighted scores that informed the sticky routing decision show
up in the log. The existing all-zero fallback still hides them in the
degenerate case where scoring couldn't run (e.g. no metrics available).

## Testing

- `pnpm format`
- `pnpm --filter ui build` + `tsc --noEmit` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the visibility logic for Provider Scores to display them in additional scenarios where they are applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->