### PR TITLE
fix(models): deactivate mimo-v2-flash at Xiaomi switch

### DIFF
--- a/packages/models/src/models/xiaomi.ts
+++ b/packages/models/src/models/xiaomi.ts
@@ -124,6 +124,11 @@ export const xiaomiModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				// Xiaomi retires mimo-v2-flash and auto-forwards requests to
+				// mimo-v2.5 (billed as the new model) at Beijing 2026-06-18 00:00.
+				// Deactivate at the switch so requests error instead of silently
+				// routing to a different model.
+				deactivatedAt: new Date("2026-06-17T16:00:00Z"),
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

Xiaomi MiMo Open Platform is retiring `mimo-v2-flash`. Per their notice, at **Beijing 2026-06-18 00:00** (UTC 2026-06-17 16:00) requests to `mimo-v2-flash` will be **silently auto-forwarded to `mimo-v2.5` and billed at the new model's pricing**.

We can't have a model route to a different one under the hood, so this deactivates the `mimo-v2-flash` provider mapping at exactly that switch time. After it, requests to `mimo-v2-flash` return an error instead of silently hitting `mimo-v2.5`.

- `mimo-v2-tts` is not in our catalog, so no change was needed for it.
- `mimo-v2.5` (the replacement) already exists and is unaffected.

## Testing

- `pnpm format`
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The `mimo-v2-flash` model has been marked as retired and will be deactivated on June 17, 2026. Requests to this model after the deactivation date will return errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->