### PR TITLE
fix: provider keys search, support notify, docs indent

### DIFF
--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -1,9 +1,6 @@
 import { logger } from "@llmgateway/logger";
 
 const discordWebhookUrl = process.env.DISCORD_NOTIFICATION_URL;
-const discordSupportWebhookUrl =
-	process.env.DISCORD_SUPPORT_NOTIFICATION_URL ??
-	process.env.DISCORD_NOTIFICATION_URL;
 
 interface DiscordEmbed {
 	title: string;
@@ -245,7 +242,8 @@ export async function notifyChatSupportEscalation(args: {
 				},
 			],
 		},
-		discordSupportWebhookUrl,
+		process.env.DISCORD_SUPPORT_NOTIFICATION_URL ??
+			process.env.DISCORD_NOTIFICATION_URL,
 	);
 }
 

--- a/apps/docs/content/quick-start.mdx
+++ b/apps/docs/content/quick-start.mdx
@@ -1,20 +1,19 @@
 ---
 title: Quickstart
-description: Fastest way to start using LLM Gateway in any language or framework.
+description: Fastest way to start using LLM Gateway in any language or framework.
 icon: Rocket
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 
-Welcome to **LLM Gateway**—a single drop‑in endpoint that lets you call today’s best large‑language models while keeping **your existing code** and development workflow intact.
+Welcome to **LLM Gateway**—a single drop‑in endpoint that lets you call today’s best large‑language models while keeping **your existing code** and development workflow intact.
 
-> **TL;DR** — Point your HTTP requests to `https://api.llmgateway.io/v1/…`, supply your `LLM_GATEWAY_API_KEY`, and you’re done.
+> **TL;DR** — Point your HTTP requests to `https://api.llmgateway.io/v1/…`, supply your `LLM_GATEWAY_API_KEY`, and you’re done.
 
 ---
 
-## 1 · Get an API key
+## 1 · Get an API key
 
 1. Sign in to the dashboard.
 2. Create a new Project → _Copy the key_.
@@ -42,154 +41,171 @@ export LLM_GATEWAY_API_KEY="llmgtwy_XXXXXXXXXXXXXXXX"
   persist
 >
   <Tab value="cURL">
-    <DynamicCodeBlock lang="bash" code={`curl -X POST https://api.llmgateway.io/v1/chat/completions \\
-  -H "Content-Type: application/json" \\
-  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \\
+
+```bash
+curl -X POST https://api.llmgateway.io/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
   -d '{
-  "model": "gpt-4o",
-  "messages": [
-    {"role": "user", "content": "Hello, how are you?"}
-  ]
-}'`} />
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "Hello, how are you?"}
+    ]
+  }'
+```
+
   </Tab>
   <Tab value="TypeScript">
-    <DynamicCodeBlock lang="typescript" code={`const response = await fetch('https://api.llmgateway.io/v1/chat/completions', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    'Authorization': \`Bearer \${process.env.LLM_GATEWAY_API_KEY}\`
-  },
-  body: JSON.stringify({
-    model: 'gpt-4o',
-    messages: [
-      { role: 'user', content: 'Hello, how are you?' }
-    ]
-  })
+
+```typescript
+const response = await fetch("https://api.llmgateway.io/v1/chat/completions", {
+	method: "POST",
+	headers: {
+		"Content-Type": "application/json",
+		Authorization: `Bearer ${process.env.LLM_GATEWAY_API_KEY}`,
+	},
+	body: JSON.stringify({
+		model: "gpt-4o",
+		messages: [{ role: "user", content: "Hello, how are you?" }],
+	}),
 });
 
 if (!response.ok) {
-throw new Error(\`HTTP error! status: \${response.status}\`);
+	throw new Error(`HTTP error! status: ${response.status}`);
 }
 
 const data = await response.json();
-console.log(data.choices[0].message.content);`} />
+console.log(data.choices[0].message.content);
+```
 
   </Tab>
   <Tab value="React">
-    <DynamicCodeBlock lang="tsx" code={`import { useState } from 'react'
+
+```tsx
+import { useState } from "react";
 
 function ChatComponent() {
-const [response, setResponse] = useState('');
-const [loading, setLoading] = useState(false);
+	const [response, setResponse] = useState("");
+	const [loading, setLoading] = useState(false);
 
-const sendMessage = async () => {
-setLoading(true);
-try {
-const res = await fetch('https://api.llmgateway.io/v1/chat/completions', {
-method: 'POST',
-headers: {
-'Content-Type': 'application/json',
-'Authorization': \`Bearer \${process.env.REACT_APP_LLM_GATEWAY_API_KEY}\`
-},
-body: JSON.stringify({
-model: 'gpt-4o',
-messages: [
-{ role: 'user', content: 'Hello, how are you?' }
-]
-})
-});
+	const sendMessage = async () => {
+		setLoading(true);
+		try {
+			const res = await fetch("https://api.llmgateway.io/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${process.env.REACT_APP_LLM_GATEWAY_API_KEY}`,
+				},
+				body: JSON.stringify({
+					model: "gpt-4o",
+					messages: [{ role: "user", content: "Hello, how are you?" }],
+				}),
+			});
 
