### PR TITLE
docs: harden default Terms of Use and Privacy Policy

### DIFF
--- a/apps/ui/src/content/legal/privacy.md
+++ b/apps/ui/src/content/legal/privacy.md
@@ -114,7 +114,7 @@ If you belong to an organization:
 - Owners and Admins can view and manage member data and roles.
 - Access is limited by assigned roles (Owner, Admin, Developer, Restricted Access).
 
-You can manage permissions from the **Team Settings** page. Your organization is responsible for the personal data it processes through the Service and for the lawfulness of the Customer Data it submits.
+You can manage permissions from the **Team** page. Your organization is responsible for the personal data it processes through the Service and for the lawfulness of the Customer Data it submits.
 
 ---
 

--- a/apps/ui/src/content/legal/privacy.md
+++ b/apps/ui/src/content/legal/privacy.md
@@ -1,171 +1,200 @@
 ---
 id: "2"
 slug: "privacy"
-date: "2025-10-21"
+date: "2026-06-11"
 title: "Privacy Policy"
-description: "Read LLM Gateway’s Privacy Policy to understand how we collect, use, and protect your data. Learn about data retention, AI request storage, cookies, and your privacy rights when using our AI gateway platform."
+description: "Read LLM Gateway’s Privacy Policy to understand how we collect, use, share, and protect your data, our roles as controller and processor, AI provider routing, your GDPR and CCPA rights, data retention, and international transfers."
 ---
 
 # Privacy Policy
 
 **Effective Date:** October 21, 2025  
-**Last Updated:** June 5, 2026
+**Last Updated:** June 11, 2026
 
