### PR TITLE
chore(models): deactivate Nebius legacy models

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -181,6 +181,7 @@ export const deepseekModels = [
 			{
 				providerId: "nebius",
 				externalId: "deepseek-ai/DeepSeek-V3.2",
+				deactivatedAt: new Date("2026-06-22"),
 				inputPrice: "0.3e-6",
 				outputPrice: "0.45e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -242,6 +242,7 @@ export const moonshotModels = [
 				// Streaming tool calls and response_format: json_object are unreliable on Nebius
 				stability: "unstable",
 				externalId: "moonshotai/Kimi-K2.5",
+				deactivatedAt: new Date("2026-06-22"),
 				inputPrice: "0.5e-6",
 				cachedInputPrice: "0.02e-6",
 				outputPrice: "2.5e-6",

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -229,6 +229,7 @@ export const zaiModels = [
 			{
 				providerId: "nebius",
 				externalId: "zai-org/GLM-5",
+				deactivatedAt: new Date("2026-06-22"),
 				inputPrice: "1.0e-6",
 				outputPrice: "3.2e-6",
 				requestPrice: "0",


### PR DESCRIPTION
## Summary

Nebius notified us that several legacy model APIs will be **disabled on 2026-06-22**. This marks the affected Nebius provider mappings with `deactivatedAt: new Date("2026-06-22")` — the established convention in this repo — so the gateway stops routing to them after that date while preserving the mappings (and their pricing) for historical cost lookups.

## Affected Nebius mappings

Of the models in Nebius's notice, only three are actually carried by this gateway as Nebius mappings:

- `deepseek-ai/DeepSeek-V3.2` (`deepseek.ts`)
- `moonshotai/Kimi-K2.5` (`moonshot.ts`)
- `zai-org/GLM-5` (`zai.ts`)

## Why the rest were not touched

The remaining entries in Nebius's notice are either:
- **`-fast` tier variants** (`DeepSeek-V3.2-fast`, `MiniMax-M2.5-fast`, `Kimi-K2.5-fast`, `gpt-oss-120b-fast`, `Qwen3-235B-A22B-Thinking-2507-fast`, `Qwen3-Next-80B-A3B-Thinking-fast`, `Qwen3.5-397B-A17B-fast`) — not carried here, and
- **models not offered via Nebius** (`PrimeIntellect/INTELLECT-3`).

The non-fast equivalents the gateway *does* carry on Nebius (`gpt-oss-120b`, `Qwen3-235B-A22B-Thinking-2507`, `MiniMax-M2.5`, etc.) are **not** in the deprecation notice and remain active.

## Verification

- `pnpm format` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model availability schedules for Nebius provider, setting deactivation dates of June 22, 2026 for DeepSeek V3.2, Kimi K2.5, and GLM-5 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->