### PR TITLE
test: fix video routing tie after priority change

### DIFF
--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -933,7 +933,10 @@ describe("getCheapestFromAvailableProviders", () => {
 			},
 		);
 
-		expect(cheapestProvider?.provider.providerId).toBe("avalanche");
+		// google-vertex and avalanche have identical per-second pricing, so this
+		// is a price tie; the price-only path deterministically selects the
+		// first-listed provider (google-vertex).
+		expect(cheapestProvider?.provider.providerId).toBe("google-vertex");
 
 		const vertexScore = cheapestProvider?.metadata.providerScores.find(
 			(provider) => provider.providerId === "google-vertex",


### PR DESCRIPTION
## Summary

`pnpm test:unit` was failing on `main` after the recent "adapt provider priorities" commits (d4eb6880e, 4d29cf047):

```
FAIL packages/actions/src/models.spec.ts > getCheapestFromAvailableProviders > should use per-second pricing for video providers
Expected: "avalanche"
Received: "google-vertex"
```

## Root cause

`google-vertex` previously carried a `priority: 0.8` penalty. The price-only routing path computes `effectivePrice = price / priority`, so vertex's effective price was `3.2 / 0.8 = 4.0` while avalanche stayed at `3.2` — making avalanche the winner.

The priority commits removed vertex's `0.8` penalty (it now defaults to `1.0`). `google-vertex` and `avalanche` have identical per-second video pricing (`default_audio: 0.4` → 8s × 0.4 = 3.2), so it is now a genuine price tie. The price-only path uses a strict `<` comparison, so it deterministically selects the first-listed provider — `google-vertex`.

## Fix

The test's real purpose (verifying per-second pricing computes to 3.2 for both providers) still holds; only the now-stale selection assertion needed updating. This follows the precedent of #2503 ("test: fix routing tests broken by provider priority").

`pnpm format` and `pnpm build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated video provider pricing test to verify deterministic tie-breaking behavior when providers have identical per-second costs, ensuring consistent selection of the first-listed provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->