### PR TITLE
test: migrate vitest poolOptions + guard TEST_MODELS

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -104,6 +104,43 @@ if (specifiedProviders) {
 	console.log(`TEST_PROVIDERS specified: ${specifiedProviders.join(", ")}`);
 }
 
+/**
+ * Check whether a single TEST_MODELS entry matches at least one real
+ * provider/model mapping (regions expanded).
+ */
+function testModelMatchesAnyMapping(entry: ParsedTestModel): boolean {
+	return models.some((model) => {
+		if (model.id !== entry.modelId) {
+			return false;
+		}
+		return expandAllProviderRegions(
+			model.providers as ProviderModelMapping[],
+		).some(
+			(p) =>
+				p.providerId === entry.providerId &&
+				(entry.region === undefined || p.region === entry.region),
+		);
+	});
+}
+
+// Fail loudly if TEST_MODELS is set but some entries match zero mappings.
+// Otherwise a typo'd model string silently runs no tests and "passes",
+// giving a false sense of security.
+if (specifiedModels && parsedTestModels) {
+	const unmatched = specifiedModels.filter(
+		(_, i) => !testModelMatchesAnyMapping(parsedTestModels[i]),
+	);
+	if (unmatched.length > 0) {
+		throw new Error(
+			`TEST_MODELS contains ${unmatched.length} entr${
+				unmatched.length === 1 ? "y that matches" : "ies that match"
+			} no provider/model mapping: ${unmatched.join(
+				", ",
+			)}. Check for typos (expected "provider/model" or "provider/model:region").`,
+		);
+	}
+}
+
 function hasAllRequiredProviderEnvVars(providerId: string): boolean {
 	const def = getProviderDefinition(providerId);
 	if (!def) {

--- a/vitest/vitest.e2e.config.mts
+++ b/vitest/vitest.e2e.config.mts
@@ -20,11 +20,7 @@ export default defineConfig({
 		},
 		// Configure parallel execution with pool of 16 threads
 		pool: "threads",
-		poolOptions: {
-			threads: {
-				maxThreads: 16,
-				minThreads: 8,
-			},
-		},
+		maxWorkers: 16,
+		minWorkers: 8,
 	},
 });


### PR DESCRIPTION
## Summary

Two test-infra fixes:

1. **Migrate Vitest 4 `poolOptions`** — `test.poolOptions` was removed in Vitest 4 (the project runs `vitest@4.1.8`), which emitted a deprecation warning on every e2e run. The `poolOptions.threads.maxThreads/minThreads` settings are now the top-level `maxWorkers`/`minWorkers` options.

2. **Fail e2e when `TEST_MODELS` matches no mapping** — previously a typo'd `TEST_MODELS` entry (e.g. `openai/gpt-4o-minii`) would silently run zero tests and report success, giving a false sense of security. The e2e harness now exits 1 at load time if any `TEST_MODELS` entry matches no provider/model mapping (regions expanded), listing the offending entries.

## Testing

- `TEST_MODELS="openai/this-model-does-not-exist" pnpm test:e2e` → exits 1 with a clear "matches no provider/model mapping" error.
- `TEST_MODELS="openai/gpt-4o-mini"` → guard stays silent, tests run normally.
- e2e config loads with no `poolOptions` deprecation warning.
- `pnpm build` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test selection validation so invalid test model entries are caught early instead of silently resulting in no tests running.
  * Expanded matching checks to better handle regional provider coverage, reducing false negatives when configuring test targets.

* **Chores**
  * Updated end-to-end test worker settings to use the latest configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->