### PR TITLE
fix(gateway): synthesize Bedrock toolConfig from history

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2101,6 +2101,92 @@ describe("prepareRequestBody - AWS Bedrock", () => {
 			],
 		});
 	});
+	test("synthesizes toolConfig when history has tool blocks but request omits tools", async () => {
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-opus-4-8",
+			null,
+			"anthropic.claude-opus-4-8",
+			[
+				{ role: "user", content: "What is the weather in Berlin?" },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "tool_1",
+							type: "function",
+							function: {
+								name: "get_weather",
+								arguments: JSON.stringify({ city: "Berlin" }),
+							},
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "tool_1",
+					content: JSON.stringify({ temperature: 17, unit: "celsius" }),
+				},
+				{ role: "user", content: "Thanks, what should I wear?" },
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined, // tools omitted on the follow-up turn
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		// Bedrock requires toolConfig whenever toolUse/toolResult blocks are
+		// present in the history, so it must be synthesized from the tool
+		// names seen in the assistant toolUse blocks.
+		expect(requestBody.toolConfig).toEqual({
+			tools: [
+				{
+					toolSpec: {
+						name: "get_weather",
+						inputSchema: {
+							json: {
+								type: "object",
+								properties: {},
+							},
+						},
+					},
+				},
+			],
+		});
+	});
+
+	test("does not synthesize toolConfig when history has no tool blocks", async () => {
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-opus-4-8",
+			null,
+			"anthropic.claude-opus-4-8",
+			[{ role: "user", content: "Hello there" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.toolConfig).toBeUndefined();
+	});
 });
 
 describe("prepareRequestBody - reasoning.max_tokens forwarding", () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2368,6 +2368,46 @@ export async function prepareRequestBody(
 				}
 			}
 
+			// Bedrock's Converse API rejects any request whose message history
+			// contains toolUse/toolResult blocks unless `toolConfig` is also
+			// defined ("The toolConfig field must be defined when using toolUse
+			// and toolResult content blocks."). OpenAI and Anthropic both accept
+			// tool blocks in history without re-declaring tools on the follow-up
+			// turn, so a request that omits `tools` but continues a tool-use
+			// conversation succeeds on those providers and only 400s on Bedrock.
+			// When that happens, synthesize a minimal toolConfig from the tool
+			// names already present in the assistant toolUse blocks so the
+			// history validates.
+			if (!requestBody.toolConfig) {
+				const historyToolNames = new Set<string>();
+				for (const bedrockMessage of bedrockMessages) {
+					if (!Array.isArray(bedrockMessage.content)) {
+						continue;
+					}
+					for (const block of bedrockMessage.content) {
+						if (block?.toolUse?.name) {
+							historyToolNames.add(block.toolUse.name);
+						}
+					}
+				}
+
+				if (historyToolNames.size > 0) {
+					requestBody.toolConfig = {
+						tools: Array.from(historyToolNames).map((name) => ({
+							toolSpec: {
+								name,
+								inputSchema: {
+									json: {
+										type: "object",
+										properties: {},
+									},
+								},
+							},
+						})),
+					};
+				}
+			}
+
 			// Add inferenceConfig for optional parameters
 			const inferenceConfig: any = {};
 			if (temperature !== undefined) {


### PR DESCRIPTION
## Problem

A request from Zed (`claude-opus-4-8`) returned a `client_error` / 400 from AWS Bedrock:

```
{"message":"The toolConfig field must be defined when using toolUse and toolResult content blocks."}
```

This is **not a client error**. The request continued a tool-use conversation — its message history contained assistant `tool_calls` and `tool` results — but did not re-declare the `tools` array on that follow-up turn. That's valid OpenAI-compatible input: OpenAI's own API and Anthropic's native API both accept tool blocks in the history without `tools` present in the current request.

The gap is provider-specific strictness. AWS Bedrock's Converse API **requires** `toolConfig` to be present whenever any `toolUse`/`toolResult` block appears in messages. The exact same request would have succeeded on Anthropic — and in the captured log both providers were available, but **session-sticky routing pinned the turn to Bedrock**, so the request 400'd purely because of which provider it landed on for the same model. That portability leak is exactly what the gateway should paper over.

In `packages/actions/src/prepare-request-body.ts`, the Bedrock branch always converts history `tool_calls` → `toolUse` blocks and `tool` results → `toolResult` blocks, but only set `toolConfig` when the current request supplied `tools`.

## Fix

When no `toolConfig` was built from the request's `tools`, synthesize a minimal one from the tool names already present in the assistant `toolUse` blocks (name + permissive `{type:"object"}` input schema). Bedrock only needs the tools declared for the history blocks to validate — the original descriptions/schemas aren't required.

## Tests

- New unit test: history has tool blocks but the request omits `tools` → `toolConfig` is synthesized from the `toolUse` names.
- New unit test: plain conversation with no tool blocks → `toolConfig` stays undefined (no regression for the common case).

`pnpm format`, the `prepare-request-body` spec (101 passing), and `turbo run build --filter=gateway` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AWS Bedrock integration to properly handle tool-use and tool-result blocks in conversation continuations. Tool configurations are now automatically synthesized from prior conversation history when needed, preventing errors on follow-up turns.

* **Tests**
  * Added comprehensive test coverage for automatic tool configuration synthesis in multi-turn conversations, covering scenarios with and without prior tool usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->