### PR TITLE
fix(gateway): respect caller 1h cache_control ttl

### DIFF
--- a/apps/docs/content/features/caching/provider-cache-control.mdx
+++ b/apps/docs/content/features/caching/provider-cache-control.mdx
@@ -100,6 +100,14 @@ To mark content as cacheable, send the message content as an array of blocks and
 
 Use `ttl: "5m"` (the default if omitted) for short-lived caches that match a single user's session, and `ttl: "1h"` when the same prefix will be reused over a longer window (for example, a coding agent that keeps the same project context warm across many requests).
 
+### Mixing explicit markers with automatic injection
+
+Anthropic requires cache breakpoints with longer TTLs to appear before shorter ones (blocks are processed in the order `tools`, `system`, `messages`). The markers LLM Gateway injects automatically use the default 5-minute TTL, so they could never legally precede an explicit `ttl: "1h"` marker in your messages. To keep both features compatible:
+
+- When your request contains an explicit `ttl: "1h"` marker in the **messages**, LLM Gateway skips its automatic marker injection for that request entirely and forwards only your markers — the same behavior you would get calling the provider directly.
+- A `ttl: "1h"` marker only on the **system** prompt does not disable automatic injection, since 5-minute breakpoints after it still satisfy the ordering rule.
+- Explicit markers that use the default 5-minute TTL coexist with automatic injection (capped at 4 breakpoints total per Anthropic's limit).
+
 <Callout type="warning">
 	Cache writes are billed at a premium (typically 1.25x for 5m and 2x for 1h on
 	Anthropic) the first time a cached block is created. After that, cache reads

--- a/apps/gateway/src/native-anthropic-cache.e2e.ts
+++ b/apps/gateway/src/native-anthropic-cache.e2e.ts
@@ -596,6 +596,82 @@ describeCache(
 			},
 		);
 
+		// Regression: a caller-supplied ttl:"1h" marker in the *messages* (e.g.
+		// RisuAI's rolling "Automatic Cache Point") must suppress the gateway's
+		// heuristic 5m markers (long-system + turn-boundary). Anthropic requires
+		// longer TTLs before shorter ones, so an injected 5m marker ahead of the
+		// caller's 1h marker used to fail the whole request with "a ttl='1h'
+		// cache_control block must not come after a ttl='5m' cache_control block".
+		(hasAnthropicKey ? test : test.skip)(
+			"native messages defers to caller 1h ttl markers in multi-turn conversations",
+			getTestOptions(),
+			async () => {
+				const longText = buildLongSystemPrompt();
+				const body = {
+					model: "anthropic/claude-haiku-4-5",
+					max_tokens: 50,
+					system: longText,
+					messages: [
+						{ role: "user" as const, content: "Hello, who are you?" },
+						{
+							role: "assistant" as const,
+							content: "I'm an assistant. How can I help?",
+						},
+						{
+							role: "user" as const,
+							content: [
+								{
+									type: "text" as const,
+									text: "Just reply OK.",
+									cache_control: {
+										type: "ephemeral" as const,
+										ttl: "1h" as const,
+									},
+								},
+							],
+						},
+					],
+				};
+
+				const send = async () => {
+					const requestId = generateTestRequestId();
+					const res = await app.request("/v1/messages", {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							"x-request-id": requestId,
+							Authorization: `Bearer real-token`,
+						},
+						body: JSON.stringify(body),
+					});
+					const json = await res.json();
+					if (logMode) {
+						console.log(
+							"native /v1/messages multi-turn 1h",
+							requestId,
+							"status",
+							res.status,
+							"usage",
+							JSON.stringify(json.usage),
+						);
+					}
+					return { status: res.status, json };
+				};
+
+				const first = await send();
+				expect(first.status).toBe(200);
+				// With auto-injection deferred, the only breakpoint is the caller's
+				// 1h marker, so any cache write must be attributed entirely to the
+				// 1h tier.
+				const firstBreakdown = first.json.usage?.cache_creation;
+				if (first.json.usage?.cache_creation_input_tokens > 0) {
+					expect(firstBreakdown).toBeDefined();
+					expect(firstBreakdown.ephemeral_1h_input_tokens).toBeGreaterThan(0);
+					expect(firstBreakdown.ephemeral_5m_input_tokens).toBe(0);
+				}
+			},
+		);
+
 		// 1h cache TTL via Bedrock /v1/chat/completions: opts into Bedrock's 1h
 		// cache write rate (2x base) on a model that supports it (Haiku 4.5) and
 		// asserts the gateway forwards ttl:"1h" to the Converse API cachePoint and

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -324,6 +324,121 @@ describe("prepareRequestBody - Anthropic", () => {
 			}
 		}
 	});
