### PR TITLE
chore(models): add Together GLM-5.1 cached price

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -45,6 +45,7 @@ export const zaiModels = [
 				providerId: "together-ai",
 				externalId: "zai-org/GLM-5.1",
 				inputPrice: "1.4e-6",
+				cachedInputPrice: "0.26e-6",
 				outputPrice: "4.4e-6",
 				requestPrice: "0",
 				contextSize: 202752,


### PR DESCRIPTION
## Summary

Together AI cut the prompt-caching price on `zai-org/GLM-5.1` (cached input $1.40 → $0.26 per 1M tokens, effective June 9, 2026). The `together-ai` mapping for GLM-5.1 had no `cachedInputPrice` set, so it defaulted to the full input rate. This adds the discounted cached rate.

- `packages/models/src/models/zai.ts`: add `cachedInputPrice: "0.26e-6"` to the GLM-5.1 `together-ai` provider mapping.

## Notes

The same announcement also lowered the cached price on `Qwen/Qwen3.5-397B-A17B` ($0.60 → $0.35), but this repo has no `together-ai` mapping for that model (only `alibaba`, `novita`, and `nebius`), so there is nothing to update there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)