### PR TITLE
refactor(gateway): resolve models by catalog id only

### DIFF
--- a/apps/gateway/src/chat/tools/parse-model-input.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-model-input.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { parseModelInput } from "./parse-model-input.js";
+import { resolveModelInfo } from "./resolve-model-info.js";
+
+describe("parseModelInput / resolveModelInfo catalog-id-only routing", () => {
+	// Routing must carry the canonical catalog id, never the upstream externalId.
+	// Two catalog entries can share an externalId (e.g. a free and a paid
+	// sibling), so collapsing to the externalId would let resolution pick the
+	// wrong entry. The upstream externalId is derived later from the selected
+	// provider mapping.
+	it("preserves the catalog id for the provider-prefixed form", () => {
+		const result = parseModelInput("anthropic/claude-haiku-4-5");
+		expect(result.requestedModel).toBe("claude-haiku-4-5");
+		expect(result.requestedProvider).toBe("anthropic");
+	});
+
+	it("resolves the requested catalog entry strictly by id", () => {
+		const { requestedModel, requestedProvider } = parseModelInput(
+			"anthropic/claude-haiku-4-5",
+		);
+		const { modelInfo } = resolveModelInfo(requestedModel, requestedProvider);
+		expect(modelInfo.id).toBe("claude-haiku-4-5");
+	});
+
+	it("still resolves a non-colliding model unchanged", () => {
+		const { requestedModel, requestedProvider } =
+			parseModelInput("openai/gpt-4o-mini");
+		expect(requestedModel).toBe("gpt-4o-mini");
+		const { modelInfo } = resolveModelInfo(requestedModel, requestedProvider);
+		expect(modelInfo.id).toBe("gpt-4o-mini");
+	});
+
+	// Strict catalog-id-only routing: the provider/externalId form (upstream id)
+	// is no longer accepted — callers must use the catalog id.
+	it("rejects the provider/externalId form", () => {
+		expect(() => parseModelInput("together-ai/zai-org/GLM-5.1")).toThrow();
+	});
+
+	it("accepts the canonical provider/catalog-id form", () => {
+		const result = parseModelInput("together-ai/glm-5.1");
+		expect(result.requestedModel).toBe("glm-5.1");
+		expect(result.requestedProvider).toBe("together-ai");
+	});
+});

--- a/apps/gateway/src/chat/tools/parse-model-input.ts
+++ b/apps/gateway/src/chat/tools/parse-model-input.ts
@@ -72,15 +72,8 @@ export function parseModelInput(modelInput: string): ParseModelInputResult {
 					m.providers.some((p) => p.providerId === requestedProvider),
 			);
 
-			// Fall back to matching by model name only
+			// Fall back to matching by catalog id only
 			modelDef ??= models.find((m) => m.id === modelName);
