### PR TITLE
feat: add chat product hunt launch popup

### DIFF
--- a/apps/ui/src/app/page.tsx
+++ b/apps/ui/src/app/page.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 
 import { HeroRSC } from "@/components/landing/hero-rsc";
+import { ProductHuntPopup } from "@/components/landing/product-hunt-popup";
 
 const Features = dynamic(() => import("@/components/landing/features"));
 const Testimonials = dynamic(() =>
@@ -35,6 +36,7 @@ export default function Home() {
 			<EnterpriseCTA />
 			<CallToAction />
 			<Footer />
+			<ProductHuntPopup />
 		</>
 	);
 }

--- a/apps/ui/src/components/landing/product-hunt-popup.tsx
+++ b/apps/ui/src/components/landing/product-hunt-popup.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { ArrowUp, X } from "lucide-react";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "ph_chat_popup_dismissed";
+const PH_URL =
+	"https://www.producthunt.com/products/llm-gateway?launch=llm-gateway-chat";
+
+const BARS = [
+	"from-green-400 to-emerald-500 shadow-emerald-500/40",
+	"from-pink-400 to-rose-500 shadow-rose-500/40",
+	"from-blue-400 to-blue-600 shadow-blue-500/40",
+	"from-amber-300 to-orange-500 shadow-orange-500/40",
+	"from-violet-400 to-purple-600 shadow-purple-500/40",
+	"from-teal-300 to-cyan-500 shadow-cyan-500/40",
+];
+
+export function ProductHuntPopup() {
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		if (
+			typeof window === "undefined" ||
+			localStorage.getItem(STORAGE_KEY) === "true"
+		) {
+			return;
+		}
+		const t = setTimeout(() => setOpen(true), 1500);
+		return () => clearTimeout(t);
+	}, []);
+
+	const dismiss = () => {
+		localStorage.setItem(STORAGE_KEY, "true");
+		setOpen(false);
+	};
+
+	if (!open) {
+		return null;
+	}
+
+	return (
+		<div className="fixed bottom-4 right-4 z-50 w-[calc(100vw-2rem)] max-w-[420px] animate-in fade-in slide-in-from-bottom-4 duration-500">
+			<div className="relative overflow-hidden rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl">
+				<div className="flex items-start justify-between">
+					<div className="flex items-center gap-2 rounded-full bg-gradient-to-r from-orange-500 to-red-500 py-1 pl-1 pr-3">
+						<span className="flex size-5 items-center justify-center rounded-full bg-white text-[11px] font-bold text-orange-500">
+							P
+						</span>
+						<span className="text-xs font-semibold text-white">Live now</span>
+					</div>
+					<button
+						onClick={dismiss}
+						aria-label="Dismiss"
+						className="text-zinc-500 transition-colors hover:text-zinc-300"
+					>
+						<X className="size-5" />
+					</button>
+				</div>
+
+				<div className="mt-6">
+					<Image
+						src="/brand/logo-white.svg"
+						alt="LLM Gateway"
+						width={36}
+						height={36}
+						className="opacity-90"
+					/>
+				</div>
+
+				<h3 className="mt-4 text-3xl font-bold leading-tight text-white">
+					We're on
+					<br />
+					Product Hunt!
+				</h3>
+
+				<p className="mt-4 text-sm leading-relaxed text-zinc-400">
+					LLM Gateway Chat is live today — 210+ models across chat, image,
+					video, audio & group. Your upvote means the world.
+				</p>
+
+				<div className="mt-6 flex items-center gap-2">
+					{BARS.map((bar) => (
+						<span
+							key={bar}
+							className={`h-1.5 flex-1 rounded-full bg-gradient-to-r shadow-[0_0_12px] ${bar}`}
+						/>
+					))}
+				</div>
+
+				<a
+					href={PH_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={dismiss}
+					className="mt-7 flex items-center justify-center gap-2 rounded-xl bg-white py-3 text-sm font-semibold text-zinc-950 transition-colors hover:bg-zinc-100"
+				>
+					<ArrowUp className="size-4" />
+					Upvote on Product Hunt
+				</a>
+
+				<button
+					onClick={dismiss}
+					className="mt-3 w-full text-center text-sm text-zinc-500 transition-colors hover:text-zinc-300"
+				>
+					Maybe later
+				</button>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a dismissible **Product Hunt launch popup** for the **LLM Gateway Chat** launch, mirroring the popup we shipped for the DevPass launch.

Per request, the popup lives on the **`apps/ui` landing page** (`llmgateway.io`) — our highest-traffic surface — to maximize upvote reach, and links to the chat launch listing.

This PR is **ready to merge whenever we go live**; the popup shows immediately once merged.

## What's included

- New `apps/ui/src/components/landing/product-hunt-popup.tsx` — a fixed bottom-right card matching the launch design:
  - "Live now" Product Hunt badge + dismiss (X)
  - LLM Gateway logo
  - "We're on Product Hunt!" heading
  - Copy: *"LLM Gateway Chat is live today — 210+ models across chat, image, video, audio & group. Your upvote means the world."*
  - Six glowing gradient "model" bars
  - "Upvote on Product Hunt" CTA + "Maybe later" dismiss
- Rendered on the landing page via `apps/ui/src/app/page.tsx`
- Appears 1.5s after load; dismissal persists via `localStorage` key `ph_chat_popup_dismissed`

**Launch link:** https://www.producthunt.com/products/llm-gateway?launch=llm-gateway-chat

## Verification

- `turbo run build --filter=ui` passes
- `pnpm format` clean
- Verified visually in the local `ui` dev server (popup renders correctly, dismiss + localStorage gating work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A Product Hunt promotion popup now appears on the landing page. The popup displays after a brief delay on initial page load and features branded messaging with a prominent call-to-action button to upvote. You can dismiss it at any time, and your dismissal preference will be saved for future visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->