### PR TITLE
perf(api): cache public provider stats aggregation

### DIFF
--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -1,7 +1,13 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
-import { and, db, gte, modelProviderMappingHistory, sql } from "@llmgateway/db";
+import {
+	and,
+	cdb,
+	gte,
+	modelProviderMappingHistory,
+	sql,
+} from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -42,6 +48,12 @@ const listRoute = createRoute({
 	},
 });
 
+// The provider grid tolerates several minutes of staleness (the UI itself sets
+// a 5-minute staleTime), and the worker only appends new minute rows, so a
+// short read-through cache turns the heavy full-window aggregation into at most
+// one Postgres hit per window value per TTL instead of one per request.
+const STATS_CACHE_TTL_SECONDS = 300;
+
 function windowToStartDate(window: string): Date {
 	const now = new Date();
 	const startDate = new Date(now);
@@ -64,7 +76,7 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 	const { window = "7d" } = c.req.valid("query");
 	const startDate = windowToStartDate(window);
 
-	const rows = await db
+	const rows = await cdb
 		.select({
 			providerId: modelProviderMappingHistory.providerId,
 			logsCount: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`,
@@ -77,7 +89,18 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 		})
 		.from(modelProviderMappingHistory)
 		.where(and(gte(modelProviderMappingHistory.minuteTimestamp, startDate)))
-		.groupBy(modelProviderMappingHistory.providerId);
+		.groupBy(modelProviderMappingHistory.providerId)
+		// Pin a stable, window-scoped cache tag. Without it Drizzle keys the
+		// cache on the rendered SQL + params, and `startDate` is derived from
+		// `now` on every request, so the key would never repeat and the heavy
+		// aggregation would run against Postgres each time. autoInvalidate is off
+		// so the result expires on the TTL alone rather than being busted by the
+		// worker's continuous minute-row inserts.
+		.$withCache({
+			tag: `publicProviderStats:${window}`,
+			autoInvalidate: false,
+			config: { ex: STATS_CACHE_TTL_SECONDS },
+		});
 
 	const providers = rows.map((r) => {
 		const logsCount = Number(r.logsCount) || 0;


### PR DESCRIPTION
## Where the slow query comes from

The 3-minute query is the aggregation in `apps/api/src/routes/public-providers-stats.ts`, which powers the providers grid (`apps/ui/src/components/providers/providers-grid.tsx`). It groups `model_provider_mapping_history` by `provider_id` over the requested window (default 7d, up to 30d).

Two things made it slow:

1. **No caching.** The endpoint is public and used `db` (uncached), so the full-window aggregation ran against Postgres on **every request**. `swrWrap` (used elsewhere) is only a stale-on-error fallback — it always runs the fetcher — so the real read-through cache in this repo is Drizzle's `cdb.$withCache`, exactly as `getProviderMetricsFromHistory` uses it.
2. **Unbounded table.** `model_provider_mapping_history` gets one row per (mapping, minute) and is **never pruned** — the data-retention job only nulls verbose columns on the `log` table. So the history table grows forever and the windowed scan touches millions of rows, with no covering index over the summed columns (heap fetch per row).

## This change

Routes the query through the cached client (`cdb`) with a stable, window-scoped tag and a 5-minute TTL (matching the UI's `staleTime`):

- The heavy aggregation now runs at most **once per window value per TTL** instead of once per request.
- `autoInvalidate: false` so the worker's continuous minute-row inserts don't bust the key; it expires on the TTL alone.
- The tag is pinned because `startDate` is derived from `now` each request — without it Drizzle would key on the rendered SQL+params and never get a cache hit (the same bug already documented in `provider-metrics-history.ts`).

## Follow-ups worth considering (not in this PR)

- **Covering index** on `model_provider_mapping_history (minute_timestamp) INCLUDE (provider_id, logs_count, errors_count, cached_count, total_time_to_first_token, total_output_tokens, total_duration)` to make the cold (cache-miss) query index-only instead of a heap scan. Note Drizzle 1.0.0-beta.1's index builder has no `include()`, so this needs a hand-edited migration SQL, and it adds write amplification on a hot, unbounded table.
- **Retention/pre-aggregation** for `model_provider_mapping_history` — the table grows unbounded; a rollup of windowed provider stats (or pruning old minute rows) would bound both this query and storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Public provider statistics endpoint now uses caching to deliver faster response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->