### PR TITLE
fix(billing): use real Stripe period end for renewal date

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1155,11 +1155,17 @@ devPlans.openapi(changeTier, async (c) => {
 				remainingFraction,
 			);
 
+			// A mid-cycle upgrade preserves the billing anchor, so persist Stripe's
+			// actual period end as the renewal date instead of letting the UI
+			// project a fresh cycle from the upgrade date.
 			await db
 				.update(tables.organization)
 				.set({
 					devPlan: newTier,
 					devPlanCreditsLimit: creditPreview.newCreditsLimit.toString(),
+					devPlanExpiresAt: new Date(
+						subscriptionItem.current_period_end * 1000,
+					),
 				})
 				.where(eq(tables.organization.id, personalOrg.id));
 

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -169,6 +169,7 @@ function makeInvoiceEvent(overrides: {
 	amountPaid: number;
 	invoiceId: string;
 	metadata?: Record<string, string>;
+	periodEnd?: number;
 }): Stripe.InvoicePaymentSucceededEvent {
 	return {
 		id: "evt_test_invoice",
@@ -183,7 +184,12 @@ function makeInvoiceEvent(overrides: {
 				currency: "usd",
 				payment_intent: "pi_test_001",
 				metadata: overrides.metadata ?? { organizationId: ORG_ID },
-				lines: { data: [] },
+				lines: {
+					data:
+						overrides.periodEnd !== undefined
+							? [{ period: { end: overrides.periodEnd } }]
+							: [],
+				},
 			},
 		},
 	} as unknown as Stripe.InvoicePaymentSucceededEvent;
@@ -302,6 +308,25 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 
 		expect(sendEmailMock).toHaveBeenCalledTimes(1);
 		expect(sendEmailMock.mock.calls[0][0].to).toBe("default-billing@acme.test");
+	});
+
+	test("records the new period end as the renewal date on a cycle renewal", async () => {
+		await seedUsedDevPlanOrg();
+
+		const periodEnd = Math.floor(Date.now() / 1000) + SECONDS_IN_TWO_WEEKS;
+		await handleInvoicePaymentSucceeded(
+			makeInvoiceEvent({
+				billingReason: "subscription_cycle",
+				amountPaid: 7900,
+				invoiceId: "in_cycle_period_001",
+				periodEnd,
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlanExpiresAt?.getTime()).toBe(periodEnd * 1000);
 	});
 
 	test("does NOT reset credits on a proration invoice from a tier change", async () => {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -479,6 +479,16 @@ export type FinalizeDevPlanResult =
 	| { status: "no_payment_method" }
 	| { status: "invalid_session"; reason: string };
 
+// The current billing period end is the authoritative renewal date. It lives on
+// the subscription item (not the subscription) in current Stripe API versions.
+// Returns null when the subscription has no items yet (e.g. mid-creation).
+function getSubscriptionPeriodEnd(
+	subscription: Stripe.Subscription,
+): Date | null {
+	const periodEnd = subscription.items.data[0]?.current_period_end;
+	return periodEnd ? new Date(periodEnd * 1000) : null;
+}
+
 function isStripePaymentIntent(value: unknown): value is Stripe.PaymentIntent {
 	if (!value || typeof value !== "object") {
 		return false;
@@ -989,6 +999,7 @@ export async function finalizeDevPlanSetupSession(
 			devPlanCreditsLimit: creditsLimit.toString(),
 			devPlanCreditsUsed: "0",
 			devPlanBillingCycleStart: new Date(),
+			devPlanExpiresAt: getSubscriptionPeriodEnd(subscription),
 			devPlanStripeSubscriptionId: subscription.id,
 			devPlanCancelled: false,
 			devPlanCycle,
@@ -3073,6 +3084,13 @@ export async function handleInvoicePaymentSucceeded(event: {
 		const creditsLimit = getDevPlanCreditsLimit(initialDevPlanTier);
 		const fingerprint = await getSubscriptionCardFingerprint(subscriptionId);
 
+		// First invoice line covers the initial period, so its end is the real
+		// `current_period_end` (= first renewal date).
+		const initialPeriodEnd = invoice.lines.data.reduce(
+			(max, line) => Math.max(max, line.period?.end ?? 0),
+			0,
+		);
+
 		const claimed = await db
 			.update(tables.organization)
 			.set({
@@ -3080,6 +3098,9 @@ export async function handleInvoicePaymentSucceeded(event: {
 				devPlanCreditsLimit: creditsLimit.toString(),
 				devPlanCreditsUsed: "0",
 				devPlanBillingCycleStart: new Date(),
+				devPlanExpiresAt: initialPeriodEnd
+					? new Date(initialPeriodEnd * 1000)
+					: undefined,
 				devPlanStripeSubscriptionId: subscriptionId,
 				devPlanCancelled: false,
 				devPlanCycle: initialDevPlanCycle,
@@ -3273,6 +3294,16 @@ export async function handleInvoicePaymentSucceeded(event: {
 			);
 		}
 
+		// The renewal invoice's line items cover the upcoming period, so the
+		// latest line period end is the new `current_period_end` (= next renewal
+		// date). Record it alongside the cycle reset so the dashboard reflects the
+		// new schedule immediately rather than waiting for the follow-up
+		// `customer.subscription.updated` event.
+		const renewedPeriodEnd = invoice.lines.data.reduce(
+			(max, line) => Math.max(max, line.period?.end ?? 0),
+			0,
+		);
+
 		// Reset credits used and update billing cycle start. Also reset the
 		// limit to the full tier allotment: mid-cycle tier changes leave the
 		// limit at a prorated value, and a fresh cycle should grant the tier's
@@ -3288,6 +3319,9 @@ export async function handleInvoicePaymentSucceeded(event: {
 				devPlanCreditsFrozen: false,
 				devPlanCreditsLimitBeforeFreeze: null,
 				devPlanBillingCycleStart: new Date(),
+				devPlanExpiresAt: renewedPeriodEnd
+					? new Date(renewedPeriodEnd * 1000)
+					: undefined,
 				devPlanCancelled: false,
 			})
 			.where(eq(tables.organization.id, organizationId));

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -150,16 +150,28 @@ export default function BillingClient({
 	const cycle = devPlanStatus.devPlanCycle ?? "monthly";
 	const cancelled = devPlanStatus.devPlanCancelled ?? false;
 	const billingCycleStart = devPlanStatus.devPlanBillingCycleStart ?? null;
+	const currentPeriodEnd = devPlanStatus.devPlanExpiresAt ?? null;
 
 	const renewalHint = (() => {
-		if (!billingCycleStart) {
+		// Prefer Stripe's real `current_period_end`; only fall back to projecting a
+		// cycle from `billingCycleStart` for legacy rows missing the recorded end.
+		// The projection diverges from the actual schedule after a mid-cycle
+		// proration upgrade (the anchor is preserved, the cycle start is not).
+		const renewAt = currentPeriodEnd
+			? new Date(currentPeriodEnd)
+			: billingCycleStart
+				? (() => {
+						const d = new Date(billingCycleStart);
+						if (cycle === "annual") {
+							d.setFullYear(d.getFullYear() + 1);
+						} else {
+							d.setMonth(d.getMonth() + 1);
+						}
+						return d;
+					})()
+				: null;
+		if (!renewAt) {
 			return "—";
-		}
-		const renewAt = new Date(billingCycleStart);
-		if (cycle === "annual") {
-			renewAt.setFullYear(renewAt.getFullYear() + 1);
-		} else {
-			renewAt.setMonth(renewAt.getMonth() + 1);
 		}
 		const when = format(renewAt, "MMM d, yyyy");
 		return cancelled

--- a/apps/code/src/app/dashboard/(main)/page.tsx
+++ b/apps/code/src/app/dashboard/(main)/page.tsx
@@ -85,6 +85,7 @@ export default function UsagePage() {
 				planName={currentPlanName}
 				planPrice={currentPlanData?.price}
 				billingCycleStart={devPlanStatus.devPlanBillingCycleStart ?? null}
+				currentPeriodEnd={devPlanStatus.devPlanExpiresAt ?? null}
 				cancelledAtPeriodEnd={devPlanStatus.devPlanCancelled ?? false}
 				cycle={devPlanStatus.devPlanCycle ?? "monthly"}
 			/>

--- a/apps/code/src/app/dashboard/components/UsageOverview.tsx
+++ b/apps/code/src/app/dashboard/components/UsageOverview.tsx
@@ -21,6 +21,7 @@ interface UsageOverviewProps {
 	planName: string;
 	planPrice?: number;
 	billingCycleStart: string | null;
+	currentPeriodEnd: string | null;
 	cancelledAtPeriodEnd: boolean;
 	cycle?: DevPlanCycle;
 }
@@ -113,6 +114,7 @@ export default function UsageOverview({
 	planName,
 	planPrice,
 	billingCycleStart,
+	currentPeriodEnd,
 	cancelledAtPeriodEnd,
 	cycle = "monthly",
 }: UsageOverviewProps) {
@@ -170,18 +172,34 @@ export default function UsageOverview({
 		? `Since ${format(new Date(billingCycleStart), "MMM d, yyyy")}`
 		: "Active";
 
-	const cycleEndsHint = cancelledAtPeriodEnd
-		? "Cancels at period end"
+	// The renewal/period-end date must come from Stripe's actual
+	// `current_period_end` (surfaced as `currentPeriodEnd`), not from
+	// `billingCycleStart + 1 cycle`. The derived value diverges from the real
+	// billing schedule whenever the cycle anchor and the stored cycle start drift
+	// apart — most visibly after a mid-cycle proration upgrade, where the anchor
+	// is preserved but the dashboard would otherwise project a full cycle from the
+	// upgrade date. Fall back to the derived estimate only for legacy rows where
+	// the real period end hasn't been recorded yet.
+	const renewAt = currentPeriodEnd
+		? new Date(currentPeriodEnd)
 		: billingCycleStart
 			? (() => {
-					const renewAt = new Date(billingCycleStart);
+					const d = new Date(billingCycleStart);
 					if (cycle === "annual") {
-						renewAt.setFullYear(renewAt.getFullYear() + 1);
+						d.setFullYear(d.getFullYear() + 1);
 					} else {
-						renewAt.setMonth(renewAt.getMonth() + 1);
+						d.setMonth(d.getMonth() + 1);
 					}
-					return `Renews in ${formatDistanceToNowStrict(renewAt)}`;
+					return d;
 				})()
+			: null;
+
+	const cycleEndsHint = cancelledAtPeriodEnd
+		? renewAt
+			? `Cancels ${format(renewAt, "MMM d, yyyy")}`
+			: "Cancels at period end"
+		: renewAt
+			? `Renews in ${formatDistanceToNowStrict(renewAt)}`
 			: "—";
 
 	return (


### PR DESCRIPTION
## Problem

On the DevPass dashboard, the plan card showed e.g.:

> LITE plan · $29/mo · Since Jun 5, 2026 · **Renews in 23 days**

The renewal date was wrong after a **mid-cycle tier upgrade with proration**. It was derived as `devPlanBillingCycleStart + 1 month` (or `+ 1 year`). A mid-cycle upgrade preserves the Stripe billing anchor, but the projection restarts a full cycle from the upgrade/cycle-start date, so the displayed renewal drifts away from when the customer is actually billed.

## Fix

Use `devPlanExpiresAt` — Stripe's real `current_period_end`, which the rest of the codebase already treats as the renewal date (gateway "wait for renewal on …" messages, admin DevPass table) — for the dashboard and billing renewal hints. The derived `billingCycleStart + 1 cycle` estimate is kept only as a fallback for legacy rows where the real period end hasn't been recorded yet.

To make the value reliable (instead of depending on a later `customer.subscription.updated` webhook), `devPlanExpiresAt` is now also persisted with the actual period end at:
- initial activation (setup-mode finalize + initial invoice branch),
- cycle renewal (`subscription_cycle` invoice — read from the invoice line period),
- mid-cycle tier upgrade (`changeTier`, which already computes the period end).

## Changes
- `apps/code/.../UsageOverview.tsx`, `.../page.tsx`, `.../billing/BillingClient.tsx` — prefer `devPlanExpiresAt` for the renewal/period-end date, fall back to the derived estimate.
- `apps/api/src/stripe.ts` — add `getSubscriptionPeriodEnd` helper; set `devPlanExpiresAt` on activation and renewal.
- `apps/api/src/routes/dev-plans.ts` — set `devPlanExpiresAt` on tier upgrade.
- `apps/api/src/stripe.spec.ts` — assert the renewal records the new period end.

## Testing
- `vitest run apps/api/src/stripe.spec.ts` — 11 passed
- `pnpm format` + `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved accuracy of dev plan renewal dates by syncing billing/renewal timing with the authoritative Stripe subscription period end.
* Updated renewal and cancellation messaging to use the correct billing cycle end date when available, falling back to prior estimates only for legacy/missing data.
* Enhanced Billing and Usage screens so renewal hints and related messaging prioritize the server-provided renewal timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->