### PR TITLE
feat(ratings): require 100 requests to rate a model

### DIFF
--- a/apps/api/src/routes/model-ratings.spec.ts
+++ b/apps/api/src/routes/model-ratings.spec.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const ORG_ID = "test-org-ratings";
+const PROJECT_ID = "test-project-ratings";
+const MODEL_ID = "gpt-4o";
+
+async function seedOrgAndProject() {
+	await db.insert(tables.organization).values({
+		id: ORG_ID,
+		name: "Test User's Workspace",
+		billingEmail: "admin@example.com",
+		isPersonal: true,
+	});
+	await db.insert(tables.userOrganization).values({
+		userId: "test-user-id",
+		organizationId: ORG_ID,
+		role: "owner",
+	});
+	await db.insert(tables.project).values({
+		id: PROJECT_ID,
+		name: "Test Project",
+		organizationId: ORG_ID,
+	});
+}
+
+async function seedModelUsage(requestCount: number, usedModel = MODEL_ID) {
+	await db.insert(tables.projectHourlyModelStats).values({
+		projectId: PROJECT_ID,
+		hourTimestamp: new Date("2026-06-01T00:00:00Z"),
+		usedModel,
+		usedProvider: "openai",
+		requestCount,
+	});
+}
+
+describe("model-ratings", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+		await seedOrgAndProject();
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.modelRating);
+		await deleteAll();
+	});
+
+	test("GET / reports ineligible with no usage", async () => {
+		const res = await app.request(`/model-ratings?modelId=${MODEL_ID}`, {
+			headers: { Cookie: token },
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.rating).toBeNull();
+		expect(body.eligibility.canRate).toBe(false);
+		expect(body.eligibility.requestCount).toBe(0);
+		expect(body.eligibility.minimumRequests).toBe(100);
+	});
+
+	test("POST / is rejected below the request threshold", async () => {
+		await seedModelUsage(99);
+
+		const res = await app.request("/model-ratings", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: token },
+			body: JSON.stringify({ modelId: MODEL_ID, rating: 5 }),
+		});
+		expect(res.status).toBe(403);
+
+		const rows = await db.query.modelRating.findMany({
+			where: { userId: { eq: "test-user-id" } },
+		});
+		expect(rows).toHaveLength(0);
+	});
+
+	test("GET / reports eligible once usage reaches the threshold", async () => {
+		await seedModelUsage(100);
+
+		const res = await app.request(`/model-ratings?modelId=${MODEL_ID}`, {
+			headers: { Cookie: token },
+		});
+		const body = await res.json();
+		expect(body.eligibility.canRate).toBe(true);
+		expect(body.eligibility.requestCount).toBe(100);
+	});
+
+	test("POST / succeeds at or above the request threshold", async () => {
+		await seedModelUsage(100);
+
+		const res = await app.request("/model-ratings", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: token },
+			body: JSON.stringify({
+				modelId: MODEL_ID,
+				rating: 4,
+				comment: "Solid model.",
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.rating.rating).toBe(4);
+
+		const rows = await db.query.modelRating.findMany({
+			where: { userId: { eq: "test-user-id" } },
+		});
+		expect(rows).toHaveLength(1);
+	});
+
+	test("POST / counts usage across the provider/model log format", async () => {
+		await seedModelUsage(150, "openai/gpt-4o");
+
+		const res = await app.request("/model-ratings", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Cookie: token },
+			body: JSON.stringify({ modelId: MODEL_ID, rating: 5 }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	test("POST / requires authentication", async () => {
+		const res = await app.request("/model-ratings", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ modelId: MODEL_ID, rating: 5 }),
+		});
+		expect(res.status).toBe(401);
+	});
+});

--- a/apps/api/src/routes/model-ratings.ts
+++ b/apps/api/src/routes/model-ratings.ts
@@ -2,12 +2,61 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { and, db, eq, tables } from "@llmgateway/db";
+import { and, db, eq, inArray, sql, tables } from "@llmgateway/db";
 import { models as modelDefinitions } from "@llmgateway/models";
 
 import type { ServerTypes } from "@/vars.js";
 
 export const modelRatings = new OpenAPIHono<ServerTypes>();
