### PR TITLE
docs: build single apps via turbo filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ NOTE: these commands can only be run in the root directory of the repository, no
 - `pnpm build` - Build all applications for production. ALWAYS run this after finishing work on a feature. ALWAYS run a full build to make sure things fork.
 - `pnpm clean` - Clean build artifacts and cache directories
 
+To build a single app, ALWAYS use a Turbo filter (`turbo run build --filter=<app>`), e.g. `turbo run build --filter=gateway`. NEVER use `pnpm --filter <app> build` for builds: that runs the app's `tsc` directly without rebuilding workspace dependency packages first, so it compiles against stale `dist/` artifacts and produces spurious errors (missing `@llmgateway/*` modules, "value not in type union", etc.). Turbo's `build` depends on `^build`, so a Turbo filter builds the dependency packages in topological order first.
+
 ### Code Quality
 
 NOTE: these commands can only be run in the root directory of the repository, not in individual app directories.


### PR DESCRIPTION
## What

Updates `AGENTS.md` to direct agents to build a single app with a Turbo filter (`turbo run build --filter=<app>`) and to **never** use `pnpm --filter <app> build` for builds.

## Why

`pnpm --filter <app> build` runs the app's `tsc` directly without rebuilding workspace dependency packages first. It therefore compiles against stale `dist/` artifacts and emits spurious errors — missing `@llmgateway/*` modules, "value not in type union" (e.g. the `"768p"` video-resolution enum), and a cascade of implicit-`any` errors.

Turbo's `build` task depends on `^build`, so a Turbo filter builds the dependency packages in topological order first, matching the full `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified development commands for building single apps with Turbo, including proper filtering syntax and warnings about potential build artifact issues when using incorrect build methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->