-
-			modelDef ??= models.find((m) =>
-				m.providers.some(
-					(p) =>
-						p.externalId === modelName && p.providerId === requestedProvider,
-				),
-			);
 
 			if (!modelDef) {
 				throw new HTTPException(400, {
@@ -94,24 +87,15 @@ export function parseModelInput(modelInput: string): ParseModelInputResult {
 				});
 			}
 
-			const providerMapping = modelDef.providers.find(
-				(p) => p.providerId === requestedProvider,
-			);
-			requestedModel = (providerMapping?.externalId ?? modelName) as Model;
+			// Use the canonical catalog id, never the upstream externalId: two
+			// catalog entries (e.g. a free and a paid sibling) can share the same
+			// externalId, so collapsing to externalId here would let downstream
+			// resolution pick the wrong entry. The upstream externalId is derived
+			// separately from the selected provider mapping at request time.
+			requestedModel = modelDef.id as Model;
 		}
 	} else if (models.find((m) => m.id === modelInput)) {
 		requestedModel = modelInput as Model;
-	} else if (
-		models.find((m) => m.providers.find((p) => p.externalId === modelInput))
-	) {
-		const model = models.find((m) =>
-			m.providers.find((p) => p.externalId === modelInput),
-		);
-		const provider = model?.providers.find((p) => p.externalId === modelInput);
-
-		throw new HTTPException(400, {
-			message: `Model ${modelInput} must be requested with a provider prefix. Use the format: ${provider?.providerId}/${model?.id}`,
-		});
 	} else {
 		throw new HTTPException(400, {
 			message: `Requested model ${modelInput} not supported`,

--- a/apps/gateway/src/chat/tools/resolve-model-info.ts
+++ b/apps/gateway/src/chat/tools/resolve-model-info.ts
@@ -63,7 +63,9 @@ export function resolveModelInfo(
 				? requestedModel.slice(0, lastColonIdx)
 				: requestedModel;
 
-		// First try to find by model ID
+		// Resolve strictly by catalog id. externalId is the upstream provider's
+		// model name and must never be used to identify a catalog entry — two
+		// entries (e.g. a free and a paid sibling) can share the same externalId.
 		// When a specific provider is requested, prefer the definition that includes that provider
 		let foundModel = requestedProvider
 			? models.find(
@@ -73,29 +75,6 @@ export function resolveModelInfo(
 				)
 			: undefined;
 		foundModel ??= models.find((m) => m.id === baseRequestedModel);
-
-		// If not found, search by provider external id
-		// If a specific provider is requested, match both externalId and providerId
-		if (!foundModel) {
-			if (requestedProvider) {
-				foundModel = models.find((m) =>
-					m.providers.find(
-						(p) =>
-							(p.externalId === requestedModel ||
-								p.externalId === baseRequestedModel) &&
-							p.providerId === requestedProvider,
-					),
-				);
-			} else {
-				foundModel = models.find((m) =>
-					m.providers.find(
-						(p) =>
-							p.externalId === requestedModel ||
-							p.externalId === baseRequestedModel,
-					),
-				);
-			}
-		}
 
 		if (!foundModel) {
 			throw new HTTPException(400, {

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -228,7 +228,7 @@ function findEmbeddingMapping(modelId: string): {
 			if (requestedProvider && candidate.providerId !== requestedProvider) {
 				continue;
 			}
-			if (model.id === modelKey || candidate.externalId === modelKey) {
+			if (model.id === modelKey) {
 				return {
 					mapping: candidate,
 					modelDef: model,

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -566,12 +566,7 @@ function assertImageModel(model: string): void {
 	if (modelKey === "auto" || modelKey === "custom") {
 		return;
 	}
-	const modelInfo = models.find(
-		(m) =>
-			m.id === model ||
-			m.id === modelKey ||
-			m.providers.some((p) => p.externalId === modelKey),
-	);
+	const modelInfo = models.find((m) => m.id === model || m.id === modelKey);
 	if (modelInfo) {
 		validateModelOutput(modelInfo, modelKey, ["image"]);
 	}

--- a/apps/gateway/src/ocr/ocr.ts
+++ b/apps/gateway/src/ocr/ocr.ts
@@ -206,7 +206,7 @@ function findOcrMapping(modelId: string): {
 			if (requestedProvider && candidate.providerId !== requestedProvider) {
 				continue;
 			}
-			if (model.id === modelKey || candidate.externalId === modelKey) {
+			if (model.id === modelKey) {
 				return {
 					mapping: candidate,
 					modelDef: model,

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -266,7 +266,7 @@ function findSpeechMapping(modelId: string): {
 			if (requestedProvider && candidate.providerId !== requestedProvider) {
 				continue;
 			}
-			if (model.id === modelKey || candidate.externalId === modelKey) {
+			if (model.id === modelKey) {
 				return {
 					mapping: candidate,
 					modelDef: model,

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -25,7 +25,7 @@ import type { providers } from "./providers.js";
 
 export type Provider = (typeof providers)[number]["id"];
 
-export type Model = (typeof models)[number]["providers"][number]["externalId"];
+export type Model = (typeof models)[number]["id"];
 
 /**
  * Decimal-safe price representation. Always a string so values are preserved


### PR DESCRIPTION
## Summary

`externalId` is the upstream provider's model name and must **never** identify a catalog entry — two entries (e.g. a free and a paid sibling) can share the same `externalId`. This removes all `externalId`-based model resolution:

- `parse-model-input.ts` — drop the `provider/externalId` fallback and the bare-externalId "use a provider prefix" branch. Resolution is catalog-id only.
- `resolve-model-info.ts` — drop the (now-dead) `externalId` fallback; resolve strictly by `m.id`.
- `embeddings.ts`, `speech.ts`, `ocr.ts`, `images.ts` — replace `id || externalId` matching with `id` only.
- `models.ts` — narrow the `Model` type to the catalog-id union (it previously also included `externalId`s, which no longer occur in routing).

The upstream `externalId` is still derived from the **selected** provider mapping at request time (`usedExternalId`), so upstream API calls are unchanged.

## Behavior change

Requests must now use the catalog-id form (`together-ai/glm-5.1`). The upstream-id form (`together-ai/zai-org/GLM-5.1`) now returns 400 "not supported". No test or the e2e harness relied on the externalId form (e2e always builds `${providerId}/${model.id}`).

## Why this matters

Fixes a class of bug where a model requested by its catalog id was silently resolved to a different catalog entry that happened to share the same upstream `externalId` (e.g. a free model collapsing onto its paid sibling). The regression tests assert the catalog id is preserved end-to-end, the `provider/externalId` form is rejected, and resolution is strictly id-based.

## Verification

- `parse-model-input` spec: 5/5.
- Full `pnpm build` succeeds (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model selection now relies on the canonical model identifier, improving consistency across chat, embeddings, OCR, speech, and image workflows.
  * Canonical `provider/model` identifiers are accepted, while older provider-specific alias forms are no longer recognized in these paths.
  * Requests that previously resolved to the wrong model via aliases now return the expected result or a clearer “not found” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->