### PR TITLE
fix: docs code sample indentation and footer compliance links

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -6,3 +6,9 @@
 :root {
 	--fd-layout-width: 1600px;
 }
+
+pre,
+code {
+	-moz-tab-size: 2;
+	tab-size: 2;
+}

--- a/apps/ui/src/components/landing/footer.tsx
+++ b/apps/ui/src/components/landing/footer.tsx
@@ -338,6 +338,81 @@ export default function Footer() {
 
 						<div>
 							<h3 className="font-display text-sm font-semibold mb-4 text-foreground">
+								Compliance
+							</h3>
+							<ul className="space-y-2">
+								<li>
+									<a
+										href="https://security.llmgateway.io/"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Trust Center
+									</a>
+								</li>
+								<li>
+									<a
+										href="https://security.llmgateway.io/"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Security Portal
+									</a>
+								</li>
+								<li>
+									<Link
+										href="/legal/terms"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+										prefetch={true}
+									>
+										Terms
+									</Link>
+								</li>
+								<li>
+									<Link
+										href="/legal/privacy"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+										prefetch={true}
+									>
+										Privacy Policy
+									</Link>
+								</li>
+								<li>
+									<Link
+										href="/legal/privacy"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+										prefetch={true}
+									>
+										GDPR
+									</Link>
+								</li>
+								<li>
+									<a
+										href="https://security.llmgateway.io/"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										SOC 2 Type II
+									</a>
+								</li>
+								<li>
+									<a
+										href="https://status.llmgateway.io/"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Status
+									</a>
+								</li>
+							</ul>
+						</div>
+
+						<div>
+							<h3 className="font-display text-sm font-semibold mb-4 text-foreground">
 								Compare
 							</h3>
 							<ul className="space-y-2">
@@ -504,22 +579,6 @@ export default function Footer() {
 					<p className="text-muted-foreground text-sm">
 						&copy; {new Date().getFullYear()} LLM Gateway. All rights reserved.
 					</p>
-					<div className="flex items-center gap-6">
-						<Link
-							href="/legal/privacy"
-							className="text-sm text-muted-foreground hover:underline underline-offset-4 hover:text-foreground"
-							prefetch={true}
-						>
-							Privacy Policy
-						</Link>
-						<Link
-							href="/legal/terms"
-							className="text-sm text-muted-foreground hover:underline underline-offset-4 hover:text-foreground"
-							prefetch={true}
-						>
-							Terms of Use
-						</Link>
-					</div>
 				</div>
 			</div>
 		</footer>


### PR DESCRIPTION
Set tab-size: 2 on docs code blocks so tab-indented samples render
at the intended width instead of the browser default of 8 columns.

Add a Compliance group to the footer (Trust Center, Security Portal,
Terms, Privacy Policy, GDPR, SOC 2 Type II, Status) and drop the
duplicated privacy/terms links from the bottom bar.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012E2wVH5p6hcccqVsmWHALH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Compliance section in the footer with links to Trust Center, Security Portal, SOC 2 Type II certification, GDPR information, and Status page.
  * Reorganized footer layout to streamline legal links.

* **Style**
  * Improved code block formatting with consistent tab spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->