### PR TITLE
fix(email): gate emails on verified org owner

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1193,6 +1193,7 @@ devPlans.openapi(changeTier, async (c) => {
 							invoiceNumber: upgradeTransaction.id,
 							invoiceDate: new Date(),
 							organizationName: personalOrg.name,
+							organizationId: personalOrg.id,
 							...billingDetails,
 							lineItems: [
 								{

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -857,6 +857,7 @@ export async function finalizeDevPlanSetupSession(
 				try {
 					await sendTransactionalEmail({
 						to: notifyEmail,
+						organizationId: organization.id,
 						subject: "DevPass activation failed — card already in use",
 						html: generateDevPlanDuplicateCardEmailHtml(organization.name),
 					});
@@ -1051,6 +1052,7 @@ export async function finalizeDevPlanSetupSession(
 		try {
 			const billingDetails = await resolveDevPassBillingDetails(organization);
 			await generateAndEmailInvoice({
+				organizationId: organization.id,
 				invoiceNumber: transaction.id,
 				invoiceDate: new Date(),
 				organizationName: organization.name,
@@ -1289,6 +1291,7 @@ async function handleCheckoutSessionCompleted(
 
 				try {
 					await generateAndEmailInvoice({
+						organizationId: organization.id,
 						invoiceNumber: transaction.id,
 						invoiceDate: new Date(),
 						organizationName: organization.name,
@@ -1412,6 +1415,7 @@ async function handleCheckoutSessionCompleted(
 					const billingDetails =
 						await resolveDevPassBillingDetails(organization);
 					await generateAndEmailInvoice({
+						organizationId: organization.id,
 						invoiceNumber: transaction.id,
 						invoiceDate: new Date(),
 						organizationName: organization.name,
@@ -1524,6 +1528,7 @@ async function handleCheckoutSessionCompleted(
 				// Generate and email invoice
 				try {
 					await generateAndEmailInvoice({
+						organizationId: organization.id,
 						invoiceNumber: transaction.id,
 						invoiceDate: new Date(),
 						organizationName: organization.name,
@@ -1784,6 +1789,7 @@ async function recordCreditTopUp({
 
 	try {
 		await generateAndEmailInvoice({
+			organizationId,
 			invoiceNumber: completedTransaction.id,
 			invoiceDate: new Date(),
 			organizationName: organization.name,
@@ -2369,6 +2375,7 @@ async function handlePaymentIntentSucceeded(
 
 		try {
 			await generateAndEmailInvoice({
+				organizationId: organization.id,
 				invoiceNumber: completedTransactionId,
 				invoiceDate: new Date(),
 				organizationName: organization.name,
@@ -2608,6 +2615,7 @@ export async function handlePaymentIntentFailed(
 		try {
 			await sendTransactionalEmail({
 				to: organization.billingEmail,
+				organizationId: organization.id,
 				subject: "Payment Failed - Action Required",
 				html: generatePaymentFailureEmailHtml(organization.name, {
 					errorMessage,
@@ -3111,6 +3119,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 		try {
 			const billingDetails = await resolveDevPassBillingDetails(organization);
 			await generateAndEmailInvoice({
+				organizationId: organization.id,
 				invoiceNumber: transaction.id,
 				invoiceDate: new Date(),
 				organizationName: organization.name,
@@ -3244,6 +3253,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 		try {
 			const billingDetails = await resolveDevPassBillingDetails(organization);
 			await generateAndEmailInvoice({
+				organizationId: organization.id,
 				invoiceNumber: renewalTransaction.id,
 				invoiceDate: new Date(),
 				organizationName: organization.name,
@@ -3370,6 +3380,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 			try {
 				const billingDetails = await resolveDevPassBillingDetails(organization);
 				await generateAndEmailInvoice({
+					organizationId: organization.id,
 					invoiceNumber: upgradeTransaction.id,
 					invoiceDate: new Date(),
 					organizationName: organization.name,
@@ -3446,6 +3457,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 
 			// Generate and email invoice
 			await generateAndEmailInvoice({
+				organizationId: organization.id,
 				invoiceNumber: transaction.id,
 				invoiceDate: new Date(),
 				organizationName: organization.name,
@@ -3897,6 +3909,7 @@ export async function handleSubscriptionUpdated(
 			if (organization.billingEmail) {
 				await sendTransactionalEmail({
 					to: organization.billingEmail,
+					organizationId: organization.id,
 					subject: "Before you go — could we get your feedback?",
 					html: generateDevPlanCancellationFeedbackEmailHtml(organization.name),
 				});
@@ -4094,6 +4107,7 @@ async function handleSubscriptionDeleted(
 
 		await sendTransactionalEmail({
 			to: organization.billingEmail,
+			organizationId: organization.id,
 			subject: "Your LLMGateway Chat Plan Has Been Cancelled",
 			html: generateSubscriptionCancelledEmailHtml(organization.name),
 		});
@@ -4153,6 +4167,7 @@ async function handleSubscriptionDeleted(
 		// Send dev plan cancelled email
 		await sendTransactionalEmail({
 			to: organization.billingEmail,
+			organizationId: organization.id,
 			subject: "Your LLMGateway Dev Plan Has Been Cancelled",
 			html: generateSubscriptionCancelledEmailHtml(organization.name),
 		});
@@ -4204,6 +4219,7 @@ async function handleSubscriptionDeleted(
 		// Send subscription cancelled email
 		await sendTransactionalEmail({
 			to: organization.billingEmail,
+			organizationId: organization.id,
 			subject: "Your LLMGateway Subscription Has Been Cancelled",
 			html: generateSubscriptionCancelledEmailHtml(organization.name),
 		});

--- a/apps/api/src/utils/email.ts
+++ b/apps/api/src/utils/email.ts
@@ -1,3 +1,4 @@
+import { isOrgOwnerEmailVerified } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
 	fromEmail,
@@ -43,6 +44,14 @@ export interface TransactionalEmailOptions {
 	 * keys so they can be filtered or audited.
 	 */
 	logSafe?: boolean;
+	/**
+	 * When set, the email is only sent if the organization's owner has a
+	 * verified account email. If the owner is unverified the send is skipped
+	 * and logged (policy: never send transactional emails to unverified
+	 * accounts). Omit only for emails that must reach unverified addresses,
+	 * such as the email-verification and password-reset emails.
+	 */
+	organizationId?: string;
 }
 
 export async function sendTransactionalEmail({
@@ -53,7 +62,18 @@ export async function sendTransactionalEmail({
 	attachments,
 	strict = false,
 	logSafe = false,
+	organizationId,
 }: TransactionalEmailOptions): Promise<void> {
+	// Policy gate: never send org-scoped transactional emails to an
+	// organization whose owner has not verified their email.
+	if (organizationId && !(await isOrgOwnerEmailVerified(organizationId))) {
+		logger.warn(
+			"Skipping transactional email: organization owner email not verified",
+			{ to, subject, organizationId },
+		);
+		return;
+	}
+
 	// In non-production environments, just log the email content
 	if (process.env.NODE_ENV !== "production") {
 		logger.info("Email content (not sent in non-production)", {

--- a/apps/api/src/utils/invoice.spec.ts
+++ b/apps/api/src/utils/invoice.spec.ts
@@ -23,6 +23,7 @@ describe("generateInvoicePDF", () => {
 		invoiceNumber: "INV-2025-001",
 		invoiceDate: new Date("2025-01-15"),
 		organizationName: "Test Organization",
+		organizationId: "org-test-id",
 		billingEmail: "billing@example.com",
 		lineItems: [
 			{ description: "API Usage - January 2025", amount: 100.5 },
@@ -201,6 +202,7 @@ describe("generateInvoicePDF", () => {
 			invoiceNumber: "INV-MIN-001",
 			invoiceDate: new Date("2025-01-01"),
 			organizationName: "Minimal Org",
+			organizationId: "org-minimal-id",
 			billingEmail: "min@example.com",
 			lineItems: [{ description: "Service", amount: 100 }],
 			currency: "USD",
@@ -342,6 +344,7 @@ describe("generateAndEmailInvoice", () => {
 		invoiceNumber: "INV-2025-001",
 		invoiceDate: new Date("2025-01-15"),
 		organizationName: "Test Organization",
+		organizationId: "org-test-id",
 		billingEmail: "billing@example.com",
 		lineItems: [
 			{ description: "API Usage - January 2025", amount: 100.5 },

--- a/apps/api/src/utils/invoice.ts
+++ b/apps/api/src/utils/invoice.ts
@@ -24,6 +24,9 @@ export interface InvoiceData {
 	invoiceNumber: string;
 	invoiceDate: Date;
 	organizationName: string;
+	// Organization the invoice belongs to. Used to gate delivery on the owner's
+	// verified email; see sendTransactionalEmail.
+	organizationId: string;
 	billingEmail: string;
 	billingCompany?: string | null;
 	billingAddress?: string | null;
@@ -211,6 +214,7 @@ export async function generateAndEmailInvoice(
 
 		await sendTransactionalEmail({
 			to: data.billingEmail,
+			organizationId: data.organizationId,
 			subject: `Invoice ${escapedInvoiceNumber} - LLMGateway`,
 			attachments: [
 				{

--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -9,6 +9,7 @@ import {
 	organization,
 	project,
 	projectHourlyStats,
+	resolveVerifiedOrgRecipient,
 	sql,
 	transaction,
 	userOrganization,
@@ -137,34 +138,6 @@ The LLM Gateway Team`,
 	}
 }
 
-// ─── Recipient Resolution ────────────────────────────────────────────────────
-
-async function getOrgRecipientEmail(
-	organizationId: string,
-): Promise<string | null> {
-	const org = await db.query.organization.findFirst({
-		where: { id: { eq: organizationId } },
-	});
-
-	if (org?.billingEmail) {
-		return org.billingEmail;
-	}
-
-	const ownerMembership = await db.query.userOrganization.findFirst({
-		where: {
-			organizationId: { eq: organizationId },
-			role: { eq: "owner" },
-		},
-		with: { user: true },
-	});
-
-	if (!ownerMembership?.user?.emailVerified) {
-		return null;
-	}
-
-	return ownerMembership.user.email ?? null;
-}
-
 // ─── Send & Record ───────────────────────────────────────────────────────────
 
 async function sendAndRecord(
@@ -265,7 +238,7 @@ export async function processNoPurchaseEmails(): Promise<void> {
 		if (isStopRequested()) {
 			break;
 		}
-		const email = await getOrgRecipientEmail(organizationId);
+		const email = await resolveVerifiedOrgRecipient(organizationId);
 		if (!email) {
 			logger.warn("No email found for org, skipping no_purchase follow-up", {
 				organizationId,
@@ -367,7 +340,7 @@ async function processLowUsageEmails(): Promise<void> {
 		}
 		const organizationId = row.organization_id;
 		try {
-			const email = await getOrgRecipientEmail(organizationId);
+			const email = await resolveVerifiedOrgRecipient(organizationId);
 			if (!email) {
 				logger.warn("No email found for org, skipping low_usage follow-up", {
 					organizationId,
@@ -444,7 +417,7 @@ async function processNoRepurchaseEmails(): Promise<void> {
 		}
 		const organizationId = row.organization_id;
 		try {
-			const email = await getOrgRecipientEmail(organizationId);
+			const email = await resolveVerifiedOrgRecipient(organizationId);
 			if (!email) {
 				logger.warn(
 					"No email found for org, skipping no_repurchase follow-up",
@@ -501,8 +474,6 @@ The LLM Gateway Team`;
 
 	await sendFollowUpEmail({ to: opts.to, subject, text });
 }
-
-export { getOrgRecipientEmail };
 
 // ─── Main orchestrator ───────────────────────────────────────────────────────
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -26,6 +26,7 @@ import {
 	type LogInsertData,
 	lt,
 	organization,
+	resolveVerifiedOrgRecipient,
 	shortid,
 	sql,
 	tables,
@@ -43,7 +44,6 @@ import {
 
 import { posthog } from "./posthog.js";
 import {
-	getOrgRecipientEmail,
 	runFollowUpEmailsLoop,
 	sendLowBalanceEmail,
 } from "./services/follow-up-emails.js";
@@ -1540,7 +1540,7 @@ async function enqueueLowBalanceEmail(
 	emailType: "low_balance_20" | "low_balance_5",
 	currentBalance: number,
 ): Promise<void> {
-	const email = await getOrgRecipientEmail(organizationId);
+	const email = await resolveVerifiedOrgRecipient(organizationId);
 	if (!email) {
 		return;
 	}

--- a/packages/db/src/email-recipients.ts
+++ b/packages/db/src/email-recipients.ts
@@ -1,45 +1,66 @@
 import { db } from "./db.js";
 
 // Policy: org-scoped transactional and lifecycle emails must only be sent when
-// the organization's owner has verified their account email. `billingEmail` is
-// a free-form, user-editable field, so it cannot be trusted on its own — the
-// owner's verified email is the signal that the account is real.
+// the organization has at least one owner whose account email is verified.
+// `billingEmail` is a free-form, user-editable field, so it cannot be trusted
+// on its own — a verified owner is the signal that the account is real.
+//
+// An organization can have multiple `owner` memberships, so these helpers must
+// not depend on which row the database happens to return first. Verification is
+// an existence check across all owners (an org is legitimate if any owner has
+// verified — a freshly invited, not-yet-verified co-owner must not block
+// delivery), and the owner-email fallback is picked by a stable order rather
+// than arbitrary database ordering.
+
+interface OwnerMembership {
+	id: string;
+	createdAt: Date;
+	user: { email: string; emailVerified: boolean } | null;
+}
+
+async function getOwnerMembershipsStable(
+	organizationId: string,
+): Promise<OwnerMembership[]> {
+	const owners = await db.query.userOrganization.findMany({
+		where: {
+			organizationId: { eq: organizationId },
+			role: { eq: "owner" },
+		},
+		with: { user: true },
+	});
+
+	// Deterministic order independent of DB row order: oldest membership first,
+	// breaking createdAt ties by the stable membership id.
+	return [...owners].sort(
+		(a, b) =>
+			a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id),
+	);
+}
 
 /**
- * Returns true only if the organization's owner has a verified account email.
- * Use to gate org-scoped emails sent to `organization.billingEmail`.
+ * Returns true if the organization has at least one owner with a verified
+ * account email. Use to gate org-scoped emails sent to
+ * `organization.billingEmail`. Order-independent existence check.
  */
 export async function isOrgOwnerEmailVerified(
 	organizationId: string,
 ): Promise<boolean> {
-	const ownerMembership = await db.query.userOrganization.findFirst({
-		where: {
-			organizationId: { eq: organizationId },
-			role: { eq: "owner" },
-		},
-		with: { user: true },
-	});
-
-	return ownerMembership?.user?.emailVerified ?? false;
+	const owners = await getOwnerMembershipsStable(organizationId);
+	return owners.some((m) => m.user?.emailVerified === true);
 }
 
 /**
- * Resolves the recipient address for an org-scoped email, or `null` when the
- * organization's owner has not verified their email. Prefers the org's
- * `billingEmail`, falling back to the owner's account email.
+ * Resolves the recipient address for an org-scoped email, or `null` when no
+ * owner of the organization has a verified email. Prefers the org's
+ * `billingEmail`, falling back to the earliest verified owner's account email.
  */
 export async function resolveVerifiedOrgRecipient(
 	organizationId: string,
 ): Promise<string | null> {
-	const ownerMembership = await db.query.userOrganization.findFirst({
-		where: {
-			organizationId: { eq: organizationId },
-			role: { eq: "owner" },
-		},
-		with: { user: true },
-	});
+	const owners = await getOwnerMembershipsStable(organizationId);
+	const verifiedOwner = owners.find((m) => m.user?.emailVerified === true);
 
-	if (!ownerMembership?.user?.emailVerified) {
+	if (!verifiedOwner) {
 		return null;
 	}
 
@@ -47,5 +68,5 @@ export async function resolveVerifiedOrgRecipient(
 		where: { id: { eq: organizationId } },
 	});
 
-	return org?.billingEmail ?? ownerMembership.user.email ?? null;
+	return org?.billingEmail ?? verifiedOwner.user?.email ?? null;
 }

--- a/packages/db/src/email-recipients.ts
+++ b/packages/db/src/email-recipients.ts
@@ -1,0 +1,51 @@
+import { db } from "./db.js";
+
+// Policy: org-scoped transactional and lifecycle emails must only be sent when
+// the organization's owner has verified their account email. `billingEmail` is
+// a free-form, user-editable field, so it cannot be trusted on its own — the
+// owner's verified email is the signal that the account is real.
+
+/**
+ * Returns true only if the organization's owner has a verified account email.
+ * Use to gate org-scoped emails sent to `organization.billingEmail`.
+ */
+export async function isOrgOwnerEmailVerified(
+	organizationId: string,
+): Promise<boolean> {
+	const ownerMembership = await db.query.userOrganization.findFirst({
+		where: {
+			organizationId: { eq: organizationId },
+			role: { eq: "owner" },
+		},
+		with: { user: true },
+	});
+
+	return ownerMembership?.user?.emailVerified ?? false;
+}
+
+/**
+ * Resolves the recipient address for an org-scoped email, or `null` when the
+ * organization's owner has not verified their email. Prefers the org's
+ * `billingEmail`, falling back to the owner's account email.
+ */
+export async function resolveVerifiedOrgRecipient(
+	organizationId: string,
+): Promise<string | null> {
+	const ownerMembership = await db.query.userOrganization.findFirst({
+		where: {
+			organizationId: { eq: organizationId },
+			role: { eq: "owner" },
+		},
+		with: { user: true },
+	});
+
+	if (!ownerMembership?.user?.emailVerified) {
+		return null;
+	}
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: organizationId } },
+	});
+
+	return org?.billingEmail ?? ownerMembership.user.email ?? null;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,6 +5,7 @@ export * from "./cdb.js";
 export * from "./api-key-period-limit.js";
 export * from "./cache-helpers.js";
 export * from "./discount-helpers.js";
+export * from "./email-recipients.js";
 export * from "./rate-limit-helpers.js";
 export * from "./schema.js";
 export * from "./log-payloads.js";


### PR DESCRIPTION
## Problem

We must never send transactional emails to unverified users/emails — but today we do.

Transactional and lifecycle emails are sent to `organization.billingEmail` with **no email-verification check**:

- `billingEmail` is auto-seeded from the user's email at org creation (`personal-org.ts`, `default-org.ts`) and is freely user-editable in settings, so the worker's owner-`emailVerified` fallback in `getOrgRecipientEmail` was **never reached** — the early `return org.billingEmail` always fired.
- The Stripe webhook senders (payment failure, invoices, DevPass duplicate-card, plan/subscription cancellations) had **no gate at all** and sent straight to `billingEmail`.

Net effect: a user who signs up and never verifies still receives nudge, invoice, payment-failure and cancellation emails.

The verification email itself and the password-reset email legitimately go to unverified addresses and must keep doing so.

## Fix (Option A — gate on the org owner's verified email)

Org-scoped emails are sent only when the **organization owner's account email is verified**. `billingEmail` stays the recipient, so a legitimately-verified account can still route invoices to a separate billing contact — we just no longer email orgs whose owner never proved they own the account.

- New `@llmgateway/db` helpers: `isOrgOwnerEmailVerified(orgId)` and `resolveVerifiedOrgRecipient(orgId)` (returns `null` when the owner is unverified).
- `sendTransactionalEmail` gains an optional `organizationId`; when set, the send is skipped + logged if the owner is unverified. The verification and password-reset emails omit it and are unaffected.
- `generateAndEmailInvoice` requires `organizationId` on `InvoiceData` (compile-enforced coverage across all invoice call sites) and passes it through.
- All 6 direct Stripe webhook `sendTransactionalEmail` senders now pass `organizationId`.
- Worker follow-up nudges and low-balance alerts resolve recipients via `resolveVerifiedOrgRecipient`, replacing the old `getOrgRecipientEmail` whose `billingEmail` short-circuit bypassed the check.

Staff/internal emails (chat-support, enterprise contact → `replyToEmail`) and admin manual sends are intentionally not gated.

Self-hosted is unaffected: it auto-sets `emailVerified: true`, and verification is only enabled when `HOSTED === "true"`.

## Testing

- `pnpm turbo run build --filter=api --filter=worker` (and deps) — green.
- `pnpm vitest run apps/api/src/utils/invoice.spec.ts apps/api/src/stripe.spec.ts` — 41 passed.
- `pnpm format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transactional emails and invoices now use organization context to better control delivery.
  * Email delivery is skipped when the organization owner’s email is unverified, reducing misdirected messages.
  * Follow-up and low-balance emails now resolve to a verified organization recipient more reliably.
* **New Features**
  * Invoices now include organization details as part of emailed billing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->