-LLM Gateway (“we”, “our”, or “us”) provides a unified AI gateway platform that enables users to connect, manage, and analyze AI models across multiple providers.  
-This Privacy Policy explains how we collect, use, and protect your personal information when you use our website, services, or applications (collectively, the “Service”).
+LLM Gateway (“we”, “our”, or “us”) provides a unified AI gateway platform that enables users to connect, manage, and analyze AI models across multiple providers. This Privacy Policy explains how we collect, use, share, and protect personal information when you use our website, APIs, SDKs, dashboards, and related services (collectively, the “Service”).
+
+This Policy is incorporated into and subject to our [Terms of Use](https://llmgateway.io/terms). Capitalized terms not defined here have the meaning given in the Terms.
 
 ---
 
-## 1. Information We Collect
+## 1. Our Role: Controller and Processor
+
+Our role depends on the data involved:
+
+- **As a controller.** For account, billing, website, and usage-analytics data, we determine the purposes and means of processing and act as the **data controller**.
+- **As a processor / service provider.** For the prompts, inputs, and content you submit to be routed to AI providers (“Customer Data”), we act as a **processor** (under GDPR) and a **service provider** (under the CCPA) on your behalf. You are responsible, as controller, for the Customer Data you submit and for having a lawful basis to submit it. Enterprise customers may enter into a separate **Data Processing Addendum (DPA)** that governs this processing; where a signed DPA exists, it controls over this Policy with respect to Customer Data.
+
+We **do not use Customer Data (your prompts, inputs, or the responses returned to you) to train any models.** Customer Data is processed solely to provide the Service and according to your retention settings.
+
+---
+
+## 2. Information We Collect
 
 ### a. Account Information
 
-When you register an account, we collect your **name**, **email address**, and **organization details**.  
-For Pro and Enterprise users, we may also collect billing details such as company name, address, and payment information (processed securely via **Stripe**).
+When you register, we collect your **name**, **email address**, and **organization details**. For paid and enterprise users, we may also collect billing details such as company name, address, and payment information (processed securely via **Stripe**).
 
 ### b. Usage Data
 
-We automatically collect technical and usage information when you use our Service, including:
+We automatically collect technical and usage information when you use the Service, including:
 
 - IP address, browser type, and device information
 - Log data, API requests, and timestamps
 - Model usage statistics (e.g., provider name, tokens used, latency, and cost)
 
-### c. AI Request Data
+### c. AI Request Data (Customer Data)
 
 Depending on your **data retention settings**, we may store:
 
 - **Retain All Data:** Request payloads and responses with metadata
-- **Metadata Only:** Usage, pricing, and provider statistics (excluding content)
+- **Metadata Only:** Usage, pricing, and provider statistics (excluding request content)
 
-You can configure this setting under **Settings → Policies** in your organization dashboard.
+You can configure this under **Settings → Policies** in your organization dashboard. Regardless of setting, request content is transmitted to the AI provider you select in order to fulfill the request (see [Data Sharing](#5-data-sharing)).
 
 ### d. Payment Information
 
-We use **Stripe** to process payments. Your payment data is handled by Stripe in accordance with their [Privacy Policy](https://stripe.com/privacy).  
-We do not store your credit card information.
+We use **Stripe** to process payments. Your payment data is handled by Stripe under their [Privacy Policy](https://stripe.com/privacy). **We do not store your full credit card information.**
 
 ### e. Cookies and Analytics
 
-We use cookies and similar technologies to analyze usage, improve functionality, and enhance user experience.  
-You can control cookie preferences through your browser settings.
+We use cookies and similar technologies to operate the site, analyze usage, and improve the Service. You can control cookies through your browser settings; some features may not function without them.
 
 ---
 
-## 2. How We Use Your Information
+## 3. Legal Bases for Processing (EU/UK)
+
+Where the GDPR or UK GDPR applies, we rely on the following legal bases:
+
+- **Performance of a contract** — to provide the Service, manage your account, and process payments.
+- **Legitimate interests** — to secure, maintain, analyze, and improve the Service and prevent abuse, balanced against your rights.
+- **Legal obligation** — to retain billing and tax records and respond to lawful requests.
+- **Consent** — for optional marketing communications and non-essential cookies, which you may withdraw at any time.
+
+---
+
+## 4. How We Use Your Information
 
 We use your data to:
 
-- Provide, maintain, and improve our Service
+- Provide, maintain, secure, and improve the Service
 - Authenticate and manage your account
-- Monitor API usage and enforce fair use policies
+- Monitor API usage and enforce our acceptable use and fair use policies
 - Process billing and send transactional emails
-- Improve model performance insights and product analytics
-- Communicate updates, promotions, or security alerts
+- Produce usage, performance, and product analytics
+- Communicate updates, security alerts, and (where permitted) promotions
+
+We do **not** sell your personal information, and we do **not** use Customer Data to train AI models.
 
 ---
 
-## 3. Data Retention
+## 5. Data Sharing
 
-We keep your personal data only as long as necessary for the purposes it was collected, or as required by law:
+We do **not sell** your personal information. We share limited data only as needed with:
 
-- **Account and profile data** (name, email, login credentials, API keys): retained while your account is active. When you delete your account, this data is deleted promptly.
-- **Usage logs** (request metadata, token counts, costs): the content of requests and responses is governed by your organization’s retention setting below; aggregated usage and cost metadata is retained for analytics and billing accuracy.
-  - **Retain All Data:** Saves request payloads and responses with metadata
-  - **Metadata Only:** Saves only usage and cost metadata, excluding request content
-- **Billing and accounting records** (purchases of credits, payments, invoices, and the transaction history of credits bought and spent): we are legally required to retain these under applicable tax and accounting law. We keep them for **10 years**, even after you delete your account, after which they are deleted or anonymized.
-
-Where we retain billing records after account deletion, we restrict our processing of that data to what the law requires, and we anonymize personal identifiers that are not needed for the accounting record.
-
----
-
-## 4. Data Sharing
-
-We do **not sell** your personal information.  
-We may share limited data with:
-
-- **Service Providers:** For hosting (e.g. Google Cloud), analytics, or payments
-- **AI Providers:** When routing your API requests to the selected model (e.g., OpenAI, Anthropic, Mistral, etc.)
-- **Legal Authorities:** Only if required by law or to protect our rights and users’ safety
-
-Each provider processes data under their own privacy terms.
+- **Service Providers / Sub-processors:** for hosting, analytics, payments, and email (see below).
+- **AI Providers:** when routing your API requests to the model you select (e.g., OpenAI, Anthropic, Google, Mistral, and others). Once your request reaches a provider, that provider processes it under **its own terms, privacy policy, and data-training practices**, which vary by provider and which we do not control. You can review each provider's terms, privacy policy, headquarters, certifications, and AI-training and data-retention practices on our [Providers page](https://llmgateway.io/providers) before selecting a model.
+- **Legal Authorities:** only where required by law or to protect our rights, users, or the public.
+- **Business transfers:** in connection with a merger, acquisition, financing, or sale of assets, subject to this Policy.
 
 ### Sub-processors
 
 We rely on a small set of vetted sub-processors, each bound by contractual data-protection obligations:
 
-- **Stripe** — payment and subscription processing. Stripe acts as a separate processor and retains its own payment records to meet its legal and tax obligations, in accordance with their [Privacy Policy](https://stripe.com/privacy).
+- **Stripe** — payment and subscription processing. Stripe acts as a separate processor and retains its own payment records to meet its legal and tax obligations, under their [Privacy Policy](https://stripe.com/privacy).
 - **Google Cloud** — application hosting and database storage
 - **Resend** — transactional and product email delivery
-- **AI Providers** — as listed in the model catalog, when routing your requests
+- **AI Providers** — as listed on our [Providers page](https://llmgateway.io/providers), when routing your requests
 
 ---
 
-## 5. Team and Organization Management
+## 6. Team and Organization Management
 
 If you belong to an organization:
 
 - Owners and Admins can view and manage member data and roles.
 - Access is limited by assigned roles (Owner, Admin, Developer, Restricted Access).
 
-You can manage permissions from the **Team Settings** page.
+You can manage permissions from the **Team Settings** page. Your organization is responsible for the personal data it processes through the Service and for the lawfulness of the Customer Data it submits.
 
 ---
 
-## 6. Security
+## 7. Data Retention
 
-We implement industry-standard measures to protect your data, including:
+We keep personal data only as long as necessary for the purposes it was collected, or as required by law:
+
+- **Account and profile data** (name, email, login credentials, API keys): retained while your account is active; deleted promptly when you delete your account.
+- **AI request content and metadata:** request and response content is governed by your organization's retention setting (Retain All Data vs Metadata Only); aggregated usage and cost metadata is retained for analytics and billing accuracy.
+- **Billing and accounting records** (purchases of credits, payments, invoices, and the transaction history of credits bought and spent): retained for **10 years** to comply with applicable tax and accounting law, even after account deletion, after which they are deleted or anonymized.
+
+Where we retain billing records after account deletion, we restrict processing of that data to what the law requires and anonymize personal identifiers not needed for the accounting record.
+
+---
+
+## 8. Security
+
+We implement industry-standard technical and organizational measures to protect personal data, including:
 
 - HTTPS and encryption in transit
 - Access controls and authentication for sensitive data
 - Regular security reviews and monitoring
 
-However, no system is completely secure. You are responsible for safeguarding your account credentials.
+No system is completely secure, and we cannot guarantee absolute security. You are responsible for safeguarding your account credentials and API keys. If we become aware of a personal-data breach affecting you, we will notify you and any relevant authorities as required by applicable law.
 
 ---
 
-## 7. Your Rights
+## 9. Your Privacy Rights
 
 Depending on your location, you may have the right to:
 
-- Access, correct, or delete your data
-- Export your data in a machine-readable format
+- Access, correct, or delete your personal data
+- Export your data in a machine-readable format (portability)
 - Withdraw consent for specific processing activities
 - Object to or restrict certain processing activities
 
-You can make requests via **[contact@llmgateway.io](mailto:contact@llmgateway.io)**.
+You can exercise these rights by emailing **[contact@llmgateway.io](mailto:contact@llmgateway.io)**. We will respond within the timeframe required by applicable law and may need to verify your identity first. You will not be discriminated against for exercising your rights.
+
+### EU/UK (GDPR)
+
+If you are in the EU/EEA or UK, you may exercise the rights above and **lodge a complaint with your local data protection supervisory authority**. International transfers of your data are safeguarded as described in [Section 11](#11-international-transfers).
+
+### California (CCPA/CPRA)
+
+If you are a California resident, you have the right to know, access, delete, and correct your personal information, and to opt out of its sale or sharing. **We do not sell or share personal information** as those terms are defined under the CCPA/CPRA, and we do not use it for cross-context behavioral advertising. We act as a **service provider** with respect to Customer Data processed on our customers' behalf. To exercise your rights, contact us at the email above; you may use an authorized agent.
 
 ### Limits on the right to erasure
 
-We will honor erasure requests except where we are legally obliged to retain data. In particular, **records of credits you purchased and spent** are kept to comply with tax and accounting law (see [Data Retention](#3-data-retention)) and cannot be deleted on request during the statutory retention period. During that period we limit our processing of those records to what the law requires. Once the retention period ends, the data is deleted or anonymized.
-
-If you are in the EU/EEA or UK, you also have the right to lodge a complaint with your data protection supervisory authority.
+We will honor erasure requests except where we are legally obliged to retain data. In particular, **records of credits you purchased and spent** are kept to comply with tax and accounting law (see [Data Retention](#7-data-retention)) and cannot be deleted on request during the statutory retention period. During that period we limit our processing of those records to what the law requires. Once the period ends, the data is deleted or anonymized.
 
 ---
 
-## 8. International Transfers
+## 10. AI Providers and Your Data
 
-Data may be processed and stored on servers located in the European Union or the United States.  
-We ensure that any data transfers comply with applicable data protection laws (e.g., GDPR).
+When you route a request, the **content of that request is sent to the AI provider you select** so it can generate a response. Each provider handles data under its own policies, which differ in retention, sub-processing, geographic location, certifications (e.g., SOC 2, ISO 27001), and whether they use inputs for model training. We do not control those practices.
 
----
-
-## 9. Children’s Privacy
-
-Our Service is **not intended for individuals under 16 years of age**.  
-We do not knowingly collect personal information from minors.
+Before selecting a model, we encourage you to review the provider's policies on our [Providers page](https://llmgateway.io/providers), which links to each provider's terms, privacy policy, and data-training and compliance information. You are responsible for ensuring your selected provider is appropriate for the sensitivity of the data you submit.
 
 ---
 
-## 10. Changes to This Policy
+## 11. International Transfers
 
-We may update this Privacy Policy periodically.  
-The latest version will always be available on our [Privacy Policy page](https://llmgateway.io/privacy).
+Data may be processed and stored on servers located in the **European Union or the United States**, and may be transferred to AI providers and sub-processors in other countries. Where we transfer personal data internationally, we use appropriate safeguards required by applicable law, such as the **Standard Contractual Clauses (SCCs)** or equivalent mechanisms, to protect your data.
 
 ---
 
-## 11. Contact Us
+## 12. Children’s Privacy
 
-If you have any questions about this Privacy Policy or your data, contact us at:  
-📧 **[contact@llmgateway.io](mailto:contact@llmgateway.io)**
+The Service is **not intended for or directed to individuals under 18 years of age**, consistent with our [Terms of Use](https://llmgateway.io/terms). We do not knowingly collect personal information from anyone under 18. If you believe a minor has provided us personal information, contact us and we will delete it.
+
+---
+
+## 13. Changes to This Policy
+
+We may update this Privacy Policy periodically. The latest version will always be available on our [Privacy Policy page](https://llmgateway.io/privacy), with an updated “Last Updated” date. For **material changes**, we will provide reasonable notice (for example, by email or in-product notice). Your continued use of the Service after the changes take effect constitutes acceptance of the updated Policy.
+
+---
+
+## 14. Contact Us
+
+If you have any questions about this Privacy Policy or your data, or wish to exercise your rights, contact us at:  
+📧 **[contact@llmgateway.io](mailto:contact@llmgateway.io)**  
 🌐 **[llmgateway.io](https://llmgateway.io)**

--- a/apps/ui/src/content/legal/terms.md
+++ b/apps/ui/src/content/legal/terms.md
@@ -1,191 +1,261 @@
 ---
 id: "1"
 slug: "terms"
-date: "2025-10-21"
+date: "2026-06-11"
 title: "Terms Of Use"
-description: "Review the Terms of Use for LLM Gateway. Learn about account eligibility, billing, data usage, AI provider policies, and user responsibilities when accessing our multi-provider AI gateway platform."
+description: "Review the Terms of Use for LLM Gateway. Learn about account eligibility, billing, credits, AI outputs, acceptable use, warranties, liability, and dispute resolution when using our multi-provider AI gateway platform."
 ---
 
 # Terms of Use
 
-**Effective Date:** October 21, 2025  
-**Last Updated:** October 21, 2025
+**Effective Date:** June 11, 2026  
+**Last Updated:** June 11, 2026
 
-Welcome to **LLM Gateway** (“we”, “our”, or “us”). These Terms of Use (“Terms”) govern your access to and use of the LLM Gateway platform, including our website **[llmgateway.io](https://llmgateway.io)**, APIs, SDKs, and any related products or services (collectively, the “Service”).
+Welcome to **LLM Gateway** (“we”, “our”, or “us”). These Terms of Use (“Terms”) form a binding legal agreement between you (“you” or “Customer”) and LLM Gateway and govern your access to and use of the LLM Gateway platform, including our website **[llmgateway.io](https://llmgateway.io)**, APIs, SDKs, dashboards, and any related products or services (collectively, the “Service”).
 
-By accessing or using the Service, you agree to be bound by these Terms. If you do not agree, please discontinue use immediately.
+**By clicking “I agree,” creating an account, or accessing or using the Service, you acknowledge that you have read, understood, and agree to be bound by these Terms and by our [Privacy Policy](https://llmgateway.io/privacy), which is incorporated by reference. If you do not agree, do not access or use the Service.**
+
+If you accept these Terms on behalf of an organization, you represent and warrant that you have the authority to bind that organization, and “you” refers to that organization.
+
+> **Please read Section 12 (Disclaimers), Section 13 (Limitation of Liability), and Section 15 (Dispute Resolution and Arbitration) carefully. They limit our liability and affect your legal rights, including how disputes are resolved and your ability to bring claims.**
 
 ---
 
 ## 1. Overview
 
-LLM Gateway provides an API gateway and management platform for connecting to multiple AI model providers.  
-The Service allows users to:
+LLM Gateway provides an API gateway and management platform for connecting to multiple third-party AI model providers. The Service allows users to:
 
 - Route and monitor API requests to AI providers
 - Manage API keys, usage data, and billing
 - Analyze performance and model metrics
 
+LLM Gateway acts as a **routing, management, and analytics layer**. We do not create, control, or guarantee the AI models or the outputs they generate.
+
 ---
 
 ## 2. Eligibility
 
-You must:
+To use the Service, you must:
 
-- Be at least 16 years old (or the age of digital consent in your country)
-- Have the legal authority to enter into these Terms
-- Use the Service in compliance with applicable laws and regulations
+- Be at least **18 years old** and have the legal capacity to enter into a binding contract;
+- Have the legal authority to enter into these Terms (individually or on behalf of your organization); and
+- Use the Service in compliance with all applicable laws, regulations, and third-party provider terms.
 
-If you use the Service on behalf of an organization, you represent that you are authorized to bind that organization to these Terms.
+The Service is not directed to, and may not be used by, anyone under 18. We may refuse, suspend, or terminate access to anyone at our discretion.
 
 ---
 
 ## 3. Accounts and Access
 
-You must create an account to use certain features of the Service. You are responsible for:
+You must create an account to use certain features. You are responsible for:
 
-- Maintaining the confidentiality of your login credentials
-- All activity under your account
-- Ensuring information provided is accurate and up-to-date
+- Maintaining the confidentiality and security of your login credentials and API keys;
+- All activity that occurs under your account or API keys, whether or not authorized by you; and
+- Ensuring the information you provide is accurate, current, and complete.
 
-You agree to notify us immediately of any unauthorized access to your account.
+You agree to notify us immediately of any unauthorized access to or use of your account. We are **not liable** for any loss or damage arising from your failure to safeguard your credentials or API keys.
 
 ---
 
-## 4. Plans and Billing
+## 4. Plans, Credits, and Billing
 
-LLM Gateway offers free and enterprise plans:
+LLM Gateway offers free and paid plans, including pay-as-you-go (“PAYG”) usage:
 
-- **Free Plan:** Full features with generous limits
-- **Enterprise Plan:** Custom integrations, dedicated support, and SLA
+- **Free Plan:** Core features with usage limits, provided strictly on an “as is” basis.
+- **Paid / PAYG Plans:** You purchase credits or pay for usage as you make requests through the platform.
 
-You may purchase credits to use with the Service. Credits are consumed as you make API requests through the platform. All credit purchases are final and **non-refundable**, except where required by applicable law.
+You agree to the following billing terms:
 
-Billing is processed securely through **Stripe**. You authorize us to charge your payment method for all applicable fees.
-All fees are non-refundable unless required by law.
+- **Credits and fees are non-refundable** and are consumed as you use the Service, except where a refund is required by applicable law. Unused credits may expire as described at the point of purchase.
+- Billing is processed by **Stripe**. You authorize us (and our payment processor) to **charge your payment method** for all applicable fees, including recurring and usage-based charges, and to **automatically replenish credits** if you enable auto-recharge.
+- All fees are **exclusive of taxes**. You are responsible for all applicable taxes, duties, and similar charges, other than taxes based on our net income.
+- You are responsible for all charges incurred under your account, including charges resulting from unauthorized use of your credentials or API keys.
+- If a payment fails, is reversed, or is charged back, we may **suspend or terminate** your access and recover amounts owed. Initiating a chargeback for legitimate charges is a breach of these Terms.
+- We may change our pricing or plan features at any time. Price changes apply prospectively from the date posted or otherwise communicated.
+
+Any service levels, support commitments, or uptime targets apply **only** if expressly stated in a separate written agreement signed by us (see Section 16). The free and standard PAYG Service is provided **without any service-level commitment**.
 
 ---
 
 ## 5. Data and Privacy
 
-Your data is processed according to our [Privacy Policy](https://llmgateway.io/privacy).  
-You control how your data is stored under **Settings → Policies**, including whether to:
+Your data is processed in accordance with our [Privacy Policy](https://llmgateway.io/privacy). You control how request data is stored under **Settings → Policies**, including whether to:
 
-- **Retain All Data** (request payloads and responses)
-- **Store Metadata Only** (usage statistics and pricing data)
+- **Retain All Data** (request payloads and responses); or
+- **Store Metadata Only** (usage statistics and pricing data).
 
-By using the Service, you consent to data processing and transfers as described in our Privacy Policy.
+By using the Service, you consent to the collection, processing, and transfer of data as described in the Privacy Policy. You are solely responsible for the data, prompts, and content you submit to the Service (“Customer Data”), including ensuring you have all rights and consents necessary to submit it and to have it processed by us and by the AI providers you select.
 
 ---
 
 ## 6. Acceptable Use
 
-You agree **not to**:
+You agree **not to**, and not to permit any third party to:
 
-- Use the Service for illegal or harmful activities
-- Interfere with the normal operation of the platform
-- Attempt to access unauthorized data or systems
-- Resell or redistribute the Service without permission
-- Circumvent rate limits or authentication controls
+- Use the Service for any illegal, infringing, fraudulent, or harmful activity;
+- Submit, generate, or distribute content that is unlawful, defamatory, abusive, or that violates the rights of others, including intellectual property or privacy rights;
+- Generate or facilitate child sexual abuse material, content that exploits or endangers minors, or content that promotes violence, self-harm, or terrorism;
+- Use the Service to develop or train a competing product, or to build a competing model using Service outputs, except as permitted by law;
+- Interfere with, disrupt, overload, or attempt to gain unauthorized access to the Service, its systems, or other accounts;
+- Resell, sublicense, or redistribute the Service without our prior written permission;
+- Circumvent or attempt to circumvent rate limits, usage limits, authentication, billing, or security controls;
+- Use the Service in violation of any AI provider's terms or acceptable use policies; or
+- Use the Service in any **high-risk activity** where failure or inaccuracy could lead to death, personal injury, or severe physical, environmental, or property damage (including medical diagnosis or treatment, life support, emergency services, autonomous vehicles, or critical infrastructure).
 
-We reserve the right to suspend or terminate accounts engaging in abuse, fraud, or policy violations.
+You are solely responsible for your use of the Service and any content you submit or generate. We may, but are not obligated to, monitor use of the Service and may remove content or suspend access for any suspected violation.
 
 ---
 
-## 7. AI Provider Usage
+## 7. AI Provider Usage and Outputs
 
-When using AI models through LLM Gateway, you are also subject to the **terms and policies** of the respective model providers (e.g., OpenAI, Anthropic, Mistral, Google, etc.).  
-LLM Gateway acts as a router and analytics layer — we do not control or assume responsibility for provider responses.
+When using AI models through LLM Gateway, you are also subject to the **terms, policies, and usage restrictions** of the respective model providers (e.g., OpenAI, Anthropic, Mistral, Google, and others). It is your responsibility to review and comply with those terms.
+
+**You acknowledge and agree that:**
+
+- AI outputs are generated by third-party models and may be **inaccurate, incomplete, outdated, biased, offensive, or otherwise unreliable** ("hallucinations"), and may not be unique to you.
+- **AI outputs do not constitute professional advice** of any kind (including legal, medical, financial, or tax advice). You are responsible for independently reviewing, verifying, and validating any output before relying on or acting upon it.
+- We **do not control, endorse, or assume responsibility** for any AI model, provider, or output, including the accuracy of outputs, the intellectual-property status of outputs, or how providers process your data.
+- You bear all responsibility and risk for your use of AI outputs and for any decisions or actions taken based on them.
 
 ---
 
 ## 8. Intellectual Property
 
-All rights, titles, and interests in and to the Service (including software, design, and branding) are owned by **LLM Gateway** or its licensors.
+All rights, title, and interest in and to the Service (including the software, design, branding, and all related intellectual property) are and remain owned by **LLM Gateway** or its licensors. We grant you a limited, non-exclusive, non-transferable, revocable license to access and use the Service in accordance with these Terms. No other rights are granted, whether by implication, estoppel, or otherwise.
 
-You retain ownership of your own data and prompts.  
-You grant us a limited license to process and analyze your data for the purpose of providing the Service.
+You retain ownership of your Customer Data and prompts. You grant us a **worldwide, non-exclusive, royalty-free license** to host, copy, process, transmit, and display Customer Data solely as necessary to provide, secure, and improve the Service and as described in our Privacy Policy.
 
----
-
-## 9. Team and Organization Features
-
-If you are part of an organization:
-
-- Owners can manage members, billing, and organization settings
-- Admins can manage projects and API keys but cannot modify owners or billing
-- Developers can view usage and manage projects
-- Restricted users have API-only access
-
-Team management is available for all users.
+If you provide feedback, suggestions, or ideas about the Service (“Feedback”), you grant us a **perpetual, irrevocable, worldwide, royalty-free license** to use and exploit the Feedback for any purpose without obligation or compensation to you.
 
 ---
 
-## 10. Termination
+## 9. Beta and Free Features
 
-You may cancel your account at any time through the dashboard.  
-We may suspend or terminate your account if:
-
-- You violate these Terms
-- You misuse the Service
-- Required by law or regulation
-
-Upon termination, your access will cease, and stored data will be deleted according to your retention settings.
+We may offer features identified as beta, preview, experimental, or free (“Beta Features”). Beta Features are provided **“as is,” without warranty or support**, may be changed or discontinued at any time, and are **not subject to any service-level or liability commitment**. We are not liable for any harm arising from your use of Beta Features.
 
 ---
 
-## 11. Disclaimers
+## 10. Team and Organization Features
 
-The Service is provided **“as is”** and **“as available”** without warranties of any kind, either express or implied.  
-We do not guarantee:
+If you use organization features:
 
-- That the Service will be error-free or uninterrupted
-- The accuracy or reliability of AI model outputs
-- That your use will meet specific performance or compliance requirements
+- **Owners** can manage members, billing, and organization settings;
+- **Admins** can manage projects and API keys but cannot modify owners or billing;
+- **Developers** can view usage and manage projects; and
+- **Restricted users** have API-only access.
 
-Use of the Service and AI outputs is at your own discretion and risk.
-
----
-
-## 12. Limitation of Liability
-
-To the fullest extent permitted by law:
-
-- LLM Gateway is **not liable** for indirect, incidental, or consequential damages
-- Our total liability for any claim arising from these Terms shall not exceed the amount you paid (if any) in the preceding **three (3) months**
+The organization is responsible for its users' compliance with these Terms and for all activity within the organization's account.
 
 ---
 
-## 13. Indemnification
+## 11. Suspension and Termination
 
-You agree to indemnify and hold harmless **LLM Gateway**, its founders, employees, and partners from any claims, damages, or expenses resulting from:
+You may cancel your account at any time through the dashboard. Cancellation does not entitle you to a refund of any prepaid fees or credits.
 
-- Your use or misuse of the Service
-- Your violation of these Terms or third-party rights
+We may **suspend or terminate** your access to all or part of the Service, with or without notice, if:
 
----
+- You violate or we reasonably suspect you have violated these Terms;
+- Your use poses a security, legal, or operational risk to us, other users, or third parties;
+- Your payment is overdue, fails, or is reversed; or
+- We are required to do so by law or by an AI provider.
 
-## 14. Modifications
+We may suspend access **immediately and without prior notice** where we reasonably believe doing so is necessary to protect the Service, other users, or our providers. We are **not liable** to you for any suspension or termination made in accordance with these Terms.
 
-We may update or modify these Terms at any time.  
-The latest version will always be available on our [Terms of Use page](https://llmgateway.io/terms).  
-Your continued use of the Service after any change constitutes acceptance of the updated Terms.
-
----
-
-## 15. Governing Law
-
-These Terms are governed by and construed under the laws of **Delaware, United States**, without regard to conflict of law principles.  
-Any disputes shall be resolved in the courts located in Delaware, USA.
+Upon termination, your right to use the Service ceases immediately, and stored data will be deleted in accordance with your retention settings and our Privacy Policy. Sections that by their nature should survive termination will survive (see Section 18).
 
 ---
 
-## 16. Contact Us
+## 12. Disclaimers
+
+**THE SERVICE, INCLUDING ALL AI OUTPUTS AND ANY BETA OR FREE FEATURES, IS PROVIDED “AS IS” AND “AS AVAILABLE,” WITH ALL FAULTS AND WITHOUT WARRANTY OF ANY KIND.**
+
+**TO THE FULLEST EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, AND ANY WARRANTIES ARISING FROM COURSE OF DEALING OR USAGE OF TRADE.**
+
+We do not warrant that:
+
+- The Service will be uninterrupted, secure, timely, or error-free;
+- AI outputs will be accurate, reliable, lawful, non-infringing, or fit for any purpose; or
+- The Service will meet your specific requirements or any compliance, performance, or availability standard.
+
+Your use of the Service and any AI outputs is **entirely at your own risk**. Some jurisdictions do not allow the exclusion of certain warranties, so some of the above exclusions may not apply to you.
+
+---
+
+## 13. Limitation of Liability
+
+**TO THE FULLEST EXTENT PERMITTED BY LAW:**
+
+- **WE WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUE, DATA, GOODWILL, OR BUSINESS OPPORTUNITIES, REGARDLESS OF THE THEORY OF LIABILITY AND EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.**
+- **WE ARE NOT LIABLE FOR ANY LOSS OR DAMAGE ARISING FROM AI OUTPUTS, THIRD-PARTY PROVIDERS, YOUR RELIANCE ON THE SERVICE, OR ANY CONTENT YOU SUBMIT OR GENERATE.**
+- **OUR TOTAL AGGREGATE LIABILITY FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THESE TERMS OR THE SERVICE WILL NOT EXCEED THE GREATER OF (A) THE TOTAL AMOUNT YOU PAID TO US FOR THE SERVICE IN THE TWELVE (12) MONTHS IMMEDIATELY PRECEDING THE EVENT GIVING RISE TO THE CLAIM, OR (B) USD $100.**
+
+These limitations apply regardless of whether the claim is based in contract, tort (including negligence), strict liability, or any other theory, and apply even if any remedy fails of its essential purpose. The parties agree these limitations reflect a reasonable allocation of risk and are an essential basis of the bargain. Some jurisdictions do not allow certain limitations, so some of the above may not apply to you.
+
+---
+
+## 14. Indemnification
+
+You agree to **defend, indemnify, and hold harmless** LLM Gateway and its founders, owners, employees, contractors, licensors, and partners (the “Indemnified Parties”) from and against any and all claims, demands, damages, losses, liabilities, penalties, costs, and expenses (including reasonable attorneys' fees) arising out of or relating to:
+
+- Your access to or use of the Service;
+- Your Customer Data, prompts, or any content you submit or generate;
+- Your violation of these Terms, applicable law, or any third-party or provider rights; or
+- Your use of, or reliance on, any AI output.
+
+We will provide you with reasonable notice of any claim subject to indemnification. We reserve the right to assume the exclusive defense and control of any matter subject to indemnification by you, in which case you agree to cooperate with our defense. You may not settle any claim in a way that imposes any obligation or liability on an Indemnified Party without our prior written consent.
+
+---
+
+## 15. Dispute Resolution and Arbitration
+
+**Please read this section carefully — it affects your legal rights, including a waiver of class actions and jury trials.**
+
+**Informal resolution.** Before initiating any formal proceeding, you agree to first contact us at **contact@llmgateway.io** and attempt to resolve the dispute informally for at least **thirty (30) days** after notice.
+
+**Binding arbitration.** Except as set out below, any dispute, claim, or controversy arising out of or relating to these Terms or the Service that is not resolved informally will be settled by **final and binding individual arbitration**, rather than in court. Arbitration will be conducted by a recognized arbitration body under its applicable rules. Judgment on the award may be entered in any court of competent jurisdiction.
+
+**Class action and jury waiver.** **You and we agree that each may bring claims against the other only in an individual capacity, and not as a plaintiff or class member in any purported class, collective, consolidated, or representative proceeding. You and we waive any right to a jury trial.**
+
+**Exceptions.** Either party may (a) bring an individual claim in small-claims court, and (b) seek injunctive or equitable relief in court to protect its intellectual property or confidential information.
+
+If the class-action waiver is found unenforceable as to a particular claim, that claim (and only that claim) will be severed and proceed in court, while all other claims remain in arbitration.
+
+---
+
+## 16. Relationship with Other Agreements
+
+If you have entered into a **separate written agreement** with us that is signed by both parties (such as a Master Services Agreement, Enterprise Agreement, or Order Form) governing your use of the Service, that agreement **controls to the extent of any conflict** with these Terms with respect to the subject matter it covers. In all other respects, these Terms continue to apply. Purchase orders, vendor portals, or other terms you provide do **not** apply and are expressly rejected unless we agree to them in a signed writing.
+
+---
+
+## 17. Modifications
+
+We may update or modify these Terms at any time. The latest version will always be available on our [Terms of Use page](https://llmgateway.io/terms), with an updated “Last Updated” date. For **material changes**, we will provide reasonable notice (for example, by email or in-product notice). Your continued use of the Service after changes take effect constitutes acceptance of the updated Terms. If you do not agree to the changes, you must stop using the Service.
+
+---
+
+## 18. General
+
+- **Governing law.** These Terms are governed by the laws of the **State of Delaware, United States**, without regard to its conflict-of-law principles. Subject to Section 15, any dispute not subject to arbitration will be brought exclusively in the state or federal courts located in Delaware, and you consent to their jurisdiction.
+- **Survival.** Sections 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16, and 18, and any other provisions that by their nature should survive, will survive termination of these Terms.
+- **Assignment.** You may not assign or transfer these Terms without our prior written consent. We may assign these Terms freely, including in connection with a merger, acquisition, or sale of assets.
+- **Entire agreement.** These Terms, together with the Privacy Policy and any document expressly incorporated by reference, constitute the entire agreement between you and us regarding the Service and supersede all prior or contemporaneous understandings, subject to Section 16.
+- **Severability.** If any provision is held invalid or unenforceable, that provision will be enforced to the maximum extent permissible and the remaining provisions will remain in full force and effect.
+- **No waiver.** Our failure to enforce any provision is not a waiver of our right to do so later.
+- **Force majeure.** We are not liable for any failure or delay caused by events beyond our reasonable control, including provider outages, internet failures, acts of God, or governmental action.
+- **No third-party beneficiaries.** These Terms do not create any third-party beneficiary rights, except for the Indemnified Parties under Section 14.
+- **Export and sanctions compliance.** You represent that you are not located in, or a resident of, any country or on any list subject to U.S. or other applicable export-control or sanctions restrictions, and that you will not use the Service in violation of such laws.
+- **Relationship.** The parties are independent contractors. These Terms do not create any partnership, joint venture, agency, or employment relationship.
+- **Notices.** We may provide notices to you by email or through the Service. You may contact us at the address below.
+
+---
+
+## 19. Contact Us
 
 If you have questions about these Terms, contact us at:  
-📧 **[contact@llmgateway.io](mailto:contact@llmgateway.io)**
+📧 **[contact@llmgateway.io](mailto:contact@llmgateway.io)**  
 🌐 **[llmgateway.io](https://llmgateway.io)**
 
 ---
 
-© 2025 LLM Gateway. All rights reserved.
+© 2026 LLM Gateway. All rights reserved.

--- a/apps/ui/src/content/legal/terms.md
+++ b/apps/ui/src/content/legal/terms.md
@@ -191,6 +191,8 @@ Your use of the Service and any AI outputs is **entirely at your own risk**. Som
 
 These limitations apply regardless of whether the claim is based in contract, tort (including negligence), strict liability, or any other theory, and apply even if any remedy fails of its essential purpose. The parties agree these limitations reflect a reasonable allocation of risk and are an essential basis of the bargain. Some jurisdictions do not allow certain limitations, so some of the above may not apply to you.
 
+**Exclusive remedy.** To the fullest extent permitted by law, your **sole and exclusive remedy** for any dissatisfaction with, or loss or damage arising from, the Service is to stop using the Service and, where applicable, terminate your account. Any refund, where one is required by law, is limited as set out in Section 4 and is your only monetary remedy.
+
 ---
 
 ## 14. Indemnification


### PR DESCRIPTION
## Summary

Hardening pass on both default legal documents for our high-risk, low-margin **self-serve / PAYG** users, while cleanly deferring to negotiated enterprise contracts (MSAs/Order Forms/DPAs).

- `apps/ui/src/content/legal/terms.md` — rewritten Terms of Use
- `apps/ui/src/content/legal/privacy.md` — hardened Privacy Policy + links to the Providers page

## Terms of Use changes

- **Disclaimers (§12):** conspicuous ALL-CAPS warranty disclaimer naming implied warranties (merchantability, fitness, title, non-infringement).
- **Limitation of liability (§13):** cap is greater of 12 months' fees or $100 (was "last 3 months" → $0 for free users); excludes indirect/consequential damages; survives failure of essential purpose.
- **AI-specific terms (§7):** outputs may be inaccurate/"hallucinated", are not professional advice, must be independently verified; no responsibility for provider outputs.
- **High-risk use ban (§6):** medical, life-support, autonomous-vehicle, critical-infrastructure, plus illegal content, CSAM, competing-model training.
- **Dispute resolution (§15):** binding individual arbitration + class-action and jury-trial waiver, with a 30-day informal step and small-claims / IP-injunction carve-outs.
- **Precedence (§16):** signed MSAs/Order Forms control over these Terms; customer POs/vendor terms rejected.
- **Enforceability:** clickwrap acceptance language; eligibility raised 16 → 18.
- **Billing (§4):** taxes, chargeback-as-breach, suspension, no SLA unless separately signed.
- Added survival, assignment, force majeure, entire agreement, export/sanctions, no third-party beneficiaries, notices, feedback license, Beta/Free features.

## Privacy Policy changes

- **Controller/processor roles:** new section clarifying we are a processor / CCPA **service provider** for Customer Data, with DPA precedence for enterprise.
- **No model training on Customer Data:** explicit statement that prompts/responses are not used to train models.
- **GDPR legal bases** section; expanded **EU/UK** and **California (CCPA/CPRA)** rights (no sale/share, right to complain to a DPA).
- **Providers page links:** Data Sharing and a new "AI Providers and Your Data" section link to https://llmgateway.io/providers so users can review each provider's terms, privacy policy, certifications, and AI-training practices before selecting a model.
- International transfers via **Standard Contractual Clauses**; breach-notification commitment; business-transfer disclosure.
- Children's age aligned to **18** to match the Terms; material-change notice added.

## Note

Strong drafts, but both should get a final review by counsel before going live. Covers only the default self-serve documents; enterprise terms and a standalone DPA are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Terms of Use effective June 11, 2026: eligibility raised to 18+, expanded billing/credits and payment/recovery rules (including PAYG, non‑refundable/expiring credits, auto‑recharge, Stripe, tax allocation), clarified SLA scope, stronger data/privacy controls and acceptable‑use prohibitions, explicit AI output/risk disclaimers, updated IP/feedback licensing, beta/free feature terms, expanded suspension/termination, revised liability/indemnity, and binding individual arbitration with specified exceptions.
  * Updated Privacy Policy effective June 11, 2026: reorganized data categories, retention options, legal bases, third‑party handling and transfers, user rights and notices, and explicit statement that customer data is not used to train models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->