-      if (!res.ok) {
-        throw new Error(\`HTTP error! status: \${res.status}\`);
-      }
+			if (!res.ok) {
+				throw new Error(`HTTP error! status: ${res.status}`);
+			}
 
-      const data = await res.json();
-      setResponse(data.choices[0].message.content);
-    } catch (error) {
-      console.error('Error:', error);
-    } finally {
-      setLoading(false);
-    }
+			const data = await res.json();
+			setResponse(data.choices[0].message.content);
+		} catch (error) {
+			console.error("Error:", error);
+		} finally {
+			setLoading(false);
+		}
+	};
 
-};
-
-return (
-
-<div>
-	<button onClick={sendMessage} disabled={loading}>
-		{loading ? "Sending..." : "Send Message"}
-	</button>
-	{response && <p>{response}</p>}
-</div>
-); }
+	return (
+		<div>
+			<button onClick={sendMessage} disabled={loading}>
+				{loading ? "Sending..." : "Send Message"}
+			</button>
+			{response && <p>{response}</p>}
+		</div>
+	);
+}
 
 export default ChatComponent;
-`} />
+```
+
   </Tab>
   <Tab value="Next.js">
-    <DynamicCodeBlock lang="typescript" code={`; // app/api/chat/route.ts
+
+```typescript
+// app/api/chat/route.ts
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
-  const { message } = await request.json();
+	const { message } = await request.json();
 
-const response = await fetch('https://api.llmgateway.io/v1/chat/completions', {
-method: 'POST',
-headers: {
-'Content-Type': 'application/json',
-'Authorization': \`Bearer \${process.env.LLM_GATEWAY_API_KEY}\`
-},
-body: JSON.stringify({
-model: 'gpt-4o',
-messages: [
-{ role: 'user', content: message }
-]
-})
-});
+	const response = await fetch(
+		"https://api.llmgateway.io/v1/chat/completions",
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${process.env.LLM_GATEWAY_API_KEY}`,
+			},
+			body: JSON.stringify({
+				model: "gpt-4o",
+				messages: [{ role: "user", content: message }],
+			}),
+		},
+	);
 
-if (!response.ok) {
-return NextResponse.json({ error: 'Failed to get response' }, { status: response.status });
-}
+	if (!response.ok) {
+		return NextResponse.json(
+			{ error: "Failed to get response" },
+			{ status: response.status },
+		);
+	}
 
-const data = await response.json();
+	const data = await response.json();
 
-return NextResponse.json({
-message: data.choices[0].message.content
-});
+	return NextResponse.json({
+		message: data.choices[0].message.content,
+	});
 }
 
 // Usage in component:
 // const response = await fetch('/api/chat', {
