### PR TITLE
fix(anthropic): accept server-side tools on /v1/messages

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -589,6 +589,12 @@ anthropic.openapi(messages, async (c) => {
 						...(tool.user_location
 							? { user_location: tool.user_location }
 							: {}),
+						...(tool.allowed_domains
+							? { allowed_domains: tool.allowed_domains }
+							: {}),
+						...(tool.blocked_domains
+							? { blocked_domains: tool.blocked_domains }
+							: {}),
 					};
 				}
 

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -88,11 +88,51 @@ const anthropicMessageSchema = z.object({
 		.optional(),
 });
 
-const anthropicToolSchema = z.object({
+// Standard Anthropic "custom" tools: a name plus a JSON schema describing the
+// parameters the model should produce.
+const anthropicCustomToolSchema = z.object({
+	type: z.literal("custom").optional(),
 	name: z.string(),
-	description: z.string(),
+	description: z.string().optional(),
 	input_schema: z.record(z.unknown()),
+	cache_control: z
+		.object({
+			type: z.enum(["ephemeral"]),
+			ttl: z.enum(["5m", "1h"]).optional(),
+		})
+		.nullish(),
 });
+
+// Anthropic server-side tools (e.g. web_search_20250305, code_execution_*).
+// These are executed by Anthropic, carry a versioned `type` instead of an
+// `input_schema`, and must not be validated as custom tools.
+const anthropicServerToolSchema = z.object({
+	type: z.string(),
+	name: z.string(),
+	max_uses: z.number().optional(),
+	allowed_domains: z.array(z.string()).optional(),
+	blocked_domains: z.array(z.string()).optional(),
+	user_location: z
+		.object({
+			type: z.literal("approximate").optional(),
+			city: z.string().optional(),
+			region: z.string().optional(),
+			country: z.string().optional(),
+			timezone: z.string().optional(),
+		})
+		.optional(),
+	cache_control: z
+		.object({
+			type: z.enum(["ephemeral"]),
+			ttl: z.enum(["5m", "1h"]).optional(),
+		})
+		.nullish(),
+});
+
+const anthropicToolSchema = z.union([
+	anthropicCustomToolSchema,
+	anthropicServerToolSchema,
+]);
 
 const anthropicRequestSchema = z.object({
 	model: z.string().openapi({
@@ -522,17 +562,43 @@ anthropic.openapi(messages, async (c) => {
 		}
 	}
 
-	// Transform tools if provided
+	// Transform tools if provided. Custom tools map to OpenAI function tools;
+	// Anthropic server-side tools (e.g. web_search_20250305) carry a versioned
+	// `type` and no `input_schema`, so they're translated to the internal
+	// `web_search` tool the chat completions endpoint understands. Server tools
+	// we can't represent are dropped (with a warning) rather than rejected.
 	let openaiTools;
 	if (anthropicRequest.tools) {
-		openaiTools = anthropicRequest.tools.map((tool) => ({
-			type: "function",
-			function: {
-				name: tool.name,
-				description: tool.description,
-				parameters: tool.input_schema,
-			},
-		}));
+		openaiTools = anthropicRequest.tools
+			.map((tool) => {
+				if ("input_schema" in tool) {
+					return {
+						type: "function",
+						function: {
+							name: tool.name,
+							description: tool.description,
+							parameters: tool.input_schema,
+						},
+					};
+				}
+
+				if (tool.type.startsWith("web_search")) {
+					return {
+						type: "web_search",
+						...(tool.max_uses !== undefined ? { max_uses: tool.max_uses } : {}),
+						...(tool.user_location
+							? { user_location: tool.user_location }
+							: {}),
+					};
+				}
+
+				logger.warn("Dropping unsupported Anthropic server tool", {
+					type: tool.type,
+					name: tool.name,
+				});
+				return null;
+			})
+			.filter((tool): tool is NonNullable<typeof tool> => tool !== null);
 	}
 
 	// Build OpenAI request
@@ -544,7 +610,7 @@ anthropic.openapi(messages, async (c) => {
 		stream: anthropicRequest.stream,
 	};
 
-	if (openaiTools) {
+	if (openaiTools && openaiTools.length > 0) {
 		openaiRequest.tools = openaiTools;
 	}
 

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -5065,4 +5065,136 @@ describe("api", () => {
 			expect(Number(logs[0].cost)).toBe(0);
 		});
 	});
+
+	describe("native /v1/messages server-side tools", () => {
+		// Anthropic server-side tools (e.g. web_search_20250305) carry a versioned
+		// `type` and no `description`/`input_schema`. They must pass validation and
+		// be forwarded to the provider, not rejected as malformed custom tools.
+		test("forwards Anthropic web_search server tool to the provider", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			let capturedBody: any;
+			const originalFetch = globalThis.fetch;
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(async (input, init) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url;
+
+					if (url.includes(`${mockServerUrl}/v1/messages`)) {
+						capturedBody = JSON.parse(init?.body as string);
+						return new Response(
+							JSON.stringify({
+								id: "msg_ws",
+								type: "message",
+								role: "assistant",
+								model: "claude-sonnet-4-6",
+								content: [
+									{
+										type: "text",
+										text: "The latest version is web_search_20250305.",
+									},
+								],
+								stop_reason: "end_turn",
+								stop_sequence: null,
+								usage: { input_tokens: 50, output_tokens: 10 },
+							}),
+							{
+								status: 200,
+								headers: { "Content-Type": "application/json" },
+							},
+						);
+					}
+
+					return await originalFetch(input as RequestInfo | URL, init);
+				});
+
+			try {
+				const res = await app.request("/v1/messages", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-sonnet-4-6",
+						max_tokens: 1024,
+						messages: [
+							{
+								role: "user",
+								content:
+									"Search the web for the latest Anthropic web search tool version.",
+							},
+						],
+						tools: [
+							{
+								type: "web_search_20250305",
+								name: "web_search",
+								max_uses: 3,
+							},
+						],
+					}),
+				});
+
+				// The request must NOT be rejected with a ZodError about missing
+				// `description`/`input_schema` on the server tool.
+				expect(res.status).toBe(200);
+
+				// The server tool must reach the Anthropic provider as a native
+				// web_search tool.
+				const forwardedTools = capturedBody?.tools ?? [];
+				expect(
+					forwardedTools.some(
+						(t: { type?: string }) => t.type === "web_search_20250305",
+					),
+				).toBe(true);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
+		test("still rejects a custom tool missing input_schema", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "anthropic/claude-sonnet-4-6",
+					max_tokens: 1024,
+					messages: [{ role: "user", content: "hi" }],
+					tools: [{ name: "get_weather", description: "Get the weather" }],
+				}),
+			});
+
+			expect(res.status).toBe(400);
+		});
+	});
 });

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -5149,6 +5149,12 @@ describe("api", () => {
 								type: "web_search_20250305",
 								name: "web_search",
 								max_uses: 3,
+								allowed_domains: ["anthropic.com", "docs.anthropic.com"],
+								user_location: {
+									type: "approximate",
+									city: "San Francisco",
+									country: "US",
+								},
 							},
 						],
 					}),
