### PR TITLE
feat(ui): add monetization & showcase templates

### DIFF
--- a/apps/docs/content/guides/cli.mdx
+++ b/apps/docs/content/guides/cli.mdx
@@ -412,12 +412,18 @@ npx @llmgateway/cli credits [--org <id>] [--json]
 
 ### Web Applications
 
+- **`embeddable-credits`** — Monetize your AI app in 5 minutes. End-user wallets and in-app credit purchases ("Stripe for AI") with the embeddable SDK.
 - **`image-generation`** — Full-stack AI image generation app (Next.js 16, React 19). Multi-provider support with a unified API.
 - **`ai-chatbot`** — AI chatbot with streaming responses.
 - **`og-image-generator`** — AI-powered OG image generator.
 - **`feedback-dashboard`** — Customer feedback sentiment dashboard.
 - **`writing-assistant`** — AI writing assistant with text actions.
 - **`qa-agent`** — AI-powered QA testing agent with browser automation, real-time action timeline, and live browser preview.
+- **`showcase`** — Public, filterable gallery of apps built with LLM Gateway templates. Static and deployable, with a "Submit your app" flow.
+
+### Bots
+
+- **`slack-qa-bot`** — Slack bot that streams AI answers and keeps thread context.
 
 ### CLI Agents
 

