### PR TITLE
feat(ui): add enterprise trial + refresh pricing

### DIFF
--- a/apps/ui/src/components/enterprise/hero.tsx
+++ b/apps/ui/src/components/enterprise/hero.tsx
@@ -97,6 +97,9 @@ export function HeroEnterprise({
 							<Link href="/signup">Explore The Product</Link>
 						</Button>
 					</div>
+					<p className="mt-5 text-sm text-muted-foreground">
+						Every enterprise plan starts with a 30-day trial.
+					</p>
 
 					<div className="mt-16 grid grid-cols-2 gap-4 sm:grid-cols-4 lg:gap-6">
 						<StatCard

--- a/apps/ui/src/components/enterprise/pricing.tsx
+++ b/apps/ui/src/components/enterprise/pricing.tsx
@@ -26,6 +26,7 @@ const plans = [
 		description: "Fully managed with custom scaling and pricing",
 		features: [
 			"Everything in Self-Hosted",
+			"30-day trial to start",
 			"Fully managed infrastructure",
 			"Custom rate limits",
 			"Volume-based pricing",
@@ -43,12 +44,17 @@ export function PricingEnterprise() {
 		<section id="pricing" className="py-20 sm:py-28 bg-muted/30">
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 				<div className="mx-auto max-w-2xl text-center mb-16">
+					<span className="mb-4 inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1.5 text-xs font-mono uppercase tracking-wider text-blue-500">
+						<span className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-pulse" />
+						30-day trial included
+					</span>
 					<h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl lg:text-5xl text-balance">
 						Enterprise pricing that scales with you
 					</h2>
 					<p className="text-lg text-muted-foreground text-balance leading-relaxed">
 						Choose between self-hosted control or fully managed convenience.
-						Both options include all enterprise features.
+						Both options include all enterprise features, and every plan starts
+						with a 30-day trial.
 					</p>
 				</div>
 				<div className="mx-auto max-w-5xl grid gap-8 lg:grid-cols-2">
@@ -85,7 +91,8 @@ export function PricingEnterprise() {
 					))}
 				</div>
 				<p className="mt-8 text-center text-sm text-muted-foreground">
-					Contact us for custom plans and enterprise agreements.
+					Every plan starts with a 30-day trial. Contact us for custom plans and
+					enterprise agreements.
 				</p>
 			</div>
 		</section>

--- a/apps/ui/src/components/pricing/pricing-table.tsx
+++ b/apps/ui/src/components/pricing/pricing-table.tsx
@@ -25,6 +25,11 @@ const pricingFeatures: PricingFeature[] = [
 		enterprise: "Volume discounts",
 	},
 	{
+		name: "Free Trial",
+		free: "Free forever",
+		enterprise: "30-day trial",
+	},
+	{
 		name: "Models",
 		description: "280+ unique models across 35+ providers",
 		learnMoreLink: "/models",
@@ -105,18 +110,50 @@ const pricingFeatures: PricingFeature[] = [
 		enterprise: true,
 	},
 	{
-		name: "Data Policy-Based Routing",
-		description: "Route based on data policies",
+		name: "Enterprise Audit Logs",
+		description: "Immutable, SIEM-ready audit trails",
+		learnMoreLink: "/enterprise/audit-logs",
+		learnMoreText: "Learn more →",
 		free: false,
 		enterprise: true,
 	},
 	{
-		name: "Managed Policy Enforcement",
+		name: "Enterprise Guardrails",
+		description: "Prompt injection, PII & secret detection",
+		learnMoreLink: "/enterprise/guardrails",
+		learnMoreText: "Learn more →",
+		free: false,
+		enterprise: true,
+	},
+	{
+		name: "Per-Project Routing Overrides",
+		description: "Region pinning, fallback & cost ceilings per project",
+		learnMoreLink: "/enterprise/routing-overrides",
+		learnMoreText: "Learn more →",
+		free: false,
+		enterprise: true,
+	},
+	{
+		name: "Provider Compliance Policies",
+		description: "Route only to SOC 2 / ISO 27001 / GDPR providers",
+		learnMoreLink: "/enterprise/compliance",
+		learnMoreText: "Learn more →",
+		free: false,
+		enterprise: true,
+	},
+	{
+		name: "Discord & Slack Alerts",
+		description: "Real-time webhook alerts to your channels",
+		learnMoreLink: "/enterprise/discord-notifications",
+		learnMoreText: "Learn more →",
 		free: false,
 		enterprise: true,
 	},
 	{
 		name: "SSO/SAML",
+		description: "SAML 2.0 & OIDC with SCIM provisioning",
+		learnMoreLink: "/enterprise/sso-saml",
+		learnMoreText: "Learn more →",
 		free: false,
 		enterprise: true,
 	},
@@ -127,6 +164,9 @@ const pricingFeatures: PricingFeature[] = [
 	},
 	{
 		name: "Chat App (Whitelabel)",
+		description: "Ship the playground under your own brand & domain",
+		learnMoreLink: "/enterprise/white-label",
+		learnMoreText: "Learn more →",
 		free: false,
 		enterprise: true,
 	},
@@ -152,7 +192,7 @@ const pricingFeatures: PricingFeature[] = [
 	{
 		name: "Support",
 		free: "Discord Community",
-		enterprise: "24/7 SLA + Discord channel",
+		enterprise: "24/7 SLA + Slack channel",
 	},
 ];
 
@@ -193,6 +233,9 @@ export function PricingTable() {
 									<div className="text-2xl font-bold mt-1">Custom</div>
 									<div className="text-sm text-muted-foreground">
 										Contact us
+									</div>
+									<div className="mt-1 text-xs font-medium text-blue-600 dark:text-blue-400">
+										30-day trial
 									</div>
 								</th>
 							</tr>


### PR DESCRIPTION
## What

Two landing-page updates in `apps/ui`:

### `/enterprise` — 30-day trial
- Hero: a "Every enterprise plan starts with a 30-day trial." line under the CTAs.
- Pricing section: a "30-day trial included" badge in the header, a "30-day trial to start" feature on the Enterprise Cloud plan, copy update, and a footnote.

### `/pricing` — refresh the comparison table
- Added rows for the newly shipped enterprise capabilities, each with a deep-link **Learn more →** to its `/enterprise/<slug>` page:
  - Enterprise Audit Logs
  - Enterprise Guardrails
  - Per-Project Routing Overrides
  - Provider Compliance Policies (replaces the generic "Data Policy-Based Routing")
  - Discord & Slack Alerts
  - Added deep links to existing **SSO/SAML** and **Chat App (Whitelabel)** rows
- Added a **Free Trial** row (`Free forever` vs `30-day trial`) and a `30-day trial` note under the Enterprise column header.
- Replaced the enterprise support line **"24/7 SLA + Discord channel"** → **"24/7 SLA + Slack channel"**.

## Testing
- `turbo run build --filter=ui` passes (`/pricing` and `/enterprise` compile cleanly).
- `pnpm format` / lint-staged clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prominent "30-day trial" messaging throughout enterprise pricing pages and hero section.
  * Introduced new enterprise features including audit logs, guardrails, routing overrides, compliance policies, and alert integrations.

* **Updates**
  * Enhanced enterprise feature descriptions with additional learning resources.
  * Updated support channel options for enterprise customers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->