### PR TITLE
fix(minimax-m3): update context window to 512K

### DIFF
--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -5,7 +5,7 @@ export const minimaxModels = [
 		id: "minimax-m3",
 		name: "MiniMax M3",
 		description:
-			"MiniMax M3 is a multimodal foundation model with 1M token context, native multimodal understanding, and MiniMax Sparse Attention (MSA) for efficient long-context inference.",
+			"MiniMax M3 is a multimodal foundation model with 512K token context, native multimodal understanding, and MiniMax Sparse Attention (MSA) for efficient long-context inference.",
 		family: "minimax",
 		releasedAt: new Date("2026-06-01"),
 		providers: [
@@ -16,7 +16,7 @@ export const minimaxModels = [
 				cachedInputPrice: "0.12e-6",
 				outputPrice: "2.4e-6",
 				requestPrice: "0",
-				contextSize: 1048576,
+				contextSize: 512000,
 				maxOutput: 131072,
 				streaming: true,
 				reasoning: true,


### PR DESCRIPTION
## Summary
Updates the MiniMax M3 model configuration to reflect the correct context window size of 512K tokens instead of 1M tokens.

## Changes
- Updated model description to specify 512K token context (was 1M)
- Corrected `contextSize` value from 1048576 (1M) to 512000 (512K) in the provider configuration

## Details
This change corrects the documented and configured context window for the MiniMax M3 model to match the actual capabilities of the model.

https://claude.ai/code/session_01LNuFkB9pCRr4wRTEBdJzSQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reduced minimax-m3 model context size from 1M to 512K tokens to reflect accurate specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->