### PR TITLE
feat(compare): cursor page, logos & OG images

### DIFF
--- a/apps/code/content-collections.ts
+++ b/apps/code/content-collections.ts
@@ -28,6 +28,9 @@ const comparisons = defineCollection({
 		description: z.string(),
 		// Hero
 		competitor: z.string(),
+		// Key into the brand-logos registry (e.g. "cursor", "opencode"). When
+		// omitted the UI falls back to a monogram tile built from the competitor.
+		competitorLogo: z.string().optional(),
 		competitorTagline: z.string(),
 		tagline: z.string(),
 		devpassPrice: z.string(),

--- a/apps/code/src/app/compare/[slug]/opengraph-image.tsx
+++ b/apps/code/src/app/compare/[slug]/opengraph-image.tsx
@@ -18,7 +18,7 @@ export function generateStaticParams() {
 
 function Tile({ spec, devpass }: { spec: BrandSpec; devpass?: boolean }) {
 	const tileSize = 150;
-	const inner = 84;
+	const inner = Math.round(tileSize * spec.scale);
 	const background = devpass ? "#fafafa" : spec.bg;
 	const color = devpass ? "#0a0a0b" : spec.fg;
 	const Mark = spec.Mark;

--- a/apps/code/src/app/compare/[slug]/opengraph-image.tsx
+++ b/apps/code/src/app/compare/[slug]/opengraph-image.tsx
@@ -1,0 +1,212 @@
+import { ImageResponse } from "next/og";
+
+import { getBrand, type BrandSpec } from "@/components/brand-logos";
+
+import { allComparisons } from "content-collections";
+
+import type { Comparison } from "content-collections";
+
+export const alt = "DevPass comparison";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export function generateStaticParams() {
+	return allComparisons
+		.filter((entry: Comparison) => !entry.draft)
+		.map((entry: Comparison) => ({ slug: entry.slug }));
+}
+
+function Tile({ spec, devpass }: { spec: BrandSpec; devpass?: boolean }) {
+	const tileSize = 150;
+	const inner = 84;
+	const background = devpass ? "#fafafa" : spec.bg;
+	const color = devpass ? "#0a0a0b" : spec.fg;
+	const Mark = spec.Mark;
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				width: tileSize,
+				height: tileSize,
+				borderRadius: 32,
+				background,
+				color,
+				border: "1px solid rgba(255,255,255,0.12)",
+				boxShadow: "0 24px 60px rgba(0,0,0,0.45)",
+			}}
+		>
+			{Mark ? (
+				<Mark size={inner} />
+			) : (
+				<span style={{ fontSize: 72, fontWeight: 700, lineHeight: 1 }}>
+					{spec.mono ?? spec.label.charAt(0)}
+				</span>
+			)}
+		</div>
+	);
+}
+
+export default async function CompareOgImage({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { slug } = await params;
+	const entry = allComparisons.find((e: Comparison) => e.slug === slug);
+
+	const competitorName = entry?.competitor ?? "the alternatives";
+	const title = entry?.title ?? "DevPass vs the alternatives";
+	const devpassSpec = getBrand("devpass");
+	const competitorSpec = getBrand(entry?.competitorLogo ?? entry?.competitor);
+
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "space-between",
+					background: "#0a0a0b",
+					backgroundImage:
+						"radial-gradient(900px 500px at 50% -10%, rgba(255,255,255,0.10), transparent 60%)",
+					padding: 64,
+					fontFamily:
+						"system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+				}}
+			>
+				{/* Header */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+					}}
+				>
+					<div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+						<div
+							style={{
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								width: 44,
+								height: 44,
+								borderRadius: 12,
+								background: "#fafafa",
+								color: "#0a0a0b",
+								fontSize: 22,
+								fontWeight: 700,
+							}}
+						>
+							{"</>"}
+						</div>
+						<div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+							<span style={{ color: "#fafafa", fontSize: 30, fontWeight: 700 }}>
+								DevPass
+							</span>
+							<span style={{ color: "#71717a", fontSize: 20 }}>
+								by LLM Gateway
+							</span>
+						</div>
+					</div>
+					<div
+						style={{
+							display: "flex",
+							padding: "10px 20px",
+							borderRadius: 9999,
+							background: "rgba(255,255,255,0.06)",
+							border: "1px solid rgba(255,255,255,0.14)",
+							color: "#d4d4d8",
+							fontSize: 20,
+							fontWeight: 600,
+							letterSpacing: 2,
+							textTransform: "uppercase",
+						}}
+					>
+						Comparison
+					</div>
+				</div>
+
+				{/* Arena */}
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						gap: 34,
+					}}
+				>
+					<div style={{ display: "flex", alignItems: "center", gap: 44 }}>
+						<Tile spec={devpassSpec} devpass />
+						<div
+							style={{
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								width: 72,
+								height: 72,
+								borderRadius: 9999,
+								background: "#18181b",
+								border: "1px solid rgba(255,255,255,0.16)",
+								color: "#a1a1aa",
+								fontSize: 26,
+								fontWeight: 700,
+								letterSpacing: 1,
+							}}
+						>
+							VS
+						</div>
+						<Tile spec={competitorSpec} />
+					</div>
+
+					<div
+						style={{
+							display: "flex",
+							color: "#fafafa",
+							fontSize: 68,
+							fontWeight: 700,
+							letterSpacing: "-0.02em",
+							textAlign: "center",
+						}}
+					>
+						{title}
+					</div>
+				</div>
+
+				{/* Footer */}
+				<div
+					style={{
+						display: "flex",
+						alignItems: "flex-end",
+						justifyContent: "space-between",
+					}}
+				>
+					<div style={{ display: "flex", gap: 40 }}>
+						<div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+							<span style={{ color: "#71717a", fontSize: 18 }}>DevPass</span>
+							<span style={{ color: "#fafafa", fontSize: 26, fontWeight: 600 }}>
+								{entry?.devpassPrice ?? "$29–$179/mo"}
+							</span>
+						</div>
+						<div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+							<span style={{ color: "#71717a", fontSize: 18 }}>
+								{competitorName}
+							</span>
+							<span style={{ color: "#d4d4d8", fontSize: 26, fontWeight: 600 }}>
+								{entry?.competitorPrice ?? "—"}
+							</span>
+						</div>
+					</div>
+					<span style={{ color: "#71717a", fontSize: 20 }}>
+						devpass.llmgateway.io
+					</span>
+				</div>
+			</div>
+		),
+		size,
+	);
+}

--- a/apps/code/src/app/compare/[slug]/page.tsx
+++ b/apps/code/src/app/compare/[slug]/page.tsx
@@ -1,8 +1,9 @@
-import { ArrowLeft, ArrowRight, Sparkles } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import Markdown from "markdown-to-jsx";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { BrandTile } from "@/components/brand-logos";
 import { ComparisonTable } from "@/components/ComparisonTable";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
@@ -62,6 +63,46 @@ export async function generateMetadata({
 			description: entry.description,
 		},
 	};
