### PR TITLE
feat(admin): search orgs by member email

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1632,6 +1632,7 @@ admin.openapi(getOrganizations, async (c) => {
 				sql`LOWER(${tables.organization.name}) LIKE ${`%${searchLower}%`}`,
 				sql`LOWER(${tables.organization.billingEmail}) LIKE ${`%${searchLower}%`}`,
 				sql`${tables.organization.id} LIKE ${`%${search}%`}`,
+				sql`EXISTS (SELECT 1 FROM ${tables.userOrganization} uo JOIN ${tables.user} u ON uo.user_id = u.id WHERE uo.organization_id = ${tables.organization.id} AND LOWER(u.email) LIKE ${`%${searchLower}%`})`,
 			)
 		: undefined;
 

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -221,7 +221,7 @@ export default async function OrganizationsPage({
 						<input
 							type="text"
 							name="search"
-							placeholder="Search by name, email, or ID..."
+							placeholder="Search by name, email, member email, or ID..."
 							defaultValue={search}
 							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
 						/>


### PR DESCRIPTION
## Summary

Admin organization search now also matches organizations by the email of any of their members, not just the org name, billing email, and ID.

Previously, searching for a user's email in the admin Organizations page returned no results unless that email happened to be the org's billing email. This adds an `EXISTS` subquery over `userOrganization` joined with `user`, so an org is matched when any member's email matches the query.

## Changes

- `apps/api/src/routes/admin.ts`: added a member-email `EXISTS` clause to the organizations search `whereClause` (applies to both the count and the list query).
- `ee/admin/src/app/organizations/page.tsx`: updated the search placeholder to "Search by name, email, member email, or ID...".

## Testing

- `pnpm --filter api build` ✅
- `pnpm --filter admin build` ✅
- `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization search now includes member and owner email addresses, enabling users to find organizations by searching for linked user email addresses in addition to organization name, billing email, and ID.

* **Documentation**
  * Updated search field descriptions to reflect newly searchable attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->