### PR TITLE
fix(gateway): detect ai studio streaming served tier

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -8865,6 +8865,7 @@ chat.openapi(completions, async (c) => {
 									{
 										const served = resolveServedServiceTier({
 											trafficType: data?.usageMetadata?.trafficType,
+											serviceTierBody: data?.usageMetadata?.serviceTier,
 										});
 										if (served) {
 											servedServiceTier = served;
@@ -12028,6 +12029,7 @@ chat.openapi(completions, async (c) => {
 	{
 		const served = resolveServedServiceTier({
 			trafficType: json?.usageMetadata?.trafficType,
+			serviceTierBody: json?.usageMetadata?.serviceTier,
 		});
 		if (served) {
 			servedServiceTier = served;

--- a/packages/actions/src/apply-google-service-tier.spec.ts
+++ b/packages/actions/src/apply-google-service-tier.spec.ts
@@ -81,10 +81,35 @@ describe("resolveServedServiceTier", () => {
 		).toBeNull();
 	});
 
+	it("maps the AI Studio usageMetadata.serviceTier body field to a tier id", () => {
+		// Streaming AI Studio responses omit the header and carry the served tier
+		// in the body instead.
+		expect(resolveServedServiceTier({ serviceTierBody: "flex" })).toBe("flex");
+		expect(resolveServedServiceTier({ serviceTierBody: "priority" })).toBe(
+			"priority",
+		);
+		expect(
+			resolveServedServiceTier({ serviceTierBody: "standard" }),
+		).toBeNull();
+	});
+
+	it("prefers the header but falls back to the body field", () => {
+		expect(
+			resolveServedServiceTier({
+				serviceTierHeader: null,
+				serviceTierBody: "flex",
+			}),
+		).toBe("flex");
+	});
+
 	it("returns null when no signals are present", () => {
 		expect(resolveServedServiceTier({})).toBeNull();
 		expect(
-			resolveServedServiceTier({ trafficType: null, serviceTierHeader: null }),
+			resolveServedServiceTier({
+				trafficType: null,
+				serviceTierHeader: null,
+				serviceTierBody: null,
+			}),
 		).toBeNull();
 	});
 });

--- a/packages/actions/src/apply-google-service-tier.ts
+++ b/packages/actions/src/apply-google-service-tier.ts
@@ -98,7 +98,11 @@ export function providerKeyBaseUrlSupportsServiceTier(
  * - Vertex AI reports the served tier in `usageMetadata.trafficType`
  *   (`ON_DEMAND_PRIORITY` / `ON_DEMAND_FLEX` / `ON_DEMAND`).
  * - The Gemini Developer API (AI Studio / glacier) reports it in the
- *   `x-gemini-service-tier` response header (`priority` / `flex` / `standard`).
+ *   `x-gemini-service-tier` response header (`priority` / `flex` / `standard`)
+ *   on unary responses, but streaming responses omit that header and instead
+ *   carry it in the body as `usageMetadata.serviceTier` (`flex` / `priority` /
+ *   `standard`). Both are checked so streaming requests aren't misread as
+ *   standard.
  *
  * Billing keys off this value rather than the requested tier so a downgraded
  * request is charged at the rate it actually ran at.
@@ -106,6 +110,7 @@ export function providerKeyBaseUrlSupportsServiceTier(
 export function resolveServedServiceTier(signals: {
 	trafficType?: string | null;
 	serviceTierHeader?: string | null;
+	serviceTierBody?: string | null;
 }): "flex" | "priority" | null {
 	const trafficType = signals.trafficType?.toUpperCase();
 	if (trafficType === "ON_DEMAND_PRIORITY") {
@@ -114,11 +119,13 @@ export function resolveServedServiceTier(signals: {
 	if (trafficType === "ON_DEMAND_FLEX") {
 		return "flex";
 	}
-	const header = signals.serviceTierHeader?.toLowerCase();
-	if (header === "priority") {
+	const tier = (
+		signals.serviceTierHeader ?? signals.serviceTierBody
+	)?.toLowerCase();
+	if (tier === "priority") {
 		return "priority";
 	}
-	if (header === "flex") {
+	if (tier === "flex") {
 		return "flex";
 	}
 	return null;


### PR DESCRIPTION
## Summary

On **AI Studio** (Gemini Developer API), `service_tier` flex/priority **does work** — a direct call returns the served tier. But on **streaming** responses Google omits the `x-gemini-service-tier` response header and instead reports the served tier in the body as `usageMetadata.serviceTier` (`flex` / `priority` / `standard`). Unary responses include both.

The gateway only read the header, so every **streamed** Flex/Priority AI Studio request resolved to `null` (standard) — mis-billing, and making the selected tier look like it did nothing.

`resolveServedServiceTier` now also reads the `usageMetadata.serviceTier` body field; the header still takes precedence when present.

## Verification

Verified against the live Google API with `gemini-3.1-pro-preview`:
- Direct AI Studio call → unary response has both header `x-gemini-service-tier: flex` and body `usageMetadata.serviceTier: flex`; **streaming response has only the body field**.
- Through the gateway (streaming): AI Studio `flex` now resolves `flex`, `priority` resolves `priority` (previously both resolved to standard).
- Vertex is unaffected (served tier still resolved from `usageMetadata.trafficType`).
- `pnpm format`, full `pnpm build`, and unit tests pass (18 tests in `apply-google-service-tier.spec.ts`, incl. new body-field cases).

## Scope

This PR only fixes served-tier **detection** for AI Studio streaming. It does **not** change how web search is routed across service tiers (a separate Vertex Flex + grounding change was considered and dropped for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)