### PR TITLE
feat(admin): add 10k/100k/1m max-log tiers

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7789,7 +7789,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 // via a fallback provider, so they should not count against a mapping's
 // stability — but callers can opt to include them via `includeRetried`.
 const UNSTABLE_MAPPINGS_DEFAULT_LOG_LIMIT = 100;
-const UNSTABLE_MAPPINGS_MAX_LOG_LIMIT = 10000;
+const UNSTABLE_MAPPINGS_MAX_LOG_LIMIT = 1000000;
 
 // Supported time windows for the rankings, mapping each selectable value to its
 // SQL interval bound and an hours count surfaced to the UI for the description.

--- a/ee/admin/src/lib/unstable-mappings-params.ts
+++ b/ee/admin/src/lib/unstable-mappings-params.ts
@@ -26,13 +26,16 @@ export function parseUnstableWindow(value: string | undefined): UnstableWindow {
 }
 
 export const UNSTABLE_LOG_LIMIT_DEFAULT = 100;
-export const UNSTABLE_LOG_LIMIT_MAX = 10000;
+export const UNSTABLE_LOG_LIMIT_MAX = 1000000;
 
 export const UNSTABLE_LOG_LIMIT_OPTIONS: { value: string; label: string }[] = [
 	{ value: "100", label: "100" },
 	{ value: "500", label: "500" },
 	{ value: "1000", label: "1,000" },
 	{ value: "5000", label: "5,000" },
+	{ value: "10000", label: "10k" },
+	{ value: "100000", label: "100k" },
+	{ value: "1000000", label: "1m" },
 ];
 
 // Accepts any value in [1, MAX] so hand-crafted dashboard links work, snapping


### PR DESCRIPTION
## Summary

Expands the **Max logs** sample selector on the admin **Unstable Mappings** page with three larger tiers — **10k**, **100k**, and **1m** — on top of the existing 100 / 500 / 1,000 / 5,000 options.

## Changes

- `ee/admin/src/lib/unstable-mappings-params.ts` — add `10000` / `100000` / `1000000` options to `UNSTABLE_LOG_LIMIT_OPTIONS` and raise `UNSTABLE_LOG_LIMIT_MAX` from `10000` to `1000000`.
- `apps/api/src/routes/admin.ts` — raise the backend `UNSTABLE_MAPPINGS_MAX_LOG_LIMIT` cap from `10000` to `1000000` so the new tiers validate (used by both the `/unstable-mappings` and `/unstable-mappings/errors` routes).

## Notes

The selector is URL-driven (`?logLimit=`), so the larger tiers are also reachable via shared/bookmarked dashboard links. Larger sample caps run heavier aggregation queries, but this is an admin-only diagnostic view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the available log limit choices for unstable mappings, adding higher options up to 1 million.
  * Increased the maximum supported log limit for unstable mappings requests, allowing much larger result sets.

* **Bug Fixes**
  * Updated validation so the admin unstable mappings pages accept the new higher limit values consistently across related views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->