### PR TITLE
fix(gateway): keep reasoning on unpinned routing

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -98,6 +98,7 @@ import {
 	InvalidFileContentError,
 	parseGoogleUpstreamDocumentError,
 	prepareRequestBody,
+	selectProviderMapping,
 	RequestError,
 	UnsupportedAudioFormatError,
 	UnsupportedDocumentFormatError,
@@ -5008,9 +5009,16 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	// Check if the selected provider supports reasoning (from specific mapping, not any)
-	const selectedProviderMapping = modelInfo.providers.find(
-		(p) => p.providerId === usedProvider && p.region === usedRegion,
+	// Check if the selected provider supports reasoning (from specific mapping, not
+	// any). Resolves the exact (providerId, region) mapping when available and falls
+	// back to the region-agnostic mapping otherwise — unpinned routing leaves
+	// `modelInfo.providers` un-expanded (root mapping only, `region: undefined`)
+	// while `usedRegion` resolves to a concrete value (e.g. AWS Bedrock's `global`),
+	// so an exact-region lookup would silently drop reasoning support.
+	const selectedProviderMapping = selectProviderMapping(
+		modelInfo.providers,
+		usedProvider,
+		usedRegion,
 	);
 	let supportsReasoning = selectedProviderMapping?.reasoning === true;
 	let splitTaggedReasoning =

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -11,6 +11,7 @@ import {
 	getProviderEndpoint,
 	getProviderHeaders,
 	prepareRequestBody,
+	selectProviderMapping,
 } from "@llmgateway/actions";
 import {
 	type BaseMessage,
@@ -373,10 +374,16 @@ export async function resolveProviderContext(
 	}
 
 	// --- Look up the specific provider mapping for the selected provider ---
-	// modelInfo.providers is already expanded (regions flattened into separate entries)
+	// `modelInfo.providers` is region-expanded only when a provider was explicitly
+	// requested; for unpinned routing it holds just the region-agnostic root
+	// mapping (`region: undefined`) while `usedRegion` is a concrete value
+	// (e.g. AWS Bedrock's `global`). Resolve via the shared fallback helper so a
+	// retry/alternate-key request keeps reasoning support instead of dropping it.
 	const usedRegion = providerMapping.region;
-	const providerMappingForSelected = modelInfo.providers.find(
-		(p) => p.providerId === usedProvider && p.region === usedRegion,
+	const providerMappingForSelected = selectProviderMapping(
+		modelInfo.providers,
+		usedProvider,
+		usedRegion,
 	);
 
 	// --- Region validation ---

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -9,3 +9,4 @@ export * from "./get-provider-endpoint.js";
 export * from "./get-cheapest-from-available-providers.js";
 export * from "./validate-provider-key.js";
 export * from "./get-cheapest-model-for-provider.js";
+export * from "./select-provider-mapping.js";

--- a/packages/actions/src/select-provider-mapping.spec.ts
+++ b/packages/actions/src/select-provider-mapping.spec.ts
@@ -52,6 +52,32 @@ describe("selectProviderMapping", () => {
 		expect(mapping?.maxOutput).toBe(128000);
 	});
 
+	it("prefers the region-agnostic root over a concrete-region entry when the exact region misses (order-independent)", () => {
+		// A concrete-region entry is listed before the root, and usedRegion matches
+		// neither. The fallback must still resolve to the region-agnostic root
+		// mapping rather than the first array element.
+		const providers: ProviderModelMapping[] = [
+			{
+				providerId: "aws-bedrock",
+				externalId: "anthropic.claude-opus-4-6-v1",
+				streaming: true,
+				region: "us",
+				reasoning: true,
+			},
+			{
+				providerId: "aws-bedrock",
+				externalId: "anthropic.claude-opus-4-6-v1",
+				streaming: true,
+				region: undefined,
+				reasoning: true,
+			},
+		];
+
+		const mapping = selectProviderMapping(providers, "aws-bedrock", "global");
+
+		expect(mapping?.region).toBeUndefined();
+	});
+
 	it("returns undefined when no mapping matches the provider", () => {
 		const providers: ProviderModelMapping[] = [
 			{

--- a/packages/actions/src/select-provider-mapping.spec.ts
+++ b/packages/actions/src/select-provider-mapping.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { selectProviderMapping } from "./select-provider-mapping.js";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+describe("selectProviderMapping", () => {
+	it("falls back to the region-agnostic mapping when only the root entry exists (unpinned AWS Bedrock regression)", () => {
+		// Unpinned routing leaves modelInfo.providers un-expanded: only the
+		// synthetic root mapping (region: undefined) survives, but the gateway
+		// resolves usedRegion to a concrete "global". Before the fix the exact
+		// lookup returned undefined -> supportsReasoning became false -> Bedrock
+		// Claude returned no reasoning.
+		const providers: ProviderModelMapping[] = [
+			{
+				providerId: "aws-bedrock",
+				externalId: "anthropic.claude-opus-4-6-v1",
+				streaming: true,
+				region: undefined,
+				reasoning: true,
+			},
+		];
+
+		const mapping = selectProviderMapping(providers, "aws-bedrock", "global");
+
+		expect(mapping).toBeDefined();
+		expect(mapping?.reasoning).toBe(true);
+	});
+
+	it("prefers the exact region match when an expanded entry is present", () => {
+		const providers: ProviderModelMapping[] = [
+			{
+				providerId: "aws-bedrock",
+				externalId: "anthropic.claude-opus-4-6-v1",
+				streaming: true,
+				region: undefined,
+				reasoning: true,
+			},
+			{
+				providerId: "aws-bedrock",
+				externalId: "anthropic.claude-opus-4-6-v1",
+				streaming: true,
+				region: "global",
+				reasoning: true,
+				maxOutput: 128000,
+			},
+		];
+
+		const mapping = selectProviderMapping(providers, "aws-bedrock", "global");
+
+		expect(mapping?.region).toBe("global");
+		expect(mapping?.maxOutput).toBe(128000);
+	});
+
+	it("returns undefined when no mapping matches the provider", () => {
+		const providers: ProviderModelMapping[] = [
+			{
+				providerId: "openai",
+				externalId: "gpt-5",
+				streaming: true,
+				region: undefined,
+			},
+		];
+
+		expect(
+			selectProviderMapping(providers, "aws-bedrock", "global"),
+		).toBeUndefined();
+	});
+
+	it("matches a region-less mapping when usedRegion is undefined", () => {
+		const providers: ProviderModelMapping[] = [
+			{
+				providerId: "anthropic",
+				externalId: "claude-opus-4-6",
+				streaming: true,
+				region: undefined,
+				reasoning: true,
+			},
+		];
+
+		const mapping = selectProviderMapping(providers, "anthropic", undefined);
+
+		expect(mapping?.reasoning).toBe(true);
+	});
+});

--- a/packages/actions/src/select-provider-mapping.ts
+++ b/packages/actions/src/select-provider-mapping.ts
@@ -1,0 +1,30 @@
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+/**
+ * Resolve the provider mapping whose capability flags (reasoning, etc.) describe
+ * the provider/region actually selected for a request.
+ *
+ * Prefers an exact `(providerId, region)` match. Falls back to the
+ * region-agnostic provider mapping when no region-specific entry exists, because
+ * unpinned routing leaves `modelInfo.providers` un-expanded (only the synthetic
+ * root mapping with `region: undefined` survives) while the gateway still
+ * resolves a concrete `usedRegion` (e.g. AWS Bedrock's `global`). Without the
+ * fallback the exact match fails (`'global' !== undefined`) and capability flags
+ * such as reasoning support are silently dropped.
+ *
+ * Capability flags are inherited uniformly from the base mapping across region
+ * expansion (only pricing/context/output/streaming may be overridden per region;
+ * see `ProviderRegion`), so the region-agnostic mapping carries identical flags
+ * to every regional variant and the fallback is lossless.
+ */
+export function selectProviderMapping(
+	providers: ProviderModelMapping[],
+	usedProvider: string | undefined,
+	usedRegion: string | undefined,
+): ProviderModelMapping | undefined {
+	return (
+		providers.find(
+			(p) => p.providerId === usedProvider && p.region === usedRegion,
+		) ?? providers.find((p) => p.providerId === usedProvider)
+	);
+}

--- a/packages/actions/src/select-provider-mapping.ts
+++ b/packages/actions/src/select-provider-mapping.ts
@@ -16,6 +16,12 @@ import type { ProviderModelMapping } from "@llmgateway/models";
  * expansion (only pricing/context/output/streaming may be overridden per region;
  * see `ProviderRegion`), so the region-agnostic mapping carries identical flags
  * to every regional variant and the fallback is lossless.
+ *
+ * Resolution order: exact `(providerId, region)` → the region-agnostic root
+ * mapping (`region: undefined`) → any mapping for the provider. The explicit
+ * root step keeps the fallback deterministic rather than dependent on the order
+ * of `providers`; the final any-provider step is a safety net for the unlikely
+ * case where the root entry was filtered out but a concrete-region entry remains.
  */
 export function selectProviderMapping(
 	providers: ProviderModelMapping[],
@@ -25,6 +31,10 @@ export function selectProviderMapping(
 	return (
 		providers.find(
 			(p) => p.providerId === usedProvider && p.region === usedRegion,
-		) ?? providers.find((p) => p.providerId === usedProvider)
+		) ??
+		providers.find(
+			(p) => p.providerId === usedProvider && p.region === undefined,
+		) ??
+		providers.find((p) => p.providerId === usedProvider)
 	);
 }


### PR DESCRIPTION
## Problem

Reasoning was silently dropped for Claude models on AWS Bedrock when the model was requested **without a provider prefix**.

| Requested model | Routed to | Reasoning before |
|---|---|---|
| `aws-bedrock/claude-opus-4-6` (pinned) | aws-bedrock | ✅ yes |
| `claude-opus-4-6` (unpinned) | aws-bedrock | ❌ **none** (`reasoning_tokens: 0`) |

Reported by users via RisuAI: `reasoning_effort: high` on `claude-opus-4-6` / `claude-opus-4-8` produced no `<Thoughts>` / `delta.reasoning` / reasoning tokens, but the same request pinned to `aws-bedrock/...` worked.

## Root cause

`useExpandedRoutingProviders` is true only when a provider is explicitly requested. For **unpinned** routing, `modelInfo.providers` keeps only the region-agnostic **root** mapping (`region: undefined`) — region expansion (`expandProviderRegions`) is never applied to it. Meanwhile routing still resolves `usedRegion` to a concrete value (AWS Bedrock's `global`, `pinDefaultRegion: true`).

The capability lookup in `chat.ts` matched on exact region equality:

```ts
modelInfo.providers.find(p => p.providerId === usedProvider && p.region === usedRegion)
```

`'global' !== undefined` → no match → `supportsReasoning = false` (and `splitTaggedReasoning` / `healStreamingJsonOutput`) → `prepareRequestBody` skipped the entire thinking block → Bedrock Claude returned no reasoning.

## Fix

Resolve the mapping with a region-agnostic fallback — prefer the exact `(providerId, region)` mapping, otherwise fall back to the provider-level mapping. Capability flags (`reasoning`, `reasoningMode`, `splitTaggedReasoning`, `healStreamingJsonOutput`) cannot be overridden per region (`ProviderRegion` only permits pricing/context/output/streaming overrides), so the base mapping carries identical flags to every regional variant and the fallback is lossless. Extracted into a pure `selectProviderMapping` helper in `@llmgateway/actions` with unit tests.

## Verification

Live against AWS Bedrock (gateway run locally with real Bedrock key):

| Case | Before | After |
|---|---|---|
| unpinned `claude-opus-4-6` → bedrock | 0 reasoning tokens | **187** |
| unpinned `claude-opus-4-8` → bedrock | 0 reasoning tokens | **160** |
| pinned `aws-bedrock/claude-opus-4-6:global` | reasons | reasons (no regression) |
| `anthropic/claude-opus-4-6` | reasons | reasons (no regression) |
| unpinned `claude-haiku-4-5` (no reasoning support) | 400 | 400 (not over-enabled) |

- New unit test fails before the fix and passes after.
- `pnpm format` and full `pnpm build` pass; existing `prepare-request-body` reasoning specs unchanged.
- Adversarially reviewed for sibling bugs: the other `(providerId, region)` lookups in the rate-limit/uptime fallback and dev-plan paths are gated by `requestedProvider` (the pinned path, where providers are already region-expanded), so they are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider capability detection (including reasoning support) by resolving the correct provider/region mapping with reliable region-agnostic fallbacks when an exact region entry isn’t present.

* **Tests**
  * Added a new test suite covering provider mapping resolution scenarios: exact region matches, region-agnostic fallback selection, order independence, no-match behavior, and handling of undefined regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->