### PR TITLE
fix: stop imposing catalog assumptions on custom providers

### DIFF
--- a/apps/gateway/src/chat-custom-provider.e2e.ts
+++ b/apps/gateway/src/chat-custom-provider.e2e.ts
@@ -197,6 +197,29 @@ describe("Custom Provider E2E", () => {
 			);
 		});
 
+		test("should not cap max_tokens for custom providers", async () => {
+			await setupTestData({ mode: "api-keys", includeProviderKey: true });
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "my-custom/qwen3.6-plus",
+					max_tokens: 32000,
+					messages: [{ role: "user", content: "hello" }],
+				}),
+			});
+
+			const json = await res.json();
+			expect(res.status).toBe(200);
+			expect(json.choices[0].message.content).toBe(
+				"Hello from custom provider!",
+			);
+		});
+
 		test("should succeed in hybrid mode with custom provider key", async () => {
 			await setupTestData({
 				mode: "hybrid",

--- a/apps/gateway/src/chat-custom-provider.e2e.ts
+++ b/apps/gateway/src/chat-custom-provider.e2e.ts
@@ -220,6 +220,29 @@ describe("Custom Provider E2E", () => {
 			);
 		});
 
+		test("should not reject json_object response_format for custom providers", async () => {
+			await setupTestData({ mode: "api-keys", includeProviderKey: true });
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "my-custom/qwen3.6-plus",
+					response_format: { type: "json_object" },
+					messages: [{ role: "user", content: "hello" }],
+				}),
+			});
+
+			const json = await res.json();
+			expect(res.status).toBe(200);
+			expect(json.choices[0].message.content).toBe(
+				"Hello from custom provider!",
+			);
+		});
+
 		test("should succeed in hybrid mode with custom provider key", async () => {
 			await setupTestData({
 				mode: "hybrid",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3886,9 +3886,12 @@ chat.openapi(completions, async (c) => {
 					inputPrice: "0",
 					outputPrice: "0",
 					// Custom providers have no catalog entry, so the gateway cannot
-					// know contextSize, maxOutput, or vision support. Leave them
-					// unset rather than guessing — the upstream provider enforces
-					// its own limits and capabilities.
+					// know their limits (contextSize, maxOutput) or capabilities
+					// (vision, jsonOutput, ...). Leave them unset rather than
+					// guessing — capability validation is skipped for custom
+					// providers and the upstream provider enforces its own limits.
+					// `streaming` is required by the type but is never read for
+					// custom providers (streaming support comes from the catalog).
 					streaming: true,
 				},
 			],

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3886,7 +3886,10 @@ chat.openapi(completions, async (c) => {
 					inputPrice: "0",
 					outputPrice: "0",
 					contextSize: 8192,
-					maxOutput: 4096,
+					// Custom providers have no catalog entry, so the gateway does not
+					// know the real output limit. Leave it uncapped and let the
+					// upstream provider enforce its own max_tokens limit.
+					maxOutput: undefined,
 					streaming: true,
 					vision: false,
 				},

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3885,13 +3885,11 @@ chat.openapi(completions, async (c) => {
 					externalId: usedExternalId,
 					inputPrice: "0",
 					outputPrice: "0",
-					contextSize: 8192,
-					// Custom providers have no catalog entry, so the gateway does not
-					// know the real output limit. Leave it uncapped and let the
-					// upstream provider enforce its own max_tokens limit.
-					maxOutput: undefined,
+					// Custom providers have no catalog entry, so the gateway cannot
+					// know contextSize, maxOutput, or vision support. Leave them
+					// unset rather than guessing — the upstream provider enforces
+					// its own limits and capabilities.
 					streaming: true,
-					vision: false,
 				},
 			],
 		};

--- a/apps/gateway/src/chat/tools/resolve-model-info.ts
+++ b/apps/gateway/src/chat/tools/resolve-model-info.ts
@@ -41,13 +41,11 @@ export function resolveModelInfo(
 					externalId: requestedModel,
 					inputPrice: "0",
 					outputPrice: "0",
-					contextSize: 8192,
-					// Custom providers have no catalog entry, so the gateway does not
-					// know the real output limit. Leave it uncapped and let the
-					// upstream provider enforce its own max_tokens limit.
-					maxOutput: undefined,
+					// Custom providers have no catalog entry, so the gateway cannot
+					// know contextSize, maxOutput, or vision support. Leave them
+					// unset rather than guessing — the upstream provider enforces
+					// its own limits and capabilities.
 					streaming: true,
-					vision: false,
 					jsonOutput: true,
 				},
 			],

--- a/apps/gateway/src/chat/tools/resolve-model-info.ts
+++ b/apps/gateway/src/chat/tools/resolve-model-info.ts
@@ -42,11 +42,13 @@ export function resolveModelInfo(
 					inputPrice: "0",
 					outputPrice: "0",
 					// Custom providers have no catalog entry, so the gateway cannot
-					// know contextSize, maxOutput, or vision support. Leave them
-					// unset rather than guessing — the upstream provider enforces
-					// its own limits and capabilities.
+					// know their limits (contextSize, maxOutput) or capabilities
+					// (vision, jsonOutput, ...). Leave them unset rather than
+					// guessing — capability validation is skipped for custom
+					// providers and the upstream provider enforces its own limits.
+					// `streaming` is required by the type but is never read for
+					// custom providers (streaming support comes from the catalog).
 					streaming: true,
-					jsonOutput: true,
 				},
 			],
 		};

--- a/apps/gateway/src/chat/tools/resolve-model-info.ts
+++ b/apps/gateway/src/chat/tools/resolve-model-info.ts
@@ -42,7 +42,10 @@ export function resolveModelInfo(
 					inputPrice: "0",
 					outputPrice: "0",
 					contextSize: 8192,
-					maxOutput: 4096,
+					// Custom providers have no catalog entry, so the gateway does not
+					// know the real output limit. Leave it uncapped and let the
+					// upstream provider enforce its own max_tokens limit.
+					maxOutput: undefined,
 					streaming: true,
 					vision: false,
 					jsonOutput: true,

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -98,6 +98,20 @@ describe("validateModelCapabilities - vision", () => {
 	});
 });
 
