### PR TITLE
fix(admin): mappings table uses hourly buckets >24h

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7595,52 +7595,54 @@ admin.openapi(getModelProviderMappings, async (c) => {
 		return { startDate, endDateExclusive };
 	})();
 
-	const statsJoin = dateRange
+	// Ranges longer than 24h aggregate the hourly rollup so a full-window scan
+	// across every mapping doesn't read minute rows (mirrors the models list).
+	const mappingHistory = dateRange
+		? pickMappingHistoryTable(
+				isHourlyRange(dateRange.startDate, dateRange.endDateExclusive),
+			)
+		: null;
+
+	const statsJoin = mappingHistory
 		? db
 				.select({
-					mappingId: modelProviderMappingHistory.modelProviderMappingId,
+					mappingId: mappingHistory.table.modelProviderMappingId,
 					logsCount:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.logsCount}), 0)`.as(
 							"logsCount",
 						),
 					errorsCount:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.errorsCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.errorsCount}), 0)`.as(
 							"errorsCount",
 						),
 					clientErrorsCount:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.clientErrorsCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.clientErrorsCount}), 0)`.as(
 							"clientErrorsCount",
 						),
 					gatewayErrorsCount:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.gatewayErrorsCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.gatewayErrorsCount}), 0)`.as(
 							"gatewayErrorsCount",
 						),
 					upstreamErrorsCount:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.upstreamErrorsCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.upstreamErrorsCount}), 0)`.as(
 							"upstreamErrorsCount",
 						),
 					cachedCount:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.cachedCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.cachedCount}), 0)`.as(
 							"cachedCount",
 						),
-					cost: sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalCost}), 0)`.as(
+					cost: sql<number>`COALESCE(SUM(${mappingHistory.table.totalCost}), 0)`.as(
 						"cost",
 					),
 				})
-				.from(modelProviderMappingHistory)
+				.from(mappingHistory.table)
 				.where(
 					and(
-						gte(
-							modelProviderMappingHistory.minuteTimestamp,
-							dateRange.startDate,
-						),
-						lt(
-							modelProviderMappingHistory.minuteTimestamp,
-							dateRange.endDateExclusive,
-						),
+						gte(mappingHistory.bucket, dateRange!.startDate),
+						lt(mappingHistory.bucket, dateRange!.endDateExclusive),
 					),
 				)
-				.groupBy(modelProviderMappingHistory.modelProviderMappingId)
+				.groupBy(mappingHistory.table.modelProviderMappingId)
 				.as("mapping_stats_sub")
 		: db
 				.select({
@@ -7658,41 +7660,35 @@ admin.openapi(getModelProviderMappings, async (c) => {
 				.from(tables.modelProviderMapping)
 				.as("mapping_stats_sub");
 
-	const totalsPromise = dateRange
+	const totalsPromise = mappingHistory
 		? db
 				.select({
 					totalRequests:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.logsCount}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.logsCount}), 0)`.as(
 							"totalRequests",
 						),
 					totalTokens:
-						sql<number>`COALESCE(SUM(CAST(${modelProviderMappingHistory.totalTokens} AS NUMERIC)), 0)`.as(
+						sql<number>`COALESCE(SUM(CAST(${mappingHistory.table.totalTokens} AS NUMERIC)), 0)`.as(
 							"totalTokens",
 						),
 					totalCost:
-						sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalCost}), 0)`.as(
+						sql<number>`COALESCE(SUM(${mappingHistory.table.totalCost}), 0)`.as(
 							"totalCost",
 						),
 				})
-				.from(modelProviderMappingHistory)
+				.from(mappingHistory.table)
 				.innerJoin(
 					tables.modelProviderMapping,
 					eq(
-						modelProviderMappingHistory.modelProviderMappingId,
+						mappingHistory.table.modelProviderMappingId,
 						tables.modelProviderMapping.id,
 					),
 				)
 				.where(
 					and(
 						whereClause,
-						gte(
-							modelProviderMappingHistory.minuteTimestamp,
-							dateRange.startDate,
-						),
-						lt(
-							modelProviderMappingHistory.minuteTimestamp,
-							dateRange.endDateExclusive,
-						),
+						gte(mappingHistory.bucket, dateRange!.startDate),
+						lt(mappingHistory.bucket, dateRange!.endDateExclusive),
 					),
 				)
 		: Promise.resolve([


### PR DESCRIPTION
## Problem

On the admin **model-provider-mappings** page, the per-row stats table (Requests / Cost / Errors / Avg TTFT) still read the **minute-level** history table even for windows longer than 24h (2d/3d/7d/30d/90d). The graph for the same rows already switched to the hourly rollup in #2723, so the numbers diverged — and for ranges older than the minute-history retention window the table undercounted (or showed zero).

The providers and models list handlers were already fixed in that commit; the mappings handler (`getModelProviderMappings`) was missed and hardcoded `modelProviderMappingHistory.minuteTimestamp` in both its per-row `statsJoin` and its `totalsPromise`.

## Fix

Mirror the providers/models handlers: derive the source table + bucket column with `pickMappingHistoryTable(isHourlyRange(startDate, endDateExclusive))` and use the returned `bucket` for the `gte`/`lt` range predicates in both queries. Windows >24h now aggregate the hourly rollup, matching the graph.

No schema or API-shape changes; only which physical table the aggregation reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized admin API queries for model provider mappings to use more efficient query patterns, automatically selecting appropriate data granularity based on requested time ranges to reduce query load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->