### PR TITLE
fix(gateway): anthropic tool pairing + caching

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -372,6 +372,13 @@ anthropic.openapi(messages, async (c) => {
 	}
 
 	// Transform messages using the approach from claude-code-proxy
+
+	// Ids of preceding assistant `function_call` turns (synthesized when the
+	// client omitted one), so the legacy `function` result that follows can
+	// reference the same call. Falling back to the function name instead would
+	// break the tool_call_id pairing contract of the inner completions endpoint.
+	const pendingLegacyToolCallIds: string[] = [];
+
 	for (const message of anthropicRequest.messages) {
 		// Handle tool role → convert to OpenAI tool format
 		if (message.role === "tool") {
@@ -391,7 +398,10 @@ anthropic.openapi(messages, async (c) => {
 			openaiMessages.push({
 				role: "tool",
 				content: message.content,
-				tool_call_id: message.tool_call_id ?? message.name,
+				tool_call_id:
+					message.tool_call_id ??
+					pendingLegacyToolCallIds.shift() ??
+					message.name,
 			});
 			continue;
 		}
@@ -408,11 +418,14 @@ anthropic.openapi(messages, async (c) => {
 
 		// Handle assistant messages with function_call (legacy OpenAI format)
 		if (message.role === "assistant" && message.function_call) {
+			const toolCallId =
+				message.function_call.id ??
+				`call_${Math.random().toString(36).substring(2, 10)}`;
+			pendingLegacyToolCallIds.push(toolCallId);
+
 			const toolCalls = [
 				{
-					id:
-						message.function_call.id ??
-						`call_${Math.random().toString(36).substring(2, 10)}`,
+					id: toolCallId,
 					type: "function" as const,
 					function: {
 						name: message.function_call.name,
@@ -498,13 +511,28 @@ anthropic.openapi(messages, async (c) => {
 				});
 			}
 
-			// Handle any remaining text content as a user message
-			const textContent = message.content
-				.filter((block) => block.type === "text")
-				.map((block) => block.text)
-				.join("");
+			// Handle any remaining text content as a user message, preserving
+			// cache_control markers the same way the generic text path below does.
+			const textBlocks = message.content.filter(
+				(block) => block.type === "text",
+			);
+			const hasAnyCacheControl = textBlocks.some(
+				(block) => block.cache_control,
+			);
+			const textContent = textBlocks.map((block) => block.text).join("");
 
-			if (textContent) {
+			if (hasAnyCacheControl) {
+				openaiMessages.push({
+					role: "user",
+					content: textBlocks.map((block) => ({
+						type: "text",
+						text: block.text,
+						...(block.cache_control && {
+							cache_control: block.cache_control,
+						}),
+					})),
+				});
+			} else if (textContent) {
 				openaiMessages.push({
 					role: "user",
 					content: textContent,

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -197,6 +197,234 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 	});
 
+	test("/v1/messages pairs a legacy id-less function_call with its function result", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const originalFetch = globalThis.fetch;
+		let upstreamBody: any = null;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url === `${mockServerUrl}/v1/chat/completions`) {
+					const body =
+						input instanceof Request ? await input.text() : String(init?.body);
+					upstreamBody = JSON.parse(body);
+
+					return new Response(
+						JSON.stringify({
+							id: "chatcmpl-fn-pairing",
+							object: "chat.completion",
+							created: 1774549411,
+							model: "llmgateway/custom",
+							choices: [
+								{
+									index: 0,
+									message: { role: "assistant", content: "It's sunny." },
+									finish_reason: "stop",
+								},
+							],
+							usage: {
+								prompt_tokens: 5,
+								completion_tokens: 3,
+								total_tokens: 8,
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		try {
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					max_tokens: 1024,
+					messages: [
+						{ role: "user", content: "What's the weather in Paris?" },
+						{
+							role: "assistant",
+							content: "",
+							function_call: {
+								name: "get_weather",
+								arguments: '{"city":"Paris"}',
+							},
+						},
+						{ role: "function", name: "get_weather", content: "sunny" },
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(upstreamBody).toBeTruthy();
+
+			const assistantMsg = upstreamBody.messages.find(
+				(m: any) => m.role === "assistant" && m.tool_calls,
+			);
+			const toolMsg = upstreamBody.messages.find((m: any) => m.role === "tool");
+			const synthesizedId = assistantMsg.tool_calls[0].id;
+
+			// The function result must reference the synthesized call id, not the
+			// function name — otherwise providers reject the tool_call_id mismatch.
+			expect(synthesizedId).toMatch(/^call_/);
+			expect(toolMsg.tool_call_id).toBe(synthesizedId);
+			expect(toolMsg.tool_call_id).not.toBe("get_weather");
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	test("/v1/messages forwards tool_result-turn text as structured content (cache_control opt-in)", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const originalFetch = globalThis.fetch;
+		let upstreamBody: any = null;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url === `${mockServerUrl}/v1/chat/completions`) {
+					const body =
+						input instanceof Request ? await input.text() : String(init?.body);
+					upstreamBody = JSON.parse(body);
+
+					return new Response(
+						JSON.stringify({
+							id: "chatcmpl-cache-control",
+							object: "chat.completion",
+							created: 1774549411,
+							model: "llmgateway/custom",
+							choices: [
+								{
+									index: 0,
+									message: { role: "assistant", content: "Done." },
+									finish_reason: "stop",
+								},
+							],
+							usage: {
+								prompt_tokens: 5,
+								completion_tokens: 3,
+								total_tokens: 8,
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		try {
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					max_tokens: 1024,
+					messages: [
+						{ role: "user", content: "Look up the weather." },
+						{
+							role: "assistant",
+							content: [
+								{
+									type: "tool_use",
+									id: "toolu_1",
+									name: "get_weather",
+									input: { city: "Paris" },
+								},
+							],
+						},
+						{
+							role: "user",
+							content: [
+								{
+									type: "tool_result",
+									tool_use_id: "toolu_1",
+									content: "sunny",
+								},
+								{
+									type: "text",
+									text: "Given the above, what should I wear?",
+									cache_control: { type: "ephemeral" },
+								},
+							],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(upstreamBody).toBeTruthy();
+
+			// The trailing text turn must be forwarded as the per-block array form
+			// (carrying its cache_control marker into the inner pipeline) rather
+			// than flattened to a plain string, which silently dropped the cache
+			// opt-in before the fix. Whether cache_control reaches the wire is then
+			// a per-provider decision in prepare-request-body — the non-caching
+			// llmgateway provider strips it downstream, which is expected.
+			const userMsgs = upstreamBody.messages.filter(
+				(m: any) => m.role === "user",
+			);
+			const textTurn = userMsgs.find((m: any) => Array.isArray(m.content));
+			expect(textTurn).toBeTruthy();
+			const textBlock = textTurn.content.find((b: any) => b.type === "text");
+			expect(textBlock).toBeTruthy();
+			expect(textBlock.text).toBe("Given the above, what should I wear?");
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
 	test("/v1/messages surfaces reasoning as a thinking block (non-streaming)", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",


### PR DESCRIPTION
## Summary

PR #2616 targeted issue #2508 (the native `/v1/messages` endpoint 400ing on `thinking`/`redacted_thinking` blocks in history). **That fix already landed in `main` via #2745**, so its core change is redundant. This PR carries forward only the **two genuine, still-unfixed bugs** the #2616 review surfaced in the Anthropic → OpenAI message transform — applied inline on current `main` (no refactor, no duplicate thinking-block work).

## Changes

- **Legacy `function_call` id pairing.** An id-less assistant `function_call` synthesizes a random `call_*` id, but the following `role:"function"` result fell back to the function *name* — breaking the `tool_call_id` pairing contract of the inner `/v1/chat/completions` endpoint (providers rejected the mismatch with a 400). The synthesized id is now tracked and reused by the matching result.
- **`cache_control` preservation in `tool_result` turns.** Text blocks accompanying `tool_result` blocks were flattened into a plain string, silently dropping any `cache_control` marker. They now keep the per-block array form (matching the generic text path), so the cache opt-in reaches the inner pipeline; per-provider forwarding/stripping then remains `prepare-request-body`'s decision.

## Tests

Two new `/v1/messages` integration tests in `api.spec.ts` (mirroring the existing #2745 pattern, asserting the transformed upstream body):

- legacy id-less `function_call` + `role:"function"` → the tool result's `tool_call_id` equals the synthesized `call_*` id, not the function name.
- text alongside `tool_result` → forwarded as structured array content (the form that carries the `cache_control` opt-in) rather than a flattened string.

## Verification

- `pnpm format`, `pnpm build` (tsc + OpenAPI regen) clean.
- All 8 `/v1/messages` tests pass (6 existing + 2 new).

Relates to #2616 / #2508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility for legacy tool calling patterns in API conversations.
  * Corrected preservation of cache control metadata when forwarding structured message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->