### PR TITLE
feat(ui): add plain-English summary to legal pages

### DIFF
--- a/apps/ui/src/app/legal/[slug]/page.tsx
+++ b/apps/ui/src/app/legal/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { HeroRSC } from "@/components/landing/hero-rsc";
+import { LegalSummary } from "@/components/legal/legal-summary";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
 import { allLegals } from "content-collections";
@@ -41,6 +42,8 @@ export default async function LegalEntryPage({ params }: LegalEntryPageProps) {
 								Back Home
 							</Link>
 						</div>
+
+						<LegalSummary slug={slug} />
 
 						<article className="prose prose-lg dark:prose-invert max-w-none">
 							<div className="prose prose-lg dark:prose-invert max-w-none">

--- a/apps/ui/src/components/legal/legal-summary.tsx
+++ b/apps/ui/src/components/legal/legal-summary.tsx
@@ -1,0 +1,221 @@
+import {
+	BadgeCheck,
+	Ban,
+	DatabaseZap,
+	FileText,
+	Info,
+	KeyRound,
+	ListChecks,
+	Scale,
+	ShieldCheck,
+	UserX,
+	Wallet,
+} from "lucide-react";
+import Link from "next/link";
+
+import { Card, CardContent } from "@/lib/components/card";
+
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SummaryCard {
+	icon: LucideIcon;
+	title: string;
+	body: ReactNode;
+}
+
+const providersLink = (
+	<Link
+		href="/providers"
+		className="text-primary hover:text-primary/80 underline underline-offset-4"
+	>
+		Providers page
+	</Link>
+);
+
+const privacyCards: SummaryCard[] = [
+	{
+		icon: DatabaseZap,
+		title: "Only metadata is logged by default",
+		body: (
+			<>
+				Out of the box we store usage metadata only — tokens, cost, latency and
+				which provider was used — never the content of your prompts or
+				responses. You can optionally turn on full request retention under{" "}
+				<span className="text-foreground font-medium">Settings → Policies</span>{" "}
+				if you want it.
+			</>
+		),
+	},
+	{
+		icon: UserX,
+		title: "AI requests are sent anonymously",
+		body: (
+			<>
+				When we route a request to a provider, it is forwarded without any link
+				to your LLM Gateway account. Providers receive the request on its own
+				and cannot connect it back to your identity.
+			</>
+		),
+	},
+	{
+		icon: ShieldCheck,
+		title: "We never sell your data",
+		body: (
+			<>
+				Your personal information is never sold. Data is shared only with a
+				small set of vetted sub-processors (Stripe, Google Cloud, Resend) and
+				the AI provider you choose to route to.
+			</>
+		),
+	},
+	{
+		icon: FileText,
+		title: "Provider terms are transparent",
+		body: (
+			<>
+				Each provider&apos;s data retention timeframe and whether your data is
+				used for AI training is listed on the {providersLink} and on every
+				individual provider detail page.
+			</>
+		),
+	},
+	{
+		icon: BadgeCheck,
+		title: "You stay in control",
+		body: (
+			<>
+				You can access, export or delete your data at any time. Billing records
+				are kept for 10 years where tax and accounting law requires it.
+			</>
+		),
+	},
+	{
+		icon: KeyRound,
+		title: "We don’t store payment details",
+		body: (
+			<>
+				Payments are handled securely by Stripe. We never see or store your
+				credit card information.
+			</>
+		),
+	},
+];
+
+const termsCards: SummaryCard[] = [
+	{
+		icon: Info,
+		title: "What LLM Gateway is",
+		body: (
+			<>
+				We are a router and analytics layer in front of many AI providers. We
+				pass your requests through and report on them — we don&apos;t control or
+				guarantee the providers&apos; outputs.
+			</>
+		),
+	},
+	{
+		icon: Wallet,
+		title: "Free plan & pay-as-you-go credits",
+		body: (
+			<>
+				There&apos;s a free plan with generous limits. You can buy credits that
+				are consumed as you make requests. Credits are non-refundable except
+				where the law requires otherwise.
+			</>
+		),
+	},
+	{
+		icon: FileText,
+		title: "You own your data and prompts",
+		body: (
+			<>
+				Your prompts and data stay yours. You grant us a limited license to
+				process them only to provide the Service.
+			</>
+		),
+	},
+	{
+		icon: Scale,
+		title: "Provider terms also apply",
+		body: (
+			<>
+				Using a model means you also agree to that provider&apos;s terms. Their
+				policies and data handling are listed on the {providersLink}.
+			</>
+		),
+	},
+	{
+		icon: Ban,
+		title: "Fair use",
+		body: (
+			<>
+				No illegal or harmful use, no circumventing rate limits or auth.
+				Accounts abusing the Service may be suspended or terminated.
+			</>
+		),
+	},
+	{
+		icon: ListChecks,
+		title: "Provided “as is”",
+		body: (
+			<>
+				The Service and AI outputs come without warranties and our liability is
+				limited. Use of AI outputs is at your own discretion and risk.
+			</>
+		),
+	},
+];
+
+const summaries: Record<string, { heading: string; cards: SummaryCard[] }> = {
+	privacy: { heading: "Privacy in plain English", cards: privacyCards },
+	terms: { heading: "Terms in plain English", cards: termsCards },
+};
+
+export function LegalSummary({ slug }: { slug: string }) {
+	const summary = summaries[slug];
+
+	if (!summary) {
+		return null;
+	}
+
+	return (
+		<section className="mb-12 not-prose">
+			<div className="mb-6">
+				<h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-2">
+					{summary.heading}
+				</h2>
+				<p className="text-sm text-muted-foreground">
+					A human-readable summary of the key points. This overview is for
+					convenience only and is{" "}
+					<span className="text-foreground font-medium">
+						not legally binding
+					</span>
+					— the full text below is what governs.
+				</p>
+			</div>
+			<div className="grid gap-4 sm:grid-cols-2">
+				{summary.cards.map((card) => {
+					const Icon = card.icon;
+					return (
+						<Card key={card.title} className="gap-3 py-5">
+							<CardContent className="flex gap-3">
+								<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+									<Icon className="h-5 w-5" />
+								</div>
+								<div className="space-y-1">
+									<h3 className="font-semibold leading-snug text-foreground">
+										{card.title}
+									</h3>
+									<p className="text-sm leading-6 text-muted-foreground">
+										{card.body}
+									</p>
+								</div>
+							</CardContent>
+						</Card>
+					);
+				})}
+			</div>
+		</section>
+	);
+}


### PR DESCRIPTION
## What

Adds a non-legally-binding, human-readable summary to the top of the **Privacy Policy** and **Terms of Use** pages (`llmgateway.io/legal/privacy` and `/legal/terms`), rendered as a grid of summary cards with icons.

A new `LegalSummary` server component (`apps/ui/src/components/legal/legal-summary.tsx`) is rendered above the full legal text on the `[slug]` legal page. It only renders for the `privacy` and `terms` slugs and includes a clear disclaimer that the summary is **not legally binding** and the full text below governs.

### Privacy highlights
- **Only metadata is logged by default** — tokens, cost, latency, provider — never prompt/response content; full retention is opt-in under Settings → Policies.
- **AI requests are sent anonymously** to providers with no link to your LLM Gateway account and cannot be connected back.
- We never sell data; payment details aren't stored; you stay in control of your data.
- **Provider-specific terms are transparent** — links out to the [Providers page](https://llmgateway.io/providers) where each provider's data-retention timeframe and whether data is used for AI training is listed (and on each provider detail page).

### Terms highlights
- What LLM Gateway is (router + analytics layer), free plan & pay-as-you-go credits, you own your data/prompts, provider terms also apply, fair use, and "as is" disclaimer.

## Testing
- `pnpm format` ✅
- `pnpm build` ✅ (full monorepo build, 17/17 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a summary section to legal pages that displays key policy information in an easy-to-scan card-based layout with icons and descriptions for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->