### PR TITLE
feat: add AtlasCloud Kling v3 video support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,6 +205,10 @@ LLM_PERPLEXITY_API_KEY=your_perplexity_key_here
 # Alibaba
 LLM_ALIBABA_API_KEY=your_alibaba_key_here
 
+# AtlasCloud
+LLM_ATLASCLOUD_API_KEY=your_atlascloud_key_here
+# AtlasCloud API URL: https://api.atlascloud.ai
+
 # Nebius
 LLM_NEBIUS_API_KEY=your_nebius_key_here
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - Use cookies for user-settings which are not saved in the database to ensure SSR works
 - Apply DRY principles for code reuse
 - Do not add explicit caching or memoization around `process.env` reads or parsed env-var values unless there is a measured hot-path need
-- Exception: in `packages/models`, explicit duplication of model/provider mappings is acceptable and preferred over helper-based expansion. This is the only place in the repo where duplicating model definitions is OK.
+- Exception: in `packages/models`, explicit duplication of model/provider mappings is acceptable and preferred over helper-based expansion. This is the only place in the repo where duplicating model definitions is OK. NEVER add helper functions (e.g. `makeModel(...)`/`makeProvider(...)`) that build model or provider definition objects, even when it means repeating fields across entries — write each model and provider mapping out in full as a plain object literal in the `models` array. Small shared `const` values are fine, but the definition objects themselves must not be constructed by a function.
 - No unnecessary code comments
 - Do not use broad try/catch in API handlers unless to check for specific errors; instead, let errors propagate and be handled by the global error handler
 

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -14,6 +14,7 @@ Currently available models:
 
 - **Veo 3.1** through `avalanche` (1080p, 4k) and `google-vertex` (720p, 1080p, 4k)
 - **Seedance 2.0**, **Seedance 2.0 Fast**, and **Seedance 1.5 Pro** through `bytedance` (720p, 1080p)
+- **KLING v3.0** and **KLING v3.0 Turbo** through `atlascloud` (720p, 1080p; KLING v3.0 also 4k)
 
 You can find the current list of video-capable models on our [models page with the video filter enabled](https://llmgateway.io/models?filters=1&videoGeneration=true) or programmatically through the [/v1/models endpoint](/v1_models).
 
@@ -53,21 +54,26 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | Veo 3.1                           | `google-vertex` | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840` | `4`, `6`, `8`, `10` |
 | Veo 3.1                           | `avalanche`     | `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840`                         | `8`                 |
 | Seedance 2.0 / 2.0 Fast / 1.5 Pro | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `5`, `10`           |
+| KLING v3.0                        | `atlascloud`    | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840` | `5`, `10`           |
+| KLING v3.0 Turbo                  | `atlascloud`    | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `5`, `10`           |
 
-Requests return `400` when the selected provider cannot serve the requested `size` or `seconds`. Seedance derives `aspect_ratio` from the requested `size` (16:9 for landscape, 9:16 for portrait).
+Requests return `400` when the selected provider cannot serve the requested `size` or `seconds`. Seedance and KLING v3.0 derive `aspect_ratio` from the requested `size` (16:9 for landscape, 9:16 for portrait).
+
+**KLING v3.0 Turbo** always generates audio and does not support `audio: false`; silent requests return a `400`. Use **KLING v3.0** (`kling-v3-0`) when you need silent output.
 
 ### First/last frame inputs
 
 Frame inputs interpolate a video between a starting frame and an optional ending frame. You provide the first frame as `image` and, optionally, the ending frame as `last_frame`. The gateway tags each one with the correct role for the provider, so you don't set roles yourself.
 
-| Field        | Required           | Accepted input                   | Available on                                                                             |
-| ------------ | ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------- |
-| `image`      | for frame mode     | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), Veo 3.1 (`google-vertex`, `avalanche`), `minimax`, `xai` |
-| `last_frame` | no (needs `image`) | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), Veo 3.1 (`google-vertex`, `avalanche`)                   |
+| Field        | Required           | Accepted input                   | Available on                                                                                                                    |
+| ------------ | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `image`      | for frame mode     | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), **KLING v3.0 / Turbo** (`atlascloud`), Veo 3.1 (`google-vertex`, `avalanche`), `minimax`, `xai` |
+| `last_frame` | no (needs `image`) | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), **KLING v3.0 / Turbo** (`atlascloud`), Veo 3.1 (`google-vertex`, `avalanche`)                   |
 
 #### Rules and limits
 
 - **Seedance scope.** Frame inputs are supported on **Seedance 2.0** and **Seedance 2.0 Fast** (`seedance-2-0`, `seedance-2-0-fast`). Sending `image`/`last_frame` to Seedance 1.5 Pro or any other ByteDance model returns a `400`.
+- **KLING scope.** Frame inputs are supported on **KLING v3.0** and **KLING v3.0 Turbo** (`kling-v3-0`, `kling-v3-0-turbo`). The gateway uploads base64 frames to AtlasCloud's media endpoint automatically, so both HTTPS URLs and base64 data URLs are accepted.
 - **`last_frame` requires `image`.** Providing `last_frame` without `image` returns a `400`.
 - **Not combinable with references.** First/last frame inputs (`image`, `last_frame`) cannot be combined with reference inputs (`reference_images`, `input_reference`, `reference_videos`, `reference_audios`).
 
@@ -84,6 +90,21 @@ curl -X POST "https://api.llmgateway.io/v1/videos" \
     "size": "1280x720",
     "image": { "image_url": "https://example.com/first-frame.png" },
     "last_frame": { "image_url": "https://example.com/last-frame.png" }
+  }'
+```
+
+#### Example (KLING v3.0 image-to-video)
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/videos" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kling-v3-0",
+    "prompt": "Animate the scene with gentle camera motion",
+    "seconds": 5,
+    "size": "1280x720",
+    "image": { "image_url": "https://example.com/first-frame.png" }
   }'
 ```
 
@@ -110,7 +131,7 @@ You can mix all three reference types in one request. The `prompt` can be a ligh
 - **HTTPS only for video and audio.** `reference_videos` and `reference_audios` must be publicly reachable HTTPS URLs (the provider fetches them). base64 data URLs are rejected for video/audio; images may be HTTPS URLs or base64 data URLs.
 - **Reference video resolution.** Seedance requires reference video frames to be at least ~409,600 pixels (roughly 480p or larger). Low-resolution clips such as 360p are rejected with a `400`.
 - **Not combinable with frames.** Reference inputs (`reference_images`, `reference_videos`, `reference_audios`) cannot be combined with the first/last frame inputs (`image`, `last_frame`).
-- **Provider scope.** Reference videos and audio are only supported on Seedance 2.0 models; sending them to other models returns a `400`.
+- **Provider scope.** Reference videos and audio are only supported on Seedance 2.0 models; sending them to other models returns a `400`. **KLING v3.0** does not support any reference inputs (`reference_images`, `reference_videos`, `reference_audios`); use first/last frame inputs instead.
 - **Moderation still applies.** The output is subject to the provider's content moderation. Blocked generations finish as `failed` and are logged with a `content_filter` finish reason.
 
 #### Examples
@@ -181,7 +202,7 @@ curl -X POST "https://api.llmgateway.io/v1/videos" \
 
 Video generation requires at least `$1.00` in available organization credits before the job is submitted upstream.
 
-Pricing is per second of generated video. For Seedance, enabling audio can increase the per-second rate on models that price audio and video separately.
+Pricing is per second of generated video. For Seedance and KLING v3.0, enabling audio can increase the per-second rate on models that price audio and video separately.
 
 Veo 3.1:
 
@@ -206,6 +227,16 @@ Seedance (ByteDance):
 | `seedance-2-0-fast` | `bytedance` | 1080p      | `$0.2722 / second`  | `$0.2722 / second`  |
 | `seedance-1-5-pro`  | `bytedance` | 720p       | `$0.05184 / second` | `$0.02592 / second` |
 | `seedance-1-5-pro`  | `bytedance` | 1080p      | `$0.1166 / second`  | `$0.05832 / second` |
+
+KLING (AtlasCloud):
+
+| Model              | Provider     | Resolution | With audio        | Video only        |
+| ------------------ | ------------ | ---------- | ----------------- | ----------------- |
+| `kling-v3-0`       | `atlascloud` | 720p       | `$0.126 / second` | `$0.084 / second` |
+| `kling-v3-0`       | `atlascloud` | 1080p      | `$0.168 / second` | `$0.112 / second` |
+| `kling-v3-0`       | `atlascloud` | 4k         | `$0.42 / second`  | `$0.42 / second`  |
+| `kling-v3-0-turbo` | `atlascloud` | 720p       | `$0.168 / second` | n/a (audio only)  |
+| `kling-v3-0-turbo` | `atlascloud` | 1080p      | `$0.21 / second`  | n/a (audio only)  |
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/videos" \
@@ -256,6 +287,8 @@ Typical statuses:
 `google-vertex` follows Vertex AI's long-running operation flow. The gateway submits Veo generation with `predictLongRunning`, polls with `fetchPredictOperation`, and streams the final bytes through the gateway content endpoint once the operation is done.
 
 `bytedance` uses the ModelArk `/contents/generations/tasks` endpoint. The gateway submits the job, polls the upstream task status, and exposes the final video bytes through the gateway content endpoint once the task succeeds.
