### PR TITLE
fix(gateway): validate API key on MCP endpoint

### DIFF
--- a/apps/gateway/src/mcp/mcp.spec.ts
+++ b/apps/gateway/src/mcp/mcp.spec.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import { clearCache } from "@/test-utils/test-helpers.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+describe("MCP endpoint authentication", () => {
+	async function seedActiveKey() {
+		await db
+			.insert(tables.user)
+			.values({ id: "user-id", name: "user", email: "user" })
+			.onConflictDoNothing();
+		await db
+			.insert(tables.organization)
+			.values({
+				id: "org-id",
+				name: "Test Organization",
+				billingEmail: "user",
+				plan: "pro",
+				retentionLevel: "retain",
+				credits: "100.00",
+			})
+			.onConflictDoNothing();
+		await db
+			.insert(tables.userOrganization)
+			.values({
+				id: "user-org-id",
+				userId: "user-id",
+				organizationId: "org-id",
+			})
+			.onConflictDoNothing();
+		await db
+			.insert(tables.project)
+			.values({
+				id: "project-id",
+				name: "Test Project",
+				organizationId: "org-id",
+				mode: "api-keys",
+			})
+			.onConflictDoNothing();
+		await db
+			.insert(tables.apiKey)
+			.values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			})
+			.onConflictDoNothing();
+	}
+
+	async function reset() {
+		await clearCache();
+		await db.delete(tables.apiKey);
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.project);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
+	}
+
+	beforeEach(reset);
+	afterEach(reset);
+
+	const listModelsCall = {
+		jsonrpc: "2.0",
+		id: 1,
+		method: "tools/call",
+		params: { name: "list-models", arguments: { limit: 5 } },
+	};
+
+	test("rejects requests without an API key", async () => {
+		const res = await app.request("/mcp", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(listModelsCall),
+		});
+
+		expect(res.status).toBe(401);
+		const json = await res.json();
+		expect(json.error.code).toBe(-32001);
+	});
+
+	test("rejects an arbitrary unvalidated API key (GHSA-8h26-h6v8-f9cg)", async () => {
+		const res = await app.request("/mcp", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer fake-key-any-string",
+			},
+			body: JSON.stringify(listModelsCall),
+		});
+
+		expect(res.status).toBe(401);
+		const json = await res.json();
+		expect(json.error.code).toBe(-32001);
+		expect(JSON.stringify(json)).not.toContain("list-models");
+	});
+
+	test("accepts a valid active API key and returns the model catalog", async () => {
+		await seedActiveKey();
+
+		const res = await app.request("/mcp", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify(listModelsCall),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.error).toBeUndefined();
+		expect(json.result).toBeDefined();
+	});
+
+	test("rejects an inactive API key", async () => {
+		await seedActiveKey();
+		await db
+			.update(tables.apiKey)
+			.set({ status: "inactive" })
+			.where(eq(tables.apiKey.token, "real-token"));
+
+		const res = await app.request("/mcp", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify(listModelsCall),
+		});
+
+		expect(res.status).toBe(401);
+		const json = await res.json();
+		expect(json.error.code).toBe(-32001);
+	});
+});

--- a/apps/gateway/src/mcp/mcp.ts
+++ b/apps/gateway/src/mcp/mcp.ts
@@ -4,8 +4,11 @@ import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { assertApiKeyWithinUsageLimits } from "@/lib/api-key-usage-limits.js";
+import { findApiKeyByToken } from "@/lib/cached-queries.js";
 import { parseApiToken } from "@/lib/extract-api-token.js";
 
 import { parseDataUrl } from "@llmgateway/actions";
@@ -1128,6 +1131,44 @@ export async function mcpHandler(c: Context): Promise<Response> {
 					code: -32001,
 					message:
 						"Authentication required. Provide API key via Authorization header or x-api-key.",
+				},
+				id: null,
+			},
+			401,
+		);
+	}
+
+	// Validate the API key against the database, mirroring the gateway's chat
+	// endpoint. Without this, any arbitrary string was accepted as a valid key
+	// (GHSA-8h26-h6v8-f9cg).
+	const apiKeyRecord = await findApiKeyByToken(apiKey);
+	if (!apiKeyRecord || apiKeyRecord.status !== "active") {
+		return c.json(
+			{
+				jsonrpc: "2.0",
+				error: {
+					code: -32001,
+					message:
+						"Invalid or inactive LLMGateway API key. Generate a new token on the 'API Keys' page.",
+				},
+				id: null,
+			},
+			401,
+		);
+	}
+
+	try {
+		assertApiKeyWithinUsageLimits(apiKeyRecord);
+	} catch (error) {
+		return c.json(
+			{
+				jsonrpc: "2.0",
+				error: {
+					code: -32001,
+					message:
+						error instanceof HTTPException
+							? error.message
+							: "LLMGateway API key cannot be used.",
 				},
 				id: null,
 			},


### PR DESCRIPTION
## Summary

The `/mcp` handler (`apps/gateway/src/mcp/mcp.ts`) extracted the API key from the `Authorization`/`x-api-key` header via `parseApiToken()` but **never validated it against the database**. Any non-empty string was accepted as a valid key (CWE-306, [GHSA-8h26-h6v8-f9cg](https://github.com/theopenco/llmgateway/security/advisories/GHSA-8h26-h6v8-f9cg)).

Impact in practice is **Low**: the only data reachable without a valid key were the purely-local `list-models` / `list-image-models` tools, which return the already-public model catalog and pricing. The `chat` / `generate-image` / `generate-nano-banana` tools forward the key to `/v1/chat/completions`, which validates downstream, so there was no unauthenticated inference or billing impact. The residual issue is that unauthenticated callers could allocate session IDs and open SSE connections (in-memory `sseConnections` map) — a minor resource-consumption vector.

## Fix

After extracting the token, validate it the same way the chat endpoint does (`chat.ts:1837`):

- `findApiKeyByToken(apiKey)` → 401 if not found
- reject non-`active` keys → 401
- `assertApiKeyWithinUsageLimits(...)` → 401 if over limit

All responses stay in JSON-RPC error shape.

## Tests

New `apps/gateway/src/mcp/mcp.spec.ts` covers:
- missing key → 401
- arbitrary unvalidated key → 401 (the vuln; asserts catalog is **not** leaked)
- valid active key → 200 with model catalog
- inactive key → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication checks for MCP requests, so only valid, active API keys are accepted.
  * Requests with missing, invalid, or inactive API keys now return a consistent unauthorized error.
  * Added coverage to verify error handling and successful responses for authenticated MCP access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->