### PR TITLE
feat(code): show model family icon on coding cards

### DIFF
--- a/apps/code/src/components/CodingModelsShowcase.tsx
+++ b/apps/code/src/components/CodingModelsShowcase.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { models, type ModelDefinition } from "@llmgateway/models";
-import { getProviderIcon } from "@llmgateway/shared/components";
+import { getModelFamilyIcon } from "@llmgateway/shared/components";
 
 export type CodingModelsView = "all" | "cheap" | "flagship";
 
@@ -188,9 +188,7 @@ export function CodingModelsShowcase({
 			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 				{recommendedModels.map((model) => {
 					const provider = getCheapestProvider(model.providers);
-					const ProviderIcon = provider
-						? getProviderIcon(provider.providerId)
-						: null;
+					const FamilyIcon = getModelFamilyIcon(model.family);
 					const category = idByCategory.get(model.id);
 
 					return (
@@ -207,11 +205,9 @@ export function CodingModelsShowcase({
 							<div className="flex items-start justify-between gap-2">
 								<div className="flex-1 min-w-0">
 									<div className="flex items-center gap-2">
-										{ProviderIcon && (
-											<div className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-muted">
-												<ProviderIcon className="h-4 w-4" />
-											</div>
-										)}
+										<div className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-muted">
+											<FamilyIcon className="h-4 w-4" />
+										</div>
 										<span className="font-medium text-sm truncate">
 											{model.name ?? model.id}
 										</span>

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -1079,7 +1079,7 @@ describe("fallback and error status code handling", () => {
 				.values({
 					id: "glm-4.6",
 					name: "GLM-4.6",
-					family: "glm",
+					family: "zai",
 					releasedAt: new Date("2025-09-30"),
 				})
 				.onConflictDoNothing();
@@ -1218,7 +1218,7 @@ describe("fallback and error status code handling", () => {
 				.values({
 					id: "glm-4.6",
 					name: "GLM-4.6",
-					family: "glm",
+					family: "zai",
 					releasedAt: new Date("2025-09-30"),
 				})
 				.onConflictDoNothing();
@@ -1341,7 +1341,7 @@ describe("fallback and error status code handling", () => {
 				.values({
 					id: "glm-4.6",
 					name: "GLM-4.6",
-					family: "glm",
+					family: "zai",
 					releasedAt: new Date("2025-09-30"),
 				})
 				.onConflictDoNothing();

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -6,7 +6,7 @@ export const zaiModels = [
 		name: "GLM-5.2",
 		description:
 			"Zhipu GLM-5.2 flagship model for long-horizon coding and agentic engineering tasks with a 1M context window.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2026-06-13"),
 		providers: [
 			{
@@ -81,7 +81,7 @@ export const zaiModels = [
 		name: "GLM-5.1",
 		description:
 			"Zhipu GLM-5.1 flagship model engineered for long-horizon autonomous tasks with enhanced coding and agentic capabilities.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2026-04-07"),
 		providers: [
 			{
@@ -186,7 +186,7 @@ export const zaiModels = [
 		id: "glm-5",
 		name: "GLM-5",
 		description: "Zhipu GLM-5 with advanced reasoning capabilities.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2026-02-15"),
 		providers: [
 			{
@@ -321,7 +321,7 @@ export const zaiModels = [
 		id: "glm-4.5",
 		name: "GLM-4.5",
 		description: "Zhipu GLM-4.5 with reasoning capabilities.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-07-28"),
 		providers: [
 			{
@@ -379,7 +379,7 @@ export const zaiModels = [
 		id: "glm-4.5v",
 		name: "GLM-4.5V",
 		description: "GLM-4.5 with vision support.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-08-11"),
 		providers: [
 			{
@@ -420,7 +420,7 @@ export const zaiModels = [
 		id: "glm-4.5-air",
 		name: "GLM-4.5 Air",
 		description: "Lightweight GLM-4.5 variant.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-07-25"),
 		providers: [
 			{
@@ -477,7 +477,7 @@ export const zaiModels = [
 		id: "glm-4.5-x",
 		name: "GLM-4.5 X",
 		description: "Extended GLM-4.5 with advanced reasoning.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-07-28"),
 		providers: [
 			{
@@ -502,7 +502,7 @@ export const zaiModels = [
 		id: "glm-4.5-airx",
 		name: "GLM-4.5 AirX",
 		description: "Enhanced GLM-4.5 Air variant.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-07-28"),
 		providers: [
 			{
@@ -527,7 +527,7 @@ export const zaiModels = [
 		id: "glm-4.5-flash",
 		name: "GLM-4.5 Flash",
 		description: "Free, fast GLM-4.5 model.",
-		family: "glm",
+		family: "zai",
 		free: true,
 		stability: "unstable",
 		releasedAt: new Date("2025-08-13"),
@@ -553,7 +553,7 @@ export const zaiModels = [
 		id: "glm-4.7",
 		name: "GLM-4.7",
 		description: "Latest GLM with enhanced reasoning capabilities.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-12-22"),
 		providers: [
 			{
@@ -716,7 +716,7 @@ export const zaiModels = [
 		id: "glm-4.7-flashx",
 		name: "GLM-4.7 FlashX",
 		description: "Lightweight, high-speed GLM-4.7 variant.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-12-22"),
 		providers: [
 			{
@@ -746,7 +746,7 @@ export const zaiModels = [
 		id: "glm-4.7-flash-free",
 		name: "GLM-4.7 Flash (Free)",
 		description: "Free, lightweight GLM-4.7 model.",
-		family: "glm",
+		family: "zai",
 		free: true,
 		stability: "unstable",
 		releasedAt: new Date("2025-12-22"),
@@ -773,7 +773,7 @@ export const zaiModels = [
 		id: "glm-4.7-flash",
 		name: "GLM-4.7 Flash",
 		description: "Lightweight, high-speed GLM-4.7 model.",
-		family: "glm",
+		family: "zai",
 		stability: "unstable",
 		releasedAt: new Date("2025-12-22"),
 		providers: [
@@ -815,7 +815,7 @@ export const zaiModels = [
 		id: "glm-4.6",
 		name: "GLM-4.6",
 		description: "Updated GLM with reasoning capabilities.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-09-30"),
 		providers: [
 			{
@@ -905,7 +905,7 @@ export const zaiModels = [
 		id: "glm-4-32b-0414-128k",
 		name: "GLM-4 32B (0414-128k)",
 		description: "GLM-4 32B instruction-tuned model.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-04-14"),
 		providers: [
 			{
@@ -930,7 +930,7 @@ export const zaiModels = [
 		name: "GLM-4.6V",
 		description:
 			"Flagship vision-language model (106B) with native function calling support.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-12-08"),
 		providers: [
 			{
@@ -969,7 +969,7 @@ export const zaiModels = [
 		id: "glm-4.6v-flashx",
 		name: "GLM-4.6V FlashX",
 		description: "Fast vision-language model with extended capabilities.",
-		family: "glm",
+		family: "zai",
 		releasedAt: new Date("2025-12-08"),
 		providers: [
 			{
@@ -994,7 +994,7 @@ export const zaiModels = [
 		name: "GLM-4.6V Flash",
 		description:
 			"Ultra-fast, lightweight vision-language model (9B) for low-latency workloads.",
-		family: "glm",
+		family: "zai",
 		free: true,
 		stability: "unstable",
 		releasedAt: new Date("2025-12-08"),
@@ -1067,7 +1067,7 @@ export const zaiModels = [
 		name: "GLM-Image",
 		description:
 			"Z.AI's GLM-Image text-to-image generation model with hybrid auto-regressive architecture, excellent for text-rendering and knowledge-intensive generation.",
-		family: "glm",
+		family: "zai",
 		output: ["text", "image"],
 		releasedAt: new Date("2025-01-14"),
 		providers: [

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1311,6 +1311,65 @@ export const SakanaIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
 	</svg>
 );
 
+// Gemini Icon (Google model family)
+export const GeminiIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="none"
+	>
+		<defs>
+			<linearGradient
+				id="geminiFamilyGradient"
+				x1="0"
+				y1="0"
+				x2="24"
+				y2="24"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop offset="0%" stopColor="#4285F4" />
+				<stop offset="50%" stopColor="#9168F6" />
+				<stop offset="100%" stopColor="#D96570" />
+			</linearGradient>
+		</defs>
+		<path
+			d="M12 0c0 6.627-5.373 12-12 12 6.627 0 12 5.373 12 12 0-6.627 5.373-12 12-12-6.627 0-12-5.373-12-12Z"
+			fill="url(#geminiFamilyGradient)"
+		/>
+	</svg>
+);
+
+// Meta Icon (Llama model family)
+export const MetaIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="none"
+	>
+		<path
+			d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303Zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.527-3.817l-.821-1.371-.929-1.566c.183-.286.355-.555.508-.798.756-1.181 1.355-1.668 1.957-1.668.633 0 1.166.27 1.598.83.262.342.4.713.526 1.244l.054.235Zm-10.158.162c.726 0 1.27.292 1.857.788.379.32.787.749 1.245 1.282l-.65 1.015c-.395.617-.74 1.13-1.05 1.59-1.193 1.762-1.918 2.658-2.71 3.272-.582.451-1.014.62-1.493.62-.668 0-1.276-.288-1.617-.913-.32-.585-.495-1.412-.495-2.41 0-1.913.55-3.926 1.461-5.337.665-1.025 1.35-1.4 1.952-1.4Z"
+			fill="#0866FF"
+		/>
+	</svg>
+);
+
+// Nvidia Icon (Nvidia model family)
+export const NvidiaIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="none"
+	>
+		<path
+			d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.49-1.954-4-1.954a6.95 6.95 0 0 0-.796.04m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.034-1.095-.1v1.32c.3.037.61.062.92.062 3.957 0 6.82-2.022 9.59-4.408.46.37 2.345 1.265 2.733 1.66-2.633 2.204-8.766 3.978-12.256 3.978-.337 0-.66-.02-.98-.05v1.854H24V4.063zm0 10.326v1.128c-3.658-.652-4.673-4.455-4.673-4.455s1.756-1.945 4.673-2.26v1.237l-.006-.001c-1.532-.184-2.729 1.247-2.729 1.247s.671 2.41 2.735 3.104M2.456 9.793s2.167-3.198 6.502-3.53V4.917C4.153 5.296 0 9.382 0 9.382s2.352 6.799 8.948 7.42v-1.223c-4.84-.604-6.492-5.786-6.492-5.786z"
+			fill="#76B900"
+		/>
+	</svg>
+);
+
 export const ProviderIcons = {
 	atlascloud: AtlasCloudIcon,
 	anthropic: AnthropicIcon,
@@ -1410,4 +1469,43 @@ export const getProviderIcon = (
 		.toLowerCase()
 		.replace(/[^a-z0-9]/g, "-") as ProviderIconKey;
 	return ProviderIcons[normalizedProvider] || Logo;
+};
+
+// Maps a model's `family` (e.g. "glm", "google", "meta") to its brand icon so
+// that cards display the model maker's logo rather than whichever provider
+// happens to serve it cheapest. Families without a dedicated logo fall back to
+// the LLM Gateway logo via getModelFamilyIcon.
+export const ModelFamilyIcons: Record<
+	string,
+	React.FC<React.SVGProps<SVGSVGElement>>
+> = {
+	alibaba: AlibabaIcon,
+	anthropic: AnthropicIcon,
+	atlascloud: AtlasCloudIcon,
+	bytedance: BytedanceIcon,
+	deepseek: DeepseekIcon,
+	elevenlabs: ElevenLabsIcon,
+	glm: ZaiIcon,
+	google: GeminiIcon,
+	llmgateway: Logo,
+	meta: MetaIcon,
+	minimax: MinimaxIcon,
+	mistral: MistralIcon,
+	moonshot: MoonshotIcon,
+	nvidia: NvidiaIcon,
+	openai: OpenAIIcon,
+	perplexity: PerplexityIcon,
+	reve: ReveIcon,
+	sakana: SakanaIcon,
+	xai: XAIIcon,
+	xiaomi: XiaomiIcon,
+	zai: ZaiIcon,
+};
+
+// Helper function to get an icon by a model's family, falling back to the LLM
+// Gateway logo for families without a dedicated brand icon.
+export const getModelFamilyIcon = (
+	family: string,
+): React.FC<React.SVGProps<SVGSVGElement>> => {
+	return ModelFamilyIcons[family] ?? Logo;
 };

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1485,7 +1485,6 @@ export const ModelFamilyIcons: Record<
 	bytedance: BytedanceIcon,
 	deepseek: DeepseekIcon,
 	elevenlabs: ElevenLabsIcon,
-	glm: ZaiIcon,
 	google: GeminiIcon,
 	llmgateway: Logo,
 	meta: MetaIcon,


### PR DESCRIPTION
## Summary

The "Recommended for coding agents" cards (`apps/code`) previously showed the icon of whichever provider served the model cheapest. This is misleading — e.g. **GLM-5.2** rendered the cheapest serving provider's logo rather than its actual maker.

Now each card shows the model's **brand/family logo** based on `model.family`, where `family` denotes the model's **creator**.

## Changes

- **Icon by family**: Added `getModelFamilyIcon(family)` + `ModelFamilyIcons` map in `packages/shared/src/components/provider-icons.tsx`, reusing existing SVG React logos and falling back to the LLM Gateway logo for families without a dedicated brand icon. Added three new brand icons that didn't exist yet: `GeminiIcon`, `MetaIcon`, `NvidiaIcon`.
- **`CodingModelsShowcase`** now derives its card icon from `model.family` instead of the cheapest provider mapping (pricing/context still come from the cheapest provider).
- **Renamed the `glm` family to `zai`**: family should denote the creator, and GLM models are made by Z.ai. Updated all GLM model definitions (`packages/models/src/models/zai.ts`) and the gateway fallback test fixtures. Dropped the now-redundant `glm` icon alias since the `zai` family already maps to the Zai logo.

## Family → logo coverage

`alibaba, anthropic, atlascloud, bytedance, deepseek, elevenlabs, google→Gemini, meta, minimax, mistral, moonshot, nvidia, openai, perplexity, reve, sakana, xai, xiaomi, zai` all resolve to a brand icon; unknown families fall back to the LLM Gateway logo.

## Testing

- `pnpm turbo run build --filter=@llmgateway/models --filter=@llmgateway/shared --filter=code` ✅
- `pnpm vitest run apps/gateway/src/fallback.spec.ts` ✅ (50 passed)
- `pnpm lint` / `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)