### PR TITLE
fix(bedrock): handle deprecated params for Opus 4.8

### DIFF
--- a/packages/actions/src/prepare-request-body.adaptive.spec.ts
+++ b/packages/actions/src/prepare-request-body.adaptive.spec.ts
@@ -88,3 +88,66 @@ describe("prepareRequestBody - adaptive thinking (Opus 4.6/4.7/4.8)", () => {
 		});
 	});
 });
+
+interface BedrockAdaptiveBody {
+	additionalModelRequestFields?: {
+		thinking?: { type: "adaptive" | "enabled"; display?: string };
+		output_config?: { effort?: string };
+	};
+	inferenceConfig?: { temperature?: number; topP?: number; maxTokens?: number };
+}
+
+async function buildBedrockBody(opts: {
+	effort?: "low" | "medium" | "high";
+	reasoning_effort?: "low" | "medium" | "high" | "xhigh";
+	temperature?: number;
+	top_p?: number;
+}): Promise<BedrockAdaptiveBody> {
+	return (await prepareRequestBody(
+		"aws-bedrock",
+		"claude-opus-4-8",
+		"global",
+		"anthropic.claude-opus-4-8",
+		[{ role: "user", content: "hi" }],
+		false, // stream
+		opts.temperature, // temperature
+		undefined, // max_tokens
+		opts.top_p, // top_p
+		undefined, // frequency_penalty
+		undefined, // presence_penalty
+		undefined, // response_format
+		undefined, // tools
+		undefined, // tool_choice
+		opts.reasoning_effort, // reasoning_effort
+		true, // supportsReasoning
+		false, // isProd
+		20, // maxImageSizeMB
+		null, // userPlan
+		undefined, // sensitive_word_check
+		undefined, // image_config
+		opts.effort, // effort
+	)) as BedrockAdaptiveBody;
+}
+
+describe("prepareRequestBody - Bedrock Opus 4.8 deprecated params", () => {
+	test("top-level effort activates adaptive thinking without temperature", async () => {
+		const body = await buildBedrockBody({ effort: "high" });
+		expect(body.additionalModelRequestFields?.thinking).toEqual({
+			type: "adaptive",
+			display: "summarized",
+		});
+		expect(body.additionalModelRequestFields?.output_config?.effort).toBe(
+			"high",
+		);
+		// temperature is deprecated for Opus 4.8 and must not be forced to 1.
+		expect(body.inferenceConfig?.temperature).toBeUndefined();
+	});
+
+	test("reasoning_effort does not force the deprecated temperature", async () => {
+		const body = await buildBedrockBody({ reasoning_effort: "high" });
+		expect(body.additionalModelRequestFields?.output_config?.effort).toBe(
+			"high",
+		);
+		expect(body.inferenceConfig?.temperature).toBeUndefined();
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2498,7 +2498,10 @@ export async function prepareRequestBody(
 			}
 
 			// Enable thinking for Bedrock Anthropic models when reasoning is supported
-			if (supportsReasoning && (reasoning_effort || reasoning_max_tokens)) {
+			if (
+				supportsReasoning &&
+				(effort || reasoning_effort || reasoning_max_tokens)
+			) {
 				if (providerMappingForOptions?.reasoningMode === "adaptive") {
 					// Opus 4.7+ uses adaptive thinking: `thinking: { type: "adaptive" }` with
 					// `output_config.effort` controlling depth. `budget_tokens` is rejected.
@@ -2581,8 +2584,18 @@ export async function prepareRequestBody(
 						inferenceConfig.maxTokens = reasoningFloor;
 					}
 				}
-				// Anthropic requires temperature to be exactly 1 when thinking is enabled
-				inferenceConfig.temperature = 1;
+				// Anthropic requires temperature to be exactly 1 when thinking is
+				// enabled — but only for models that still accept temperature. Opus
+				// 4.8 deprecated temperature/top_p and returns a 400 for any value,
+				// so honor the mapping's supportedParameters and omit it there.
+				const bedrockSupportedParams =
+					providerMappingForOptions?.supportedParameters;
+				if (
+					!bedrockSupportedParams ||
+					bedrockSupportedParams.includes("temperature")
+				) {
+					inferenceConfig.temperature = 1;
+				}
 				if (Object.keys(inferenceConfig).length > 0) {
 					requestBody.inferenceConfig = inferenceConfig;
 				}

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -1243,8 +1243,11 @@ export const anthropicModels = [
 				tools: true,
 				// `temperature` and `top_p` are deprecated for Opus 4.8 on Bedrock
 				// and rejected with a 400, so they are omitted here to strip them
-				// from forwarded requests.
-				supportedParameters: ["max_tokens", "effort"],
+				// from forwarded requests. `effort` is intentionally excluded: the
+				// Bedrock Converse builder only honors it alongside
+				// reasoning_effort/reasoning_max_tokens, so advertising it would
+				// silently ignore effort-only requests instead of returning a 400.
+				supportedParameters: ["max_tokens"],
 				regions: [
 					{ id: "global" },
 					{ id: "us" },

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -1241,6 +1241,10 @@ export const anthropicModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
+				// `temperature` and `top_p` are deprecated for Opus 4.8 on Bedrock
+				// and rejected with a 400, so they are omitted here to strip them
+				// from forwarded requests.
+				supportedParameters: ["max_tokens", "effort"],
 				regions: [
 					{ id: "global" },
 					{ id: "us" },

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -1242,12 +1242,10 @@ export const anthropicModels = [
 				vision: true,
 				tools: true,
 				// `temperature` and `top_p` are deprecated for Opus 4.8 on Bedrock
-				// and rejected with a 400, so they are omitted here to strip them
-				// from forwarded requests. `effort` is intentionally excluded: the
-				// Bedrock Converse builder only honors it alongside
-				// reasoning_effort/reasoning_max_tokens, so advertising it would
-				// silently ignore effort-only requests instead of returning a 400.
-				supportedParameters: ["max_tokens"],
+				// and rejected with a 400, so they are excluded here to strip them
+				// from forwarded requests. `effort` drives adaptive thinking via the
+				// Bedrock Converse builder (output_config.effort).
+				supportedParameters: ["max_tokens", "effort"],
 				regions: [
 					{ id: "global" },
 					{ id: "us" },


### PR DESCRIPTION
## Problem

AWS Bedrock returns 400s for `claude-opus-4-8` requests:

- `` `temperature` is deprecated for this model. `` (59×)
- `` `top_p` is deprecated for this model. `` (29×)

Anthropic deprecated `temperature` and `top_p` for Opus 4.8 on Bedrock. Two paths were affected:

1. **Plain requests** — the gateway forwarded `temperature`/`top_p` straight through.
2. **Reasoning requests** — the Bedrock Converse builder forced `inferenceConfig.temperature = 1` whenever thinking was enabled, so even `reasoning_effort` requests to `bedrock/claude-opus-4-8` 400'd. It also only entered the thinking branch on `reasoning_effort`/`reasoning_max_tokens`, ignoring the top-level `effort` parameter.

## Fix

- **`packages/models/src/models/anthropic.ts`** — set `supportedParameters: ["max_tokens", "effort"]` on the `aws-bedrock` mapping. The gateway already strips any sampling param not in this list before building the request body (`chat.ts:5779`), so `temperature`/`top_p` are dropped from forwarded requests.
- **`packages/actions/src/prepare-request-body.ts`** — the Bedrock Converse builder now:
  - enters adaptive thinking when top-level `effort` is set (not just `reasoning_effort`/`reasoning_max_tokens`), and
  - skips the forced `temperature = 1` when the mapping's `supportedParameters` excludes `temperature` (only Opus 4.8 today — older models keep the existing behavior).
- **Tests** — added Bedrock coverage in `prepare-request-body.adaptive.spec.ts` asserting Opus 4.8 builds adaptive thinking from both `effort` and `reasoning_effort` without emitting the deprecated `temperature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bedrock-hosted Claude request preparation to avoid sending unsupported/deprecated parameters, reducing the chance of rejected requests.
  * Updated thinking/reasoning behavior to correctly activate adaptive thinking when effort options are provided, and to no longer force temperature when it’s not supported.
* **Tests**
  * Added coverage for Bedrock-specific deprecated-parameter handling and adaptive thinking request shaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->