### PR TITLE
fix(zai): request and normalize web search citations

### DIFF
--- a/apps/gateway/src/chat-websearch.e2e.ts
+++ b/apps/gateway/src/chat-websearch.e2e.ts
@@ -19,6 +19,12 @@ const testWebSearch = process.env.TEST_WEB_SEARCH;
 // Skip all tests if TEST_WEB_SEARCH is not set
 const describeWebSearch = testWebSearch ? describe : describe.skip;
 
+// Z.ai GLM chat completions perform (and bill for) web search but currently
+// don't surface the source records back, even with `search_result: true`, so
+// there are no citation annotations to assert. The request still asks for them
+// and the parser normalizes a root-level `web_search` array when present, so
+// this exception only suppresses the annotation assertion — the web-search cost
+// assertion below still applies to Z.ai.
 const expectsWebSearchAnnotations = (model: string) =>
 	!model.startsWith("zai/");
 

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -48,6 +48,67 @@ describe("parseProviderResponse", () => {
 			expect(result.content).toBe("Current news summary.");
 			expect(result.webSearchCount).toBe(1);
 		});
+
+		it("normalizes root-level web_search source records into annotations", () => {
+			const json = {
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: "Summary with sources.",
+						},
+						finish_reason: "stop",
+					},
+				],
+				web_search: [
+					{
+						title: "Example article",
+						link: "https://example.com/article",
+						content: "Some snippet",
+						refer: "ref_1",
+					},
+					{
+						title: "Second source",
+						link: "https://example.org/news",
+						refer: "ref_2",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"zai",
+				"glm-5.2",
+				json,
+				[],
+				true,
+				false,
+				true,
+			);
+
+			expect(result.content).toBe("Summary with sources.");
+			expect(result.webSearchCount).toBe(2);
+			expect(result.annotations).toEqual([
+				{
+					type: "url_citation",
+					url_citation: {
+						url: "https://example.com/article",
+						title: "Example article",
+					},
+				},
+				{
+					type: "url_citation",
+					url_citation: {
+						url: "https://example.org/news",
+						title: "Second source",
+					},
+				},
+			]);
+		});
 	});
 
 	describe("google reasoning output", () => {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -948,11 +948,13 @@ export function parseProviderResponse(
 					webSearchCount = 1; // Search models bill per request, not per citation
 				}
 
-				// For ZAI, extract web search info if present
-				// ZAI includes web_search content in the response
+				// For ZAI, extract web search info if present.
+				// When `search_result: true` is requested, Z.ai returns the sources in
+				// a root-level `web_search` array (per Z.ai docs); some responses nest
+				// it under the message instead, so check both locations.
 				if (usedProvider === "zai") {
 					const webSearchResults =
-						json.choices?.[0]?.message?.web_search ?? null;
+						json.web_search ?? json.choices?.[0]?.message?.web_search ?? null;
 					if (webSearchResults && Array.isArray(webSearchResults)) {
 						webSearchCount = webSearchResults.length;
 						for (const result of webSearchResults) {
@@ -965,6 +967,9 @@ export function parseProviderResponse(
 							});
 						}
 					} else if (webSearchRequested) {
+						// GLM chat completions perform the search and bill for it, but
+						// don't always surface source records, so fall back to counting a
+						// single search when the tool was requested.
 						webSearchCount = 1;
 					}
 				}

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1557,7 +1557,9 @@ export async function prepareRequestBody(
 			}
 
 			// Add web search tool for ZAI
-			// ZAI uses a web_search tool with enable flag and search_engine config
+			// ZAI uses a web_search tool with enable flag and search_engine config.
+			// `search_result: true` asks Z.ai to return the source records so we can
+			// surface them as citation annotations (see parse-provider-response.ts).
 			if (webSearchTool) {
 				requestBody.tools ??= [];
 				requestBody.tools.push({
@@ -1565,6 +1567,7 @@ export async function prepareRequestBody(
 					web_search: {
 						enable: true,
 						search_engine: "search-prime",
+						search_result: true,
 					},
 				});
 			}


### PR DESCRIPTION
## Summary

Follow-up to the [Codex review on #2706](https://github.com/theopenco/llmgateway/pull/2706#discussion). The merged PR skipped the web-search citation assertion for `zai/*` instead of surfacing source records. This addresses the underlying concern: actually **request** the sources from Z.ai and **normalize** them into `message.annotations`.

### Changes
- **Request sources** (`packages/actions/src/prepare-request-body.ts`): the Z.ai `web_search` tool now sends `search_result: true`, the documented flag that asks Z.ai to return source records.
- **Normalize from the correct location** (`apps/gateway/src/chat/tools/parse-provider-response.ts`): per the Z.ai docs the `web_search` array is returned at the **root level** of the response, not under `choices[0].message`. The parser now reads `json.web_search` and falls back to the message-nested location. The `webSearchRequested` count fallback is kept and documented.
- **Unit test** (`parse-provider-response.spec.ts`): verifies a root-level `web_search` array is normalized into `url_citation` annotations with the right `webSearchCount`.
- **e2e** (`chat-websearch.e2e.ts`): documents *why* the annotation assertion is skipped for `zai/` — GLM chat completions perform and bill for the search but currently don't surface source records back, even with `search_result: true`. The web-search **cost** assertion still applies to Z.ai.

### Why the e2e exception stays
Tested live against the Z.ai API (`glm-5.2`/`glm-4.6`, multiple engines, `search_result` as both boolean and string): the chat completions endpoint never returns the `web_search` source array, although the standalone `/web_search` API does. So citations cannot be asserted for the available GLM models today — but the gateway now correctly requests and parses them, so any GLM model that does surface sources will produce annotations automatically.

## Validation
- `pnpm exec vitest run apps/gateway/src/chat/tools/parse-provider-response.spec.ts --no-file-parallelism` (26 passed)
- `DATABASE_URL=... TEST_MODELS="zai/glm-5.2" TEST_WEB_SEARCH=true E2E_TEST=true pnpm exec vitest run -c vitest/vitest.e2e.config.mts apps/gateway/src/chat-websearch.e2e.ts --no-file-parallelism` (4 passed, streaming + non-streaming)
- `pnpm format`
- `pnpm build` (17/17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Z.ai web search result extraction and citation handling for accurate cost tracking.

* **Tests**
  * Added test coverage for Z.ai web search functionality to verify proper result normalization and annotation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->