### PR TITLE
chore(seed): add admin to enterprise org

### DIFF
--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1882,6 +1882,15 @@ async function seed() {
 		role: "owner",
 	});
 
+	// Also make the default admin (admin@example.com) an admin of the enterprise
+	// org so it can be reached by switching orgs with the same login.
+	await upsert(tables.userOrganization, {
+		id: "enterprise-admin-user-org-id",
+		userId: "test-user-id",
+		organizationId: "enterprise-org-id",
+		role: "admin",
+	});
+
 	await upsert(tables.project, {
 		id: "enterprise-project-id",
 		name: "Enterprise Project",


### PR DESCRIPTION
## Summary

Adds `admin@example.com` (`test-user-id`) as an **admin** of the seeded enterprise org (`enterprise-org-id`), in addition to the existing `enterprise-user-id` owner.

This lets you switch into the existing seeded enterprise org using the same default admin login, instead of needing to log in as `enterprise@example.com`.

## Changes

- `packages/db/src/seed.ts`: new `userOrganization` upsert linking `test-user-id` to `enterprise-org-id` with role `admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database seed configuration to support admin role assignment in multi-organization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->