### PR TITLE
perf(worker): fix log drain idle-poll + concurrency

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -110,6 +110,15 @@ const AUTO_TOPUP_DISABLE_AFTER_MS =
 
 // Configuration for batch processing
 const LOG_QUEUE_BATCH_SIZE = Number(process.env.LOG_QUEUE_BATCH_SIZE) || 100;
+// Number of log-drain loops to run concurrently in-process. Each loop pulls an
+// independent batch (LPOP is atomic, so there is no double-processing) and
+// inserts on its own pool connection, multiplying drain throughput without
+// adding worker replicas. Bounded by the DB pool size and Postgres write
+// capacity.
+const LOG_QUEUE_CONCURRENCY = Math.max(
+	1,
+	Number(process.env.LOG_QUEUE_CONCURRENCY) || 4,
+);
 // Cache organization retention levels to avoid a serial Postgres round-trip
 // before every log batch insert. retentionLevel changes rarely; the short TTL
 // bounds how long a stale value can keep retaining or stripping log payloads.
@@ -1666,21 +1675,24 @@ let activeLoops = 0;
 let stopFailed = false;
 
 // Independent worker loops
-async function runLogQueueLoop() {
+async function runLogQueueLoop(loopIndex = 0) {
 	activeLoops++;
-	logger.info("Starting log queue processing loop...");
+	logger.info(`Starting log queue processing loop ${loopIndex}...`);
 	try {
 		while (!isStopRequested()) {
 			try {
 				const drained = await processLogQueue();
-				// When a full batch came back the queue is almost certainly still
-				// backed up, so skip the sleep and immediately drain the next batch.
-				if (drained < LOG_QUEUE_BATCH_SIZE) {
+				// Only idle-poll when the queue came back empty. As long as any
+				// messages were drained the queue is still backed up, so loop
+				// straight into the next batch instead of sleeping. Tying this to
+				// LOG_QUEUE_BATCH_SIZE was wrong: when the batch size is raised
+				// above the steady-state queue depth the sleep fired every cycle.
+				if (drained === 0) {
 					await interruptibleSleep(1000);
 				}
 			} catch (error) {
 				logger.error(
-					"Error in log queue loop",
+					`Error in log queue loop ${loopIndex}`,
 					error instanceof Error ? error : new Error(String(error)),
 				);
 				await interruptibleSleep(5000);
@@ -1688,7 +1700,7 @@ async function runLogQueueLoop() {
 		}
 	} finally {
 		activeLoops--;
-		logger.info("Log queue loop stopped");
+		logger.info(`Log queue loop ${loopIndex} stopped`);
 	}
 }
 
@@ -2468,7 +2480,7 @@ export async function startWorker() {
 	// Start all worker loops (all sequential — each waits for completion before scheduling next run)
 	logger.info("Starting worker loops...");
 	logger.info(
-		`- Log queue: dequeues up to ${LOG_QUEUE_BATCH_SIZE} logs per iteration`,
+		`- Log queue: ${LOG_QUEUE_CONCURRENCY} concurrent loop(s), each dequeues up to ${LOG_QUEUE_BATCH_SIZE} logs per iteration`,
 	);
 	logger.info(
 		`- Credit processing: processes up to ${CREDIT_BATCH_SIZE} logs per batch`,
@@ -2506,7 +2518,9 @@ export async function startWorker() {
 	void runAggregatedStatsLoop();
 	void runProjectStatsLoop();
 	void runGlobalStatsLoop();
-	void runLogQueueLoop();
+	for (let i = 0; i < LOG_QUEUE_CONCURRENCY; i++) {
+		void runLogQueueLoop(i);
+	}
 	void runAutoTopUpLoop();
 	void runBatchProcessLoop();
 	void runDataRetentionLoop();


### PR DESCRIPTION
## Summary

Follow-up to #2649. Prod timing logs (added in #2649) revealed the real bottleneck and a bug in the previous aggressive-drain guard.

### What the prod logs showed

```
Processed log batch: 251 rows (org lookup 0ms, insert 1814ms)
Processed log batch: 240 rows (org lookup 12ms, insert 1378ms)
Processed log batch: 109 rows (org lookup 0ms, insert 609ms)
```

- **org lookup: 0–13ms** — the retention-level cache from #2649 works; negligible.
- **insert: ~6ms/row, roughly constant** regardless of batch size (9 indexes + 6 large JSON/JSONB columns) — a single serial inserter tops out ~150 rows/s.
- **The 1s idle-poll fired on every cycle.** Batches were 98–251 rows but `LOG_QUEUE_BATCH_SIZE` is raised above that in prod, so `drained < LOG_QUEUE_BATCH_SIZE` was always true → it slept every cycle even with a full backlog, roughly halving throughput.

### Changes

1. **Fix the idle-poll guard** — sleep only when the queue comes back empty (`drained === 0`), not when the batch was smaller than `LOG_QUEUE_BATCH_SIZE`. Tying it to batch size breaks whenever the configured batch size exceeds the steady-state queue depth.
2. **Add `LOG_QUEUE_CONCURRENCY` (default 4)** — run N drain loops in-process. LPOP is atomic so batches never overlap, the circuit breaker is shared state, and each insert uses its own pool connection (pool max 20). Multiplies drain throughput **without adding worker replicas**, bounded by DB write capacity.

### Expected impact

- Idle-poll fix alone: ~86 → ~150 rows/s (removes the per-cycle 1s sleep under backlog).
- Concurrency ×4: up to ~4× beyond that until Postgres write/CPU saturates. Tune `LOG_QUEUE_CONCURRENCY` down if the DB feels pressure.

## Test plan

- `pnpm build` — passes
- `pnpm vitest run apps/worker/src/worker.spec.ts` — 7/7 pass
- Worker replicas intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log queue processing now operates with configurable concurrency levels to improve throughput and system efficiency (default: 4 concurrent workers)
  * Enhanced queue draining optimizes resource utilization by reducing unnecessary idle delays and resuming processing immediately when logs are available
  * Updated startup logging displays active concurrency configuration for operational transparency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->