### PR TITLE
fix(gateway): remove deprecated root error fields

### DIFF
--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -155,13 +155,16 @@ The gateway reads the client IP from the first entry in the `X-Forwarded-For` he
 
 ## Error Handling
 
-When API keys encounter IAM rule violations, the API returns specific error messages:
+When API keys encounter IAM rule violations, the API returns a `403` with the standard OpenAI error envelope:
 
 ```json
 {
-	"error": true,
-	"status": 403,
-	"message": "Access denied: Model gpt-4 is not in the allowed models list"
+	"error": {
+		"message": "Access denied: Model gpt-4 is not in the allowed models list",
+		"type": "invalid_request_error",
+		"param": null,
+		"code": "permission_denied"
+	}
 }
 ```
 

--- a/apps/docs/content/resources/error-handling.mdx
+++ b/apps/docs/content/resources/error-handling.mdx
@@ -78,29 +78,6 @@ The Anthropic-compatible Messages endpoint (`/v1/messages`) returns errors in An
 }
 ```
 
-## Deprecated Compatibility Fields
-
-<Callout type="warning">
-	For backwards compatibility during the migration to the OpenAI-compatible
-	format, error responses currently also include top-level `message` and
-	`status` fields that mirror the previous error shape. **These fields are
-	deprecated and will be removed in a future release.** Read `error.message`
-	from the envelope and use the HTTP response status code instead.
-</Callout>
-
-```json
-{
-	"error": {
-		"message": "Unauthorized: LLMGateway API key reached its usage limit.",
-		"type": "invalid_request_error",
-		"param": null,
-		"code": "invalid_api_key"
-	},
-	"message": "Unauthorized: LLMGateway API key reached its usage limit.",
-	"status": 401
-}
-```
-
 ## Related
 
 - [Rate Limits](/resources/rate-limits) — details on `429` responses and rate limit headers.

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -3197,7 +3197,7 @@ describe("api", () => {
 		expect(res.status).toBe(400);
 		const errorMessage = await res.text();
 		expect(errorMessage).toMatchInlineSnapshot(
-			`"{"error":{"message":"No API key set for provider: openai. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.","type":"invalid_request_error","param":null,"code":null},"message":"No API key set for provider: openai. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.","status":400}"`,
+			`"{"error":{"message":"No API key set for provider: openai. Please add a provider key in your settings or add credits and switch to credits or hybrid mode.","type":"invalid_request_error","param":null,"code":null}}"`,
 		);
 	});
 

--- a/apps/gateway/src/lib/error-response.spec.ts
+++ b/apps/gateway/src/lib/error-response.spec.ts
@@ -21,8 +21,6 @@ describe("error-response", () => {
 				param: null,
 				code: "invalid_api_key",
 			},
-			message: "Unauthorized: LLMGateway API key reached its usage limit.",
-			status: 401,
 		});
 	});
 
@@ -53,8 +51,6 @@ describe("error-response", () => {
 				param: "messages",
 				code: "invalid_json",
 			},
-			message: "bad input",
-			status: 400,
 		});
 	});
 
@@ -63,8 +59,6 @@ describe("error-response", () => {
 			{
 				type: "error",
 				error: { type: "permission_error", message: "denied" },
-				message: "denied",
-				status: 403,
 			},
 		);
 		expect(getAnthropicErrorType(429)).toBe("rate_limit_error");

--- a/apps/gateway/src/lib/error-response.ts
+++ b/apps/gateway/src/lib/error-response.ts
@@ -10,16 +10,6 @@ export interface OpenAIErrorBody {
 		param: string | null;
 		code: string | null;
 	};
-	/**
-	 * @deprecated Backwards-compat mirror of the legacy `{ error, status, message }`
-	 * shape. Read `error.message` instead; this top-level field will be removed soon.
-	 */
-	message: string;
-	/**
-	 * @deprecated Backwards-compat mirror of the legacy `{ error, status, message }`
-	 * shape. Use the HTTP response status instead; this field will be removed soon.
-	 */
-	status: number;
 }
 
 export interface AnthropicErrorBody {
@@ -28,16 +18,6 @@ export interface AnthropicErrorBody {
 		type: string;
 		message: string;
 	};
-	/**
-	 * @deprecated Backwards-compat mirror of the legacy `{ error, status, message }`
-	 * shape. Read `error.message` instead; this top-level field will be removed soon.
-	 */
-	message: string;
-	/**
-	 * @deprecated Backwards-compat mirror of the legacy `{ error, status, message }`
-	 * shape. Use the HTTP response status instead; this field will be removed soon.
-	 */
-	status: number;
 }
 
 // Maps an HTTP status code to the canonical OpenAI `error.type`/`error.code`
@@ -122,9 +102,6 @@ export function buildOpenAIErrorBody(opts: {
 			param: opts.param ?? null,
 			code: opts.code !== undefined ? opts.code : meta.code,
 		},
-		// Deprecated legacy fields, kept temporarily for backwards compatibility.
-		message: opts.message,
-		status: opts.status,
 	};
 }
 
@@ -139,8 +116,5 @@ export function buildAnthropicErrorBody(opts: {
 			type: opts.type ?? getAnthropicErrorType(opts.status),
 			message: opts.message,
 		},
-		// Deprecated legacy fields, kept temporarily for backwards compatibility.
-		message: opts.message,
-		status: opts.status,
 	};
 }

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -1342,9 +1342,11 @@ describe("videos", () => {
 
 		expect(res.status).toBe(400);
 		await expect(res.json()).resolves.toMatchObject({
-			message: expect.stringContaining(
-				"audio=false is unsupported because this provider mapping only supports audio-enabled output",
-			),
+			error: {
+				message: expect.stringContaining(
+					"audio=false is unsupported because this provider mapping only supports audio-enabled output",
+				),
+			},
 		});
 	});
 


### PR DESCRIPTION
## Summary

The chat completions (and other gateway) error responses were temporarily returning top-level `message` and `status` fields alongside the OpenAI/Anthropic error envelope, purely for backwards compatibility during the migration to the standard envelope. Now that the migration has been announced, this removes those deprecated mirror fields.

Error responses now return only the standard envelope:

- OpenAI-compatible endpoints: `{ "error": { message, type, param, code } }`
- Anthropic `/v1/messages`: `{ "type": "error", "error": { type, message } }`

## Changes

- `apps/gateway/src/lib/error-response.ts` — drop the deprecated root-level `message`/`status` from `OpenAIErrorBody`/`AnthropicErrorBody` and their builder functions.
- `apps/gateway/src/lib/error-response.spec.ts`, `apps/gateway/src/api.spec.ts` — update expectations/inline snapshot to the envelope-only shape.
- `apps/docs/content/resources/error-handling.mdx` — remove the "Deprecated Compatibility Fields" section.
- `apps/docs/content/features/api-keys.mdx` — update the outdated IAM error example to the current OpenAI envelope.

## Testing

- `pnpm test:unit` (error-response + api.spec missing-provider-key test) — passing
- `pnpm format` and `pnpm build` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated error handling docs to show the standardized OpenAI-style nested error envelope
  * Removed deprecated compatibility notes and examples

* **Refactor**
  * Standardized error response envelope to use provider-specific nested `error` objects
  * Removed legacy top-level `message` and `status` fields

* **Tests**
  * Updated tests to assert the new nested error payload format
<!-- end of auto-generated comment: release notes by coderabbit.ai -->