--- a/apps/ui/src/app/ship/page.tsx
+++ b/apps/ui/src/app/ship/page.tsx
@@ -18,6 +18,13 @@ export const metadata: Metadata = {
 
 const templates = [
 	{
+		name: "Embeddable Credits",
+		description:
+			"Monetize your AI app — a drop-in wallet and checkout so end-users buy credits and use AI in-app.",
+		command: "npx @llmgateway/cli init --template embeddable-credits",
+		tags: ["Next.js", "Embeddable SDK", "Monetization"],
+	},
+	{
 		name: "AI Chatbot",
 		description:
 			"Streaming chat with conversation history and model switching.",
@@ -58,6 +65,13 @@ const templates = [
 			"AI-powered QA testing agent with browser automation and real-time action timeline.",
 		command: "npx @llmgateway/cli init --template qa-agent",
 		tags: ["Next.js", "AI SDK", "Browser Automation"],
+	},
+	{
+		name: "Showcase",
+		description:
+			"A static, deployable gallery of apps built with LLM Gateway templates, with filtering and submissions.",
+		command: "npx @llmgateway/cli init --template showcase",
+		tags: ["Next.js", "Tailwind CSS", "Static"],
 	},
 ];
 

--- a/apps/ui/src/app/templates/page.tsx
+++ b/apps/ui/src/app/templates/page.tsx
@@ -1,17 +1,20 @@
+import { LayoutGrid, Wallet } from "lucide-react";
+
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { TemplateCards } from "@/components/templates/template-cards";
+import { Button } from "@/lib/components/button";
 
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
 	title: "AI App Templates — Production-Ready Starters",
 	description:
-		"Production-ready templates to jumpstart your AI applications. Image generation, chatbots, and more.",
+		"Production-ready templates to jumpstart your AI applications — image generation, chatbots, end-user monetization, and more.",
 	openGraph: {
 		title: "AI App Templates — Production-Ready Starters",
 		description:
-			"Production-ready templates to jumpstart your AI applications. Image generation, chatbots, and more.",
+			"Production-ready templates to jumpstart your AI applications — image generation, chatbots, end-user monetization, and more.",
 	},
 };
 
@@ -33,6 +36,77 @@ export default function TemplatesPage() {
 					<TemplateCards />
 				</div>
 			</section>
+
+			{/* Showcase + Powered-By distribution loop */}
+			<section className="py-16 sm:py-20 bg-muted/30">
+				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+					<div className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2">
+						<div className="flex flex-col rounded-2xl border bg-card p-8 shadow-sm">
+							<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500 to-rose-500 shadow-lg">
+								<LayoutGrid className="h-6 w-6 text-white" />
+							</div>
+							<h3 className="mt-5 text-xl font-bold tracking-tight">
+								Built something? Get featured.
+							</h3>
+							<p className="mt-2 flex-1 text-muted-foreground leading-relaxed">
+								Ship an app on any template and add it to the Showcase — a
+								public, filterable gallery of apps built with LLM Gateway.
+								It&apos;s a deployable template itself, so you can host your
+								own.
+							</p>
+							<div className="mt-6 flex flex-col gap-3 sm:flex-row">
+								<Button asChild className="font-semibold">
+									<a
+										href="https://github.com/theopenco/llmgateway-templates/issues/new?template=showcase-submission.yml"
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										Submit your app
+									</a>
+								</Button>
+								<Button variant="outline" asChild>
+									<a
+										href="https://github.com/theopenco/llmgateway-templates/tree/main/templates/showcase"
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										View the Showcase
+									</a>
+								</Button>
+							</div>
+						</div>
+
+						<div className="flex flex-col rounded-2xl border bg-card p-8 shadow-sm">
+							<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-cyan-500 shadow-lg">
+								<Wallet className="h-6 w-6 text-white" />
+							</div>
+							<h3 className="mt-5 text-xl font-bold tracking-tight">
+								Add the Powered-By badge
+							</h3>
+							<p className="mt-2 flex-1 text-muted-foreground leading-relaxed">
+								Every app you deploy can carry a small &ldquo;Powered by LLM
+								Gateway&rdquo; badge. It ships with the embeddable SDK (
+								<code className="rounded bg-muted px-1.5 py-0.5 text-sm">
+									&lt;PoweredBy /&gt;
+								</code>
+								) and as a dependency-free copy you can drop into any footer.
+							</p>
+							<div className="mt-6">
+								<Button variant="outline" asChild>
+									<a
+										href="https://docs.llmgateway.io/features/llm-sdk"
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										Read the SDK docs
+									</a>
+								</Button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
 			<Footer />
 		</div>
 	);

--- a/apps/ui/src/components/templates/template-cards.tsx
+++ b/apps/ui/src/components/templates/template-cards.tsx
@@ -15,6 +15,8 @@ import {
 	Sparkles,
 	Github,
 	Play,
+	Wallet,
+	LayoutGrid,
 } from "lucide-react";
 import Image from "next/image";
 import { useState, useCallback } from "react";
@@ -27,9 +29,9 @@ interface Template {
 	name: string;
 	description: string;
 	href: string;
-	demoUrl: string;
+	demoUrl?: string;
 	demoLabel?: string;
-	image: string;
+	image?: string;
 	icon: typeof ImageIcon;
 	tags: string[];
 	gradient: string;
@@ -37,6 +39,16 @@ interface Template {
 }
 
 const templates: Template[] = [
+	{
+		name: "Embeddable Credits",
+		description:
+			'Monetize your AI app in 5 minutes. Drop in a wallet + checkout so your end-users buy credits and use AI in-app, billed to their own balance — the "Stripe for AI" flagship.',
+		href: "https://github.com/theopenco/llmgateway-templates/tree/main/templates/embeddable-credits",
+		icon: Wallet,
+		tags: ["TypeScript", "Next.js", "Embeddable SDK"],
+		gradient: "from-emerald-500/20 via-teal-500/20 to-cyan-500/20",
+		featured: true,
+	},
 	{
 		name: "Image Generation",
 		description:
@@ -106,6 +118,15 @@ const templates: Template[] = [
 		tags: ["TypeScript", "Next.js", "AI SDK"],
 		gradient: "from-cyan-500/20 via-teal-500/20 to-blue-500/20",
 	},
+	{
+		name: "Showcase",
+		description:
+			'A static, deployable gallery of apps built with LLM Gateway templates. Tag and type filtering, a "Submit your app" flow, and a Powered-By badge baked in — fork it or use the community directory.',
+		href: "https://github.com/theopenco/llmgateway-templates/tree/main/templates/showcase",
+		icon: LayoutGrid,
+		tags: ["TypeScript", "Next.js", "Tailwind CSS"],
+		gradient: "from-amber-500/20 via-orange-500/20 to-rose-500/20",
+	},
 ];
 
 export function TemplateCards() {
@@ -155,13 +176,21 @@ export function TemplateCards() {
 
 					{/* Preview image */}
 					<div className="relative aspect-video overflow-hidden">
-						<Image
-							src={template.image}
-							alt={`${template.name} preview`}
-							width={1200}
-							height={675}
-							className="h-full w-full object-cover"
-						/>
+						{template.image ? (
+							<Image
+								src={template.image}
+								alt={`${template.name} preview`}
+								width={1200}
+								height={675}
+								className="h-full w-full object-cover"
+							/>
+						) : (
+							<div
+								className={`flex h-full w-full items-center justify-center bg-gradient-to-br ${template.gradient}`}
+							>
+								<template.icon className="h-16 w-16 text-foreground/70" />
+							</div>
+						)}
 						<div className="absolute inset-0 bg-gradient-to-t from-background/80 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
 					</div>
 
@@ -197,22 +226,30 @@ export function TemplateCards() {
 
 						{/* Actions */}
 						<div className="flex flex-col sm:flex-row gap-3 pt-2 mt-auto">
-							<Button asChild className="flex-1 gap-2 font-semibold">
-								<a
-									href={template.demoUrl}
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{template.demoLabel ? (
-										<Play className="h-4 w-4" />
-									) : (
-										<ExternalLink className="h-4 w-4" />
-									)}
-									{template.demoLabel ?? "Live Demo"}
-									<ArrowUpRight className="h-4 w-4 opacity-50 group-hover:opacity-100 transition-opacity" />
-								</a>
-							</Button>
-							<Button variant="outline" asChild className="gap-2">
+							{template.demoUrl && (
+								<Button asChild className="flex-1 gap-2 font-semibold">
+									<a
+										href={template.demoUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{template.demoLabel ? (
+											<Play className="h-4 w-4" />
+										) : (
+											<ExternalLink className="h-4 w-4" />
+										)}
+										{template.demoLabel ?? "Live Demo"}
+										<ArrowUpRight className="h-4 w-4 opacity-50 group-hover:opacity-100 transition-opacity" />
+									</a>
+								</Button>
+							)}
+							<Button
+								variant={template.demoUrl ? "outline" : "default"}
+								asChild
+								className={
+									template.demoUrl ? "gap-2" : "flex-1 gap-2 font-semibold"
+								}
+							>
 								<a
 									href={template.href}
 									target="_blank"


### PR DESCRIPTION
## What & why

[llmgateway-templates#11](https://github.com/theopenco/llmgateway-templates/pull/11) added two new templates and a referral badge to the open-source templates repo, but none of it was surfaced on llmgateway.io. This PR closes that gap so the new work is discoverable to developers.

### Templates gallery (`/templates`)
- Adds **Embeddable Credits** — the flagship *"Monetize your AI app in 5 minutes"* template — as the first, **Featured** card.
- Adds **Showcase** — the static, deployable gallery template.
- `image` and `demoUrl` are now optional on the `Template` type. Neither new template has a hosted live-demo or screenshot yet (the candidate Vercel URLs 404), so cards without a preview render an icon-on-gradient hero, and cards without a demo promote the **GitHub** button to primary. Existing cards are unchanged.

### Powered-By + Showcase callout (`/templates`)
- New section after the gallery driving the PR's distribution loop: **Submit your app** to the Showcase (pre-filled GitHub issue) and an explainer for the **Powered by LLM Gateway** referral badge, linking to the SDK docs.

### Quick-start page (`/ship`)
- Both templates added to the clone-and-deploy list.

### Docs
- Refreshes the stale Available Templates list in the CLI guide (`embeddable-credits`, `showcase`, `slack-qa-bot`).

## Verification
- `turbo run build --filter=ui --filter=docs` → **14/14 tasks successful** ✅
- `pnpm format` clean; lockfile untouched (no dependency changes — only existing `lucide-react` icons and shared components are used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new templates: **Embeddable Credits** and **Showcase**.
  * Introduced a new **Bots** template category with **Slack QA Bot**.
  * Added a new **Showcase + Powered-By** section with helpful links and resources.

* **UI Improvements**
  * Updated template browsing so cards display better when a preview image isn’t available.
  * Improved template action buttons to show only relevant options for each template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->