### PR TITLE
perf(playground): lazy-load studio history media

### DIFF
--- a/apps/api/src/routes/playground.ts
+++ b/apps/api/src/routes/playground.ts
@@ -5,7 +5,7 @@ import { HTTPException } from "hono/http-exception";
 import { buildOrgHistoryFilter } from "@/utils/org-history-filter.js";
 import { getOrCreateChatOrg } from "@/utils/personal-org.js";
 
-import { db, tables, shortid, desc, eq, and } from "@llmgateway/db";
+import { db, tables, shortid, desc, eq, and, sql } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -191,6 +191,22 @@ const imageHistoryItemSchema = z.object({
 	models: z.array(imageModelResultSchema),
 });
 
+// Lightweight list representation: no base64 payloads. Full image data is
+// served per item by GET /image-history/{id} and the thumbnail endpoint.
+const imageHistoryListModelSchema = z.object({
+	modelId: z.string(),
+	modelName: z.string(),
+	imageCount: z.number(),
+	error: z.string().optional(),
+});
+
+const imageHistoryListItemSchema = z.object({
+	id: z.string(),
+	prompt: z.string(),
+	createdAt: z.string(),
+	models: z.array(imageHistoryListModelSchema),
+});
+
 const audioModelResultSchema = z.object({
 	modelId: z.string(),
 	modelName: z.string(),
@@ -215,21 +231,16 @@ const videoModelResultSchema = z.object({
 	error: z.string().optional(),
 });
 
-const videoHistoryItemSchema = z.object({
+// Lightweight list representation: frame/reference input images are not
+// inlined as base64. The client builds preview URLs from the boolean/count
+// flags pointing at GET /video-history/{id}/input-image/{index}.
+const videoHistoryListItemSchema = z.object({
 	id: z.string(),
 	prompt: z.string(),
 	createdAt: z.string(),
-	frameInputs: z
-		.object({
-			start: z
-				.object({ dataUrl: z.string(), mediaType: z.string() })
-				.nullable(),
-			end: z.object({ dataUrl: z.string(), mediaType: z.string() }).nullable(),
-		})
-		.nullable(),
-	referenceImages: z
-		.array(z.object({ dataUrl: z.string(), mediaType: z.string() }))
-		.nullable(),
+	hasStartFrame: z.boolean(),
+	hasEndFrame: z.boolean(),
+	referenceImageCount: z.number(),
 	models: z.array(videoModelResultSchema),
 });
 
@@ -247,11 +258,11 @@ const listImageHistory = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({ items: z.array(imageHistoryItemSchema) }),
+					schema: z.object({ items: z.array(imageHistoryListItemSchema) }),
 				},
 			},
 			description:
-				"List of image generation history for the authenticated user",
+				"List of image generation history for the authenticated user, without base64 image payloads",
 		},
 	},
 });
@@ -268,8 +279,36 @@ playground.openapi(listImageHistory, async (c) => {
 		organizationId,
 	);
 
+	// Project the models jsonb down to metadata in SQL so the base64 image
+	// payloads never leave Postgres for the list view.
 	const rows = await db
-		.select()
+		.select({
+			id: tables.playgroundImageHistory.id,
+			prompt: tables.playgroundImageHistory.prompt,
+			createdAt: tables.playgroundImageHistory.createdAt,
+			models: sql<
+				{
+					modelId: string;
+					modelName: string;
+					imageCount: number;
+					error: string | null;
+				}[]
+			>`(
+				select coalesce(
+					jsonb_agg(
+						jsonb_build_object(
+							'modelId', m.value ->> 'modelId',
+							'modelName', m.value ->> 'modelName',
+							'imageCount', coalesce(jsonb_array_length(m.value -> 'images'), 0),
+							'error', m.value ->> 'error'
+						)
+						order by m.ord
+					),
+					'[]'::jsonb
+				)
+				from jsonb_array_elements(${tables.playgroundImageHistory.models}) with ordinality as m(value, ord)
+			)`,
+		})
 		.from(tables.playgroundImageHistory)
 		.where(and(eq(tables.playgroundImageHistory.userId, user.id), orgFilter))
 		.orderBy(desc(tables.playgroundImageHistory.createdAt));
@@ -279,10 +318,92 @@ playground.openapi(listImageHistory, async (c) => {
 			id: row.id,
 			prompt: row.prompt,
 			createdAt: row.createdAt.toISOString(),
-			inputImages: row.inputImages ?? null,
-			models: row.models,
+			models: row.models.map((m) => ({
+				modelId: m.modelId,
+				modelName: m.modelName,
+				imageCount: m.imageCount,
+				...(m.error ? { error: m.error } : {}),
+			})),
 		})),
 	});
