### PR TITLE
feat(gateway): gate service tiers to upstream provider keys

### DIFF
--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -63,6 +63,17 @@ the exact tiers exposed by each provider card.
 	configured image mappings are Flex-only.
 </Callout>
 
+<Callout type="warn">
+	Flex and Priority are only honored when the request reaches Google directly,
+	so a `google-vertex` / `google-ai-studio` provider key with a **custom base
+	URL** (a proxy) is excluded from service-tier routing — a proxy may silently
+	drop the tier and serve standard. With multiple providers/keys, the gateway
+	routes around the ineligible key automatically; if a request pins a provider
+	whose only key uses a custom base URL, it returns a 400 instead of silently
+	downgrading. Keys with no custom base URL (the managed default) are always
+	eligible.
+</Callout>
+
 ## Pricing uses multipliers
 
 Service tiers do not define separate model prices in LLM Gateway. They multiply

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -94,6 +94,8 @@ import {
 	getDiscountedProviderSelectionPrice,
 	getProviderEndpoint,
 	getProviderHeaders,
+	isPremiumServiceTier,
+	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
 	googleProviderSupportsAudioFormat,
 	InvalidFileContentError,
@@ -187,7 +189,11 @@ import { extractReasoning } from "./tools/extract-reasoning.js";
 import { extractTokenUsage } from "./tools/extract-token-usage.js";
 import { extractToolCalls } from "./tools/extract-tool-calls.js";
 import { getFinishReasonFromError } from "./tools/get-finish-reason-from-error.js";
-import { getProviderEnv } from "./tools/get-provider-env.js";
+import {
+	getProviderEnv,
+	getServiceTierIneligibleEnvIndices,
+	hasServiceTierEligibleEnvCredential,
+} from "./tools/get-provider-env.js";
 import { hasMeaningfulAssistantOutput } from "./tools/has-meaningful-assistant-output.js";
 import { healJsonResponse } from "./tools/heal-json-response.js";
 import { isModelTrulyFree } from "./tools/is-model-truly-free.js";
@@ -930,7 +936,7 @@ function getForwardedServiceTier(
 function isRequestedServiceTier(
 	serviceTier: "auto" | "default" | "flex" | "priority" | undefined,
 ): serviceTier is "flex" | "priority" {
-	return serviceTier === "flex" || serviceTier === "priority";
+	return isPremiumServiceTier(serviceTier);
 }
 
 function providerMatchesRequestedProvider(
@@ -2645,11 +2651,71 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// Flex/Priority is only honored when the request reaches the provider's real
+	// upstream endpoint — a provider key with a custom base URL (proxy) may
+	// silently drop the tier and be billed/reported as standard. Exclude
+	// providers that have no upstream-eligible credential from service-tier
+	// routing (mirroring the compliance policy): auto/model-id routing drops
+	// them, and only fails when none remain; a pinned provider with no eligible
+	// key returns a clear 400 instead of silently downgrading.
+	let serviceTierOrgKeys:
+		| InferSelectModel<typeof tables.providerKey>[]
+		| undefined;
+	const isProviderServiceTierEligible = (providerId: string): boolean => {
+		const dbKeys = (serviceTierOrgKeys ?? []).filter(
+			(key) => key.provider === providerId,
+		);
+		const hasCompliantDbKey = dbKeys.some((key) =>
+			providerKeyBaseUrlSupportsServiceTier(
+				providerId as Provider,
+				key.baseUrl,
+			),
+		);
+		// An env credential is eligible only when at least one of its (possibly
+		// comma-indexed) base URLs targets the managed upstream — a custom base URL
+		// on every env index is just as ineligible as a custom DB key. In hybrid
+		// mode env is used only when no DB key is picked, which the
+		// serviceTierKeyFilter guarantees for a custom base URL.
+		const envEligible =
+			(project.mode === "credits" || project.mode === "hybrid") &&
+			hasServiceTierEligibleEnvCredential(providerId as Provider);
+		if (project.mode === "api-keys") {
+			return hasCompliantDbKey;
+		}
+		return hasCompliantDbKey || envEligible;
+	};
+	const enforceServiceTierKeyEligibility = async () => {
+		if (!isRequestedServiceTier(service_tier)) {
+			return;
+		}
+		if (serviceTierOrgKeys === undefined) {
+			serviceTierOrgKeys = await findActiveProviderKeys(project.organizationId);
+		}
+		iamFilteredModelProviders = iamFilteredModelProviders.filter((provider) =>
+			isProviderServiceTierEligible(provider.providerId),
+		);
+		expandedIamFilteredModelProviders =
+			expandedIamFilteredModelProviders.filter((provider) =>
+				isProviderServiceTierEligible(provider.providerId),
+			);
+		const pinnedIneligible =
+			usedProvider !== undefined &&
+			usedProvider !== "llmgateway" &&
+			usedProvider !== "custom" &&
+			!isProviderServiceTierEligible(usedProvider);
+		if (iamFilteredModelProviders.length === 0 || pinnedIneligible) {
+			throw new HTTPException(400, {
+				message: `Service tier '${service_tier}' requires a provider key that targets the original upstream endpoint. Remove the custom base URL from the ${pinnedIneligible ? `${usedProvider} ` : ""}provider key or omit service_tier.`,
+			});
+		}
+	};
+
 	// For auto routing, modelInfo is still the synthetic "llmgateway" model here;
 	// compliance is enforced after the real model/provider is resolved (and the
 	// auto candidate set is compliance-filtered during selection below).
 	if (usedInternalModel !== "auto") {
 		await enforceCompliancePolicy();
+		await enforceServiceTierKeyEligibility();
 	}
 
 	// Pricing override for custom-provider requests that match an enterprise
@@ -3260,6 +3326,7 @@ chat.openapi(completions, async (c) => {
 				expandedIamFilteredModelProviders.filter(providerSupportsCachedInput);
 		}
 		await enforceCompliancePolicy();
+		await enforceServiceTierKeyEligibility();
 	} else if (
 		(usedProvider === "llmgateway" && usedInternalModel === "custom") ||
 		usedInternalModel === "custom"
@@ -4464,6 +4531,17 @@ chat.openapi(completions, async (c) => {
 	// credential via envVarName instead of blaming an unused DB key. Endpoint
 	// and option resolution still use providerKey for BYOK base URLs/options.
 	let trackedKeyHealthId: string | undefined;
+	// Flex/Priority is only honored when the request reaches the provider's real
+	// upstream endpoint. Skip provider keys whose custom base URL (proxy) may
+	// silently drop the tier, so a compliant key (or the managed env credential
+	// in hybrid mode) is used instead.
+	const serviceTierKeyFilter = isRequestedServiceTier(service_tier)
+		? (key: InferSelectModel<typeof tables.providerKey>) =>
+				providerKeyBaseUrlSupportsServiceTier(
+					key.provider as Provider,
+					key.baseUrl,
+				)
+		: undefined;
 	if (
 		project.mode === "credits" &&
 		(usedProvider === "custom" || usedProvider === "llmgateway")
@@ -4487,6 +4565,8 @@ chat.openapi(completions, async (c) => {
 				project.organizationId,
 				usedProvider,
 				usedInternalModel,
+				undefined,
+				serviceTierKeyFilter,
 			);
 		}
 
@@ -4590,6 +4670,9 @@ chat.openapi(completions, async (c) => {
 
 		const envResult = getProviderEnv(usedProvider, {
 			selectionScope: usedInternalModel,
+			excludedIndices: isRequestedServiceTier(service_tier)
+				? getServiceTierIneligibleEnvIndices(usedProvider as Provider)
+				: undefined,
 		});
 		usedToken = envResult.token;
 		configIndex = envResult.configIndex;
@@ -4624,6 +4707,8 @@ chat.openapi(completions, async (c) => {
 				project.organizationId,
 				usedProvider,
 				usedInternalModel,
+				undefined,
+				serviceTierKeyFilter,
 			);
 		}
 
@@ -4716,6 +4801,9 @@ chat.openapi(completions, async (c) => {
 
 			const envResult = getProviderEnv(usedProvider, {
 				selectionScope: usedInternalModel,
+				excludedIndices: isRequestedServiceTier(service_tier)
+					? getServiceTierIneligibleEnvIndices(usedProvider as Provider)
+					: undefined,
 			});
 			usedToken = envResult.token;
 			configIndex = envResult.configIndex;

--- a/apps/gateway/src/chat/tools/get-provider-env.spec.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.spec.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { reportKeyError, resetKeyHealth } from "@/lib/api-key-health.js";
 import { resetRoundRobinCounters } from "@/lib/round-robin-env.js";
 
-import { getProviderEnv } from "./get-provider-env.js";
+import {
+	getProviderEnv,
+	getServiceTierIneligibleEnvIndices,
+	hasServiceTierEligibleEnvCredential,
+} from "./get-provider-env.js";
 
 describe("getProviderEnv", () => {
 	const originalOpenAIKey = process.env.LLM_OPENAI_API_KEY;
@@ -72,5 +76,85 @@ describe("getProviderEnv", () => {
 
 		expect(gpt4Selection.configIndex).toBe(1);
 		expect(claudeSelection.configIndex).toBe(0);
+	});
+});
+
+describe("service-tier env credential eligibility", () => {
+	const originalKey = process.env.LLM_GOOGLE_VERTEX_API_KEY;
+	const originalBaseUrl = process.env.LLM_GOOGLE_VERTEX_BASE_URL;
+	const originalRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
+
+	afterEach(() => {
+		if (originalKey === undefined) {
+			delete process.env.LLM_GOOGLE_VERTEX_API_KEY;
+		} else {
+			process.env.LLM_GOOGLE_VERTEX_API_KEY = originalKey;
+		}
+		if (originalBaseUrl === undefined) {
+			delete process.env.LLM_GOOGLE_VERTEX_BASE_URL;
+		} else {
+			process.env.LLM_GOOGLE_VERTEX_BASE_URL = originalBaseUrl;
+		}
+		if (originalRegion === undefined) {
+			delete process.env.LLM_GOOGLE_VERTEX_REGION;
+		} else {
+			process.env.LLM_GOOGLE_VERTEX_REGION = originalRegion;
+		}
+	});
+
+	it("flags only the env indices whose base URL is a custom proxy", () => {
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
+		process.env.LLM_GOOGLE_VERTEX_BASE_URL =
+			"https://vertex-proxy.invalid,https://aiplatform.googleapis.com";
+
+		const ineligible = getServiceTierIneligibleEnvIndices("google-vertex");
+		expect([...ineligible]).toEqual([0]);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
+	});
+
+	it("treats an unset base URL as the eligible managed default", () => {
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a";
+		delete process.env.LLM_GOOGLE_VERTEX_BASE_URL;
+
+		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual(
+			[],
+		);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
+	});
+
+	it("reports no eligible credential when every index is a custom proxy", () => {
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
+		process.env.LLM_GOOGLE_VERTEX_BASE_URL =
+			"https://proxy-one.invalid,https://proxy-two.invalid";
+
+		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual([
+			0, 1,
+		]);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(false);
+	});
+
+	it("flags a non-global Vertex region index as ineligible", () => {
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
+		delete process.env.LLM_GOOGLE_VERTEX_BASE_URL;
+		process.env.LLM_GOOGLE_VERTEX_REGION = "global,us-central1";
+
+		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual([
+			1,
+		]);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
+	});
+
+	it("rejects when the only base-URL-compliant index is a non-global region", () => {
+		// index 0: proxy base URL (global region); index 1: canonical upstream but
+		// us-central1 — neither can carry the tier, so the provider is ineligible.
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
+		process.env.LLM_GOOGLE_VERTEX_BASE_URL =
+			"https://vertex-proxy.invalid,https://aiplatform.googleapis.com";
+		process.env.LLM_GOOGLE_VERTEX_REGION = "global,us-central1";
+
+		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual([
+			0, 1,
+		]);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(false);
 	});
 });

--- a/apps/gateway/src/chat/tools/get-provider-env.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.ts
@@ -5,7 +5,9 @@ import {
 	peekRoundRobinValue,
 } from "@/lib/round-robin-env.js";
 
+import { providerKeyBaseUrlSupportsServiceTier } from "@llmgateway/actions";
 import {
+	getProviderEnvValue,
 	getProviderEnvVar,
 	getProviderEnvConfig,
 	type Provider,
@@ -15,6 +17,81 @@ export interface ProviderEnvResult {
 	token: string;
 	configIndex: number;
 	envVarName: string;
+}
+
+function getEnvCredentialCount(provider: Provider): number {
+	const envVar = getProviderEnvVar(provider);
+	const value = envVar ? process.env[envVar] : undefined;
+	if (!value) {
+		return 0;
+	}
+	return value
+		.split(",")
+		.map((v) => v.trim())
+		.filter((v) => v.length > 0).length;
+}
+
+/**
+ * Whether a single env credential index can carry a Flex/Priority service-tier
+ * request. Requires:
+ * - an eligible base URL (managed default / canonical upstream, not a proxy);
+ * - for google-vertex, a global region — Flex/Priority PayGo is served only on
+ *   the global endpoint, and a non-global index would have its tier header
+ *   dropped by getForwardedServiceTier and be silently served as standard.
+ *
+ * Base URL and region are comma-indexed in lockstep with the API-key env var,
+ * so this is evaluated per index.
+ */
+function isServiceTierEligibleEnvIndex(
+	provider: Provider,
+	index: number,
+): boolean {
+	const baseUrl = getProviderEnvValue(provider, "baseUrl", index);
+	if (!providerKeyBaseUrlSupportsServiceTier(provider, baseUrl)) {
+		return false;
+	}
+	if (provider === "google-vertex") {
+		const region = getProviderEnvValue(provider, "region", index, "global");
+		if (region !== "global") {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * Env credential indices that are NOT eligible to carry a Flex/Priority
+ * service-tier request. Used to exclude those indices from round-robin
+ * selection so a service-tier request lands on a credential that hits the real
+ * upstream on a tier-capable endpoint.
+ */
+export function getServiceTierIneligibleEnvIndices(
+	provider: Provider,
+): Set<number> {
+	const ineligible = new Set<number>();
+	const count = getEnvCredentialCount(provider);
+	for (let index = 0; index < count; index++) {
+		if (!isServiceTierEligibleEnvIndex(provider, index)) {
+			ineligible.add(index);
+		}
+	}
+	return ineligible;
+}
+
+/**
+ * Whether at least one env credential for the provider targets an upstream
+ * endpoint eligible for service-tier requests.
+ */
+export function hasServiceTierEligibleEnvCredential(
+	provider: Provider,
+): boolean {
+	const count = getEnvCredentialCount(provider);
+	for (let index = 0; index < count; index++) {
+		if (isServiceTierEligibleEnvIndex(provider, index)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 interface GetProviderEnvOptions {

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -10,7 +10,9 @@ import { getVertexOpenAIAccessToken } from "@/lib/vertex-openai-token.js";
 import {
 	getProviderEndpoint,
 	getProviderHeaders,
+	isPremiumServiceTier,
 	prepareRequestBody,
+	providerKeyBaseUrlSupportsServiceTier,
 	selectProviderMapping,
 } from "@llmgateway/actions";
 import {
@@ -35,7 +37,10 @@ import {
 	isPremiumModel,
 } from "@llmgateway/shared";
 
-import { getProviderEnv } from "./get-provider-env.js";
+import {
+	getProviderEnv,
+	getServiceTierIneligibleEnvIndices,
+} from "./get-provider-env.js";
 
 import type { InferSelectModel, tables } from "@llmgateway/db";
 
@@ -305,6 +310,32 @@ export async function resolveProviderContext(
 	let configIndex = 0;
 	let envVarName: string | undefined;
 
+	// Flex/Priority is only honored when the request reaches the provider's real
+	// upstream endpoint. Skip provider keys whose custom base URL (proxy) may
+	// silently drop the tier, so a compliant key (or the managed env credential)
+	// is used instead.
+	const serviceTierKeyFilter = isPremiumServiceTier(options.service_tier)
+		? (key: InferSelectModel<typeof tables.providerKey>) =>
+				providerKeyBaseUrlSupportsServiceTier(
+					key.provider as Provider,
+					key.baseUrl,
+				)
+		: undefined;
+	// Exclude env credential indices whose base URL can't honor the tier, merged
+	// with any already-failed indices, so env fallback also lands on the upstream.
+	const serviceTierEnvExcludedIndices = (
+		provider: Provider,
+	): ReadonlySet<number> | undefined => {
+		if (!serviceTierKeyFilter) {
+			return options.excludedEnvKeyIndices;
+		}
+		const ineligible = getServiceTierIneligibleEnvIndices(provider);
+		if (ineligible.size === 0) {
+			return options.excludedEnvKeyIndices;
+		}
+		return new Set([...(options.excludedEnvKeyIndices ?? []), ...ineligible]);
+	};
+
 	if (project.mode === "api-keys") {
 		if (usedProvider === "custom" && options.customProviderName) {
 			providerKey = await findCustomProviderKey(
@@ -319,6 +350,7 @@ export async function resolveProviderContext(
 				usedProvider,
 				usedInternalModel,
 				options.excludedProviderKeyIds,
+				serviceTierKeyFilter,
 			);
 		}
 
@@ -332,7 +364,7 @@ export async function resolveProviderContext(
 	} else if (project.mode === "credits") {
 		assertOrganizationHasCreditsForEnvFallback(organization, modelInfo);
 		const envResult = getProviderEnv(usedProvider as Provider, {
-			excludedIndices: options.excludedEnvKeyIndices,
+			excludedIndices: serviceTierEnvExcludedIndices(usedProvider as Provider),
 			selectionScope: usedInternalModel,
 		});
 		usedToken = envResult.token;
@@ -352,6 +384,7 @@ export async function resolveProviderContext(
 				usedProvider,
 				usedInternalModel,
 				options.excludedProviderKeyIds,
+				serviceTierKeyFilter,
 			);
 		}
 
@@ -360,7 +393,9 @@ export async function resolveProviderContext(
 		} else {
 			assertOrganizationHasCreditsForEnvFallback(organization, modelInfo);
 			const envResult = getProviderEnv(usedProvider as Provider, {
-				excludedIndices: options.excludedEnvKeyIndices,
+				excludedIndices: serviceTierEnvExcludedIndices(
+					usedProvider as Provider,
+				),
 				selectionScope: usedInternalModel,
 			});
 			usedToken = envResult.token;

--- a/packages/actions/src/apply-google-service-tier.spec.ts
+++ b/packages/actions/src/apply-google-service-tier.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
 	applyGoogleServiceTier,
+	isPremiumServiceTier,
+	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
 } from "./apply-google-service-tier.js";
 
@@ -84,5 +86,74 @@ describe("resolveServedServiceTier", () => {
 		expect(
 			resolveServedServiceTier({ trafficType: null, serviceTierHeader: null }),
 		).toBeNull();
+	});
+});
+
+describe("isPremiumServiceTier", () => {
+	it("accepts only flex and priority", () => {
+		expect(isPremiumServiceTier("flex")).toBe(true);
+		expect(isPremiumServiceTier("priority")).toBe(true);
+		for (const tier of ["auto", "default", "", null, undefined]) {
+			expect(isPremiumServiceTier(tier)).toBe(false);
+		}
+	});
+});
+
+describe("providerKeyBaseUrlSupportsServiceTier", () => {
+	it("ignores trailing slashes when matching the canonical upstream", () => {
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"google-vertex",
+				"https://aiplatform.googleapis.com///",
+			),
+		).toBe(true);
+	});
+
+	it("allows a key with no custom base URL (managed default)", () => {
+		expect(providerKeyBaseUrlSupportsServiceTier("google-vertex", null)).toBe(
+			true,
+		);
+		expect(
+			providerKeyBaseUrlSupportsServiceTier("google-ai-studio", undefined),
+		).toBe(true);
+	});
+
+	it("allows a key whose base URL matches the canonical upstream", () => {
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"google-vertex",
+				"https://aiplatform.googleapis.com",
+			),
+		).toBe(true);
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"google-ai-studio",
+				"https://generativelanguage.googleapis.com/",
+			),
+		).toBe(true);
+	});
+
+	it("rejects a custom (proxy) base URL on the google tier providers", () => {
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"google-vertex",
+				"https://my-proxy.example.com",
+			),
+		).toBe(false);
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"google-ai-studio",
+				"https://gateway.internal/v1",
+			),
+		).toBe(false);
+	});
+
+	it("ignores providers without an upstream-only rule", () => {
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"openai",
+				"https://my-proxy.example.com",
+			),
+		).toBe(true);
 	});
 });

--- a/packages/actions/src/apply-google-service-tier.ts
+++ b/packages/actions/src/apply-google-service-tier.ts
@@ -31,6 +31,66 @@ export function applyGoogleServiceTier(
 }
 
 /**
+ * Canonical upstream base URLs for the Google providers that honor the
+ * OpenAI-compatible `service_tier` (Flex / Priority). A premium tier is only
+ * guaranteed to apply when the request reaches Google directly: a provider key
+ * pointing at a proxy / custom base URL may silently drop the tier header (Vertex)
+ * or body field (AI Studio), so the gateway would bill and report the standard
+ * tier even though the caller asked for Flex/Priority. Service-tier routing is
+ * therefore restricted to keys that target these endpoints.
+ */
+const SERVICE_TIER_UPSTREAM_BASE_URLS: Partial<Record<ProviderId, string>> = {
+	"google-ai-studio": "https://generativelanguage.googleapis.com",
+	"google-vertex": "https://aiplatform.googleapis.com",
+};
+
+/**
+ * The OpenAI-compatible processing tiers that select premium (Flex / Priority)
+ * inference. Shared so every service-tier code path agrees on the accepted
+ * values instead of re-inlining the literal union.
+ */
+export function isPremiumServiceTier(
+	serviceTier: string | null | undefined,
+): serviceTier is "flex" | "priority" {
+	return serviceTier === "flex" || serviceTier === "priority";
+}
+
+function normalizeServiceTierBaseUrl(baseUrl: string): string {
+	// Strip trailing slashes without a backtracking regex (avoids the
+	// polynomial-ReDoS CodeQL flags for `/\/+$/` on attacker-influenced input).
+	const trimmed = baseUrl.trim();
+	let end = trimmed.length;
+	while (end > 0 && trimmed[end - 1] === "/") {
+		end--;
+	}
+	return trimmed.slice(0, end).toLowerCase();
+}
+
+/**
+ * Whether a provider key's base URL is eligible to carry a Flex/Priority
+ * service-tier request. Eligible when the provider has no upstream-only rule, or
+ * when the key uses the managed default (no custom base URL), or when the custom
+ * base URL exactly matches the provider's canonical upstream. A custom base URL
+ * on google-ai-studio / google-vertex is the only case this rejects.
+ */
+export function providerKeyBaseUrlSupportsServiceTier(
+	provider: ProviderId,
+	baseUrl: string | null | undefined,
+): boolean {
+	const upstream = SERVICE_TIER_UPSTREAM_BASE_URLS[provider];
+	if (!upstream) {
+		return true;
+	}
+	if (!baseUrl) {
+		return true;
+	}
+	return (
+		normalizeServiceTierBaseUrl(baseUrl) ===
+		normalizeServiceTierBaseUrl(upstream)
+	);
+}
+
+/**
  * Resolve the processing tier the provider actually served from the upstream
  * response signals. Returns "flex" / "priority", or null for the standard tier
  * (including when Google downgraded an unsupported tier to standard).


### PR DESCRIPTION
## Summary

Flex/Priority service tiers are only honored when the request reaches Google **directly**. A `google-vertex` / `google-ai-studio` credential pointing at a **custom base URL** (a proxy) may silently drop the tier header (Vertex) or body field (AI Studio) — the upstream then serves standard, and the gateway bills/reports standard, even though the caller asked for Priority. This PR routes service-tier requests only to credentials that target the canonical upstream endpoint, covering **both** DB provider keys and env credentials.

## Behavior

- **Auto / model-id routing** — non-compliant providers are **excluded** from the routing candidate set (`iamFilteredModelProviders`, mirroring the existing compliance-policy pattern). The gateway routes around the ineligible credential to a compliant provider; it does **not** 4xx when a compliant alternative exists.
- **DB provider keys** — a non-compliant key is skipped at resolution via `findProviderKey`'s `filter` (in hybrid mode it falls back to the env credential).
- **Env credentials** — env keys are comma-indexed with per-index base URLs (`LLM_..._BASE_URL`). Indices whose base URL is a custom proxy are excluded from selection for service-tier requests, so the request lands on an upstream index.
- **Empty / unset base URL = managed upstream default = eligible.**
- **Pinned provider with no eligible credential** — returns a clear `400` instead of silently downgrading.
- **Non-service-tier requests are unaffected** — custom base URLs continue to work exactly as before.

Eligibility: a credential is eligible if it has **no custom base URL** (managed default) or its base URL exactly matches the provider's canonical upstream (`https://aiplatform.googleapis.com` for Vertex, `https://generativelanguage.googleapis.com` for AI Studio). Providers without an upstream-only rule (e.g. OpenAI) are always eligible.

## Implementation

- `packages/actions`: `providerKeyBaseUrlSupportsServiceTier(provider, baseUrl)` helper + unit tests.
- `apps/gateway` `chat.ts`: `enforceServiceTierKeyEligibility()` filters the candidate provider list (initial selection + `selectNextProvider` fallback) and 400s only when pinned/none-remain; `serviceTierKeyFilter` passed to inline `findProviderKey`; env `getProviderEnv` calls exclude non-compliant indices.
- `get-provider-env.ts`: `getServiceTierIneligibleEnvIndices` / `hasServiceTierEligibleEnvCredential` + unit tests.
- `resolve-provider-context.ts` (retry path): same DB-key and env-index filtering.
- Docs note in `service-tiers.mdx`.

## Verification (live, real Vertex/AI Studio)

| Scenario | Result |
|---|---|
| Compliant priority (env upstream) | served priority, billed 1.8x |
| Hybrid + non-compliant DB key | skipped the proxy key, used env, billed 1.8x |
| api-keys, model-id routing, non-compliant vertex + compliant ai-studio | routed to ai-studio, no 4xx |
| api-keys, pinned vertex, only non-compliant key | clear 400 |
| Two env creds `[proxy, upstream]`, priority | `configIndex=1` -> `aiplatform.googleapis.com` (proxy excluded) |
| Same two env creds, **non**-priority | `configIndex=0` -> `vertex-proxy-test.invalid` (proxy used; unaffected) |
| End-to-end log row after auto-route | `requested_service_tier=priority`, `used_service_tier=priority` |

The env-credential case was confirmed deterministically via the resolved endpoint URL: a `priority` request selected the upstream index while a non-tier request selected the proxy index. The persisted log row shows both requested and used tier = `priority`.

`pnpm format`, full `pnpm build`, and unit tests (21: `apply-google-service-tier` + `get-provider-env`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Flex/priority tier routing to ensure it’s only applied when provider keys/env credentials can reach Google directly.
  * Prevents silent tier downgrades for proxy/custom base URLs and returns a 400 when an incompatible tier is pinned or no eligible providers remain.
  * Applies consistent eligibility filtering across provider-key and credential selection (including credits and hybrid flows).

* **Documentation**
  * Added a warning callout clarifying proxy/custom base URL behavior, multiple-key routing, and pinned-tier handling.

* **Tests**
  * Expanded coverage for service-tier eligibility based on base URL rules for Google providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->