### PR TITLE
perf(worker): drain credit-processing loop

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -711,12 +711,13 @@ export async function cleanupExpiredLogData(): Promise<void> {
 	}
 }
 
-export async function batchProcessLogs(): Promise<void> {
+export async function batchProcessLogs(): Promise<number> {
 	const lockAcquired = await acquireLock(CREDIT_PROCESSING_LOCK_KEY);
 	if (!lockAcquired) {
-		return;
+		return 0;
 	}
 
+	let processedCount = 0;
 	const deductedOrgIds: string[] = [];
 	// LLM SDK: wallets that crossed below the low-balance threshold this
 	// batch — webhooks are enqueued after the transaction commits.
@@ -780,6 +781,8 @@ export async function batchProcessLogs(): Promise<void> {
 			if (unprocessedLogs.rows.length === 0) {
 				return;
 			}
+
+			processedCount = unprocessedLogs.rows.length;
 
 			logger.info(
 				`Processing ${unprocessedLogs.rows.length} logs for credit deduction and API key usage`,
@@ -1356,6 +1359,8 @@ export async function batchProcessLogs(): Promise<void> {
 	} finally {
 		await releaseLock(CREDIT_PROCESSING_LOCK_KEY);
 	}
+
+	return processedCount;
 }
 
 async function checkLowBalanceAlerts(orgIds: string[]): Promise<void> {
@@ -1741,9 +1746,15 @@ async function runBatchProcessLoop() {
 	try {
 		while (!isStopRequested()) {
 			try {
-				await batchProcessLogs();
+				const processed = await batchProcessLogs();
 
-				await interruptibleSleep(interval);
+				// A full batch means more unprocessed logs remain, so loop straight
+				// into the next batch instead of sleeping. Without this the loop is
+				// hard-capped at CREDIT_BATCH_SIZE / interval logs per second (e.g.
+				// 100 / 5s = 20/s) regardless of how far behind credit processing is.
+				if (processed < CREDIT_BATCH_SIZE) {
+					await interruptibleSleep(interval);
+				}
 			} catch (error) {
 				logger.error(
 					"Error in batch process loop",

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -729,7 +729,10 @@ export async function batchProcessLogs(): Promise<number> {
 	}> = [];
 
 	try {
-		await db.transaction(async (tx) => {
+		// Only batches that actually commit count toward processedCount, so a
+		// rolled-back transaction leaves it at 0 and the loop backs off instead
+		// of hot-looping on a failing batch.
+		processedCount = await db.transaction(async (tx) => {
 			// Get unprocessed logs with row-level locking to prevent concurrent processing
 			const rows = await tx
 				.select({
@@ -779,10 +782,8 @@ export async function batchProcessLogs(): Promise<number> {
 			const unprocessedLogs = { rows };
 
 			if (unprocessedLogs.rows.length === 0) {
-				return;
+				return 0;
 			}
-
-			processedCount = unprocessedLogs.rows.length;
 
 			logger.info(
 				`Processing ${unprocessedLogs.rows.length} logs for credit deduction and API key usage`,
@@ -1324,6 +1325,8 @@ export async function batchProcessLogs(): Promise<number> {
 				.where(inArray(log.id, logIds));
 
 			logger.debug(`Marked ${logIds.length} logs as processed`);
+
+			return unprocessedLogs.rows.length;
 		});
 
 		// Async low-balance alert check (outside transaction, non-blocking)


### PR DESCRIPTION
## Summary

**This is the actual cause of the constant ~20 r/s** on the GCP "log-process" metric — and it's a different loop than the log-*insert* work in #2649/#2653.

The `kind: "log-process"` log is emitted once per log inside `batchProcessLogs()` (worker.ts:819) — the **credit-deduction / billing** loop, which sets `processedAt`. That metric counts those entries, so it measures credit-processing throughput, not Postgres insert rate.

### Root cause

`batchProcessLogs()` processes at most `CREDIT_BATCH_SIZE` (default **100**) unprocessed logs per call, then `runBatchProcessLoop` slept a fixed `BATCH_PROCESSING_INTERVAL_SECONDS` (= `CREDIT_BATCH_INTERVAL`, default **5s**) on **every** cycle — backlog or not:

```
100 logs / 5s = 20 logs/s   ← constant, exactly what the metric showed
```

The fixed sleep made it a hard ceiling independent of how far behind billing was.

### Change

- `batchProcessLogs()` now returns the number of logs processed.
- The loop only idle-sleeps when the batch came back **short** of `CREDIT_BATCH_SIZE` (caught up). A full batch means more unprocessed logs remain, so it loops straight into the next batch.

Throughput is now bounded by per-batch transaction time instead of the artificial 5s floor — roughly an order of magnitude headroom. Correctness is unchanged: still one transaction per batch, `SELECT ... FOR UPDATE SKIP LOCKED` + setting `processedAt` in the same transaction prevents double-processing/double-billing.

### Note on the earlier PRs

#2649 (org-cache + insert timing) and #2653 (insert-loop idle-poll + concurrency) fixed real issues in the **log-insert** loop (`processLogQueue`), which was doing ~86 rows/s — they just weren't the loop this metric tracks. They remain valid; this PR fixes the credit loop the "log-process" metric actually measures.

## Test plan

- `pnpm build` — passes
- `pnpm vitest run apps/worker/src/log-processing.spec.ts` — 11/11 pass (run isolated; the worker specs share a DB and produce false failures if run in parallel, per AGENTS.md)
- Worker replicas unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved background log processing so the worker adapts its pacing based on how many records it processed each cycle. This reduces unnecessary waiting when large batches are handled, resulting in faster throughput and more timely processing of queued items while preserving stability when fewer items are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->