+});
+
+// ── GET /image-history/:id ───────────────────────────────────────────────────
+
+const getImageHistoryItem = createRoute({
+	method: "get",
+	path: "/image-history/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ item: imageHistoryItemSchema }),
+				},
+			},
+			description: "Full image history item including base64 image data",
+		},
+	},
+});
+
+playground.openapi(getImageHistoryItem, async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.valid("param");
+
+	const row = await db.query.playgroundImageHistory.findFirst({
+		where: { id: { eq: id }, userId: { eq: user.id } },
+	});
+
+	if (!row) {
+		throw new HTTPException(404, { message: "Not found" });
+	}
+
+	return c.json({
+		item: {
+			id: row.id,
+			prompt: row.prompt,
+			createdAt: row.createdAt.toISOString(),
+			inputImages: row.inputImages ?? null,
+			models: row.models,
+		},
+	});
+});
+
+// ── GET /image-history/:id/thumbnail ─────────────────────────────────────────
+// Serves the first generated image as binary for sidebar thumbnails so the
+// list endpoint can stay free of base64 payloads. Items are immutable, hence
+// the aggressive cache header.
+
+playground.get("/image-history/:id/thumbnail", async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const id = c.req.param("id");
+
+	const row = await db.query.playgroundImageHistory.findFirst({
+		where: { id: { eq: id }, userId: { eq: user.id } },
+	});
+
+	if (!row) {
+		throw new HTTPException(404, { message: "Not found" });
+	}
+
+	const image = row.models.flatMap((m) => m.images)[0];
+	if (!image) {
+		throw new HTTPException(404, { message: "No image available" });
+	}
+
+	c.header("Content-Type", image.mediaType);
+	c.header("Cache-Control", "private, max-age=31536000, immutable");
+	return c.body(Buffer.from(image.base64, "base64"));
 });
 
 // ── POST /image-history ──────────────────────────────────────────────────────
@@ -310,10 +431,10 @@ const saveImageHistory = createRoute({
 		201: {
 			content: {
 				"application/json": {
-					schema: z.object({ item: imageHistoryItemSchema }),
+					schema: z.object({ item: imageHistoryListItemSchema }),
 				},
 			},
-			description: "Saved image history item",
+			description: "Saved image history item (lightweight, no image data)",
 		},
 	},
 });
@@ -335,7 +456,11 @@ playground.openapi(saveImageHistory, async (c) => {
 			inputImages: body.inputImages ?? null,
 			models: body.models,
 		})
-		.returning();
+		.returning({
+			id: tables.playgroundImageHistory.id,
+			prompt: tables.playgroundImageHistory.prompt,
+			createdAt: tables.playgroundImageHistory.createdAt,
+		});
 
 	return c.json(
 		{
@@ -343,8 +468,12 @@ playground.openapi(saveImageHistory, async (c) => {
 				id: row.id,
 				prompt: row.prompt,
 				createdAt: row.createdAt.toISOString(),
-				inputImages: row.inputImages ?? null,
-				models: row.models,
+				models: body.models.map((m) => ({
+					modelId: m.modelId,
+					modelName: m.modelName,
+					imageCount: m.images.length,
+					...(m.error ? { error: m.error } : {}),
+				})),
 			},
 		},
 		201,
@@ -413,10 +542,16 @@ const renameImageHistory = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({ item: imageHistoryItemSchema }),
+					schema: z.object({
+						item: z.object({
+							id: z.string(),
+							prompt: z.string(),
+							createdAt: z.string(),
+						}),
+					}),
 				},
 			},
-			description: "Updated image history item",
+			description: "Updated image history item (lightweight)",
 		},
 	},
 });
@@ -439,7 +574,11 @@ playground.openapi(renameImageHistory, async (c) => {
 				eq(tables.playgroundImageHistory.userId, user.id),
 			),
 		)
