### PR TITLE
feat(video): add Alibaba Wan 2.6 text-to-video

### DIFF
--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -1194,6 +1194,8 @@ function getDefaultVideoProviderBaseUrl(providerId: Provider): string | null {
 			return "https://aiplatform.googleapis.com";
 		case "minimax":
 			return "https://api.minimax.io";
+		case "alibaba":
+			return "https://dashscope-intl.aliyuncs.com";
 		default:
 			return null;
 	}
@@ -3404,6 +3406,79 @@ async function createXaiVideoJob(
 	return { upstreamId, upstreamRequest, upstreamResponse };
 }
 
+async function createAlibabaVideoJob(
+	providerContext: ProviderContext,
+	providerMapping: ProviderModelMapping,
+	videoSize: VideoSizeConfig,
+	prompt: string,
+	durationSeconds: number,
+): Promise<{
+	upstreamId: string;
+	upstreamRequest: Record<string, unknown>;
+	upstreamResponse: Record<string, unknown>;
+}> {
+	const upstreamModelName = providerMapping.externalId;
+	const upstreamRequest: Record<string, unknown> = {
+		model: upstreamModelName,
+		input: {
+			prompt,
+		},
+		parameters: {
+			size: `${videoSize.width}*${videoSize.height}`,
+			duration: durationSeconds,
+		},
+	};
+
+	const upstreamUrl = joinUrl(
+		providerContext.baseUrl,
+		"/api/v1/services/aigc/video-generation/video-synthesis",
+	);
+	const rawResponse = await fetchUpstreamJson(upstreamUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"X-DashScope-Async": "enable",
+			...getProviderHeaders("alibaba", providerContext.token, {
+				requestId: providerContext.requestId,
+			}),
+		},
+		body: JSON.stringify(upstreamRequest),
+	});
+
+	const output =
+		rawResponse.output && typeof rawResponse.output === "object"
+			? (rawResponse.output as Record<string, unknown>)
+			: null;
+	const taskId =
+		output && typeof output.task_id === "string" ? output.task_id : null;
+	if (!taskId) {
+		const message =
+			typeof rawResponse.message === "string"
+				? rawResponse.message
+				: "Alibaba video response did not include a task id";
+		const code =
+			typeof rawResponse.code === "string" ? rawResponse.code : undefined;
+		throw new HTTPException(502, {
+			message: code
+				? `Alibaba video API error: ${message} (code ${code})`
+				: message,
+		});
+	}
+
+	const upstreamResponse = addRequestedVideoMetadata(
+		{
+			...rawResponse,
+			task_id: taskId,
+			model: upstreamModelName,
+			status: "queued",
+			duration: durationSeconds,
+		},
+		videoSize,
+	);
+
+	return { upstreamId: taskId, upstreamRequest, upstreamResponse };
+}
+
 async function createUpstreamVideoJob(
 	providerContext: ProviderContext,
 	providerMapping: ProviderModelMapping,
@@ -3504,6 +3579,14 @@ async function createUpstreamVideoJob(
 				prompt,
 				durationSeconds,
 				processedFirstFrame,
+			);
+		case "alibaba":
+			return await createAlibabaVideoJob(
+				providerContext,
+				providerMapping,
+				videoSize,
+				prompt,
+				durationSeconds,
 			);
 		default:
 			throw new HTTPException(500, {

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -145,6 +145,8 @@ function getDefaultVideoProviderBaseUrl(providerId: Provider): string | null {
 			return "https://aiplatform.googleapis.com";
 		case "minimax":
 			return "https://api.minimax.io";
+		case "alibaba":
+			return "https://dashscope-intl.aliyuncs.com";
 		default:
 			return null;
 	}
@@ -1830,6 +1832,78 @@ function isMinimaxVideoProvider(providerId: string): boolean {
 	return providerId === "minimax";
 }
 
+function isAlibabaVideoProvider(providerId: string): boolean {
+	return providerId === "alibaba";
+}
+
+async function fetchAlibabaStatus(
+	job: VideoJobRecord,
+	providerContext: ResolvedVideoProviderContext,
+): Promise<Record<string, unknown>> {
+	const url = joinUrl(
+		providerContext.baseUrl,
+		`/api/v1/tasks/${job.upstreamId}`,
+	);
+	const { body, response } = await fetchJsonResponse(url, {
+		method: "GET",
+		headers: getVideoProviderHeaders(job, providerContext),
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			typeof body.message === "string"
+				? body.message
+				: `Alibaba status request failed with status ${response.status}`,
+		);
+	}
+
+	const output =
+		body.output && typeof body.output === "object"
+			? (body.output as Record<string, unknown>)
+			: {};
+	const rawStatus =
+		typeof output.task_status === "string" ? output.task_status : "PENDING";
+	const status = normalizeVideoStatus(rawStatus);
+	const videoUrl =
+		typeof output.video_url === "string" ? output.video_url : null;
+
+	return addRequestedVideoMetadata(job, {
+		...body,
+		status,
+		progress:
+			status === "completed"
+				? 100
+				: status === "failed"
+					? 100
+					: status === "in_progress"
+						? 50
+						: 0,
+		url: videoUrl,
+		video_url: videoUrl,
+		output_url: videoUrl,
+		mime_type: videoUrl ? "video/mp4" : undefined,
+		error:
+			status === "failed"
+				? {
+						message:
+							typeof output.message === "string"
+								? output.message
+								: typeof body.message === "string"
+									? body.message
+									: "Alibaba video generation failed",
+						code:
+							typeof output.code === "string"
+								? output.code
+								: typeof body.code === "string"
+									? body.code
+									: undefined,
+						details: body,
+					}
+				: null,
+		alibaba_raw_response: body,
+	});
+}
+
 async function fetchMinimaxStatus(
 	job: VideoJobRecord,
 	providerContext: ResolvedVideoProviderContext,
@@ -1980,6 +2054,10 @@ async function fetchUpstreamStatus(
 		return await fetchMinimaxStatus(job, providerContext);
 	}
 
+	if (isAlibabaVideoProvider(job.usedProvider)) {
+		return await fetchAlibabaStatus(job, providerContext);
+	}
+
 	return await fetchGenericVideoStatus(job, providerContext);
 }
 
@@ -2014,7 +2092,8 @@ async function fetchUpstreamContentMetadata(
 		job.usedProvider === "avalanche" ||
 		job.usedProvider === "xai" ||
 		isGoogleVertexVideoProvider(job.usedProvider) ||
-		isMinimaxVideoProvider(job.usedProvider)
+		isMinimaxVideoProvider(job.usedProvider) ||
+		isAlibabaVideoProvider(job.usedProvider)
 	) {
 		return null;
 	}

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2609,4 +2609,42 @@ export const alibabaModels = [
 			},
 		],
 	},
+	{
+		id: "wan-2-6-t2v",
+		name: "Wan 2.6 Text-to-Video",
+		description:
+			"Alibaba's Wan 2.6 text-to-video model generating short clips with synchronized audio from a text prompt.",
+		family: "alibaba",
+		output: ["video"],
+		maxVideoDurationSeconds: 15,
+		releasedAt: new Date("2026-01-15"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "alibaba",
+				externalId: "wan2.6-t2v",
+				inputPrice: "0",
+				outputPrice: "0",
+				requestPrice: "0",
+				perSecondPrice: {
+					default: "0.08",
+					"720p": "0.08",
+					"1080p": "0.12",
+				},
+				contextSize: 2000,
+				maxOutput: 1,
+				streaming: false,
+				vision: false,
+				tools: false,
+				jsonOutput: false,
+				videoGenerations: true,
+				supportedVideoSizes: ["1280x720", "720x1280", "1920x1080", "1080x1920"],
+				supportedVideoDurationsSeconds: [
+					2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+				],
+				supportsVideoAudio: true,
+				supportsVideoWithoutAudio: false,
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];

--- a/packages/shared/src/content-filter.spec.ts
+++ b/packages/shared/src/content-filter.spec.ts
@@ -29,6 +29,12 @@ describe("isContentFilterErrorText", () => {
 		).toBe(true);
 	});
 
+	test("detects Alibaba DashScope Wan green-net moderation", () => {
+		expect(
+			isContentFilterErrorText("Green net check failed for input text"),
+		).toBe(true);
+	});
+
 	test("returns false for generic upstream errors and empty input", () => {
 		expect(isContentFilterErrorText("Internal server error")).toBe(false);
 		expect(isContentFilterErrorText("the task id was not found")).toBe(false);

--- a/packages/shared/src/content-filter.ts
+++ b/packages/shared/src/content-filter.ts
@@ -7,7 +7,8 @@
  * - Azure OpenAI: `ResponsibleAIPolicyViolation`, `Microsoft's content management policy`
  * - ByteDance / DeepSeek (incl. Seedance video moderation, e.g.
  *   `OutputVideoSensitiveContentDetected`): `SensitiveContentDetected`
- * - Alibaba / DashScope: `data_inspection_failed`
+ * - Alibaba / DashScope: `data_inspection_failed`, `Green net check failed`
+ *   (Wan video green-net moderation)
  * - OpenAI safety system (e.g. Sora / gpt-image): `rejected by the safety system`
  */
 const CONTENT_FILTER_ERROR_SIGNALS = [
@@ -15,6 +16,7 @@ const CONTENT_FILTER_ERROR_SIGNALS = [
 	"SensitiveContentDetected",
 	"data_inspection_failed",
 	"Input data may contain inappropriate content",
+	"Green net check failed",
 	"Microsoft's content management policy",
 	"Your request was rejected by the safety system",
 ];


### PR DESCRIPTION
## Summary

Adds **video generation via Alibaba (DashScope)** to the gateway, starting with the text-to-video model `wan-2-6-t2v` (`wan2.6-t2v`). This is the first video integration for the existing Alibaba provider; only text-to-video is wired up for now.

## What changed

- **`packages/models`** — new `wan-2-6-t2v` model (`output: ["video"]`, `videoGenerations: true`) with:
  - Per-second pricing: `$0.08/s` (720p) and `$0.12/s` (1080p)
  - Supported sizes `1280x720 / 720x1280 / 1920x1080 / 1080x1920` and durations `2–15s`
  - Audio always on (`supportsVideoAudio: true`, `supportsVideoWithoutAudio: false`) — DashScope auto-dubs wan2.6 output and exposes no disable toggle
  - Mapping marked `test: "skip"` so it is excluded from the default e2e suite
- **`apps/gateway/src/videos/videos.ts`** — `createAlibabaVideoJob` submits an async DashScope task via `POST /api/v1/services/aigc/video-generation/video-synthesis` with the `X-DashScope-Async: enable` header and `{ model, input.prompt, parameters.{size,duration} }` body (size converted to DashScope `W*H` format). Added the dispatcher case and the default base URL.
- **`apps/worker/src/services/video-jobs.ts`** — `fetchAlibabaStatus` polls `GET /api/v1/tasks/{task_id}`, maps `output.task_status` (PENDING/RUNNING/SUCCEEDED/FAILED) to the canonical status and surfaces the direct `output.video_url`. Alibaba is excluded from the `/v1/videos/{id}/content` metadata fetch since DashScope returns a direct OSS URL.

Defaults to the international endpoint `https://dashscope-intl.aliyuncs.com` (matching the existing Alibaba chat default). Uses the existing `LLM_ALIBABA_API_KEY` credential — no new env/provider setup required.

## Testing

- `pnpm format` and `pnpm build` pass
- `pnpm vitest run packages/models/src/providers.spec.ts apps/gateway/src/lib/alibaba-pricing.spec.ts` — 153 passed
- E2E intentionally skipped (real paid video API)

## Notes / follow-ups (out of scope)

- Image-to-video and region selection (the provider already declares Singapore/US/Beijing endpoints) are not wired up yet — text-to-video only, as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Alibaba (DashScope) as a video-generation provider.
  * New "Wan 2.6 Text-to-Video" model: up to 15s, multiple resolutions, audio support, per-second pricing.

* **Content & Moderation**
  * Recognition of Alibaba "green-net" moderation signals (improved content-filter matching).

* **Tests**
  * Added a test covering the new moderation signal handling.

* **Integration**
  * Worker/status polling and provider status handling updated to include Alibaba.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->