### PR TITLE
fix(gateway): don't error on empty length-limited response

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -60,6 +60,7 @@ import {
 	calculateDataStorageCost,
 	getUnifiedFinishReason,
 	isContentFilterFinishReason,
+	isLengthLimitFinishReason,
 	insertLog as _insertLog,
 } from "@/lib/logs.js";
 import {
@@ -9538,12 +9539,20 @@ chat.openapi(completions, async (c) => {
 						finishReason,
 						usedProvider,
 					);
+					// A length-limit finish reason (e.g. a tiny `max_tokens`) can
+					// legitimately produce no content, so treat an empty response in
+					// that case as expected rather than an upstream error.
+					const isLengthLimitStreamingResponse = isLengthLimitFinishReason(
+						finishReason,
+						usedProvider,
+					);
 					const hasEmptyResponse =
 						!streamingError &&
 						!hasUpstreamErrorFinishReason &&
 						finishReason &&
 						finishReason !== "incomplete" &&
 						!isContentFilterStreamingResponse &&
+						!isLengthLimitStreamingResponse &&
 						(!calculatedCompletionTokens || calculatedCompletionTokens === 0) &&
 						(!calculatedReasoningTokens || calculatedReasoningTokens === 0) &&
 						(!fullContent || fullContent.trim() === "") &&
@@ -12119,10 +12128,18 @@ chat.openapi(completions, async (c) => {
 		finishReason,
 		usedProvider,
 	);
+	// A length-limit finish reason (e.g. a tiny `max_tokens`) can legitimately
+	// produce no content at all, so an empty response in that case is expected
+	// behavior rather than an upstream error.
+	const isLengthLimitResponse = isLengthLimitFinishReason(
+		finishReason,
+		usedProvider,
+	);
 	const hasEmptyNonStreamingResponse =
 		!!finishReason &&
 		finishReason !== "incomplete" &&
 		!isContentFilterResponse &&
+		!isLengthLimitResponse &&
 		!hasMeaningfulAssistantOutput({
 			completionTokens: calculatedCompletionTokens,
 			reasoningTokens: calculatedReasoningTokens,

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -7,6 +7,7 @@ import {
 	getUnifiedFinishReason,
 	isContentFilterFinishReason,
 	isExpectedUnknownFinishReason,
+	isLengthLimitFinishReason,
 } from "./logs.js";
 
 describe("getUnifiedFinishReason", () => {
@@ -289,6 +290,29 @@ describe("isContentFilterFinishReason", () => {
 
 	it("returns true for OpenAI content filters", () => {
 		expect(isContentFilterFinishReason("content_filter", "openai")).toBe(true);
+	});
+});
+
+describe("isLengthLimitFinishReason", () => {
+	it("returns true for Google MAX_TOKENS (e.g. tiny max_tokens)", () => {
+		expect(isLengthLimitFinishReason("MAX_TOKENS", "google-ai-studio")).toBe(
+			true,
+		);
+		expect(isLengthLimitFinishReason("MAX_TOKENS", "google-vertex")).toBe(true);
+	});
+
+	it("returns true for OpenAI length finish reason", () => {
+		expect(isLengthLimitFinishReason("length", "openai")).toBe(true);
+	});
+
+	it("returns true for Anthropic max_tokens finish reason", () => {
+		expect(isLengthLimitFinishReason("max_tokens", "anthropic")).toBe(true);
+	});
+
+	it("returns false for normal stop finish reasons", () => {
+		expect(isLengthLimitFinishReason("STOP", "google-ai-studio")).toBe(false);
+		expect(isLengthLimitFinishReason("stop", "openai")).toBe(false);
+		expect(isLengthLimitFinishReason(null, "openai")).toBe(false);
 	});
 });
 

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -194,6 +194,23 @@ export function isContentFilterFinishReason(
 }
 
 /**
+ * Whether the finish reason indicates the model stopped because it reached the
+ * token limit (e.g. a small `max_tokens`). With a tiny limit (such as
+ * `max_tokens: 1`) providers like Google can legitimately return no content at
+ * all, so an empty response with this finish reason is expected behavior, not an
+ * upstream error.
+ */
+export function isLengthLimitFinishReason(
+	finishReason: string | null | undefined,
+	provider: string | null | undefined,
+): boolean {
+	return (
+		getUnifiedFinishReason(finishReason, provider) ===
+		UnifiedFinishReason.LENGTH_LIMIT
+	);
+}
+
+/**
  * Map unified finish reason to an error type for metrics (if applicable)
  */
 function getErrorTypeFromUnifiedFinishReason(


### PR DESCRIPTION
## Problem

A request with a tiny `max_tokens` (e.g. `max_tokens: 1`) to `gemini-pro-latest` (and other Google models) was being returned to the client as a **500 "Empty Response"** upstream error:

```json
{"statusCode":500,"statusText":"Empty Response","responseText":"Response finished successfully but returned no content or tool calls"}
```

### Root cause

With `max_tokens: 1`, Google exhausts the token budget immediately and returns `finishReason: MAX_TOKENS` with **zero completion tokens, zero reasoning tokens, and empty content**. The gateway's empty-response detection (both the streaming and non-streaming paths in `chat.ts`) treats any finished response with no meaningful output as an upstream error — so it rewrote the finish reason to `upstream_error`, set `hasError: true`, and surfaced a 500.

This is wrong: hitting the token limit before emitting any content is **expected** behavior. OpenAI, for the same request, simply returns `200` with `finish_reason: "length"` and empty content.

## Fix

Exclude length-limit finish reasons from the empty-response error check, mirroring the existing content-filter exclusion. Added an `isLengthLimitFinishReason` helper (built on the existing `getUnifiedFinishReason` mapping, which already maps `MAX_TOKENS` / `max_tokens` / `length` → `LENGTH_LIMIT` across providers) and applied it in both the streaming and non-streaming checks.

The client now receives the OpenAI-compatible result: `200` with `finish_reason: "length"` (already mapped via `mapFinishReasonToOpenai`) and empty content, and the log records `hasError: false`.

## Testing

- Added unit tests for `isLengthLimitFinishReason` covering Google `MAX_TOKENS`, OpenAI `length`, Anthropic `max_tokens`, and negative cases (`logs.spec.ts`, 32 tests pass).
- `pnpm turbo run build --filter=gateway` passes.
- `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of length-limited model responses so they are no longer misclassified as empty errors.
  * Applied the same correction for both streaming and non-streaming chat responses.
* **Tests**
  * Added coverage for finish-reason handling across multiple providers, including length-limit and normal stop cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->