### PR TITLE
fix(gateway): honor cancellation during body read

### DIFF
--- a/apps/gateway/src/cancellation.spec.ts
+++ b/apps/gateway/src/cancellation.spec.ts
@@ -175,4 +175,27 @@ describe("client cancellation logging", () => {
 		expect(log.hasError).toBe(false);
 		expect(log.errorDetails).toBeNull();
 	});
+
+	test("abort while reading a non-OK error body is logged as canceled, not an error", async () => {
+		const controller = new AbortController();
+		// Mock returns a 500 status + a partial error body, then hangs without
+		// finishing it. The abort lands while the gateway is awaiting res.text()
+		// on the error path, exercising the error-body cancellation path.
+		const requestPromise = postChat(
+			`TRIGGER_5XX_BODY_HANG ${Math.random()}`,
+			controller.signal,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		controller.abort();
+
+		await expect(requestPromise).rejects.toThrow();
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		const log = logs[0];
+		expect(log.canceled).toBe(true);
+		expect(log.finishReason).toBe("canceled");
+		expect(log.hasError).toBe(false);
+		expect(log.errorDetails).toBeNull();
+	});
 });

--- a/apps/gateway/src/cancellation.spec.ts
+++ b/apps/gateway/src/cancellation.spec.ts
@@ -152,4 +152,27 @@ describe("client cancellation logging", () => {
 		expect(log.hasError).toBe(false);
 		expect(log.errorDetails).toBeNull();
 	});
