### PR TITLE
fix(security): block ssrf via user content urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,11 +99,13 @@ PASSKEY_RP_NAME=LLMGateway
 # Required in production. Generate with: openssl rand -base64 32
 GATEWAY_API_KEY_HASH_SECRET=your-api-key-hash-secret-here
 
-# Custom/BYOK provider base URLs are SSRF-validated by default: they must use
-# https and must not point at a private/loopback/link-local/metadata or internal
-# host. Set to "true" ONLY on a trusted self-hosted deployment that needs to
-# reach an internal or http-only model server (e.g. a local Ollama). Leave unset
-# in any multi-tenant / cloud deployment.
+# Custom/BYOK provider base URLs AND user-supplied content URLs (image/video
+# URLs in chat, image, and video requests that the gateway fetches server-side)
+# are SSRF-validated by default: they must use https and must not point at a
+# private/loopback/link-local/metadata or internal host. Set to "true" ONLY on a
+# trusted self-hosted deployment that needs to reach an internal or http-only
+# model server or media host (e.g. a local Ollama). Leave unset in any
+# multi-tenant / cloud deployment.
 # ALLOW_INSECURE_PROVIDER_URLS=true
 
 # Secret used to sign video content access tokens (JWT).

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -241,7 +241,11 @@ async function extractImagesFromChatResponse(
 				) {
 					// Handle URL-based images (e.g. Z.AI, Alibaba, ByteDance)
 					try {
-						const result = await processImageUrl(imageUrl);
+						// Trusted upstream provider response, not request input: skip the
+						// user-content SSRF guard (CDNs may redirect to signed URLs).
+						const result = await processImageUrl(imageUrl, false, 20, null, {
+							validateSsrf: false,
+						});
 						imageObjects.push({
 							b64_json: result.data,
 							revised_prompt: prompt,

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -18,6 +18,7 @@ import {
 	type ToolChoiceType,
 	type WebSearchTool,
 } from "@llmgateway/models";
+import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import { parseDataUrl } from "./parse-data-url.js";
 import { transformAnthropicMessages } from "./transform-anthropic-messages.js";
@@ -103,7 +104,10 @@ async function fetchImageAsBlob(
 		};
 	}
 
-	const response = await fetch(url);
+	// SSRF: the URL comes from the request body, so validate it does not resolve
+	// to an internal host and refuse redirects before fetching.
+	await assertSafeUserContentUrl(url);
+	const response = await fetch(url, { redirect: "error" });
 	if (!response.ok) {
 		throw new Error(
 			`Failed to fetch image ${url}: ${response.status} ${response.statusText}`,

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -1,4 +1,5 @@
 import { logger } from "@llmgateway/logger";
+import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import { parseDataUrl } from "./parse-data-url.js";
 
@@ -27,13 +28,21 @@ function getImageSizeErrorMessage(
 }
 
 /**
- * Processes an image URL or data URL and converts it to base64
+ * Processes an image URL or data URL and converts it to base64.
+ *
+ * `validateSsrf` (default true) applies the user-content SSRF guard to remote
+ * URLs before fetching and refuses redirects, so a tenant-supplied image URL in
+ * a chat/image/video request cannot make the gateway fetch an internal host.
+ * Pass `validateSsrf: false` only for URLs that originate from a trusted upstream
+ * provider response (which may legitimately redirect to a signed CDN URL), not
+ * from the request body.
  */
 export async function processImageUrl(
 	url: string,
 	isProd = false,
 	maxSizeMB = 20,
 	userPlan: "free" | "pro" | "enterprise" | null = null,
+	{ validateSsrf = true }: { validateSsrf?: boolean } = {},
 ): Promise<{ data: string; mimeType: string }> {
 	// Handle data URLs directly without network fetch
 	if (url.startsWith("data:")) {
@@ -83,8 +92,19 @@ export async function processImageUrl(
 		throw new Error("Image URLs must use HTTPS protocol in production");
 	}
 
+	// SSRF: a tenant-supplied content URL must not resolve to an internal host.
+	// No-op when the guard is disabled (self-hosted / local test).
+	if (validateSsrf) {
+		await assertSafeUserContentUrl(url);
+	}
+
 	try {
-		const response = await fetch(url);
+		const response = await fetch(url, {
+			// SSRF: refuse redirects so a validated public host cannot 3xx the
+			// gateway onward to an internal one. Trusted provider-response URLs opt
+			// out (validateSsrf: false) since CDNs legitimately redirect.
+			redirect: validateSsrf ? "error" : "follow",
+		});
 
 		if (!response.ok) {
 			logger.warn(`Failed to fetch image from URL (${response.status})`, {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -131,6 +131,7 @@ export {
 } from "./routing-config.js";
 
 export {
+	assertSafeContentUrl,
 	assertSafeProviderBaseUrl,
 	assertSafeWebhookUrl,
 	isPrivateOrReservedIp,

--- a/packages/shared/src/url-safety-node.spec.ts
+++ b/packages/shared/src/url-safety-node.spec.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { assertSafeUserContentUrl } from "./url-safety-node.js";
+
+describe("assertSafeUserContentUrl", () => {
+	const originalFlag = process.env.ALLOW_INSECURE_PROVIDER_URLS;
+
+	afterEach(() => {
+		if (originalFlag === undefined) {
+			delete process.env.ALLOW_INSECURE_PROVIDER_URLS;
+		} else {
+			process.env.ALLOW_INSECURE_PROVIDER_URLS = originalFlag;
+		}
+	});
+
+	describe("with the guard enabled", () => {
+		beforeEach(() => {
+			delete process.env.ALLOW_INSECURE_PROVIDER_URLS;
+		});
+
+		it("rejects http URLs before any DNS lookup", async () => {
+			await expect(
+				assertSafeUserContentUrl("http://cdn.example.com/x.png"),
+			).rejects.toThrow("Content URL must use https");
+		});
+
+		it("rejects private/reserved IP literals before any DNS lookup", async () => {
+			for (const url of [
+				"https://127.0.0.1/x.png",
+				"https://169.254.169.254/x.png",
+				"https://10.0.0.5/x.png",
+				"https://[::1]/x.png",
+			]) {
+				await expect(assertSafeUserContentUrl(url)).rejects.toThrow();
+			}
+		});
+
+		it("rejects internal hostnames before any DNS lookup", async () => {
+			await expect(
+				assertSafeUserContentUrl("https://metadata.google.internal/x"),
+			).rejects.toThrow("disallowed internal host");
+		});
+
+		it("passes through data URLs without a network fetch", async () => {
+			await expect(
+				assertSafeUserContentUrl("data:image/png;base64,iVBORw0KGgo="),
+			).resolves.toBeUndefined();
+		});
+	});
+
+	describe("with the guard disabled", () => {
+		beforeEach(() => {
+			process.env.ALLOW_INSECURE_PROVIDER_URLS = "true";
+		});
+
+		it("is a no-op even for http and internal targets", async () => {
+			await expect(
+				assertSafeUserContentUrl("http://localhost:8080/x.png"),
+			).resolves.toBeUndefined();
+			await expect(
+				assertSafeUserContentUrl("http://169.254.169.254/x.png"),
+			).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/shared/src/url-safety-node.ts
+++ b/packages/shared/src/url-safety-node.ts
@@ -1,17 +1,36 @@
 /**
- * Node-only SSRF guard for tenant-supplied provider base URLs. Layers DNS
- * resolution on top of the browser-safe `assertSafeProviderBaseUrl` so a
- * hostname that resolves to a private/reserved address is rejected at
- * registration time. Kept in a separate entrypoint because it imports
+ * Node-only SSRF guards for tenant-supplied outbound `fetch()` targets (provider
+ * base URLs and user-supplied content URLs). Layers DNS resolution on top of the
+ * browser-safe validators so a hostname that resolves to a private/reserved
+ * address is also rejected. Kept in a separate entrypoint because it imports
  * `node:dns` and must not leak into the browser barrel.
  */
 import { lookup } from "node:dns/promises";
 
 import {
+	assertSafeContentUrl,
 	assertSafeProviderBaseUrl,
 	isPrivateOrReservedIp,
 	isProviderUrlGuardEnabled,
 } from "./url-safety.js";
+
+/**
+ * Resolve a hostname and throw if any returned address is private/reserved
+ * (incl. IPv4-mapped IPv6). Shared by the provider and content URL guards.
+ */
+async function assertResolvedHostSafe(
+	hostname: string,
+	label: string,
+): Promise<void> {
+	const resolved = await lookup(hostname, { all: true });
+	for (const { address } of resolved) {
+		if (isPrivateOrReservedIp(address)) {
+			throw new Error(
+				`${label} host ${hostname} resolves to a disallowed address (${address})`,
+			);
+		}
+	}
+}
 
 /**
  * Validate a provider `baseUrl` is safe to store and later use as an outbound
@@ -31,12 +50,33 @@ export async function assertSafeProviderUrl(rawUrl: string): Promise<void> {
 
 	const url = assertSafeProviderBaseUrl(rawUrl);
 
-	const resolved = await lookup(url.hostname, { all: true });
-	for (const { address } of resolved) {
-		if (isPrivateOrReservedIp(address)) {
-			throw new Error(
-				`Provider base URL host ${url.hostname} resolves to a disallowed address (${address})`,
-			);
-		}
+	await assertResolvedHostSafe(url.hostname, "Provider base URL");
+}
+
+/**
+ * Validate a user-supplied content URL (image/video/document URL in a chat,
+ * image, or video request) before the gateway fetches it server-side: https, not
+ * an internal host/IP literal, and whose hostname does not resolve to a
+ * private/reserved address. `data:` URLs are not network fetches and pass
+ * through. No-op when the guard is disabled via `ALLOW_INSECURE_PROVIDER_URLS`
+ * (which also relaxes outbound content fetches so self-hosted/local-test
+ * deployments can reach http/localhost media). Throws `Error` on an unsafe
+ * target.
+ *
+ * Unlike provider base URLs, content URLs are validated per request because they
+ * arrive in the request body. Callers must still refuse redirects on the fetch
+ * (`redirect: "error"`) so a validated host cannot 3xx onward to an internal one.
+ */
+export async function assertSafeUserContentUrl(rawUrl: string): Promise<void> {
+	if (!isProviderUrlGuardEnabled()) {
+		return;
 	}
+
+	if (rawUrl.startsWith("data:")) {
+		return;
+	}
+
+	const url = assertSafeContentUrl(rawUrl);
+
+	await assertResolvedHostSafe(url.hostname, "Content URL");
 }

--- a/packages/shared/src/url-safety.spec.ts
+++ b/packages/shared/src/url-safety.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+	assertSafeContentUrl,
 	assertSafeProviderBaseUrl,
 	isPrivateOrReservedIp,
 	isProviderUrlGuardEnabled,
@@ -101,6 +102,54 @@ describe("assertSafeProviderBaseUrl", () => {
 		expect(() => assertSafeProviderBaseUrl("file:///etc/passwd")).toThrow();
 		expect(() => assertSafeProviderBaseUrl("gopher://127.0.0.1")).toThrow();
 		expect(() => assertSafeProviderBaseUrl("not a url")).toThrow();
+	});
+});
+
+describe("assertSafeContentUrl", () => {
+	it("accepts public https media URLs", () => {
+		expect(() =>
+			assertSafeContentUrl("https://cdn.example.com/image.png"),
+		).not.toThrow();
+		expect(() =>
+			assertSafeContentUrl("https://example.com:8443/video.mp4"),
+		).not.toThrow();
+	});
+
+	it("rejects http URLs (even public)", () => {
+		expect(() =>
+			assertSafeContentUrl("http://cdn.example.com/image.png"),
+		).toThrow("Content URL must use https");
+	});
+
+	it("rejects loopback and reserved IP literals", () => {
+		for (const url of [
+			"http://127.0.0.1/x.png",
+			"https://169.254.169.254/latest/meta-data",
+			"http://10.0.0.5/a.jpg",
+			"http://192.168.1.1/a.jpg",
+			"https://[::1]/a.jpg",
+		]) {
+			expect(() => assertSafeContentUrl(url)).toThrow();
+		}
+	});
+
+	it("rejects internal hostnames", () => {
+		for (const url of [
+			"http://localhost/a.png",
+			"http://metadata.google.internal/x",
+			"https://foo.internal/x.png",
+			"https://service.local/x.png",
+		]) {
+			expect(() => assertSafeContentUrl(url)).toThrow();
+		}
+	});
+
+	it("rejects non-https schemes and malformed URLs", () => {
+		expect(() => assertSafeContentUrl("file:///etc/passwd")).toThrow();
+		expect(() => assertSafeContentUrl("gopher://127.0.0.1")).toThrow();
+		expect(() => assertSafeContentUrl("not a url")).toThrow(
+			"Invalid content URL",
+		);
 	});
 });
 

--- a/packages/shared/src/url-safety.ts
+++ b/packages/shared/src/url-safety.ts
@@ -195,3 +195,43 @@ export function assertSafeProviderBaseUrl(rawUrl: string): URL {
 
 	return url;
 }
+
+/**
+ * Validate a user-supplied content URL (an image/video/document URL embedded in
+ * a chat-completion, image, or video request) that the gateway will fetch
+ * server-side. Same SSRF rules as provider base URLs: must be https and must not
+ * point at a private/loopback/link-local/metadata IP literal or an obvious
+ * internal hostname. Throws `Error` with a descriptive message; returns the
+ * parsed URL on success. Does NOT resolve DNS — `assertSafeUserContentUrl` in
+ * url-safety-node wraps this with a DNS lookup so a hostname resolving to an
+ * internal address is also rejected.
+ */
+export function assertSafeContentUrl(rawUrl: string): URL {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		throw new Error("Invalid content URL");
+	}
+
+	if (url.protocol !== "https:") {
+		throw new Error("Content URL must use https");
+	}
+
+	const host = url.hostname.toLowerCase();
+
+	if (
+		BLOCKED_HOSTS.has(host) ||
+		BLOCKED_HOST_SUFFIXES.some((s) => host.endsWith(s))
+	) {
+		throw new Error("Content URL points at a disallowed internal host");
+	}
+
+	const isIpLiteral =
+		IPV4_RE.test(host) || host.includes(":") || rawUrl.includes("[");
+	if (isIpLiteral && isPrivateOrReservedIp(host)) {
+		throw new Error("Content URL points at a private or reserved address");
+	}
+
+	return url;
+}


### PR DESCRIPTION
## Summary

A recent fix blocked SSRF via custom/BYOK provider base URLs (#2725). This extends the **same checks** to **user-supplied content URLs** that the gateway fetches **server-side**.

Several routes accept URLs in the request body and the gateway itself fetches them (to convert to base64 / upload as multipart):

- **Chat completions** — `image_url` parts for providers that need inline data (Google, Anthropic) flow through `processImageUrl`.
- **Image edits / generation** — `images[].image_url` (`apps/gateway/src/images/images.ts` + OpenAI/Azure multipart `fetchImageAsBlob`).
- **Video generation** — `first_frame`, `last_frame`, `reference_images` (`processVideoImageInput`).

Previously these were fetched with a bare `fetch(url)` and only an HTTPS-in-production check. A URL pointing at `http://`, a private/loopback/link-local IP, the cloud metadata endpoint (`169.254.169.254`), or an internal hostname would make the gateway reach internal infrastructure.

> Note: URLs that are merely **passed through** to the upstream provider (e.g. xAI / Z.AI image URLs, video `reference_videos`/`reference_audios`) are fetched by the provider, not the gateway, so they are not a gateway SSRF vector and are unchanged (they already require HTTPS via schema).

## Changes

- `@llmgateway/shared`: add `assertSafeContentUrl` (sync, browser-safe) and `assertSafeUserContentUrl` (Node, DNS-resolving) mirroring the provider-URL guards — https only, no private/reserved IP literal, no internal hostname, and DNS resolution so a hostname resolving to an internal address is rejected (defeats DNS rebinding).
- Gated by the existing `ALLOW_INSECURE_PROVIDER_URLS` flag so trusted self-hosted / local-test deployments can still reach http/localhost media (the test suite already sets this). `.env.example` updated to document the broadened scope.
- Enforce in `processImageUrl` and `fetchImageAsBlob`, and **refuse redirects** (`redirect: "error"`) so a validated public host cannot 3xx the gateway onward to an internal one.
- Trusted **upstream provider-response** image URLs (`images.ts` `extractImagesFromChatResponse`, e.g. Z.AI/Alibaba/ByteDance CDNs that legitimately redirect to signed URLs) opt out via `validateSsrf: false`.

## Testing

- New unit tests: `url-safety.spec.ts` (`assertSafeContentUrl`) and `url-safety-node.spec.ts` (`assertSafeUserContentUrl` — rejects http/private/internal before DNS, passes data: URLs through, no-op when the guard is disabled).
- `pnpm format` and full `pnpm build` pass; existing `prepare-request-body` / `transform-google-messages` specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security validation for image URLs from custom providers and user-supplied content, with improved protection against Server-Side Request Forgery (SSRF) attacks
  * Added configurable SSRF protection for trusted self-hosted deployments requiring internal or HTTP-only resources

* **Documentation**
  * Expanded configuration documentation with clearer guidance on URL security requirements and when to disable SSRF validation for self-hosted environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->