### PR TITLE
feat: allow empryo source for CLI connect

### DIFF
--- a/apps/ui/src/app/connect/cli/page.tsx
+++ b/apps/ui/src/app/connect/cli/page.tsx
@@ -75,7 +75,7 @@ function readParams(): ConnectParams | null {
 		callback,
 		state,
 		source: params.get("source") ?? "coding CLI",
-		name: (params.get("name") ?? "DevPass Code CLI").slice(0, 80),
+		name: (params.get("name") ?? "").slice(0, 80),
 		org: params.get("org") === "devpass" ? "devpass" : "default",
 	};
 }
@@ -126,7 +126,9 @@ export default function ConnectCliPage() {
 		createApiKey.mutate(
 			{
 				body: {
-					description: `${displayName} (CLI) — ${params.name}`.slice(0, 100),
+					description: `${displayName} (CLI)${
+						params.name ? ` — ${params.name}` : ""
+					}`.slice(0, 100),
 					projectId: project.id,
 					usageLimit: null,
 					expiresAt,

--- a/packages/shared/src/coding-agents.spec.ts
+++ b/packages/shared/src/coding-agents.spec.ts
@@ -16,6 +16,7 @@ describe("isRecognizedCodingAgent", () => {
 		expect(isRecognizedCodingAgent("cursor")).toBe(true);
 		expect(isRecognizedCodingAgent("autohand")).toBe(true);
 		expect(isRecognizedCodingAgent("soulforge")).toBe(true);
+		expect(isRecognizedCodingAgent("empryo")).toBe(true);
 		expect(isRecognizedCodingAgent("n8n")).toBe(true);
 		expect(isRecognizedCodingAgent("openclaw")).toBe(true);
 		expect(isRecognizedCodingAgent("aider")).toBe(true);

--- a/packages/shared/src/coding-agents.ts
+++ b/packages/shared/src/coding-agents.ts
@@ -74,6 +74,12 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 		userAgentPatterns: [/^soulforge\//i],
 	},
 	{
+		id: "empryo",
+		label: "Empryo",
+		xSourceValues: ["empryo"],
+		userAgentPatterns: [/^empryo\//i, /\bempryo\b/i],
+	},
+	{
 		id: "n8n",
 		label: "n8n",
 		xSourceValues: ["n8n"],


### PR DESCRIPTION
## Summary

- Adds **Empryo** to the `CODING_AGENTS` registry in `@llmgateway/shared` (`source=empryo`, UA patterns `empryo/...`), so it passes `isRecognizedCodingAgent` in both the gateway's DevPass source restriction and the `/connect/cli` authorize screen. Empryo's CLI can now flip `LLMGATEWAY_SOURCE=empryo` instead of riding the `devpass-code` id.
- **OpenCode** was already allowlisted (`opencode` / `open-code`) — no change needed there.
- The `/connect/cli` authorize screen already derives its title, description, and button from the `source` param, so it now shows the actual connecting agent by name: DevPass Code, SoulForge, OpenCode, or Empryo.
- Removes the hardcoded `"DevPass Code CLI"` default for the `name` param on the connect page, so minted API-key descriptions are labeled after the actual connecting agent (e.g. `Empryo (CLI) — <machine>`) instead of falling back to a DevPass Code label.

## Testing

- `vitest run` on `coding-agents.spec.ts` (new `empryo` assertion) and `detect-coding-agent.spec.ts` — 27 tests pass
- Full `pnpm build` — 17/17 tasks successful
- `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5e7GfzZdBuF7SWTaGzhza

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Empryo coding agent, including recognition and display in supported agent lists.
* **Bug Fixes**
  * Improved CLI connection API key details by using the provided name when available and keeping descriptions cleaner when it isn’t.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->