-// method: 'POST',
-// headers: { 'Content-Type': 'application/json' },
-// body: JSON.stringify({ message: 'Hello, how are you?' })
-// });`} />
+//   method: 'POST',
+//   headers: { 'Content-Type': 'application/json' },
+//   body: JSON.stringify({ message: 'Hello, how are you?' })
+// });
+```
 
   </Tab>
   <Tab value="Python">
-    <DynamicCodeBlock lang="python" code={`import requests
+
+```python
+import requests
 import os
 
 response = requests.post(
-'https://api.llmgateway.io/v1/chat/completions',
-headers={
-'Content-Type': 'application/json',
-'Authorization': f'Bearer {os.getenv("LLM_GATEWAY_API_KEY")}'
-},
-json={
-'model': 'gpt-4o',
-'messages': [
-{'role': 'user', 'content': 'Hello, how are you?'}
-]
-}
+    'https://api.llmgateway.io/v1/chat/completions',
+    headers={
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {os.getenv("LLM_GATEWAY_API_KEY")}'
+    },
+    json={
+        'model': 'gpt-4o',
+        'messages': [
+            {'role': 'user', 'content': 'Hello, how are you?'}
+        ]
+    }
 )
 
 response.raise_for_status()
-print(response.json()['choices'][0]['message']['content'])`} />
+print(response.json()['choices'][0]['message']['content'])
+```
 
   </Tab>
   <Tab value="Java">
-    <DynamicCodeBlock lang="java" code={`import java.net.http.HttpClient;
+
+```java
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.URI;
@@ -197,35 +213,38 @@ import java.net.URI;
 String apiKey = System.getenv("LLM_GATEWAY_API_KEY");
 String requestBody = """
 {
-\"model\": \"gpt-4o\",
-\"messages\": [
-{\"role\": \"user\", \"content\": \"Hello, how are you?\"}
-]
+  "model": "gpt-4o",
+  "messages": [
+    {"role": "user", "content": "Hello, how are you?"}
+  ]
 }
 """;
 
 HttpRequest request = HttpRequest.newBuilder()
-.uri(URI.create("https://api.llmgateway.io/v1/chat/completions"))
-.header("Content-Type", "application/json")
-.header("Authorization", "Bearer " + apiKey)
-.POST(HttpRequest.BodyPublishers.ofString(requestBody))
-.build();
+    .uri(URI.create("https://api.llmgateway.io/v1/chat/completions"))
+    .header("Content-Type", "application/json")
+    .header("Authorization", "Bearer " + apiKey)
+    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+    .build();
 
 HttpResponse<String> response = HttpClient.newHttpClient()
-.send(request, HttpResponse.BodyHandlers.ofString());
+    .send(request, HttpResponse.BodyHandlers.ofString());
 
-System.out.println(response.body());`} />
+System.out.println(response.body());
+```
 
   </Tab>
   <Tab value="Rust">
-    <DynamicCodeBlock lang="rust" code={`use reqwest::Client;
+
+```rust
+use reqwest::Client;
 use serde_json::json;
 use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-let client = Client::new();
-let api_key = env::var("LLM_GATEWAY_API_KEY")?;
+    let client = Client::new();
+    let api_key = env::var("LLM_GATEWAY_API_KEY")?;
 
     let response = client
         .post("https://api.llmgateway.io/v1/chat/completions")
@@ -243,12 +262,14 @@ let api_key = env::var("LLM_GATEWAY_API_KEY")?;
     let result: serde_json::Value = response.json().await?;
     println!("{}", result["choices"][0]["message"]["content"]);
     Ok(())
-
-}`} />
+}
+```
 
   </Tab>
   <Tab value="Go">
-    <DynamicCodeBlock lang="go" code={`package main
+
+```go
+package main
 
 import (
     "bytes"
@@ -259,20 +280,20 @@ import (
 )
 
 type ChatRequest struct {
-Model string ` + "`json:\"model\"`" + `
-Messages []Message ` + "`json:\"messages\"`" + `
+    Model    string    `json:"model"`
+    Messages []Message `json:"messages"`
 }
 
 type Message struct {
-Role string ` + "`json:\"role\"`" + `
-Content string ` + "`json:\"content\"`" + `
+    Role    string `json:"role"`
+    Content string `json:"content"`
 }
 
 func main() {
-apiKey := os.Getenv("LLM_GATEWAY_API_KEY")
+    apiKey := os.Getenv("LLM_GATEWAY_API_KEY")
 
     requestBody := ChatRequest{
-        Model: "gpt-4o",
+        Model:    "gpt-4o",
         Messages: []Message{{Role: "user", Content: "Hello, how are you?"}},
     }
 
@@ -287,19 +308,21 @@ apiKey := os.Getenv("LLM_GATEWAY_API_KEY")
     defer resp.Body.Close()
 
     fmt.Println("Response received")
-
-}`} />
+}
+```
 
   </Tab>
   <Tab value="PHP">
-    <DynamicCodeBlock lang="php" code={`<?php
+
+```php
+<?php
 $apiKey = $_ENV['LLM_GATEWAY_API_KEY'];
 
 $data = [
-'model' => 'gpt-4o',
-'messages' => [
-['role' => 'user', 'content' => 'Hello, how are you?']
-]
+    'model' => 'gpt-4o',
+    'messages' => [
+        ['role' => 'user', 'content' => 'Hello, how are you?']
+    ]
 ];
 
 $options = [
@@ -310,27 +333,30 @@ $options = [
         ],
         'method' => 'POST',
         'content' => json_encode($data)
-]
+    ]
 ];
 
 $context = stream_context_create($options);
 $response = file_get_contents(
-'https://api.llmgateway.io/v1/chat/completions',
-false,
-$context
+    'https://api.llmgateway.io/v1/chat/completions',
+    false,
+    $context
 );
 
 if ($response === FALSE) {
-throw new Exception('Request failed');
+    throw new Exception('Request failed');
 }
 
 $result = json_decode($response, true);
 echo $result['choices'][0]['message']['content'];
-?>`} />
+?>
+```
 
   </Tab>
   <Tab value="Ruby">
-    <DynamicCodeBlock lang="ruby" code={`require 'net/http'
+
+```ruby
+require 'net/http'
 require 'json'
 require 'uri'
 
@@ -343,20 +369,21 @@ request['Content-Type'] = 'application/json'
 request['Authorization'] = "Bearer #{ENV['LLM_GATEWAY_API_KEY']}"
 
 request.body = {
-model: 'gpt-4o',
-messages: [
-{ role: 'user', content: 'Hello, how are you?' }
-]
+  model: 'gpt-4o',
+  messages: [
+    { role: 'user', content: 'Hello, how are you?' }
+  ]
 }.to_json
 
 response = http.request(request)
 
 if response.code != '200'
-raise "HTTP Error: #{response.code}"
+  raise "HTTP Error: #{response.code}"
 end
 
 result = JSON.parse(response.body)
-puts result['choices'][0]['message']['content']`} />
+puts result['choices'][0]['message']['content']
+```
 
   </Tab>
 </Tabs>
@@ -409,14 +436,14 @@ console.log(completion.choices[0].message.content);
 
 ---
 
-## 4 · Going further
+## 4 · Going further
 
 - **Streaming**: pass `stream: true` to any request—Gateway will proxy the event stream unchanged.
 - **Monitoring**: Every call appears in the dashboard with latency, cost & provider breakdown.
 
 ---
 
-## 5 · FAQ
+## 5 · FAQ
 
 <Accordions type="single">
 	<Accordion title="Which models are supported?">
@@ -449,7 +476,7 @@ console.log(completion.choices[0].message.content);
 
 ---
 
-## 6 · Next steps
+## 6 · Next steps
 
 - Read [Self host docs](/self-host) guide.
 - Drop into our [GitHub](https://github.com/theopenco/llmgateway) for help or feature requests.

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -91,7 +91,9 @@ export function CreateProviderKeyDialog({
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
 
-		if (!selectedProvider || !token) {
+		const trimmedToken = token.trim();
+
+		if (!selectedProvider || !trimmedToken) {
 			toast({
 				title: "Error",
 				description: !selectedProvider
@@ -143,7 +145,7 @@ export function CreateProviderKeyDialog({
 			organizationId: string;
 		} = {
 			provider: selectedProvider,
-			token,
+			token: trimmedToken,
 			organizationId: selectedOrganization.id,
 		};
 		if (baseUrl) {
@@ -240,8 +242,16 @@ export function CreateProviderKeyDialog({
 							err.error && typeof err.error === "object"
 								? (err.error as Record<string, unknown>)
 								: err;
+						const issues = Array.isArray(nested.issues)
+							? (nested.issues as { message?: unknown }[])
+							: undefined;
 						if (typeof nested.message === "string") {
 							description = nested.message;
+						} else if (
+							issues?.length &&
+							typeof issues[0]?.message === "string"
+						) {
+							description = issues[0].message;
 						}
 					} else if (error instanceof Error) {
 						description = error.message;

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -91,7 +91,9 @@ export function CreateProviderKeyDialog({
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
 
-		const trimmedToken = token.trim();
+		// Strip whitespace and zero-width characters that get pasted in when a key
+		// is copied from wrapped text (newlines, non-breaking / zero-width spaces).
+		const trimmedToken = token.replace(/[\s\u200B-\u200D\u2060\uFEFF]/g, "");
 
 		if (!selectedProvider || !trimmedToken) {
 			toast({

--- a/apps/ui/src/components/provider-keys/provider-keys-client.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-client.tsx
@@ -7,7 +7,6 @@ import { CreditsRecommendationBanner } from "@/components/provider-keys/credits-
 import { ProviderKeysList } from "@/components/provider-keys/provider-keys-list";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { Button } from "@/lib/components/button";
-import { Card, CardContent } from "@/lib/components/card";
 
 import type { ProviderKeyOptions } from "@llmgateway/db";
 
@@ -36,12 +35,12 @@ export function ProviderKeysClient({
 
 	return (
 		<div className="flex flex-col">
-			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
-				<div className="flex items-center justify-between">
-					<div>
-						<h2 className="text-3xl font-bold tracking-tight">Provider Keys</h2>
-						<p className="text-muted-foreground">
-							Provider keys allow you to use your own API keys with LLM Gateway
+			<div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<div className="space-y-1">
+						<h2 className="text-2xl font-bold tracking-tight">Provider Keys</h2>
+						<p className="max-w-2xl text-sm text-muted-foreground">
+							Bring your own provider API keys to use them through LLM Gateway
 							without additional fees.
 						</p>
 					</div>
@@ -49,7 +48,7 @@ export function ProviderKeysClient({
 						<CreateProviderKeyDialog
 							selectedOrganization={selectedOrganization}
 						>
-							<Button>
+							<Button className="w-full sm:w-auto">
 								<Plus className="mr-2 h-4 w-4" />
 								Add Provider Key
 							</Button>
@@ -57,16 +56,10 @@ export function ProviderKeysClient({
 					)}
 				</div>
 				<CreditsRecommendationBanner />
-				<div className="space-y-4">
-					<Card>
-						<CardContent>
-							<ProviderKeysList
-								selectedOrganization={selectedOrganization}
-								initialData={initialProviderKeysData}
-							/>
-						</CardContent>
-					</Card>
-				</div>
+				<ProviderKeysList
+					selectedOrganization={selectedOrganization}
+					initialData={initialProviderKeysData}
+				/>
 			</div>
 		</div>
 	);

--- a/apps/ui/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-list.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { KeyIcon, MoreHorizontal } from "lucide-react";
+import { KeyIcon, MoreHorizontal, Plus, Search } from "lucide-react";
 import Link from "next/link";
+import { useMemo, useState } from "react";
 
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import {
@@ -26,6 +27,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/lib/components/dropdown-menu";
+import { Input } from "@/lib/components/input";
 import { StatusBadge } from "@/lib/components/status-badge";
 import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
@@ -78,6 +80,7 @@ export function ProviderKeysList({
 	const queryClient = useQueryClient();
 	const api = useApi();
 	const { buildOrgUrl } = useDashboardNavigation();
+	const [search, setSearch] = useState("");
 
 	const queryKey = api.queryOptions("get", "/keys/provider").queryKey;
 
@@ -94,45 +97,59 @@ export function ProviderKeysList({
 	const deleteMutation = api.useMutation("delete", "/keys/provider/{id}");
 	const toggleMutation = api.useMutation("patch", "/keys/provider/{id}");
 
-	if (!selectedOrganization) {
-		return (
-			<div className="flex flex-col items-center justify-center py-16 text-muted-foreground text-center">
-				<div className="mb-4">
-					<KeyIcon className="h-10 w-10 text-gray-500" />
-				</div>
-				<p className="text-gray-400 mb-6">
-					Please select an organization to view provider keys.
-				</p>
-			</div>
-		);
-	}
-
-	// Filter provider keys by selected organization
-	const organizationKeys =
-		data?.providerKeys
-			.filter((key) => key.status !== "deleted")
-			.filter((key) => key.organizationId === selectedOrganization.id) ?? [];
-
 	// Filter out LLM Gateway from the providers list
-	const availableProviders = providers.filter(
-		(provider) => provider.id !== "llmgateway",
+	const availableProviders = useMemo(
+		() => providers.filter((provider) => provider.id !== "llmgateway"),
+		[],
 	);
-	const providerKeysByProvider = new Map(
-		availableProviders.map((provider) => [
-			provider.id,
-			organizationKeys
-				.filter((key) => key.provider === provider.id)
-				.sort((a, b) => {
-					const createdAtDiff =
-						new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-					if (createdAtDiff !== 0) {
-						return createdAtDiff;
-					}
 
-					return a.id.localeCompare(b.id);
-				}),
-		]),
+	const organizationKeys = useMemo(
+		() =>
+			selectedOrganization
+				? (data?.providerKeys
+						.filter((key) => key.status !== "deleted")
+						.filter((key) => key.organizationId === selectedOrganization.id) ??
+					[])
+				: [],
+		[data, selectedOrganization],
 	);
+
+	const keysByProvider = useMemo(
+		() =>
+			new Map(
+				availableProviders.map((provider) => [
+					provider.id,
+					organizationKeys
+						.filter((key) => key.provider === provider.id)
+						.sort((a, b) => {
+							const createdAtDiff =
+								new Date(a.createdAt).getTime() -
+								new Date(b.createdAt).getTime();
+							if (createdAtDiff !== 0) {
+								return createdAtDiff;
+							}
+
+							return a.id.localeCompare(b.id);
+						}),
+				]),
+			),
+		[availableProviders, organizationKeys],
+	);
+
+	const normalizedSearch = search.trim().toLowerCase();
+	const filteredProviders = availableProviders.filter(
+		(provider) =>
+			!normalizedSearch ||
+			provider.name.toLowerCase().includes(normalizedSearch) ||
+			provider.id.toLowerCase().includes(normalizedSearch),
+	);
+	const configuredProviders = filteredProviders.filter(
+		(provider) => (keysByProvider.get(provider.id)?.length ?? 0) > 0,
+	);
+	const providersToAdd = filteredProviders.filter(
+		(provider) => (keysByProvider.get(provider.id)?.length ?? 0) === 0,
+	);
+	const totalKeys = organizationKeys.length;
 
 	const deleteKey = (id: string) => {
 		deleteMutation.mutate(
@@ -181,176 +198,265 @@ export function ProviderKeysList({
 		);
 	};
 
+	if (!selectedOrganization) {
+		return (
+			<div className="flex flex-col items-center justify-center py-16 text-muted-foreground text-center">
+				<div className="mb-4">
+					<KeyIcon className="h-10 w-10 text-gray-500" />
+				</div>
+				<p className="text-gray-400 mb-6">
+					Please select an organization to view provider keys.
+				</p>
+			</div>
+		);
+	}
+
 	return (
 		<div className="space-y-6">
-			<div className="space-y-2">
-				{availableProviders.map((provider) => {
-					const LogoComponent = getProviderIcon(provider.id);
-					const providerKeys = providerKeysByProvider.get(provider.id) ?? [];
+			<div className="relative">
+				<Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+				<Input
+					type="search"
+					placeholder="Search providers by name..."
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					className="pl-9"
+				/>
+			</div>
 
-					return (
-						<div key={provider.id} className="border border-border rounded-lg">
-							<div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-								<div className="flex items-start gap-3 sm:items-center">
-									<div className="flex shrink-0 items-center justify-center w-10 h-10 rounded-lg bg-background border">
-										{LogoComponent ? (
-											<LogoComponent className="h-6 w-6" />
-										) : (
-											<div className="w-6 h-6 bg-muted rounded" />
-										)}
-									</div>
-									<div className="flex min-w-0 flex-col">
-										<div className="flex items-center gap-2 flex-wrap">
-											<span className="font-medium">{provider.name}</span>
-											{providerKeys.length > 0 && (
-												<Badge variant="outline" className="text-xs">
-													{providerKeys.length} key
-													{providerKeys.length === 1 ? "" : "s"}
-												</Badge>
-											)}
-										</div>
-										<p className="text-sm text-muted-foreground">
-											{provider.id === "custom"
-												? "Add multiple named OpenAI-compatible providers."
-												: "Add one or more keys to load balance requests for this provider."}
-										</p>
-									</div>
-								</div>
-
-								<CreateProviderKeyDialog
-									selectedOrganization={selectedOrganization}
-									preselectedProvider={provider.id}
-								>
-									<Button
-										variant="outline"
-										size="sm"
-										className="w-full sm:w-auto sm:shrink-0"
-									>
-										Add Key
-									</Button>
-								</CreateProviderKeyDialog>
+			{configuredProviders.length === 0 && providersToAdd.length === 0 ? (
+				<div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border py-12 text-center text-muted-foreground">
+					<Search className="mb-3 h-8 w-8 opacity-60" />
+					<p className="text-sm">
+						No providers match{" "}
+						<span className="font-medium text-foreground">“{search}”</span>.
+					</p>
+				</div>
+			) : (
+				<>
+					{configuredProviders.length > 0 && (
+						<section className="space-y-3">
+							<div className="flex items-center gap-2">
+								<h3 className="text-sm font-semibold tracking-tight">
+									Your providers
+								</h3>
+								<Badge variant="secondary" className="text-xs">
+									{totalKeys} key{totalKeys === 1 ? "" : "s"}
+								</Badge>
 							</div>
 
-							{providerKeys.length > 0 ? (
-								<div className="border-t border-border">
-									{providerKeys.map((providerKey) => (
+							<div className="space-y-3">
+								{configuredProviders.map((provider) => {
+									const LogoComponent = getProviderIcon(provider.id);
+									const providerKeys = keysByProvider.get(provider.id) ?? [];
+
+									return (
 										<div
-											key={providerKey.id}
-											className="flex items-center justify-between gap-4 p-4"
+											key={provider.id}
+											className="rounded-lg border border-border"
 										>
-											<div className="min-w-0 flex-1">
-												<div className="flex items-center gap-2 flex-wrap">
-													{provider.id === "custom" && providerKey.name && (
-														<Badge variant="secondary" className="text-xs">
-															{providerKey.name}
-														</Badge>
-													)}
-													{providerKey.baseUrl && (
-														<Badge variant="outline" className="text-xs">
-															{providerKey.baseUrl}
-														</Badge>
-													)}
-													{providerKey.options &&
-														Object.entries(providerKey.options).map(
-															([key, value]) =>
-																value && (
-																	<Badge
-																		key={key}
-																		variant="outline"
-																		className="text-xs"
-																	>
-																		{formatOptionLabel(key, String(value))}
-																	</Badge>
-																),
+											<div className="flex items-center justify-between gap-3 p-3">
+												<div className="flex min-w-0 items-center gap-2.5">
+													<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border bg-background">
+														{LogoComponent ? (
+															<LogoComponent className="h-5 w-5" />
+														) : (
+															<div className="h-5 w-5 rounded bg-muted" />
 														)}
+													</div>
+													<div className="flex items-center gap-2">
+														<span className="font-medium">{provider.name}</span>
+														<Badge variant="outline" className="text-xs">
+															{providerKeys.length} key
+															{providerKeys.length === 1 ? "" : "s"}
+														</Badge>
+													</div>
 												</div>
-												<div className="flex items-center gap-2 mt-2">
-													<StatusBadge
-														status={providerKey.status}
-														variant="simple"
-													/>
-													<span className="text-xs text-muted-foreground font-mono block max-w-[280px] truncate">
-														{providerKey.maskedToken}
-													</span>
-												</div>
+
+												<CreateProviderKeyDialog
+													selectedOrganization={selectedOrganization}
+													preselectedProvider={provider.id}
+												>
+													<Button
+														variant="ghost"
+														size="sm"
+														className="shrink-0"
+													>
+														<Plus className="mr-1.5 h-4 w-4" />
+														Add key
+													</Button>
+												</CreateProviderKeyDialog>
 											</div>
 
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild>
-													<Button variant="ghost" size="sm">
-														<MoreHorizontal className="h-4 w-4" />
-														<span className="sr-only">Open menu</span>
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													<DropdownMenuLabel>Actions</DropdownMenuLabel>
-													{provider.id === "custom" && (
-														<DropdownMenuItem asChild>
-															<Link
-																href={
-																	`${buildOrgUrl("org/custom-models")}?providerKey=${providerKey.id}` as never
-																}
-															>
-																Manage models
-															</Link>
-														</DropdownMenuItem>
-													)}
-													<DropdownMenuItem
-														onClick={() =>
-															toggleStatus(providerKey.id, providerKey.status)
-														}
+											<div className="divide-y divide-border border-t border-border">
+												{providerKeys.map((providerKey) => (
+													<div
+														key={providerKey.id}
+														className="flex items-center justify-between gap-3 px-3 py-2.5"
 													>
-														{providerKey.status === "active"
-															? "Deactivate"
-															: "Activate"}
-													</DropdownMenuItem>
-													<DropdownMenuSeparator />
-													<AlertDialog>
-														<AlertDialogTrigger asChild>
-															<DropdownMenuItem
-																onSelect={(e) => e.preventDefault()}
-																className="text-destructive focus:text-destructive"
-															>
-																Delete
-															</DropdownMenuItem>
-														</AlertDialogTrigger>
-														<AlertDialogContent>
-															<AlertDialogHeader>
-																<AlertDialogTitle>
-																	Are you absolutely sure?
-																</AlertDialogTitle>
-																<AlertDialogDescription>
-																	This action cannot be undone. This will
-																	permanently delete the provider key and any
-																	applications using it will no longer be able
-																	to access the API.
-																</AlertDialogDescription>
-															</AlertDialogHeader>
-															<AlertDialogFooter>
-																<AlertDialogCancel>Cancel</AlertDialogCancel>
-																<AlertDialogAction
-																	onClick={() => deleteKey(providerKey.id)}
-																	className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+														<div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+															<StatusBadge
+																status={providerKey.status}
+																variant="simple"
+															/>
+															{provider.id === "custom" && providerKey.name && (
+																<Badge variant="secondary" className="text-xs">
+																	{providerKey.name}
+																</Badge>
+															)}
+															<span className="max-w-[200px] truncate font-mono text-xs text-muted-foreground">
+																{providerKey.maskedToken}
+															</span>
+															{providerKey.baseUrl && (
+																<Badge
+																	variant="outline"
+																	className="max-w-[220px] truncate text-xs"
 																>
-																	Delete
-																</AlertDialogAction>
-															</AlertDialogFooter>
-														</AlertDialogContent>
-													</AlertDialog>
-												</DropdownMenuContent>
-											</DropdownMenu>
+																	{providerKey.baseUrl}
+																</Badge>
+															)}
+															{providerKey.options &&
+																Object.entries(providerKey.options).map(
+																	([key, value]) =>
+																		value && (
+																			<Badge
+																				key={key}
+																				variant="outline"
+																				className="text-xs"
+																			>
+																				{formatOptionLabel(key, String(value))}
+																			</Badge>
+																		),
+																)}
+														</div>
+
+														<DropdownMenu>
+															<DropdownMenuTrigger asChild>
+																<Button
+																	variant="ghost"
+																	size="sm"
+																	className="shrink-0"
+																>
+																	<MoreHorizontal className="h-4 w-4" />
+																	<span className="sr-only">Open menu</span>
+																</Button>
+															</DropdownMenuTrigger>
+															<DropdownMenuContent align="end">
+																<DropdownMenuLabel>Actions</DropdownMenuLabel>
+																{provider.id === "custom" && (
+																	<DropdownMenuItem asChild>
+																		<Link
+																			href={
+																				`${buildOrgUrl("org/custom-models")}?providerKey=${providerKey.id}` as never
+																			}
+																		>
+																			Manage models
+																		</Link>
+																	</DropdownMenuItem>
+																)}
+																<DropdownMenuItem
+																	onClick={() =>
+																		toggleStatus(
+																			providerKey.id,
+																			providerKey.status,
+																		)
+																	}
+																>
+																	{providerKey.status === "active"
+																		? "Deactivate"
+																		: "Activate"}
+																</DropdownMenuItem>
+																<DropdownMenuSeparator />
+																<AlertDialog>
+																	<AlertDialogTrigger asChild>
+																		<DropdownMenuItem
+																			onSelect={(e) => e.preventDefault()}
+																			className="text-destructive focus:text-destructive"
+																		>
+																			Delete
+																		</DropdownMenuItem>
+																	</AlertDialogTrigger>
+																	<AlertDialogContent>
+																		<AlertDialogHeader>
+																			<AlertDialogTitle>
+																				Are you absolutely sure?
+																			</AlertDialogTitle>
+																			<AlertDialogDescription>
+																				This action cannot be undone. This will
+																				permanently delete the provider key and
+																				any applications using it will no longer
+																				be able to access the API.
+																			</AlertDialogDescription>
+																		</AlertDialogHeader>
+																		<AlertDialogFooter>
+																			<AlertDialogCancel>
+																				Cancel
+																			</AlertDialogCancel>
+																			<AlertDialogAction
+																				onClick={() =>
+																					deleteKey(providerKey.id)
+																				}
+																				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+																			>
+																				Delete
+																			</AlertDialogAction>
+																		</AlertDialogFooter>
+																	</AlertDialogContent>
+																</AlertDialog>
+															</DropdownMenuContent>
+														</DropdownMenu>
+													</div>
+												))}
+											</div>
 										</div>
-									))}
-								</div>
-							) : (
-								<div className="px-4 pb-4 text-sm text-muted-foreground">
-									No keys added yet.
-								</div>
-							)}
-						</div>
-					);
-				})}
-			</div>
+									);
+								})}
+							</div>
+						</section>
+					)}
+
+					{providersToAdd.length > 0 && (
+						<section className="space-y-3">
+							<h3 className="text-sm font-semibold tracking-tight">
+								{configuredProviders.length > 0
+									? "Add another provider"
+									: "Connect a provider"}
+							</h3>
+
+							<div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+								{providersToAdd.map((provider) => {
+									const LogoComponent = getProviderIcon(provider.id);
+
+									return (
+										<CreateProviderKeyDialog
+											key={provider.id}
+											selectedOrganization={selectedOrganization}
+											preselectedProvider={provider.id}
+										>
+											<button
+												type="button"
+												className="group flex items-center gap-2.5 rounded-lg border border-border p-2.5 text-left transition-colors hover:border-primary/40 hover:bg-accent"
+											>
+												<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-background">
+													{LogoComponent ? (
+														<LogoComponent className="h-5 w-5" />
+													) : (
+														<div className="h-4 w-4 rounded bg-muted" />
+													)}
+												</div>
+												<span className="min-w-0 flex-1 truncate text-sm font-medium">
+													{provider.name}
+												</span>
+												<Plus className="h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+											</button>
+										</CreateProviderKeyDialog>
+									);
+								})}
+							</div>
+						</section>
+					)}
+				</>
+			)}
 		</div>
 	);
 }

--- a/apps/ui/src/components/provider-keys/provider-select.tsx
+++ b/apps/ui/src/components/provider-keys/provider-select.tsx
@@ -1,12 +1,23 @@
 "use client";
 
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/lib/components/button";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/lib/components/select";
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/lib/components/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/lib/components/popover";
+import { cn } from "@/lib/utils";
 
 import { providerLogoUrls } from "@llmgateway/shared/components";
 
@@ -33,37 +44,78 @@ export function ProviderSelect({
 	providers,
 	loading = false,
 	placeholder = "Select provider...",
-	emptyMessage = "No providers available",
+	emptyMessage = "No providers found.",
 	disabled = false,
 }: ProviderSelectProps) {
+	const [open, setOpen] = useState(false);
+
+	const selected = providers.find((provider) => provider.id === value);
+	const SelectedLogo = selected
+		? providerLogoUrls[selected.id as ProviderId]
+		: undefined;
+
 	return (
-		<Select onValueChange={onValueChange} value={value} disabled={disabled}>
-			<SelectTrigger className="w-full">
-				<SelectValue placeholder={placeholder} />
-			</SelectTrigger>
-			<SelectContent>
-				{loading ? (
-					<SelectItem value="loading" disabled>
-						Loading providers...
-					</SelectItem>
-				) : providers.length > 0 ? (
-					providers.map((provider) => {
-						const LogoComponent = providerLogoUrls[provider.id as ProviderId];
-						return (
-							<SelectItem key={provider.id} value={provider.id}>
-								<div className="flex items-center gap-2">
-									{LogoComponent && <LogoComponent className="h-4 w-4" />}
-									<span>{provider.name}</span>
-								</div>
-							</SelectItem>
-						);
-					})
-				) : (
-					<SelectItem value="none" disabled>
-						{emptyMessage}
-					</SelectItem>
-				)}
-			</SelectContent>
-		</Select>
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					role="combobox"
+					aria-expanded={open}
+					disabled={disabled || loading}
+					className="w-full justify-between font-normal"
+				>
+					{selected ? (
+						<span className="flex min-w-0 items-center gap-2">
+							{SelectedLogo && <SelectedLogo className="h-4 w-4 shrink-0" />}
+							<span className="truncate">{selected.name}</span>
+						</span>
+					) : (
+						<span className="text-muted-foreground">
+							{loading ? "Loading providers..." : placeholder}
+						</span>
+					)}
+					<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-[--radix-popover-trigger-width] p-0"
+				align="start"
+			>
+				<Command>
+					<CommandInput placeholder="Search providers..." />
+					<CommandList>
+						<CommandEmpty>{emptyMessage}</CommandEmpty>
+						<CommandGroup>
+							{providers.map((provider) => {
+								const LogoComponent =
+									providerLogoUrls[provider.id as ProviderId];
+								return (
+									<CommandItem
+										key={provider.id}
+										value={`${provider.name} ${provider.id}`}
+										onSelect={() => {
+											onValueChange?.(provider.id);
+											setOpen(false);
+										}}
+									>
+										{LogoComponent && (
+											<LogoComponent className="h-4 w-4 shrink-0" />
+										)}
+										<span className="truncate">{provider.name}</span>
+										<Check
+											className={cn(
+												"ml-auto h-4 w-4 shrink-0",
+												value === provider.id ? "opacity-100" : "opacity-0",
+											)}
+										/>
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
 	);
 }


### PR DESCRIPTION
## Summary

Bundles fixes/improvements across the API, dashboard, and docs.

### 1. Restore support escalation Discord notifications (`apps/api`)
Escalation notifications stopped reaching the customer support channel. `notifyChatSupportEscalation` resolved `DISCORD_SUPPORT_NOTIFICATION_URL` from a **module-scope const** read once at module load. PR #2409 fixed exactly this class of bug for enterprise notifications (resolving the webhook env at call time) but explicitly left the support path untouched. A module-load env read does not reliably pick up the deploy/runtime value, so notifications silently no-op'd. Now resolved at call time, matching the proven enterprise pattern.

### 2. Searchable provider picker + compact Provider Keys page (`apps/ui`)
- **Search by name**: the provider picker is now a searchable combobox (Popover + Command), so you can filter providers by name both on the Provider Keys page and inside the **Add Provider Key** dialog.
- **Compact redesign**: replaced the long list of ~65 full-width provider rows with a search box, a **Your providers** section showing only configured providers with their keys, and a dense responsive grid of the remaining providers to connect.

### 3. Clearer provider-key validation errors (`apps/ui`)
The Add Provider Key dialog always showed a generic *"check your key and region"* message, hiding the real reason a key was rejected (e.g. pasting the **masked** `sk-…••••` display value, or a key with a trailing newline). The dialog now surfaces the API's specific message — including the "API key contains invalid characters / not a masked version" hint — and trims the pasted token so copy artifacts no longer fail validation.

### 4. Fix quickstart code-example indentation (`apps/docs`)
The quickstart samples rendered with broken indentation in every language. Root cause: they used `<DynamicCodeBlock code={\`...\`} />` with multi-line **template-literal strings**, whose indentation Prettier's MDX formatter mangles — it *produces* the broken output on every format. Switched each language tab to a **fenced code block**, which Prettier formats correctly and keeps stable (verified `prettier --check` is idempotent). Indentation is now correct across cURL, TypeScript, React, Next.js, Python, Java, Rust, Go, PHP, and Ruby.

## Testing
- `pnpm turbo run build --filter=api --filter=ui --filter=docs` ✅
- `pnpm turbo run lint --filter=ui --filter=api --filter=docs` ✅ (ESLint + Prettier)
- Verified live in the running app: provider search (page + dialog), the dialog combobox holds focus inside the modal, a valid OpenAI key validates + saves (200), and a masked/whitespace key now shows the specific error.
- `prettier --check apps/docs/content/quick-start.mdx` is stable (no re-mangling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider search to quickly filter and manage available providers.

* **Documentation**
  * Refreshed the quickstart guide with clearer, updated multi-language examples and streamlined error-handling snippets.

* **UI Updates**
  * Redesigned the provider management screens for improved structure, spacing, and readability.
  * Upgraded provider selection to a searchable popover/command-style picker with improved empty-state messaging.

* **Bug Fixes**
  * Trim whitespace/hidden characters from provider API keys before validation and submission.
  * Improved validation error details shown in the toast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->