### PR TITLE
fix(security): patch js-yaml DoS via gray-matter

### DIFF
--- a/infra/split.dockerfile
+++ b/infra/split.dockerfile
@@ -57,6 +57,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=api... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=api
@@ -67,6 +68,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=gateway... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=gateway
@@ -77,6 +79,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=ui... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=ui
@@ -87,6 +90,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=playground... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=playground
@@ -97,6 +101,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=worker... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=worker
@@ -107,6 +112,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=docs... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=docs
@@ -117,6 +123,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=admin... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=admin
@@ -127,6 +134,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --parents packages/**/package.json .
 COPY --parents apps/**/package.json .
 COPY --parents ee/**/package.json .
+COPY patches/ ./patches/
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm --filter=code... install --frozen-lockfile
 COPY . .
 RUN --mount=type=cache,target=/app/.turbo pnpm run build --filter=code

--- a/infra/unified.dockerfile
+++ b/infra/unified.dockerfile
@@ -84,6 +84,7 @@ COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY --parents packages/*/package.json .
 COPY --parents apps/*/package.json .
 COPY --parents ee/*/package.json .
+COPY patches/ ./patches/
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
 			"brace-expansion@>=2 <2.0.3": "^2.0.3",
 			"brace-expansion@>=5 <5.0.6": "^5.0.6",
 			"mermaid@>=11 <11.15.0": "^11.15.0",
-			"js-yaml@>=3 <3.14.2": "^3.14.2",
-			"js-yaml@>=4 <=4.1.1": "^4.2.0",
+			"js-yaml@<4.2.0": "^4.2.0",
 			"mdast-util-to-hast@>=13 <13.2.1": "^13.2.1",
 			"ajv@>=6 <6.14.0": "^6.14.0",
 			"@tootallnate/once@<2.0.1": "^2.0.1",
@@ -125,6 +124,9 @@
 					"zod": "*"
 				}
 			}
+		},
+		"patchedDependencies": {
+			"gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch"
 		}
 	},
 	"dependencies": {

--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,18 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index eebdf42eb721b756d4f554b09b943774faa659b0..0000000000000000000000000000000000000000
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..bba7b012fb901eb37498cb953a34cfdc44098fd7 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,8 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  parse: (yaml.load || yaml.safeLoad).bind(yaml),
++  stringify: (yaml.dump || yaml.safeDump).bind(yaml)
+ };
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,7 @@ overrides:
   brace-expansion@>=2 <2.0.3: ^2.0.3
   brace-expansion@>=5 <5.0.6: ^5.0.6
   mermaid@>=11 <11.15.0: ^11.15.0
-  js-yaml@>=3 <3.14.2: ^3.14.2
-  js-yaml@>=4 <=4.1.1: ^4.2.0
+  js-yaml@<4.2.0: ^4.2.0
   mdast-util-to-hast@>=13 <13.2.1: ^13.2.1
   ajv@>=6 <6.14.0: ^6.14.0
   '@tootallnate/once@<2.0.1': ^2.0.1
@@ -52,6 +51,11 @@ overrides:
   '@babel/core@<=7.29.0': ^7.29.6
 
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
+
+patchedDependencies:
+  gray-matter@4.0.3:
+    hash: 5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc
+    path: patches/gray-matter@4.0.3.patch
 
 importers:
 
@@ -6137,9 +6141,6 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -7612,11 +7613,6 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -8799,10 +8795,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -11072,9 +11064,6 @@ packages:
   split@0.3.3:
     resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -12802,7 +12791,7 @@ snapshots:
       camelcase: 8.0.0
       chokidar: 4.0.3
       esbuild: 0.28.1
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc)
       p-limit: 6.2.0
       picomatch: 4.0.4
       pluralize: 8.0.0
@@ -17247,10 +17236,6 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   argv-formatter@1.0.0: {}
@@ -18988,8 +18973,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
-  esprima@4.0.1: {}
-
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -19709,9 +19692,9 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc):
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -20343,11 +20326,6 @@ snapshots:
   js-md4@0.3.2: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -22997,8 +22975,6 @@ snapshots:
   split@0.3.3:
     dependencies:
       through: 2.3.8
-
-  sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
 


### PR DESCRIPTION
## Summary

Audit and remediation of open Dependabot security alerts.

I scanned the full resolved dependency tree (2096 packages) and all GitHub Actions against the GitHub Advisory Database (via OSV, the same source that powers Dependabot), and cross-checked with `pnpm audit`.

**Result: there are no open high or critical vulnerabilities.** The 45 existing `pnpm.overrides` already remediate every previously-flagged high/critical advisory. GitHub's own push response confirms the same — the default branch currently has exactly **1 moderate** alert and **0 high / 0 critical** ([alert #316](https://github.com/theopenco/llmgateway/security/dependabot/316)).

This PR fixes that one remaining alert so the dependency tree is fully clean.

## The fix

**`GHSA-h67p-54hq-rp68` / `CVE-2026-53550`** — js-yaml: quadratic-complexity DoS in merge-key handling via repeated aliases. Affects all `js-yaml < 4.2.0`. It was reaching the tree as `js-yaml@3.14.2`, pulled transitively by `gray-matter@4.0.3` (via `@content-collections/core` in `apps/code`).

- Replaced the two narrower js-yaml overrides with a single `js-yaml@<4.2.0: ^4.2.0`, forcing **all** js-yaml (including gray-matter's 3.x) up to the patched `4.2.0`.
- `gray-matter@4.0.3` calls `yaml.safeLoad` / `yaml.safeDump`, which were removed in js-yaml 4.x, so it's patched (`patches/gray-matter@4.0.3.patch`) to use `yaml.load` / `yaml.dump` with a fallback to the legacy names. `patchedDependencies` wires the patch in.
- Dockerfiles (`infra/split.dockerfile`, `infra/unified.dockerfile`) now `COPY patches/` before each `pnpm install --frozen-lockfile` so patched installs don't fail with ENOENT in CI/image builds.

## Verification

- `pnpm audit` → **No known vulnerabilities found** (was: 1 moderate)
- Full OSV re-scan of the resolved tree → **0 vulnerable packages**
- gray-matter runtime check: parses YAML frontmatter correctly on js-yaml 4.2.0
- `pnpm format` ✓ &nbsp; `pnpm build` ✓ (17/17) &nbsp; `pnpm test:unit` ✓ (2179 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kGqfr3UZhb6HZMyceVpmj

---
_Generated by [Claude Code](https://claude.ai/code/session_017kGqfr3UZhb6HZMyceVpmj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Included patch files in build images so installs and builds can complete correctly across services.
  * Improved compatibility with newer YAML-related dependencies, reducing build/runtime issues.
* **Chores**
  * Updated dependency pinning to use a single version range for one YAML package.
  * Added support for applying a package patch during installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->