### PR TITLE
fix(gateway): always block direct provider on dev plans

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -102,6 +102,38 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/chat/completions rejects direct provider pinning for dev-plan orgs even with allowAllModels", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// allowAllModels only widens which models are available — it must never
+		// let a coding plan pin a specific provider/mapping.
+		await harness.setDevPlan({ devPlan: "pro", allowAllModels: true });
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o",
+				messages: [{ role: "user", content: "hi" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Direct provider routing is not available on coding plans",
+		);
+	});
+
 	test("/v1/chat/completions e2e success", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2348,26 +2348,30 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	if (isDevPlanRestricted) {
-		if (!isCodingModel(modelInfo)) {
-			throw new HTTPException(403, {
-				message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at devpass.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
-			});
-		}
+	if (isDevPlanRestricted && !isCodingModel(modelInfo)) {
+		throw new HTTPException(403, {
+			message: `Model ${modelInfo.id} is not available for coding plans. Coding plans only include models optimized for coding tasks with prompt caching, tool calling, JSON output, and streaming support. You can enable access to all models in your dashboard settings at devpass.llmgateway.io/dashboard, though this may significantly increase costs due to lack of prompt caching.`,
+		});
+	}
 
+	// Direct provider/mapping pinning is never allowed on coding plans,
+	// regardless of `devPlanAllowAllModels` — that toggle only controls which
+	// models are available, not whether routing can be pinned to a single
+	// provider. The gateway must own routing so it can prefer cached mappings.
+	if (isDevPlan) {
 		if (
 			requestedProvider &&
 			requestedProvider !== "llmgateway" &&
 			requestedProvider !== "custom"
 		) {
 			throw new HTTPException(403, {
-				message: `Direct provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+				message: `Direct provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing.`,
 			});
 		}
 
 		if (requestedProvider === "custom") {
 			throw new HTTPException(403, {
-				message: `Custom provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing. You can enable access to all models in your dashboard settings at code.llmgateway.io/dashboard.`,
+				message: `Custom provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing.`,
 			});
 		}
 	}


### PR DESCRIPTION
## Problem

On dev plans (devpass / coding plans), a request that pins a specific provider/mapping in the model string — e.g. `deepseek/deepseek-v4-pro` — was still accepted and routed directly to that provider (`direct-provider-specified`). It should never be allowed: the gateway must own routing so it can prefer cached mappings.

## Cause

The direct-provider rejection lived inside the `isDevPlanRestricted` block in `apps/gateway/src/chat/chat.ts`:

```ts
const isDevPlanRestricted = Boolean(
	organization?.isPersonal &&
		organization.devPlan !== "none" &&
		!organization.devPlanAllowAllModels,
);
```

When an org enables **allow all models**, `isDevPlanRestricted` becomes `false` and the *entire* block — including the direct-provider/custom guard — is skipped. But the allow-all-models toggle is only meant to widen *which models* are available (beyond the recommended coding set), not to permit pinning a single provider/mapping.

## Fix

- Keep the non-coding-model rejection gated on `isDevPlanRestricted` (that *is* the allow-all-models toggle's job).
- Hoist the direct-provider and custom-provider rejections out and gate them on `isDevPlan`, so pinning is blocked for **any** coding plan regardless of `devPlanAllowAllModels`.
- Dropped the now-misleading "enable access to all models" workaround sentence from those two error messages, since enabling the toggle no longer unlocks direct routing.

## Test

Added `apps/gateway/src/api.spec.ts` case: a dev-plan org with `allowAllModels: true` requesting `openai/gpt-4o` now gets `403 Direct provider routing is not available on coding plans`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Direct provider routing is now properly blocked for coding plan organizations, returning HTTP 403 responses with clearer and more concise error messages that better explain the restriction.

* **Tests**
  * Added test case to verify direct provider routing restrictions are correctly enforced for coding plan organizations, even when the model allowlist includes all available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->