### PR TITLE
feat(scripts): weekly+monthly traffic Discord report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -333,3 +333,19 @@ DISCORD_SUPPORT_NOTIFICATION_URL=
 # Discord webhook for enterprise contact requests (#enterprise channel).
 # Falls back to DISCORD_NOTIFICATION_URL when unset.
 DISCORD_ENTERPRISE_NOTIFICATION_URL=
+# Discord webhook for the weekly/monthly traffic report (#traffic channel).
+# Used by the `traffic-report` script / GitHub Actions workflow. Keep this
+# secret out of the repo — set it in GitHub Actions secrets, not here.
+DISCORD_TRAFFIC_NOTIFICATION_URL=
+
+# =============================================================================
+# TRAFFIC REPORTING (OPTIONAL)
+# =============================================================================
+# Used by packages/scripts `traffic-report` to query PostHog for the weekly /
+# monthly #traffic Discord report. Requires a PostHog *personal* API key (read
+# scope) — distinct from the POSTHOG_KEY ingestion key above.
+POSTHOG_PERSONAL_API_KEY=
+# PostHog project id (defaults to the LLMGateway project when unset).
+POSTHOG_PROJECT_ID=163518
+# PostHog query API host (defaults to https://us.posthog.com when unset).
+POSTHOG_QUERY_HOST=https://us.posthog.com

--- a/.env.example
+++ b/.env.example
@@ -345,7 +345,8 @@ DISCORD_TRAFFIC_NOTIFICATION_URL=
 # monthly #traffic Discord report. Requires a PostHog *personal* API key (read
 # scope) — distinct from the POSTHOG_KEY ingestion key above.
 POSTHOG_PERSONAL_API_KEY=
-# PostHog project id (defaults to the LLMGateway project when unset).
+# PostHog project id — required (no default; the script fails fast if unset so
+# it never queries the wrong project). 163518 is the LLMGateway project.
 POSTHOG_PROJECT_ID=163518
 # PostHog query API host (defaults to https://us.posthog.com when unset).
 POSTHOG_QUERY_HOST=https://us.posthog.com

--- a/.github/workflows/traffic-report.yml
+++ b/.github/workflows/traffic-report.yml
@@ -1,0 +1,66 @@
+name: traffic-report
+
+on:
+  schedule:
+    # Weekly — Mondays 08:00 UTC, reports the just-completed Mon–Sun week.
+    - cron: "0 8 * * 1"
+    # Monthly — 1st of the month 08:30 UTC, reports the just-completed month.
+    - cron: "30 8 1 * *"
+  workflow_dispatch:
+    inputs:
+      period:
+        description: "Reporting period"
+        type: choice
+        options:
+          - week
+          - month
+        default: week
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Collect versions
+        run: |
+          echo "nodejs_version=$(cat .tool-versions | grep 'nodejs' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
+          echo "pnpm_version=$(cat .tool-versions | grep 'pnpm' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
+
+      - uses: pnpm/action-setup@v6.0.9
+        with:
+          version: ${{ env.pnpm_version }}
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ env.nodejs_version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Determine period
+        id: period
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            PERIOD="${{ github.event.inputs.period }}"
+          elif [[ "${{ github.event.schedule }}" == "30 8 1 * *" ]]; then
+            PERIOD="month"
+          else
+            PERIOD="week"
+          fi
+          echo "period=${PERIOD}" >> "$GITHUB_OUTPUT"
+
+      - name: Send traffic report
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          POSTHOG_QUERY_HOST: ${{ secrets.POSTHOG_QUERY_HOST }}
+          DISCORD_TRAFFIC_NOTIFICATION_URL: ${{ secrets.DISCORD_TRAFFIC_NOTIFICATION_URL }}
+        run: pnpm --filter @llmgateway/scripts traffic-report --period=${{ steps.period.outputs.period }}