+
+`atlascloud` uses the AtlasCloud `/api/v1/model/generateVideo` endpoint and polls `/api/v1/model/prediction/{id}` for status. The gateway resolves the upstream KLING variant (standard, turbo, or 4k) and task type (text-to-video or image-to-video) from your request, then streams the final video bytes through the gateway content endpoint once the prediction completes.
 
 ## Download the Video
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -351,8 +351,10 @@ interface MockVideoJobState {
 		mimeType: string;
 		referenceType: string;
 	}>;
+	referenceVideoUrls?: string[];
 	imageUrls?: string[];
 	generationType?: string;
+	requestBody?: unknown;
 	size?: string;
 	duration?: number;
 	resolution?: string;
@@ -1872,6 +1874,109 @@ mockOpenAIServer.post("/contents/generations/tasks", async (c) => {
 	});
 });
 
+mockOpenAIServer.post("/api/v1/model/uploadMedia", async (c) => {
+	const authHeader = c.req.header("Authorization");
+	if (!authHeader?.startsWith("Bearer ")) {
+		c.status(401);
+		return c.json({
+			error: {
+				message: "Unauthorized",
+			},
+		});
+	}
+
+	const formData = await c.req.formData();
+	const file = formData.get("file");
+	if (!(file instanceof File)) {
+		c.status(400);
+		return c.json({
+			error: {
+				message: "file is required",
+			},
+		});
+	}
+
+	videoCounter++;
+	const url = `${currentMockServerUrl}/uploads/atlascloud-media-${videoCounter}.png`;
+	if (videoCounter % 2 === 0) {
+		return c.json({
+			data: url,
+		});
+	}
+	return c.json({
+		data: {
+			temporary_url: url,
+		},
+	});
+});
+
+mockOpenAIServer.post("/api/v1/model/generateVideo", async (c) => {
+	const body = await c.req.json();
+	const prompt = typeof body.prompt === "string" ? body.prompt : "";
+	const statusTrigger = extractStatusCodeTrigger(prompt);
+	if (statusTrigger) {
+		c.status(statusTrigger.statusCode as any);
+		return c.json(statusTrigger.errorResponse);
+	}
+
+	videoCounter++;
+	const id = `atlascloud_prediction_${videoCounter}`;
+	const videoSize =
+		body.aspect_ratio === "9:16"
+			? getMockVideoSizeMetadata("720x1280")
+			: getMockVideoSizeMetadata("1280x720");
+	const imageUrls = [
+		typeof body.image === "string" ? body.image : null,
+		typeof body.end_image === "string" ? body.end_image : null,
+		typeof body.image_url === "string" ? body.image_url : null,
+		typeof body.end_image_url === "string" ? body.end_image_url : null,
+		...(Array.isArray(body.reference_image_urls)
+			? body.reference_image_urls.filter(
+					(value: unknown): value is string => typeof value === "string",
+				)
+			: []),
+	].filter((value): value is string => value !== null);
+	const referenceVideoUrls = Array.isArray(body.reference_video_urls)
+		? body.reference_video_urls.filter(
+				(value: unknown): value is string => typeof value === "string",
+			)
+		: [];
+	const job: MockVideoJobState = {
+		id,
+		object: "video",
+		model: typeof body.model === "string" ? body.model : "atlascloud-video",
+		status: "queued",
+		progress: 0,
+		imageUrls,
+		referenceVideoUrls,
+		requestBody: body,
+		size: videoSize.size,
+		duration: typeof body.duration === "number" ? body.duration : undefined,
+		resolution: videoSize.resolution,
+		width: videoSize.width,
+		height: videoSize.height,
+		generateAudio:
+			typeof body.sound === "boolean"
+				? body.sound
+				: typeof body.audio === "boolean"
+					? body.audio
+					: undefined,
+		created_at: Math.floor(Date.now() / 1000),
+		completed_at: null,
+		expires_at: null,
+		error: null,
+	};
+
+	videoJobs.set(id, job);
+
+	return c.json({
+		data: {
+			id,
+			status: "created",
+		},
+	});
+});
+
 mockOpenAIServer.post("/api/file-base64-upload", async (c) => {
 	const authHeader = c.req.header("Authorization");
 	if (!authHeader?.startsWith("Bearer ")) {
@@ -2447,6 +2552,36 @@ mockOpenAIServer.get("/api/v1/jobs/recordInfo", async (c) => {
 			completeTime: job.completed_at ? job.completed_at * 1000 : null,
 			createTime: job.created_at * 1000,
 			updateTime: (job.completed_at ?? job.created_at) * 1000,
+		},
+	});
+});
+
+mockOpenAIServer.get("/api/v1/model/prediction/:id", async (c) => {
+	const id = c.req.param("id");
+	const job = videoJobs.get(id);
+	if (!job) {
+		c.status(404);
+		return c.json({
+			error: {
+				message: "prediction not found",
+			},
+		});
+	}
+
+	return c.json({
+		data: {
+			id,
+			status:
+				job.status === "queued"
+					? "created"
+					: job.status === "in_progress"
+						? "processing"
+						: job.status,
+			outputs:
+				job.status === "completed"
+					? [`${currentMockServerUrl}/mock-assets/${id}`]
+					: [],
+			error: job.status === "failed" ? job.error?.message : null,
 		},
 	});
 });

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -724,6 +724,10 @@ describe("videos", () => {
 			baseUrl: mockServerUrl,
 		});
 
+		const seconds = 5;
+		const fourKPerSecondPrice = 0.42;
+		const expectedCost = fourKPerSecondPrice * seconds;
+
 		for (const [requestId, audio] of [
 			["atlascloud-audio-request", true],
 			["atlascloud-silent-request", false],
@@ -739,7 +743,7 @@ describe("videos", () => {
 					model: "atlascloud/kling-v3-0",
 					prompt: `A precise product turntable, audio=${audio}`,
 					size: "3840x2160",
-					seconds: 5,
+					seconds,
 					audio,
 				}),
 			});
@@ -766,10 +770,10 @@ describe("videos", () => {
 		expect(logs).toHaveLength(2);
 		const videoOutputCosts = logs.map((log) => log.videoOutputCost ?? 0).sort();
 		const totalCosts = logs.map((log) => log.cost ?? 0).sort();
-		expect(videoOutputCosts[0]).toBeCloseTo(2.1, 6);
-		expect(videoOutputCosts[1]).toBeCloseTo(2.1, 6);
-		expect(totalCosts[0]).toBeCloseTo(2.1, 6);
-		expect(totalCosts[1]).toBeCloseTo(2.1, 6);
+		expect(videoOutputCosts[0]).toBeCloseTo(expectedCost, 6);
+		expect(videoOutputCosts[1]).toBeCloseTo(expectedCost, 6);
+		expect(totalCosts[0]).toBeCloseTo(expectedCost, 6);
+		expect(totalCosts[1]).toBeCloseTo(expectedCost, 6);
 	});
 
 	test("/v1/videos restricts reference inputs to Seedance 2.0 models", async () => {

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -707,7 +707,7 @@ describe("videos", () => {
 		});
 	});
 