@@ -5159,13 +5165,23 @@ describe("api", () => {
 				expect(res.status).toBe(200);
 
 				// The server tool must reach the Anthropic provider as a native
-				// web_search tool.
+				// web_search tool, preserving its configuration (max_uses, domain
+				// filters, user_location).
 				const forwardedTools = capturedBody?.tools ?? [];
-				expect(
-					forwardedTools.some(
-						(t: { type?: string }) => t.type === "web_search_20250305",
-					),
-				).toBe(true);
+				const forwardedWebSearch = forwardedTools.find(
+					(t: { type?: string }) => t.type === "web_search_20250305",
+				);
+				expect(forwardedWebSearch).toBeDefined();
+				expect(forwardedWebSearch.max_uses).toBe(3);
+				expect(forwardedWebSearch.allowed_domains).toEqual([
+					"anthropic.com",
+					"docs.anthropic.com",
+				]);
+				expect(forwardedWebSearch.user_location).toEqual({
+					type: "approximate",
+					city: "San Francisco",
+					country: "US",
+				});
 			} finally {
 				fetchSpy.mockRestore();
 			}
@@ -5195,6 +5211,8 @@ describe("api", () => {
 			});
 
 			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(JSON.stringify(json)).toContain("input_schema");
 		});
 	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1534,6 +1534,8 @@ chat.openapi(completions, async (c) => {
 				user_location: foundTool.user_location,
 				search_context_size: foundTool.search_context_size,
 				max_uses: foundTool.max_uses,
+				allowed_domains: foundTool.allowed_domains,
+				blocked_domains: foundTool.blocked_domains,
 			};
 			// Remove the web_search tool from the tools array so it's not sent as a regular tool
 			tools.splice(webSearchToolIndex, 1);

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -244,6 +244,8 @@ export const completionsRequestSchema = z.object({
 						.optional(),
 					search_context_size: z.enum(["low", "medium", "high"]).optional(),
 					max_uses: z.number().optional(),
+					allowed_domains: z.array(z.string()).optional(),
+					blocked_domains: z.array(z.string()).optional(),
 				}),
 			]),
 		)

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1829,6 +1829,19 @@ export async function prepareRequestBody(
 				if (webSearchTool.max_uses) {
 					webSearch.max_uses = webSearchTool.max_uses;
 				}
+				// Anthropic accepts either allowed_domains or blocked_domains, not both.
+				if (webSearchTool.allowed_domains?.length) {
+					webSearch.allowed_domains = webSearchTool.allowed_domains;
+				} else if (webSearchTool.blocked_domains?.length) {
+					webSearch.blocked_domains = webSearchTool.blocked_domains;
+				}
+				if (webSearchTool.user_location) {
+					// Anthropic requires the discriminating `type: "approximate"`.
+					webSearch.user_location = {
+						...webSearchTool.user_location,
+						type: "approximate",
+					};
+				}
 				requestBody.tools.push(webSearch);
 			}
 

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -519,13 +519,14 @@ export function hasMaxTokens(
 export interface WebSearchTool {
 	type: "web_search";
 	/**
-	 * User location for localized search results (OpenAI)
+	 * User location for localized search results (OpenAI and Anthropic)
 	 */
 	user_location?: {
 		type: "approximate";
 		city?: string;
 		region?: string;
 		country?: string;
+		timezone?: string;
 	};
 	/**
 	 * Controls how much context is retrieved from the web (OpenAI)
@@ -538,6 +539,16 @@ export interface WebSearchTool {
 	 * Maximum number of web searches to perform (Anthropic)
 	 */
 	max_uses?: number;
+	/**
+	 * Restrict search results to these domains (Anthropic). Mutually exclusive
+	 * with blocked_domains.
+	 */
+	allowed_domains?: string[];
+	/**
+	 * Exclude these domains from search results (Anthropic). Mutually exclusive
+	 * with allowed_domains.
+	 */
+	blocked_domains?: string[];
 }
 
 /**


### PR DESCRIPTION
## Problem

The native Anthropic `/v1/messages` endpoint rejected valid requests that included Anthropic **server-side tools** (e.g. `web_search_20250305`). Sending Anthropic's documented web search request:

```json
{
  "model": "claude-sonnet-4-6",
  "max_tokens": 4096,
  "messages": [{ "role": "user", "content": "Search the web ..." }],
  "tools": [{ "type": "web_search_20250305", "name": "web_search", "max_uses": 3 }]
}
```

returned a `ZodError`:

```json
{"success":false,"error":{"issues":[
  {"code":"invalid_type","path":["tools",0,"description"],"message":"Required"},
  {"code":"invalid_type","path":["tools",0,"input_schema"],"message":"Required"}
],"name":"ZodError"}}
```

The same request works when sent directly to `api.anthropic.com`.

## Root cause

The endpoint's tool schema (`anthropicToolSchema`) required `description` **and** `input_schema` on **every** tool. Server-side tools carry a versioned `type` and have neither field, so validation failed before the request ever reached a provider.

## Fix

- Split the tool schema into a union: standard **custom tools** (`name` + `input_schema`) and Anthropic **server-side tools** (`type` + `name` + optional config like `max_uses`, `user_location`, `allowed_domains`).
- In the Anthropic → OpenAI translation, map `web_search*` server tools to the internal `web_search` tool that the chat completions endpoint already forwards to Anthropic as `web_search_20250305` (preserving `max_uses`/`user_location`).
- Unsupported server tools are dropped with a warning rather than rejecting the whole request.

## Tests

Added two unit tests in `apps/gateway/src/api.spec.ts`:
- A `web_search_20250305` server tool passes validation and is forwarded to the Anthropic provider as a native `web_search_20250305` tool.
- A malformed custom tool (missing `input_schema`) is still rejected with `400`.

`pnpm build`, `pnpm format`, and the new tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Anthropic native server-side tools (such as web search) alongside custom tools
  * Enhanced tool configuration with additional parameters including allowed domains, blocked domains, and user location settings

* **Tests**
  * Added comprehensive test coverage for server-side tool handling and custom tool validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->