### PR TITLE
feat(code): show DevPass invoice history

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1177,6 +1177,7 @@ devPlans.openapi(changeTier, async (c) => {
 						organizationId: personalOrg.id,
 						type: "dev_plan_upgrade",
 						amount: paidUpgrade.amount.toString(),
+						creditAmount: creditPreview.proratedCreditDelta.toString(),
 						currency: "USD",
 						status: "completed",
 						stripePaymentIntentId: paidUpgrade.paymentIntentId,
@@ -1737,6 +1738,77 @@ devPlans.openapi(updateBillingDetails, async (c) => {
 		own: pickBillingFields(updatedOrg),
 		default: pickBillingFields(defaultOrg ?? updatedOrg),
 	});
+});
+
+// List past DevPass invoices (plan start, renewals and upgrades) with the
+// amount charged and the virtual credits granted for each billing event.
+const getInvoices = createRoute({
+	method: "get",
+	path: "/invoices",
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						invoices: z.array(
+							z.object({
+								id: z.string(),
+								type: z.enum([
+									"dev_plan_start",
+									"dev_plan_renewal",
+									"dev_plan_upgrade",
+								]),
+								date: z.string(),
+								amount: z.string().nullable(),
+								creditAmount: z.string().nullable(),
+								currency: z.string(),
+								status: z.enum(["pending", "completed", "failed"]),
+								description: z.string().nullable(),
+							}),
+						),
+					}),
+				},
+			},
+			description: "DevPass invoices retrieved successfully",
+		},
+	},
+});
+
+devPlans.openapi(getInvoices, async (c) => {
+	const user = c.get("user");
+
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const personalOrg = await findPersonalOrg(user.id);
+	if (!personalOrg) {
+		return c.json({ invoices: [] });
+	}
+
+	const transactions = await db.query.transaction.findMany({
+		where: {
+			organizationId: { eq: personalOrg.id },
+			type: { in: ["dev_plan_start", "dev_plan_renewal", "dev_plan_upgrade"] },
+		},
+		orderBy: {
+			createdAt: "desc",
+		},
+	});
+
+	const invoices = transactions.map((t) => ({
+		id: t.id,
+		type: t.type as "dev_plan_start" | "dev_plan_renewal" | "dev_plan_upgrade",
+		date: t.createdAt.toISOString(),
+		amount: t.amount,
+		creditAmount: t.creditAmount,
+		currency: t.currency,
+		status: t.status,
+		description: t.description,
+	}));
+
+	return c.json({ invoices });
 });
 
 // Rotate the dev-plan API key — invalidates the current key and issues a new one

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -44,6 +44,10 @@ const DevPassBillingDetails = dynamic(
 	() => import("@/app/dashboard/components/DevPassBillingDetails"),
 );
 
