### PR TITLE
fix(db): empty hourly rollups before bigint widen

### DIFF
--- a/packages/db/migrations/1781729055_quiet_major_mapleleaf.sql
+++ b/packages/db/migrations/1781729055_quiet_major_mapleleaf.sql
@@ -1,3 +1,8 @@
+-- Empty the derived hourly rollup tables first so the integer->bigint conversion
+-- runs against empty tables (instant, no full-table rewrite / long ACCESS EXCLUSIVE
+-- lock). The worker repopulates these from the minute-level history tables.
+TRUNCATE TABLE "model_history_hourly";--> statement-breakpoint
+TRUNCATE TABLE "model_provider_mapping_history_hourly";--> statement-breakpoint
 ALTER TABLE "model_history_hourly" ALTER COLUMN "total_input_tokens" SET DATA TYPE bigint;--> statement-breakpoint
 ALTER TABLE "model_history_hourly" ALTER COLUMN "total_output_tokens" SET DATA TYPE bigint;--> statement-breakpoint
 ALTER TABLE "model_history_hourly" ALTER COLUMN "total_tokens" SET DATA TYPE bigint;--> statement-breakpoint


### PR DESCRIPTION
## Problem

The `integer → bigint` widening of the token columns on `model_history_hourly` and `model_provider_mapping_history_hourly` (migration `1781729055_quiet_major_mapleleaf`, from #2726) does an in-place `ALTER COLUMN ... SET DATA TYPE bigint`. In Postgres that rewrites the **entire table + all indexes** under an `ACCESS EXCLUSIVE` lock.

On prod these tables are large enough that the rewrite never completes within `statement_timeout`. Migrations run at API boot (`apps/api/src/serve.ts`, `RUN_MIGRATIONS=true`) and `process.exit(1)` on failure, so the migration fails → pod restarts → retries → **crash loop**. It showed up in DB monitoring as an `ALTER TABLE model_history_hourly ...` statement with ~30s avg execution, 0 rows, and hundreds of calls (one per restart). Every migration after this one is also blocked.

## Fix

These hourly tables are **derived rollups** — the worker rebuilds any missing hour from the minute-level history tables (`stats-calculator.ts` hourly backfill, which walks from the earliest minute row forward and recomputes idempotently).

So `TRUNCATE` both tables first, then run the existing `bigint` conversion against empty tables: instant, no rewrite, no long lock. The worker repopulates the buckets on its next runs.

Only the generated `.sql` was edited (per repo migration conventions); the schema, snapshot, and journal are unchanged, so the end-state schema is still `bigint` with no drift.

## Caveat

Existing hourly aggregates are dropped and rebuilt from minute data, so any hours older than the minute-history retention window are not recovered. Acceptable here — this is a newly-shipped feature with little history, and the rollup is fully regenerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database schema update to support larger token count values in historical data records, improving system capacity for tracking token usage across data rollup periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->