### PR TITLE
perf(worker): use array param for batch log updates

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -678,7 +678,14 @@ export async function cleanupExpiredLogData(): Promise<void> {
 						responsesApiData: null,
 						dataRetentionCleanedUp: true,
 					})
-					.where(inArray(log.id, idsToClean));
+					// Use `= ANY($1)` with a single array parameter instead of
+					// `inArray()`, which expands to `IN ($1, $2, ...)` with a
+					// variable number of binds per batch. A varying placeholder
+					// count makes pg_stat_statements fingerprint every batch size
+					// as a distinct query, so one logical operation shows up as
+					// thousands of individual queries. The array form keeps the
+					// query text constant.
+					.where(sql`${log.id} = ANY(${sql.param(idsToClean)}::text[])`);
 
 				return recordsToClean.length;
 			});
@@ -1312,13 +1319,15 @@ export async function batchProcessLogs(): Promise<void> {
 				}
 			}
 
-			// Mark all logs as processed within the same transaction
+			// Mark all logs as processed within the same transaction.
+			// `= ANY($1)` keeps the query text constant across batch sizes; see
+			// the data-retention cleanup above for why this matters.
 			await tx
 				.update(log)
 				.set({
 					processedAt: new Date(),
 				})
-				.where(inArray(log.id, logIds));
+				.where(sql`${log.id} = ANY(${sql.param(logIds)}::text[])`);
 
 			logger.debug(`Marked ${logIds.length} logs as processed`);
 		});


### PR DESCRIPTION
## Problem

The data-retention cleanup and the `processedAt` batch update in `apps/worker/src/worker.ts` used `inArray(log.id, ids)`, which Drizzle expands to `IN ($1, $2, … $N)` with a **variable** number of bind parameters per batch.

A varying placeholder count means `pg_stat_statements` / RDS Performance Insights fingerprint each distinct batch size as a *separate* query. One logical operation (e.g. the retention cleanup) therefore shows up as thousands of "individual queries" in query monitoring instead of a single aggregated entry.

## Fix

Switch both batch updates to `= ANY($1::text[])` with the id list bound as a **single** array parameter (`sql.param(ids)`). The query text is now constant regardless of batch size, so monitoring tools aggregate it as one query. Planner behavior and index usage are unchanged.

Verified the generated SQL collapses to a constant `"log"."id" = ANY($1::text[])` across batch sizes, and the worker `log-processing` suite (11 tests) passes against a real Postgres, confirming node-postgres serializes the array param correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal log processing query patterns to improve database performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->