### PR TITLE
feat(admin): add client error and has-error log filters

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2615,6 +2615,7 @@ const getProjectLogs = createRoute({
 			model: z.string().optional(),
 			source: z.string().optional(),
 			unifiedFinishReason: z.string().optional(),
+			hasError: z.string().optional(),
 		}),
 	},
 	responses: {
@@ -2636,7 +2637,8 @@ admin.openapi(getProjectLogs, async (c) => {
 	const { orgId, projectId } = c.req.valid("param");
 	const query = c.req.valid("query");
 	const limit = query.limit ?? 50;
-	const { cursor, provider, model, source, unifiedFinishReason } = query;
+	const { cursor, provider, model, source, unifiedFinishReason, hasError } =
+		query;
 
 	// Verify project belongs to the organization
 	const project = await db.query.project.findFirst({
@@ -2681,6 +2683,10 @@ admin.openapi(getProjectLogs, async (c) => {
 		whereConditions.push(
 			eq(tables.log.unifiedFinishReason, unifiedFinishReason),
 		);
+	}
+
+	if (hasError === "true") {
+		whereConditions.push(eq(tables.log.hasError, true));
 	}
 
 	if (cursor) {

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx
@@ -41,6 +41,7 @@ const UnifiedFinishReason = {
 	LENGTH_LIMIT: "length_limit",
 	CONTENT_FILTER: "content_filter",
 	TOOL_CALLS: "tool_calls",
+	CLIENT_ERROR: "client_error",
 	GATEWAY_ERROR: "gateway_error",
 	UPSTREAM_ERROR: "upstream_error",
 	CANCELED: "canceled",
@@ -95,6 +96,7 @@ export function ProjectLogsSection({
 	const model = searchParams.get("model") ?? "all";
 	const source = searchParams.get("source") ?? "all";
 	const unifiedFinishReason = searchParams.get("unifiedFinishReason") ?? "all";
+	const hasError = searchParams.get("hasError") ?? "all";
 
 	const updateFilters = useCallback(
 		(updates: Record<string, string>) => {
@@ -133,8 +135,11 @@ export function ProjectLogsSection({
 		if (unifiedFinishReason !== "all") {
 			filters.unifiedFinishReason = unifiedFinishReason;
 		}
+		if (hasError === "true") {
+			filters.hasError = "true";
+		}
 		return Object.keys(filters).length > 0 ? filters : undefined;
-	}, [provider, model, source, unifiedFinishReason]);
+	}, [provider, model, source, unifiedFinishReason, hasError]);
 
 	const loadLogs = useCallback(
 		async (cursor?: string, options?: { background?: boolean }) => {
@@ -350,6 +355,19 @@ export function ProjectLogsSection({
 									.replace(/\b\w/g, (l) => l.toUpperCase())}
 							</SelectItem>
 						))}
+					</SelectContent>
+				</Select>
+
+				<Select
+					value={hasError}
+					onValueChange={(value) => updateFilters({ hasError: value })}
+				>
+					<SelectTrigger className="w-[160px]">
+						<SelectValue placeholder="Filter by error" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="all">Default</SelectItem>
+						<SelectItem value="true">Has Error</SelectItem>
 					</SelectContent>
 				</Select>
 

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -36,6 +36,7 @@ export async function loadProjectLogsAction(
 		model?: string;
 		source?: string;
 		unifiedFinishReason?: string;
+		hasError?: string;
 	},
 ) {
 	const $api = await createServerApiClient();


### PR DESCRIPTION
## Summary

Extends the **project view logs** in the admin panel (`ee/admin`) with two filtering additions requested for triaging logs:

- **Client Error** finish reason — adds `CLIENT_ERROR: "client_error"` to the unified finish reason filter dropdown, matching the `client_error` value already used elsewhere (e.g. `apps/api/src/testing.ts` aggregates).
- **Has Error filter** — a new dropdown with `Default` (no filter) and `Has Error` (`has_error = true`) options.

## Changes

- `apps/api/src/routes/admin.ts` — `getProjectLogs` route now accepts a `hasError` query param and filters on `tables.log.hasError = true` when set to `"true"`.
- `ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-logs.tsx` — adds the `Client Error` finish reason option, the new error filter `Select`, and wires `hasError` through the URL search params / `getFilters`.
- `ee/admin/src/lib/admin-organizations.ts` — extends the `loadProjectLogsAction` filters type with `hasError`.

Generated client types (`v1.d.ts`, `openapi.json`) are gitignored and regenerated at build time.

## Testing

- `pnpm format`
- `pnpm turbo run build --filter=admin --filter=api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error filtering capability to project logs. Users can now filter logs to display only entries with errors using a new "Filter by error" dropdown option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->