### PR TITLE
fix(ui): hide DevPass card for enterprise orgs

### DIFF
--- a/apps/ui/src/components/dashboard/devpass-card.tsx
+++ b/apps/ui/src/components/dashboard/devpass-card.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, ChevronDown, ChevronUp, Terminal } from "lucide-react";
 import { useState } from "react";
 
 import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
+import { useDashboardContext } from "@/lib/dashboard-context";
 
 import { DEV_PLAN_PRICES } from "@llmgateway/shared";
 
@@ -23,7 +24,12 @@ interface DevPassCardProps {
 }
 
 export function DevPassCard({ defaultCollapsed = false }: DevPassCardProps) {
+	const { selectedOrganization } = useDashboardContext();
 	const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+	if (selectedOrganization?.plan === "enterprise") {
+		return null;
+	}
 
 	const toggle = () => {
 		const next = !collapsed;


### PR DESCRIPTION
## Summary

Hides the "DevPass — Separate product" dashboard card for organizations on the enterprise plan. DevPass is a self-serve coding-plan product that isn't relevant to enterprise customers, so the upsell card should not appear for them.

The gate lives inside `DevPassCard` itself (reading `selectedOrganization.plan` from the dashboard context), so it applies consistently to both render sites (main dashboard and the agents page) without duplicating the check.

## Changes

- `apps/ui/src/components/dashboard/devpass-card.tsx`: return `null` when the selected organization's plan is `enterprise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The DevPass card now hides automatically for enterprise organizations, preventing it from appearing where it shouldn’t.
  * Improved dashboard behavior by showing only the relevant card content based on organization type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->