### PR TITLE
feat(speech): add ElevenLabs text-to-speech provider

### DIFF
--- a/apps/gateway/src/speech/speech.spec.ts
+++ b/apps/gateway/src/speech/speech.spec.ts
@@ -12,7 +12,7 @@ describe("speech", () => {
 	async function seedKeys(
 		token: string,
 		apiKeyId: string,
-		provider: "google-ai-studio" | "openai" = "google-ai-studio",
+		provider: "google-ai-studio" | "openai" | "elevenlabs" = "google-ai-studio",
 	) {
 		await db.insert(tables.apiKey).values({
 			id: apiKeyId,
@@ -21,9 +21,15 @@ describe("speech", () => {
 			description: "Test API Key",
 			createdBy: "user-id",
 		});
+		const providerToken =
+			provider === "openai"
+				? "openai-test-key"
+				: provider === "elevenlabs"
+					? "elevenlabs-test-key"
+					: "google-test-key";
 		await db.insert(tables.providerKey).values({
 			id: `provider-key-${provider}-${apiKeyId}`,
-			token: provider === "openai" ? "openai-test-key" : "google-test-key",
+			token: providerToken,
 			provider,
 			organizationId: "org-id",
 			baseUrl: harness.mockServerUrl,
@@ -210,6 +216,95 @@ describe("speech", () => {
 		expect(log?.finishReason).toBe("stop");
 		// tts-1 bills $15 / 1M input characters.
 		expect(Number(log?.inputCost)).toBeCloseTo(input.length * 15e-6, 12);
+	});
+
+	test("/v1/audio/speech proxies ElevenLabs and bills by characters", async () => {
+		await seedKeys(
+			"real-token-speech-eleven",
+			"token-id-speech-eleven",
+			"elevenlabs",
+		);
+
+		const input = "Hello from ElevenLabs";
+		const res = await app.request("/v1/audio/speech", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-speech-eleven",
+			},
+			body: JSON.stringify({
+				model: "eleven-multilingual-v2",
+				input,
+				voice: "Sarah",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		// Default ElevenLabs format is mp3.
+		expect(res.headers.get("Content-Type")).toBe("audio/mpeg");
+		const bytes = Buffer.from(await res.arrayBuffer());
+		expect(bytes.toString("ascii")).toBe("MOCK_ELEVENLABS_AUDIO");
+
+		const logs = await waitForLogs(1);
+		const log = logs.find(
+			(l) => l.usedModel === "elevenlabs/eleven-multilingual-v2",
+		);
+		expect(log).toBeDefined();
+		expect(log?.hasError).toBe(false);
+		expect(log?.finishReason).toBe("stop");
+		// eleven-multilingual-v2 bills $110 / 1M input characters.
+		expect(Number(log?.inputCost)).toBeCloseTo(input.length * 110e-6, 12);
+	});
+
+	test("/v1/audio/speech returns a WAV file from ElevenLabs", async () => {
+		await seedKeys(
+			"real-token-speech-eleven-wav",
+			"token-id-speech-eleven-wav",
+			"elevenlabs",
+		);
+
+		const res = await app.request("/v1/audio/speech", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-speech-eleven-wav",
+			},
+			body: JSON.stringify({
+				model: "eleven-flash-v2-5",
+				input: "Hello there",
+				response_format: "wav",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toBe("audio/wav");
+		const bytes = Buffer.from(await res.arrayBuffer());
+		expect(bytes.toString("ascii")).toBe("MOCK_ELEVENLABS_AUDIO");
+	});
+
+	test("/v1/audio/speech rejects unsupported ElevenLabs response_format", async () => {
+		await seedKeys(
+			"real-token-speech-eleven-aac",
+			"token-id-speech-eleven-aac",
+			"elevenlabs",
+		);
+
+		const res = await app.request("/v1/audio/speech", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-speech-eleven-aac",
+			},
+			body: JSON.stringify({
+				model: "eleven-multilingual-v2",
+				input: "Hello there",
+				response_format: "aac",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("Unsupported response_format");
 	});
 
 	test("/v1/audio/speech bills gpt-4o-mini-tts on SSE token usage", async () => {

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -37,6 +37,7 @@ import { getProviderHeaders } from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
+	ELEVENLABS_VOICE_IDS,
 	getProviderEnvValue,
 	models as modelDefinitions,
 } from "@llmgateway/models";
@@ -150,9 +151,14 @@ function extractUpstreamErrorMessage(value: unknown, fallback: string): string {
 const PROVIDER_BASE_URL_DEFAULTS: Partial<Record<string, string>> = {
 	"google-ai-studio": "https://generativelanguage.googleapis.com",
 	openai: "https://api.openai.com",
+	elevenlabs: "https://api.elevenlabs.io",
 };
 
-const SUPPORTED_PROVIDERS = new Set(["google-ai-studio", "openai"]);
+const SUPPORTED_PROVIDERS = new Set([
+	"google-ai-studio",
+	"openai",
+	"elevenlabs",
+]);
 
 // Response formats Gemini can satisfy. Gemini emits raw PCM, so the gateway can
 // only return PCM directly or wrapped in a WAV container.
@@ -176,6 +182,22 @@ const OPENAI_CONTENT_TYPES: Record<string, string> = {
 	flac: "audio/flac",
 	wav: "audio/wav",
 	pcm: "audio/pcm",
+};
+
+// ElevenLabs returns the audio already encoded in the requested format. It does
+// not support aac/flac, but adds first-class WAV (RIFF-wrapped) output, so the
+// gateway can pass every supported format straight through.
+const ELEVENLABS_RESPONSE_FORMATS = new Set(["mp3", "wav", "pcm", "opus"]);
+
+// Maps the gateway's generic response_format to the concrete ElevenLabs
+// `output_format` query value (codec + sample rate + bitrate). WAV and PCM use
+// 24 kHz — a standard TTS rate available on every ElevenLabs plan, since the
+// 44.1 kHz WAV/PCM variants require a paid subscription.
+const ELEVENLABS_OUTPUT_FORMATS: Record<string, string> = {
+	mp3: "mp3_44100_128",
+	wav: "wav_24000",
+	pcm: "pcm_24000",
+	opus: "opus_48000_128",
 };
 
 /**
@@ -420,6 +442,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 	const upstreamModel = mapping.externalId;
 	const providerId = mapping.providerId;
 	const isOpenAI = providerId === "openai";
+	const isElevenLabs = providerId === "elevenlabs";
+	// OpenAI and ElevenLabs both return audio already encoded in the requested
+	// format and bill independently of Gemini's inline-PCM path.
+	const isEncodedPassthrough = isOpenAI || isElevenLabs;
 	// OpenAI models split into two billing/transport modes:
 	//   - character-billed (tts-1, tts-1-hd): plain binary response, no usage.
 	//   - token-billed (gpt-4o-mini-tts): request stream_format=sse so the
@@ -442,17 +468,22 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 		);
 	}
 
-	const responseFormat = request.response_format ?? (isOpenAI ? "mp3" : "wav");
+	const responseFormat =
+		request.response_format ?? (isEncodedPassthrough ? "mp3" : "wav");
 	const allowedFormats = isOpenAI
 		? OPENAI_RESPONSE_FORMATS
-		: GOOGLE_RESPONSE_FORMATS;
+		: isElevenLabs
+			? ELEVENLABS_RESPONSE_FORMATS
+			: GOOGLE_RESPONSE_FORMATS;
 	if (!allowedFormats.has(responseFormat)) {
 		return c.json(
 			{
 				error: {
 					message: isOpenAI
 						? `Unsupported response_format '${responseFormat}'.`
-						: `Unsupported response_format '${responseFormat}'. Gemini speech models only support 'wav' and 'pcm'.`,
+						: isElevenLabs
+							? `Unsupported response_format '${responseFormat}'. ElevenLabs supports 'mp3', 'wav', 'pcm' and 'opus'.`
+							: `Unsupported response_format '${responseFormat}'. Gemini speech models only support 'wav' and 'pcm'.`,
 					type: "invalid_request_error",
 					param: "response_format",
 					code: "unsupported_response_format",
@@ -591,17 +622,27 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					: {}),
 				...(useSse ? { stream_format: "sse" } : {}),
 			}
-		: {
-				contents: [{ role: "user", parts: [{ text: promptText }] }],
-				generationConfig: {
-					responseModalities: ["AUDIO"],
-					speechConfig: {
-						voiceConfig: {
-							prebuiltVoiceConfig: { voiceName: voice },
+		: isElevenLabs
+			? {
+					// The voice id is encoded in the URL path; the output format is a
+					// query param. `speed` is forwarded via voice_settings when set.
+					text: request.input,
+					model_id: upstreamModel,
+					...(request.speed !== undefined
+						? { voice_settings: { speed: request.speed } }
+						: {}),
+				}
+			: {
+					contents: [{ role: "user", parts: [{ text: promptText }] }],
+					generationConfig: {
+						responseModalities: ["AUDIO"],
+						speechConfig: {
+							voiceConfig: {
+								prebuiltVoiceConfig: { voiceName: voice },
+							},
 						},
 					},
-				},
-			};
+				};
 
 	interface SpeechAttempt {
 		providerKey: InferSelectModel<typeof tables.providerKey> | undefined;
@@ -708,9 +749,18 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 			PROVIDER_BASE_URL_DEFAULTS[providerId] ??
 			"https://generativelanguage.googleapis.com";
 
+		const elevenLabsOutputFormat =
+			ELEVENLABS_OUTPUT_FORMATS[responseFormat] ?? "mp3_44100_128";
+		// ElevenLabs voices are addressed by id. Resolve our friendly voice name
+		// to the upstream id, falling back to the raw value so callers may also
+		// pass a voice id directly.
+		const elevenLabsVoiceId = ELEVENLABS_VOICE_IDS[voice] ?? voice;
+
 		const upstreamUrl = isOpenAI
 			? `${resolvedBaseUrl}/v1/audio/speech`
-			: `${resolvedBaseUrl}/v1beta/models/${upstreamModel}:generateContent?key=${encodeURIComponent(usedToken)}`;
+			: isElevenLabs
+				? `${resolvedBaseUrl}/v1/text-to-speech/${encodeURIComponent(elevenLabsVoiceId)}?output_format=${elevenLabsOutputFormat}`
+				: `${resolvedBaseUrl}/v1beta/models/${upstreamModel}:generateContent?key=${encodeURIComponent(usedToken)}`;
 
 		return { providerKey, usedToken, configIndex, envVarName, upstreamUrl };
 	}
@@ -1074,8 +1124,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 				reportTrackedKeySuccess(attempt.providerKey.id, upstreamModel);
 			}
 
-			// OpenAI returns the audio already encoded in the requested format.
-			if (isOpenAI) {
+			// OpenAI and ElevenLabs return the audio already encoded in the
+			// requested format. ElevenLabs bills by input characters, matching the
+			// binary (non-SSE) OpenAI path below.
+			if (isEncodedPassthrough) {
 				let out: Buffer;
 				let contentType: string;
 				let inputCost: number;
@@ -1215,7 +1267,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					outputCost =
 						outputTokens !== null ? outputTokens * outputAudioPrice : 0;
 				} else {
-					// tts-1 / tts-1-hd: binary passthrough billed by input characters.
+					// tts-1 / tts-1-hd and all ElevenLabs models: binary passthrough
+					// billed by input characters.
 					out = Buffer.from(await upstreamResponse.arrayBuffer());
 					contentType =
 						upstreamResponse.headers.get("content-type") ??

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -191,12 +191,12 @@ const ELEVENLABS_RESPONSE_FORMATS = new Set(["mp3", "wav", "pcm", "opus"]);
 
 // Maps the gateway's generic response_format to the concrete ElevenLabs
 // `output_format` query value (codec + sample rate + bitrate). WAV and PCM use
-// 24 kHz — a standard TTS rate available on every ElevenLabs plan, since the
-// 44.1 kHz WAV/PCM variants require a paid subscription.
+// 32 kHz — the highest rate available across all paid plans (and free), since
+// the 44.1 kHz WAV/PCM variants are gated behind the Pro tier.
 const ELEVENLABS_OUTPUT_FORMATS: Record<string, string> = {
 	mp3: "mp3_44100_128",
-	wav: "wav_24000",
-	pcm: "pcm_24000",
+	wav: "wav_32000",
+	pcm: "pcm_32000",
 	opus: "opus_48000_128",
 };
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1173,6 +1173,36 @@ mockOpenAIServer.post("/v1/audio/speech", async (c) => {
 	});
 });
 
+// ElevenLabs text-to-speech: POST /v1/text-to-speech/{voice_id}?output_format=…
+// Returns the audio already encoded; the content type is derived from the
+// requested output_format query param.
+mockOpenAIServer.post("/v1/text-to-speech/:voiceId", async (c) => {
+	const body = await c.req.json();
+	const text = typeof body.text === "string" ? body.text : "";
+
+	const statusTrigger = extractStatusCodeTrigger(text);
+	if (statusTrigger) {
+		c.status(statusTrigger.statusCode as any);
+		return c.json(statusTrigger.errorResponse);
+	}
+	if (text.includes("TRIGGER_ERROR")) {
+		c.status(500);
+		return c.json(sampleErrorResponse);
+	}
+
+	const outputFormat = c.req.query("output_format") ?? "mp3_44100_128";
+	const contentType = outputFormat.startsWith("wav")
+		? "audio/wav"
+		: outputFormat.startsWith("pcm")
+			? "audio/pcm"
+			: outputFormat.startsWith("opus")
+				? "audio/opus"
+				: "audio/mpeg";
+	const audio = Buffer.from("MOCK_ELEVENLABS_AUDIO");
+
+	return c.body(audio, 200, { "Content-Type": contentType });
+});
+
 mockOpenAIServer.post("/v1/embeddings", async (c) => {
 	const body = await c.req.json();
 	const inputs = Array.isArray(body.input) ? body.input : [body.input];

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -7,6 +7,7 @@ export const providerLogoUrls: Partial<
 > = {
 	openai: ProviderIcons.openai,
 	anthropic: ProviderIcons.anthropic,
+	elevenlabs: ProviderIcons.elevenlabs,
 	"google-ai-studio": ProviderIcons["google-ai-studio"],
 	glacier: ProviderIcons.glacier,
 	"google-vertex": ProviderIcons["google-vertex"],

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -84,6 +84,11 @@ export function getProviderHeaders(
 				...requestIdHeader,
 				"api-key": token,
 			};
+		case "elevenlabs":
+			return {
+				...requestIdHeader,
+				"xi-api-key": token,
+			};
 		case "openai":
 		case "inference.net":
 		case "xai":

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./testing.js";
 export * from "./models.js";
+export { ELEVENLABS_VOICE_IDS } from "./models/elevenlabs.js";
 export * from "./provider.js";
 export * from "./providers.js";
 export * from "./types.js";

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -2,6 +2,7 @@ import { alibabaModels } from "./models/alibaba.js";
 import { anthropicModels } from "./models/anthropic.js";
 import { bytedanceModels } from "./models/bytedance.js";
 import { deepseekModels } from "./models/deepseek.js";
+import { elevenlabsModels } from "./models/elevenlabs.js";
 import { googleModels } from "./models/google.js";
 import { llmgatewayModels } from "./models/llmgateway.js";
 import { metaModels } from "./models/meta.js";
@@ -588,4 +589,5 @@ export const models = [
 	...nousresearchModels,
 	...nvidiaModels,
 	...zaiModels,
+	...elevenlabsModels,
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/elevenlabs.ts
+++ b/packages/models/src/models/elevenlabs.ts
@@ -1,0 +1,141 @@
+import type { ModelDefinition } from "@/models.js";
+
+/**
+ * Built-in ElevenLabs voices, mapped from a friendly name to the upstream
+ * voice id used in the `/v1/text-to-speech/{voice_id}` path. These are the
+ * standard "premade" default voices available to every account (including free
+ * plans); newer library-only voices such as Aria/Charlotte are intentionally
+ * omitted since they require a paid subscription. The first entry ("Sarah") is
+ * the default when the caller omits `voice`. The gateway resolves the friendly
+ * name to the id at request time, and also accepts a raw voice id directly.
+ */
+export const ELEVENLABS_VOICE_IDS: Record<string, string> = {
+	Sarah: "EXAVITQu4vr4xnSDxMaL",
+	Roger: "CwhRBWXzGAHq8TQ4Fs17",
+	Laura: "FGY2WhTYpPnrIDTdsKH5",
+	Charlie: "IKne3meq5aSn9XLyUdCD",
+	George: "JBFqnCBsd6RMkjVDRZzb",
+	Callum: "N2lVS1w4EtoT3dr4eOWO",
+	River: "SAz9YHcvj6GT2YYXdXww",
+	Liam: "TX3LPaxmHKxFdv7VOQHJ",
+	Alice: "Xb7hH8MSUJpSbSDYk0k2",
+	Matilda: "XrExE9yKIg1WjnnlVkGX",
+	Will: "bIHbv24MWmeRgasZH58o",
+	Jessica: "cgSgspJ2msm6clMCkdW9",
+	Eric: "cjVigY5qzO86Huf0OWal",
+	Chris: "iP95p4xoKVk53GoZ742B",
+	Brian: "nPczCjzI2devNBz1zQrb",
+	Daniel: "onwK4e9ZLuTAKqWW03F9",
+	Lily: "pFZP5JQG7iQjIQuC4Bku",
+	Bill: "pqHfZKP75CvOlQylNhV4",
+};
+
+const ELEVENLABS_VOICES = Object.keys(ELEVENLABS_VOICE_IDS);
+
+export const elevenlabsModels = [
+	{
+		id: "eleven-multilingual-v2",
+		name: "Eleven Multilingual v2",
+		description:
+			"ElevenLabs' most lifelike text-to-speech model with rich emotional expression across 29 languages. Generates speech via the /v1/audio/speech endpoint.",
+		family: "elevenlabs",
+		output: ["audio"],
+		releasedAt: new Date("2023-08-22"),
+		providers: [
+			{
+				providerId: "elevenlabs",
+				externalId: "eleven_multilingual_v2",
+				inputPrice: "0",
+				outputPrice: "0",
+				// Billed per input character. ElevenLabs bills full-rate (1 credit
+				// per character) for the multilingual/v3 models; published API rates
+				// land around $0.11 per 1,000 characters.
+				inputCharacterPrice: "110e-6",
+				requestPrice: "0",
+				contextSize: 10000,
+				streaming: false,
+				tools: false,
+				jsonOutput: false,
+				speechGenerations: true,
+				supportedVoices: ELEVENLABS_VOICES,
+			},
+		],
+	},
+	{
+		id: "eleven-v3",
+		name: "Eleven v3",
+		description:
+			"ElevenLabs' most expressive, human-like text-to-speech model supporting 70+ languages. Generates speech via the /v1/audio/speech endpoint.",
+		family: "elevenlabs",
+		output: ["audio"],
+		releasedAt: new Date("2025-06-05"),
+		providers: [
+			{
+				providerId: "elevenlabs",
+				externalId: "eleven_v3",
+				inputPrice: "0",
+				outputPrice: "0",
+				inputCharacterPrice: "110e-6",
+				requestPrice: "0",
+				contextSize: 5000,
+				streaming: false,
+				tools: false,
+				jsonOutput: false,
+				speechGenerations: true,
+				supportedVoices: ELEVENLABS_VOICES,
+			},
+		],
+	},
+	{
+		id: "eleven-flash-v2-5",
+		name: "Eleven Flash v2.5",
+		description:
+			"Ultra-fast, low-latency ElevenLabs text-to-speech model optimized for real-time use across 32 languages. Generates speech via the /v1/audio/speech endpoint.",
+		family: "elevenlabs",
+		output: ["audio"],
+		releasedAt: new Date("2024-12-03"),
+		providers: [
+			{
+				providerId: "elevenlabs",
+				externalId: "eleven_flash_v2_5",
+				inputPrice: "0",
+				outputPrice: "0",
+				// Flash/Turbo bill at the discounted half-credit rate (~$0.055 per
+				// 1,000 characters).
+				inputCharacterPrice: "55e-6",
+				requestPrice: "0",
+				contextSize: 40000,
+				streaming: false,
+				tools: false,
+				jsonOutput: false,
+				speechGenerations: true,
+				supportedVoices: ELEVENLABS_VOICES,
+			},
+		],
+	},
+	{
+		id: "eleven-turbo-v2-5",
+		name: "Eleven Turbo v2.5",
+		description:
+			"Fast, balanced ElevenLabs text-to-speech model with low latency across 32 languages. Generates speech via the /v1/audio/speech endpoint.",
+		family: "elevenlabs",
+		output: ["audio"],
+		releasedAt: new Date("2024-07-18"),
+		providers: [
+			{
+				providerId: "elevenlabs",
+				externalId: "eleven_turbo_v2_5",
+				inputPrice: "0",
+				outputPrice: "0",
+				inputCharacterPrice: "55e-6",
+				requestPrice: "0",
+				contextSize: 40000,
+				streaming: false,
+				tools: false,
+				jsonOutput: false,
+				speechGenerations: true,
+				supportedVoices: ELEVENLABS_VOICES,
+			},
+		],
+	},
+] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/elevenlabs.ts
+++ b/packages/models/src/models/elevenlabs.ts
@@ -2,15 +2,17 @@ import type { ModelDefinition } from "@/models.js";
 
 /**
  * Built-in ElevenLabs voices, mapped from a friendly name to the upstream
- * voice id used in the `/v1/text-to-speech/{voice_id}` path. These are the
- * standard "premade" default voices available to every account (including free
- * plans); newer library-only voices such as Aria/Charlotte are intentionally
- * omitted since they require a paid subscription. The first entry ("Sarah") is
- * the default when the caller omits `voice`. The gateway resolves the friendly
- * name to the id at request time, and also accepts a raw voice id directly.
+ * voice id used in the `/v1/text-to-speech/{voice_id}` path. The first entry
+ * ("Sarah") is the default when the caller omits `voice`; it is a "premade"
+ * voice available on every plan tier (including free), so the default never
+ * fails for an arbitrary key. "Aria" and "Charlotte" are library voices that
+ * require a paid ElevenLabs subscription, so they are offered but not the
+ * default. The gateway resolves the friendly name to the id at request time,
+ * and also accepts a raw voice id directly.
  */
 export const ELEVENLABS_VOICE_IDS: Record<string, string> = {
 	Sarah: "EXAVITQu4vr4xnSDxMaL",
+	Aria: "9BWtsMINqrJLrRacOk9x",
 	Roger: "CwhRBWXzGAHq8TQ4Fs17",
 	Laura: "FGY2WhTYpPnrIDTdsKH5",
 	Charlie: "IKne3meq5aSn9XLyUdCD",
@@ -18,6 +20,7 @@ export const ELEVENLABS_VOICE_IDS: Record<string, string> = {
 	Callum: "N2lVS1w4EtoT3dr4eOWO",
 	River: "SAz9YHcvj6GT2YYXdXww",
 	Liam: "TX3LPaxmHKxFdv7VOQHJ",
+	Charlotte: "XB0fDUnXU5powFXDhCwa",
 	Alice: "Xb7hH8MSUJpSbSDYk0k2",
 	Matilda: "XrExE9yKIg1WjnnlVkGX",
 	Will: "bIHbv24MWmeRgasZH58o",

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1193,6 +1193,37 @@ export const providers: ProviderDefinition[] = [
 			gdpr: true,
 		},
 	},
+	{
+		id: "elevenlabs",
+		name: "ElevenLabs",
+		description:
+			"ElevenLabs provides lifelike, low-latency text-to-speech models in 70+ languages.",
+		env: {
+			required: {
+				apiKey: "LLM_ELEVENLABS_API_KEY",
+			},
+			optional: {
+				baseUrl: "LLM_ELEVENLABS_BASE_URL",
+			},
+		},
+		streaming: false,
+		cancellation: true,
+		color: "#000000",
+		website: "https://elevenlabs.io",
+		announcement: null,
+		termsUrl: "https://elevenlabs.io/terms-of-use",
+		privacyPolicyUrl: "https://elevenlabs.io/privacy-policy",
+		headquarters: "US",
+		dataPolicy: {
+			apiTraining: false,
+			consumerTraining: false,
+			promptLogging: true,
+			retentionPeriod: null,
+			soc2: true,
+			iso27001: false,
+			gdpr: true,
+		},
+	},
 ] as const satisfies ProviderDefinition[];
 
 export type ProviderId = (typeof providers)[number]["id"];

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1257,8 +1257,23 @@ export const DeepInfraIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 	</svg>
 );
 
+export const ElevenLabsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
+	props,
+) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 512 512"
+		fill="currentColor"
+	>
+		<rect x="120" y="96" width="80" height="320" rx="12" />
+		<rect x="312" y="96" width="80" height="320" rx="12" />
+	</svg>
+);
+
 export const ProviderIcons = {
 	anthropic: AnthropicIcon,
+	elevenlabs: ElevenLabsIcon,
 	bytedance: BytedanceIcon,
 	deepseek: DeepseekIcon,
 	"google-ai-studio": GoogleStudioAIIcon,
@@ -1299,6 +1314,7 @@ export const providerLogoUrls: Partial<
 > = {
 	openai: ProviderIcons.openai,
 	anthropic: ProviderIcons.anthropic,
+	elevenlabs: ProviderIcons.elevenlabs,
 	bytedance: ProviderIcons.bytedance,
 	"google-ai-studio": ProviderIcons["google-ai-studio"],
 	glacier: ProviderIcons.glacier,


### PR DESCRIPTION
## Summary

Adds **ElevenLabs** as a speech-generation provider, wired into the gateway's existing `/v1/audio/speech` endpoint. Four text-to-speech models are exposed:

| Model id | Upstream | Notes |
|---|---|---|
| `eleven-multilingual-v2` | `eleven_multilingual_v2` | Most lifelike, 29 languages |
| `eleven-v3` | `eleven_v3` | Most expressive, 70+ languages |
| `eleven-flash-v2-5` | `eleven_flash_v2_5` | Ultra-fast, low latency |
| `eleven-turbo-v2-5` | `eleven_turbo_v2_5` | Fast, balanced |

## Changes

- **Provider definition** (`packages/models`): new `elevenlabs` provider using `LLM_ELEVENLABS_API_KEY` (+ optional `LLM_ELEVENLABS_BASE_URL`), plus the four model definitions in a new `models/elevenlabs.ts`.
- **Voices**: a catalog of named voices mapped to upstream voice ids. Callers may pass a friendly name or a raw voice id. The default is **Sarah** — a "premade" voice available on every plan tier — so the default never 402s for an arbitrary key. Library voices (**Aria**, **Charlotte**) are offered for paid keys but not used as the default.
- **Auth** (`packages/actions`): ElevenLabs uses the `xi-api-key` header.
- **Gateway speech handler** (`apps/gateway`): ElevenLabs is a binary passthrough billed by input characters, reusing the existing OpenAI binary path. Supports `mp3` (default), `wav`, `pcm`, and `opus`. WAV/PCM use 32 kHz — the highest rate available outside ElevenLabs' Pro tier (44.1 kHz WAV/PCM is Pro-only); `mp3` stays at 44.1 kHz/128 kbps.
- **UI**: ElevenLabs provider icon.
- **Tests**: mock-server endpoint for `/v1/text-to-speech/{voice_id}` and three new cases in `speech.spec.ts` (character billing, WAV output, unsupported-format rejection).

## Verification

Ran the gateway locally against the **live ElevenLabs API** (paid/credits account). All four models returned valid audio:

- `mp3` → valid MPEG layer III (ID3) for every model
- `wav` → RIFF/WAVE, 16-bit mono 32 kHz
- `pcm` → raw PCM, 32 kHz
- `opus` → Ogg Opus, 48 kHz

Both premade (Sarah) and library voices (Aria, Charlotte) generate audio. Cost is logged via character-based billing (multilingual/v3 at `110e-6`/char, flash/turbo at `55e-6`/char), with `finish_reason=stop` and no errors. Voice validation and unsupported-format handling return proper 400s.

`pnpm build`, `pnpm format`, and the speech/models unit suites all pass.

## Note on defaults

The default voice is kept as **Sarah** (premade, works on all tiers) rather than ElevenLabs' canonical **Aria** (a library voice that requires a paid plan), so the default never fails for a free bring-your-own key. Easy to flip to Aria if preferred. Similarly, WAV/PCM are capped at 32 kHz for cross-tier availability; 44.1 kHz would require everyone's key to be on the Pro tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ElevenLabs text-to-speech as a selectable provider with built-in voice options and model support
  * Support for multiple audio output formats (WAV, PCM, Opus, MP3) and provider-specific format handling
  * Provider icon/logo added to the UI

* **Tests**
  * Expanded test coverage for ElevenLabs TTS: format handling, binary audio responses, and validation/error cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->