### PR TITLE
feat(admin): add daily gain bar charts to dashboard

### DIFF
--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { format, parseISO } from "date-fns";
-import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
+import { useMemo } from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	Line,
+	LineChart,
+	XAxis,
+} from "recharts";
 
 import {
 	Card,
@@ -42,6 +51,9 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 1,
 });
 
+const POSITIVE_COLOR = "hsl(142 71% 45%)";
+const NEGATIVE_COLOR = "hsl(0 72% 51%)";
+
 export function RevenueChart({
 	data,
 	totalNet,
@@ -49,6 +61,15 @@ export function RevenueChart({
 	data: TimeseriesDataPoint[];
 	totalNet: number;
 }) {
+	const dailyData = useMemo(
+		() =>
+			data.map((point, index) => ({
+				date: point.date,
+				dailyNet: point.net - (index > 0 ? data[index - 1].net : 0),
+			})),
+		[data],
+	);
+
 	return (
 		<Card>
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
@@ -131,6 +152,47 @@ export function RevenueChart({
 						/>
 					</LineChart>
 				</ChartContainer>
+				<div className="mt-2 px-2 sm:px-0">
+					<p className="mb-1 px-2 text-xs text-muted-foreground sm:px-3">
+						Net gain per day
+					</p>
+					<ChartContainer
+						config={chartConfig}
+						className="aspect-auto h-[60px] w-full"
+					>
+						<BarChart data={dailyData} margin={{ left: 12, right: 12 }}>
+							<XAxis dataKey="date" hide />
+							<ChartTooltip
+								cursor={false}
+								content={
+									<ChartTooltipContent
+										className="w-[180px]"
+										labelFormatter={(value: string) => {
+											const date = parseISO(value);
+											return format(date, "MMM d, yyyy");
+										}}
+										formatter={(value) => (
+											<>
+												<span className="text-muted-foreground">Net gain</span>
+												<span className="ml-auto font-mono font-medium tabular-nums">
+													{currencyFormatter.format(Number(value))}
+												</span>
+											</>
+										)}
+									/>
+								}
+							/>
+							<Bar dataKey="dailyNet" radius={1}>
+								{dailyData.map((point) => (
+									<Cell
+										key={point.date}
+										fill={point.dailyNet >= 0 ? POSITIVE_COLOR : NEGATIVE_COLOR}
+									/>
+								))}
+							</Bar>
+						</BarChart>
+					</ChartContainer>
+				</div>
 			</CardContent>
 		</Card>
 	);

--- a/ee/admin/src/components/signups-chart.tsx
+++ b/ee/admin/src/components/signups-chart.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { format, parseISO } from "date-fns";
-import { useState } from "react";
-import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
+import { useMemo, useState } from "react";
+import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis } from "recharts";
 
 import {
 	Card,
@@ -47,6 +47,16 @@ export function SignupsChart({
 	totals: { signups: number; paidCustomers: number };
 }) {
 	const [activeChart, setActiveChart] = useState<ActiveChart>("signups");
+
+	const dailyData = useMemo(
+		() =>
+			data.map((point, index) => ({
+				date: point.date,
+				daily:
+					point[activeChart] - (index > 0 ? data[index - 1][activeChart] : 0),
+			})),
+		[data, activeChart],
+	);
 
 	return (
 		<Card>
@@ -114,6 +124,46 @@ export function SignupsChart({
 						/>
 					</LineChart>
 				</ChartContainer>
+				<div className="mt-2 px-2 sm:px-0">
+					<p className="mb-1 px-2 text-xs text-muted-foreground sm:px-3">
+						New {chartConfig[activeChart].label.toLowerCase()} per day
+					</p>
+					<ChartContainer
+						config={chartConfig}
+						className="aspect-auto h-[60px] w-full"
+					>
+						<BarChart data={dailyData} margin={{ left: 12, right: 12 }}>
+							<XAxis dataKey="date" hide />
+							<ChartTooltip
+								cursor={false}
+								content={
+									<ChartTooltipContent
+										className="w-[160px]"
+										labelFormatter={(value: string) => {
+											const date = parseISO(value);
+											return format(date, "MMM d, yyyy");
+										}}
+										formatter={(value) => (
+											<>
+												<span className="text-muted-foreground">
+													New {chartConfig[activeChart].label.toLowerCase()}
+												</span>
+												<span className="ml-auto font-mono font-medium tabular-nums">
+													{numberFormatter.format(Number(value))}
+												</span>
+											</>
+										)}
+									/>
+								}
+							/>
+							<Bar
+								dataKey="daily"
+								fill={`var(--color-${activeChart})`}
+								radius={1}
+							/>
+						</BarChart>
+					</ChartContainer>
+				</div>
 			</CardContent>
 		</Card>
 	);


### PR DESCRIPTION
## Summary

On the main admin dashboard, adds a small bar chart below each of the two main charts (**Signups & Paid Customers** and **Revenue**) showing the relative net gain per day.

The existing charts plot cumulative series, so the new bars are computed on the client as the per-day delta of the cumulative values (no API change needed).

- **Signups chart**: bars show new signups (or new paid customers) per day, following the active metric toggle. Uses the same color as the selected line.
- **Revenue chart**: bars show net gain per day; positive days are green, negative days (refunds outweigh revenue) are red.

Each bar chart has its own tooltip with the exact daily figure.

## Testing

- `pnpm format`
- `pnpm turbo run build --filter=admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Revenue chart now displays a "Net gain per day" bar visualization below the existing chart.
  * Signups chart now displays daily new metrics visualization below the existing chart.
  * Both daily metrics use color-coding to highlight positive (green) and negative (red) trends at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->