### PR TITLE
feat(auth): add social login to signup pages

### DIFF
--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -12,6 +12,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod/v3";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { Button } from "@/components/ui/button";
 import {
 	Form,
@@ -246,7 +247,7 @@ function SignupForm() {
 						</p>
 					</div>
 
-					<div className="mt-8">
+					<div className="mt-8 space-y-4">
 						<Form {...form}>
 							<form
 								onSubmit={form.handleSubmit(onSubmit)}
@@ -315,6 +316,24 @@ function SignupForm() {
 								</Button>
 							</form>
 						</Form>
+
+						<div className="relative">
+							<div className="absolute inset-0 flex items-center">
+								<span className="w-full border-t" />
+							</div>
+							<div className="relative flex justify-center text-xs uppercase">
+								<span className="bg-background px-2 text-muted-foreground">
+									Or
+								</span>
+							</div>
+						</div>
+
+						<SocialAuthButtons
+							isLoading={isLoading}
+							setIsLoading={setIsLoading}
+							callbackPath={returnUrl}
+							errorCallbackPath="/signup"
+						/>
 					</div>
 
 					<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/playground/src/app/login/page.tsx
+++ b/apps/playground/src/app/login/page.tsx
@@ -11,6 +11,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod/v3";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { Button } from "@/components/ui/button";
 import {
 	Form,
@@ -245,6 +246,12 @@ function Login() {
 						<span className="bg-background px-2 text-muted-foreground">Or</span>
 					</div>
 				</div>
+				<SocialAuthButtons
+					isLoading={isLoading}
+					setIsLoading={setIsLoading}
+					callbackPath={returnUrl}
+					errorCallbackPath="/login"
+				/>
 				<Button
 					onClick={handlePasskeySignIn}
 					variant="outline"

--- a/apps/playground/src/app/signup/page.tsx
+++ b/apps/playground/src/app/signup/page.tsx
@@ -12,6 +12,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod/v3";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { Button } from "@/components/ui/button";
 import {
 	Form,
@@ -199,6 +200,20 @@ function Signup() {
 						</Button>
 					</form>
 				</Form>
+				<div className="relative">
+					<div className="absolute inset-0 flex items-center">
+						<span className="w-full border-t" />
+					</div>
+					<div className="relative flex justify-center text-xs uppercase">
+						<span className="bg-background px-2 text-muted-foreground">Or</span>
+					</div>
+				</div>
+				<SocialAuthButtons
+					isLoading={isLoading}
+					setIsLoading={setIsLoading}
+					callbackPath={returnUrl}
+					errorCallbackPath="/signup"
+				/>
 				<p className="px-8 text-center text-sm text-muted-foreground">
 					<Link
 						href="/login"

--- a/apps/playground/src/components/social-auth-buttons.tsx
+++ b/apps/playground/src/components/social-auth-buttons.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Github, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/auth-client";
+import { useAppConfig } from "@/lib/config";
+
+interface SocialAuthButtonsProps {
+	isLoading: boolean;
+	setIsLoading: (loading: boolean) => void;
+	callbackPath: string;
+	errorCallbackPath: string;
+}
+
+export function SocialAuthButtons({
+	isLoading,
+	setIsLoading,
+	callbackPath,
+	errorCallbackPath,
+}: SocialAuthButtonsProps) {
+	const { signIn } = useAuth();
+	const { githubAuth, googleAuth } = useAppConfig();
+
+	if (!githubAuth && !googleAuth) {
+		return null;
+	}
+
+	async function handleSocialSignIn(provider: "github" | "google") {
+		setIsLoading(true);
+		try {
+			const res = await signIn.social({
+				provider,
+				callbackURL: location.protocol + "//" + location.host + callbackPath,
+				errorCallbackURL:
+					location.protocol + "//" + location.host + errorCallbackPath,
+			});
+			if (res?.error) {
+				toast.error(res.error.message ?? `Failed to sign in with ${provider}`, {
+					style: {
+						backgroundColor: "var(--destructive)",
+						color: "var(--destructive-foreground)",
+					},
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="grid gap-3 sm:grid-cols-2">
+			{githubAuth && (
+				<Button
+					onClick={() => handleSocialSignIn("github")}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<Github className="mr-2 h-4 w-4" />
+					)}
+					GitHub
+				</Button>
+			)}
+			{googleAuth && (
+				<Button
+					onClick={() => handleSocialSignIn("google")}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+							<path
+								d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+								fill="#4285F4"
+							/>
+							<path
+								d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+								fill="#34A853"
+							/>
+							<path
+								d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+								fill="#FBBC05"
+							/>
+							<path
+								d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+								fill="#EA4335"
+							/>
+						</svg>
+					)}
+					Google
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/playground/src/lib/config-server.ts
+++ b/apps/playground/src/lib/config-server.ts
@@ -9,6 +9,8 @@ export interface AppConfig {
 	adminUrl: string;
 	posthogKey?: string;
 	posthogHost?: string;
+	githubAuth: boolean;
+	googleAuth: boolean;
 }
 
 export function getConfig(): AppConfig {
@@ -25,5 +27,7 @@ export function getConfig(): AppConfig {
 		adminUrl: process.env.ADMIN_URL ?? "http://localhost:3006",
 		posthogKey: process.env.POSTHOG_KEY,
 		posthogHost: process.env.POSTHOG_HOST,
+		githubAuth: !!process.env.GITHUB_CLIENT_ID,
+		googleAuth: !!process.env.GOOGLE_CLIENT_ID,
 	};
 }

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -4,14 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { WebAuthnAbortService } from "@simplewebauthn/browser";
 import { useQueryClient } from "@tanstack/react-query";
 import { motion } from "framer-motion";
-import {
-	Loader2,
-	KeySquare,
-	Github,
-	Eye,
-	EyeOff,
-	ArrowRight,
-} from "lucide-react";
+import { Loader2, KeySquare, Eye, EyeOff, ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
@@ -19,6 +12,7 @@ import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 import { getAuthErrorMessage } from "@/lib/auth-errors";
@@ -33,7 +27,6 @@ import {
 } from "@/lib/components/form";
 import { Input } from "@/lib/components/input";
 import { toast } from "@/lib/components/use-toast";
-import { useAppConfig } from "@/lib/config";
 
 const formSchema = z.object({
 	email: z.string().email({
@@ -51,7 +44,6 @@ export default function Login() {
 	const [isLoading, setIsLoading] = useState(false);
 	const [showPassword, setShowPassword] = useState(false);
 	const { signIn } = useAuth();
-	const { githubAuth, googleAuth } = useAppConfig();
 
 	useUser({
 		redirectTo: "/dashboard",
@@ -300,95 +292,12 @@ export default function Login() {
 				</div>
 
 				{/* Alternative sign-in methods */}
-				<div className="grid gap-3 sm:grid-cols-2">
-					{githubAuth && (
-						<Button
-							onClick={async () => {
-								setIsLoading(true);
-								try {
-									const res = await signIn.social({
-										provider: "github",
-										callbackURL:
-											location.protocol + "//" + location.host + "/dashboard",
-										errorCallbackURL:
-											location.protocol + "//" + location.host + "/login",
-									});
-									if (res?.error) {
-										toast({
-											title:
-												res.error.message ?? "Failed to sign in with GitHub",
-											variant: "destructive",
-										});
-									}
-								} finally {
-									setIsLoading(false);
-								}
-							}}
-							variant="outline"
-							className="w-full"
-							disabled={isLoading}
-						>
-							{isLoading ? (
-								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-							) : (
-								<Github className="mr-2 h-4 w-4" />
-							)}
-							GitHub
-						</Button>
-					)}
-					{googleAuth && (
-						<Button
-							onClick={async () => {
-								setIsLoading(true);
-								try {
-									const res = await signIn.social({
-										provider: "google",
-										callbackURL:
-											location.protocol + "//" + location.host + "/dashboard",
-										errorCallbackURL:
-											location.protocol + "//" + location.host + "/login",
-									});
-									if (res?.error) {
-										toast({
-											title:
-												res.error.message ?? "Failed to sign in with Google",
-											variant: "destructive",
-										});
-									}
-								} finally {
-									setIsLoading(false);
-								}
-							}}
-							variant="outline"
-							className="w-full"
-							disabled={isLoading}
-						>
-							{isLoading ? (
-								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-							) : (
-								<svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-									<path
-										d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-										fill="#4285F4"
-									/>
-									<path
-										d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-										fill="#34A853"
-									/>
-									<path
-										d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-										fill="#FBBC05"
-									/>
-									<path
-										d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-										fill="#EA4335"
-									/>
-								</svg>
-							)}
-							Google
-						</Button>
-					)}
-				</div>
+				<SocialAuthButtons
+					isLoading={isLoading}
+					setIsLoading={setIsLoading}
+					callbackPath="/dashboard"
+					errorCallbackPath="/login"
+				/>
 
 				<Button
 					onClick={handlePasskeySignIn}

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 import { getAuthErrorMessage } from "@/lib/auth-errors";
@@ -284,6 +285,24 @@ export default function Signup() {
 						</Button>
 					</form>
 				</Form>
+
+				{/* Divider */}
+				<div className="relative">
+					<div className="absolute inset-0 flex items-center">
+						<span className="w-full border-t" />
+					</div>
+					<div className="relative flex justify-center text-xs uppercase">
+						<span className="bg-background px-2 text-muted-foreground">Or</span>
+					</div>
+				</div>
+
+				{/* Social sign-up methods */}
+				<SocialAuthButtons
+					isLoading={isLoading}
+					setIsLoading={setIsLoading}
+					callbackPath="/dashboard"
+					errorCallbackPath="/signup"
+				/>
 			</div>
 
 			<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/ui/src/components/social-auth-buttons.tsx
+++ b/apps/ui/src/components/social-auth-buttons.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Github, Loader2 } from "lucide-react";
+
+import { useAuth } from "@/lib/auth-client";
+import { Button } from "@/lib/components/button";
+import { toast } from "@/lib/components/use-toast";
+import { useAppConfig } from "@/lib/config";
+
+interface SocialAuthButtonsProps {
+	isLoading: boolean;
+	setIsLoading: (loading: boolean) => void;
+	callbackPath: string;
+	errorCallbackPath: string;
+}
+
+export function SocialAuthButtons({
+	isLoading,
+	setIsLoading,
+	callbackPath,
+	errorCallbackPath,
+}: SocialAuthButtonsProps) {
+	const { signIn } = useAuth();
+	const { githubAuth, googleAuth } = useAppConfig();
+
+	if (!githubAuth && !googleAuth) {
+		return null;
+	}
+
+	async function handleSocialSignIn(provider: "github" | "google") {
+		setIsLoading(true);
+		try {
+			const res = await signIn.social({
+				provider,
+				callbackURL: location.protocol + "//" + location.host + callbackPath,
+				errorCallbackURL:
+					location.protocol + "//" + location.host + errorCallbackPath,
+			});
+			if (res?.error) {
+				toast({
+					title: res.error.message ?? `Failed to sign in with ${provider}`,
+					variant: "destructive",
+				});
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<div className="grid gap-3 sm:grid-cols-2">
+			{githubAuth && (
+				<Button
+					onClick={() => handleSocialSignIn("github")}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<Github className="mr-2 h-4 w-4" />
+					)}
+					GitHub
+				</Button>
+			)}
+			{googleAuth && (
+				<Button
+					onClick={() => handleSocialSignIn("google")}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+							<path
+								d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+								fill="#4285F4"
+							/>
+							<path
+								d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+								fill="#34A853"
+							/>
+							<path
+								d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+								fill="#FBBC05"
+							/>
+							<path
+								d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+								fill="#EA4335"
+							/>
+						</svg>
+					)}
+					Google
+				</Button>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Google and GitHub social login were completely missing from the signup pages. This adds them across all three sign-up surfaces: **UI**, **DevPass** (`apps/code`), and **Chat** (`apps/playground`).

## Changes

- **UI** (`apps/ui`): Extracted a shared `SocialAuthButtons` component and reused it on both the login and signup pages, replacing the ~100 lines of duplicated inline GitHub/Google button markup that previously only lived on login.
- **DevPass** (`apps/code`): Added the existing `SocialAuthButtons` component (already used on login) to the signup page, with an "Or" divider.
- **Chat** (`apps/playground`): Added a new `SocialAuthButtons` component (matching the others, using `sonner` toasts) and wired it into both signup and login. Exposed `githubAuth`/`googleAuth` in the playground app config so the buttons render only when the providers are configured.

All buttons are gated on `githubAuth`/`googleAuth` config flags (derived from `GITHUB_CLIENT_ID` / `GOOGLE_CLIENT_ID`), matching the backend's `socialProviders` setup in `apps/api/src/auth/config.ts` — so they hide cleanly when a provider isn't configured.

## Testing

- `pnpm format` ✅
- `pnpm build` ✅ (17/17 apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social authentication now available for signup and login flows
  * Users can authenticate using GitHub or Google accounts
  * Visual dividers separate social sign-in options from traditional authentication methods
  * Loading indicators display during authentication process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->