### PR TITLE
fix(gateway): log upstream 502/503/504 as warn not error

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -177,7 +177,16 @@ app.onError((error, c) => {
 	if (error instanceof HTTPException) {
 		const status = error.status;
 
-		if (status >= 500) {
+		// 502/503/504 are upstream/gateway conditions (e.g. a provider
+		// terminating the connection), not application bugs. They are already
+		// recorded as request logs via insertLog by the chat handler, so log
+		// them at warn level instead of error to avoid alerting noise.
+		if (status === 502 || status === 503 || status === 504) {
+			logger.warn("Upstream gateway error", {
+				status,
+				message: error.message,
+			});
+		} else if (status >= 500) {
 			logger.error("HTTP 500 exception", error);
 		} else {
 			logger.warn("HTTP client error", { status, message: error.message });


### PR DESCRIPTION
## Problem

GCP surfaced repeated `ERROR` alerts like:

```
Failed to read response from provider: terminated
  at forwardToChatCompletions (/app/src/images/images.ts:604:9)
  at async processImageEdit (/app/src/images/images.ts:1129:23)
```

This happens when an upstream provider terminates the connection mid-request during an image edit/generation.

## Root cause

1. Image edit/generation forwards to `/v1/chat/completions` via an in-process `app.request` (`images.ts:584`).
2. When the upstream connection is `terminated`, the chat handler **already records the failure** via `insertLog` (`chat.ts:11103`, `hasError: true`) and returns a `502`.
3. `forwardToChatCompletions` re-throws the `502` as an `HTTPException` (`images.ts:604`).
4. The global `onError` handler logged **any** `status >= 500` via `logger.error` (`app.ts:181`) → spurious `ERROR` alert.

The request is therefore already captured as a request-level logged error (`insertLog`), attributed to the real image model/provider — the only defect is the extra `logger.error`.

## Fix

Treat `502` / `503` / `504` as upstream/gateway conditions and log them at `warn` level instead of `error`, consistent with the existing `TimeoutError` (`504`) handling. Genuine internal errors (`500`, other `5xx`) still log at `error`.

No change to client-facing responses; the failure remains recorded via `insertLog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted error logging for gateway-related responses so `502`, `503`, and `504` are logged as warnings instead of errors.
  * Kept other server-side errors logged as errors, while non-server HTTP errors continue to log as warnings.
  * Error responses to users remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->