### PR TITLE
feat(api): expose key usage & limit reset times

### DIFF
--- a/apps/api/src/routes/platform-wallet.ts
+++ b/apps/api/src/routes/platform-wallet.ts
@@ -6,7 +6,11 @@ import { endUserSessionAuth } from "@/lib/end-user-session-auth.js";
 import { getStripe } from "@/routes/payments.js";
 import { ensureEndCustomerStripeCustomer } from "@/stripe.js";
 
-import { db } from "@llmgateway/db";
+import {
+	apiKeyPeriodDurationUnits,
+	db,
+	getApiKeyCurrentPeriodState,
+} from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
 	calculateFees,
@@ -149,6 +153,21 @@ const getBalance = createRoute({
 								description: z.string().nullable(),
 							}),
 						),
+						// Spend limits enforced on this session, with the values consumed
+						// so far and the reset time of the windowed limit. `null` limit
+						// fields mean that cap is not configured (uncapped).
+						limits: z.object({
+							usageLimit: z.string().nullable(),
+							usage: z.string(),
+							periodUsageLimit: z.string().nullable(),
+							periodUsageDurationValue: z.number().int().nullable(),
+							periodUsageDurationUnit: z
+								.enum(apiKeyPeriodDurationUnits)
+								.nullable(),
+							currentPeriodUsage: z.string(),
+							currentPeriodStartedAt: z.string().nullable(),
+							currentPeriodResetAt: z.string().nullable(),
+						}),
 					}),
 				},
 			},
