### PR TITLE
feat(video): first/last frame for Seedance 2.0

### DIFF
--- a/apps/api/src/routes/video.ts
+++ b/apps/api/src/routes/video.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { userHasOrganizationAccess } from "@/utils/authorization.js";
 
 import { db } from "@llmgateway/db";
+import { buildSignedGatewayVideoLogContentUrl } from "@llmgateway/shared/video-access";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -42,6 +43,15 @@ const videoJobResponseSchema = z.object({
 			details: z.unknown().optional(),
 		})
 		.nullable(),
+	content: z
+		.array(
+			z.object({
+				type: z.literal("video"),
+				url: z.string(),
+				mime_type: z.string().nullable().optional(),
+			}),
+		)
+		.optional(),
 });
 
 const getVideoStatus = createRoute({
@@ -92,6 +102,29 @@ video.openapi(getVideoStatus, async (c) => {
 		throw new HTTPException(404, { message: "Video not found" });
 	}
 
+	let content:
+		| { type: "video"; url: string; mime_type?: string | null }[]
+		| undefined;
+	if (job.status === "completed") {
+		const log = await db.query.log.findFirst({
+			where: {
+				requestId: { eq: job.requestId },
+			},
+			columns: {
+				id: true,
+			},
+		});
+		if (log) {
+			content = [
+				{
+					type: "video" as const,
+					url: buildSignedGatewayVideoLogContentUrl(log.id),
+					mime_type: job.contentType ?? null,
+				},
+			];
+		}
+	}
+
 	return c.json(
 		{
 			id: job.id,
@@ -107,6 +140,7 @@ video.openapi(getVideoStatus, async (c) => {
 			completed_at: toUnixTimestamp(job.completedAt),
 			expires_at: toUnixTimestamp(job.expiresAt),
 			error: job.error ?? null,
+			content,
 		},
 		200,
 	);

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -37,8 +37,8 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | `seconds`          | number  | yes      | Duration in seconds. Supported values depend on the model (see below)                                                      |
 | `size`             | string  | no       | `widthxheight`, limited to the sizes supported by the selected model and provider                                          |
 | `audio`            | boolean | no       | Whether to include audio in the output (default `true`). Only honored when the model supports both audio and silent output |
-| `image`            | object  | no       | Optional first frame for image-to-video generation                                                                         |
-| `last_frame`       | object  | no       | Optional ending frame when `image` is provided                                                                             |
+| `image`            | object  | no       | Optional first frame for image-to-video generation (see first/last frame inputs below)                                     |
+| `last_frame`       | object  | no       | Optional ending frame when `image` is provided (see first/last frame inputs below)                                         |
 | `reference_images` | array   | no       | One to three provider-specific image inputs                                                                                |
 | `input_reference`  | object  | no       | Alias for one or more `reference_images`                                                                                   |
 | `reference_videos` | array   | no       | One to three reference video HTTPS URLs (Seedance 2.0 only, see below)                                                     |
@@ -55,6 +55,37 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | Seedance 2.0 / 2.0 Fast / 1.5 Pro | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `5`, `10`           |
 
 Requests return `400` when the selected provider cannot serve the requested `size` or `seconds`. Seedance derives `aspect_ratio` from the requested `size` (16:9 for landscape, 9:16 for portrait).
+
+### First/last frame inputs
+
+Frame inputs interpolate a video between a starting frame and an optional ending frame. You provide the first frame as `image` and, optionally, the ending frame as `last_frame`. The gateway tags each one with the correct role for the provider, so you don't set roles yourself.
+
+| Field        | Required           | Accepted input                   | Available on                                                                             |
+| ------------ | ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `image`      | for frame mode     | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), Veo 3.1 (`google-vertex`, `avalanche`), `minimax`, `xai` |
+| `last_frame` | no (needs `image`) | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), Veo 3.1 (`google-vertex`, `avalanche`)                   |
+
+#### Rules and limits
+
+- **Seedance scope.** Frame inputs are supported on **Seedance 2.0** and **Seedance 2.0 Fast** (`seedance-2-0`, `seedance-2-0-fast`). Sending `image`/`last_frame` to Seedance 1.5 Pro or any other ByteDance model returns a `400`.
+- **`last_frame` requires `image`.** Providing `last_frame` without `image` returns a `400`.
+- **Not combinable with references.** First/last frame inputs (`image`, `last_frame`) cannot be combined with reference inputs (`reference_images`, `reference_videos`, `reference_audios`).
+
+#### Example (Seedance 2.0)
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/videos" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "seedance-2-0",
+    "prompt": "Morph smoothly from the first frame into the last frame",
+    "seconds": 5,
+    "size": "1280x720",
+    "image": { "image_url": "https://example.com/first-frame.png" },
+    "last_frame": { "image_url": "https://example.com/last-frame.png" }
+  }'
+```
 
 ### Reference-guided generation (Seedance 2.0)
 

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -69,7 +69,7 @@ Frame inputs interpolate a video between a starting frame and an optional ending
 
 - **Seedance scope.** Frame inputs are supported on **Seedance 2.0** and **Seedance 2.0 Fast** (`seedance-2-0`, `seedance-2-0-fast`). Sending `image`/`last_frame` to Seedance 1.5 Pro or any other ByteDance model returns a `400`.
 - **`last_frame` requires `image`.** Providing `last_frame` without `image` returns a `400`.
-- **Not combinable with references.** First/last frame inputs (`image`, `last_frame`) cannot be combined with reference inputs (`reference_images`, `reference_videos`, `reference_audios`).
+- **Not combinable with references.** First/last frame inputs (`image`, `last_frame`) cannot be combined with reference inputs (`reference_images`, `input_reference`, `reference_videos`, `reference_audios`).
 
 #### Example (Seedance 2.0)
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1757,6 +1757,75 @@ mockOpenAIServer.post("/api/v1/jobs/createTask", async (c) => {
 	});
 });
 
+mockOpenAIServer.post("/contents/generations/tasks", async (c) => {
+	const body = await c.req.json();
+	const content = Array.isArray(body.content) ? body.content : [];
+	const promptItem = content.find(
+		(item: unknown): item is { text: string } =>
+			!!item &&
+			typeof item === "object" &&
+			(item as Record<string, unknown>).type === "text",
+	);
+	const prompt =
+		promptItem && typeof promptItem.text === "string" ? promptItem.text : "";
+	const statusTrigger = extractStatusCodeTrigger(prompt);
+	if (statusTrigger) {
+		c.status(statusTrigger.statusCode as any);
+		return c.json(statusTrigger.errorResponse);
+	}
+
+	const parseFrameByRole = (role: string) => {
+		const item = content.find(
+			(entry: unknown): entry is Record<string, unknown> =>
+				!!entry &&
+				typeof entry === "object" &&
+				(entry as Record<string, unknown>).role === role,
+		);
+		const url =
+			item &&
+			typeof item.image_url === "object" &&
+			item.image_url !== null &&
+			typeof (item.image_url as Record<string, unknown>).url === "string"
+				? ((item.image_url as Record<string, unknown>).url as string)
+				: undefined;
+		if (!url) {
+			return undefined;
+		}
+		const match = url.match(/^data:([^;]+);base64,(.*)$/);
+		if (!match) {
+			return undefined;
+		}
+		return {
+			mimeType: match[1],
+			bytesBase64Encoded: match[2],
+		};
+	};
+
+	videoCounter++;
+	const id = `bytedance_task_${videoCounter}`;
+	const job: MockVideoJobState = {
+		id,
+		object: "video",
+		model: typeof body.model === "string" ? body.model : "seedance-2-0",
+		status: "queued",
+		progress: 0,
+		firstFrame: parseFrameByRole("first_frame"),
+		lastFrame: parseFrameByRole("last_frame"),
+		duration: typeof body.duration === "number" ? body.duration : undefined,
+		created_at: Math.floor(Date.now() / 1000),
+		completed_at: null,
+		expires_at: null,
+		error: null,
+	};
+
+	videoJobs.set(id, job);
+
+	return c.json({
+		id,
+		status: "queued",
+	});
+});
+
 mockOpenAIServer.post("/api/file-base64-upload", async (c) => {
 	const authHeader = c.req.header("Authorization");
 	if (!authHeader?.startsWith("Bearer ")) {

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -1015,6 +1015,103 @@ describe("videos", () => {
 		}
 	});
 
+	test("/v1/videos forwards frame inputs to bytedance Seedance 2.0", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-bytedance-key",
+			provider: "bytedance",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0",
+				prompt: "Morph from the first frame into the last frame",
+				size: "1280x720",
+				seconds: 5,
+				image: {
+					image_url: "data:image/png;base64,aGVsbG8=",
+				},
+				last_frame: {
+					image_url: "data:image/png;base64,d29ybGQ=",
+				},
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const created = await createRes.json();
+
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: created.id } },
+		});
+		expect(videoJob?.usedProvider).toBe("bytedance");
+
+		const mockVideo = getMockVideo(videoJob!.upstreamId);
+		expect(mockVideo?.firstFrame).toEqual({
+			bytesBase64Encoded: "aGVsbG8=",
+			mimeType: "image/png",
+		});
+		expect(mockVideo?.lastFrame).toEqual({
+			bytesBase64Encoded: "d29ybGQ=",
+			mimeType: "image/png",
+		});
+	});
+
+	test("/v1/videos rejects frame inputs on non-Seedance-2.0 bytedance models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-bytedance-key",
+			provider: "bytedance",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "bytedance/seedance-1-5-pro",
+				prompt: "Morph from the first frame into the last frame",
+				size: "1280x720",
+				seconds: 5,
+				image: {
+					image_url: "data:image/png;base64,aGVsbG8=",
+				},
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"frame inputs are currently only supported on bytedance Seedance 2.0",
+		);
+	});
+
 	test("/v1/videos forwards reference images to google-vertex preview", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
 		const originalGoogleVertexRegion = process.env.LLM_GOOGLE_VERTEX_REGION;

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -855,7 +855,7 @@ function isSoraVideoModelName(externalId: string): boolean {
 	return externalId === "sora-2" || externalId === "sora-2-pro";
 }
 
-function isBytedanceReferenceModel(externalId: string): boolean {
+function isBytedanceSeedance2Model(externalId: string): boolean {
 	return (
 		externalId === "dreamina-seedance-2-0-260128" ||
 		externalId === "dreamina-seedance-2-0-fast-260128"
@@ -934,17 +934,23 @@ function getVideoProviderConstraintReasons(
 		);
 	}
 
-	if (
-		!isSoraVideoModelName(provider.externalId) &&
-		inputMode === "frames" &&
-		!isGoogleVertexVideoProvider(provider.providerId) &&
-		provider.providerId !== "avalanche" &&
-		provider.providerId !== "minimax" &&
-		provider.providerId !== "xai"
-	) {
-		reasons.push(
-			"frame inputs are currently only supported through google-vertex, avalanche, minimax, or xai",
-		);
+	if (!isSoraVideoModelName(provider.externalId) && inputMode === "frames") {
+		if (provider.providerId === "bytedance") {
+			if (!isBytedanceSeedance2Model(provider.externalId)) {
+				reasons.push(
+					"frame inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast)",
+				);
+			}
+		} else if (
+			!isGoogleVertexVideoProvider(provider.providerId) &&
+			provider.providerId !== "avalanche" &&
+			provider.providerId !== "minimax" &&
+			provider.providerId !== "xai"
+		) {
+			reasons.push(
+				"frame inputs are currently only supported through google-vertex, avalanche, minimax, xai, or bytedance",
+			);
+		}
 	}
 
 	if (inputMode === "reference") {
@@ -969,7 +975,7 @@ function getVideoProviderConstraintReasons(
 		}
 
 		if (provider.providerId === "bytedance") {
-			if (!isBytedanceReferenceModel(provider.externalId)) {
+			if (!isBytedanceSeedance2Model(provider.externalId)) {
 				reasons.push(
 					"reference inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast)",
 				);
@@ -3159,6 +3165,7 @@ async function createBytedanceVideoJob(
 	includeAudio: boolean,
 	firstFrameInput: VideoImageInput | undefined,
 	processedFirstFrame: ProcessedVideoImageInput | null,
+	processedLastFrame: ProcessedVideoImageInput | null,
 	processedReferenceImages: ProcessedVideoImageInput[],
 	referenceVideoUrls: string[],
 	referenceAudioUrls: string[],
@@ -3182,6 +3189,16 @@ async function createBytedanceVideoJob(
 				url: `data:${processedFirstFrame.mimeType};base64,${processedFirstFrame.bytesBase64Encoded}`,
 			},
 			role: "first_frame",
+		});
+	}
+
+	if (processedLastFrame) {
+		content.push({
+			type: "image_url",
+			image_url: {
+				url: `data:${processedLastFrame.mimeType};base64,${processedLastFrame.bytesBase64Encoded}`,
+			},
+			role: "last_frame",
 		});
 	}
 
@@ -3552,6 +3569,7 @@ async function createUpstreamVideoJob(
 				includeAudio,
 				firstFrameInput,
 				processedFirstFrame,
+				processedLastFrame,
 				processedReferenceImages,
 				referenceVideoUrls,
 				referenceAudioUrls,

--- a/apps/playground/src/app/api/video/[videoId]/content/route.ts
+++ b/apps/playground/src/app/api/video/[videoId]/content/route.ts
@@ -11,6 +11,7 @@ import { getUser } from "@/lib/getUser";
 export const dynamic = "force-dynamic";
 
 const SESSION_COOKIE_KEY = "better-auth.session_token";
+const STATUS_TIMEOUT_MS = 10_000;
 
 export async function GET(
 	req: Request,
@@ -37,15 +38,27 @@ export async function GET(
 	// playback works for any video the user can access regardless of which
 	// playground API key is currently active.
 	const { apiBackendUrl } = getConfig();
-	const statusResponse = await fetch(
-		`${apiBackendUrl}/video/${encodeURIComponent(videoId)}`,
-		{
-			headers: {
-				Cookie: cookieHeader,
+	let statusResponse: Response;
+	try {
+		statusResponse = await fetch(
+			`${apiBackendUrl}/video/${encodeURIComponent(videoId)}`,
+			{
+				headers: {
+					Cookie: cookieHeader,
+				},
+				cache: "no-store",
+				signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
 			},
-			cache: "no-store",
-		},
-	);
+		);
+	} catch (error) {
+		if (error instanceof Error && error.name === "TimeoutError") {
+			return NextResponse.json(
+				{ error: "Video content request timed out" },
+				{ status: 504 },
+			);
+		}
+		throw error;
+	}
 
 	if (!statusResponse.ok) {
 		const body = await readGatewayResponseBody(statusResponse);
@@ -66,6 +79,8 @@ export async function GET(
 		);
 	}
 
+	// No timeout here: this streams the (potentially large) video body, and a
+	// fixed timeout would abort slow but healthy downloads mid-stream.
 	const rangeHeader = req.headers.get("Range");
 	const response = await fetch(sourceUrl, {
 		headers: {

--- a/apps/playground/src/app/api/video/[videoId]/content/route.ts
+++ b/apps/playground/src/app/api/video/[videoId]/content/route.ts
@@ -5,10 +5,12 @@ import {
 	getGatewayErrorMessage,
 	readGatewayResponseBody,
 } from "@/app/api/video/utils";
-import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
+import { getConfig } from "@/lib/config-server";
 import { getUser } from "@/lib/getUser";
 
 export const dynamic = "force-dynamic";
+
+const SESSION_COOKIE_KEY = "better-auth.session_token";
 
 export async function GET(
 	req: Request,
@@ -22,33 +24,55 @@ export async function GET(
 	const { videoId } = await params;
 
 	const cookieStore = await cookies();
-	const apiKey =
-		cookieStore.get(PLAYGROUND_KEY_COOKIE_NAME)?.value ??
-		cookieStore.get(`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`)?.value;
+	const sessionCookie = cookieStore.get(SESSION_COOKIE_KEY);
+	const secureSessionCookie = cookieStore.get(`__Secure-${SESSION_COOKIE_KEY}`);
+	const cookieHeader = secureSessionCookie
+		? `__Secure-${SESSION_COOKIE_KEY}=${secureSessionCookie.value}`
+		: sessionCookie
+			? `${SESSION_COOKIE_KEY}=${sessionCookie.value}`
+			: "";
 
-	if (!apiKey) {
-		return NextResponse.json({ error: "Missing API key" }, { status: 400 });
-	}
-
-	const gatewayBaseUrl =
-		process.env.GATEWAY_URL?.replace(/\/v1$/, "") ??
-		(process.env.NODE_ENV === "development"
-			? "http://localhost:4001"
-			: "https://api.llmgateway.io");
-
-	const rangeHeader = req.headers.get("Range");
-
-	const response = await fetch(
-		`${gatewayBaseUrl}/v1/videos/${encodeURIComponent(videoId)}/content`,
+	// Resolve the signed, keyless content URL through the session-authorized API
+	// (org-scoped access) rather than the project-scoped gateway API key, so
+	// playback works for any video the user can access regardless of which
+	// playground API key is currently active.
+	const { apiBackendUrl } = getConfig();
+	const statusResponse = await fetch(
+		`${apiBackendUrl}/video/${encodeURIComponent(videoId)}`,
 		{
 			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"x-source": "chat.llmgateway.io",
-				...(rangeHeader ? { Range: rangeHeader } : {}),
+				Cookie: cookieHeader,
 			},
 			cache: "no-store",
 		},
 	);
+
+	if (!statusResponse.ok) {
+		const body = await readGatewayResponseBody(statusResponse);
+		return NextResponse.json(
+			{ error: getGatewayErrorMessage(body, "Failed to fetch video content") },
+			{ status: statusResponse.status },
+		);
+	}
+
+	const job = (await statusResponse.json()) as {
+		content?: { url: string; mime_type?: string | null }[];
+	};
+	const sourceUrl = job.content?.[0]?.url;
+	if (!sourceUrl) {
+		return NextResponse.json(
+			{ error: "Video content is not available yet" },
+			{ status: 404 },
+		);
+	}
+
+	const rangeHeader = req.headers.get("Range");
+	const response = await fetch(sourceUrl, {
+		headers: {
+			...(rangeHeader ? { Range: rangeHeader } : {}),
+		},
+		cache: "no-store",
+	});
 
 	if (!response.ok && response.status !== 206) {
 		const body = await readGatewayResponseBody(response);

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -286,4 +286,32 @@ describe("Seedance 2.0 reference capabilities", () => {
 		expect(options.sizes).toHaveLength(0);
 		expect(options.durations).toHaveLength(0);
 	});
+
+	test("frame mode keeps size/duration options for Seedance 2.0", () => {
+		const model = makeModel([makeSeedanceMapping()], "seedance-2-0");
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["seedance-2-0"],
+			"frames",
+		);
+
+		expect(options.sizes).toContain("1280x720");
+		expect(options.sizes).toContain("1920x1080");
+		expect(options.durations).toContain(10);
+	});
+
+	test("frame mode is rejected for non-2.0 bytedance models", () => {
+		const model = makeModel(
+			[makeSeedanceMapping({ modelId: "seedance-1-5-pro" })],
+			"seedance-1-5-pro",
+		);
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["seedance-1-5-pro"],
+			"frames",
+		);
+
+		expect(options.sizes).toHaveLength(0);
+		expect(options.durations).toHaveLength(0);
+	});
 });

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -5,6 +5,7 @@ import {
 	getSupportedVideoRequestOptions,
 	getSupportedVideoSizesForSelection,
 	getNormalizedVideoRequestSelection,
+	supportsVideoFrameInput,
 	supportsVideoReferenceInput,
 	supportsVideoReferenceVideoInput,
 	supportsVideoReferenceAudioInput,
@@ -213,6 +214,15 @@ describe("Seedance 2.0 reference capabilities", () => {
 			...overrides,
 		});
 	}
+
+	test("supportsVideoFrameInput is true for Seedance 2.0 bytedance", () => {
+		expect(supportsVideoFrameInput("seedance-2-0")).toBe(true);
+		expect(supportsVideoFrameInput("seedance-2-0-fast")).toBe(true);
+		expect(supportsVideoFrameInput("bytedance/seedance-2-0")).toBe(true);
+		expect(supportsVideoFrameInput("bytedance/seedance-2-0-fast")).toBe(true);
+		expect(supportsVideoFrameInput("bytedance/seedance-1-5-pro")).toBe(false);
+		expect(supportsVideoFrameInput("google-vertex/seedance-2-0")).toBe(false);
+	});
 
 	test("supportsVideoReferenceInput is true for Seedance 2.0", () => {
 		expect(supportsVideoReferenceInput("seedance-2-0")).toBe(true);

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -227,14 +227,23 @@ function mappingSupportsVideoRequest(
 		return false;
 	}
 
-	if (
-		inputMode === "frames" &&
-		mapping.providerId !== "google-vertex" &&
-		mapping.providerId !== "avalanche" &&
-		mapping.providerId !== "minimax" &&
-		mapping.providerId !== "xai"
-	) {
-		return false;
+	if (inputMode === "frames") {
+		// Match by canonical root model id — never by the upstream externalId.
+		if (mapping.providerId === "bytedance") {
+			return (
+				mapping.modelId === "seedance-2-0" ||
+				mapping.modelId === "seedance-2-0-fast"
+			);
+		}
+
+		if (
+			mapping.providerId !== "google-vertex" &&
+			mapping.providerId !== "avalanche" &&
+			mapping.providerId !== "minimax" &&
+			mapping.providerId !== "xai"
+		) {
+			return false;
+		}
 	}
 
 	if (inputMode === "reference") {

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -102,6 +102,10 @@ export function supportsVideoFrameInput(modelId: string): boolean {
 		? modelId.split("/", 2)
 		: [undefined, modelId];
 
+	if (isSeedance2ReferenceModel(rootModelId)) {
+		return providerId === undefined || providerId === "bytedance";
+	}
+
 	if (rootModelId === "minimax-hailuo-2-3") {
 		return providerId === undefined || providerId === "minimax";
 	}


### PR DESCRIPTION
## Summary

Two related changes, both surfaced while testing ByteDance Seedance 2.0 video generation in the playground.

### 1. First/last frame inputs for Seedance 2.0

ByteDance Seedance 2.0 supports first/last frame conditioning for image-to-video, but the gateway and playground didn't expose it:

- The playground hid the **First/Last frame** pickers behind `supportsVideoFrameInput()`, which only returned `true` for Veo / MiniMax / Grok models.
- The gateway's `createBytedanceVideoJob()` only forwarded the **first** frame — a `last_frame` was silently dropped, and frame inputs were rejected for ByteDance by the constraint checker.

Changes:
- **Gateway** (`videos.ts`): forward `last_frame` as a `role: "last_frame"` content entry; allow `inputMode === "frames"` for Seedance 2.0 mappings (non-2.0 ByteDance models still rejected with a clear message); renamed `isBytedanceReferenceModel` → `isBytedanceSeedance2Model`.
- **Playground** (`video-gen.ts`): `supportsVideoFrameInput()` returns `true` for Seedance 2.0.
- **Docs** (`video-generation.mdx`): new **First/last frame inputs** section with a provider table (Seedance 2.0 called out), rules, and example.
- **Tests**: ByteDance video mock handler + forwarding/rejection tests; playground capability test.

### 2. Fix "Video unavailable" for cross-project video playback

After generating a video, the playground could show **"Video unavailable"** even though the job completed successfully with a valid content URL. Root cause: the playground polls video **status** via the session/org-authorized API app, but loaded the **content** through the project-scoped gateway API key. When the active playground key's project differed from the project that owns the job (e.g. after an org/project switch, or a rotated auto-generated key), the gateway returned `404 "Video not found"`.

Verified against a real completed Seedance 2.0 job: the gateway returned the full video to the owning key (200) but 404 to a different project's key — exactly the playground's symptom.

Changes:
- **API** (`routes/video.ts`): the video status route now returns a keyless signed content URL (`buildSignedGatewayVideoLogContentUrl`), scoped by the same org-access check it already performs.
- **Playground** (`[videoId]/content/route.ts`): the content proxy resolves that signed URL via the session-authorized API instead of the project-scoped gateway key. Playback now works for any video the user can access, and stored history URLs stay durable (each load re-resolves a fresh signed URL).

## Verification
- `pnpm format` ✅ · `pnpm build` ✅ · docs build ✅
- Gateway video spec ✅ 30/30 · playground video-gen spec ✅ 13/13
- End-to-end against a real completed job: API-route-produced signed URL streams the full 8.9 MB video keyless (HTTP 200); confirmed the gateway 404s for a wrong-project key (the original bug) and 200s for the owning key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Seedance 2.0 `image`/`last_frame` inputs using the Bytedance provider.
  * Video job status responses for completed videos can now include `content` (signed playback URLs).
* **Bug Fixes**
  * Enforced frame/reference validation rules and improved rejection messaging for incompatible model/provider combinations.
* **Tests**
  * Added/extended test coverage for Seedance 2.0 Bytedance frame requests, compatibility detection, and OpenAI mock task generation.
* **Documentation**
  * Updated `POST /v1/videos` supported fields and added first/last frame interpolation guidance and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->