### PR TITLE
feat(models): add Tundra stealth provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,10 @@ LLM_GOOGLE_AI_STUDIO_API_KEY=your_google_ai_studio_key_here
 LLM_GLACIER_API_KEY=your_glacier_key_here
 LLM_GLACIER_BASE_URL=https://your-glacier-base-url
 
+# Tundra
+LLM_TUNDRA_API_KEY=your_tundra_key_here
+LLM_TUNDRA_BASE_URL=https://your-tundra-base-url
+
 # Google Vertex AI (Gemini models)
 LLM_GOOGLE_VERTEX_API_KEY=your_google_vertex_api_key_here
 LLM_GOOGLE_CLOUD_PROJECT=your_google_cloud_project_id

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ llmgateway_data
 *.txt
 docker-compose-override-*.yml
 benchmark_results.json
+benchmark-*.json
 *.pdf
 *.b64
 /output.png

--- a/apps/gateway/src/chat/tools/transform-openai-streaming.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.ts
@@ -71,6 +71,17 @@ export function transformOpenaiStreaming(
 			role: delta.role ?? "assistant",
 		};
 
+		// Some upstreams (e.g. the Tundra endpoint) emit an empty
+		// `tool_calls: []` array in the leading delta chunk. OpenAI never sends an
+		// empty tool_calls array, and downstream consumers treat any present
+		// tool_calls field as an actual tool-call delta, so drop it when empty.
+		if (
+			Array.isArray(newDelta.tool_calls) &&
+			newDelta.tool_calls.length === 0
+		) {
+			delete newDelta.tool_calls;
+		}
+
 		const normalizedReasoning =
 			newDelta.reasoning ??
 			newDelta.reasoning_content ??

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1349,6 +1349,7 @@ export function transformStreamingToOpenai(
 		case "minimax":
 		case "embercloud":
 		case "granite":
+		case "tundra":
 		case "xiaomi":
 		case "azure-ai-foundry":
 		case "vertex-openai":

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -238,6 +238,16 @@ export function getProviderEndpoint(
 					);
 				}
 				break;
+			case "tundra":
+				url = skipEnvVars
+					? undefined
+					: getProviderEnvValue("tundra", "baseUrl", configIndex);
+				if (!url) {
+					throw new Error(
+						"Tundra provider requires LLM_TUNDRA_BASE_URL environment variable",
+					);
+				}
+				break;
 			case "inference.net":
 				url = "https://api.inference.net";
 				break;
