### PR TITLE
feat(db): tag SQL queries with app for Query Insights

### DIFF
--- a/apps/api/src/serve.ts
+++ b/apps/api/src/serve.ts
@@ -1,6 +1,6 @@
 import { serve, type ServerType } from "@hono/node-server";
 
-import { closeDatabase, runMigrations } from "@llmgateway/db";
+import { closeDatabase, runMigrations, setQueryTags } from "@llmgateway/db";
 import {
 	initializeInstrumentation,
 	shutdownInstrumentation,
@@ -26,6 +26,9 @@ let sdk: NodeSDK | null = null;
 
 async function startServer() {
 	const port = Number(process.env.PORT) || 4002;
+
+	// Tag every DB query with the originating service for Cloud SQL Query Insights
+	setQueryTags({ application: "api" });
 
 	// Initialize tracing for API service
 	try {

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -1,7 +1,7 @@
 import { serve } from "@hono/node-server";
 
 import { redisClient } from "@llmgateway/cache";
-import { closeDatabase } from "@llmgateway/db";
+import { closeDatabase, setQueryTags } from "@llmgateway/db";
 import {
 	initializeInstrumentation,
 	shutdownInstrumentation,
@@ -24,6 +24,9 @@ const keepAliveTimeoutS = Number(process.env.KEEP_ALIVE_TIMEOUT_S) || 620;
 let sdk: NodeSDK | null = null;
 
 async function startServer() {
+	// Tag every DB query with the originating service for Cloud SQL Query Insights
+	setQueryTags({ application: "gateway" });
+
 	// Initialize tracing for gateway service
 	try {
 		sdk = initializeInstrumentation({

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 
+import { setQueryTags } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
 import { startWorker, stopWorker } from "./worker.js";
@@ -61,6 +62,9 @@ function isDirectExecution() {
 }
 
 if (isDirectExecution()) {
+	// Tag every DB query with the originating service for Cloud SQL Query Insights
+	setQueryTags({ application: "worker" });
+
 	logger.info("Starting worker application...");
 	startWorker().catch((error) => {
 		logger.error(

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,15 +4,8 @@ import { Pool } from "pg";
 
 import { logger } from "@llmgateway/logger";
 
-import { patchClientQuery, setQueryTags } from "./query-tags.js";
+import { patchClientQuery } from "./query-tags.js";
 import { relations } from "./relations.js";
-
-// Optional default tag from the environment so deployments can label queries
-// without code changes. App entrypoints typically override this via
-// setQueryTags({ application: "..." }).
-if (process.env.DB_APPLICATION_NAME) {
-	setQueryTags({ application: process.env.DB_APPLICATION_NAME });
-}
 
 // Single shared pool for all database connections
 // This prevents connection exhaustion from having multiple pools

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,7 +4,15 @@ import { Pool } from "pg";
 
 import { logger } from "@llmgateway/logger";
 
+import { patchClientQuery, setQueryTags } from "./query-tags.js";
 import { relations } from "./relations.js";
+
+// Optional default tag from the environment so deployments can label queries
+// without code changes. App entrypoints typically override this via
+// setQueryTags({ application: "..." }).
+if (process.env.DB_APPLICATION_NAME) {
+	setQueryTags({ application: process.env.DB_APPLICATION_NAME });
+}
 
 // Single shared pool for all database connections
 // This prevents connection exhaustion from having multiple pools
@@ -27,8 +35,10 @@ pool.on("error", (err) => {
 	logger.error("Unexpected database pool error", err);
 });
 
-// Log when pool connects (trace level to avoid noise in production)
-pool.on("connect", () => {
+// Log when pool connects (trace level to avoid noise in production) and patch
+// the new client so every statement it runs carries the sqlcommenter tag.
+pool.on("connect", (client) => {
+	patchClientQuery(client);
 	logger.trace("New database connection established");
 });
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -13,6 +13,7 @@ export * from "./migrate.js";
 export * from "./relations.js";
 export * from "./provider-metrics.js";
 export * from "./provider-metrics-history.js";
+export * from "./query-tags.js";
 export * from "./webhook-helpers.js";
 
 export * from "drizzle-orm";

--- a/packages/db/src/query-tags.spec.ts
+++ b/packages/db/src/query-tags.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	getQueryTagComment,
+	patchClientQuery,
+	setQueryTags,
+} from "./query-tags.js";
+
+import type { PoolClient } from "pg";
+
+afterEach(() => {
+	// Reset to the untagged state so tests don't leak into each other.
+	setQueryTags({});
+});
+
+describe("setQueryTags / getQueryTagComment", () => {
+	it("produces a sqlcommenter comment", () => {
+		setQueryTags({ application: "gateway" });
+		expect(getQueryTagComment()).toBe("/*application='gateway'*/");
+	});
+
+	it("sorts keys and drops empty values", () => {
+		setQueryTags({ route: "/v1/chat", application: "api", controller: "" });
+		expect(getQueryTagComment()).toBe(
+			"/*application='api',route='%2Fv1%2Fchat'*/",
+		);
+	});
+
+	it("url-encodes keys and values", () => {
+		setQueryTags({ application: "my app's worker" });
+		expect(getQueryTagComment()).toBe(
+			"/*application='my%20app%27s%20worker'*/",
+		);
+	});
+
+	it("returns an empty comment when no tags are set", () => {
+		setQueryTags({});
+		expect(getQueryTagComment()).toBe("");
+	});
+});
+
+describe("patchClientQuery", () => {
+	function makeClient() {
+		const spy = vi.fn(() => Promise.resolve({ rows: [] }));
+		const client = { query: spy } as unknown as PoolClient;
+		return { client, spy };
+	}
+
+	it("appends the comment to string queries", async () => {
+		setQueryTags({ application: "gateway" });
+		const { client, spy } = makeClient();
+		patchClientQuery(client);
+
+		await client.query("SELECT 1");
+		expect(spy).toHaveBeenCalledWith("SELECT 1 /*application='gateway'*/");
+	});
+
+	it("appends the comment to config-object queries and preserves values", async () => {
+		setQueryTags({ application: "api" });
+		const { client, spy } = makeClient();
+		patchClientQuery(client);
+
+		await client.query({ text: "SELECT $1", values: [1] });
+		expect(spy).toHaveBeenCalledWith({
+			text: "SELECT $1 /*application='api'*/",
+			values: [1],
+		});
+	});
+
+	it("does not tag when no tags are set", async () => {
+		setQueryTags({});
+		const { client, spy } = makeClient();
+		patchClientQuery(client);
+
+		await client.query("SELECT 1");
+		expect(spy).toHaveBeenCalledWith("SELECT 1");
+	});
+
+	it("does not double-tag statements that already have a comment", async () => {
+		setQueryTags({ application: "gateway" });
+		const { client, spy } = makeClient();
+		patchClientQuery(client);
+
+		await client.query("SELECT 1 /*existing*/");
+		expect(spy).toHaveBeenCalledWith("SELECT 1 /*existing*/");
+	});
+
+	it("leaves submittable configs untouched", async () => {
+		setQueryTags({ application: "gateway" });
+		const { client, spy } = makeClient();
+		patchClientQuery(client);
+
+		const submittable = { text: "SELECT 1", submit: () => undefined };
+		await client.query(submittable as never);
+		expect(spy).toHaveBeenCalledWith(submittable);
+	});
+
+	it("is idempotent", () => {
+		setQueryTags({ application: "gateway" });
+		const { client, spy } = makeClient();
+		patchClientQuery(client);
+		const patched = client.query;
+		patchClientQuery(client);
+		expect(client.query).toBe(patched);
+		expect(client.query).not.toBe(spy);
+	});
+});

--- a/packages/db/src/query-tags.ts
+++ b/packages/db/src/query-tags.ts
@@ -41,8 +41,8 @@ function serialize(tags: QueryTags): string {
 }
 
 /**
- * Set the process-wide tags appended to every SQL query. Call once at app
- * startup, e.g. `setQueryTags({ application: "gateway" })`.
+ * Set the process-wide tags appended to every SQL query. Call once at each
+ * app's startup, e.g. `setQueryTags({ application: "gateway" })`.
  *
  * Tags are static per process on purpose: the comment becomes part of the query
  * text, so a per-request value would break prepared-statement caching and could

--- a/packages/db/src/query-tags.ts
+++ b/packages/db/src/query-tags.ts
@@ -1,0 +1,107 @@
+import type { PoolClient } from "pg";
+
+/**
+ * Tags appended to every SQL statement as a sqlcommenter comment so the source
+ * of a query is visible in Google Cloud SQL Query Insights.
+ *
+ * Query Insights only aggregates on a fixed set of tag keys: `application`,
+ * `route`, `controller`, `action`, `framework`, `db_driver`, `traceparent` and
+ * `tracestate`. Use `application` (e.g. "gateway", "api", "worker") to see
+ * which service issued a query in the Query Insights "By tag" view. Other keys
+ * are still emitted in the SQL comment but are not given their own dimension.
+ */
+export interface QueryTags {
+	[key: string]: string | undefined;
+}
+
+let comment = "";
+
+/**
+ * URL-encode per the sqlcommenter spec, including the characters that
+ * encodeURIComponent leaves untouched.
+ */
+function encode(value: string): string {
+	return encodeURIComponent(value).replace(
+		/[!'()*]/g,
+		(c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+	);
+}
+
+/**
+ * Serialize tags into a sqlcommenter comment: keys sorted alphabetically,
+ * key and value URL-encoded, value single-quoted. For example, the tag
+ * { application: "gateway" } becomes a comment containing application='gateway'.
+ */
+function serialize(tags: QueryTags): string {
+	const parts = Object.keys(tags)
+		.filter((key) => tags[key] !== undefined && tags[key] !== "")
+		.sort()
+		.map((key) => `${encode(key)}='${encode(String(tags[key]))}'`);
+	return parts.length ? `/*${parts.join(",")}*/` : "";
+}
+
+/**
+ * Set the process-wide tags appended to every SQL query. Call once at app
+ * startup, e.g. `setQueryTags({ application: "gateway" })`.
+ *
+ * Tags are static per process on purpose: the comment becomes part of the query
+ * text, so a per-request value would break prepared-statement caching and could
+ * spam Query Insights with unique statements.
+ */
+export function setQueryTags(tags: QueryTags): void {
+	comment = serialize(tags);
+}
+
+/** The current sqlcommenter comment, or "" when no tags are set. */
+export function getQueryTagComment(): string {
+	return comment;
+}
+
+function tag(text: string): string {
+	if (!comment) {
+		return text;
+	}
+	// Leave statements that already carry a comment untouched, to avoid
+	// double-tagging or interfering with an intentional comment.
+	if (text.includes("/*")) {
+		return text;
+	}
+	return `${text} ${comment}`;
+}
+
+const PATCHED = Symbol.for("llmgateway.db.queryTagPatched");
+
+/**
+ * Patch a pg client's `query` so every statement it runs gets the current tag
+ * comment appended. Patching the client (rather than the pool) also covers
+ * transactions, which check out a dedicated client and bypass `pool.query`.
+ *
+ * Idempotent: a client is patched at most once.
+ */
+export function patchClientQuery(client: PoolClient): void {
+	const target = client as unknown as Record<symbol, unknown> & {
+		query: (...args: unknown[]) => unknown;
+	};
+	if (target[PATCHED]) {
+		return;
+	}
+	target[PATCHED] = true;
+
+	const original = client.query.bind(client);
+	target.query = function (config: unknown, ...rest: unknown[]) {
+		if (typeof config === "string") {
+			config = tag(config);
+		} else if (
+			config &&
+			typeof config === "object" &&
+			typeof (config as { text?: unknown }).text === "string" &&
+			// Submittable configs (Cursor, prepared queries) carry their own
+			// lifecycle; don't rewrite them.
+			typeof (config as { submit?: unknown }).submit !== "function"
+		) {
+			const cfg = config as { text: string };
+			config = { ...cfg, text: tag(cfg.text) };
+		}
+		return original(config as never, ...(rest as never[]));
+	};
+}


### PR DESCRIPTION
## What

Appends a [sqlcommenter](https://google.github.io/sqlcommenter/) comment to every SQL statement (e.g. `SELECT ... /*application='gateway'*/`) so **Google Cloud SQL Query Insights** can show which service issued a query in its *By tag* view.

Query Insights only aggregates on a fixed set of tag keys (`application`, `route`, `controller`, `action`, `framework`, `db_driver`, `traceparent`). We use `application` — the tag designed for "which app" — set per process to `gateway` / `api` / `worker`.

## How

- New `packages/db/src/query-tags.ts`:
  - `setQueryTags({ application })` — set process-wide tags (serialized sqlcommenter, keys sorted, URL-encoded).
  - `patchClientQuery(client)` — appends the comment to a pg client's `query`. Idempotent; skips statements that already carry a comment and Submittable configs (cursors).
- `packages/db/src/db.ts` patches each connection in the existing `pool.on('connect')` handler. This is the **single chokepoint** that covers `db`, `cdb` (cache misses) and transactions (which check out a dedicated client via `pool.connect()`), without coupling to drizzle internals.
- Each app hardcodes its tag at startup: gateway/api `serve.ts`, worker `index.ts` (guarded to the direct-execution path).
- Unit tests in `query-tags.spec.ts` (10 tests).

## Why this approach

Drizzle has **no native query tagging** ([drizzle-orm#2147](https://github.com/drizzle-team/drizzle-orm/issues/2147) is open/unimplemented). The community package `@query-doctor/sqlcommenter-drizzle` patches drizzle's internal `session.prepareQuery` and runs `new Error().stack` per query for file attribution — fragile to drizzle version changes and costly on the gateway's hot path. Patching the shared pg `Pool` at the client level is more robust here: this repo runs two drizzle instances (`db` + `cdb`) plus better-auth and migrations over one pool, and tags are static per process so prepared-statement caching is unaffected (verified `name` is `undefined` for non-prepared queries, and the repo uses no `.prepare()` calls).

Tags are static per process by design. Per-route tagging is intentionally omitted (it inflates Query Insights' normalized-query cardinality); it can be added later via an AsyncLocalStorage layer in middleware if needed.

## Safety

The patched `query` wrapper is a **true no-op until `setQueryTags()` is called** (returns the input unchanged when no tags are set), and the only behavioral change once set is appending a comment Postgres ignores. No named prepared statements and no pg COPY usage in the repo, so the two classic sqlcommenter footguns don't apply.

## Test plan

- [x] `pnpm test:unit` for `query-tags.spec.ts` — 10/10 pass
- [x] `pnpm format`
- [x] `pnpm build` — 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)