+}
+
+function Pole({
+	brand,
+	name,
+	caption,
+	price,
+	recommended,
+}: {
+	brand: string;
+	name: string;
+	caption: string;
+	price: string;
+	recommended?: boolean;
+}) {
+	return (
+		<div
+			className={`relative flex flex-col items-center rounded-2xl border bg-card px-6 py-7 text-center ${
+				recommended
+					? "border-foreground/30 shadow-md ring-1 ring-foreground/10"
+					: ""
+			}`}
+		>
+			{recommended && (
+				<span className="absolute -top-2.5 rounded-full bg-foreground px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-background">
+					Our pick
+				</span>
+			)}
+			<BrandTile brand={brand} size={56} radius={16} />
+			<div className="mt-3 text-base font-semibold tracking-tight text-foreground">
+				{name}
+			</div>
+			<p className="mt-1 min-h-[32px] text-xs leading-5 text-muted-foreground">
+				{caption}
+			</p>
+			<div className="mt-3 font-mono text-sm font-semibold tabular-nums text-foreground">
+				{price}
+			</div>
+		</div>
+	);
 }
 
 export default async function ComparePage({ params }: ComparePageProps) {
@@ -126,48 +167,63 @@ export default async function ComparePage({ params }: ComparePageProps) {
 			<Header />
 
 			<main>
-				{/* Hero */}
+				{/* Hero — versus arena */}
 				<section className="relative overflow-hidden border-b">
-					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-muted/60 via-transparent to-transparent" />
-					<div className="container relative mx-auto max-w-4xl px-4 pt-16 pb-12 sm:pt-20">
+					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_55%_55%_at_50%_-5%,_var(--tw-gradient-stops))] from-muted/70 via-transparent to-transparent" />
+					<div
+						className="pointer-events-none absolute inset-0 opacity-[0.04]"
+						style={{
+							backgroundImage:
+								"linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)",
+							backgroundSize: "44px 44px",
+							maskImage:
+								"radial-gradient(ellipse 70% 55% at 50% 0%, black, transparent)",
+						}}
+					/>
+					<div className="container relative mx-auto max-w-3xl px-4 pt-16 pb-14 sm:pt-20">
 						<Link
 							href="/compare"
-							className="mb-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+							className="mb-8 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
 						>
 							<ArrowLeft className="h-3.5 w-3.5" />
 							All comparisons
 						</Link>
-						<div className="mb-5 inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/50 px-4 py-1.5 text-sm text-muted-foreground">
-							<Sparkles className="h-3.5 w-3.5" />
-							Comparison
-						</div>
-						<h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-							{entry.title}
-						</h1>
-						<p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted-foreground">
-							{entry.tagline}
-						</p>
 
-						<div className="mt-8 flex flex-wrap gap-3">
-							<div className="rounded-xl border bg-card px-4 py-3">
-								<div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-									DevPass
-								</div>
-								<div className="mt-0.5 font-mono text-lg font-semibold tabular-nums">
-									{entry.devpassPrice}
-								</div>
+						<div className="text-center">
+							<div className="mb-4 inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/50 px-4 py-1.5 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+								Head to head
 							</div>
-							<div className="rounded-xl border bg-card px-4 py-3">
-								<div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-									{entry.competitor}
-								</div>
-								<div className="mt-0.5 font-mono text-lg font-semibold tabular-nums">
-									{entry.competitorPrice}
-								</div>
-							</div>
+							<h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl">
+								{entry.title}
+							</h1>
+							<p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-pretty text-muted-foreground">
+								{entry.tagline}
+							</p>
 						</div>
 
-						<div className="mt-8 flex flex-col gap-3 sm:flex-row">
+						{/* Arena */}
+						<div className="relative mt-10 grid grid-cols-1 items-stretch gap-4 sm:grid-cols-[1fr_auto_1fr]">
+							<Pole
+								brand="devpass"
+								name="DevPass"
+								caption="One key, 200+ models at provider rates"
+								price={entry.devpassPrice}
+								recommended
+							/>
+							<div className="flex items-center justify-center">
+								<div className="flex h-11 w-11 items-center justify-center rounded-full border bg-background text-xs font-bold uppercase tracking-wider text-muted-foreground shadow-sm">
+									vs
+								</div>
+							</div>
+							<Pole
+								brand={entry.competitorLogo ?? entry.competitor}
+								name={entry.competitor}
+								caption={entry.competitorTagline}
+								price={entry.competitorPrice}
+							/>
+						</div>
+
+						<div className="mt-9 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
 							<CodeCTATracker cta="get_started" location="compare_hero">
 								<Button size="lg" className="gap-2" asChild>
 									<Link href="/signup?plan=pro">
@@ -210,6 +266,7 @@ export default async function ComparePage({ params }: ComparePageProps) {
 						</p>
 						<ComparisonTable
 							competitor={entry.competitor}
+							competitorLogo={entry.competitorLogo}
 							features={entry.features}
 						/>
 					</div>
@@ -252,6 +309,9 @@ export default async function ComparePage({ params }: ComparePageProps) {
 				{/* CTA */}
 				<section className="border-t px-4 py-20">
 					<div className="container mx-auto max-w-2xl text-center">
+						<div className="mb-6 flex items-center justify-center gap-3">
+							<BrandTile brand="devpass" size={44} radius={12} />
+						</div>
 						<h2 className="mb-3 text-3xl font-bold tracking-tight">
 							One key. Every model.
 						</h2>

--- a/apps/code/src/app/compare/opengraph-image.tsx
+++ b/apps/code/src/app/compare/opengraph-image.tsx
@@ -1,0 +1,163 @@
+import { ImageResponse } from "next/og";
+
+import { getBrand, type BrandSpec } from "@/components/brand-logos";
+
+import { allComparisons } from "content-collections";
+
+import type { Comparison } from "content-collections";
+
+export const alt = "DevPass vs the alternatives — coding plan comparisons";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+function Tile({ spec, devpass }: { spec: BrandSpec; devpass?: boolean }) {
+	const tileSize = 96;
+	const inner = 52;
+	const background = devpass ? "#fafafa" : spec.bg;
+	const color = devpass ? "#0a0a0b" : spec.fg;
+	const Mark = spec.Mark;
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				width: tileSize,
+				height: tileSize,
+				borderRadius: 22,
+				background,
+				color,
+				border: "1px solid rgba(255,255,255,0.12)",
+				boxShadow: "0 18px 40px rgba(0,0,0,0.4)",
+			}}
+		>
+			{Mark ? (
+				<Mark size={inner} />
+			) : (
+				<span style={{ fontSize: 44, fontWeight: 700, lineHeight: 1 }}>
+					{spec.mono ?? spec.label.charAt(0)}
+				</span>
+			)}
+		</div>
+	);
+}
+
+export default function CompareIndexOgImage() {
+	const competitors = allComparisons
+		.filter((e: Comparison) => !e.draft)
+		.sort((a: Comparison, b: Comparison) =>
+			a.competitor.localeCompare(b.competitor),
+		)
+		.map((e: Comparison) => getBrand(e.competitorLogo ?? e.competitor));
+
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "space-between",
+					background: "#0a0a0b",
+					backgroundImage:
+						"radial-gradient(900px 500px at 50% -10%, rgba(255,255,255,0.10), transparent 60%)",
+					padding: 64,
+					fontFamily:
+						"system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+				}}
+			>
+				<div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							width: 44,
+							height: 44,
+							borderRadius: 12,
+							background: "#fafafa",
+							color: "#0a0a0b",
+							fontSize: 22,
+							fontWeight: 700,
+						}}
+					>
+						{"</>"}
+					</div>
+					<div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+						<span style={{ color: "#fafafa", fontSize: 30, fontWeight: 700 }}>
+							DevPass
+						</span>
+						<span style={{ color: "#71717a", fontSize: 20 }}>
+							by LLM Gateway
+						</span>
+					</div>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						gap: 28,
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							color: "#fafafa",
+							fontSize: 76,
+							fontWeight: 700,
+							letterSpacing: "-0.02em",
+						}}
+					>
+						DevPass vs the alternatives
+					</div>
+					<div style={{ display: "flex", color: "#a1a1aa", fontSize: 30 }}>
+						One key to 200+ models — frontier and open-weight — at provider
+						rates.
+					</div>
+
+					{/* Logo lineup */}
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 16,
+							marginTop: 12,
+						}}
+					>
+						<Tile spec={getBrand("devpass")} devpass />
+						<span
+							style={{
+								display: "flex",
+								color: "#52525b",
+								fontSize: 22,
+								fontWeight: 700,
+								letterSpacing: 4,
+								padding: "0 4px",
+							}}
+						>
+							VS
+						</span>
+						{competitors.map((spec, i) => (
+							<Tile key={i} spec={spec} />
+						))}
+					</div>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						justifyContent: "flex-end",
+						color: "#71717a",
+						fontSize: 20,
+					}}
+				>
+					devpass.llmgateway.io/compare
+				</div>
+			</div>
+		),
+		size,
+	);
+}

