### PR TITLE
feat(admin): model view toggle on timeseries breakdown

### DIFF
--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -508,7 +508,15 @@ export function GlobalStatsClient() {
 									: "request count"}{" "}
 							per day
 							{showTimeseriesBreakdown
-								? ` broken down by ${groupBy === "model" ? "model" : "source"}`
+								? ` broken down by ${
+										groupBy === "model"
+											? modelView === "provider"
+												? "provider"
+												: modelView === "canonical"
+													? "canonical model"
+													: "mapping"
+											: "source"
+									}`
 								: ` across all ${groupBy === "model" ? "models" : "sources"}`}
 							.
 						</CardDescription>
@@ -527,6 +535,25 @@ export function GlobalStatsClient() {
 							)}
 							Breakdown
 						</Button>
+						{showTimeseriesBreakdown && groupBy === "model" ? (
+							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
+								{MODEL_VIEW_OPTIONS.map((opt) => {
+									const Icon = opt.icon;
+									return (
+										<Button
+											key={opt.value}
+											variant={modelView === opt.value ? "default" : "ghost"}
+											size="sm"
+											className="h-7 gap-1.5 px-3 text-xs"
+											onClick={() => setModelView(opt.value)}
+										>
+											<Icon className="h-3.5 w-3.5" />
+											{opt.label}
+										</Button>
+									);
+								})}
+							</div>
+						) : null}
 						<div className="flex items-center gap-1">
 							{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
 								(m) => (


### PR DESCRIPTION
## Summary

The Global Stats admin page already lets you switch the **Daily timeseries** chart into a stacked breakdown view via the **Breakdown** toggle. Until now that breakdown was always keyed by model *mapping*, with no way to change the dimension from this chart — you had to scroll down to the **Cost share** chart to switch between Mappings / Canonical / Providers.

This surfaces the same `Mappings | Canonical | Providers` selector in the Daily timeseries chart header, shown when the breakdown view is active and the page is grouped by model.

## Details

- The `modelView` query param already drives the API's `timeseriesBreakdown` keying (`mapping` → full `provider/model`, `canonical` → canonical model id, `provider` → provider), so no backend changes were needed — this only exposes the existing control where the breakdown is rendered.
- The selector reuses `MODEL_VIEW_OPTIONS` and the shared `setModelView` handler, so changing it stays in sync with the Cost share chart (both read the same URL param).
- Updated the chart description to reflect the chosen dimension ("broken down by mapping / canonical model / provider / source").

## Testing

- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a model-view toggle control to the global statistics breakdown view, allowing selection between provider, canonical model, and mapping options when grouping by model.
  * Enhanced daily timeseries description to reflect the specific model view selection in breakdown mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->