### PR TITLE
fix(gateway): correct model-level deactivated_at in /v1/models

### DIFF
--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "vitest";
 
 import { app } from "@/app.js";
 
-import { providers } from "@llmgateway/models";
+import { models as modelsList, providers } from "@llmgateway/models";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
 
 describe("Models API", () => {
 	test("GET /v1/models should return a list of models", async () => {
@@ -53,12 +55,11 @@ describe("Models API", () => {
 
 		const json = await res.json();
 
-		// The deactivated_at field on a model represents the earliest deactivation date
-		// among all its providers. A model is only excluded if ALL providers are deactivated.
-		// Therefore, models with past deactivated_at dates may still appear if they have
-		// at least one active provider. This test verifies the response is successful and
-		// contains models, but cannot make assumptions about deactivated_at dates since
-		// partially deactivated models (some providers deactivated) are correctly included.
+		// The model-level deactivated_at field is only set once EVERY provider
+		// mapping has a deactivation date, and then reports the latest of them
+		// (when the model becomes fully unavailable). A model is only excluded once
+		// all providers are deactivated, so partially deactivated models still
+		// appear and a present deactivated_at may be in the past.
 
 		// Verify we got some models back
 		expect(json.data.length).toBeGreaterThan(0);
@@ -70,6 +71,38 @@ describe("Models API", () => {
 				expect(deactivatedAt instanceof Date).toBe(true);
 				expect(isNaN(deactivatedAt.getTime())).toBe(false);
 			}
+		}
+	});
+
+	test("GET /v1/models reports model-level deprecated_at/deactivated_at as the latest date across all mappings, set only when every mapping has one", async () => {
+		const res = await app.request("/v1/models?include_deactivated=true");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+		expect(json.data.length).toBeGreaterThan(0);
+
+		const definitionById = new Map(modelsList.map((m) => [m.id, m]));
+
+		const expectedDate = (dates: (Date | undefined)[]) => {
+			if (dates.length === 0 || dates.some((d) => d === undefined)) {
+				return undefined;
+			}
+			return (dates as Date[])
+				.reduce((latest, d) => (d.getTime() > latest.getTime() ? d : latest))
+				.toISOString();
+		};
+
+		for (const model of json.data) {
+			const definition = definitionById.get(model.id);
+			expect(definition).toBeDefined();
+			const mappings = definition!.providers as ProviderModelMapping[];
+
+			expect(model.deactivated_at).toBe(
+				expectedDate(mappings.map((p) => p.deactivatedAt)),
+			);
+			expect(model.deprecated_at).toBe(
+				expectedDate(mappings.map((p) => p.deprecatedAt)),
+			);
 		}
 	});
 
@@ -93,10 +126,11 @@ describe("Models API", () => {
 
 		const json = await res.json();
 
-		// The deprecated_at field represents the earliest deprecation date among all providers.
-		// A model is only excluded when ALL its providers are deprecated (have past dates).
-		// Models with some deprecated providers (past dates) but other active providers
-		// are correctly included, so we can't assume deprecated_at is always in the future.
+		// The model-level deprecated_at field is only set once EVERY provider
+		// mapping has a deprecation date, and then reports the latest of them.
+		// A model is only excluded when ALL its providers are deprecated (have past
+		// dates), so models with some deprecated providers but other active
+		// providers are correctly included, and deprecated_at may be undefined.
 
 		// Verify we got some models back and the response is valid
 		expect(json.data.length).toBeGreaterThan(0);

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -314,18 +314,17 @@ modelsApi.openapi(listModels, async (c) => {
 						(p) => (p as ProviderModelMapping).jsonOutputSchema === true,
 					) || false,
 				free: model.free ?? false,
-				// Calculate earliest deprecatedAt from all provider mappings
-				deprecated_at: model.providers
-					.map((p) => (p as ProviderModelMapping).deprecatedAt)
-					.filter((d): d is Date => d !== undefined)
-					.sort((a, b) => a.getTime() - b.getTime())[0]
-					?.toISOString(),
-				// Calculate earliest deactivatedAt from all provider mappings
-				deactivated_at: model.providers
-					.map((p) => (p as ProviderModelMapping).deactivatedAt)
-					.filter((d): d is Date => d !== undefined)
-					.sort((a, b) => a.getTime() - b.getTime())[0]
-					?.toISOString(),
+				// A model is only deprecated/deactivated once EVERY provider mapping
+				// is — the same `.every()` semantics used for filtering above. Report
+				// the date the model fully deprecates/deactivates (when its last
+				// remaining mapping does), and only when every mapping carries a date;
+				// if any mapping has none, the model never fully deprecates/deactivates.
+				deprecated_at: getModelLevelDate(
+					model.providers.map((p) => (p as ProviderModelMapping).deprecatedAt),
+				),
+				deactivated_at: getModelLevelDate(
+					model.providers.map((p) => (p as ProviderModelMapping).deactivatedAt),
+				),
 				stability: model.stability,
 			};
 		});
@@ -336,6 +335,21 @@ modelsApi.openapi(listModels, async (c) => {
 		throw new HTTPException(500, { message: "Internal server error" });
 	}
 });
+
+// Collapse the per-provider-mapping deprecation/deactivation dates into a single
+// model-level date. A model is only considered deprecated/deactivated once every
+// mapping is, so return the latest date (when the last mapping flips) and only
+// when every mapping has one. If any mapping has no date, the model never fully
+// flips, so return undefined.
+function getModelLevelDate(dates: (Date | undefined)[]): string | undefined {
+	if (dates.length === 0 || dates.some((d) => d === undefined)) {
+		return undefined;
+	}
+
+	return (dates as Date[])
+		.reduce((latest, d) => (d.getTime() > latest.getTime() ? d : latest))
+		.toISOString();
+}
 
 function getPerRequestLimits(
 	model: ModelDefinition,


### PR DESCRIPTION
## Problem

The `/v1/models` endpoint computed each model's `deprecated_at` / `deactivated_at` as the **earliest** date among its provider mappings, and emitted the field even when only a *single* mapping carried a date.

That contradicts the filtering logic right above it, which only hides a model once **every** provider mapping is deactivated/deprecated (`.every()`). The result: a model with one deactivated provider and another still-active one was advertised to clients as `deactivated_at: <past date>` even though it remains fully usable via the other provider.

The premise that deactivation is "a model-level signal with no per-provider equivalent" doesn't hold in this codebase — `deactivatedAt`/`deprecatedAt` live on the per-provider mapping (`ProviderModelMapping`), so the model-level value has to be *derived* consistently with how models are filtered.

## Fix

Derive the model-level date via a small `getModelLevelDate` helper that:

- returns the **latest** mapping date (the point at which the model's last remaining provider flips, i.e. when the model truly becomes unavailable), and
- only emits a value when **every** mapping carries a date; if any mapping has none, the model never fully deprecates/deactivates, so the field is omitted.

This matches the `.every()` semantics used for filtering.

## Tests

- Updated the misleading "earliest date" comments in `models.spec.ts`.
- Added an invariant test cross-referencing the endpoint response against the model definitions: `deactivated_at`/`deprecated_at` equal the latest mapping date and are only present when every mapping has one.
- `models.spec.ts`: 16/16 passing. `pnpm build` and `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the calculation of model deprecation and deactivation dates to use the latest date across all provider mappings, with these fields now set only when all provider mappings have corresponding dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->