### PR TITLE
fix(ui): per-language syntax highlighting

### DIFF
--- a/apps/ui/src/components/landing/code-example.tsx
+++ b/apps/ui/src/components/landing/code-example.tsx
@@ -2,8 +2,8 @@
 
 import { Check, Copy } from "lucide-react";
 import { useTheme } from "next-themes";
-import { Highlight, themes } from "prism-react-renderer";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Fragment } from "react";
+import { createHighlighter } from "shiki";
 
 import { Button } from "@/lib/components/button";
 import { toast } from "@/lib/components/use-toast";
@@ -11,7 +11,8 @@ import { cn } from "@/lib/utils";
 
 import { AnimatedGroup } from "./animated-group";
 
-import type { Language } from "prism-react-renderer";
+import type { CSSProperties } from "react";
+import type { BundledLanguage, Highlighter, ThemedToken } from "shiki";
 
 const codeExamples = {
 	curl: {
@@ -204,16 +205,85 @@ const bullets = [
 	"Every request tracked with cost, latency, and token usage",
 ];
 
+const highlightLangs: BundledLanguage[] = [
+	"bash",
+	"typescript",
+	"python",
+	"java",
+	"rust",
+	"go",
+	"php",
+	"ruby",
+];
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+function getHighlighter() {
+	if (!highlighterPromise) {
+		highlighterPromise = createHighlighter({
+			langs: highlightLangs,
+			themes: ["dracula", "github-light"],
+		});
+	}
+	return highlighterPromise;
+}
+
+// Shiki encodes font styles as bitflags: 1 = italic, 2 = bold, 4 = underline.
+function tokenStyle(token: ThemedToken): CSSProperties {
+	const fontStyle = token.fontStyle ?? 0;
+	return {
+		color: token.color,
+		fontStyle: fontStyle & 1 ? "italic" : undefined,
+		fontWeight: fontStyle & 2 ? "bold" : undefined,
+		textDecoration: fontStyle & 4 ? "underline" : undefined,
+	};
+}
+
+interface Highlighted {
+	tokens: ThemedToken[][];
+	bg: string;
+	fg: string;
+}
+
 export function CodeExample() {
 	const [activeTab, setActiveTab] =
 		useState<keyof typeof codeExamples>("python");
 	const { resolvedTheme } = useTheme();
-	const [mounted, setMounted] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const [highlighted, setHighlighted] = useState<Highlighted | null>(null);
+
+	const currentExample = codeExamples[activeTab];
 
 	useEffect(() => {
-		setMounted(true);
-	}, []);
+		let cancelled = false;
+		const theme = resolvedTheme === "dark" ? "dracula" : "github-light";
+
+		async function highlight() {
+			try {
+				const highlighter = await getHighlighter();
+				if (cancelled) {
+					return;
+				}
+				const result = highlighter.codeToTokens(currentExample.code, {
+					lang: currentExample.language as BundledLanguage,
+					theme,
+				});
+				setHighlighted({
+					tokens: result.tokens,
+					bg: result.bg ?? "transparent",
+					fg: result.fg ?? "inherit",
+				});
+			} catch (error) {
+				console.error("Failed to highlight code:", error);
+			}
+		}
+
+		void highlight();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [currentExample.code, currentExample.language, resolvedTheme]);
 
 	const copyToClipboard = async (text: string, language: string) => {
 		try {
@@ -235,8 +305,6 @@ export function CodeExample() {
 			});
 		}
 	};
-
-	const currentExample = codeExamples[activeTab];
 
 	return (
 		<section className="py-24 md:py-32">
@@ -350,48 +418,28 @@ export function CodeExample() {
 							</div>
 
 							<div className="relative bg-background">
-								<Highlight
-									code={currentExample.code}
-									language={currentExample.language as Language}
-									theme={
-										mounted && resolvedTheme === "dark"
-											? themes.dracula
-											: themes.github
-									}
+								<pre
+									className="p-6 overflow-x-auto text-sm leading-relaxed font-mono max-h-96 overflow-y-auto"
+									style={{
+										backgroundColor: highlighted?.bg,
+										color: highlighted?.fg,
+									}}
 								>
-									{({
-										className,
-										style,
-										tokens,
-										getLineProps,
-										getTokenProps,
-									}) => (
-										<pre
-											className={cn(
-												"p-6 overflow-x-auto text-sm leading-relaxed font-mono max-h-96 overflow-y-auto",
-												className,
-											)}
-											style={{
-												...style,
-												padding: 24,
-												borderRadius: 0,
-												overflowX: "auto",
-											}}
-										>
-											{tokens.map((line, i) => {
-												const lineProps = getLineProps({ line });
-												return (
-													<div key={i} {...lineProps}>
-														{line.map((token, key) => {
-															const tokenProps = getTokenProps({ token });
-															return <span key={key} {...tokenProps} />;
-														})}
-													</div>
-												);
-											})}
-										</pre>
-									)}
-								</Highlight>
+									<code>
+										{highlighted
+											? highlighted.tokens.map((line, i) => (
+													<Fragment key={i}>
+														{line.map((token, key) => (
+															<span key={key} style={tokenStyle(token)}>
+																{token.content}
+															</span>
+														))}
+														{i < highlighted.tokens.length - 1 ? "\n" : null}
+													</Fragment>
+												))
+											: currentExample.code}
+									</code>
+								</pre>
 							</div>
 						</div>
 					</div>

--- a/apps/ui/src/components/landing/code-example.tsx
+++ b/apps/ui/src/components/landing/code-example.tsx
@@ -240,6 +240,7 @@ function tokenStyle(token: ThemedToken): CSSProperties {
 }
 
 interface Highlighted {
+	key: string;
 	tokens: ThemedToken[][];
 	bg: string;
 	fg: string;
@@ -253,10 +254,15 @@ export function CodeExample() {
 	const [highlighted, setHighlighted] = useState<Highlighted | null>(null);
 
 	const currentExample = codeExamples[activeTab];
+	const theme = resolvedTheme === "dark" ? "dracula" : "github-light";
+	const highlightKey = `${activeTab}:${theme}`;
+	// Only use highlighted output that matches the current snippet + theme;
+	// otherwise fall back to raw code so a stale snippet is never rendered.
+	const activeHighlight =
+		highlighted?.key === highlightKey ? highlighted : null;
 
 	useEffect(() => {
 		let cancelled = false;
-		const theme = resolvedTheme === "dark" ? "dracula" : "github-light";
 
 		async function highlight() {
 			try {
@@ -269,12 +275,16 @@ export function CodeExample() {
 					theme,
 				});
 				setHighlighted({
+					key: highlightKey,
 					tokens: result.tokens,
 					bg: result.bg ?? "transparent",
 					fg: result.fg ?? "inherit",
 				});
 			} catch (error) {
 				console.error("Failed to highlight code:", error);
+				if (!cancelled) {
+					setHighlighted(null);
+				}
 			}
 		}
 
@@ -283,7 +293,7 @@ export function CodeExample() {
 		return () => {
 			cancelled = true;
 		};
-	}, [currentExample.code, currentExample.language, resolvedTheme]);
+	}, [currentExample.code, currentExample.language, theme, highlightKey]);
 
 	const copyToClipboard = async (text: string, language: string) => {
 		try {
@@ -421,20 +431,22 @@ export function CodeExample() {
 								<pre
 									className="p-6 overflow-x-auto text-sm leading-relaxed font-mono max-h-96 overflow-y-auto"
 									style={{
-										backgroundColor: highlighted?.bg,
-										color: highlighted?.fg,
+										backgroundColor: activeHighlight?.bg,
+										color: activeHighlight?.fg,
 									}}
 								>
 									<code>
-										{highlighted
-											? highlighted.tokens.map((line, i) => (
+										{activeHighlight
+											? activeHighlight.tokens.map((line, i) => (
 													<Fragment key={i}>
 														{line.map((token, key) => (
 															<span key={key} style={tokenStyle(token)}>
 																{token.content}
 															</span>
 														))}
-														{i < highlighted.tokens.length - 1 ? "\n" : null}
+														{i < activeHighlight.tokens.length - 1
+															? "\n"
+															: null}
 													</Fragment>
 												))
 											: currentExample.code}


### PR DESCRIPTION
## Problem

The landing-page integration code-example block rendered several language snippets as **plain monochrome text** (see PHP in the screenshot). It used `prism-react-renderer`, whose vendored Prism bundle only ships a subset of grammars. The snippets for **cURL (bash), Java, PHP, and Ruby** were not among them, so they fell through to an unhighlighted plain-text render while Python/TypeScript/Go/Rust looked fine.

`prismjs` isn't installed separately, so lazy-registering the missing Prism grammars wasn't possible without adding a dependency.

## Fix

Swap the highlighter in `apps/ui/src/components/landing/code-example.tsx` from `prism-react-renderer` to **Shiki**, which is already a dependency (`shiki@3.22.0`, also used in the playground) and bundles accurate TextMate grammars for every language in the block.

- A cached `createHighlighter` singleton loads only the 8 languages used here plus the two themes.
- Theme is preserved: **dracula** (dark) / **github-light** (light), matching the previous look.
- Tokens render as styled spans (color + italic/bold/underline from Shiki's font-style flags).
- Raw code is shown as an immediate fallback while async highlighting loads, so there's no empty flash and no SSR/hydration mismatch.

## Verification

- `turbo run build --filter=ui` ✅ and `eslint` clean
- Rendered each tab locally and confirmed distinct per-token colors for the previously-broken grammars:
  - cURL (bash): 4 colors · Ruby: 6 · Java: 6 · PHP: 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced landing page code examples with improved, theme-aware syntax highlighting and more accurate token styling.
  * Code blocks now display richer formatting (e.g., bold/italic/underline) and consistent language-specific colors.

* **Bug Fixes**
  * Prevented stale or out-of-date highlighting from appearing when the selected snippet or theme changes, including safe handling during unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->