### PR TITLE
feat: devpass growth loops + OCR OG image fix

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,7 @@ import { publicChatSupport } from "./routes/public-chat-support.js";
 import { publicConfig } from "./routes/public-config.js";
 import { publicContact } from "./routes/public-contact.js";
 import { publicDiscounts } from "./routes/public-discounts.js";
+import { publicLeaderboard } from "./routes/public-leaderboard.js";
 import { publicModelRatings } from "./routes/public-model-ratings.js";
 import { publicNewsletter } from "./routes/public-newsletter.js";
 import { publicProfile } from "./routes/public-profile.js";
@@ -268,6 +269,7 @@ app.route("/public/chat-support", publicChatSupport);
 app.route("/public/chats/share", publicChatShares);
 app.route("/public/apps", publicApps);
 app.route("/public/profile", publicProfile);
+app.route("/public/leaderboard", publicLeaderboard);
 app.route("/public/providers/stats", publicProvidersStats);
 app.route("/public/model-ratings", publicModelRatings);
 

--- a/apps/api/src/routes/public-leaderboard.ts
+++ b/apps/api/src/routes/public-leaderboard.ts
@@ -1,0 +1,180 @@
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { z } from "zod";
+
+import { CODING_AGENT_SOURCES } from "@/utils/profile.js";
+
+import {
+	and,
+	db,
+	desc,
+	eq,
+	gte,
+	inArray,
+	isNotNull,
+	ne,
+	organization,
+	project,
+	projectHourlySourceStats,
+	projectHourlyStats,
+	sql,
+	user,
+	userOrganization,
+} from "@llmgateway/db";
+
+import type { ServerTypes } from "@/vars.js";
+
+export const publicLeaderboard = new OpenAPIHono<ServerTypes>();
+
+const leaderboardEntrySchema = z.object({
+	rank: z.number(),
+	username: z.string(),
+	name: z.string().nullable(),
+	image: z.string().nullable(),
+	totalTokens: z.number(),
+	totalRequests: z.number(),
+	topAgent: z.string().nullable(),
+});
+
+const leaderboardSchema = z.object({
+	entries: z.array(leaderboardEntrySchema),
+});
+
+const getLeaderboard = createRoute({
+	method: "get",
+	path: "/",
+	request: {
+		query: z.object({
+			limit: z.coerce.number().int().min(1).max(100).optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: leaderboardSchema,
+				},
+			},
+			description:
+				"Public DevPass profiles ranked by total tokens routed over the last year.",
+		},
+	},
+});
+
+publicLeaderboard.openapi(getLeaderboard, async (c) => {
+	const { limit } = c.req.valid("query");
+	const take = limit ?? 50;
+
+	const startDate = new Date();
+	startDate.setUTCHours(0, 0, 0, 0);
+	startDate.setUTCDate(startDate.getUTCDate() - 364);
+
+	const totalTokensExpr = sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC)), 0)`;
+
+	const rankedRows = await db
+		.select({
+			userId: user.id,
+			username: user.username,
+			name: user.name,
+			image: user.image,
+			totalTokens: totalTokensExpr.as("totalTokens"),
+			totalRequests:
+				sql<number>`COALESCE(SUM(${projectHourlyStats.requestCount}), 0)`.as(
+					"totalRequests",
+				),
+		})
+		.from(user)
+		.innerJoin(userOrganization, eq(userOrganization.userId, user.id))
+		.innerJoin(
+			organization,
+			and(
+				eq(organization.id, userOrganization.organizationId),
+				eq(organization.kind, "devpass"),
+				ne(organization.devPlan, "none"),
+			),
+		)
+		.innerJoin(
+			project,
+			and(
+				eq(project.organizationId, organization.id),
+				ne(project.status, "deleted"),
+			),
+		)
+		.innerJoin(
+			projectHourlyStats,
+			and(
+				eq(projectHourlyStats.projectId, project.id),
+				gte(projectHourlyStats.hourTimestamp, startDate),
+			),
+		)
+		.where(and(eq(user.profilePublic, true), isNotNull(user.username)))
+		.groupBy(user.id, user.username, user.name, user.image)
+		.orderBy(desc(totalTokensExpr))
+		.limit(take);
+
+	const rankedUsers = rankedRows.filter((r) => r.username !== null);
+	const userIds = rankedUsers.map((r) => r.userId);
+
+	const topAgentByUser = new Map<string, string>();
+	if (userIds.length > 0) {
+		const agentRows = await db
+			.select({
+				userId: user.id,
+				source: projectHourlySourceStats.source,
+				requestCount:
+					sql<number>`COALESCE(SUM(${projectHourlySourceStats.requestCount}), 0)`.as(
+						"requestCount",
+					),
+			})
+			.from(user)
+			.innerJoin(userOrganization, eq(userOrganization.userId, user.id))
+			.innerJoin(
+				organization,
+				and(
+					eq(organization.id, userOrganization.organizationId),
+					eq(organization.kind, "devpass"),
+				),
+			)
+			.innerJoin(
+				project,
+				and(
+					eq(project.organizationId, organization.id),
+					ne(project.status, "deleted"),
+				),
+			)
+			.innerJoin(
+				projectHourlySourceStats,
+				eq(projectHourlySourceStats.projectId, project.id),
+			)
+			.where(
+				and(
+					inArray(user.id, userIds),
+					inArray(projectHourlySourceStats.source, CODING_AGENT_SOURCES),
+				),
+			)
+			.groupBy(user.id, projectHourlySourceStats.source);
+
+		const bestByUser = new Map<string, { source: string; count: number }>();
+		for (const row of agentRows) {
+			const count = Number(row.requestCount);
+			const current = bestByUser.get(row.userId);
+			if (!current || count > current.count) {
+				bestByUser.set(row.userId, { source: row.source, count });
+			}
+		}
+		for (const [id, best] of bestByUser) {
+			topAgentByUser.set(id, best.source);
+		}
+	}
+
+	const entries = rankedUsers.map((row, index) => ({
+		rank: index + 1,
+		username: row.username as string,
+		name: row.name,
+		image: row.image,
+		totalTokens: Number(row.totalTokens),
+		totalRequests: Number(row.totalRequests),
+		topAgent: topAgentByUser.get(row.userId) ?? null,
+	}));
+
+	return c.json({ entries }, 200);
+});

--- a/apps/api/src/utils/profile.ts
+++ b/apps/api/src/utils/profile.ts
@@ -60,7 +60,7 @@ export const profileSchema = z.object({
 
 // Coding-agent x-source values that count toward a profile's agent stats.
 // Mirrors the AGENTS definitions used by the DevPass dashboard UI.
-const CODING_AGENT_SOURCES = [
+export const CODING_AGENT_SOURCES = [
 	"claude.com/claude-code",
 	"opencode",
 	"open-code",

--- a/apps/code/public/devpass-badge.svg
+++ b/apps/code/public/devpass-badge.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="138" height="20" role="img" aria-label="powered by: DevPass">
+	<title>powered by: DevPass</title>
+	<linearGradient id="s" x2="0" y2="100%">
+		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+		<stop offset="1" stop-opacity=".1"/>
+	</linearGradient>
+	<clipPath id="r">
+		<rect width="138" height="20" rx="3" fill="#fff"/>
+	</clipPath>
+	<g clip-path="url(#r)">
+		<rect width="73" height="20" fill="#2d2d33"/>
+		<rect x="73" width="65" height="20" fill="#10b981"/>
+		<rect width="138" height="20" fill="url(#s)"/>
+	</g>
+	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+		<text x="36.5" y="14">powered by</text>
+		<text x="105.5" y="14" font-weight="bold">DevPass</text>
+	</g>
+</svg>

--- a/apps/code/src/app/compare/[slug]/page.tsx
+++ b/apps/code/src/app/compare/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { ComparisonTable } from "@/components/ComparisonTable";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 import { CodeCTATracker } from "@/components/LandingTracker";
+import { SwitchIn60 } from "@/components/SwitchIn60";
 import { Button } from "@/components/ui/button";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
@@ -305,6 +306,9 @@ export default async function ComparePage({ params }: ComparePageProps) {
 						</div>
 					</section>
 				)}
+
+				{/* Switch in 60 seconds */}
+				<SwitchIn60 />
 
 				{/* CTA */}
 				<section className="border-t px-4 py-20">

--- a/apps/code/src/app/leaderboard/page.tsx
+++ b/apps/code/src/app/leaderboard/page.tsx
@@ -1,0 +1,114 @@
+import { Trophy } from "lucide-react";
+import Link from "next/link";
+
+import { Footer } from "@/components/Footer";
+import { GetDevPassButton } from "@/components/GetDevPassButton";
+import { Header } from "@/components/Header";
+import { LeaderboardList } from "@/components/leaderboard/LeaderboardList";
+import { Button } from "@/components/ui/button";
+import { fetchLeaderboard } from "@/lib/leaderboard";
+
+import type { Metadata } from "next";
+
+const BASE_URL = "https://devpass.llmgateway.io";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+	title: "DevPass Leaderboard — Developers ranked by tokens routed",
+	description:
+		"See which developers route the most tokens through DevPass — one key, every model. Make your profile public to claim your spot.",
+	alternates: { canonical: "/leaderboard" },
+	openGraph: {
+		title: "DevPass Leaderboard — Developers ranked by tokens routed",
+		description:
+			"The developers routing the most tokens through DevPass. One key, every model.",
+		type: "website",
+		url: `${BASE_URL}/leaderboard`,
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "DevPass Leaderboard",
+		description:
+			"The developers routing the most tokens through DevPass. One key, every model.",
+	},
+};
+
+export default async function LeaderboardPage() {
+	const entries = await fetchLeaderboard(100);
+
+	return (
+		<div className="min-h-screen bg-background">
+			<Header />
+
+			<main>
+				{/* Hero */}
+				<section className="relative overflow-hidden border-b">
+					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_55%_55%_at_50%_-5%,_var(--tw-gradient-stops))] from-emerald-500/10 via-transparent to-transparent" />
+					<div className="container relative mx-auto max-w-3xl px-4 pt-16 pb-12 text-center sm:pt-20">
+						<div className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+							<Trophy className="h-3.5 w-3.5" />
+							Live leaderboard
+						</div>
+						<h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl">
+							The most prolific developers on DevPass
+						</h1>
+						<p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-pretty text-muted-foreground">
+							Ranked by tokens routed across every model in the last year. One
+							key, every model — these developers ship with all of them.
+						</p>
+						<div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+							<GetDevPassButton
+								cta="get_started"
+								location="leaderboard_hero"
+								signupHref="/signup?plan=pro"
+								showArrow
+							/>
+							<Button size="lg" variant="ghost" asChild>
+								<Link href="/profile">Claim your spot</Link>
+							</Button>
+						</div>
+					</div>
+				</section>
+
+				{/* Board */}
+				<section className="px-4 py-12">
+					<div className="container mx-auto max-w-3xl">
+						<LeaderboardList entries={entries} />
+						<p className="mt-4 text-center text-xs text-muted-foreground">
+							Only developers with a public profile appear here. Totals cover
+							the last 12 months and refresh periodically.
+						</p>
+					</div>
+				</section>
+
+				{/* CTA */}
+				<section className="border-t bg-muted/20 px-4 py-16">
+					<div className="container mx-auto max-w-2xl text-center">
+						<h2 className="mb-3 text-2xl font-bold tracking-tight sm:text-3xl">
+							Want your name on the board?
+						</h2>
+						<p className="mb-8 text-muted-foreground">
+							Flip your profile public, then ship. Every request you route
+							climbs the ranks — and your profile becomes a shareable record of
+							what you build.
+						</p>
+						<div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+							<GetDevPassButton
+								cta="get_started"
+								location="leaderboard_bottom_cta"
+								signupHref="/signup?plan=pro"
+								showArrow
+							/>
+							<Button size="lg" variant="ghost" asChild>
+								<Link href="/profile">Make my profile public</Link>
+							</Button>
+						</div>
+					</div>
+				</section>
+			</main>
+
+			<Footer />
+		</div>
+	);
+}

--- a/apps/code/src/app/sitemap.ts
+++ b/apps/code/src/app/sitemap.ts
@@ -37,6 +37,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/leaderboard`,
+			lastModified: new Date(),
+			changeFrequency: "daily",
+			priority: 0.7,
+		},
+		{
 			url: `${baseUrl}/legal/privacy`,
 			lastModified: new Date(),
 			changeFrequency: "yearly",

--- a/apps/code/src/components/Header.tsx
+++ b/apps/code/src/components/Header.tsx
@@ -42,6 +42,9 @@ export function Header() {
 						<Link href="/compare">Compare</Link>
 					</Button>
 					<Button variant="ghost" size="sm" asChild>
+						<Link href="/leaderboard">Leaderboard</Link>
+					</Button>
+					<Button variant="ghost" size="sm" asChild>
 						<a href={config.docsUrl} target="_blank" rel="noopener noreferrer">
 							Docs
 						</a>
@@ -103,6 +106,13 @@ export function Header() {
 						onClick={() => setMenuOpen(false)}
 					>
 						Compare
+					</Link>
+					<Link
+						href="/leaderboard"
+						className="block text-sm text-muted-foreground hover:text-foreground transition-colors"
+						onClick={() => setMenuOpen(false)}
+					>
+						Leaderboard
 					</Link>
 					<a
 						href={config.docsUrl}

--- a/apps/code/src/components/SwitchIn60.tsx
+++ b/apps/code/src/components/SwitchIn60.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { ArrowRight, Check, Clock, Copy } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+import { CodeCTATracker } from "@/components/LandingTracker";
+import { Button } from "@/components/ui/button";
+
+import {
+	AnthropicIcon,
+	OpenCodeIcon,
+	SoulForgeIcon,
+} from "@llmgateway/shared/components";
+
+import type { ComponentType, SVGProps } from "react";
+
+const API_BASE = "https://api.llmgateway.io";
+
+interface Step {
+	label: string;
+	code?: string;
+}
+
+interface ToolGuide {
+	id: string;
+	label: string;
+	icon: ComponentType<SVGProps<SVGSVGElement>>;
+	blurb: string;
+	steps: Step[];
+}
+
+const OpenAiGlyph: ComponentType<SVGProps<SVGSVGElement>> = (props) => (
+	<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+		<rect x="3" y="3" width="18" height="18" rx="4" strokeWidth="1.5" />
+		<path d="M8 12h8M12 8v8" strokeWidth="1.5" strokeLinecap="round" />
+	</svg>
+);
+
+const TOOLS: ToolGuide[] = [
+	{
+		id: "claude-code",
+		label: "Claude Code",
+		icon: AnthropicIcon,
+		blurb: "Two env vars. No SDK changes, no reinstall.",
+		steps: [
+			{
+				label: "Point Claude Code at DevPass",
+				code: `export ANTHROPIC_BASE_URL=${API_BASE}\nexport ANTHROPIC_AUTH_TOKEN=<your-devpass-key>`,
+			},
+			{
+				label: "Run it — switch models with one ANTHROPIC_MODEL flip",
+				code: "claude",
+			},
+		],
+	},
+	{
+		id: "opencode",
+		label: "OpenCode",
+		icon: OpenCodeIcon,
+		blurb: "Built in. No env vars, no config files.",
+		steps: [
+			{ label: "Launch OpenCode", code: "opencode" },
+			{ label: "Type /connect, pick LLM Gateway, paste your DevPass key" },
+		],
+	},
+	{
+		id: "soulforge",
+		label: "SoulForge",
+		icon: SoulForgeIcon,
+		blurb: "Paste one key and the whole catalog is live.",
+		steps: [
+			{ label: "Launch SoulForge", code: "soulforge" },
+			{ label: "Type /keys and paste your DevPass key" },
+		],
+	},
+	{
+		id: "openai",
+		label: "Anything else",
+		icon: OpenAiGlyph,
+		blurb: "Cursor, Cline, Aider, Continue — any OpenAI-compatible tool.",
+		steps: [
+			{
+				label: "Set the base URL and key in your tool's settings",
+				code: `Base URL: ${API_BASE}/v1\nAPI key:  <your-devpass-key>`,
+			},
+			{ label: "Pick any model id — Claude, GPT, Gemini, GLM, Qwen…" },
+		],
+	},
+];
+
+function CopyBlock({ code }: { code: string }) {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		if (!navigator.clipboard?.writeText) {
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(code);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			setCopied(false);
+		}
+	};
+
+	return (
+		<div className="group relative overflow-hidden rounded-lg border border-border/60 bg-background">
+			<pre className="overflow-x-auto px-3.5 py-3 font-mono text-xs leading-6 text-foreground/90">
+				{code}
+			</pre>
+			<button
+				type="button"
+				onClick={handleCopy}
+				aria-label="Copy command"
+				className="absolute right-2 top-2 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+			>
+				{copied ? (
+					<Check className="h-3.5 w-3.5 text-emerald-500" />
+				) : (
+					<Copy className="h-3.5 w-3.5" />
+				)}
+			</button>
+		</div>
+	);
+}
+
+export function SwitchIn60() {
+	const [active, setActive] = useState(TOOLS[0].id);
+	const tool = TOOLS.find((t) => t.id === active) ?? TOOLS[0];
+
+	return (
+		<section id="switch-in-60" className="border-t bg-muted/20 px-4 py-16">
+			<div className="container mx-auto max-w-3xl">
+				<div className="mb-1.5 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+					<Clock className="h-3.5 w-3.5" />
+					Switch in 60 seconds
+				</div>
+				<h2 className="mt-3 text-2xl font-bold tracking-tight sm:text-3xl">
+					Keep your editor. Point it at DevPass.
+				</h2>
+				<p className="mt-2 max-w-2xl text-muted-foreground">
+					No migration project, no rewrite. Your existing tool, every model, one
+					key. Switching back is just as fast — so there&apos;s nothing to lose.
+				</p>
+
+				<div className="mt-7 flex flex-wrap gap-2">
+					{TOOLS.map((t) => {
+						const Icon = t.icon;
+						const isActive = t.id === active;
+						return (
+							<button
+								key={t.id}
+								type="button"
+								onClick={() => setActive(t.id)}
+								className={`inline-flex items-center gap-2 rounded-lg border px-3.5 py-2 text-sm font-medium transition-colors ${
+									isActive
+										? "border-foreground/30 bg-card text-foreground shadow-sm"
+										: "border-border/60 text-muted-foreground hover:text-foreground"
+								}`}
+							>
+								<Icon className="h-4 w-4" />
+								{t.label}
+							</button>
+						);
+					})}
+				</div>
+
+				<div className="mt-5 rounded-2xl border bg-card p-5 sm:p-6">
+					<p className="mb-5 text-sm text-muted-foreground">{tool.blurb}</p>
+					<ol className="space-y-4">
+						{tool.steps.map((step, index) => (
+							<li key={step.label} className="flex gap-3.5">
+								<span className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border border-border/60 bg-background text-xs font-semibold tabular-nums text-muted-foreground">
+									{index + 1}
+								</span>
+								<div className="min-w-0 flex-1 space-y-2">
+									<p className="text-sm font-medium text-foreground">
+										{step.label}
+									</p>
+									{step.code && <CopyBlock code={step.code} />}
+								</div>
+							</li>
+						))}
+					</ol>
+
+					<div className="mt-6 flex flex-col gap-3 border-t pt-5 sm:flex-row sm:items-center">
+						<CodeCTATracker cta="get_started" location="compare_switch_in_60">
+							<Button className="gap-2" asChild>
+								<Link href="/signup?plan=pro">
+									Get your DevPass key
+									<ArrowRight className="h-4 w-4" />
+								</Link>
+							</Button>
+						</CodeCTATracker>
+						<p className="text-xs text-muted-foreground">
+							Need the full walkthrough? See the{" "}
+							<Link href="/guides" className="underline hover:text-foreground">
+								setup guides
+							</Link>
+							.
+						</p>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/code/src/components/leaderboard/LeaderboardList.tsx
+++ b/apps/code/src/components/leaderboard/LeaderboardList.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+
+import {
+	AGENTS,
+	formatTokens,
+	type AgentDefinition,
+} from "@/app/dashboard/components/coding-agents-shared";
+
+import type { LeaderboardEntry } from "@/lib/leaderboard";
+
+const AGENT_BY_SOURCE = new Map<string, AgentDefinition>();
+for (const agent of AGENTS) {
+	for (const source of agent.sources) {
+		AGENT_BY_SOURCE.set(source.toLowerCase(), agent);
+	}
+}
+
+function initials(name: string | null, username: string): string {
+	const source = name?.trim() || username;
+	const parts = source.split(/\s+/).filter(Boolean);
+	if (parts.length >= 2) {
+		return (parts[0][0] + parts[1][0]).toUpperCase();
+	}
+	return source.slice(0, 2).toUpperCase();
+}
+
+function rankAccent(rank: number): string {
+	switch (rank) {
+		case 1:
+			return "from-amber-300 to-amber-500 text-amber-950";
+		case 2:
+			return "from-slate-200 to-slate-400 text-slate-900";
+		case 3:
+			return "from-orange-300 to-orange-600 text-orange-950";
+		default:
+			return "";
+	}
+}
+
+function LeaderboardRow({ entry }: { entry: LeaderboardEntry }) {
+	const displayName = entry.name?.trim() || entry.username;
+	const agent = entry.topAgent
+		? AGENT_BY_SOURCE.get(entry.topAgent.toLowerCase())
+		: undefined;
+	const AgentIcon = agent?.icon;
+	const isTop = entry.rank <= 3;
+
+	return (
+		<Link
+			href={`/profiles/${entry.username}`}
+			className={`flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-muted/40 sm:px-5 ${
+				isTop ? "bg-emerald-500/[0.04]" : ""
+			}`}
+		>
+			{/* Rank */}
+			<div className="flex w-8 flex-shrink-0 justify-center">
+				{isTop ? (
+					<span
+						className={`flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br text-sm font-bold tabular-nums shadow-sm ${rankAccent(
+							entry.rank,
+						)}`}
+					>
+						{entry.rank}
+					</span>
+				) : (
+					<span className="text-sm font-medium tabular-nums text-muted-foreground">
+						{entry.rank}
+					</span>
+				)}
+			</div>
+
+			{/* Avatar */}
+			<div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-xl ring-1 ring-border">
+				{entry.image ? (
+					<img
+						src={entry.image}
+						alt={displayName}
+						className="h-full w-full object-cover"
+					/>
+				) : (
+					<div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-emerald-500/20 to-emerald-500/5 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+						{initials(entry.name, entry.username)}
+					</div>
+				)}
+			</div>
+
+			{/* Identity */}
+			<div className="min-w-0 flex-1">
+				<p className="truncate text-sm font-semibold tracking-tight">
+					{displayName}
+				</p>
+				<p className="truncate text-xs text-muted-foreground">
+					@{entry.username}
+				</p>
+			</div>
+
+			{/* Top agent */}
+			{agent && AgentIcon && (
+				<div className="hidden items-center gap-1.5 rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground md:inline-flex">
+					<AgentIcon className="h-3.5 w-3.5" />
+					{agent.label}
+				</div>
+			)}
+
+			{/* Tokens */}
+			<div className="w-20 flex-shrink-0 text-right sm:w-28">
+				<p className="text-sm font-bold tabular-nums text-emerald-600 dark:text-emerald-400 sm:text-base">
+					{formatTokens(entry.totalTokens)}
+				</p>
+				<p className="hidden text-[11px] text-muted-foreground sm:block">
+					{entry.totalRequests.toLocaleString()} requests
+				</p>
+			</div>
+		</Link>
+	);
+}
+
+export function LeaderboardList({ entries }: { entries: LeaderboardEntry[] }) {
+	if (entries.length === 0) {
+		return (
+			<div className="rounded-2xl border bg-card p-10 text-center">
+				<p className="text-sm text-muted-foreground">
+					The board is warming up. Make your profile public to claim a spot.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="overflow-hidden rounded-2xl border bg-card">
+			<div className="flex items-center gap-4 border-b bg-muted/30 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground sm:px-5">
+				<span className="w-8 text-center">#</span>
+				<span className="flex-1">Developer</span>
+				<span className="w-20 text-right sm:w-28">Tokens routed</span>
+			</div>
+			<div className="divide-y divide-border/60">
+				{entries.map((entry) => (
+					<LeaderboardRow key={entry.username} entry={entry} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/code/src/components/profile/ProfileView.tsx
+++ b/apps/code/src/components/profile/ProfileView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Calendar, Coins, Flame, Github, Hash, Zap } from "lucide-react";
+import Link from "next/link";
 
 import {
 	AGENTS,
@@ -9,6 +10,8 @@ import {
 } from "@/app/dashboard/components/coding-agents-shared";
 import { ProfileHeatmap } from "@/components/profile/ProfileHeatmap";
 import { ProfileTokensChart } from "@/components/profile/ProfileTokensChart";
+import { ProfileViewerCta } from "@/components/profile/ProfileViewerCta";
+import { ProfileWrapped } from "@/components/profile/ProfileWrapped";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
 
@@ -118,6 +121,13 @@ export function ProfileView({ profile }: { profile: ProfileData }) {
 					)}
 				</div>
 			</div>
+
+			{/* Wrapped card + share toolkit */}
+			{profile.username && (
+				<div className="mt-8">
+					<ProfileWrapped profile={profile} />
+				</div>
+			)}
 
 			<div className="mt-8 grid gap-8 lg:grid-cols-[240px_1fr]">
 				{/* Sidebar */}
@@ -293,6 +303,20 @@ export function ProfileView({ profile }: { profile: ProfileData }) {
 						<ProfileTokensChart activity={profile.activity} />
 					</section>
 				</div>
+			</div>
+
+			{/* Convert logged-out visitors */}
+			<ProfileViewerCta profile={profile} />
+
+			{/* Powered by */}
+			<div className="mt-10 border-t pt-6 text-center text-xs text-muted-foreground">
+				<Link href="/" className="transition-colors hover:text-foreground">
+					Powered by{" "}
+					<span className="font-semibold text-emerald-600 dark:text-emerald-400">
+						DevPass
+					</span>{" "}
+					— one key, every model
+				</Link>
 			</div>
 		</div>
 	);

--- a/apps/code/src/components/profile/ProfileViewerCta.tsx
+++ b/apps/code/src/components/profile/ProfileViewerCta.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+
+import { formatTokens } from "@/app/dashboard/components/coding-agents-shared";
+import { GetDevPassButton } from "@/components/GetDevPassButton";
+import { Button } from "@/components/ui/button";
+import { useUser } from "@/hooks/useUser";
+
+import type { ProfileData } from "@/components/profile/ProfileView";
+
+export function ProfileViewerCta({ profile }: { profile: ProfileData }) {
+	const { user, isLoading } = useUser();
+
+	// Only pitch logged-out visitors — existing users already have a key.
+	if (isLoading || user) {
+		return null;
+	}
+
+	const displayName =
+		profile.name?.trim() || profile.username || "This developer";
+
+	return (
+		<section className="relative mt-10 overflow-hidden rounded-2xl border border-emerald-500/20 bg-card p-8 text-center">
+			<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_60%_at_50%_-10%,_rgba(16,185,129,0.12),_transparent)]" />
+			<div className="relative">
+				<p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-600 dark:text-emerald-400">
+					Powered by DevPass
+				</p>
+				<h2 className="mx-auto mt-3 max-w-xl text-2xl font-bold tracking-tight sm:text-3xl">
+					One key. Every model. Three flat prices.
+				</h2>
+				<p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+					{displayName} has routed {formatTokens(profile.stats.totalTokens)}{" "}
+					tokens through DevPass — Claude, GPT, Gemini, GLM and more, all from a
+					single key. Start your own and turn every dollar into $3 of model
+					usage.
+				</p>
+				<div className="mt-7 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+					<GetDevPassButton
+						cta="get_started"
+						location="profile_viewer_cta"
+						signupHref="/signup?plan=pro"
+						showArrow
+					/>
+					<Button size="lg" variant="ghost" asChild>
+						<Link href="/leaderboard">See the leaderboard</Link>
+					</Button>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/code/src/components/profile/ProfileWrapped.tsx
+++ b/apps/code/src/components/profile/ProfileWrapped.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { Check, Copy, Flame, Link2, Sparkles } from "lucide-react";
+import { useState } from "react";
+
+import {
+	AGENTS,
+	formatTokens,
+	type AgentDefinition,
+} from "@/app/dashboard/components/coding-agents-shared";
+import { Button } from "@/components/ui/button";
+
+import type { ProfileData } from "@/components/profile/ProfileView";
+
+const SITE_URL = "https://devpass.llmgateway.io";
+
+const AGENT_BY_SOURCE = new Map<string, AgentDefinition>();
+for (const agent of AGENTS) {
+	for (const source of agent.sources) {
+		AGENT_BY_SOURCE.set(source.toLowerCase(), agent);
+	}
+}
+
+function useCopy() {
+	const [copied, setCopied] = useState(false);
+	const copy = async (text: string) => {
+		if (!navigator.clipboard?.writeText) {
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			setCopied(false);
+		}
+	};
+	return { copied, copy };
+}
+
+function WrappedStat({ value, label }: { value: string; label: string }) {
+	return (
+		<div>
+			<div className="whitespace-nowrap text-xl font-bold tabular-nums text-white">
+				{value}
+			</div>
+			<div className="mt-0.5 text-[11px] font-medium uppercase tracking-wide text-white/60">
+				{label}
+			</div>
+		</div>
+	);
+}
+
+export function ProfileWrapped({ profile }: { profile: ProfileData }) {
+	const linkCopy = useCopy();
+	const badgeCopy = useCopy();
+
+	const handle = profile.username ?? "";
+	const displayName = profile.name?.trim() || handle || "DevPass user";
+	const profileUrl = `${SITE_URL}/profiles/${handle}`;
+	const topAgent =
+		profile.agents.length > 0
+			? AGENT_BY_SOURCE.get(profile.agents[0].source.toLowerCase())
+			: undefined;
+
+	const badgeMarkdown = `[![Powered by DevPass](${SITE_URL}/devpass-badge.svg)](${profileUrl})`;
+
+	const tweetText = `My DevPass coding profile: ${formatTokens(
+		profile.stats.totalTokens,
+	)} tokens routed, ${profile.stats.activeDays} active days, ${
+		profile.stats.currentStreak
+	}-day streak. One key, every model.`;
+	const tweetUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(
+		tweetText,
+	)}&url=${encodeURIComponent(profileUrl)}`;
+
+	return (
+		<div className="space-y-3">
+			{/* Wrapped card — full-width banner, built to screenshot */}
+			<div className="relative overflow-hidden rounded-2xl border border-emerald-500/20 bg-[#07120d] p-6">
+				<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_80%_at_90%_-10%,_rgba(16,185,129,0.28),_transparent)]" />
+				<div className="relative">
+					<div className="flex items-center justify-between">
+						<div className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-400">
+							<Sparkles className="h-3.5 w-3.5" />
+							Coding wrapped
+						</div>
+						<span className="text-xs font-medium text-white/50">DevPass</span>
+					</div>
+
+					<div className="mt-5 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+						<div>
+							<p className="text-sm text-white/70">{displayName} routed</p>
+							<div className="mt-1 flex items-baseline gap-2">
+								<span className="text-4xl font-bold tabular-nums text-white sm:text-5xl">
+									{formatTokens(profile.stats.totalTokens)}
+								</span>
+								<span className="text-sm font-medium text-white/60">
+									tokens this year
+								</span>
+							</div>
+						</div>
+
+						<div className="flex gap-8 sm:gap-10">
+							<WrappedStat
+								value={`${profile.stats.activeDays}`}
+								label="Active days"
+							/>
+							<WrappedStat
+								value={`${profile.stats.currentStreak}d`}
+								label="Streak"
+							/>
+							<WrappedStat
+								value={topAgent?.label ?? "Multi-tool"}
+								label="Top agent"
+							/>
+						</div>
+					</div>
+
+					<div className="mt-6 flex items-center gap-1.5 border-t border-white/10 pt-4 text-xs text-white/50">
+						<Flame className="h-3.5 w-3.5 text-emerald-400" />
+						devpass.llmgateway.io/profiles/{handle}
+					</div>
+				</div>
+			</div>
+
+			{/* Share toolkit */}
+			<div className="rounded-2xl border bg-card p-4 sm:p-5">
+				<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+					<div className="flex flex-shrink-0 gap-2">
+						<Button className="gap-2" asChild>
+							<a href={tweetUrl} target="_blank" rel="noopener noreferrer">
+								<svg
+									viewBox="0 0 24 24"
+									className="h-4 w-4 fill-current"
+									aria-hidden="true"
+								>
+									<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+								</svg>
+								Share on X
+							</a>
+						</Button>
+						<Button
+							variant="outline"
+							className="gap-2"
+							onClick={() => linkCopy.copy(profileUrl)}
+						>
+							{linkCopy.copied ? (
+								<Check className="h-4 w-4 text-emerald-500" />
+							) : (
+								<Link2 className="h-4 w-4" />
+							)}
+							{linkCopy.copied ? "Copied" : "Copy link"}
+						</Button>
+					</div>
+
+					<div className="min-w-0 flex-1">
+						<p className="mb-1.5 text-xs font-medium text-muted-foreground">
+							README badge
+						</p>
+						<div className="relative overflow-hidden rounded-lg border border-border/60 bg-background">
+							<pre className="overflow-x-auto px-3 py-2.5 pr-10 font-mono text-[11px] leading-5 text-foreground/80">
+								{badgeMarkdown}
+							</pre>
+							<button
+								type="button"
+								onClick={() => badgeCopy.copy(badgeMarkdown)}
+								aria-label="Copy badge markdown"
+								className="absolute right-1.5 top-1.5 rounded-md border border-border/60 bg-card p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+							>
+								{badgeCopy.copied ? (
+									<Check className="h-3.5 w-3.5 text-emerald-500" />
+								) : (
+									<Copy className="h-3.5 w-3.5" />
+								)}
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/code/src/lib/leaderboard.ts
+++ b/apps/code/src/lib/leaderboard.ts
@@ -1,0 +1,31 @@
+import { getConfig } from "@/lib/config-server";
+
+import type { paths } from "@/lib/api/v1";
+
+export type LeaderboardResponse =
+	paths["/public/leaderboard"]["get"]["responses"][200]["content"]["application/json"];
+
+export type LeaderboardEntry = LeaderboardResponse["entries"][number];
+
+/**
+ * Fetch the public DevPass leaderboard (profiles ranked by tokens routed).
+ * Returns an empty list on failure. Used by the public /leaderboard page.
+ */
+export async function fetchLeaderboard(
+	limit = 50,
+): Promise<LeaderboardEntry[]> {
+	const config = getConfig();
+	try {
+		const res = await fetch(
+			`${config.apiBackendUrl}/public/leaderboard?limit=${limit}`,
+			{ next: { revalidate: 300 } },
+		);
+		if (!res.ok) {
+			return [];
+		}
+		const json = (await res.json()) as LeaderboardResponse;
+		return json.entries;
+	} catch {
+		return [];
+	}
+}

--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -138,8 +138,15 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			: undefined;
 		const isVideoGen = selectedMapping?.videoGenerations === true;
 		const isImageGen = selectedMapping?.imageGenerations === true;
+		const isOcr = selectedMapping?.ocr === true;
+		const ocrPagePrice =
+			selectedMapping?.ocrPagePrice !== undefined &&
+			selectedMapping?.ocrPagePrice !== null
+				? Number(selectedMapping.ocrPagePrice)
+				: undefined;
+		const hasOcrPricing = ocrPagePrice !== undefined && ocrPagePrice > 0;
 		const hasTokenPricing =
-			pricing?.input ?? pricing?.output ?? pricing?.cachedInput;
+			!isOcr && (pricing?.input ?? pricing?.output ?? pricing?.cachedInput);
 
 		const contextSize = selectedMapping?.contextSize ?? 0;
 
@@ -359,9 +366,10 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 							gap: 28,
 						}}
 					>
-						{(hasTokenPricing ??
-							(requestPrice !== undefined && requestPrice !== 0) ??
-							(perSecondPrice && Object.keys(perSecondPrice).length > 0)) && (
+						{(hasTokenPricing ||
+							(requestPrice !== undefined && requestPrice !== 0) ||
+							(perSecondPrice && Object.keys(perSecondPrice).length > 0) ||
+							hasOcrPricing) && (
 							<span
 								style={{
 									color: "#6B7280",
@@ -373,14 +381,16 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 							>
 								{isVideoGen && perSecondPrice
 									? "Pricing per second"
-									: isImageGen &&
-										  requestPrice !== undefined &&
-										  requestPrice !== 0 &&
-										  !hasTokenPricing
-										? "Pricing per request"
-										: requestPrice !== undefined && requestPrice !== 0
-											? "Pricing"
-											: "Pricing per 1M tokens"}
+									: hasOcrPricing
+										? "Pricing per 1K pages"
+										: isImageGen &&
+											  requestPrice !== undefined &&
+											  requestPrice !== 0 &&
+											  !hasTokenPricing
+											? "Pricing per request"
+											: requestPrice !== undefined && requestPrice !== 0
+												? "Pricing"
+												: "Pricing per 1M tokens"}
 							</span>
 						)}
 						<div
@@ -481,6 +491,36 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 									</span>
 									<span style={{ fontWeight: 700, fontSize: 56 }}>
 										${requestPrice.toFixed(4)}
+									</span>
+								</div>
+							)}
+
+							{/* OCR per-1K-pages price */}
+							{ocrPagePrice !== undefined && ocrPagePrice > 0 && (
+								<div
+									style={{
+										display: "flex",
+										flexDirection: "column",
+										gap: 10,
+										padding: "28px 36px",
+										backgroundColor: "#0A0A0A",
+										borderRadius: 20,
+										border: "1px solid #1F2937",
+									}}
+								>
+									<span
+										style={{
+											color: "#9CA3AF",
+											fontSize: 20,
+											fontWeight: 500,
+											textTransform: "uppercase",
+											letterSpacing: "0.05em",
+										}}
+									>
+										Per 1K Pages
+									</span>
+									<span style={{ fontWeight: 700, fontSize: 56 }}>
+										${(ocrPagePrice * 1000).toFixed(2)}
 									</span>
 								</div>
 							)}


### PR DESCRIPTION
## Summary

Two changes:

1. **Fix the OCR model OpenGraph image** to show per-page pricing.
2. **Add growth loops to DevPass** — a public leaderboard, shareable profiles, a powered-by badge, and a "Switch in 60 seconds" migration section on comparison pages.

## 1. OCR OpenGraph image fix (`apps/ui`)

OCR models such as `mistral-ocr-latest` set `inputPrice`/`outputPrice` to the string `"0"`. Those are truthy, so the model OG card rendered **"Pricing per 1M tokens → Input $0.00 / Output $0.00"** instead of the real price.

The card now detects OCR mappings (via the `ocr` flag), suppresses the token-pricing cards, and renders a **"Per 1K Pages → $X.XX"** card with a **"Pricing per 1K pages"** label — matching the format already used on the model page and model card. It's driven by `ocrPagePrice`, so any future OCR model works automatically. This lands on the canonical shareable URL (`/models/<id>` → its OG points at `…/<provider>/opengraph-image`).

## 2. DevPass growth loops (`apps/code`, `apps/api`)

- **Public leaderboard** at `/leaderboard` ranking public DevPass profiles by tokens routed, backed by a new `GET /public/leaderboard` endpoint that aggregates the existing hourly-stats rollups and resolves each developer's top coding agent. Only opted-in public profiles appear.
- **Shareable profiles**: a "Coding Wrapped" banner (built to screenshot) plus a share toolkit — Share on X, copy link.
- **Powered-by loop**: a copy-paste README badge (self-hosted `devpass-badge.svg`) and a "Powered by DevPass" footer on profiles.
- **Logged-out viewer CTA** on profiles to convert visitors into signups.
- **"Switch in 60 seconds"** — a reusable section wired into every comparison page (with a `#switch-in-60` anchor) showing copy-paste setup for Claude Code, OpenCode, SoulForge, and any OpenAI-compatible tool.
- Header nav and sitemap updated for the leaderboard.

## Notes

- No DB schema changes / no migration. The leaderboard reads existing `project_hourly_stats` and `project_hourly_source_stats` rollups.
- `apps/api/openapi.json` and the generated typed clients are git-ignored and regenerated by the build pipeline.

## Verification

- `pnpm format` and a production build (`turbo run build --filter=ui --filter=api --filter=code`) pass.
- Verified end-to-end against a local stack: the leaderboard ranks correctly with resolved top agents, profiles render the Wrapped banner / share toolkit / README badge / logged-out CTA, and the Switch-in-60 tabs work on comparison pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public live leaderboard page with ranked users, stats, and top-agent highlights.
  * Added leaderboard data to the main navigation and sitemap.
  * Added shareable profile/wrapped sections and a setup guide panel on profile and compare pages.
  * Expanded image pricing visuals to support OCR pricing.

* **Bug Fixes**
  * Improved leaderboard/profile data loading with safe fallbacks when content is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->