### PR TITLE
fix(gateway): recover tool_call_id for Responses API

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2837,6 +2837,210 @@ describe("prepareRequestBody - max_tokens forwarding", () => {
 				image_url: dataUrl,
 			});
 		});
+
+		const responsesArgs = (messages: any[]) =>
+			[
+				"openai",
+				"gpt-5",
+				null,
+				"gpt-5",
+				messages,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+				false,
+				20,
+				null,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // useResponsesApi
+			] as const;
+
+		test("pairs tool result with preceding tool_call via explicit tool_call_id", async () => {
+			const requestBody = (await prepareRequestBody(
+				...responsesArgs([
+					{ role: "user", content: "weather in Berlin?" },
+					{
+						role: "assistant",
+						content: "",
+						tool_calls: [
+							{
+								id: "call_abc",
+								type: "function",
+								function: {
+									name: "get_weather",
+									arguments: JSON.stringify({ city: "Berlin" }),
+								},
+							},
+						],
+					},
+					{
+						role: "tool",
+						tool_call_id: "call_abc",
+						content: JSON.stringify({ temperature: 17 }),
+					},
+				]),
+			)) as any;
+
+			const output = requestBody.input.find(
+				(i: any) => i.type === "function_call_output",
+			);
+			expect(output).toEqual({
+				type: "function_call_output",
+				call_id: "call_abc",
+				output: JSON.stringify({ temperature: 17 }),
+			});
+		});
+
+		test("recovers call_id when a lone tool result omits tool_call_id", async () => {
+			const requestBody = (await prepareRequestBody(
+				...responsesArgs([
+					{ role: "user", content: "weather in Berlin?" },
+					{
+						role: "assistant",
+						content: "",
+						tool_calls: [
+							{
+								id: "call_abc",
+								type: "function",
+								function: {
+									name: "get_weather",
+									arguments: JSON.stringify({ city: "Berlin" }),
+								},
+							},
+						],
+					},
+					{
+						role: "tool",
+						content: JSON.stringify({ temperature: 17 }),
+					},
+				]),
+			)) as any;
+
+			const output = requestBody.input.find(
+				(i: any) => i.type === "function_call_output",
+			);
+			expect(output.call_id).toBe("call_abc");
+		});
+
+		test("matches legacy function-role results by unique name", async () => {
+			const requestBody = (await prepareRequestBody(
+				...responsesArgs([
+					{ role: "user", content: "weather and time in Berlin?" },
+					{
+						role: "assistant",
+						content: "",
+						tool_calls: [
+							{
+								id: "call_weather",
+								type: "function",
+								function: { name: "get_weather", arguments: "{}" },
+							},
+							{
+								id: "call_time",
+								type: "function",
+								function: { name: "get_time", arguments: "{}" },
+							},
+						],
+					},
+					// Legacy `function` role: no tool_call_id, only name. Matched by
+					// unique name, so out-of-order results still resolve correctly.
+					{
+						role: "function",
+						name: "get_time",
+						content: JSON.stringify({ time: "20:52" }),
+					},
+					{
+						role: "function",
+						name: "get_weather",
+						content: JSON.stringify({ temperature: 17 }),
+					},
+				]),
+			)) as any;
+
+			const outputs = requestBody.input.filter(
+				(i: any) => i.type === "function_call_output",
+			);
+			expect(outputs).toEqual([
+				{
+					type: "function_call_output",
+					call_id: "call_time",
+					output: JSON.stringify({ time: "20:52" }),
+				},
+				{
+					type: "function_call_output",
+					call_id: "call_weather",
+					output: JSON.stringify({ temperature: 17 }),
+				},
+			]);
+		});
+
+		test("throws when explicit tool_call_id matches no preceding call", async () => {
+			await expect(
+				prepareRequestBody(
+					...responsesArgs([
+						{ role: "user", content: "weather in Berlin?" },
+						{
+							role: "assistant",
+							content: "",
+							tool_calls: [
+								{
+									id: "call_abc",
+									type: "function",
+									function: { name: "get_weather", arguments: "{}" },
+								},
+							],
+						},
+						{
+							role: "tool",
+							tool_call_id: "call_does_not_exist",
+							content: JSON.stringify({ temperature: 17 }),
+						},
+					]),
+				),
+			).rejects.toBeInstanceOf(RequestError);
+		});
+
+		test("throws for ambiguous parallel results missing tool_call_id", async () => {
+			await expect(
+				prepareRequestBody(
+					...responsesArgs([
+						{ role: "user", content: "weather and time?" },
+						{
+							role: "assistant",
+							content: "",
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									function: { name: "get_weather", arguments: "{}" },
+								},
+								{
+									id: "call_2",
+									type: "function",
+									function: { name: "get_time", arguments: "{}" },
+								},
+							],
+						},
+						// Two unmatched calls, no id, no name → ambiguous, must throw
+						// rather than guess which call this output belongs to.
+						{ role: "tool", content: JSON.stringify({ temperature: 17 }) },
+					]),
+				),
+			).rejects.toBeInstanceOf(RequestError);
+		});
 	});
 
 	describe("google-ai-studio", () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -656,18 +656,65 @@ function transformContentForResponsesApi(content: any, role: string): any {
  * The Responses API uses a flat list of "items" rather than messages:
  * - Regular messages become items with role/content
  * - Assistant tool_calls become separate { type: "function_call" } items
- * - Tool result messages become { type: "function_call_output" } items
+ * - Tool result messages (role "tool" and the legacy role "function") become
+ *   { type: "function_call_output" } items
  * Content types are also transformed (text -> input_text/output_text, image_url -> input_image)
+ *
+ * Tool results are paired with their function call via `call_id`. The Chat
+ * Completions spec requires `tool_call_id` on `tool` messages, but real callers
+ * sometimes omit it (legacy `function` role results carry only `name`, and some
+ * clients drop the id when replaying history). We recover the id from the
+ * preceding unmatched function calls, but only when the pairing is unambiguous:
+ * by explicit id, by a unique matching function name, or when exactly one call
+ * is still unmatched. Ambiguous cases throw rather than risk attaching a result
+ * to the wrong call.
  */
 function transformMessagesForResponsesApi(messages: any[]): any[] {
 	const items: any[] = [];
 
+	// FIFO of function calls emitted from assistant tool_calls that have not yet
+	// been consumed by a function_call_output. Used to recover the call_id of a
+	// tool/function result message that omits tool_call_id.
+	const pendingCalls: { callId: string; name?: string }[] = [];
+
+	const resolveCallId = (msg: any): string | undefined => {
+		// Explicit tool_call_id wins, but only if it references a real pending
+		// call. An id that matches nothing is orphaned (OpenAI would reject the
+		// function_call_output), so surface a clean 400 rather than trust it.
+		if (msg.tool_call_id) {
+			const idx = pendingCalls.findIndex((c) => c.callId === msg.tool_call_id);
+			if (idx === -1) {
+				return undefined;
+			}
+			pendingCalls.splice(idx, 1);
+			return msg.tool_call_id;
+		}
+		// No explicit id: recover only when the pairing is unambiguous. Guessing
+		// (oldest-first) silently misattributes a tool output to the wrong call
+		// when parallel results arrive out of order, so prefer a clean 400.
+		// Legacy `function` role (and tool messages that carry a function name):
+		// pair only when exactly one pending call shares that name.
+		if (msg.name) {
+			const named = pendingCalls.filter((c) => c.name === msg.name);
+			if (named.length === 1) {
+				const idx = pendingCalls.findIndex((c) => c.name === msg.name);
+				return pendingCalls.splice(idx, 1)[0].callId;
+			}
+		}
+		// Otherwise recover only when exactly one call is still unmatched.
+		if (pendingCalls.length === 1) {
+			return pendingCalls.shift()?.callId;
+		}
+		return undefined;
+	};
+
 	for (const msg of messages) {
-		// Tool result messages become function_call_output items
-		if (msg.role === "tool") {
-			if (!msg.tool_call_id) {
+		// Tool/function result messages become function_call_output items
+		if (msg.role === "tool" || msg.role === "function") {
+			const callId = resolveCallId(msg);
+			if (!callId) {
 				throw new RequestError(
-					"tool message is missing tool_call_id, required for Responses API function_call_output",
+					"tool message could not be matched to a preceding tool call; the Responses API requires every function_call_output to reference a function_call (supply tool_call_id)",
 				);
 			}
 			const output =
@@ -678,7 +725,7 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 						: "";
 			items.push({
 				type: "function_call_output",
-				call_id: msg.tool_call_id,
+				call_id: callId,
 				output,
 			});
 			continue;
@@ -705,6 +752,10 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 					call_id: toolCall.id,
 					name: toolCall.function.name,
 					arguments: toolCall.function.arguments,
+				});
+				pendingCalls.push({
+					callId: toolCall.id,
+					name: toolCall.function?.name,
 				});
 			}
 			continue;


### PR DESCRIPTION
## Context

This builds on **#2748** (already merged), which made the missing-`tool_call_id` case return a clean **400** (`RequestError`) instead of a 500 — but #2748 only *rejects* the request, it doesn't recover. This PR adds the actual recovery so valid-but-imperfect tool histories succeed.

Rebased onto current `main`; reuses the existing `RequestError` (no new error class, no `app.ts`/`chat.ts` changes). Diff is now just the transform + tests.

## Problem

When a model routes through OpenAI's **Responses API** (e.g. `gpt-5-pro`), tool result messages are converted to `function_call_output` items, which **must carry a `call_id`** referencing a preceding `function_call`. The transform rejected any `tool` message lacking `tool_call_id`.

Per the [official Chat Completions reference](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create), `tool_call_id` *is* required on `tool` messages — but two valid/real shapes don't carry it:

1. **Legacy `function` role** results carry only `name`, never `tool_call_id`, and weren't handled at all.
2. **`tool` results that drop `tool_call_id`** — common when clients replay history; the id is still recoverable from the matching assistant `tool_calls`.

Our request schema accepts `role: z.string()` + `tool_call_id` optional, so these reach the transform.

## Fix

`transformMessagesForResponsesApi` now recovers a missing `call_id` from preceding unmatched function calls, but **only when the pairing is unambiguous**:

1. explicit `tool_call_id` (validated against pending calls — an id matching nothing is treated as orphaned);
2. else a **unique** matching function `name` (covers the legacy `function` role);
3. else when **exactly one** call is still unmatched.

Ambiguous cases (e.g. multiple parallel results with no id and no distinguishing name) throw `RequestError` → 400 rather than guessing and silently attaching a result to the wrong call. Well-formed requests always carry `tool_call_id`, so they never hit the recovery path.

Credit to @RATCHAW for the unique-only refinement.

## Tests

Added 5 cases to the `openai (Responses API)` suite: explicit-id pairing, lone-result id recovery, legacy `function`-role unique-name matching, unmatched-explicit-id 400, and ambiguous-parallel-results 400. Full `prepare-request-body.spec.ts` (106 tests) passes; `pnpm format` and gateway/actions builds are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)