### PR TITLE
perf(routing): stabilize cached query keys

### DIFF
--- a/apps/gateway/src/lib/cached-queries-swr.spec.ts
+++ b/apps/gateway/src/lib/cached-queries-swr.spec.ts
@@ -38,6 +38,7 @@ const testProviderKeyOpenAi = "test-provider-key-swr-openai";
 const testProviderKeyAnthropic = "test-provider-key-swr-anthropic";
 const testIamRuleId = "test-iam-rule-swr";
 const testDiscountId = "test-discount-swr";
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 async function flushDrizzleCache(): Promise<void> {
 	const keys = await redisClient.keys("drizzle:cache:*");
@@ -151,6 +152,9 @@ describe("cached-queries SWR integration", () => {
 			model: "gpt-4",
 			discountPercent: "0.25",
 			reason: "SWR test discount",
+			// Non-null future expiry so the JS expiry filter has a value to evaluate
+			// (exercises the active-discount path, including on a Drizzle cache hit).
+			expiresAt: new Date(Date.now() + ONE_YEAR_MS),
 		});
 	});
 
@@ -262,6 +266,21 @@ describe("cached-queries SWR integration", () => {
 				`${SWR_PREFIX}discount:${testOrgId}:openai:gpt-4`,
 			);
 			expect(mirror).not.toBeNull();
+		});
+
+		it("findEffectiveDiscount resolves an expiring discount on a Drizzle cache hit", async () => {
+			// First call populates the Drizzle cache.
+			const first = await findEffectiveDiscount(testOrgId, "openai", "gpt-4");
+			expect(first.discount).toBe("0.25");
+
+			// Drop the SWR mirror so the next call can't fall back to it — it must
+			// resolve through the Drizzle cache and apply the JS expiry filter to the
+			// cached row (whose expiresAt is non-null) without erroring.
+			await flushSwrOnly();
+
+			const second = await findEffectiveDiscount(testOrgId, "openai", "gpt-4");
+			expect(second.discount).toBe("0.25");
+			expect(second.source).toBe("org_provider_model");
 		});
 	});
 

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -15,7 +15,6 @@ import {
 	and,
 	asc,
 	eq,
-	gte,
 	getTableName,
 	inArray,
 	isNull,
@@ -533,24 +532,25 @@ export async function findEffectiveDiscount(
 		`discount:${orgPart}:${provider}:${model}`,
 		[discountTableName],
 		async () => {
-			const now = new Date();
-			const notExpiredCondition = or(
-				isNull(discountTable.expiresAt),
-				gte(discountTable.expiresAt, now),
-			);
-
-			const discounts = await db
+			// The expiry filter is applied in JS below, NOT in SQL: a `now` Date in
+			// the WHERE clause becomes a query parameter, and the cached client keys
+			// its cache on hashQuery(sql, params). A per-request millisecond `now`
+			// would make that key unique every call, so the cache would never hit and
+			// this (hot, per-provider-candidate) lookup would query Postgres on every
+			// request. Keeping the SQL time-independent lets the cache key stay stable
+			// while expiry is still evaluated fresh on each call.
+			const rows = await db
 				.select({
 					id: discountTable.id,
 					organizationId: discountTable.organizationId,
 					provider: discountTable.provider,
 					model: discountTable.model,
 					discountPercent: discountTable.discountPercent,
+					expiresAt: discountTable.expiresAt,
 				})
 				.from(discountTable)
 				.where(
 					and(
-						notExpiredCondition,
 						or(
 							isNull(discountTable.organizationId),
 							organizationId
@@ -564,6 +564,11 @@ export async function findEffectiveDiscount(
 						or(eq(discountTable.model, model), isNull(discountTable.model)),
 					),
 				);
+
+			const now = Date.now();
+			const discounts = rows.filter(
+				(row) => row.expiresAt === null || row.expiresAt.getTime() >= now,
+			);
 
 			const modelMatches = (discountModel: string | null): boolean =>
 				discountModel !== null && discountModel === model;

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -567,7 +567,12 @@ export async function findEffectiveDiscount(
 
 			const now = Date.now();
 			const discounts = rows.filter(
-				(row) => row.expiresAt === null || row.expiresAt.getTime() >= now,
+				// expiresAt is a Date on both a fresh query and a Drizzle cache hit
+				// (the cache stores the raw pg result and re-applies the timestamp
+				// parser on restore). Wrap in new Date() defensively so the compare
+				// is robust even if a serialized value ever reaches here.
+				(row) =>
+					row.expiresAt === null || new Date(row.expiresAt).getTime() >= now,
 			);
 
 			const modelMatches = (discountModel: string | null): boolean =>

--- a/packages/db/src/provider-metrics-history.ts
+++ b/packages/db/src/provider-metrics-history.ts
@@ -68,7 +68,10 @@ const HISTORY_SWR_TTL_SECONDS = 30;
  * Runs a weighted aggregation against model_provider_mapping_history with
  * the supplied tier weights. SWR-cached by (history-config-hash, modelIds)
  * so concurrent requests with the same model set + history config share
- * one DB hit, and so the gateway stays warm if Postgres falls over.
+ * one DB hit, and so the gateway stays warm if Postgres falls over. The
+ * underlying Drizzle cache is pinned to a stable tag (see below) so the
+ * per-request time-window params don't bust the key; it expires on the TTL
+ * alone so high throughput doesn't translate into constant aggregations.
  */
 export async function getProviderMetricsFromHistory(
 	combinations: Array<{
@@ -158,7 +161,21 @@ export async function getProviderMetricsFromHistory(
 					modelProviderMappingHistory.modelId,
 					modelProviderMappingHistory.providerId,
 				)
-				.$withCache({ config: { ex: HISTORY_SWR_TTL_SECONDS } });
+				// Pin a stable cache tag. Without it, Drizzle keys the cache on
+				// hashQuery(sql, params), and the params include windowStart/tier
+				// boundaries derived from Date.now() at millisecond precision — so
+				// every request produced a unique key and the cache never hit,
+				// forcing the heavy weighted aggregation to run against Postgres on
+				// every request (catastrophic under high throughput). The tag is the
+				// same timestamp-independent key the SWR mirror uses, so requests
+				// with the same model set + history config share one cached result.
+				// autoInvalidate is off: routing metrics tolerate up to
+				// HISTORY_SWR_TTL_SECONDS of staleness and expire on the TTL alone.
+				.$withCache({
+					tag: cacheKey,
+					autoInvalidate: false,
+					config: { ex: HISTORY_SWR_TTL_SECONDS },
+				});
 
 			return result as unknown as HistoryRow[];
 		},


### PR DESCRIPTION
## Problem

Under high throughput on chat completions (~50 r/s), Postgres gets overloaded. Two hot-path queries that *appear* to be cached were in fact hitting Postgres on **every** request.

## Root cause (shared)

The cached Drizzle client (`cdb`) uses a Redis cache with strategy `"all"`. Unless a `$withCache({ tag })` is given, the cache key is `hashQuery(sql, JSON.stringify(params))`. When a query embeds a `Date` derived from `Date.now()` at **millisecond** precision as a SQL parameter, the key is unique on every request, so the cache **never hits**.

`swrWrap` does not save us here: it always calls the fetcher on the happy path and only serves its Redis mirror as a *fallback when Postgres errors* — so a stable swrWrap key does nothing to reduce DB load. The real per-request cache is the Drizzle `$withCache` layer, and its key was being busted.

(Note: `autoInvalidate`-on-write was *not* the lever — the worker writes these tables via the **uncached** `db`, so `onMutate`/table-invalidation never fires for them.)

## Fixes

**1. `packages/db/src/provider-metrics-history.ts` — routing metrics aggregation**
The weighted `sum(...)` aggregation over `model_provider_mapping_history` derives its window/tier boundaries from `Date.now()`, which entered the query as params → unique key per request → every routing decision re-ran the heavy aggregation against Postgres. Fix: pin a stable `$withCache({ tag })` using the timestamp-independent `(history-config-hash, modelIds)` key (the same key the SWR mirror already uses), so requests with the same model set + history config share one cached result for the 30s TTL.

**2. `apps/gateway/src/lib/cached-queries.ts` — `findEffectiveDiscount`**
The discount lookup filtered `expiresAt >= now` **in SQL**, so the `now` Date param busted the cache key the same way. This path is especially hot — it runs once **per provider candidate** during routing. Fix: drop the time predicate from SQL and apply the expiry filter in JS (evaluated fresh per call). The SQL is now time-independent → the cache key is stable → the cache actually hits, while expiry is still evaluated correctly on every call.

Both queries already tolerate up to their cache TTL of staleness by design, so only *when* the cache refreshes changes — not correctness.

## Impact

DB load for each of these drops from ~one query per request to at most one per TTL per distinct cache key.

## Testing

- `pnpm format` — clean
- `pnpm build` — 17/17 successful
- `pnpm vitest run` discount cache tests — pass (other failures in the suite are pre-existing local DB-seeding/FK issues, in unrelated tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how historical provider metrics are cached and refreshed, emphasizing TTL-based expiry under continuous writes.

* **Bug Fixes**
  * Made cache behavior more consistent for metric reads during heavy history writes.
  * Ensured discount expiry is evaluated at query time so expiring and non-expiring discounts are handled correctly.

* **Tests**
  * Added integration coverage to verify discount expiry and cache mirror behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->