### PR TITLE
feat(responses): resolve item_reference input items

### DIFF
--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -10,6 +10,7 @@ import {
 	createCompletionEvents,
 	createFailedEvent,
 } from "./tools/convert-streaming-to-responses.js";
+import { resolveItemReferences } from "./tools/response-state.js";
 
 vi.mock("@llmgateway/db", async (importOriginal) => {
 	const actual = await importOriginal<Record<string, unknown>>();
@@ -20,6 +21,9 @@ vi.mock("@llmgateway/db", async (importOriginal) => {
 				from: vi.fn().mockReturnValue({
 					where: vi.fn().mockReturnValue({
 						limit: vi.fn().mockResolvedValue([]),
+						orderBy: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([]),
+						}),
 					}),
 				}),
 			}),
@@ -31,6 +35,14 @@ vi.mock("@llmgateway/db", async (importOriginal) => {
 		},
 	};
 });
+
+const redisGet = vi.fn();
+vi.mock("@llmgateway/cache", () => ({
+	redisClient: {
+		get: (...args: unknown[]) => redisGet(...args),
+		set: vi.fn().mockResolvedValue("OK"),
+	},
+}));
 
 vi.mock("@llmgateway/logger", () => ({
 	logger: {
@@ -95,6 +107,24 @@ describe("responsesRequestSchema", () => {
 
 		expect(result.success).toBe(true);
 		expect(result.data?.reasoning?.effort).toBe("high");
+	});
+
+	it("accepts item_reference items mixed with messages and outputs", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "gpt-5.5",
+			input: [
+				{ role: "developer", content: "be helpful" },
+				{ role: "user", content: "hi" },
+				{ type: "item_reference", id: "fc_97KANutVc7ZxBoNerPUN1FE2" },
+				{
+					type: "function_call_output",
+					call_id: "call_rvsx8tvgGBCjGB8HitLxPG1F",
+					output: "done",
+				},
+			],
+		});
+
+		expect(result.success).toBe(true);
 	});
 });
 
@@ -625,5 +655,77 @@ describe("streaming conversion", () => {
 		expect(data.type).toBe("response.failed");
 		expect(data.response.status).toBe("failed");
 		expect(data.response.id).toBe(state.responseId);
+	});
+});
+
+describe("resolveItemReferences", () => {
+	const storedFunctionCall = {
+		type: "function_call",
+		id: "fc_97KANutVc7ZxBoNerPUN1FE2",
+		call_id: "call_rvsx8tvgGBCjGB8HitLxPG1F",
+		name: "view_image",
+		arguments: '{"path":"/tmp/a.png"}',
+		status: "completed",
+	};
+
+	it("returns input unchanged when there are no item_reference items", async () => {
+		const input = [
+			{ role: "user", content: "hi" },
+			{ type: "function_call_output", call_id: "call_1", output: "done" },
+		];
+		const result = await resolveItemReferences(input, "project_1");
+		expect(result).toBe(input);
+		expect(redisGet).not.toHaveBeenCalled();
+	});
+
+	it("replaces an item_reference with the resolved stored item", async () => {
+		redisGet.mockResolvedValueOnce(JSON.stringify(storedFunctionCall));
+		const input = [
+			{ role: "developer", content: "be helpful" },
+			{ role: "user", content: "hi" },
+			{ type: "item_reference", id: "fc_97KANutVc7ZxBoNerPUN1FE2" },
+			{
+				type: "function_call_output",
+				call_id: "call_rvsx8tvgGBCjGB8HitLxPG1F",
+				output: "done",
+			},
+		];
+
+		const resolved = await resolveItemReferences(input, "project_1");
+
+		expect(resolved[2]).toEqual(storedFunctionCall);
+
+		// The resolved function_call must convert into an assistant tool_calls
+		// message that precedes the tool result, otherwise strict providers reject
+		// the orphaned tool message.
+		const messages = convertResponsesInputToMessages(
+			resolved as Parameters<typeof convertResponsesInputToMessages>[0],
+		);
+		const assistantIdx = messages.findIndex((m) => m.role === "assistant");
+		const toolIdx = messages.findIndex((m) => m.role === "tool");
+		expect(assistantIdx).toBeGreaterThanOrEqual(0);
+		expect(toolIdx).toBeGreaterThan(assistantIdx);
+		expect(messages[assistantIdx]!.tool_calls).toEqual([
+			{
+				id: "call_rvsx8tvgGBCjGB8HitLxPG1F",
+				type: "function",
+				function: {
+					name: "view_image",
+					arguments: '{"path":"/tmp/a.png"}',
+				},
+			},
+		]);
+	});
+
+	it("drops item_reference items that cannot be resolved", async () => {
+		redisGet.mockResolvedValueOnce(null);
+		const input = [
+			{ role: "user", content: "hi" },
+			{ type: "item_reference", id: "fc_missing" },
+		];
+
+		const resolved = await resolveItemReferences(input, "project_1");
+
+		expect(resolved).toEqual([{ role: "user", content: "hi" }]);
 	});
 });

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -33,7 +33,11 @@ import {
 	createCompletionEvents,
 	createFailedEvent,
 } from "./tools/convert-streaming-to-responses.js";
