### PR TITLE
ci: add weekly tag + release workflow

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,46 @@
+name: weekly-release
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  weekly-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute next version
+        id: version
+        run: |
+          LATEST=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+          if [[ -z "$LATEST" ]]; then
+            LATEST="v0.0.0"
+          fi
+          VERSION="${LATEST#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          NEXT="v${MAJOR}.$((MINOR + 1)).0"
+          echo "Latest tag: ${LATEST}, next release: ${NEXT}"
+          echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and release
+        # Use a custom PAT (not the default GITHUB_TOKEN) so that the
+        # `release: published` event triggers the images.yml workflow.
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.next }}" \
+            --repo "${{ github.repository }}" \
+            --target main \
+            --title "${{ steps.version.outputs.next }}" \
+            --generate-notes


### PR DESCRIPTION
## What

Adds a new scheduled GitHub Actions workflow (`.github/workflows/weekly-release.yml`) that creates a fresh tag + GitHub release every week.

- Runs on a cron schedule every **Monday at 09:00 UTC** (plus `workflow_dispatch` for manual runs).
- Computes the next version by taking the latest `vX.Y.Z` tag and bumping the **minor** (e.g. `v1.4.0` → `v1.5.0`), defaulting to `v0.1.0` if none exist.
- Creates the tag and a release on `main` with auto-generated notes via `gh release create`.

## Why it triggers the existing docker publish

The existing `images.yml` workflow already builds and publishes the docker images on `release: [published]`. The key detail: **the default `GITHUB_TOKEN` does not trigger downstream workflow events** (GitHub's recursion guard). So this workflow uses the repo's existing custom PAT `secrets.GH_TOKEN` — the same token `image-actions.yml` uses with the comment _"use custom token so actions get triggered on push"_ — to create the release. This ensures the `release: published` event fires and `images.yml` runs the docker image publish.

No application code changed; this is CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated weekly release process has been established. Releases will now be generated every Monday at 09:00 UTC, with manual triggering available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->