### PR TITLE
refactor(models): derive premium tier from pricing

### DIFF
--- a/apps/docs/content/learn/model-categories.mdx
+++ b/apps/docs/content/learn/model-categories.mdx
@@ -16,10 +16,10 @@ Every model in the gateway is sorted into a category. Categories power dashboard
 
 ## Categories
 
-| Category     | Description                                                                                                                           |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **Premium**  | Frontier / flagship models — Anthropic Opus, OpenAI's Pro and reasoning models (o1, o3, GPT-5 Pro), Google Gemini Pro, and xAI Grok 4 |
-| **Standard** | Every other model — the broad catalog of fast, cost-effective everyday models                                                         |
+| Category     | Description                                                                                                             |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| **Premium**  | High-cost frontier / flagship models — priced at **$15+ per million output tokens** or **$5+ per million input tokens** |
+| **Standard** | Every other model — the broad catalog of fast, cost-effective everyday models                                           |
 
 You can browse the full catalog on the [**Supported Models**](https://llmgateway.io/models) page and filter by use case, capabilities, provider, price, and context size.
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,9 +37,10 @@ export {
 
 export {
 	getModelCategory,
+	HIGH_COST_INPUT_PRICE,
+	HIGH_COST_OUTPUT_PRICE,
 	isPremiumModel,
 	type ModelCategory,
-	PREMIUM_MODEL_IDS,
 } from "./model-categories.js";
 
 export {

--- a/packages/shared/src/model-categories.spec.ts
+++ b/packages/shared/src/model-categories.spec.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	getModelCategory,
-	isPremiumModel,
-	PREMIUM_MODEL_IDS,
-} from "./model-categories.js";
+import { getModelCategory, isPremiumModel } from "./model-categories.js";
 
 describe("model-categories", () => {
 	it("classifies a known premium model as premium", () => {
@@ -35,9 +31,5 @@ describe("model-categories", () => {
 	it("classifies a known standard model as standard", () => {
 		expect(isPremiumModel("gpt-4o-mini")).toBe(false);
 		expect(getModelCategory("gpt-4o-mini")).toBe("standard");
-	});
-
-	it("has a non-empty premium set", () => {
-		expect(PREMIUM_MODEL_IDS.size).toBeGreaterThan(0);
 	});
 });

--- a/packages/shared/src/model-categories.ts
+++ b/packages/shared/src/model-categories.ts
@@ -1,55 +1,48 @@
+import { models } from "@llmgateway/models";
+
 /**
  * Model category classification used for analytics, dashboard filtering,
  * and tier-aware features.
  *
- * - `premium`: frontier/flagship models (top-tier reasoning, coding, and
- *   multimodal models from the major providers).
+ * - `premium`: high-cost frontier/flagship models, determined purely from
+ *   pricing rather than a hardcoded list. A model is premium when any of its
+ *   provider mappings is priced at or above the thresholds below.
  * - `standard`: everything else.
- *
- * The list below is the initial categorization. Update it as the model
- * catalogue evolves.
  */
 
 export type ModelCategory = "standard" | "premium";
 
-export const PREMIUM_MODEL_IDS = new Set<string>([
-	// Anthropic — Opus family
-	"claude-3-opus",
-	"claude-opus-4-20250514",
-	"claude-opus-4-1-20250805",
-	"claude-opus-4-5-20251101",
-	"claude-opus-4-6",
-	"claude-opus-4-7",
-	"claude-opus-4-8",
+/**
+ * Output price (USD per token) at or above which a model is considered
+ * high cost. Equivalent to $15 per million output tokens.
+ */
+export const HIGH_COST_OUTPUT_PRICE = 15e-6;
 
-	// OpenAI — Pro and reasoning flagships
-	"o1",
-	"o3",
-	"gpt-5-pro",
-	"gpt-5.1",
-	"gpt-5.2",
-	"gpt-5.2-pro",
-	"gpt-5.4",
-	"gpt-5.4-pro",
-	"gpt-5.5",
-	"gpt-5.5-pro",
-	"gpt-5.1-codex",
-	"gpt-5.2-codex",
-	"gpt-5.3-codex",
-
-	// Google — Gemini Pro
-	"gemini-3-pro-preview",
-	"gemini-3.1-pro-preview",
-
-	// xAI — Grok 4 top tier
-	"grok-4",
-	"grok-4-3",
-	"grok-4-20-beta-0309-reasoning",
-	"grok-4-20-multi-agent-beta-0309",
-]);
+/**
+ * Input price (USD per token) at or above which a model is considered
+ * high cost. Equivalent to $5 per million input tokens.
+ */
+export const HIGH_COST_INPUT_PRICE = 5e-6;
 
 export function isPremiumModel(modelId: string): boolean {
-	return PREMIUM_MODEL_IDS.has(modelId);
+	const model = models.find((m) => m.id === modelId);
+	if (!model) {
+		return false;
+	}
+	return model.providers.some((provider) => {
+		const inputPrice =
+			provider.inputPrice !== undefined
+				? parseFloat(provider.inputPrice)
+				: undefined;
+		const outputPrice =
+			provider.outputPrice !== undefined
+				? parseFloat(provider.outputPrice)
+				: undefined;
+		return (
+			(outputPrice !== undefined && outputPrice >= HIGH_COST_OUTPUT_PRICE) ||
+			(inputPrice !== undefined && inputPrice >= HIGH_COST_INPUT_PRICE)
+		);
+	});
 }
 
 export function getModelCategory(modelId: string): ModelCategory {


### PR DESCRIPTION
## Summary

Replaces the hardcoded \`PREMIUM_MODEL_IDS\` list in \`packages/shared/src/model-categories.ts\` with a pricing-based check. A model is now classified as **premium / high cost** when any of its provider mappings is priced at:

- **≥ \$15 per million output tokens** (\`outputPrice >= 15e-6\`), or
- **≥ \$5 per million input tokens** (\`inputPrice >= 5e-6\`)

This keeps the category in sync with the catalog automatically — new flagship models no longer need to be manually added to a list, and models whose prices drop are reclassified accordingly.

## Changes

- \`isPremiumModel\` now looks up the model in \`@llmgateway/models\` and evaluates its pricing against the thresholds (exported as \`HIGH_COST_OUTPUT_PRICE\` / \`HIGH_COST_INPUT_PRICE\`).
- Removed the \`PREMIUM_MODEL_IDS\` set and its re-export.
- Updated the model-categories docs to describe the cost-based definition.
- Updated unit tests.

The public signature (\`isPremiumModel(modelId)\`, \`getModelCategory(modelId)\`) is unchanged, so the DevPass premium fair-use cap and worker analytics keep working without changes.

## Test plan

- \`packages/shared/src/model-categories.spec.ts\` passes (Opus family still premium, gpt-4o-mini still standard).
- \`pnpm build\` — 17/17 tasks succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Premium and Standard model category descriptions to use pricing thresholds. Premium models are now defined as those with $15+ per million output tokens or $5+ per million input tokens.

* **Chores**
  * Refactored premium model detection logic to evaluate pricing thresholds dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->