### PR TITLE
fix(gateway): drop message name in Responses API input

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -3041,6 +3041,23 @@ describe("prepareRequestBody - max_tokens forwarding", () => {
 				),
 			).rejects.toBeInstanceOf(RequestError);
 		});
+
+		test("drops message `name` (Responses API rejects input[N].name)", async () => {
+			const requestBody = (await prepareRequestBody(
+				...responsesArgs([
+					{ role: "system", content: "be terse", name: "system_helper" },
+					{ role: "user", content: "hello", name: "alice" },
+				]),
+			)) as any;
+
+			expect(requestBody.input.every((i: any) => i.name === undefined)).toBe(
+				true,
+			);
+			expect(requestBody.input).toEqual([
+				{ role: "system", content: [{ type: "input_text", text: "be terse" }] },
+				{ role: "user", content: [{ type: "input_text", text: "hello" }] },
+			]);
+		});
 	});
 
 	describe("google-ai-studio", () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -761,18 +761,15 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 			continue;
 		}
 
-		// Regular messages: transform content types
-		const transformed: any = {
+		// Regular messages: transform content types. The Responses API input
+		// message items only accept `role`/`content` and reject `name` (Chat
+		// Completions allows `name` on system/user/assistant messages), so it is
+		// intentionally dropped here to avoid a 400 "Unknown parameter:
+		// 'input[N].name'".
+		items.push({
 			role: msg.role,
 			content: transformContentForResponsesApi(msg.content, msg.role),
-		};
-
-		// Copy name if present (for developer/system messages)
-		if (msg.name) {
-			transformed.name = msg.name;
-		}
-
-		items.push(transformed);
+		});
 	}
 
 	return items;


### PR DESCRIPTION
## Problem

`azure/gpt-5.4` (and other openai/azure/sakana models routed through the **Responses API**) were failing with a recurring `client_error`:

```
400 Bad Request
Unknown parameter: 'input[27].name'.
```

## Root cause

The Chat Completions spec allows a `name` field on `system`/`user`/`assistant` messages, but the OpenAI/Azure **Responses API** input message items accept only `role` and `content` — a `name` field is rejected.

`transformMessagesForResponsesApi` in `packages/actions/src/prepare-request-body.ts` copied `name` through verbatim when present, so any incoming message carrying a `name` produced a 400 referencing `input[N].name` (where N is its position in the flattened input array).

## Fix

Drop the `name` field when building Responses API message input items. (The `name` on `function_call` items is unaffected — that is valid and required for the Responses API.)

Added a regression test asserting `name` is stripped from input message items.

## Testing

- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts` — 107 passed
- `pnpm build` — all 17 tasks succeeded
- `pnpm format`

Note: the `DeploymentNotFound` / `getaddrinfo ENOTFOUND` errors in the same logs are Azure deployment/DNS config issues, not code bugs, and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)