### PR TITLE
fix(gateway): handle deepinfra in streaming transform

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1336,6 +1336,7 @@ export function transformStreamingToOpenai(
 		case "canopywave":
 		case "inference.net":
 		case "together-ai":
+		case "deepinfra":
 		case "custom":
 		case "nanogpt":
 		case "bytedance":


### PR DESCRIPTION
## Problem

Streaming requests routed to DeepInfra logged a warning on every chunk:

```
WARN (llmgateway): [streaming] Unknown provider using OpenAI fallback
    provider: "deepinfra"
    model: "glm-5.1"
```

DeepInfra uses the OpenAI-compatible `/chat/completions` endpoint, but `deepinfra` was missing from the provider `switch` in `transform-streaming-to-openai.ts`. Every streamed chunk fell through to the `default` case, which still works (it applies the same OpenAI transform) but emits a noisy warning per chunk.

## Fix

Add `deepinfra` to the OpenAI-compatible case list alongside the other OpenAI-compatible providers (`together-ai`, `inference.net`, etc.), so chunks are handled explicitly and the warning is no longer logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved streaming response handling for the DeepInfra provider by normalizing finish reason values to align with OpenAI's standard format, ensuring consistent behavior across all supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->