### PR TITLE
fix(worker): dedup no_purchase email per owner

### DIFF
--- a/apps/worker/src/services/follow-up-emails.spec.ts
+++ b/apps/worker/src/services/follow-up-emails.spec.ts
@@ -75,6 +75,62 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 		expect(sent).toHaveLength(0);
 	});
 
+	it("sends the no_purchase email only once when the owner has multiple credit-less orgs", async () => {
+		const [owner] = await db
+			.insert(user)
+			.values({
+				email: "multi@example.com",
+				name: "Multi Org User",
+				emailVerified: true,
+			})
+			.returning();
+
+		const [orgA] = await db
+			.insert(organization)
+			.values({
+				name: "Org A",
+				status: "active",
+				devPlan: "none",
+				billingEmail: owner.email,
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		const [orgB] = await db
+			.insert(organization)
+			.values({
+				name: "Org B",
+				status: "active",
+				devPlan: "none",
+				billingEmail: owner.email,
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		await db.insert(userOrganization).values([
+			{ userId: owner.id, organizationId: orgA.id, role: "owner" },
+			{ userId: owner.id, organizationId: orgB.id, role: "owner" },
+		]);
+
+		await processNoPurchaseEmails();
+
+		const sent = await db
+			.select()
+			.from(followUpEmail)
+			.where(eq(followUpEmail.emailType, "no_purchase"));
+		expect(sent).toHaveLength(1);
+		expect([orgA.id, orgB.id]).toContain(sent[0].organizationId);
+
+		// A subsequent run must not email the owner again via the other org.
+		await processNoPurchaseEmails();
+
+		const sentAfter = await db
+			.select()
+			.from(followUpEmail)
+			.where(eq(followUpEmail.emailType, "no_purchase"));
+		expect(sentAfter).toHaveLength(1);
+	});
+
 	it("sends the no_purchase email when the owner has no DevPass", async () => {
 		const [freeUser] = await db
 			.insert(user)

--- a/apps/worker/src/services/follow-up-emails.spec.ts
+++ b/apps/worker/src/services/follow-up-emails.spec.ts
@@ -131,6 +131,104 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 		expect(sentAfter).toHaveLength(1);
 	});
 
+	it("skips personal (DevPass) and chat orgs, only nudging the normal org", async () => {
+		const [owner] = await db
+			.insert(user)
+			.values({
+				email: "scoped@example.com",
+				name: "Scoped User",
+				emailVerified: true,
+			})
+			.returning();
+
+		const [personalOrg] = await db
+			.insert(organization)
+			.values({
+				name: "Personal",
+				status: "active",
+				isPersonal: true,
+				devPlan: "none",
+				billingEmail: owner.email,
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		const [chatOrg] = await db
+			.insert(organization)
+			.values({
+				name: "Chat",
+				status: "active",
+				isChat: true,
+				devPlan: "none",
+				billingEmail: owner.email,
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		const [normalOrg] = await db
+			.insert(organization)
+			.values({
+				name: "Default",
+				status: "active",
+				devPlan: "none",
+				billingEmail: owner.email,
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		await db.insert(userOrganization).values([
+			{ userId: owner.id, organizationId: personalOrg.id, role: "owner" },
+			{ userId: owner.id, organizationId: chatOrg.id, role: "owner" },
+			{ userId: owner.id, organizationId: normalOrg.id, role: "owner" },
+		]);
+
+		await processNoPurchaseEmails();
+
+		const sent = await db
+			.select()
+			.from(followUpEmail)
+			.where(eq(followUpEmail.emailType, "no_purchase"));
+		expect(sent).toHaveLength(1);
+		expect(sent[0].organizationId).toBe(normalOrg.id);
+	});
+
+	it("does not nudge an owner whose only orgs are personal or chat", async () => {
+		const [owner] = await db
+			.insert(user)
+			.values({
+				email: "chatonly@example.com",
+				name: "Chat Only User",
+				emailVerified: true,
+			})
+			.returning();
+
+		const [chatOrg] = await db
+			.insert(organization)
+			.values({
+				name: "Chat",
+				status: "active",
+				isChat: true,
+				devPlan: "none",
+				billingEmail: owner.email,
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		await db.insert(userOrganization).values({
+			userId: owner.id,
+			organizationId: chatOrg.id,
+			role: "owner",
+		});
+
+		await processNoPurchaseEmails();
+
+		const sent = await db
+			.select()
+			.from(followUpEmail)
+			.where(eq(followUpEmail.emailType, "no_purchase"));
+		expect(sent).toHaveLength(0);
+	});
+
 	it("sends the no_purchase email when the owner has no DevPass", async () => {
 		const [freeUser] = await db
 			.insert(user)

--- a/apps/worker/src/services/follow-up-emails.spec.ts
+++ b/apps/worker/src/services/follow-up-emails.spec.ts
@@ -75,7 +75,7 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 		expect(sent).toHaveLength(0);
 	});
 
-	it("sends the no_purchase email only once when the owner has multiple credit-less orgs", async () => {
+	it("nudges a shared recipient only once across multiple credit-less orgs", async () => {
 		const [owner] = await db
 			.insert(user)
 			.values({
@@ -85,13 +85,14 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 			})
 			.returning();
 
+		// Both orgs bill the same address, so the recipient must be nudged once.
 		const [orgA] = await db
 			.insert(organization)
 			.values({
 				name: "Org A",
 				status: "active",
 				devPlan: "none",
-				billingEmail: owner.email,
+				billingEmail: "shared@example.com",
 				createdAt: TWO_DAYS_AGO,
 			})
 			.returning();
@@ -102,7 +103,7 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 				name: "Org B",
 				status: "active",
 				devPlan: "none",
-				billingEmail: owner.email,
+				billingEmail: "shared@example.com",
 				createdAt: TWO_DAYS_AGO,
 			})
 			.returning();
@@ -120,8 +121,9 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 			.where(eq(followUpEmail.emailType, "no_purchase"));
 		expect(sent).toHaveLength(1);
 		expect([orgA.id, orgB.id]).toContain(sent[0].organizationId);
+		expect(sent[0].sentTo).toBe("shared@example.com");
 
-		// A subsequent run must not email the owner again via the other org.
+		// A subsequent run must not email the same recipient again via the other org.
 		await processNoPurchaseEmails();
 
 		const sentAfter = await db
@@ -129,6 +131,58 @@ describe("processNoPurchaseEmails DevPass exclusion", () => {
 			.from(followUpEmail)
 			.where(eq(followUpEmail.emailType, "no_purchase"));
 		expect(sentAfter).toHaveLength(1);
+	});
+
+	it("nudges each distinct recipient even when orgs share an owner", async () => {
+		const [owner] = await db
+			.insert(user)
+			.values({
+				email: "distinct@example.com",
+				name: "Distinct Recipient User",
+				emailVerified: true,
+			})
+			.returning();
+
+		// Same owner, but each org bills a different address — both addresses are
+		// legitimate, never-nudged recipients and should each receive the email.
+		const [orgA] = await db
+			.insert(organization)
+			.values({
+				name: "Org A",
+				status: "active",
+				devPlan: "none",
+				billingEmail: "billing-a@example.com",
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		const [orgB] = await db
+			.insert(organization)
+			.values({
+				name: "Org B",
+				status: "active",
+				devPlan: "none",
+				billingEmail: "billing-b@example.com",
+				createdAt: TWO_DAYS_AGO,
+			})
+			.returning();
+
+		await db.insert(userOrganization).values([
+			{ userId: owner.id, organizationId: orgA.id, role: "owner" },
+			{ userId: owner.id, organizationId: orgB.id, role: "owner" },
+		]);
+
+		await processNoPurchaseEmails();
+
+		const sent = await db
+			.select()
+			.from(followUpEmail)
+			.where(eq(followUpEmail.emailType, "no_purchase"));
+		expect(sent).toHaveLength(2);
+		expect(sent.map((s) => s.sentTo).sort()).toEqual([
+			"billing-a@example.com",
+			"billing-b@example.com",
+		]);
 	});
 
 	it("skips personal (DevPass) and chat orgs, only nudging the normal org", async () => {

--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -5,6 +5,7 @@ import {
 	db,
 	eq,
 	followUpEmail,
+	inArray,
 	organization,
 	project,
 	projectHourlyStats,
@@ -213,16 +214,8 @@ export async function processNoPurchaseEmails(): Promise<void> {
 	const eligibleOrgs = await db
 		.select({
 			organizationId: organization.id,
-			ownerUserId: userOrganization.userId,
 		})
 		.from(organization)
-		.innerJoin(
-			userOrganization,
-			and(
-				eq(userOrganization.organizationId, organization.id),
-				eq(userOrganization.role, "owner"),
-			),
-		)
 		.where(
 			and(
 				sql`${organization.createdAt} < ${twentyFourHoursAgo}`,
@@ -241,18 +234,10 @@ export async function processNoPurchaseEmails(): Promise<void> {
 					WHERE ${transaction.type} = 'credit_topup'
 					AND ${transaction.status} = 'completed'
 				)`,
-				// The no_purchase nudge is a per-user concern, not per-org: a single
-				// owner can have several credit-less orgs. Skip the org if its owner
-				// already received this email on ANY of their orgs, so they aren't
-				// emailed once per organization.
-				sql`NOT EXISTS (
-					SELECT 1
-					FROM ${followUpEmail} sent
-					JOIN ${userOrganization} sent_owner
-						ON sent_owner.organization_id = sent.organization_id
-						AND sent_owner.role = 'owner'
-					WHERE sent.email_type = 'no_purchase'
-					AND sent_owner.user_id = ${userOrganization.userId}
+				sql`${organization.id} NOT IN (
+					SELECT ${followUpEmail.organizationId}
+					FROM ${followUpEmail}
+					WHERE ${followUpEmail.emailType} = 'no_purchase'
 				)`,
 				// Skip orgs whose owner already subscribes to a DevPass plan on any
 				// of their organizations — they shouldn't be nudged to add credits.
@@ -271,27 +256,57 @@ export async function processNoPurchaseEmails(): Promise<void> {
 			),
 		);
 
-	// Guard against emailing the same owner more than once within a single run:
-	// two of their orgs can both pass the cross-run SQL check before either has
-	// a recorded send.
-	const handledOwners = new Set<string>();
-	for (const { organizationId, ownerUserId } of eligibleOrgs) {
+	// Resolve the recipient for each org up front so we can deduplicate on the
+	// actual address the email is delivered to (billingEmail, falling back to the
+	// owner). Keying on the recipient — not org ownership — means a shared billing
+	// contact is nudged once across all their orgs, while a co-owner with their
+	// own address still gets nudged for their own credit-less org.
+	const candidates: { organizationId: string; email: string }[] = [];
+	for (const { organizationId } of eligibleOrgs) {
 		if (isStopRequested()) {
 			break;
 		}
-		if (handledOwners.has(ownerUserId)) {
+		const email = await getOrgRecipientEmail(organizationId);
+		if (!email) {
+			logger.warn("No email found for org, skipping no_purchase follow-up", {
+				organizationId,
+			});
+			continue;
+		}
+		candidates.push({ organizationId, email });
+	}
+
+	if (candidates.length === 0) {
+		return;
+	}
+
+	// Recipients already nudged in a previous run, matched on the recorded
+	// recipient address (sentTo) rather than current org ownership, which can
+	// change after the fact.
+	const recipientEmails = [...new Set(candidates.map((c) => c.email))];
+	const priorSends = await db
+		.select({ sentTo: followUpEmail.sentTo })
+		.from(followUpEmail)
+		.where(
+			and(
+				eq(followUpEmail.emailType, "no_purchase"),
+				inArray(followUpEmail.sentTo, recipientEmails),
+			),
+		);
+	const handledRecipients = new Set(priorSends.map((r) => r.sentTo));
+
+	for (const { organizationId, email } of candidates) {
+		if (isStopRequested()) {
+			break;
+		}
+		// Within-run guard: two orgs sharing a recipient both pass the cross-run
+		// check above before either send is recorded.
+		if (handledRecipients.has(email)) {
 			continue;
 		}
 		try {
-			const email = await getOrgRecipientEmail(organizationId);
-			if (!email) {
-				logger.warn("No email found for org, skipping no_purchase follow-up", {
-					organizationId,
-				});
-				continue;
-			}
 			await sendAndRecord(organizationId, "no_purchase", email);
-			handledOwners.add(ownerUserId);
+			handledRecipients.add(email);
 		} catch (error) {
 			logger.error(
 				`Error sending no_purchase follow-up for org ${organizationId}`,

--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -213,8 +213,16 @@ export async function processNoPurchaseEmails(): Promise<void> {
 	const eligibleOrgs = await db
 		.select({
 			organizationId: organization.id,
+			ownerUserId: userOrganization.userId,
 		})
 		.from(organization)
+		.innerJoin(
+			userOrganization,
+			and(
+				eq(userOrganization.organizationId, organization.id),
+				eq(userOrganization.role, "owner"),
+			),
+		)
 		.where(
 			and(
 				sql`${organization.createdAt} < ${twentyFourHoursAgo}`,
@@ -227,10 +235,18 @@ export async function processNoPurchaseEmails(): Promise<void> {
 					WHERE ${transaction.type} = 'credit_topup'
 					AND ${transaction.status} = 'completed'
 				)`,
-				sql`${organization.id} NOT IN (
-					SELECT ${followUpEmail.organizationId}
-					FROM ${followUpEmail}
-					WHERE ${followUpEmail.emailType} = 'no_purchase'
+				// The no_purchase nudge is a per-user concern, not per-org: a single
+				// owner can have several credit-less orgs. Skip the org if its owner
+				// already received this email on ANY of their orgs, so they aren't
+				// emailed once per organization.
+				sql`NOT EXISTS (
+					SELECT 1
+					FROM ${followUpEmail} sent
+					JOIN ${userOrganization} sent_owner
+						ON sent_owner.organization_id = sent.organization_id
+						AND sent_owner.role = 'owner'
+					WHERE sent.email_type = 'no_purchase'
+					AND sent_owner.user_id = ${userOrganization.userId}
 				)`,
 				// Skip orgs whose owner already subscribes to a DevPass plan on any
 				// of their organizations — they shouldn't be nudged to add credits.
@@ -249,9 +265,16 @@ export async function processNoPurchaseEmails(): Promise<void> {
 			),
 		);
 
-	for (const { organizationId } of eligibleOrgs) {
+	// Guard against emailing the same owner more than once within a single run:
+	// two of their orgs can both pass the cross-run SQL check before either has
+	// a recorded send.
+	const handledOwners = new Set<string>();
+	for (const { organizationId, ownerUserId } of eligibleOrgs) {
 		if (isStopRequested()) {
 			break;
+		}
+		if (handledOwners.has(ownerUserId)) {
+			continue;
 		}
 		try {
 			const email = await getOrgRecipientEmail(organizationId);
@@ -262,6 +285,7 @@ export async function processNoPurchaseEmails(): Promise<void> {
 				continue;
 			}
 			await sendAndRecord(organizationId, "no_purchase", email);
+			handledOwners.add(ownerUserId);
 		} catch (error) {
 			logger.error(
 				`Error sending no_purchase follow-up for org ${organizationId}`,

--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -229,6 +229,12 @@ export async function processNoPurchaseEmails(): Promise<void> {
 				sql`${organization.createdAt} > ${maxAgeAgo}`,
 				eq(organization.devPlan, "none"),
 				eq(organization.status, "active"),
+				// Only nudge normal pay-as-you-go team orgs. Personal orgs back the
+				// DevPass coding product and chat orgs back chat.llmgateway.io — both
+				// have their own billing and are hidden from the dashboard, so they
+				// should never receive the "add credits" email.
+				eq(organization.isPersonal, false),
+				eq(organization.isChat, false),
 				sql`${organization.id} NOT IN (
 					SELECT ${transaction.organizationId}
 					FROM ${transaction}


### PR DESCRIPTION
## Problem

Users reported receiving the "you haven't added any credits yet" onboarding email **multiple times**. Two distinct causes:

1. **Per-org dedup, per-user delivery.** The `no_purchase` email is deduplicated per **organization** (`follow_up_email` unique on `(organization_id, email_type)`), but it's delivered to a single recipient (`billingEmail`, falling back to the owner's email). A single user / billing contact can own several credit-less orgs, so they got the identical nudge once per org.
2. **Wrong org types in scope.** Eligibility only filtered on `devPlan`/owner-DevPass. That left **chat orgs** (`isChat`, backing chat.llmgateway.io) and plan-less **personal/DevPass orgs** (`isPersonal`) eligible — neither should ever get an "add credits" nudge.

## Fix

- **Dedup on the recipient address, not org ownership.** Each eligible org's recipient is resolved up front (`billingEmail ?? owner`), then deduplicated against the recorded `sentTo` of prior `no_purchase` sends (cross-run) plus a within-run `Set` (two orgs sharing a recipient both pass the cross-run check before either send is recorded). Keying on the delivered address — rather than the recorded org's current owners — means a shared billing contact is nudged once across all their orgs, a co-owner with their own address still gets nudged, and attribution doesn't shift if ownership changes later.
- **Scope to normal orgs only:** require `isPersonal = false` and `isChat = false`, so DevPass personal orgs and chat orgs are excluded.

The per-org dedup record and its unique constraint are unchanged (a backstop); this narrows *which orgs* are eligible and *who* counts as already-nudged.

## Tests

- Shared recipient across two credit-less orgs → exactly one email; a second run doesn't re-email.
- Distinct recipients sharing an owner → each address nudged.
- Owner with personal + chat + normal orgs → only the normal org is nudged.
- Owner with only personal/chat orgs → no email.
- Existing DevPass-exclusion test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicate no-purchase follow-up emails by deduplicating recipients across multiple eligible organizations.
  * Tightened follow-up eligibility to exclude personal and chat organizations from nudging.
  * Improved idempotency so rerunning the processor won’t create additional no-purchase records for the same recipient.

* **Tests**
  * Added scenarios covering recipient de-duplication, rerun behavior, and exclusion rules (personal/chat orgs), including cases where no follow-ups should be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->