### PR TITLE
fix(gateway): drop jsonOutput from coding-model gating

### DIFF
--- a/apps/gateway/src/lib/coding-models.spec.ts
+++ b/apps/gateway/src/lib/coding-models.spec.ts
@@ -45,7 +45,7 @@ describe("providerSupportsCachedInput", () => {
 });
 
 describe("isCodingModel", () => {
-	it("returns true when at least one stable provider has cached pricing, tools, JSON output, and streaming", () => {
+	it("returns true when at least one stable provider has cached pricing, tools, and streaming", () => {
 		expect(isCodingModel(baseModel)).toBe(true);
 	});
 
@@ -76,13 +76,13 @@ describe("isCodingModel", () => {
 		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
 	});
 
-	it("returns false when no provider supports JSON output", () => {
+	it("returns true even when no provider supports JSON output", () => {
 		const provider: ProviderModelMapping = {
 			...baseProvider,
 			jsonOutput: false,
 			jsonOutputSchema: false,
 		};
-		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(false);
+		expect(isCodingModel({ ...baseModel, providers: [provider] })).toBe(true);
 	});
 
 	it("returns false when streaming is explicitly disabled", () => {

--- a/apps/gateway/src/lib/coding-models.ts
+++ b/apps/gateway/src/lib/coding-models.ts
@@ -12,7 +12,6 @@ export function providerSupportsCachedInput(
  * - Not free
  * - Not unstable/experimental stability
  * - At least one stable provider with:
- *   - JSON output support (jsonOutput OR jsonOutputSchema)
  *   - Tool calling support
  *   - Streaming support
  *   - Cached input pricing
@@ -35,9 +34,6 @@ export function isCodingModel(model: ModelDefinition): boolean {
 			return false;
 		}
 
-		// Must have JSON output support
-		const hasJsonOutput = p.jsonOutput === true || p.jsonOutputSchema === true;
-
 		// Must have tool calling
 		const hasTools = p.tools === true;
 
@@ -47,6 +43,6 @@ export function isCodingModel(model: ModelDefinition): boolean {
 		// Must have cached input pricing
 		const hasCachedInputPrice = providerSupportsCachedInput(p);
 
-		return hasJsonOutput && hasTools && hasStreaming && hasCachedInputPrice;
+		return hasTools && hasStreaming && hasCachedInputPrice;
 	});
 }


### PR DESCRIPTION
## What

Loosen the coding-plan model gating (`isCodingModel`) so it no longer requires a provider mapping to support JSON output.

Previously a model qualified as a "coding model" (available by default on a dev/coding plan, with the allow-all-models toggle off) only if at least one stable provider mapping supported **all** of: tool calling, streaming, cached input pricing, **and** JSON output (`jsonOutput` or `jsonOutputSchema`).

JSON output is not essential for coding workloads, and requiring it excluded otherwise fully capable models. This drops that single criterion; tools + streaming + cached-input pricing are still required, and the free/unstable/experimental exclusions are unchanged.

## Effect

13 chat models become available by default on coding plans (toggle off):

- `claude-3-5-sonnet-20240620`, `claude-3-haiku`, `claude-3-haiku-20240307`, `claude-3-opus`
- `deepseek-v3.1`
- `gpt-5.2-chat-latest`, `gpt-5.3-chat-latest`, `gpt-oss-120b`
- `kimi-k2.7-code-highspeed`
- `minimax-m2`, `minimax-m2.5-highspeed`, `minimax-m2.7-highspeed`
- `qwen3-coder-next`

## Testing

- Updated `coding-models.spec.ts`: the JSON-output case now asserts the model still qualifies; the descriptive test name dropped "JSON output". All 13 unit tests pass.
- `pnpm format` and a clean gateway build (`turbo run build --filter=gateway`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the classification system for coding models to be more inclusive and less restrictive. The updated criteria now focus on three essential capabilities: tool support, streaming functionality, and cached input pricing. This improvement allows a broader set of models to qualify as coding models, expanding user options and flexibility when selecting models for development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->