### PR TITLE
fix(models): lower Together DeepSeek V4 Pro pricing

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -244,9 +244,9 @@ export const deepseekModels = [
 			{
 				providerId: "together-ai",
 				externalId: "deepseek-ai/DeepSeek-V4-Pro",
-				inputPrice: "2.1e-6",
+				inputPrice: "1.74e-6",
 				cachedInputPrice: "0.2e-6",
-				outputPrice: "4.4e-6",
+				outputPrice: "3.48e-6",
 				requestPrice: "0",
 				contextSize: 163840,
 				maxOutput: 163840,


### PR DESCRIPTION
## Summary

Together AI [announced](mailto:support@together.ai) reduced pricing for `deepseek-ai/DeepSeek-V4-Pro`, effective June 9, 2026. This updates the `together-ai` provider mapping for `deepseek-v4-pro` accordingly.

Updated pricing (per 1M tokens):

| | Old | New |
|---|---|---|
| Input | \$2.10 | \$1.74 |
| Cached input | \$0.20 | \$0.20 (unchanged) |
| Output | \$4.40 | \$3.48 |

## Test plan

- [x] `pnpm format`
- [x] `pnpm --filter @llmgateway/models build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)