### PR TITLE
feat(chat): add admin link to escalation email

### DIFF
--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -605,6 +605,9 @@ publicChatSupport.post("/escalate", async (c) => {
 	const escapedName = escapeHtml(name ?? "Not provided");
 	const escapedEmail = escapeHtml(email ?? "Not provided");
 	const escapedConversationId = escapeHtml(conversationId);
+	const adminBaseUrl = process.env.ADMIN_URL ?? "https://admin.llmgateway.io";
+	const adminConversationUrl = `${adminBaseUrl}/chat-support-logs?chat=${encodeURIComponent(conversationId)}`;
+	const escapedAdminConversationUrl = escapeHtml(adminConversationUrl);
 	const escapedTranscript = (messages ?? [])
 		.map(
 			(m) =>
@@ -627,6 +630,7 @@ publicChatSupport.post("/escalate", async (c) => {
 <p style="margin:0 0 15px;font-size:16px;color:#333;"><strong>Name:</strong> ${escapedName}</p>
 <p style="margin:0 0 15px;font-size:16px;color:#333;"><strong>Email:</strong> ${escapedEmail}</p>
 <p style="margin:0 0 15px;font-size:16px;color:#333;"><strong>Conversation ID:</strong> ${escapedConversationId}</p>
+<p style="margin:0 0 15px;font-size:16px;color:#333;"><strong>Admin dashboard:</strong> <a href="${escapedAdminConversationUrl}" style="color:#0066cc;">View conversation</a></p>
 <hr style="border:none;border-top:1px solid #e9ecef;margin:20px 0;">
 <h2 style="margin:0 0 15px;font-size:16px;color:#333;">Conversation History</h2>
 <div style="background:#fff;border:1px solid #e9ecef;border-radius:6px;padding:15px;font-size:14px;line-height:1.6;color:#333;white-space:pre-wrap;">${escapedTranscript}</div>


### PR DESCRIPTION
## Summary

The internal **Chat Support Escalation** email now includes a direct link to the chat support admin dashboard with the conversation id pre-selected, so the team can open the escalated conversation in one click.

- Builds `${ADMIN_URL ?? "https://admin.llmgateway.io"}/chat-support-logs?chat=<conversationId>` (defaults to the prod admin URL, overridable via `ADMIN_URL`).
- Conversation id is URL-encoded and the href is HTML-escaped, consistent with the existing escaping in this handler.
- Rendered as a "View conversation" link directly under the Conversation ID row.

File: `apps/api/src/routes/public-chat-support.ts` (`POST /escalate`).

## Testing

- `pnpm format`
- `pnpm turbo run build --filter=api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct “Admin dashboard” link to escalation emails for chat support conversations.
  * The link opens the relevant conversation log in the admin interface, making it faster to review support issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->