### PR TITLE
fix(gateway): classify 402 as gateway_error

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -17,6 +17,16 @@ describe("getFinishReasonFromError", () => {
 		expect(getFinishReasonFromError(404)).toBe("upstream_error");
 	});
 
+	it("returns gateway_error for 402 insufficient balance", () => {
+		expect(getFinishReasonFromError(402)).toBe("gateway_error");
+		expect(
+			getFinishReasonFromError(
+				402,
+				'{"error":{"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}}',
+			),
+		).toBe("gateway_error");
+	});
+
 	it("returns content_filter for Azure ResponsibleAIPolicyViolation", () => {
 		const azureError = JSON.stringify({
 			error: {

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -33,6 +33,14 @@ export function getFinishReasonFromError(
 		return "upstream_error";
 	}
 
+	// 402 Payment Required indicates the gateway's provider account is out of
+	// funds (e.g. DeepSeek "Insufficient Balance"). This is a gateway-side
+	// account problem, not a client error, so classify as gateway_error to allow
+	// fallback to another provider.
+	if (statusCode === 402) {
+		return "gateway_error";
+	}
+
 	// Provider content-moderation / safety blocks (Azure ResponsibleAIPolicyViolation,
 	// ByteDance/DeepSeek SensitiveContentDetected, Alibaba data_inspection_failed,
 	// Azure content management policy, OpenAI safety system rejection, etc.)


### PR DESCRIPTION
## Problem

Upstream `402 Payment Required` responses were being logged with a `client_error` finish reason. The reported case came from the DeepSeek API returning:

```json
{"error":{"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}}
```

A 402 means the gateway's own provider account is out of funds — it is not a client error and should not be attributed to the caller.

## Fix

`getFinishReasonFromError` now maps `402` to `gateway_error`, consistent with how 401/403 credential failures are already handled. This:

- correctly attributes the error to the gateway/provider account rather than the client, and
- makes the request eligible for fallback to another healthy provider (`gateway_error` is a retryable error type).

Added unit coverage for both a bare 402 and the DeepSeek "Insufficient Balance" payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system resilience by enhancing how the system handles insufficient balance errors, enabling better request routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->