### PR TITLE
fix(gateway): warn-log expected upstream stream close

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -9269,7 +9269,7 @@ chat.openapi(completions, async (c) => {
 							phase: "upstream_read",
 						});
 
-						logger.error("Error reading upstream stream", toError(error), {
+						const upstreamReadErrorMeta = {
 							requestId,
 							usedProvider,
 							requestedProvider,
@@ -9294,12 +9294,30 @@ chat.openapi(completions, async (c) => {
 							firstTokenReceived,
 							firstReasoningTokenReceived,
 							unifiedFinishReason: getUnifiedFinishReason(
-								normalizedStreamingError.client.type === "gateway_error"
-									? "gateway_error"
-									: "upstream_error",
+								normalizedStreamingError.terminated
+									? "upstream_error"
+									: "gateway_error",
 								usedProvider,
 							),
-						});
+						};
+
+						// An upstream-side socket close (e.g. "terminated: other side
+						// closed") is an expected provider disconnect, not a gateway/server
+						// fault, so log it at warn severity to avoid raising server-error
+						// alerts. Genuine gateway-side streaming read faults stay at error.
+						if (normalizedStreamingError.terminated) {
+							logger.warn(
+								"Error reading upstream stream",
+								toError(error),
+								upstreamReadErrorMeta,
+							);
+						} else {
+							logger.error(
+								"Error reading upstream stream",
+								toError(error),
+								upstreamReadErrorMeta,
+							);
+						}
 
 						// Forward the error to the client with the buffered content that caused the error
 						try {
@@ -9326,6 +9344,12 @@ chat.openapi(completions, async (c) => {
 						}
 
 						streamingError = normalizedStreamingError.log;
+						// Classify the inference log so it isn't recorded as UNKNOWN: an
+						// upstream socket close is an upstream error, a genuine read fault
+						// is a gateway error.
+						finishReason = normalizedStreamingError.terminated
+							? "upstream_error"
+							: "gateway_error";
 					}
 				} finally {
 					// Clean up the reader to prevent file descriptor leaks

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
@@ -22,6 +22,7 @@ describe("normalizeStreamingError", () => {
 			phase: "upstream_read",
 		});
 
+		expect(normalized.terminated).toBe(true);
 		expect(normalized.client.message).toBe(
 			"Upstream stream terminated unexpectedly before completion",
 		);
@@ -45,6 +46,7 @@ describe("normalizeStreamingError", () => {
 			phase: "upstream_read",
 		});
 
+		expect(normalized.terminated).toBe(false);
 		expect(normalized.client.message).toBe(
 			"Streaming error: Unexpected end of JSON input",
 		);

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.ts
@@ -14,6 +14,13 @@ export interface NormalizeStreamingErrorOptions {
 }
 
 export interface NormalizedStreamingError {
+	/**
+	 * True when the failure is an expected upstream-side disconnect (the provider
+	 * closed the socket mid-stream, e.g. "terminated: other side closed"), rather
+	 * than a gateway-side streaming read fault. Callers use this to avoid logging
+	 * the error at server-error severity and to classify it as an upstream error.
+	 */
+	terminated: boolean;
 	client: {
 		message: string;
 		type: "gateway_error";
@@ -163,6 +170,7 @@ export function normalizeStreamingError(
 	const responseText = cause ? `${rawMessage} | cause: ${cause}` : rawMessage;
 
 	return {
+		terminated,
 		client: {
 			message,
 			type: "gateway_error",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -145,9 +145,10 @@ class LLMGatewayLogger {
 		this.logger.info(this.mergeOptionalArg(traceContext, extra), message);
 	}
 
-	public warn(message: string, extra?: object | Error): void {
+	public warn(message: string, ...args: unknown[]): void {
 		const traceContext = this.getTraceContext();
-		this.logger.warn(this.mergeOptionalArg(traceContext, extra), message);
+		const merged = this.mergeArgs(traceContext, args);
+		this.logger.warn(merged, message);
 	}
 
 	public error(message: string, ...args: unknown[]): void {


### PR DESCRIPTION
## What

That GCP `ERROR` alert — `TypeError: terminated` / `cause: "other side closed"` from undici, surfacing at `Fetch.onAborted` → `TLSSocket.onHttpSocketClose` — is a **provider closing the streaming socket mid-response**. It's an expected upstream disconnect, not a gateway/server fault.

Two problems with how it was logged:

1. **App logger:** the upstream-read catch branch in `chat.ts` logged via `logger.error`, raising it to `ERROR` severity and tripping server-error alerts — even though `normalizeStreamingError` already classified the case as a `502 "Upstream Stream Terminated"`. The sibling paths (timeout, stream-truncated, empty-response) all use `logger.warn` for the same class of expected failure; this one was the outlier.
2. **Inference log:** this branch set `streamingError` (so `hasError: true` was recorded) but never set `finishReason`, so the request log classified as `UNKNOWN` instead of `UPSTREAM_ERROR`.

## Changes

- `normalizeStreamingError` now exposes a `terminated` boolean (true for upstream socket closes — `terminated` / `other side closed` / `ECONNRESET` / `UND_ERR_*` / socket).
- `chat.ts` upstream-read catch:
  - logs at `warn` when `terminated`, keeps `error` for genuine gateway-side read faults
  - sets `finishReason` to `upstream_error` (terminated) or `gateway_error` (read fault) so the inference log records the correct error kind instead of `UNKNOWN`
  - the `unifiedFinishReason` log field now reflects `terminated` instead of the always-`gateway_error` check (`client.type` was hardcoded, so it always evaluated to gateway_error).
- `logger.warn` is now variadic like `logger.error`/`fatal`, so the warn path can carry both the `Error` and the metadata object (backward compatible — existing single-arg calls are unaffected).

The client-facing response and `hasError`/`errorDetails` recording are unchanged — only severity and finish-reason classification change.

## Test

- Updated `normalize-streaming-error.spec.ts` to assert `terminated` for both the undici-socket-close and the generic-read-error cases.
- `pnpm vitest run` for the normalize + logger specs: 19 passing.
- `turbo run build --filter=gateway` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved streaming error handling by distinguishing upstream disconnections from gateway faults with appropriate log severity levels.
  * Enhanced error classification for stream interruptions to better identify root causes.

* **Tests**
  * Updated test coverage for streaming error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->