-	test("/v1/videos bills AtlasCloud audio and silent output at separate rates", async () => {
+	test("/v1/videos bills AtlasCloud 4K audio and silent output at the same rate", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",
 			token: "real-token",
@@ -738,7 +738,7 @@ describe("videos", () => {
 				body: JSON.stringify({
 					model: "atlascloud/kling-v3-0",
 					prompt: `A precise product turntable, audio=${audio}`,
-					size: "1280x720",
+					size: "3840x2160",
 					seconds: 5,
 					audio,
 				}),
@@ -750,7 +750,7 @@ describe("videos", () => {
 			});
 			const mockVideo = getMockVideo(videoJob!.upstreamId);
 			expect(mockVideo?.requestBody).toMatchObject({
-				model: "kwaivgi/kling-v3.0-std/text-to-video",
+				model: "kwaivgi/kling-v3.0-4k/text-to-video",
 				sound: audio,
 			});
 			setMockVideoStatus(videoJob!.upstreamId, "completed");
@@ -766,10 +766,10 @@ describe("videos", () => {
 		expect(logs).toHaveLength(2);
 		const videoOutputCosts = logs.map((log) => log.videoOutputCost ?? 0).sort();
 		const totalCosts = logs.map((log) => log.cost ?? 0).sort();
-		expect(videoOutputCosts[0]).toBeCloseTo(0.42, 6);
-		expect(videoOutputCosts[1]).toBeCloseTo(0.63, 6);
-		expect(totalCosts[0]).toBeCloseTo(0.42, 6);
-		expect(totalCosts[1]).toBeCloseTo(0.63, 6);
+		expect(videoOutputCosts[0]).toBeCloseTo(2.1, 6);
+		expect(videoOutputCosts[1]).toBeCloseTo(2.1, 6);
+		expect(totalCosts[0]).toBeCloseTo(2.1, 6);
+		expect(totalCosts[1]).toBeCloseTo(2.1, 6);
 	});
 
 	test("/v1/videos restricts reference inputs to Seedance 2.0 models", async () => {

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -395,6 +395,383 @@ describe("videos", () => {
 		);
 	});
 
+	test("/v1/videos forwards AtlasCloud text-to-video requests", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0",
+				prompt: "A city street reflected in rain at night",
+				size: "1280x720",
+				seconds: 5,
+				audio: false,
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const created = await createRes.json();
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: created.id } },
+		});
+		expect(videoJob?.usedProvider).toBe("atlascloud");
+		expect(videoJob?.usedModel).toBe("kwaivgi/kling-v3.0-std/text-to-video");
+
+		const mockVideo = getMockVideo(videoJob!.upstreamId);
+		expect(mockVideo?.requestBody).toMatchObject({
+			model: "kwaivgi/kling-v3.0-std/text-to-video",
+			prompt: "A city street reflected in rain at night",
+			duration: 5,
+			aspect_ratio: "16:9",
+			sound: false,
+		});
+	});
+
+	test("/v1/videos uploads AtlasCloud image-to-video frame inputs", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0-turbo",
+				prompt: "Animate this product shot with a slow camera push",
+				size: "720x1280",
+				seconds: 10,
+				image: { image_url: "data:image/png;base64,aGVsbG8=" },
+				last_frame: { image_url: "data:image/png;base64,d29ybGQ=" },
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const created = await createRes.json();
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: created.id } },
+		});
+		const mockVideo = getMockVideo(videoJob!.upstreamId);
+		expect(mockVideo?.imageUrls).toHaveLength(2);
+		expect(mockVideo?.imageUrls?.[0]).toContain("/uploads/atlascloud-media-");
+		expect(mockVideo?.requestBody).toMatchObject({
+			model: "kwaivgi/kling-v3.0-turbo/image-to-video",
+			aspect_ratio: "9:16",
+		});
+		expect(mockVideo?.requestBody).toHaveProperty("image");
+		expect(mockVideo?.requestBody).toHaveProperty("end_image");
+		expect(mockVideo?.requestBody).not.toHaveProperty("sound");
+		expect(mockVideo?.requestBody).not.toHaveProperty("image_url");
+		expect(mockVideo?.requestBody).not.toHaveProperty("end_image_url");
+	});
+
+	test("/v1/videos routes AtlasCloud 4K requests to the 4K upstream model", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0",
+				prompt: "A cinematic wide shot in 4K",
+				size: "3840x2160",
+				seconds: 5,
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const created = await createRes.json();
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: created.id } },
+		});
+		const mockVideo = getMockVideo(videoJob!.upstreamId);
+		expect(mockVideo?.requestBody).toMatchObject({
+			model: "kwaivgi/kling-v3.0-4k/text-to-video",
+			aspect_ratio: "16:9",
+		});
+	});
+
+	test("/v1/videos rejects AtlasCloud Turbo 4K requests", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0-turbo",
+				prompt: "A cinematic wide shot in 4K",
+				size: "3840x2160",
+				seconds: 5,
+			}),
+		});
+
+		expect(createRes.status).toBe(400);
+		await expect(createRes.json()).resolves.toMatchObject({
+			error: {
+				message: expect.stringContaining("size 3840x2160 is unsupported"),
+			},
+		});
+	});
+
+	test("/v1/videos rejects AtlasCloud Turbo silent requests", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0-turbo",
+				prompt: "A silent product turntable",
+				size: "1280x720",
+				seconds: 5,
+				audio: false,
+			}),
+		});
+
+		expect(createRes.status).toBe(400);
+		await expect(createRes.json()).resolves.toMatchObject({
+			error: {
+				message: expect.stringContaining("audio=false is unsupported"),
+			},
+		});
+	});
+
+	test("/v1/videos rejects AtlasCloud reference inputs", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0",
+				prompt: "Use these references for character and motion",
+				size: "1280x720",
+				seconds: 5,
+				reference_images: [
+					{ image_url: "https://example.com/character.png" },
+					{ image_url: "data:image/png;base64,aGVsbG8=" },
+				],
+				reference_videos: ["https://example.com/motion.mp4"],
+			}),
+		});
+
+		expect(createRes.status).toBe(400);
+		await expect(createRes.json()).resolves.toMatchObject({
+			error: {
+				message: expect.stringContaining(
+					"reference inputs are unsupported on AtlasCloud KLING v3.0 models",
+				),
+			},
+		});
+	});
+
+	test("/v1/videos rejects AtlasCloud reference audio", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "atlascloud/kling-v3-0-turbo",
+				prompt: "Use the reference track",
+				size: "1280x720",
+				seconds: 5,
+				reference_audios: ["https://example.com/reference.mp3"],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		await expect(res.json()).resolves.toMatchObject({
+			error: {
+				message: expect.stringContaining(
+					"reference inputs are unsupported on AtlasCloud KLING v3.0 models",
+				),
+			},
+		});
+	});
+
+	test("/v1/videos bills AtlasCloud audio and silent output at separate rates", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-atlascloud",
+			token: "atlascloud-test-token",
+			provider: "atlascloud",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		for (const [requestId, audio] of [
+			["atlascloud-audio-request", true],
+			["atlascloud-silent-request", false],
+		] as const) {
+			const createRes = await app.request("/v1/videos", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					model: "atlascloud/kling-v3-0",
+					prompt: `A precise product turntable, audio=${audio}`,
+					size: "1280x720",
+					seconds: 5,
+					audio,
+				}),
+			});
+			expect(createRes.status).toBe(200);
+			const created = await createRes.json();
+			const videoJob = await db.query.videoJob.findFirst({
+				where: { id: { eq: created.id } },
+			});
+			const mockVideo = getMockVideo(videoJob!.upstreamId);
+			expect(mockVideo?.requestBody).toMatchObject({
+				model: "kwaivgi/kling-v3.0-std/text-to-video",
+				sound: audio,
+			});
+			setMockVideoStatus(videoJob!.upstreamId, "completed");
+		}
+
+		await processPendingVideoJobs();
+
+		const logs = await db.query.log.findMany({
+			where: {
+				usedModel: { eq: "atlascloud/kling-v3-0" },
+			},
+		});
+		expect(logs).toHaveLength(2);
+		const videoOutputCosts = logs.map((log) => log.videoOutputCost ?? 0).sort();
+		const totalCosts = logs.map((log) => log.cost ?? 0).sort();
+		expect(videoOutputCosts[0]).toBeCloseTo(0.42, 6);
+		expect(videoOutputCosts[1]).toBeCloseTo(0.63, 6);
+		expect(totalCosts[0]).toBeCloseTo(0.42, 6);
+		expect(totalCosts[1]).toBeCloseTo(0.63, 6);
+	});
+
 	test("/v1/videos restricts reference inputs to Seedance 2.0 models", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -887,6 +887,17 @@ function isGoogleVertexVideoProvider(providerId: string): boolean {
 	return providerId === "google-vertex";
 }
 
+function isAtlasCloudVideoProvider(providerId: string): boolean {
+	return providerId === "atlascloud";
+}
+
+function isAtlasCloudCollapsedKlingModel(externalId: string): boolean {
+	return (
+		externalId === "kwaivgi/kling-v3.0" ||
+		externalId === "kwaivgi/kling-v3.0-turbo"
+	);
+}
+
 function getVideoProviderConstraintReasons(
 	provider: ProviderModelMapping,
 	videoSize: VideoSizeConfig,
@@ -962,6 +973,17 @@ function getVideoProviderConstraintReasons(
 					"frame inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast)",
 				);
 			}
+		} else if (isAtlasCloudVideoProvider(provider.providerId)) {
+			if (!isAtlasCloudCollapsedKlingModel(provider.externalId)) {
+				reasons.push(
+					"frame inputs are only supported on AtlasCloud KLING video models",
+				);
+			}
+			if (videoDurationSeconds !== 5 && videoDurationSeconds !== 10) {
+				reasons.push(
+					"duration is unsupported because AtlasCloud KLING v3.0 only supports 5s and 10s outputs",
+				);
+			}
 		} else if (
 			!isGoogleVertexVideoProvider(provider.providerId) &&
 			provider.providerId !== "avalanche" &&
@@ -991,6 +1013,14 @@ function getVideoProviderConstraintReasons(
 					"Sora reference-image video generation supports exactly 1 input image",
 				);
 			}