+
+	test("abort while reading the response body is logged as canceled, not an error", async () => {
+		const controller = new AbortController();
+		// Mock returns 200 headers + a partial body, then hangs without
+		// finishing it. The abort lands while the gateway is awaiting
+		// res.json(), exercising the body-read cancellation path.
+		const requestPromise = postChat(
+			`TRIGGER_BODY_HANG ${Math.random()}`,
+			controller.signal,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 500));
+		controller.abort();
+
+		await expect(requestPromise).rejects.toThrow();
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		const log = logs[0];
+		expect(log.canceled).toBe(true);
+		expect(log.finishReason).toBe("canceled");
+		expect(log.hasError).toBe(false);
+		expect(log.errorDetails).toBeNull();
+	});
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11847,6 +11847,27 @@ chat.openapi(completions, async (c) => {
 		// canceled request (same log shape as the fetch-cancellation path)
 		// instead of misreporting it as an upstream failure or a bare 499.
 		if (bodyError.name === "AbortError") {
+			// The post-loop success append already recorded this provider as a
+			// succeeded routing attempt. Drop it before logging the cancellation
+			// so a client disconnect isn't counted as a provider success in the
+			// routing trace (matching the fetch-cancellation path, which records
+			// no succeeded attempt). A cancel is not a provider failure, so the
+			// attempt is removed rather than flipped to failed.
+			for (let i = routingAttempts.length - 1; i >= 0; i--) {
+				if (
+					routingAttempts[i].provider === usedProvider &&
+					routingAttempts[i].succeeded
+				) {
+					routingAttempts.splice(i, 1);
+					break;
+				}
+			}
+			if (routingMetadata) {
+				routingMetadata = {
+					...routingMetadata,
+					routing: routingAttempts,
+				};
+			}
 			return await respondCanceled();
 		}
 		// Both a read timeout and a mid-body socket failure (e.g. undici

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11021,6 +11021,14 @@ chat.openapi(completions, async (c) => {
 			// Get the error response text
 			// Body read can throw TimeoutError if the abort signal fires during consumption
 			let errorResponseText: string;
+			// Keep the client-abort listener attached across the error-body read
+			// (it was removed when the fetch settled) so a disconnect during
+			// res.text() aborts the read and is recorded as canceled. Re-run
+			// onAbort if the client already disconnected in the gap.
+			c.req.raw.signal.addEventListener("abort", onAbort);
+			if (c.req.raw.signal.aborted) {
+				onAbort();
+			}
 			try {
 				const rawErrorResponseText = await res.text();
 				errorResponseText = usesAwsBedrockConverse()
@@ -11031,11 +11039,12 @@ chat.openapi(completions, async (c) => {
 				if (!(bodyError instanceof Error)) {
 					throw bodyError;
 				}
-				// A client disconnect can abort the in-flight body read; rethrow
-				// so the cancellation path (app.onError -> 499) is preserved
-				// instead of misreporting it as an upstream failure.
+				// A client disconnect aborts the in-flight error-body read; record
+				// it as a canceled request (same log shape as the fetch-
+				// cancellation path) instead of misreporting it as an upstream
+				// failure or a bare 499.
 				if (bodyError.name === "AbortError") {
-					throw bodyError;
+					return await respondCanceled();
 				}
 				// A read timeout or a mid-body socket failure (e.g. undici
 				// "terminated: other side closed" / ECONNRESET) both surface
@@ -11150,6 +11159,8 @@ chat.openapi(completions, async (c) => {
 						isTimeoutBody ? 504 : 502,
 					);
 				}
+			} finally {
+				c.req.raw.signal.removeEventListener("abort", onAbort);
 			}
 
 			// If the upstream Google provider rejected the request because the

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -10478,6 +10478,152 @@ chat.openapi(completions, async (c) => {
 	// Add event listener for the 'close' event on the connection
 	c.req.raw.signal.addEventListener("abort", onAbort);
 
+	// Build and persist the canceled-request log, then return the 400 "request
+	// canceled" response. Shared by the in-loop fetch-cancellation path and the
+	// body-read cancellation path so a client disconnect is always recorded as
+	// canceled rather than surfacing as an error or a bare 499.
+	const respondCanceled = async () => {
+		const canceledNonStreamingPluginIds = plugins?.map((p) => p.id) ?? [];
+
+		const billCancelled = shouldBillCancelledRequests();
+		let cancelledCosts: Awaited<ReturnType<typeof calculateCosts>> | null =
+			null;
+		let estimatedPromptTokens: number | null = null;
+
+		if (billCancelled) {
+			const tokenEstimation = estimateTokens(
+				usedProvider!,
+				messages,
+				null,
+				null,
+				null,
+			);
+			estimatedPromptTokens = tokenEstimation.calculatedPromptTokens;
+
+			cancelledCosts = await calculateCosts(
+				usedInternalModel,
+				usedProvider!,
+				usedRegion ?? null,
+				estimatedPromptTokens,
+				0, // No completion tokens
+				null, // No cached tokens
+				{
+					prompt: messages
+						.map((m) => messageContentToString(m.content))
+						.join("\n"),
+					completion: "",
+				},
+				null, // No reasoning tokens
+				0, // No output images
+				undefined,
+				inputImageCount,
+				webSearchTool ? 1 : null, // Bill for web search if it was enabled
+				project.organizationId,
+				undefined, // imageQuality
+				null, // reportedImageInputTokens
+				null, // reportedImageOutputTokens
+				{ servedServiceTier, customPricing: customPricingMapping },
+			);
+		}
+
+		const baseLogEntry = createLogEntry(
+			requestId,
+			project,
+			apiKey,
+			providerKey?.id,
+			usedModelFormatted!,
+			usedModelMapping!,
+			usedProvider!,
+			initialRequestedModel,
+			requestedProvider,
+			messages,
+			temperature,
+			max_tokens,
+			top_p,
+			frequency_penalty,
+			presence_penalty,
+			reasoning_effort,
+			reasoning_max_tokens,
+			effort,
+			response_format,
+			tools,
+			tool_choice,
+			source,
+			customHeaders,
+			debugMode,
+			userAgent,
+			image_config,
+			routingMetadata,
+			rawBody,
+			null, // No response for canceled request
+			requestBody, // The request that was prepared before cancellation
+			null, // No upstream response for canceled request
+			canceledNonStreamingPluginIds,
+			undefined, // No plugin results for canceled request
+		);
+
+		await insertLogEntry({
+			...baseLogEntry,
+			duration: Date.now() - startTime,
+			timeToFirstToken: null, // Not applicable for canceled request
+			timeToFirstReasoningToken: null, // Not applicable for canceled request
+			responseSize: 0,
+			content: null,
+			reasoningContent: null,
+			finishReason: "canceled",
+			promptTokens: billCancelled
+				? (cancelledCosts?.promptTokens ?? estimatedPromptTokens)?.toString()
+				: null,
+			completionTokens: billCancelled ? "0" : null,
+			totalTokens: billCancelled
+				? (cancelledCosts?.promptTokens ?? estimatedPromptTokens)?.toString()
+				: null,
+			reasoningTokens: null,
+			cachedTokens: null,
+			hasError: false,
+			streamed: false,
+			canceled: true,
+			errorDetails: null,
+			inputCost: cancelledCosts?.inputCost ?? null,
+			outputCost: cancelledCosts?.outputCost ?? null,
+			cachedInputCost: cancelledCosts?.cachedInputCost ?? null,
+			requestCost: cancelledCosts?.requestCost ?? null,
+			webSearchCost: cancelledCosts?.webSearchCost ?? null,
+			imageInputTokens: cancelledCosts?.imageInputTokens?.toString() ?? null,
+			imageOutputTokens: cancelledCosts?.imageOutputTokens?.toString() ?? null,
+			imageInputCost: cancelledCosts?.imageInputCost ?? null,
+			imageOutputCost: cancelledCosts?.imageOutputCost ?? null,
+			audioInputTokens: cancelledCosts?.audioInputTokens?.toString() ?? null,
+			audioInputCost: cancelledCosts?.audioInputCost ?? null,
+			cost: cancelledCosts?.totalCost ?? null,
+			estimatedCost: cancelledCosts?.estimatedCost ?? false,
+			discount: cancelledCosts?.discount ?? null,
+			dataStorageCost: billCancelled
+				? calculateDataStorageCost(
+						cancelledCosts?.promptTokens ?? estimatedPromptTokens,
+						null,
+						0,
+						null,
+						retentionLevel,
+					)
+				: "0",
+			cached: false,
+			toolResults: null,
+		});
+
+		return c.json(
+			{
+				error: {
+					message: "Request canceled by client",
+					type: "canceled",
+					param: null,
+					code: "request_canceled",
+				},
+			},
+			400,
+		); // Using 400 status code for client closed request
+	};
+
 	// --- Retry loop for provider fallback ---
 	const routingAttempts: RoutingAttempt[] = [];
 	const failedProviderIds = new Set<string>();
@@ -10868,152 +11014,7 @@ chat.openapi(completions, async (c) => {
 
 		// If the request was canceled, log it and return a response
 		if (canceled) {
-			// Log the canceled request
-			// Extract plugin IDs for logging (canceled non-streaming)
-			const canceledNonStreamingPluginIds = plugins?.map((p) => p.id) ?? [];
-
-			// Calculate costs for cancelled request if billing is enabled
-			const billCancelled = shouldBillCancelledRequests();
-			let cancelledCosts: Awaited<ReturnType<typeof calculateCosts>> | null =
-				null;
-			let estimatedPromptTokens: number | null = null;
-
-			if (billCancelled) {
-				// Estimate prompt tokens from messages
-				const tokenEstimation = estimateTokens(
-					usedProvider,
-					messages,
-					null,
-					null,
-					null,
-				);
-				estimatedPromptTokens = tokenEstimation.calculatedPromptTokens;
-
-				// Calculate costs based on prompt tokens only (no completion for non-streaming cancel)
-				// If web search tool was enabled, count it as 1 search for billing
-				cancelledCosts = await calculateCosts(
-					usedInternalModel,
-					usedProvider,
-					usedRegion ?? null,
-					estimatedPromptTokens,
-					0, // No completion tokens
-					null, // No cached tokens
-					{
-						prompt: messages
-							.map((m) => messageContentToString(m.content))
-							.join("\n"),
-						completion: "",
-					},
-					null, // No reasoning tokens
-					0, // No output images
-					undefined,
-					inputImageCount,
-					webSearchTool ? 1 : null, // Bill for web search if it was enabled
-					project.organizationId,
-					undefined, // imageQuality
-					null, // reportedImageInputTokens
-					null, // reportedImageOutputTokens
-					{ servedServiceTier, customPricing: customPricingMapping },
-				);
-			}
-
-			const baseLogEntry = createLogEntry(
-				requestId,
-				project,
-				apiKey,
-				providerKey?.id,
-				usedModelFormatted,
-				usedModelMapping,
-				usedProvider,
-				initialRequestedModel,
-				requestedProvider,
-				messages,
-				temperature,
-				max_tokens,
-				top_p,
-				frequency_penalty,
-				presence_penalty,
-				reasoning_effort,
-				reasoning_max_tokens,
-				effort,
-				response_format,
-				tools,
-				tool_choice,
-				source,
-				customHeaders,
-				debugMode,
-				userAgent,
-				image_config,
-				routingMetadata,
-				rawBody,
-				null, // No response for canceled request
-				requestBody, // The request that was prepared before cancellation
-				null, // No upstream response for canceled request
-				canceledNonStreamingPluginIds,
-				undefined, // No plugin results for canceled request
-			);
-
-			await insertLogEntry({
-				...baseLogEntry,
-				duration,
-				timeToFirstToken: null, // Not applicable for canceled request
-				timeToFirstReasoningToken: null, // Not applicable for canceled request
-				responseSize: 0,
-				content: null,
-				reasoningContent: null,
-				finishReason: "canceled",
-				promptTokens: billCancelled
-					? (cancelledCosts?.promptTokens ?? estimatedPromptTokens)?.toString()
-					: null,
-				completionTokens: billCancelled ? "0" : null,
-				totalTokens: billCancelled
-					? (cancelledCosts?.promptTokens ?? estimatedPromptTokens)?.toString()
-					: null,
-				reasoningTokens: null,
-				cachedTokens: null,
-				hasError: false,
-				streamed: false,
-				canceled: true,
-				errorDetails: null,
-				inputCost: cancelledCosts?.inputCost ?? null,
-				outputCost: cancelledCosts?.outputCost ?? null,
-				cachedInputCost: cancelledCosts?.cachedInputCost ?? null,
-				requestCost: cancelledCosts?.requestCost ?? null,
-				webSearchCost: cancelledCosts?.webSearchCost ?? null,
-				imageInputTokens: cancelledCosts?.imageInputTokens?.toString() ?? null,
-				imageOutputTokens:
-					cancelledCosts?.imageOutputTokens?.toString() ?? null,
-				imageInputCost: cancelledCosts?.imageInputCost ?? null,
-				imageOutputCost: cancelledCosts?.imageOutputCost ?? null,
-				audioInputTokens: cancelledCosts?.audioInputTokens?.toString() ?? null,
-				audioInputCost: cancelledCosts?.audioInputCost ?? null,
-				cost: cancelledCosts?.totalCost ?? null,
-				estimatedCost: cancelledCosts?.estimatedCost ?? false,
-				discount: cancelledCosts?.discount ?? null,
-				dataStorageCost: billCancelled
-					? calculateDataStorageCost(
-							cancelledCosts?.promptTokens ?? estimatedPromptTokens,
-							null,
-							0,
-							null,
-							retentionLevel,
-						)
-					: "0",
-				cached: false,
-				toolResults: null,
-			});
-
-			return c.json(
-				{
-					error: {
-						message: "Request canceled by client",
-						type: "canceled",
-						param: null,
-						code: "request_canceled",
-					},
-				},
-				400,
-			); // Using 400 status code for client closed request
+			return await respondCanceled();
 		}
 
 		if (res && !res.ok) {
@@ -11579,6 +11580,15 @@ chat.openapi(completions, async (c) => {
 	}
 
 	let json: any;
+	// Keep the client-abort listener attached across the body read. The
+	// per-attempt listener was removed when the fetch settled, so without this a
+	// client disconnect during res.json()/res.text() would neither abort the
+	// upstream read nor be recorded as canceled. Re-run onAbort if the client
+	// already disconnected in the gap before we re-attached.
+	c.req.raw.signal.addEventListener("abort", onAbort);
+	if (c.req.raw.signal.aborted) {
+		onAbort();
+	}
 	try {
 		if (forceStream && res.body) {
 			// Stream-only model: upstream returned SSE but client expects JSON.
@@ -11822,11 +11832,11 @@ chat.openapi(completions, async (c) => {
 		if (!(bodyError instanceof Error)) {
 			throw bodyError;
 		}
-		// A client disconnect can abort the in-flight body read; rethrow so the
-		// cancellation path (app.onError -> 499) is preserved instead of
-		// misreporting it as an upstream failure.
+		// A client disconnect aborts the in-flight body read; record it as a
+		// canceled request (same log shape as the fetch-cancellation path)
+		// instead of misreporting it as an upstream failure or a bare 499.
 		if (bodyError.name === "AbortError") {
-			throw bodyError;
+			return await respondCanceled();
 		}
 		// Both a read timeout and a mid-body socket failure (e.g. undici
 		// "terminated: other side closed" / ECONNRESET) surface here: the
@@ -11998,6 +12008,8 @@ chat.openapi(completions, async (c) => {
 				isTimeoutBody ? 504 : 502,
 			);
 		}
+	} finally {
+		c.req.raw.signal.removeEventListener("abort", onAbort);
 	}
 	if (process.env.NODE_ENV !== "production") {
 		logger.debug("API response", { response: json });

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1141,6 +1141,34 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		});
 	}
 
+	// Simulate an upstream that returns a non-OK status (500) plus a partial
+	// error body, then hangs without finishing it. The gateway's res.text() on
+	// the error path blocks waiting for the rest, letting a test abort the
+	// client mid-read to exercise the non-streaming error-body cancellation
+	// path. The trigger deliberately avoids the "TRIGGER_ERROR" substring so the
+	// generic-error handler above doesn't short-circuit it.
+	if (hasUserMessageTrigger(chatMessages, "TRIGGER_5XX_BODY_HANG")) {
+		const encoder = new TextEncoder();
+		let sentPartialBody = false;
+		const hangingErrorBody = new ReadableStream({
+			pull(controller) {
+				if (!sentPartialBody) {
+					sentPartialBody = true;
+					// Flush a partial JSON body so headers are written first.
+					controller.enqueue(encoder.encode('{"error":{"message":"partial'));
+					return;
+				}
+				// Never enqueue more and never close: the body read hangs until the
+				// client disconnects.
+				return new Promise<void>(() => {});
+			},
+		});
+		return new Response(hangingErrorBody, {
+			status: 500,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
 	const baseChoice = sampleChatCompletionResponse.choices[0];
 	const choices = Array.from({ length: requestedN }, (_, index) => ({
 		...baseChoice,

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1113,6 +1113,34 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		});
 	}
 
+	// Simulate an upstream that returns response headers (200) and a partial
+	// body, then hangs forever without finishing it. The gateway's res.json()
+	// blocks waiting for the rest, letting a test abort the client mid-read to
+	// exercise the non-streaming body-read cancellation path.
+	if (hasUserMessageTrigger(chatMessages, "TRIGGER_BODY_HANG")) {
+		const encoder = new TextEncoder();
+		let sentPartialBody = false;
+		const hangingBody = new ReadableStream({
+			pull(controller) {
+				if (!sentPartialBody) {
+					sentPartialBody = true;
+					// Flush a partial JSON body so headers are written first.
+					controller.enqueue(
+						encoder.encode('{"id":"chatcmpl-123","object":"chat.completion"'),
+					);
+					return;
+				}
+				// Never enqueue more and never close: the body read hangs until the
+				// client disconnects.
+				return new Promise<void>(() => {});
+			},
+		});
+		return new Response(hangingBody, {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
 	const baseChoice = sampleChatCompletionResponse.choices[0];
 	const choices = Array.from({ length: requestedN }, (_, index) => ({
 		...baseChoice,


### PR DESCRIPTION
## Summary

Builds on the socket-close / cancellation work in #2826 and adds the follow-up fix discussed there: **honor client cancellation during the non-streaming body read**, recording it as a canceled log rather than letting it hang or surface as an error.

### Background (carried from #2826)
- `fix(gateway): handle body-read socket close` — `terminated`/ECONNRESET while reading the upstream body → classified 502 `upstream_error` instead of an unhandled 500.
- `fix(gateway): preserve AbortError during body read` — rethrow `AbortError` so cancellations aren't misreported as upstream failures.
- `test(gateway): cover client cancellation logging` — real-server test asserting a fetch-phase cancellation is logged as canceled.

### New fix
In the non-streaming path the client-abort listener was removed as soon as the fetch settled, so a client disconnect during `res.json()` / `res.text()`:
1. never aborted the in-flight upstream read (the gateway held the connection until timeout), and
2. would have surfaced as a bare 499 rather than a `canceled` log.

This PR:
- **Keeps the abort listener attached across the body read.** It is re-attached right before the body read (and re-runs `onAbort` if the client already disconnected in the gap), then torn down in a `finally`. A disconnect now promptly aborts `res.json()` via the existing combined fetch signal.
- **Routes a body-read `AbortError` to the canceled-log path.** The canceled-logging + 400 response is extracted into a shared `respondCanceled()` helper, called from both the fetch-cancellation path and the body-read catch, so cancellation is logged identically (`canceled: true`, `finishReason: "canceled"`, `hasError: false`) regardless of when the client drops.

### Tests
- New `TRIGGER_BODY_HANG` mock: returns 200 headers + a partial body, then hangs.
- New real-server test in `cancellation.spec.ts`: aborts the client while the gateway is reading the body and asserts a **canceled** log (not an error). Passes alongside the existing fetch-phase cancellation test.
- All 51 `fallback.spec.ts` tests pass; `pnpm build` (gateway) and `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-streaming handling of client disconnects so aborted requests during response-body reads are consistently reported as cancellations (not errors), including standardized `request_canceled` responses.
  * Added more accurate routing-attempt accounting to avoid counting aborted disconnects as successful attempts.
* **Tests**
  * Added coverage for client aborts occurring while reading both successful and 5xx upstream response bodies.
  * Updated the mock OpenAI server to simulate hanging partial response bodies for these cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->