### PR TITLE
fix: log media input client errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - Never force push on main/default branch; force pushing is only acceptable on feature branches
 - When resolving conflicts involving `pnpm-lock.yaml`, just run `pnpm install` to automatically resolve them
 - When writing pull request titles, use the conventional commit message format and limit to max 50 characters
+- Always open pull requests as normal ready-for-review PRs, not draft PRs, unless the user explicitly asks for a draft PR
 - When creating a pull request, always write/update both the PR title and description; if the PR's scope changes in later commits, update the title and description to reflect the final scope before handing it off
 - Always use pnpm for package management
 - Use cookies for user-settings which are not saved in the database to ensure SSR works

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -10,7 +10,11 @@ import {
 	resetKeyHealth,
 } from "./lib/api-key-health.js";
 import { createGatewayApiTestHarness } from "./test-utils/gateway-api-test-harness.js";
-import { readAll, waitForLogs } from "./test-utils/test-helpers.js";
+import {
+	readAll,
+	waitForLogByRequestId,
+	waitForLogs,
+} from "./test-utils/test-helpers.js";
 
 describe("api", () => {
 	const harness = createGatewayApiTestHarness();
@@ -1628,6 +1632,50 @@ describe("api", () => {
 		const json = await res.json();
 		expect(JSON.stringify(json)).not.toContain("Invalid enum value");
 		expect(JSON.stringify(json)).not.toContain('"path":["size"]');
+	});
+
+	test("/v1/images/edits logs oversized image input client errors", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-image-edit-oversized",
+			token: "real-token-image-edit-oversized",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const requestId = "image-edit-oversized-request";
+		const oversizedImageDataUrl = `data:image/png;base64,${"A".repeat(28 * 1024 * 1024)}`;
+
+		const res = await app.request("/v1/images/edits", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-image-edit-oversized",
+				"x-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "gemini-3-pro-image-preview",
+				prompt: "Add a neon city reflection to this image",
+				images: [
+					{
+						image_url: oversizedImageDataUrl,
+					},
+				],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error.message).toContain("Image size");
+		expect(json.error.message).toContain("exceeds your current limit");
+
+		const log = await waitForLogByRequestId(requestId);
+		expect(log.finishReason).toBe("client_error");
+		expect(log.unifiedFinishReason).toBe("client_error");
+		expect(log.hasError).toBe(true);
+		expect(log.errorDetails?.statusCode).toBe(400);
+		expect(log.errorDetails?.responseText).toContain("Image size");
+		expect(log.usedProvider).toBe("llmgateway");
 	});
 
 	test("/v1/images/generations forwards X-No-Fallback to chat completions", async () => {

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1660,6 +1660,9 @@ describe("api", () => {
 					{
 						image_url: oversizedImageDataUrl,
 					},
+					{
+						image_url: oversizedImageDataUrl,
+					},
 				],
 			}),
 		});
