### PR TITLE
fix(admin): sort global stats tooltip by value

### DIFF
--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -617,6 +617,7 @@ export function GlobalStatsClient() {
 									content={
 										<ChartTooltipContent
 											className="w-[220px]"
+											sortByValue={showTimeseriesBreakdown}
 											labelFormatter={(value) => {
 												if (typeof value !== "string" || !value) {
 													return "";

--- a/ee/admin/src/components/ui/chart.tsx
+++ b/ee/admin/src/components/ui/chart.tsx
@@ -123,6 +123,7 @@ const ChartTooltipContent = ({
 	color,
 	nameKey,
 	labelKey,
+	sortByValue = false,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
 	React.ComponentProps<"div"> & {
 		hideLabel?: boolean;
@@ -130,6 +131,7 @@ const ChartTooltipContent = ({
 		indicator?: "line" | "dot" | "dashed";
 		nameKey?: string;
 		labelKey?: string;
+		sortByValue?: boolean;
 	} & { ref?: React.RefObject<HTMLDivElement | null> }) => {
 	const { config } = useChart();
 
@@ -187,6 +189,7 @@ const ChartTooltipContent = ({
 			<div className="grid gap-1.5">
 				{payload
 					.filter((item) => item.type !== "none")
+					.sort((a, b) => (sortByValue ? Number(b.value) - Number(a.value) : 0))
 					.map((item, index) => {
 						const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
 						const itemConfig = getPayloadConfigFromPayload(config, item, key);


### PR DESCRIPTION
## Summary

In the admin dashboard global stats graphs, the stacked timeseries bar chart tooltip listed providers in chart series order, which made it hard to read at a glance (see the attached screenshot where values jumped around).

This sorts the tooltip items by value descending so the largest contributors appear first.

## Changes

- Add an opt-in `sortByValue` prop to the shared `ChartTooltipContent` component (`ee/admin/src/components/ui/chart.tsx`). When enabled, payload items are sorted by numeric value descending. Default is `false`, so all other charts are unaffected.
- Enable `sortByValue` on the global stats timeseries bar chart tooltip when showing the per-provider/model breakdown (`ee/admin/src/app/global-stats/client.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart tooltips in the admin global statistics dashboard now support sorting by numeric value when viewing timeseries breakdowns, improving data readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->