### PR TITLE
fix(gateway): log missing tool_call_id as client_error

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import {
 	InvalidFileContentError,
+	MissingToolCallIdError,
 	UnsupportedAudioFormatError,
 	UnsupportedDocumentFormatError,
 } from "@llmgateway/actions";
@@ -161,6 +162,11 @@ app.onError((error, c) => {
 			mimeType: error.mimeType,
 			providerTarget: error.providerTarget,
 		});
+		return renderGatewayError(c, 400, error.message);
+	}
+
+	if (error instanceof MissingToolCallIdError) {
+		logger.warn("Missing tool_call_id", { message: error.message });
 		return renderGatewayError(c, 400, error.message);
 	}
 

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 
 import {
 	InvalidFileContentError,
-	MissingToolCallIdError,
+	RequestError,
 	UnsupportedAudioFormatError,
 	UnsupportedDocumentFormatError,
 } from "@llmgateway/actions";
@@ -165,9 +165,12 @@ app.onError((error, c) => {
 		return renderGatewayError(c, 400, error.message);
 	}
 
-	if (error instanceof MissingToolCallIdError) {
-		logger.warn("Missing tool_call_id", { message: error.message });
-		return renderGatewayError(c, 400, error.message);
+	if (error instanceof RequestError) {
+		logger.warn("Invalid request", {
+			message: error.message,
+			statusCode: error.statusCode,
+		});
+		return renderGatewayError(c, error.statusCode, error.message);
 	}
 
 	if (error instanceof HTTPException) {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -96,6 +96,7 @@ import {
 	resolveServedServiceTier,
 	googleProviderSupportsAudioFormat,
 	InvalidFileContentError,
+	MissingToolCallIdError,
 	parseGoogleUpstreamDocumentError,
 	prepareRequestBody,
 	UnsupportedAudioFormatError,
@@ -5773,7 +5774,8 @@ chat.openapi(completions, async (c) => {
 		if (
 			e instanceof InvalidFileContentError ||
 			e instanceof UnsupportedAudioFormatError ||
-			e instanceof UnsupportedDocumentFormatError
+			e instanceof UnsupportedDocumentFormatError ||
+			e instanceof MissingToolCallIdError
 		) {
 			try {
 				await insertLogEntry({

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -96,9 +96,9 @@ import {
 	resolveServedServiceTier,
 	googleProviderSupportsAudioFormat,
 	InvalidFileContentError,
-	MissingToolCallIdError,
 	parseGoogleUpstreamDocumentError,
 	prepareRequestBody,
+	RequestError,
 	UnsupportedAudioFormatError,
 	UnsupportedDocumentFormatError,
 	type RoutingMetadata,
@@ -5775,8 +5775,9 @@ chat.openapi(completions, async (c) => {
 			e instanceof InvalidFileContentError ||
 			e instanceof UnsupportedAudioFormatError ||
 			e instanceof UnsupportedDocumentFormatError ||
-			e instanceof MissingToolCallIdError
+			e instanceof RequestError
 		) {
+			const statusCode = e instanceof RequestError ? e.statusCode : 400;
 			try {
 				await insertLogEntry({
 					...createLogEntry(
@@ -5818,7 +5819,7 @@ chat.openapi(completions, async (c) => {
 					streamed: !!stream,
 					canceled: false,
 					errorDetails: {
-						statusCode: 400,
+						statusCode,
 						statusText: "Bad Request",
 						responseText: e.message,
 						cause: e.constructor.name,

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 
-import { prepareRequestBody } from "./prepare-request-body.js";
+import {
+	MissingToolCallIdError,
+	prepareRequestBody,
+} from "./prepare-request-body.js";
 
 import type { AnthropicRequestBody } from "@llmgateway/models";
 
@@ -506,6 +509,42 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 
 		expect(requestBody.prompt_cache_key).toBe("tenant-a");
 		expect(requestBody.prompt_cache_retention).toBe("in_memory");
+	});
+
+	test("should throw a typed MissingToolCallIdError for tool messages without tool_call_id", async () => {
+		await expect(
+			prepareRequestBody(
+				"openai",
+				"gpt-5.5",
+				null,
+				"gpt-5.5",
+				[
+					{ role: "user", content: "Hello!" },
+					{ role: "tool", content: "result" } as any,
+				],
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+				false,
+				20,
+				null,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true,
+			),
+		).rejects.toBeInstanceOf(MissingToolCallIdError);
 	});
 
 	test("should not forward OpenAI prompt cache controls to Azure", async () => {

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import {
-	MissingToolCallIdError,
-	prepareRequestBody,
-} from "./prepare-request-body.js";
+import { prepareRequestBody, RequestError } from "./prepare-request-body.js";
 
 import type { AnthropicRequestBody } from "@llmgateway/models";
 
@@ -511,7 +508,7 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 		expect(requestBody.prompt_cache_retention).toBe("in_memory");
 	});
 
-	test("should throw a typed MissingToolCallIdError for tool messages without tool_call_id", async () => {
+	test("should throw a typed RequestError for tool messages without tool_call_id", async () => {
 		await expect(
 			prepareRequestBody(
 				"openai",
@@ -544,7 +541,7 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 				undefined,
 				true,
 			),
-		).rejects.toBeInstanceOf(MissingToolCallIdError);
+		).rejects.toBeInstanceOf(RequestError);
 	});
 
 	test("should not forward OpenAI prompt cache controls to Azure", async () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -26,6 +26,20 @@ import { transformGoogleMessages } from "./transform-google-messages.js";
 
 type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
 
+/**
+ * Thrown when a tool message reaches the Responses API transform without a
+ * `tool_call_id`, which is required to build a `function_call_output` item.
+ * The gateway maps this to HTTP 400 and writes a client_error log row so the
+ * rejected request still shows up in the user's activity history instead of
+ * surfacing as a generic 500 with no log.
+ */
+export class MissingToolCallIdError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = "MissingToolCallIdError";
+	}
+}
+
 function getProviderMapping(
 	modelDef: ModelDefinition | undefined,
 	usedProvider: ProviderId,
@@ -649,7 +663,7 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 		// Tool result messages become function_call_output items
 		if (msg.role === "tool") {
 			if (!msg.tool_call_id) {
-				throw new Error(
+				throw new MissingToolCallIdError(
 					"tool message is missing tool_call_id, required for Responses API function_call_output",
 				);
 			}

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -27,16 +27,19 @@ import { transformGoogleMessages } from "./transform-google-messages.js";
 type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
 
 /**
- * Thrown when a tool message reaches the Responses API transform without a
- * `tool_call_id`, which is required to build a `function_call_output` item.
- * The gateway maps this to HTTP 400 and writes a client_error log row so the
- * rejected request still shows up in the user's activity history instead of
- * surfacing as a generic 500 with no log.
+ * Generic typed error for invalid client requests detected before we hit the
+ * upstream provider (e.g. malformed message shapes). The gateway maps this to
+ * the carried `statusCode` (default 400) and writes a client_error log row so
+ * the rejected request still shows up in the user's activity history instead
+ * of surfacing as a generic 500 with no log. Reuse this for any similar
+ * pre-upstream request validation failure.
  */
-export class MissingToolCallIdError extends Error {
-	public constructor(message: string) {
+export class RequestError extends Error {
+	public readonly statusCode: number;
+	public constructor(message: string, statusCode = 400) {
 		super(message);
-		this.name = "MissingToolCallIdError";
+		this.name = "RequestError";
+		this.statusCode = statusCode;
 	}
 }
 
@@ -663,7 +666,7 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 		// Tool result messages become function_call_output items
 		if (msg.role === "tool") {
 			if (!msg.tool_call_id) {
-				throw new MissingToolCallIdError(
+				throw new RequestError(
 					"tool message is missing tool_call_id, required for Responses API function_call_output",
 				);
 			}


### PR DESCRIPTION
## Problem

When a tool message reached the OpenAI Responses API transform without a `tool_call_id`, `transformMessagesForResponsesApi` threw a plain `Error`. `app.onError` mapped this to a generic 500, and crucially **no log row was written**, so the rejected request never appeared in the user's activity history.

## Fix

Introduce a reusable typed `RequestError` in `prepare-request-body.ts` (exported via the package barrel) for invalid client requests detected before hitting the upstream provider. It carries a `statusCode` (default 400) so it can be reused for other similar pre-upstream validation failures.

- Throw `RequestError` for the missing `tool_call_id` case.
- In `chat.ts`, include it in the `prepareRequestBody` catch block so a `client_error` `insertLog` entry is written, using the error's `statusCode`.
- In `app.ts`, map it to the carried status code instead of a generic 500.

The rejected request now shows up in history as a client error, like the other pre-upstream input validation errors.

## Test

Added a unit test asserting `prepareRequestBody` rejects with `RequestError` for a tool message lacking `tool_call_id` under the Responses API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation with specific HTTP status codes and clearer error messages for invalid inputs
  * Enhanced message validation to catch missing required fields before processing

* **Tests**
  * Added validation test coverage for message format requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->