### PR TITLE
fix(api): grant dev plan upgrade credits in webhook

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -11,8 +11,6 @@ import { cdb, db, tables, eq, shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
 	DEV_PLAN_PRICES,
-	getDevPlanCreditsLimit,
-	getProratedCreditDelta,
 	type DevPlanCycle,
 	type DevPlanTier,
 } from "@llmgateway/shared";
@@ -760,41 +758,18 @@ devPlans.openapi(changeTier, async (c) => {
 		if (isUpgrade) {
 			// Only update local DB after Stripe confirms the upgrade is paid/active.
 			//
-			// Credits track prorated dollars: a mid-cycle upgrade grants only the
-			// prorated difference between the two tiers' allotments for the
-			// remaining part of the billing period, mirroring the prorated amount
-			// Stripe charges. Granting the full new-tier allotment on every
-			// upgrade would let a user upgrade cheaply near the end of a cycle to
-			// receive a near-full fresh allotment. Clamp to the new tier's full
-			// allotment so a carried-over higher limit (e.g. credits kept from a
-			// prior downgrade) can never push the balance above the tier cap.
-			const subscriptionItem = updated.items.data[0];
-			const periodStart = subscriptionItem.current_period_start;
-			const periodEnd = subscriptionItem.current_period_end;
-			const nowSeconds = Math.floor(Date.now() / 1000);
-			const periodLength = periodEnd - periodStart;
-			const remainingFraction =
-				periodLength > 0 ? (periodEnd - nowSeconds) / periodLength : 0;
-
-			const creditDelta = getProratedCreditDelta(
-				currentTier,
-				newTier,
-				remainingFraction,
-			);
-			const currentLimit = parseFloat(personalOrg.devPlanCreditsLimit ?? "0");
-			const newCreditsLimit = Math.min(
-				getDevPlanCreditsLimit(newTier),
-				Math.max(0, currentLimit + creditDelta),
-			);
-
-			// The upgrade's proration invoice fires `invoice.payment_succeeded`,
-			// which records the `dev_plan_upgrade` transaction (with the amount
-			// collected) — so we don't record one here to avoid double-counting.
+			// Flip the tier immediately so the new tier's model gating and limits
+			// take effect right away. The prorated credit grant is applied by the
+			// proration invoice's `invoice.payment_succeeded`
+			// (`subscription_update`) webhook, which is the single source of truth
+			// for the upgrade credit delta: it derives the delta from the dollars
+			// actually collected (never from Stripe subscription-period fields,
+			// which can be absent on the update response and silently zero out the
+			// grant) and records the canonical `dev_plan_upgrade` transaction.
 			await db
 				.update(tables.organization)
 				.set({
 					devPlan: newTier,
-					devPlanCreditsLimit: newCreditsLimit.toString(),
 				})
 				.where(eq(tables.organization.id, personalOrg.id));
 		} else {

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -303,13 +303,14 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 		expect(sendEmailMock.mock.calls[0][0].to).toBe("default-billing@acme.test");
 	});
 
-	test("does NOT reset credits on a proration invoice from a tier change", async () => {
-		await seedUsedDevPlanOrg();
+	test("grants prorated credits but does NOT reset usage on a tier-change proration invoice", async () => {
+		// Seed below the pro cap so the granted delta is visible (and not clamped).
+		await seedUsedDevPlanOrg({ devPlanCreditsLimit: "100" });
 
 		await handleInvoicePaymentSucceeded(
 			makeInvoiceEvent({
 				billingReason: "subscription_update",
-				amountPaid: 9221,
+				amountPaid: 4835,
 				invoiceId: "in_proration_001",
 			}),
 		);
@@ -320,14 +321,41 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 		// The credit usage must be preserved — otherwise a user could
 		// downgrade then upgrade to repeatedly refresh their full balance.
 		expect(org?.devPlanCreditsUsed).toBe("150");
+		// Prorated grant = dollars collected ($48.35) × multiplier (3) = $145.05,
+		// added to the existing limit: 100 + 145.05 = 245.05, clamped to pro cap 237.
+		expect(org?.devPlanCreditsLimit).toBe("237");
 
 		const txns = await db.query.transaction.findMany({
 			where: { organizationId: { eq: ORG_ID } },
 		});
 		expect(txns).toHaveLength(1);
 		expect(txns[0].type).toBe("dev_plan_upgrade");
-		expect(txns[0].creditAmount).toBeNull();
-		expect(txns[0].amount).toBe("92.21");
+		expect(txns[0].creditAmount).toBe("145.05");
+		expect(txns[0].amount).toBe("48.35");
+	});
+
+	test("clamps the prorated upgrade grant to the new tier's full allotment", async () => {
+		await seedUsedDevPlanOrg({ devPlanCreditsLimit: "87" });
+
+		await handleInvoicePaymentSucceeded(
+			makeInvoiceEvent({
+				billingReason: "subscription_update",
+				amountPaid: 1000,
+				invoiceId: "in_proration_002",
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		// 87 + ($10 × 3 = 30) = 117, below the pro cap (237), so the full delta lands.
+		expect(org?.devPlanCreditsLimit).toBe("117");
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(1);
+		expect(txns[0].creditAmount).toBe("30");
 	});
 
 	test("skips processing an invoice that was already recorded", async () => {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -16,6 +16,7 @@ import { logger } from "@llmgateway/logger";
 import {
 	getChatPlanCreditsLimit,
 	getDevPlanCreditsLimit,
+	getDevPlanCreditsMultiplier,
 	type ChatPlanCycle,
 	type ChatPlanTier,
 	type DevPlanCycle,
@@ -3309,16 +3310,39 @@ export async function handleInvoicePaymentSucceeded(event: {
 		isDevPlanSubscription &&
 		invoice.billing_reason === "subscription_update"
 	) {
-		// Proration invoice from a mid-cycle upgrade. The change-tier endpoint
-		// already adjusted `devPlanCreditsLimit` (prorated); here we record the
-		// upgrade — with the amount actually collected — as the single canonical
-		// `dev_plan_upgrade` transaction (change-tier deliberately does not record
-		// one for upgrades, to avoid double-counting). We do NOT reset
-		// `devPlanCreditsUsed` or grant a fresh allotment.
+		// Proration invoice from a mid-cycle upgrade. This webhook is the single
+		// source of truth for the upgrade credit grant: the change-tier endpoint
+		// only flips `devPlan` and leaves crediting to us, so the grant lands
+		// regardless of which path drove the upgrade and never depends on Stripe
+		// subscription-period fields (which can be absent on the update response).
+		//
+		// Credits track prorated dollars: each tier's allotment is its price times
+		// the credits multiplier, so the prorated credit delta is exactly the
+		// dollars actually collected on this proration invoice times that
+		// multiplier — mirroring how Stripe prorated the charge. Clamp to the new
+		// tier's full allotment so a carried-over higher limit (e.g. credits kept
+		// from a prior downgrade) can never push the balance above the cap. We do
+		// NOT reset `devPlanCreditsUsed`. The invoice-level idempotency guard above
+		// ensures this grant runs at most once per proration invoice.
+		const proratedDollars = invoice.amount_paid / 100;
+		const creditDelta = Math.max(
+			0,
+			proratedDollars * getDevPlanCreditsMultiplier(),
+		);
+		const currentLimit = parseFloat(organization.devPlanCreditsLimit ?? "0");
+		const tierCap = getDevPlanCreditsLimit(organization.devPlan as DevPlanTier);
+		const newCreditsLimit = Math.min(tierCap, currentLimit + creditDelta);
+
+		await db
+			.update(tables.organization)
+			.set({ devPlanCreditsLimit: newCreditsLimit.toString() })
+			.where(eq(tables.organization.id, organizationId));
+
 		await db.insert(tables.transaction).values({
 			organizationId,
 			type: "dev_plan_upgrade",
-			amount: (invoice.amount_paid / 100).toString(),
+			amount: proratedDollars.toString(),
+			creditAmount: creditDelta.toString(),
 			currency: invoice.currency.toUpperCase(),
 			status: "completed",
 			stripePaymentIntentId: (invoice as any).payment_intent,
@@ -3327,7 +3351,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 		});
 
 		logger.info(
-			`Recorded dev plan upgrade proration invoice for organization ${organizationId}; credits left unchanged`,
+			`Granted ${creditDelta} prorated dev plan upgrade credits for organization ${organizationId} (limit ${currentLimit} -> ${newCreditsLimit})`,
 		);
 	} else if (isDevPlanSubscription) {
 		// Any other dev-plan invoice (e.g. `manual`, or a `subscription_create`

--- a/packages/shared/src/dev-plans.ts
+++ b/packages/shared/src/dev-plans.ts
@@ -11,9 +11,12 @@ export type DevPlanTier = keyof typeof DEV_PLAN_PRICES;
 // removal of the yearly option; no new annual subscriptions are created.
 export type DevPlanCycle = "monthly" | "annual";
 
+export function getDevPlanCreditsMultiplier(): number {
+	return parseFloat(process.env.DEV_PLAN_CREDITS_MULTIPLIER ?? "3");
+}
+
 export function getDevPlanCreditsLimit(tier: DevPlanTier): number {
-	const multiplier = parseFloat(process.env.DEV_PLAN_CREDITS_MULTIPLIER ?? "3");
-	return DEV_PLAN_PRICES[tier] * multiplier;
+	return DEV_PLAN_PRICES[tier] * getDevPlanCreditsMultiplier();
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export {
 	type DevPlanCycle,
 	type DevPlanTier,
 	getDevPlanCreditsLimit,
+	getDevPlanCreditsMultiplier,
 	getDevPlanPremiumWeeklyLimit,
 	getRemainingPremiumWeeklyAllowance,
 	getProratedCreditDelta,


### PR DESCRIPTION
## Problem

A mid-cycle dev plan upgrade can flip the org to the new tier while silently failing to grant the prorated credits — leaving the subscriber on the higher tier with the **lower tier's credit limit**.

Root cause: the `changeTier` endpoint computed the prorated grant from the `subscriptions.update` response's `current_period_start`/`current_period_end` fields:

```ts
const periodLength = periodEnd - periodStart;
const remainingFraction = periodLength > 0 ? (periodEnd - nowSeconds) / periodLength : 0;
```

When those fields come back absent/invalid on the update response, `periodLength > 0` is false → `remainingFraction = 0` → `creditDelta = 0` → `min(cap, currentLimit + 0) = currentLimit`. The tier still flips, but the limit stays put.

Observed in prod: a LITE→PRO upgrade left an org on `pro` with `dev_plan_credits_limit = 87` (the LITE allotment) instead of the prorated PRO value, and the `dev_plan_upgrade` transaction had a null `creditAmount`.

## Fix

Make the proration invoice's `invoice.payment_succeeded` (`subscription_update`) webhook the **single source of truth** for the upgrade credit grant:

- `changeTier` now only flips `devPlan` (so the new tier's gating/limits apply immediately).
- The webhook grants the prorated delta computed from the **dollars actually collected** on the proration invoice × the credits multiplier (each tier's allotment is its price × multiplier, so `delta = collected × multiplier`). This never depends on Stripe subscription-period fields, and it covers the grant **regardless of which path drove the upgrade** (e.g. Stripe customer portal).
- The grant is clamped to the new tier's full allotment and does **not** reset `devPlanCreditsUsed`.
- The existing invoice-level idempotency guard (bail if a transaction already exists for the invoice id) keeps the grant exactly-once across Stripe webhook retries.
- The `dev_plan_upgrade` transaction now records its `creditAmount`.

Adds a shared `getDevPlanCreditsMultiplier()` helper (DRY with `getDevPlanCreditsLimit`).

## Tests

- Updated `stripe.spec.ts`: the proration-invoice test now asserts the prorated grant lands (and usage is preserved), plus a new case verifying the clamp to the tier cap.
- `pnpm build`, `pnpm lint`, and the affected unit specs (`stripe.spec.ts`, `dev-plans.spec.ts`) pass.

## Affected prod data

Existing orgs that already hit this bug need a one-time manual credit correction (set `dev_plan_credits_limit` to the prorated value and backfill the upgrade transaction's `credit_amount`); this PR only prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade-related invoice payments now automatically grant prorated dev-plan credits.
  * Credit limits are capped at the tier maximum, preventing over-allocation.

* **Bug Fixes**
  * Improved handling of tier changes so existing usage is preserved when prorated credits are applied.
  * Transaction records now include the correct credit and payment amounts for upgrade invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->