### PR TITLE
fix(gateway): retry Azure missing-deployment 400

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -186,6 +186,24 @@ describe("getFinishReasonFromError", () => {
 		);
 	});
 
+	it("returns gateway_error for Azure missing deployment errors", () => {
+		const azureDeploymentError = JSON.stringify({
+			type: "error",
+			error: {
+				type: "invalid_request_error",
+				code: null,
+				headers: { "x-ms-fe-error": "true" },
+				message:
+					"Could not find an existing deployment to match the model in the request. Please verify the model matches an existing deployment in the account.",
+				param: null,
+			},
+			sequence_number: 2,
+		});
+		expect(getFinishReasonFromError(400, azureDeploymentError)).toBe(
+			"gateway_error",
+		);
+	});
+
 	it("returns gateway_error for upstream 'Unknown model' messages", () => {
 		expect(
 			getFinishReasonFromError(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -80,6 +80,18 @@ export function getFinishReasonFromError(
 		return "gateway_error";
 	}
 
+	// Azure returns a 400 when the resolved deployment does not exist for the
+	// account behind the selected key (e.g. "Could not find an existing
+	// deployment to match the model in the request."). This is a per-key/account
+	// configuration gap rather than a client problem, so classify as
+	// gateway_error so the request can be retried with another key or provider.
+	if (
+		errorText &&
+		/could not find an existing deployment to match the model/i.test(errorText)
+	) {
+		return "gateway_error";
+	}
+
 	// zai content filter
 	if (
 		errorText?.includes(


### PR DESCRIPTION
## Problem

Azure returns an HTTP 400 with the body:

```json
{"type":"error","error":{"type":"invalid_request_error","code":null,"headers":{"x-ms-fe-error":"true"},"message":"Could not find an existing deployment to match the model in the request. Please verify the model matches an existing deployment in the account."}}
```

when the resolved deployment does not exist for the account behind the selected provider key. This is a per-key/account configuration gap — another key for the same provider may have the deployment — but `getFinishReasonFromError` classified it as a terminal `client_error`. As a result the request failed immediately without rotating keys or falling back to another provider (`shouldRetryAlternateKey` / `shouldRetryRequest` both return false for `client_error`).

## Fix

Classify the Azure missing-deployment 400 as `gateway_error`, matching how the existing "Unknown model" and bare "Not Found" mapping-gap cases are handled. `gateway_error` is retryable, so the gateway now automatically retries with another key (and falls back to another provider if needed).

## Testing

- Added a unit test in `get-finish-reason-from-error.spec.ts` for the Azure deployment error payload.
- `pnpm vitest run apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts` — 22 passed.
- `pnpm format` and `turbo run build --filter=gateway` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for Azure deployment scenarios by improving detection of missing deployment configurations and classifying them appropriately as gateway errors.

* **Tests**
  * Added test cases to validate error classification for Azure missing deployment scenarios, ensuring robust error handling and proper system responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->