### PR TITLE
fix(gateway): only recover tool_call_id if unique

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2816,35 +2816,36 @@ describe("prepareRequestBody - max_tokens forwarding", () => {
 			expect(output.call_id).toBe("call_abc");
 		});
 
-		test("recovers call_ids in order for parallel tool results missing ids", async () => {
-			const requestBody = (await prepareRequestBody(
-				...responsesArgs([
-					{ role: "user", content: "weather and time in Berlin?" },
-					{
-						role: "assistant",
-						content: "",
-						tool_calls: [
-							{
-								id: "call_1",
-								type: "function",
-								function: { name: "get_weather", arguments: "{}" },
-							},
-							{
-								id: "call_2",
-								type: "function",
-								function: { name: "get_time", arguments: "{}" },
-							},
-						],
-					},
-					{ role: "tool", content: JSON.stringify({ temperature: 17 }) },
-					{ role: "tool", content: JSON.stringify({ time: "20:52" }) },
-				]),
-			)) as any;
-
-			const outputs = requestBody.input.filter(
-				(i: any) => i.type === "function_call_output",
-			);
-			expect(outputs.map((o: any) => o.call_id)).toEqual(["call_1", "call_2"]);
+		test("throws for ambiguous parallel tool results missing ids and names", async () => {
+			// Two pending calls and two results carrying neither tool_call_id nor a
+			// name to disambiguate. Guessing oldest-first would silently
+			// misattribute outputs if the results arrived out of order, so the
+			// transform rejects rather than corrupt the conversation.
+			await expect(
+				prepareRequestBody(
+					...responsesArgs([
+						{ role: "user", content: "weather and time in Berlin?" },
+						{
+							role: "assistant",
+							content: "",
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									function: { name: "get_weather", arguments: "{}" },
+								},
+								{
+									id: "call_2",
+									type: "function",
+									function: { name: "get_time", arguments: "{}" },
+								},
+							],
+						},
+						{ role: "tool", content: JSON.stringify({ temperature: 17 }) },
+						{ role: "tool", content: JSON.stringify({ time: "20:52" }) },
+					]),
+				),
+			).rejects.toBeInstanceOf(OrphanedToolMessageError);
 		});
 
 		test("matches legacy function-role results by name", async () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -662,8 +662,10 @@ export class OrphanedToolMessageError extends Error {
  * Completions spec requires `tool_call_id` on `tool` messages, but real callers
  * sometimes omit it (legacy `function` role results carry only `name`, and some
  * clients drop the id when replaying history). To stay compatible we recover
- * the id from the preceding unmatched function calls: by explicit id, then by
- * matching function name, then by oldest-first ordering.
+ * the id from the preceding unmatched function calls, but only when the pairing
+ * is unambiguous: by explicit id, by a unique matching function name, or when
+ * exactly one call is still unmatched. Ambiguous cases throw rather than risk
+ * attaching a result to the wrong call.
  */
 function transformMessagesForResponsesApi(messages: any[]): any[] {
 	const items: any[] = [];
@@ -686,16 +688,20 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 			pendingCalls.splice(idx, 1);
 			return msg.tool_call_id;
 		}
+		// No explicit id: recover only when the pairing is unambiguous. Guessing
+		// (oldest-first) silently misattributes a tool output to the wrong call
+		// when parallel results arrive out of order, so prefer a clean 400.
 		// Legacy `function` role (and tool messages that carry a function name):
-		// pair with the earliest pending call sharing that name.
+		// pair only when exactly one pending call shares that name.
 		if (msg.name) {
-			const idx = pendingCalls.findIndex((c) => c.name === msg.name);
-			if (idx !== -1) {
+			const named = pendingCalls.filter((c) => c.name === msg.name);
+			if (named.length === 1) {
+				const idx = pendingCalls.findIndex((c) => c.name === msg.name);
 				return pendingCalls.splice(idx, 1)[0].callId;
 			}
 		}
-		// Fall back to the oldest unmatched call (ordered tool turns).
-		if (pendingCalls.length > 0) {
+		// Otherwise recover only when exactly one call is still unmatched.
+		if (pendingCalls.length === 1) {
 			return pendingCalls.shift()?.callId;
 		}
 		return undefined;


### PR DESCRIPTION
## What

Stacks on top of #2749. That PR recovers a missing `tool_call_id` when translating Chat Completions tool results into Responses API `function_call_output` items. This hardens the recovery so it never silently attaches a result to the wrong call.

## Why

The recovery in #2749 had two ambiguous fallbacks when a tool result omits `tool_call_id`:

- the **first** pending call sharing the function name
- the **oldest** unmatched call (FIFO)

With parallel tool calls whose results omit `tool_call_id` and arrive **out of order**, the FIFO fallback pairs a result with the wrong `call_id` — a silent conversation corruption with no error surfaced.

## How

`resolveCallId` now recovers a missing id only when the pairing is **unambiguous**:

- explicit `tool_call_id` matching a pending call (unchanged)
- exactly **one** pending call with the result's function name
- exactly **one** pending call still unmatched

Otherwise it throws `OrphanedToolMessageError` (already mapped to a clean 400) instead of guessing. Well-formed requests always carry `tool_call_id`, so they never reach the recovery path and are unaffected.

## Testing

- `packages/actions` unit suite green (250 tests). The former "recovers call_ids in order for parallel results missing ids" test now asserts a clean rejection for the ambiguous case.
- Verified end-to-end against **live OpenAI** via curl on `/v1/chat/completions` (`gpt-5-nano`): single / parallel / reverse-order / sequential / streaming tool round-trips → `200` with correct output; orphaned or unpairable results → clean `400`, zero `500`s. A non-Responses model (`gpt-4o-mini`) confirmed the unchanged chat path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
