### PR TITLE
fix(gateway): pricing from active provider in /v1/models

### DIFF
--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -229,6 +229,77 @@ describe("Models API", () => {
 		]);
 	});
 
+	test("GET /v1/models should derive model-level pricing from an active provider mapping, not a deactivated one", async () => {
+		const res = await app.request("/v1/models");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+		const now = new Date();
+
+		const isActive = (p: ProviderModelMapping) =>
+			!(p.deactivatedAt && now > p.deactivatedAt) &&
+			!(p.deprecatedAt && now > p.deprecatedAt);
+		const hasPricing = (p: ProviderModelMapping) =>
+			p.inputPrice !== undefined ||
+			p.outputPrice !== undefined ||
+			p.imageInputPrice !== undefined ||
+			p.perSecondPrice !== undefined ||
+			p.ocrPagePrice !== undefined;
+
+		const definitionById = new Map(modelsList.map((m) => [m.id, m]));
+
+		for (const model of json.data) {
+			const definition = definitionById.get(model.id);
+			expect(definition).toBeDefined();
+			const mappings = definition!.providers as ProviderModelMapping[];
+
+			const expected =
+				mappings.find((p) => isActive(p) && hasPricing(p)) ??
+				mappings.find((p) => hasPricing(p));
+
+			expect(model.pricing.prompt).toBe(
+				expected?.inputPrice?.toString() ?? "0",
+			);
+			expect(model.pricing.input_cache_read).toBe(
+				expected?.cachedInputPrice?.toString() ?? "0",
+			);
+		}
+
+		// deepseek-v3.2's first mapping (deepseek) is deactivated, so the
+		// model-level cache-read price must not be DeepSeek's 0.028e-6.
+		const deepseek = json.data.find(
+			(model: any) => model.id === "deepseek-v3.2",
+		);
+		expect(deepseek).toBeDefined();
+		expect(deepseek.pricing.input_cache_read).not.toBe("0.028e-6");
+	});
+
+	test("GET /v1/models exposes cache pricing detail per provider mapping", async () => {
+		const res = await app.request("/v1/models?include_deactivated=true");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+		const definitionById = new Map(modelsList.map((m) => [m.id, m]));
+
+		const deepseek = json.data.find(
+			(model: any) => model.id === "deepseek-v3.2",
+		);
+		expect(deepseek).toBeDefined();
+
+		const definition = definitionById.get("deepseek-v3.2")!;
+		for (const provider of deepseek.providers) {
+			const mapping = (definition.providers as ProviderModelMapping[]).find(
+				(p) => p.providerId === provider.providerId,
+			);
+			expect(mapping).toBeDefined();
+			if (mapping!.cachedInputPrice !== undefined) {
+				expect(provider.pricing?.input_cache_read).toBe(
+					mapping!.cachedInputPrice.toString(),
+				);
+			}
+		}
+	});
+
 	test("GET /v1/models should expose per-page OCR pricing for mistral-ocr-latest", async () => {
 		const res = await app.request("/v1/models");
 		expect(res.status).toBe(200);

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -229,7 +229,7 @@ describe("Models API", () => {
 		]);
 	});
 
