### PR TITLE
feat(anthropic): native passthrough for /v1/messages

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -4,6 +4,11 @@ import { streamSSE } from "hono/streaming";
 
 import { app } from "@/app.js";
 import {
+	NATIVE_ANTHROPIC_PASSTHROUGH_FIELD,
+	NATIVE_ANTHROPIC_PASSTHROUGH_HEADER,
+	nativeAnthropicPassthroughNonce,
+} from "@/chat/native-passthrough.js";
+import {
 	buildAnthropicErrorBody,
 	getAnthropicErrorType,
 } from "@/lib/error-response.js";
@@ -656,6 +661,11 @@ anthropic.openapi(messages, async (c) => {
 			"x-debug": c.req.header("x-debug") ?? "",
 			"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
 			...(sessionId ? { "x-session-id": sessionId } : {}),
+			// Ask the chat-completions pipeline to return the raw upstream
+			// Anthropic response verbatim when served by an Anthropic-native
+			// provider, so native content blocks (web search, citations,
+			// thinking) survive instead of the lossy OpenAI round-trip.
+			[NATIVE_ANTHROPIC_PASSTHROUGH_HEADER]: nativeAnthropicPassthroughNonce,
 		},
 		body: JSON.stringify(openaiRequest),
 	});
@@ -729,6 +739,52 @@ anthropic.openapi(messages, async (c) => {
 				const decoder = new TextDecoder();
 
 				let buffer = "";
+
+				// Native passthrough detection: the chat-completions pipeline emits a
+				// raw Anthropic SSE stream (which begins with `event: message_start`)
+				// when served by an Anthropic-native provider. A reconstructed stream
+				// (e.g. fallback to a non-Anthropic provider) is OpenAI chunks. Peek
+				// the first event(s) to classify; forward verbatim when native,
+				// otherwise fall through to the OpenAI->Anthropic reconstruction below
+				// (seeded with the already-read buffer).
+				let isNativePassthrough = false;
+				let classified = false;
+				while (!classified) {
+					const { done, value } = await reader.read();
+					if (done) {
+						classified = true;
+						break;
+					}
+					buffer += decoder.decode(value, { stream: true });
+					if (
+						/(^|\n)event: ?message_start(\r?\n|$)/.test(buffer) ||
+						/"type"\s*:\s*"message_start"/.test(buffer)
+					) {
+						isNativePassthrough = true;
+						classified = true;
+					} else if (
+						/"object"\s*:\s*"chat\.completion(\.chunk)?"/.test(buffer) ||
+						buffer.includes("data: [DONE]") ||
+						buffer.length > 65536
+					) {
+						classified = true;
+					}
+				}
+
+				if (isNativePassthrough) {
+					if (buffer) {
+						await stream.write(buffer);
+					}
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) {
+							break;
+						}
+						await stream.write(decoder.decode(value, { stream: true }));
+					}
+					return;
+				}
+
 				let messageId = "";
 				let model = "";
 				const contentBlocks: Array<{
@@ -1117,6 +1173,16 @@ anthropic.openapi(messages, async (c) => {
 		throw new HTTPException(500, {
 			message: `Failed to parse OpenAI response: ${error instanceof Error ? error.message : String(error)}`,
 		});
+	}
+
+	// Native Anthropic passthrough: when the pipeline served this request with an
+	// Anthropic-native provider, it attaches the raw upstream Anthropic body.
+	// Return it verbatim so web search (server_tool_use / web_search_tool_result),
+	// citations, and thinking blocks match the Messages API exactly.
+	const nativePassthrough =
+		openaiResponse?.[NATIVE_ANTHROPIC_PASSTHROUGH_FIELD];
+	if (nativePassthrough && typeof nativePassthrough === "object") {
+		return c.json(nativePassthrough);
 	}
 
 	// Transform OpenAI response to Anthropic format

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -5215,4 +5215,310 @@ describe("api", () => {
 			expect(JSON.stringify(json)).toContain("input_schema");
 		});
 	});
