### PR TITLE
perf(api): split internal models query to avoid lateral join

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -142,20 +142,18 @@ const getModelsRoute = createRoute({
 internalModels.openapi(getModelsRoute, async (c) => {
 	const now = new Date();
 
-	const [models, globalDiscounts] = await Promise.all([
+	const [models, activeMappings, globalDiscounts] = await Promise.all([
 		db.query.model.findMany({
 			where: {
 				status: { eq: "active" },
 			},
-			with: {
-				modelProviderMappings: {
-					where: {
-						status: { eq: "active" },
-					},
-				},
-			},
 			orderBy: {
 				createdAt: "desc",
+			},
+		}),
+		db.query.modelProviderMapping.findMany({
+			where: {
+				status: { eq: "active" },
 			},
 		}),
 		db
@@ -175,6 +173,16 @@ internalModels.openapi(getModelsRoute, async (c) => {
 				),
 			),
 	]);
+
+	const mappingsByModelId = new Map<string, typeof activeMappings>();
+	for (const mapping of activeMappings) {
+		const existing = mappingsByModelId.get(mapping.modelId);
+		if (existing) {
+			existing.push(mapping);
+		} else {
+			mappingsByModelId.set(mapping.modelId, [mapping]);
+		}
+	}
 
 	// Find the best global discount for a given provider+model. Discounts are
 	// always keyed by the root model ID.
@@ -218,7 +226,7 @@ internalModels.openapi(getModelsRoute, async (c) => {
 	// Transform and apply effective discount
 	const transformedModels = models.map((model) => ({
 		...model,
-		mappings: model.modelProviderMappings.map((mapping) => {
+		mappings: (mappingsByModelId.get(model.id) ?? []).map((mapping) => {
 			const sharedMapping: ProviderModelMapping | null =
 				modelDefinitions
 					.find((modelDefinition) => modelDefinition.id === model.id)


### PR DESCRIPTION
## Problem

The `GET /internal/models` query (`db.query.model.findMany` with `modelProviderMappings`) compiles to a relational query that runs a **correlated lateral subquery per model row**. The query plan showed a nested loop with ~297 individual index scans on `model_provider_mapping` (one per active model), which dominated the cost (`1086.71`, ~14.7ms in the nested loop) even after the `model_provider_mapping_status_model_id_idx` index was added in #2755.

## Change

Replace the single relational query with two flat queries run in parallel:

- all active `model` rows
- all active `model_provider_mapping` rows

then stitch the mappings onto each model by `modelId` in memory (`Map<modelId, mappings[]>`). This reads each table once instead of doing N index scans, eliminating the nested loop entirely. The response shape is unchanged.

## Verification

- `pnpm turbo run build --filter=api` passes
- `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency of the models API endpoint by optimizing how provider mappings are retrieved and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->