@@ -170,11 +189,22 @@ platformWallet.openapi(getBalance, async (c) => {
 		throw new HTTPException(404, { message: "Wallet not found" });
 	}
 
+	// Spend limits live on the session token itself (carried forward across
+	// rotations), not on the wallet.
+	const sessionRecord = await db.query.endUserSession.findFirst({
+		where: { id: { eq: session.sessionId } },
+	});
+	if (!sessionRecord) {
+		throw new HTTPException(401, { message: "Invalid session token" });
+	}
+
 	const ledger = await db.query.walletLedger.findMany({
 		where: { walletId: { eq: session.walletId } },
 		orderBy: { createdAt: "desc" },
 		limit: 10,
 	});
+
+	const currentPeriod = getApiKeyCurrentPeriodState(sessionRecord);
 
 	return c.json({
 		balance: wallet.balance,
@@ -187,6 +217,20 @@ platformWallet.openapi(getBalance, async (c) => {
 			createdAt: row.createdAt.toISOString(),
 			description: row.description,
 		})),
+		limits: {
+			usageLimit: sessionRecord.usageLimit,
+			usage: sessionRecord.usage,
+			periodUsageLimit: sessionRecord.periodUsageLimit,
+			periodUsageDurationValue: sessionRecord.periodUsageDurationValue,
+			periodUsageDurationUnit: sessionRecord.periodUsageDurationUnit,
+			currentPeriodUsage: currentPeriod.usage,
+			currentPeriodStartedAt: currentPeriod.startedAt
+				? currentPeriod.startedAt.toISOString()
+				: null,
+			currentPeriodResetAt: currentPeriod.resetAt
+				? currentPeriod.resetAt.toISOString()
+				: null,
+		},
 	});
 });
 

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { maskToken } from "@/lib/maskToken.js";
 import {
 	buildApiKeyLimitAuditChanges,
 	createApiKeyForProject,
@@ -20,7 +21,7 @@ import {
 import { createProjectForOrg } from "@/routes/projects.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
-import { db, eq, tables } from "@llmgateway/db";
+import { db, eq, getApiKeyCurrentPeriodState, tables } from "@llmgateway/db";
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 
 import type { ServerTypes } from "@/vars.js";
@@ -109,6 +110,52 @@ async function loadApiKeyForOrg(apiKeyId: string, organizationId: string) {
 
 	return apiKey as typeof apiKey & {
 		project: NonNullable<typeof apiKey.project>;
+	};
+}
+
+interface SerializableApiKey {
+	id: string;
+	createdAt: Date;
+	updatedAt: Date;
+	description: string;
+	status: "active" | "inactive" | "deleted" | null;
+	projectId: string;
+	createdBy: string;
+	token: string;
+	usageLimit: string | null;
+	usage: string;
+	periodUsageLimit: string | null;
+	periodUsageDurationValue: number | null;
+	periodUsageDurationUnit: "hour" | "day" | "week" | "month" | null;
+	currentPeriodUsage: string;
+	currentPeriodStartedAt: Date | null;
+}
+
+/**
+ * Shape a gateway API key row for the master API, exposing the configured
+ * limits alongside the values consumed so far and — for a windowed limit —
+ * the time the current period resets. Never leaks the plain token.
+ */
+function serializeApiKeyForMaster(apiKey: SerializableApiKey) {
+	const currentPeriod = getApiKeyCurrentPeriodState(apiKey);
+
+	return {
+		id: apiKey.id,
+		createdAt: apiKey.createdAt,
+		updatedAt: apiKey.updatedAt,
+		description: apiKey.description,
+		status: apiKey.status,
+		projectId: apiKey.projectId,
+		createdBy: apiKey.createdBy,
+		maskedToken: maskToken(apiKey.token),
+		usageLimit: apiKey.usageLimit,
+		usage: apiKey.usage,
+		periodUsageLimit: apiKey.periodUsageLimit,
+		periodUsageDurationValue: apiKey.periodUsageDurationValue,
+		periodUsageDurationUnit: apiKey.periodUsageDurationUnit,
+		currentPeriodUsage: currentPeriod.usage,
+		currentPeriodStartedAt: currentPeriod.startedAt,
+		currentPeriodResetAt: currentPeriod.resetAt,
 	};
 }
 
@@ -481,10 +528,18 @@ const apiKeyDetailSchema = z.object({
 	status: z.enum(["active", "inactive", "deleted"]).nullable(),
 	projectId: z.string(),
 	createdBy: z.string(),
+	maskedToken: z.string(),
 	usageLimit: z.string().nullable(),
+	// Total spend accrued against `usageLimit` over the key's lifetime.
+	usage: z.string(),
 	periodUsageLimit: z.string().nullable(),
 	periodUsageDurationValue: z.number().int().nullable(),
 	periodUsageDurationUnit: apiKeyPeriodUnit.nullable(),
+	// Spend accrued in the current window, and when that window resets. Both are
+	// null / "0" when no period limit is configured or the window has lapsed.
+	currentPeriodUsage: z.string(),
+	currentPeriodStartedAt: z.date().nullable(),
+	currentPeriodResetAt: z.date().nullable(),
 });
 
 const updateApiKeyBody = z
@@ -651,7 +706,106 @@ v1Master.openapi(updateApiKey, async (c) => {
 		});
 	}
 
-	return c.json({ apiKey: updated });
+	return c.json({ apiKey: serializeApiKeyForMaster(updated) });
+});
+
+const listApiKeysQuery = z.object({
+	projectId: z.string().min(1).optional(),
+});
+
+const listApiKeys = createRoute({
+	method: "get",
+	path: "/keys",
+	request: {
+		query: listApiKeysQuery,
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						apiKeys: z.array(apiKeyDetailSchema).openapi({}),
+					}),
+				},
+			},
+			description:
+				"List gateway API keys in the master key's organization, with configured limits, consumed usage, and the current-period reset time. Optionally filter by projectId.",
+		},
+	},
+});
+
+v1Master.openapi(listApiKeys, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { projectId } = c.req.valid("query");
+
+	const projects = await db.query.project.findMany({
+		where: {
+			organizationId: { eq: masterKey.organizationId },
+			status: { ne: "deleted" },
+		},
+		columns: { id: true },
+	});
+	const projectIds = projects.map((p) => p.id);
+
+	if (projectId && !projectIds.includes(projectId)) {
+		throw new HTTPException(404, {
+			message: "Project not found in this organization",
+		});
+	}
+
+	if (projectIds.length === 0) {
+		return c.json({ apiKeys: [] });
+	}
+
+	const apiKeys = await db.query.apiKey.findMany({
+		where: {
+			projectId: { in: projectId ? [projectId] : projectIds },
+			// Only developer-created keys; hide platform and LLM SDK aggregate keys.
+			keyType: { eq: "user" },
+			status: { ne: "deleted" },
+		},
+		orderBy: { createdAt: "desc" },
+	});
+
+	return c.json({ apiKeys: apiKeys.map(serializeApiKeyForMaster) });
+});
+
+const getApiKey = createRoute({
+	method: "get",
+	path: "/keys/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						apiKey: apiKeyDetailSchema.openapi({}),
+					}),
+				},
+			},
+			description:
+				"Get a gateway API key with its configured limits, consumed usage, and the current-period reset time.",
+		},
+	},
+});
+
+v1Master.openapi(getApiKey, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+
+	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
+
+	return c.json({ apiKey: serializeApiKeyForMaster(apiKey) });
 });
 
 const deleteApiKey = createRoute({

--- a/apps/docs/content/features/embeddable-payments.mdx
+++ b/apps/docs/content/features/embeddable-payments.mdx
@@ -189,6 +189,27 @@ const { balance } = await client.getBalance();
 
 The headless client also exposes `chat()`, `image()`, `embeddings()`, `getBalance()`, `createTopUp(amount)`, and `getConfig()`.
 
+### Spend limits
+
+`getBalance()` (and `useBalance()`) also returns a `limits` object describing the spend limits enforced on the session, the amount consumed so far, and — when a windowed limit is configured — when it resets. This lets you show the user how much of their allowance is left before a request is rejected.
+
+```ts
+const { balance, limits } = await client.getBalance();
+
+// limits: {
+//   usageLimit,                // lifetime spend cap (null = uncapped)
+//   usage,                     // consumed over the session's lifetime
+//   periodUsageLimit,          // per-window cap (null = no windowed limit)
+//   periodUsageDurationValue,  // e.g. 1
+//   periodUsageDurationUnit,   // "hour" | "day" | "week" | "month"
+//   currentPeriodUsage,        // consumed in the current window
+//   currentPeriodStartedAt,    // ISO timestamp, or null
+//   currentPeriodResetAt,      // ISO timestamp the window resets, or null
+// }
+```
+
+`null` limit fields mean that cap is not configured. `currentPeriodUsage` is `"0"` and `currentPeriodResetAt` is `null` until the first spend in a fresh window.
+
 ## Buying credits
 
 `<BuyCredits amount={10} />` creates a Stripe PaymentIntent scoped to the user's wallet, renders Stripe's `PaymentElement`, and confirms the payment. Once LLM Gateway's webhook processes it, the wallet is credited the **net** amount (after your markup) and your margin accrues to your organization.

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -150,6 +150,95 @@ Response (200):
 { "message": "Project deleted successfully" }
 ```
 
+### List gateway API keys
+
+`GET /v1/master/keys`
+
+Returns the developer-created gateway API keys in the master key's organization, each with its configured limits, the usage consumed so far, and — when a windowed limit is set — the time the current period resets. Pass an optional `projectId` query parameter to scope the list to a single project.
+
+```bash
+curl "https://internal.llmgateway.io/v1/master/keys?projectId=proj_..." \
+  -H "Authorization: Bearer $MASTER_KEY"
+```
+
+Response (200):
+
+```json
+{
+	"apiKeys": [
+		{
+			"id": "ak_...",
+			"description": "Customer ACME — production key",
+			"status": "active",
+			"projectId": "proj_...",
+			"createdBy": "usr_...",
+			"maskedToken": "llmgtwy_...abcd",
+			"usageLimit": "100.00",
+			"usage": "42.13",
+			"periodUsageLimit": "10.00",
+			"periodUsageDurationValue": 1,
+			"periodUsageDurationUnit": "day",
+			"currentPeriodUsage": "3.50",
+			"currentPeriodStartedAt": "2025-01-15T00:00:00.000Z",
+			"currentPeriodResetAt": "2025-01-16T00:00:00.000Z",
+			"createdAt": "...",
+			"updatedAt": "..."
+		}
+	]
+}
+```
+
+Limit and usage fields:
+
+| Field                      | Description                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| `usageLimit`               | Lifetime spend cap (`null` when uncapped)                                          |
+| `usage`                    | Total spend accrued against `usageLimit` over the key's lifetime                   |
+| `periodUsageLimit`         | Recurring per-window spend cap (`null` when no windowed limit is configured)       |
+| `periodUsageDurationValue` | Length of the window, paired with `periodUsageDurationUnit`                        |
+| `periodUsageDurationUnit`  | `"hour" \| "day" \| "week" \| "month"`                                             |
+| `currentPeriodUsage`       | Spend accrued in the current window (`"0"` when unconfigured or the window lapsed) |
+| `currentPeriodStartedAt`   | When the current window began (`null` when unconfigured or lapsed)                 |
+| `currentPeriodResetAt`     | When the windowed limit resets (`null` when unconfigured or lapsed)                |
+
+The plain token is never returned by this endpoint — only a masked form for identification.
+
+### Get a gateway API key
+
+`GET /v1/master/keys/{id}`
+
+Returns a single gateway API key in the master key's organization, with the same limit, usage, and reset-time fields as the list endpoint.
+
+```bash
+curl https://internal.llmgateway.io/v1/master/keys/ak_... \
+  -H "Authorization: Bearer $MASTER_KEY"
+```
+
+Response (200):
+
+```json
+{
+	"apiKey": {
+		"id": "ak_...",
+		"description": "Customer ACME — production key",
+		"status": "active",
+		"projectId": "proj_...",
+		"createdBy": "usr_...",
+		"maskedToken": "llmgtwy_...abcd",
+		"usageLimit": "100.00",
+		"usage": "42.13",
+		"periodUsageLimit": "10.00",
+		"periodUsageDurationValue": 1,
+		"periodUsageDurationUnit": "day",
+		"currentPeriodUsage": "3.50",
+		"currentPeriodStartedAt": "2025-01-15T00:00:00.000Z",
+		"currentPeriodResetAt": "2025-01-16T00:00:00.000Z",
+		"createdAt": "...",
+		"updatedAt": "..."
+	}
+}
+```
+
 ### Create a gateway API key
 
 `POST /v1/master/keys`
@@ -224,7 +313,7 @@ Body parameters (all optional, at least one required):
 | `periodUsageDurationValue` | number \| null                         | Required if `periodUsageLimit` is set  |
 | `periodUsageDurationUnit`  | `"hour" \| "day" \| "week" \| "month"` | Required if `periodUsageLimit` is set  |
 
-Response (200): the updated API key (the plain token is **not** included — it is only returned at creation).
+Response (200): the updated API key, including its configured limits, consumed `usage` / `currentPeriodUsage`, and the `currentPeriodResetAt` window-reset time (same fields as the [list endpoint](#list-gateway-api-keys)). The plain token is **not** included — it is only returned at creation.
 
 ### Delete a gateway API key
 


### PR DESCRIPTION
## What

Surface **how much of an enforced limit has been consumed** and **when a windowed limit resets** on the token-based key APIs, so a caller can see their remaining allowance without waiting for a 401/402.

### Master-key API (primary) — `/v1/master/*`

The master-key API could create/update/delete gateway API keys but had **no way to read them**, and its update response omitted consumed usage and reset time.

- **New** `GET /v1/master/keys` (optional `?projectId=` filter) and `GET /v1/master/keys/{id}` — list/read the org's developer-created gateway keys.
- All key responses (list, get, and **update**) now include, alongside the configured limits:
  - `usage` — lifetime spend against `usageLimit`
  - `currentPeriodUsage` — spend in the current window
  - `currentPeriodStartedAt` — when the current window began
  - `currentPeriodResetAt` — **when the windowed limit resets**
  - `maskedToken` — for identifying keys (plain token never returned)
- Reset/period fields reuse the existing `getApiKeyCurrentPeriodState` helper, so semantics match the dashboard key API (expired/unstarted windows report `0` usage and a `null` reset time). List is scoped to the org and hides platform / LLM-SDK aggregate keys (`keyType = "user"`).

### End-user SDK balance — `GET /v1/wallet/balance`

`GET /balance` (ephemeral `es_…` session token) now returns a `limits` object with the session's `usageLimit`/`usage`, windowed `periodUsageLimit`/`currentPeriodUsage`, and `currentPeriodResetAt`, so the LLM SDK can show remaining allowance in-app.

## Docs

- `apps/docs/.../master-keys.mdx` — new List/Get key sections with a limit-field table; update-response note refreshed.
- `apps/docs/.../embeddable-payments.mdx` — documents the `limits` object on `getBalance()`/`useBalance()`.

## Notes

- `pnpm format` and `pnpm turbo run build --filter=api --filter=docs` all pass; the API OpenAPI spec regenerates cleanly.
- No existing tests cover these routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)