### PR TITLE
perf(worker): skip zero-traffic per-minute history rows

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -592,8 +592,10 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 	const { modelId } = c.req.valid("param");
 
 	const WINDOW_MINUTES = 240; // 4h
-	const WINDOW_MS = WINDOW_MINUTES * 60_000;
-	const since = new Date(Date.now() - WINDOW_MS);
+	const MINUTE_MS = 60_000;
+	const WINDOW_MS = WINDOW_MINUTES * MINUTE_MS;
+	const now = Date.now();
+	const since = new Date(now - WINDOW_MS);
 
 	// Active providers serving this model — included even if they have no
 	// recent traffic so the page can render an idle state for them.
@@ -726,6 +728,38 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			totalTokens: Number(r.totalTokens),
 		});
 		byProvider.set(key, entry);
+	}
+
+	// The worker only persists per-minute rows for mappings that had traffic, so
+	// idle minutes are absent from `rows`. Fill the window to a dense minute grid
+	// (zero rows for idle minutes) so the time series renders without gaps, which
+	// reproduces the previous behavior when all-zero rows were written.
+	const gridStart = Math.ceil(since.getTime() / MINUTE_MS) * MINUTE_MS;
+	const gridEnd = Math.floor(now / MINUTE_MS) * MINUTE_MS;
+	const gridTimestamps: string[] = [];
+	for (let t = gridStart; t <= gridEnd; t += MINUTE_MS) {
+		gridTimestamps.push(new Date(t).toISOString());
+	}
+
+	for (const entry of byProvider.values()) {
+		const pointsByTimestamp = new Map(
+			entry.points.map((pt) => [pt.timestamp, pt]),
+		);
+		entry.points = gridTimestamps.map(
+			(timestamp) =>
+				pointsByTimestamp.get(timestamp) ?? {
+					timestamp,
+					logsCount: 0,
+					errorsCount: 0,
+					clientErrorsCount: 0,
+					gatewayErrorsCount: 0,
+					upstreamErrorsCount: 0,
+					cachedCount: 0,
+					totalDuration: 0,
+					totalTimeToFirstToken: 0,
+					totalTokens: 0,
+				},
+		);
 	}
 
 	const providers = Array.from(byProvider.values()).map((p) => {

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -735,7 +735,9 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 	// (zero rows for idle minutes) so the time series renders without gaps, which
 	// reproduces the previous behavior when all-zero rows were written.
 	const gridStart = Math.ceil(since.getTime() / MINUTE_MS) * MINUTE_MS;
-	const gridEnd = Math.floor(now / MINUTE_MS) * MINUTE_MS;
+	// Use now-1 so an exact minute boundary doesn't add a 241st (empty, just-
+	// started) bucket; the series stays a stable WINDOW_MINUTES length.
+	const gridEnd = Math.floor((now - 1) / MINUTE_MS) * MINUTE_MS;
 	const gridTimestamps: string[] = [];
 	for (let t = gridStart; t <= gridEnd; t += MINUTE_MS) {
 		gridTimestamps.push(new Date(t).toISOString());

--- a/apps/worker/src/services/stats-calculator.spec.ts
+++ b/apps/worker/src/services/stats-calculator.spec.ts
@@ -29,6 +29,33 @@ import {
 // Mock current time for consistent testing
 const mockDate = new Date("2024-01-01T12:30:00.000Z");
 
+function makeLog(
+	id: string,
+	minute: Date,
+	modelId: string,
+	providerId: string,
+) {
+	return {
+		id,
+		requestId: `req-${id}`,
+		organizationId: "org-1",
+		projectId: "proj-1",
+		apiKeyId: "key-1",
+		duration: 1000,
+		requestedModel: modelId,
+		requestedProvider: providerId,
+		usedModel: `${providerId}/${modelId}`,
+		usedProvider: providerId,
+		responseSize: 100,
+		hasError: false,
+		completionTokens: "100",
+		unifiedFinishReason: "completed",
+		mode: "api-keys" as const,
+		usedMode: "api-keys" as const,
+		createdAt: new Date(minute.getTime() + 30000),
+	};
+}
+
 describe("stats-calculator", () => {
 	beforeEach(async () => {
 		// Mock Date to have consistent time-based tests
@@ -869,36 +896,22 @@ describe("stats-calculator", () => {
 
 			await calculateMinutelyHistory();
 
-			// Should create history records for existing mappings only, ignoring the invalid log
+			// The invalid log references no known mapping, so no history rows are
+			// written (zero-traffic rows are skipped entirely).
 			const historyRecords = await db
 				.select()
 				.from(modelProviderMappingHistory);
-			expect(historyRecords.length).toBeGreaterThanOrEqual(2); // Our test mappings
-
-			// All should have zero stats since the log was for non-existent model/provider
-			for (const record of historyRecords) {
-				expect(record.logsCount).toBe(0);
-				expect(record.totalOutputTokens).toBe(0);
-			}
+			expect(historyRecords).toHaveLength(0);
 		});
 
 		it("should handle empty logs gracefully", async () => {
 			await calculateMinutelyHistory();
 
-			// Should create history records for all mappings with zero stats
+			// With no traffic, no history rows are written.
 			const historyRecords = await db
 				.select()
 				.from(modelProviderMappingHistory);
-			expect(historyRecords.length).toBeGreaterThanOrEqual(2); // Our test mappings
-
-			// All should have zero stats since no logs were inserted
-			for (const record of historyRecords) {
-				expect(record.logsCount).toBe(0);
-				expect(record.errorsCount).toBe(0);
-				expect(record.totalOutputTokens).toBe(0);
-				expect(record.totalDuration).toBe(0);
-				expect(record.cachedCount).toBe(0);
-			}
+			expect(historyRecords).toHaveLength(0);
 		});
 
 		it("should update existing history records on conflict", async () => {
@@ -941,13 +954,14 @@ describe("stats-calculator", () => {
 
 			await calculateMinutelyHistory();
 
-			// Should have records for both mappings (including inactive one)
+			// Only the trafficked mapping (gpt-4/openai) gets a row; the inactive
+			// claude mapping is skipped.
 			const historyRecords = await db
 				.select()
 				.from(modelProviderMappingHistory);
-			expect(historyRecords.length).toBeGreaterThanOrEqual(2); // At least the 2 test mappings
+			expect(historyRecords).toHaveLength(1);
 
-			// Check the active mapping was updated
+			// Check the active mapping was updated (existing row upserted)
 			const gptRecord = historyRecords.find(
 				(r) => r.modelId === "gpt-4" && r.providerId === "openai",
 			);
@@ -955,18 +969,16 @@ describe("stats-calculator", () => {
 			expect(gptRecord?.logsCount).toBe(1);
 			expect(gptRecord?.totalOutputTokens).toBe(100);
 
-			// Check inactive mapping has zero stats
+			// Inactive mapping has no row (zero-traffic rows are skipped)
 			const claudeRecord = historyRecords.find(
 				(r) =>
 					r.modelId === "claude-3-5-sonnet" && r.providerId === "anthropic",
 			);
-			expect(claudeRecord).toBeTruthy();
-			expect(claudeRecord?.logsCount).toBe(0);
-			expect(claudeRecord?.totalOutputTokens).toBe(0);
+			expect(claudeRecord).toBeUndefined();
 
-			// Check that model history was also created
+			// Check that model history was also created for the trafficked model only
 			const modelHistoryRecords = await db.select().from(modelHistory);
-			expect(modelHistoryRecords.length).toBeGreaterThanOrEqual(2); // At least 2 models
+			expect(modelHistoryRecords).toHaveLength(1);
 
 			const gptModelRecord = modelHistoryRecords.find(
 				(r) => r.modelId === "gpt-4",
@@ -978,42 +990,22 @@ describe("stats-calculator", () => {
 			const claudeModelRecord = modelHistoryRecords.find(
 				(r) => r.modelId === "claude-3-5-sonnet",
 			);
-			expect(claudeModelRecord).toBeTruthy();
-			expect(claudeModelRecord?.logsCount).toBe(0); // No logs for claude in this test
-			expect(claudeModelRecord?.totalOutputTokens).toBe(0);
+			expect(claudeModelRecord).toBeUndefined();
 		});
 
-		it("should create entries for inactive model-provider mappings", async () => {
-			// Don't insert any logs, so all mappings should be inactive
+		it("should not create entries for inactive model-provider mappings", async () => {
+			// Don't insert any logs, so all mappings are inactive this minute
 
 			await calculateMinutelyHistory();
 
-			// Should create history records for all model-provider mappings
+			// No history rows are written for mappings without traffic
 			const historyRecords = await db
 				.select()
 				.from(modelProviderMappingHistory);
-			expect(historyRecords.length).toBeGreaterThanOrEqual(2); // At least our 2 test mappings
+			expect(historyRecords).toHaveLength(0);
 
-			// All should have zero stats since no logs were inserted
-			for (const record of historyRecords) {
-				expect(record.logsCount).toBe(0);
-				expect(record.errorsCount).toBe(0);
-				expect(record.totalOutputTokens).toBe(0);
-				expect(record.totalDuration).toBe(0);
-				expect(record.cachedCount).toBe(0);
-			}
-
-			// Check model history was also created with zero stats
 			const modelHistoryRecords = await db.select().from(modelHistory);
-			expect(modelHistoryRecords.length).toBeGreaterThanOrEqual(2); // At least our 2 test models
-
-			for (const record of modelHistoryRecords) {
-				expect(record.logsCount).toBe(0);
-				expect(record.errorsCount).toBe(0);
-				expect(record.totalOutputTokens).toBe(0);
-				expect(record.totalDuration).toBe(0);
-				expect(record.cachedCount).toBe(0);
-			}
+			expect(modelHistoryRecords).toHaveLength(0);
 		});
 	});
 
@@ -1102,22 +1094,14 @@ describe("stats-calculator", () => {
 			expect(anthropicMapping?.logsCount).toBe(1);
 		});
 
-		it("should create model history entries for inactive models", async () => {
-			// Don't insert any logs, so all models should have zero stats
+		it("should not create model history entries for inactive models", async () => {
+			// Don't insert any logs, so all models are inactive this minute
 
 			await calculateMinutelyHistory();
 
+			// No model history rows are written without traffic
 			const modelHistoryRecords = await db.select().from(modelHistory);
-			expect(modelHistoryRecords.length).toBeGreaterThanOrEqual(2); // At least our 2 test models
-
-			// All should have zero stats since no logs were inserted
-			for (const record of modelHistoryRecords) {
-				expect(record.logsCount).toBe(0);
-				expect(record.errorsCount).toBe(0);
-				expect(record.totalOutputTokens).toBe(0);
-				expect(record.totalDuration).toBe(0);
-				expect(record.cachedCount).toBe(0);
-			}
+			expect(modelHistoryRecords).toHaveLength(0);
 		});
 
 		it("should handle model history conflicts with upsert", async () => {
@@ -1330,6 +1314,20 @@ describe("stats-calculator", () => {
 			// Set time to 12:30 so we backfill from 12:25 to 12:29 (5 minutes)
 			vi.setSystemTime(new Date("2024-01-01T12:30:00.000Z"));
 
+			// Seed traffic for both mappings in each backfilled minute so backfill
+			// produces rows (zero-traffic minutes are skipped).
+			const backfillMinutes = [25, 26, 27, 28, 29].map(
+				(m) => new Date(`2024-01-01T12:${m}:00.000Z`),
+			);
+			await db
+				.insert(log)
+				.values(
+					backfillMinutes.flatMap((minute, i) => [
+						makeLog(`gpt-${i}`, minute, "gpt-4", "openai"),
+						makeLog(`claude-${i}`, minute, "claude-3-5-sonnet", "anthropic"),
+					]),
+				);
+
 			await backfillHistoryIfNeeded();
 
 			const historyRecords = await db
@@ -1401,6 +1399,20 @@ describe("stats-calculator", () => {
 				totalCachedTokens: 0,
 				totalDuration: 2000,
 			});
+
+			// Seed traffic for the missing minutes (12:26-12:29) so backfill produces
+			// rows (zero-traffic minutes are skipped).
+			const missingMinutes = [26, 27, 28, 29].map(
+				(m) => new Date(`2024-01-01T12:${m}:00.000Z`),
+			);
+			await db
+				.insert(log)
+				.values(
+					missingMinutes.flatMap((minute, i) => [
+						makeLog(`gpt-${i}`, minute, "gpt-4", "openai"),
+						makeLog(`claude-${i}`, minute, "claude-3-5-sonnet", "anthropic"),
+					]),
+				);
 
 			await backfillHistoryIfNeeded();
 

--- a/apps/worker/src/services/stats-calculator.spec.ts
+++ b/apps/worker/src/services/stats-calculator.spec.ts
@@ -1007,6 +1007,60 @@ describe("stats-calculator", () => {
 			const modelHistoryRecords = await db.select().from(modelHistory);
 			expect(modelHistoryRecords).toHaveLength(0);
 		});
+
+		it("should delete stale rows when traffic drops to zero for a minute", async () => {
+			const previousMinuteStart = new Date("2024-01-01T12:29:00.000Z");
+
+			// Simulate a row written by an earlier pass (e.g. before a same-provider
+			// retry got linked and filtered out) that now has no traffic.
+			await db.insert(modelProviderMappingHistory).values({
+				modelId: "gpt-4",
+				providerId: "openai",
+				modelProviderMappingId: "mapping-1",
+				minuteTimestamp: previousMinuteStart,
+				logsCount: 1,
+				errorsCount: 1,
+				upstreamErrorsCount: 1,
+			});
+			await db.insert(modelHistory).values({
+				modelId: "gpt-4",
+				minuteTimestamp: previousMinuteStart,
+				logsCount: 1,
+				errorsCount: 1,
+				upstreamErrorsCount: 1,
+			});
+
+			// Only the claude mapping has traffic this minute.
+			await db
+				.insert(log)
+				.values([
+					makeLog(
+						"log-1",
+						previousMinuteStart,
+						"claude-3-5-sonnet",
+						"anthropic",
+					),
+				]);
+
+			await calculateMinutelyHistory();
+
+			// The stale gpt-4 rows must be removed (not left as phantom counts).
+			const mappingRecords = await db
+				.select()
+				.from(modelProviderMappingHistory);
+			expect(
+				mappingRecords.find((r) => r.modelProviderMappingId === "mapping-1"),
+			).toBeUndefined();
+			expect(
+				mappingRecords.find((r) => r.modelProviderMappingId === "mapping-2"),
+			).toBeTruthy();
+
+			const modelRecords = await db.select().from(modelHistory);
+			expect(modelRecords.find((r) => r.modelId === "gpt-4")).toBeUndefined();
+			expect(
+				modelRecords.find((r) => r.modelId === "claude-3-5-sonnet"),
+			).toBeTruthy();
+		});
 	});
 
 	describe("model history tracking", () => {
@@ -1306,6 +1360,65 @@ describe("stats-calculator", () => {
 			const openaiProvider = providers[0]!;
 			expect(openaiProvider.logsCount).toBe(0); // Should remain 0
 			expect(openaiProvider.statsUpdatedAt).toBeNull(); // Should not be updated
+		});
+
+		it("should reset stats for entities that aged out of the window", async () => {
+			const now = new Date("2024-01-01T12:30:00.000Z");
+
+			// Stale persisted stats for entities with no recent history (sparse
+			// history no longer emits zero rows to age these out).
+			await db
+				.update(provider)
+				.set({ logsCount: 100, errorsCount: 10 })
+				.where(eq(provider.id, "openai"));
+			await db
+				.update(model)
+				.set({ logsCount: 100, errorsCount: 10 })
+				.where(eq(model.id, "gpt-4"));
+			await db
+				.update(modelProviderMapping)
+				.set({ logsCount: 100, errorsCount: 10 })
+				.where(eq(modelProviderMapping.id, "mapping-1"));
+
+			// Recent traffic for a different entity that should keep its stats.
+			await db.insert(modelProviderMappingHistory).values({
+				modelId: "claude-3-5-sonnet",
+				providerId: "anthropic",
+				modelProviderMappingId: "mapping-2",
+				minuteTimestamp: minutesAgo(now, 5),
+				logsCount: 5,
+				errorsCount: 1,
+			});
+
+			await calculateAggregatedStatistics();
+
+			const openai = (
+				await db.select().from(provider).where(eq(provider.id, "openai"))
+			)[0]!;
+			expect(openai.logsCount).toBe(0); // Aged out → reset
+			const gpt4 = (
+				await db.select().from(model).where(eq(model.id, "gpt-4"))
+			)[0]!;
+			expect(gpt4.logsCount).toBe(0); // Aged out → reset
+			const mapping1 = (
+				await db
+					.select()
+					.from(modelProviderMapping)
+					.where(eq(modelProviderMapping.id, "mapping-1"))
+			)[0]!;
+			expect(mapping1.logsCount).toBe(0); // Aged out → reset
+
+			const anthropic = (
+				await db.select().from(provider).where(eq(provider.id, "anthropic"))
+			)[0]!;
+			expect(anthropic.logsCount).toBe(5); // Still active → window aggregate
+			const mapping2 = (
+				await db
+					.select()
+					.from(modelProviderMapping)
+					.where(eq(modelProviderMapping.id, "mapping-2"))
+			)[0]!;
+			expect(mapping2.logsCount).toBe(5); // Still active → window aggregate
 		});
 	});
 

--- a/apps/worker/src/services/stats-calculator.spec.ts
+++ b/apps/worker/src/services/stats-calculator.spec.ts
@@ -1677,6 +1677,97 @@ describe("stats-calculator", () => {
 			expect(gptCurrent?.errorsCount).toBe(1);
 		});
 
+		it("should clear hourly rows when their minute groups disappear", async () => {
+			// Stale hourly rows whose minute data has since dropped to zero.
+			// gpt-4/mapping-1 in the current hour (12:00) where other traffic
+			// remains, and claude/mapping-2 in the previous hour (11:00) which
+			// becomes entirely empty.
+			await db.insert(modelHistoryHourly).values([
+				{ modelId: "gpt-4", hourTimestamp: currentHour, logsCount: 50 },
+				{
+					modelId: "claude-3-5-sonnet",
+					hourTimestamp: previousHour,
+					logsCount: 30,
+				},
+			]);
+			await db.insert(modelProviderMappingHistoryHourly).values([
+				{
+					modelId: "gpt-4",
+					providerId: "openai",
+					modelProviderMappingId: "mapping-1",
+					hourTimestamp: currentHour,
+					logsCount: 50,
+				},
+				{
+					modelId: "claude-3-5-sonnet",
+					providerId: "anthropic",
+					modelProviderMappingId: "mapping-2",
+					hourTimestamp: previousHour,
+					logsCount: 30,
+				},
+			]);
+
+			// Only claude has minute traffic in the current hour; nothing in 11:00.
+			await db.insert(modelHistory).values({
+				modelId: "claude-3-5-sonnet",
+				minuteTimestamp: new Date("2024-01-01T12:05:00.000Z"),
+				logsCount: 3,
+			});
+			await db.insert(modelProviderMappingHistory).values({
+				modelId: "claude-3-5-sonnet",
+				providerId: "anthropic",
+				modelProviderMappingId: "mapping-2",
+				minuteTimestamp: new Date("2024-01-01T12:05:00.000Z"),
+				logsCount: 3,
+			});
+
+			await calculateHourlyHistory();
+
+			const modelHourly = await db.select().from(modelHistoryHourly);
+			// gpt-4 group vanished from the current hour → its stale row removed
+			expect(
+				modelHourly.find(
+					(r) =>
+						r.modelId === "gpt-4" &&
+						r.hourTimestamp.getTime() === currentHour.getTime(),
+				),
+			).toBeUndefined();
+			// claude's stale previous-hour row (now fully empty) removed
+			expect(
+				modelHourly.find(
+					(r) => r.hourTimestamp.getTime() === previousHour.getTime(),
+				),
+			).toBeUndefined();
+			// claude's current-hour row is recomputed from live minute data
+			expect(
+				modelHourly.find(
+					(r) =>
+						r.modelId === "claude-3-5-sonnet" &&
+						r.hourTimestamp.getTime() === currentHour.getTime(),
+				)?.logsCount,
+			).toBe(3);
+
+			const mappingHourly = await db
+				.select()
+				.from(modelProviderMappingHistoryHourly);
+			expect(
+				mappingHourly.find(
+					(r) =>
+						r.modelProviderMappingId === "mapping-1" &&
+						r.hourTimestamp.getTime() === currentHour.getTime(),
+				),
+			).toBeUndefined();
+			expect(
+				mappingHourly.find(
+					(r) => r.hourTimestamp.getTime() === previousHour.getTime(),
+				),
+			).toBeUndefined();
+			expect(
+				mappingHourly.find((r) => r.modelProviderMappingId === "mapping-2")
+					?.logsCount,
+			).toBe(3);
+		});
+
 		it("should roll up token totals exceeding the 32-bit integer range", async () => {
 			// Each minute fits in a 32-bit int, but the hourly sum (4e9) exceeds
 			// 2,147,483,647, which would throw if the rollup narrowed tokens to int.

--- a/apps/worker/src/services/stats-calculator.ts
+++ b/apps/worker/src/services/stats-calculator.ts
@@ -382,56 +382,39 @@ async function calculateModelHistoryForMinute(targetMinute: Date) {
 
 		const stat = activeModelsMap.get(modelEntry.modelId);
 
-		// Use actual stats if available, otherwise create zero stats
-		const logsCount = stat?.logsCount ?? 0;
-		const errorsCount = stat?.errorsCount ?? 0;
-		const clientErrorsCount = stat?.clientErrorsCount ?? 0;
-		const gatewayErrorsCount = stat?.gatewayErrorsCount ?? 0;
-		const upstreamErrorsCount = stat?.upstreamErrorsCount ?? 0;
-		const completedCount = stat?.completedCount ?? 0;
-		const lengthLimitCount = stat?.lengthLimitCount ?? 0;
-		const contentFilterCount = stat?.contentFilterCount ?? 0;
-		const toolCallsCount = stat?.toolCallsCount ?? 0;
-		const canceledCount = stat?.canceledCount ?? 0;
-		const unknownFinishCount = stat?.unknownFinishCount ?? 0;
-		const cachedCount = stat?.cachedCount ?? 0;
-		const totalInputTokens = stat?.totalInputTokens ?? 0;
-		const totalOutputTokens = stat?.totalOutputTokens ?? 0;
-		const totalTokens = stat?.totalTokens ?? 0;
-		const totalReasoningTokens = stat?.totalReasoningTokens ?? 0;
-		const totalCachedTokens = stat?.totalCachedTokens ?? 0;
-		const totalDuration = stat?.totalDuration ?? 0;
-		const totalTimeToFirstToken = stat?.totalTimeToFirstToken ?? 0;
-		const totalTimeToFirstReasoningToken =
-			stat?.totalTimeToFirstReasoningToken ?? 0;
-		const totalCost = stat?.totalCost ?? 0;
+		// Skip models with no traffic this minute: an all-zero row carries no
+		// information (every reader uses COALESCE(SUM(...)) and treats absent
+		// rows as zero), so we avoid writing it.
+		if (!stat) {
+			continue;
+		}
 
 		// Collect the history record for this minute; written in one bulk upsert
 		// below instead of a per-model round-trip.
 		modelHistoryValues.push({
 			modelId: modelEntry.modelId,
 			minuteTimestamp: roundedTargetMinute,
-			logsCount,
-			errorsCount,
-			clientErrorsCount,
-			gatewayErrorsCount,
-			upstreamErrorsCount,
-			completedCount,
-			lengthLimitCount,
-			contentFilterCount,
-			toolCallsCount,
-			canceledCount,
-			unknownFinishCount,
-			cachedCount,
-			totalInputTokens,
-			totalOutputTokens,
-			totalTokens,
-			totalReasoningTokens,
-			totalCachedTokens,
-			totalDuration,
-			totalTimeToFirstToken,
-			totalTimeToFirstReasoningToken,
-			totalCost,
+			logsCount: stat.logsCount,
+			errorsCount: stat.errorsCount,
+			clientErrorsCount: stat.clientErrorsCount,
+			gatewayErrorsCount: stat.gatewayErrorsCount,
+			upstreamErrorsCount: stat.upstreamErrorsCount,
+			completedCount: stat.completedCount,
+			lengthLimitCount: stat.lengthLimitCount,
+			contentFilterCount: stat.contentFilterCount,
+			toolCallsCount: stat.toolCallsCount,
+			canceledCount: stat.canceledCount,
+			unknownFinishCount: stat.unknownFinishCount,
+			cachedCount: stat.cachedCount,
+			totalInputTokens: stat.totalInputTokens,
+			totalOutputTokens: stat.totalOutputTokens,
+			totalTokens: stat.totalTokens,
+			totalReasoningTokens: stat.totalReasoningTokens,
+			totalCachedTokens: stat.totalCachedTokens,
+			totalDuration: stat.totalDuration,
+			totalTimeToFirstToken: stat.totalTimeToFirstToken,
+			totalTimeToFirstReasoningToken: stat.totalTimeToFirstReasoningToken,
+			totalCost: stat.totalCost,
 		});
 	}
 
@@ -653,31 +636,14 @@ async function calculateHistoryForMinute(targetMinute: Date) {
 		const key = `${mapping.modelId}-${mapping.providerId}-${mapping.region ?? ""}`;
 		const stat = activeMappingsMap.get(key);
 
-		// Use actual stats if available, otherwise create zero stats
-		const logsCount = stat?.logsCount ?? 0;
-		const errorsCount = stat?.errorsCount ?? 0;
-		const clientErrorsCount = stat?.clientErrorsCount ?? 0;
-		const gatewayErrorsCount = stat?.gatewayErrorsCount ?? 0;
-		const upstreamErrorsCount = stat?.upstreamErrorsCount ?? 0;
-		const completedCount = stat?.completedCount ?? 0;
-		const lengthLimitCount = stat?.lengthLimitCount ?? 0;
-		const contentFilterCount = stat?.contentFilterCount ?? 0;
-		const toolCallsCount = stat?.toolCallsCount ?? 0;
-		const canceledCount = stat?.canceledCount ?? 0;
-		const unknownFinishCount = stat?.unknownFinishCount ?? 0;
-		const cachedCount = stat?.cachedCount ?? 0;
-		const totalInputTokens = stat?.totalInputTokens ?? 0;
-		const totalOutputTokens = stat?.totalOutputTokens ?? 0;
-		const totalTokens = stat?.totalTokens ?? 0;
-		const totalReasoningTokens = stat?.totalReasoningTokens ?? 0;
-		const totalCachedTokens = stat?.totalCachedTokens ?? 0;
-		const totalDuration = stat?.totalDuration ?? 0;
-		const totalTimeToFirstToken = stat?.totalTimeToFirstToken ?? 0;
-		const totalTimeToFirstReasoningToken =
-			stat?.totalTimeToFirstReasoningToken ?? 0;
-		const totalCost = stat?.totalCost ?? 0;
+		// Skip mappings with no traffic this minute: an all-zero row carries no
+		// information (every reader uses COALESCE(SUM(...)) and treats absent
+		// rows as zero), so we avoid writing it.
+		if (!stat) {
+			continue;
+		}
 
-		if (logsCount > 0) {
+		if (stat.logsCount > 0) {
 			activeMappingsCount++;
 		}
 
@@ -688,27 +654,27 @@ async function calculateHistoryForMinute(targetMinute: Date) {
 			providerId: mapping.providerId,
 			modelProviderMappingId: mapping.id, // Exact model_provider_mapping.id
 			minuteTimestamp: roundedTargetMinute,
-			logsCount,
-			errorsCount,
-			clientErrorsCount,
-			gatewayErrorsCount,
-			upstreamErrorsCount,
-			completedCount,
-			lengthLimitCount,
-			contentFilterCount,
-			toolCallsCount,
-			canceledCount,
-			unknownFinishCount,
-			cachedCount,
-			totalInputTokens,
-			totalOutputTokens,
-			totalTokens,
-			totalReasoningTokens,
-			totalCachedTokens,
-			totalDuration,
-			totalTimeToFirstToken,
-			totalTimeToFirstReasoningToken,
-			totalCost,
+			logsCount: stat.logsCount,
+			errorsCount: stat.errorsCount,
+			clientErrorsCount: stat.clientErrorsCount,
+			gatewayErrorsCount: stat.gatewayErrorsCount,
+			upstreamErrorsCount: stat.upstreamErrorsCount,
+			completedCount: stat.completedCount,
+			lengthLimitCount: stat.lengthLimitCount,
+			contentFilterCount: stat.contentFilterCount,
+			toolCallsCount: stat.toolCallsCount,
+			canceledCount: stat.canceledCount,
+			unknownFinishCount: stat.unknownFinishCount,
+			cachedCount: stat.cachedCount,
+			totalInputTokens: stat.totalInputTokens,
+			totalOutputTokens: stat.totalOutputTokens,
+			totalTokens: stat.totalTokens,
+			totalReasoningTokens: stat.totalReasoningTokens,
+			totalCachedTokens: stat.totalCachedTokens,
+			totalDuration: stat.totalDuration,
+			totalTimeToFirstToken: stat.totalTimeToFirstToken,
+			totalTimeToFirstReasoningToken: stat.totalTimeToFirstReasoningToken,
+			totalCost: stat.totalCost,
 		});
 	}
 

--- a/apps/worker/src/services/stats-calculator.ts
+++ b/apps/worker/src/services/stats-calculator.ts
@@ -936,8 +936,16 @@ export async function calculateCurrentMinuteHistory() {
  * model_history_hourly row per model. Idempotent: re-running an hour recomputes
  * its totals from the current minute data and overwrites the existing row.
  * @param targetHour Any time within the hour to aggregate
+ * @param reconcile When true, also delete hourly rows whose minute groups have
+ *   disappeared. Only safe for hours whose minute data is still authoritative
+ *   (the live current/previous hour) — minute history is pruned after 30 days
+ *   while the hourly rollup is kept forever, so reconciling a hour with pruned
+ *   minutes would wrongly drop retained data. Backfill leaves this off.
  */
-async function calculateModelHistoryForHour(targetHour: Date) {
+async function calculateModelHistoryForHour(
+	targetHour: Date,
+	reconcile = false,
+) {
 	const roundedHour = roundToHourStart(targetHour);
 	const hourEnd = new Date(roundedHour.getTime() + ONE_HOUR_MS);
 	const database = db;
@@ -987,6 +995,24 @@ async function calculateModelHistoryForHour(targetHour: Date) {
 			});
 	}
 
+	// Drop any hourly row whose minute groups have since disappeared (e.g. the
+	// hour's only traffic was recomputed to zero), which the upsert above can't
+	// reach and would otherwise leave as a stale nonzero hour. Guarded by
+	// `reconcile` so it never runs for hours with pruned minute data.
+	if (reconcile) {
+		const presentModelIds = hourlyStats.map((row) => row.modelId);
+		await database
+			.delete(modelHistoryHourly)
+			.where(
+				presentModelIds.length > 0
+					? and(
+							eq(modelHistoryHourly.hourTimestamp, roundedHour),
+							notInArray(modelHistoryHourly.modelId, presentModelIds),
+						)
+					: eq(modelHistoryHourly.hourTimestamp, roundedHour),
+			);
+	}
+
 	return { totalModels: hourlyStats.length };
 }
 
@@ -994,8 +1020,14 @@ async function calculateModelHistoryForHour(targetHour: Date) {
  * Roll up one hour of model_provider_mapping_history (the 60 minute rows) into a
  * single model_provider_mapping_history_hourly row per mapping. Idempotent.
  * @param targetHour Any time within the hour to aggregate
+ * @param reconcile When true, also delete hourly rows whose minute groups have
+ *   disappeared. Only safe for hours whose minute data is still authoritative
+ *   (the live current/previous hour) — see calculateModelHistoryForHour.
  */
-async function calculateMappingHistoryForHour(targetHour: Date) {
+async function calculateMappingHistoryForHour(
+	targetHour: Date,
+	reconcile = false,
+) {
 	const roundedHour = roundToHourStart(targetHour);
 	const hourEnd = new Date(roundedHour.getTime() + ONE_HOUR_MS);
 	const database = db;
@@ -1061,15 +1093,41 @@ async function calculateMappingHistoryForHour(targetHour: Date) {
 			});
 	}
 
+	// Drop any hourly row whose minute groups have since disappeared (e.g. the
+	// hour's only traffic was recomputed to zero), which the upsert above can't
+	// reach and would otherwise leave as a stale nonzero hour. Guarded by
+	// `reconcile` so it never runs for hours with pruned minute data.
+	if (reconcile) {
+		const presentMappingIds = hourlyStats.map(
+			(row) => row.modelProviderMappingId,
+		);
+		await database
+			.delete(modelProviderMappingHistoryHourly)
+			.where(
+				presentMappingIds.length > 0
+					? and(
+							eq(modelProviderMappingHistoryHourly.hourTimestamp, roundedHour),
+							notInArray(
+								modelProviderMappingHistoryHourly.modelProviderMappingId,
+								presentMappingIds,
+							),
+						)
+					: eq(modelProviderMappingHistoryHourly.hourTimestamp, roundedHour),
+			);
+	}
+
 	return { totalMappings: hourlyStats.length };
 }
 
 /**
  * Roll up a single hour of minute history into the hourly summary tables.
  */
-async function calculateHistoryForHour(targetHour: Date) {
-	const mappingResult = await calculateMappingHistoryForHour(targetHour);
-	const modelResult = await calculateModelHistoryForHour(targetHour);
+async function calculateHistoryForHour(targetHour: Date, reconcile = false) {
+	const mappingResult = await calculateMappingHistoryForHour(
+		targetHour,
+		reconcile,
+	);
+	const modelResult = await calculateModelHistoryForHour(targetHour, reconcile);
 	return { mappingResult, modelResult };
 }
 
@@ -1083,8 +1141,10 @@ export async function calculateHourlyHistory() {
 	const previousHourStart = new Date(currentHourStart.getTime() - ONE_HOUR_MS);
 
 	try {
-		await calculateHistoryForHour(previousHourStart);
-		await calculateHistoryForHour(currentHourStart);
+		// Reconcile only the live current/previous hour, where minute data is still
+		// authoritative, so a group that dropped to zero clears its stale hourly row.
+		await calculateHistoryForHour(previousHourStart, true);
+		await calculateHistoryForHour(currentHourStart, true);
 
 		logger.debug(
 			`Recorded hourly history for ${previousHourStart.toISOString()} and ${currentHourStart.toISOString()}`,

--- a/apps/worker/src/services/stats-calculator.ts
+++ b/apps/worker/src/services/stats-calculator.ts
@@ -11,9 +11,11 @@ import {
 	sql,
 	asc,
 	eq,
+	gt,
 	gte,
 	lt,
 	and,
+	notInArray,
 	type SQL,
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
@@ -434,6 +436,21 @@ async function calculateModelHistoryForMinute(targetMinute: Date) {
 			});
 	}
 
+	// Remove any row left over for this minute from an earlier pass whose traffic
+	// has since dropped to zero (e.g. a same-provider-region retry got linked and
+	// filtered out). Without this the phantom row would keep counting.
+	const presentModelIds = modelHistoryValues.map((value) => value.modelId);
+	await database
+		.delete(modelHistory)
+		.where(
+			presentModelIds.length > 0
+				? and(
+						eq(modelHistory.minuteTimestamp, roundedTargetMinute),
+						notInArray(modelHistory.modelId, presentModelIds),
+					)
+				: eq(modelHistory.minuteTimestamp, roundedTargetMinute),
+		);
+
 	return {
 		totalModels: allModels.length,
 		activeModels: modelStats.length,
@@ -698,6 +715,29 @@ async function calculateHistoryForMinute(targetMinute: Date) {
 				set: mappingHistoryUpsertSet,
 			});
 	}
+
+	// Remove any row left over for this minute from an earlier pass whose traffic
+	// has since dropped to zero (e.g. a same-provider-region retry got linked and
+	// filtered out). Without this the phantom row would keep counting.
+	const presentMappingIds = mappingHistoryValues.map(
+		(value) => value.modelProviderMappingId,
+	);
+	await database
+		.delete(modelProviderMappingHistory)
+		.where(
+			presentMappingIds.length > 0
+				? and(
+						eq(
+							modelProviderMappingHistory.minuteTimestamp,
+							roundedTargetMinute,
+						),
+						notInArray(
+							modelProviderMappingHistory.modelProviderMappingId,
+							presentMappingIds,
+						),
+					)
+				: eq(modelProviderMappingHistory.minuteTimestamp, roundedTargetMinute),
+		);
 
 	return {
 		totalMappings: allMappings.length,
@@ -1394,6 +1434,62 @@ export async function calculateAggregatedStatistics() {
 		logger.debug(
 			`Updated statistics for ${mappingUpdateCount} model-provider mappings`,
 		);
+
+		// Zero out entities whose traffic has fully aged out of the rollup window.
+		// With sparse history they no longer appear in the aggregate, so without an
+		// explicit reset their last nonzero counts would persist indefinitely.
+		const zeroStats = {
+			logsCount: 0,
+			errorsCount: 0,
+			clientErrorsCount: 0,
+			gatewayErrorsCount: 0,
+			upstreamErrorsCount: 0,
+			cachedCount: 0,
+			statsUpdatedAt: now,
+			updatedAt: now,
+		};
+
+		const aggregatedProviderIds = [...providerMap.keys()];
+		await database
+			.update(provider)
+			.set(zeroStats)
+			.where(
+				aggregatedProviderIds.length > 0
+					? and(
+							gt(provider.logsCount, 0),
+							notInArray(provider.id, aggregatedProviderIds),
+						)
+					: gt(provider.logsCount, 0),
+			);
+
+		const aggregatedModelIds = [...modelMap.keys()];
+		await database
+			.update(model)
+			.set(zeroStats)
+			.where(
+				aggregatedModelIds.length > 0
+					? and(
+							gt(model.logsCount, 0),
+							notInArray(model.id, aggregatedModelIds),
+						)
+					: gt(model.logsCount, 0),
+			);
+
+		const aggregatedMappingIds = mappingAggregates
+			.map((row) => row.modelProviderMappingId)
+			.filter((id): id is string => Boolean(id));
+		await database
+			.update(modelProviderMapping)
+			.set(zeroStats)
+			.where(
+				aggregatedMappingIds.length > 0
+					? and(
+							gt(modelProviderMapping.logsCount, 0),
+							notInArray(modelProviderMapping.id, aggregatedMappingIds),
+						)
+					: gt(modelProviderMapping.logsCount, 0),
+			);
+
 		logger.debug("Aggregated statistics calculation completed successfully");
 	} catch (error) {
 		logger.error("Error calculating aggregated statistics:", error as Error);


### PR DESCRIPTION
## Context

Follow-up to #2764 (which batched the per-minute history upserts). That cut the *commit/statement* count, but the worker still **produces a row for every active model and every active model-provider mapping every minute — even when that model/mapping had zero traffic** that minute.

In `apps/worker/src/services/stats-calculator.ts`, both `calculateModelHistoryForMinute` and `calculateHistoryForMinute` looped over *all* active models/mappings and fell back to `stat?.x ?? 0`, pushing an all-zero row when there was no traffic. With hundreds of mappings × every minute, this is the dominant write volume into `model_history` / `model_provider_mapping_history` (the #1/#2 load drivers in the Cloud SQL Query Insights graph), and it bloats both tables and every downstream scan.

These all-zero rows carry **no information**: every reader either uses `COALESCE(SUM(...))`/GROUP-BY (treating absent rows as zero) or renders a time series.

## Change

- **Worker:** skip writing zero-traffic rows. Per-minute write volume drops from `O(active models + active mappings)` to `O(those that actually had traffic this minute)`. The hourly rollup reads these rows via `COALESCE(SUM(...))`, so hourly rows become correspondingly sparse with no reader impact.
- **API:** the model-uptime time series (`GET /internal/models/{id}/uptime`) is the only gap-sensitive reader — it plots one point per stored minute. Gap-fill it **server-side** to a dense 240-minute grid (zero-filling idle minutes) so the chart still renders without gaps. All aggregate values (uptime %, TTFT, throughput, "N data points") are unchanged — a zero-filled bucket reproduces exactly what a stored all-zero row produced before.
- **Tests:** updated `stats-calculator.spec.ts` to assert idle models/mappings get **no** row, and seeded traffic in the backfill tests so they still exercise the gap-fill path. 31/31 pass.

## Known bounded side effect

`backfillHistoryIfNeeded` derives its watermark from `MAX(minuteTimestamp)`. If the most recent minutes had zero *global* traffic, no row exists for them, so on the next worker restart the gap branch re-scans those idle minutes (writing nothing). This is bounded (capped by `maxIterations`, each empty minute a cheap indexed range scan) and only happens at startup — the steady-state `calculateMinutelyHistory` path processes the previous minute directly and is watermark-independent, so there is no per-minute loop. Left unchanged.

## Verification

- `pnpm format`, `pnpm build` (full) — green
- `pnpm test:unit` for the worker stats-calculator spec — 31/31 pass
- All other history readers (routing metrics, benchmarks, public provider stats) use `COALESCE(SUM)` and are gap-tolerant by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uptime now returns a gap-free per-provider minute series for the requested window, filling missing minutes with zeros.
  * Minutely statistics/history no longer write all-zero “phantom” records when there’s no traffic, and stale history rows are removed when traffic drops.
  * Aggregated statistics now correctly reset entities once their traffic ages out.
* **Chores**
  * Backfill and minutely history now align stored minutes to actual trafficked periods.
* **Tests**
  * Updated and expanded minutely-history, backfill, and hourly-rollup assertions to match the new “skip zero-traffic rows / reconcile stale rows” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->