### PR TITLE
fix(gateway): guard non-object video upstream JSON

### DIFF
--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -2714,7 +2714,15 @@ async function fetchUpstreamJson(
 
 	if (text.length > 0) {
 		try {
-			body = JSON.parse(text) as Record<string, unknown>;
+			const parsed: unknown = JSON.parse(text);
+			body =
+				typeof parsed === "object" && parsed !== null
+					? (parsed as Record<string, unknown>)
+					: {
+							error: {
+								message: text,
+							},
+						};
 		} catch {
 			body = {
 				error: {


### PR DESCRIPTION
## Problem

Production gateway crashed with:

```
TypeError: Cannot read properties of null (reading 'msg')
    at fetchUpstreamJson (/app/src/videos/videos.ts:2728:15)
    at uploadAtlasCloudMedia (.../videos.ts:3270)
    at getAtlasCloudImageUrl (.../videos.ts:3360)
    at createAtlasCloudVideoJob (.../videos.ts:3390)
```

`fetchUpstreamJson` annotated the parsed response body as `Record<string, unknown>`, but `JSON.parse` returns `any`. When an upstream provider responded with a body of the literal text `null` (or any non-object JSON primitive), `body` became `null`, and the subsequent `typeof body.msg` dereferenced `null` and threw.

## Fix

Guard the parse result: only treat a non-null `object` as the body. Anything else (null / primitive) falls back to wrapping the raw text in an `error` object — the same path already used for non-JSON responses.

## Testing

- `pnpm turbo run build --filter=gateway` passes
- Formatted with prettier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for upstream API responses to more reliably process and report malformed or unexpected data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->