### PR TITLE
fix(gateway): guard recursive $ref schema expansion

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1107,6 +1107,128 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		});
 	});
 
+	test("should not overflow the stack on self-referential $ref schemas", async () => {
+		const recursiveTools = [
+			{
+				type: "function" as const,
+				function: {
+					name: "build_tree",
+					description: "Build a recursive tree",
+					parameters: {
+						type: "object",
+						properties: {
+							root: { $ref: "#/$defs/TreeNode" },
+						},
+						$defs: {
+							TreeNode: {
+								type: "object",
+								properties: {
+									value: { type: "string" },
+									children: {
+										type: "array",
+										items: { $ref: "#/$defs/TreeNode" },
+									},
+								},
+								required: ["value"],
+							},
+						},
+						required: ["root"],
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			null,
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			recursiveTools,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+		expect(params.$defs).toBeUndefined();
+		// The recursive node is expanded one level then collapsed to a generic
+		// object where it would otherwise recurse forever.
+		expect(params.properties.root.properties.value).toEqual({
+			type: "string",
+		});
+		expect(params.properties.root.properties.children.items).toEqual({
+			type: "object",
+		});
+	});
+
+	test("should not overflow the stack on self-referential $ref schemas for bedrock", async () => {
+		const recursiveTools = [
+			{
+				type: "function" as const,
+				function: {
+					name: "build_tree",
+					description: "Build a recursive tree",
+					parameters: {
+						type: "object",
+						properties: {
+							root: { $ref: "#/$defs/TreeNode" },
+						},
+						$defs: {
+							TreeNode: {
+								type: "object",
+								properties: {
+									value: { type: "string" },
+									children: {
+										type: "array",
+										items: { $ref: "#/$defs/TreeNode" },
+									},
+								},
+								required: ["value"],
+							},
+						},
+						required: ["root"],
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"aws-bedrock",
+			"claude-sonnet-4-6",
+			null,
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			recursiveTools,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const toolSpec = requestBody.toolConfig.tools[0].toolSpec;
+		const schema = toolSpec.inputSchema.json;
+		expect(schema.properties.root.properties.children.items).toEqual({
+			type: "object",
+			properties: {},
+		});
+	});
+
 	test("should strip additionalProperties from tool parameters", async () => {
 		const toolsWithAdditionalProps = [
 			{

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -340,6 +340,7 @@ function resolveRef(ref: string, rootDefs: Record<string, any>): any {
 function stripUnsupportedSchemaProperties(
 	schema: any,
 	rootDefs?: Record<string, any>,
+	seenRefs: Set<string> = new Set(),
 ): any {
 	if (!schema || typeof schema !== "object") {
 		return schema;
@@ -347,7 +348,7 @@ function stripUnsupportedSchemaProperties(
 
 	if (Array.isArray(schema)) {
 		return schema.map((item) =>
-			stripUnsupportedSchemaProperties(item, rootDefs),
+			stripUnsupportedSchemaProperties(item, rootDefs, seenRefs),
 		);
 	}
 
@@ -356,10 +357,24 @@ function stripUnsupportedSchemaProperties(
 
 	// Handle $ref - expand the reference inline
 	if (schema.$ref) {
+		// Guard against self-referential schemas (recursive types). Since Google
+		// doesn't support $ref, an inline-expanded cycle would recurse forever and
+		// overflow the stack, so we collapse the recursive node to a generic object.
+		if (seenRefs.has(schema.$ref)) {
+			const fallback: any = { type: "object" };
+			if (schema.description) {
+				fallback.description = schema.description;
+			}
+			return fallback;
+		}
 		const resolved = resolveRef(schema.$ref, defs);
 		if (resolved) {
 			// Expand the reference, preserving only description and default from the original node
-			const expanded = stripUnsupportedSchemaProperties({ ...resolved }, defs);
+			const expanded = stripUnsupportedSchemaProperties(
+				{ ...resolved },
+				defs,
+				new Set(seenRefs).add(schema.$ref),
+			);
 			if (schema.description && !expanded.description) {
 				expanded.description = schema.description;
 			}
@@ -439,6 +454,7 @@ function stripUnsupportedSchemaProperties(
 				cleanedProps[propName] = stripUnsupportedSchemaProperties(
 					propSchema,
 					defs,
+					seenRefs,
 				);
 			}
 			cleaned[key] = cleanedProps;
@@ -447,7 +463,7 @@ function stripUnsupportedSchemaProperties(
 
 		// Recursively clean nested objects
 		if (value && typeof value === "object") {
-			cleaned[key] = stripUnsupportedSchemaProperties(value, defs);
+			cleaned[key] = stripUnsupportedSchemaProperties(value, defs, seenRefs);
 		} else {
 			cleaned[key] = value;
 		}
@@ -491,21 +507,38 @@ function mapGoogleImageSize(imageSize: string): string {
 function sanitizeBedrockSchema(
 	schema: any,
 	rootDefs?: Record<string, any>,
+	seenRefs: Set<string> = new Set(),
 ): any {
 	if (!schema || typeof schema !== "object") {
 		return schema;
 	}
 
 	if (Array.isArray(schema)) {
-		return schema.map((item) => sanitizeBedrockSchema(item, rootDefs));
+		return schema.map((item) =>
+			sanitizeBedrockSchema(item, rootDefs, seenRefs),
+		);
 	}
 
 	const defs = rootDefs ?? schema.$defs ?? schema.definitions ?? {};
 
 	if (typeof schema.$ref === "string") {
+		// Guard against self-referential schemas (recursive types). Bedrock doesn't
+		// support $ref, so an inline-expanded cycle would recurse forever and
+		// overflow the stack; collapse the recursive node to a generic object.
+		if (seenRefs.has(schema.$ref)) {
+			const fallback: any = { type: "object", properties: {} };
+			if (schema.description) {
+				fallback.description = schema.description;
+			}
+			return fallback;
+		}
 		const resolved = resolveRef(schema.$ref, defs);
 		if (resolved) {
-			const expanded = sanitizeBedrockSchema({ ...resolved }, defs);
+			const expanded = sanitizeBedrockSchema(
+				{ ...resolved },
+				defs,
+				new Set(seenRefs).add(schema.$ref),
+			);
 			if (schema.description && !expanded.description) {
 				expanded.description = schema.description;
 			}
@@ -548,14 +581,14 @@ function sanitizeBedrockSchema(
 			cleaned.properties = Object.fromEntries(
 				Object.entries(value).map(([propertyName, propertyValue]) => [
 					propertyName,
-					sanitizeBedrockSchema(propertyValue, defs),
+					sanitizeBedrockSchema(propertyValue, defs, seenRefs),
 				]),
 			);
 			continue;
 		}
 
 		if (value && typeof value === "object") {
-			cleaned[key] = sanitizeBedrockSchema(value, defs);
+			cleaned[key] = sanitizeBedrockSchema(value, defs, seenRefs);
 		} else {
 			cleaned[key] = value;
 		}


### PR DESCRIPTION
## Problem

The gateway crashed with `RangeError: Maximum call stack size exceeded` in `prepare-request-body.ts` (`stripUnsupportedSchemaProperties`):

```
RangeError: Maximum call stack size exceeded
    at stripUnsupportedSchemaProperties (.../prepare-request-body.ts:349)
```

When a request carries a tool whose JSON schema is **self-referential** — a recursive type whose `$def` references itself (e.g. a tree node with `children: { items: { $ref: "#/$defs/TreeNode" } }`) — the schema sanitizers for Google and Bedrock expand `$ref` **inline**. Because those providers don't support `$ref`, the expansion follows the cycle forever and overflows the stack, taking down the gateway pod.

## Fix

Thread a `seenRefs` set through the recursion in both `stripUnsupportedSchemaProperties` (Google) and `sanitizeBedrockSchema` (Bedrock). When a `$ref` already on the active expansion path is encountered again, collapse it to a generic object schema (preserving its `description`) instead of recursing. Sibling references to the same `$def` are unaffected — each path gets its own copied set, so non-recursive reuse still fully expands.

`sanitizeCerebrasSchema` is not affected: it preserves `$defs`/`$ref` rather than expanding them, so it never follows the cycle.

## Tests

Added two regression tests (Google + Bedrock) that pass a self-referential `TreeNode` tool schema and assert the recursive node is expanded one level then collapsed, with no stack overflow. Full `prepare-request-body.spec.ts` suite passes (109 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)