### PR TITLE
fix(ui): mint CLI connect keys in DevPass org

### DIFF
--- a/apps/ui/src/app/connect/cli/page.tsx
+++ b/apps/ui/src/app/connect/cli/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 
+import { useDefaultProject } from "@/hooks/useDefaultProject";
 import { useDevPassProject } from "@/hooks/useDevPassProject";
 import { useUser } from "@/hooks/useUser";
 import { Button } from "@/lib/components/button";
@@ -26,6 +27,10 @@ interface ConnectParams {
 	state: string;
 	source: string;
 	name: string;
+	// Which org the minted key should live in. The CLI passes "devpass" when
+	// connecting the DevPass subscription provider so usage bills the DevPass
+	// plan; pay-as-you-go connects keep using the default dashboard org.
+	org: "default" | "devpass";
 }
 
 /**
@@ -71,6 +76,7 @@ function readParams(): ConnectParams | null {
 		state,
 		source: params.get("source") ?? "coding CLI",
 		name: (params.get("name") ?? "DevPass Code CLI").slice(0, 80),
+		org: params.get("org") === "devpass" ? "devpass" : "default",
 	};
 }
 
@@ -78,11 +84,6 @@ export default function ConnectCliPage() {
 	const api = useApi();
 	const posthog = usePostHog();
 	const { user, isLoading: userLoading } = useUser();
-	const {
-		data: devPass,
-		isLoading: projectLoading,
-		isError: projectError,
-	} = useDevPassProject();
 
 	// Read query params only after mount so SSR and the first client render agree.
 	const [params, setParams] = useState<ConnectParams | null>(null);
@@ -94,6 +95,20 @@ export default function ConnectCliPage() {
 		setMounted(true);
 	}, []);
 
+	const wantsDevPassOrg = params?.org === "devpass";
+	const devPassResult = useDevPassProject({ enabled: wantsDevPassOrg });
+	const defaultResult = useDefaultProject();
+
+	const project = wantsDevPassOrg
+		? devPassResult.data?.project
+		: defaultResult.data;
+	const projectLoading = wantsDevPassOrg
+		? devPassResult.isLoading
+		: defaultResult.isLoading;
+	const projectError = wantsDevPassOrg
+		? devPassResult.isError
+		: defaultResult.isError;
+
 	const createApiKey = api.useMutation("post", "/keys/api");
 
 	const displayName = params
@@ -101,7 +116,7 @@ export default function ConnectCliPage() {
 		: "";
 
 	const authorize = () => {
-		if (!params || !devPass?.project.id || createApiKey.isPending) {
+		if (!params || !project?.id || createApiKey.isPending) {
 			return;
 		}
 
@@ -112,7 +127,7 @@ export default function ConnectCliPage() {
 			{
 				body: {
 					description: `${displayName} (CLI) — ${params.name}`.slice(0, 100),
-					projectId: devPass.project.id,
+					projectId: project.id,
 					usageLimit: null,
 					expiresAt,
 				},
@@ -232,12 +247,20 @@ export default function ConnectCliPage() {
 					<span>
 						Signed in as{" "}
 						<span className="font-medium text-foreground">{user.email}</span>
-						{devPass?.organization.name ? (
+						{wantsDevPassOrg && devPassResult.data?.organization.name ? (
 							<>
 								{" "}
 								· organization{" "}
 								<span className="font-medium text-foreground">
-									{devPass.organization.name}
+									{devPassResult.data.organization.name}
+								</span>
+							</>
+						) : !wantsDevPassOrg && project?.name ? (
+							<>
+								{" "}
+								· project{" "}
+								<span className="font-medium text-foreground">
+									{project.name}
 								</span>
 							</>
 						) : null}
@@ -253,9 +276,7 @@ export default function ConnectCliPage() {
 				<Button
 					className="w-full"
 					onClick={authorize}
-					disabled={
-						createApiKey.isPending || projectLoading || !devPass?.project.id
-					}
+					disabled={createApiKey.isPending || projectLoading || !project?.id}
 				>
 					{createApiKey.isPending ? (
 						<>
@@ -268,8 +289,9 @@ export default function ConnectCliPage() {
 				</Button>
 				{projectError ? (
 					<p className="text-xs text-destructive">
-						Couldn&apos;t load your DevPass organization. Refresh this page and
-						try again.
+						{wantsDevPassOrg
+							? "Couldn't load your DevPass organization. Refresh this page and try again."
+							: "No project found on your account. Finish setup in the dashboard first."}
 					</p>
 				) : null}
 			</CardFooter>

--- a/apps/ui/src/app/connect/cli/page.tsx
+++ b/apps/ui/src/app/connect/cli/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 
-import { useDefaultProject } from "@/hooks/useDefaultProject";
+import { useDevPassProject } from "@/hooks/useDevPassProject";
 import { useUser } from "@/hooks/useUser";
 import { Button } from "@/lib/components/button";
 import {
@@ -79,10 +79,10 @@ export default function ConnectCliPage() {
 	const posthog = usePostHog();
 	const { user, isLoading: userLoading } = useUser();
 	const {
-		data: defaultProject,
+		data: devPass,
 		isLoading: projectLoading,
 		isError: projectError,
-	} = useDefaultProject();
+	} = useDevPassProject();
 
 	// Read query params only after mount so SSR and the first client render agree.
 	const [params, setParams] = useState<ConnectParams | null>(null);
@@ -101,7 +101,7 @@ export default function ConnectCliPage() {
 		: "";
 
 	const authorize = () => {
-		if (!params || !defaultProject?.id || createApiKey.isPending) {
+		if (!params || !devPass?.project.id || createApiKey.isPending) {
 			return;
 		}
 
@@ -112,7 +112,7 @@ export default function ConnectCliPage() {
 			{
 				body: {
 					description: `${displayName} (CLI) — ${params.name}`.slice(0, 100),
-					projectId: defaultProject.id,
+					projectId: devPass.project.id,
 					usageLimit: null,
 					expiresAt,
 				},
@@ -232,12 +232,12 @@ export default function ConnectCliPage() {
 					<span>
 						Signed in as{" "}
 						<span className="font-medium text-foreground">{user.email}</span>
-						{defaultProject?.name ? (
+						{devPass?.organization.name ? (
 							<>
 								{" "}
-								· project{" "}
+								· organization{" "}
 								<span className="font-medium text-foreground">
-									{defaultProject.name}
+									{devPass.organization.name}
 								</span>
 							</>
 						) : null}
@@ -254,7 +254,7 @@ export default function ConnectCliPage() {
 					className="w-full"
 					onClick={authorize}
 					disabled={
-						createApiKey.isPending || projectLoading || !defaultProject?.id
+						createApiKey.isPending || projectLoading || !devPass?.project.id
 					}
 				>
 					{createApiKey.isPending ? (
@@ -268,8 +268,8 @@ export default function ConnectCliPage() {
 				</Button>
 				{projectError ? (
 					<p className="text-xs text-destructive">
-						No project found on your account. Finish setup in the dashboard
-						first.
+						Couldn&apos;t load your DevPass organization. Refresh this page and
+						try again.
 					</p>
 				) : null}
 			</CardFooter>

--- a/apps/ui/src/hooks/useDevPassProject.ts
+++ b/apps/ui/src/hooks/useDevPassProject.ts
@@ -1,0 +1,50 @@
+import { useApi } from "@/lib/fetch-client";
+
+// Resolves the user's personal DevPass organization (created on demand by the
+// API) and its default project. CLI connect keys are minted here — not in a
+// regular dashboard org — so usage is billed against the user's DevPass plan.
+export function useDevPassProject() {
+	const api = useApi();
+
+	const {
+		data: personalOrg,
+		isLoading: orgLoading,
+		isError: orgError,
+	} = api.useQuery("get", "/dev-plans/personal-org");
+
+	const {
+		data: projectsData,
+		isLoading: projectsLoading,
+		isError: projectsError,
+	} = api.useQuery(
+		"get",
+		"/orgs/{id}/projects",
+		{
+			params: {
+				path: { id: personalOrg?.id ?? "" },
+			},
+		},
+		{
+			enabled: !!personalOrg?.id,
+		},
+	);
+
+	const isLoading = orgLoading || (!!personalOrg && projectsLoading);
+
+	if (isLoading) {
+		return { data: null, isError: false, isLoading: true };
+	}
+
+	if (orgError || projectsError || !projectsData?.projects?.length) {
+		return { data: null, isError: true, isLoading: false };
+	}
+
+	return {
+		data: {
+			organization: personalOrg!,
+			project: projectsData.projects[0],
+		},
+		isError: false,
+		isLoading: false,
+	};
+}

--- a/apps/ui/src/hooks/useDevPassProject.ts
+++ b/apps/ui/src/hooks/useDevPassProject.ts
@@ -1,16 +1,18 @@
 import { useApi } from "@/lib/fetch-client";
 
 // Resolves the user's personal DevPass organization (created on demand by the
-// API) and its default project. CLI connect keys are minted here — not in a
-// regular dashboard org — so usage is billed against the user's DevPass plan.
-export function useDevPassProject() {
+// API) and its default project. DevPass CLI connect keys are minted here — not
+// in a regular dashboard org — so usage is billed against the DevPass plan.
+// Pass enabled: false to skip the lookup (it creates the org as a side effect).
+export function useDevPassProject(options?: { enabled?: boolean }) {
 	const api = useApi();
+	const enabled = options?.enabled ?? true;
 
 	const {
 		data: personalOrg,
 		isLoading: orgLoading,
 		isError: orgError,
-	} = api.useQuery("get", "/dev-plans/personal-org");
+	} = api.useQuery("get", "/dev-plans/personal-org", {}, { enabled });
 
 	const {
 		data: projectsData,
@@ -25,11 +27,15 @@ export function useDevPassProject() {
 			},
 		},
 		{
-			enabled: !!personalOrg?.id,
+			enabled: enabled && !!personalOrg?.id,
 		},
 	);
 
 	const isLoading = orgLoading || (!!personalOrg && projectsLoading);
+
+	if (!enabled) {
+		return { data: null, isError: false, isLoading: false };
+	}
 
 	if (isLoading) {
 		return { data: null, isError: false, isLoading: true };


### PR DESCRIPTION
## Summary

The `/connect/cli` flow created every API key in the user's **default dashboard organization**, so DevPass subscription connects billed pay-as-you-go credits instead of the DevPass plan.

The key's org now follows which provider the CLI is connecting, via a new `org` query param:

- `org=devpass` (sent by the CLI for the `llmgateway-devpass` subscription provider) → key is minted in the personal DevPass org, resolved via `GET /dev-plans/personal-org` (get-or-create) through the new `useDevPassProject` hook, so gateway billing routes by `org.kind === "devpass"`. The authorize card shows `· organization DevPass`.
- `org=default` / absent (pay-as-you-go `llmgateway` provider and other coding agents) → unchanged: key lands in the default org's project, card shows `· project <name>`.

The DevPass org lookup is gated behind the param so a pay-as-you-go connect never creates a personal org as a side effect.

Companion CLI change: theopenco/devpass-code#1 (passes `org` per provider).

## Test plan

- `turbo run build --filter=ui` passes
- Verified both param variants render the correct org/project context on the authorize card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tQZmLkxbu5uH8sZx1ZU5W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the CLI authorization flow to select the appropriate DevPass context (via URL parameter) and use DevPass project details for API key creation.
  * “Signed in as” now displays the DevPass organization name when available.

* **Bug Fixes**
  * The “Authorize” action now remains disabled until the selected project information is fully loaded and valid.
  * Authorization error messages are now tailored to DevPass vs the default context to guide recovery more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->