@@ -1676,6 +1679,11 @@ describe("api", () => {
 		expect(log.errorDetails?.statusCode).toBe(400);
 		expect(log.errorDetails?.responseText).toContain("Image size");
 		expect(log.usedProvider).toBe("llmgateway");
+
+		const logs = await db.query.log.findMany({
+			where: { requestId: { eq: requestId } },
+		});
+		expect(logs).toHaveLength(1);
 	});
 
 	test("/v1/images/generations forwards X-No-Fallback to chat completions", async () => {

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -74,6 +74,12 @@ interface ImageClientErrorLogRequest {
 	aspect_ratio?: string;
 }
 
+interface ImageClientErrorLogContext {
+	apiKey: NonNullable<Awaited<ReturnType<typeof findApiKeyByToken>>>;
+	project: NonNullable<Awaited<ReturnType<typeof findProjectById>>>;
+	requestId: string;
+}
+
 const imageGenerationsResponseSchema = z.object({
 	created: z.number(),
 	data: z.array(
@@ -400,8 +406,49 @@ function getStatusText(status: number): string {
 	}
 }
 
+function createImageClientErrorLogContextResolver(
+	c: Context,
+): () => Promise<ImageClientErrorLogContext | null> {
+	let logContextPromise: Promise<ImageClientErrorLogContext | null> | null =
+		null;
+
+	return async () => {
+		logContextPromise ??= resolveImageClientErrorLogContext(c);
+		return await logContextPromise;
+	};
+}
+
+async function resolveImageClientErrorLogContext(
+	c: Context,
+): Promise<ImageClientErrorLogContext | null> {
+	const token = parseApiToken(c);
+	if (!token) {
+		return null;
+	}
+
+	const apiKey = await findApiKeyByToken(token);
+	if (!apiKey || apiKey.status !== "active") {
+		return null;
+	}
+
+	const project = await findProjectById(apiKey.projectId);
+	if (!project || project.status === "deleted") {
+		return null;
+	}
+
+	const requestId = c.req.header("x-request-id")?.trim() || shortid(40);
+	c.header("x-request-id", requestId);
+
+	return {
+		apiKey,
+		project,
+		requestId,
+	};
+}
+
 async function logImageClientError(
 	c: Context,
+	getLogContext: () => Promise<ImageClientErrorLogContext | null>,
 	request: ImageClientErrorLogRequest,
 	status: number,
 	message: string,
@@ -412,23 +459,10 @@ async function logImageClientError(
 	}
 
 	try {
-		const token = parseApiToken(c);
-		if (!token) {
+		const logContext = await getLogContext();
+		if (!logContext) {
 			return;
 		}
-
-		const apiKey = await findApiKeyByToken(token);
-		if (!apiKey || apiKey.status !== "active") {
-			return;
-		}
-
-		const project = await findProjectById(apiKey.projectId);
-		if (!project || project.status === "deleted") {
-			return;
-		}
-
-		const requestId = c.req.header("x-request-id")?.trim() || shortid(40);
-		c.header("x-request-id", requestId);
 
 		const requestedModel = request.model ?? "auto";
 		const usedModel = resolveImageRequestModel(request.model);
@@ -444,9 +478,9 @@ async function logImageClientError(
 
 		await insertLog({
 			...createLogEntry({
-				requestId,
-				project,
-				apiKey,
+				requestId: logContext.requestId,
+				project: logContext.project,
+				apiKey: logContext.apiKey,
 				usedModel,
 				usedProvider: "llmgateway",
 				requestedModel,
@@ -560,6 +594,7 @@ export const images = new OpenAPIHono<ServerTypes>();
 
 images.openapi(generations, async (c) => {
 	const startedAt = Date.now();
+	const getLogContext = createImageClientErrorLogContextResolver(c);
 
 	// Manual request parsing with better error handling
 	let rawBody: unknown;
@@ -568,6 +603,7 @@ images.openapi(generations, async (c) => {
 	} catch {
 		await logImageClientError(
 			c,
+			getLogContext,
 			{ endpoint: "images.generations" },
 			400,
 			"Invalid JSON in request body",
@@ -584,6 +620,7 @@ images.openapi(generations, async (c) => {
 		const message = `Invalid request parameters: ${validationResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`;
 		await logImageClientError(
 			c,
+			getLogContext,
 			buildImageClientErrorLogRequest("images.generations", rawBody),
 			400,
 			message,
@@ -925,6 +962,7 @@ async function parseMultipartEditsRequest(
  */
 async function processImageEdit(
 	c: Context,
+	getLogContext: () => Promise<ImageClientErrorLogContext | null>,
 	request: ImageEditsRequest,
 	startedAt = Date.now(),
 ) {
@@ -941,7 +979,14 @@ async function processImageEdit(
 	for (const [index, image] of request.images.entries()) {
 		if (!isSupportedInputImageUrl(image.image_url)) {
 			const message = `images[${index}].image_url must be an https URL or a base64 data URL`;
-			await logImageClientError(c, logRequest, 400, message, startedAt);
+			await logImageClientError(
+				c,
+				getLogContext,
+				logRequest,
+				400,
+				message,
+				startedAt,
+			);
 			throw new HTTPException(400, {
 				message,
 			});
@@ -961,7 +1006,14 @@ async function processImageEdit(
 						? error.message
 						: "Failed to process image input";
 				const message = `images[${index}].image_url is invalid: ${errorMessage}`;
-				await logImageClientError(c, logRequest, 400, message, startedAt);
+				await logImageClientError(
+					c,
+					getLogContext,
+					logRequest,
+					400,
+					message,
+					startedAt,
+				);
 				throw new HTTPException(400, {
 					message,
 				});
@@ -1081,6 +1133,7 @@ images.post("/edits", async (c, next) => {
 		return await next();
 	}
 
+	const getLogContext = createImageClientErrorLogContextResolver(c);
 	let request: ImageEditsRequest;
 	try {
 		request = await parseMultipartEditsRequest(c);
@@ -1088,6 +1141,7 @@ images.post("/edits", async (c, next) => {
 		if (error instanceof HTTPException && error.status >= 400) {
 			await logImageClientError(
 				c,
+				getLogContext,
 				{ endpoint: "images.edits" },
 				error.status,
 				error.message,
@@ -1097,17 +1151,19 @@ images.post("/edits", async (c, next) => {
 		throw error;
 	}
 
-	return await processImageEdit(c, request, startedAt);
+	return await processImageEdit(c, getLogContext, request, startedAt);
 });
 
 images.openapi(edits, async (c) => {
 	const startedAt = Date.now();
+	const getLogContext = createImageClientErrorLogContextResolver(c);
 	let rawBody: unknown;
 	try {
 		rawBody = await c.req.json();
 	} catch {
 		await logImageClientError(
 			c,
+			getLogContext,
 			{ endpoint: "images.edits" },
 			400,
 			"Invalid JSON in request body",
@@ -1123,6 +1179,7 @@ images.openapi(edits, async (c) => {
 		const message = `Invalid request parameters: ${validationResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`;
 		await logImageClientError(
 			c,
+			getLogContext,
 			buildImageClientErrorLogRequest("images.edits", rawBody),
 			400,
 			message,
@@ -1133,5 +1190,10 @@ images.openapi(edits, async (c) => {
 		});
 	}
 
-	return await processImageEdit(c, validationResult.data, startedAt);
+	return await processImageEdit(
+		c,
+		getLogContext,
+		validationResult.data,
+		startedAt,
+	);
 });

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -975,51 +975,53 @@ async function processImageEdit(
 		quality: request.quality,
 		aspect_ratio: request.aspect_ratio,
 	};
-	const imageUrls: string[] = [];
-	for (const [index, image] of request.images.entries()) {
-		if (!isSupportedInputImageUrl(image.image_url)) {
-			const message = `images[${index}].image_url must be an https URL or a base64 data URL`;
-			await logImageClientError(
-				c,
-				getLogContext,
-				logRequest,
-				400,
-				message,
-				startedAt,
+	const { imageResults, imageCount } = await (async () => {
+		try {
+			const imageUrls: string[] = [];
+			for (const [index, image] of request.images.entries()) {
+				if (!isSupportedInputImageUrl(image.image_url)) {
+					throw new HTTPException(400, {
+						message: `images[${index}].image_url must be an https URL or a base64 data URL`,
+					});
+				}
+				imageUrls.push(image.image_url);
+			}
+
+			const isProd = process.env.NODE_ENV === "production";
+			const imageResults = await Promise.all(
+				imageUrls.map(async (url, index) => {
+					try {
+						return await processImageUrl(url, isProd);
+					} catch (error) {
+						const errorMessage =
+							error instanceof Error
+								? error.message
+								: "Failed to process image input";
+						throw new HTTPException(400, {
+							message: `images[${index}].image_url is invalid: ${errorMessage}`,
+						});
+					}
+				}),
 			);
-			throw new HTTPException(400, {
-				message,
-			});
-		}
-		imageUrls.push(image.image_url);
-	}
-
-	const isProd = process.env.NODE_ENV === "production";
-
-	const imageResults = await Promise.all(
-		imageUrls.map(async (url, index) => {
-			try {
-				return await processImageUrl(url, isProd);
-			} catch (error) {
-				const errorMessage =
-					error instanceof Error
-						? error.message
-						: "Failed to process image input";
-				const message = `images[${index}].image_url is invalid: ${errorMessage}`;
+			return { imageResults, imageCount: imageUrls.length };
+		} catch (error) {
+			if (
+				error instanceof HTTPException &&
+				error.status >= 400 &&
+				error.status < 500
+			) {
 				await logImageClientError(
 					c,
 					getLogContext,
 					logRequest,
-					400,
-					message,
+					error.status,
+					error.message,
 					startedAt,
 				);
-				throw new HTTPException(400, {
-					message,
-				});
 			}
-		}),
-	);
+			throw error;
+		}
+	})();
 
 	const contentParts: Array<Record<string, unknown>> = [];
 
@@ -1083,7 +1085,7 @@ async function processImageEdit(
 	logger.debug("Images Edit API - forwarding to chat completions", {
 		model,
 		prompt: request.prompt.slice(0, 200),
-		imageCount: imageUrls.length,
+		imageCount,
 		n: request.n,
 		size: request.size,
 		aspectRatio: request.aspect_ratio,

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -2,8 +2,14 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 
 import { app } from "@/app.js";
+import { createLogEntry } from "@/chat/tools/create-log-entry.js";
+import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
+import { findApiKeyByToken, findProjectById } from "@/lib/cached-queries.js";
+import { parseApiToken } from "@/lib/extract-api-token.js";
+import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 
 import { parseDataUrl, processImageUrl } from "@llmgateway/actions";
+import { shortid } from "@llmgateway/db";
 import { logger, toError } from "@llmgateway/logger";
 
 import type { ServerTypes } from "@/vars.js";
@@ -57,6 +63,16 @@ const imageGenerationsRequestSchema = z.object({
 });
 
 type ImageGenerationsRequest = z.infer<typeof imageGenerationsRequestSchema>;
+
+interface ImageClientErrorLogRequest {
+	endpoint: "images.generations" | "images.edits";
+	model?: string;
+	prompt?: string;
+	n?: number;
+	size?: string;
+	quality?: string;
+	aspect_ratio?: string;
+}
 
 const imageGenerationsResponseSchema = z.object({
 	created: z.number(),
@@ -321,6 +337,183 @@ function forwardHeaders(c: Context): Record<string, string> {
 	};
 }
 
+function resolveImageRequestModel(model: string | undefined): string {
+	return !model || model === "auto" ? "gemini-3-pro-image-preview" : model;
+}
+
+function getStringProperty(
+	value: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const property = value[key];
+	return typeof property === "string" ? property : undefined;
+}
+
+function getNumberProperty(
+	value: Record<string, unknown>,
+	key: string,
+): number | undefined {
+	const property = value[key];
+	return typeof property === "number" ? property : undefined;
+}
+
+function buildImageClientErrorLogRequest(
+	endpoint: ImageClientErrorLogRequest["endpoint"],
+	rawBody: unknown,
+): ImageClientErrorLogRequest {
+	if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+		return { endpoint };
+	}
+
+	const body = rawBody as Record<string, unknown>;
+	return {
+		endpoint,
+		model: getStringProperty(body, "model"),
+		prompt: getStringProperty(body, "prompt"),
+		n: getNumberProperty(body, "n"),
+		size: getStringProperty(body, "size"),
+		quality: getStringProperty(body, "quality"),
+		aspect_ratio: getStringProperty(body, "aspect_ratio"),
+	};
+}
+
+function getStatusText(status: number): string {
+	switch (status) {
+		case 400:
+			return "Bad Request";
+		case 401:
+			return "Unauthorized";
+		case 403:
+			return "Forbidden";
+		case 404:
+			return "Not Found";
+		case 413:
+			return "Payload Too Large";
+		case 415:
+			return "Unsupported Media Type";
+		case 422:
+			return "Unprocessable Entity";
+		case 429:
+			return "Too Many Requests";
+		default:
+			return "Client Error";
+	}
+}
+
+async function logImageClientError(
+	c: Context,
+	request: ImageClientErrorLogRequest,
+	status: number,
+	message: string,
+	startedAt: number,
+): Promise<void> {
+	if (status < 400 || status >= 500) {
+		return;
+	}
+
+	try {
+		const token = parseApiToken(c);
+		if (!token) {
+			return;
+		}
+
+		const apiKey = await findApiKeyByToken(token);
+		if (!apiKey || apiKey.status !== "active") {
+			return;
+		}
+
+		const project = await findProjectById(apiKey.projectId);
+		if (!project || project.status === "deleted") {
+			return;
+		}
+
+		const requestId = c.req.header("x-request-id")?.trim() || shortid(40);
+		c.header("x-request-id", requestId);
+
+		const requestedModel = request.model ?? "auto";
+		const usedModel = resolveImageRequestModel(request.model);
+		const responseText = message;
+		const imageConfig =
+			request.aspect_ratio || request.size || request.quality
+				? {
+						...(request.aspect_ratio && { aspect_ratio: request.aspect_ratio }),
+						...(request.size && { image_size: request.size }),
+						...(request.quality && { image_quality: request.quality }),
+					}
+				: undefined;
+
+		await insertLog({
+			...createLogEntry({
+				requestId,
+				project,
+				apiKey,
+				usedModel,
+				usedProvider: "llmgateway",
+				requestedModel,
+				messages: [
+					{
+						role: "user",
+						content: request.prompt ?? "",
+					},
+				],
+				source: c.req.header("x-source") ?? undefined,
+				customHeaders: extractCustomHeaders(c),
+				debugMode: false,
+				userAgent: c.req.header("user-agent"),
+				imageConfig,
+			}),
+			duration: Date.now() - startedAt,
+			timeToFirstToken: null,
+			timeToFirstReasoningToken: null,
+			responseSize: responseText.length,
+			content: null,
+			reasoningContent: null,
+			finishReason: "client_error",
+			promptTokens: null,
+			completionTokens: null,
+			totalTokens: null,
+			reasoningTokens: null,
+			cachedTokens: null,
+			cacheWriteTokens: null,
+			hasError: true,
+			streamed: false,
+			canceled: false,
+			errorDetails: {
+				statusCode: status,
+				statusText: getStatusText(status),
+				responseText,
+			},
+			inputCost: 0,
+			outputCost: 0,
+			cachedInputCost: 0,
+			cacheWriteInputCost: 0,
+			requestCost: 0,
+			webSearchCost: 0,
+			contentFilterCost: null,
+			imageInputTokens: null,
+			imageOutputTokens: null,
+			imageInputCost: null,
+			imageOutputCost: null,
+			audioInputTokens: null,
+			audioInputCost: null,
+			cost: 0,
+			estimatedCost: false,
+			discount: null,
+			pricingTier: null,
+			serviceTier: null,
+			dataStorageCost: calculateDataStorageCost(null, null, null, null),
+			cached: false,
+			tools: null,
+			toolResults: null,
+			toolChoice: null,
+		});
+	} catch (error) {
+		logger.warn("Images API - failed to log client error", {
+			err: toError(error),
+		});
+	}
+}
+
 async function forwardToChatCompletions(
 	c: Context,
 	chatRequest: Record<string, unknown>,
@@ -366,11 +559,20 @@ async function forwardToChatCompletions(
 export const images = new OpenAPIHono<ServerTypes>();
 
 images.openapi(generations, async (c) => {
+	const startedAt = Date.now();
+
 	// Manual request parsing with better error handling
 	let rawBody: unknown;
 	try {
 		rawBody = await c.req.json();
 	} catch {
+		await logImageClientError(
+			c,
+			{ endpoint: "images.generations" },
+			400,
+			"Invalid JSON in request body",
+			startedAt,
+		);
 		throw new HTTPException(400, {
 			message: "Invalid JSON in request body",
 		});
@@ -379,8 +581,16 @@ images.openapi(generations, async (c) => {
 	// Validate against schema
 	const validationResult = imageGenerationsRequestSchema.safeParse(rawBody);
 	if (!validationResult.success) {
+		const message = `Invalid request parameters: ${validationResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`;
+		await logImageClientError(
+			c,
+			buildImageClientErrorLogRequest("images.generations", rawBody),
+			400,
+			message,
+			startedAt,
+		);
 		throw new HTTPException(400, {
-			message: `Invalid request parameters: ${validationResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`,
+			message,
 		});
 	}
 
@@ -713,12 +923,27 @@ async function parseMultipartEditsRequest(
 /**
  * Shared processing logic for image edits (used by both JSON and multipart handlers).
  */
-async function processImageEdit(c: Context, request: ImageEditsRequest) {
+async function processImageEdit(
+	c: Context,
+	request: ImageEditsRequest,
+	startedAt = Date.now(),
+) {
+	const logRequest: ImageClientErrorLogRequest = {
+		endpoint: "images.edits",
+		model: request.model,
+		prompt: request.prompt,
+		n: request.n,
+		size: request.size,
+		quality: request.quality,
+		aspect_ratio: request.aspect_ratio,
+	};
 	const imageUrls: string[] = [];
 	for (const [index, image] of request.images.entries()) {
 		if (!isSupportedInputImageUrl(image.image_url)) {
+			const message = `images[${index}].image_url must be an https URL or a base64 data URL`;
+			await logImageClientError(c, logRequest, 400, message, startedAt);
 			throw new HTTPException(400, {
-				message: `images[${index}].image_url must be an https URL or a base64 data URL`,
+				message,
 			});
 		}
 		imageUrls.push(image.image_url);
@@ -735,8 +960,10 @@ async function processImageEdit(c: Context, request: ImageEditsRequest) {
 					error instanceof Error
 						? error.message
 						: "Failed to process image input";
+				const message = `images[${index}].image_url is invalid: ${errorMessage}`;
+				await logImageClientError(c, logRequest, 400, message, startedAt);
 				throw new HTTPException(400, {
-					message: `images[${index}].image_url is invalid: ${errorMessage}`,
+					message,
 				});
 			}
 		}),
@@ -848,20 +1075,44 @@ async function processImageEdit(c: Context, request: ImageEditsRequest) {
 
 // Multipart/form-data handler for OpenAI-compatible clients (must be before openapi route)
 images.post("/edits", async (c, next) => {
+	const startedAt = Date.now();
 	const contentType = c.req.header("Content-Type") ?? "";
 	if (!contentType.includes("multipart/form-data")) {
 		return await next();
 	}
 
-	const request = await parseMultipartEditsRequest(c);
-	return await processImageEdit(c, request);
+	let request: ImageEditsRequest;
+	try {
+		request = await parseMultipartEditsRequest(c);
+	} catch (error) {
+		if (error instanceof HTTPException && error.status >= 400) {
+			await logImageClientError(
+				c,
+				{ endpoint: "images.edits" },
+				error.status,
+				error.message,
+				startedAt,
+			);
+		}
+		throw error;
+	}
+
+	return await processImageEdit(c, request, startedAt);
 });
 
 images.openapi(edits, async (c) => {
+	const startedAt = Date.now();
 	let rawBody: unknown;
 	try {
 		rawBody = await c.req.json();
 	} catch {
+		await logImageClientError(
+			c,
+			{ endpoint: "images.edits" },
+			400,
+			"Invalid JSON in request body",
+			startedAt,
+		);
 		throw new HTTPException(400, {
 			message: "Invalid JSON in request body",
 		});
@@ -869,10 +1120,18 @@ images.openapi(edits, async (c) => {
 
 	const validationResult = imageEditsRequestSchema.safeParse(rawBody);
 	if (!validationResult.success) {
+		const message = `Invalid request parameters: ${validationResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`;
+		await logImageClientError(
+			c,
+			buildImageClientErrorLogRequest("images.edits", rawBody),
+			400,
+			message,
+			startedAt,
+		);
 		throw new HTTPException(400, {
-			message: `Invalid request parameters: ${validationResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`,
+			message,
 		});
 	}
 
-	return await processImageEdit(c, validationResult.data);
+	return await processImageEdit(c, validationResult.data, startedAt);
 });

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -269,6 +269,64 @@ describe("videos", () => {
 		);
 	});
 
+	test("/v1/videos logs oversized reference image client errors", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-video-oversized-image",
+			token: "real-token-video-oversized-image",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-video-oversized-image",
+			token: "sk-bytedance-key",
+			provider: "bytedance",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const requestId = "video-oversized-reference-image-request";
+		const oversizedImageDataUrl = `data:image/png;base64,${"A".repeat(28 * 1024 * 1024)}`;
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-video-oversized-image",
+				"x-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0",
+				prompt: "Animate this product reference image",
+				size: "1280x720",
+				seconds: 5,
+				reference_images: [
+					{
+						image_url: oversizedImageDataUrl,
+					},
+				],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error.message).toContain("Invalid image input");
+		expect(json.error.message).toContain("Image size");
+		expect(json.error.message).toContain("exceeds your current limit");
+
+		const logs = await db.query.log.findMany({
+			where: { requestId: { eq: requestId } },
+		});
+		expect(logs).toHaveLength(1);
+		expect(logs[0].finishReason).toBe("client_error");
+		expect(logs[0].unifiedFinishReason).toBe("client_error");
+		expect(logs[0].hasError).toBe(true);
+		expect(logs[0].errorDetails?.statusCode).toBe(400);
+		expect(logs[0].errorDetails?.responseText).toContain("Image size");
+		expect(logs[0].usedProvider).toBe("bytedance");
+	});
+
 	test("/v1/videos rejects non-https reference audios", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -45,6 +45,7 @@ import {
 	sql,
 	shortid,
 	tables,
+	UnifiedFinishReason,
 	type InferSelectModel,
 } from "@llmgateway/db";
 import { logger, toError } from "@llmgateway/logger";
@@ -621,6 +622,19 @@ interface ProcessedVideoImageInput {
 }
 
 type VideoInputMode = "none" | "frames" | "reference";
+
+function getFormattedRequestedVideoModel(
+	normalizedModel: string,
+	requestedProvider: string | undefined,
+): string {
+	return requestedProvider
+		? `${requestedProvider}/${normalizedModel}`
+		: normalizedModel;
+}
+
+function getFormattedUsedVideoModel(provider: Provider, model: string): string {
+	return `${provider}/${model}`;
+}
 
 function getVideoImageFileExtension(mimeType: string): string {
 	switch (mimeType) {
@@ -3756,6 +3770,158 @@ async function processVideoImageInputs(
 	).filter((image): image is ProcessedVideoImageInput => image !== null);
 }
 
+function buildVideoClientErrorRoutingMetadata(
+	routingMetadata: RoutingMetadata | undefined,
+	providerContext: ProviderContext,
+	modelId: string,
+	statusCode: number,
+): RoutingMetadata | null {
+	const routingAttempt: RoutingAttempt = {
+		provider: providerContext.providerId,
+		model: modelId,
+		status_code: statusCode,
+		error_type: "client_error",
+		succeeded: false,
+	};
+
+	if (!routingMetadata) {
+		return {
+			availableProviders: [providerContext.providerId],
+			selectedProvider: providerContext.providerId,
+			selectionReason: "client_error",
+			providerScores: [
+				{
+					providerId: providerContext.providerId,
+					score: 0,
+					price: 0,
+					failed: true,
+					status_code: statusCode,
+					error_type: "client_error",
+				},
+			],
+			routing: [routingAttempt],
+		};
+	}
+
+	return {
+		...routingMetadata,
+		selectedProvider: providerContext.providerId,
+		routing: [routingAttempt],
+		providerScores: routingMetadata.providerScores.map((score) =>
+			score.providerId === providerContext.providerId
+				? {
+						...score,
+						failed: true,
+						status_code: statusCode,
+						error_type: "client_error",
+					}
+				: score,
+		),
+	};
+}
+
+async function insertVideoClientErrorLog(options: {
+	request: z.infer<typeof createVideoRequestSchema>;
+	requestId: string;
+	apiKey: GatewayApiKey;
+	project: InferSelectModel<typeof tables.project>;
+	organization: InferSelectModel<typeof tables.organization>;
+	normalizedModel: string;
+	requestedProvider: string | undefined;
+	providerContext: ProviderContext;
+	upstreamModelName: string;
+	routingMetadata: RoutingMetadata | undefined;
+	statusCode: number;
+	message: string;
+	startedAt: number;
+}): Promise<void> {
+	const responseText = options.message;
+	await db.insert(tables.log).values({
+		requestId: options.requestId,
+		organizationId: options.organization.id,
+		projectId: options.project.id,
+		apiKeyId: options.apiKey.id,
+		endUserSessionId: options.apiKey.endUserSession?.id ?? null,
+		endCustomerWalletId: options.apiKey.endCustomerWalletId ?? null,
+		duration: Math.max(0, Date.now() - options.startedAt),
+		timeToFirstToken: null,
+		timeToFirstReasoningToken: null,
+		requestedModel: getFormattedRequestedVideoModel(
+			options.normalizedModel,
+			options.requestedProvider,
+		),
+		requestedProvider: options.requestedProvider ?? null,
+		usedModel: getFormattedUsedVideoModel(
+			options.providerContext.providerId,
+			options.normalizedModel,
+		),
+		usedModelMapping: options.upstreamModelName,
+		usedProvider: options.providerContext.providerId,
+		responseSize: responseText.length,
+		content: null,
+		reasoningContent: null,
+		finishReason: "client_error",
+		unifiedFinishReason: UnifiedFinishReason.CLIENT_ERROR,
+		promptTokens: null,
+		completionTokens: null,
+		totalTokens: null,
+		reasoningTokens: null,
+		cachedTokens: null,
+		cacheWriteTokens: null,
+		messages:
+			options.organization.retentionLevel === "retain"
+				? [
+						{
+							role: "user",
+							content: options.request.prompt,
+						},
+					]
+				: null,
+		hasError: true,
+		errorDetails: {
+			statusCode: options.statusCode,
+			statusText: "Bad Request",
+			responseText,
+		},
+		cost: 0,
+		inputCost: 0,
+		outputCost: 0,
+		cachedInputCost: 0,
+		cacheWriteInputCost: 0,
+		requestCost: 0,
+		webSearchCost: 0,
+		contentFilterCost: null,
+		imageInputTokens: null,
+		imageOutputTokens: null,
+		imageInputCost: null,
+		imageOutputCost: null,
+		audioInputTokens: null,
+		audioInputCost: null,
+		videoOutputCost: 0,
+		estimatedCost: false,
+		discount: null,
+		pricingTier: null,
+		serviceTier: null,
+		canceled: false,
+		streamed: false,
+		cached: false,
+		mode: options.project.mode,
+		usedMode: options.providerContext.usedMode,
+		routingMetadata: buildVideoClientErrorRoutingMetadata(
+			options.routingMetadata,
+			options.providerContext,
+			options.normalizedModel,
+			options.statusCode,
+		),
+		processedAt: null,
+		rawRequest: null,
+		rawResponse: null,
+		upstreamRequest: null,
+		upstreamResponse: null,
+		dataStorageCost: "0",
+	});
+}
+
 async function uploadAvalancheBase64Image(
 	providerContext: ProviderContext,
 	image: ProcessedVideoImageInput,
@@ -3818,6 +3984,7 @@ async function getAvalancheImageUrl(
 }
 
 videos.openapi(createVideo, async (c) => {
+	const startedAt = Date.now();
 	const { rawBody, request } = await parseJsonBody(c);
 	const { apiKey, project, organization, wallet, requestId, routingCfg } =
 		await requireRequestContext(c);
@@ -3918,10 +4085,34 @@ videos.openapi(createVideo, async (c) => {
 	let selectedProviderContext = providerContext;
 	let selectedUpstreamModelName = upstreamModelName;
 	let enrichedRoutingMetadata = routingMetadata;
-	const processedFirstFrame = await processVideoImageInput(firstFrameInput);
-	const processedLastFrameInput = await processVideoImageInput(lastFrameInput);
-	const processedReferenceImages =
-		await processVideoImageInputs(referenceImageInputs);
+	let processedFirstFrame: ProcessedVideoImageInput | null;
+	let processedLastFrameInput: ProcessedVideoImageInput | null;
+	let processedReferenceImages: ProcessedVideoImageInput[];
+	try {
+		processedFirstFrame = await processVideoImageInput(firstFrameInput);
+		processedLastFrameInput = await processVideoImageInput(lastFrameInput);
+		processedReferenceImages =
+			await processVideoImageInputs(referenceImageInputs);
+	} catch (error) {
+		if (error instanceof HTTPException && error.status >= 400) {
+			await insertVideoClientErrorLog({
+				request,
+				requestId,
+				apiKey,
+				project,
+				organization,
+				normalizedModel,
+				requestedProvider,
+				providerContext: selectedProviderContext,
+				upstreamModelName: selectedUpstreamModelName,
+				routingMetadata: enrichedRoutingMetadata,
+				statusCode: error.status,
+				message: error.message,
+				startedAt,
+			});
+		}
+		throw error;
+	}
 	const routingAttempts: RoutingAttempt[] = [];
 	const failedProviders = new Set<string>();
 	let retryCount = 0;


### PR DESCRIPTION
## Summary
- add gateway log rows for video-studio 4xx image preprocessing failures before a video job is created
- preserve request/provider/routing metadata while avoiding raw media payload storage
- keep image endpoint oversized-input 4xx logging covered for the same error class
- log image edit preprocessing failures once per rejected request, even when multiple input images fail
- reuse a lazy per-request image log context instead of having the image log helper parse/query auth and project state itself
- add regression coverage for oversized image edit and video reference images
- document that future PRs should be opened ready for review unless draft mode is explicitly requested

## Verification
- pnpm format
- pnpm exec turbo run build --filter=gateway
- pnpm vitest run apps/gateway/src/api.spec.ts --no-file-parallelism
- pnpm vitest run apps/gateway/src/videos/videos.spec.ts --no-file-parallelism
- pnpm build

## Notes
- pnpm test:unit was attempted earlier, but the local suite failed outside this change in DB/Redis-backed specs: worker sync-models FK fixture failures, Redis ECONNREFUSED, and cascading API/gateway DB-backed failures. Focused gateway image/video coverage and builds pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error validation for oversized image payloads in image editing requests with clear error messaging including size limit details.
  * Enhanced error handling for oversized reference images in video generation requests.

* **Tests**
  * Added test coverage for oversized image payload rejection.
  * Added test coverage for oversized reference image validation in video operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->