### PR TITLE
fix(zai): map content filter + drop temperature

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -84,13 +84,13 @@ describe("getFinishReasonFromError", () => {
 		expect(getFinishReasonFromError(400, alibabaError)).toBe("content_filter");
 	});
 
-	it("returns client_error for zai content filter", () => {
+	it("returns content_filter for zai content filter", () => {
 		expect(
 			getFinishReasonFromError(
 				400,
 				"System detected potentially unsafe or sensitive content in input or generation",
 			),
-		).toBe("client_error");
+		).toBe("content_filter");
 	});
 
 	it("returns client_error for OpenAI JSON format validation error", () => {

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -92,15 +92,6 @@ export function getFinishReasonFromError(
 		return "gateway_error";
 	}
 
-	// zai content filter
-	if (
-		errorText?.includes(
-			"System detected potentially unsafe or sensitive content in input or generation",
-		)
-	) {
-		return "client_error";
-	}
-
 	// Check for specific client validation errors from providers
 	if (statusCode === 400 && errorText) {
 		// OpenAI JSON format validation error

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -998,6 +998,26 @@ export const zaiModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+				// zai rejects temperature outside [0,1] with a 400 ("The temperature
+				// parameter is illegal"). Exclude it so out-of-range values are stripped
+				// instead of failing the request.
+				supportedParameters: [
+					"messages",
+					"model",
+					"stream",
+					"stream_options",
+					"top_p",
+					"max_tokens",
+					"max_completion_tokens",
+					"seed",
+					"stop",
+					"response_format",
+					"tools",
+					"tool_choice",
+					"parallel_tool_calls",
+					"reasoning",
+					"reasoning_effort",
+				],
 			},
 		],
 	},

--- a/packages/shared/src/content-filter.spec.ts
+++ b/packages/shared/src/content-filter.spec.ts
@@ -35,6 +35,14 @@ describe("isContentFilterErrorText", () => {
 		).toBe(true);
 	});
 
+	test("detects Z.AI / Zhipu GLM content moderation (code 1301)", () => {
+		expect(
+			isContentFilterErrorText(
+				"System detected potentially unsafe or sensitive content in input or generation. Please avoid using prompts that may generate sensitive content.",
+			),
+		).toBe(true);
+	});
+
 	test("returns false for generic upstream errors and empty input", () => {
 		expect(isContentFilterErrorText("Internal server error")).toBe(false);
 		expect(isContentFilterErrorText("the task id was not found")).toBe(false);

--- a/packages/shared/src/content-filter.ts
+++ b/packages/shared/src/content-filter.ts
@@ -10,6 +10,8 @@
  * - Alibaba / DashScope: `data_inspection_failed`, `Green net check failed`
  *   (Wan video green-net moderation)
  * - OpenAI safety system (e.g. Sora / gpt-image): `rejected by the safety system`
+ * - Z.AI / Zhipu (GLM, code 1301): `System detected potentially unsafe or
+ *   sensitive content in input or generation`
  */
 const CONTENT_FILTER_ERROR_SIGNALS = [
 	"ResponsibleAIPolicyViolation",
@@ -19,6 +21,7 @@ const CONTENT_FILTER_ERROR_SIGNALS = [
 	"Green net check failed",
 	"Microsoft's content management policy",
 	"Your request was rejected by the safety system",
+	"System detected potentially unsafe or sensitive content in input or generation",
 ];
 
 /**


### PR DESCRIPTION
## What

Fixes two recurring Z.AI (GLM) error classes surfaced in the error dashboard.

### 1. Content filter misclassification (code 1301)

Z.AI returns a 400 with `{"error":{"code":"1301","message":"System detected potentially unsafe or sensitive content in input or generation..."}}` for moderation blocks. This was special-cased as `client_error`, inconsistent with every other provider's moderation block.

- Added the `1301` message to the shared `CONTENT_FILTER_ERROR_SIGNALS` so `isContentFilterErrorText` detects it.
- Removed the bespoke `client_error` branch in `get-finish-reason-from-error.ts`; it now resolves to `content_filter` like Azure/ByteDance/Alibaba/OpenAI, so it routes and reports consistently.

### 2. Illegal temperature on `glm-4.6v-flash` (code 1210)

Z.AI rejects `temperature` outside `[0,1]` with `400 "The temperature parameter is illegal.：限制数值范围[0,1]"`. Added a `supportedParameters` list to the `glm-4.6v-flash` zai mapping that omits `temperature`, so out-of-range values are stripped instead of failing the request.

## Not addressed (upstream/client issues, not fixable here)

- `1305` / `1302` (429 overload / rate limit) — upstream capacity, already classified as `upstream_error`.
- `1210` image parse error (`图片输入格式/解析错误`) — malformed client image input.
- `HeadersTimeoutError` — upstream latency.

## Tests

- `content-filter.spec.ts`: added a case for the 1301 signal.
- `get-finish-reason-from-error.spec.ts`: updated zai expectation to `content_filter`.
- `pnpm format` + gateway/models/shared builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so more content-safety and invalid-request responses are classified correctly.
  * Added support for an additional content-filter message pattern, including Z.AI/Zhipu GLM moderation errors.
  * Updated model capabilities so a supported model no longer advertises an unsupported parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->