### PR TITLE
fix(gateway): surface reasoning in /v1/messages

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -771,6 +771,7 @@ anthropic.openapi(messages, async (c) => {
 					cache_read_input_tokens: 0,
 				};
 				let currentTextBlockIndex: number | null = null;
+				let currentThinkingBlockIndex: number | null = null;
 				const toolCallBlockIndex = new Map<number, number>();
 				let currentEventType: string | null = null;
 				let stopReason: string | null = null;
@@ -971,6 +972,48 @@ anthropic.openapi(messages, async (c) => {
 									continue;
 								}
 
+								// Handle reasoning delta. The upstream chat completions
+								// stream normalizes provider reasoning fields to
+								// `delta.reasoning`; surface it as an Anthropic
+								// `thinking` block (which precedes text/tool output).
+								const reasoningDelta =
+									delta.reasoning ?? delta.reasoning_content;
+								if (
+									typeof reasoningDelta === "string" &&
+									reasoningDelta.length > 0
+								) {
+									if (currentThinkingBlockIndex === null) {
+										currentThinkingBlockIndex = contentBlocks.length;
+										contentBlocks.push({ type: "thinking", text: "" });
+										await stream.writeSSE({
+											data: JSON.stringify({
+												type: "content_block_start",
+												index: currentThinkingBlockIndex,
+												content_block: { type: "thinking", thinking: "" },
+											}),
+											event: "content_block_start",
+										});
+									}
+
+									const thinkingBlock =
+										contentBlocks[currentThinkingBlockIndex];
+									if (thinkingBlock && thinkingBlock.text !== undefined) {
+										thinkingBlock.text += reasoningDelta;
+									}
+
+									await stream.writeSSE({
+										data: JSON.stringify({
+											type: "content_block_delta",
+											index: currentThinkingBlockIndex,
+											delta: {
+												type: "thinking_delta",
+												thinking: reasoningDelta,
+											},
+										}),
+										event: "content_block_delta",
+									});
+								}
+
 								// Handle content delta
 								if (delta.content) {
 									// Find or create a text block
@@ -1138,6 +1181,18 @@ anthropic.openapi(messages, async (c) => {
 
 	// Transform OpenAI response to Anthropic format
 	const content: any[] = [];
+
+	// Surface reasoning as an Anthropic `thinking` block. Anthropic places
+	// thinking before the assistant's text/tool output, so emit it first.
+	const responseReasoning =
+		openaiResponse.choices?.[0]?.message?.reasoning ??
+		openaiResponse.choices?.[0]?.message?.reasoning_content;
+	if (typeof responseReasoning === "string" && responseReasoning.length > 0) {
+		content.push({
+			type: "thinking",
+			thinking: responseReasoning,
+		});
+	}
 
 	if (openaiResponse.choices?.[0]?.message?.content) {
 		content.push({

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -197,6 +197,115 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 	});
 
+	test("/v1/messages surfaces reasoning as a thinking block (non-streaming)", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "TRIGGER_REASONING" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+
+		const thinkingBlock = json.content.find(
+			(block: any) => block.type === "thinking",
+		);
+		expect(thinkingBlock).toBeTruthy();
+		expect(thinkingBlock.thinking).toBe(
+			"Let me think about this step by step.",
+		);
+
+		// Thinking must precede the assistant's text output, matching Anthropic.
+		const textIndex = json.content.findIndex(
+			(block: any) => block.type === "text",
+		);
+		const thinkingIndex = json.content.findIndex(
+			(block: any) => block.type === "thinking",
+		);
+		expect(thinkingIndex).toBeLessThan(textIndex);
+	});
+
+	test("/v1/messages surfaces reasoning as thinking_delta events (streaming)", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				stream: true,
+				messages: [{ role: "user", content: "TRIGGER_REASONING" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.text();
+
+		const events = body
+			.split("\n")
+			.filter((line) => line.startsWith("data: "))
+			.map((line) => line.slice(6).trim())
+			.filter((data) => data && data !== "[DONE]")
+			.map((data) => JSON.parse(data));
+
+		const thinkingStart = events.find(
+			(e) =>
+				e.type === "content_block_start" &&
+				e.content_block?.type === "thinking",
+		);
+		expect(thinkingStart).toBeTruthy();
+
+		const thinkingDelta = events.find(
+			(e) =>
+				e.type === "content_block_delta" && e.delta?.type === "thinking_delta",
+		);
+		expect(thinkingDelta).toBeTruthy();
+		expect(thinkingDelta.delta.thinking).toBe(
+			"Let me think about this step by step.",
+		);
+	});
+
 	test("/v1/chat/completions blocks providers failing the compliance policy", async () => {
 		// OpenAI's dataPolicy has promptLogging: true, so blockPromptLogging removes
 		// it. gpt-4o's only other (azure) mapping is deactivated, leaving no provider.

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -840,6 +840,11 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		chatMessages,
 		"ZERO_TOKENS",
 	);
+	const shouldReturnReasoning = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_REASONING",
+	);
+	const reasoningContent = "Let me think about this step by step.";
 	const shouldTruncateStream = hasUserMessageTrigger(
 		chatMessages,
 		"TRIGGER_TRUNCATED_STREAM",
@@ -969,6 +974,28 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 				return;
 			}
 
+			// Reasoning chunks (emitted before content, like real providers).
+			if (shouldReturnReasoning) {
+				for (let index = 0; index < requestedN; index++) {
+					await stream.writeSSE({
+						data: JSON.stringify({
+							id: "chatcmpl-123",
+							object: "chat.completion.chunk",
+							created: Math.floor(Date.now() / 1000),
+							model: body.model ?? "gpt-4o-mini",
+							choices: [
+								{
+									index,
+									delta: { reasoning: reasoningContent },
+									finish_reason: null,
+								},
+							],
+						}),
+						id: String(eventId++),
+					});
+				}
+			}
+
 			// Content chunks: one per choice index. For n > 1 each variant tags
 			// the content so the test can assert that no two choice streams
 			// were merged into one buffer.
@@ -1060,6 +1087,7 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 				requestedN > 1
 					? `${assistantContent} (variant ${index + 1})`
 					: assistantContent,
+			...(shouldReturnReasoning && { reasoning: reasoningContent }),
 		},
 	}));
 


### PR DESCRIPTION
## Problem

On the Anthropic-compatible `/v1/messages` endpoint, the OpenAI→Anthropic response translation only handled `content` (text) and `tool_calls` — it **never read `reasoning`**. So even when the underlying model reasoned (verified: hundreds of reasoning tokens billed, `reasoning` field populated on the internal response), native Anthropic clients (Claude Code, the Anthropic SDK) received a billed-but-invisible reasoning. This is the "reasoning seems disabled on `/v1/messages`" report.

## Fix

Emit reasoning as an Anthropic `thinking` content block in **both** response paths in `apps/gateway/src/anthropic/anthropic.ts`:

- **Non-streaming**: read `message.reasoning` (fallback `message.reasoning_content`) and push a `{ type: "thinking", thinking }` block, placed **before** the text block to match Anthropic's ordering.
- **Streaming**: handle `delta.reasoning` by opening a `thinking` content block and emitting `content_block_delta` events with `{ type: "thinking_delta", thinking }`.

The internal chat-completions stream already normalizes provider reasoning fields to `delta.reasoning` / `message.reasoning`, so this reads the canonical field.

### Round-trip safety

The request schema already accepts `thinking`/`redacted_thinking` blocks in conversation history and strips them when translating Anthropic→OpenAI, so echoing these blocks back (as Claude Code does) does not error — even though the gateway does not have provider thinking signatures to attach.

### Scope

This PR fixes the response-side drop only. The separate `/v1/messages` hard-400 on native budget thinking (`thinking: {type:"enabled", budget_tokens}`) is a request-translation issue and is out of scope here.

## Tests

Added a `TRIGGER_REASONING` trigger to the mock OpenAI server (emits `reasoning` in both streaming deltas and the non-streaming message) and two tests in `api.spec.ts`:

- non-streaming: asserts a `thinking` block is present and precedes the text block
- streaming: asserts `content_block_start` (type `thinking`) and `thinking_delta` events are emitted

`pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway now surfaces AI reasoning as thinking content blocks in responses for both streaming and non-streaming requests, with proper ordering and formatting.

* **Tests**
  * Added end-to-end tests validating thinking block output and incremental updates across streaming and non-streaming modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->