### PR TITLE
fix(gateway): handle body-read socket close

### DIFF
--- a/apps/gateway/src/cancellation.spec.ts
+++ b/apps/gateway/src/cancellation.spec.ts
@@ -1,0 +1,155 @@
+import { serve } from "@hono/node-server";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "vitest";
+
+import { db, tables } from "@llmgateway/db";
+
+import { app } from "./app.js";
+import {
+	startMockServer,
+	stopMockServer,
+} from "./test-utils/mock-openai-server.js";
+import { clearCache, waitForLogs } from "./test-utils/test-helpers.js";
+
+import type { ServerType } from "@hono/node-server";
+
+// These tests exercise *real* client cancellation: the gateway is served over
+// an actual HTTP socket so that aborting the client request closes the socket
+// and fires the handler's `c.req.raw.signal`. The in-process `app.request()`
+// harness used elsewhere does not surface the client abort to the handler, so
+// cancellation cannot be tested there.
+describe("client cancellation logging", () => {
+	let mockServerUrl: string;
+	let gatewayServer: ServerType;
+	let gatewayUrl: string;
+
+	async function setupFixtures() {
+		await db
+			.insert(tables.user)
+			.values({ id: "user-id", name: "user", email: "user" })
+			.onConflictDoNothing();
+		await db
+			.insert(tables.organization)
+			.values({
+				id: "org-id",
+				name: "Test Organization",
+				billingEmail: "user",
+				plan: "pro",
+				retentionLevel: "retain",
+				credits: "100.00",
+			})
+			.onConflictDoNothing();
+		await db
+			.insert(tables.userOrganization)
+			.values({
+				id: "user-org-id",
+				userId: "user-id",
+				organizationId: "org-id",
+			})
+			.onConflictDoNothing();
+		await db
+			.insert(tables.project)
+			.values({
+				id: "project-id",
+				name: "Test Project",
+				organizationId: "org-id",
+				mode: "api-keys",
+			})
+			.onConflictDoNothing();
+		await db
+			.insert(tables.apiKey)
+			.values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			})
+			.onConflictDoNothing();
+		// llmgateway provider has cancellation: true, so requestCanBeCanceled is
+		// true and the abort propagates to the upstream request.
+		await db
+			.insert(tables.providerKey)
+			.values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "llmgateway",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			})
+			.onConflictDoNothing();
+	}
+
+	async function resetState() {
+		await clearCache();
+		await db.delete(tables.log);
+		await db.delete(tables.providerKey);
+		await db.delete(tables.apiKey);
+		await db.delete(tables.project);
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
+	}
+
+	beforeAll(async () => {
+		mockServerUrl = await startMockServer();
+		gatewayUrl = await new Promise<string>((resolve) => {
+			gatewayServer = serve({ fetch: app.fetch, port: 0 }, (info) =>
+				resolve(`http://localhost:${info.port}`),
+			);
+		});
+	});
+
+	afterAll(async () => {
+		stopMockServer();
+		await new Promise<void>((resolve) => gatewayServer.close(() => resolve()));
+	});
+
+	beforeEach(async () => {
+		await resetState();
+		await setupFixtures();
+	});
+
+	function postChat(content: string, signal: AbortSignal) {
+		return fetch(`${gatewayUrl}/v1/chat/completions`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				messages: [{ role: "user", content }],
+			}),
+			signal,
+		});
+	}
+
+	test("abort before the upstream responds is logged as canceled, not an error", async () => {
+		const controller = new AbortController();
+		// Mock delays 5s before sending any response; abort lands while the
+		// gateway is awaiting the upstream fetch.
+		const requestPromise = postChat(
+			`TRIGGER_TIMEOUT_5000 ${Math.random()}`,
+			controller.signal,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		controller.abort();
+
+		await expect(requestPromise).rejects.toThrow();
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		const log = logs[0];
+		expect(log.canceled).toBe(true);
+		expect(log.finishReason).toBe("canceled");
+		expect(log.hasError).toBe(false);
+		expect(log.errorDetails).toBeNull();
+	});
+});

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11836,6 +11836,58 @@ chat.openapi(completions, async (c) => {
 				},
 			);
 
