### PR TITLE
fix(models): require releasedAt on every model

### DIFF
--- a/packages/models/src/model-metadata.spec.ts
+++ b/packages/models/src/model-metadata.spec.ts
@@ -14,4 +14,25 @@ describe("model metadata", () => {
 			maxOutput: 8_192,
 		});
 	});
+
+	it("sets releasedAt for every model", () => {
+		const missing = models
+			.filter((model) => !model.releasedAt)
+			.map((model) => model.id);
+
+		expect(missing).toEqual([]);
+	});
+
+	it("uses valid Date instances for releasedAt", () => {
+		const invalid = models
+			.filter(
+				(model) =>
+					model.releasedAt !== undefined &&
+					(!(model.releasedAt instanceof Date) ||
+						Number.isNaN(model.releasedAt.getTime())),
+			)
+			.map((model) => model.id);
+
+		expect(invalid).toEqual([]);
+	});
 });

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1365,6 +1365,7 @@ export const alibabaModels = [
 		description:
 			"Alibaba's Qwen3 Coder Next model optimized for coding tasks with 262K context.",
 		family: "alibaba",
+		releasedAt: new Date("2026-02-04"),
 		providers: [
 			{
 				providerId: "embercloud",

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -33,6 +33,7 @@ export const minimaxModels = [
 		description:
 			"MiniMax M2.7 with stronger reasoning and coding performance for complex tasks.",
 		family: "minimax",
+		releasedAt: new Date("2026-03-18"),
 		providers: [
 			{
 				providerId: "minimax",
@@ -89,6 +90,7 @@ export const minimaxModels = [
 		description:
 			"Highspeed MiniMax M2.7 variant with the same model quality and lower latency.",
 		family: "minimax",
+		releasedAt: new Date("2026-03-18"),
 		providers: [
 			{
 				providerId: "minimax",
@@ -223,6 +225,7 @@ export const minimaxModels = [
 		description:
 			"Highspeed MiniMax M2.5 variant with the same model quality and lower latency.",
 		family: "minimax",
+		releasedAt: new Date("2026-02-15"),
 		providers: [
 			{
 				providerId: "minimax",


### PR DESCRIPTION
## Problem

PR #2797 changed the gateway `/v1/models` response to derive the OpenAI-compatible `created` timestamp from each model's `releasedAt` date, falling back to `undefined` when the field is missing. A few active models had no `releasedAt`, so JSON serialization dropped `created` entirely for them — breaking clients (and the response-shape expectation) that rely on it.

## Fix

- **Enforce the invariant with a test.** Added a unit test in `packages/models/src/model-metadata.spec.ts` asserting every model defines a `releasedAt`, plus one asserting each `releasedAt` is a valid `Date`. This prevents the regression from recurring whenever a new model is added.
- **Backfilled the missing dates** (researched from provider announcements):
  - `minimax-m2.7` → 2026-03-18
  - `minimax-m2.7-highspeed` → 2026-03-18 (variant of M2.7)
  - `minimax-m2.5-highspeed` → 2026-02-15 (variant of M2.5)
  - `qwen3-coder-next` → 2026-02-04

With every model now carrying a `releasedAt`, `/v1/models` always returns a numeric `created` timestamp.

## Testing

- `vitest run packages/models/src/model-metadata.spec.ts` — 3 passed
- `pnpm format`, `turbo run build --filter=@llmgateway/models --filter=gateway`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added test coverage for model release date metadata validation across all models

## Chores
- Updated release date information for Alibaba Qwen3 Coder Next model
- Updated release date information for three MiniMax models (M2.7, M2.7 HighSpeed, M2.5 HighSpeed)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->