### PR TITLE
fix(gateway): accept anthropic thinking blocks

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -61,6 +61,18 @@ const anthropicMessageSchema = z.object({
 					content: z.union([z.string(), z.array(z.unknown())]).optional(),
 					is_error: z.boolean().optional(),
 				}),
+				// Extended-thinking blocks echoed back in conversation history. They
+				// carry no value for the internal OpenAI-format request, so they're
+				// accepted here and stripped during transformation.
+				z.object({
+					type: z.literal("thinking"),
+					thinking: z.string(),
+					signature: z.string().optional(),
+				}),
+				z.object({
+					type: z.literal("redacted_thinking"),
+					data: z.string(),
+				}),
 			]),
 		),
 	]),
@@ -527,26 +539,31 @@ anthropic.openapi(messages, async (c) => {
 				// For multi-modal content, or text content with cache_control markers,
 				// transform blocks while preserving cache_control so the inner
 				// completions path can forward it to Anthropic.
-				const content = message.content.map((block) => {
-					if (block.type === "text" && block.text) {
-						return {
-							type: "text",
-							text: block.text,
-							...(block.cache_control && {
-								cache_control: block.cache_control,
-							}),
-						};
-					}
-					if (block.type === "image" && block.source) {
-						return {
-							type: "image_url",
-							image_url: {
-								url: `data:${block.source.media_type};base64,${block.source.data}`,
-							},
-						};
-					}
-					return block;
-				});
+				const content = message.content
+					.filter(
+						(block) =>
+							block.type !== "thinking" && block.type !== "redacted_thinking",
+					)
+					.map((block) => {
+						if (block.type === "text" && block.text) {
+							return {
+								type: "text",
+								text: block.text,
+								...(block.cache_control && {
+									cache_control: block.cache_control,
+								}),
+							};
+						}
+						if (block.type === "image" && block.source) {
+							return {
+								type: "image_url",
+								image_url: {
+									url: `data:${block.source.media_type};base64,${block.source.data}`,
+								},
+							};
+						}
+						return block;
+					});
 
 				openaiMessages.push({
 					role: message.role,

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -148,6 +148,55 @@ describe("api", () => {
 		expect(logs[0].finishReason).toBe("stop");
 	});
 
+	test("/v1/messages accepts thinking blocks in conversation history", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				messages: [
+					{ role: "user", content: "What is 2+2?" },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "thinking",
+								thinking: "The user is asking for basic arithmetic.",
+								signature: "sig-abc",
+							},
+							{ type: "text", text: "4" },
+						],
+					},
+					{ role: "user", content: "Thanks!" },
+				],
+			}),
+		});
+
+		// Before the fix this returned 400 with a Zod invalid_union error
+		// because `thinking` blocks weren't whitelisted in the content schema.
+		expect(res.status).toBe(200);
+	});
+
 	test("/v1/chat/completions blocks providers failing the compliance policy", async () => {
 		// OpenAI's dataPolicy has promptLogging: true, so blockPromptLogging removes
 		// it. gpt-4o's only other (azure) mapping is deactivated, leaving no provider.


### PR DESCRIPTION
## Summary

Fixes #2508. When a client using extended thinking (e.g. Claude Code, the Anthropic SDK with `thinking` enabled) sends assistant messages whose history contains `{ type: "thinking" }` content blocks, the gateway returned a `400 Bad Request`. The internal Zod content-block union only whitelisted `text`, `image`, `tool_use`, and `tool_result`, so any echoed-back thinking block failed the discriminator and broke multi-turn sessions as soon as the model actually emitted reasoning.

## Changes

- **`apps/gateway/src/anthropic/anthropic.ts`**
  - Add `thinking` and `redacted_thinking` to the Anthropic request content-block union so they pass validation.
  - Strip `thinking`/`redacted_thinking` blocks when transforming to the internal OpenAI format (the multi-modal path previously passed unknown blocks through raw via the `return block` fallback). The existing `tool_use` assistant branch already drops them by filtering to text/tool_use only.
- **`apps/gateway/src/api.spec.ts`**
  - Add a `/v1/messages` test sending a thinking block in conversation history and asserting a `200` instead of the prior `400`.

## Testing

- `pnpm vitest run apps/gateway/src/api.spec.ts -t "messages"` — passes
- `turbo run build --filter=gateway` — passes
- `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for thinking and redacted thinking content blocks in conversation history.

* **Bug Fixes**
  * Resolved validation errors when extended-thinking content blocks were included in message exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->