### PR TITLE
fix(api): strip region suffix in log model filter

### DIFF
--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -269,6 +269,50 @@ describe("logs route", () => {
 			expect(json.pagination.limit).toBe(50);
 		});
 
+		test("should filter logs by model with a region-suffixed usedModel", async () => {
+			// usedModel is stored as `provider/modelId[:region]`. The model filter
+			// receives the bare model id, so the region suffix must be stripped.
+			await db.insert(tables.log).values({
+				id: "test-log-id-region",
+				requestId: "test-log-id-region",
+				organizationId: "test-org-id",
+				projectId: "test-project-id",
+				apiKeyId: "test-api-key-id",
+				duration: 100,
+				requestedModel: "claude-opus-4-6",
+				requestedProvider: "aws-bedrock",
+				usedModel: "aws-bedrock/claude-opus-4-6:global",
+				usedProvider: "aws-bedrock",
+				responseSize: 1000,
+				content: "Test response with region-suffixed model",
+				finishReason: "stop",
+				promptTokens: "10",
+				completionTokens: "20",
+				totalTokens: "30",
+				temperature: 0.7,
+				maxTokens: 100,
+				messages: JSON.stringify([{ role: "user", content: "Hello region" }]),
+				mode: "api-keys",
+				usedMode: "api-keys",
+			});
+
+			const params = new URLSearchParams({
+				projectId: "test-project-id",
+				model: "claude-opus-4-6",
+			});
+			const res = await app.request("/logs?" + params, {
+				method: "GET",
+				headers: {
+					Cookie: token,
+				},
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.logs.length).toBe(1);
+			expect(json.logs[0].id).toBe("test-log-id-region");
+		});
+
 		test("should filter logs by custom header", async () => {
 			// First, add a log with a custom header
 			await db.insert(tables.log).values({

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -523,13 +523,14 @@ logs.openapi(get, async (c) => {
 		whereConditions.push(lte(tables.log.createdAt, new Date(endDate)));
 	}
 
-	// Add model filter - match the model name part after the slash,
+	// Add model filter - match the model id part after the slash and before any
+	// `:region` suffix (usedModel is stored as `provider/modelId[:region]`),
 	// or the full value if there's no slash (seed data / legacy format)
 	if (model) {
 		whereConditions.push(
 			sql`CASE WHEN ${tables.log.usedModel} LIKE '%/%'
-				THEN SPLIT_PART(${tables.log.usedModel}, '/', 2)
-				ELSE ${tables.log.usedModel}
+				THEN SPLIT_PART(SPLIT_PART(${tables.log.usedModel}, '/', 2), ':', 1)
+				ELSE SPLIT_PART(${tables.log.usedModel}, ':', 1)
 			END = ${model}`,
 		);
 	}

--- a/apps/api/src/routes/model-ratings.ts
+++ b/apps/api/src/routes/model-ratings.ts
@@ -49,8 +49,8 @@ async function getModelRequestCount(
 			and(
 				inArray(tables.projectHourlyModelStats.projectId, projectIds),
 				sql`CASE WHEN ${tables.projectHourlyModelStats.usedModel} LIKE '%/%'
-					THEN SPLIT_PART(${tables.projectHourlyModelStats.usedModel}, '/', 2)
-					ELSE ${tables.projectHourlyModelStats.usedModel}
+					THEN SPLIT_PART(SPLIT_PART(${tables.projectHourlyModelStats.usedModel}, '/', 2), ':', 1)
+					ELSE SPLIT_PART(${tables.projectHourlyModelStats.usedModel}, ':', 1)
 				END = ${modelId}`,
 			),
 		);


### PR DESCRIPTION
## Problem

In the admin project detail page (and the main UI) "Recent Logs" section, selecting a model in the **Filter by model** picker returned **no logs**, even when matching logs clearly existed.

### Root cause

The log model filter compared `usedModel`'s part after the slash against the bare model id sent by the frontend:

```sql
CASE WHEN usedModel LIKE '%/%'
  THEN SPLIT_PART(usedModel, '/', 2)
  ELSE usedModel
END = model
```

But `usedModel` is stored as `provider/modelId[:region]` (see `formatUsedModelForDisplay`). For a region-qualified model the after-slash part is e.g. `claude-opus-4-6:global`, while the frontend sends the bare id `claude-opus-4-6` (model-definition `id`). The `:global` suffix made the comparison always fail, so every region-routed model returned zero logs.

## Fix

Strip the `:region` suffix before comparing, in both:

- `apps/api/src/routes/logs.ts` — the logs list model filter
- `apps/api/src/routes/model-ratings.ts` — the identical pattern in the rating-eligibility usage query (region-routed models were under-counted, blocking ratings)

Model ids in the registry never contain `:`, so `SPLIT_PART(..., ':', 1)` is safe.

## Test

Added a regression test in `logs.spec.ts` that inserts a log with `usedModel: "aws-bedrock/claude-opus-4-6:global"` and asserts filtering by `model=claude-opus-4-6` returns it.

- `npx vitest run apps/api/src/routes/logs.spec.ts` — 13 passed
- `npx vitest run apps/api/src/routes/model-ratings.spec.ts` — 6 passed
- `pnpm format` and `turbo run build --filter=api` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed log filtering to correctly handle model IDs with provider and region information when querying by model name
  * Improved model rating count calculations to consistently extract and match model identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->