+
+			return reasons;
+		}
+
+		if (isAtlasCloudVideoProvider(provider.providerId)) {
+			reasons.push(
+				"reference inputs are unsupported on AtlasCloud KLING v3.0 models",
+			);
 
 			return reasons;
 		}
@@ -1154,13 +1184,38 @@ function getAvalancheSoraTaskModelName(
 	return `${baseModelName}-${inputMode === "reference" ? "image" : "text"}-to-video`;
 }
 
+function getAtlasCloudTaskName(inputMode: VideoInputMode): string {
+	if (inputMode === "frames") {
+		return "image-to-video";
+	}
+
+	return "text-to-video";
+}
+
+function getAtlasCloudVideoModelName(
+	baseModelName: string,
+	videoSize: VideoSizeConfig,
+	inputMode: VideoInputMode,
+): string {
+	const taskName = getAtlasCloudTaskName(inputMode);
+	const isTurbo = baseModelName === "kwaivgi/kling-v3.0-turbo";
+
+	if (videoSize.resolution === "4k") {
+		return `kwaivgi/kling-v3.0-4k/${taskName}`;
+	}
+
+	return `kwaivgi/kling-v3.0-${isTurbo ? "turbo" : "std"}/${taskName}`;
+}
+
 function getVideoUpstreamModelName(
 	providerId: Provider,
 	baseModelName: string,
-	_videoSize: VideoSizeConfig,
-	_inputMode: VideoInputMode,
+	videoSize: VideoSizeConfig,
+	inputMode: VideoInputMode,
 ): string {
 	switch (providerId) {
+		case "atlascloud":
+			return getAtlasCloudVideoModelName(baseModelName, videoSize, inputMode);
 		case "avalanche":
 			return getAvalancheVideoModelName(baseModelName);
 		case "bytedance":
@@ -1215,6 +1270,8 @@ function getDefaultVideoProviderBaseUrl(providerId: Provider): string | null {
 			return "https://api.openai.com";
 		case "xai":
 			return "https://api.x.ai";
+		case "atlascloud":
+			return "https://api.atlascloud.ai";
 		case "bytedance":
 			return "https://ark.ap-southeast.bytepluses.com/api/v3";
 		case "google-vertex":
@@ -3185,6 +3242,219 @@ function getBytedanceVideoAspectRatio(videoSize: VideoSizeConfig): string {
 	return "16:9";
 }
 
+function getAtlasCloudVideoAspectRatio(videoSize: VideoSizeConfig): string {
+	return videoSize.orientation === "portrait" ? "9:16" : "16:9";
+}
+
+function atlasCloudVideoModelAcceptsSound(modelName: string): boolean {
+	return !modelName.startsWith("kwaivgi/kling-v3.0-turbo/");
+}
+
+async function uploadAtlasCloudMedia(
+	providerContext: ProviderContext,
+	image: ProcessedVideoImageInput,
+): Promise<string> {
+	const uploadUrl = joinUrl(
+		providerContext.baseUrl,
+		"/api/v1/model/uploadMedia",
+	);
+	const fileExtension = getVideoImageFileExtension(image.mimeType);
+	const formData = new FormData();
+	formData.append(
+		"file",
+		new Blob([Buffer.from(image.bytesBase64Encoded, "base64")], {
+			type: image.mimeType,
+		}),
+		`input.${fileExtension}`,
+	);
+	const response = await fetchUpstreamJson(uploadUrl, {
+		method: "POST",
+		headers: getProviderHeaders("atlascloud", providerContext.token, {
+			requestId: providerContext.requestId,
+		}),
+		body: formData,
+	});
+	const uploadedUrl = extractAtlasCloudUploadedMediaUrl(response);
+
+	if (!uploadedUrl) {
+		throw new HTTPException(502, {
+			message: "AtlasCloud media upload did not return a usable URL",
+		});
+	}
+
+	return uploadedUrl;
+}
+
+function extractAtlasCloudUploadedMediaUrl(
+	response: Record<string, unknown>,
+): string | null {
+	const preferredKeys = new Set([
+		"url",
+		"fileUrl",
+		"file_url",
+		"downloadUrl",
+		"download_url",
+		"mediaUrl",
+		"media_url",
+		"temporaryUrl",
+		"temporary_url",
+		"tempUrl",
+		"temp_url",
+	]);
+
+	const isHttpUrl = (value: unknown): value is string =>
+		typeof value === "string" && /^https?:\/\//i.test(value);
+
+	const visitPreferred = (value: unknown): string | null => {
+		if (isHttpUrl(value)) {
+			return value;
+		}
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				const found = visitPreferred(item);
+				if (found) {
+					return found;
+				}
+			}
+			return null;
+		}
+		if (!value || typeof value !== "object") {
+			return null;
+		}
+
+		const record = value as Record<string, unknown>;
+		for (const key of preferredKeys) {
+			const found = visitPreferred(record[key]);
+			if (found) {
+				return found;
+			}
+		}
+		for (const nested of Object.values(record)) {
+			const found = visitPreferred(nested);
+			if (found) {
+				return found;
+			}
+		}
+		return null;
+	};
+
+	return visitPreferred(response);
+}
+
+async function getAtlasCloudImageUrl(
+	providerContext: ProviderContext,
+	videoImage: VideoImageInput,
+): Promise<string> {
+	const imageUrl = getVideoImageUrl(videoImage);
+	if (/^https:\/\//i.test(imageUrl)) {
+		return imageUrl;
+	}
+
+	const processedImage = await processVideoImageInput(videoImage);
+	if (!processedImage) {
+		throw new HTTPException(400, {
+			message: "image must include a non-empty image URL",
+		});
+	}
+
+	return await uploadAtlasCloudMedia(providerContext, processedImage);
+}
+
+async function createAtlasCloudVideoJob(
+	providerContext: ProviderContext,
+	providerMapping: ProviderModelMapping,
+	videoSize: VideoSizeConfig,
+	prompt: string,
+	durationSeconds: number,
+	includeAudio: boolean,
+	firstFrameInput: VideoImageInput | undefined,
+	lastFrameInput: VideoImageInput | undefined,
+	referenceImageInputs: VideoImageInput[],
+	referenceVideoUrls: string[],
+): Promise<{
+	upstreamId: string;
+	upstreamRequest: Record<string, unknown>;
+	upstreamResponse: Record<string, unknown>;
+}> {
+	const upstreamModelName = getVideoUpstreamModelName(
+		"atlascloud",
+		providerMapping.externalId,
+		videoSize,
+		referenceImageInputs.length > 0 || referenceVideoUrls.length > 0
+			? "reference"
+			: firstFrameInput || lastFrameInput
+				? "frames"
+				: "none",
+	);
+	const imageUrl = firstFrameInput
+		? await getAtlasCloudImageUrl(providerContext, firstFrameInput)
+		: null;
+	const endImageUrl = lastFrameInput
+		? await getAtlasCloudImageUrl(providerContext, lastFrameInput)
+		: null;
+	const referenceImageUrls =
+		referenceImageInputs.length > 0
+			? await Promise.all(
+					referenceImageInputs.map((imageInput) =>
+						getAtlasCloudImageUrl(providerContext, imageInput),
+					),
+				)
+			: [];
+	const upstreamRequest: Record<string, unknown> = {
+		model: upstreamModelName,
+		prompt,
+		duration: durationSeconds,
+		aspect_ratio: getAtlasCloudVideoAspectRatio(videoSize),
+		...(atlasCloudVideoModelAcceptsSound(upstreamModelName)
+			? { sound: includeAudio }
+			: {}),
+		...(imageUrl ? { image: imageUrl } : {}),
+		...(endImageUrl ? { end_image: endImageUrl } : {}),
+		...(referenceImageUrls.length > 0
+			? { reference_image_urls: referenceImageUrls }
+			: {}),
+		...(referenceVideoUrls.length > 0
+			? { reference_video_urls: referenceVideoUrls }
+			: {}),
+	};
+
+	const upstreamUrl = joinUrl(
+		providerContext.baseUrl,
+		"/api/v1/model/generateVideo",
+	);
+	const rawResponse = await fetchUpstreamJson(upstreamUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...getProviderHeaders("atlascloud", providerContext.token, {
+				requestId: providerContext.requestId,
+			}),
+		},
+		body: JSON.stringify(upstreamRequest),
+	});
+
+	const upstreamResponse = addRequestedVideoMetadata(
+		{
+			...rawResponse,
+			model: upstreamModelName,
+			status: "queued",
+			duration: durationSeconds,
+			aspect_ratio: upstreamRequest.aspect_ratio,
+			sound: includeAudio,
+			audio: includeAudio,
+		},
+		videoSize,
+	);
+	const upstreamId = extractUpstreamVideoId(upstreamResponse);
+	if (!upstreamId) {
+		throw new HTTPException(502, {
+			message: "AtlasCloud video response did not include a prediction id",
+		});
+	}
+
+	return { upstreamId, upstreamRequest, upstreamResponse };
+}
+
 async function createBytedanceVideoJob(
 	providerContext: ProviderContext,
 	providerMapping: ProviderModelMapping,
@@ -3550,6 +3820,19 @@ async function createUpstreamVideoJob(
 	upstreamResponse: Record<string, unknown>;
 }> {
 	switch (providerContext.providerId) {
+		case "atlascloud":
+			return await createAtlasCloudVideoJob(
+				providerContext,
+				providerMapping,
+				videoSize,
+				prompt,
+				durationSeconds,
+				includeAudio,
+				firstFrameInput,
+				lastFrameInput,
+				referenceImageInputs,
+				referenceVideoUrls,
+			);
 		case "xai":
 			return await createXaiVideoJob(
 				providerContext,

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -316,6 +316,78 @@ describe("Seedance 2.0 reference capabilities", () => {
 	});
 });
 
+describe("AtlasCloud KLING v3.0 frame capabilities", () => {
+	function makeAtlasCloudKlingMapping(
+		overrides: Partial<ApiModelProviderMapping> = {},
+	): ApiModelProviderMapping {
+		return makeMapping({
+			modelId: "kling-v3-0",
+			providerId: "atlascloud",
+			externalId: "kwaivgi/kling-v3.0",
+			supportedVideoSizes: [
+				"1280x720",
+				"720x1280",
+				"1920x1080",
+				"1080x1920",
+				"3840x2160",
+				"2160x3840",
+			],
+			supportedVideoDurationsSeconds: [5, 10],
+			supportedVideoDurationsSecondsImageToVideo: null,
+			...overrides,
+		});
+	}
+
+	test("supportsVideoFrameInput is true for AtlasCloud Kling", () => {
+		expect(supportsVideoFrameInput("kling-v3-0")).toBe(true);
+		expect(supportsVideoFrameInput("kling-v3-0-turbo")).toBe(true);
+		expect(supportsVideoFrameInput("atlascloud/kling-v3-0")).toBe(true);
+		expect(supportsVideoFrameInput("atlascloud/kling-v3-0-turbo")).toBe(true);
+		expect(supportsVideoFrameInput("openai/kling-v3-0")).toBe(false);
+	});
+
+	test("frame mode keeps AtlasCloud Kling 5s and 10s options", () => {
+		const model = makeModel([makeAtlasCloudKlingMapping()], "kling-v3-0");
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["kling-v3-0"],
+			"frames",
+		);
+
+		expect(options.sizes).toContain("1280x720");
+		expect(options.sizes).toContain("3840x2160");
+		expect(options.durations).toEqual([5, 10]);
+	});
+
+	test("frame mode does not offer 4K for AtlasCloud Kling Turbo", () => {
+		const model = makeModel(
+			[
+				makeAtlasCloudKlingMapping({
+					modelId: "kling-v3-0-turbo",
+					externalId: "kwaivgi/kling-v3.0-turbo",
+					supportedVideoSizes: [
+						"1280x720",
+						"720x1280",
+						"1920x1080",
+						"1080x1920",
+					],
+				}),
+			],
+			"kling-v3-0-turbo",
+		);
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["kling-v3-0-turbo"],
+			"frames",
+		);
+
+		expect(options.sizes).toContain("1920x1080");
+		expect(options.sizes).not.toContain("3840x2160");
+		expect(options.sizes).not.toContain("2160x3840");
+		expect(options.durations).toEqual([5, 10]);
+	});
+});
+
 describe("Grok Imagine Video 1.5 capabilities", () => {
 	test("supportsVideoFrameInput is true for grok-imagine-video-1-5", () => {
 		expect(supportsVideoFrameInput("grok-imagine-video-1-5")).toBe(true);

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -12,7 +12,7 @@ export type VideoSize =
 	| "3840x2160"
 	| "2160x3840";
 
-export type VideoDuration = 4 | 6 | 8 | 10 | 12 | 15;
+export type VideoDuration = 4 | 5 | 6 | 8 | 10 | 12 | 15;
 
 export interface VideoInputImage {
 	dataUrl: string;
@@ -72,7 +72,7 @@ export interface VideoGalleryItem {
 
 export type VideoInputMode = "none" | "frames" | "reference";
 
-const VIDEO_DURATIONS: VideoDuration[] = [4, 6, 8, 10, 12, 15];
+const VIDEO_DURATIONS: VideoDuration[] = [4, 5, 6, 8, 10, 12, 15];
 
 const VIDEO_SIZE_LABELS: Record<VideoSize, string> = {
 	"848x480": "480p Landscape",
@@ -114,6 +114,10 @@ export function supportsVideoFrameInput(modelId: string): boolean {
 		return providerId === undefined || providerId === "xai";
 	}
 
+	if (isAtlasCloudKlingVideoModel(rootModelId)) {
+		return providerId === undefined || providerId === "atlascloud";
+	}
+
 	if (
 		rootModelId !== "veo-3.1-generate-preview" &&
 		rootModelId !== "veo-3.1-fast-generate-preview"
@@ -138,6 +142,10 @@ function isGrokImagineVideoModel(rootModelId: string): boolean {
 		rootModelId === "grok-imagine-video-1-5-preview" ||
 		rootModelId === "grok-imagine-video-1.5-preview"
 	);
+}
+
+function isAtlasCloudKlingVideoModel(rootModelId: string): boolean {
+	return rootModelId === "kling-v3-0" || rootModelId === "kling-v3-0-turbo";
 }
 
 export function supportsVideoReferenceInput(modelId: string): boolean {
@@ -248,7 +256,8 @@ function mappingSupportsVideoRequest(
 			mapping.providerId !== "google-vertex" &&
 			mapping.providerId !== "avalanche" &&
 			mapping.providerId !== "minimax" &&
-			mapping.providerId !== "xai"
+			mapping.providerId !== "xai" &&
+			mapping.providerId !== "atlascloud"
 		) {
 			return false;
 		}

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -5,6 +5,7 @@ import type { ProviderId } from "@llmgateway/models";
 export const providerLogoUrls: Partial<
 	Record<ProviderId, React.FC<React.SVGProps<SVGSVGElement>>>
 > = {
+	atlascloud: ProviderIcons.atlascloud,
 	openai: ProviderIcons.openai,
 	anthropic: ProviderIcons.anthropic,
 	elevenlabs: ProviderIcons.elevenlabs,

--- a/apps/ui/src/lib/discount.spec.ts
+++ b/apps/ui/src/lib/discount.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { models } from "@llmgateway/models";
+import { models, type ProviderModelMapping } from "@llmgateway/models";
 
 import {
 	applyDiscount,
@@ -11,7 +11,9 @@ import {
 } from "./discount";
 
 const qwen = models.find((m) => m.id === "qwen3.7-max")!;
-const alibaba = qwen.providers.find((p) => p.providerId === "alibaba")!;
+const alibaba = qwen.providers.find(
+	(p) => p.providerId === "alibaba",
+)! as ProviderModelMapping;
 const novita = qwen.providers.find((p) => p.providerId === "novita")!;
 
 // Mocked global 50% discount on qwen3.7-max, as configured in the admin

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -141,6 +141,8 @@ function getDefaultVideoProviderBaseUrl(providerId: Provider): string | null {
 			return "https://api.openai.com";
 		case "xai":
 			return "https://api.x.ai";
+		case "atlascloud":
+			return "https://api.atlascloud.ai";
 		case "bytedance":
 			return "https://ark.ap-southeast.bytepluses.com/api/v3";
 		case "google-vertex":
@@ -453,6 +455,9 @@ function extractContentUrl(body: Record<string, unknown>): string | null {
 
 		if (Array.isArray(candidate)) {
 			for (const item of candidate) {
+				if (typeof item === "string" && item.startsWith("http")) {
+					return item;
+				}
 				if (
 					item &&
 					typeof item === "object" &&
@@ -1930,6 +1935,88 @@ function isAlibabaVideoProvider(providerId: string): boolean {
 	return providerId === "alibaba";
 }
 
+function isAtlasCloudVideoProvider(providerId: string): boolean {
+	return providerId === "atlascloud";
+}
+
+async function fetchAtlasCloudStatus(
+	job: VideoJobRecord,
+	providerContext: ResolvedVideoProviderContext,
+): Promise<Record<string, unknown>> {
+	const url = joinUrl(
+		providerContext.baseUrl,
+		`/api/v1/model/prediction/${job.upstreamId}`,
+	);
+	const { body, response } = await fetchJsonResponse(url, {
+		method: "GET",
+		headers: getVideoProviderHeaders(job, providerContext),
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			typeof body.error === "object" &&
+			body.error &&
+			"message" in body.error &&
+			typeof body.error.message === "string"
+				? body.error.message
+				: `AtlasCloud status request failed with status ${response.status}`,
+		);
+	}
+
+	const data =
+		body.data && typeof body.data === "object"
+			? (body.data as Record<string, unknown>)
+			: body;
+	const status = normalizeVideoStatus(data.status);
+	const outputs = Array.isArray(data.outputs) ? data.outputs : [];
+	const outputUrl =
+		outputs
+			.map((output) =>
+				typeof output === "string"
+					? output
+					: output &&
+						  typeof output === "object" &&
+						  "url" in output &&
+						  typeof output.url === "string"
+						? output.url
+						: null,
+			)
+			.find((url) => url !== null) ?? null;
+
+	return addRequestedVideoMetadata(job, {
+		...body,
+		status,
+		progress:
+			status === "completed"
+				? 100
+				: status === "failed"
+					? 100
+					: status === "in_progress"
+						? 50
+						: 0,
+		url: outputUrl,
+		output_url: outputUrl,
+		outputs,
+		mime_type: outputUrl ? "video/mp4" : undefined,
+		error:
+			status === "failed"
+				? {
+						message:
+							typeof data.error === "string"
+								? data.error
+								: data.error &&
+									  typeof data.error === "object" &&
+									  "message" in data.error &&
+									  typeof data.error.message === "string"
+									? data.error.message
+									: "AtlasCloud video generation failed",
+						details: body,
+					}
+				: null,
+		atlascloud_raw_response: body,
+	});
+}
+
 async function fetchAlibabaStatus(
 	job: VideoJobRecord,
 	providerContext: ResolvedVideoProviderContext,
@@ -2152,6 +2239,10 @@ async function fetchUpstreamStatus(
 		return await fetchAlibabaStatus(job, providerContext);
 	}
 
+	if (isAtlasCloudVideoProvider(job.usedProvider)) {
+		return await fetchAtlasCloudStatus(job, providerContext);
+	}
+
 	return await fetchGenericVideoStatus(job, providerContext);
 }
 
@@ -2187,7 +2278,8 @@ async function fetchUpstreamContentMetadata(
 		job.usedProvider === "xai" ||
 		isGoogleVertexVideoProvider(job.usedProvider) ||
 		isMinimaxVideoProvider(job.usedProvider) ||
-		isAlibabaVideoProvider(job.usedProvider)
+		isAlibabaVideoProvider(job.usedProvider) ||
+		isAtlasCloudVideoProvider(job.usedProvider)
 	) {
 		return null;
 	}

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { metricsKey } from "@llmgateway/db";
 import {
 	models,
+	type ModelDefinition,
 	type ProviderModelMapping,
 	type BaseMessage,
 	type OpenAIRequestBody,
@@ -39,21 +40,25 @@ describe("Models", () => {
 	});
 
 	it("should include o1-mini model", () => {
-		const o1MiniModel = models.find((model) => model.id === "o1-mini");
+		const o1MiniModel = models.find((model) => model.id === "o1-mini") as
+			| ModelDefinition
+			| undefined;
 		expect(o1MiniModel).toBeDefined();
 		expect(o1MiniModel?.supportsSystemRole).toBe(false);
 		expect(o1MiniModel?.family).toBe("openai");
 	});
 
 	it("should mark Claude Sonnet 4.6 provider mappings as vision-capable", () => {
-		const sonnet46 = models.find((model) => model.id === "claude-sonnet-4-6");
+		const sonnet46 = models.find(
+			(model) => model.id === "claude-sonnet-4-6",
+		) as ModelDefinition | undefined;
 
 		expect(sonnet46).toBeDefined();
-		expect(sonnet46?.providers.map((provider) => provider.vision)).toEqual([
-			true,
-			true,
-			true,
-		]);
+		expect(
+			sonnet46?.providers.map(
+				(provider: ProviderModelMapping) => provider.vision,
+			),
+		).toEqual([true, true, true]);
 	});
 
 	it("should have free: true when provider mapping has zero pricing", () => {

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -1,5 +1,6 @@
 import { alibabaModels } from "./models/alibaba.js";
 import { anthropicModels } from "./models/anthropic.js";
+import { atlascloudModels } from "./models/atlascloud.js";
 import { bytedanceModels } from "./models/bytedance.js";
 import { deepseekModels } from "./models/deepseek.js";
 import { elevenlabsModels } from "./models/elevenlabs.js";
@@ -603,6 +604,7 @@ export const models = [
 	...minimaxModels,
 	...moonshotModels,
 	...alibabaModels,
+	...atlascloudModels,
 	...bytedanceModels,
 	...nousresearchModels,
 	...reveModels,

--- a/packages/models/src/models/atlascloud.ts
+++ b/packages/models/src/models/atlascloud.ts
@@ -92,7 +92,7 @@ export const atlascloudModels = [
 			"720p_video": "0.084",
 			"1080p_audio": "0.168",
 			"1080p_video": "0.112",
-			"4k_audio": "0.63",
+			"4k_audio": "0.42",
 			"4k_video": "0.42",
 		},
 	}),

--- a/packages/models/src/models/atlascloud.ts
+++ b/packages/models/src/models/atlascloud.ts
@@ -1,113 +1,90 @@
-import type { ModelDefinition, ProviderModelMapping } from "@/models.js";
-
-const ATLASCLOUD_STANDARD_VIDEO_SIZES = [
-	"1280x720",
-	"720x1280",
-	"1920x1080",
-	"1080x1920",
-	"3840x2160",
-	"2160x3840",
-] as const;
-const ATLASCLOUD_TURBO_VIDEO_SIZES = [
-	"1280x720",
-	"720x1280",
-	"1920x1080",
-	"1080x1920",
-] as const;
-const ATLASCLOUD_DURATIONS = [5, 10] as const;
-
-function atlasCloudVideoProvider(options: {
-	externalId: string;
-	perSecondPrice: ProviderModelMapping["perSecondPrice"];
-	supportedVideoSizes:
-		| typeof ATLASCLOUD_STANDARD_VIDEO_SIZES
-		| typeof ATLASCLOUD_TURBO_VIDEO_SIZES;
-	supportsVideoWithoutAudio?: boolean;
-}): ProviderModelMapping {
-	return {
-		test: "skip",
-		providerId: "atlascloud",
-		externalId: options.externalId,
-		inputPrice: undefined,
-		outputPrice: undefined,
-		requestPrice: undefined,
-		perSecondPrice: options.perSecondPrice,
-		contextSize: 2000,
-		maxOutput: 1,
-		streaming: false,
-		vision: true,
-		tools: false,
-		jsonOutput: false,
-		videoGenerations: true,
-		supportedVideoSizes: [...options.supportedVideoSizes],
-		supportedVideoDurationsSeconds: [...ATLASCLOUD_DURATIONS],
-		supportsVideoAudio: true,
-		supportsVideoWithoutAudio: options.supportsVideoWithoutAudio ?? true,
-	};
-}
-
-function atlasCloudKlingModel(options: {
-	id: string;
-	name: string;
-	description: string;
-	externalId: string;
-	perSecondPrice: ProviderModelMapping["perSecondPrice"];
-	supportedVideoSizes:
-		| typeof ATLASCLOUD_STANDARD_VIDEO_SIZES
-		| typeof ATLASCLOUD_TURBO_VIDEO_SIZES;
-	supportsVideoWithoutAudio?: boolean;
-}): ModelDefinition {
-	return {
-		id: options.id,
-		name: options.name,
-		description: options.description,
-		family: "atlascloud",
-		output: ["video"],
-		maxVideoDurationSeconds: Math.max(...ATLASCLOUD_DURATIONS),
-		stability: "beta",
-		releasedAt: new Date("2026-06-20"),
-		providers: [
-			atlasCloudVideoProvider({
-				externalId: options.externalId,
-				perSecondPrice: options.perSecondPrice,
-				supportedVideoSizes: options.supportedVideoSizes,
-				supportsVideoWithoutAudio: options.supportsVideoWithoutAudio,
-			}),
-		],
-	};
-}
+import type { ModelDefinition } from "@/models.js";
 
 export const atlascloudModels = [
-	atlasCloudKlingModel({
+	{
 		id: "kling-v3-0",
 		name: "KLING v3.0",
 		description:
 			"AtlasCloud KLING v3.0 video generation. Routes text, image, duration, and 4K requests to the matching upstream KLING v3.0 model.",
-		externalId: "kwaivgi/kling-v3.0",
-		supportedVideoSizes: ATLASCLOUD_STANDARD_VIDEO_SIZES,
-		perSecondPrice: {
-			default_audio: "0.126",
-			default_video: "0.084",
-			"720p_audio": "0.126",
-			"720p_video": "0.084",
-			"1080p_audio": "0.168",
-			"1080p_video": "0.112",
-			"4k_audio": "0.42",
-			"4k_video": "0.42",
-		},
-	}),
-	atlasCloudKlingModel({
+		family: "atlascloud",
+		output: ["video"],
+		maxVideoDurationSeconds: 10,
+		stability: "beta",
+		releasedAt: new Date("2026-06-20"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "atlascloud",
+				externalId: "kwaivgi/kling-v3.0",
+				inputPrice: undefined,
+				outputPrice: undefined,
+				requestPrice: undefined,
+				perSecondPrice: {
+					default_audio: "0.126",
+					default_video: "0.084",
+					"720p_audio": "0.126",
+					"720p_video": "0.084",
+					"1080p_audio": "0.168",
+					"1080p_video": "0.112",
+					"4k_audio": "0.42",
+					"4k_video": "0.42",
+				},
+				contextSize: 2000,
+				maxOutput: 1,
+				streaming: false,
+				vision: true,
+				tools: false,
+				jsonOutput: false,
+				videoGenerations: true,
+				supportedVideoSizes: [
+					"1280x720",
+					"720x1280",
+					"1920x1080",
+					"1080x1920",
+					"3840x2160",
+					"2160x3840",
+				],
+				supportedVideoDurationsSeconds: [5, 10],
+				supportsVideoAudio: true,
+				supportsVideoWithoutAudio: true,
+			},
+		],
+	},
+	{
 		id: "kling-v3-0-turbo",
 		name: "KLING v3.0 Turbo",
 		description:
 			"AtlasCloud KLING v3.0 Turbo video generation. Routes text, image, and duration requests to the matching upstream KLING v3.0 Turbo model.",
-		externalId: "kwaivgi/kling-v3.0-turbo",
-		supportedVideoSizes: ATLASCLOUD_TURBO_VIDEO_SIZES,
-		supportsVideoWithoutAudio: false,
-		perSecondPrice: {
-			default_audio: "0.168",
-			"720p_audio": "0.168",
-			"1080p_audio": "0.21",
-		},
-	}),
+		family: "atlascloud",
+		output: ["video"],
+		maxVideoDurationSeconds: 10,
+		stability: "beta",
+		releasedAt: new Date("2026-06-20"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "atlascloud",
+				externalId: "kwaivgi/kling-v3.0-turbo",
+				inputPrice: undefined,
+				outputPrice: undefined,
+				requestPrice: undefined,
+				perSecondPrice: {
+					default_audio: "0.168",
+					"720p_audio": "0.168",
+					"1080p_audio": "0.21",
+				},
+				contextSize: 2000,
+				maxOutput: 1,
+				streaming: false,
+				vision: true,
+				tools: false,
+				jsonOutput: false,
+				videoGenerations: true,
+				supportedVideoSizes: ["1280x720", "720x1280", "1920x1080", "1080x1920"],
+				supportedVideoDurationsSeconds: [5, 10],
+				supportsVideoAudio: true,
+				supportsVideoWithoutAudio: false,
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];

--- a/packages/models/src/models/atlascloud.ts
+++ b/packages/models/src/models/atlascloud.ts
@@ -1,0 +1,113 @@
+import type { ModelDefinition, ProviderModelMapping } from "@/models.js";
+
+const ATLASCLOUD_STANDARD_VIDEO_SIZES = [
+	"1280x720",
+	"720x1280",
+	"1920x1080",
+	"1080x1920",
+	"3840x2160",
+	"2160x3840",
+] as const;
+const ATLASCLOUD_TURBO_VIDEO_SIZES = [
+	"1280x720",
+	"720x1280",
+	"1920x1080",
+	"1080x1920",
+] as const;
+const ATLASCLOUD_DURATIONS = [5, 10] as const;
+
+function atlasCloudVideoProvider(options: {
+	externalId: string;
+	perSecondPrice: ProviderModelMapping["perSecondPrice"];
+	supportedVideoSizes:
+		| typeof ATLASCLOUD_STANDARD_VIDEO_SIZES
+		| typeof ATLASCLOUD_TURBO_VIDEO_SIZES;
+	supportsVideoWithoutAudio?: boolean;
+}): ProviderModelMapping {
+	return {
+		test: "skip",
+		providerId: "atlascloud",
+		externalId: options.externalId,
+		inputPrice: undefined,
+		outputPrice: undefined,
+		requestPrice: undefined,
+		perSecondPrice: options.perSecondPrice,
+		contextSize: 2000,
+		maxOutput: 1,
+		streaming: false,
+		vision: true,
+		tools: false,
+		jsonOutput: false,
+		videoGenerations: true,
+		supportedVideoSizes: [...options.supportedVideoSizes],
+		supportedVideoDurationsSeconds: [...ATLASCLOUD_DURATIONS],
+		supportsVideoAudio: true,
+		supportsVideoWithoutAudio: options.supportsVideoWithoutAudio ?? true,
+	};
+}
+
+function atlasCloudKlingModel(options: {
+	id: string;
+	name: string;
+	description: string;
+	externalId: string;
+	perSecondPrice: ProviderModelMapping["perSecondPrice"];
+	supportedVideoSizes:
+		| typeof ATLASCLOUD_STANDARD_VIDEO_SIZES
+		| typeof ATLASCLOUD_TURBO_VIDEO_SIZES;
+	supportsVideoWithoutAudio?: boolean;
+}): ModelDefinition {
+	return {
+		id: options.id,
+		name: options.name,
+		description: options.description,
+		family: "atlascloud",
+		output: ["video"],
+		maxVideoDurationSeconds: Math.max(...ATLASCLOUD_DURATIONS),
+		stability: "beta",
+		releasedAt: new Date("2026-06-20"),
+		providers: [
+			atlasCloudVideoProvider({
+				externalId: options.externalId,
+				perSecondPrice: options.perSecondPrice,
+				supportedVideoSizes: options.supportedVideoSizes,
+				supportsVideoWithoutAudio: options.supportsVideoWithoutAudio,
+			}),
+		],
+	};
+}
+
+export const atlascloudModels = [
+	atlasCloudKlingModel({
+		id: "kling-v3-0",
+		name: "KLING v3.0",
+		description:
+			"AtlasCloud KLING v3.0 video generation. Routes text, image, duration, and 4K requests to the matching upstream KLING v3.0 model.",
+		externalId: "kwaivgi/kling-v3.0",
+		supportedVideoSizes: ATLASCLOUD_STANDARD_VIDEO_SIZES,
+		perSecondPrice: {
+			default_audio: "0.126",
+			default_video: "0.084",
+			"720p_audio": "0.126",
+			"720p_video": "0.084",
+			"1080p_audio": "0.168",
+			"1080p_video": "0.112",
+			"4k_audio": "0.63",
+			"4k_video": "0.42",
+		},
+	}),
+	atlasCloudKlingModel({
+		id: "kling-v3-0-turbo",
+		name: "KLING v3.0 Turbo",
+		description:
+			"AtlasCloud KLING v3.0 Turbo video generation. Routes text, image, and duration requests to the matching upstream KLING v3.0 Turbo model.",
+		externalId: "kwaivgi/kling-v3.0-turbo",
+		supportedVideoSizes: ATLASCLOUD_TURBO_VIDEO_SIZES,
+		supportsVideoWithoutAudio: false,
+		perSecondPrice: {
+			default_audio: "0.168",
+			"720p_audio": "0.168",
+			"1080p_audio": "0.21",
+		},
+	}),
+] as const satisfies ModelDefinition[];

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -289,7 +289,7 @@ describe("AtlasCloud video models", () => {
 					"720p_video": "0.084",
 					"1080p_audio": "0.168",
 					"1080p_video": "0.112",
-					"4k_audio": "0.63",
+					"4k_audio": "0.42",
 					"4k_video": "0.42",
 				},
 				[5, 10],

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -9,6 +9,8 @@ import {
 	providers,
 } from "./providers.js";
 
+import type { ModelDefinition, ProviderModelMapping } from "./models.js";
+
 interface ProviderWithRegions {
 	regions?: readonly { id: string }[];
 }
@@ -249,4 +251,96 @@ describe("AWS Bedrock Anthropic regions", () => {
 			expect(getRegionIds(bedrockMapping)).toEqual(expectedRegions);
 		});
 	}
+});
+
+describe("AtlasCloud video models", () => {
+	it("defines provider metadata and environment variables", () => {
+		const provider = providers.find((item) => item.id === "atlascloud");
+
+		expect(provider?.env.required.apiKey).toBe("LLM_ATLASCLOUD_API_KEY");
+		expect(provider?.env.optional?.baseUrl).toBe("LLM_ATLASCLOUD_BASE_URL");
+		expect(provider?.termsUrl).toBe("https://atlascloud.ai/privacy");
+		expect(provider?.privacyPolicyUrl).toBe(
+			"https://www.atlascloud.ai/privacy",
+		);
+		expect(provider?.dataPolicy?.soc2).toBe(true);
+		expect(provider?.dataPolicy?.gdpr).toBe(true);
+		expect(provider?.additionalLinks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					link: "https://www.atlascloud.ai/zero-data-retention",
+				}),
+				expect.objectContaining({
+					link: "https://www.atlascloud.ai/data-deletion-policy",
+				}),
+			]),
+		);
+	});
+
+	it("uses exact external ids, durations, sizes, and per-second prices", () => {
+		const expected = [
+			[
+				"kling-v3-0",
+				"kwaivgi/kling-v3.0",
+				{
+					default_audio: "0.126",
+					default_video: "0.084",
+					"720p_audio": "0.126",
+					"720p_video": "0.084",
+					"1080p_audio": "0.168",
+					"1080p_video": "0.112",
+					"4k_audio": "0.63",
+					"4k_video": "0.42",
+				},
+				[5, 10],
+				[
+					"1280x720",
+					"720x1280",
+					"1920x1080",
+					"1080x1920",
+					"3840x2160",
+					"2160x3840",
+				],
+				true,
+			],
+			[
+				"kling-v3-0-turbo",
+				"kwaivgi/kling-v3.0-turbo",
+				{
+					default_audio: "0.168",
+					"720p_audio": "0.168",
+					"1080p_audio": "0.21",
+				},
+				[5, 10],
+				["1280x720", "720x1280", "1920x1080", "1080x1920"],
+				false,
+			],
+		] as const;
+
+		for (const [
+			modelId,
+			externalId,
+			perSecondPrice,
+			durations,
+			sizes,
+			supportsVideoWithoutAudio,
+		] of expected) {
+			const model = models.find((candidate) => candidate.id === modelId) as
+				| ModelDefinition
+				| undefined;
+			const mapping = model?.providers.find(
+				(provider) => provider.providerId === "atlascloud",
+			) as ProviderModelMapping | undefined;
+
+			expect(mapping?.externalId).toBe(externalId);
+			expect(mapping?.perSecondPrice).toEqual(perSecondPrice);
+			expect(mapping?.supportedVideoDurationsSeconds).toEqual(durations);
+			expect(model?.imageInputRequired).toBeUndefined();
+			expect(mapping?.supportedVideoSizes).toEqual(sizes);
+			expect(mapping?.supportedVideoSizes).not.toContain("1024x1024");
+			expect(mapping?.supportsVideoWithoutAudio).toBe(
+				supportsVideoWithoutAudio ?? true,
+			);
+		}
+	});
 });

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -675,6 +675,47 @@ export const providers: ProviderDefinition[] = [
 		},
 	},
 	{
+		id: "atlascloud",
+		name: "AtlasCloud",
+		description:
+			"AtlasCloud provides unified APIs for video, image, audio, and language generation models.",
+		env: {
+			required: {
+				apiKey: "LLM_ATLASCLOUD_API_KEY",
+			},
+			optional: {
+				baseUrl: "LLM_ATLASCLOUD_BASE_URL",
+			},
+		},
+		streaming: false,
+		cancellation: false,
+		color: "#0F766E",
+		website: "https://www.atlascloud.ai",
+		statusPageUrl: null,
+		announcement: null,
+		termsUrl: "https://atlascloud.ai/privacy",
+		privacyPolicyUrl: "https://www.atlascloud.ai/privacy",
+		headquarters: null,
+		dataPolicy: {
+			apiTraining: null,
+			consumerTraining: null,
+			promptLogging: null,
+			retentionPeriod: "varies by service; Enterprise ZDR available",
+			soc2: true,
+			gdpr: true,
+		},
+		additionalLinks: [
+			{
+				desc: "Zero Data Retention and DPA",
+				link: "https://www.atlascloud.ai/zero-data-retention",
+			},
+			{
+				desc: "Data deletion policy",
+				link: "https://www.atlascloud.ai/data-deletion-policy",
+			},
+		],
+	},
+	{
 		id: "aws-bedrock",
 		name: "AWS Bedrock",
 		description: "Amazon Bedrock - fully managed service for foundation models",

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1282,7 +1282,30 @@ export const ElevenLabsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 	</svg>
 );
 
+export const AtlasCloudIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
+	props,
+) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 32 32"
+		fill="none"
+	>
+		<rect width="32" height="32" rx="7" fill="#7C3AED" />
+		<path
+			fill="#FFFFFF"
+			d="M15.98 6.5 7.65 25.5h4.35l1.36-3.45h7.88l1.37 3.45h4.49L18.67 6.5h-2.69Zm-1.36 12.18 2.69-6.75 2.67 6.75h-5.36Z"
+		/>
+		<path
+			fill="#FFFFFF"
+			d="M10.18 23.16c2.85-1.15 5.43-1.33 7.79-.54l-.92-2.32c-2.05-.45-4.12-.22-6.22.68l-.65 2.18Z"
+			opacity=".82"
+		/>
+	</svg>
+);
+
 export const ProviderIcons = {
+	atlascloud: AtlasCloudIcon,
 	anthropic: AnthropicIcon,
 	elevenlabs: ElevenLabsIcon,
 	bytedance: BytedanceIcon,
@@ -1324,6 +1347,7 @@ export type ProviderIconKey = keyof typeof ProviderIcons;
 export const providerLogoUrls: Partial<
 	Record<ProviderId | ProviderIconKey, React.FC<React.SVGProps<SVGSVGElement>>>
 > = {
+	atlascloud: ProviderIcons.atlascloud,
 	openai: ProviderIcons.openai,
 	anthropic: ProviderIcons.anthropic,
 	elevenlabs: ProviderIcons.elevenlabs,


### PR DESCRIPTION
## Summary
- add AtlasCloud as a video provider with env configuration and provider icon
- expose only KLING v3.0 normal and turbo public video models under `/v1/videos`
- add AtlasCloud upload, generation, polling, and billing support
- add AtlasCloud terms/privacy, SOC 2/GDPR metadata, ZDR/DPA, and data deletion links
- keep O3 models, Turbo 4K, and Turbo no-audio unsupported

## Pricing
Checked against AtlasCloud's KLING pricing guide and using non-discounted/package-derived prices.

| Model | Quality | Sound | Per second | 5 seconds |
| --- | --- | --- | ---: | ---: |
| `kling-v3-0` | 720p/default | with sound | `$0.126` | `$0.63` |
| `kling-v3-0` | 720p/default | without sound | `$0.084` | `$0.42` |
| `kling-v3-0` | 1080p | with sound | `$0.168` | `$0.84` |
| `kling-v3-0` | 1080p | without sound | `$0.112` | `$0.56` |
| `kling-v3-0` | 4K | with sound | `$0.42` | `$2.10` |
| `kling-v3-0` | 4K | without sound | `$0.42` | `$2.10` |
| `kling-v3-0-turbo` | 720p/default | with sound | `$0.168` | `$0.84` |
| `kling-v3-0-turbo` | 1080p | with sound | `$0.21` | `$1.05` |

`kling-v3-0-turbo` does not support no-audio requests in this integration because the AtlasCloud Turbo schemas do not expose a `sound` toggle. Requests that need no-audio should use `kling-v3-0`.

## Production activity check
Sanitized June 20, 2026 DB/log summary:
- 13 completed AtlasCloud jobs
- 0 pending/failed AtlasCloud jobs found
- total AtlasCloud video cost logged: `$13.44`

Breakdown:
| Logged model mapping | Jobs | Total video cost |
| --- | ---: | ---: |
| `kwaivgi/kling-v3.0-std/image-to-video` | `4` | `$2.45` |
| `kwaivgi/kling-v3.0-4k/text-to-video` | `2` | `$5.25` |
| `kwaivgi/kling-v3.0-turbo/text-to-video` | `5` | `$4.06` |
| `kwaivgi/kling-v3.0-turbo/image-to-video` | `2` | `$1.68` |

## Tests
- `pnpm exec vitest run packages/models/src/providers.spec.ts`
- `pnpm --filter @llmgateway/models build`
- `pnpm --filter @llmgateway/models format`
- `pnpm format`
- `pnpm build`
- `pnpm lint`
- `GATEWAY_URL=http://localhost:4001 pnpm exec vitest run apps/gateway/src/videos/videos.spec.ts`
