### PR TITLE
fix(billing): don't charge unbilled refusals

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -4618,4 +4618,302 @@ describe("api", () => {
 			).toBe(true);
 		});
 	});
+
+	describe("refusal billing", () => {
+		// Anthropic-family models emit stop_reason "refusal" when a safety
+		// classifier blocks the response. Per Anthropic's billing policy, a
+		// refusal that arrives before any output is generated is not billed; a
+		// refusal that already produced output is billed for what was generated.
+		function spyRefusalResponse(
+			matchUrlFragment: string,
+			body: unknown,
+		): ReturnType<typeof vi.spyOn> {
+			const originalFetch = globalThis.fetch;
+			return vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(async (input, init) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url;
+
+					if (url.includes(matchUrlFragment)) {
+						return new Response(JSON.stringify(body), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+
+					return await originalFetch(input as RequestInfo | URL, init);
+				});
+		}
+
+		test("anthropic refusal with no output is not billed", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const fetchSpy = spyRefusalResponse(`${mockServerUrl}/v1/messages`, {
+				id: "msg_refusal",
+				type: "message",
+				role: "assistant",
+				model: "claude-fable-5",
+				content: [],
+				stop_reason: "refusal",
+				stop_sequence: null,
+				usage: { input_tokens: 100, output_tokens: 0 },
+			});
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-fable-5",
+						messages: [{ role: "user", content: "Trigger a refusal" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				// Client sees the OpenAI-canonical content_filter reason.
+				expect(json.choices[0].finish_reason).toBe("content_filter");
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			// Raw provider reason preserved; unified reason classified.
+			expect(logs[0].finishReason).toBe("refusal");
+			expect(logs[0].unifiedFinishReason).toBe("content_filter");
+			expect(logs[0].hasError).toBe(false);
+			// A refusal before any output is generated must not be charged.
+			expect(Number(logs[0].cost)).toBe(0);
+			expect(Number(logs[0].inputCost)).toBe(0);
+			expect(Number(logs[0].outputCost)).toBe(0);
+			// Usage tokens are still recorded for analytics (informational only).
+			expect(Number(logs[0].promptTokens)).toBe(100);
+		});
+
+		test("anthropic refusal after partial output is still billed", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const fetchSpy = spyRefusalResponse(`${mockServerUrl}/v1/messages`, {
+				id: "msg_refusal_partial",
+				type: "message",
+				role: "assistant",
+				model: "claude-fable-5",
+				content: [{ type: "text", text: "Here is the start of an answer" }],
+				stop_reason: "refusal",
+				stop_sequence: null,
+				usage: { input_tokens: 100, output_tokens: 20 },
+			});
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-fable-5",
+						messages: [{ role: "user", content: "Trigger a refusal" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(logs[0].finishReason).toBe("refusal");
+			expect(logs[0].unifiedFinishReason).toBe("content_filter");
+			// Output was generated before the refusal, so it is billed normally:
+			// 100 input * 10e-6 + 20 output * 50e-6 = 0.002.
+			expect(Number(logs[0].cost)).toBeCloseTo(0.002);
+		});
+
+		test("aws-bedrock refusal with no output is not billed", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "aws-test-key",
+				provider: "aws-bedrock",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const fetchSpy = spyRefusalResponse("/converse", {
+				output: { message: { content: [], role: "assistant" } },
+				stopReason: "refusal",
+				usage: { inputTokens: 100, outputTokens: 0, totalTokens: 100 },
+			});
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "aws-bedrock/claude-fable-5",
+						messages: [{ role: "user", content: "Trigger a refusal" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				expect(json.choices[0].finish_reason).toBe("content_filter");
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(logs[0].finishReason).toBe("refusal");
+			expect(logs[0].unifiedFinishReason).toBe("content_filter");
+			expect(logs[0].hasError).toBe(false);
+			expect(Number(logs[0].cost)).toBe(0);
+			expect(Number(logs[0].promptTokens)).toBe(100);
+		});
+
+		test("streaming anthropic refusal with no output is not billed", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			// Anthropic surfaces streaming-classifier refusals as a message_delta
+			// with stop_reason "refusal" and no generated content.
+			const sse = [
+				`event: message_start\ndata: ${JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_stream_refusal",
+						type: "message",
+						role: "assistant",
+						model: "claude-fable-5",
+						content: [],
+						usage: { input_tokens: 100, output_tokens: 0 },
+					},
+				})}\n\n`,
+				`event: message_delta\ndata: ${JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "refusal", stop_sequence: null },
+					usage: { output_tokens: 0 },
+				})}\n\n`,
+				`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+			].join("");
+
+			const originalFetch = globalThis.fetch;
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(async (input, init) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url;
+					if (url.includes(`${mockServerUrl}/v1/messages`)) {
+						const stream = new ReadableStream({
+							start(controller) {
+								controller.enqueue(new TextEncoder().encode(sse));
+								controller.close();
+							},
+						});
+						return new Response(stream, {
+							status: 200,
+							headers: { "Content-Type": "text/event-stream" },
+						});
+					}
+					return await originalFetch(input as RequestInfo | URL, init);
+				});
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-fable-5",
+						messages: [{ role: "user", content: "Trigger a refusal" }],
+						stream: true,
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const streamResult = await readAll(res.body);
+				expect(
+					streamResult.chunks.some(
+						(chunk) => chunk.choices?.[0]?.finish_reason === "content_filter",
+					),
+				).toBe(true);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(logs[0].finishReason).toBe("refusal");
+			expect(logs[0].unifiedFinishReason).toBe("content_filter");
+			expect(Number(logs[0].cost)).toBe(0);
+		});
+	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -28,7 +28,12 @@ import {
 	isCodingModel,
 	providerSupportsCachedInput,
 } from "@/lib/coding-models.js";
-import { calculateCosts, shouldBillCancelledRequests } from "@/lib/costs.js";
+import {
+	calculateCosts,
+	isRefusalFinishReason,
+	shouldBillCancelledRequests,
+	zeroInferenceCosts,
+} from "@/lib/costs.js";
 import {
 	assertOriginAllowed,
 	assertTestWalletModelAllowed,
@@ -8307,7 +8312,17 @@ chat.openapi(completions, async (c) => {
 								if (Array.isArray(transformedData.choices)) {
 									for (const choice of transformedData.choices) {
 										if (choice?.finish_reason) {
-											finishReason = choice.finish_reason;
+											// Anthropic/Vertex-Anthropic finish reasons are owned by
+											// the provider-specific switch below, which reads the raw
+											// stop_reason (e.g. "refusal") from message_delta. Don't
+											// let the transformed message_stop chunk (mapped to
+											// "stop") clobber a refusal captured moments earlier.
+											if (
+												usedProvider !== "anthropic" &&
+												usedProvider !== "vertex-anthropic"
+											) {
+												finishReason = choice.finish_reason;
+											}
 											sawProviderTerminalEvent = true;
 											sentDownstreamFinishReasonChunk = true;
 										}
@@ -8481,10 +8496,29 @@ chat.openapi(completions, async (c) => {
 											data.type === "message_stop" ||
 											data.stop_reason
 										) {
-											finishReason = data.stop_reason ?? "end_turn";
+											// message_stop carries no stop_reason of its own — the
+											// real terminal reason arrived in the preceding
+											// message_delta. Only fall back to end_turn when we never
+											// captured one, so we don't clobber e.g. a "refusal".
+											finishReason =
+												data.stop_reason ?? finishReason ?? "end_turn";
 											sawProviderTerminalEvent = true;
 										} else if (data.delta?.stop_reason) {
 											finishReason = data.delta.stop_reason;
+											sawProviderTerminalEvent = true;
+										}
+										break;
+									case "aws-bedrock":
+										// The client-facing finish_reason comes from the
+										// transformed chunk (a refusal is surfaced as
+										// content_filter). Internally, preserve the raw
+										// "refusal" stop reason from the messageStop event so
+										// billing can skip charging an unbilled refusal.
+										if (
+											data.__aws_event_type === "messageStop" &&
+											data.stopReason === "refusal"
+										) {
+											finishReason = "refusal";
 											sawProviderTerminalEvent = true;
 										}
 										break;
@@ -9069,6 +9103,24 @@ chat.openapi(completions, async (c) => {
 								reasoningTokens,
 								retentionLevel,
 							);
+						}
+
+						// Anthropic-family refusal that produced no output is not billed
+						// (per Anthropic's policy: a refusal before any generated output
+						// is informational only). A mid-stream refusal that already
+						// produced content is billed normally.
+						if (
+							streamingCostsEarly.totalCost !== null &&
+							isRefusalFinishReason(finishReason, usedProvider) &&
+							!hasMeaningfulAssistantOutput({
+								completionTokens: calculatedCompletionTokens,
+								reasoningTokens,
+								content: fullContent,
+								toolResults: streamingToolCalls,
+								images: null,
+							})
+						) {
+							zeroInferenceCosts(streamingCostsEarly);
 						}
 
 						// Always send final usage chunk with cost data for SDK compatibility
@@ -11278,6 +11330,25 @@ chat.openapi(completions, async (c) => {
 		},
 		finishReason === "content_filter",
 	);
+
+	// Anthropic-family refusal that produced no output is not billed (per
+	// Anthropic's policy: a refusal before any generated output is informational
+	// only). A refusal that already produced content is billed normally. This is
+	// applied before transformResponseToOpenai so the cost echoed back to the
+	// client also reflects the zeroed charge.
+	if (
+		isRefusalFinishReason(finishReason, usedProvider) &&
+		!hasMeaningfulAssistantOutput({
+			completionTokens: calculatedCompletionTokens,
+			reasoningTokens: calculatedReasoningTokens,
+			content,
+			toolResults,
+			images: convertedImages,
+		})
+	) {
+		zeroInferenceCosts(costs);
+	}
+
 	costs.dataStorageCost = toDataStorageCostNumber(
 		costs.promptTokens ?? calculatedPromptTokens,
 		cachedTokens,

--- a/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
+++ b/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
@@ -21,6 +21,14 @@ export function mapFinishReasonToOpenai(
 		return "content_filter";
 	}
 
+	// Anthropic-family safety-classifier refusals (`stop_reason: "refusal"` on
+	// the direct API, Vertex, and Bedrock) have no OpenAI-canonical equivalent.
+	// Surface them as "content_filter" so OpenAI-compatible clients don't fall
+	// back to "other"/"stop" for a policy refusal.
+	if (finishReason === "refusal") {
+		return "content_filter";
+	}
+
 	switch (finishReason) {
 		case "stop":
 		case "length":

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -259,6 +259,49 @@ describe("parseProviderResponse", () => {
 		});
 	});
 
+	describe("refusal finish reason", () => {
+		it("preserves the raw 'refusal' stop reason for aws-bedrock", () => {
+			const json = {
+				output: {
+					message: { content: [], role: "assistant" },
+				},
+				stopReason: "refusal",
+				usage: {
+					inputTokens: 100,
+					outputTokens: 0,
+					totalTokens: 100,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"aws-bedrock",
+				"anthropic.claude-sonnet-4-5-20250929-v1:0",
+				json,
+			);
+
+			expect(result.finishReason).toBe("refusal");
+		});
+
+		it("surfaces the raw 'refusal' stop_reason for anthropic", () => {
+			const json = {
+				content: [],
+				stop_reason: "refusal",
+				usage: {
+					input_tokens: 100,
+					output_tokens: 0,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"anthropic",
+				"claude-opus-4-8",
+				json,
+			);
+
+			expect(result.finishReason).toBe("refusal");
+		});
+	});
+
 	describe("anthropic cachedTokens", () => {
 		it("returns cachedTokens as 0 when cache_read_input_tokens is 0", () => {
 			const json = {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -100,6 +100,11 @@ export function parseProviderResponse(
 				finishReason = "tool_calls";
 			} else if (stopReason === "content_filtered") {
 				finishReason = "content_filter";
+			} else if (stopReason === "refusal") {
+				// Anthropic-on-Bedrock safety-classifier refusal. Preserve the raw
+				// reason so downstream billing can skip charging an unbilled refusal
+				// (getUnifiedFinishReason maps it to content_filter for the log).
+				finishReason = "refusal";
 			} else {
 				finishReason = "stop"; // default fallback
 			}

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -611,7 +611,16 @@ export function transformResponseToOpenai(
 							...(toolResults && { tool_calls: toolResults }),
 							...(annotations && annotations.length > 0 && { annotations }),
 						},
-						finish_reason: finishReason ?? "stop",
+						// parseProviderResponse already maps Bedrock stop reasons to
+						// OpenAI-canonical values; mapFinishReasonToOpenai is idempotent
+						// for those and additionally surfaces a "refusal" as
+						// "content_filter" for OpenAI-compatible clients.
+						finish_reason:
+							mapFinishReasonToOpenai(
+								finishReason,
+								usedProvider,
+								!!toolResults,
+							) ?? "stop",
 					},
 				],
 				usage: buildUsageObject(

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -179,6 +179,32 @@ describe("transformStreamingToOpenai", () => {
 		expect(warn).not.toHaveBeenCalled();
 	});
 
+	it("maps AWS Bedrock messageStop refusal to content_filter", () => {
+		warn.mockClear();
+
+		const result = transformStreamingToOpenai(
+			"aws-bedrock",
+			"anthropic.claude-fable-5",
+			{
+				__aws_event_type: "messageStop",
+				stopReason: "refusal",
+			},
+			[],
+		);
+
+		expect(result).toMatchObject({
+			object: "chat.completion.chunk",
+			choices: [
+				{
+					index: 0,
+					delta: {},
+					finish_reason: "content_filter",
+				},
+			],
+		});
+		expect(warn).not.toHaveBeenCalled();
+	});
+
 	it("maps AWS Bedrock metadata cache creation details", () => {
 		warn.mockClear();
 

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1239,7 +1239,10 @@ export function transformStreamingToOpenai(
 					finishReason = "length";
 				} else if (stopReason === "tool_use") {
 					finishReason = "tool_calls";
-				} else if (stopReason === "content_filtered") {
+				} else if (
+					stopReason === "content_filtered" ||
+					stopReason === "refusal"
+				) {
 					finishReason = "content_filter";
 				}
 

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateCosts } from "./costs.js";
+import {
+	calculateCosts,
+	isRefusalFinishReason,
+	zeroInferenceCosts,
+} from "./costs.js";
 
 const { mockGetEffectiveDiscount } = vi.hoisted(() => ({
 	mockGetEffectiveDiscount: vi.fn(),
@@ -1477,5 +1481,61 @@ describe("calculateCosts", () => {
 				implicit.cachedInputCost ?? 0,
 			);
 		});
+	});
+});
+
+describe("isRefusalFinishReason", () => {
+	it("is true for refusal on Anthropic-family providers", () => {
+		expect(isRefusalFinishReason("refusal", "anthropic")).toBe(true);
+		expect(isRefusalFinishReason("refusal", "vertex-anthropic")).toBe(true);
+		expect(isRefusalFinishReason("refusal", "aws-bedrock")).toBe(true);
+	});
+
+	it("is false for non-refusal finish reasons", () => {
+		expect(isRefusalFinishReason("stop", "anthropic")).toBe(false);
+		expect(isRefusalFinishReason("content_filter", "aws-bedrock")).toBe(false);
+		expect(isRefusalFinishReason(null, "anthropic")).toBe(false);
+		expect(isRefusalFinishReason(undefined, "anthropic")).toBe(false);
+	});
+
+	it("is false for refusal on non-Anthropic providers", () => {
+		expect(isRefusalFinishReason("refusal", "openai")).toBe(false);
+		expect(isRefusalFinishReason("refusal", "google-ai-studio")).toBe(false);
+		expect(isRefusalFinishReason("refusal", null)).toBe(false);
+	});
+});
+
+describe("zeroInferenceCosts", () => {
+	it("zeroes every inference cost field in place but leaves data storage", () => {
+		const costs = {
+			inputCost: 0.5,
+			outputCost: 0.5,
+			cachedInputCost: 0.1,
+			cacheWriteInputCost: 0.1,
+			requestCost: 0.2,
+			webSearchCost: 0.3,
+			contentFilterCost: 0.05,
+			imageInputCost: 0.4,
+			imageOutputCost: 0.4,
+			audioInputCost: 0.2,
+			totalCost: 3.25,
+			dataStorageCost: 0.01 as number | null,
+		};
+
+		zeroInferenceCosts(costs);
+
+		expect(costs.inputCost).toBe(0);
+		expect(costs.outputCost).toBe(0);
+		expect(costs.cachedInputCost).toBe(0);
+		expect(costs.cacheWriteInputCost).toBe(0);
+		expect(costs.requestCost).toBe(0);
+		expect(costs.webSearchCost).toBe(0);
+		expect(costs.contentFilterCost).toBe(0);
+		expect(costs.imageInputCost).toBe(0);
+		expect(costs.imageOutputCost).toBe(0);
+		expect(costs.audioInputCost).toBe(0);
+		expect(costs.totalCost).toBe(0);
+		// Storage retention is billed separately from inference.
+		expect(costs.dataStorageCost).toBe(0.01);
 	});
 });

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -50,6 +50,66 @@ interface ChatMessage {
 }
 
 /**
+ * True when a provider's terminal reason is a safety-classifier "refusal".
+ *
+ * Anthropic-family models (the direct Anthropic API, Anthropic on Vertex, and
+ * Anthropic on AWS Bedrock) emit `stop_reason: "refusal"` when a streaming
+ * classifier intervenes on a potential policy violation. Per Anthropic's
+ * documented billing policy, a refusal that arrives before any output is
+ * generated is not billed (the usage counts in that response are informational
+ * only). Callers pair this with an "any output generated?" check to decide
+ * whether to zero the cost — see {@link zeroInferenceCosts}.
+ */
+export function isRefusalFinishReason(
+	finishReason: string | null | undefined,
+	provider: string | null | undefined,
+): boolean {
+	if (finishReason !== "refusal") {
+		return false;
+	}
+	return (
+		provider === "anthropic" ||
+		provider === "vertex-anthropic" ||
+		provider === "aws-bedrock"
+	);
+}
+
+interface MutableInferenceCosts {
+	inputCost: number | null;
+	outputCost: number | null;
+	cachedInputCost: number | null;
+	cacheWriteInputCost: number | null;
+	requestCost: number | null;
+	webSearchCost: number | null;
+	contentFilterCost: number | null;
+	imageInputCost: number | null;
+	imageOutputCost: number | null;
+	audioInputCost: number | null;
+	totalCost: number | null;
+}
+
+/**
+ * Zero out every inference cost field in-place. Used for unbilled refusals (a
+ * refusal that arrives before any output is generated) so the request is still
+ * recorded with full token usage for analytics but is not charged. Data
+ * storage cost is intentionally left untouched since retention is billed
+ * separately from inference.
+ */
+export function zeroInferenceCosts(costs: MutableInferenceCosts): void {
+	costs.inputCost = 0;
+	costs.outputCost = 0;
+	costs.cachedInputCost = 0;
+	costs.cacheWriteInputCost = 0;
+	costs.requestCost = 0;
+	costs.webSearchCost = 0;
+	costs.contentFilterCost = 0;
+	costs.imageInputCost = 0;
+	costs.imageOutputCost = 0;
+	costs.audioInputCost = 0;
+	costs.totalCost = 0;
+}
+
+/**
  * Check if billing for cancelled requests is enabled via environment variable.
  * Defaults to false if not set.
  */

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -55,6 +55,12 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps aws-bedrock refusal to content filter", () => {
+		expect(getUnifiedFinishReason("refusal", "aws-bedrock")).toBe(
+			UnifiedFinishReason.CONTENT_FILTER,
+		);
+	});
+
 	it("maps Google AI Studio finish reasons correctly (original Google format)", () => {
 		expect(getUnifiedFinishReason("STOP", "google-ai-studio")).toBe(
 			UnifiedFinishReason.COMPLETED,

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -63,6 +63,13 @@ export function getUnifiedFinishReason(
 	if (finishReason === "llmgateway_content_filter") {
 		return UnifiedFinishReason.CONTENT_FILTER;
 	}
+	// Anthropic-family safety-classifier refusals surface as `stop_reason:
+	// "refusal"` across the direct API, Vertex, and Bedrock. Map it uniformly
+	// here so providers handled by the default branch below (e.g. aws-bedrock)
+	// classify refusals as content filtering rather than UNKNOWN.
+	if (finishReason === "refusal") {
+		return UnifiedFinishReason.CONTENT_FILTER;
+	}
 
 	switch (provider) {
 		case "anthropic":


### PR DESCRIPTION
## Problem

Anthropic-family models (direct Anthropic, Vertex, and AWS Bedrock) emit `stop_reason: "refusal"` when a streaming safety classifier blocks a response. Per [Anthropic's documented billing policy](https://docs.anthropic.com/en/api/handling-stop-reasons):

> When a refusal arrives before Claude generates any output, you are not billed for the request… When Claude generates output before the refusal, you are billed for that request.

The gateway was charging for **all** refusals, including the no-output (prompt-stage) refusals that should be free. This affects both `anthropic` and `aws-bedrock`.

## Fix

- **New helpers** (`lib/costs.ts`): `isRefusalFinishReason()` (refusal on anthropic / vertex-anthropic / aws-bedrock) and `zeroInferenceCosts()` (zero every inference cost field in place; data-storage retention is billed separately and left intact).
- **No-charge logic** in both the streaming and non-streaming success paths: when a refusal produced **no** output (reusing the existing `hasMeaningfulAssistantOutput` check), the inference cost is zeroed — for both the log and the cost echoed back to the client. A **mid-stream** refusal that already produced content stays billed for what was generated.
- **AWS Bedrock**: preserve the raw `"refusal"` reason in the non-streaming parse and the streaming finish-reason switch so billing can detect it; surface the OpenAI-canonical `content_filter` to clients (`mapFinishReasonToOpenai` + the Bedrock streaming/non-streaming transforms) and classify it as `content_filter` in `getUnifiedFinishReason`.
- **Latent streaming bug**: the trailing Anthropic `message_stop` event was clobbering a `refusal` captured from the preceding `message_delta` with `"end_turn"` — which both mis-billed the refusal and mislabeled the log. `message_stop` now keeps the already-captured terminal reason.

Refusals are still fully recorded (tokens, finish reason) for analytics — they're just not charged when no output was generated.

## Verification

Ran end-to-end through the actual gateway (`app.request`) against simulated provider refusal responses:

- `anthropic` refusal, no output → **not billed** (`cost == 0`), `finishReason: "refusal"`, `unifiedFinishReason: "content_filter"`, client sees `content_filter`.
- `anthropic` refusal **after** partial output → **billed** normally (`cost ≈ 0.002`).
- `aws-bedrock` refusal, no output → **not billed** (`cost == 0`).
- `anthropic` **streaming** refusal, no output → **not billed**.

Plus unit tests for the new helpers, the unified/canonical mappings, and the Bedrock parse + streaming transform. Full `apps/gateway` spec suite (1285 tests), `pnpm format`, and `pnpm build` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing to correctly handle refusal responses; no charges are incurred when providers refuse to generate content with no meaningful output.
  * Improved refusal handling consistency across multiple AI providers.
  * Enhanced streaming support for refusal responses with proper status mapping.

* **New Features**
  * Added better normalization and mapping of refusal reasons across different provider formats for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->