### PR TITLE
fix(gateway): Bedrock reasoning tokens + budget 400

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -673,6 +673,15 @@ anthropic.openapi(messages, async (c) => {
 			"x-debug": c.req.header("x-debug") ?? "",
 			"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
 			...(sessionId ? { "x-session-id": sessionId } : {}),
+			// Signal to the inner /v1/chat/completions handler that the caller used
+			// Anthropic's explicit-budget thinking API (`thinking.type: "enabled"`).
+			// On adaptive-only models the budget maps to an unsupported
+			// reasoning.max_tokens; the inner handler uses this to mirror Anthropic's
+			// own "use adaptive thinking" 400 (and log it as a client_error) instead
+			// of surfacing the confusing OpenAI-flavored capability error.
+			...(anthropicRequest.thinking?.type === "enabled"
+				? { "x-llmgateway-thinking-type": "enabled" }
+				: {}),
 		},
 		body: JSON.stringify(openaiRequest),
 	});
@@ -684,27 +693,30 @@ anthropic.openapi(messages, async (c) => {
 		});
 		const errorData = await response.text();
 
+		// The upstream here is our own /v1/chat/completions, which returns an
+		// OpenAI envelope `{ error: { message, type, ... } }`. Surface that inner
+		// message directly (both streaming and non-streaming) instead of dumping
+		// the raw JSON, so native Anthropic clients get a clean error string.
+		let parsedError: unknown = null;
+		try {
+			parsedError = JSON.parse(errorData);
+		} catch {
+			parsedError = null;
+		}
+		const innerMessage =
+			parsedError &&
+			typeof parsedError === "object" &&
+			"error" in parsedError &&
+			parsedError.error &&
+			typeof parsedError.error === "object" &&
+			"message" in parsedError.error &&
+			typeof parsedError.error.message === "string"
+				? parsedError.error.message
+				: errorData || response.statusText;
+
 		if (anthropicRequest.stream) {
-			let parsedError: unknown = null;
-			try {
-				parsedError = JSON.parse(errorData);
-			} catch {
-				parsedError = null;
-			}
 			// Derive the Anthropic error type from the HTTP status so streamed
-			// errors match the non-streaming path. The upstream here is our own
-			// /v1/chat/completions, which returns an OpenAI envelope whose `type`
-			// (e.g. invalid_request_error) would otherwise pass through verbatim.
-			const innerMessage =
-				parsedError &&
-				typeof parsedError === "object" &&
-				"error" in parsedError &&
-				parsedError.error &&
-				typeof parsedError.error === "object" &&
-				"message" in parsedError.error &&
-				typeof parsedError.error.message === "string"
-					? parsedError.error.message
-					: errorData || response.statusText;
+			// errors match the non-streaming path.
 			const errorEvent = buildAnthropicErrorEvent({
 				type: "error",
 				error: {
@@ -726,7 +738,7 @@ anthropic.openapi(messages, async (c) => {
 
 		return c.json(
 			buildAnthropicErrorBody({
-				message: `Request failed: ${errorData}`,
+				message: innerMessage,
 				status: response.status,
 			}),
 			response.status as 400 | 401 | 402 | 403 | 404 | 429 | 500,

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -306,6 +306,42 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/messages mirrors Anthropic's rejection of budget thinking on adaptive-only models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "claude-opus-4-8",
+				max_tokens: 1024,
+				thinking: { type: "enabled", budget_tokens: 8000 },
+				messages: [{ role: "user", content: "What is 2+2?" }],
+			}),
+		});
+
+		// Opus 4.6+ are adaptive-only and reject `thinking.type: "enabled"`. The
+		// gateway passes Anthropic's 400 through verbatim instead of silently
+		// translating the (unsupported) budget into adaptive thinking.
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as {
+			type: string;
+			error: { type: string; message: string };
+		};
+		expect(body.type).toBe("error");
+		expect(body.error.type).toBe("invalid_request_error");
+		expect(body.error.message).toContain("thinking.type.adaptive");
+	});
+
 	test("/v1/chat/completions blocks providers failing the compliance policy", async () => {
 		// OpenAI's dataPolicy has promptLogging: true, so blockPromptLogging removes
 		// it. gpt-4o's only other (azure) mapping is deactivated, leaving no provider.

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -212,6 +212,7 @@ import {
 	formatUsedModelForDisplay,
 	resolveProviderContext,
 } from "./tools/resolve-provider-context.js";
+import { resolveReasoningTokens } from "./tools/resolve-reasoning-tokens.js";
 import {
 	type RoutingAttempt,
 	getErrorType,
@@ -2387,16 +2388,116 @@ chat.openapi(completions, async (c) => {
 	}
 
 	// Validate model capabilities (JSON output, reasoning, tools, web search, documents)
-	validateModelCapabilities(modelInfo, requestedModel, requestedProvider, {
-		response_format,
-		reasoning_effort,
-		reasoning_max_tokens,
-		tools,
-		tool_choice,
-		webSearchTool,
-		hasImages,
-		hasDocuments,
-	});
+	try {
+		validateModelCapabilities(modelInfo, requestedModel, requestedProvider, {
+			response_format,
+			reasoning_effort,
+			reasoning_max_tokens,
+			tools,
+			tool_choice,
+			webSearchTool,
+			hasImages,
+			hasDocuments,
+		});
+	} catch (capabilityError) {
+		// The /v1/messages layer flags requests that used Anthropic's explicit-budget
+		// thinking API (`thinking.type: "enabled"`). On adaptive-only models the
+		// mapped reasoning.max_tokens is unsupported and validateModelCapabilities
+		// rejects it. Mirror Anthropic's own "use adaptive thinking" 400 and surface
+		// it in the activity feed as a client_error — the raw capability error is
+		// OpenAI-flavored (mentions a field the native client never sent) and isn't
+		// logged otherwise, so the user never sees the rejected request in history.
+		const usedAnthropicBudgetThinking =
+			c.req.header("x-llmgateway-thinking-type") === "enabled";
+		if (
+			usedAnthropicBudgetThinking &&
+			reasoning_max_tokens !== undefined &&
+			capabilityError instanceof HTTPException &&
+			capabilityError.message.includes("reasoning.max_tokens")
+		) {
+			const message = `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`;
+			try {
+				// Use _insertLog directly (not insertLogEntry): the local insertLog
+				// wrapper is declared further down and would be in its temporal dead
+				// zone here. Mirrors the early service-tier rejection log above.
+				await _insertLog(
+					{
+						...createLogEntry(
+							requestId,
+							project,
+							apiKey,
+							undefined,
+							"",
+							undefined,
+							"llmgateway",
+							requestedModel,
+							requestedProvider,
+							messages as any[],
+							temperature,
+							max_tokens,
+							top_p,
+							frequency_penalty,
+							presence_penalty,
+							reasoning_effort,
+							reasoning_max_tokens,
+							effort as "low" | "medium" | "high" | undefined,
+							response_format,
+							tools,
+							tool_choice,
+							source,
+							customHeaders,
+							debugMode,
+							userAgent,
+							image_config,
+						),
+						...(logIdOverride ? { id: logIdOverride } : {}),
+						responsesApiData,
+						content: null,
+						responseSize: 0,
+						finishReason: "client_error",
+						promptTokens: null,
+						completionTokens: null,
+						totalTokens: null,
+						reasoningTokens: null,
+						cachedTokens: null,
+						hasError: true,
+						streamed: !!stream,
+						canceled: false,
+						errorDetails: {
+							statusCode: 400,
+							statusText: "Bad Request",
+							responseText: message,
+							cause: "unsupported_reasoning_budget",
+						},
+						duration: 0,
+						timeToFirstToken: null,
+						inputCost: 0,
+						outputCost: 0,
+						cachedInputCost: 0,
+						requestCost: 0,
+						webSearchCost: 0,
+						imageInputTokens: null,
+						imageOutputTokens: null,
+						imageInputCost: null,
+						imageOutputCost: null,
+						cost: 0,
+						estimatedCost: false,
+						discount: null,
+						pricingTier: null,
+						serviceTier: null,
+						dataStorageCost: "0",
+					},
+					{ syncInsert: syncLogInsert },
+				);
+			} catch (error) {
+				logger.error("Failed to log budget-thinking rejection", {
+					error: toError(error),
+				});
+			}
+			throw new HTTPException(400, { message });
+		}
+		throw capabilityError;
+	}
 
 	let usedProvider = requestedProvider;
 	// Canonical LLM Gateway model id (root id). Used for every internal
@@ -8130,6 +8231,14 @@ chat.openapi(completions, async (c) => {
 									// Include costs in response for all users
 									const shouldIncludeCosts = true;
 
+									// Approximate reasoning tokens when the provider streamed
+									// reasoning content but no count (e.g. AWS Bedrock).
+									// Display only — totals/costs keep the raw reasoningTokens.
+									const calculatedReasoningTokens = resolveReasoningTokens(
+										reasoningTokens,
+										fullReasoningContent,
+									);
+
 									const finalStreamUsage: Record<string, any> = {
 										prompt_tokens: Math.max(
 											1,
@@ -8147,9 +8256,9 @@ chat.openapi(completions, async (c) => {
 													0) +
 												(reasoningTokens ?? 0),
 										),
-										...(reasoningTokens !== null &&
-											reasoningTokens > 0 && {
-												reasoning_tokens: reasoningTokens,
+										...(calculatedReasoningTokens !== null &&
+											calculatedReasoningTokens > 0 && {
+												reasoning_tokens: calculatedReasoningTokens,
 											}),
 										...((cachedTokens !== null ||
 											(cacheCreationTokens !== null &&
@@ -8198,7 +8307,7 @@ chat.openapi(completions, async (c) => {
 											: null,
 										cachedTokens,
 										cacheCreationTokens,
-										reasoningTokens,
+										reasoningTokens: calculatedReasoningTokens,
 										audioInputTokens,
 									});
 									const finalUsageChunk = {
@@ -9254,12 +9363,12 @@ chat.openapi(completions, async (c) => {
 							(calculatedPromptTokens ?? 0) + (calculatedCompletionTokens ?? 0);
 					}
 
-					// Estimate reasoning tokens if not provided but reasoning content exists
-					let calculatedReasoningTokens = reasoningTokens;
-					if (!reasoningTokens && fullReasoningContent) {
-						calculatedReasoningTokens =
-							estimateTokensFromContent(fullReasoningContent);
-					}
+					// Approximate reasoning tokens when the provider streamed reasoning
+					// content but no count (e.g. AWS Bedrock). Display/logging only.
+					const calculatedReasoningTokens = resolveReasoningTokens(
+						reasoningTokens,
+						fullReasoningContent,
+					);
 
 					if (
 						!streamingError &&
@@ -9634,9 +9743,9 @@ chat.openapi(completions, async (c) => {
 											1,
 											Math.round(adjPrompt + adjCompletion),
 										),
-										...(reasoningTokens !== null &&
-											reasoningTokens > 0 && {
-												reasoning_tokens: reasoningTokens,
+										...(calculatedReasoningTokens !== null &&
+											calculatedReasoningTokens > 0 && {
+												reasoning_tokens: calculatedReasoningTokens,
 											}),
 										...((cachedTokens !== null ||
 											(cacheCreationTokens !== null &&
@@ -9684,7 +9793,7 @@ chat.openapi(completions, async (c) => {
 										},
 										cachedTokens,
 										cacheCreationTokens,
-										reasoningTokens,
+										reasoningTokens: calculatedReasoningTokens,
 										audioInputTokens,
 									});
 									return earlyUsage;
@@ -11768,11 +11877,13 @@ chat.openapi(completions, async (c) => {
 	let calculatedPromptTokens = estimatedTokens.calculatedPromptTokens;
 	const calculatedCompletionTokens = estimatedTokens.calculatedCompletionTokens;
 
-	// Estimate reasoning tokens if not provided but reasoning content exists
-	let calculatedReasoningTokens = reasoningTokens;
-	if (!reasoningTokens && reasoningContent) {
-		calculatedReasoningTokens = estimateTokensFromContent(reasoningContent);
-	}
+	// Approximate reasoning tokens when the provider returned reasoning content
+	// but no count (e.g. AWS Bedrock). Display/logging only — never fed into
+	// calculateCosts below, which keeps the raw reasoningTokens.
+	const calculatedReasoningTokens = resolveReasoningTokens(
+		reasoningTokens,
+		reasoningContent,
+	);
 	const costs = await calculateCosts(
 		usedInternalModel,
 		usedProvider,
@@ -11862,7 +11973,7 @@ chat.openapi(completions, async (c) => {
 		(costs.promptTokens ?? calculatedPromptTokens ?? 0) +
 			(costs.completionTokens ?? calculatedCompletionTokens ?? 0) +
 			(reasoningTokens ?? 0),
-		reasoningTokens,
+		calculatedReasoningTokens,
 		cachedTokens,
 		toolResults,
 		convertedImages,

--- a/apps/gateway/src/chat/tools/resolve-reasoning-tokens.spec.ts
+++ b/apps/gateway/src/chat/tools/resolve-reasoning-tokens.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveReasoningTokens } from "./resolve-reasoning-tokens.js";
+
+describe("resolveReasoningTokens", () => {
+	test("returns the upstream count when the provider itemized it", () => {
+		expect(resolveReasoningTokens(994, "some reasoning text")).toBe(994);
+	});
+
+	test("prefers the upstream count even when reasoning content is present", () => {
+		// A real count always wins over the estimate.
+		expect(resolveReasoningTokens(120, "x".repeat(4000))).toBe(120);
+	});
+
+	test("estimates from reasoning content when the count is missing (Bedrock)", () => {
+		const reasoning =
+			"I am reasoning carefully about this problem step by step.";
+		const result = resolveReasoningTokens(null, reasoning);
+		expect(result).not.toBeNull();
+		expect(result).toBeGreaterThan(0);
+	});
+
+	test("estimates from reasoning content when the count is zero", () => {
+		const result = resolveReasoningTokens(0, "reasoning happened here");
+		expect(result).toBeGreaterThan(0);
+	});
+
+	test("returns null when there is neither a count nor reasoning content", () => {
+		expect(resolveReasoningTokens(null, null)).toBeNull();
+		expect(resolveReasoningTokens(null, "")).toBeNull();
+	});
+});

--- a/apps/gateway/src/chat/tools/resolve-reasoning-tokens.ts
+++ b/apps/gateway/src/chat/tools/resolve-reasoning-tokens.ts
@@ -1,0 +1,31 @@
+import { estimateTokensFromContent } from "./estimate-tokens-from-content.js";
+
+/**
+ * Resolve the reasoning-token count to surface for display and logging.
+ *
+ * Some providers return reasoning *content* but never a reasoning *token*
+ * count. The clearest case is AWS Bedrock via the Converse API: its
+ * `TokenUsage` struct only exposes `inputTokens` / `outputTokens` /
+ * `totalTokens` (+ cache fields) — there is no reasoning field, and the
+ * reasoning is bundled into `outputTokens`. Reporting `reasoning_tokens: 0` in
+ * that case is misleading (the model did reason), so when the provider didn't
+ * itemize the count we approximate it from the returned reasoning text — the
+ * same approach other gateways (e.g. OpenRouter) take for Bedrock.
+ *
+ * This is for display/logging only. Inference cost is computed from the
+ * upstream token counts (where Bedrock's reasoning already lives inside
+ * `outputTokens`), so the estimate is never fed back into cost calculation and
+ * the bundled reasoning is never double-charged.
+ */
+export function resolveReasoningTokens(
+	reasoningTokens: number | null,
+	reasoningContent: string | null,
+): number | null {
+	if (reasoningTokens) {
+		return reasoningTokens;
+	}
+	if (reasoningContent) {
+		return estimateTokensFromContent(reasoningContent);
+	}
+	return reasoningTokens;
+}

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -770,6 +770,43 @@ describe("fallback and error status code handling", () => {
 			);
 		});
 
+		test("/v1/messages budget thinking on adaptive model logs a client_error", async () => {
+			await setupKeys("anthropic");
+
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "claude-opus-4-8",
+					max_tokens: 1024,
+					thinking: { type: "enabled", budget_tokens: 8000 },
+					messages: [{ role: "user", content: "What is 2+2?" }],
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const body = (await res.json()) as {
+				type: string;
+				error: { type: string; message: string };
+			};
+			expect(body.type).toBe("error");
+			expect(body.error.message).toContain("thinking.type.adaptive");
+
+			// The rejection must be visible in the activity feed as a client_error,
+			// not silently dropped by the global error handler.
+			const logs = await waitForLogs(1);
+			const log = logs[0];
+			expect(log.finishReason).toBe("client_error");
+			expect(log.hasError).toBe(true);
+			expect(log.errorDetails?.statusCode).toBe(400);
+			expect(log.errorDetails?.responseText).toContain(
+				"thinking.type.adaptive",
+			);
+		});
+
 		test("streaming aws-bedrock success closes cleanly", async () => {
 			await setupKeys("aws-bedrock");
 


### PR DESCRIPTION
Two related fixes for extended-thinking on adaptive Opus models (4.6/4.7/4.8), verified **end-to-end against AWS Bedrock** (live `LLM_AWS_BEDROCK_API_KEY`).

---

## Fix 1 — mirror Anthropic's budget-thinking 400 on `/v1/messages` (+ log it)

A `/v1/messages` request with budget extended thinking (`thinking: {type:"enabled", budget_tokens:N}` — the Claude Code / Anthropic SDK default) was rejected with a confusing **OpenAI-flavored** error on adaptive-only Opus models:

> Model claude-opus-4-8 does not support **reasoning.max_tokens**…

…a field the native client never sent. The model defs are correct — a direct Anthropic call rejects `thinking.type:"enabled"` on these models too. The gateway now mirrors Anthropic's contract verbatim:

> `"thinking.type.enabled"` is not supported for this model. Use `"thinking.type.adaptive"` and `"output_config.effort"` to control thinking behavior.

**The rejection is now logged as a `client_error`** for end-user visibility (activity feed). Because the `/v1/messages` translation layer has no auth context, the check runs in the authenticated inner `/v1/chat/completions` flow: the messages layer signals budget thinking via an internal header, and the chat handler mirrors the message + inserts the log (matching the existing pre-upstream rejection pattern, e.g. guardrails / unsupported service tier). Native `/v1/chat/completions` callers (no header) keep the original capability error, unchanged. The non-streaming `/v1/messages` error path also now surfaces the clean inner message instead of `Request failed: {raw json}` (streaming already did).

Budget-capable models (e.g. `claude-sonnet-4-5`) are unaffected. Provider-agnostic (anthropic / aws-bedrock / vertex-anthropic).

**Verified (Bedrock):** opus-4-6/4-7/4-8 + budget → mirrored 400 (clean message, streaming + non-streaming); sonnet-4-5 + budget → 200; adaptive thinking → 200; client_error log row inserted.

---

## Fix 2 — surface Bedrock reasoning token counts (`reasoning_tokens: 0` → real estimate)

AWS Bedrock's **Converse API exposes no reasoning/thinking token field** — its [`TokenUsage`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_TokenUsage.html) struct only has input/output/total (+ cache) tokens, and reasoning is **bundled into `outputTokens`**. So Bedrock-routed Opus reported `reasoning_tokens: 0` on `/v1/chat/completions` even when the model demonstrably reasoned (reasoning content was returned) — the misleading "reasoning doesn't work" signal users reported.

Confirmed against AWS docs + raw response capture + [Effect-TS #6186](https://github.com/Effect-TS/effect/issues/6186), and against OpenRouter (which surfaces non-zero `reasoning_tokens` for the same Bedrock model by **tokenizing the returned reasoning text**).

The gateway already estimated reasoning tokens from the returned reasoning text for logging, but the **client-facing usage used the raw (null) upstream value**. This wires the existing estimate to the client usage at all three emission points (non-streaming response + both streaming final-usage chunks) via a shared `resolveReasoningTokens` helper — matching OpenRouter.

**Cost-safe:** the estimate is display/logging only. Inference cost still uses the raw upstream `reasoningTokens` (null for Bedrock), so reasoning already inside `outputTokens` is never double-charged, and `total_tokens` stays `prompt + completion`. Providers that report a real count (Anthropic/Google/OpenAI) are unaffected — the real value always wins.

**Verified (Bedrock opus-4-8, `reasoning_effort: high`):**

| | reasoning_tokens (before → after) | total_tokens | cost |
|---|---|---|---|
| non-streaming | `0` → **26** | 471 = 51+420 ✓ | $0.010755 = 420×\$25/M + 51×\$5/M ✓ (no inflation) |
| streaming | `0` → **48** | 505 = 50+455 ✓ | $0.011625 = 455×\$25/M + 50×\$5/M ✓ |

---

## Tests
- `api.spec.ts` — opus-4-8 + budget thinking → 400 with Anthropic's message.
- `fallback.spec.ts` — `/v1/messages` budget thinking → 400 **and** a `client_error` log row (finishReason, errorDetails, statusCode).
- `resolve-reasoning-tokens.spec.ts` — real count wins; estimate fills in when count missing/zero; null when no reasoning.

Build, format, unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/v1/messages` error handling to better extract and return upstream error details when requests fail.
  * Added clearer 400 validation for models that don’t support explicit budget thinking when using `thinking.type=enabled`, with guidance to switch to `thinking.type=adaptive`.

* **Improvements**
  * Enhanced `usage.reasoning_tokens` reporting by resolving an approximate value from reasoning content when providers don’t return a concrete count (streaming and non-streaming).

* **Tests**
  * Added/expanded gateway and fallback tests for the explicit-budget rejection behavior.
  * Added unit tests for reasoning-token resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->