### PR TITLE
feat(ui): link image/video models to studio

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -311,6 +311,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 
 							<ModelCtaButton
 								modelId={decodedName}
+								output={modelDef.output}
 								size="sm"
 								className="gap-2"
 								iconClassName="h-3 w-3"

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -251,6 +251,7 @@ export default async function ModelPage({ params }: PageProps) {
 
 							<ModelCtaButton
 								modelId={decodedName}
+								output={modelDef.output}
 								size="sm"
 								className="gap-2"
 								iconClassName="h-3 w-3"

--- a/apps/ui/src/components/models/detail-provider-cards.tsx
+++ b/apps/ui/src/components/models/detail-provider-cards.tsx
@@ -129,7 +129,10 @@ export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 								copiedModel={copiedModel}
 								isImageGen={isImageGen}
 							/>
-							<ModelCtaButton modelId={`${providerId}/${model.id}`} />
+							<ModelCtaButton
+								modelId={`${providerId}/${model.id}`}
+								output={model.output}
+							/>
 						</div>
 					);
 				})}

--- a/apps/ui/src/components/models/model-card.tsx
+++ b/apps/ui/src/components/models/model-card.tsx
@@ -408,6 +408,7 @@ export function ModelCard({
 					<div className="mt-4 pt-4 border-t border-border/30">
 						<ModelCtaButton
 							modelId={`${groupedByProvider[0]?.providerId}/${model.id}`}
+							output={model.output}
 							onClick={(e) => e.stopPropagation()}
 						/>
 					</div>

--- a/apps/ui/src/components/models/model-cta-button.tsx
+++ b/apps/ui/src/components/models/model-cta-button.tsx
@@ -8,12 +8,14 @@ import { useAppConfig } from "@/lib/config";
 
 export function ModelCtaButton({
 	modelId,
+	output,
 	size = "default",
 	className = "w-full gap-2 font-semibold group/cta",
 	iconClassName = "h-4 w-4 transition-transform group-hover/cta:translate-x-0.5",
 	onClick,
 }: {
 	modelId: string;
+	output?: readonly string[] | null;
 	size?: "default" | "sm";
 	className?: string;
 	iconClassName?: string;
@@ -24,6 +26,11 @@ export function ModelCtaButton({
 	const isLoggedIn = !!user && !isLoading;
 
 	if (isLoggedIn) {
+		const studioPath = output?.includes("video")
+			? "/video"
+			: output?.includes("image")
+				? "/image"
+				: "";
 		return (
 			<Button
 				variant="default"
@@ -33,7 +40,7 @@ export function ModelCtaButton({
 				asChild
 			>
 				<a
-					href={`${config.playgroundUrl}?model=${encodeURIComponent(modelId)}`}
+					href={`${config.playgroundUrl}${studioPath}?model=${encodeURIComponent(modelId)}`}
 					target="_blank"
 					rel="noopener noreferrer"
 				>


### PR DESCRIPTION
## Summary

On a model detail page like `https://llmgateway.io/models/minimax-hailuo-2-3/minimax`, the **Try in Playground** CTA always linked to the generic playground root, even for image and video models. Image/video models belong in the dedicated **Image Studio** (`/image`) and **Video Studio** (`/video`).

This routes the CTA to the right studio based on the model's `output` modality:

- `output` includes `"video"` → `/video?model=…`
- `output` includes `"image"` → `/image?model=…`
- otherwise → playground root (`?model=…`), unchanged

Both studio pages already read the `?model=` query param to preselect the model, so the selected model carries over.

## Changes

- `model-cta-button.tsx`: added optional `output` prop; computes the studio sub-path.
- Passed `output` from all four call sites: model `[name]/[provider]` page, model `[name]` page, `model-card.tsx`, and `detail-provider-cards.tsx`.

## Testing

- `pnpm format` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Try in Playground" button now directs users to the appropriate studio environment based on the model's output type (video, image, or default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->