+			// The provider returned response headers (2xx) but the body read
+			// failed, so the post-loop success attempt was already appended to
+			// `routing` as succeeded. Flip it to a failed attempt and re-derive
+			// routingMetadata so dashboards and stored traces don't show this
+			// provider as green for a request that ultimately errored.
+			const bodyErrorType = isTimeoutBody
+				? "upstream_timeout"
+				: "upstream_error";
+			for (let i = routingAttempts.length - 1; i >= 0; i--) {
+				if (
+					routingAttempts[i].provider === usedProvider &&
+					routingAttempts[i].succeeded
+				) {
+					routingAttempts[i] = buildRoutingAttempt(
+						usedProvider,
+						usedInternalModel,
+						res.status,
+						bodyErrorType,
+						false,
+						{
+							region: usedRegion,
+							apiKeyHash: usedApiKeyHash,
+							logId: finalLogId,
+						},
+					);
+					break;
+				}
+			}
+			if (routingMetadata) {
+				const failedMap = new Map(
+					routingAttempts
+						.filter((a) => !a.succeeded)
+						.map((f) => [f.provider, f]),
+				);
+				routingMetadata = {
+					...routingMetadata,
+					routing: routingAttempts,
+					providerScores: routingMetadata.providerScores.map((score) => {
+						const failure = failedMap.get(score.providerId);
+						if (failure) {
+							return {
+								...score,
+								failed: true,
+								status_code: failure.status_code,
+								error_type: failure.error_type,
+							};
+						}
+						return score;
+					}),
+				};
+			}
+
 			const bodyTimeoutPluginIds = plugins?.map((p) => p.id) ?? [];
 			const baseLogEntry = createLogEntry(
 				requestId,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11012,6 +11012,12 @@ chat.openapi(completions, async (c) => {
 				if (!(bodyError instanceof Error)) {
 					throw bodyError;
 				}
+				// A client disconnect can abort the in-flight body read; rethrow
+				// so the cancellation path (app.onError -> 499) is preserved
+				// instead of misreporting it as an upstream failure.
+				if (bodyError.name === "AbortError") {
+					throw bodyError;
+				}
 				// A read timeout or a mid-body socket failure (e.g. undici
 				// "terminated: other side closed" / ECONNRESET) both surface
 				// here while reading the upstream error body. Treat them as
@@ -11796,6 +11802,12 @@ chat.openapi(completions, async (c) => {
 	} catch (bodyError) {
 		// Re-throw non-Error values (mirrors the fetch catch above).
 		if (!(bodyError instanceof Error)) {
+			throw bodyError;
+		}
+		// A client disconnect can abort the in-flight body read; rethrow so the
+		// cancellation path (app.onError -> 499) is preserved instead of
+		// misreporting it as an upstream failure.
+		if (bodyError.name === "AbortError") {
 			throw bodyError;
 		}
 		// Both a read timeout and a mid-body socket failure (e.g. undici

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11008,22 +11008,34 @@ chat.openapi(completions, async (c) => {
 					? extractAwsBedrockHttpError(res, rawErrorResponseText)
 					: rawErrorResponseText;
 			} catch (bodyError) {
-				if (isTimeoutError(bodyError)) {
-					const errorMessage =
-						bodyError instanceof Error
-							? bodyError.message
-							: "Timeout reading error response body";
+				// Re-throw non-Error values (mirrors the fetch catch above).
+				if (!(bodyError instanceof Error)) {
+					throw bodyError;
+				}
+				// A read timeout or a mid-body socket failure (e.g. undici
+				// "terminated: other side closed" / ECONNRESET) both surface
+				// here while reading the upstream error body. Treat them as
+				// upstream errors instead of bubbling up as an unhandled 500.
+				{
+					const isTimeoutBody = isTimeoutError(bodyError);
+					const errorMessage = bodyError.message;
 					const bodyErrorCause = extractErrorCause(bodyError);
-					logger.warn("Timeout reading error response body", {
-						usedProvider,
-						usedInternalModel,
-						status: res.status,
-						cause: bodyErrorCause,
-						unifiedFinishReason: getUnifiedFinishReason(
-							"upstream_error",
+					logger.warn(
+						isTimeoutBody
+							? "Timeout reading error response body"
+							: "Error reading error response body",
+						{
+							error: errorMessage,
 							usedProvider,
-						),
-					});
+							usedInternalModel,
+							status: res.status,
+							cause: bodyErrorCause,
+							unifiedFinishReason: getUnifiedFinishReason(
+								"upstream_error",
+								usedProvider,
+							),
+						},
+					);
 
 					const bodyTimeoutPluginIds = plugins?.map((p) => p.id) ?? [];
 					const baseLogEntry = createLogEntry(
@@ -11081,7 +11093,7 @@ chat.openapi(completions, async (c) => {
 						canceled: false,
 						errorDetails: {
 							statusCode: res.status,
-							statusText: "TimeoutError",
+							statusText: isTimeoutBody ? "TimeoutError" : bodyError.name,
 							responseText: errorMessage,
 							cause: bodyErrorCause,
 						},
@@ -11102,16 +11114,17 @@ chat.openapi(completions, async (c) => {
 					return c.json(
 						{
 							error: {
-								message: `Upstream provider timeout: ${errorMessage}`,
-								type: "upstream_timeout",
+								message: isTimeoutBody
+									? `Upstream provider timeout: ${errorMessage}`
+									: `Failed to read response from provider: ${errorMessage}`,
+								type: isTimeoutBody ? "upstream_timeout" : "upstream_error",
 								param: null,
-								code: "timeout",
+								code: isTimeoutBody ? "timeout" : "fetch_failed",
 							},
 						},
-						504,
+						isTimeoutBody ? 504 : 502,
 					);
 				}
-				throw bodyError;
 			}
 
 			// If the upstream Google provider rejected the request because the
@@ -11781,22 +11794,35 @@ chat.openapi(completions, async (c) => {
 			json = await res.json();
 		}
 	} catch (bodyError) {
-		if (isTimeoutError(bodyError)) {
-			const errorMessage =
-				bodyError instanceof Error
-					? bodyError.message
-					: "Timeout reading response body";
+		// Re-throw non-Error values (mirrors the fetch catch above).
+		if (!(bodyError instanceof Error)) {
+			throw bodyError;
+		}
+		// Both a read timeout and a mid-body socket failure (e.g. undici
+		// "terminated: other side closed" / ECONNRESET) surface here: the
+		// upstream already returned response headers but then failed while we
+		// read the body. Treat them all as upstream errors instead of letting
+		// them bubble to the global handler as an unhandled 500.
+		{
+			const isTimeoutBody = isTimeoutError(bodyError);
+			const errorMessage = bodyError.message;
 			const bodyReadCause = extractErrorCause(bodyError);
-			logger.warn("Timeout reading response body", {
-				usedProvider,
-				usedInternalModel,
-				initialRequestedModel,
-				cause: bodyReadCause,
-				unifiedFinishReason: getUnifiedFinishReason(
-					"upstream_error",
+			logger.warn(
+				isTimeoutBody
+					? "Timeout reading response body"
+					: "Error reading response body",
+				{
+					error: errorMessage,
 					usedProvider,
-				),
-			});
+					usedInternalModel,
+					initialRequestedModel,
+					cause: bodyReadCause,
+					unifiedFinishReason: getUnifiedFinishReason(
+						"upstream_error",
+						usedProvider,
+					),
+				},
+			);
 
 			const bodyTimeoutPluginIds = plugins?.map((p) => p.id) ?? [];
 			const baseLogEntry = createLogEntry(
@@ -11854,7 +11880,7 @@ chat.openapi(completions, async (c) => {
 				canceled: false,
 				errorDetails: {
 					statusCode: res.status,
-					statusText: "TimeoutError",
+					statusText: isTimeoutBody ? "TimeoutError" : bodyError.name,
 					responseText: errorMessage,
 					cause: bodyReadCause,
 				},
@@ -11875,16 +11901,21 @@ chat.openapi(completions, async (c) => {
 			return c.json(
 				{
 					error: {
-						message: `Upstream provider timeout: ${errorMessage}`,
-						type: "upstream_timeout",
+						message: isTimeoutBody
+							? `Upstream provider timeout: ${errorMessage}`
+							: `Failed to read response from provider: ${errorMessage}`,
+						type: isTimeoutBody ? "upstream_timeout" : "upstream_error",
 						param: null,
-						code: "timeout",
+						code: isTimeoutBody ? "timeout" : "fetch_failed",
+						requestedProvider,
+						usedProvider,
+						requestedModel: initialRequestedModel,
+						usedInternalModel,
 					},
 				},
-				504,
+				isTimeoutBody ? 504 : 502,
 			);
 		}
-		throw bodyError;
 	}
 	if (process.env.NODE_ENV !== "production") {
 		logger.debug("API response", { response: json });

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -455,6 +455,44 @@ describe("fallback and error status code handling", () => {
 			expect(log.requestedModel).toBe("llmgateway/custom");
 		});
 
+		test("mid-body failure marks the routed provider attempt as failed, not a succeeded routing attempt", async () => {
+			await setupMultiProviderKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					// Auto-routed (no provider prefix) so routingMetadata is populated.
+					model: "glm-4.7",
+					messages: [{ role: "user", content: "TRIGGER_BODY_ABORT" }],
+				}),
+			});
+
+			expect(res.status).toBe(502);
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			const log = logs[0];
+			expect(log.hasError).toBe(true);
+			expect(log.finishReason).toBe("upstream_error");
+
+			// The headers arrived (2xx) but the body read failed, so the provider
+			// must not be recorded as a succeeded (green) routing attempt.
+			const routing = log.routingMetadata?.routing ?? [];
+			expect(routing.length).toBeGreaterThanOrEqual(1);
+			expect(routing.every((a) => a.succeeded === false)).toBe(true);
+			expect(routing.some((a) => a.error_type === "upstream_error")).toBe(true);
+
+			// The used provider's score is flagged as failed.
+			const usedScore = log.routingMetadata?.providerScores?.find(
+				(s) => s.providerId === log.usedProvider,
+			);
+			expect(usedScore?.failed).toBe(true);
+		});
+
 		test("429 rate limit is classified as upstream_error with correct error details in DB log", async () => {
 			await setupCustomKeys();
 

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -423,6 +423,38 @@ describe("fallback and error status code handling", () => {
 			expect(log.requestedModel).toBe("llmgateway/custom");
 		});
 
+		test("upstream socket close while reading the response body is classified as upstream_error (502), not an unhandled 500", async () => {
+			await setupCustomKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "TRIGGER_BODY_ABORT" }],
+				}),
+			});
+
+			expect(res.status).toBe(502);
+			const json = await res.json();
+			expect(json).toHaveProperty("error");
+			expect(json.error.type).toBe("upstream_error");
+			expect(json.error.code).toBe("fetch_failed");
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+
+			const log = logs[0];
+			expect(log.finishReason).toBe("upstream_error");
+			expect(log.hasError).toBe(true);
+			expect(log.errorDetails).toBeTruthy();
+			expect(log.usedProvider).toBe("llmgateway");
+			expect(log.requestedModel).toBe("llmgateway/custom");
+		});
+
 		test("429 rate limit is classified as upstream_error with correct error details in DB log", async () => {
 			await setupCustomKeys();
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1079,6 +1079,33 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 			});
 		});
 	}
+
+	// Simulate an upstream that returns response headers (200) and a partial
+	// body, then closes the socket before the body completes. The gateway's
+	// res.json() then throws undici's "terminated: other side closed"
+	// TypeError, exercising the non-streaming body-read failure path.
+	if (hasUserMessageTrigger(chatMessages, "TRIGGER_BODY_ABORT")) {
+		const encoder = new TextEncoder();
+		let sentPartialBody = false;
+		const abortedBody = new ReadableStream({
+			pull(controller) {
+				if (!sentPartialBody) {
+					sentPartialBody = true;
+					// Flush a partial JSON body so headers are written first.
+					controller.enqueue(
+						encoder.encode('{"id":"chatcmpl-123","object":"chat.completion"'),
+					);
+					return;
+				}
+				controller.error(new Error("simulated upstream socket close"));
+			},
+		});
+		return new Response(abortedBody, {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
 	const baseChoice = sampleChatCompletionResponse.choices[0];
 	const choices = Array.from({ length: requestedN }, (_, index) => ({
 		...baseChoice,


### PR DESCRIPTION
## Problem

Production was returning **HTTP 500 "Unhandled error"** for upstream socket failures like:

```
{"err":{"message":"terminated: other side closed", ...
  at TLSSocket.onHttpSocketClose ...
caused by: SocketError: other side closed
```

This happens when an upstream LLM provider returns response **headers (200)** and then **closes the TCP/TLS socket mid-body** (timeout on their side, model crash, load shedding, proxy reset). The gateway's `res.json()` then throws undici's `TypeError: terminated`.

## Root cause

In the non-streaming chat path (`apps/gateway/src/chat/chat.ts`), the two body-read `catch (bodyError)` blocks only treated a `TimeoutError` as recoverable (→ 504) and **rethrew everything else**:

```ts
} catch (bodyError) {
  if (isTimeoutError(bodyError)) { ... return 504 }
  throw bodyError; // <- undici "terminated" lands here → app.onError → 500
}
```

So a mid-body socket close escaped to the global handler, logged as `Unhandled error` (level 50) and returned a **500** instead of being classified as a provider/upstream error. (The streaming path already catches this in its reader loop; the fetch-error path already returns 502 — only the body-read path had the gap.)

## Fix

Generalize both non-streaming body-read catch blocks (success body read and `!res.ok` error-body read) so a mid-body socket failure (undici `terminated` / `ECONNRESET`, etc.) is:

- logged as `Error reading response body` (warn, with cause),
- recorded in the DB log with `finishReason: upstream_error`,
- returned as a **502 `upstream_error` / `fetch_failed`**, matching the existing fetch-error path.

Timeouts keep their existing 504 behavior. Non-`Error` values are still rethrown.

> Note: the body read happens after the retry loop exits, so fallback to another provider isn't available at that point — this change makes the failure a clean, classified 502 rather than an unhandled 500. Retrying body-read failures via fallback would be a larger follow-up.

## Test

- Added a `TRIGGER_BODY_ABORT` hook to the mock OpenAI server that flushes a partial JSON body then closes the socket, faithfully reproducing undici `terminated: other side closed`.
- Added a regression test asserting the request now returns **502 `upstream_error`** and writes a `hasError` DB log. The test log confirms the exact production error is reproduced:

  ```
  WARN Error reading response body
    cause: "SocketError: other side closed (code: UND_ERR_SOCKET)"
    error: "terminated"
  ```

All 51 tests in `fallback.spec.ts` pass; `pnpm build` (gateway) and `pnpm format` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-streaming provider responses that fail while reading or parsing the upstream body (e.g., cut off mid-body).
  * Client errors are now more accurately classified as upstream failures rather than unhandled server errors.
  * Timeouts return a timeout-style response; non-timeout body-read/parsing failures return a “failed to read response from provider” message with appropriate gateway status.
  * Warning logs now distinguish timeout vs non-timeout body-read/parsing issues and include the underlying cause context.
  * Added a test to prevent upstream socket-closure cases from surfacing as generic 500s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->