### PR TITLE
feat(gateway): gate routes by model output capability

### DIFF
--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -27,6 +27,40 @@ const mixedVisionModel = getModel("qwen3-max");
 
 const embeddingModel = getModel("text-embedding-3-small");
 
+// Pick a stable fixture for each single-output capability straight from the
+// registry so the tests don't pin to a specific model id that may churn.
+function getModelByOutput(output: string): ModelDefinition {
+	const m = (models as readonly ModelDefinition[]).find(
+		(model) =>
+			Array.isArray(model.output) &&
+			model.output.length === 1 &&
+			model.output[0] === output,
+	);
+	if (!m) {
+		throw new Error(`Test fixture missing: no model with output ["${output}"]`);
+	}
+	return m;
+}
+
+const ocrModel = getModelByOutput("ocr");
+const videoModel = getModelByOutput("video");
+const audioModel = getModelByOutput("audio");
+const imageOnlyModel = getModelByOutput("image");
+const textImageModel = (() => {
+	const m = (models as readonly ModelDefinition[]).find(
+		(model) =>
+			Array.isArray(model.output) &&
+			model.output.includes("text") &&
+			model.output.includes("image"),
+	);
+	if (!m) {
+		throw new Error(
+			'Test fixture missing: no model with output ["text","image"]',
+		);
+	}
+	return m;
+})();
+
 describe("validateModelCapabilities - vision", () => {
 	it("rejects when explicit provider does not support vision", () => {
 		expect(() =>
@@ -152,6 +186,45 @@ describe("validateModelCapabilities - embeddings", () => {
 		).not.toThrow();
 		expect(() =>
 			validateModelCapabilities(embeddingModel, "custom", undefined, {}),
+		).not.toThrow();
+	});
+});
+
+describe("validateModelCapabilities - output capability", () => {
+	it("rejects OCR models on chat completions", () => {
+		expect(() =>
+			validateModelCapabilities(ocrModel, ocrModel.id, undefined, {}),
+		).toThrow(HTTPException);
+	});
+
+	it("rejects video models on chat completions", () => {
+		expect(() =>
+			validateModelCapabilities(videoModel, videoModel.id, undefined, {}),
+		).toThrow(HTTPException);
+	});
+
+	it("rejects audio (speech) models on chat completions", () => {
+		expect(() =>
+			validateModelCapabilities(audioModel, audioModel.id, undefined, {}),
+		).toThrow(HTTPException);
+	});
+
+	it("allows image-output models (image generation routes through chat)", () => {
+		expect(() =>
+			validateModelCapabilities(
+				imageOnlyModel,
+				imageOnlyModel.id,
+				undefined,
+				{},
+			),
+		).not.toThrow();
+		expect(() =>
+			validateModelCapabilities(
+				textImageModel,
+				textImageModel.id,
+				undefined,
+				{},
+			),
 		).not.toThrow();
 	});
 });

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -1,5 +1,7 @@
 import { HTTPException } from "hono/http-exception";
 
+import { validateModelOutput } from "@/lib/validate-model-output.js";
+
 import { logger } from "@llmgateway/logger";
 
 import type {
@@ -54,25 +56,11 @@ export function validateModelCapabilities(
 		return;
 	}
 
-	if (
-		requestedModel !== "auto" &&
-		requestedModel !== "custom" &&
-		modelInfo.output?.includes("embedding")
-	) {
-		throw new HTTPException(400, {
-			message: `Model ${requestedModel} is an embeddings model and cannot be used with /v1/chat/completions. Use the /v1/embeddings endpoint instead.`,
-		});
-	}
-
-	if (
-		requestedModel !== "auto" &&
-		requestedModel !== "custom" &&
-		modelInfo.providers.some((p) => (p as ProviderModelMapping).ocr === true)
-	) {
-		throw new HTTPException(400, {
-			message: `Model ${requestedModel} is an OCR model and cannot be used with /v1/chat/completions. Use the /v1/ocr endpoint instead.`,
-		});
-	}
+	// Chat completions serve text and image output (image generation is routed
+	// through this endpoint). Any model that only produces embeddings, OCR,
+	// video, or audio belongs to a dedicated endpoint and is rejected here with
+	// a pointer to the right one.
+	validateModelOutput(modelInfo, requestedModel, ["text", "image"]);
 
 	// Validate vision capability when the request contains images.
 	// Skip this check for "auto" and "custom" models as they will be resolved dynamically.

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -7,10 +7,12 @@ import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
 import { findApiKeyByToken, findProjectById } from "@/lib/cached-queries.js";
 import { parseApiToken } from "@/lib/extract-api-token.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import { validateModelOutput } from "@/lib/validate-model-output.js";
 
 import { parseDataUrl, processImageUrl } from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { logger, toError } from "@llmgateway/logger";
+import { models } from "@llmgateway/models";
 
 import type { ServerTypes } from "@/vars.js";
 import type { Context } from "hono";
@@ -553,6 +555,28 @@ async function logImageClientError(
 	}
 }
 
+// Reject non-image models up front. Image generation forwards to
+// /v1/chat/completions (which accepts text and image models), so without this
+// guard a text-only model would be forwarded and produce a chat completion the
+// images endpoint can't turn into an image. Unknown models are left to the chat
+// handler to reject as "model not found".
+function assertImageModel(model: string): void {
+	const slashIdx = model.indexOf("/");
+	const modelKey = slashIdx > 0 ? model.slice(slashIdx + 1) : model;
+	if (modelKey === "auto" || modelKey === "custom") {
+		return;
+	}
+	const modelInfo = models.find(
+		(m) =>
+			m.id === model ||
+			m.id === modelKey ||
+			m.providers.some((p) => p.externalId === modelKey),
+	);
+	if (modelInfo) {
+		validateModelOutput(modelInfo, modelKey, ["image"]);
+	}
+}
+
 async function forwardToChatCompletions(
 	c: Context,
 	chatRequest: Record<string, unknown>,
@@ -641,6 +665,8 @@ images.openapi(generations, async (c) => {
 	// Resolve "auto" model to a default image generation model
 	const model =
 		request.model === "auto" ? "gemini-3-pro-image-preview" : request.model;
+
+	assertImageModel(model);
 
 	// Build the chat completions request
 	const chatPrompt = buildImagePrompt(request);
@@ -1054,6 +1080,8 @@ async function processImageEdit(
 		request.model === "auto" || !request.model
 			? "gemini-3-pro-image-preview"
 			: request.model;
+
+	assertImageModel(model);
 
 	const chatRequest: Record<string, unknown> = {
 		model,

--- a/apps/gateway/src/lib/validate-model-output.ts
+++ b/apps/gateway/src/lib/validate-model-output.ts
@@ -1,0 +1,68 @@
+import { HTTPException } from "hono/http-exception";
+
+import type { ModelDefinition } from "@llmgateway/models";
+
+/**
+ * The kinds of output a model can produce. Each kind maps 1:1 to the gateway
+ * endpoint that serves it, so the requested model's declared output is the
+ * single signal used to gate every route.
+ */
+export type ModelOutput =
+	| "text"
+	| "image"
+	| "video"
+	| "embedding"
+	| "audio"
+	| "ocr";
+
+const OUTPUT_ENDPOINT: Record<
+	ModelOutput,
+	{ label: string; endpoint: string }
+> = {
+	text: { label: "a chat", endpoint: "/v1/chat/completions" },
+	image: { label: "an image generation", endpoint: "/v1/images/generations" },
+	video: { label: "a video generation", endpoint: "/v1/videos" },
+	embedding: { label: "an embeddings", endpoint: "/v1/embeddings" },
+	audio: { label: "a speech", endpoint: "/v1/audio/speech" },
+	ocr: { label: "an OCR", endpoint: "/v1/ocr" },
+};
+
+/**
+ * The model's declared output capabilities. Models that don't declare an
+ * `output` are text models (the default), so the absence of the field reads as
+ * `["text"]`.
+ */
+export function getModelOutputs(modelInfo: ModelDefinition): ModelOutput[] {
+	return modelInfo.output && modelInfo.output.length > 0
+		? modelInfo.output
+		: ["text"];
+}
+
+/**
+ * Reject (400) a model whose declared output capabilities don't intersect the
+ * output types the calling endpoint serves. "auto" and "custom" are resolved
+ * dynamically, so they always pass. The error points the caller at the endpoint
+ * that matches the model's primary output (e.g. an embeddings model requested on
+ * /v1/chat/completions is told to use /v1/embeddings instead).
+ */
+export function validateModelOutput(
+	modelInfo: ModelDefinition,
+	requestedModel: string,
+	accepted: ModelOutput[],
+): void {
+	if (requestedModel === "auto" || requestedModel === "custom") {
+		return;
+	}
+
+	const outputs = getModelOutputs(modelInfo);
+	if (outputs.some((output) => accepted.includes(output))) {
+		return;
+	}
+
+	const primary = OUTPUT_ENDPOINT[outputs[0]];
+	const wanted = OUTPUT_ENDPOINT[accepted[0]];
+
+	throw new HTTPException(400, {
+		message: `Model ${requestedModel} is ${primary.label} model and cannot be used with ${wanted.endpoint}. Use the ${primary.endpoint} endpoint instead.`,
+	});
+}

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -343,6 +343,9 @@ describe("Models API", () => {
 		);
 
 		expect(ocrModel).toBeDefined();
+		// OCR surfaces as its own output modality so third-party clients can
+		// reference the same taxonomy as the model catalog.
+		expect(ocrModel.architecture.output_modalities).toEqual(["ocr"]);
 		// $4 per 1,000 pages.
 		expect(ocrModel.pricing.ocr_page).toBe("0.004");
 		const mistralProvider = ocrModel.providers.find(

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -201,14 +201,19 @@ modelsApi.openapi(listModels, async (c) => {
 				inputModalities.push("image");
 			}
 
-			// Determine output modalities from model definition or default to text only
+			// Determine output modalities from model definition or default to text
+			// only. OCR is an internal routing capability rather than a public
+			// output modality — OCR models genuinely return text — so it surfaces
+			// as "text" here (per-page pricing already distinguishes them).
 			const outputModalities: (
 				| "text"
 				| "image"
 				| "video"
 				| "embedding"
 				| "audio"
-			)[] = model.output ?? ["text"];
+			)[] = (model.output ?? ["text"]).map((modality) =>
+				modality === "ocr" ? "text" : modality,
+			);
 
 			// Source the model-level pricing from the cheapest provider mapping
 			// that is actually serving the model (not deactivated/deprecated), so

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -23,7 +23,7 @@ const modelSchema = z.object({
 	architecture: z.object({
 		input_modalities: z.array(z.enum(["text", "image", "video", "embedding"])),
 		output_modalities: z.array(
-			z.enum(["text", "image", "video", "embedding", "audio"]),
+			z.enum(["text", "image", "video", "embedding", "audio", "ocr"]),
 		),
 		tokenizer: z.string().optional(),
 	}),
@@ -201,19 +201,17 @@ modelsApi.openapi(listModels, async (c) => {
 				inputModalities.push("image");
 			}
 
-			// Determine output modalities from model definition or default to text
-			// only. OCR is an internal routing capability rather than a public
-			// output modality — OCR models genuinely return text — so it surfaces
-			// as "text" here (per-page pricing already distinguishes them).
+			// Determine output modalities from the model definition or default to
+			// text only. These mirror the model catalog 1:1 (including "ocr") so
+			// third-party clients can reference the same modality taxonomy.
 			const outputModalities: (
 				| "text"
 				| "image"
 				| "video"
 				| "embedding"
 				| "audio"
-			)[] = (model.output ?? ["text"]).map((modality) =>
-				modality === "ocr" ? "text" : modality,
-			);
+				| "ocr"
+			)[] = model.output ?? ["text"];
 
 			// Source the model-level pricing from the cheapest provider mapping
 			// that is actually serving the model (not deactivated/deprecated), so

--- a/packages/models/src/model-metadata.spec.ts
+++ b/packages/models/src/model-metadata.spec.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from "vitest";
 
 import { models } from "./models.js";
 
+import type { ModelDefinition, ProviderModelMapping } from "./models.js";
+
+// A model's non-text capabilities are signalled by per-mapping flags, but the
+// gateway routes gate requests on the model-level `output` array. The two must
+// agree: a model that serves a dedicated endpoint (embeddings, OCR, etc.) must
+// declare the matching output, or chat completions (which defaults a missing
+// `output` to ["text"]) would wrongly accept it. Image is intentionally allowed
+// on chat completions, so image-gen models just need "image" present — they may
+// also output text.
+const REQUIRED_OUTPUT_BY_FLAG: {
+	flag: keyof ProviderModelMapping;
+	output: string;
+}[] = [
+	{ flag: "imageGenerations", output: "image" },
+	{ flag: "embeddings", output: "embedding" },
+	{ flag: "speechGenerations", output: "audio" },
+	{ flag: "videoGenerations", output: "video" },
+	{ flag: "ocr", output: "ocr" },
+];
+
 describe("model metadata", () => {
 	it("uses Azure Foundry limits for Grok 4.3", () => {
 		const grok43 = models.find((model) => model.id === "grok-4-3");
@@ -34,5 +54,27 @@ describe("model metadata", () => {
 			.map((model) => model.id);
 
 		expect(invalid).toEqual([]);
+	});
+
+	it("declares matching output for every non-text capability flag", () => {
+		const offenders: string[] = [];
+
+		for (const model of models as readonly ModelDefinition[]) {
+			const outputs: string[] = model.output ?? ["text"];
+
+			for (const { flag, output } of REQUIRED_OUTPUT_BY_FLAG) {
+				const hasFlag = model.providers.some(
+					(provider) => (provider as ProviderModelMapping)[flag] === true,
+				);
+
+				if (hasFlag && !outputs.includes(output)) {
+					offenders.push(
+						`${model.id} (flag "${flag}" needs output "${output}")`,
+					);
+				}
+			}
+		}
+
+		expect(offenders).toEqual([]);
 	});
 });

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -571,7 +571,7 @@ export interface ModelDefinition {
 	/**
 	 * Output formats supported by the model (defaults to ['text'] if not specified)
 	 */
-	output?: ("text" | "image" | "video" | "embedding" | "audio")[];
+	output?: ("text" | "image" | "video" | "embedding" | "audio" | "ocr")[];
 	/**
 	 * Whether this model requires an image input to function (e.g. image editing models).
 	 */

--- a/packages/models/src/models/mistral.ts
+++ b/packages/models/src/models/mistral.ts
@@ -232,6 +232,7 @@ export const mistralModels = [
 			"Mistral's OCR model that extracts text, tables, and structure from documents and images as markdown via the /v1/ocr endpoint.",
 		family: "mistral",
 		releasedAt: new Date("2025-03-06"),
+		output: ["ocr"],
 		providers: [
 			{
 				providerId: "mistral",


### PR DESCRIPTION
## Summary

Distinguishes model types by their declared `output` capability instead of ad-hoc, per-route signals, and enforces it uniformly across routes.

**Background:** OCR models (e.g. `mistral-ocr-latest`) genuinely return text, so they can't be told apart from chat models by output modality alone — that's why they previously needed a special-case check. Rather than a pricing heuristic, this PR makes the model's `output` capability the single source of truth: OCR becomes a first-class output type, and every endpoint checks it.

## Changes

- **`output: ["ocr"]`** — added `"ocr"` to the `ModelDefinition.output` union and tagged `mistral-ocr-latest`, so OCR is a declared output capability rather than something only the per-provider `ocr` flag knows about.
- **Shared `validateModelOutput` helper** (`apps/gateway/src/lib/`) — rejects (400) a model whose declared outputs don't intersect what the endpoint serves, and points the caller at the right endpoint (e.g. *"Model X is an OCR model … Use the /v1/ocr endpoint instead."*).
- **Chat** — `validateModelCapabilities` now accepts only `text`/`image` output, replacing the embedding + OCR special cases. Image output is allowed because image generation routes through `/v1/chat/completions` (so text-only, image-only, and text+image all pass). This also closes the gap that previously let **video / audio / image-only** models through. `/v1/responses` and `/v1/messages` forward to chat, so they inherit this.
- **Images** — guards that the requested model actually produces image output before forwarding to chat completions (auto/custom and unknown models pass through as before).
- **`/v1/models`** — surfaces `output_modalities` 1:1 with the model catalog, **including `["ocr"]`** (added to the public schema enum), so third-party clients can reference the same modality taxonomy. Per-page pricing (`ocr_page`) remains alongside.

Routes that resolve models through a per-mapping capability flag (`embeddings`, `speechGenerations`, `videoGenerations`, `ocr`) already reject mismatched models at resolution, so they were left as-is.

## Defaults / safety

A missing `output` defaults to `["text"]`, so the ~290 existing chat models need no change — only non-text models opt in. A new `model-metadata` invariant test asserts that any model carrying a non-text capability flag (`imageGenerations`/`embeddings`/`speechGenerations`/`videoGenerations`/`ocr`) declares the matching `output`, so a non-text model can't silently default to text and get wrongly accepted on chat. (This invariant would have caught the original OCR bug.)

## Tests

- New `validateModelCapabilities - output capability` cases: rejects OCR/video/audio on chat, allows image-output models.
- `model-metadata` invariant: output ⇄ capability-flag consistency.
- `/v1/models` spec asserts `mistral-ocr-latest` → `output_modalities: ["ocr"]`.
- Existing OCR, models, and image API specs pass; `pnpm build` and `pnpm format` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)