--- a/.github/workflows/traffic-report.yml
+++ b/.github/workflows/traffic-report.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Send traffic report
         env:
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
-          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          # Project id is non-secret config; the script requires it explicitly
+          # so reports never run against the wrong project. Override via a repo
+          # variable if needed.
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID || '163518' }}
           POSTHOG_QUERY_HOST: ${{ secrets.POSTHOG_QUERY_HOST }}
           DISCORD_TRAFFIC_NOTIFICATION_URL: ${{ secrets.DISCORD_TRAFFIC_NOTIFICATION_URL }}
         run: pnpm --filter @llmgateway/scripts traffic-report --period=${{ steps.period.outputs.period }}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -14,6 +14,7 @@
 		"model-release-dates": "tsx src/model-release-dates.ts",
 		"send": "tsx src/send.ts",
 		"stripe-earnings": "tsx src/stripe-earnings.ts",
+		"traffic-report": "tsx src/traffic-report.ts",
 		"test-gemini-tools-complex": "tsx src/test-gemini-tools-complex.ts",
 		"test-gemini-tools-simple": "tsx src/test-gemini-tools-simple.ts"
 	},

--- a/packages/scripts/src/traffic-report.ts
+++ b/packages/scripts/src/traffic-report.ts
@@ -1,0 +1,521 @@
+/* eslint-disable no-console */
+import { fileURLToPath } from "node:url";
+
+type Period = "week" | "month";
+
+interface Range {
+	start: Date; // inclusive
+	end: Date; // exclusive
+}
+
+interface ReportWindow {
+	period: Period;
+	current: Range;
+	previous: Range;
+	rangeLabel: string;
+	comparisonLabel: string;
+}
+
+interface ProductTraffic {
+	pageviews: number;
+	visitors: number;
+	sessions: number;
+}
+
+interface PeriodPair {
+	current: number;
+	previous: number;
+}
+
+interface ReportData {
+	products: Map<string, { current: ProductTraffic; previous: ProductTraffic }>;
+	overall: { current: ProductTraffic; previous: ProductTraffic };
+	events: Map<string, PeriodPair>;
+	sources: Array<{ source: string; visitors: number }>;
+	traffic: Map<string, PeriodPair>; // bucket -> human/bot/ai
+}
+
+const PRODUCTS: ReadonlyArray<{ host: string; label: string }> = [
+	{ host: "llmgateway.io", label: "LLM Gateway" },
+	{ host: "devpass.llmgateway.io", label: "DevPass" },
+	{ host: "chat.llmgateway.io", label: "Chat" },
+	{ host: "docs.llmgateway.io", label: "Docs" },
+];
+
+const EVENTS: ReadonlyArray<{ event: string; label: string }> = [
+	{ event: "user_signed_up", label: "Signups" },
+	{ event: "credits_purchased", label: "Credit purchases" },
+	{ event: "dev_plan_started", label: "DevPass starts" },
+	{ event: "chat_plan_started", label: "Chat plan starts" },
+	{ event: "onboarding_completed", label: "Onboarding done" },
+	{ event: "playground_chat_sent", label: "Playground chats" },
+	{ event: "cta_clicked", label: "CTA clicks" },
+	{ event: "pricing_plan_clicked", label: "Pricing clicks" },
+	{ event: "enterprise_contact_submitted", label: "Enterprise leads" },
+];
+
+const HOST_LIST = PRODUCTS.map((p) => `'${p.host}'`).join(",");
+
+function nonEmpty(value: string | undefined): string | undefined {
+	if (!value || value.trim() === "") {
+		return undefined;
+	}
+	return value.trim();
+}
+
+const POSTHOG_HOST =
+	nonEmpty(process.env.POSTHOG_QUERY_HOST) ?? "https://us.posthog.com";
+const POSTHOG_PROJECT_ID = nonEmpty(process.env.POSTHOG_PROJECT_ID) ?? "163518";
+const POSTHOG_PERSONAL_API_KEY = nonEmpty(process.env.POSTHOG_PERSONAL_API_KEY);
+const DISCORD_TRAFFIC_NOTIFICATION_URL = nonEmpty(
+	process.env.DISCORD_TRAFFIC_NOTIFICATION_URL,
+);
+
+function startOfUtcDay(d: Date): Date {
+	return new Date(
+		Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+	);
+}
+
+const DAY_MS = 86_400_000;
+
+function shiftDays(d: Date, days: number): Date {
+	const offsetMs = days * DAY_MS;
+	return new Date(d.getTime() + offsetMs);
+}
+
+function startOfUtcWeek(d: Date): Date {
+	const day = startOfUtcDay(d);
+	const diff = (day.getUTCDay() + 6) % 7; // days since Monday
+	return shiftDays(day, -diff);
+}
+
+function startOfUtcMonth(d: Date): Date {
+	return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+function addUtcMonths(d: Date, n: number): Date {
+	return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + n, 1));
+}
+
+function formatDay(d: Date): string {
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	});
+}
+
+function buildWindow(period: Period, now: Date): ReportWindow {
+	if (period === "week") {
+		const thisWeek = startOfUtcWeek(now);
+		const current: Range = {
+			start: shiftDays(thisWeek, -7),
+			end: thisWeek,
+		};
+		const previous: Range = {
+			start: shiftDays(thisWeek, -14),
+			end: shiftDays(thisWeek, -7),
+		};
+		const lastDay = shiftDays(current.end, -1);
+		return {
+			period,
+			current,
+			previous,
+			rangeLabel: `${formatDay(current.start)} – ${formatDay(
+				lastDay,
+			)}, ${current.start.getUTCFullYear()}`,
+			comparisonLabel: "vs previous week",
+		};
+	}
+
+	const thisMonth = startOfUtcMonth(now);
+	const current: Range = { start: addUtcMonths(thisMonth, -1), end: thisMonth };
+	const previous: Range = {
+		start: addUtcMonths(thisMonth, -2),
+		end: addUtcMonths(thisMonth, -1),
+	};
+	return {
+		period,
+		current,
+		previous,
+		rangeLabel: current.start.toLocaleDateString("en-US", {
+			month: "long",
+			year: "numeric",
+			timeZone: "UTC",
+		}),
+		comparisonLabel: "vs previous month",
+	};
+}
+
+function hogqlTimestamp(d: Date): string {
+	return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+async function runHogql(query: string): Promise<unknown[][]> {
+	if (!POSTHOG_PERSONAL_API_KEY) {
+		throw new Error(
+			"POSTHOG_PERSONAL_API_KEY environment variable is required to query PostHog.",
+		);
+	}
+	const response = await fetch(
+		`${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/query/`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${POSTHOG_PERSONAL_API_KEY}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+		},
+	);
+	if (!response.ok) {
+		throw new Error(
+			`PostHog query failed: ${response.status} - ${await response.text()}`,
+		);
+	}
+	const data = (await response.json()) as { results?: unknown[][] };
+	return data.results ?? [];
+}
+
+function num(value: unknown): number {
+	const n = Number(value);
+	return Number.isFinite(n) ? n : 0;
+}
+
+async function fetchReport(window: ReportWindow): Promise<ReportData> {
+	const prevStart = hogqlTimestamp(window.previous.start);
+	const curStart = hogqlTimestamp(window.current.start);
+	const curEnd = hogqlTimestamp(window.current.end);
+	const periodExpr = `if(timestamp >= toDateTime('${curStart}'), 'current', 'previous')`;
+	const rangeExpr = `timestamp >= toDateTime('${prevStart}') AND timestamp < toDateTime('${curEnd}')`;
+
+	const perHostQuery = `
+		SELECT properties.$host AS host, ${periodExpr} AS period,
+			count() AS pageviews,
+			count(DISTINCT person_id) AS visitors,
+			count(DISTINCT properties.$session_id) AS sessions
+		FROM events
+		WHERE event = '$pageview' AND ${rangeExpr}
+			AND properties.$host IN (${HOST_LIST})
+		GROUP BY host, period`;
+
+	const overallQuery = `
+		SELECT ${periodExpr} AS period,
+			count() AS pageviews,
+			count(DISTINCT person_id) AS visitors,
+			count(DISTINCT properties.$session_id) AS sessions
+		FROM events
+		WHERE event = '$pageview' AND ${rangeExpr}
+			AND properties.$host IN (${HOST_LIST})
+		GROUP BY period`;
+
+	const eventList = EVENTS.map((e) => `'${e.event}'`).join(",");
+	const eventsQuery = `
+		SELECT event, ${periodExpr} AS period, count() AS hits
+		FROM events
+		WHERE event IN (${eventList}) AND ${rangeExpr}
+		GROUP BY event, period`;
+
+	const sourcesQuery = `
+		SELECT coalesce(nullIf(properties.$referring_domain, ''), '$direct') AS source,
+			count(DISTINCT person_id) AS visitors
+		FROM events
+		WHERE event = '$pageview'
+			AND timestamp >= toDateTime('${curStart}') AND timestamp < toDateTime('${curEnd}')
+			AND properties.$host IN (${HOST_LIST})
+		GROUP BY source
+		ORDER BY visitors DESC
+		LIMIT 6`;
+
+	const trafficQuery = `
+		SELECT ${periodExpr} AS period,
+			multiIf(
+				properties.$virt_traffic_category IN ('ai_crawler','ai_search','ai_assistant'), 'ai',
+				properties.$virt_is_bot = true, 'bot',
+				'human'
+			) AS bucket,
+			count() AS hits
+		FROM events
+		WHERE event = '$pageview' AND ${rangeExpr}
+			AND properties.$host IN (${HOST_LIST})
+		GROUP BY period, bucket`;
+
+	const [perHost, overall, events, sources, traffic] = await Promise.all([
+		runHogql(perHostQuery),
+		runHogql(overallQuery),
+		runHogql(eventsQuery),
+		runHogql(sourcesQuery),
+		runHogql(trafficQuery),
+	]);
+
+	const products = new Map<
+		string,
+		{ current: ProductTraffic; previous: ProductTraffic }
+	>();
+	for (const { host } of PRODUCTS) {
+		products.set(host, {
+			current: { pageviews: 0, visitors: 0, sessions: 0 },
+			previous: { pageviews: 0, visitors: 0, sessions: 0 },
+		});
+	}
+	for (const row of perHost) {
+		const host = String(row[0]);
+		const entry = products.get(host);
+		if (!entry) {
+			continue;
+		}
+		const bucket = row[1] === "current" ? entry.current : entry.previous;
+		bucket.pageviews = num(row[2]);
+		bucket.visitors = num(row[3]);
+		bucket.sessions = num(row[4]);
+	}
+
+	const overallData = {
+		current: { pageviews: 0, visitors: 0, sessions: 0 },
+		previous: { pageviews: 0, visitors: 0, sessions: 0 },
+	};
+	for (const row of overall) {
+		const bucket =
+			row[0] === "current" ? overallData.current : overallData.previous;
+		bucket.pageviews = num(row[1]);
+		bucket.visitors = num(row[2]);
+		bucket.sessions = num(row[3]);
+	}
+
+	const eventsData = new Map<string, PeriodPair>();
+	for (const { event } of EVENTS) {
+		eventsData.set(event, { current: 0, previous: 0 });
+	}
+	for (const row of events) {
+		const entry = eventsData.get(String(row[0]));
+		if (!entry) {
+			continue;
+		}
+		if (row[1] === "current") {
+			entry.current = num(row[2]);
+		} else {
+			entry.previous = num(row[2]);
+		}
+	}
+
+	const sourcesData = sources.map((row) => ({
+		source: row[0] === "$direct" ? "direct" : String(row[0]),
+		visitors: num(row[1]),
+	}));
+
+	const trafficData = new Map<string, PeriodPair>();
+	for (const bucket of ["human", "bot", "ai"]) {
+		trafficData.set(bucket, { current: 0, previous: 0 });
+	}
+	for (const row of traffic) {
+		const entry = trafficData.get(String(row[1]));
+		if (!entry) {
+			continue;
+		}
+		if (row[0] === "current") {
+			entry.current = num(row[2]);
+		} else {
+			entry.previous = num(row[2]);
+		}
+	}
+
+	return {
+		products,
+		overall: overallData,
+		events: eventsData,
+		sources: sourcesData,
+		traffic: trafficData,
+	};
+}
+
+function formatInt(n: number): string {
+	return Math.round(n).toLocaleString("en-US");
+}
+
+function formatDelta(current: number, previous: number): string {
+	if (previous === 0) {
+		return current > 0 ? "new" : "–";
+	}
+	const pct = ((current - previous) / previous) * 100;
+	const sign = pct > 0 ? "+" : "";
+	return `${sign}${pct.toFixed(1)}%`;
+}
+
+type Align = "left" | "right";
+
+function renderTable(
+	headers: string[],
+	rows: string[][],
+	align: Align[],
+): string {
+	const widths = headers.map((header, i) =>
+		Math.max(header.length, ...rows.map((row) => row[i].length)),
+	);
+	const pad = (cell: string, i: number): string =>
+		align[i] === "right" ? cell.padStart(widths[i]) : cell.padEnd(widths[i]);
+	const line = (cells: string[]): string =>
+		cells.map((cell, i) => pad(cell, i)).join("  ");
+	const divider = widths.map((w) => "─".repeat(w)).join("  ");
+	return [line(headers), divider, ...rows.map(line)].join("\n");
+}
+
+function buildEmbed(window: ReportWindow, data: ReportData) {
+	const periodTitle = window.period === "week" ? "Weekly" : "Monthly";
+	const icon = window.period === "week" ? "📊" : "📈";
+
+	const productRows = PRODUCTS.map(({ host, label }) => {
+		const entry = data.products.get(host);
+		const cur = entry?.current ?? { pageviews: 0, visitors: 0, sessions: 0 };
+		const prev = entry?.previous ?? { pageviews: 0, visitors: 0, sessions: 0 };
+		return [
+			label,
+			formatInt(cur.visitors),
+			formatDelta(cur.visitors, prev.visitors),
+			formatInt(cur.pageviews),
+			formatInt(cur.sessions),
+		];
+	});
+	productRows.push([
+		"All (unique)",
+		formatInt(data.overall.current.visitors),
+		formatDelta(data.overall.current.visitors, data.overall.previous.visitors),
+		formatInt(data.overall.current.pageviews),
+		formatInt(data.overall.current.sessions),
+	]);
+	const productTable = renderTable(
+		["Product", "Visitors", "Δ", "Views", "Sessions"],
+		productRows,
+		["left", "right", "right", "right", "right"],
+	);
+
+	const eventRows = EVENTS.map(({ event, label }) => {
+		const pair = data.events.get(event) ?? { current: 0, previous: 0 };
+		return [
+			label,
+			formatInt(pair.current),
+			formatDelta(pair.current, pair.previous),
+		];
+	});
+	const eventTable = renderTable(["Metric", "Count", "Δ"], eventRows, [
+		"left",
+		"right",
+		"right",
+	]);
+
+	const sources = data.sources
+		.map((s) => `${s.source} (${formatInt(s.visitors)})`)
+		.join(" · ");
+
+	const ai = data.traffic.get("ai") ?? { current: 0, previous: 0 };
+	const human = data.traffic.get("human") ?? { current: 0, previous: 0 };
+	const bot = data.traffic.get("bot") ?? { current: 0, previous: 0 };
+	const totalHits = ai.current + human.current + bot.current;
+	const aiAndBot = ai.current + bot.current;
+	const automatedShare =
+		totalHits > 0 ? ((aiAndBot / totalHits) * 100).toFixed(1) : "0.0";
+
+	const description = [
+		`**${window.rangeLabel}** · ${window.comparisonLabel}`,
+		"",
+		"**Traffic by product**",
+		"```",
+		productTable,
+		"```",
+		"**Conversions & engagement**",
+		"```",
+		eventTable,
+		"```",
+		`**Top sources** · ${sources || "no data"}`,
+		"",
+		`**AI & bots** · AI assistant/crawler views: ${formatInt(
+			ai.current,
+		)} (${formatDelta(ai.current, ai.previous)}) · automated share ${automatedShare}%`,
+	].join("\n");
+
+	return {
+		title: `${icon} ${periodTitle} Traffic Report · ${window.rangeLabel}`,
+		description,
+		color: window.period === "week" ? 0x6366f1 : 0x8b5cf6,
+		footer: { text: "LLM Gateway · PostHog analytics" },
+		timestamp: new Date().toISOString(),
+	};
+}
+
+async function postToDiscord(
+	embed: ReturnType<typeof buildEmbed>,
+): Promise<void> {
+	if (!DISCORD_TRAFFIC_NOTIFICATION_URL) {
+		throw new Error(
+			"DISCORD_TRAFFIC_NOTIFICATION_URL environment variable is required to post the report.",
+		);
+	}
+	const response = await fetch(DISCORD_TRAFFIC_NOTIFICATION_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ embeds: [embed] }),
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Discord webhook error: ${response.status} - ${await response.text()}`,
+		);
+	}
+}
+
+function parsePeriod(): Period {
+	const arg = process.argv.find((a) => a.startsWith("--period="));
+	const value = arg?.slice("--period=".length);
+	if (value === "month") {
+		return "month";
+	}
+	if (value && value !== "week") {
+		throw new Error(`Invalid --period: ${value} (expected "week" or "month")`);
+	}
+	return "week";
+}
+
+function parseAt(): Date {
+	const arg = process.argv.find((a) => a.startsWith("--at="));
+	if (!arg) {
+		return new Date();
+	}
+	const date = new Date(arg.slice("--at=".length));
+	if (Number.isNaN(date.getTime())) {
+		throw new Error(`Invalid --at date: ${arg.slice("--at=".length)}`);
+	}
+	return date;
+}
+
+async function main(): Promise<void> {
+	const period = parsePeriod();
+	const dryRun = process.argv.includes("--dry-run");
+	const window = buildWindow(period, parseAt());
+
+	console.log(
+		`Building ${period} traffic report for ${window.rangeLabel} (${window.comparisonLabel})`,
+	);
+
+	const data = await fetchReport(window);
+	const embed = buildEmbed(window, data);
+
+	if (dryRun) {
+		console.log("\n--- DRY RUN (not posting to Discord) ---\n");
+		console.log(embed.title);
+		console.log(embed.description);
+		return;
+	}
+
+	await postToDiscord(embed);
+	console.log("Traffic report posted to Discord.");
+}
+
+const isEntrypoint = process.argv[1] === fileURLToPath(import.meta.url);
+if (isEntrypoint) {
+	main().catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});
+}
+
+export { buildWindow, buildEmbed, fetchReport };
+export type { ReportWindow, ReportData, Period };

--- a/packages/scripts/src/traffic-report.ts
+++ b/packages/scripts/src/traffic-report.ts
@@ -32,6 +32,7 @@ interface ReportData {
 	overall: { current: ProductTraffic; previous: ProductTraffic };
 	events: Map<string, PeriodPair>;
 	sources: Array<{ source: string; visitors: number }>;
+	sourcesByProduct: Map<string, Array<{ source: string; visitors: number }>>;
 	traffic: Map<string, PeriodPair>; // bucket -> human/bot/ai
 }
 
@@ -65,11 +66,13 @@ function nonEmpty(value: string | undefined): string | undefined {
 
 const POSTHOG_HOST =
 	nonEmpty(process.env.POSTHOG_QUERY_HOST) ?? "https://us.posthog.com";
-const POSTHOG_PROJECT_ID = nonEmpty(process.env.POSTHOG_PROJECT_ID) ?? "163518";
+const POSTHOG_PROJECT_ID = nonEmpty(process.env.POSTHOG_PROJECT_ID);
 const POSTHOG_PERSONAL_API_KEY = nonEmpty(process.env.POSTHOG_PERSONAL_API_KEY);
 const DISCORD_TRAFFIC_NOTIFICATION_URL = nonEmpty(
 	process.env.DISCORD_TRAFFIC_NOTIFICATION_URL,
 );
+
+const REQUEST_TIMEOUT_MS = 30_000;
 
 function startOfUtcDay(d: Date): Date {
 	return new Date(
@@ -118,13 +121,19 @@ function buildWindow(period: Period, now: Date): ReportWindow {
 			end: shiftDays(thisWeek, -7),
 		};
 		const lastDay = shiftDays(current.end, -1);
+		const startYear = current.start.getUTCFullYear();
+		const endYear = lastDay.getUTCFullYear();
+		const rangeLabel =
+			startYear === endYear
+				? `${formatDay(current.start)} – ${formatDay(lastDay)}, ${endYear}`
+				: `${formatDay(current.start)}, ${startYear} – ${formatDay(
+						lastDay,
+					)}, ${endYear}`;
 		return {
 			period,
 			current,
 			previous,
-			rangeLabel: `${formatDay(current.start)} – ${formatDay(
-				lastDay,
-			)}, ${current.start.getUTCFullYear()}`,
+			rangeLabel,
 			comparisonLabel: "vs previous week",
 		};
 	}
@@ -158,6 +167,11 @@ async function runHogql(query: string): Promise<unknown[][]> {
 			"POSTHOG_PERSONAL_API_KEY environment variable is required to query PostHog.",
 		);
 	}
+	if (!POSTHOG_PROJECT_ID) {
+		throw new Error(
+			"POSTHOG_PROJECT_ID environment variable is required to query PostHog.",
+		);
+	}
 	const response = await fetch(
 		`${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/query/`,
 		{
@@ -167,6 +181,7 @@ async function runHogql(query: string): Promise<unknown[][]> {
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 		},
 	);
 	if (!response.ok) {
@@ -228,6 +243,25 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 		ORDER BY visitors DESC
 		LIMIT 6`;
 
+	const sourcesByProductQuery = `
+		SELECT host, source, visitors
+		FROM (
+			SELECT host, source, visitors,
+				row_number() OVER (PARTITION BY host ORDER BY visitors DESC) AS rn
+			FROM (
+				SELECT properties.$host AS host,
+					coalesce(nullIf(properties.$referring_domain, ''), '$direct') AS source,
+					count(DISTINCT person_id) AS visitors
+				FROM events
+				WHERE event = '$pageview'
+					AND timestamp >= toDateTime('${curStart}') AND timestamp < toDateTime('${curEnd}')
+					AND properties.$host IN (${HOST_LIST})
+				GROUP BY host, source
+			)
+		)
+		WHERE rn <= 3
+		ORDER BY host, visitors DESC`;
+
 	const trafficQuery = `
 		SELECT ${periodExpr} AS period,
 			multiIf(
@@ -241,13 +275,15 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 			AND properties.$host IN (${HOST_LIST})
 		GROUP BY period, bucket`;
 
-	const [perHost, overall, events, sources, traffic] = await Promise.all([
-		runHogql(perHostQuery),
-		runHogql(overallQuery),
-		runHogql(eventsQuery),
-		runHogql(sourcesQuery),
-		runHogql(trafficQuery),
-	]);
+	const [perHost, overall, events, sources, sourcesByHost, traffic] =
+		await Promise.all([
+			runHogql(perHostQuery),
+			runHogql(overallQuery),
+			runHogql(eventsQuery),
+			runHogql(sourcesQuery),
+			runHogql(sourcesByProductQuery),
+			runHogql(trafficQuery),
+		]);
 
 	const products = new Map<
 		string,
@@ -304,6 +340,24 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 		visitors: num(row[1]),
 	}));
 
