### PR TITLE
feat(gateway): serve metrics on internal-only port

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -18,8 +18,6 @@ import { db } from "@llmgateway/db";
 import {
 	createHonoRequestLogger,
 	createRequestLifecycleMiddleware,
-	getMetrics,
-	getMetricsContentType,
 } from "@llmgateway/instrumentation";
 import { logger, toError } from "@llmgateway/logger";
 import { HealthChecker } from "@llmgateway/shared";
@@ -320,32 +318,6 @@ app.openapi(root, async (c) => {
 	const { response, statusCode } = healthChecker.createHealthResponse(health);
 
 	return c.json(response, statusCode as 200 | 503);
-});
-
-// Prometheus metrics endpoint
-const metricsRoute = createRoute({
-	summary: "Prometheus metrics",
-	description: "Prometheus metrics endpoint for scraping.",
-	operationId: "metrics",
-	method: "get",
-	path: "/metrics",
-	responses: {
-		200: {
-			content: {
-				"text/plain": {
-					schema: z.string(),
-				},
-			},
-			description: "Prometheus metrics in exposition format.",
-		},
-	},
-});
-
-app.openapi(metricsRoute, async (c) => {
-	const metrics = await getMetrics();
-	return c.text(metrics, 200, {
-		"Content-Type": getMetricsContentType(),
-	});
 });
 
 const v1 = new OpenAPIHono<ServerTypes>();

--- a/apps/gateway/src/metrics-app.ts
+++ b/apps/gateway/src/metrics-app.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+
+import { getMetrics, getMetricsContentType } from "@llmgateway/instrumentation";
+
+// Standalone Prometheus metrics app. This is served on a separate port
+// (METRICS_PORT) that is only exposed inside the cluster, so the metrics are
+// never reachable through the public gateway ingress.
+export const metricsApp = new Hono();
+
+metricsApp.get("/metrics", async (c) => {
+	const metrics = await getMetrics();
+	return c.text(metrics, 200, {
+		"Content-Type": getMetricsContentType(),
+	});
+});

--- a/apps/gateway/src/metrics-endpoint.spec.ts
+++ b/apps/gateway/src/metrics-endpoint.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { app } from "./app.js";
+import { metricsApp } from "./metrics-app.js";
+
+describe("metrics endpoint isolation", () => {
+	test("the public gateway app does not expose /metrics", async () => {
+		const res = await app.request("/metrics");
+		expect(res.status).toBe(404);
+	});
+
+	test("the internal metrics app serves Prometheus metrics", async () => {
+		const res = await metricsApp.request("/metrics");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toContain("text/plain");
+	});
+});

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -9,6 +9,7 @@ import {
 import { logger, toError } from "@llmgateway/logger";
 
 import { app } from "./app.js";
+import { metricsApp } from "./metrics-app.js";
 
 import type { ServerType } from "@hono/node-server";
 import type { NodeSDK } from "@opentelemetry/sdk-node";
@@ -16,12 +17,18 @@ import type { Server } from "node:http";
 
 const port = Number(process.env.PORT) || 4001;
 
+// The Prometheus metrics endpoint is served on a separate port so it can be
+// exposed only internally (via the cluster network / Service) and never through
+// the public gateway ingress.
+const metricsPort = Number(process.env.METRICS_PORT) || 9090;
+
 // GCP Load Balancer has a fixed 600s keepalive timeout. Node.js default is 5s.
 // If Node closes the connection first, the LB sends requests on stale connections → 502.
 // Default to 620s (above GCP's 600s) to ensure the LB closes first.
 const keepAliveTimeoutS = Number(process.env.KEEP_ALIVE_TIMEOUT_S) || 620;
 
 let sdk: NodeSDK | null = null;
+let metricsServer: ServerType | null = null;
 
 async function startServer() {
 	// Tag every DB query with the originating service for Cloud SQL Query Insights
@@ -37,6 +44,13 @@ async function startServer() {
 		logger.error("Failed to initialize instrumentation", error as Error);
 		// Continue without tracing
 	}
+
+	// Serve Prometheus metrics on a separate, internal-only port.
+	logger.info("Metrics server starting", { port: metricsPort });
+	metricsServer = serve({
+		port: metricsPort,
+		fetch: metricsApp.fetch,
+	});
 
 	logger.info("Server starting", { port });
 
@@ -104,6 +118,12 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 		logger.info("Closing HTTP server");
 		await closeServer(server);
 		logger.info("HTTP server closed");
+
+		if (metricsServer) {
+			logger.info("Closing metrics server");
+			metricsServer.close();
+			logger.info("Metrics server closed");
+		}
 
 		logger.info("Closing database connection");
 		await closeDatabase();

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -121,7 +121,7 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 
 		if (metricsServer) {
 			logger.info("Closing metrics server");
-			metricsServer.close();
+			await closeServer(metricsServer);
 			logger.info("Metrics server closed");
 		}
 

--- a/infra/helm/llmgateway/templates/configmap.yaml
+++ b/infra/helm/llmgateway/templates/configmap.yaml
@@ -55,6 +55,9 @@ data:
   PASSKEY_RP_NAME: {{ .Values.auth.passkey.rpName | quote }}
   {{- end }}
 
+  # Internal-only Prometheus metrics port (served separately from the public API)
+  METRICS_PORT: {{ .Values.gateway.metricsPort | default 9090 | quote }}
+
   # Gateway timeouts
   {{- with .Values.gateway.config }}
   {{- if .gatewayTimeoutMs }}

--- a/infra/helm/llmgateway/templates/gateway-deployment.yaml
+++ b/infra/helm/llmgateway/templates/gateway-deployment.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ .Values.gateway.metricsPort | default 9090 | quote }}
     spec:
       {{- include "llmgateway.imagePullSecrets" . | nindent 6 }}
       initContainers:
