### PR TITLE
perf(api): serve provider stats from hourly rollup

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9,6 +9,13 @@ import { parseReferralBonusPercent } from "@/lib/referral-bonus.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
 import { notDevpassFilter } from "@/utils/devpass-filter.js";
+import {
+	HOURLY_BUCKET_THRESHOLD_MINUTES,
+	floorToHourStart,
+	isHourlyRange,
+	pickMappingHistoryTable,
+	pickModelHistoryTable,
+} from "@/utils/history-window.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
@@ -4624,10 +4631,6 @@ const HISTORY_WINDOW_MINUTES: Record<string, number> = {
 	"90d": 129600,
 };
 
-// Windows longer than 24h read the hourly rollup tables instead of the minute
-// tables, so a 30d/90d range scans hours rather than millions of minute rows.
-const HOURLY_BUCKET_THRESHOLD_MINUTES = 1440;
-
 function getHistoryStartDate(window: string): Date {
 	const minutes = HISTORY_WINDOW_MINUTES[window] ?? 240;
 	const ms = minutes * 60 * 1000;
@@ -4638,66 +4641,6 @@ function isHourlyWindow(window: string): boolean {
 	return (
 		(HISTORY_WINDOW_MINUTES[window] ?? 240) > HOURLY_BUCKET_THRESHOLD_MINUTES
 	);
-}
-
-// Same threshold as isHourlyWindow but for the list endpoints, which take an
-// explicit [from, to) range instead of a named window.
-function isHourlyRange(from: Date, to: Date): boolean {
-	return (
-		to.getTime() - from.getTime() > HOURLY_BUCKET_THRESHOLD_MINUTES * 60 * 1000
-	);
-}
-
-// Floor a date to the start of its hour so the hourly-table range filter aligns
-// to bucket boundaries.
-function floorToHourStart(date: Date): Date {
-	const d = new Date(date);
-	d.setMinutes(0, 0, 0);
-	return d;
-}
-
-// The minute and hourly history tables share identical metric column names and
-// differ only in their timestamp column. These pickers return the right source
-// for a window plus its bucket column, so aggregate/timeseries queries can serve
-// both without duplicating every SUM(). The hourly table is cast to the minute
-// table's type because the metric columns line up exactly at runtime; callers
-// must use the returned `bucket` for any timestamp predicate (never
-// `table.minuteTimestamp`, which does not exist on the hourly table).
-function pickMappingHistoryTable(hourly: boolean): {
-	table: typeof modelProviderMappingHistory;
-	bucket:
-		| typeof modelProviderMappingHistory.minuteTimestamp
-		| typeof modelProviderMappingHistoryHourly.hourTimestamp;
-} {
-	if (hourly) {
-		return {
-			table:
-				modelProviderMappingHistoryHourly as unknown as typeof modelProviderMappingHistory,
-			bucket: modelProviderMappingHistoryHourly.hourTimestamp,
-		};
-	}
-	return {
-		table: modelProviderMappingHistory,
-		bucket: modelProviderMappingHistory.minuteTimestamp,
-	};
-}
-
-function pickModelHistoryTable(hourly: boolean): {
-	table: typeof modelHistory;
-	bucket:
-		| typeof modelHistory.minuteTimestamp
-		| typeof modelHistoryHourly.hourTimestamp;
-} {
-	if (hourly) {
-		return {
-			table: modelHistoryHourly as unknown as typeof modelHistory,
-			bucket: modelHistoryHourly.hourTimestamp,
-		};
-	}
-	return {
-		table: modelHistory,
-		bucket: modelHistory.minuteTimestamp,
-	};
 }
 
 // Model detail – lists providers that serve a given model (with stats)

--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -2,12 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
 import {
-	and,
-	cdb,
-	gte,
-	modelProviderMappingHistory,
-	sql,
-} from "@llmgateway/db";
+	floorToHourStart,
+	pickMappingHistoryTable,
+} from "@/utils/history-window.js";
+
+import { and, cdb, gte, sql } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -74,22 +73,32 @@ function windowToStartDate(window: string): Date {
 
 publicProvidersStats.openapi(listRoute, async (c) => {
 	const { window = "7d" } = c.req.valid("query");
-	const startDate = windowToStartDate(window);
+
+	// Every supported window except 24h is longer than the hourly threshold, so
+	// 7d/30d aggregate the hourly rollup (~60x fewer rows) instead of scanning
+	// millions of minute rows. The bucket boundary is floored to the hour so the
+	// range filter lines up with the hourly rows; the in-progress current hour
+	// the worker hasn't rolled up yet is negligible for a multi-day window.
+	const hourly = window !== "24h";
+	const { table: mph, bucket: mphTs } = pickMappingHistoryTable(hourly);
+	const startDate = hourly
+		? floorToHourStart(windowToStartDate(window))
+		: windowToStartDate(window);
 
 	const rows = await cdb
 		.select({
-			providerId: modelProviderMappingHistory.providerId,
-			logsCount: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`,
-			errorsCount: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`,
-			cachedCount: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`,
-			totalTimeToFirstToken: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstToken}), 0)`,
-			totalOutputTokens: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.totalOutputTokens}), 0)`,
-			totalDuration: sql<string>`COALESCE(SUM(${modelProviderMappingHistory.totalDuration}), 0)`,
-			updatedAt: sql<Date | null>`MAX(${modelProviderMappingHistory.minuteTimestamp})`,
+			providerId: mph.providerId,
+			logsCount: sql<string>`COALESCE(SUM(${mph.logsCount}), 0)`,
+			errorsCount: sql<string>`COALESCE(SUM(${mph.errorsCount}), 0)`,
+			cachedCount: sql<string>`COALESCE(SUM(${mph.cachedCount}), 0)`,
+			totalTimeToFirstToken: sql<string>`COALESCE(SUM(${mph.totalTimeToFirstToken}), 0)`,
+			totalOutputTokens: sql<string>`COALESCE(SUM(${mph.totalOutputTokens}), 0)`,
+			totalDuration: sql<string>`COALESCE(SUM(${mph.totalDuration}), 0)`,
+			updatedAt: sql<Date | null>`MAX(${mphTs})`,
 		})
-		.from(modelProviderMappingHistory)
-		.where(and(gte(modelProviderMappingHistory.minuteTimestamp, startDate)))
-		.groupBy(modelProviderMappingHistory.providerId)
+		.from(mph)
+		.where(and(gte(mphTs, startDate)))
+		.groupBy(mph.providerId)
 		// Pin a stable, window-scoped cache tag. Without it Drizzle keys the
 		// cache on the rendered SQL + params, and `startDate` is derived from
 		// `now` on every request, so the key would never repeat and the heavy

--- a/apps/api/src/utils/history-window.ts
+++ b/apps/api/src/utils/history-window.ts
@@ -1,0 +1,69 @@
+import {
+	modelHistory,
+	modelHistoryHourly,
+	modelProviderMappingHistory,
+	modelProviderMappingHistoryHourly,
+} from "@llmgateway/db";
+
+// Windows longer than 24h read the hourly rollup tables instead of the minute
+// tables, so a 7d/30d/90d range scans hours rather than millions of minute rows.
+export const HOURLY_BUCKET_THRESHOLD_MINUTES = 1440;
+
+// Floor a date to the start of its hour so the hourly-table range filter aligns
+// to bucket boundaries.
+export function floorToHourStart(date: Date): Date {
+	const d = new Date(date);
+	d.setMinutes(0, 0, 0);
+	return d;
+}
+
+// Whether a [from, to) range is long enough to be served from the hourly rollup.
+export function isHourlyRange(from: Date, to: Date): boolean {
+	return (
+		to.getTime() - from.getTime() > HOURLY_BUCKET_THRESHOLD_MINUTES * 60 * 1000
+	);
+}
+
+// The minute and hourly history tables share identical metric column names and
+// differ only in their timestamp column. These pickers return the right source
+// for a window plus its bucket column, so aggregate/timeseries queries can serve
+// both without duplicating every SUM(). The hourly table is cast to the minute
+// table's type because the metric columns line up exactly at runtime; callers
+// must use the returned `bucket` for any timestamp predicate (never
+// `table.minuteTimestamp`, which does not exist on the hourly table).
+export function pickMappingHistoryTable(hourly: boolean): {
+	table: typeof modelProviderMappingHistory;
+	bucket:
+		| typeof modelProviderMappingHistory.minuteTimestamp
+		| typeof modelProviderMappingHistoryHourly.hourTimestamp;
+} {
+	if (hourly) {
+		return {
+			table:
+				modelProviderMappingHistoryHourly as unknown as typeof modelProviderMappingHistory,
+			bucket: modelProviderMappingHistoryHourly.hourTimestamp,
+		};
+	}
+	return {
+		table: modelProviderMappingHistory,
+		bucket: modelProviderMappingHistory.minuteTimestamp,
+	};
+}
+
+export function pickModelHistoryTable(hourly: boolean): {
+	table: typeof modelHistory;
+	bucket:
+		| typeof modelHistory.minuteTimestamp
+		| typeof modelHistoryHourly.hourTimestamp;
+} {
+	if (hourly) {
+		return {
+			table: modelHistoryHourly as unknown as typeof modelHistory,
+			bucket: modelHistoryHourly.hourTimestamp,
+		};
+	}
+	return {
+		table: modelHistory,
+		bucket: modelHistory.minuteTimestamp,
+	};
+}


### PR DESCRIPTION
## Problem

The public `/public/providers/stats` endpoint (default `7d` window, used by the provider grid on the homepage) still aggregates the raw **minute** table `model_provider_mapping_history`. In prod this query was averaging **~3.65 min** (p95 4.3 min), scanning ~1.7M rows per execution:

```sql
SELECT provider_id, COALESCE(SUM(logs_count),0), ... , MAX(minute_timestamp)
FROM model_provider_mapping_history
WHERE minute_timestamp >= $1
GROUP BY provider_id
```

The covering index added in #2713 (`model_provider_mapping_history_provider_stats_idx`) didn't fix it — an index can't avoid *summing* millions of rows. The query plan still falls back to an index scan over the full 7d range (1.26M shared blocks read).

## Fix

Route the `7d`/`30d` windows to the **hourly rollup** table `model_provider_mapping_history_hourly` (added in #2723), which holds ~60x fewer rows. `24h` keeps minute granularity. The hourly table is fully backfilled from the earliest minute row by the worker (`backfillHourlyHistoryIfNeeded`), so multi-day windows return complete data; only the in-progress current hour is excluded, which is negligible for a multi-day uptime/latency stat.

The minute-vs-hourly table pickers were previously private helpers inside `admin.ts`. Extracted them into a shared `apps/api/src/utils/history-window.ts` and reused them in both the admin routes and the public endpoint (DRY).

## Testing

- `pnpm format`
- `pnpm turbo run build --filter=api` (passes; admin.ts refactor type-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized provider statistics queries with hourly data aggregation for faster performance.

* **Refactor**
  * Consolidated history-window utilities into a shared module for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->