### PR TITLE
fix(dev-plans): guard tier change on canceled sub

### DIFF
--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -466,4 +466,55 @@ describe("dev plan tier changes", () => {
 			claimedCycleStart.getTime(),
 		);
 	});
+
+	it("rejects a tier change on an already-ended subscription", async () => {
+		// The subscription is fully canceled in Stripe but the
+		// `customer.subscription.deleted` webhook hasn't reset the org yet. Stripe
+		// would reject the price update with `invalid_canceled_subscription_fields`,
+		// so bail out with a 409 before ever calling update.
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			customer: "cus_dev_plan",
+			status: "canceled",
+			metadata: {
+				organizationId: ORG_ID,
+				subscriptionType: "dev_plan",
+				devPlan: "lite",
+				devPlanCycle: "monthly",
+			},
+			items: {
+				data: [
+					{
+						id: "si_dev_plan",
+						current_period_start: nowSeconds - 500,
+						current_period_end: nowSeconds + 500,
+						price: {
+							id: "price_lite",
+						},
+					},
+				],
+			},
+		});
+
+		const res = await app.request("/dev-plans/change-tier", {
+			method: "POST",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				newTier: "pro",
+			}),
+		});
+
+		expect(res.status).toBe(409);
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+
+		// The change aborted before claiming the cycle, so nothing is persisted.
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlan).toBe("lite");
+		expect(org?.devPlanLastTierChangeCycleStart).toBeNull();
+	});
 });

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1060,6 +1060,25 @@ devPlans.openapi(changeTier, async (c) => {
 		const subscription =
 			await getStripe().subscriptions.retrieve(subscriptionId);
 
+		// A subscription Stripe has fully ended (`canceled`, or expired before its
+		// first payment) can no longer have its price/items changed: Stripe rejects
+		// the update with `invalid_canceled_subscription_fields`, which previously
+		// surfaced as a generic 500. This state is normally transient — the
+		// `customer.subscription.deleted` webhook resets the org's dev plan to
+		// "none", after which this handler short-circuits earlier — but a downgrade
+		// (which has no active-status guard below) reaching Stripe before that
+		// webhook lands, or if it was missed, would hit the rejected update. Bail
+		// out early with a clear message and without claiming the per-cycle change.
+		if (
+			subscription.status === "canceled" ||
+			subscription.status === "incomplete_expired"
+		) {
+			throw new HTTPException(409, {
+				message:
+					"Your dev plan subscription has ended. Subscribe again to choose a new plan.",
+			});
+		}
+
 		if (
 			isUpgrade &&
 			subscription.status !== "active" &&


### PR DESCRIPTION
## Problem

Production error alert:

> `Failed to change dev plan tier` at `apps/api/src/routes/dev-plans.ts:1372`

accompanied by a Stripe `invalid_canceled_subscription_fields` error at the same timestamp.

The dev-plan **change-tier** handler retrieves the Stripe subscription and then calls `subscriptions.update` to swap the price. When the subscription has been **fully ended** by Stripe (`status: canceled`, or `incomplete_expired`), Stripe rejects that update with `invalid_canceled_subscription_fields`. The catch block only maps `card_declined` / `invoice_payment_required` to a graceful 402, so this fell through to the generic `500 "Failed to change dev plan tier"`.

### How the org reaches this state

Normally the `customer.subscription.deleted` webhook resets the org's `devPlan` to `"none"` and clears `devPlanStripeSubscriptionId`, after which the handler short-circuits at the `devPlan === "none"` check. But in the window **before that webhook lands** (or if it was missed), the org still has a live tier + subscription id. The **upgrade** path is guarded (it throws a 402 for any non-active/trialing status), but the **downgrade** path had no status guard, so it reached the rejected Stripe update.

## Fix

Add an early guard right after retrieving the subscription — before claiming the per-cycle change or calling Stripe — that returns a clear **409** when the subscription is `canceled` or `incomplete_expired`, for both upgrade and downgrade paths:

> Your dev plan subscription has ended. Subscribe again to choose a new plan.

## Test

Added a spec asserting that a change-tier request against a `canceled` subscription returns 409, never calls `subscriptions.update`, and leaves the org's tier and per-cycle claim untouched. All 6 dev-plan tier-change tests pass; `pnpm format` and `api` build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dev plan tier changes when the linked subscription has ended or is no longer eligible.
  * Users now receive a clear conflict response if they try to change tiers after cancellation or expiration.
  * Confirmed that failed tier-change attempts do not alter the current plan or billing-cycle tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->