### PR TITLE
fix(api): make DevPass renewal credit reset atomic

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3997,21 +3997,68 @@ export async function handleInvoicePaymentSucceeded(event: {
 			organization.devPlan) as DevPlanTier;
 		const creditsLimit = getDevPlanCreditsLimit(effectiveTier);
 
-		// Create transaction record for dev plan renewal
-		const [renewalTransaction] = await db
-			.insert(tables.transaction)
-			.values({
-				organizationId,
-				type: "dev_plan_renewal",
-				amount: (invoice.amount_paid / 100).toString(),
-				creditAmount: creditsLimit.toString(),
-				currency: invoice.currency.toUpperCase(),
-				status: "completed",
-				stripePaymentIntentId: (invoice as any).payment_intent,
-				stripeInvoiceId: invoice.id,
-				description: `Dev Plan ${effectiveTier.toUpperCase()} renewed`,
-			})
-			.returning();
+		// Insert the renewal transaction and reset the credit cycle in ONE
+		// transaction so they commit together. Previously the insert and the
+		// credit reset were separate awaited statements: if the process died (or
+		// the update threw) after the transaction row committed but before the
+		// reset, the row remained and the idempotency guard above short-circuited
+		// every Stripe retry — leaving a "completed" renewal with credits never
+		// refreshed (stale `devPlanCreditsUsed`/cycle start) while the renewal
+		// date still advanced via `customer.subscription.updated`. onConflictDoNothing
+		// on the unique stripeInvoiceId index makes the pair atomically idempotent
+		// across Stripe's duplicate `invoice.paid`/`invoice.payment_succeeded`
+		// events. Reset the limit to the full tier allotment: mid-cycle upgrades
+		// leave the limit above it (unused-credit rollover), and that rollover only
+		// lasts until this renewal. Persist the effective tier and clear the pending
+		// downgrade so a scheduled downgrade becomes the active plan now. Clear any
+		// dunning freeze state since the limit is now authoritative again.
+		const renewalTransaction = await db.transaction(async (tx) => {
+			const [created] = await tx
+				.insert(tables.transaction)
+				.values({
+					organizationId,
+					type: "dev_plan_renewal",
+					amount: (invoice.amount_paid / 100).toString(),
+					creditAmount: creditsLimit.toString(),
+					currency: invoice.currency.toUpperCase(),
+					status: "completed",
+					stripePaymentIntentId: (invoice as any).payment_intent,
+					stripeInvoiceId: invoice.id,
+					description: `Dev Plan ${effectiveTier.toUpperCase()} renewed`,
+				})
+				.onConflictDoNothing()
+				.returning();
+
+			if (created) {
+				await tx
+					.update(tables.organization)
+					.set({
+						devPlan: effectiveTier,
+						devPlanPendingTier: null,
+						devPlanCreditsLimit: creditsLimit.toString(),
+						devPlanCreditsUsed: "0",
+						devPlanPremiumCreditsUsed: "0",
+						devPlanPremiumWeekStart: new Date(),
+						devPlanIncludedResetPassesUsed: 0,
+						devPlanCreditsFrozen: false,
+						devPlanCreditsLimitBeforeFreeze: null,
+						devPlanBillingCycleStart: new Date(),
+						devPlanExpiresAt: renewedPeriodEnd
+							? new Date(renewedPeriodEnd * 1000)
+							: undefined,
+						devPlanCancelled: false,
+					})
+					.where(eq(tables.organization.id, organizationId));
+			}
+
+			return created;
+		});
+
+		// Row already existed (concurrent/duplicate event won the insert): the
+		// winning path reconciled state and emailed, so bail out here.
+		if (!renewalTransaction) {
+			return;
+		}
 
 		try {
 			const billingDetails = await resolveDevPassBillingDetails(organization);
@@ -4035,32 +4082,6 @@ export async function handleInvoicePaymentSucceeded(event: {
 				e as Error,
 			);
 		}
-
-		// Reset credits used and update billing cycle start. Also reset the
-		// limit to the full tier allotment: mid-cycle upgrades leave the limit
-		// above it (unused-credit rollover), and that rollover only lasts until
-		// this renewal. Persist the effective tier and clear the pending
-		// downgrade so a scheduled downgrade becomes the active plan now. Clear
-		// any dunning freeze state since the limit is now authoritative again.
-		await db
-			.update(tables.organization)
-			.set({
-				devPlan: effectiveTier,
-				devPlanPendingTier: null,
-				devPlanCreditsLimit: creditsLimit.toString(),
-				devPlanCreditsUsed: "0",
-				devPlanPremiumCreditsUsed: "0",
-				devPlanPremiumWeekStart: new Date(),
-				devPlanIncludedResetPassesUsed: 0,
-				devPlanCreditsFrozen: false,
-				devPlanCreditsLimitBeforeFreeze: null,
-				devPlanBillingCycleStart: new Date(),
-				devPlanExpiresAt: renewedPeriodEnd
-					? new Date(renewedPeriodEnd * 1000)
-					: undefined,
-				devPlanCancelled: false,
-			})
-			.where(eq(tables.organization.id, organizationId));
 
 		logger.info(
 			`Dev plan ${effectiveTier} renewed for organization ${organizationId}, credits reset to 0/${creditsLimit}`,


### PR DESCRIPTION
## Problem

A DevPass ("Dev Plan LITE") customer reported their July renewal "failed": no July credits, even though a `dev_plan_renewal` transaction shows **completed / $87 credits** and the dashboard renewal date correctly advanced to Aug 2.

The transaction row and the renewal date advanced, but the customer's actual credit cycle (`devPlanCreditsUsed` / `devPlanBillingCycleStart`) was never reset — so their June usage carried over and they had ~no usable July balance.

## Root cause

In `handleInvoicePaymentSucceeded`, the `isDevPlanRenewal` branch ran two independent, non-atomic statements:

1. `db.insert(transaction)` — the `dev_plan_renewal` row (status `completed`)
2. an awaited `generateAndEmailInvoice(...)` network call
3. `db.update(organization)` — the actual credit-cycle reset (`devPlanCreditsUsed = 0`, limit, cycle start, expiry)

If the process died — or the org update threw — after step 1 committed but before step 3, the transaction row persisted permanently. On every Stripe retry (and on the paired `invoice.paid`/`invoice.payment_succeeded` event), the invoice-level idempotency guard finds the existing row and `return`s early **before** reaching the reset. Meanwhile `customer.subscription.updated` advances `devPlanExpiresAt` to the new period end without touching credits — so the dashboard date looks correct while the credits are stale. Net result: exactly the reported symptom.

The sibling `dev_plan_upgrade` branch already guards against this by wrapping insert + reconcile in a single `db.transaction` with `onConflictDoNothing()`.

## Fix

Wrap the renewal transaction insert and the credit-cycle reset in one `db.transaction`, with `onConflictDoNothing()` on the unique `stripeInvoiceId` index, mirroring the upgrade branch. Both writes now commit or roll back together, so a crash can no longer leave a recorded renewal with un-reset credits. The email and analytics are gated on winning the insert, so duplicate Stripe events can't double-email or diverge state.

Existing customers already stuck in the diverged state are fixed via a separate prod SQL reconciliation (not part of this PR).

## Testing
- `pnpm format`
- `pnpm turbo run build --filter=api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DevPlan renewal handling to prevent duplicate renewal processing when the same payment event is received multiple times.
  * Made renewal billing updates more reliable by applying them as an atomic, single-step update to reduce partial changes.
  * On successful renewals, credit cycle resets now also clear any frozen billing state to ensure the next cycle starts cleanly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->