### PR TITLE
fix(models): add 1h cache write price to Claude Fable 5

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -16,6 +16,7 @@ export const anthropicModels = [
 				outputPrice: "50.0e-6",
 				cachedInputPrice: "1.0e-6",
 				cacheWriteInputPrice: "12.5e-6",
+				cacheWriteInputPrice1h: "20.0e-6",
 				minCacheableTokens: 1024,
 				requestPrice: "0",
 				contextSize: 1000000,


### PR DESCRIPTION
## Summary

The most recent commit (#2607, "feat(models): add Claude Fable 5 to Anthropic provider") introduced a unit test failure in `apps/gateway/src/lib/anthropic-pricing.spec.ts`.

The `claude-fable-5` provider mapping sets `cacheWriteInputPrice` but did not define `cacheWriteInputPrice1h`. The pricing test enforces that every Anthropic mapping with a 5m cache-write price also defines the 1h cache-write price — otherwise 1h cache writes would silently bill at the 5m rate.

This adds the missing `cacheWriteInputPrice1h: "20.0e-6"`, which matches the standard 2× base input price (`10.0e-6`) and satisfies the ratio assertions in the same test suite.

## Test plan

- `npx vitest run apps/gateway/src/lib/anthropic-pricing.spec.ts` → 119 passed
- `pnpm format` and `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated pricing information for Claude Fable 5 model to include cache write input pricing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->