### PR TITLE
feat(code): edit billing details before purchase

### DIFF
--- a/apps/code/src/app/dashboard/components/BillingDetailsDialog.tsx
+++ b/apps/code/src/app/dashboard/components/BillingDetailsDialog.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+
+import DevPassBillingDetails from "./DevPassBillingDetails";
+
+export default function BillingDetailsDialog({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>{children}</DialogTrigger>
+			<DialogContent className="max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>Billing details</DialogTitle>
+					<DialogDescription>
+						Add the company and address details you want on your DevPass
+						invoices. You can change these any time.
+					</DialogDescription>
+				</DialogHeader>
+				<DevPassBillingDetails embedded onSaved={() => setOpen(false)} />
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/code/src/app/dashboard/components/DevPassBillingDetails.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassBillingDetails.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -18,18 +19,43 @@ type BillingDetails =
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export default function DevPassBillingDetails() {
+interface DevPassBillingDetailsProps {
+	// When rendered inside the billing-details dialog the surrounding chrome
+	// (heading + card border) is provided by the dialog, so it is omitted here.
+	embedded?: boolean;
+	// Called after a successful save (used to close the dialog).
+	onSaved?: () => void;
+}
+
+export default function DevPassBillingDetails({
+	embedded,
+	onSaved,
+}: DevPassBillingDetailsProps = {}) {
 	const api = useApi();
 	const { data } = api.useQuery("get", "/dev-plans/billing-details", {});
 
 	if (!data) {
-		return null;
+		return embedded ? (
+			<div className="flex justify-center py-8">
+				<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+			</div>
+		) : null;
 	}
 
-	return <BillingDetailsForm data={data} />;
+	return (
+		<BillingDetailsForm data={data} embedded={embedded} onSaved={onSaved} />
+	);
 }
 
-function BillingDetailsForm({ data }: { data: BillingDetails }) {
+function BillingDetailsForm({
+	data,
+	embedded,
+	onSaved,
+}: {
+	data: BillingDetails;
+	embedded?: boolean;
+	onSaved?: () => void;
+}) {
 	const api = useApi();
 	const queryClient = useQueryClient();
 
@@ -105,6 +131,7 @@ function BillingDetailsForm({ data }: { data: BillingDetails }) {
 			await updateMutation.mutateAsync({ body });
 			await invalidate();
 			toast.success("Billing details saved");
+			onSaved?.();
 		} catch {
 			toast.error("Failed to save billing details");
 		}
@@ -112,12 +139,18 @@ function BillingDetailsForm({ data }: { data: BillingDetails }) {
 
 	return (
 		<div>
-			<h2 className="mb-1 font-semibold">Billing details</h2>
-			<p className="mb-4 text-sm text-muted-foreground">
-				These details appear on your DevPass invoices.
-			</p>
+			{!embedded && (
+				<>
+					<h2 className="mb-1 font-semibold">Billing details</h2>
+					<p className="mb-4 text-sm text-muted-foreground">
+						These details appear on your DevPass invoices.
+					</p>
+				</>
+			)}
 
-			<div className="rounded-xl border p-5 space-y-5">
+			<div
+				className={embedded ? "space-y-5" : "rounded-xl border p-5 space-y-5"}
+			>
 				<div className="flex items-center justify-between gap-4">
 					<div className="space-y-0.5">
 						<Label

--- a/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
+++ b/apps/code/src/app/dashboard/components/InactivePlanChooser.tsx
@@ -4,6 +4,8 @@ import { ArrowRight, Check, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
+import BillingDetailsDialog from "./BillingDetailsDialog";
+
 import type { PlanOption, PlanTier } from "@/app/dashboard/types";
 
 interface InactivePlanChooserProps {
@@ -92,7 +94,15 @@ export default function InactivePlanChooser({
 function InvoiceInfoLabel() {
 	return (
 		<p className="mx-auto mt-4 max-w-2xl text-center text-[11px] leading-relaxed text-muted-foreground">
-			Need company/address details on your invoice? Update billing settings
+			Need company/address details on your invoice?{" "}
+			<BillingDetailsDialog>
+				<button
+					type="button"
+					className="font-medium underline underline-offset-2 hover:text-foreground"
+				>
+					Update billing settings
+				</button>
+			</BillingDetailsDialog>{" "}
 			before purchase. We email the invoice automatically after payment.
 		</p>
 	);

--- a/apps/code/src/components/ui/dialog.tsx
+++ b/apps/code/src/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Dialog({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn(
+				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	children,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+	showCloseButton?: boolean;
+}) {
+	return (
+		<DialogPortal data-slot="dialog-portal">
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				{showCloseButton && (
+					<DialogPrimitive.Close
+						data-slot="dialog-close"
+						className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+					>
+						<XIcon />
+						<span className="sr-only">Close</span>
+					</DialogPrimitive.Close>
+				)}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-header"
+			className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn(
+				"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn("text-lg leading-none font-semibold", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn("text-muted-foreground text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
+};


### PR DESCRIPTION
## Summary

In the DevPass plan chooser, the invoice note said *"Need company/address details on your invoice? Update billing settings before purchase."* — but the billing page (where those details live) is gated behind an active plan, so there was no way to actually do it before the initial purchase.

This makes **"Update billing settings"** a working link that opens a dialog containing **only** the billing-details form. The user can fill in company name, address, tax ID, and invoice notes before subscribing, while the rest of the billing page (payment method, invoices, change tier, cancel) stays out of reach until a plan is active — i.e. restricted just to that.

## Changes

- Add a shadcn `Dialog` UI component to `apps/code` (`@radix-ui/react-dialog` was already a dependency).
- `DevPassBillingDetails`: add an `embedded` mode (drops its own heading/card chrome so the dialog provides them) and an `onSaved` callback (closes the dialog after a successful save). Existing billing-page usage is unchanged.
- New `BillingDetailsDialog` wrapper that renders the embedded form in a modal.
- `InactivePlanChooser`: "Update billing settings" is now a dialog trigger instead of plain text.

The `GET/PATCH /dev-plans/billing-details` endpoints only require an authenticated user with a personal org (created at signup), so they work fine pre-purchase.

## Testing

- `pnpm format`
- `pnpm turbo run build --filter=code` ✅
- `pnpm turbo run lint --filter=code` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a billing details dialog that opens from the invoice billing prompt.
  * Billing details can now be edited in a modal-style view without leaving the current page.

* **Bug Fixes**
  * Improved the billing details form so it displays correctly when used inside a dialog.
  * The dialog now closes automatically after billing details are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->