### PR TITLE
fix(api): zero-fill missing days in /activity range

### DIFF
--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -223,6 +223,46 @@ describe("activity endpoint", () => {
 		expect(modelData).toHaveProperty("cost");
 	});
 
+	test("GET /activity should zero-fill missing days for from/to range", async () => {
+		const today = new Date();
+		const fiveDaysAgo = new Date(today);
+		fiveDaysAgo.setUTCDate(fiveDaysAgo.getUTCDate() - 5);
+		const fromStr = fiveDaysAgo.toISOString().slice(0, 10);
+		const toStr = today.toISOString().slice(0, 10);
+
+		const params = new URLSearchParams({
+			from: fromStr,
+			to: toStr,
+			timezone: "UTC",
+		});
+		const res = await app.request("/activity?" + params, {
+			headers: {
+				Cookie: token,
+			},
+		});
+
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(Array.isArray(data.activity)).toBe(true);
+		// Six contiguous days (fromStr..toStr inclusive), even though only three
+		// of them have logged activity — the rest must be zero-filled.
+		expect(data.activity.length).toBe(6);
+		expect(data.activity.map((d: { date: string }) => d.date)).toEqual([
+			...Array.from({ length: 6 }, (_, i) => {
+				const d = new Date(fiveDaysAgo);
+				d.setUTCDate(d.getUTCDate() + i);
+				return d.toISOString().slice(0, 10);
+			}),
+		]);
+
+		// The oldest day in the window has no activity and must be a zero row.
+		const emptyDay = data.activity[0];
+		expect(emptyDay.requestCount).toBe(0);
+		expect(emptyDay.cost).toBe(0);
+		expect(emptyDay.totalTokens).toBe(0);
+		expect(emptyDay.modelBreakdown).toEqual([]);
+	});
+
 	test("GET /activity should filter by projectId", async () => {
 		const params = new URLSearchParams({
 			days: "7",

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -627,9 +627,10 @@ activity.openapi(getActivity, async (c) => {
 			};
 		});
 
-		const paddedActivity = timeRange
-			? padActivity(activityData, startDate, endDate, isHourly, timeZone)
-			: activityData;
+		const paddedActivity =
+			timeRange || (from && to)
+				? padActivity(activityData, startDate, endDate, isHourly, timeZone)
+				: activityData;
 
 		return c.json({
 			activity: paddedActivity,
@@ -948,9 +949,10 @@ activity.openapi(getActivity, async (c) => {
 		};
 	});
 
-	const paddedActivity = timeRange
-		? padActivity(activityData, startDate, endDate, isHourly, timeZone)
-		: activityData;
+	const paddedActivity =
+		timeRange || (from && to)
+			? padActivity(activityData, startDate, endDate, isHourly, timeZone)
+			: activityData;
 
 	return c.json({
 		activity: paddedActivity,


### PR DESCRIPTION
## Problem

On the analytics page, the cost-by-model-over-time graph only rendered days that actually had data — days with no activity were skipped entirely, producing a sparse/uneven X-axis instead of a continuous one.

## Root cause

`/activity` already has zero-fill infrastructure (`padActivity` + `buildEmptyActivityRow` + `generateTimeSlots`), but it was only applied for `timeRange` queries. The analytics page calls `/activity` with `from`/`to` params, which returned the raw `GROUP BY` output — so only buckets with activity were emitted.

## Fix

Extend `padActivity` to the `from && to` branch at both return sites in `apps/api/src/routes/activity.ts`. The response now includes every day in the requested range, with empty days zero-filled — matching the existing model-stats / dashboard activity-chart behaviour.

The legacy `days=` default path is left unchanged. Added a unit test asserting that a `from`/`to` range with gaps returns a contiguous, zero-filled day list.

## Testing

- `pnpm vitest run apps/api/src/routes/activity.spec.ts` → 21 passed
- `pnpm turbo run build --filter=api` → success
- `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)