### PR TITLE
fix(billing): prevent & contain duplicate DevPass subscriptions

### DIFF
--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -39,13 +39,14 @@ function makeUpdatedEvent(overrides: {
 	cancelAtPeriodEnd: boolean;
 	status?: Stripe.Subscription.Status;
 	metadata?: Record<string, string>;
+	subscriptionId?: string;
 }): Stripe.CustomerSubscriptionUpdatedEvent {
 	return {
 		id: "evt_test_updated",
 		type: "customer.subscription.updated",
 		data: {
 			object: {
-				id: SUB_ID,
+				id: overrides.subscriptionId ?? SUB_ID,
 				customer: "cus_test_feedback",
 				cancel_at_period_end: overrides.cancelAtPeriodEnd,
 				status: overrides.status ?? "active",
@@ -381,6 +382,45 @@ describe("handleSubscriptionUpdated — dev plan credit freeze/restore", () => {
 		expect(org?.devPlanCreditsLimit).toBe("90");
 		expect(org?.devPlanCreditsFrozen).toBe(true);
 		expect(org?.devPlanCreditsLimitBeforeFreeze).toBe("312");
+	});
+
+	test("does NOT freeze when a superseded (stale) subscription expires", async () => {
+		// Repro of the production incident: the customer's first DevPass checkout
+		// attempt failed and its incomplete subscription later flipped to
+		// `incomplete_expired`. Their *active* subscription is a different id. The
+		// stale expiry event must not freeze the healthy plan.
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			devPlan: "pro",
+			devPlanCreditsLimit: "237",
+			devPlanCreditsUsed: "19.67",
+			devPlanCreditsFrozen: false,
+			devPlanStripeSubscriptionId: SUB_ID,
+			devPlanCancelled: false,
+		});
+
+		await handleSubscriptionUpdated(
+			makeUpdatedEvent({
+				cancelAtPeriodEnd: false,
+				status: "incomplete_expired",
+				subscriptionId: "sub_stale_first_attempt",
+				metadata: {
+					organizationId: ORG_ID,
+					subscriptionType: "dev_plan",
+				},
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlanCreditsLimit).toBe("237");
+		expect(org?.devPlanCreditsFrozen).toBe(false);
+		// The stale event must not touch the active subscription's expiry/cancel
+		// flags either.
+		expect(org?.devPlanCancelled).toBe(false);
 	});
 });
 

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -4,6 +4,7 @@ import { db, tables } from "@llmgateway/db";
 
 import {
 	handleInvoicePaymentSucceeded,
+	handlePaymentIntentFailed,
 	handleSubscriptionUpdated,
 } from "./stripe.js";
 import { deleteAll } from "./testing.js";
@@ -380,5 +381,90 @@ describe("handleSubscriptionUpdated — dev plan credit freeze/restore", () => {
 		expect(org?.devPlanCreditsLimit).toBe("90");
 		expect(org?.devPlanCreditsFrozen).toBe(true);
 		expect(org?.devPlanCreditsLimitBeforeFreeze).toBe("312");
+	});
+});
+
+function makeFailedPaymentIntentEvent(overrides: {
+	amount: number;
+	metadata: Record<string, string>;
+	id?: string;
+}): Stripe.PaymentIntentPaymentFailedEvent {
+	return {
+		id: "evt_test_pi_failed",
+		type: "payment_intent.payment_failed",
+		data: {
+			object: {
+				id: overrides.id ?? "pi_test_failed_001",
+				customer: "cus_test_pi_failed",
+				amount: overrides.amount,
+				currency: "usd",
+				metadata: overrides.metadata,
+				last_payment_error: {
+					message: "Your card was declined.",
+					code: "card_declined",
+					decline_code: "generic_decline",
+				},
+			},
+		},
+	} as unknown as Stripe.PaymentIntentPaymentFailedEvent;
+}
+
+describe("handlePaymentIntentFailed — subscription invoice vs credit top-up", () => {
+	beforeEach(async () => {
+		await deleteAll();
+		sendEmailMock.mockClear();
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	test("does not record a credit_topup for a failed subscription invoice payment", async () => {
+		await seedDevPlanOrg();
+
+		await handlePaymentIntentFailed(
+			makeFailedPaymentIntentEvent({
+				amount: 7900,
+				metadata: {
+					organizationId: ORG_ID,
+					subscriptionType: "dev_plan",
+				},
+			}),
+		);
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(0);
+
+		// Subscription-failure tracking still runs (count bumped, dunning email).
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.paymentFailureCount).toBe(1);
+		expect(sendEmailMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("records a credit_topup for a failed manual credit purchase", async () => {
+		await seedDevPlanOrg();
+
+		await handlePaymentIntentFailed(
+			makeFailedPaymentIntentEvent({
+				amount: 5150,
+				metadata: {
+					organizationId: ORG_ID,
+					baseAmount: "50",
+				},
+			}),
+		);
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(1);
+		expect(txns[0].type).toBe("credit_topup");
+		expect(txns[0].status).toBe("failed");
+		expect(txns[0].creditAmount).toBe("50");
 	});
 });

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -2342,7 +2342,7 @@ async function handlePaymentIntentSucceeded(
 	);
 }
 
-async function handlePaymentIntentFailed(
+export async function handlePaymentIntentFailed(
 	event: Stripe.PaymentIntentPaymentFailedEvent,
 ) {
 	const paymentIntent = event.data.object;
@@ -2414,29 +2414,54 @@ async function handlePaymentIntentFailed(
 		stripePaymentIntentId: paymentIntent.id,
 	});
 
-	// Check if this is an auto top-up with an existing pending transaction
+	// Only credit top-up payment intents may be recorded as a `credit_topup`
+	// transaction. Subscription invoice payments (Pro / DevPass / chat plan) also
+	// emit `payment_intent.payment_failed`, but recording them here produced a
+	// phantom "Credit top-up failed" row on the customer's billing history (and
+	// the credit-purchase paths never create such a charge). Mirror the
+	// `baseAmount` guard in handlePaymentIntentSucceeded: actual top-ups always
+	// set `baseAmount` (manual + auto) or carry a pending `transactionId`;
+	// subscription invoice intents carry neither. Failure tracking above
+	// (paymentFailure row + dunning email) still runs for subscription invoices,
+	// and dev/chat plan credit freezes are handled in handleInvoicePaymentFailed.
 	const transactionId = metadata?.transactionId;
-	if (transactionId) {
-		// Update existing pending transaction to failed
-		const updatedTransaction = await db
-			.update(tables.transaction)
-			.set({
-				status: "failed",
-				description: `Auto top-up failed via Stripe webhook: ${errorMessage}`,
-			})
-			.where(eq(tables.transaction.id, transactionId))
-			.returning()
-			.then((rows) => rows[0]);
+	const isCreditTopup =
+		metadata?.baseAmount !== undefined || transactionId !== undefined;
+	if (isCreditTopup) {
+		if (transactionId) {
+			// Update existing pending transaction to failed
+			const updatedTransaction = await db
+				.update(tables.transaction)
+				.set({
+					status: "failed",
+					description: `Auto top-up failed via Stripe webhook: ${errorMessage}`,
+				})
+				.where(eq(tables.transaction.id, transactionId))
+				.returning()
+				.then((rows) => rows[0]);
 
-		if (updatedTransaction) {
-			logger.info(
-				`Updated pending transaction ${transactionId} to failed for organization ${organizationId}`,
-			);
+			if (updatedTransaction) {
+				logger.info(
+					`Updated pending transaction ${transactionId} to failed for organization ${organizationId}`,
+				);
+			} else {
+				logger.warn(
+					`Could not find pending transaction ${transactionId} for organization ${organizationId}`,
+				);
+				// Fallback: create new failed transaction record
+				await db.insert(tables.transaction).values({
+					organizationId,
+					type: "credit_topup",
+					creditAmount: creditAmount ? creditAmount.toString() : null,
+					amount: totalAmountInDollars.toString(),
+					currency: paymentIntent.currency.toUpperCase(),
+					status: "failed",
+					stripePaymentIntentId: paymentIntent.id,
+					description: `Credit top-up failed via Stripe (fallback): ${errorMessage}`,
+				});
+			}
 		} else {
-			logger.warn(
-				`Could not find pending transaction ${transactionId} for organization ${organizationId}`,
-			);
-			// Fallback: create new failed transaction record
+			// Create new failed transaction record (for manual top-ups or payments without transactionId)
 			await db.insert(tables.transaction).values({
 				organizationId,
 				type: "credit_topup",
@@ -2445,21 +2470,9 @@ async function handlePaymentIntentFailed(
 				currency: paymentIntent.currency.toUpperCase(),
 				status: "failed",
 				stripePaymentIntentId: paymentIntent.id,
-				description: `Credit top-up failed via Stripe (fallback): ${errorMessage}`,
+				description: `Credit top-up failed via Stripe: ${errorMessage}`,
 			});
 		}
-	} else {
-		// Create new failed transaction record (for manual top-ups or payments without transactionId)
-		await db.insert(tables.transaction).values({
-			organizationId,
-			type: "credit_topup",
-			creditAmount: creditAmount ? creditAmount.toString() : null,
-			amount: totalAmountInDollars.toString(),
-			currency: paymentIntent.currency.toUpperCase(),
-			status: "failed",
-			stripePaymentIntentId: paymentIntent.id,
-			description: `Credit top-up failed via Stripe: ${errorMessage}`,
-		});
 	}
 
 	// Update payment failure tracking with exponential backoff

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3578,6 +3578,37 @@ export async function handleSubscriptionUpdated(
 		metadata?.subscriptionType === "dev_plan" ||
 		organization.devPlanStripeSubscriptionId === subscription.id;
 
+	// A subscription event can target a *superseded* subscription — e.g. an
+	// abandoned first checkout attempt whose payment never completed and that
+	// Stripe later marks `incomplete_expired`. Its metadata still carries
+	// `subscriptionType: dev_plan`/`chat_plan`, so the metadata-based detection
+	// above would let that stale event mutate billing state (expiry/cancel flags)
+	// and — far worse — `freezeDevPlanCredits` would pin the *active* plan's
+	// credit limit to current usage, silently throttling a healthy subscriber.
+	// Once the org has activated a specific subscription, only that subscription
+	// may drive these changes. (handleInvoicePaymentFailed already gates isDevPlan
+	// on this matching id; this mirrors it for subscription.updated.)
+	if (
+		isDevPlan &&
+		organization.devPlanStripeSubscriptionId &&
+		organization.devPlanStripeSubscriptionId !== subscription.id
+	) {
+		logger.info(
+			`Ignoring stale dev-plan subscription.updated ${subscription.id} for org ${organizationId} (active sub: ${organization.devPlanStripeSubscriptionId}, status: ${subscription.status})`,
+		);
+		return;
+	}
+	if (
+		isChatPlan &&
+		organization.chatPlanStripeSubscriptionId &&
+		organization.chatPlanStripeSubscriptionId !== subscription.id
+	) {
+		logger.info(
+			`Ignoring stale chat-plan subscription.updated ${subscription.id} for org ${organizationId} (active sub: ${organization.chatPlanStripeSubscriptionId}, status: ${subscription.status})`,
+		);
+		return;
+	}
+
 	// Update plan expiration date
 	const expiresAt = currentPeriodEnd
 		? new Date(currentPeriodEnd * 1000)

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -648,6 +648,85 @@ async function findDevPlanSubscriptionForSetupSession(
 	});
 }
 
+/**
+ * Cancel stale DevPass subscriptions left on the customer by an earlier checkout
+ * attempt. A setup-mode checkout creates one subscription per setup session, so
+ * a first attempt whose payment never completes leaves a dangling `incomplete`
+ * subscription that later flips to `incomplete_expired` — emitting events for a
+ * plan the org never activated and, before the id-gating fix, freezing the
+ * active plan's credits. Before activating the current session's subscription we
+ * cancel those dangling attempts so the customer is never left with duplicate
+ * DevPass subscriptions. The current session's own subscription is matched by
+ * `setupSessionId` and never cancelled — which also keeps this safe under the
+ * finalize/webhook race (both runs share the same session id).
+ */
+async function cancelStaleDevPlanSubscriptions(
+	customerId: string,
+	currentSessionId: string,
+): Promise<void> {
+	const subscriptions = await getStripe().subscriptions.list({
+		customer: customerId,
+		status: "all",
+		limit: 100,
+	});
+	const stale = subscriptions.data.filter(
+		(s) =>
+			s.metadata?.subscriptionType === "dev_plan" &&
+			s.metadata?.setupSessionId !== currentSessionId &&
+			(s.status === "incomplete" || s.status === "past_due"),
+	);
+	for (const s of stale) {
+		try {
+			await getStripe().subscriptions.cancel(s.id);
+			logger.info(
+				`Cancelled stale DevPass subscription ${s.id} (status ${s.status}) for customer ${customerId}`,
+			);
+		} catch (err) {
+			logger.warn(`Failed to cancel stale DevPass subscription ${s.id}`, {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+}
+
+/**
+ * Collapse duplicate copies of a card down to a single payment method. Each
+ * setup session saves the card as a fresh PaymentMethod object, so a retried
+ * checkout would otherwise leave several PaymentMethods for the same physical
+ * card on the customer. Keeps `keepPaymentMethodId` and detaches every other
+ * payment method that shares its fingerprint.
+ */
+async function detachDuplicateCardPaymentMethods(
+	customerId: string,
+	keepPaymentMethodId: string,
+	fingerprint: string | null,
+): Promise<void> {
+	if (!fingerprint) {
+		return;
+	}
+	const paymentMethods = await getStripe().paymentMethods.list({
+		customer: customerId,
+		type: "card",
+		limit: 100,
+	});
+	const duplicates = paymentMethods.data.filter(
+		(pm) =>
+			pm.id !== keepPaymentMethodId && pm.card?.fingerprint === fingerprint,
+	);
+	for (const pm of duplicates) {
+		try {
+			await getStripe().paymentMethods.detach(pm.id);
+			logger.info(
+				`Detached duplicate card ${pm.id} (fingerprint ${fingerprint}) from customer ${customerId}`,
+			);
+		} catch (err) {
+			logger.warn(`Failed to detach duplicate card ${pm.id}`, {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+}
+
 function shouldForceDevPlan3dsChallenge(): boolean {
 	return process.env.STRIPE_DEV_PLAN_FORCE_3DS === "true";
 }
@@ -799,6 +878,19 @@ export async function finalizeDevPlanSetupSession(
 	await getStripe().customers.update(stripeCustomerId, {
 		invoice_settings: { default_payment_method: paymentMethod.id },
 	});
+
+	// Prevent duplicate DevPass subscriptions/cards from a retried checkout. A
+	// failed first attempt leaves a dangling `incomplete` subscription and a
+	// duplicate copy of the card on the customer; cancel the former and detach the
+	// latter before creating/activating this session's subscription. Cancel stale
+	// subscriptions before detaching cards so we never detach a card still
+	// referenced by a live subscription.
+	await cancelStaleDevPlanSubscriptions(stripeCustomerId, sessionId);
+	await detachDuplicateCardPaymentMethods(
+		stripeCustomerId,
+		paymentMethod.id,
+		fingerprint,
+	);
 
 	// The /finalize endpoint and the checkout.session.completed webhook can
 	// race for the same setup session. We guard against duplicate subscription


### PR DESCRIPTION
## The incident

A PRO DevPass customer reported their dashboard allowance was "only \$20" (vs the expected ~\$237 = \$79 × 3), showing "Allowance reached for this billing cycle" after spending \$19.67 — plus a baffling failed **\$79 "Credit Topup"** they never initiated.

Stripe data showed the customer's checkout produced **two** subscriptions and **two** copies of the same card:

| Stripe | | |
|---|---|---|
| Code Pro — **Expired** | first attempt, 04:04 | \$79 payment **Cancelled/Failed** ("the attached payment method has been removed") |
| Code Pro — **Active** | second attempt, 04:06 | \$79 payment **Succeeded**, next invoice 14 Jul |
| Visa •••• 2613 ×2 | | same card attached twice |

The \$237 was granted correctly by the active subscription, the card is valid, and the subscription is healthy. The duplicate first attempt then corrupted everything. This PR fixes the duplicate at the **source** and **contains** the two ways a stale subscription leaked into billing state.

## Fix 1 (root cause) — prevent duplicates being created

Setup-mode checkout creates one subscription per setup session, and the pre-checkout guard only blocks *fully activated* plans (`dev-plans.ts:200`) — so a retried checkout after a failed first attempt creates a second subscription, and each session saves the card as a fresh PaymentMethod (within-org fingerprint dedup was absent).

In `finalizeDevPlanSetupSession`, before creating/activating this session's subscription:
- **Cancel** any stale `incomplete`/`past_due` DevPass subscriptions from prior attempts (matched on metadata; the current session is excluded via `setupSessionId`, keeping it safe under the finalize/webhook race).
- **Detach** duplicate copies of the card by fingerprint, keeping the one in use.

Result: a customer ends up with exactly one DevPass subscription and one card.

## Fix 2 (the "\$20") — stale subscription froze the active plan

`handleSubscriptionUpdated` detected the plan type from event metadata alone:

```ts
const isDevPlan =
	metadata?.subscriptionType === "dev_plan" ||
	organization.devPlanStripeSubscriptionId === subscription.id;
```

~24h after checkout the abandoned first subscription flipped to `incomplete_expired`; its `customer.subscription.updated` still carried `subscriptionType: dev_plan`, so the dev-plan branch ran for a subscription that wasn't the org's active one → `freezeDevPlanCredits` pinned `devPlanCreditsLimit` to the \$19.67 already spent. The dashboard renders that as "\$20" via `toFixed(0)`, \$0.00 remaining / 100% used — matching the screenshot. `handleInvoicePaymentFailed` already gated on the matching id; this mirrors it for `subscription.updated`.

## Fix 3 — subscription invoice failure mislabeled as a credit top-up

The first attempt's failed \$79 fired `payment_intent.payment_failed`. `handlePaymentIntentFailed` recorded a `credit_topup` for *every* non-wallet failed intent — including subscription invoices — producing the phantom "Credit top-up failed" row. The success handler already guards this via `baseAmount === undefined`; the failure handler now does too (only records a top-up when `baseAmount` is set or a pending `transactionId` exists). Subscription-failure tracking (paymentFailure row + dunning email) is preserved.

> Edge case in practice — failed DevPass renewals are rare (new + monthly), and this row came from the unusual "payment method has been removed" retry, not a routine decline.

## Immediate customer remediation (data, not code)

Their subscription is active and card valid (an earlier "update your card" diagnosis was wrong). Unfreeze: set `devPlanCreditsFrozen=false` and restore `devPlanCreditsLimit` from `devPlanCreditsLimitBeforeFreeze` (\$237). With Fix 2, a `subscription.updated` on the active sub would also auto-restore via `restoreDevPlanCredits`.

## Tests

`stripe.spec.ts` (13 passing, +3 cases):
- stale (different-id) `incomplete_expired` subscription update → does **not** freeze the active plan or touch cancel flags
- failed subscription invoice intent → **no** `credit_topup` row, but failure tracking still runs
- failed manual credit purchase (`baseAmount` set) → `credit_topup` failed row recorded

The Fix 1 cleanup helpers call Stripe directly; consistent with the existing `finalizeDevPlanSetupSession` (no Stripe-mock coverage), each Stripe call is individually guarded so a single failure can't abort activation.

## Follow-up (not in this PR)

Dashboard messaging: a frozen account shows "Allowance reached… Upgrade to keep coding" rather than a payment-failure prompt; `devPlanCreditsFrozen` isn't exposed by `/dev-plans/status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected payment failure handling to properly separate failed subscription-invoice payments from manual credit purchases.
  * Subscription failures now trigger dunning email and failure tracking without creating incorrect credit top-up transactions.
  * Prevented superseded/expired subscription update events from altering the current active subscription’s state.

* **New Features**
  * Improved dev-plan subscription setup by cleaning up stale incomplete subscriptions and removing duplicate saved cards.

* **Tests**
  * Expanded coverage for payment-intent failure and subscription update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->