+	const sourcesByProduct = new Map<
+		string,
+		Array<{ source: string; visitors: number }>
+	>();
+	for (const { host } of PRODUCTS) {
+		sourcesByProduct.set(host, []);
+	}
+	for (const row of sourcesByHost) {
+		const list = sourcesByProduct.get(String(row[0]));
+		if (!list) {
+			continue;
+		}
+		list.push({
+			source: row[1] === "$direct" ? "direct" : String(row[1]),
+			visitors: num(row[2]),
+		});
+	}
+
 	const trafficData = new Map<string, PeriodPair>();
 	for (const bucket of ["human", "bot", "ai"]) {
 		trafficData.set(bucket, { current: 0, previous: 0 });
@@ -325,6 +379,7 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 		overall: overallData,
 		events: eventsData,
 		sources: sourcesData,
+		sourcesByProduct,
 		traffic: trafficData,
 	};
 }
@@ -407,6 +462,14 @@ function buildEmbed(window: ReportWindow, data: ReportData) {
 		.map((s) => `${s.source} (${formatInt(s.visitors)})`)
 		.join(" · ");
 
+	const sourcesByProduct = PRODUCTS.map(({ host, label }) => {
+		const list = data.sourcesByProduct.get(host) ?? [];
+		const formatted = list
+			.map((s) => `${s.source} (${formatInt(s.visitors)})`)
+			.join(" · ");
+		return `${label} · ${formatted || "no data"}`;
+	}).join("\n");
+
 	const ai = data.traffic.get("ai") ?? { current: 0, previous: 0 };
 	const human = data.traffic.get("human") ?? { current: 0, previous: 0 };
 	const bot = data.traffic.get("bot") ?? { current: 0, previous: 0 };
@@ -427,6 +490,9 @@ function buildEmbed(window: ReportWindow, data: ReportData) {
 		eventTable,
 		"```",
 		`**Top sources** · ${sources || "no data"}`,
+		"",
+		"**Top sources by product**",
+		sourcesByProduct,
 		"",
 		`**AI & bots** · AI assistant/crawler views: ${formatInt(
 			ai.current,
@@ -454,6 +520,7 @@ async function postToDiscord(
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ embeds: [embed] }),
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 	});
 	if (!response.ok) {
 		throw new Error(


### PR DESCRIPTION
## What

Adds an automated **weekly + monthly traffic report** that pulls analytics from PostHog for all four LLM Gateway products and posts a formatted summary to the **#traffic** Discord channel.

- **Weekly** — every Monday 08:00 UTC, reporting the just-completed Mon–Sun week vs the week before.
- **Monthly** — 1st of each month 08:30 UTC, reporting the just-completed calendar month vs the month before.

## What's in the report

Each report is a single Discord embed with:

- **Traffic by product** — pageviews, unique visitors, and sessions for `llmgateway.io`, `devpass.llmgateway.io`, `chat.llmgateway.io`, `docs.llmgateway.io`, each with the period-over-period delta, plus a true distinct-visitor total row.
- **Conversions & engagement** — signups, credit purchases, DevPass starts, chat-plan starts, onboarding completions, playground chats, CTA clicks, pricing clicks, and enterprise leads, each with deltas.
- **Top sources** — top referring domains by visitors.
- **AI & bots** — AI assistant/crawler pageviews (an AEO signal) and the automated-traffic share.

All metrics come from PostHog via the HogQL query API; every query was validated against live project data.

### Example output (real numbers, week of Jun 22–28)

```
Product       Visitors       Δ   Views  Sessions
────────────  ────────  ──────  ──────  ────────
LLM Gateway      3,613  -16.8%  15,350     4,742
DevPass            568  +37.5%   7,071     1,666
Chat               251  -34.8%   1,031       355
Docs               623  +15.4%   1,744       748
All (unique)     4,820  -10.4%  25,196     7,511
```

## How it works

- New standalone script `packages/scripts/src/traffic-report.ts`, run via `pnpm --filter @llmgateway/scripts traffic-report --period=week|month`. Supports `--dry-run` (prints instead of posting) and `--at=<ISO>` (compute the window for a specific date, for testing/backfill).
- New workflow `.github/workflows/traffic-report.yml` with the two cron schedules + `workflow_dispatch` for manual runs. It mirrors the existing `run.yml` node/pnpm setup and needs only `pnpm install` (the script imports no workspace packages — just Node built-ins + global `fetch`).

## Secret handling

The Discord webhook is **never committed**. The script reads everything from env / GitHub Actions secrets:

| Secret | Purpose |
| --- | --- |
| `DISCORD_TRAFFIC_NOTIFICATION_URL` | #traffic webhook |
| `POSTHOG_PERSONAL_API_KEY` | PostHog **personal** API key (read scope) for the query API |
| `POSTHOG_PROJECT_ID` | optional — defaults to the LLMGateway project |
| `POSTHOG_QUERY_HOST` | optional — defaults to `https://us.posthog.com` |

`.env.example` gets blank placeholders for local use.

## Before it runs

Add these repo secrets in **Settings → Secrets and variables → Actions**:

- `DISCORD_TRAFFIC_NOTIFICATION_URL` — the #traffic channel webhook
- `POSTHOG_PERSONAL_API_KEY` — create one at PostHog → Settings → Personal API keys (read scope is enough)

Then trigger the workflow manually once (**Actions → traffic-report → Run workflow**) to confirm the message lands in #traffic.

## Testing

- All HogQL queries validated against live PostHog data (per-host traffic, conversion events, sources, AI/bot buckets).
- Week/month boundary math checked across week, month, and year-rollover dates.
- Embed rendering verified with real numbers; `eslint` + `prettier` clean; `tsc` reports no errors for the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated traffic reporting workflow that runs weekly and monthly, with manual triggering available.
  * Introduced a traffic report generator that compiles recent and comparison stats and posts a formatted summary to a Discord webhook (or supports a dry-run output).
  * Added a new scripts command to generate the report on demand.
* **Documentation**
  * Updated the example environment configuration with Discord notification and PostHog reporting settings required for traffic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->