### PR TITLE
fix(gateway): serve and expose Vertex service tiers

### DIFF
--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -49,10 +49,12 @@ the exact tiers exposed by each provider card.
   Priority uses the model-specific multiplier shown on the model page.
 
 - **Google Vertex AI** (`google-vertex`) — sent as the
-  `X-Vertex-AI-LLM-Shared-Request-Type` request header. Flex and Priority are
-  served only on the **global** endpoint, which is the gateway default. Google
-  Flex PayGo applies a 0.5x multiplier; Google Priority PayGo applies a 1.8x
-  multiplier.
+  `X-Vertex-AI-LLM-Shared-Request-Type` request header, together with
+  `X-Vertex-AI-LLM-Request-Type: shared` so the request bypasses any Provisioned
+  Throughput on the project and actually reaches the shared Flex/Priority tier.
+  Flex and Priority are served only on the **global** endpoint, which is the
+  gateway default. Google Flex PayGo applies a 0.5x multiplier; Google Priority
+  PayGo applies a 1.8x multiplier.
 - **Google AI Studio / Gemini API** (`google-ai-studio`) — sent as a
   `service_tier` field in the request body for configured models that opt in.
 

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -867,11 +867,137 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 		const json = await res.json();
 		expect(json.service_tier).toBe("priority");
+		// Requested vs served tier are surfaced in the response metadata.
+		expect(json.metadata?.requested_service_tier).toBe("priority");
+		expect(json.metadata?.used_service_tier).toBe("priority");
 
 		const logs = await waitForLogs(1);
 		expect(logs.length).toBe(1);
 		expect(logs[0].requestedServiceTier).toBe("priority");
 		expect(logs[0].usedServiceTier).toBe("priority");
