### PR TITLE
feat(admin): model view toggle on cost breakdown

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1087,7 +1087,7 @@ admin.openapi(getTimeseries, async (c) => {
 	});
 });
 
-const globalStatsRangeSchema = z.enum(["7d", "30d", "90d", "365d"]);
+const globalStatsRangeSchema = z.enum(["7d", "30d", "90d", "365d", "all"]);
 const globalStatsGroupBySchema = z.enum(["model", "source"]);
 const globalStatsModelViewSchema = z.enum(["mapping", "canonical", "provider"]);
 const globalStatsDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
@@ -1176,6 +1176,14 @@ admin.openapi(getGlobalStats, async (c) => {
 	const dayMs = 24 * 60 * 60 * 1000;
 	const MAX_GLOBAL_STATS_DAYS = 731;
 
+	const sourceTable =
+		groupBy === "model" ? globalModelStats : globalSourceStats;
+
+	// `all` means "all time": derive the span from the first/last recorded day
+	// so the card matches the dashboard's all-time totals instead of silently
+	// truncating to a fixed window.
+	const allTime = !query.from && !query.to && query.range === "all";
+
 	let startDate: Date;
 	let endDate: Date;
 	if (query.from && query.to) {
@@ -1188,9 +1196,26 @@ admin.openapi(getGlobalStats, async (c) => {
 			startDate = endDate;
 			endDate = tmp;
 		}
+	} else if (allTime) {
+		const bounds = await db
+			.select({
+				minDay: sql<
+					string | null
+				>`to_char(MIN(${sourceTable.dayTimestamp}), 'YYYY-MM-DD')`.as("minDay"),
+				maxDay: sql<
+					string | null
+				>`to_char(MAX(${sourceTable.dayTimestamp}), 'YYYY-MM-DD')`.as("maxDay"),
+			})
+			.from(sourceTable);
+		const minDay = bounds[0]?.minDay ?? null;
+		const maxDay = bounds[0]?.maxDay ?? null;
+		endDate = maxDay ? new Date(maxDay + "T00:00:00Z") : new Date();
+		endDate.setUTCHours(0, 0, 0, 0);
+		startDate = minDay ? new Date(minDay + "T00:00:00Z") : new Date(endDate);
+		startDate.setUTCHours(0, 0, 0, 0);
 	} else {
-		const range = query.range ?? "30d";
-		const rangeDays: Record<typeof range, number> = {
+		const range = query.range && query.range !== "all" ? query.range : "30d";
+		const rangeDays: Record<"7d" | "30d" | "90d" | "365d", number> = {
 			"7d": 7,
 			"30d": 30,
 			"90d": 90,
@@ -1205,13 +1230,11 @@ admin.openapi(getGlobalStats, async (c) => {
 	if (days < 1) {
 		days = 1;
 	}
-	if (days > MAX_GLOBAL_STATS_DAYS) {
+	// All-time spans the full recorded history; only bounded windows are capped.
+	if (!allTime && days > MAX_GLOBAL_STATS_DAYS) {
 		days = MAX_GLOBAL_STATS_DAYS;
 		startDate = new Date(endDate.getTime() - (days - 1) * dayMs); // eslint-disable-line no-mixed-operators
 	}
-
-	const sourceTable =
-		groupBy === "model" ? globalModelStats : globalSourceStats;
 
 	const metricSums = {
 		requestCount:

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Cpu, Layers, Server } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { Button } from "@/components/ui/button";
@@ -112,20 +112,28 @@ export function CostByModelChart({
 	const [activeView, setActiveView] = useState<ActiveView>("cost");
 	const [modelView, setModelView] = useState<GlobalStatsModelView>("mapping");
 	const useDateRange = Boolean(from && to && fetchDataRange);
+	const requestIdRef = useRef(0);
 
 	const loadData = useCallback(async () => {
+		const requestId = ++requestIdRef.current;
 		setLoading(true);
 		try {
 			const result =
 				useDateRange && fetchDataRange
 					? await fetchDataRange(from!, to!, modelView)
 					: await fetchData(window, modelView);
-			setData(result);
+			if (requestId === requestIdRef.current) {
+				setData(result);
+			}
 		} catch (error) {
 			console.error("Failed to load cost by model:", error);
-			setData(null);
+			if (requestId === requestIdRef.current) {
+				setData(null);
+			}
 		} finally {
-			setLoading(false);
+			if (requestId === requestIdRef.current) {
+				setLoading(false);
+			}
 		}
 	}, [fetchData, fetchDataRange, window, modelView, from, to, useDateRange]);
 

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -50,17 +50,6 @@ const viewConfigs: Record<ActiveView, ChartConfig> = {
 	},
 };
 
-const defaultWindowOptions: { value: TokenWindow; label: string }[] = [
-	{ value: "1h", label: "1h" },
-	{ value: "4h", label: "4h" },
-	{ value: "12h", label: "12h" },
-	{ value: "1d", label: "24h" },
-	{ value: "7d", label: "7d" },
-	{ value: "30d", label: "30d" },
-	{ value: "90d", label: "90d" },
-	{ value: "365d", label: "365d" },
-];
-
 const modelViewOptions: {
 	value: GlobalStatsModelView;
 	label: string;
@@ -83,45 +72,53 @@ export function CostByModelChart({
 	fetchData,
 	fetchDataRange,
 	externalWindow,
-	windowOptions = defaultWindowOptions,
 	showModelView = false,
+	modelView: controlledModelView,
+	onModelViewChange,
+	forceRange = false,
 	from,
 	to,
 }: {
 	title: string;
 	description?: string;
-	fetchData: (
+	fetchData?: (
 		window: TokenWindow,
 		modelView: GlobalStatsModelView,
 	) => Promise<CostByModelData | null>;
 	fetchDataRange?: (
-		from: string,
-		to: string,
+		from: string | undefined,
+		to: string | undefined,
 		modelView: GlobalStatsModelView,
 	) => Promise<CostByModelData | null>;
 	externalWindow?: TokenWindow;
-	windowOptions?: { value: TokenWindow; label: string }[];
 	showModelView?: boolean;
+	modelView?: GlobalStatsModelView;
+	onModelViewChange?: (value: GlobalStatsModelView) => void;
+	forceRange?: boolean;
 	from?: string;
 	to?: string;
 }) {
 	const [data, setData] = useState<CostByModelData | null>(null);
 	const [loading, setLoading] = useState(true);
-	const [internalWindow, setInternalWindow] = useState<TokenWindow>("7d");
-	const window = externalWindow ?? internalWindow;
+	const window = externalWindow ?? "7d";
 	const [activeView, setActiveView] = useState<ActiveView>("cost");
-	const [modelView, setModelView] = useState<GlobalStatsModelView>("mapping");
-	const useDateRange = Boolean(from && to && fetchDataRange);
+	const [internalModelView, setInternalModelView] =
+		useState<GlobalStatsModelView>("mapping");
+	const modelView = controlledModelView ?? internalModelView;
+	const setModelView = onModelViewChange ?? setInternalModelView;
+	const useRange = forceRange || Boolean(from && to);
 	const requestIdRef = useRef(0);
 
 	const loadData = useCallback(async () => {
 		const requestId = ++requestIdRef.current;
 		setLoading(true);
 		try {
-			const result =
-				useDateRange && fetchDataRange
-					? await fetchDataRange(from!, to!, modelView)
-					: await fetchData(window, modelView);
+			let result: CostByModelData | null = null;
+			if (useRange && fetchDataRange) {
+				result = await fetchDataRange(from, to, modelView);
+			} else if (fetchData) {
+				result = await fetchData(window, modelView);
+			}
 			if (requestId === requestIdRef.current) {
 				setData(result);
 			}
@@ -135,7 +132,7 @@ export function CostByModelChart({
 				setLoading(false);
 			}
 		}
-	}, [fetchData, fetchDataRange, window, modelView, from, to, useDateRange]);
+	}, [fetchData, fetchDataRange, window, modelView, from, to, useRange]);
 
 	useEffect(() => {
 		void loadData();
@@ -174,21 +171,6 @@ export function CostByModelChart({
 							</div>
 						)}
 					</div>
-					{!externalWindow && !useDateRange && (
-						<div className="flex items-center gap-1">
-							{windowOptions.map((opt) => (
-								<Button
-									key={opt.value}
-									variant={window === opt.value ? "default" : "outline"}
-									size="sm"
-									className="h-7 px-2 text-xs"
-									onClick={() => setInternalWindow(opt.value)}
-								>
-									{opt.label}
-								</Button>
-							))}
-						</div>
-					)}
 				</div>
 				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
 					<div className="flex items-center gap-1">

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Cpu, Layers, Server } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
@@ -19,7 +20,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
-import type { TokenWindow } from "@/lib/types";
+import type { GlobalStatsModelView, TokenWindow } from "@/lib/types";
 
 export interface CostByModelEntry {
 	model: string;
@@ -49,7 +50,7 @@ const viewConfigs: Record<ActiveView, ChartConfig> = {
 	},
 };
 
-const windowOptions: { value: TokenWindow; label: string }[] = [
+const defaultWindowOptions: { value: TokenWindow; label: string }[] = [
 	{ value: "1h", label: "1h" },
 	{ value: "4h", label: "4h" },
 	{ value: "12h", label: "12h" },
@@ -58,6 +59,16 @@ const windowOptions: { value: TokenWindow; label: string }[] = [
 	{ value: "30d", label: "30d" },
 	{ value: "90d", label: "90d" },
 	{ value: "365d", label: "365d" },
+];
+
+const modelViewOptions: {
+	value: GlobalStatsModelView;
+	label: string;
+	icon: typeof Cpu;
+}[] = [
+	{ value: "mapping", label: "Mappings", icon: Layers },
+	{ value: "canonical", label: "Canonical", icon: Cpu },
+	{ value: "provider", label: "Providers", icon: Server },
 ];
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -72,17 +83,25 @@ export function CostByModelChart({
 	fetchData,
 	fetchDataRange,
 	externalWindow,
+	windowOptions = defaultWindowOptions,
+	showModelView = false,
 	from,
 	to,
 }: {
 	title: string;
 	description?: string;
-	fetchData: (window: TokenWindow) => Promise<CostByModelData | null>;
+	fetchData: (
+		window: TokenWindow,
+		modelView: GlobalStatsModelView,
+	) => Promise<CostByModelData | null>;
 	fetchDataRange?: (
 		from: string,
 		to: string,
+		modelView: GlobalStatsModelView,
 	) => Promise<CostByModelData | null>;
 	externalWindow?: TokenWindow;
+	windowOptions?: { value: TokenWindow; label: string }[];
+	showModelView?: boolean;
 	from?: string;
 	to?: string;
 }) {
@@ -91,6 +110,7 @@ export function CostByModelChart({
 	const [internalWindow, setInternalWindow] = useState<TokenWindow>("7d");
 	const window = externalWindow ?? internalWindow;
 	const [activeView, setActiveView] = useState<ActiveView>("cost");
+	const [modelView, setModelView] = useState<GlobalStatsModelView>("mapping");
 	const useDateRange = Boolean(from && to && fetchDataRange);
 
 	const loadData = useCallback(async () => {
@@ -98,8 +118,8 @@ export function CostByModelChart({
 		try {
 			const result =
 				useDateRange && fetchDataRange
-					? await fetchDataRange(from!, to!)
-					: await fetchData(window);
+					? await fetchDataRange(from!, to!, modelView)
+					: await fetchData(window, modelView);
 			setData(result);
 		} catch (error) {
 			console.error("Failed to load cost by model:", error);
@@ -107,7 +127,7 @@ export function CostByModelChart({
 		} finally {
 			setLoading(false);
 		}
-	}, [fetchData, fetchDataRange, window, from, to, useDateRange]);
+	}, [fetchData, fetchDataRange, window, modelView, from, to, useDateRange]);
 
 	useEffect(() => {
 		void loadData();
@@ -162,21 +182,42 @@ export function CostByModelChart({
 						</div>
 					)}
 				</div>
-				<div className="flex items-center gap-1 border-b pb-2">
-					{viewTabs.map((tab) => (
-						<button
-							key={tab.key}
-							className={cn(
-								"rounded-md px-3 py-1 text-xs font-medium transition-colors",
-								activeView === tab.key
-									? "bg-primary text-primary-foreground"
-									: "text-muted-foreground hover:text-foreground",
-							)}
-							onClick={() => setActiveView(tab.key)}
-						>
-							{tab.label}
-						</button>
-					))}
+				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
+					<div className="flex items-center gap-1">
+						{viewTabs.map((tab) => (
+							<button
+								key={tab.key}
+								className={cn(
+									"rounded-md px-3 py-1 text-xs font-medium transition-colors",
+									activeView === tab.key
+										? "bg-primary text-primary-foreground"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+								onClick={() => setActiveView(tab.key)}
+							>
+								{tab.label}
+							</button>
+						))}
+					</div>
+					{showModelView && (
+						<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
+							{modelViewOptions.map((opt) => {
+								const Icon = opt.icon;
+								return (
+									<Button
+										key={opt.value}
+										variant={modelView === opt.value ? "default" : "ghost"}
+										size="sm"
+										className="h-7 gap-1.5 px-3 text-xs"
+										onClick={() => setModelView(opt.value)}
+									>
+										<Icon className="h-3.5 w-3.5" />
+										{opt.label}
+									</Button>
+								);
+							})}
+						</div>
+					)}
 				</div>
 			</CardHeader>
 			<CardContent className="px-2 pb-4 sm:px-6">

--- a/ee/admin/src/components/dashboard-cost-by-model.tsx
+++ b/ee/admin/src/components/dashboard-cost-by-model.tsx
@@ -1,21 +1,24 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
 import { CostByModelChart } from "@/components/cost-by-model-chart";
-import {
-	getGlobalCostByModel,
-	getGlobalCostByModelRange,
-} from "@/lib/admin-history";
+import { getGlobalCostByModel } from "@/lib/admin-history";
 
-import type { GlobalStatsModelView, TokenWindow } from "@/lib/types";
+import type { GlobalStatsModelView } from "@/lib/types";
 
-const windowOptions: { value: TokenWindow; label: string }[] = [
-	{ value: "7d", label: "7d" },
-	{ value: "30d", label: "30d" },
-	{ value: "90d", label: "90d" },
-	{ value: "365d", label: "365d" },
+const VALID_MODEL_VIEWS: GlobalStatsModelView[] = [
+	"mapping",
+	"canonical",
+	"provider",
 ];
+
+function parseModelView(value: string | null): GlobalStatsModelView {
+	return VALID_MODEL_VIEWS.includes(value as GlobalStatsModelView)
+		? (value as GlobalStatsModelView)
+		: "mapping";
+}
 
 export function DashboardCostByModel({
 	from,
@@ -24,20 +27,27 @@ export function DashboardCostByModel({
 	from?: string;
 	to?: string;
 }) {
-	const fetchData = useCallback(
-		async (window: TokenWindow, modelView: GlobalStatsModelView) => {
-			return await getGlobalCostByModel(window, modelView);
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const modelView = parseModelView(searchParams.get("modelView"));
+
+	const setModelView = useCallback(
+		(value: GlobalStatsModelView) => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.set("modelView", value);
+			router.replace(`${pathname}?${params.toString()}`, { scroll: false });
 		},
-		[],
+		[router, pathname, searchParams],
 	);
 
 	const fetchDataRange = useCallback(
 		async (
-			rangeFrom: string,
-			rangeTo: string,
-			modelView: GlobalStatsModelView,
+			rangeFrom: string | undefined,
+			rangeTo: string | undefined,
+			view: GlobalStatsModelView,
 		) => {
-			return await getGlobalCostByModelRange(rangeFrom, rangeTo, modelView);
+			return await getGlobalCostByModel(rangeFrom, rangeTo, view);
 		},
 		[],
 	);
@@ -46,10 +56,11 @@ export function DashboardCostByModel({
 		<CostByModelChart
 			title="Cost by Model"
 			description="Top 20 by cost across all organizations"
-			fetchData={fetchData}
 			fetchDataRange={fetchDataRange}
-			windowOptions={windowOptions}
+			forceRange
 			showModelView
+			modelView={modelView}
+			onModelViewChange={setModelView}
 			from={from}
 			to={to}
 		/>

--- a/ee/admin/src/components/dashboard-cost-by-model.tsx
+++ b/ee/admin/src/components/dashboard-cost-by-model.tsx
@@ -8,7 +8,14 @@ import {
 	getGlobalCostByModelRange,
 } from "@/lib/admin-history";
 
-import type { TokenWindow } from "@/lib/types";
+import type { GlobalStatsModelView, TokenWindow } from "@/lib/types";
+
+const windowOptions: { value: TokenWindow; label: string }[] = [
+	{ value: "7d", label: "7d" },
+	{ value: "30d", label: "30d" },
+	{ value: "90d", label: "90d" },
+	{ value: "365d", label: "365d" },
+];
 
 export function DashboardCostByModel({
 	from,
@@ -17,13 +24,20 @@ export function DashboardCostByModel({
 	from?: string;
 	to?: string;
 }) {
-	const fetchData = useCallback(async (window: TokenWindow) => {
-		return await getGlobalCostByModel(window);
-	}, []);
+	const fetchData = useCallback(
+		async (window: TokenWindow, modelView: GlobalStatsModelView) => {
+			return await getGlobalCostByModel(window, modelView);
+		},
+		[],
+	);
 
 	const fetchDataRange = useCallback(
-		async (rangeFrom: string, rangeTo: string) => {
-			return await getGlobalCostByModelRange(rangeFrom, rangeTo);
+		async (
+			rangeFrom: string,
+			rangeTo: string,
+			modelView: GlobalStatsModelView,
+		) => {
+			return await getGlobalCostByModelRange(rangeFrom, rangeTo, modelView);
 		},
 		[],
 	);
@@ -31,9 +45,11 @@ export function DashboardCostByModel({
 	return (
 		<CostByModelChart
 			title="Cost by Model"
-			description="Top 20 models by cost across all organizations"
+			description="Top 20 by cost across all organizations"
 			fetchData={fetchData}
 			fetchDataRange={fetchDataRange}
+			windowOptions={windowOptions}
+			showModelView
 			from={from}
 			to={to}
 		/>

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -137,45 +137,17 @@ function mapGlobalStatsToCostByModel(
 }
 
 export async function getGlobalCostByModel(
-	window: TokenWindow,
+	from: string | undefined,
+	to: string | undefined,
 	modelView: GlobalStatsModelView = "mapping",
 ) {
 	const $api = await createServerApiClient();
-	const range: "7d" | "30d" | "90d" | "365d" =
-		window === "30d" || window === "90d" || window === "365d" ? window : "7d";
-	const { data } = await $api.GET("/admin/global-stats", {
-		params: { query: { range, modelView, groupBy: "model" } },
-	});
-	return mapGlobalStatsToCostByModel(data, window);
-}
-
-export async function getGlobalCostByModelRange(
-	from: string,
-	to: string,
-	modelView: GlobalStatsModelView = "mapping",
-) {
-	const $api = await createServerApiClient();
-	const { data } = await $api.GET("/admin/global-stats", {
-		params: { query: { from, to, modelView, groupBy: "model" } },
-	});
-	const fromDate = new Date(from);
-	const toDate = new Date(to);
-	const daysDiff = Math.ceil(
-		(toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24),
-	);
-	let window: TokenWindow;
-	if (daysDiff <= 1) {
-		window = "1d";
-	} else if (daysDiff <= 7) {
-		window = "7d";
-	} else if (daysDiff <= 30) {
-		window = "30d";
-	} else if (daysDiff <= 90) {
-		window = "90d";
-	} else {
-		window = "365d";
-	}
-	return mapGlobalStatsToCostByModel(data, window);
+	const query =
+		from && to
+			? { from, to, modelView, groupBy: "model" as const }
+			: { range: "365d" as const, modelView, groupBy: "model" as const };
+	const { data } = await $api.GET("/admin/global-stats", { params: { query } });
+	return mapGlobalStatsToCostByModel(data, "30d");
 }
 
 export async function getOrgCostByModel(orgId: string, window: TokenWindow) {

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -2,7 +2,7 @@
 
 import { createServerApiClient } from "./server-api";
 
-import type { ModelView, TokenWindow } from "./types";
+import type { GlobalStatsModelView, ModelView, TokenWindow } from "./types";
 import type { HistoryWindow } from "@/components/history-chart";
 
 export async function getProviderHistory(
@@ -102,20 +102,63 @@ export async function getMappingDetail(
 	return data ?? null;
 }
 
-export async function getGlobalCostByModel(window: TokenWindow) {
-	const $api = await createServerApiClient();
-	const { data } = await $api.GET("/admin/metrics/cost-by-model", {
-		params: { query: { window } },
-	});
-	return data ?? null;
+function mapGlobalStatsToCostByModel(
+	data:
+		| {
+				totals: { cost: number; requestCount: number };
+				breakdown: {
+					label: string;
+					cost: number;
+					requestCount: number;
+					totalTokens: number;
+				}[];
+		  }
+		| undefined,
+	window: TokenWindow,
+) {
+	if (!data) {
+		return null;
+	}
+	const models = data.breakdown
+		.map((entry) => ({
+			model: entry.label,
+			cost: entry.cost,
+			requestCount: entry.requestCount,
+			totalTokens: entry.totalTokens,
+		}))
+		.sort((a, b) => b.cost - a.cost)
+		.slice(0, 20);
+	return {
+		window,
+		models,
+		totalCost: data.totals.cost,
+		totalRequests: data.totals.requestCount,
+	};
 }
 
-export async function getGlobalCostByModelRange(from?: string, to?: string) {
+export async function getGlobalCostByModel(
+	window: TokenWindow,
+	modelView: GlobalStatsModelView = "mapping",
+) {
 	const $api = await createServerApiClient();
-	const { data } = await $api.GET("/admin/metrics/cost-by-model", {
-		params: { query: { from, to } },
+	const range: "7d" | "30d" | "90d" | "365d" =
+		window === "30d" || window === "90d" || window === "365d" ? window : "7d";
+	const { data } = await $api.GET("/admin/global-stats", {
+		params: { query: { range, modelView, groupBy: "model" } },
 	});
-	return data ?? null;
+	return mapGlobalStatsToCostByModel(data, window);
+}
+
+export async function getGlobalCostByModelRange(
+	from: string,
+	to: string,
+	modelView: GlobalStatsModelView = "mapping",
+) {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/global-stats", {
+		params: { query: { from, to, modelView, groupBy: "model" } },
+	});
+	return mapGlobalStatsToCostByModel(data, "30d");
 }
 
 export async function getOrgCostByModel(orgId: string, window: TokenWindow) {

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -145,7 +145,7 @@ export async function getGlobalCostByModel(
 	const query =
 		from && to
 			? { from, to, modelView, groupBy: "model" as const }
-			: { range: "365d" as const, modelView, groupBy: "model" as const };
+			: { range: "all" as const, modelView, groupBy: "model" as const };
 	const { data } = await $api.GET("/admin/global-stats", { params: { query } });
 	return mapGlobalStatsToCostByModel(data, "30d");
 }

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -158,7 +158,24 @@ export async function getGlobalCostByModelRange(
 	const { data } = await $api.GET("/admin/global-stats", {
 		params: { query: { from, to, modelView, groupBy: "model" } },
 	});
-	return mapGlobalStatsToCostByModel(data, "30d");
+	const fromDate = new Date(from);
+	const toDate = new Date(to);
+	const daysDiff = Math.ceil(
+		(toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24),
+	);
+	let window: TokenWindow;
+	if (daysDiff <= 1) {
+		window = "1d";
+	} else if (daysDiff <= 7) {
+		window = "7d";
+	} else if (daysDiff <= 30) {
+		window = "30d";
+	} else if (daysDiff <= 90) {
+		window = "90d";
+	} else {
+		window = "365d";
+	}
+	return mapGlobalStatsToCostByModel(data, window);
 }
 
 export async function getOrgCostByModel(orgId: string, window: TokenWindow) {

--- a/ee/admin/src/lib/types.ts
+++ b/ee/admin/src/lib/types.ts
@@ -104,6 +104,10 @@ export type CostByModelTimeseriesResponse =
 	GetJsonResponse<"/admin/organizations/{orgId}/cost-by-model-timeseries">;
 export type ModelView = CostByModelTimeseriesResponse["modelView"];
 
+// Global stats
+export type GlobalStatsResponse = GetJsonResponse<"/admin/global-stats">;
+export type GlobalStatsModelView = GlobalStatsResponse["modelView"];
+
 // Model-Provider Mappings
 export type ModelProviderMappingsResponse =
 	GetJsonResponse<"/admin/model-provider-mappings">;


### PR DESCRIPTION
## What

The admin dashboard **Cost by Model** breakdown ("Top 20 by cost across all organizations") now:

- Uses the **global stats endpoint** (`/admin/global-stats`) instead of `/admin/metrics/cost-by-model`.
- Has the same **Mappings / Canonical / Providers** toggle as the Global Stats page, persisted in **URL query state** (`?modelView=`).
- **No longer has its own time-window selector.** It follows the dashboard's top-right **date range picker** (the same `from`/`to` that drive every other card on the page).
- Shows **true all-time** data when the picker is on "All time" (no `from`/`to`), so its totals span the same range as the all-time `/admin/metrics` figures next to it — instead of silently truncating to the last year.

## How

- `apps/api` `/admin/global-stats`: added an explicit `range=all` mode that derives the span from the first/last recorded `dayTimestamp` and skips the 731-day cap, so all-time requests aggregate the full history. Bounded windows (`7d/30d/90d/365d`, custom `from`/`to`) are unchanged and still capped.
- `admin-history.ts`: a single `getGlobalCostByModel(from, to, modelView)` calls `/admin/global-stats` (with `groupBy=model` + the selected `modelView`) and maps its `breakdown` + `totals` into the existing `CostByModelData` shape (top 20 by cost). No `from`/`to` → `range=all`.
- `cost-by-model-chart.tsx`: removed the internal window selector; added `forceRange`, a controllable `modelView` + `onModelViewChange`, and the `showModelView` toggle (matching Global Stats styling); kept the async race guard. `fetchData` is now optional.
- `dashboard-cost-by-model.tsx`: reads/writes `modelView` via `useSearchParams` + `router.replace`, passes the parent `from`/`to`, enables `forceRange`/`showModelView`.
- `types.ts`: added `GlobalStatsModelView` (the existing `ModelView` is only `mapping`/`canonical`; global stats also supports `provider`).

The shared `CostByModelChart` stays backward compatible — the per-org Cost by Model view is unchanged (its own `?window=` selector, no model-view toggle).

## Testing

- `pnpm turbo run build --filter=api --filter=admin` ✅
- `pnpm format` / `prettier --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a model-view selector to the cost-by-model chart, allowing users to switch breakdown perspectives.
  * Updated the chart’s model view to persist via a URL query parameter and stay in sync with the chart.
  * Extended the global stats endpoint to support all-time queries (`range=all`).
* **Bug Fixes**
  * Fixed stale/out-of-order async chart loads by ignoring outdated responses.
* **UI/Improvements**
  * Refreshed the chart header layout and clarified the description text.
  * Simplified time/window selection so the chart uses the externally provided window by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->