### PR TITLE
fix(actions): fall back when no region validation model

### DIFF
--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -36,72 +36,81 @@ function getValidationModel(
 		: undefined;
 
 	const currentDate = new Date();
-	const providerModels = models
-		.flatMap((model) => {
-			const providerMapping = model.providers.find(
-				(p) => p.providerId === provider,
-			) as ProviderModelMapping | undefined;
-			if (!providerMapping) {
-				return [];
-			}
-
-			// If a region is selected, only consider models available in that region
-			if (selectedRegion && providerMapping.regions) {
-				if (!providerMapping.regions.some((r) => r.id === selectedRegion)) {
+	const collectModels = (restrictToRegion: boolean) =>
+		models
+			.flatMap((model) => {
+				const providerMapping = model.providers.find(
+					(p) => p.providerId === provider,
+				) as ProviderModelMapping | undefined;
+				if (!providerMapping) {
 					return [];
 				}
-			}
 
-			const providerStability =
-				"stability" in providerMapping
-					? (providerMapping.stability as string | undefined)
-					: undefined;
-			const modelStability =
-				"stability" in model
-					? (model.stability as string | undefined)
-					: undefined;
-			const effectiveStability = providerStability ?? modelStability;
-			const isStable =
-				effectiveStability !== "unstable" &&
-				effectiveStability !== "experimental";
+				// If a region is selected, only consider models available in that region
+				if (restrictToRegion && selectedRegion && providerMapping.regions) {
+					if (!providerMapping.regions.some((r) => r.id === selectedRegion)) {
+						return [];
+					}
+				}
 
-			const isDeprecated =
-				providerMapping.deprecatedAt &&
-				currentDate >= providerMapping.deprecatedAt;
-			const isDeactivated =
-				providerMapping.deactivatedAt &&
-				currentDate >= providerMapping.deactivatedAt;
+				const providerStability =
+					"stability" in providerMapping
+						? (providerMapping.stability as string | undefined)
+						: undefined;
+				const modelStability =
+					"stability" in model
+						? (model.stability as string | undefined)
+						: undefined;
+				const effectiveStability = providerStability ?? modelStability;
+				const isStable =
+					effectiveStability !== "unstable" &&
+					effectiveStability !== "experimental";
 
-			if (
-				!isStable ||
-				isDeprecated ||
-				isDeactivated ||
-				providerMapping.imageGenerations ||
-				providerMapping.videoGenerations ||
-				providerMapping.embeddings ||
-				providerMapping.speechGenerations
-			) {
-				return [];
-			}
+				const isDeprecated =
+					providerMapping.deprecatedAt &&
+					currentDate >= providerMapping.deprecatedAt;
+				const isDeactivated =
+					providerMapping.deactivatedAt &&
+					currentDate >= providerMapping.deactivatedAt;
 
-			const hasPricing =
-				providerMapping.inputPrice !== undefined &&
-				providerMapping.outputPrice !== undefined;
-			const inputPrice = Number(providerMapping.inputPrice ?? "0");
-			const outputPrice = Number(providerMapping.outputPrice ?? "0");
-			const averagePrice = hasPricing
-				? (inputPrice + outputPrice) / 2
-				: Number.MAX_VALUE;
+				if (
+					!isStable ||
+					isDeprecated ||
+					isDeactivated ||
+					providerMapping.imageGenerations ||
+					providerMapping.videoGenerations ||
+					providerMapping.embeddings ||
+					providerMapping.speechGenerations
+				) {
+					return [];
+				}
 
-			return [
-				{
-					modelId: model.id,
-					externalId: providerMapping.externalId,
-					price: averagePrice,
-				},
-			];
-		})
-		.sort((a, b) => a.price - b.price);
+				const hasPricing =
+					providerMapping.inputPrice !== undefined &&
+					providerMapping.outputPrice !== undefined;
+				const inputPrice = Number(providerMapping.inputPrice ?? "0");
+				const outputPrice = Number(providerMapping.outputPrice ?? "0");
+				const averagePrice = hasPricing
+					? (inputPrice + outputPrice) / 2
+					: Number.MAX_VALUE;
+
+				return [
+					{
+						modelId: model.id,
+						externalId: providerMapping.externalId,
+						price: averagePrice,
+					},
+				];
+			})
+			.sort((a, b) => a.price - b.price);
+
+	// Prefer a model available in the selected region. If none is declared for
+	// that region (e.g. a data-residency AWS region that no model lists), fall
+	// back to any model for the provider so validation can still proceed.
+	const regionModels = selectedRegion ? collectModels(true) : [];
+	const providerModels = regionModels.length
+		? regionModels
+		: collectModels(false);
 
 	const best = providerModels[0];
 	return best ? { modelId: best.modelId, externalId: best.externalId } : null;


### PR DESCRIPTION
## Problem

AWS Bedrock provider key validation throws:

```
No suitable validation model found for provider aws-bedrock
```

The Bedrock `regionConfig` offers many regions (e.g. `eu-north-1`, `ap-southeast-1`, `jp`, `apac`, `us-east-1`, `eu-west-1`, …), but active models only declare a subset in their `regions` field (`global`, `us`, `eu`, `au`, `us-west-2`, `eu-west-2`). When a provider key is pinned to a region no model lists, `getValidationModel` filters out every candidate and returns `null`, causing the exception.

## Fix

`getValidationModel` now first looks for a model available in the selected region, and if none is declared there, falls back to a region-agnostic selection so validation can still proceed (the endpoint is still resolved for the selected region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation model selection with improved filtering of deprecated models and region-aware fallback handling. Validation now proceeds reliably even when region-specific options are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->