+	});
+
+	test("/v1/chat/completions omits service tier metadata without a tier request", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-no-service-tier-meta",
+			token: "real-token-no-service-tier-meta",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-no-service-tier-meta",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-no-service-tier-meta",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.5",
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.metadata?.requested_service_tier).toBeUndefined();
+		expect(json.metadata?.used_service_tier).toBeUndefined();
+	});
+
+	test("/v1/chat/completions streams service tier in the final usage chunk", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-service-tier-stream",
+			token: "real-token-service-tier-stream",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-service-tier-stream",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-service-tier-stream",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.5",
+				service_tier: "priority",
+				stream: true,
+				stream_options: { include_usage: true },
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const streamResult = await readAll(res.body);
+		const tierChunk = streamResult.chunks.find(
+			(chunk) => chunk?.metadata?.requested_service_tier !== undefined,
+		);
+		expect(tierChunk).toBeDefined();
+		expect(tierChunk.metadata.requested_service_tier).toBe("priority");
+		expect(tierChunk.metadata.used_service_tier).toBe("priority");
+	});
+
+	test("/v1/chat/completions records requested service tier on upstream errors", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-service-tier-upstream-error",
+			token: "real-token-service-tier-upstream-error",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// OpenAI supports the priority tier and is not subject to the upstream
+		// base-URL restriction, so a mock base URL is allowed here — letting the
+		// request reach the (error-returning) upstream instead of being rejected
+		// before it ever serves a tier.
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-service-tier-upstream-error",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-service-tier-upstream-error",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.5",
+				service_tier: "priority",
+				messages: [{ role: "user", content: "TRIGGER_ERROR" }],
+			}),
+		});
+
+		expect(res.status).not.toBe(200);
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].hasError).toBe(true);
+		// The upstream errored before serving a tier, but the requested tier is
+		// still threaded onto the error log via the insertLogEntry wrapper.
+		expect(logs[0].requestedServiceTier).toBe("priority");
+		expect(logs[0].usedServiceTier).toBeNull();
 	});
 
 	test("/v1/chat/completions forwards generated request id upstream", async () => {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1453,6 +1453,13 @@ chat.openapi(completions, async (c) => {
 	const requestedServiceTier = isRequestedServiceTier(service_tier)
 		? service_tier
 		: null;
+	// The processing tier the provider actually served (Flex / Priority),
+	// resolved from the upstream response — Vertex's usageMetadata.trafficType or
+	// AI Studio's x-gemini-service-tier header. Billing scales token costs by
+	// this served tier (not the requested one) since Google downgrades
+	// unsupported tiers to standard. Null = standard / no tier. Declared here
+	// (ahead of the insertLogEntry wrapper) so every log path can record it.
+	let servedServiceTier: "flex" | "priority" | null = null;
 
 	// Sticky-routing session key, in priority order: the explicit x-session-id
 	// header, then x-session-affinity (sent by coding agents such as opencode),
@@ -1696,6 +1703,12 @@ chat.openapi(completions, async (c) => {
 	const insertLogEntry = (logData: LogInsertData) =>
 		insertLog(
 			{
+				// Service tiers default from the request-level requested tier and the
+				// served tier resolved so far, so every log path (guardrail/validation
+				// rejections, cache hits, streaming/upstream errors, fetch errors)
+				// records them. Explicit values in logData still win.
+				requestedServiceTier,
+				usedServiceTier: servedServiceTier,
 				...logData,
 				...(logIdOverride && !logData.retried ? { id: logIdOverride } : {}),
 				responsesApiData,
@@ -1895,6 +1908,11 @@ chat.openapi(completions, async (c) => {
 			organizationId: project.organizationId,
 			projectId: apiKey.projectId,
 			discount: discount ?? null,
+			// Surface the requested vs served tier so callers can detect downgrades.
+			// Read at call time, so the streaming final usage chunk reflects the tier
+			// resolved from the upstream response.
+			requestedServiceTier,
+			usedServiceTier: servedServiceTier,
 		});
 
 	let configIndex = 0; // Index for round-robin environment variables
@@ -2549,12 +2567,6 @@ chat.openapi(completions, async (c) => {
 	let usedExternalId: string = requestedModel;
 	let usedRegion: string | undefined = requestedRegion;
 	let routingMetadata: RoutingMetadata | undefined;
-	// The processing tier the provider actually served (Flex / Priority),
-	// resolved from the upstream response — Vertex's usageMetadata.trafficType or
-	// AI Studio's x-gemini-service-tier header. Billing scales token costs by
-	// this served tier (not the requested one) since Google downgrades
-	// unsupported tiers to standard. Null = standard / no tier.
-	let servedServiceTier: "flex" | "priority" | null = null;
 
 	// Extract retention level for data storage cost calculation
 	const retentionLevel = organization?.retentionLevel ?? "none";
@@ -6601,6 +6613,10 @@ chat.openapi(completions, async (c) => {
 					}
 
 					try {
+						// Clear any tier served by a previous attempt so a fallback
+						// that fails before fetch returns (timeout/connection error)
+						// logs no served tier instead of the prior provider's.
+						servedServiceTier = null;
 						const forwardedServiceTier = getForwardedServiceTier(
 							usedInternalModel,
 							usedProvider,
@@ -10358,8 +10374,6 @@ chat.openapi(completions, async (c) => {
 						estimatedCost: costs.estimatedCost,
 						discount: costs.discount,
 						pricingTier: costs.pricingTier,
-						requestedServiceTier,
-						usedServiceTier: servedServiceTier,
 						dataStorageCost: shouldIncludeTokensForBilling
 							? calculateDataStorageCost(
 									calculatedPromptTokens,
@@ -10543,6 +10557,10 @@ chat.openapi(completions, async (c) => {
 		fetchError = null;
 		isTimeoutFetchError = false;
 		res = undefined;
+		// Clear any tier served by a previous attempt so a fallback that fails
+		// before fetch returns (timeout/connection error) logs no served tier
+		// instead of inheriting the prior provider's.
+		servedServiceTier = null;
 
 		try {
 			const forwardedServiceTier = getForwardedServiceTier(
@@ -12332,8 +12350,6 @@ chat.openapi(completions, async (c) => {
 		estimatedCost: costs.estimatedCost,
 		discount: costs.discount,
 		pricingTier: costs.pricingTier,
-		requestedServiceTier,
-		usedServiceTier: servedServiceTier,
 		dataStorageCost: calculateDataStorageCost(
 			calculatedPromptTokens,
 			cachedTokens,

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -26,6 +26,15 @@ export interface ResponseMetadataExtras {
 	organizationId?: string;
 	projectId?: string;
 	discount?: number | null;
+	/**
+	 * The Flex/Priority tier the caller requested. When set, both
+	 * `requested_service_tier` and `used_service_tier` are surfaced in the
+	 * response metadata (and the streaming final usage chunk). Null/undefined for
+	 * standard requests, which omit the fields entirely.
+	 */
+	requestedServiceTier?: "flex" | "priority" | null;
+	/** The tier actually served upstream (null when downgraded to standard). */
+	usedServiceTier?: "flex" | "priority" | null;
 }
 
 export function toResponseMetadataExtras(
@@ -42,6 +51,12 @@ export function toResponseMetadataExtras(
 			: {}),
 		...(extras.projectId ? { project_id: extras.projectId } : {}),
 		discount: extras.discount ?? null,
+		...(extras.requestedServiceTier
+			? {
+					requested_service_tier: extras.requestedServiceTier,
+					used_service_tier: extras.usedServiceTier ?? null,
+				}
+			: {}),
 	};
 }
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -579,19 +579,23 @@ function delay(ms: number): Promise<void> {
 mockOpenAIServer.post("/v1/responses", async (c) => {
 	const body = await c.req.json();
 
-	// Check if this request should trigger an error response
-	const shouldError = body.input?.some?.(
-		(msg: any) =>
-			msg.role === "user" && msg.content?.includes?.("TRIGGER_ERROR"),
-	);
+	// Get the user's message to include in the response. Used for both the error
+	// triggers below and the echoed assistant content. Responses-API input
+	// content is an array of parts, so extract the text rather than calling
+	// `.includes` on the raw content (which would miss array-form messages).
+	const userMessage = getResponsesApiUserMessage(body.input);
 
-	if (shouldError) {
+	// Check if this request should trigger an error response
+	const statusTrigger = extractStatusCodeTrigger(userMessage);
+	if (statusTrigger) {
+		c.status(statusTrigger.statusCode as any);
+		return c.json(statusTrigger.errorResponse);
+	}
+
+	if (userMessage.includes("TRIGGER_ERROR")) {
 		c.status(500);
 		return c.json(sampleErrorResponse);
 	}
-
-	// Get the user's message to include in the response
-	const userMessage = getResponsesApiUserMessage(body.input);
 	const shouldEndAfterDoneEvent = userMessage.includes(
 		"TRIGGER_RESPONSES_DONE_WITHOUT_COMPLETED",
 	);
@@ -608,6 +612,9 @@ mockOpenAIServer.post("/v1/responses", async (c) => {
 				object: "response",
 				created_at: Math.floor(Date.now() / 1000),
 				model: body.model ?? "gpt-5-nano",
+				...(typeof body.service_tier === "string"
+					? { service_tier: body.service_tier }
+					: {}),
 			};
 
 			await stream.writeSSE({

--- a/packages/actions/src/get-provider-headers.spec.ts
+++ b/packages/actions/src/get-provider-headers.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getProviderHeaders } from "./get-provider-headers.js";
 
 const VERTEX_TIER_HEADER = "X-Vertex-AI-LLM-Shared-Request-Type";
+const VERTEX_REQUEST_TYPE_HEADER = "X-Vertex-AI-LLM-Request-Type";
 
 describe("getProviderHeaders - Google Vertex service tiers", () => {
 	it("sets the flex shared-request-type header for google-vertex", () => {
@@ -10,6 +11,8 @@ describe("getProviderHeaders - Google Vertex service tiers", () => {
 			serviceTier: "flex",
 		});
 		expect(headers[VERTEX_TIER_HEADER]).toBe("flex");
+		// Bypass Provisioned Throughput so the shared Flex tier is actually used.
+		expect(headers[VERTEX_REQUEST_TYPE_HEADER]).toBe("shared");
 	});
 
 	it("sets the priority shared-request-type header for google-vertex", () => {
@@ -17,12 +20,18 @@ describe("getProviderHeaders - Google Vertex service tiers", () => {
 			serviceTier: "priority",
 		});
 		expect(headers[VERTEX_TIER_HEADER]).toBe("priority");
+		expect(headers[VERTEX_REQUEST_TYPE_HEADER]).toBe("shared");
 	});
 
-	it("omits the header for the standard/default tier", () => {
+	it("omits the headers for the standard/default tier", () => {
 		expect(
 			getProviderHeaders("google-vertex", "token", { serviceTier: "default" })[
 				VERTEX_TIER_HEADER
+			],
+		).toBeUndefined();
+		expect(
+			getProviderHeaders("google-vertex", "token", { serviceTier: "default" })[
+				VERTEX_REQUEST_TYPE_HEADER
 			],
 		).toBeUndefined();
 		expect(
@@ -32,9 +41,10 @@ describe("getProviderHeaders - Google Vertex service tiers", () => {
 		).toBeUndefined();
 	});
 
-	it("omits the header when no service tier is provided", () => {
+	it("omits the headers when no service tier is provided", () => {
 		const headers = getProviderHeaders("google-vertex", "token");
 		expect(headers[VERTEX_TIER_HEADER]).toBeUndefined();
+		expect(headers[VERTEX_REQUEST_TYPE_HEADER]).toBeUndefined();
 	});
 
 	it("preserves the request id alongside the tier header", () => {

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -46,15 +46,25 @@ export function getProviderHeaders(
 			return requestIdHeader;
 		case "google-vertex": {
 			// Map the OpenAI-compatible `service_tier` to Vertex's Flex / Priority
-			// PayGo header. Only "flex" and "priority" are valid; standard/default
-			// requests omit the header. Flex and Priority PayGo are served only on
-			// the global endpoint (the gateway's default Vertex region).
+			// PayGo headers. Only "flex" and "priority" are valid; standard/default
+			// requests omit them. Flex and Priority PayGo are served only on the
+			// global endpoint (the gateway's default Vertex region).
+			//
+			// Two headers are required: `X-Vertex-AI-LLM-Shared-Request-Type`
+			// selects the tier, and `X-Vertex-AI-LLM-Request-Type: shared` forces
+			// the shared PayGo path. Without the latter, a project that has
+			// Provisioned Throughput allocated consumes PT first and never reaches
+			// the shared Flex/Priority tier, so the request is silently served (and
+			// billed) as standard. An explicit service_tier request always wants the
+			// shared tier, so we bypass PT unconditionally (no-op on projects
+			// without PT).
 			if (
 				options?.serviceTier === "flex" ||
 				options?.serviceTier === "priority"
 			) {
 				return {
 					...requestIdHeader,
+					"X-Vertex-AI-LLM-Request-Type": "shared",
 					"X-Vertex-AI-LLM-Shared-Request-Type": options.serviceTier,
 				};
 			}


### PR DESCRIPTION
## The fix: Vertex Priority/Flex PayGo needs two headers

Vertex requires **both**:
- `X-Vertex-AI-LLM-Shared-Request-Type: priority|flex` — selects the tier (the gateway already sent this)
- `X-Vertex-AI-LLM-Request-Type: shared` — forces the shared PayGo path (**was missing**)

Without the second header, a project that has **Provisioned Throughput** allocated consumes PT first and never reaches the shared Flex/Priority tier — so the request is silently served (and billed) as **standard** even though `priority` was requested. This is why production showed `requested=priority` / `used=null` on `aiplatform.googleapis.com` projects with PT, while projects without PT worked. We now send both headers for flex/priority (no-op on projects without PT, so it's safe everywhere).

Per [Google's docs](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/priority-paygo) and [liteLLM](https://docs.litellm.ai/docs/tutorials/vertex_ai_pay_go): *"To bypass Provisioned Throughput entirely, also set requestType: 'shared'."*

## Also in this PR: surface & log requested vs served tier

- **Response**: `requested_service_tier` + `used_service_tier` added to the response `metadata` (non-streaming) and the **streaming final usage chunk** (via `buildFinalResponseMetadata` / `toResponseMetadataExtras`). Emitted only when a premium tier was requested; `used` is `null` on a downgrade so callers can detect it.
- **Logs** (follow-up to #2816): default both fields in the `insertLogEntry` wrapper so every chat log path (guardrail/validation rejections, cache hits, streaming/upstream errors, fetch errors) records them; **reset `servedServiceTier` per retry attempt** so a fallback that fails before `fetch` returns logs no served tier instead of inheriting the previous provider's.

## Tests / infra

- `get-provider-headers` test asserts **both** Vertex headers on flex/priority and their absence otherwise.
- Upstream-error test uses `openai/gpt-5.5` (not subject to #2821's upstream base-URL rule) so it still reaches the error path; mock `/v1/responses` handler is array-safe for `TRIGGER_ERROR` / `TRIGGER_STATUS_*` and echoes `service_tier` when streaming.
- New tests: non-streaming metadata present on a priority request / absent without one; streaming final chunk carries both fields.

## Verification

`pnpm test:unit` (132 files), full `apps/gateway/src/api.spec.ts` (101 passed / 2 skipped), `pnpm format`, full `pnpm build` all pass. The two-header behavior was confirmed against Google's Priority PayGo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)