-		.returning();
+		.returning({
+			id: tables.playgroundImageHistory.id,
+			prompt: tables.playgroundImageHistory.prompt,
+			createdAt: tables.playgroundImageHistory.createdAt,
+		});
 
 	if (!row) {
 		throw new HTTPException(404, { message: "Not found" });
@@ -450,8 +589,6 @@ playground.openapi(renameImageHistory, async (c) => {
 			id: row.id,
 			prompt: row.prompt,
 			createdAt: row.createdAt.toISOString(),
-			inputImages: row.inputImages ?? null,
-			models: row.models,
 		},
 	});
 });
@@ -691,11 +828,11 @@ const listVideoHistory = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({ items: z.array(videoHistoryItemSchema) }),
+					schema: z.object({ items: z.array(videoHistoryListItemSchema) }),
 				},
 			},
 			description:
-				"List of video generation history for the authenticated user",
+				"List of video generation history for the authenticated user, without base64 input image payloads",
 		},
 	},
 });
@@ -712,8 +849,21 @@ playground.openapi(listVideoHistory, async (c) => {
 		organizationId,
 	);
 
+	// frameInputs/referenceImages hold base64 data URLs; only presence flags
+	// leave Postgres for the list view. The client builds preview URLs against
+	// GET /video-history/{id}/input-image/{index} from these flags.
 	const rows = await db
-		.select()
+		.select({
+			id: tables.playgroundVideoHistory.id,
+			prompt: tables.playgroundVideoHistory.prompt,
+			createdAt: tables.playgroundVideoHistory.createdAt,
+			models: tables.playgroundVideoHistory.models,
+			// jsonb_typeof guards: stored frame inputs use explicit JSON nulls
+			// ({"start": null}), which `is not null` would misreport as present.
+			hasStartFrame: sql<boolean>`coalesce(jsonb_typeof(${tables.playgroundVideoHistory.frameInputs} -> 'start') = 'object', false)`,
+			hasEndFrame: sql<boolean>`coalesce(jsonb_typeof(${tables.playgroundVideoHistory.frameInputs} -> 'end') = 'object', false)`,
+			referenceImageCount: sql<number>`case when jsonb_typeof(${tables.playgroundVideoHistory.referenceImages}) = 'array' then jsonb_array_length(${tables.playgroundVideoHistory.referenceImages}) else 0 end`,
+		})
 		.from(tables.playgroundVideoHistory)
 		.where(and(eq(tables.playgroundVideoHistory.userId, user.id), orgFilter))
 		.orderBy(desc(tables.playgroundVideoHistory.createdAt));
@@ -723,11 +873,57 @@ playground.openapi(listVideoHistory, async (c) => {
 			id: row.id,
 			prompt: row.prompt,
 			createdAt: row.createdAt.toISOString(),
-			frameInputs: row.frameInputs ?? null,
-			referenceImages: row.referenceImages ?? null,
+			hasStartFrame: row.hasStartFrame,
+			hasEndFrame: row.hasEndFrame,
+			referenceImageCount: row.referenceImageCount,
 			models: row.models,
 		})),
 	});
+});
+
+// ── GET /video-history/:id/input-image/:index ────────────────────────────────
+// Serves frame/reference input images as binary for history previews. Index
+// enumerates [start frame, end frame, ...reference images] in order, matching
+// the flags returned by the list endpoint.
+
+playground.get("/video-history/:id/input-image/:index", async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const id = c.req.param("id");
+	const index = Number(c.req.param("index"));
+	if (!Number.isInteger(index) || index < 0) {
+		throw new HTTPException(400, { message: "Invalid index" });
+	}
+
+	const row = await db.query.playgroundVideoHistory.findFirst({
+		where: { id: { eq: id }, userId: { eq: user.id } },
+	});
+
+	if (!row) {
+		throw new HTTPException(404, { message: "Not found" });
+	}
+
+	const inputs = [
+		...(row.frameInputs?.start ? [row.frameInputs.start] : []),
+		...(row.frameInputs?.end ? [row.frameInputs.end] : []),
+		...(row.referenceImages ?? []),
+	];
+	const input = inputs[index];
+	if (!input) {
+		throw new HTTPException(404, { message: "No input image available" });
+	}
+
+	if (!input.dataUrl.startsWith("data:")) {
+		return c.redirect(input.dataUrl);
+	}
+
+	const base64 = input.dataUrl.split(",")[1] ?? "";
+	c.header("Content-Type", input.mediaType);
+	c.header("Cache-Control", "private, max-age=31536000, immutable");
+	return c.body(Buffer.from(base64, "base64"));
 });
 
 // ── POST /video-history ──────────────────────────────────────────────────────