-import { storeResponse, getStoredResponse } from "./tools/response-state.js";
+import {
+	storeResponse,
+	getStoredResponse,
+	resolveItemReferences,
+} from "./tools/response-state.js";
 
 import type { ServerTypes } from "@/vars.js";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -216,6 +220,11 @@ responses.post("/", async (c) => {
 			req.instructions = stored.instructions;
 		}
 	}
+
+	// Resolve any item_reference items (e.g. a function_call the gateway emitted
+	// in a prior response that a stateful client references instead of resending)
+	// back to their concrete stored items before conversion.
+	inputItems = await resolveItemReferences(inputItems, projectId);
 
 	// Convert Responses API input to chat completions messages
 	const messages = convertResponsesInputToMessages(
@@ -429,16 +438,20 @@ responses.post("/", async (c) => {
 							completionEvents[completionEvents.length - 1]!.data,
 						);
 						const completedResponse = completedData.response;
-						await storeResponse(logId, {
-							id: logId,
-							input: inputItems,
-							output: completedResponse?.output ?? [],
-							instructions: req.instructions,
-							model: req.model,
-							status: completedResponse?.status ?? "completed",
-							usage: completedResponse?.usage,
-							created_at: completedResponse?.created_at,
-						});
+						await storeResponse(
+							logId,
+							{
+								id: logId,
+								input: inputItems,
+								output: completedResponse?.output ?? [],
+								instructions: req.instructions,
+								model: req.model,
+								status: completedResponse?.status ?? "completed",
+								usage: completedResponse?.usage,
+								created_at: completedResponse?.created_at,
+							},
+							projectId,
+						);
 					}
 					return true;
 				}
