### PR TITLE
fix: respect browser timezone in usage charts

### DIFF
--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -335,6 +335,106 @@ describe("activity endpoint", () => {
 		expect(res.status).toBe(401);
 	});
 
+	test("GET /activity should bucket dates in the requested timezone", async () => {
+		await db.delete(tables.log);
+
+		// Late evening UTC yesterday is already the next day in Athens (UTC+2/+3)
+		const lateUtc = new Date();
+		lateUtc.setUTCDate(lateUtc.getUTCDate() - 1);
+		lateUtc.setUTCHours(23, 30, 0, 0);
+
+		await db.insert(tables.log).values({
+			id: "tz-test-1",
+			requestId: "tz-test-1",
+			createdAt: lateUtc,
+			updatedAt: lateUtc,
+			organizationId: "test-org-id",
+			projectId: "test-project-id",
+			apiKeyId: "test-api-key-id",
+			duration: 100,
+			requestedModel: "gpt-4",
+			requestedProvider: "openai",
+			usedModel: "gpt-4",
+			usedProvider: "openai",
+			responseSize: 1000,
+			promptTokens: "10",
+			completionTokens: "20",
+			totalTokens: "30",
+			messages: JSON.stringify([{ role: "user", content: "Test" }]),
+			mode: "api-keys",
+			usedMode: "api-keys",
+		});
+
+		await aggregateLogsForTesting();
+
+		const utcRes = await app.request("/activity?days=7&timezone=UTC", {
+			headers: {
+				Cookie: token,
+			},
+		});
+		expect(utcRes.status).toBe(200);
+		const utcData = await utcRes.json();
+		expect(utcData.activity.length).toBe(1);
+		expect(utcData.activity[0].date).toBe(lateUtc.toISOString().slice(0, 10));
+
+		const athensRes = await app.request(
+			"/activity?days=7&timezone=Europe/Athens",
+			{
+				headers: {
+					Cookie: token,
+				},
+			},
+		);
+		expect(athensRes.status).toBe(200);
+		const athensData = await athensRes.json();
+		expect(athensData.activity.length).toBe(1);
+		const expectedAthensDate = new Intl.DateTimeFormat("en-CA", {
+			timeZone: "Europe/Athens",
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		}).format(lateUtc);
+		expect(athensData.activity[0].date).toBe(expectedAthensDate);
+		expect(athensData.activity[0].date).not.toBe(utcData.activity[0].date);
+	});
+
+	test("GET /activity hourly buckets should align with the requested timezone", async () => {
+		const res = await app.request(
+			"/activity?timeRange=24h&timezone=Asia/Kolkata",
+			{
+				headers: {
+					Cookie: token,
+				},
+			},
+		);
+
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.granularity).toBe("hourly");
+		expect(data.activity.length).toBeGreaterThan(0);
+
+		// Kolkata is UTC+5:30, so UTC hour buckets land on half-hour wall times
+		for (const row of data.activity) {
+			expect(row.date).toMatch(/T\d{2}:30:00$/);
+		}
+
+		// The logs inserted "now" in beforeEach must land in a padded slot
+		const totalRequests = data.activity.reduce(
+			(sum: number, row: { requestCount: number }) => sum + row.requestCount,
+			0,
+		);
+		expect(totalRequests).toBeGreaterThan(0);
+	});
+
+	test("GET /activity should reject an invalid timezone", async () => {
+		const res = await app.request("/activity?days=7&timezone=not/a-zone", {
+			headers: {
+				Cookie: token,
+			},
+		});
+		expect(res.status).toBe(400);
+	});
+
 	test("GET /activity should correctly aggregate token counts", async () => {
 		// Clear existing logs and insert test data with known values
 		await db.delete(tables.log);

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -22,8 +22,84 @@ import {
 } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
+import type { SQLWrapper } from "@llmgateway/db";
 
 export const activity = new OpenAPIHono<ServerTypes>();
+
+function isValidTimeZone(timeZone: string): boolean {
+	try {
+		Intl.DateTimeFormat("en-US", { timeZone });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// Intl.DateTimeFormat construction is expensive and generateTimeSlots calls it
+// in a loop (up to ~8800 iterations for 365d), so reuse one formatter per zone.
+const timeZoneFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function getTimeZoneFormatter(timeZone: string): Intl.DateTimeFormat {
+	let formatter = timeZoneFormatters.get(timeZone);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat("en-US", {
+			timeZone,
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			second: "2-digit",
+			hourCycle: "h23",
+		});
+		timeZoneFormatters.set(timeZone, formatter);
+	}
+	return formatter;
+}
+
+function getTimeZoneParts(date: Date, timeZone: string) {
+	const parts = getTimeZoneFormatter(timeZone).formatToParts(date);
+	const result: Record<string, string> = {};
+	for (const part of parts) {
+		result[part.type] = part.value;
+	}
+	return result;
+}
+
+function formatInTimeZone(
+	date: Date,
+	timeZone: string,
+	isHourly: boolean,
+): string {
+	const p = getTimeZoneParts(date, timeZone);
+	const day = `${p.year}-${p.month}-${p.day}`;
+	return isHourly ? `${day}T${p.hour}:${p.minute}:${p.second}` : day;
+}
+
+function timeZoneOffsetMs(date: Date, timeZone: string): number {
+	const p = getTimeZoneParts(date, timeZone);
+	const asUtc = Date.UTC(
+		Number(p.year),
+		Number(p.month) - 1,
+		Number(p.day),
+		Number(p.hour),
+		Number(p.minute),
+		Number(p.second),
+	);
+	const wholeSecondsMs = Math.trunc(date.getTime() / 1000) * 1000;
+	return asUtc - wholeSecondsMs;
+}
+
+// Interpret a local wall-clock ISO string (no offset) in the given timezone
+// and return the corresponding UTC instant. Two passes to converge across DST
+// boundaries.
+function zonedTimeToUtc(localIso: string, timeZone: string): Date {
+	const wallClock = new Date(localIso + "Z");
+	const guess = new Date(
+		wallClock.getTime() - timeZoneOffsetMs(wallClock, timeZone),
+	);
+	return new Date(wallClock.getTime() - timeZoneOffsetMs(guess, timeZone));
+}
 
 // Define the response schema for model-specific usage
 const modelUsageSchema = z.object({
@@ -84,52 +160,24 @@ const dailyActivitySchema = z.object({
 
 type ActivityRow = z.infer<typeof dailyActivitySchema>;
 
+// Walk UTC hour boundaries (matching the hourly rollup buckets) and label each
+// in the requested timezone, deduping consecutive labels for daily granularity
+// and DST fall-back overlaps.
 function generateTimeSlots(
 	startDate: Date,
 	endDate: Date,
 	isHourly: boolean,
+	timeZone: string,
 ): string[] {
 	const slots: string[] = [];
-	if (isHourly) {
-		const cur = new Date(
-			Date.UTC(
-				startDate.getUTCFullYear(),
-				startDate.getUTCMonth(),
-				startDate.getUTCDate(),
-				startDate.getUTCHours(),
-			),
-		);
-		const end = new Date(
-			Date.UTC(
-				endDate.getUTCFullYear(),
-				endDate.getUTCMonth(),
-				endDate.getUTCDate(),
-				endDate.getUTCHours(),
-			),
-		);
-		while (cur.getTime() <= end.getTime()) {
-			slots.push(cur.toISOString().slice(0, 19));
-			cur.setUTCHours(cur.getUTCHours() + 1);
+	const cur = new Date(startDate);
+	cur.setUTCMinutes(0, 0, 0);
+	while (cur.getTime() <= endDate.getTime()) {
+		const slot = formatInTimeZone(cur, timeZone, isHourly);
+		if (slots[slots.length - 1] !== slot) {
+			slots.push(slot);
 		}
-	} else {
-		const cur = new Date(
-			Date.UTC(
-				startDate.getUTCFullYear(),
-				startDate.getUTCMonth(),
-				startDate.getUTCDate(),
-			),
-		);
-		const end = new Date(
-			Date.UTC(
-				endDate.getUTCFullYear(),
-				endDate.getUTCMonth(),
-				endDate.getUTCDate(),
-			),
-		);
-		while (cur.getTime() <= end.getTime()) {
-			slots.push(cur.toISOString().slice(0, 10));
-			cur.setUTCDate(cur.getUTCDate() + 1);
-		}
+		cur.setUTCHours(cur.getUTCHours() + 1);
 	}
 	return slots;
 }
@@ -175,8 +223,9 @@ function padActivity(
 	startDate: Date,
 	endDate: Date,
 	isHourly: boolean,
+	timeZone: string,
 ): ActivityRow[] {
-	const slots = generateTimeSlots(startDate, endDate, isHourly);
+	const slots = generateTimeSlots(startDate, endDate, isHourly, timeZone);
 	const byDate = new Map(rows.map((r) => [r.date, r]));
 	return slots.map((slot) => byDate.get(slot) ?? buildEmptyActivityRow(slot));
 }
@@ -198,6 +247,11 @@ const getActivity = createRoute({
 			apiKeyId: z.string().optional(),
 			timeRange: z.enum(["1h", "4h", "24h", "7d", "30d", "365d"]).optional(),
 			groupBy: z.enum(["model", "apiKey"]).optional(),
+			timezone: z
+				.string()
+				.max(64)
+				.refine(isValidTimeZone, { message: "Invalid IANA timezone" })
+				.optional(),
 		}),
 	},
 	responses: {
@@ -225,9 +279,10 @@ activity.openapi(getActivity, async (c) => {
 	}
 
 	// Get the query parameters
-	const { days, from, to, projectId, apiKeyId, timeRange, groupBy } =
+	const { days, from, to, projectId, apiKeyId, timeRange, groupBy, timezone } =
 		c.req.valid("query");
 	const breakdownByApiKey = groupBy === "apiKey";
+	const timeZone = timezone ?? "UTC";
 
 	// Calculate the date range and granularity
 	let startDate: Date;
@@ -264,8 +319,8 @@ activity.openapi(getActivity, async (c) => {
 				break;
 		}
 	} else if (from && to) {
-		startDate = new Date(from + "T00:00:00");
-		endDate = new Date(to + "T23:59:59.999");
+		startDate = zonedTimeToUtc(from + "T00:00:00.000", timeZone);
+		endDate = zonedTimeToUtc(to + "T23:59:59.999", timeZone);
 	} else {
 		const effectiveDays = days ?? 7;
 		endDate = new Date();
@@ -275,6 +330,15 @@ activity.openapi(getActivity, async (c) => {
 
 	// SQL expressions that change based on granularity
 	const isHourly = granularity === "hourly";
+
+	// Bucket UTC-stored hour timestamps as wall-clock strings in the caller's
+	// timezone, so daily grouping happens at local midnight rather than UTC.
+	// Grouping/ordering use positional references because a repeated bind
+	// parameter would make the GROUP BY expression differ from the SELECT one.
+	const bucketDate = (column: SQLWrapper) =>
+		isHourly
+			? sql<string>`to_char(${column} AT TIME ZONE 'UTC' AT TIME ZONE ${timeZone}, 'YYYY-MM-DD"T"HH24:MI:SS')`
+			: sql<string>`to_char(${column} AT TIME ZONE 'UTC' AT TIME ZONE ${timeZone}, 'YYYY-MM-DD')`;
 
 	// Get all organizations the user is a member of
 	const organizationIds = await getUserOrganizationIds(user.id);
@@ -317,11 +381,7 @@ activity.openapi(getActivity, async (c) => {
 		// Query aggregated data from apiKeyHourlyStats table
 		const hourlyAggregates = await db
 			.select({
-				date: isHourly
-					? sql<string>`to_char(${apiKeyHourlyStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-							"date",
-						)
-					: sql<string>`DATE(${apiKeyHourlyStats.hourTimestamp})`.as("date"),
+				date: bucketDate(apiKeyHourlyStats.hourTimestamp).as("date"),
 				requestCount:
 					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.requestCount}), 0)`.as(
 						"requestCount",
@@ -435,27 +495,13 @@ activity.openapi(getActivity, async (c) => {
 					lte(apiKeyHourlyStats.hourTimestamp, endDate),
 				),
 			)
-			.groupBy(
-				isHourly
-					? sql`${apiKeyHourlyStats.hourTimestamp}`
-					: sql`DATE(${apiKeyHourlyStats.hourTimestamp})`,
-			)
-			.orderBy(
-				isHourly
-					? sql`${apiKeyHourlyStats.hourTimestamp} ASC`
-					: sql`DATE(${apiKeyHourlyStats.hourTimestamp}) ASC`,
-			);
+			.groupBy(sql`1`)
+			.orderBy(sql`1 ASC`);
 
 		// Query model breakdown from apiKeyHourlyModelStats table
 		const modelBreakdowns = await db
 			.select({
-				date: isHourly
-					? sql<string>`to_char(${apiKeyHourlyModelStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-							"date",
-						)
-					: sql<string>`DATE(${apiKeyHourlyModelStats.hourTimestamp})`.as(
-							"date",
-						),
+				date: bucketDate(apiKeyHourlyModelStats.hourTimestamp).as("date"),
 				usedModel: apiKeyHourlyModelStats.usedModel,
 				usedProvider: apiKeyHourlyModelStats.usedProvider,
 				requestCount:
@@ -488,15 +534,9 @@ activity.openapi(getActivity, async (c) => {
 				),
 			)
 			.groupBy(
-				isHourly
-					? sql`${apiKeyHourlyModelStats.hourTimestamp}, ${apiKeyHourlyModelStats.usedModel}, ${apiKeyHourlyModelStats.usedProvider}`
-					: sql`DATE(${apiKeyHourlyModelStats.hourTimestamp}), ${apiKeyHourlyModelStats.usedModel}, ${apiKeyHourlyModelStats.usedProvider}`,
+				sql`1, ${apiKeyHourlyModelStats.usedModel}, ${apiKeyHourlyModelStats.usedProvider}`,
 			)
-			.orderBy(
-				isHourly
-					? sql`${apiKeyHourlyModelStats.hourTimestamp} ASC, ${apiKeyHourlyModelStats.usedModel} ASC`
-					: sql`DATE(${apiKeyHourlyModelStats.hourTimestamp}) ASC, ${apiKeyHourlyModelStats.usedModel} ASC`,
-			);
+			.orderBy(sql`1 ASC, ${apiKeyHourlyModelStats.usedModel} ASC`);
 
 		const modelBreakdownByDate = new Map<
 			string,
@@ -588,7 +628,7 @@ activity.openapi(getActivity, async (c) => {
 		});
 
 		const paddedActivity = timeRange
-			? padActivity(activityData, startDate, endDate, isHourly)
+			? padActivity(activityData, startDate, endDate, isHourly, timeZone)
 			: activityData;
 
 		return c.json({
@@ -601,11 +641,7 @@ activity.openapi(getActivity, async (c) => {
 	// Query aggregated data from projectHourlyStats table
 	const hourlyAggregates = await db
 		.select({
-			date: isHourly
-				? sql<string>`to_char(${projectHourlyStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-						"date",
-					)
-				: sql<string>`DATE(${projectHourlyStats.hourTimestamp})`.as("date"),
+			date: bucketDate(projectHourlyStats.hourTimestamp).as("date"),
 			requestCount:
 				sql<number>`COALESCE(SUM(${projectHourlyStats.requestCount}), 0)`.as(
 					"requestCount",
@@ -718,16 +754,8 @@ activity.openapi(getActivity, async (c) => {
 				lte(projectHourlyStats.hourTimestamp, endDate),
 			),
 		)
-		.groupBy(
-			isHourly
-				? sql`${projectHourlyStats.hourTimestamp}`
-				: sql`DATE(${projectHourlyStats.hourTimestamp})`,
-		)
-		.orderBy(
-			isHourly
-				? sql`${projectHourlyStats.hourTimestamp} ASC`
-				: sql`DATE(${projectHourlyStats.hourTimestamp}) ASC`,
-		);
+		.groupBy(sql`1`)
+		.orderBy(sql`1 ASC`);
 
 	// Create a map to organize model breakdowns by date.
 	// Only query when not breaking down by api key — saves an aggregate scan
@@ -739,13 +767,7 @@ activity.openapi(getActivity, async (c) => {
 	if (!breakdownByApiKey) {
 		const modelBreakdowns = await db
 			.select({
-				date: isHourly
-					? sql<string>`to_char(${projectHourlyModelStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-							"date",
-						)
-					: sql<string>`DATE(${projectHourlyModelStats.hourTimestamp})`.as(
-							"date",
-						),
+				date: bucketDate(projectHourlyModelStats.hourTimestamp).as("date"),
 				usedModel: projectHourlyModelStats.usedModel,
 				usedProvider: projectHourlyModelStats.usedProvider,
 				requestCount:
@@ -777,15 +799,9 @@ activity.openapi(getActivity, async (c) => {
 				),
 			)
 			.groupBy(
-				isHourly
-					? sql`${projectHourlyModelStats.hourTimestamp}, ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`
-					: sql`DATE(${projectHourlyModelStats.hourTimestamp}), ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`,
+				sql`1, ${projectHourlyModelStats.usedModel}, ${projectHourlyModelStats.usedProvider}`,
 			)
-			.orderBy(
-				isHourly
-					? sql`${projectHourlyModelStats.hourTimestamp} ASC, ${projectHourlyModelStats.usedModel} ASC`
-					: sql`DATE(${projectHourlyModelStats.hourTimestamp}) ASC, ${projectHourlyModelStats.usedModel} ASC`,
-			);
+			.orderBy(sql`1 ASC, ${projectHourlyModelStats.usedModel} ASC`);
 
 		for (const breakdown of modelBreakdowns) {
 			if (!modelBreakdownByDate.has(breakdown.date)) {
@@ -811,11 +827,7 @@ activity.openapi(getActivity, async (c) => {
 	if (breakdownByApiKey) {
 		const apiKeyBreakdowns = await db
 			.select({
-				date: isHourly
-					? sql<string>`to_char(${apiKeyHourlyStats.hourTimestamp}, 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
-							"date",
-						)
-					: sql<string>`DATE(${apiKeyHourlyStats.hourTimestamp})`.as("date"),
+				date: bucketDate(apiKeyHourlyStats.hourTimestamp).as("date"),
 				apiKeyId: apiKeyHourlyStats.apiKeyId,
 				description: apiKey.description,
 				requestCount:
@@ -848,16 +860,8 @@ activity.openapi(getActivity, async (c) => {
 					lte(apiKeyHourlyStats.hourTimestamp, endDate),
 				),
 			)
-			.groupBy(
-				isHourly
-					? sql`${apiKeyHourlyStats.hourTimestamp}, ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`
-					: sql`DATE(${apiKeyHourlyStats.hourTimestamp}), ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`,
-			)
-			.orderBy(
-				isHourly
-					? sql`${apiKeyHourlyStats.hourTimestamp} ASC, ${apiKeyHourlyStats.apiKeyId} ASC`
-					: sql`DATE(${apiKeyHourlyStats.hourTimestamp}) ASC, ${apiKeyHourlyStats.apiKeyId} ASC`,
-			);
+			.groupBy(sql`1, ${apiKeyHourlyStats.apiKeyId}, ${apiKey.description}`)
+			.orderBy(sql`1 ASC, ${apiKeyHourlyStats.apiKeyId} ASC`);
 
 		for (const breakdown of apiKeyBreakdowns) {
 			if (!apiKeyBreakdownByDate.has(breakdown.date)) {
@@ -945,7 +949,7 @@ activity.openapi(getActivity, async (c) => {
 	});
 
 	const paddedActivity = timeRange
-		? padActivity(activityData, startDate, endDate, isHourly)
+		? padActivity(activityData, startDate, endDate, isHourly, timeZone)
 		: activityData;
 
 	return c.json({

--- a/apps/ui/src/components/dashboard/activity-chart.tsx
+++ b/apps/ui/src/components/dashboard/activity-chart.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-	addDays,
-	addHours,
-	differenceInCalendarDays,
-	format,
-	parseISO,
-} from "date-fns";
+import { addDays, differenceInCalendarDays, format, parseISO } from "date-fns";
 import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 import {
@@ -36,6 +30,7 @@ import {
 	SelectValue,
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import type { TimeRangeValue } from "@/components/time-range-picker";
 import type {
@@ -266,9 +261,11 @@ export function ActivityChart({
 	// Build query params based on whether we're using timeRange or date range
 	const queryParams = useMemo(() => {
 		const breakdownParam = groupBy === "apiKey" ? { groupBy } : {};
+		const timezone = getBrowserTimeZone();
 		if (timeRange) {
 			return {
 				timeRange,
+				timezone,
 				...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
 				...(apiKeyId ? { apiKeyId } : {}),
 				...breakdownParam,
@@ -278,6 +275,7 @@ export function ActivityChart({
 		return {
 			from: format(from, "yyyy-MM-dd"),
 			to: format(to, "yyyy-MM-dd"),
+			timezone,
 			...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
 			...(apiKeyId ? { apiKeyId } : {}),
 			...breakdownParam,
@@ -395,30 +393,12 @@ export function ActivityChart({
 		);
 	}
 
-	// Generate the expected time slots (hourly or daily)
+	// Generate the expected time slots (hourly or daily). For timeRange queries
+	// the backend already returns padded, ordered buckets in the requested
+	// timezone, so use them as-is instead of regenerating them locally.
 	const slots: string[] = [];
-	if (hourly && timeRange) {
-		const totalHours = getTimeRangeHours(timeRange);
-		const now = new Date();
-		// Truncate to the current hour
-		const endHour = new Date(
-			now.getFullYear(),
-			now.getMonth(),
-			now.getDate(),
-			now.getHours(),
-		);
-		const startHour = addHours(endHour, -totalHours);
-		for (let i = 0; i < totalHours; i++) {
-			const hour = addHours(startHour, i);
-			slots.push(format(hour, "yyyy-MM-dd'T'HH:mm:ss"));
-		}
-	} else if (timeRange) {
-		const totalDays = getTimeRangeHours(timeRange) / 24;
-		const now = new Date();
-		for (let i = totalDays - 1; i >= 0; i--) {
-			const d = addDays(now, -i);
-			slots.push(format(d, "yyyy-MM-dd"));
-		}
+	if (timeRange) {
+		slots.push(...data.activity.map((item) => item.date));
 	} else {
 		const { from, to } = getDateRangeFromParams(searchParams);
 		const totalDays = differenceInCalendarDays(to, from) + 1;

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -57,6 +57,7 @@ import {
 	SelectValue,
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import type { ActivitT } from "@/types/activity";
 
@@ -107,6 +108,7 @@ export function DashboardClient({
 				query: {
 					from: fromStr,
 					to: toStr,
+					timezone: getBrowserTimeZone(),
 					...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
 				},
 			},

--- a/apps/ui/src/components/usage/cache-rate-chart.tsx
+++ b/apps/ui/src/components/usage/cache-rate-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { getDateRangeFromParams } from "@/components/date-range-picker";
 import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import type { ActivitT } from "@/types/activity";
 import type { TooltipProps } from "recharts";
@@ -71,6 +72,7 @@ export function CacheRateChart({
 				query: {
 					from: fromStr,
 					to: toStr,
+					timezone: getBrowserTimeZone(),
 					...(projectId ? { projectId: projectId } : {}),
 					...(apiKeyId ? { apiKeyId } : {}),
 				},

--- a/apps/ui/src/components/usage/cost-breakdown-chart.tsx
+++ b/apps/ui/src/components/usage/cost-breakdown-chart.tsx
@@ -18,6 +18,7 @@ import {
 	PopoverTrigger,
 } from "@/lib/components/popover";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import { providers } from "@llmgateway/models";
 
@@ -105,6 +106,7 @@ export function CostBreakdownChart({
 				query: {
 					from: fromStr,
 					to: toStr,
+					timezone: getBrowserTimeZone(),
 					...(effectiveProjectId ? { projectId: effectiveProjectId } : {}),
 					...(apiKeyId ? { apiKeyId } : {}),
 				},

--- a/apps/ui/src/components/usage/error-rate-chart.tsx
+++ b/apps/ui/src/components/usage/error-rate-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { getDateRangeFromParams } from "@/components/date-range-picker";
 import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import type { ActivitT } from "@/types/activity";
 import type { TooltipProps } from "recharts";
@@ -71,6 +72,7 @@ export function ErrorRateChart({
 				query: {
 					from: fromStr,
 					to: toStr,
+					timezone: getBrowserTimeZone(),
 					...(projectId ? { projectId: projectId } : {}),
 					...(apiKeyId ? { apiKeyId } : {}),
 				},

--- a/apps/ui/src/components/usage/model-usage-table.tsx
+++ b/apps/ui/src/components/usage/model-usage-table.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/components/table";
 import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import type { ActivityModelUsage, ActivitT } from "@/types/activity";
 
@@ -52,6 +53,7 @@ export function ModelUsageTable({
 				query: {
 					from: fromStr,
 					to: toStr,
+					timezone: getBrowserTimeZone(),
 					...(projectId ? { projectId: projectId } : {}),
 					...(apiKeyId ? { apiKeyId } : {}),
 				},

--- a/apps/ui/src/components/usage/usage-chart.tsx
+++ b/apps/ui/src/components/usage/usage-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { getDateRangeFromParams } from "@/components/date-range-picker";
 import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
+import { getBrowserTimeZone } from "@/lib/timezone";
 
 import type { ActivitT } from "@/types/activity";
 import type { TooltipProps } from "recharts";
@@ -68,6 +69,7 @@ export function UsageChart({
 				query: {
 					from: fromStr,
 					to: toStr,
+					timezone: getBrowserTimeZone(),
 					...(projectId ? { projectId: projectId } : {}),
 					...(apiKeyId ? { apiKeyId } : {}),
 				},

--- a/apps/ui/src/lib/timezone.ts
+++ b/apps/ui/src/lib/timezone.ts
@@ -1,0 +1,7 @@
+export function getBrowserTimeZone(): string {
+	try {
+		return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+	} catch {
+		return "UTC";
+	}
+}


### PR DESCRIPTION
## Problem

A customer reported that the Model Usage chart renders time buckets in UTC while other areas show correct local timing — for users in Europe/Athens, traffic appeared 3 hours behind.

Root cause: the `/activity` endpoint bucketed hourly/daily stats at UTC boundaries and returned offset-less wall-clock strings (`2026-06-10T13:00:00`, `2026-06-09`), which the charts parsed with `parseISO()` as **local** time — so UTC clock readings were displayed as if they were local, with no conversion anywhere in the stack. The daily charts on Usage & Metrics had the same bug, just less visible (the skew only shows near midnight); the hourly Model Usage chart made it obvious.

## Fix

Bucket server-side in the caller's timezone instead of relabeling on the client (relabeling can't fix daily charts — those are *grouped* at UTC midnight in SQL).

**API (`apps/api/src/routes/activity.ts`):**
- New optional `timezone` query param: IANA name, validated against `Intl`, max 64 chars, defaults to `UTC` (existing clients unaffected)
- Bucket expressions use `hour_timestamp AT TIME ZONE 'UTC' AT TIME ZONE $tz` for both hourly and daily granularity; grouping/ordering switched to positional references since a repeated bind parameter would make the GROUP BY expression differ from the SELECT one
- `from`/`to` date strings are now interpreted as midnight in the requested timezone (previously the server's local time)
- Padded empty slots are generated in the same timezone, walking UTC hour boundaries so labels match SQL output exactly (incl. DST fall-back dedupe)

**UI (`apps/ui`):**
- All seven `/activity` consumers (Model Usage chart, Request Volume, Error Rate, Cache Rate, Cost Breakdown, Top Models table, overview dashboard) send `Intl.DateTimeFormat().resolvedOptions().timeZone`
- The Model Usage chart now uses the backend's padded, ordered buckets directly for `timeRange` queries instead of regenerating slots locally — this also fixes half-hour-offset zones (Asia/Kolkata etc.), where locally generated `:00` slots would never have matched the backend's `:30` buckets

## Notes

- Server-side prefetches (`initialData`) still fetch with the UTC default since the browser timezone isn't known during SSR; the client refetches with the correct timezone on mount
- Half-hour-offset zones get daily buckets offset by the sub-hour remainder — inherent to the hourly rollup tables, affects display only
- An org/project timezone setting (the customer's alternative ask) can be layered on later by overriding the browser value

## Testing

- 3 new tests: daily buckets shift across the Athens midnight boundary (UTC vs Europe/Athens on the same data), hourly buckets align at `:30` for Asia/Kolkata with real data landing in padded slots, invalid timezone → 400
- All 20 activity spec tests pass; full `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity data now displays in your local timezone. Charts and reports automatically detect and use your browser's timezone for accurate date and time representation.

* **Tests**
  * Added comprehensive test coverage for timezone-aware data bucketing and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->