### PR TITLE
perf(worker): prune settled buckets in stale-stats scan

### DIFF
--- a/apps/worker/src/services/project-stats-aggregator.ts
+++ b/apps/worker/src/services/project-stats-aggregator.ts
@@ -503,6 +503,13 @@ export async function aggregateHistoricalStats() {
 						staleStart
 							? sql`${projectHourlyStats.hourTimestamp} >= ${staleStart}::timestamp`
 							: undefined,
+						// A bucket can only be stale if it was last aggregated before its
+						// hour ended: a log in [hour, hour+1h) can only be newer than
+						// updatedAt when updatedAt < hour+1h. This is implied by the EXISTS
+						// below, but stating it as a single-table predicate lets Postgres
+						// prune settled buckets during the scan instead of running the
+						// correlated log lookup for every recent bucket.
+						sql`${projectHourlyStats.updatedAt} < ${projectHourlyStats.hourTimestamp} + interval '1 hour'`,
 						sql`EXISTS (
 							SELECT 1 FROM ${log}
 							WHERE ${log.projectId} = ${projectHourlyStats.projectId}


### PR DESCRIPTION
## Summary

Optimizes the stale-bucket scan in `apps/worker/src/services/project-stats-aggregator.ts` that finds `project_hourly_stats` rows whose source logs changed since the last aggregation.

The query's `WHERE` only filtered by `hour_timestamp >= staleStart`, then ran a correlated `EXISTS` log lookup for **every** recent bucket. The query plan showed a bitmap heap scan returning ~3,906 candidate buckets feeding a nested loop that took ~55ms — to ultimately return **0** stale buckets. Cost scaled with the number of recent buckets, not with how many were actually stale.

## Fix

A bucket can only be stale if a log in its `[hour, hour+1h)` window is newer than `updated_at`. Since a log's `created_at` is effectively its insertion time, `created_at > updated_at` **and** `created_at < hour+1h` together require `updated_at < hour+1h`. So any bucket last aggregated at/after its hour ended can never become stale.

This adds that as a single-table predicate:

```sql
project_hourly_stats.updated_at < project_hourly_stats.hour_timestamp + interval '1 hour'
```

It is logically implied by the existing `EXISTS`, so **results are unchanged** — but Postgres can now prune already-settled buckets during the heap scan instead of probing the `log` index once per recent bucket.

## Behavior

No functional change. Same rows returned; the implied predicate just lets the planner skip the per-bucket correlated lookup for settled hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of historical project statistics aggregation by refining the stale data bucket filtering mechanism, ensuring more reliable statistical calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->