### PR TITLE
fix(gateway): block provider routing on dev plans always

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -131,6 +131,40 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/chat/completions rejects provider-targeting model strings for dev-plan orgs even with allowAllModels", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// allow-all-models only relaxes the model-level coding/cached-input
+		// restrictions — it must NOT unlock direct provider routing. The
+		// `provider/model` format stays blocked; only the canonical root id
+		// (`deepseek-v4-pro`) is allowed on dev plans.
+		await harness.setDevPlan({ devPlan: "pro", allowAllModels: true });
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "deepseek/deepseek-v4-pro",
+				messages: [{ role: "user", content: "hi" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Direct provider routing is not available on coding plans",
+		);
+	});
+
 	test("/v1/chat/completions e2e success", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2388,9 +2388,7 @@ chat.openapi(completions, async (c) => {
 	// The specific-provider check denies a request like `groq/gpt-oss-120b` where the
 	// model qualifies as coding overall but the named mapping itself is uncached.
 	const isDevPlanRestricted = Boolean(
-		organization?.kind === "devpass" &&
-			organization.devPlan !== "none" &&
-			!organization.devPlanAllowAllModels,
+		isDevPlan && !organization?.devPlanAllowAllModels,
 	);
 
 	// Source restriction is gated behind DEVPASS_ENFORCE_SOURCE_RESTRICTION so it
@@ -2408,26 +2406,33 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	if (isDevPlanRestricted) {
-		if (!isCodingModel(modelInfo)) {
-			throw new HTTPException(403, {
-				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at devpass.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
-			});
-		}
-
+	// Provider-targeting model strings (`provider/model`, `custom/model`) are
+	// never allowed on dev plans — only canonical root model ids. This is
+	// independent of allow-all-models: that flag only relaxes the model-level
+	// coding/cached-input restrictions below, it does not unlock direct or
+	// custom provider routing.
+	if (isDevPlan) {
 		if (
 			requestedProvider &&
 			requestedProvider !== "llmgateway" &&
 			requestedProvider !== "custom"
 		) {
 			throw new HTTPException(403, {
-				message: `Direct provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+				message: `Direct provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing.`,
 			});
 		}
 
 		if (requestedProvider === "custom") {
 			throw new HTTPException(403, {
-				message: `Custom provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+				message: `Custom provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing.`,
+			});
+		}
+	}
+
+	if (isDevPlanRestricted) {
+		if (!isCodingModel(modelInfo)) {
+			throw new HTTPException(403, {
+				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at devpass.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
 			});
 		}
 	}


### PR DESCRIPTION
## Summary

This confirms and fixes the behavior raised: targeting a specific provider for DeepSeek (e.g. `deepseek/deepseek-v4-pro`) worked on a dev pass once the "allow all models" feature was enabled. It shouldn't — only canonical model ids (e.g. `deepseek-v4-pro`) are allowed for dev pass, regardless of allow-all-models.

### Root cause

The direct- and custom-provider routing rejections lived inside the `if (isDevPlanRestricted)` block. `isDevPlanRestricted` is `false` when `devPlanAllowAllModels` is on, so enabling allow-all-models silently also unlocked the `provider/model` routing format.

### Fix

Split the two concerns:
- **Routing-format restriction** (`provider/model`, `custom/model`) now applies to **any** dev plan via the existing `isDevPlan` flag — independent of allow-all-models.
- **Model-level restriction** (coding-model + cached-input requirement) stays gated by `isDevPlanRestricted`, i.e. relaxed by allow-all-models.

Removed the now-misleading "enable access to all models" hint from the routing-format error messages, since that flag no longer affects them.

### Test

Added a gateway test asserting `deepseek/deepseek-v4-pro` is rejected with 403 ("Direct provider routing is not available on coding plans") even with `allowAllModels: true`. Existing image-output dev-plan tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development-plan (coding-plan) access rules were updated so model eligibility and provider-routing restrictions are enforced independently.
  * Direct provider routing and custom provider routing are now rejected with `403` immediately, even when all models are allowed.
  * Error messages now instruct using the root model id (without `provider/model`) and remove outdated dashboard guidance.

* **Tests**
  * Added a `POST /v1/chat/completions` test verifying provider-targeting model strings are rejected with `403` and the expected error text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->