+describe("validateModelCapabilities - custom providers", () => {
+	it("skips all capability checks when the provider is custom", () => {
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "qwen3.6-plus", "custom", {
+				hasImages: true,
+				hasDocuments: true,
+				response_format: { type: "json_object" },
+				reasoning_effort: "high",
+				tools: [{ type: "function" }],
+			}),
+		).not.toThrow();
+	});
+});
+
 describe("validateModelCapabilities - embeddings", () => {
 	it("rejects embedding-only models on chat completions", () => {
 		expect(() =>

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -47,6 +47,13 @@ export function validateModelCapabilities(
 		hasDocuments,
 	} = options;
 
+	// Custom providers have no catalog entry, so the gateway cannot know which
+	// capabilities they support. Skip all capability validation and let the
+	// upstream provider reject anything it doesn't support.
+	if (requestedProvider === "custom") {
+		return;
+	}
+
 	if (
 		requestedModel !== "auto" &&
 		requestedModel !== "custom" &&


### PR DESCRIPTION
## Problem

Requests to a custom provider were rejected when `max_tokens` exceeded 4096, even when the underlying model supports far more:

```
{"error":{"message":"The requested max_tokens (32000) exceeds the maximum output tokens allowed for model qwen3.6-plus (4096)","type":"invalid_request_error"}}
```

Custom providers have no entry in the model catalog, so the gateway synthesizes a mock `ModelDefinition`. That mock hardcoded placeholder values it cannot actually know — `maxOutput: 4096`, `contextSize: 8192`, `vision: false`, `jsonOutput: true`. These guesses both imposed false limits (the `maxOutput` cap above) and gated capability rejections (vision/JSON/tools) on values the gateway has no way to determine.

## Fix

Treat custom providers as fully opaque — the upstream provider is the authority on limits and capabilities:

- **Drop the guessed fields** (`maxOutput`, `contextSize`, `vision`, `jsonOutput`) from the synthesized custom-provider mapping in both places it is built (`resolve-model-info.ts` and `chat.ts`). The `max_tokens` validation guards on `maxOutput !== undefined`, so it is now skipped for custom providers; `contextSize` only feeds auto-routing (which never applies to a pinned custom provider) and has a fallback.
- **Skip capability validation for custom providers** in `validateModelCapabilities` (early return when `requestedProvider === "custom"`), consistent with how it already skips the bare `auto`/`custom` model strings. This covers vision, documents, JSON output, JSON schema, reasoning, and tools — none of which the gateway can know for a custom endpoint.

`streaming: true` is kept only because the type requires it; it is never read for custom providers (streaming support is computed from the catalog via `getModelStreamingSupport`, which returns `null` for a non-catalog model and therefore never rejects). Pricing stays `"0"` (BYOK, not billed by the gateway).

## Tests

- `chat-custom-provider.e2e.ts`: added regression tests for `max_tokens: 32000` and `response_format: json_object` against a custom provider, both asserting `200`. Full suite (8 tests) passes.
- `validate-model-capabilities.spec.ts`: added a test asserting all capability checks are skipped when the provider is custom (12 tests pass).

`pnpm format` and `pnpm build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway no longer imposes artificial limits or capability checks on custom providers; requested max_tokens and provider capabilities are honored/handled upstream. Streaming support preserved.

* **Tests**
  * Added E2E tests verifying large max_tokens and JSON-object response_format work with custom providers.
  * Added unit tests ensuring capability validation is skipped for custom providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->