### PR TITLE
feat(ui): collect Azure AI Foundry resource on key add

### DIFF
--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -57,6 +57,9 @@ export function CreateProviderKeyDialog({
 	>("ai-foundry");
 	const [azureValidationModel, setAzureValidationModel] =
 		useState("gpt-4o-mini");
+	const [azureAiFoundryResource, setAzureAiFoundryResource] = useState("");
+	const [azureAiFoundryApiVersion, setAzureAiFoundryApiVersion] =
+		useState("2024-05-01-preview");
 	const [selectedRegion, setSelectedRegion] = useState("");
 	const [googleVertexProjectId, setGoogleVertexProjectId] = useState("");
 	const [isValidating, setIsValidating] = useState(false);
@@ -170,6 +173,33 @@ export function CreateProviderKeyDialog({
 			};
 		}
 
+		if (selectedProvider === "azure-ai-foundry") {
+			if (!azureAiFoundryResource) {
+				toast({
+					title: "Error",
+					description: "Azure AI Foundry resource name is required",
+					variant: "destructive",
+				});
+				return;
+			}
+			if (!/^[a-zA-Z0-9-]{1,64}$/.test(azureAiFoundryResource)) {
+				toast({
+					title: "Error",
+					description:
+						"Resource name must be 1-64 characters and contain only letters, numbers, and hyphens",
+					variant: "destructive",
+				});
+				return;
+			}
+			payload.options = {
+				...payload.options,
+				azure_ai_foundry_resource: azureAiFoundryResource,
+				...(azureAiFoundryApiVersion
+					? { azure_ai_foundry_api_version: azureAiFoundryApiVersion }
+					: {}),
+			};
+		}
+
 		if (selectedProvider === "google-vertex" && googleVertexProjectId) {
 			payload.options = {
 				...payload.options,
@@ -233,6 +263,8 @@ export function CreateProviderKeyDialog({
 			setAzureApiVersion("2024-10-21");
 			setAzureDeploymentType("ai-foundry");
 			setAzureValidationModel("gpt-4o-mini");
+			setAzureAiFoundryResource("");
+			setAzureAiFoundryApiVersion("2024-05-01-preview");
 			setSelectedRegion("");
 			setGoogleVertexProjectId("");
 		}, 300);
@@ -392,6 +424,41 @@ export function CreateProviderKeyDialog({
 								<p className="text-sm text-muted-foreground">
 									Model deployment name to use for validating the API key
 									(default: gpt-4o-mini)
+								</p>
+							</div>
+						</>
+					)}
+
+					{selectedProvider === "azure-ai-foundry" && (
+						<>
+							<div className="space-y-2">
+								<Label htmlFor="azure-ai-foundry-resource">Resource Name</Label>
+								<Input
+									id="azure-ai-foundry-resource"
+									type="text"
+									placeholder="my-resource"
+									value={azureAiFoundryResource}
+									onChange={(e) => setAzureAiFoundryResource(e.target.value)}
+									required
+								/>
+								<p className="text-sm text-muted-foreground">
+									Your Azure AI Foundry resource name from the base URL:
+									https://&lt;resource-name&gt;.services.ai.azure.com
+								</p>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="azure-ai-foundry-api-version">
+									API Version
+								</Label>
+								<Input
+									id="azure-ai-foundry-api-version"
+									type="text"
+									placeholder="2024-05-01-preview"
+									value={azureAiFoundryApiVersion}
+									onChange={(e) => setAzureAiFoundryApiVersion(e.target.value)}
+								/>
+								<p className="text-sm text-muted-foreground">
+									Azure AI Foundry API version (default: 2024-05-01-preview)
 								</p>
 							</div>
 						</>


### PR DESCRIPTION
## Problem

Adding an Azure AI Foundry provider key in the dashboard failed server-side with:

```
Azure AI Foundry resource is required - set via provider options or LLM_AZURE_AI_FOUNDRY_RESOURCE env var
```

The create-provider-key dialog had special-cased handling for `azure` (Azure OpenAI), `google-vertex`, `custom`, and region-based providers — but **not** for `azure-ai-foundry`. As a result the dialog only collected the API key and submitted a payload with no `options.azure_ai_foundry_resource`. Both key validation (`validate-provider-key.ts`, which calls `getProviderEndpoint` with `skipEnvVars: true`) and request-time routing then hit the `if (!resource)` branch and threw. Because BYOK keys skip env vars, the `LLM_AZURE_AI_FOUNDRY_RESOURCE` fallback never applied.

## Fix

Add the missing form handling for `azure-ai-foundry` in the create provider key dialog, mirroring the existing Azure OpenAI block:

- **Resource Name** — required field, validated client-side against `^[a-zA-Z0-9-]{1,64}$` (same regex the gateway enforces) so the error can no longer reach the server. Written to `options.azure_ai_foundry_resource`.
- **API Version** — optional field defaulting to `2024-05-01-preview`, written to `options.azure_ai_foundry_api_version`.

The requirement is now enforced before submission, so it is no longer possible to create a foundry key that errors at validation/request time for a missing resource.

## Testing

- `pnpm format`
- `pnpm exec turbo run build --filter=ui` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Azure AI Foundry as a new provider option for creating API keys.
  * Configure resource name and optional API version settings when selecting Azure AI Foundry provider.
  * Form includes validation for Azure AI Foundry resource name format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->