@@ -765,10 +961,10 @@ const saveVideoHistory = createRoute({
 		201: {
 			content: {
 				"application/json": {
-					schema: z.object({ item: videoHistoryItemSchema }),
+					schema: z.object({ item: videoHistoryListItemSchema }),
 				},
 			},
-			description: "Saved video history item",
+			description: "Saved video history item (lightweight, no input images)",
 		},
 	},
 });
@@ -791,7 +987,11 @@ playground.openapi(saveVideoHistory, async (c) => {
 			referenceImages: body.referenceImages ?? null,
 			models: body.models,
 		})
-		.returning();
+		.returning({
+			id: tables.playgroundVideoHistory.id,
+			prompt: tables.playgroundVideoHistory.prompt,
+			createdAt: tables.playgroundVideoHistory.createdAt,
+		});
 
 	return c.json(
 		{
@@ -799,9 +999,10 @@ playground.openapi(saveVideoHistory, async (c) => {
 				id: row.id,
 				prompt: row.prompt,
 				createdAt: row.createdAt.toISOString(),
-				frameInputs: row.frameInputs ?? null,
-				referenceImages: row.referenceImages ?? null,
-				models: row.models,
+				hasStartFrame: !!body.frameInputs?.start,
+				hasEndFrame: !!body.frameInputs?.end,
+				referenceImageCount: body.referenceImages?.length ?? 0,
+				models: body.models,
 			},
 		},
 		201,
@@ -870,10 +1071,16 @@ const renameVideoHistory = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({ item: videoHistoryItemSchema }),
+					schema: z.object({
+						item: z.object({
+							id: z.string(),
+							prompt: z.string(),
+							createdAt: z.string(),
+						}),
+					}),
 				},
 			},
-			description: "Updated video history item",
+			description: "Updated video history item (lightweight)",
 		},
 	},
 });
@@ -896,7 +1103,11 @@ playground.openapi(renameVideoHistory, async (c) => {
 				eq(tables.playgroundVideoHistory.userId, user.id),
 			),
 		)
-		.returning();
+		.returning({
+			id: tables.playgroundVideoHistory.id,
+			prompt: tables.playgroundVideoHistory.prompt,
+			createdAt: tables.playgroundVideoHistory.createdAt,
+		});
 
 	if (!row) {
 		throw new HTTPException(404, { message: "Not found" });
@@ -907,9 +1118,6 @@ playground.openapi(renameVideoHistory, async (c) => {
 			id: row.id,
 			prompt: row.prompt,
 			createdAt: row.createdAt.toISOString(),
-			frameInputs: row.frameInputs ?? null,
-			referenceImages: row.referenceImages ?? null,
-			models: row.models,
 		},
 	});
 });

