### PR TITLE
fix(gateway): skip vertex flex for native web search

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -98,6 +98,7 @@ import {
 	isPremiumServiceTier,
 	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
+	webSearchDisablesServiceTier,
 	googleProviderSupportsAudioFormat,
 	InvalidFileContentError,
 	parseGoogleUpstreamDocumentError,
@@ -913,9 +914,16 @@ function getForwardedServiceTier(
 	provider: Provider,
 	region: string | undefined,
 	serviceTier: "auto" | "default" | "flex" | "priority" | undefined,
+	webSearchEnabled: boolean,
 	configIndex?: number,
 ): "flex" | "priority" | undefined {
 	if (serviceTier !== "flex" && serviceTier !== "priority") {
+		return undefined;
+	}
+	// Flex can't reliably serve native web search on Vertex (the heavier
+	// grounding request drops/empties on the deprioritized shared-Flex tier), so
+	// a grounding request never forwards Flex — it falls back to standard instead.
+	if (webSearchDisablesServiceTier(provider, serviceTier, webSearchEnabled)) {
 		return undefined;
 	}
 	const effectiveRegion =
@@ -5994,6 +6002,7 @@ chat.openapi(completions, async (c) => {
 				usedProvider,
 				usedRegion,
 				service_tier,
+				!!webSearchTool,
 				configIndex,
 			),
 		);
@@ -6613,6 +6622,7 @@ chat.openapi(completions, async (c) => {
 							usedProvider,
 							usedRegion,
 							service_tier,
+							!!webSearchTool,
 							configIndex,
 						);
 						const headers = getProviderHeaders(usedProvider, usedToken, {
@@ -8849,6 +8859,7 @@ chat.openapi(completions, async (c) => {
 											usedProvider,
 											usedRegion,
 											service_tier,
+											!!webSearchTool,
 											configIndex,
 										),
 										data,
@@ -10559,6 +10570,7 @@ chat.openapi(completions, async (c) => {
 				usedProvider,
 				usedRegion,
 				service_tier,
+				!!webSearchTool,
 				configIndex,
 			);
 			const headers = getProviderHeaders(usedProvider, usedToken, {
@@ -12006,6 +12018,7 @@ chat.openapi(completions, async (c) => {
 			usedProvider,
 			usedRegion,
 			service_tier,
+			!!webSearchTool,
 			configIndex,
 		),
 		json,

--- a/packages/actions/src/apply-google-service-tier.spec.ts
+++ b/packages/actions/src/apply-google-service-tier.spec.ts
@@ -5,6 +5,7 @@ import {
 	isPremiumServiceTier,
 	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
+	webSearchDisablesServiceTier,
 } from "./apply-google-service-tier.js";
 
 import type { GoogleRequestBody } from "@llmgateway/models";
@@ -155,5 +156,44 @@ describe("providerKeyBaseUrlSupportsServiceTier", () => {
 				"https://my-proxy.example.com",
 			),
 		).toBe(true);
+	});
+});
+
+describe("webSearchDisablesServiceTier", () => {
+	it("drops flex on Vertex-compatible providers when web search is on", () => {
+		for (const provider of ["google-vertex", "quartz"] as const) {
+			expect(webSearchDisablesServiceTier(provider, "flex", true)).toBe(true);
+		}
+	});
+
+	it("leaves AI Studio flex alone (it serves grounding quickly)", () => {
+		expect(webSearchDisablesServiceTier("google-ai-studio", "flex", true)).toBe(
+			false,
+		);
+		expect(webSearchDisablesServiceTier("glacier", "flex", true)).toBe(false);
+	});
+
+	it("never drops priority (it serves grounding fine)", () => {
+		expect(
+			webSearchDisablesServiceTier("google-vertex", "priority", true),
+		).toBe(false);
+	});
+
+	it("is a no-op without web search", () => {
+		expect(webSearchDisablesServiceTier("google-vertex", "flex", false)).toBe(
+			false,
+		);
+	});
+
+	it("ignores non-Vertex providers", () => {
+		expect(webSearchDisablesServiceTier("openai", "flex", true)).toBe(false);
+	});
+
+	it("ignores standard/default/auto and missing tiers", () => {
+		for (const tier of ["auto", "default", "standard", "", null, undefined]) {
+			expect(webSearchDisablesServiceTier("google-vertex", tier, true)).toBe(
+				false,
+			);
+		}
 	});
 });

--- a/packages/actions/src/apply-google-service-tier.ts
+++ b/packages/actions/src/apply-google-service-tier.ts
@@ -55,6 +55,40 @@ export function isPremiumServiceTier(
 	return serviceTier === "flex" || serviceTier === "priority";
 }
 
+/**
+ * Vertex-compatible providers serve Flex through the deprioritized shared-PayGo
+ * path (the `X-Vertex-AI-LLM-Shared-Request-Type: flex` header). Native web
+ * search (grounding) is a far heavier request — the model fans out to live
+ * search before generating — and on this path it routinely exceeds client
+ * timeouts (measured tens of seconds up to >200s, vs ~40s on the standard tier
+ * and ~35s on Priority), so callers see empty responses at a high rate.
+ *
+ * AI Studio's Flex serves grounding quickly (~30-50s) and is deliberately
+ * excluded — only the Vertex shared-Flex path has this problem.
+ */
+const VERTEX_FLEX_GROUNDING_PROVIDERS: ReadonlySet<ProviderId> =
+	new Set<ProviderId>(["google-vertex", "quartz"]);
+
+/**
+ * Whether a requested premium tier must be dropped because it can't reliably
+ * serve a native web search (grounding) request. Vertex Flex + grounding times
+ * out far too often to be usable, so when web search is enabled we never
+ * forward Flex to a Vertex provider: the request falls back to the standard
+ * tier (working, billed as standard) instead of timing out. Priority handles
+ * grounding fine and is left untouched, as is AI Studio Flex.
+ */
+export function webSearchDisablesServiceTier(
+	provider: ProviderId,
+	serviceTier: string | null | undefined,
+	webSearchEnabled: boolean,
+): boolean {
+	return (
+		webSearchEnabled &&
+		serviceTier === "flex" &&
+		VERTEX_FLEX_GROUNDING_PROVIDERS.has(provider)
+	);
+}
+
 function normalizeServiceTierBaseUrl(baseUrl: string): string {
 	// Strip trailing slashes without a backtracking regex (avoids the
 	// polynomial-ReDoS CodeQL flags for `/\/+$/` on attacker-influenced input).


### PR DESCRIPTION
## Summary

Native web search (grounding) on Vertex's deprioritized shared-PayGo **Flex** path routinely exceeds client timeouts, so callers see empty responses at a high rate. Measured latency for `gemini-3.1-pro-preview` + `web_search` on Vertex (live API):

| Tier | Latency | Reliability |
|---|---|---|
| **flex** | 117s–>200s | times out at a high rate |
| standard | ~40s–200s | mostly OK |
| priority | ~35s | reliable |

The standard tier is meaningfully faster than Flex for grounding, and Priority is fast but costs 3.6× — so we don't silently upgrade. **When web search is enabled, the gateway no longer forwards Flex to Vertex-compatible providers; it falls back to the standard tier.** Priority is untouched, and **AI Studio Flex is excluded** because it serves grounding in ~30–50s (verified: reliable).

Implemented as a small pure helper `webSearchDisablesServiceTier(provider, tier, webSearchEnabled)` wired into `getForwardedServiceTier`, so the header path (Vertex) and body path (AI Studio) stay consistent.

## Verification

Verified live against the Google API:
- Vertex `flex` + `web_search` → completes in ~40s (standard speed), no Flex header forwarded.
- Vertex `flex` **without** web search → still served as `ON_DEMAND_FLEX` (the gate is grounding-specific).
- `pnpm format`, gateway build, and unit tests pass (incl. new `webSearchDisablesServiceTier` cases).

## Note

This was split out of #2851 per request — it changes how web search is routed across service tiers, so it can be reviewed/held independently. The Vertex Flex grounding latency itself is a Google-side characteristic; this routes around it conservatively rather than masking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)