@@ -660,6 +670,7 @@ export function getProviderEndpoint(
 		case "minimax":
 		case "xiaomi":
 		case "embercloud":
+		case "tundra":
 		case "custom":
 		default:
 			return `${url}/v1/chat/completions`;

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1436,6 +1436,18 @@ export async function prepareRequestBody(
 
 	if (
 		forcesToolUse &&
+		usedProvider === "tundra" &&
+		resolvedToolChoice === "required"
+	) {
+		// The Tundra upstream rejects tool_choice="required" with a 400.
+		// Named/forced function choice works, so only downgrade the "required"
+		// sentinel to "auto" so the request still succeeds.
+		resolvedToolChoice = "auto";
+		requestBody.tool_choice = "auto";
+	}
+
+	if (
+		forcesToolUse &&
 		usedProvider === "azure" &&
 		usedInternalModel === "gpt-oss-120b"
 	) {

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -394,6 +394,28 @@ export const moonshotModels = [
 				tools: false,
 				jsonOutput: false,
 			},
+			{
+				providerId: "tundra",
+				externalId: "kimi-k2.6",
+				inputPrice: "0.4e-6",
+				cachedInputPrice: "0.08e-6",
+				outputPrice: "2.2e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 262144,
+				streaming: true,
+				reasoning: true,
+				// The Tundra endpoint is asymmetric: streaming responses
+				// emit thinking in a separate reasoning_content field, but
+				// non-streaming responses inline it into content with no
+				// reasoning_content. Mark reasoning output as omitted so the gateway
+				// keeps streaming content clean (reasoning_content -> reasoning) yet
+				// does not require structured reasoning to be returned.
+				reasoningOutput: "omit",
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 	{

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1281,6 +1281,28 @@ export const providers: ProviderDefinition[] = [
 		dataPolicy: null,
 	},
 	{
+		id: "tundra",
+		name: "Tundra",
+		description: "Tundra is a stealth provider with an OpenAI-compatible API.",
+		env: {
+			required: {
+				apiKey: "LLM_TUNDRA_API_KEY",
+				baseUrl: "LLM_TUNDRA_BASE_URL",
+			},
+		},
+		streaming: true,
+		cancellation: true,
+		color: "#5b8db8",
+		website: null,
+		statusPageUrl: null,
+		announcement: null,
+		termsUrl: null,
+		privacyPolicyUrl: null,
+		headquarters: null,
+		dataPolicy: null,
+		priority: 1.1,
+	},
+	{
 		id: "xiaomi",
 		name: "Xiaomi",
 		description:

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -8,6 +8,7 @@
 		"analyze-content-filter": "tsx src/analyze-content-filter.ts",
 		"api-key-hash": "tsx src/api-key-hash.ts",
 		"api-ping": "tsx src/api-ping.ts",
+		"benchmark-model": "tsx --env-file=../../.env src/benchmark-model.ts",
 		"backfill-stripe-refunds": "tsx src/backfill-stripe-refunds.ts",
 		"export-models-dev": "tsx src/export-models-dev.ts",
 		"generate-test-logs": "tsx src/generate-test-logs.ts",
@@ -18,6 +19,7 @@
 		"test-gemini-tools-simple": "tsx src/test-gemini-tools-simple.ts"
 	},
 	"dependencies": {
+		"@llmgateway/actions": "workspace:*",
 		"@llmgateway/db": "workspace:*",
 		"@llmgateway/models": "workspace:*",
 		"@llmgateway/shared": "workspace:*",

--- a/packages/scripts/src/benchmark-model.ts
+++ b/packages/scripts/src/benchmark-model.ts
@@ -1,0 +1,394 @@
+/* eslint-disable no-console */
+/**
+ * Benchmark a model's response performance across every provider that serves
+ * it. Hits each provider's upstream directly (not through the gateway) so the
+ * numbers reflect raw model/provider performance, using the gateway's own
+ * endpoint + header resolution from the model registry.
+ *
+ * Measures time-to-first-token (TTFT), total latency, decode throughput
+ * (output tokens / generation time), and runs verifiable quality checks so a
+ * degraded/quantized variant on any provider is caught.
+ *
+ * Usage (env vars must hold the provider API keys, e.g. via `--env-file`):
+ *   pnpm --filter @llmgateway/scripts benchmark-model <model-id> [providers] [runs]
+ *   pnpm --filter @llmgateway/scripts benchmark-model kimi-k2.6
+ *   pnpm --filter @llmgateway/scripts benchmark-model kimi-k2.6 moonshot,tundra 2
+ *
+ * Only OpenAI-compatible chat providers are supported (the benchmark sends a
+ * plain OpenAI chat-completions body); other providers are reported as errors.
+ */
+import { writeFileSync } from "fs";
+
+import { getProviderEndpoint, getProviderHeaders } from "@llmgateway/actions";
+import {
+	models,
+	getProviderEnvVar,
+	expandAllProviderRegions,
+	type ProviderModelMapping,
+} from "@llmgateway/models";
+
+interface Prompt {
+	id: string;
+	maxTokens: number;
+	messages: { role: string; content: string }[];
+	check?: (content: string) => { ok: boolean | null; detail: string };
+}
+
+const PROMPTS: Prompt[] = [
+	{
+		id: "reasoning",
+		maxTokens: 4000,
+		messages: [
+			{
+				role: "user",
+				content:
+					"Solve carefully and show your work.\n" +
+					"1) A bag has 5 red, 4 blue, and 3 green marbles. You draw 3 at random " +
+					"without replacement. Give the exact probability (as a reduced fraction) " +
+					"that you draw exactly one marble of each color.\n" +
+					"2) How many positive integers n <= 1000 are divisible by 3 or 5 but NOT by 7?\n" +
+					"End your answer with a line exactly of the form: FINAL: <p1>; <p2>  " +
+					"where p1 is the reduced fraction and p2 is the integer count.",
+			},
+		],
+		check: (content) => {
+			// ground truth: 60/220 = 3/11 ; (333+200-66) - (47+28-9) = 401
+			const m = content.match(/FINAL:\s*([^\n;]+);\s*([^\n]+)/);
+			if (!m) {
+				return { ok: null, detail: "no FINAL line" };
+			}
+			const okP1 = m[1].replace(/\s/g, "") === "3/11";
+			const okP2 = /\b401\b/.test(m[2]);
+			return {
+				ok: okP1 && okP2,
+				detail: `p1=${okP1 ? "Y" : "N"} p2=${okP2 ? "Y" : "N"}`,
+			};
+		},
+	},
+	{
+		id: "coding",
+		maxTokens: 4000,
+		messages: [
+			{
+				role: "user",
+				content:
+					"Write a single JavaScript function `longestPalindrome(s)` that returns the " +
+					"longest palindromic substring of s (any one if ties). It must run in " +
+					"O(n^2) time or better and handle empty strings. Return ONLY one fenced " +
+					"```js code block with just the function, no prose.",
+			},
+		],
+		check: (content) => {
+			const m = content.match(
+				/```(?:javascript|js|typescript|ts)?\s*([\s\S]*?)```/,
+			);
+			const code = m ? m[1] : content;
+			try {
+				// Intentionally execute the model-generated code to validate it.
+				// eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+				const factory = new Function(`${code}\nreturn longestPalindrome;`);
+				const fn = factory() as (s: string) => string;
+				const cases: [string, string[]][] = [
+					["babad", ["bab", "aba"]],
+					["cbbd", ["bb"]],
+					["", [""]],
+					["a", ["a"]],
+					["forgeeksskeegfor", ["geeksskeeg"]],
+					["abacdfgdcaba", ["aba", "aca"]],
+				];
+				for (const [s, expected] of cases) {
+					const got = fn(s);
+					if (!expected.includes(got)) {
+						return {
+							ok: false,
+							detail: `f(${JSON.stringify(s)})=${JSON.stringify(got)} not in ${JSON.stringify(expected)}`,
+						};
+					}
+				}
+				return { ok: true, detail: "6/6 cases" };
+			} catch (e) {
+				return {
+					ok: false,
+					detail: e instanceof Error ? e.message : String(e),
+				};
+			}
+		},
+	},
+	{
+		id: "throughput",
+		maxTokens: 4000,
+		messages: [
+			{
+				role: "user",
+				content:
+					"Write a clear ~700 word technical explanation of how HTTP/2 multiplexing " +
+					"works, how it differs from HTTP/1.1 head-of-line blocking, and what role " +
+					"streams, frames, and flow control play. Write continuous prose, no headings.",
+			},
+		],
+		check: (content) => {
+			const words = content.trim().split(/\s+/).filter(Boolean).length;
+			return { ok: words >= 400, detail: `${words} words` };
+		},
+	},
+];
+
+interface Delta {
+	content?: string;
+	reasoning_content?: string;
+	reasoning?: string;
+}
+interface Usage {
+	completion_tokens?: number;
+}
+interface Chunk {
+	choices?: { delta?: Delta; finish_reason?: string | null }[];
+	usage?: Usage;
+}
+
+interface CallResult {
+	error: string | null;
+	ttft: number | null;
+	total: number;
+	content: string;
+	reasoning: string;
+	completionTokens: number | null;
+	finish: string | null;
+}
+
+async function streamCall(
+	url: string,
+	headers: Record<string, string>,
+	body: unknown,
+): Promise<CallResult> {
+	const t0 = performance.now();
+	let res: Response;
+	try {
+		res = await fetch(url, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+		});
+	} catch (e) {
+		return blank(t0, `${e instanceof Error ? e.message : String(e)}`);
+	}
+	if (!res.ok || !res.body) {
+		const detail = (await res.text()).slice(0, 200);
+		return blank(t0, `HTTP ${res.status}: ${detail}`);
+	}
+
+	let ttft: number | null = null;
+	let content = "";
+	let reasoning = "";
+	let completionTokens: number | null = null;
+	let finish: string | null = null;
+
+	const reader = res.body.getReader();
+	const decoder = new TextDecoder();
+	let buf = "";
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		buf += decoder.decode(value, { stream: true });
+		const lines = buf.split("\n");
+		buf = lines.pop() ?? "";
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed.startsWith("data:")) {
+				continue;
+			}
+			const payload = trimmed.slice(5).trim();
+			if (payload === "[DONE]") {
+				continue;
+			}
+			let chunk: Chunk;
+			try {
+				chunk = JSON.parse(payload) as Chunk;
+			} catch {
+				continue;
+			}
+			if (typeof chunk.usage?.completion_tokens === "number") {
+				completionTokens = chunk.usage.completion_tokens;
+			}
+			const choice = chunk.choices?.[0];
+			if (!choice) {
+				continue;
+			}
+			if (choice.finish_reason) {
+				finish = choice.finish_reason;
+			}
+			const piece = choice.delta?.content;
+			const rpiece = choice.delta?.reasoning_content ?? choice.delta?.reasoning;
+			if (piece) {
+				ttft ??= (performance.now() - t0) / 1000;
+				content += piece;
+			}
+			if (rpiece) {
+				ttft ??= (performance.now() - t0) / 1000;
+				reasoning += rpiece;
+			}
+		}
+	}
+	return {
+		error: null,
+		ttft,
+		total: (performance.now() - t0) / 1000,
+		content,
+		reasoning,
+		completionTokens,
+		finish,
+	};
+}
+
+function blank(t0: number, error: string): CallResult {
+	return {
+		error,
+		ttft: null,
+		total: (performance.now() - t0) / 1000,
+		content: "",
+		reasoning: "",
+		completionTokens: null,
+		finish: null,
+	};
+}
+
+function fmt(x: number | null): string {
+	return typeof x === "number" ? x.toFixed(2) : "-";
+}
+
+async function main(): Promise<void> {
+	const modelId = process.argv[2];
+	if (!modelId) {
+		console.error(
+			"usage: benchmark-model <model-id> [provider1,provider2] [runs]",
+		);
+		process.exit(1);
+	}
+	const providerFilter = process.argv[3]
+		? process.argv[3].split(",").map((s) => s.trim())
+		: undefined;
+	const runs = process.argv[4] ? Number(process.argv[4]) : 1;
+
+	const model = models.find((m) => m.id === modelId);
+	if (!model) {
+		console.error(`unknown model: ${modelId}`);
+		process.exit(1);
+	}
+
+	const mappings = expandAllProviderRegions(
+		model.providers as ProviderModelMapping[],
+	).filter((m) => !providerFilter || providerFilter.includes(m.providerId));
+
+	console.log(
+		`Benchmarking ${modelId} across ${mappings.length} provider mapping(s), ${runs} run(s) each\n`,
+	);
+
+	const results: Record<string, Record<string, CallResult[]>> = {};
+
+	for (const prompt of PROMPTS) {
+		results[prompt.id] = {};
+		for (const mapping of mappings) {
+			const label = mapping.region
+				? `${mapping.providerId}:${mapping.region}`
+				: mapping.providerId;
+			const envVar = getProviderEnvVar(mapping.providerId);
+			const token = envVar
+				? process.env[envVar]?.split(",")[0]?.trim()
+				: undefined;
+			if (!token) {
+				console.log(
+					`[${prompt.id.padEnd(11)}] ${label.padEnd(16)} no key (${envVar})`,
+				);
+				continue;
+			}
+
+			const runResults: CallResult[] = [];
+			for (let i = 0; i < runs; i++) {
+				let url: string;
+				try {
+					url = getProviderEndpoint(
+						mapping.providerId,
+						undefined,
+						modelId,
+						token,
+						true,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						undefined,
+						mapping.region,
+						false,
+						modelId,
+					);
+				} catch (e) {
+					runResults.push(
+						blank(
+							performance.now(),
+							e instanceof Error ? e.message : String(e),
+						),
+					);
+					continue;
+				}
+				const headers: Record<string, string> = {
+					"Content-Type": "application/json",
+					...getProviderHeaders(mapping.providerId, token),
+				};
+				const body = {
+					model: mapping.externalId,
+					messages: prompt.messages,
+					stream: true,
+					stream_options: { include_usage: true },
+					max_tokens: prompt.maxTokens,
+				};
+				const r = await streamCall(url, headers, body);
+				runResults.push(r);
+
+				const decode = r.ttft !== null && r.total ? r.total - r.ttft : null;
+				const toks =
+					r.completionTokens && decode && decode > 0
+						? r.completionTokens / decode
+						: null;
+				console.log(
+					`[${prompt.id.padEnd(11)}] ${label.padEnd(16)} run${i + 1} ` +
+						`ttft=${fmt(r.ttft)}s total=${fmt(r.total)}s out_tok=${r.completionTokens} ` +
+						`tok/s=${fmt(toks)} content=${r.content.length}c reason=${r.reasoning.length}c ` +
+						`finish=${r.finish} ${r.error ?? "ok"}`,
+				);
+			}
+			results[prompt.id][label] = runResults;
+		}
+		console.log();
+	}
+
+	console.log("=== QUALITY ===");
+	const labels = Array.from(
+		new Set(PROMPTS.flatMap((p) => Object.keys(results[p.id] ?? {}))),
+	);
+	for (const label of labels) {
+		const parts: string[] = [];
+		for (const prompt of PROMPTS) {
+			const rs = results[prompt.id]?.[label];
+			const withContent = rs?.find((r) => r.content);
+			if (!prompt.check) {
+				continue;
+			}
+			if (!withContent) {
+				parts.push(`${prompt.id}[no output]`);
+				continue;
+			}
+			const { ok, detail } = prompt.check(withContent.content);
+			const mark = ok === null ? "?" : ok ? "PASS" : "FAIL";
+			parts.push(`${prompt.id}[${mark}: ${detail}]`);
+		}
+		console.log(`${label.padEnd(16)} ${parts.join("  ")}`);
+	}
+
+	const out = `benchmark-${modelId.replace(/[^a-z0-9.-]/gi, "_")}.json`;
+	writeFileSync(out, JSON.stringify(results, null, 2));
+	console.log(`\nRaw results written to ${out}`);
+}
+
+void main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1523,6 +1523,9 @@ importers:
 
   packages/scripts:
     dependencies:
+      '@llmgateway/actions':
+        specifier: workspace:*
+        version: link:../actions
       '@llmgateway/db':
         specifier: workspace:*
         version: link:../db


### PR DESCRIPTION
## Summary

Adds the **Tundra** stealth provider — an OpenAI-compatible endpoint whose base URL and API key are configured exclusively via environment variables (`LLM_TUNDRA_BASE_URL` / `LLM_TUNDRA_API_KEY`), plus a `kimi-k2.6` mapping for it.

## Changes

- **Provider registration** (`packages/models/src/providers.ts`): new `tundra` provider, OpenAI-compatible, base URL + API key required via env.
- **Endpoint resolution** (`packages/actions/src/get-provider-endpoint.ts`): reads the base URL from `LLM_TUNDRA_BASE_URL` and routes to `/v1/chat/completions`.
- **Model mapping** (`packages/models/src/models/moonshot.ts`): `kimi-k2.6` on Tundra, priced ~20% below the canopywave mapping.
- **Endpoint quirks** found via e2e testing:
  - Rejects `tool_choice="required"` → downgraded to `"auto"` in `prepare-request-body` (named function choice still works).
  - Streams a separate `reasoning_content` but inlines thinking into `content` on non-streaming responses → mapping uses `reasoning: true` + `reasoningOutput: "omit"`.
- **Streaming robustness** (`transform-openai-streaming.ts`): drop empty `tool_calls: []` arrays from leading delta chunks (general fix for OpenAI-compatible upstreams).
- **Benchmark tooling** (`packages/scripts/src/benchmark-model.ts`): a reusable script to compare a model's latency / throughput / output quality across every provider that serves it (`pnpm --filter @llmgateway/scripts benchmark-model <model-id>`).
- `.env.example` / `.gitignore` updated accordingly.

## Testing

- Full e2e suite for `tundra/kimi-k2.6`: **all green** (79 passed).
- Unit tests: **2133 passed**.
- `pnpm format` and `pnpm build` pass.
- Cross-provider benchmark confirms Tundra serves the genuine `kimi-k2.6` (identical correctness to other providers) with competitive throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Tundra provider, including setup variables and routing so requests can be sent through it.
  * Added benchmarking support for models, with results saved to timestamped JSON files.
* **Bug Fixes**
  * Improved streaming handling so empty tool-call data is ignored.
  * Adjusted tool-use behavior for Tundra to avoid rejected requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->