--- a/apps/playground/src/components/playground/image-gallery.tsx
+++ b/apps/playground/src/components/playground/image-gallery.tsx
@@ -196,7 +196,7 @@ function SingleModeItem({
 					<p className="text-sm text-destructive">{model.error}</p>
 				</div>
 			) : model.images.length === 0 && model.isLoading ? (
-				<LoadingSkeleton count={1} />
+				<LoadingSkeleton count={Math.max(1, model.imageCount ?? 1)} />
 			) : (
 				<div
 					className={`grid gap-3 ${
@@ -281,7 +281,7 @@ function ComparisonModeItem({
 								<p className="text-sm text-destructive">{model.error}</p>
 							</div>
 						) : model.images.length === 0 && model.isLoading ? (
-							<LoadingSkeleton count={1} />
+							<LoadingSkeleton count={Math.max(1, model.imageCount ?? 1)} />
 						) : (
 							<div
 								className={`grid gap-2 ${

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -15,9 +15,11 @@ import { Button } from "@/components/ui/button";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import {
 	useImageHistory,
+	useImageHistoryItem,
 	useSaveImageHistory,
 } from "@/hooks/usePlaygroundHistory";
 import { useUser } from "@/hooks/useUser";
+import { useAppConfig } from "@/lib/config";
 import { getModelImageConfig } from "@/lib/image-gen";
 import { mapModels } from "@/lib/mapmodels";
 import {
@@ -52,6 +54,7 @@ export default function ImagePageClient({
 }: ImagePageClientProps) {
 	const { user, isLoading: isUserLoading } = useUser();
 	const posthog = usePostHog();
+	const config = useAppConfig();
 	const pathname = usePathname();
 	const router = useRouter();
 	const searchParams = useSearchParams();
@@ -179,29 +182,66 @@ export default function ImagePageClient({
 	const savedItemIdsRef = useRef<Set<string>>(new Set());
 	const pendingSaveRef = useRef<{ localId: string; dbId: string } | null>(null);
 
+	// The history list is metadata-only (no base64). Image data is fetched per
+	// item below when one is selected.
 	const galleryItems = useMemo<GalleryItem[]>(() => {
 		const historical: GalleryItem[] = (historyData?.items ?? []).map(
 			(item) => ({
 				id: item.id,
 				prompt: item.prompt,
 				timestamp: new Date(item.createdAt).getTime(),
-				inputImages: item.inputImages ?? undefined,
-				models: item.models.map((m) => ({ ...m, isLoading: false })),
+				thumbnailUrl: item.models.some((m) => m.imageCount > 0)
+					? `${config.apiUrl}/playground/image-history/${item.id}/thumbnail`
+					: null,
+				models: item.models.map((m) => ({
+					modelId: m.modelId,
+					modelName: m.modelName,
+					images: [],
+					imageCount: m.imageCount,
+					error: m.error,
+					isLoading: false,
+				})),
 			}),
 		);
 		return [...activeItems, ...historical];
-	}, [activeItems, historyData]);
+	}, [activeItems, historyData, config.apiUrl]);
+
+	const { data: selectedItemDetail } = useImageHistoryItem(
+		activeItems.length === 0 ? selectedItemId : null,
+	);
 
 	const displayItems = useMemo<GalleryItem[]>(() => {
 		if (activeItems.length > 0) {
 			return activeItems;
 		}
-		if (selectedItemId) {
-			const item = galleryItems.find((i) => i.id === selectedItemId);
-			return item ? [item] : [];
+		if (!selectedItemId) {
+			return [];
+		}
+		const detail = selectedItemDetail?.item;
+		if (detail && detail.id === selectedItemId) {
+			return [
+				{
+					id: detail.id,
+					prompt: detail.prompt,
+					timestamp: new Date(detail.createdAt).getTime(),
+					inputImages: detail.inputImages ?? undefined,
+					models: detail.models.map((m) => ({ ...m, isLoading: false })),
+				},
+			];
+		}
+		// Detail still loading: render the metadata item with per-model
+		// skeletons so the gallery shows progress instead of a blank page.
+		const light = galleryItems.find((i) => i.id === selectedItemId);
+		if (light) {
+			return [
+				{
+					...light,
+					models: light.models.map((m) => ({ ...m, isLoading: !m.error })),
+				},
+			];
 		}
 		return [];
-	}, [activeItems, selectedItemId, galleryItems]);
+	}, [activeItems, selectedItemId, selectedItemDetail, galleryItems]);
 
 	// Auto-save completed active items to DB then remove from local state
 	useEffect(() => {

--- a/apps/playground/src/components/playground/image-sidebar.tsx
+++ b/apps/playground/src/components/playground/image-sidebar.tsx
@@ -213,9 +213,11 @@ function ImageHistoryRowComponent({
 	const isActive = currentItemId === item.id;
 	const isSaved = item.models.every((m) => !m.isLoading);
 	const firstImage = item.models[0]?.images[0];
-	const thumbnailSrc = firstImage
-		? `data:${firstImage.mediaType};base64,${firstImage.base64}`
-		: null;
+	const thumbnailSrc =
+		item.thumbnailUrl ??
+		(firstImage
+			? `data:${firstImage.mediaType};base64,${firstImage.base64}`
+			: null);
 
 	return (
 		<div {...ariaAttributes} style={style}>
@@ -246,6 +248,7 @@ function ImageHistoryRowComponent({
 									<img
 										src={thumbnailSrc}
 										alt="Generated image thumbnail"
+										loading="lazy"
 										className="h-8 w-8 shrink-0 rounded border object-cover mt-0.5"
 									/>
 								)}

--- a/apps/playground/src/components/playground/video-gallery.tsx
+++ b/apps/playground/src/components/playground/video-gallery.tsx
@@ -194,19 +194,7 @@ function EmptyState({
 }
 
 function VideoInputThumbnails({ item }: { item: VideoGalleryItem }) {
-	const images: { src: string; label: string }[] = [];
-
-	if (item.frameInputs?.start) {
-		images.push({ src: item.frameInputs.start.dataUrl, label: "First frame" });
-	}
-	if (item.frameInputs?.end) {
-		images.push({ src: item.frameInputs.end.dataUrl, label: "Last frame" });
-	}
-	if (item.referenceImages) {
-		item.referenceImages.forEach((ref, i) => {
-			images.push({ src: ref.dataUrl, label: `Reference ${i + 1}` });
-		});
-	}
+	const images = item.inputPreviews ?? [];
 
 	if (images.length === 0) {
 		return null;
@@ -220,6 +208,7 @@ function VideoInputThumbnails({ item }: { item: VideoGalleryItem }) {
 					src={img.src}
 					alt={img.label}
 					title={img.label}
+					loading="lazy"
 					className="h-6 w-6 rounded border object-cover"
 				/>
 			))}

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -19,6 +19,7 @@ import {
 	useVideoHistory,
 } from "@/hooks/usePlaygroundHistory";
 import { useUser } from "@/hooks/useUser";
+import { useAppConfig } from "@/lib/config";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 import { mapModels } from "@/lib/mapmodels";
 import {
@@ -69,6 +70,7 @@ export default function VideoPageClient({
 }: VideoPageClientProps) {
 	const { user, isLoading: isUserLoading } = useUser();
 	const posthog = usePostHog();
+	const config = useAppConfig();
 	const fetchClient = useFetchClient();
 	const api = useApi();
 	const pathname = usePathname();
@@ -152,27 +154,52 @@ export default function VideoPageClient({
 	const savedItemIdsRef = useRef<Set<string>>(new Set());
 	const pendingSaveRef = useRef<{ localId: string; dbId: string } | null>(null);
 
+	// The history list carries no base64 input images, only presence flags.
+	// Previews are lazily loaded binary endpoints, indexed in the same
+	// [start, end, ...references] order the API serves them in.
 	const galleryItems = useMemo<VideoGalleryItem[]>(() => {
 		const historical: VideoGalleryItem[] = (historyData?.items ?? []).map(
-			(item) => ({
-				id: item.id,
-				prompt: item.prompt,
-				timestamp: new Date(item.createdAt).getTime(),
-				frameInputs: item.frameInputs ?? undefined,
-				referenceImages: item.referenceImages ?? undefined,
-				models: item.models.map((m) => ({
-					modelId: m.modelId,
-					modelName: m.modelName,
-					job: null,
-					videoUrl: m.videoUrl,
-					expiresAt: m.expiresAt ?? null,
-					error: m.error,
-					isLoading: false,
-				})),
-			}),
+			(item) => {
+				const inputPreviews: { src: string; label: string }[] = [];
+				const inputImageUrl = (index: number) =>
+					`${config.apiUrl}/playground/video-history/${item.id}/input-image/${index}`;
+				if (item.hasStartFrame) {
+					inputPreviews.push({
+						src: inputImageUrl(inputPreviews.length),
+						label: "First frame",
+					});
+				}
+				if (item.hasEndFrame) {
+					inputPreviews.push({
+						src: inputImageUrl(inputPreviews.length),
+						label: "Last frame",
+					});
+				}
+				for (let i = 0; i < item.referenceImageCount; i++) {
+					inputPreviews.push({
+						src: inputImageUrl(inputPreviews.length),
+						label: `Reference ${i + 1}`,
+					});
+				}
+				return {
+					id: item.id,
+					prompt: item.prompt,
+					timestamp: new Date(item.createdAt).getTime(),
+					inputPreviews,
+					models: item.models.map((m) => ({
+						modelId: m.modelId,
+						modelName: m.modelName,
+						job: null,
+						videoUrl: m.videoUrl,
+						expiresAt: m.expiresAt ?? null,
+						error: m.error,
+						isLoading: false,
+					})),
+				};
+			},
 		);
 		return [...activeItems, ...historical];
-	}, [activeItems, historyData]);
+	}, [activeItems, historyData, config.apiUrl]);
 
 	const displayItems = useMemo<VideoGalleryItem[]>(() => {
 		if (activeItems.length > 0) {
@@ -617,6 +644,18 @@ export default function VideoPageClient({
 					frameInputs.start || frameInputs.end ? { ...frameInputs } : undefined,
 				referenceImages:
 					referenceImages.length > 0 ? [...referenceImages] : undefined,
+				inputPreviews: [
+					...(frameInputs.start
+						? [{ src: frameInputs.start.dataUrl, label: "First frame" }]
+						: []),
+					...(frameInputs.end
+						? [{ src: frameInputs.end.dataUrl, label: "Last frame" }]
+						: []),
+					...referenceImages.map((ref, i) => ({
+						src: ref.dataUrl,
+						label: `Reference ${i + 1}`,
+					})),
+				],
 				models: modelsToGenerate.map((modelId) => ({
 					modelId,
 					modelName: getModelName(modelId),

--- a/apps/playground/src/components/playground/video-sidebar.tsx
+++ b/apps/playground/src/components/playground/video-sidebar.tsx
@@ -172,19 +172,7 @@ function EditVideoPromptInput({
 }
 
 function HistoryThumbnails({ item }: { item: VideoGalleryItem }) {
-	const images: { src: string; label: string }[] = [];
-
-	if (item.frameInputs?.start) {
-		images.push({ src: item.frameInputs.start.dataUrl, label: "First" });
-	}
-	if (item.frameInputs?.end) {
-		images.push({ src: item.frameInputs.end.dataUrl, label: "Last" });
-	}
-	if (item.referenceImages) {
-		for (const ref of item.referenceImages) {
-			images.push({ src: ref.dataUrl, label: "Ref" });
-		}
-	}
+	const images = item.inputPreviews ?? [];
 
 	if (images.length === 0) {
 		return null;
@@ -198,6 +186,7 @@ function HistoryThumbnails({ item }: { item: VideoGalleryItem }) {
 					src={img.src}
 					alt={img.label}
 					title={img.label}
+					loading="lazy"
 					className="h-5 w-5 rounded border object-cover"
 				/>
 			))}

--- a/apps/playground/src/hooks/usePlaygroundHistory.ts
+++ b/apps/playground/src/hooks/usePlaygroundHistory.ts
@@ -12,11 +12,42 @@ export function useImageHistory(enabled = true, organizationId?: string) {
 	);
 }
 
+// Full item including base64 image data, fetched only when the item is
+// actually viewed. Items are immutable apart from prompt renames (which
+// invalidate this query), so the data never goes stale.
+export function useImageHistoryItem(id: string | null) {
+	const api = useApi();
+	return api.useQuery(
+		"get",
+		"/playground/image-history/{id}",
+		{ params: { path: { id: id ?? "" } } },
+		{ enabled: !!id, staleTime: Infinity },
+	);
+}
+
 export function useSaveImageHistory() {
 	const queryClient = useQueryClient();
 	const api = useApi();
 	return api.useMutation("post", "/playground/image-history", {
-		onSuccess: () => {
+		onSuccess: (data, variables) => {
+			// Seed the detail cache from the request body so selecting the
+			// just-saved item doesn't re-download images we already have.
+			if (variables?.body) {
+				queryClient.setQueryData(
+					api.queryOptions("get", "/playground/image-history/{id}", {
+						params: { path: { id: data.item.id } },
+					}).queryKey,
+					{
+						item: {
+							id: data.item.id,
+							prompt: data.item.prompt,
+							createdAt: data.item.createdAt,
+							inputImages: variables.body.inputImages ?? null,
+							models: variables.body.models,
+						},
+					},
+				);
+			}
 			void queryClient.invalidateQueries({
 				queryKey: api.queryOptions("get", "/playground/image-history").queryKey,
 			});
@@ -28,10 +59,18 @@ export function useRenameImageHistory() {
 	const queryClient = useQueryClient();
 	const api = useApi();
 	return api.useMutation("patch", "/playground/image-history/{id}", {
-		onSuccess: () => {
+		onSuccess: (_data, variables) => {
 			void queryClient.invalidateQueries({
 				queryKey: api.queryOptions("get", "/playground/image-history").queryKey,
 			});
+			const id = variables.params?.path?.id;
+			if (id) {
+				void queryClient.invalidateQueries({
+					queryKey: api.queryOptions("get", "/playground/image-history/{id}", {
+						params: { path: { id } },
+					}).queryKey,
+				});
+			}
 		},
 	});
 }
@@ -40,10 +79,18 @@ export function useDeleteImageHistory() {
 	const queryClient = useQueryClient();
 	const api = useApi();
 	return api.useMutation("delete", "/playground/image-history/{id}", {
-		onSuccess: () => {
+		onSuccess: (_data, variables) => {
 			void queryClient.invalidateQueries({
 				queryKey: api.queryOptions("get", "/playground/image-history").queryKey,
 			});
+			const id = variables.params?.path?.id;
+			if (id) {
+				queryClient.removeQueries({
+					queryKey: api.queryOptions("get", "/playground/image-history/{id}", {
+						params: { path: { id } },
+					}).queryKey,
+				});
+			}
 		},
 	});
 }

--- a/apps/playground/src/lib/image-gen.ts
+++ b/apps/playground/src/lib/image-gen.ts
@@ -12,10 +12,16 @@ export interface GalleryItem {
 	// switches organizations while the generation is in flight.
 	organizationId?: string;
 	inputImages?: { dataUrl: string; mediaType: string }[];
+	// Sidebar thumbnail URL for items loaded from the lightweight history
+	// list, which carries no base64 image data.
+	thumbnailUrl?: string | null;
 	models: {
 		modelId: string;
 		modelName: string;
 		images: GeneratedImage[];
+		// Number of stored images for history items whose image data hasn't
+		// been fetched yet (images stays empty until the detail query resolves).
+		imageCount?: number;
 		error?: string;
 		isLoading: boolean;
 	}[];

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -63,6 +63,10 @@ export interface VideoGalleryItem {
 	organizationId?: string;
 	frameInputs?: VideoFrameInputs;
 	referenceImages?: VideoInputImage[];
+	// Small preview images shown next to the prompt (frame/reference inputs).
+	// Data URLs for in-flight items, API input-image URLs for history items so
+	// the history list doesn't need to inline base64 payloads.
+	inputPreviews?: { src: string; label: string }[];
 	models: VideoGalleryModelResult[];
 }
 


### PR DESCRIPTION
## Summary

Image and Video Studio chat history took a long time to load because the history list endpoints returned **every generation the user ever made with all base64 payloads inlined** — no limit, no pagination — just to render the sidebar. A history of 50 image generations could mean hundreds of MB of JSON downloaded and parsed on every page open.

### API (`apps/api/src/routes/playground.ts`)

- `GET /playground/image-history` and `GET /playground/video-history` now return **metadata only** (id, prompt, createdAt, model names, image counts, input-image flags). The projection happens in SQL (jsonb), so base64 never leaves Postgres for list views.
- New `GET /playground/image-history/{id}` returns a single item's full image data, fetched only when the item is opened.
- New binary endpoints serve sidebar thumbnails lazily with `Cache-Control: immutable`:
  - `GET /playground/image-history/{id}/thumbnail` (first generated image)
  - `GET /playground/video-history/{id}/input-image/{index}` (frame/reference inputs, indexed `[start, end, ...references]`)
- POST/PATCH responses no longer echo full base64 payloads back.

### Playground (`apps/playground`)

- Sidebars use the lazy thumbnail URLs (`loading="lazy"` + browser cache; the lists are already virtualized, so only visible rows fetch).
- Opening a history item fetches its detail via a new `useImageHistoryItem` hook (`staleTime: Infinity` — items are immutable; renames invalidate). Per-model skeletons (sized by `imageCount`) show while loading.
- Saving a generation seeds the detail cache from the request body, so a just-created item doesn't re-download its own images.
- Existing DB rows work as-is — **no migration needed**.

## Notes

- Stored video `frameInputs` use explicit JSON nulls (`{"start": null}`), which a naive `is not null` check misreports as present — handled with `jsonb_typeof` guards (caught and verified against a real Postgres).
- The audio studio has the same problem (base64 audio inlined in its list endpoint) and could get the same treatment in a follow-up.

## Verification

- Full `pnpm build` passes; OpenAPI client regenerated.
- Exercised all new endpoints against local Postgres with real rows: list responses contain no base64; detail/thumbnail/input-image endpoints return correct data and cache headers; out-of-range indexes 404; foreign users' items are inaccessible (404) and absent from lists.
- `pnpm test:unit`: 1945 passed; the 1 failure (`packages/db/src/api-key-period-limit.spec.ts`, a calendar-month date assertion) is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image and video history now load faster with lightweight metadata displays
  * Thumbnail previews added for quick history item identification
  * Full image/video details fetch on-demand when selecting history items for improved responsiveness

* **Performance**
  * Lazy-loading enabled for thumbnails to reduce initial page load time
  * History lists now omit unnecessary data payloads, keeping data transfers minimal
  * Enhanced caching for faster repeat access to previously viewed items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->