### PR TITLE
feat(api): email invoice on DevPass upgrade

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -14,6 +14,7 @@ import {
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
+	DEV_PLAN_PRICES,
 	getChatPlanCreditsLimit,
 	getDevPlanCreditsLimit,
 	type ChatPlanCycle,
@@ -3315,6 +3316,26 @@ export async function handleInvoicePaymentSucceeded(event: {
 		// `dev_plan_upgrade` transaction (change-tier deliberately does not record
 		// one for upgrades, to avoid double-counting). We do NOT reset
 		// `devPlanCreditsUsed` or grant a fresh allotment.
+		//
+		// Resolve the tier from the invoice's subscription metadata rather than
+		// `organization.devPlan`: change-tier asks Stripe to invoice immediately
+		// and only writes the new tier to the DB afterward, so this proration
+		// webhook can race ahead of that write and observe the pre-upgrade tier.
+		// change-tier sets the subscription's `metadata.devPlan` to the new tier
+		// before the proration invoice is created, so the invoice payload itself
+		// carries the authoritative tier — no extra Stripe round-trip needed.
+		// Fall back to the cached tier if the metadata is missing/unrecognized.
+		const invoiceSubscriptionMetadata =
+			invoice.parent?.subscription_details?.metadata ?? undefined;
+		const metadataTier = invoiceSubscriptionMetadata?.devPlan as
+			| DevPlanTier
+			| undefined;
+		const upgradedTier: DevPlanTier | undefined =
+			metadataTier && metadataTier in DEV_PLAN_PRICES
+				? metadataTier
+				: (organization.devPlan ?? undefined);
+		const upgradedTierLabel = upgradedTier?.toUpperCase();
+
 		const [upgradeTransaction] = await db
 			.insert(tables.transaction)
 			.values({
@@ -3325,7 +3346,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 				status: "completed",
 				stripePaymentIntentId: (invoice as any).payment_intent,
 				stripeInvoiceId: invoice.id,
-				description: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade`,
+				description: `Dev Plan ${upgradedTierLabel} upgrade`,
 			})
 			.returning();
 
@@ -3338,7 +3359,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 				...billingDetails,
 				lineItems: [
 					{
-						description: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade (prorated)`,
+						description: `Dev Plan ${upgradedTierLabel} upgrade (prorated)`,
 						amount: invoice.amount_paid / 100,
 					},
 				],

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3315,16 +3315,41 @@ export async function handleInvoicePaymentSucceeded(event: {
 		// `dev_plan_upgrade` transaction (change-tier deliberately does not record
 		// one for upgrades, to avoid double-counting). We do NOT reset
 		// `devPlanCreditsUsed` or grant a fresh allotment.
-		await db.insert(tables.transaction).values({
-			organizationId,
-			type: "dev_plan_upgrade",
-			amount: (invoice.amount_paid / 100).toString(),
-			currency: invoice.currency.toUpperCase(),
-			status: "completed",
-			stripePaymentIntentId: (invoice as any).payment_intent,
-			stripeInvoiceId: invoice.id,
-			description: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade`,
-		});
+		const [upgradeTransaction] = await db
+			.insert(tables.transaction)
+			.values({
+				organizationId,
+				type: "dev_plan_upgrade",
+				amount: (invoice.amount_paid / 100).toString(),
+				currency: invoice.currency.toUpperCase(),
+				status: "completed",
+				stripePaymentIntentId: (invoice as any).payment_intent,
+				stripeInvoiceId: invoice.id,
+				description: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade`,
+			})
+			.returning();
+
+		try {
+			const billingDetails = await resolveDevPassBillingDetails(organization);
+			await generateAndEmailInvoice({
+				invoiceNumber: upgradeTransaction.id,
+				invoiceDate: new Date(),
+				organizationName: organization.name,
+				...billingDetails,
+				lineItems: [
+					{
+						description: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade (prorated)`,
+						amount: invoice.amount_paid / 100,
+					},
+				],
+				currency: invoice.currency.toUpperCase(),
+			});
+		} catch (e) {
+			logger.error(
+				"Invoice email failed (DevPass upgrade proration invoice); suppressing failure",
+				e as Error,
+			);
+		}
 
 		logger.info(
 			`Recorded dev plan upgrade proration invoice for organization ${organizationId}; credits left unchanged`,


### PR DESCRIPTION
## What

DevPass plan changes with **prorated billing** (mid-cycle upgrades) now send a customer-facing invoice email, matching renewals and initial activation, and the email names the **tier the customer actually upgraded to**.

## Why

Previously only DevPass **renewals** (`subscription_cycle`) and initial activation emailed a PDF invoice via Resend. A mid-cycle **upgrade** charges a prorated amount immediately (`proration_behavior: "always_invoice"`) but its `subscription_update` proration invoice only recorded a `dev_plan_upgrade` transaction — the customer got charged with no invoice email.

## How

In the `subscription_update` branch of `handleInvoicePaymentSucceeded` (`apps/api/src/stripe.ts`), record the upgrade transaction and call the existing `generateAndEmailInvoice` helper, resolving billing details through `resolveDevPassBillingDetails(organization)` — the same path renewals use — so the same org billing defaults/overrides apply.

**Tier source:** `change-tier` asks Stripe to invoice immediately and only writes the new `organization.devPlan` to the DB afterward, so this webhook can race ahead of that write and read the *pre-upgrade* tier (emailing e.g. "Dev Plan LITE upgrade" for a lite→pro charge). The tier is therefore resolved from the invoice's subscription metadata (`invoice.parent.subscription_details.metadata.devPlan`, set by `change-tier` before the proration invoice is created) — carried in the webhook payload, so no extra Stripe round-trip. Falls back to the cached tier if metadata is missing.

Notes:
- Reuses the shared invoice logic; no new email/PDF code.
- Zero-amount prorations are skipped automatically by `generateAndEmailInvoice` (existing `total === 0` guard).
- Downgrades use `proration_behavior: "none"` (no charge, no proration invoice), so they intentionally remain email-free.

## Testing

Verified end-to-end against the Stripe sandbox (real upgrade → proration `invoice.payment_succeeded` webhook → handler): invoice email generated with correct prorated amount and **upgraded** tier label, single `dev_plan_upgrade` transaction recorded, billing recipient resolved via the shared org-billing path. Confirmed the tier resolves to the upgraded value even when the local `organization.devPlan` write is still stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)