### PR TITLE
refactor(ui): move billing email card to billing page

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx
@@ -2,6 +2,7 @@ import { AutoTopUpSettings } from "@/components/billing/auto-topup-settings";
 import { PlanManagement } from "@/components/billing/plan-management";
 import { PaymentMethodsManagement } from "@/components/credits/payment-methods-management";
 import { TopUpCreditsButton } from "@/components/credits/top-up-credits-dialog";
+import { OrganizationBillingEmailSettings } from "@/components/settings/organization-billing-email-settings";
 import {
 	Card,
 	CardContent,
@@ -72,6 +73,18 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
 						</CardHeader>
 						<CardContent>
 							<PaymentMethodsManagement />
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Billing Email</CardTitle>
+							<CardDescription>
+								Manage your organization's billing email address.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="space-y-6">
+							<OrganizationBillingEmailSettings />
 						</CardContent>
 					</Card>
 

--- a/apps/ui/src/app/dashboard/[orgId]/org/preferences/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/preferences/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { OrganizationBillingEmailSettings } from "@/components/settings/organization-billing-email-settings";
 import { OrganizationIdSettings } from "@/components/settings/organization-id-settings";
 import { OrganizationNameSettings } from "@/components/settings/organization-name-settings";
 import {
@@ -40,17 +39,6 @@ export default function PreferencesPage() {
 						</CardHeader>
 						<CardContent className="space-y-6">
 							<OrganizationNameSettings />
-						</CardContent>
-					</Card>
-					<Card>
-						<CardHeader>
-							<CardTitle>Billing Email</CardTitle>
-							<CardDescription>
-								Manage your organization's billing email address.
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							<OrganizationBillingEmailSettings />
 						</CardContent>
 					</Card>
 				</div>


### PR DESCRIPTION
## Summary

Moves the **Billing Email** card section (with the Billing Information form) from the organization **Preferences** page to the organization **Billing** page, where it belongs alongside Credits, Plan Management, Payment Methods, and Auto Top-Up.

## Changes

- Removed the `Billing Email` card and `OrganizationBillingEmailSettings` import from `apps/ui/src/app/dashboard/[orgId]/org/preferences/page.tsx`.
- Added the `Billing Email` card to `apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx` (placed after Payment Methods, before Auto Top-Up).

No behavior change to the form itself — only its location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Billing email settings relocated from the Preferences page to the Billing dashboard for improved access to billing-related configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->