### PR TITLE
docs: document Chat Playground port 3003

### DIFF
--- a/apps/docs/content/self-host/docker-compose.mdx
+++ b/apps/docs/content/self-host/docker-compose.mdx
@@ -50,6 +50,7 @@ Pin to a specific version by replacing the `latest` image tags with the [latest 
 ## Accessing your instance
 
 - **Web Interface**: http://localhost:3002
+- **Chat Playground**: http://localhost:3003
 - **Documentation**: http://localhost:3005
 - **API Endpoint**: http://localhost:4002
 - **Gateway Endpoint**: http://localhost:4001

--- a/apps/docs/content/self-host/docker.mdx
+++ b/apps/docs/content/self-host/docker.mdx
@@ -44,6 +44,7 @@ Pin to a specific version instead of `latest` using the [latest release tag](htt
 ## Accessing your instance
 
 - **Web Interface**: http://localhost:3002
+- **Chat Playground**: http://localhost:3003
 - **Documentation**: http://localhost:3005
 - **API Endpoint**: http://localhost:4002
 - **Gateway Endpoint**: http://localhost:4001

--- a/apps/ui/src/content/blog/2025-05-01-self-host-llm-gateway.md
+++ b/apps/ui/src/content/blog/2025-05-01-self-host-llm-gateway.md
@@ -47,13 +47,14 @@ docker compose -f infra/docker-compose.split.yml up -d
 
 Once running, your services are available at:
 
-| Service | URL                   | Description                    |
-| ------- | --------------------- | ------------------------------ |
-| Web UI  | http://localhost:3002 | Dashboard and analytics        |
-| Docs    | http://localhost:3005 | Local documentation            |
-| Admin   | http://localhost:3006 | Platform administration        |
-| API     | http://localhost:4002 | Management API                 |
-| Gateway | http://localhost:4001 | LLM request gateway (use this) |
+| Service    | URL                   | Description                    |
+| ---------- | --------------------- | ------------------------------ |
+| Web UI     | http://localhost:3002 | Dashboard and analytics        |
+| Playground | http://localhost:3003 | Chat playground                |
+| Docs       | http://localhost:3005 | Local documentation            |
+| Admin      | http://localhost:3006 | Platform administration        |
+| API        | http://localhost:4002 | Management API                 |
+| Gateway    | http://localhost:4001 | LLM request gateway (use this) |
 
 ## What You Get
 


### PR DESCRIPTION
## Summary

The "Accessing your instance" lists in the self-host docs omitted the **Chat Playground (port 3003)**, even though the unified Docker image and Compose setups expose it. This made it look like the playground might not be bundled in the self-hosted image.

Adds the Chat Playground entry to:
- `apps/docs/content/self-host/docker.mdx`
- `apps/docs/content/self-host/docker-compose.mdx`
- `apps/ui/src/content/blog/2025-05-01-self-host-llm-gateway.md` (also realigned the table)

The root `README.md` only has a `docker run` snippet (which already exposes `3003`), so no service-list change was needed there.

## Test plan
- `pnpm format`
- `pnpm turbo run build --filter=docs --filter=ui` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Chat Playground** link to self-hosting docs and the instance access table.
  * Included the Playground at `http://localhost:3003` alongside the existing web interface, docs, API, and gateway links.
  * Updated the self-hosting blog guide to show the new Playground access option in the instance overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->