### PR TITLE
fix(devpass): match default billing org by email

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1618,7 +1618,7 @@ devPlans.openapi(getBillingDetails, async (c) => {
 		});
 	}
 
-	const defaultOrg = await findDefaultOrganization(user.id);
+	const defaultOrg = await findDefaultOrganization(user.id, user.email);
 
 	return c.json({
 		devPlanBillingOverride: personalOrg.devPlanBillingOverride,
@@ -1730,7 +1730,7 @@ devPlans.openapi(updateBillingDetails, async (c) => {
 		});
 	}
 
-	const defaultOrg = await findDefaultOrganization(user.id);
+	const defaultOrg = await findDefaultOrganization(user.id, user.email);
 
 	return c.json({
 		devPlanBillingOverride: updatedOrg.devPlanBillingOverride,

--- a/apps/api/src/utils/default-org.ts
+++ b/apps/api/src/utils/default-org.ts
@@ -25,7 +25,16 @@ function isActiveDashboardOrganization(userOrganization: {
 // Find the user's default dashboard organization without creating one. Used by
 // flows that only need to read the default org's settings (e.g. resolving
 // DevPass invoice billing details) and must not create rows in a webhook.
-export async function findDefaultOrganization(userId: string) {
+//
+// When `userEmail` is provided, prefer the organization whose `billingEmail`
+// matches the user's own email. This is a much stronger signal than the
+// arbitrary first-active match, which can be a false positive since a user can
+// join/leave multiple organizations they don't own. Only fall back to the
+// first-active organization when no billing-email match exists.
+export async function findDefaultOrganization(
+	userId: string,
+	userEmail?: string,
+) {
 	const userOrganizations = await db.query.userOrganization.findMany({
 		where: {
 			userId,
@@ -34,6 +43,18 @@ export async function findDefaultOrganization(userId: string) {
 			organization: true,
 		},
 	});
+
+	if (userEmail) {
+		const byBillingEmail = userOrganizations.find(
+			(userOrganization) =>
+				isActiveDashboardOrganization(userOrganization) &&
+				userOrganization.organization.billingEmail === userEmail,
+		);
+
+		if (byBillingEmail?.organization) {
+			return byBillingEmail.organization;
+		}
+	}
 
 	return (
 		userOrganizations.find(isActiveDashboardOrganization)?.organization ?? null

--- a/apps/api/src/utils/devpass-billing.ts
+++ b/apps/api/src/utils/devpass-billing.ts
@@ -48,7 +48,7 @@ export async function resolveDevPassBillingDetails(
 	});
 
 	const defaultOrg = owner?.user
-		? await findDefaultOrganization(owner.user.id)
+		? await findDefaultOrganization(owner.user.id, owner.user.email)
 		: null;
 
 	return pickBillingDetails(defaultOrg ?? personalOrg);


### PR DESCRIPTION
## Problem

The DevPass default billing details (shown in the billing settings as _"These come from your LLM Gateway organization settings"_) could default to the **wrong organization**.

`findDefaultOrganization` returned the first active `kind: "default"` organization a user belonged to. When a user has joined organizations they don't own (users can join/leave orgs freely), that first match is an arbitrary false positive — so a DevPass invoice could inherit billing details from an unrelated org.

## Fix

`findDefaultOrganization` now accepts the user's email and prefers the active organization whose `billingEmail` matches the user's own email — a far stronger signal of "this org is mine". It only falls back to the previous first-active behavior when no billing-email match exists.

Callers updated to pass the email:
- `resolveDevPassBillingDetails` (invoice generation) — uses the org owner's email
- `GET /billing-details` and `PATCH /billing-details` (dev-plans routes) — use the authenticated user's email

## Testing

- `pnpm format` ✅
- `turbo run build --filter=api` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)