### PR TITLE
chore(models): deprecate GLM-5.1 on Together AI

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -119,6 +119,7 @@ export const zaiModels = [
 			{
 				providerId: "together-ai",
 				externalId: "zai-org/GLM-5.1",
+				deactivatedAt: new Date("2026-07-10"),
 				inputPrice: "1.4e-6",
 				cachedInputPrice: "0.26e-6",
 				outputPrice: "4.4e-6",


### PR DESCRIPTION
## Summary

Together AI notified us that the serverless `zai-org/GLM-5.1` model will be deprecated on **July 10, 2026** and removed from the serverless API after that date. The recommended alternative is `zai-org/GLM-5.2`.

This marks the `together-ai` provider mapping for GLM-5.1 with `deactivatedAt: new Date("2026-07-10")`, so the mapping stays active until the deprecation date and then auto-disables (matching the existing pattern used for other deactivated provider mappings, e.g. GLM-5 on Together).

## Notes

- GLM-5.1 remains available via other providers (zai, novita, deepinfra, embercloud).
- GLM-5.2 (the recommended alternative) already exists in the catalog; Together does not serve it, so no new together-ai mapping is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model availability metadata so the `glm-5.1` provider entry is marked with a deactivation date, helping ensure it is treated appropriately after the listed cutoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->