--- a/apps/code/src/app/compare/opengraph-image.tsx
+++ b/apps/code/src/app/compare/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const contentType = "image/png";
 
 function Tile({ spec, devpass }: { spec: BrandSpec; devpass?: boolean }) {
 	const tileSize = 96;
-	const inner = 52;
+	const inner = Math.round(tileSize * spec.scale);
 	const background = devpass ? "#fafafa" : spec.bg;
 	const color = devpass ? "#0a0a0b" : spec.fg;
 	const Mark = spec.Mark;

--- a/apps/code/src/app/compare/page.tsx
+++ b/apps/code/src/app/compare/page.tsx
@@ -1,6 +1,7 @@
-import { ArrowRight, Scale } from "lucide-react";
+import { ArrowRight, Layers, Scale } from "lucide-react";
 import Link from "next/link";
 
+import { BrandTile } from "@/components/brand-logos";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 
@@ -12,12 +13,12 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "DevPass vs the Alternatives — Coding Plan Comparisons",
 	description:
-		"How DevPass compares to OpenCode Go, OpenCode Zen, FirePass, the z.ai GLM Coding Plan, and Alibaba's Qwen plan. Pricing, model catalogs, and limits side by side.",
+		"How DevPass compares to Cursor, OpenCode, FirePass, the z.ai GLM Coding Plan, and Alibaba's Qwen plan. Pricing, model catalogs, and limits side by side.",
 	alternates: { canonical: "/compare" },
 	openGraph: {
 		title: "DevPass vs the Alternatives — Coding Plan Comparisons",
 		description:
-			"How DevPass compares to OpenCode Go, OpenCode Zen, FirePass, z.ai and Alibaba Qwen. Pricing, models, and limits side by side.",
+			"How DevPass compares to Cursor, OpenCode, FirePass, z.ai and Alibaba Qwen. Pricing, models, and limits side by side.",
 		type: "website",
 		url: "https://devpass.llmgateway.io/compare",
 	},
@@ -35,47 +36,117 @@ export default function CompareIndexPage() {
 			<Header />
 
 			<main>
+				{/* Hero */}
 				<section className="relative overflow-hidden border-b">
-					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-muted/60 via-transparent to-transparent" />
-					<div className="container relative mx-auto max-w-4xl px-4 pt-20 pb-12 sm:pt-24 text-center">
+					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_60%_at_50%_-10%,_var(--tw-gradient-stops))] from-muted/70 via-transparent to-transparent" />
+					<div
+						className="pointer-events-none absolute inset-0 opacity-[0.04]"
+						style={{
+							backgroundImage:
+								"linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)",
+							backgroundSize: "44px 44px",
+							maskImage:
+								"radial-gradient(ellipse 70% 60% at 50% 0%, black, transparent)",
+						}}
+					/>
+					<div className="container relative mx-auto max-w-4xl px-4 pt-20 pb-14 text-center sm:pt-24">
 						<div className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/50 px-4 py-1.5 text-sm text-muted-foreground">
 							<Scale className="h-3.5 w-3.5" />
 							Comparisons
 						</div>
-						<h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+						<h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl">
 							DevPass vs the alternatives
 						</h1>
-						<p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-muted-foreground">
+						<p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-pretty text-muted-foreground">
 							Single-vendor plans and single-model deals each do one thing well.
 							DevPass gives you all 200+ models — frontier and open-weight —
 							under one key. Here&apos;s how it stacks up.
 						</p>
+
+						{/* Logo lineup */}
+						<div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+							<BrandTile brand="devpass" size={44} radius={12} />
+							<span className="px-1 text-xs font-medium uppercase tracking-[0.25em] text-muted-foreground/70">
+								vs
+							</span>
+							{entries.map((entry: Comparison) => (
+								<BrandTile
+									key={entry.id}
+									brand={entry.competitorLogo ?? entry.competitor}
+									size={44}
+									radius={12}
+								/>
+							))}
+						</div>
 					</div>
 				</section>
 
-				<section className="px-4 py-12">
+				{/* Cards */}
+				<section className="px-4 py-14">
 					<div className="container mx-auto max-w-4xl">
 						<div className="grid gap-5 sm:grid-cols-2">
