### PR TITLE
feat(streaming): add SSE keepalive and error handling

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -785,6 +785,21 @@ anthropic.openapi(messages, async (c) => {
 				const reader = response.body.getReader();
 				const decoder = new TextDecoder();
 
+				// SSE keepalive to prevent proxy/load balancer and client idle
+				// timeouts from closing the connection during quiet gaps (slow
+				// time-to-first-token, long reasoning before output, slow tool-arg
+				// generation). Without this, coding clients see "The socket
+				// connection was closed unexpectedly". The inner
+				// /v1/chat/completions keepalive is consumed by this translator and
+				// never reaches the client, so we emit our own here. A `: ping`
+				// comment is part of the SSE spec and ignored by the Anthropic SDK.
+				const KEEPALIVE_INTERVAL_MS = 15000;
+				const keepaliveInterval = setInterval(() => {
+					stream.write(": ping\n").catch(() => {
+						// Stream likely closed; cleanup happens in finally.
+					});
+				}, KEEPALIVE_INTERVAL_MS);
+
 				let buffer = "";
 				let messageId = "";
 				let model = "";
@@ -1183,10 +1198,49 @@ anthropic.openapi(messages, async (c) => {
 						});
 					}
 				} catch (error) {
-					throw new HTTPException(500, {
-						message: `Streaming error: ${error instanceof Error ? error.message : String(error)}`,
-					});
+					// The 200 response and SSE headers are already sent, so throwing
+					// here cannot produce an HTTP error — it would abruptly tear down
+					// the socket and the client would see "The socket connection was
+					// closed unexpectedly". Instead, emit a well-formed Anthropic
+					// terminal sequence (error event + message_stop) so the client
+					// ends the stream cleanly. A client-side abort needs no write.
+					if (error instanceof Error && error.name === "AbortError") {
+						logger.info("Anthropic streaming request aborted by client", {
+							message: error.message,
+							path: c.req.path,
+						});
+					} else {
+						logger.error(
+							"Anthropic streaming error (mid-stream)",
+							toError(error),
+							{ path: c.req.path },
+						);
+						try {
+							await stream.writeSSE({
+								data: JSON.stringify(
+									buildAnthropicErrorEvent({
+										type: "error",
+										error: {
+											type: "api_error",
+											message: `Streaming error: ${error instanceof Error ? error.message : String(error)}`,
+										},
+									}),
+								),
+								event: "error",
+							});
+							await stream.writeSSE({
+								data: JSON.stringify({ type: "message_stop" }),
+								event: "message_stop",
+							});
+						} catch (sseError) {
+							logger.error(
+								"Failed to send Anthropic streaming error event",
+								toError(sseError),
+							);
+						}
+					}
 				} finally {
+					clearInterval(keepaliveInterval);
 					reader.releaseLock();
 				}
 			},

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -409,6 +409,21 @@ responses.post("/", async (c) => {
 			const decoder = new TextDecoder();
 			let buffer = "";
 
+			// SSE keepalive to prevent proxy/load balancer and client idle
+			// timeouts from closing the connection during quiet gaps (slow
+			// time-to-first-token, long reasoning before output, slow tool-arg
+			// generation). Without this, coding clients see "The socket
+			// connection was closed unexpectedly". The inner /v1/chat/completions
+			// keepalive is consumed by this translator and never reaches the
+			// client, so we emit our own here. A `: ping` comment is part of the
+			// SSE spec and ignored by the OpenAI SDK.
+			const KEEPALIVE_INTERVAL_MS = 15000;
+			const keepaliveInterval = setInterval(() => {
+				stream.write(": ping\n").catch(() => {
+					// Stream likely closed; cleanup happens in finally.
+				});
+			}, KEEPALIVE_INTERVAL_MS);
+
 			// Send response.created
 			const createdEvent = createResponseCreatedEvent(state);
 			await stream.writeSSE({
@@ -501,15 +516,33 @@ responses.post("/", async (c) => {
 					await processLine(buffer);
 				}
 			} catch (error) {
-				logger.error("Error processing streaming response", {
-					error,
-				});
-				const failedEvent = createFailedEvent(state);
-				await stream.writeSSE({
-					event: failedEvent.event,
-					data: failedEvent.data,
-				});
+				// A client-side abort needs no terminal event — the socket is
+				// already gone, and writing would throw. For genuine errors, emit a
+				// well-formed response.failed event so the client ends the stream
+				// cleanly instead of seeing the socket close unexpectedly.
+				if (error instanceof Error && error.name === "AbortError") {
+					logger.info("Responses streaming request aborted by client", {
+						message: error.message,
+						path: c.req.path,
+					});
+				} else {
+					logger.error("Error processing streaming response", {
+						error,
+					});
+					try {
+						const failedEvent = createFailedEvent(state);
+						await stream.writeSSE({
+							event: failedEvent.event,
+							data: failedEvent.data,
+						});
+					} catch (sseError) {
+						logger.error("Failed to send response.failed event", {
+							error: sseError,
+						});
+					}
+				}
 			} finally {
+				clearInterval(keepaliveInterval);
 				reader.releaseLock();
 			}
 		});


### PR DESCRIPTION
## Summary

Improves reliability of Anthropic streaming responses by adding SSE keepalive pings to prevent proxy/load balancer timeouts during quiet gaps, and implements proper error handling for mid-stream failures that gracefully terminates the SSE stream instead of abruptly closing the connection.

## Key Changes

- **SSE Keepalive**: Added 15-second keepalive interval that emits SSE ping comments (`: ping\n`) to keep the connection alive during slow time-to-first-token, long reasoning phases, or slow tool argument generation. These pings are consumed by the translator and never reach the client.

- **Improved Streaming Error Handling**: Replaced immediate HTTP exception throwing (which cannot work after headers are sent) with proper SSE error event emission:
  - Detects client-side aborts (AbortError) and logs them as info-level events
  - For other errors, emits a well-formed Anthropic error event followed by a message_stop event, allowing clients to end the stream cleanly
  - Includes fallback error handling if SSE event writing itself fails

- **Cleanup**: Added `clearInterval(keepaliveInterval)` in the finally block to ensure the keepalive timer is properly cleaned up when the stream ends.

## Implementation Details

The keepalive mechanism uses SSE spec-compliant comment syntax (`: ping\n`) which is ignored by the Anthropic SDK but serves to keep the connection active. This prevents "The socket connection was closed unexpectedly" errors that clients would otherwise see when the connection is terminated by proxies or load balancers during quiet periods.

The error handling distinguishes between client-initiated aborts (which are expected and logged at info level) and actual streaming errors (which are logged at error level and communicated to the client via SSE events).

https://claude.ai/code/session_018uuGUkp6NaPEVSRw553RYJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added periodic SSE `: ping` keepalive messages during streaming responses to reduce idle timeout/disconnect issues.
  * Improved mid-stream error handling to send clean, terminal SSE sequences when failures occur.
  * Better handles client disconnects/aborts by avoiding unnecessary failure events and suppressing secondary send errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->