### PR TITLE
chore(billing): remove second top-up bonus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -318,12 +318,6 @@ DEV_PLAN_CREDITS_MULTIPLIER=3
 # Leave unset or set to empty to disable bonus
 FIRST_TIME_CREDIT_BONUS_MULTIPLIER=
 
-# Second top-up bonus: +X% on any top-up within N days of first purchase
-# Set multiplier to 1.1 for +10% bonus (max $25 bonus, 30-day window)
-SECOND_TOPUP_BONUS_MULTIPLIER=
-SECOND_TOPUP_BONUS_WINDOW_DAYS=30
-SECOND_TOPUP_BONUS_MAX=25
-
 # Invoice from information (company name and address on invoices)
 # Use \n for line breaks, e.g., "Company Name\nAddress Line 1\nCity, State ZIP"
 INVOICE_FROM=Fake Company\nUnited States

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -946,10 +946,7 @@ const calculateFeesRoute = createRoute({
 						bonusEnabled: z.boolean(),
 						bonusEligible: z.boolean(),
 						bonusIneligibilityReason: z.string().optional(),
-						bonusType: z
-							.enum(["first_purchase", "second_topup", "referral"])
-							.optional(),
-						secondTopupBonusExpiresInDays: z.number().optional(),
+						bonusType: z.enum(["first_purchase", "referral"]).optional(),
 					}),
 				},
 			},
@@ -1009,23 +1006,18 @@ payments.openapi(calculateFeesRoute, async (c) => {
 		isInternational,
 	});
 
-	// Calculate bonus for first-time and second top-up credit purchases
+	// Calculate bonus for first-time credit purchases
 	let bonusAmount = 0;
 	let finalCreditAmount = amount;
 	let bonusEligible = false;
 	let bonusIneligibilityReason: string | undefined;
-	let bonusType: "first_purchase" | "second_topup" | "referral" | undefined;
-	let secondTopupBonusExpiresInDays: number | undefined;
+	let bonusType: "first_purchase" | "referral" | undefined;
 
 	const firstBonusMultiplier = process.env.FIRST_TIME_CREDIT_BONUS_MULTIPLIER
 		? parseFloat(process.env.FIRST_TIME_CREDIT_BONUS_MULTIPLIER)
 		: 0;
-	const secondBonusMultiplier = process.env.SECOND_TOPUP_BONUS_MULTIPLIER
-		? parseFloat(process.env.SECOND_TOPUP_BONUS_MULTIPLIER)
-		: 0;
 
 	const firstBonusEnabled = firstBonusMultiplier > 1;
-	const secondBonusEnabled = secondBonusMultiplier > 1;
 
 	// Referral signup bonus applies to the referred org's first top-up and takes
 	// precedence over the env-driven first-time bonus. Mirrors stripe.ts so the
@@ -1036,8 +1028,7 @@ payments.openapi(calculateFeesRoute, async (c) => {
 	);
 	const referralBonusPossible = referralBonusAmount > 0;
 
-	const bonusEnabled =
-		firstBonusEnabled || secondBonusEnabled || referralBonusPossible;
+	const bonusEnabled = firstBonusEnabled || referralBonusPossible;
 
 	if (bonusEnabled) {
 		if (!userOrganization.user || !userOrganization.user.emailVerified) {
@@ -1050,7 +1041,7 @@ payments.openapi(calculateFeesRoute, async (c) => {
 					status: { eq: "completed" },
 				},
 				orderBy: { createdAt: "asc" },
-				limit: 2,
+				limit: 1,
 			});
 
 			if (previousPurchases.length === 0 && referralBonusPossible) {
@@ -1065,35 +1056,7 @@ payments.openapi(calculateFeesRoute, async (c) => {
 				const maxBonus = 50;
 				bonusAmount = Math.min(potentialBonus, maxBonus);
 				finalCreditAmount = amount + bonusAmount;
-			} else if (previousPurchases.length === 1 && secondBonusEnabled) {
-				const secondBonusWindowDays = Number(
-					process.env.SECOND_TOPUP_BONUS_WINDOW_DAYS ?? "30",
-				);
-				const secondBonusMax = Number(
-					process.env.SECOND_TOPUP_BONUS_MAX ?? "25",
-				);
-				const firstPurchaseDate = previousPurchases[0].createdAt;
-				const daysSinceFirst =
-					(Date.now() - firstPurchaseDate.getTime()) / (1000 * 60 * 60 * 24);
-
-				if (daysSinceFirst <= secondBonusWindowDays) {
-					bonusEligible = true;
-					bonusType = "second_topup";
-					const potentialBonus = amount * (secondBonusMultiplier - 1);
-					bonusAmount = Math.min(potentialBonus, secondBonusMax);
-					finalCreditAmount = amount + bonusAmount;
-					secondTopupBonusExpiresInDays = Math.ceil(
-						secondBonusWindowDays - daysSinceFirst,
-					);
-				} else {
-					bonusIneligibilityReason = "second_topup_window_expired";
-				}
-			} else if (previousPurchases.length >= 2) {
-				bonusIneligibilityReason = "already_purchased";
-			} else if (previousPurchases.length === 0 && !firstBonusEnabled) {
-				// No first-purchase bonus configured, but second might be
-				// (user hasn't purchased yet, so no second bonus either)
-			} else {
+			} else if (previousPurchases.length > 0) {
 				bonusIneligibilityReason = "already_purchased";
 			}
 		}
@@ -1108,6 +1071,5 @@ payments.openapi(calculateFeesRoute, async (c) => {
 		bonusEligible,
 		bonusIneligibilityReason,
 		bonusType,
-		secondTopupBonusExpiresInDays,
 	});
 });

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1600,12 +1600,10 @@ async function handleCheckoutSessionCompleted(
 	}
 }
 
