### PR TITLE
fix(gateway): silence MALFORMED_RESPONSE finish reason

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -123,6 +123,9 @@ describe("getUnifiedFinishReason", () => {
 		expect(
 			getUnifiedFinishReason("MALFORMED_FUNCTION_CALL", "google-ai-studio"),
 		).toBe(UnifiedFinishReason.TOOL_CALLS);
+		expect(
+			getUnifiedFinishReason("MALFORMED_RESPONSE", "google-ai-studio"),
+		).toBe(UnifiedFinishReason.UNKNOWN);
 	});
 
 	it("maps Glacier finish reasons like Google AI Studio", () => {
@@ -249,9 +252,24 @@ describe("isExpectedUnknownFinishReason", () => {
 		expect(isExpectedUnknownFinishReason("OTHER", "google-vertex")).toBe(true);
 	});
 
+	it("returns true for Google MALFORMED_RESPONSE finish reason", () => {
+		expect(
+			isExpectedUnknownFinishReason("MALFORMED_RESPONSE", "google-ai-studio"),
+		).toBe(true);
+		expect(isExpectedUnknownFinishReason("MALFORMED_RESPONSE", "glacier")).toBe(
+			true,
+		);
+		expect(
+			isExpectedUnknownFinishReason("MALFORMED_RESPONSE", "google-vertex"),
+		).toBe(true);
+	});
+
 	it("returns false for OTHER from other providers", () => {
 		expect(isExpectedUnknownFinishReason("OTHER", "openai")).toBe(false);
 		expect(isExpectedUnknownFinishReason("OTHER", "anthropic")).toBe(false);
+		expect(isExpectedUnknownFinishReason("MALFORMED_RESPONSE", "openai")).toBe(
+			false,
+		);
 	});
 
 	it("returns false for other finish reasons from Google", () => {

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -21,13 +21,14 @@ export function isExpectedUnknownFinishReason(
 	if (!finishReason) {
 		return false;
 	}
-	// Google's "OTHER" finish reason is expected and maps to UNKNOWN
+	// Google's "OTHER" and "MALFORMED_RESPONSE" finish reasons are expected and
+	// map to UNKNOWN
 	if (
 		(provider === "google-ai-studio" ||
 			provider === "glacier" ||
 			provider === "google-vertex" ||
 			provider === "quartz") &&
-		finishReason === "OTHER"
+		(finishReason === "OTHER" || finishReason === "MALFORMED_RESPONSE")
 	) {
 		return true;
 	}
@@ -124,7 +125,7 @@ export function getUnifiedFinishReason(
 			) {
 				return UnifiedFinishReason.CONTENT_FILTER;
 			}
-			if (finishReason === "OTHER") {
+			if (finishReason === "OTHER" || finishReason === "MALFORMED_RESPONSE") {
 				return UnifiedFinishReason.UNKNOWN;
 			}
 			break;


### PR DESCRIPTION
## Summary

Google providers (e.g. `google-ai-studio/gemini-3.5-flash`) occasionally return a `MALFORMED_RESPONSE` finish reason. This was hitting the "Unknown finish reason encountered" `logger.error()` path and getting reported as a server error.

This treats `MALFORMED_RESPONSE` exactly like Google's `OTHER` reason:
- It still maps to `UnifiedFinishReason.UNKNOWN`, so it is still counted as an error in metrics/logs.
- It is added to `isExpectedUnknownFinishReason()`, so it no longer triggers a `logger.error()` on the server.

## Changes
- `isExpectedUnknownFinishReason()` returns `true` for `MALFORMED_RESPONSE` from Google providers (`google-ai-studio`, `glacier`, `google-vertex`, `quartz`).
- `getUnifiedFinishReason()` maps `MALFORMED_RESPONSE` explicitly to `UNKNOWN` alongside `OTHER`.
- Added unit test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)