+const DevPassInvoices = dynamic(
+	() => import("@/app/dashboard/components/DevPassInvoices"),
+);
+
 interface BillingClientProps {
 	initialDevPlanStatus?: DevPlanStatus | null;
 	initialPaymentMethod?: PaymentMethod | null;
@@ -257,6 +261,9 @@ export default function BillingClient({
 
 			{/* Billing details (invoice details) */}
 			<DevPassBillingDetails />
+
+			{/* Past invoices */}
+			<DevPassInvoices />
 		</div>
 	);
 }

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { format, formatDistanceToNowStrict } from "date-fns";
 import { Info, Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
@@ -61,8 +62,17 @@ export default function BillingClient({
 	const { posthogKey } = config;
 	const posthog = usePostHog();
 	const api = useApi();
+	const queryClient = useQueryClient();
 
 	const { data: devPlanStatus } = useDevPlanStatus(initialDevPlanStatus);
+
+	const invalidateInvoices = () =>
+		queryClient.invalidateQueries({
+			predicate: (query) => {
+				const key = query.queryKey;
+				return Array.isArray(key) && key[1] === "/dev-plans/invoices";
+			},
+		});
 
 	const cancelMutation = api.useMutation("post", "/dev-plans/cancel");
 	const resumeMutation = api.useMutation("post", "/dev-plans/resume");
@@ -84,6 +94,9 @@ export default function BillingClient({
 			await changeTierMutation.mutateAsync({
 				body: { newTier, expectedAmountDueCents },
 			});
+			// An upgrade records a new dev_plan_upgrade invoice server-side; refetch
+			// so the Invoices section reflects the just-paid charge immediately.
+			await invalidateInvoices();
 			if (posthogKey) {
 				posthog.capture("dev_plan_tier_changed", { newTier });
 			}

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -259,11 +259,11 @@ export default function BillingClient({
 				onChangeTier={handleChangeTier}
 			/>
 
-			{/* Billing details (invoice details) */}
-			<DevPassBillingDetails />
-
 			{/* Past invoices */}
 			<DevPassInvoices />
+
+			{/* Billing details (invoice details) */}
+			<DevPassBillingDetails />
 		</div>
 	);
 }

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -26,7 +26,10 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 });
 
 function formatAmount(amount: string | null, currency: string): string {
-	const value = Number(amount ?? 0);
+	if (amount === null) {
+		return "—";
+	}
+	const value = Number(amount);
 	if (!Number.isFinite(value)) {
 		return "—";
 	}

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { format } from "date-fns";
+
+import { useApi } from "@/lib/fetch-client";
+
+import type { paths } from "@/lib/api/v1";
+
+type Invoice =
+	paths["/dev-plans/invoices"]["get"]["responses"]["200"]["content"]["application/json"]["invoices"][number];
+
+const TYPE_LABELS: Record<Invoice["type"], string> = {
+	dev_plan_start: "Plan started",
+	dev_plan_renewal: "Renewal",
+	dev_plan_upgrade: "Upgrade",
+};
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+});
+
+function formatAmount(amount: string | null, currency: string): string {
+	const value = Number(amount ?? 0);
+	if (!Number.isFinite(value)) {
+		return "—";
+	}
+	if (currency === "USD") {
+		return currencyFormatter.format(value);
+	}
+	return `${value.toFixed(2)} ${currency}`;
+}
+
+function formatCredits(creditAmount: string | null): string {
+	if (creditAmount === null) {
+		return "—";
+	}
+	const value = Number(creditAmount);
+	if (!Number.isFinite(value)) {
+		return "—";
+	}
+	return `$${value.toFixed(2)}`;
+}
+
+export default function DevPassInvoices() {
+	const api = useApi();
+	const { data } = api.useQuery("get", "/dev-plans/invoices", {});
+
+	if (!data || data.invoices.length === 0) {
+		return null;
+	}
+
+	return (
+		<div>
+			<h2 className="mb-1 font-semibold">Invoices</h2>
+			<p className="mb-4 text-sm text-muted-foreground">
+				A record of every DevPass charge, including the amount debited and the
+				usage credits granted for that billing period.
+			</p>
+
+			<div className="overflow-hidden rounded-xl border">
+				<div className="hidden grid-cols-[1fr_1fr_auto_auto] gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:grid">
+					<div>Date</div>
+					<div>Description</div>
+					<div className="text-right">Amount debited</div>
+					<div className="text-right">Credits granted</div>
+				</div>
+
+				{data.invoices.map((invoice) => (
+					<div
+						key={invoice.id}
+						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:grid-cols-[1fr_1fr_auto_auto] sm:items-center"
+					>
+						<div className="text-sm tabular-nums">
+							{format(new Date(invoice.date), "MMM d, yyyy")}
+						</div>
+						<div className="text-sm">
+							<span>{TYPE_LABELS[invoice.type]}</span>
+							{invoice.description && (
+								<span className="block text-xs text-muted-foreground">
+									{invoice.description}
+								</span>
+							)}
+							{invoice.status !== "completed" && (
+								<span className="mt-0.5 inline-block rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium capitalize text-muted-foreground">
+									{invoice.status}
+								</span>
+							)}
+						</div>
+						<div className="text-right text-sm tabular-nums sm:text-right">
+							<span className="text-xs text-muted-foreground sm:hidden">
+								Amount{" "}
+							</span>
+							{formatAmount(invoice.amount, invoice.currency)}
+						</div>
+						<div className="text-right text-sm tabular-nums text-muted-foreground sm:text-right">
+							<span className="text-xs sm:hidden">Credits </span>
+							{formatCredits(invoice.creditAmount)}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { format } from "date-fns";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { useApi } from "@/lib/fetch-client";
 
 import type { paths } from "@/lib/api/v1";
+
+const PAGE_SIZE = 10;
 
 type Invoice =
 	paths["/dev-plans/invoices"]["get"]["responses"]["200"]["content"]["application/json"]["invoices"][number];
@@ -45,10 +50,16 @@ function formatCredits(creditAmount: string | null): string {
 export default function DevPassInvoices() {
 	const api = useApi();
 	const { data } = api.useQuery("get", "/dev-plans/invoices", {});
+	const [page, setPage] = useState(0);
 
 	if (!data || data.invoices.length === 0) {
 		return null;
 	}
+
+	const pageCount = Math.ceil(data.invoices.length / PAGE_SIZE);
+	const currentPage = Math.min(page, pageCount - 1);
+	const pageStart = currentPage * PAGE_SIZE;
+	const pageInvoices = data.invoices.slice(pageStart, pageStart + PAGE_SIZE);
 
 	return (
 		<div>
@@ -66,7 +77,7 @@ export default function DevPassInvoices() {
 					<div className="text-right">Credits granted</div>
 				</div>
 
-				{data.invoices.map((invoice) => (
+				{pageInvoices.map((invoice) => (
 					<div
 						key={invoice.id}
 						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:grid-cols-[1fr_1fr_auto_auto] sm:items-center"
@@ -100,6 +111,34 @@ export default function DevPassInvoices() {
 					</div>
 				))}
 			</div>
+
+			{pageCount > 1 && (
+				<div className="mt-4 flex items-center justify-between">
+					<p className="text-xs text-muted-foreground">
+						Page {currentPage + 1} of {pageCount}
+					</p>
+					<div className="flex items-center gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setPage(currentPage - 1)}
+							disabled={currentPage === 0}
+						>
+							<ChevronLeft className="mr-1 h-4 w-4" />
+							Previous
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setPage(currentPage + 1)}
+							disabled={currentPage >= pageCount - 1}
+						>
+							Next
+							<ChevronRight className="ml-1 h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

The DevPass billing page now shows a full **Invoices** history so users can see every past charge with the date, dollar amount debited, and the virtual usage credits granted for that billing period — including plan upgrade events.

### Changes

- **New `GET /dev-plans/invoices` endpoint** (`apps/api/src/routes/dev-plans.ts`) — returns the DevPass org's `dev_plan_start`, `dev_plan_renewal`, and `dev_plan_upgrade` transactions (newest first) with `date`, `amount`, `creditAmount`, `currency`, `status`, and `description`.
- **Record `creditAmount` on `dev_plan_upgrade` transactions** so upgrade events surface the prorated credits granted (previously only the charged amount was stored).
- **New `DevPassInvoices` component** (`apps/code/src/app/dashboard/components/DevPassInvoices.tsx`) — a responsive table listing each invoice with date, description (Plan started / Renewal / Upgrade), amount debited, and credits granted. Hidden when there are no invoices.
- Wired the component into the DevPass billing page (`BillingClient.tsx`).

### Notes

- Reuses the existing `transaction` ledger — no schema changes or migrations.
- Credits drain by org kind: DevPass uses virtual plan credits (`devPlanCreditsLimit`/`Used`), so the "Credits granted" column reflects the credit allotment recorded per billing event, not the main org `credits` balance.
- The Stripe webhook fallback path for upgrades (rarely hit) still records no `creditAmount`; the primary change-tier flow now does, and the UI renders `—` when absent.

## Test plan

- `pnpm turbo run build --filter=api --filter=code` — passes
- `pnpm vitest run apps/api/src/routes/dev-plans.spec.ts` — passes
- `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new invoice history view for DevPass billing, showing past charges and credit adjustments.
  * Billing now includes a “Past invoices” section with date, type, description, status, amount, and credits.
* **Bug Fixes**
  * Upgrade transactions now correctly include the credited amount for prorated plan changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->