### PR TITLE
feat(models): deactivate free zai models, add haiku-free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - Apply DRY principles for code reuse
 - Do not add explicit caching or memoization around `process.env` reads or parsed env-var values unless there is a measured hot-path need
 - Exception: in `packages/models`, explicit duplication of model/provider mappings is acceptable and preferred over helper-based expansion. This is the only place in the repo where duplicating model definitions is OK. NEVER add helper functions (e.g. `makeModel(...)`/`makeProvider(...)`) that build model or provider definition objects, even when it means repeating fields across entries — write each model and provider mapping out in full as a plain object literal in the `models` array. Small shared `const` values are fine, but the definition objects themselves must not be constructed by a function.
+- Models and provider mappings in `packages/models` can NEVER be removed, only deactivated. To retire a model or provider mapping, set `deactivatedAt: new Date("YYYY-MM-DD")` (today's date) on the relevant provider mapping(s) instead of deleting the definition. Historical usage records and analytics reference these definitions, so deleting them breaks lookups.
 - No unnecessary code comments
 - Do not use broad try/catch in API handlers unless to check for specific errors; instead, let errors propagate and be handled by the global error handler
 

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -604,6 +604,36 @@ export const anthropicModels = [
 		],
 	},
 	{
+		id: "claude-haiku-4-5-free",
+		name: "Claude Haiku 4.5 (Free)",
+		description:
+			"Free, fast, efficient model for high-volume, low-latency applications.",
+		family: "anthropic",
+		free: true,
+		stability: "unstable",
+		releasedAt: new Date("2025-10-15"),
+		providers: [
+			{
+				providerId: "anthropic",
+				externalId: "claude-haiku-4-5",
+				inputPrice: "0",
+				outputPrice: "0",
+				cachedInputPrice: "0",
+				cacheWriteInputPrice: "0",
+				cacheWriteInputPrice1h: "0",
+				minCacheableTokens: 4096,
+				requestPrice: "0",
+				contextSize: 200000,
+				maxOutput: 64000,
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+				jsonOutputSchema: true,
+			},
+		],
+	},
+	{
 		id: "claude-haiku-4-5-20251001",
 		name: "Claude Haiku 4.5 (2025-10-01)",
 		description:

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -536,6 +536,7 @@ export const zaiModels = [
 			{
 				providerId: "zai",
 				externalId: "glm-4.5-flash",
+				deactivatedAt: new Date("2026-06-28"),
 				inputPrice: "0",
 				cachedInputPrice: "0",
 				outputPrice: "0",
@@ -755,6 +756,7 @@ export const zaiModels = [
 			{
 				providerId: "zai",
 				externalId: "glm-4.7-flash",
+				deactivatedAt: new Date("2026-06-28"),
 				inputPrice: "0",
 				cachedInputPrice: "0",
 				outputPrice: "0",
@@ -1003,6 +1005,7 @@ export const zaiModels = [
 			{
 				providerId: "zai",
 				externalId: "glm-4.6v-flash",
+				deactivatedAt: new Date("2026-06-28"),
 				inputPrice: "0",
 				cachedInputPrice: "0",
 				outputPrice: "0",


### PR DESCRIPTION
## Summary

- Deactivate (not remove) the three free zai models — `glm-4.5-flash`, `glm-4.7-flash-free`, `glm-4.6v-flash` — by setting `deactivatedAt` on their provider mappings. Definitions are kept so historical usage/analytics lookups still resolve.
- Add a new free model `claude-haiku-4-5-free` (served via `anthropic`, `free: true`, all prices zero) as the active free model. Capabilities mirror the paid `claude-haiku-4-5` (incl. `vision: true`).
- Document in `AGENTS.md` that models/provider mappings can never be removed, only deactivated.

## Notes

- The `free: true` invariant (every free model carries only zero-priced provider mappings) holds — `free-models.spec.ts` passes.
- Free-model consumers (UI filters, sandbox/test wallets) read the `free` flag dynamically, so `claude-haiku-4-5-free` takes over as the active free model while the deactivated zai models stop being routable.

## Verification

- `free-models`, `compliance`, `model-metadata` specs pass.
- Full `pnpm build` succeeds (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new free Anthropic model option with the same core capabilities as existing offerings, including streaming, vision, tools, and JSON output support.

- **Chores**
  - Updated model-management guidance to retire provider mappings instead of removing them.
  - Marked several provider mappings as deactivated, so they no longer appear as active options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->