### PR TITLE
fix(seo): host model rating on a Product type

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -28,7 +28,7 @@ import { Badge } from "@/lib/components/badge";
 import {
 	buildRatingSchema,
 	digitalOfferFields,
-	hasFullRatingData,
+	hasRatingData,
 	type ModelRatingsData,
 } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
@@ -213,7 +213,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 
 	const productSchema = {
 		"@context": "https://schema.org",
-		"@type": hasFullRatingData(ratingsData) ? "Product" : "Service",
+		"@type": hasRatingData(ratingsData) ? "Product" : "Service",
 		name: `${modelDef.name ?? modelDef.id} on ${providerInfo?.name ?? decodedProvider}`,
 		description:
 			modelDef.description ??

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -36,7 +36,7 @@ import { fetchModelDiscounts } from "@/lib/fetch-models";
 import {
 	buildRatingSchema,
 	digitalOfferFields,
-	hasFullRatingData,
+	hasRatingData,
 	type ModelRatingsData,
 } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
@@ -158,7 +158,7 @@ export default async function ModelPage({ params }: PageProps) {
 	const primaryProviderId = modelDef.providers[0]?.providerId || "default";
 	const productSchema = {
 		"@context": "https://schema.org",
-		"@type": hasFullRatingData(ratingsData) ? "Product" : "Service",
+		"@type": hasRatingData(ratingsData) ? "Product" : "Service",
 		name: modelDef.name ?? modelDef.id,
 		description:
 			modelDef.description ??

--- a/apps/ui/src/lib/rating-schema.ts
+++ b/apps/ui/src/lib/rating-schema.ts
@@ -9,13 +9,12 @@ export interface ModelRatingsData {
 	}[];
 }
 
-export function hasFullRatingData(ratings: ModelRatingsData | null) {
-	return Boolean(
-		ratings &&
-			ratings.ratingCount > 0 &&
-			ratings.averageRating &&
-			ratings.reviews.length > 0,
-	);
+// Google only renders rating/review snippets on certain types (Product,
+// SoftwareApplication, etc.) — not on Service. When this is true the page must
+// use a rating-capable @type so aggregateRating/review have a valid parent node.
+// Must stay in sync with the emit condition in buildRatingSchema below.
+export function hasRatingData(ratings: ModelRatingsData | null) {
+	return Boolean(ratings && ratings.ratingCount > 0 && ratings.averageRating);
 }
 
 export const digitalOfferFields = {


### PR DESCRIPTION
## Problem

Google Search Console flags model pages with **"Invalid object type for field `<parent_node>`"**, marking them ineligible for rich results.

Affected item: `https://llmgateway.io/models/kimi-k2.7-code` (Kimi K2.7 Code).

### Root cause

The live JSON-LD for that page emits an `aggregateRating` nested inside a **`Service`**:

```json
{
  "@type": "Service",
  "name": "Kimi K2.7 Code",
  ...
  "aggregateRating": { "@type": "AggregateRating", "ratingValue": 5, "ratingCount": 1 }
}
```

Google only renders rating/review snippets on a fixed set of types (`Product`, `SoftwareApplication`, `Organization`, `Book`, `Movie`, …) — **`Service` is not one of them**. So the rating's *parent node* (the `Service`) is the "invalid object type", which is exactly what the `<parent_node>` placeholder refers to.

This happened because of a condition mismatch in `apps/ui/src/lib/rating-schema.ts`:

- `hasFullRatingData()` (which chooses `Product` vs `Service`) required `reviews.length > 0`.
- `buildRatingSchema()` emits the `aggregateRating` whenever `ratingCount > 0 && averageRating` — **regardless of written reviews**.

Kimi K2.7 Code has **1 rating but 0 written reviews**, so it fell into the gap: `@type: "Service"` **plus** an `aggregateRating` → invalid.

## Fix

Align the two conditions so the page uses a rating-capable `Product` type *exactly* when an `aggregateRating` is emitted:

- Rename `hasFullRatingData` → `hasRatingData` and drop the `reviews.length > 0` requirement (it now matches `buildRatingSchema`'s emit condition).
- A model with ratings but no reviews now renders as `Product` with `aggregateRating` (valid); a model with no ratings stays `Service` with no rating fields (valid).

Applies to both `/models/[name]` and `/models/[name]/[provider]` pages, which share the helper.

## Testing

- `turbo run build --filter=ui` ✅
- `pnpm prettier --write` on changed files ✅
- Verified against the live JSON-LD captured from the affected URL.

After merge + deploy, use **Validate Fix** in Search Console to re-crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated product rating validation for search engine structured data across product pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->