@@ -47,6 +50,9 @@ spec:
           ports:
             - name: http
               containerPort: 80
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.gateway.metricsPort | default 9090 }}
               protocol: TCP
           envFrom:
             - configMapRef:

--- a/infra/helm/llmgateway/templates/gateway-metrics-service.yaml
+++ b/infra/helm/llmgateway/templates/gateway-metrics-service.yaml
@@ -2,16 +2,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "llmgateway.fullname" . }}-gateway
+  name: {{ include "llmgateway.fullname" . }}-gateway-metrics
   labels:
     {{- include "llmgateway.componentLabels" (dict "context" . "component" "gateway") | nindent 4 }}
 spec:
-  type: {{ .Values.gateway.service.type | default "ClusterIP" }}
+  # Always ClusterIP so the metrics endpoint stays internal to the cluster even
+  # when the main gateway Service is exposed via LoadBalancer/NodePort.
+  type: ClusterIP
   ports:
-    - port: 80
-      targetPort: http
+    - port: {{ .Values.gateway.metricsPort | default 9090 }}
+      targetPort: metrics
       protocol: TCP
-      name: http
+      name: metrics
   selector:
     {{- include "llmgateway.componentSelectorLabels" (dict "context" . "component" "gateway") | nindent 4 }}
 {{- end }}

--- a/infra/helm/llmgateway/templates/gateway-service.yaml
+++ b/infra/helm/llmgateway/templates/gateway-service.yaml
@@ -12,6 +12,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    # Metrics port is only reachable inside the cluster (ClusterIP, not routed
+    # by the ingress), so Prometheus can scrape it without exposing it publicly.
+    - port: {{ .Values.gateway.metricsPort | default 9090 }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "llmgateway.componentSelectorLabels" (dict "context" . "component" "gateway") | nindent 4 }}
 {{- end }}

--- a/infra/helm/llmgateway/values.yaml
+++ b/infra/helm/llmgateway/values.yaml
@@ -116,6 +116,9 @@ gateway:
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
+  # -- Internal-only port for the Prometheus /metrics endpoint. Exposed via the
+  # ClusterIP Service for in-cluster scraping; never routed by the ingress.
+  metricsPort: 9090
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## What

Moves the Prometheus `/metrics` endpoint off the public gateway app and onto a **separate server bound to `METRICS_PORT` (default `9090`)**, so it can be exposed only inside the cluster and is never reachable through the public gateway ingress.

## Why

`/metrics` was registered on the main gateway app, so it was served on the same port that the public ingress routes to — meaning anyone could scrape internal Prometheus metrics from the internet.

## Changes

- **`apps/gateway/src/metrics-app.ts`** — new standalone Hono app serving only `GET /metrics`.
- **`apps/gateway/src/app.ts`** — removed the `/metrics` route from the public app.
- **`apps/gateway/src/serve.ts`** — start the metrics app on `METRICS_PORT` alongside the main server, and close it during graceful shutdown.
- **Helm chart** — expose the `metrics` port on the gateway **ClusterIP Service** (not the ingress), add `prometheus.io/*` scrape annotations, wire `METRICS_PORT`, and add a `gateway.metricsPort` value (default `9090`).

## Notes

The production deployment infra (`llmgateway/llmgateway-infra`) is updated in a companion PR to scrape the new internal port.

## Testing

- `apps/gateway/src/metrics-endpoint.spec.ts` — asserts the public app returns 404 for `/metrics` and the internal metrics app serves it.
- `pnpm turbo run build --filter=gateway`, `pnpm format`, `helm template` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate internal metrics endpoint for the gateway.
  * Exposed Prometheus scraping support through cluster-only service and deployment settings.
  * Added a configurable metrics port, defaulting to `9090`.

* **Bug Fixes**
  * The public gateway no longer serves metrics on its main HTTP routes.

* **Tests**
  * Added coverage to verify public and internal metrics routes behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->