@@ -513,18 +526,25 @@ responses.post("/", async (c) => {
 
 	// Store for previous_response_id (unless store: false)
 	if (shouldStore) {
-		await storeResponse(logId, {
-			id: logId,
-			input: inputItems,
-			output: responsesResponse.output,
-			instructions: req.instructions,
-			model: req.model,
-			status: responsesResponse.status as "completed" | "incomplete" | "failed",
-			usage: (responsesResponse.usage ?? undefined) as
-				| Record<string, unknown>
-				| undefined,
-			created_at: responsesResponse.created_at,
-		});
+		await storeResponse(
+			logId,
+			{
+				id: logId,
+				input: inputItems,
+				output: responsesResponse.output,
+				instructions: req.instructions,
+				model: req.model,
+				status: responsesResponse.status as
+					| "completed"
+					| "incomplete"
+					| "failed",
+				usage: (responsesResponse.usage ?? undefined) as
+					| Record<string, unknown>
+					| undefined,
+				created_at: responsesResponse.created_at,
+			},
+			projectId,
+		);
 	}
 
 	return c.json(responsesResponse);
@@ -641,6 +661,8 @@ responses.post("/compact", async (c) => {
 		}
 	}
 
+	inputItems = await resolveItemReferences(inputItems, project.id);
+
 	if (inputItems.length === 0) {
 		return c.json(
 			{
@@ -752,16 +774,20 @@ responses.post("/compact", async (c) => {
 		createdAt,
 	);
 
-	await storeResponse(compactionId, {
-		id: compactionId,
-		input: inputItems,
-		output: compactionResponse.output,
-		instructions: req.instructions,
-		model: req.model,
-		status: "completed",
-		usage: compactionResponse.usage as unknown as Record<string, unknown>,
-		created_at: createdAt,
-	});
+	await storeResponse(
+		compactionId,
+		{
+			id: compactionId,
+			input: inputItems,
+			output: compactionResponse.output,
+			instructions: req.instructions,
+			model: req.model,
+			status: "completed",
+			usage: compactionResponse.usage as unknown as Record<string, unknown>,
+			created_at: createdAt,
+		},
+		project.id,
+	);
 
 	return c.json(compactionResponse);
 });

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -91,11 +91,22 @@ const reasoningItemSchema = z.object({
 	status: z.enum(["in_progress", "completed", "incomplete"]).optional(),
 });
 
+// Reference to an item produced by a previous (stored) response. Stateful
+// clients send these instead of re-sending the full item (e.g. a function_call
+// the gateway emitted earlier). The id points at the `id` of a stored output
+// item (e.g. `fc_...`, `msg_...`, `rs_...`) and is resolved back to the full
+// item before conversion to chat messages.
+const itemReferenceItemSchema = z.object({
+	type: z.literal("item_reference"),
+	id: z.string(),
+});
+
 const inputItemSchema = z.union([
 	messageItemSchema,
 	reasoningItemSchema,
 	functionCallItemSchema,
 	functionCallOutputItemSchema,
+	itemReferenceItemSchema,
 ]);
 
 export const responsesRequestSchema = z.object({

--- a/apps/gateway/src/responses/tools/response-state.ts
+++ b/apps/gateway/src/responses/tools/response-state.ts
@@ -1,4 +1,5 @@
-import { and, db, eq, log } from "@llmgateway/db";
+import { redisClient } from "@llmgateway/cache";
+import { and, db, desc, eq, gte, log, sql } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
 export interface StoredResponseData {
@@ -12,6 +13,160 @@ export interface StoredResponseData {
 	created_at?: number;
 }
 
+// TTL for the per-item index used to resolve `item_reference` input items.
+// The Responses API requires full data retention, so a generous window is safe;
+// in practice references are resolved on the immediately following turn.
+const ITEM_INDEX_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+// Only the DB fallback for item resolution scans rows within this recent window
+// to keep the (un-indexed) JSONB containment query bounded.
+const ITEM_FALLBACK_LOOKBACK_MS = ITEM_INDEX_TTL_SECONDS * 1000;
+
+function itemIndexKey(projectId: string, itemId: string): string {
+	return `responses:item:${projectId}:${itemId}`;
+}
+
+/**
+ * Index individual response items (by their `id`) so they can later be resolved
+ * from an `item_reference` input item. Stateful clients reference prior items
+ * (e.g. a `function_call` the gateway emitted) by id instead of re-sending them.
+ */
+async function indexResponseItems(
+	projectId: string,
+	items: unknown[],
+): Promise<void> {
+	const writes: Promise<unknown>[] = [];
+	for (const item of items) {
+		if (!item || typeof item !== "object") {
+			continue;
+		}
+		const id = (item as { id?: unknown }).id;
+		const type = (item as { type?: unknown }).type;
+		// item_reference items are pointers, not concrete items — never index them.
+		if (typeof id !== "string" || typeof type !== "string") {
+			continue;
+		}
+		if (type === "item_reference") {
+			continue;
+		}
+		writes.push(
+			redisClient.set(
+				itemIndexKey(projectId, id),
+				JSON.stringify(item),
+				"EX",
+				ITEM_INDEX_TTL_SECONDS,
+			),
+		);
+	}
+	if (writes.length === 0) {
+		return;
+	}
+	try {
+		await Promise.all(writes);
+	} catch (error) {
+		logger.warn("Failed to index response items for item_reference", {
+			projectId,
+			error,
+		});
+	}
+}
+
+/**
+ * Resolve an `item_reference` id to the concrete stored item it points at.
+ * Tries the fast Redis index first, then falls back to a project-scoped lookup
+ * over recently stored responses. Returns null when the item cannot be found.
+ */
+export async function resolveStoredItem(
+	itemId: string,
+	projectId: string,
+): Promise<Record<string, unknown> | null> {
+	try {
+		const cached = await redisClient.get(itemIndexKey(projectId, itemId));
+		if (cached) {
+			return JSON.parse(cached) as Record<string, unknown>;
+		}
+	} catch (error) {
+		logger.warn("Failed to read item index from Redis", { itemId, error });
+	}
+
+	// Fallback: scan recently stored responses for an output/input item with this
+	// id. Bounded by project and a recent time window to keep the un-indexed
+	// JSONB containment query cheap.
+	try {
+		const cutoff = new Date(Date.now() - ITEM_FALLBACK_LOOKBACK_MS);
+		const match = sql`(${log.responsesApiData} -> 'output' @> ${JSON.stringify([{ id: itemId }])}::jsonb OR ${log.responsesApiData} -> 'input' @> ${JSON.stringify([{ id: itemId }])}::jsonb)`;
+		const rows = await db
+			.select({ responsesApiData: log.responsesApiData })
+			.from(log)
+			.where(
+				and(eq(log.projectId, projectId), gte(log.createdAt, cutoff), match),
+			)
+			.orderBy(desc(log.createdAt))
+			.limit(1);
+
+		const data = rows[0]?.responsesApiData as
+			| { input?: unknown[]; output?: unknown[] }
+			| undefined;
+		if (!data) {
+			return null;
+		}
+		const found = [...(data.output ?? []), ...(data.input ?? [])].find(
+			(it) =>
+				it &&
+				typeof it === "object" &&
+				(it as { id?: unknown }).id === itemId &&
+				(it as { type?: unknown }).type !== "item_reference",
+		);
+		return (found as Record<string, unknown>) ?? null;
+	} catch (error) {
+		logger.warn("Failed to resolve stored item from DB", { itemId, error });
+		return null;
+	}
+}
+
+/**
+ * Replace any `item_reference` input items with the concrete stored items they
+ * point at. Unresolvable references are dropped (with a warning) rather than
+ * failing the whole request. Non-reference items pass through unchanged.
+ */
+export async function resolveItemReferences(
+	inputItems: unknown[],
+	projectId: string,
+): Promise<unknown[]> {
+	const hasReference = inputItems.some(
+		(it) =>
+			it &&
+			typeof it === "object" &&
+			(it as { type?: unknown }).type === "item_reference",
+	);
+	if (!hasReference) {
+		return inputItems;
+	}
+
+	const resolved: unknown[] = [];
+	for (const item of inputItems) {
+		if (
+			!item ||
+			typeof item !== "object" ||
+			(item as { type?: unknown }).type !== "item_reference"
+		) {
+			resolved.push(item);
+			continue;
+		}
+		const id = (item as { id?: unknown }).id;
+		if (typeof id !== "string") {
+			continue;
+		}
+		const found = await resolveStoredItem(id, projectId);
+		if (found) {
+			resolved.push(found);
+		} else {
+			logger.warn("Dropping unresolvable item_reference", { id, projectId });
+		}
+	}
+	return resolved;
+}
+
 /**
  * Update the log entry's responsesApiData with the complete response data (including output).
  * The log entry was inserted synchronously with partial data (output: []).
@@ -20,6 +175,7 @@ export interface StoredResponseData {
 export async function storeResponse(
 	logId: string,
 	data: StoredResponseData,
+	projectId?: string,
 ): Promise<void> {
 	try {
 		await db
@@ -31,6 +187,16 @@ export async function storeResponse(
 			logId,
 			error,
 		});
+	}
+
+	// Index items so future item_reference inputs can resolve them. Index both
+	// input and output: input may carry items resolved on earlier turns, keeping
+	// long-running references fresh.
+	if (projectId) {
+		await indexResponseItems(projectId, [
+			...(data.output ?? []),
+			...(data.input ?? []),
+		]);
 	}
 }
 


### PR DESCRIPTION
## Problem

Stateful Responses API clients (e.g. Codex / soulforge) drive multi-turn tool conversations by **re-sending the whole conversation each turn**, but instead of resending an item the gateway produced earlier (like an assistant `function_call`), they reference it by id:

```json
{ "type": "item_reference", "id": "fc_97KANutVc7ZxBoNerPUN1FE2" }
```

Our `/v1/responses` endpoint is stateless per request and the input schema didn't allow `item_reference`, so the second turn (the one replaying the tool call + its output) failed:

```
400 Invalid request: input: Invalid input
```

Reproduced exactly against the gateway: turn 0 → `200`, turn 1 (developer + user + `item_reference` → `fc_…` + `function_call_output`) → `400`.

## Fix

- **Schema**: accept `{ type: "item_reference", id }` as an input item (`apps/gateway/src/responses/schemas.ts`).
- **Indexing**: at store time, index each stored response's items (both `input` and `output`) by their `id` in Redis (`responses:item:<projectId>:<id>`), TTL 30d. Threaded `projectId` into `storeResponse`.
- **Resolution**: before converting input → chat messages, replace each `item_reference` with the concrete stored item it points at. Fast Redis lookup first, then a project-scoped, time-bounded fallback over recently stored responses if the index is cold. Unresolvable references are dropped (with a warning) rather than failing the whole request.
- Applied to both `/v1/responses` and `/v1/responses/compact`.

The resolved `function_call` then flows through the existing converter, producing an assistant `tool_calls` message that correctly precedes the tool result — so strict providers don't reject an orphaned tool message.

Since `item_reference` only makes sense with `store: true` (the gateway's default), no extra opt-in is needed.

## Tests

- Schema accepts the exact failing payload (developer + user + `item_reference` + `function_call_output`).
- `resolveItemReferences`: no-op when no references present; replaces a reference with the resolved item and verifies the resulting message ordering (assistant `tool_calls` before tool result); drops unresolvable references.
- `pnpm format`, `pnpm build`, and the responses + openresponses-compliance specs all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for referencing previously stored response items by ID in subsequent requests
  * Automatic resolution of item references with intelligent fallback mechanisms for unresolved references

* **Tests**
  * Added comprehensive test coverage for item reference resolution behavior and cache interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->