### PR TITLE
feat(models): add kimi-k2.7-code via moonshot

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -396,4 +396,35 @@ export const moonshotModels = [
 			},
 		],
 	},
+	{
+		id: "kimi-k2.7-code",
+		name: "Kimi K2.7 Code",
+		description:
+			"Kimi's most intelligent coding model with a native multimodal architecture supporting text, image, and video input, thinking modes, and agent tasks.",
+		family: "moonshot",
+		releasedAt: new Date("2026-06-12"),
+		providers: [
+			{
+				providerId: "moonshot",
+				externalId: "kimi-k2.7-code",
+				inputPrice: "0.95e-6",
+				cachedInputPrice: "0.19e-6",
+				outputPrice: "4.0e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 262144,
+				reasoning: true,
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+				supportedParameters: [
+					"max_tokens",
+					"response_format",
+					"tools",
+					"tool_choice",
+				],
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary
- Adds `kimi-k2.7-code`, Kimi's most intelligent coding model with native multimodal input (text, image, video) and thinking modes
- Moonshot provider only, at $0.95/$4.00/$0.19 per MTok (input/output/cached input), 262,144 context, mirroring the existing kimi-k2.6 moonshot mapping

## Test plan
- [x] `@llmgateway/models` builds (typecheck passes)
- [ ] E2E not run locally (no `MOONSHOT_API_KEY` in this environment) — verify with `TEST_MODELS="moonshot/kimi-k2.7-code" pnpm test:e2e -- apps/gateway/src/api.e2e.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new Kimi K2.7 Code model with enhanced reasoning and vision capabilities, extended context windows, and support for advanced features including streaming and tool integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->