+
+	describe("native /v1/messages web search response shape", () => {
+		// For Anthropic-native providers, /v1/messages must return the raw upstream
+		// Anthropic response verbatim (native passthrough) so web search blocks
+		// (server_tool_use / web_search_tool_result) and inline citations match the
+		// Messages API exactly, rather than being collapsed to a plain text block by
+		// the OpenAI round-trip.
+		const nativeWebSearchContent = [
+			{ type: "text", text: "Let me search for that." },
+			{
+				type: "server_tool_use",
+				id: "srvtoolu_1",
+				name: "web_search",
+				input: { query: "anthropic web search tool version" },
+			},
+			{
+				type: "web_search_tool_result",
+				tool_use_id: "srvtoolu_1",
+				content: [
+					{
+						type: "web_search_result",
+						title: "Web search tool",
+						url: "https://docs.anthropic.com/web-search",
+						encrypted_content: "ENCRYPTED_CONTENT_BLOB",
+						page_age: "2 days ago",
+					},
+				],
+			},
+			{
+				type: "text",
+				text: "The latest version is web_search_20250305.",
+				citations: [
+					{
+						type: "web_search_result_location",
+						cited_text: "web search tool",
+						url: "https://docs.anthropic.com/web-search",
+						title: "Web search tool",
+						encrypted_index: "ENCRYPTED_INDEX",
+					},
+				],
+			},
+		];
+
+		function spyAnthropicResponse(body: unknown, contentType: string) {
+			const originalFetch = globalThis.fetch;
+			return vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(async (input, init) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url;
+					if (url.includes(`${mockServerUrl}/v1/messages`)) {
+						return new Response(
+							typeof body === "string" ? body : JSON.stringify(body),
+							{ status: 200, headers: { "Content-Type": contentType } },
+						);
+					}
+					return await originalFetch(input as RequestInfo | URL, init);
+				});
+		}
+
+		test("returns native web search content blocks verbatim (non-streaming)", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const requestId = `native-ws-nonstream-${Date.now()}`;
+			const fetchSpy = spyAnthropicResponse(
+				{
+					id: "msg_ws_native",
+					type: "message",
+					role: "assistant",
+					model: "claude-sonnet-4-6",
+					content: nativeWebSearchContent,
+					stop_reason: "end_turn",
+					stop_sequence: null,
+					usage: { input_tokens: 50, output_tokens: 30 },
+				},
+				"application/json",
+			);
+
+			try {
+				const res = await app.request("/v1/messages", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+						"x-request-id": requestId,
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-sonnet-4-6",
+						max_tokens: 1024,
+						messages: [
+							{
+								role: "user",
+								content: "What is the latest web search version?",
+							},
+						],
+						tools: [{ type: "web_search_20250305", name: "web_search" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				// The content array must match the upstream Anthropic body verbatim,
+				// including encrypted_content / encrypted_index / page_age / citations.
+				expect(json.content).toEqual(nativeWebSearchContent);
+				expect(json.stop_reason).toBe("end_turn");
+				// The private passthrough field must never leak to the client.
+				expect(json.__nativeAnthropicPassthrough).toBeUndefined();
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			// Billing still runs: the web_search_tool_result block is counted.
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(Number(logs[0].webSearchCost)).toBeGreaterThan(0);
+		});
+
+		test("streams native web search SSE events verbatim", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const sse = [
+				`event: message_start\ndata: ${JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_ws_stream",
+						type: "message",
+						role: "assistant",
+						model: "claude-sonnet-4-6",
+						content: [],
+						stop_reason: null,
+						stop_sequence: null,
+						usage: { input_tokens: 50, output_tokens: 1 },
+					},
+				})}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: {
+						type: "server_tool_use",
+						id: "srvtoolu_1",
+						name: "web_search",
+						input: {},
+					},
+				})}\n\n`,
+				`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 1,
+					content_block: {
+						type: "web_search_tool_result",
+						tool_use_id: "srvtoolu_1",
+						content: [
+							{
+								type: "web_search_result",
+								title: "Web search tool",
+								url: "https://docs.anthropic.com/web-search",
+								encrypted_content: "ENCRYPTED_CONTENT_BLOB",
+								page_age: "2 days ago",
+							},
+						],
+					},
+				})}\n\n`,
+				`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 1 })}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 2,
+					content_block: { type: "text", text: "" },
+				})}\n\n`,
+				`event: content_block_delta\ndata: ${JSON.stringify({
+					type: "content_block_delta",
+					index: 2,
+					delta: { type: "text_delta", text: "Version web_search_20250305." },
+				})}\n\n`,
+				`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 2 })}\n\n`,
+				`event: message_delta\ndata: ${JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn", stop_sequence: null },
+					usage: { output_tokens: 25 },
+				})}\n\n`,
+				`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+			].join("");
+
+			const fetchSpy = spyAnthropicResponse(sse, "text/event-stream");
+
+			try {
+				const res = await app.request("/v1/messages", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-sonnet-4-6",
+						max_tokens: 1024,
+						stream: true,
+						messages: [{ role: "user", content: "Search the web." }],
+						tools: [{ type: "web_search_20250305", name: "web_search" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const raw = await res.text();
+
+				// Native Anthropic events are forwarded verbatim, not converted to
+				// OpenAI chat.completion.chunk events.
+				expect(raw).toContain("event: message_start");
+				expect(raw).toContain('"type":"server_tool_use"');
+				expect(raw).toContain('"type":"web_search_tool_result"');
+				expect(raw).toContain('"encrypted_content":"ENCRYPTED_CONTENT_BLOB"');
+				expect(raw).toContain("event: message_stop");
+				// No OpenAI-shaped output.
+				expect(raw).not.toContain("chat.completion.chunk");
+				expect(raw).not.toContain("data: [DONE]");
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
+		test("does not passthrough for a forged header on /v1/chat/completions", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const fetchSpy = spyAnthropicResponse(
+				{
+					id: "msg_forge",
+					type: "message",
+					role: "assistant",
+					model: "claude-sonnet-4-6",
+					content: nativeWebSearchContent,
+					stop_reason: "end_turn",
+					stop_sequence: null,
+					usage: { input_tokens: 50, output_tokens: 30 },
+				},
+				"application/json",
+			);
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+						// A forged value can't match the per-process nonce.
+						"x-native-anthropic-passthrough": "1",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-sonnet-4-6",
+						messages: [{ role: "user", content: "hi" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				// Normal OpenAI envelope; passthrough must not have triggered.
+				expect(json.choices?.[0]?.message).toBeDefined();
+				expect(json.__nativeAnthropicPassthrough).toBeUndefined();
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -149,6 +149,12 @@ import {
 	type ResolvedRoutingConfig,
 } from "@llmgateway/shared/routing-config";
 
+import {
+	NATIVE_ANTHROPIC_PASSTHROUGH_FIELD,
+	NATIVE_ANTHROPIC_PASSTHROUGH_HEADER,
+	isAnthropicNativeProvider,
+	nativeAnthropicPassthroughNonce,
+} from "./native-passthrough.js";
 import { completionsRequestSchema } from "./schemas/completions.js";
 import { anthropicRequestNeedsEffortBeta } from "./tools/anthropic-effort-beta.js";
 import { buildRoutingAttempt } from "./tools/build-routing-attempt.js";
@@ -1629,6 +1635,13 @@ chat.openapi(completions, async (c) => {
 	const logIdOverride = responsesContext?.logId;
 	const finalLogId = logIdOverride ?? shortid();
 	const responsesApiData: unknown = responsesContext?.responsesApiData ?? null;
+
+	// Native Anthropic passthrough: the /v1/messages endpoint sets this header
+	// (to a per-process nonce external clients can't forge) to request the raw
+	// upstream Anthropic response verbatim for Anthropic-native providers.
+	const nativeAnthropicPassthroughRequested =
+		c.req.header(NATIVE_ANTHROPIC_PASSTHROUGH_HEADER) ===
+		nativeAnthropicPassthroughNonce;
 
 	// Wrapper that injects Responses API fields into every log entry.
 	// Only override the id for the final log entry (retried !== true) to avoid
@@ -4774,6 +4787,10 @@ chat.openapi(completions, async (c) => {
 			prompt_cache_retention,
 			n,
 			service_tier,
+			// Namespace /v1/messages-origin requests (which always carry the nonce)
+			// separately so a native-passthrough response is never served to a
+			// direct /v1/chat/completions caller and vice versa.
+			nativeAnthropicPassthrough: nativeAnthropicPassthroughRequested,
 		};
 
 		if (stream) {
@@ -5840,6 +5857,10 @@ chat.openapi(completions, async (c) => {
 				let canceled = false;
 				let streamingError: unknown = null;
 				let doneSent = false; // Track if [DONE] has been sent downstream
+				// When true, forward raw upstream Anthropic SSE events verbatim
+				// instead of transforming to OpenAI chunks (native passthrough).
+				// Set once the serving provider is known (before the read loop).
+				let nativeAnthropicPassthroughStreaming = false;
 
 				// Raw logging variables
 				let streamingRawResponseData = ""; // Raw SSE data sent back to the client
@@ -5889,8 +5910,15 @@ chat.openapi(completions, async (c) => {
 						streamingRawResponseData += sseString;
 					}
 
-					// Capture for streaming cache if enabled
-					if (cachingEnabled && streamingCacheKey) {
+					// Capture for streaming cache if enabled. Native-passthrough
+					// streams are not cached: the cached-replay path re-injects an
+					// OpenAI metadata chunk that would corrupt a native Anthropic
+					// stream, and web-search responses are dynamic anyway.
+					if (
+						cachingEnabled &&
+						streamingCacheKey &&
+						!nativeAnthropicPassthroughStreaming
+					) {
 						streamingChunks.push({
 							data: sseData.data,
 							eventId: sseData.id ? parseInt(sseData.id, 10) : eventId,
@@ -7392,6 +7420,11 @@ chat.openapi(completions, async (c) => {
 				}
 
 				const reader = res.body.getReader();
+				// The serving provider is now final for this attempt; enable native
+				// passthrough only for Anthropic-native providers.
+				nativeAnthropicPassthroughStreaming =
+					nativeAnthropicPassthroughRequested &&
+					isAnthropicNativeProvider(usedProvider);
 				let fullContent = "";
 				let fullReasoningContent = "";
 				let finishReason = null;
@@ -8223,6 +8256,23 @@ chat.openapi(completions, async (c) => {
 									break;
 								}
 
+								// Native Anthropic passthrough: forward the raw upstream
+								// event verbatim (preserving server_tool_use /
+								// web_search_tool_result / citations) before the lossy
+								// OpenAI transform. Done here, before the null-transform
+								// skip below, so events that map to no OpenAI chunk (e.g.
+								// server_tool_use input_json_delta) are still forwarded.
+								// Billing accounting (webSearchCount, usage) below reads
+								// raw `data` and still runs.
+								if (nativeAnthropicPassthroughStreaming) {
+									await writeSSEAndCache({
+										event:
+											typeof data?.type === "string" ? data.type : undefined,
+										data: JSON.stringify(data),
+										id: String(eventId++),
+									});
+								}
+
 								// Transform streaming responses to OpenAI format for all providers
 								const transformedData = transformStreamingToOpenai(
 									streamFormatProvider,
@@ -8441,7 +8491,10 @@ chat.openapi(completions, async (c) => {
 
 								// When buffering for healing, strip content from chunks and buffer it
 								// We still send metadata (usage, finish_reason, tool_calls) but buffer text content
-								if (shouldBufferForHealing) {
+								if (nativeAnthropicPassthroughStreaming) {
+									// Already forwarded the raw event above; don't also emit
+									// the transformed OpenAI chunk.
+								} else if (shouldBufferForHealing) {
 									const deltaContent =
 										transformedData.choices?.[0]?.delta?.content;
 									if (deltaContent) {
@@ -9202,7 +9255,11 @@ chat.openapi(completions, async (c) => {
 									: new Error(String(sseError)),
 							);
 						}
-					} else if (!streamingError && !doneSent) {
+					} else if (
+						!streamingError &&
+						!doneSent &&
+						!nativeAnthropicPassthroughStreaming
+					) {
 						if (
 							finishReason &&
 							!sentDownstreamFinishReasonChunk &&
@@ -11638,6 +11695,21 @@ chat.openapi(completions, async (c) => {
 		...transformedMetadata,
 		...buildFinalResponseMetadata(costs.discount ?? null),
 	};
+
+	// Native Anthropic passthrough: attach the raw upstream Anthropic body so the
+	// /v1/messages handler can return it verbatim (preserving web search /
+	// citation / thinking blocks). Gated on the un-forgeable nonce, so it never
+	// reaches a direct /v1/chat/completions client. Attached before caching so
+	// cache hits also serve it; the field rides through caching unchanged (the
+	// strip/metadata helpers only touch `metadata`).
+	if (
+		nativeAnthropicPassthroughRequested &&
+		isAnthropicNativeProvider(usedProvider)
+	) {
+		(transformedResponse as Record<string, unknown>)[
+			NATIVE_ANTHROPIC_PASSTHROUGH_FIELD
+		] = json;
+	}
 
 	// Extract plugin IDs for logging
 	const pluginIds = plugins?.map((p) => p.id) ?? [];

--- a/apps/gateway/src/chat/native-passthrough.ts
+++ b/apps/gateway/src/chat/native-passthrough.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto";
+
+import type { Provider } from "@llmgateway/models";
+
+/**
+ * Native Anthropic passthrough signalling.
+ *
+ * The native Anthropic `/v1/messages` endpoint serves requests by calling the
+ * internal `/v1/chat/completions` pipeline and translating the response back to
+ * Anthropic shape. That round-trip is lossy for Anthropic-native content (web
+ * search `server_tool_use`/`web_search_tool_result` blocks, inline citations,
+ * thinking blocks). When the resolved provider is Anthropic-native, the upstream
+ * response is already in the exact shape the client wants, so the pipeline
+ * returns it verbatim instead.
+ *
+ * `/v1/messages` asks for this by setting the header below to the per-process
+ * nonce. The nonce is random and never exposed to clients, so a direct
+ * `/v1/chat/completions` request cannot forge it (a static value would be
+ * forgeable since both endpoints share the same Hono app). The header is only
+ * ever set on the internal `app.request()` call and is never forwarded to an
+ * upstream provider or logged.
+ */
+export const NATIVE_ANTHROPIC_PASSTHROUGH_HEADER =
+	"x-native-anthropic-passthrough";
+
+export const nativeAnthropicPassthroughNonce = randomUUID();
+
+/**
+ * Field carrying the raw upstream Anthropic response body on the internal
+ * OpenAI response object. Only present when passthrough is active; read and
+ * stripped by the `/v1/messages` handler.
+ */
+export const NATIVE_ANTHROPIC_PASSTHROUGH_FIELD =
+	"__nativeAnthropicPassthrough";
+
+/**
+ * Providers whose native response is already the Anthropic Messages shape.
+ * aws-bedrock uses the Converse API shape and is intentionally excluded.
+ */
+export function isAnthropicNativeProvider(provider: Provider): boolean {
+	return provider === "anthropic" || provider === "vertex-anthropic";
+}


### PR DESCRIPTION
## Problem

Follow-up to #2702. The native Anthropic `/v1/messages` endpoint serves requests by translating them into the internal OpenAI `/v1/chat/completions` pipeline and converting the response back to Anthropic shape. That round-trip is **lossy**: for web search it collapses the native content into a single `text` block, dropping the `server_tool_use` query block, the `web_search_tool_result` block (with `encrypted_content`/`page_age`), and the inline `citations` (`web_search_result_location` with `cited_text`/`encrypted_index`). The response shape didn't match Anthropic's Messages API.

Reported comparison: https://gist.github.com/mcowger/4b5ac55db15999fb38045fe9700039ef

## Fix — native passthrough

When the resolved provider is **Anthropic-native** (`anthropic`, `vertex-anthropic`), the upstream response is already in the exact shape the client wants, so the gateway returns it **verbatim** — both non-streaming JSON and streaming SSE — instead of reconstructing it. Billing/logging still run unchanged (web search is still counted and billed).

`/v1/messages` signals this to the chat pipeline via an **un-forgeable per-process nonce header**, so a direct `/v1/chat/completions` request can't trigger passthrough. Non-Anthropic providers (e.g. fallback to bedrock/OpenAI) keep the existing OpenAI→Anthropic reconstruction.

### How it works
- **`native-passthrough.ts`** (new): the nonce/header, the gated response field, and the `isAnthropicNativeProvider` check.
- **`chat.ts`**:
  - Non-streaming: attach the raw upstream Anthropic body under a private gated field on the response (only when the nonce is present and the provider is Anthropic-native).
  - Streaming: forward the raw Anthropic SSE events verbatim (before the lossy OpenAI transform, so `server_tool_use`/`web_search_tool_result` events that map to no OpenAI chunk are preserved), skip the transformed write, and skip the OpenAI finish/`[DONE]` synthesis. Web-search counting and cost still run via the existing `calculateCosts` path.
  - Cache key namespaces `/v1/messages`-origin requests so passthrough and non-passthrough responses never collide; passthrough streams aren't cached (avoids the replay metadata-chunk injection corrupting a native stream).
- **`anthropic.ts`**:
  - Sets the nonce header on the internal request.
  - Non-streaming: returns the gated raw body verbatim.
  - Streaming: peeks the first SSE event — if it's a native Anthropic stream (`event: message_start`) it forwards the bytes raw; otherwise it falls back to the existing reconstruction (robust against fallback to a non-Anthropic provider, with no response-header timing issues).

This also improves fidelity of `thinking`/`tool_use` blocks for all Anthropic-native `/v1/messages` responses, not just web search.

## Tests

New deterministic specs in `apps/gateway/src/api.spec.ts`:
- **Non-streaming verbatim**: the response `content` deep-equals the upstream Anthropic blocks (incl. `encrypted_content`, `page_age`, `encrypted_index`, citations); the private field never leaks; web search is billed (`webSearchCost > 0`).
- **Streaming verbatim**: native SSE events are forwarded (`message_start`, `server_tool_use`/`web_search_tool_result` `content_block_start`, `message_stop`) with no `chat.completion.chunk`/`[DONE]`.
- **Security**: a forged `x-native-anthropic-passthrough` header on `/v1/chat/completions` does not trigger passthrough.

### Manual verification (live gateway, real Anthropic key)
- Non-streaming gist payload → response contains `server_tool_use` + `web_search_tool_result` (with `encrypted_content`/`page_age`) + text with `web_search_result_location` citations + `usage.server_tool_use`.
- Streaming → native event sequence with no OpenAI leakage.
- Both billed `web_search_cost = 0.0095` ($0.01 × 1 search × 0.95 discount).

`pnpm build`, `pnpm format`, and the new + existing `/v1/messages` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native Anthropic responses, including web search results, citations, and thinking blocks, are now returned verbatim without transformation.
  * Streaming and non-streaming requests preserve encrypted content and special fields.

* **Tests**
  * Added test coverage for native Anthropic passthrough responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->