-							{entries.map((entry: Comparison) => (
+							{entries.map((entry: Comparison, idx: number) => (
 								<Link
 									key={entry.id}
 									href={`/compare/${entry.slug}`}
-									className="group flex flex-col rounded-2xl border bg-card p-6 shadow-sm transition-colors hover:border-foreground/30"
+									className="group relative flex flex-col overflow-hidden rounded-2xl border bg-card p-6 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-foreground/30 hover:shadow-lg motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both"
+									style={{ animationDelay: `${idx * 70}ms` }}
 								>
-									<div className="mb-3 flex items-center gap-2 text-sm font-medium text-muted-foreground">
-										<span className="text-foreground">DevPass</span>
-										<span className="text-muted-foreground/50">vs</span>
-										<span>{entry.competitor}</span>
+									{/* Logo face-off */}
+									<div className="mb-5 flex items-center gap-3">
+										<BrandTile brand="devpass" size={40} radius={11} />
+										<span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/60">
+											vs
+										</span>
+										<BrandTile
+											brand={entry.competitorLogo ?? entry.competitor}
+											size={40}
+											radius={11}
+										/>
 									</div>
-									<p className="flex-1 text-sm leading-6 text-muted-foreground">
+
+									<h2 className="text-lg font-semibold tracking-tight text-foreground">
+										DevPass vs {entry.competitor}
+									</h2>
+									<p className="mt-1 text-xs font-medium text-muted-foreground">
+										{entry.competitorTagline}
+									</p>
+
+									<p className="mt-4 flex-1 text-sm leading-6 text-muted-foreground line-clamp-3">
 										{entry.verdict}
 									</p>
+
+									{/* Price compare strip */}
+									<div className="mt-5 flex items-center gap-2 text-[11px] font-medium">
+										<span className="rounded-md bg-muted px-2 py-1 font-mono tabular-nums text-foreground">
+											{entry.devpassPrice}
+										</span>
+										<span className="text-muted-foreground/50">vs</span>
+										<span className="rounded-md bg-muted px-2 py-1 font-mono tabular-nums text-muted-foreground">
+											{entry.competitorPrice}
+										</span>
+									</div>
+
 									<div className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
 										Read the comparison
 										<ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
 									</div>
 								</Link>
 							))}
+						</div>
+
+						{/* Catalog note */}
+						<div className="mt-10 flex items-start gap-3 rounded-2xl border border-dashed bg-muted/30 p-5 text-sm text-muted-foreground">
+							<Layers className="mt-0.5 h-4 w-4 shrink-0 text-foreground/70" />
+							<p>
+								Every comparison weighs the same trade: a single-vendor or
+								single-tool plan versus{" "}
+								<span className="font-medium text-foreground">
+									one key to 200+ models
+								</span>{" "}
+								at provider rates, with a per-request cost dashboard and
+								commercial use on every tier.
+							</p>
 						</div>
 					</div>
 				</section>

--- a/apps/code/src/components/ComparisonTable.tsx
+++ b/apps/code/src/components/ComparisonTable.tsx
@@ -1,5 +1,7 @@
 import { Check, Minus } from "lucide-react";
 
+import { BrandTile } from "@/components/brand-logos";
+
 interface FeatureRow {
 	label: string;
 	devpass: string | boolean;
@@ -7,14 +9,24 @@ interface FeatureRow {
 	highlight?: boolean;
 }
 
-function Cell({ value }: { value: string | boolean }) {
+function Cell({
+	value,
+	accent,
+}: {
+	value: string | boolean;
+	accent?: boolean;
+}) {
 	if (typeof value === "boolean") {
 		return (
 			<>
 				{value ? (
 					<Check
 						aria-hidden="true"
-						className="mx-auto h-4 w-4 text-foreground/70"
+						className={
+							accent
+								? "mx-auto h-4 w-4 text-emerald-600 dark:text-emerald-400"
+								: "mx-auto h-4 w-4 text-foreground/70"
+						}
 					/>
 				) : (
 					<Minus
@@ -31,9 +43,11 @@ function Cell({ value }: { value: string | boolean }) {
 
 export function ComparisonTable({
 	competitor,
+	competitorLogo,
 	features,
 }: {
 	competitor: string;
+	competitorLogo?: string;
 	features: FeatureRow[];
 }) {
 	return (
@@ -43,13 +57,23 @@ export function ComparisonTable({
 					<thead>
 						<tr className="border-b bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
 							<th className="px-5 py-4 font-medium">Feature</th>
-							<th className="px-5 py-4 text-center font-medium">
-								<span className="font-semibold text-foreground">DevPass</span>
+							<th className="px-5 py-4 font-medium">
+								<div className="flex items-center justify-center gap-2">
+									<BrandTile brand="devpass" size={26} radius={8} />
+									<span className="font-semibold text-foreground">DevPass</span>
+								</div>
 							</th>
-							<th className="px-5 py-4 text-center font-medium">
-								<span className="font-semibold text-foreground">
-									{competitor}
-								</span>
+							<th className="px-5 py-4 font-medium">
+								<div className="flex items-center justify-center gap-2">
+									<BrandTile
+										brand={competitorLogo ?? competitor}
+										size={26}
+										radius={8}
+									/>
+									<span className="font-semibold text-foreground">
+										{competitor}
+									</span>
+								</div>
 							</th>
 						</tr>
 					</thead>
@@ -70,8 +94,8 @@ export function ComparisonTable({
 								>
 									{row.label}
 								</td>
-								<td className="px-5 py-3.5 text-center bg-muted/20">
-									<Cell value={row.devpass} />
+								<td className="bg-muted/20 px-5 py-3.5 text-center">
+									<Cell value={row.devpass} accent={row.highlight} />
 								</td>
 								<td className="px-5 py-3.5 text-center">
 									<Cell value={row.competitor} />

--- a/apps/code/src/components/brand-logos.tsx
+++ b/apps/code/src/components/brand-logos.tsx
@@ -1,0 +1,154 @@
+import { cn } from "@/lib/utils";
+
+import type { ReactElement } from "react";
+
+interface MarkProps {
+	size?: number;
+}
+
+/**
+ * Brand marks are intentionally plain inline SVG (no `currentColor`-less fills,
+ * no lucide, no client hooks) so the exact same components render in the DOM and
+ * inside `next/og`'s Satori renderer for the dynamic OpenGraph images.
+ */
+
+export function DevPassMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2.4}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<polyline points="16 18 22 12 16 6" />
+			<polyline points="8 6 2 12 8 18" />
+		</svg>
+	);
+}
+
+export function CursorMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 466.73 532.09"
+			aria-hidden="true"
+		>
+			<path
+				d="M457.43 125.94 244.42 2.96c-6.84-3.95-15.28-3.95-22.12 0L9.3 125.94C3.55 129.26 0 135.4 0 142.05v247.99c0 6.65 3.55 12.79 9.3 16.11l213.01 122.98c6.84 3.95 15.28 3.95 22.12 0l213.01-122.98c5.75-3.32 9.3-9.46 9.3-16.11V142.05c0-6.65-3.55-12.79-9.3-16.11zm-13.38 26.05L238.42 508.15c-1.39 2.4-5.06 1.42-5.06-1.36V273.58c0-4.66-2.49-8.97-6.53-11.31L24.87 145.67c-2.4-1.39-1.42-5.06 1.36-5.06h411.26c5.84 0 9.49 6.33 6.57 11.39h-.01Z"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}
+
+export function OpenCodeMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 240 300"
+			fill="none"
+			aria-hidden="true"
+		>
+			<path d="M180 240H60V120h120z" fill="currentColor" opacity={0.5} />
+			<path d="M180 60H60v180h120zm60 240H0V0h240z" fill="currentColor" />
+		</svg>
+	);
+}
+
+export interface BrandSpec {
+	label: string;
+	/** Tile background. For `devpass` the DOM tile is theme-aware; this value is
+	 * what the (always-dark) OpenGraph renderer uses. */
+	bg: string;
+	/** Mark / monogram color. */
+	fg: string;
+	Mark?: (props: MarkProps) => ReactElement;
+	/** Single-glyph fallback when there is no dedicated mark. */
+	mono?: string;
+}
+
+export const BRAND: Record<string, BrandSpec> = {
+	devpass: {
+		label: "DevPass",
+		bg: "#fafafa",
+		fg: "#0a0a0b",
+		Mark: DevPassMark,
+	},
+	cursor: { label: "Cursor", bg: "#0a0a0b", fg: "#ffffff", Mark: CursorMark },
+	opencode: {
+		label: "OpenCode",
+		bg: "#0a0a0b",
+		fg: "#ffffff",
+		Mark: OpenCodeMark,
+	},
+	fireworks: { label: "Fireworks", bg: "#2e1065", fg: "#c4b5fd", mono: "F" },
+	zai: { label: "z.ai", bg: "#0c2d6b", fg: "#93c5fd", mono: "z" },
+	qwen: { label: "Qwen", bg: "#312e81", fg: "#a5b4fc", mono: "Q" },
+};
+
+const FALLBACK: BrandSpec = { label: "", bg: "#27272a", fg: "#e4e4e7" };
+
+export function getBrand(key?: string): BrandSpec {
+	return (key && BRAND[key]) || FALLBACK;
+}
+
+/**
+ * Rounded brand tile for use in the DOM. `devpass` is rendered theme-aware so it
+ * reads correctly on both the light and dark site themes; every other brand uses
+ * its fixed brand color.
+ */
+export function BrandTile({
+	brand,
+	size = 48,
+	radius = 14,
+	className,
+}: {
+	brand: string;
+	size?: number;
+	radius?: number;
+	className?: string;
+}): ReactElement {
+	const spec = getBrand(brand);
+	const inner = Math.round(size * 0.56);
+	const isDevpass = brand === "devpass";
+	const Mark = spec.Mark;
+
+	return (
+		<div
+			className={cn(
+				"flex shrink-0 items-center justify-center overflow-hidden",
+				isDevpass
+					? "bg-foreground text-background"
+					: "ring-1 ring-inset ring-white/10",
+				className,
+			)}
+			style={{
+				width: size,
+				height: size,
+				borderRadius: radius,
+				...(isDevpass ? {} : { backgroundColor: spec.bg, color: spec.fg }),
+			}}
+		>
+			{Mark ? (
+				<Mark size={inner} />
+			) : (
+				<span
+					style={{
+						fontSize: Math.round(inner * 0.82),
+						fontWeight: 700,
+						lineHeight: 1,
+					}}
+				>
+					{spec.mono ?? spec.label.charAt(0)}
+				</span>
+			)}
+		</div>
+	);
+}

--- a/apps/code/src/components/brand-logos.tsx
+++ b/apps/code/src/components/brand-logos.tsx
@@ -7,9 +7,10 @@ interface MarkProps {
 }
 
 /**
- * Brand marks are intentionally plain inline SVG (no `currentColor`-less fills,
- * no lucide, no client hooks) so the exact same components render in the DOM and
- * inside `next/og`'s Satori renderer for the dynamic OpenGraph images.
+ * Brand marks are intentionally plain inline SVG (no lucide, no client hooks) so
+ * the exact same components render in the DOM and inside `next/og`'s Satori
+ * renderer for the dynamic OpenGraph images. Gradient ids are namespaced per
+ * brand to avoid `url(#id)` collisions when several marks share a document.
  */
 
 export function DevPassMark({ size = 28 }: MarkProps): ReactElement {
@@ -47,17 +48,133 @@ export function CursorMark({ size = 28 }: MarkProps): ReactElement {
 	);
 }
 
-export function OpenCodeMark({ size = 28 }: MarkProps): ReactElement {
+export function OpenCodeGoMark({ size = 28 }: MarkProps): ReactElement {
 	return (
 		<svg
 			width={size}
 			height={size}
-			viewBox="0 0 240 300"
+			viewBox="0 0 54 30"
 			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 		>
-			<path d="M180 240H60V120h120z" fill="currentColor" opacity={0.5} />
-			<path d="M180 60H60v180h120zm60 240H0V0h240z" fill="currentColor" />
+			<path d="M24 30H0V0h24v6H6v18h12v-6h-6v-6h12z" fill="currentColor" />
+			<path
+				d="M12 18h6v6H6V12h6zM48 12v12H36V12z"
+				fill="currentColor"
+				opacity={0.45}
+			/>
+			<path d="M54 30H30V0h24zm-18-6h12V6H36z" fill="currentColor" />
+		</svg>
+	);
+}
+
+export function OpenCodeZenMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 84 30"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M24 24H6v-6h12v-6h6zM6 18H0v-6h6z"
+				fill="currentColor"
+				opacity={0.45}
+			/>
+			<path
+				d="M6 24h18v6H0V18h6zm12-6H6v-6h12zm6-6h-6V6H0V0h24z"
+				fill="currentColor"
+			/>
+			<path d="M54 18v6H36v-6z" fill="currentColor" opacity={0.45} />
+			<path d="M54 18H36v6h18v6H30V0h24zm-18-6h12V6H36z" fill="currentColor" />
+			<path d="M78 30H66V12h12z" fill="currentColor" opacity={0.45} />
+			<path d="M78 6H66v24h-6V0h18zm6 24h-6V6h6z" fill="currentColor" />
+		</svg>
+	);
+}
+
+export function FireworksMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 638 315"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M318.563 221.755c-17.7 0-33.584-10.508-40.357-26.777L196.549 0h47.793l74.5 178.361L393.273 0h47.793L358.92 195.048c-6.808 16.199-22.657 26.707-40.357 26.707M425.111 314.933c-17.63 0-33.444-10.439-40.287-26.567-6.877-16.269-3.317-34.842 9.112-47.445L542.657 90.2803l18.572 43.8137-136.153 137.654 194.071-1.082 18.573 43.813-212.574.524-.07-.07zM0 314.408l18.5727-43.813 194.0703 1.082L76.525 133.988l18.5727-43.8132L243.819 240.816c12.428 12.568 16.024 31.21 9.111 47.444-6.842 16.164-22.727 26.567-40.287 26.567L.0698221 314.339z"
+				fill="#6720ff"
+			/>
+		</svg>
+	);
+}
+
+export function ZaiMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 161 129"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M161 0h-59.685L0 129h59.6854L161 0ZM148.564 109.447H89.5L74 129.001h59.064l15.5-19.554ZM84.5635-.00018068H25.5L10 19.5536h59.0635l15.5-19.55378068Z"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}
+
+export function QwenMark({ size = 28 }: MarkProps): ReactElement {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 200 200"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M174.82 108.75 155.38 75l10.26-17.25c.82-1.44.82-3.22 0-4.66l-10.26-17.25c-.52-.93-1.51-1.51-2.6-1.51h-37.9l-8.74-15.3c-.52-.93-1.51-1.51-2.6-1.51H83.3c-1.09 0-2.08.58-2.6 1.51L61.26 52.77H41.02c-1.09 0-2.08.58-2.6 1.51L28.16 71.53c-.82 1.44-.82 3.22 0 4.66l17.36 31.31-8.74 15.3c-.82 1.44-.82 3.22 0 4.66l10.26 17.25c.52.93 1.51 1.51 2.6 1.51h37.9l8.74 15.3c.52.93 1.51 1.51 2.6 1.51h20.24c1.09 0 2.08-.58 2.6-1.51l19.44-33.74h17.36c1.09 0 2.08-.58 2.6-1.51l10.26-17.25c.82-1.44.82-3.22 0-4.66z"
+				fill="url(#qwenGradA)"
+			/>
+			<path
+				d="M119.12 163.03H98.88l-11.34-18.32h-37.9l11.62-18.32H80.7l-42.28-71.1h22.84L83.3 19.03l10.26 18.32L83.3 55.29h78.28l-10.26 17.25 19.44 33.74h-19.44l-10.16-17.94-39.98 74.69z"
+				fill="#fff"
+			/>
+			<path d="M127.86 79.83H76.14l25.04 42.28z" fill="url(#qwenGradB)" />
+			<defs>
+				<radialGradient
+					id="qwenGradA"
+					cx="0"
+					cy="0"
+					r="1"
+					gradientUnits="userSpaceOnUse"
+					gradientTransform="rotate(90 0 100)scale(100)"
+				>
+					<stop stopColor="#665cee" />
+					<stop offset="1" stopColor="#332e91" />
+				</radialGradient>
+				<radialGradient
+					id="qwenGradB"
+					cx="0"
+					cy="0"
+					r="1"
+					gradientUnits="userSpaceOnUse"
+					gradientTransform="rotate(90 0 100)scale(100)"
+				>
+					<stop stopColor="#665cee" />
+					<stop offset="1" stopColor="#332e91" />
+				</radialGradient>
+			</defs>
 		</svg>
 	);
 }
@@ -67,8 +184,14 @@ export interface BrandSpec {
 	/** Tile background. For `devpass` the DOM tile is theme-aware; this value is
 	 * what the (always-dark) OpenGraph renderer uses. */
 	bg: string;
-	/** Mark / monogram color. */
+	/** Mark color (only affects `currentColor` marks) / monogram color. */
 	fg: string;
+	/** Fraction of the tile the mark occupies — tuned per logo aspect ratio. */
+	scale: number;
+	/** When true the DOM tile is theme-aware (like `devpass`): the mark uses
+	 * `currentColor` and the tile flips with the site's light/dark theme. The
+	 * fixed `bg`/`fg` are then used only by the always-dark OpenGraph renderer. */
+	adaptive?: boolean;
 	Mark?: (props: MarkProps) => ReactElement;
 	/** Single-glyph fallback when there is no dedicated mark. */
 	mono?: string;
@@ -79,21 +202,61 @@ export const BRAND: Record<string, BrandSpec> = {
 		label: "DevPass",
 		bg: "#fafafa",
 		fg: "#0a0a0b",
+		scale: 0.56,
 		Mark: DevPassMark,
 	},
-	cursor: { label: "Cursor", bg: "#0a0a0b", fg: "#ffffff", Mark: CursorMark },
-	opencode: {
-		label: "OpenCode",
+	cursor: {
+		label: "Cursor",
 		bg: "#0a0a0b",
 		fg: "#ffffff",
-		Mark: OpenCodeMark,
+		scale: 0.52,
+		Mark: CursorMark,
 	},
-	fireworks: { label: "Fireworks", bg: "#2e1065", fg: "#c4b5fd", mono: "F" },
-	zai: { label: "z.ai", bg: "#0c2d6b", fg: "#93c5fd", mono: "z" },
-	qwen: { label: "Qwen", bg: "#312e81", fg: "#a5b4fc", mono: "Q" },
+	"opencode-go": {
+		label: "OpenCode Go",
+		bg: "#18181b",
+		fg: "#f1ecec",
+		scale: 0.64,
+		adaptive: true,
+		Mark: OpenCodeGoMark,
+	},
+	"opencode-zen": {
+		label: "OpenCode Zen",
+		bg: "#18181b",
+		fg: "#f1ecec",
+		scale: 0.78,
+		adaptive: true,
+		Mark: OpenCodeZenMark,
+	},
+	fireworks: {
+		label: "Fireworks",
+		bg: "#0a0a0b",
+		fg: "#6720ff",
+		scale: 0.74,
+		Mark: FireworksMark,
+	},
+	zai: {
+		label: "z.ai",
+		bg: "#0a0a0b",
+		fg: "#ffffff",
+		scale: 0.62,
+		Mark: ZaiMark,
+	},
+	qwen: {
+		label: "Qwen",
+		bg: "#0a0a0b",
+		fg: "#a5b4fc",
+		scale: 0.72,
+		Mark: QwenMark,
+	},
 };
 
-const FALLBACK: BrandSpec = { label: "", bg: "#27272a", fg: "#e4e4e7" };
+const FALLBACK: BrandSpec = {
+	label: "",
+	bg: "#27272a",
+	fg: "#e4e4e7",
+	scale: 0.5,
+};
 
 export function getBrand(key?: string): BrandSpec {
 	return (key && BRAND[key]) || FALLBACK;
@@ -116,15 +279,15 @@ export function BrandTile({
 	className?: string;
 }): ReactElement {
 	const spec = getBrand(brand);
-	const inner = Math.round(size * 0.56);
-	const isDevpass = brand === "devpass";
+	const inner = Math.round(size * spec.scale);
+	const themeAware = brand === "devpass" || spec.adaptive === true;
 	const Mark = spec.Mark;
 
 	return (
 		<div
 			className={cn(
 				"flex shrink-0 items-center justify-center overflow-hidden",
-				isDevpass
+				themeAware
 					? "bg-foreground text-background"
 					: "ring-1 ring-inset ring-white/10",
 				className,
@@ -133,7 +296,7 @@ export function BrandTile({
 				width: size,
 				height: size,
 				borderRadius: radius,
-				...(isDevpass ? {} : { backgroundColor: spec.bg, color: spec.fg }),
+				...(themeAware ? {} : { backgroundColor: spec.bg, color: spec.fg }),
 			}}
 		>
 			{Mark ? (

--- a/apps/code/src/content/comparisons/alibaba-qwen-coding.md
+++ b/apps/code/src/content/comparisons/alibaba-qwen-coding.md
@@ -6,6 +6,7 @@ title: DevPass vs Alibaba Qwen Coding Plan
 metaTitle: "DevPass vs Alibaba Qwen Coding Plan Compared (2026)"
 description: "DevPass vs Alibaba Cloud's Qwen coding plan compared. Alibaba's plan centers on Qwen3-Coder with high request limits; DevPass is a flat plan for 200+ models — Claude, GPT-5.5, Gemini and Qwen — under one key."
 competitor: Alibaba Qwen Coding Plan
+competitorLogo: qwen
 competitorTagline: High-volume access to Qwen3-Coder and partner models
 tagline: "Alibaba's coding plan is built around Qwen3-Coder with huge request limits. DevPass is built around choice — Qwen plus 200+ other models, including the Western flagships."
 devpassPrice: "$29–$179/mo"

--- a/apps/code/src/content/comparisons/cursor.md
+++ b/apps/code/src/content/comparisons/cursor.md
@@ -1,0 +1,118 @@
+---
+id: devpass-vs-cursor
+slug: cursor
+date: 2026-06-14
+title: DevPass vs Cursor
+metaTitle: "DevPass vs Cursor (2026): Pricing, Models & Usage Compared"
+description: "DevPass vs Cursor compared. Cursor bundles an AI editor with a curated model set from $20/mo; DevPass is one API key for 200+ models at provider rates — roughly 3× the usage value — for Cursor, Claude Code, OpenCode or any tool you already use."
+competitor: Cursor
+competitorLogo: cursor
+competitorTagline: The AI-native code editor with tab, Composer and agents
+tagline: "Cursor bundles a polished AI editor with a curated set of models. DevPass hands you one key to 200+ models at provider rates — for whatever editor you already use, Cursor included. One is an app; the other is your model layer."
+devpassPrice: "$29–$179/mo"
+competitorPrice: "$20–$200/mo"
+verdict: "Cursor is the better buy if you want a finished AI editor — unlimited tab completion, the Composer agent and Bugbot, all in one app. DevPass isn't an editor: it's a single API key for 200+ models at provider rates, with roughly 3× the usage value of a Cursor plan, that drops into Claude Code, OpenCode, Zed — or Cursor itself. Pick Cursor for the all-in-one editor; pick DevPass to own your model access across every tool without lock-in."
+features:
+  - label: Starting price
+    devpass: "$29/mo (Lite)"
+    competitor: "$20/mo (Pro)"
+  - label: Models available
+    devpass: "200+"
+    competitor: "~40 curated"
+    highlight: true
+  - label: Usage value per dollar
+    devpass: "~3× provider rates ($79 → ~$237)"
+    competitor: "1× on Pro, up to 2× on Ultra"
+    highlight: true
+  - label: Built-in AI editor + tab completion
+    devpass: false
+    competitor: true
+    highlight: true
+  - label: Works in your existing tools
+    devpass: "Claude Code, OpenCode, Zed, Cline…"
+    competitor: "Cursor editor only"
+    highlight: true
+  - label: Usable inside Cursor (custom API key)
+    devpass: true
+    competitor: "n/a"
+  - label: Composer agent + Bugbot review
+    devpass: "Use any model as the agent"
+    competitor: true
+  - label: Per-request cost in real dollars
+    devpass: true
+    competitor: "Bundled credits"
+  - label: Pricing model
+    devpass: Flat plan + usage allowance
+    competitor: Included usage, then pay-as-you-go
+  - label: No model lock-in / no token markup
+    devpass: true
+    competitor: "Curated set, bundled rates"
+  - label: "SoulForge token reduction (~50% fewer tokens)"
+    devpass: true
+    competitor: false
+  - label: Commercial & team use
+    devpass: true
+    competitor: true
+faqs:
+  - question: What is Cursor and how much does it cost?
+    answer: "Cursor is an AI-native code editor — a VS Code fork with unlimited tab completion, the Composer agent, Bugbot code review and Cloud Agents built in. Individual plans are Pro at $20/mo (about $20 of model usage included), Pro Plus at $60/mo (~$70 included) and Ultra at $200/mo (~$400 included). Teams start at $40/user/mo. Beyond the included usage you continue at each model's API rate, pay-as-you-go."
+  - question: Is DevPass a replacement for Cursor?
+    answer: "Not exactly — they solve different problems. Cursor is the editor and the experience; DevPass is the model layer underneath. If you live inside Cursor for tab completion and Composer, DevPass doesn't replace that. But if your workflow is Claude Code, OpenCode, Zed or Cline, DevPass replaces the reason you'd pay Cursor: it gives you every model under one key, at provider rates, for a flat monthly price."
+  - question: Can I use DevPass inside Cursor?
+    answer: "Yes. DevPass exposes an OpenAI-compatible endpoint, so you can point Cursor's custom API key setting at it and run DevPass's 200+ models from inside the Cursor editor — while still getting per-request cost in real dollars and your flat-rate allowance. You keep Cursor's UX and swap in DevPass's catalog and pricing."
+  - question: How does DevPass pricing compare to Cursor's?
+    answer: "Cursor bundles usage into the plan: Pro is roughly break-even ($20 of usage for $20), and Ultra gives about 2× ($400 for $200). DevPass gives roughly 3× across every plan — you pay $79 on Pro and get about $237 of model usage at the providers' own published rates, metered transparently. With SoulForge cutting token use by around half, that allowance stretches further still."
+  - question: Does DevPass have tab completion or an agent like Cursor?
+    answer: "DevPass doesn't ship its own editor, tab completion or Bugbot — that's Cursor's domain. Instead it lets you run any of 200+ models as the agent inside the tools you already use, including Claude Code, OpenCode and Cursor itself. If a bundled editor experience is what you want, Cursor wins; if model breadth, transparent pricing and no lock-in matter more, DevPass does."
+---
+
+## What is Cursor?
+
+Cursor is an **AI-native code editor** — a polished VS Code fork built around AI from the ground up. You get unlimited **tab completion**, the **Composer** agent (Cursor's own coding model), **Bugbot** for automated code review, and Cloud Agents, all inside one app. Individual plans run **$20/mo (Pro)**, **$60/mo (Pro Plus)** and **$200/mo (Ultra)**, with team plans from **$40/user/mo**.
+
+Each plan bundles a dollar amount of model usage — about $20 on Pro, ~$70 on Pro Plus, ~$400 on Ultra. Cursor runs two usage pools: a cheaper **Auto / Composer** pool for everyday agentic coding, and an **API** pool billed at each model's published rate. Cross the included amount and you continue pay-as-you-go at API rates.
+
+What you're really buying with Cursor is **the experience**: a finished editor where the AI is woven into every keystroke.
+
+## What is DevPass?
+
+DevPass by LLM Gateway isn't an editor — it's the **model layer** underneath your editor. One API key unlocks **200+ models** — Claude Opus 4.7, GPT-5.5, Gemini 3.1 Pro, plus the open-weight coders like GLM, Kimi and Qwen — for a flat monthly price: **$29 (Lite)**, **$79 (Pro)** or **$179 (Max)**.
+
+Instead of bundling usage into opaque credits, DevPass meters every request at the **provider's own published rate** and shows you the dollar cost in real time. The allowance is generous: roughly **$3 of model usage for every $1 you pay** (so ~$237 of usage on the $79 Pro plan). It plugs into anything OpenAI- or Anthropic-compatible — **Claude Code, OpenCode, Zed, Cline** — and even into **Cursor itself**.
+
+## The real difference: an editor vs a model layer
+
+This is the comparison in one line:
+
+- **Cursor** is an **app**. You adopt its editor, and the models come bundled in. Brilliant if you want one finished tool that does everything — but you're inside Cursor, on Cursor's curated model set, with usage you can't see in plain dollars.
+- **DevPass** is your **model access**. You keep whatever tools you already use and point them at one key for every model, at provider rates, with a transparent per-request bill — no editor lock-in.
+
+Neither is strictly "better." They sit at different layers of your stack.
+
+## Pricing: what your money actually buys
+
+Cursor folds usage into the subscription. On **Pro**, $20/mo includes roughly $20 of API-rate usage — about break-even — though the cheaper Auto/Composer pool stretches it further for everyday work. **Ultra** gives the best ratio at about **2×** ($400 of usage for $200).
+
+DevPass gives roughly **3× on every plan**, metered at the providers' published rates:
+
+- **Lite — $29/mo** → ~$87 of model usage
+- **Pro — $79/mo** → ~$237 of model usage
+- **Max — $179/mo** → ~$537 of model usage
+
+Every request shows its exact dollar cost in your dashboard, and **SoulForge** — graph-powered context that cuts roughly half the tokens — stretches that allowance even further.
+
+## Model catalog: 200+ vs a curated set
+
+Cursor curates around **40 models** — the major Claude, GPT, Gemini and Grok releases, plus its own Composer. It's a tight, well-chosen list, but it's a list someone else picks.
+
+DevPass carries **200+ models** under the same key, frontier and open-weight, and you choose freely per request — Claude for a hard refactor, GPT-5.5 for reasoning, GLM or Qwen when you want cheap throughput. No model is gated behind a different subscription.
+
+## Can you use them together?
+
+Yes — and it's often the smart move. Because DevPass is **OpenAI-compatible**, you can point Cursor's custom API key setting at DevPass and run all 200+ models from **inside the Cursor editor** you already like, while getting DevPass's provider-rate pricing and real-dollar cost dashboard. You keep Cursor's UX; you swap in DevPass's catalog and economics.
+
+## Who should choose which
+
+**Choose Cursor if** you want a finished AI editor — unlimited tab completion, the Composer agent, Bugbot review — and you're happy living inside one polished app with a curated model set.
+
+**Choose DevPass if** you already work in Claude Code, OpenCode, Zed or Cline (or want to bring 200+ models into Cursor itself), and you value transparent provider-rate pricing, ~3× usage value, and zero model lock-in over a bundled editor experience.

--- a/apps/code/src/content/comparisons/cursor.md
+++ b/apps/code/src/content/comparisons/cursor.md
@@ -50,9 +50,6 @@ features:
   - label: "SoulForge token reduction (~50% fewer tokens)"
     devpass: true
     competitor: false
-  - label: Commercial & team use
-    devpass: true
-    competitor: true
 faqs:
   - question: What is Cursor and how much does it cost?
     answer: "Cursor is an AI-native code editor — a VS Code fork with unlimited tab completion, the Composer agent, Bugbot code review and Cloud Agents built in. Individual plans are Pro at $20/mo (about $20 of model usage included), Pro Plus at $60/mo (~$70 included) and Ultra at $200/mo (~$400 included). Teams start at $40/user/mo. Beyond the included usage you continue at each model's API rate, pay-as-you-go."

--- a/apps/code/src/content/comparisons/firepass.md
+++ b/apps/code/src/content/comparisons/firepass.md
@@ -6,6 +6,7 @@ title: DevPass vs FirePass by Fireworks
 metaTitle: "DevPass vs FirePass (Fireworks): One Model or 200+?"
 description: "DevPass vs FirePass by Fireworks compared. FirePass is $49/mo for unlimited Kimi K2.6 Turbo only; DevPass is a flat plan for 200+ models — Claude, GPT-5.5, Gemini and the open-weight coders — under one key."
 competitor: FirePass by Fireworks
+competitorLogo: fireworks
 competitorTagline: Unlimited Kimi K2.6 Turbo for personal coding
 tagline: "FirePass gives you one model with no token meter. DevPass gives you 200+ models with a usage allowance. The trade is unlimited-but-single versus broad-but-metered."
 devpassPrice: "$29–$179/mo"

--- a/apps/code/src/content/comparisons/opencode-go.md
+++ b/apps/code/src/content/comparisons/opencode-go.md
@@ -6,7 +6,7 @@ title: DevPass vs OpenCode Go
 metaTitle: "DevPass vs OpenCode Go: Best AI Coding Plan in 2026?"
 description: "DevPass vs OpenCode Go compared — pricing, models, and limits. OpenCode Go is $10/mo for 14 open-weight models; DevPass adds Claude, GPT-5.5 and Gemini for flat-rate access to 200+ under one key."
 competitor: OpenCode Go
-competitorLogo: opencode
+competitorLogo: opencode-go
 competitorTagline: Low-cost subscription for open-weight coding models
 tagline: "Both hand you a flat monthly coding subscription. Only one also gives you Claude Opus 4.7, GPT-5.5 and Gemini 3.1 Pro next to the open-weight models — with a per-request cost dashboard."
 devpassPrice: "$29–$179/mo"

--- a/apps/code/src/content/comparisons/opencode-go.md
+++ b/apps/code/src/content/comparisons/opencode-go.md
@@ -6,6 +6,7 @@ title: DevPass vs OpenCode Go
 metaTitle: "DevPass vs OpenCode Go: Best AI Coding Plan in 2026?"
 description: "DevPass vs OpenCode Go compared — pricing, models, and limits. OpenCode Go is $10/mo for 14 open-weight models; DevPass adds Claude, GPT-5.5 and Gemini for flat-rate access to 200+ under one key."
 competitor: OpenCode Go
+competitorLogo: opencode
 competitorTagline: Low-cost subscription for open-weight coding models
 tagline: "Both hand you a flat monthly coding subscription. Only one also gives you Claude Opus 4.7, GPT-5.5 and Gemini 3.1 Pro next to the open-weight models — with a per-request cost dashboard."
 devpassPrice: "$29–$179/mo"

--- a/apps/code/src/content/comparisons/opencode-zen.md
+++ b/apps/code/src/content/comparisons/opencode-zen.md
@@ -6,6 +6,7 @@ title: DevPass vs OpenCode Zen
 metaTitle: "DevPass vs OpenCode Zen: Flat Rate vs Pay-As-You-Go"
 description: "DevPass vs OpenCode Zen compared. OpenCode Zen is pay-as-you-go with zero markup on a curated model set; DevPass is a flat monthly plan for 200+ models with a fixed bill and per-request cost analytics."
 competitor: OpenCode Zen
+competitorLogo: opencode
 competitorTagline: Pay-as-you-go access to a curated set of coding models
 tagline: "OpenCode Zen charges per request with no markup. DevPass charges a flat monthly rate. The question isn't which is cheaper per token — it's whether you want a predictable bill or a metered one."
 devpassPrice: "$29–$179/mo"

--- a/apps/code/src/content/comparisons/opencode-zen.md
+++ b/apps/code/src/content/comparisons/opencode-zen.md
@@ -6,7 +6,7 @@ title: DevPass vs OpenCode Zen
 metaTitle: "DevPass vs OpenCode Zen: Flat Rate vs Pay-As-You-Go"
 description: "DevPass vs OpenCode Zen compared. OpenCode Zen is pay-as-you-go with zero markup on a curated model set; DevPass is a flat monthly plan for 200+ models with a fixed bill and per-request cost analytics."
 competitor: OpenCode Zen
-competitorLogo: opencode
+competitorLogo: opencode-zen
 competitorTagline: Pay-as-you-go access to a curated set of coding models
 tagline: "OpenCode Zen charges per request with no markup. DevPass charges a flat monthly rate. The question isn't which is cheaper per token — it's whether you want a predictable bill or a metered one."
 devpassPrice: "$29–$179/mo"

--- a/apps/code/src/content/comparisons/z-ai-glm-coding-plan.md
+++ b/apps/code/src/content/comparisons/z-ai-glm-coding-plan.md
@@ -6,6 +6,7 @@ title: DevPass vs z.ai GLM Coding Plan
 metaTitle: "DevPass vs z.ai GLM Coding Plan: One Vendor or 200+?"
 description: "DevPass vs the z.ai GLM Coding Plan compared. z.ai is a low-cost, GLM-only subscription billed quarterly; DevPass is a flat monthly plan for 200+ models — Claude, GPT-5.5, Gemini and GLM — under one key."
 competitor: z.ai GLM Coding Plan
+competitorLogo: zai
 competitorTagline: Low-cost subscription for Zhipu's GLM models
 tagline: "z.ai's coding plan is one of the cheapest ways to run GLM. DevPass costs more but isn't tied to a single vendor — GLM is just one of 200+ models on every plan."
 devpassPrice: "$29–$179/mo"


### PR DESCRIPTION
## What & why

Adds a **DevPass vs Cursor** comparison and redesigns the `/compare` pages around product logos and dynamic OpenGraph cards.

Cursor's data (Pro $20 / Pro Plus $60 / Ultra $200, the Auto+Composer vs API usage pools, Composer/Bugbot/tab completion) is taken from Cursor's published docs. The framing is deliberately honest — **"an editor vs a model layer"**: Cursor bundles a polished AI editor with a curated model set; DevPass is one key to 200+ models at provider rates (~3× usage value) that drops into Claude Code, OpenCode, Zed — or Cursor itself.

## Changes

- **New comparison** `apps/code/src/content/comparisons/cursor.md` — pricing, model-catalog and usage framing, a 12-row feature table, and 5 FAQs (emitted as `FAQPage` JSON-LD).
- **Brand-logo registry** `apps/code/src/components/brand-logos.tsx` — pure-SVG marks (DevPass code-mark, authentic Cursor cube, OpenCode, monogram fallback for Fireworks/z.ai/Qwen) that render identically in the DOM and in `next/og`'s Satori renderer.
- **Schema** — optional `competitorLogo` key on the comparison collection; all existing comparisons tagged.
- **Redesigned `/compare`** — index gets a logo lineup + face-off cards; the `[slug]` detail page gets a "versus arena" hero and a logo-headed comparison table.
- **Dynamic OpenGraph images** — `opengraph-image.tsx` for both `/compare` and `/compare/[slug]`, auto-wired into each page's `og:image` / `twitter:image`.

## Verification

- `turbo run build --filter=code` passes (incl. `tsc`)
- `eslint . && prettier --check .` clean
- Rendered the OG PNGs and screenshotted both pages live; confirmed `og:image`/`twitter:image`/canonical meta are wired correctly

## Screenshots

OG image (`/compare/cursor/opengraph-image`) shows the DevPass mark vs the Cursor cube with a price strip; the detail page leads with the versus arena and an "Our pick" marker on DevPass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional competitor logo support to comparison content, improving brand attribution in tables and cards.
  * Introduced automatic Open Graph image generation for the compare index and individual comparison pages.

* **UI/UX Improvements**
  * Refreshed the compare page layout with branded tiles, an updated “Head to head” hero, and a “catalog note” trade-off explanation.
  * Updated comparison cards and table styling to better highlight “Our pick” and brand headers.

* **Documentation**
  * Added a new Cursor comparison page with structured features and FAQ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->