### PR TITLE
fix(gateway): drop partial usage in streaming chunks

### DIFF
--- a/apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts
@@ -235,6 +235,42 @@ describe("transformOpenaiStreaming", () => {
 		expect(result.usage).toBeNull();
 	});
 
+	test("drops partial usage chunk missing core token counts (deepseek-v3.2-maas)", () => {
+		// SGLang-served deepseek-v3.2-maas on Vertex AI emits an intermediate
+		// chunk whose `usage` only carries prompt_tokens_details. Forwarding it
+		// verbatim produced `usage.prompt_tokens: undefined`, which failed the
+		// AI SDK's strict streaming schema. The usage object must be dropped.
+		const input = {
+			id: "DuhDavqEI4em1dkP7s3T0As",
+			object: "chat.completion.chunk",
+			created: 1782835214,
+			model: "deepseek-ai/deepseek-v3.2-maas",
+			choices: [
+				{
+					delta: {
+						content: "",
+						reasoning_content: null,
+						role: "assistant",
+						tool_calls: null,
+					},
+					finish_reason: null,
+					index: 0,
+					logprobs: null,
+					matched_stop: null,
+				},
+			],
+			usage: {
+				prompt_tokens_details: {
+					cached_tokens: 0,
+				},
+			},
+		};
+
+		const result = transformOpenaiStreaming(input, "deepseek-v3.2");
+
+		expect(result.usage).toBeNull();
+	});
+
 	test("should normalize MiniMax reasoning_details to reasoning", () => {
 		const input = {
 			id: "test-id",

--- a/apps/gateway/src/chat/tools/transform-openai-streaming.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.ts
@@ -10,10 +10,29 @@ function normalizeUsage(usage: any): any {
 		return usage;
 	}
 
+	// Some upstreams (e.g. SGLang-served deepseek-v3.2-maas on Vertex AI) emit an
+	// intermediate streaming chunk carrying a partial `usage` object that only has
+	// `prompt_tokens_details` and omits the core token counts. Forwarding it would
+	// produce `usage.prompt_tokens: undefined`, which fails strict client schemas
+	// (e.g. the AI SDK). Treat a usage object without the required token counts as
+	// "no usage" for this chunk rather than emitting an invalid one.
+	const promptTokens = usage.prompt_tokens;
+	const completionTokens = usage.completion_tokens;
+	if (
+		typeof promptTokens !== "number" ||
+		typeof completionTokens !== "number"
+	) {
+		return null;
+	}
+	const totalTokens =
+		typeof usage.total_tokens === "number"
+			? usage.total_tokens
+			: promptTokens + completionTokens;
+
 	const normalizedUsage: any = {
-		prompt_tokens: usage.prompt_tokens,
-		completion_tokens: usage.completion_tokens,
-		total_tokens: usage.total_tokens,
+		prompt_tokens: promptTokens,
+		completion_tokens: completionTokens,
+		total_tokens: totalTokens,
 	};
 
 	// Extract reasoning_tokens from completion_tokens_details if present


### PR DESCRIPTION
## Problem

Streaming through `vertex-openai/deepseek-v3.2` (`deepseek-ai/deepseek-v3.2-maas`) crashes strict OpenAI-compatible clients (e.g. the AI SDK used in the Playground) with:

```
Type validation failed: ... usage.prompt_tokens: expected number, received undefined
```

The upstream (SGLang-served) emits an **intermediate** streaming chunk whose `usage` object only carries `prompt_tokens_details` and omits the core token counts:

```json
"usage": { "prompt_tokens_details": { "cached_tokens": 0 } }
```

`normalizeUsage` in `transform-openai-streaming.ts` copied the `undefined` `prompt_tokens`/`completion_tokens`/`total_tokens` straight into a truthy `usage` object, which the gateway then forwarded to the client — failing the client's strict streaming schema.

## Fix

In `normalizeUsage`, treat a `usage` object that's missing the required token counts as "no usage" for that chunk (return `null`) instead of emitting an invalid one. The legitimate final usage chunk (which carries all token counts) is unaffected.

## Verification

- New regression unit test feeds the exact failing chunk through `transformOpenaiStreaming` and asserts `usage` is dropped to `null`.
- Existing `transform-openai-streaming` / `transform-streaming-to-openai` / `extract-token-usage` unit suites pass (65 tests).
- E2E run (`TEST_MODELS=vertex-openai/deepseek-v3.2`, streaming + non-streaming) confirms token and cost accounting in the final log are unchanged and correct:

| | prompt | completion | total | inputCost | outputCost | cost |
|---|---|---|---|---|---|---|
| streaming | 21 | 20 | 41 | 0.00001176 | 0.0000336 | 0.00004536 |
| non-streaming | 18 | 2 | 20 | 0.00001008 | 0.00000336 | 0.00001344 |

Both match the mapping pricing exactly (`input 0.56e-6`, `output 1.68e-6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streaming usage data so incomplete token counts are ignored instead of producing invalid output.
  * Ensured usage information is only returned when required token values are present, with totals calculated safely when possible.
  * Added coverage for a model-specific streaming case where partial usage data should be dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->