+
+// Users must have made at least this many requests on a model before they are
+// allowed to rate it, to keep ratings tied to genuine usage.
+const MINIMUM_REQUESTS_TO_RATE = 100;
+
+// Counts how many requests a user has made on a given model across all the
+// organizations they belong to. Uses the persisted hourly model stats rollups
+// rather than raw logs, since raw logs are subject to data-retention cleanup.
+// The model name may be stored as "provider/model" or just "model", so we match
+// the model portion.
+async function getModelRequestCount(
+	userId: string,
+	modelId: string,
+): Promise<number> {
+	const userOrgs = await db.query.userOrganization.findMany({
+		where: { userId },
+		columns: { organizationId: true },
+	});
+	const organizationIds = userOrgs.map((o) => o.organizationId);
+	if (organizationIds.length === 0) {
+		return 0;
+	}
+
+	const projects = await db
+		.select({ id: tables.project.id })
+		.from(tables.project)
+		.where(inArray(tables.project.organizationId, organizationIds));
+	const projectIds = projects.map((p) => p.id);
+	if (projectIds.length === 0) {
+		return 0;
+	}
+
+	const [result] = await db
+		.select({
+			value: sql<number>`COALESCE(SUM(${tables.projectHourlyModelStats.requestCount}), 0)`,
+		})
+		.from(tables.projectHourlyModelStats)
+		.where(
+			and(
+				inArray(tables.projectHourlyModelStats.projectId, projectIds),
+				sql`CASE WHEN ${tables.projectHourlyModelStats.usedModel} LIKE '%/%'
+					THEN SPLIT_PART(${tables.projectHourlyModelStats.usedModel}, '/', 2)
+					ELSE ${tables.projectHourlyModelStats.usedModel}
+				END = ${modelId}`,
+			),
+		);
+
+	return Number(result?.value ?? 0);
+}
 
 const ratingSchema = z.object({
 	modelId: z.string(),
@@ -15,6 +64,12 @@ const ratingSchema = z.object({
 	comment: z.string().nullable(),
 	createdAt: z.string().datetime(),
 	updatedAt: z.string().datetime(),
+});
+
+const eligibilitySchema = z.object({
+	canRate: z.boolean(),
+	requestCount: z.number().int(),
+	minimumRequests: z.number().int(),
 });
 
 const getOwnRating = createRoute({
@@ -27,7 +82,10 @@ const getOwnRating = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({ rating: ratingSchema.nullable() }),
+					schema: z.object({
+						rating: ratingSchema.nullable(),
+						eligibility: eligibilitySchema,
+					}),
 				},
 			},
 			description: "The authenticated user's rating for the model.",
@@ -42,9 +100,12 @@ modelRatings.openapi(getOwnRating, async (c) => {
 	}
 
 	const { modelId } = c.req.valid("query");
-	const row = await db.query.modelRating.findFirst({
-		where: { userId: authUser.id, modelId },
-	});
+	const [row, requestCount] = await Promise.all([
+		db.query.modelRating.findFirst({
+			where: { userId: authUser.id, modelId },
+		}),
+		getModelRequestCount(authUser.id, modelId),
+	]);
 
 	return c.json({
 		rating: row
@@ -56,6 +117,11 @@ modelRatings.openapi(getOwnRating, async (c) => {
 					updatedAt: row.updatedAt.toISOString(),
 				}
 			: null,
+		eligibility: {
+			canRate: requestCount >= MINIMUM_REQUESTS_TO_RATE,
+			requestCount,
+			minimumRequests: MINIMUM_REQUESTS_TO_RATE,
+		},
 	});
 });
 
@@ -98,6 +164,13 @@ modelRatings.openapi(upsertRating, async (c) => {
 	const modelExists = modelDefinitions.some((m) => m.id === modelId);
 	if (!modelExists) {
 		throw new HTTPException(404, { message: "Model not found" });
+	}
+
+	const requestCount = await getModelRequestCount(authUser.id, modelId);
+	if (requestCount < MINIMUM_REQUESTS_TO_RATE) {
+		throw new HTTPException(403, {
+			message: `You need at least ${MINIMUM_REQUESTS_TO_RATE} requests on this model before you can rate it.`,
+		});
 	}
 
 	const [row] = await db

--- a/apps/api/src/routes/model-ratings.ts
+++ b/apps/api/src/routes/model-ratings.ts
@@ -31,10 +31,10 @@ async function getModelRequestCount(
 		return 0;
 	}
 
-	const projects = await db
-		.select({ id: tables.project.id })
-		.from(tables.project)
-		.where(inArray(tables.project.organizationId, organizationIds));
+	const projects = await db.query.project.findMany({
+		where: { organizationId: { in: organizationIds } },
+		columns: { id: true },
+	});
 	const projectIds = projects.map((p) => p.id);
 	if (projectIds.length === 0) {
 		return 0;

--- a/apps/ui/src/components/models/model-rating.tsx
+++ b/apps/ui/src/components/models/model-rating.tsx
@@ -84,13 +84,15 @@ export function ModelRating({ modelId }: ModelRatingProps) {
 
 	const aggregate = aggregateQuery.data;
 	const ownRating = ownRatingQuery.data?.rating ?? null;
+	const eligibility = ownRatingQuery.data?.eligibility ?? null;
+	const canRate = !user || (eligibility?.canRate ?? false);
 
 	const displayedStars =
 		hovered ||
 		(editing ? selected : (ownRating?.rating ?? aggregate?.averageRating ?? 0));
 
 	const startEditing = (value: number) => {
-		if (!user) {
+		if (!user || !canRate) {
 			return;
 		}
 		setSelected(value);
@@ -117,11 +119,11 @@ export function ModelRating({ modelId }: ModelRatingProps) {
 								(editing ? selected : (ownRating?.rating ?? 0)) === value
 							}
 							aria-label={`${value} star${value === 1 ? "" : "s"}`}
-							disabled={!user}
+							disabled={!user || !canRate}
 							onClick={() => startEditing(value)}
-							onMouseEnter={() => user && setHovered(value)}
+							onMouseEnter={() => user && canRate && setHovered(value)}
 							onMouseLeave={() => setHovered(0)}
-							className={user ? "cursor-pointer" : "cursor-default"}
+							className={user && canRate ? "cursor-pointer" : "cursor-default"}
 						>
 							<Star
 								className={`h-5 w-5 ${
@@ -150,7 +152,14 @@ export function ModelRating({ modelId }: ModelRatingProps) {
 						Sign in to rate
 					</Link>
 				)}
-				{user && ownRating && !editing && (
+				{user && !canRate && eligibility && (
+					<span className="text-sm text-muted-foreground ml-auto">
+						Make {eligibility.minimumRequests} requests to rate (
+						{eligibility.requestCount.toLocaleString()}/
+						{eligibility.minimumRequests.toLocaleString()})
+					</span>
+				)}
+				{user && canRate && ownRating && !editing && (
 					<span className="text-sm text-muted-foreground ml-auto">
 						You rated {ownRating.rating}/5
 					</span>


### PR DESCRIPTION
Gate model rating submission behind a minimum of 100 requests on the
model, counted from persisted hourly model stats across the user's
organizations. Expose eligibility via the own-rating endpoint and reflect
it in the rating UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Eligibility status returned with model rating data, including request count and minimum threshold.

* **Updates**
  * Rating submissions are blocked until the minimum request threshold is met.
  * Rating controls disabled and edit entry prevented for ineligible users.
  * UI shows an informational message with minimum and current request counts when ineligible.

* **Tests**
  * Added end-to-end tests covering eligibility, submission blocking, provider/model formats, and auth enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->