-	test("GET /v1/models should derive model-level pricing from an active provider mapping, not a deactivated one", async () => {
+	test("GET /v1/models should derive model-level pricing from the cheapest active provider mapping", async () => {
 		const res = await app.request("/v1/models");
 		expect(res.status).toBe(200);
 
@@ -245,6 +245,34 @@ describe("Models API", () => {
 			p.imageInputPrice !== undefined ||
 			p.perSecondPrice !== undefined ||
 			p.ocrPagePrice !== undefined;
+		const score = (p: ProviderModelMapping) => {
+			const input =
+				p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
+			const output =
+				p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
+			if (input !== undefined || output !== undefined) {
+				return (input ?? 0) + (output ?? 0);
+			}
+			if (p.ocrPagePrice !== undefined) {
+				return Number(p.ocrPagePrice);
+			}
+			if (p.perSecondPrice) {
+				const values = Object.values(p.perSecondPrice).map(Number);
+				return values.length > 0 ? Math.min(...values) : Infinity;
+			}
+			if (p.requestPrice !== undefined) {
+				return Number(p.requestPrice);
+			}
+			if (p.imageInputPrice !== undefined) {
+				return Number(p.imageInputPrice);
+			}
+			return Infinity;
+		};
+		const cheapest = (candidates: ProviderModelMapping[]) =>
+			candidates.reduce<ProviderModelMapping | undefined>(
+				(best, p) => (best === undefined || score(p) < score(best) ? p : best),
+				undefined,
+			);
 
 		const definitionById = new Map(modelsList.map((m) => [m.id, m]));
 
@@ -253,9 +281,11 @@ describe("Models API", () => {
 			expect(definition).toBeDefined();
 			const mappings = definition!.providers as ProviderModelMapping[];
 
+			const active = mappings.filter((p) => isActive(p) && hasPricing(p));
 			const expected =
-				mappings.find((p) => isActive(p) && hasPricing(p)) ??
-				mappings.find((p) => hasPricing(p));
+				active.length > 0
+					? cheapest(active)
+					: cheapest(mappings.filter((p) => hasPricing(p)));
 
 			expect(model.pricing.prompt).toBe(
 				expected?.inputPrice?.toString() ?? "0",
@@ -265,13 +295,16 @@ describe("Models API", () => {
 			);
 		}
 
-		// deepseek-v3.2's first mapping (deepseek) is deactivated, so the
-		// model-level cache-read price must not be DeepSeek's 0.028e-6.
+		// deepseek-v3.2: deepinfra is the cheapest active mapping
+		// (0.26e-6 + 0.38e-6), so the root pricing must come from it and not the
+		// deactivated DeepSeek mapping (whose cache read is 0.028e-6).
 		const deepseek = json.data.find(
 			(model: any) => model.id === "deepseek-v3.2",
 		);
 		expect(deepseek).toBeDefined();
-		expect(deepseek.pricing.input_cache_read).not.toBe("0.028e-6");
+		expect(deepseek.pricing.prompt).toBe("0.26e-6");
+		expect(deepseek.pricing.completion).toBe("0.38e-6");
+		expect(deepseek.pricing.input_cache_read).toBe("0.13e-6");
 	});
 
 	test("GET /v1/models exposes cache pricing detail per provider mapping", async () => {

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -210,11 +210,9 @@ modelsApi.openapi(listModels, async (c) => {
 				| "audio"
 			)[] = model.output ?? ["text"];
 
-			// Pick the provider mapping whose pricing represents the model at the
-			// top level. Prefer a mapping that is neither deactivated nor
-			// deprecated as of now, so the model-level pricing reflects a
-			// provider that is actually serving the model; only fall back to a
-			// deactivated/deprecated mapping when no active mapping has pricing.
+			// Source the model-level pricing from the cheapest provider mapping
+			// that is actually serving the model (not deactivated/deprecated), so
+			// the root pricing reflects the best price a caller can get.
 			const pricingProvider = pickPricingProvider(model.providers, currentDate);
 
 			return {
@@ -353,10 +351,38 @@ function buildPricingFields(p: ProviderModelMapping | undefined) {
 	};
 }
 
-// Pick the provider mapping that represents the model-level pricing. Prefer a
-// mapping that is neither deactivated nor deprecated as of `currentDate` so the
-// reported pricing matches a provider actually serving the model; fall back to
-// any mapping with pricing when every active mapping lacks it.
+// A single comparable cost for a provider mapping, used to pick the cheapest
+// one. Token-priced models compare on input + output price; models priced by
+// other units (OCR per page, video per second, per request, image) fall back to
+// those. Lower is cheaper; a mapping with no comparable price sorts last.
+function pricingScore(p: ProviderModelMapping): number {
+	const input = p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
+	const output =
+		p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
+	if (input !== undefined || output !== undefined) {
+		return (input ?? 0) + (output ?? 0);
+	}
+	if (p.ocrPagePrice !== undefined) {
+		return Number(p.ocrPagePrice);
+	}
+	if (p.perSecondPrice) {
+		const values = Object.values(p.perSecondPrice).map(Number);
+		return values.length > 0 ? Math.min(...values) : Infinity;
+	}
+	if (p.requestPrice !== undefined) {
+		return Number(p.requestPrice);
+	}
+	if (p.imageInputPrice !== undefined) {
+		return Number(p.imageInputPrice);
+	}
+	return Infinity;
+}
+
+// Pick the provider mapping that represents the model-level pricing: the
+// cheapest mapping that is neither deactivated nor deprecated as of
+// `currentDate`, so the reported pricing reflects the best price a caller can
+// actually get. Only fall back to deactivated/deprecated mappings when no
+// active mapping has pricing. Ties keep the earlier mapping in definition order.
 function pickPricingProvider(
 	providerMappings: ProviderModelMapping[],
 	currentDate: Date,
@@ -365,10 +391,19 @@ function pickPricingProvider(
 		!(p.deactivatedAt && currentDate > p.deactivatedAt) &&
 		!(p.deprecatedAt && currentDate > p.deprecatedAt);
 
-	return (
-		providerMappings.find((p) => isActive(p) && hasPricing(p)) ??
-		providerMappings.find((p) => hasPricing(p))
-	);
+	const cheapest = (candidates: ProviderModelMapping[]) =>
+		candidates.reduce<ProviderModelMapping | undefined>(
+			(best, p) =>
+				best === undefined || pricingScore(p) < pricingScore(best) ? p : best,
+			undefined,
+		);
+
+	const active = providerMappings.filter((p) => isActive(p) && hasPricing(p));
+	if (active.length > 0) {
+		return cheapest(active);
+	}
+
+	return cheapest(providerMappings.filter((p) => hasPricing(p)));
 }
 
 function getPerRequestLimits(

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -43,6 +43,10 @@ const modelSchema = z.object({
 					completion: z.string(),
 					image: z.string().optional(),
 					per_second: z.record(z.string()).optional(),
+					request: z.string().optional(),
+					input_cache_read: z.string().optional(),
+					input_cache_write: z.string().optional(),
+					input_cache_write_1h: z.string().optional(),
 					ocr_page: z.string().optional(),
 				})
 				.optional(),
@@ -206,21 +210,12 @@ modelsApi.openapi(listModels, async (c) => {
 				| "audio"
 			)[] = model.output ?? ["text"];
 
-			const firstProviderWithPricing = model.providers.find(
-				(p: ProviderModelMapping) =>
-					p.inputPrice !== undefined ||
-					p.outputPrice !== undefined ||
-					p.imageInputPrice !== undefined ||
-					p.perSecondPrice !== undefined ||
-					p.ocrPagePrice !== undefined,
-			);
-
-			const inputPrice =
-				firstProviderWithPricing?.inputPrice?.toString() ?? "0";
-			const outputPrice =
-				firstProviderWithPricing?.outputPrice?.toString() ?? "0";
-			const imagePrice =
-				firstProviderWithPricing?.imageInputPrice?.toString() ?? "0";
+			// Pick the provider mapping whose pricing represents the model at the
+			// top level. Prefer a mapping that is neither deactivated nor
+			// deprecated as of now, so the model-level pricing reflects a
+			// provider that is actually serving the model; only fall back to a
+			// deactivated/deprecated mapping when no active mapping has pricing.
+			const pricingProvider = pickPricingProvider(model.providers, currentDate);
 
 			return {
 				id: model.id,
@@ -251,29 +246,9 @@ modelsApi.openapi(listModels, async (c) => {
 						supportedVideoSizes: provider.supportedVideoSizes,
 						supportsVideoAudio: provider.supportsVideoAudio,
 						supportsVideoWithoutAudio: provider.supportsVideoWithoutAudio,
-						pricing:
-							provider.inputPrice !== undefined ||
-							provider.outputPrice !== undefined ||
-							provider.imageInputPrice !== undefined ||
-							provider.perSecondPrice !== undefined ||
-							provider.ocrPagePrice !== undefined
-								? {
-										prompt: provider.inputPrice?.toString() ?? "0",
-										completion: provider.outputPrice?.toString() ?? "0",
-										image: provider.imageInputPrice?.toString() ?? "0",
-										per_second: provider.perSecondPrice
-											? Object.fromEntries(
-													Object.entries(provider.perSecondPrice).map(
-														([resolution, price]) => [
-															resolution,
-															price.toString(),
-														],
-													),
-												)
-											: undefined,
-										ocr_page: provider.ocrPagePrice?.toString(),
-									}
-								: undefined,
+						pricing: hasPricing(provider)
+							? buildPricingFields(provider)
+							: undefined,
 						streaming: provider.streaming,
 						vision: provider.vision ?? false,
 						cancellation: providerDef?.cancellation ?? false,
@@ -284,26 +259,9 @@ modelsApi.openapi(listModels, async (c) => {
 					};
 				}),
 				pricing: {
-					prompt: inputPrice,
-					completion: outputPrice,
-					image: imagePrice,
-					per_second: firstProviderWithPricing?.perSecondPrice
-						? Object.fromEntries(
-								Object.entries(firstProviderWithPricing.perSecondPrice).map(
-									([resolution, price]) => [resolution, price.toString()],
-								),
-							)
-						: undefined,
-					request: firstProviderWithPricing?.requestPrice?.toString() ?? "0",
-					input_cache_read:
-						firstProviderWithPricing?.cachedInputPrice?.toString() ?? "0",
-					input_cache_write:
-						firstProviderWithPricing?.cacheWriteInputPrice?.toString() ?? "0",
-					input_cache_write_1h:
-						firstProviderWithPricing?.cacheWriteInputPrice1h?.toString() ?? "0",
+					...buildPricingFields(pricingProvider),
 					web_search: "0", // Not defined in model definitions yet
 					internal_reasoning: "0", // Not defined in model definitions yet
-					ocr_page: firstProviderWithPricing?.ocrPagePrice?.toString(),
 				},
 				// Use context length from model definition (take the largest from all providers)
 				context_length:
@@ -357,6 +315,60 @@ function getModelLevelDate(dates: (Date | undefined)[]): string | undefined {
 	return (dates as Date[])
 		.reduce((latest, d) => (d.getTime() > latest.getTime() ? d : latest))
 		.toISOString();
+}
+
+// Whether a provider mapping carries any pricing information at all.
+function hasPricing(p: ProviderModelMapping): boolean {
+	return (
+		p.inputPrice !== undefined ||
+		p.outputPrice !== undefined ||
+		p.imageInputPrice !== undefined ||
+		p.perSecondPrice !== undefined ||
+		p.ocrPagePrice !== undefined
+	);
+}
+
+// Build the public pricing object for a provider mapping. Used both for the
+// per-provider pricing and (with a representative mapping) the model-level
+// pricing, so the two expose the same level of detail. A missing mapping or
+// missing field defaults to "0".
+function buildPricingFields(p: ProviderModelMapping | undefined) {
+	return {
+		prompt: p?.inputPrice?.toString() ?? "0",
+		completion: p?.outputPrice?.toString() ?? "0",
+		image: p?.imageInputPrice?.toString() ?? "0",
+		per_second: p?.perSecondPrice
+			? Object.fromEntries(
+					Object.entries(p.perSecondPrice).map(([resolution, price]) => [
+						resolution,
+						price.toString(),
+					]),
+				)
+			: undefined,
+		request: p?.requestPrice?.toString() ?? "0",
+		input_cache_read: p?.cachedInputPrice?.toString() ?? "0",
+		input_cache_write: p?.cacheWriteInputPrice?.toString() ?? "0",
+		input_cache_write_1h: p?.cacheWriteInputPrice1h?.toString() ?? "0",
+		ocr_page: p?.ocrPagePrice?.toString(),
+	};
+}
+
+// Pick the provider mapping that represents the model-level pricing. Prefer a
+// mapping that is neither deactivated nor deprecated as of `currentDate` so the
+// reported pricing matches a provider actually serving the model; fall back to
+// any mapping with pricing when every active mapping lacks it.
+function pickPricingProvider(
+	providerMappings: ProviderModelMapping[],
+	currentDate: Date,
+): ProviderModelMapping | undefined {
+	const isActive = (p: ProviderModelMapping) =>
+		!(p.deactivatedAt && currentDate > p.deactivatedAt) &&
+		!(p.deprecatedAt && currentDate > p.deprecatedAt);
+
+	return (
+		providerMappings.find((p) => isActive(p) && hasPricing(p)) ??
+		providerMappings.find((p) => hasPricing(p))
+	);
 }
 
 function getPerRequestLimits(


### PR DESCRIPTION
## Problem

The `/v1/models` response had two pricing issues, both visible on `deepseek-v3.2`:

1. **Model-level `pricing` was derived from a deactivated provider.** The top-level `pricing` object picked the *first* provider mapping with any pricing, regardless of status. For `deepseek-v3.2` that's the `deepseek` mapping, which is deactivated (`deactivatedAt: 2026-05-01`). So `input_cache_read` reported DeepSeek's `0.028e-6` — a rate nobody is actually charging since DeepSeek isn't serving the model.

2. **Per-provider `pricing` lacked detail.** Each entry in the `providers` array only carried `prompt`, `completion`, and `image`, while the model-level pricing exposed `request`, `input_cache_read`, `input_cache_write`, and `input_cache_write_1h`.

## Fix

- Add `pickPricingProvider()`, which sources the model-level pricing from the **cheapest** provider mapping that is **neither deactivated nor deprecated** as of now, so the root pricing reflects the best price a caller can actually get. It only falls back to a deactivated/deprecated mapping when no active one has pricing. Cost is compared via `pricingScore()` on input + output token price, falling back to OCR-per-page / video-per-second / per-request / image price for models priced by other units; ties keep the earlier mapping in definition order. For `deepseek-v3.2` the root pricing now comes from `deepinfra` (`0.26e-6` + `0.38e-6`, cache read `0.13e-6`).
- Extract `buildPricingFields()` / `hasPricing()` helpers and reuse them for both the per-provider and model-level pricing, so each provider mapping now exposes the same `request` / `input_cache_read` / `input_cache_write` / `input_cache_write_1h` detail. Updated the response Zod schema accordingly.

## Tests

Added two specs to `models.spec.ts`:
- Model-level pricing matches the cheapest-active-provider selection algorithm for every model, and `deepseek-v3.2`'s root pricing is `deepinfra`'s (`prompt 0.26e-6`, `completion 0.38e-6`, `input_cache_read 0.13e-6`) rather than the deactivated DeepSeek mapping's `0.028e-6`.
- Per-provider pricing exposes `input_cache_read` matching each mapping's `cachedInputPrice`.

All 19 specs pass; `pnpm build` (gateway + deps) and `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway model pricing so it reflects the active provider mapping when multiple provider mappings exist.
  * Prevented cache-read pricing from being sourced from deactivated or deprecated mappings.
  * Expanded model response pricing details to include request pricing and cache read/write fields where available.
  * When deactivated providers are included, pricing details now surface correctly per provider mapping.
* **Tests**
  * Added coverage for representative pricing selection and cache pricing behavior with and without deactivated mappings included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->