+
+	test("defers auto-injection when caller supplies a 1h ttl marker in messages", async () => {
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "system", content: longContent },
+				{ role: "user", content: longContent },
+				{ role: "assistant", content: "Hi!" },
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "What should I do next?",
+							cache_control: { type: "ephemeral", ttl: "1h" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			1024,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		)) as AnthropicRequestBody;
+
+		// Long system prompt must NOT get a heuristic (5m) marker — it would
+		// precede the caller's 1h marker and Anthropic rejects that ordering.
+		expect(Array.isArray(requestBody.system)).toBe(true);
+		for (const block of requestBody.system as unknown[]) {
+			expect(getCacheControl(block)).toBeUndefined();
+		}
+
+		// No auto-injected markers in messages either (long-block heuristic and
+		// turn-boundary placement are both suppressed); only the caller's own
+		// 1h marker survives, with its ttl intact.
+		const markers: unknown[] = [];
+		for (const msg of requestBody.messages) {
+			if (Array.isArray(msg.content)) {
+				for (const block of msg.content) {
+					const cacheControl = getCacheControl(block);
+					if (cacheControl) {
+						markers.push(cacheControl);
+					}
+				}
+			}
+		}
+		expect(markers).toEqual([{ type: "ephemeral", ttl: "1h" }]);
+	});
+
+	test("keeps auto-injection when caller markers do not use a 1h ttl", async () => {
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "system", content: longContent },
+				{ role: "user", content: "Hello!" },
+				{ role: "assistant", content: "Hi!" },
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "What should I do next?",
+							cache_control: { type: "ephemeral" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			1024,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		)) as AnthropicRequestBody;
+
+		// ttl-less caller markers are all 5m, same as the heuristics — no
+		// ordering conflict is possible, so the existing behavior is preserved:
+		// long system prompt and turn boundary still get auto markers.
+		expect(getCacheControl((requestBody.system as unknown[])[0])).toEqual({
+			type: "ephemeral",
+		});
+
+		const boundaryMsg = requestBody.messages[1];
+		expect(boundaryMsg.role).toBe("assistant");
+		expect(getCacheControl((boundaryMsg.content as unknown[])[0])).toEqual({
+			type: "ephemeral",
+		});
+
+		const explicitMsg = requestBody.messages[2];
+		expect(getCacheControl((explicitMsg.content as unknown[])[0])).toEqual({
+			type: "ephemeral",
+		});
+	});
 });
 
 describe("prepareRequestBody - OpenAI image generation", () => {
@@ -1568,6 +1683,109 @@ describe("prepareRequestBody - AWS Bedrock", () => {
 		expect(requestBody.messages[0].content).toEqual([
 			{ text: "What should I do next?" },
 			{ cachePoint: { type: "default", ttl: "5m" } },
+		]);
+	});
+
+	test("suppresses heuristic cachePoints when caller supplies a 1h ttl marker in messages", async () => {
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-sonnet-4-5",
+			null,
+			"anthropic.claude-sonnet-4-5-20250929-v1:0",
+			[
+				{ role: "system", content: longContent },
+				{ role: "user", content: "Hello!" },
+				{ role: "assistant", content: "Hi!" },
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "What should I do next?",
+							cache_control: { type: "ephemeral", ttl: "1h" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		)) as any;
+
+		// No heuristic cachePoint on the long system prompt and no turn-boundary
+		// cachePoint — a default-ttl (5m) point would precede the caller's 1h
+		// point, which Bedrock rejects.
+		expect(requestBody.system).toEqual([{ text: longContent }]);
+		expect(requestBody.messages[1]).toEqual({
+			role: "assistant",
+			content: [{ text: "Hi!" }],
+		});
+		expect(requestBody.messages[2].content).toEqual([
+			{ text: "What should I do next?" },
+			{ cachePoint: { type: "default", ttl: "1h" } },
+		]);
+	});
+
+	test("keeps heuristic cachePoints when a caller 1h ttl is downgraded to 5m", async () => {
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-3-7-sonnet",
+			null,
+			"anthropic.claude-3-7-sonnet-20250219-v1:0",
+			[
+				{ role: "system", content: longContent },
+				{ role: "user", content: "Hello!" },
+				{ role: "assistant", content: "Hi!" },
+				{
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: "What should I do next?",
+							cache_control: { type: "ephemeral", ttl: "1h" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+		)) as any;
+
+		// claude-3-7-sonnet has no 1h TTL on Bedrock, so the caller's marker is
+		// downgraded to a default (5m) cachePoint. With every point at 5m there
+		// is no ordering conflict, so the heuristics stay active.
+		expect(requestBody.system).toEqual([
+			{ text: longContent },
+			{ cachePoint: { type: "default" } },
+		]);
+		expect(requestBody.messages[1]).toEqual({
+			role: "assistant",
+			content: [{ text: "Hi!" }, { cachePoint: { type: "default" } }],
+		});
+		expect(requestBody.messages[2].content).toEqual([
+			{ text: "What should I do next?" },
+			{ cachePoint: { type: "default" } },
 		]);
 	});
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1657,6 +1657,25 @@ export async function prepareRequestBody(
 				(m) => m.role !== "system",
 			);
 
+			// Anthropic requires longer-TTL cache breakpoints to come before
+			// shorter ones (processing order: tools, system, messages). The
+			// gateway's heuristics inject ttl-less markers (5m default), so when
+			// the caller placed an explicit ttl:"1h" marker in the messages, any
+			// auto-injected marker would land before it and Anthropic rejects the
+			// request ("a ttl='1h' cache_control block must not come after a
+			// ttl='5m' cache_control block"). Defer entirely to the caller's
+			// caching strategy in that case. A 1h marker only on system is safe:
+			// message-level 5m markers after it satisfy the ordering.
+			const callerUses1hTtlInMessages = nonSystemMessages.some(
+				(m) =>
+					Array.isArray(m.content) &&
+					m.content.some(
+						(part) => isTextContent(part) && part.cache_control?.ttl === "1h",
+					),
+			);
+			const autoCacheControlEnabled =
+				providerCacheControlEnabled && !callerUses1hTtlInMessages;
+
 			// Build the system field with cache_control for long prompts
 			// Track cache_control usage across system and user messages (max 4 total per Anthropic's limit)
 			let systemCacheControlCount = 0;
@@ -1742,7 +1761,7 @@ export async function prepareRequestBody(
 						}
 
 						const shouldCache =
-							providerCacheControlEnabled &&
+							autoCacheControlEnabled &&
 							text.length >= minCacheableChars &&
 							systemCacheControlCount < maxCacheControlBlocks;
 
@@ -1783,7 +1802,7 @@ export async function prepareRequestBody(
 				userPlan,
 				systemCacheControlCount, // Pass count to respect the 4 block limit
 				minCacheableChars, // Model-specific minimum cacheable characters
-				providerCacheControlEnabled,
+				autoCacheControlEnabled,
 			);
 
 			// Transform tools from OpenAI format to Anthropic format
@@ -1968,6 +1987,25 @@ export async function prepareRequestBody(
 				(m) => m.role !== "system",
 			);
 
+			// Mirror the Anthropic branch: Bedrock enforces the same
+			// longer-TTL-first ordering for cachePoints, and heuristic injection
+			// emits ttl-less (5m default) points. When the caller placed an
+			// explicit ttl:"1h" marker in the messages — and the model actually
+			// supports 1h, i.e. the marker won't be downgraded to 5m — suppress
+			// heuristic cachePoint injection so an auto-added 5m point can't
+			// precede the caller's 1h point.
+			const bedrockCallerUses1hTtlInMessages =
+				bedrockSupports1hTtl &&
+				bedrockNonSystemMessages.some(
+					(m) =>
+						Array.isArray(m.content) &&
+						m.content.some(
+							(part) => isTextContent(part) && part.cache_control?.ttl === "1h",
+						),
+				);
+			const bedrockAutoCachePointEnabled =
+				providerCacheControlEnabled && !bedrockCallerUses1hTtlInMessages;
+
 			// Build the system field with cachePoint for long prompts.
 			// AWS Bedrock uses "cachePoint" (not "cacheControl") as a SEPARATE
 			// content block after the text block. Honor caller-supplied
@@ -2019,7 +2057,7 @@ export async function prepareRequestBody(
 					}
 
 					const shouldHeuristicCache =
-						providerCacheControlEnabled &&
+						bedrockAutoCachePointEnabled &&
 						!callerSetBedrockCacheControl &&
 						block.text.length >= bedrockMinCacheableChars &&
 						bedrockCacheControlCount < bedrockMaxCacheControlBlocks;
@@ -2122,7 +2160,7 @@ export async function prepareRequestBody(
 
 						// Add cachePoint as separate block for long user messages (model-specific threshold)
 						const shouldCache =
-							providerCacheControlEnabled &&
+							bedrockAutoCachePointEnabled &&
 							msg.content.length >= bedrockMinCacheableChars &&
 							bedrockCacheControlCount < bedrockMaxCacheControlBlocks;
 
@@ -2152,7 +2190,7 @@ export async function prepareRequestBody(
 									// Add cachePoint as separate block for long text parts
 									// (model-specific threshold)
 									const shouldCache =
-										providerCacheControlEnabled &&
+										bedrockAutoCachePointEnabled &&
 										part.text.length >= bedrockMinCacheableChars &&
 										bedrockCacheControlCount < bedrockMaxCacheControlBlocks;
 
@@ -2180,7 +2218,7 @@ export async function prepareRequestBody(
 			// the entire conversation prefix (all prior turns) so only the
 			// newest user message is uncached. This mirrors the Anthropic
 			// turn-boundary logic in transformAnthropicMessages.
-			if (providerCacheControlEnabled && bedrockMessages.length >= 3) {
+			if (bedrockAutoCachePointEnabled && bedrockMessages.length >= 3) {
 				let lastUserIdx = -1;
 				for (let i = bedrockMessages.length - 1; i >= 0; i--) {
 					if (bedrockMessages[i].role === "user") {


### PR DESCRIPTION
Fixes Anthropic-compatible requests failing with `a ttl='1h' cache_control block must not come after a ttl='5m' cache_control block` — the gateway's auto-injected cache markers are ttl-less (5m default) and landed before caller-supplied 1h markers, which Anthropic rejects since longer TTLs must come first. When the messages contain an explicit `ttl: "1h"` marker, the Anthropic and AWS Bedrock branches of `prepareRequestBody` now skip all heuristic marker injection (long-system, long-block, and turn-boundary) and forward the caller's markers verbatim; ttl-less/5m caller markers keep coexisting with the heuristics, as do Bedrock models that downgrade 1h to 5m. Adds unit tests for both branches plus an e2e regression test that 400s on the old code and passes now — verified against the live Anthropic API with pure `ephemeral_1h_input_tokens` cache writes and successful 1h cache reads on follow-up requests. Also documents the marker-mixing rules on the provider-cache-control docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced cache control to respect user-provided explicit cache markers with 1h TTL configuration.

* **Documentation**
  * Added guidance on combining explicit cache control markers with automatic cache injection, including ordering rules and compatibility notes.

* **Tests**
  * Added regression tests verifying proper handling of user-provided cache control markers across supported LLM providers.
  * Expanded test coverage for cache control ordering scenarios to prevent marker conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->