### PR TITLE
fix(gateway): label image provider errors as upstream

### DIFF
--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -583,20 +583,54 @@ async function forwardToChatCompletions(
 	});
 
 	if (!response.ok) {
-		logger.warn("Images API - chat completions request failed", {
-			status: response.status,
-			statusText: response.statusText,
-		});
 		const errorData = await response.text();
 		let errorMessage = `Image generation failed with status ${response.status}`;
+		let errorType: string | undefined;
 		try {
 			const parsed = JSON.parse(errorData);
 			errorMessage = parsed?.error?.message ?? parsed?.message ?? errorMessage;
+			errorType =
+				(typeof parsed?.error?.type === "string"
+					? parsed.error.type
+					: undefined) ??
+				(typeof parsed?.error?.code === "string"
+					? parsed.error.code
+					: undefined);
 		} catch {
 			// use default message
 		}
 
-		throw new HTTPException(response.status as any, {
+		// The internal chat completions handler retries and tracks unrecovered
+		// provider failures (rate limits, upstream 5xx, connection resets) itself,
+		// then returns them as an HTTP 500 with an upstream/gateway finish reason
+		// (e.g. "Error from provider zai: 429 ..."). Re-throwing that verbatim as a
+		// 500 makes app.onError log it as a backend "HTTP 500 exception" alert, even
+		// though it is a provider-side gateway error, not an application bug. Re-map
+		// those to 502 so onError labels them as an upstream gateway error and logs
+		// at warn. Genuine backend 500s carry no provider signal and stay 500.
+		const isProviderError =
+			errorType === "upstream_error" ||
+			errorType === "gateway_error" ||
+			errorType === "error" ||
+			errorMessage.startsWith("Error from provider");
+		const status =
+			response.status === 500 && isProviderError ? 502 : response.status;
+
+		if (status >= 500) {
+			logger.warn("Images API - upstream provider error", {
+				status,
+				originalStatus: response.status,
+				errorType,
+				message: errorMessage,
+			});
+		} else {
+			logger.warn("Images API - chat completions request failed", {
+				status,
+				statusText: response.statusText,
+			});
+		}
+
+		throw new HTTPException(status as any, {
 			message: errorMessage,
 		});
 	}

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -16,6 +16,7 @@ import { models } from "@llmgateway/models";
 
 import type { ServerTypes } from "@/vars.js";
 import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 const imageGenerationsRequestSchema = z.object({
 	prompt: z.string().min(1).openapi({
@@ -616,7 +617,7 @@ async function forwardToChatCompletions(
 		const status =
 			response.status === 500 && isProviderError ? 502 : response.status;
 
-		if (status >= 500) {
+		if (status === 502 || status === 503 || status === 504) {
 			logger.warn("Images API - upstream provider error", {
 				status,
 				originalStatus: response.status,
@@ -627,10 +628,11 @@ async function forwardToChatCompletions(
 			logger.warn("Images API - chat completions request failed", {
 				status,
 				statusText: response.statusText,
+				errorType,
 			});
 		}
 
-		throw new HTTPException(status as any, {
+		throw new HTTPException(status as ContentfulStatusCode, {
 			message: errorMessage,
 		});
 	}


### PR DESCRIPTION
## Problem

Provider rate limits in the image generation path surface as **backend `ERROR`-severity alerts** instead of tracked provider/gateway errors:

```
ERROR  Error from provider zai: 429 Too Many Requests {"error":{"code":"1302","message":"Rate limit reached for requests"}}
  at forwardToChatCompletions (/app/src/images/images.ts:599)
```

### Root cause

The image endpoints (`/v1/images/generations`, `/v1/images/edits`) forward to `/v1/chat/completions` internally via `app.request`. The chat handler already retries, falls back, and logs the provider failure — then returns an **HTTP 500** JSON response wrapping the unrecovered provider error (`"Error from provider zai: 429 ..."`, `error.type` = the upstream/gateway finish reason).

`forwardToChatCompletions` re-threw that verbatim as `HTTPException(500)`, so `app.onError` hit `logger.error("HTTP 500 exception")` → a backend-error alert.

When the chat endpoint is called **directly**, that same 500 is a *returned* response (never a thrown `HTTPException`), so it never reaches `onError` and never alerts. The spurious backend alert was unique to the images path re-throwing it.

## Fix

In `forwardToChatCompletions`, detect provider-wrapped upstream failures — `error.type`/`code` of `upstream_error` / `gateway_error` / `error`, or a message starting with `"Error from provider"` — and re-throw them as **502**. `app.onError` already classifies 502/503/504 as upstream gateway errors and logs them at `warn`, not `error`.

Genuine backend 500s carry no provider signal and stay 500, so real application bugs still alert.

The provider error itself is already tracked and retried inside the chat handler (DB log + `"Provider error"` warn); this change only fixes how the images path labels the final, unrecovered result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for image generation and edit requests when upstream chat completion calls fail.
  * Better classifies provider-related failures versus other errors, remapping certain upstream statuses for clearer client outcomes.
  * Error responses now surface more informative, consistently derived messages to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->