### PR TITLE
fix(gateway): reject TTS/video models in chat

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -72,6 +72,35 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/chat/completions rejects text-to-speech models with a pointer to /v1/audio/speech", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// ElevenLabs models are speech-only (output: ["audio"]) and have no chat
+		// base URL, so routing them here used to fall through to a confusing
+		// "requires a baseUrl" 500. The guard should reject them with a clear 400.
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "elevenlabs/eleven-multilingual-v2",
+				messages: [{ role: "user", content: "Hello there" }],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("/v1/audio/speech");
+	});
+
 	test("/v1/images/generations is blocked for dev-plan orgs via the chat-completions guard", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1760,6 +1760,26 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// Text-to-speech and video models are served by dedicated endpoints
+	// (/v1/audio/speech and /v1/videos). Routing them through chat completions
+	// would fall through to a confusing "requires a baseUrl" error during
+	// endpoint resolution, so reject them early with a pointer to the right
+	// endpoint. Image-only models (e.g. reve, grok-image) are intentionally
+	// allowed here — they are served by the chat-completions image flow.
+	const modelOutput = modelInfo.output;
+	if (modelOutput && !modelOutput.includes("text")) {
+		if (modelOutput.includes("audio")) {
+			throw new HTTPException(400, {
+				message: `Model ${requestedModel} is a text-to-speech model and is not available on the chat completions endpoint. Use the /v1/audio/speech endpoint instead.`,
+			});
+		}
+		if (modelOutput.includes("video")) {
+			throw new HTTPException(400, {
+				message: `Model ${requestedModel} is a video generation model and is not available on the chat completions endpoint. Use the /v1/videos endpoint instead.`,
+			});
+		}
+	}
+
 	// Validate that models requiring image input have at least one image in the request
 	if (
 		modelInfo.imageInputRequired &&


### PR DESCRIPTION
## What

The production error log showed:

```
Error: Could not use provider: elevenlabs. Provider elevenlabs requires a baseUrl
    at <anonymous> (/app/src/chat/chat.ts:5085:9)
```

ElevenLabs (and OpenAI TTS) models are **speech-only** (`output: ["audio"]`, `speechGenerations: true`) and are served by the dedicated `/v1/audio/speech` endpoint, which has its own provider base-URL map. They have no chat base URL, so when a request hit `/v1/chat/completions` with a model like `elevenlabs/eleven-multilingual-v2`, endpoint resolution fell through to the `default` case in `getProviderEndpoint` and threw a confusing `requires a baseUrl` 500.

## Fix

Add an early guard in the chat-completions handler (right after model resolution) that rejects models whose output is audio or video — they belong to dedicated endpoints — with a clear **400** pointing the caller to the right endpoint:

- audio → `/v1/audio/speech`
- video → `/v1/videos`

Image-only models (e.g. `reve`, `grok-image`) are intentionally **allowed**, since they are served by the chat-completions image-generation flow. This mirrors the existing convention in `chat-helpers.e2e.ts` that filters out audio/video-only (but not image) models from chat e2e tests.

## Test

Added a unit test in `apps/gateway/src/api.spec.ts` asserting `elevenlabs/eleven-multilingual-v2` on `/v1/chat/completions` returns 400 with a pointer to `/v1/audio/speech`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat completions endpoint now validates that models support text output before processing requests. Models that only support audio or video are rejected with helpful error messages guiding users to the correct endpoint (`/v1/audio/speech` for audio, `/v1/videos` for video).

* **Tests**
  * Added test coverage for model compatibility validation in chat completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->