### PR TITLE
fix(moonshot): deactivate retired kimi-k2-thinking line

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -128,6 +128,9 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				// 404 resource_not_found: Moonshot retired the kimi-k2-thinking line
+				// (thinking now folded into kimi-k2.6/k2.7); no longer in /v1/models.
+				deactivatedAt: new Date("2026-06-28"),
 			},
 			{
 				providerId: "bytedance",
@@ -143,6 +146,9 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: false,
+				// 404 InvalidEndpointOrModel.NotFound: BytePlus Ark dropped every
+				// kimi-k2-thinking snapshot (-251104 included) alongside Moonshot.
+				deactivatedAt: new Date("2026-06-28"),
 			},
 			{
 				test: "skip",
@@ -186,6 +192,9 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				// 404 resource_not_found: retired with the rest of the
+				// kimi-k2-thinking line; no longer in Moonshot /v1/models.
+				deactivatedAt: new Date("2026-06-28"),
 			},
 		],
 	},

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -128,8 +128,6 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
-				// 404 resource_not_found: Moonshot retired the kimi-k2-thinking line
-				// (thinking now folded into kimi-k2.6/k2.7); no longer in /v1/models.
 				deactivatedAt: new Date("2026-06-28"),
 			},
 			{
@@ -146,8 +144,6 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: false,
-				// 404 InvalidEndpointOrModel.NotFound: BytePlus Ark dropped every
-				// kimi-k2-thinking snapshot (-251104 included) alongside Moonshot.
 				deactivatedAt: new Date("2026-06-28"),
 			},
 			{
@@ -192,8 +188,6 @@ export const moonshotModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
-				// 404 resource_not_found: retired with the rest of the
-				// kimi-k2-thinking line; no longer in Moonshot /v1/models.
 				deactivatedAt: new Date("2026-06-28"),
 			},
 		],


### PR DESCRIPTION
## Context

The `e2e` job on #2835 failed on six provider/model mappings. I reproduced each failure locally against the live providers (gateway on :4001, real keys) to find the root cause. The CI "33s / retry x5" is just retry backoff over **fast** errors, so the local errors match what CI hit.

## Findings

| Model | Reproduced error | Root cause | Action |
|---|---|---|---|
| `moonshot/kimi-k2-thinking` | `404 resource_not_found` | Moonshot retired the kimi-k2-thinking line (live `/v1/models` only lists k2.5/k2.6/k2.7); BytePlus Ark dropped every snapshot too | **Fixed here** |
| `sakana/fugu-ultra` | `403 Forbidden` (HTML, `via: 1.1 google`) | Google edge/WAF blocks **all** requests incl. unauthenticated `/` — geo/WAF block from test infra, not a mapping/URL bug | Infra (see below) |
| `azure-ai-foundry/grok-4-1-fast-reasoning` | `404 DeploymentNotFound` | Foundry resource has no grok deployment (404 for every name) | Infra (unprovisioned) |
| `azure/gpt-oss-120b` | `404 DeploymentNotFound` | Azure resource has **zero** deployments (`data: []`) | Infra (unprovisioned) |
| `together-ai/gpt-oss-120b` | `503 Service Unavailable` | Provider-side outage (single/multi-turn passed in CI; the tool-call test caught the blip) | Transient |
| `aws-bedrock/claude-sonnet-4-6` | **Works now** (valid tool_call) | CI failure was a ~32s cold-start timeout, not an error | Transient flake |

## Change

Only the Moonshot failure is a real, code-fixable mapping bug. This PR deactivates the retired `kimi-k2-thinking` mappings:

- `moonshot/kimi-k2-thinking` → `deactivatedAt`
- `bytedance/kimi-k2-thinking` (`-251104`) → `deactivatedAt`
- `moonshot/kimi-k2-thinking-turbo` → `deactivatedAt`

The model keeps its `alibaba` provider (`test: skip`, active until its own `2026-07-08` deactivation), so it is not orphaned.

The other five are **not mapping bugs**: two are unprovisioned Azure resources (deployments need creating), one is a geo/WAF block on Sakana's endpoint, and two are transient provider hiccups. None are fixable by editing model definitions — flagging for an infra decision (provision the Azure deployments; confirm whether Sakana is reachable from gateway infra, else mark `test: "skip"`).

## Verification

- `turbo run build` — 17/17 ✓
- `providers.spec` / `model-metadata.spec` / `compliance.spec` — 36/36 ✓
- Live re-test: moonshot/bytedance kimi-k2-thinking all 404; mappings now excluded from e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Moonshot model availability by deactivating select offerings.
  * Added a deactivation timestamp for the kimi-k2-thinking family providers (including kimi-k2-thinking-251104 and kimi-k2-thinking-turbo) as of 2026-06-28.
  * Ensures affected options clearly reflect their unavailability date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->