-type BonusType = "first_purchase" | "second_topup" | "referral";
+type BonusType = "first_purchase" | "referral";
 
 function getBonusLabel(bonusType: BonusType | null): string {
 	switch (bonusType) {
-		case "second_topup":
-			return "second top-up bonus";
 		case "referral":
 			return "referral bonus";
 		default:
@@ -1667,18 +1665,12 @@ async function applyFirstTimeBonus({
 	const firstBonusMultiplier = process.env.FIRST_TIME_CREDIT_BONUS_MULTIPLIER
 		? parseFloat(process.env.FIRST_TIME_CREDIT_BONUS_MULTIPLIER)
 		: 0;
-	const secondBonusMultiplier = process.env.SECOND_TOPUP_BONUS_MULTIPLIER
-		? parseFloat(process.env.SECOND_TOPUP_BONUS_MULTIPLIER)
-		: 0;
 
-	const eitherBonusEnabled =
-		firstBonusMultiplier > 1 || secondBonusMultiplier > 1;
-
-	if (!eitherBonusEnabled) {
+	if (firstBonusMultiplier <= 1) {
 		return { finalCreditAmount, bonusAmount, bonusType };
 	}
 
-	if (previousPurchases.length === 0 && firstBonusMultiplier > 1) {
+	if (previousPurchases.length === 0) {
 		const potentialBonus = creditAmount * (firstBonusMultiplier - 1);
 		const maxBonus = 50;
 		bonusAmount = Math.min(potentialBonus, maxBonus);
@@ -1688,25 +1680,6 @@ async function applyFirstTimeBonus({
 		logger.info(
 			`Applied first-time bonus of $${bonusAmount} to organization ${organizationId} (${firstBonusMultiplier}x multiplier, max $${maxBonus})`,
 		);
-	} else if (previousPurchases.length === 1 && secondBonusMultiplier > 1) {
-		const secondBonusWindowDays = Number(
-			process.env.SECOND_TOPUP_BONUS_WINDOW_DAYS ?? "30",
-		);
-		const secondBonusMax = Number(process.env.SECOND_TOPUP_BONUS_MAX ?? "25");
-		const firstPurchaseDate = previousPurchases[0].createdAt;
-		const daysSinceFirst =
-			(Date.now() - firstPurchaseDate.getTime()) / (1000 * 60 * 60 * 24);
-
-		if (daysSinceFirst <= secondBonusWindowDays) {
-			const potentialBonus = creditAmount * (secondBonusMultiplier - 1);
-			bonusAmount = Math.min(potentialBonus, secondBonusMax);
-			finalCreditAmount = creditAmount + bonusAmount;
-			bonusType = "second_topup";
-
-			logger.info(
-				`Applied second top-up bonus of $${bonusAmount} to organization ${organizationId} (${secondBonusMultiplier}x multiplier, max $${secondBonusMax}, ${Math.round(daysSinceFirst)} days since first purchase)`,
-			);
-		}
 	}
 
 	return { finalCreditAmount, bonusAmount, bonusType };
@@ -1839,19 +1812,6 @@ async function recordCreditTopUp({
 			organization: organizationId,
 		},
 	});
-
-	if (bonusType === "second_topup" && bonusAmount > 0) {
-		posthog.capture({
-			distinctId: "organization",
-			event: "second_topup_bonus_applied",
-			groups: { organization: organizationId },
-			properties: {
-				bonusAmount,
-				creditAmount,
-				organization: organizationId,
-			},
-		});
-	}
 }
 
 async function handleCreditTopUpCheckout(session: Stripe.Checkout.Session) {

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -260,12 +260,6 @@ function AmountStep({
 
 	const hasBonus = feeData?.bonusAmount && feeData.bonusAmount > 0;
 
-	useEffect(() => {
-		if (feeData?.bonusType === "second_topup" && feeData.bonusEligible) {
-			posthog.capture("second_topup_bonus_eligible_viewed");
-		}
-	}, [feeData?.bonusType, feeData?.bonusEligible, posthog]);
-
 	const handleStripeCheckout = async () => {
 		posthog.capture("topup_stripe_checkout_started", { amount });
 		setCheckoutLoading(true);
@@ -300,22 +294,6 @@ function AmountStep({
 				</DialogDescription>
 			</DialogHeader>
 			<div className="space-y-5 py-2">
-				{feeData?.bonusType === "second_topup" &&
-					feeData.secondTopupBonusExpiresInDays !== undefined && (
-						<div className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-950/30">
-							<p className="text-sm font-medium text-green-800 dark:text-green-200">
-								Get +
-								{Math.round(
-									((feeData.bonusAmount ?? 0) / (feeData.baseAmount || 1)) *
-										100,
-								)}
-								% bonus on this top-up — expires in{" "}
-								{feeData.secondTopupBonusExpiresInDays} day
-								{feeData.secondTopupBonusExpiresInDays !== 1 ? "s" : ""}
-							</p>
-						</div>
-					)}
-
 				{/* Hero amount input */}
 				<div className="flex flex-col items-center gap-1.5 pt-1">
 					<Label htmlFor="amount" className="sr-only">
@@ -449,11 +427,9 @@ function AmountStep({
 									<div className="-mx-2 flex justify-between rounded bg-green-50 px-2 py-1 font-semibold text-green-600 dark:bg-green-950/50 dark:text-green-400">
 										<span>
 											🎉{" "}
-											{feeData.bonusType === "second_topup"
-												? "Second top-up bonus"
-												: feeData.bonusType === "referral"
-													? "Referral bonus"
-													: "First-time bonus"}
+											{feeData.bonusType === "referral"
+												? "Referral bonus"
+												: "First-time bonus"}
 										</span>
 										<span className="tabular-nums">
 											+${feeData.bonusAmount.toFixed(2)}
@@ -1185,11 +1161,9 @@ function ConfirmPaymentStep({
 								<div className="flex justify-between text-green-600 font-semibold bg-green-50 dark:bg-green-950/50 -mx-2 px-2 py-1 rounded">
 									<span>
 										🎉{" "}
-										{feeData.bonusType === "second_topup"
-											? "Second top-up bonus"
-											: feeData.bonusType === "referral"
-												? "Referral bonus"
-												: "First-time bonus"}
+										{feeData.bonusType === "referral"
+											? "Referral bonus"
+											: "First-time bonus"}
 									</span>
 									<span>+${feeData.bonusAmount.toFixed(2)}</span>
 								</div>


### PR DESCRIPTION
## Summary

Removes the **second top-up bonus** feature entirely (the `SECOND_TOPUP_BONUS_MULTIPLIER` thing). The first-time bonus and referral bonus are untouched.

## Changes

- **`.env.example`** — drop `SECOND_TOPUP_BONUS_MULTIPLIER`, `SECOND_TOPUP_BONUS_WINDOW_DAYS`, `SECOND_TOPUP_BONUS_MAX`.
- **`apps/api/src/stripe.ts`** — remove `second_topup` from `BonusType`, its `getBonusLabel` case, the second-bonus multiplier/window/max logic in `applyFirstTimeBonus`, and the `second_topup_bonus_applied` PostHog event.
- **`apps/api/src/routes/payments.ts`** — drop `second_topup` from the fee-calculation response schema, remove `secondTopupBonusExpiresInDays` and the window-expiry branch; `previousPurchases` lookup now only needs the first purchase.
- **`apps/ui/src/components/credits/top-up-credits-dialog.tsx`** — remove the second-topup banner, the `second_topup_bonus_eligible_viewed` capture, and the `"Second top-up bonus"` label branches.

## Testing

- `pnpm build` (api + ui) — green
- `pnpm format` — clean
- Regenerated the OpenAPI spec + typed UI client; no `second_topup` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified credit top-up bonus handling across the app. Bonus estimates and checkout labels now show only first-time or referral bonuses, and expired/second top-up bonus messaging has been removed.
* **Chores**
  * Cleaned up bonus-related configuration and tracking so unused second top-up bonus settings are no longer exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->