### PR TITLE
fix(seo): clear GSC product snippet warnings

### DIFF
--- a/apps/ui/src/app/enterprise/[slug]/page.tsx
+++ b/apps/ui/src/app/enterprise/[slug]/page.tsx
@@ -129,7 +129,7 @@ export default async function EnterpriseFeaturePage({ params }: PageProps) {
 
 	const productSchema = {
 		"@context": "https://schema.org",
-		"@type": "Product",
+		"@type": "Service",
 		name: `LLM Gateway Enterprise – ${feature.title}`,
 		description: feature.longDescription,
 		brand: {

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -25,7 +25,12 @@ import { ModelRating } from "@/components/models/model-rating";
 import { ModelStatusBadgeAuto } from "@/components/models/model-status-badge-auto";
 import { ProviderTabs } from "@/components/models/provider-tabs";
 import { Badge } from "@/lib/components/badge";
-import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
+import {
+	buildRatingSchema,
+	digitalOfferFields,
+	hasFullRatingData,
+	type ModelRatingsData,
+} from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
 import {
@@ -208,7 +213,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 
 	const productSchema = {
 		"@context": "https://schema.org",
-		"@type": "Product",
+		"@type": hasFullRatingData(ratingsData) ? "Product" : "Service",
 		name: `${modelDef.name ?? modelDef.id} on ${providerInfo?.name ?? decodedProvider}`,
 		description:
 			modelDef.description ??
@@ -233,6 +238,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 				"@type": "Organization",
 				name: "LLM Gateway",
 			},
+			...digitalOfferFields,
 		},
 		category: "AI/ML API Service",
 		...buildRatingSchema(ratingsData),

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -33,7 +33,12 @@ import {
 	perMillion,
 } from "@/lib/discount";
 import { fetchModelDiscounts } from "@/lib/fetch-models";
-import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
+import {
+	buildRatingSchema,
+	digitalOfferFields,
+	hasFullRatingData,
+	type ModelRatingsData,
+} from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
 import {
@@ -153,7 +158,7 @@ export default async function ModelPage({ params }: PageProps) {
 	const primaryProviderId = modelDef.providers[0]?.providerId || "default";
 	const productSchema = {
 		"@context": "https://schema.org",
-		"@type": "Product",
+		"@type": hasFullRatingData(ratingsData) ? "Product" : "Service",
 		name: modelDef.name ?? modelDef.id,
 		description:
 			modelDef.description ??
@@ -170,6 +175,7 @@ export default async function ModelPage({ params }: PageProps) {
 			highPrice: isFinite(highestInputPrice) ? highestInputPrice : 0,
 			offerCount: modelProviders.length,
 			availability: "https://schema.org/InStock",
+			...digitalOfferFields,
 		},
 		category: "AI/ML API Service",
 		...buildRatingSchema(ratingsData),

--- a/apps/ui/src/lib/rating-schema.ts
+++ b/apps/ui/src/lib/rating-schema.ts
@@ -9,6 +9,50 @@ export interface ModelRatingsData {
 	}[];
 }
 
+export function hasFullRatingData(ratings: ModelRatingsData | null) {
+	return Boolean(
+		ratings &&
+			ratings.ratingCount > 0 &&
+			ratings.averageRating &&
+			ratings.reviews.length > 0,
+	);
+}
+
+export const digitalOfferFields = {
+	hasMerchantReturnPolicy: {
+		"@type": "MerchantReturnPolicy",
+		applicableCountry: "US",
+		returnPolicyCategory: "https://schema.org/MerchantReturnNotPermitted",
+	},
+	shippingDetails: {
+		"@type": "OfferShippingDetails",
+		shippingRate: {
+			"@type": "MonetaryAmount",
+			value: 0,
+			currency: "USD",
+		},
+		shippingDestination: {
+			"@type": "DefinedRegion",
+			addressCountry: "US",
+		},
+		deliveryTime: {
+			"@type": "ShippingDeliveryTime",
+			handlingTime: {
+				"@type": "QuantitativeValue",
+				minValue: 0,
+				maxValue: 0,
+				unitCode: "DAY",
+			},
+			transitTime: {
+				"@type": "QuantitativeValue",
+				minValue: 0,
+				maxValue: 0,
+				unitCode: "DAY",
+			},
+		},
+	},
+};
+
 export function buildRatingSchema(ratings: ModelRatingsData | null) {
 	if (!ratings || ratings.ratingCount === 0 || !ratings.averageRating) {
 		return {};


### PR DESCRIPTION
## Summary

Google Search Console flags model pages (e.g. `/models/sora-2`, `/models/claude-haiku-4-5`) with:
- **Missing field "aggregateRating"** / **Missing field "review"** — models with no community ratings emit `Product` markup without rating fields, and Google forbids fabricating ratings, so these warnings could never clear.
- **Missing field "hasMerchantReturnPolicy" / "shippingDetails" (in "offers")** — merchant listing fields were absent from the offers.

## Changes

- **Conditional schema type**: model pages emit `Product` markup only when real rating **and** review data exists (full star-snippet eligibility, zero warnings). Unrated models emit the same data as `Service`, which is not subject to product snippet validation, so those pages drop out of the GSC report on recrawl.
- **Offers**: added `hasMerchantReturnPolicy` (returns not permitted) and `shippingDetails` (free, zero-day digital delivery) to both the `AggregateOffer` on `/models/[name]` and the `Offer` on `/models/[name]/[provider]` via a shared `digitalOfferFields` constant.
- **Enterprise pages**: `/enterprise/[slug]` emitted a `Product` with no offers/review/aggregateRating at all (invalid for product snippets) — switched to `Service`.

After deploy, re-run validation in GSC for all four issues.

## Testing

- `pnpm build` passes (all 17 tasks)
- `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Enhanced product and service structured data schemas with dynamic type selection based on available rating information
  * Added merchant return policies and shipping/delivery details to product offers to improve search engine optimization and rich snippet display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->