### PR TITLE
fix(gateway): use release date for models created field

### DIFF
--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -17,7 +17,7 @@ const modelSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	aliases: z.array(z.string()).optional(),
-	created: z.number(),
+	created: z.number().optional(),
 	description: z.string().optional(),
 	family: z.string(),
 	architecture: z.object({
@@ -223,7 +223,9 @@ modelsApi.openapi(listModels, async (c) => {
 				id: model.id,
 				name: model.name ?? model.id,
 				aliases: model.aliases,
-				created: Math.floor(Date.now() / 1000), // Current timestamp in seconds
+				created: model.releasedAt
+					? Math.floor(model.releasedAt.getTime() / 1000)
+					: undefined,
 				description: `${model.id} provided by ${model.providers.map((p) => p.providerId).join(", ")}`,
 				family: model.family,
 				architecture: {


### PR DESCRIPTION
## Problem

The `created` field on the `/v1/models` endpoint was set to `Math.floor(Date.now() / 1000)` — the current request timestamp — so every model appeared to be "created" right now instead of showing its actual release date.

## Fix

Use the model definition's `releasedAt` field (already populated for 289/293 models) to compute `created` as a Unix timestamp. When a model has no `releasedAt`, `created` is omitted rather than faked with the current time. The response schema's `created` is now `optional()` to match.

## Testing

- `pnpm turbo run build --filter=gateway` ✅
- `pnpm vitest run apps/gateway/src/models/models.spec.ts` — 16 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the models API response to derive the creation timestamp from the actual release date rather than the current time, providing more accurate information.
  * The creation timestamp field may now be omitted from API responses when release date information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->