### PR TITLE
feat(keys): add roll secret action for API keys

### DIFF
--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -3,7 +3,8 @@ import { expect, test, beforeEach, describe, afterEach } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { db, eq, tables } from "@llmgateway/db";
+import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
+import { db, eq, getTableName, tables } from "@llmgateway/db";
 
 const ONE_MINUTE_MS = 60 * 1000;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
@@ -320,6 +321,30 @@ describe("keys route", () => {
 			},
 		});
 		expect(res.status).toBe(404);
+	});
+
+	test("POST /keys/api/{id}/roll invalidates the gateway api_key cache", async () => {
+		// The gateway resolves tokens through an SWR-mirrored, cached lookup tagged
+		// with the api_key table. Roll must invalidate that cache so the old secret
+		// stops authenticating immediately. Seed an SWR entry the way the gateway
+		// would, then confirm the roll clears it.
+		const apiKeyTableName = getTableName(tables.apiKey);
+		const swrCacheKey = "apiKey:token:test-token-fingerprint";
+		await swrWrap(swrCacheKey, [apiKeyTableName], async () => ({
+			token: "test-token",
+		}));
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+
+		const res = await app.request("/keys/api/test-api-key-id/roll", {
+			method: "POST",
+			headers: {
+				Cookie: token,
+			},
+		});
+		expect(res.status).toBe(200);
+
+		// The cached lookup for the old token must be gone after the roll.
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
 	});
 
 	test("POST /keys/api creates a period usage limit", async () => {

--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -268,6 +268,60 @@ describe("keys route", () => {
 		expect(apiKey?.status).toBe("inactive");
 	});
 
+	test("POST /keys/api/{id}/roll unauthorized", async () => {
+		const res = await app.request("/keys/api/test-api-key-id/roll", {
+			method: "POST",
+		});
+		expect(res.status).toBe(401);
+	});
+
+	test("POST /keys/api/{id}/roll regenerates the secret and keeps metadata", async () => {
+		// Give the key some usage and a limit to prove they survive the roll.
+		await db
+			.update(tables.apiKey)
+			.set({ usage: "12.34", usageLimit: "100", description: "Keep Me" })
+			.where(eq(tables.apiKey.id, "test-api-key-id"));
+
+		const res = await app.request("/keys/api/test-api-key-id/roll", {
+			method: "POST",
+			headers: {
+				Cookie: token,
+			},
+		});
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json).toHaveProperty("message");
+		expect(json).toHaveProperty("apiKey");
+		// Full new secret is returned once, and it differs from the old one.
+		expect(typeof json.apiKey.token).toBe("string");
+		expect(json.apiKey.token).not.toBe("test-token");
+		expect(json.apiKey.id).toBe("test-api-key-id");
+
+		// Verify the DB was updated and metadata/stats are intact.
+		const apiKey = await db.query.apiKey.findFirst({
+			where: {
+				id: {
+					eq: "test-api-key-id",
+				},
+			},
+		});
+		expect(apiKey?.token).toBe(json.apiKey.token);
+		expect(apiKey?.token).not.toBe("test-token");
+		expect(apiKey?.description).toBe("Keep Me");
+		expect(apiKey?.usage).toBe("12.34");
+		expect(apiKey?.usageLimit).toBe("100");
+	});
+
+	test("POST /keys/api/{id}/roll returns 404 for unknown key", async () => {
+		const res = await app.request("/keys/api/does-not-exist/roll", {
+			method: "POST",
+			headers: {
+				Cookie: token,
+			},
+		});
+		expect(res.status).toBe(404);
+	});
+
 	test("POST /keys/api creates a period usage limit", async () => {
 		const res = await app.request("/keys/api", {
 			method: "POST",

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -1474,6 +1474,166 @@ keysApi.openapi(updateStatus, async (c) => {
 	});
 });
 
+// Roll (regenerate the secret of) an API key while keeping its metadata and stats
+const roll = createRoute({
+	method: "post",
+	path: "/api/{id}/roll",
+	request: {
+		params: z.object({
+			id: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+						apiKey: apiKeySchema
+							.omit({ token: true })
+							.extend({
+								token: z.string(),
+							})
+							.openapi({}),
+					}),
+				},
+			},
+			description: "API key secret regenerated successfully.",
+		},
+		401: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Unauthorized.",
+		},
+		404: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "API key not found.",
+		},
+	},
+});
+
+keysApi.openapi(roll, async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const { id } = c.req.param();
+
+	// Get the user's projects
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: {
+			userId: {
+				eq: user.id,
+			},
+		},
+		with: {
+			organization: {
+				with: {
+					projects: true,
+				},
+			},
+		},
+	});
+
+	// Get all project IDs the user has access to
+	const projectIds = userOrgs.flatMap((org) =>
+		org
+			.organization!.projects.filter((project) => project.status !== "deleted")
+			.map((project) => project.id),
+	);
+
+	// Find the API key
+	const apiKey = await db.query.apiKey.findFirst({
+		where: {
+			id: {
+				eq: id,
+			},
+			projectId: {
+				in: projectIds,
+			},
+		},
+		with: {
+			project: true,
+		},
+	});
+
+	if (!apiKey) {
+		throw new HTTPException(404, {
+			message: "API key not found",
+		});
+	}
+
+	if (!apiKey.project) {
+		throw new HTTPException(404, {
+			message: "Project not found for API key",
+		});
+	}
+
+	// Only developer keys are rolled here; platform/embeddable keys use a
+	// different token format and lifecycle.
+	if (apiKey.keyType !== "user") {
+		throw new HTTPException(400, {
+			message: "Only developer API keys can be rolled.",
+		});
+	}
+
+	// Check user role and permissions
+	const projectOrgId = apiKey.project.organizationId;
+	const userOrg = userOrgs.find((org) => org.organizationId === projectOrgId);
+	const userRole = userOrg?.role as "owner" | "admin" | "developer" | undefined;
+
+	// Developers can only modify their own API keys
+	// Owners and admins can modify any API key
+	if (userRole === "developer" && apiKey.createdBy !== user.id) {
+		throw new HTTPException(403, {
+			message: "You don't have permission to modify this API key",
+		});
+	}
+
+	const prefix =
+		process.env.NODE_ENV === "development" ? `llmgdev_` : "llmgtwy_";
+	const token = prefix + shortid(40);
+
+	const [updatedApiKey] = await db
+		.update(tables.apiKey)
+		.set({ token })
+		.where(eq(tables.apiKey.id, id))
+		.returning();
+
+	await logAuditEvent({
+		organizationId: projectOrgId,
+		userId: user.id,
+		action: "api_key.roll",
+		resourceType: "api_key",
+		resourceId: id,
+		metadata: {
+			resourceName: apiKey.description,
+		},
+	});
+
+	return c.json({
+		message: "API key secret regenerated successfully.",
+		apiKey: serializeApiKey({
+			...updatedApiKey,
+			token,
+		}),
+	});
+});
+
 // Update API key usage limit
 const updateUsageLimit = createRoute({
 	method: "patch",

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -11,6 +11,7 @@ import { logAuditEvent } from "@llmgateway/audit";
 import {
 	apiKeyPeriodDurationMaxValues,
 	apiKeyPeriodDurationUnits,
+	cdb,
 	db,
 	eq,
 	getApiKeyCurrentPeriodState,
@@ -1608,7 +1609,10 @@ keysApi.openapi(roll, async (c) => {
 		process.env.NODE_ENV === "development" ? `llmgdev_` : "llmgtwy_";
 	const token = prefix + shortid(40);
 
-	const [updatedApiKey] = await db
+	// Roll through the cached client so its onMutate invalidates the gateway's
+	// cached token lookups (Drizzle cache + SWR mirror) for the api_key table.
+	// Otherwise the old secret would keep authenticating until the cache expired.
+	const [updatedApiKey] = await cdb
 		.update(tables.apiKey)
 		.set({ token })
 		.where(eq(tables.apiKey.id, id))

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -5,6 +5,7 @@ import {
 	KeyIcon,
 	MoreHorizontal,
 	PlusIcon,
+	RefreshCwIcon,
 	Shield,
 } from "lucide-react";
 import Link from "next/link";
@@ -61,6 +62,7 @@ import { ApiKeyLimitsDialog } from "./api-key-limits-dialog";
 import { formatApiKeyExpiry } from "./api-key-ttl-fields";
 import { CreateApiKeyDialog } from "./create-api-key-dialog";
 import { ReactivateApiKeyDialog } from "./reactivate-api-key-dialog";
+import { RollApiKeyDialog } from "./roll-api-key-dialog";
 
 import type { ApiKey, Project } from "@/lib/types";
 import type { Route } from "next";
@@ -87,6 +89,7 @@ export function ApiKeysList({
 	const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
 	const [creatorFilter, setCreatorFilter] = useState<CreatorFilter>("all");
 	const [reactivateKey, setReactivateKey] = useState<ApiKey | null>(null);
+	const [rollKey, setRollKey] = useState<ApiKey | null>(null);
 
 	const getIamRulesUrl = (keyId: string) =>
 		`/dashboard/${orgId}/${projectId}/api-keys/${keyId}/iam` as Route;
@@ -139,6 +142,9 @@ export function ApiKeysList({
 		"patch",
 		"/keys/api/limit/{id}",
 	);
+
+	const { mutateAsync: rollKeyAsync, isPending: isRollPending } =
+		api.useMutation("post", "/keys/api/{id}/roll");
 
 	const allKeys = data?.apiKeys.filter((key) => key.status !== "deleted") ?? [];
 	const activeKeys = allKeys.filter((key) => key.status === "active");
@@ -312,6 +318,35 @@ export function ApiKeysList({
 				title: "Failed to reactivate API key.",
 				variant: "destructive",
 			});
+		}
+	};
+
+	const handleRoll = async (): Promise<string | undefined> => {
+		if (!rollKey) {
+			return undefined;
+		}
+
+		try {
+			const data = await rollKeyAsync({
+				params: {
+					path: { id: rollKey.id },
+				},
+			});
+
+			invalidateApiKeys();
+
+			toast({
+				title: "API Key Rolled",
+				description: "A new secret has been generated for this key.",
+			});
+
+			return data.apiKey.token;
+		} catch {
+			toast({
+				title: "Failed to roll API key.",
+				variant: "destructive",
+			});
+			return undefined;
 		}
 	};
 
@@ -675,6 +710,10 @@ export function ApiKeysList({
 															: "Activate"}{" "}
 														Key
 													</DropdownMenuItem>
+													<DropdownMenuItem onClick={() => setRollKey(key)}>
+														<RefreshCwIcon className="mr-2 h-4 w-4" />
+														Roll Key
+													</DropdownMenuItem>
 													<DropdownMenuSeparator />
 													<AlertDialog>
 														<AlertDialogTrigger asChild>
@@ -767,6 +806,10 @@ export function ApiKeysList({
 											<DropdownMenuItem onClick={() => toggleStatus(key)}>
 												{key.status === "active" ? "Deactivate" : "Activate"}{" "}
 												Key
+											</DropdownMenuItem>
+											<DropdownMenuItem onClick={() => setRollKey(key)}>
+												<RefreshCwIcon className="mr-2 h-4 w-4" />
+												Roll Key
 											</DropdownMenuItem>
 											<DropdownMenuSeparator />
 											<AlertDialog>
@@ -904,6 +947,18 @@ export function ApiKeysList({
 				}}
 				onConfirm={handleReactivate}
 				isPending={isTogglePending}
+			/>
+
+			<RollApiKeyDialog
+				apiKey={rollKey}
+				open={rollKey !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setRollKey(null);
+					}
+				}}
+				onConfirm={handleRoll}
+				isPending={isRollPending}
 			/>
 		</>
 	);

--- a/apps/ui/src/components/api-keys/roll-api-key-dialog.tsx
+++ b/apps/ui/src/components/api-keys/roll-api-key-dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/lib/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/lib/components/dialog";
+import { Input } from "@/lib/components/input";
+import { Label } from "@/lib/components/label";
+import { toast } from "@/lib/components/use-toast";
+
+import type { ApiKey } from "@/lib/types";
+
+interface RollApiKeyDialogProps {
+	apiKey: ApiKey | null;
+	isPending?: boolean;
+	onConfirm: () => Promise<string | undefined> | string | undefined;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+}
+
+export function RollApiKeyDialog({
+	apiKey,
+	isPending = false,
+	onConfirm,
+	onOpenChange,
+	open,
+}: RollApiKeyDialogProps) {
+	const [newToken, setNewToken] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (open) {
+			setNewToken(null);
+		}
+	}, [open]);
+
+	const handleConfirm = async () => {
+		const token = await onConfirm();
+		if (token) {
+			setNewToken(token);
+		}
+	};
+
+	const copyToClipboard = () => {
+		if (!newToken) {
+			return;
+		}
+		void navigator.clipboard.writeText(newToken);
+		toast({
+			title: "API Key Copied",
+			description: "The new API key has been copied to your clipboard.",
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[500px]">
+				{newToken ? (
+					<>
+						<DialogHeader>
+							<DialogTitle>API Key Rolled</DialogTitle>
+							<DialogDescription>
+								A new secret has been generated. Please copy it now as you won't
+								be able to see it again. All stats, limits, and settings for
+								this key are preserved.
+							</DialogDescription>
+						</DialogHeader>
+						<div className="space-y-4 py-4">
+							<div className="space-y-2">
+								<Label htmlFor="rolled-api-key">API Key</Label>
+								<div className="flex items-center space-x-2">
+									<Input
+										id="rolled-api-key"
+										value={newToken}
+										readOnly
+										className="font-mono text-xs"
+									/>
+									<Button
+										variant="outline"
+										size="icon"
+										onClick={copyToClipboard}
+									>
+										<Copy className="h-4 w-4" />
+										<span className="sr-only">Copy API key</span>
+									</Button>
+								</div>
+								<p className="text-muted-foreground text-xs">
+									Make sure to update any clients using the old secret. The
+									previous secret no longer works.
+								</p>
+							</div>
+							<DialogFooter>
+								<Button onClick={() => onOpenChange(false)}>Done</Button>
+							</DialogFooter>
+						</div>
+					</>
+				) : (
+					<>
+						<DialogHeader>
+							<DialogTitle>Roll API Key</DialogTitle>
+							<DialogDescription>
+								This generates a new secret for{" "}
+								{apiKey?.description ? `"${apiKey.description}"` : "this key"}{" "}
+								and immediately invalidates the current one. The key's stats,
+								limits, IAM rules, and other settings are kept intact.
+							</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => onOpenChange(false)}
+								disabled={isPending}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="button"
+								onClick={handleConfirm}
+								disabled={isPending}
+							>
+								{isPending ? "Rolling..." : "Roll Key"}
+							</Button>
+						</DialogFooter>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1969,6 +1969,7 @@ export const auditLogActions = [
 	"team_member.remove",
 	// API Key
 	"api_key.create",
+	"api_key.roll",
 	"api_key.update_status",
 	"api_key.update_limit",
 	"api_key.update_description",


### PR DESCRIPTION
## What

Adds a **Roll Key** action for API keys. Rolling regenerates the key's secret while leaving everything else — description, usage/stats, all-time and period limits, IAM rules, status, and TTL — fully intact. The freshly generated secret is shown to the user once, mirroring the create-key flow.

## Why

Users need to rotate a leaked or aging secret without losing the key's accumulated usage history, configured limits, and IAM rules — i.e. without deleting and recreating the key.

## Changes

**Backend** (`apps/api`)
- New route `POST /keys/api/{id}/roll`. Reuses the existing auth/ownership checks (developers can only roll their own keys; owners/admins any key), regenerates the token with the standard `llmgtwy_`/`llmgdev_` prefix, and returns the full new secret once.
- Restricted to `keyType: "user"` developer keys (platform/embeddable keys use a different token format and lifecycle).
- The token update runs through the **cached db client (`cdb`)** so its `onMutate` invalidates the gateway's cached token lookups — both the Drizzle cache and the SWR mirror tagged with the `api_key` table. This ensures the old secret stops authenticating immediately rather than lingering until the cache expires.
- Emits a new `api_key.roll` audit event.

**Schema** (`packages/db`)
- Added `api_key.roll` to `auditLogActions`. The `action` column is a Drizzle `text` column with a TS-level enum, so no DB migration is required.

**UI** (`apps/ui`)
- Added a "Roll Key" dropdown action (desktop + mobile) on the API keys list.
- New `RollApiKeyDialog`: confirms the roll (warning that the current secret is invalidated immediately), then reveals the new secret with a copy button.

## Tests

- `keys-api.spec.ts`: unauthorized roll → 401, successful roll regenerates the secret and preserves description/usage/limit, unknown key → 404, and a regression test asserting the `api_key` SWR cache entry is cleared after a roll.
- Full `keys-api.spec.ts` suite passes; full `pnpm test:unit` (1943 tests) passes; `pnpm format` and `pnpm build` pass.

## Review feedback addressed

- **Codex P1 (cache invalidation):** rolling now goes through the cached mutation path (`cdb`), invalidating the gateway's `findApiKeyByToken` cache + SWR mirror so the previous secret is revoked immediately. Covered by a new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Roll Key" action to regenerate API key secrets while preserving key metadata and history.
  * New dialog UI displays the newly generated secret with copy-to-clipboard functionality.
  * Roll Key action available in both desktop and mobile API key management interfaces with role-based access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->