### PR TITLE
fix(models): correct granite glm-5.2 and qwen3.7-max pricing

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1366,11 +1366,15 @@ export const alibabaModels = [
 			{
 				providerId: "granite",
 				externalId: "qwen3.7-max",
-				inputPrice: "2.5e-6",
-				outputPrice: "7.5e-6",
-				cachedInputPrice: "0.5e-6",
-				cacheReadInputPrice: "0.25e-6",
-				cacheWriteInputPrice: "3.125e-6",
+				// Granite bills qwen3.7-max at ~$1.25/$3.75 per M (novita-tier), not
+				// Alibaba's $2.5/$7.5 list. Verified against a granite prod usage log
+				// (16 in / 486 out billed $0.0017 => ~$3.46/M output); the old list
+				// rates over-billed this mapping ~2x.
+				inputPrice: "1.25e-6",
+				outputPrice: "3.75e-6",
+				cachedInputPrice: "0.25e-6",
+				cacheReadInputPrice: "0.125e-6",
+				cacheWriteInputPrice: "1.5625e-6",
 				requestPrice: "0",
 				contextSize: 1000000,
 				maxOutput: 65536,

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -62,9 +62,16 @@ export const zaiModels = [
 			{
 				providerId: "granite",
 				externalId: "glm-5.2",
-				inputPrice: "1.4e-6",
-				cachedInputPrice: "0.26e-6",
-				outputPrice: "4.4e-6",
+				// Rates verified against granite prod usage logs. The upstream's
+				// input ($0.77/M) and output ($2.695/M) rates are accurate, but it
+				// bills cache reads at ~$0.96/M — 5x its advertised $0.192/M. These
+				// values reproduce granite's per-request charges to <1% (a
+				// 79k-in/3.9k-out, 78k-cache request billed $0.0868 vs $0.0868
+				// computed). The prior z.ai reference rates ($1.4/$0.26/$4.4)
+				// mispriced every field.
+				inputPrice: "0.77e-6",
+				cachedInputPrice: "0.96e-6",
+				outputPrice: "2.695e-6",
 				requestPrice: "0",
 				contextSize: 1000000,
 				maxOutput: 128000,


### PR DESCRIPTION
## Problem

granite usage cost far more upstream than we recorded — prod totals showed our side under-counting glm-5.2 by ~3.6x. The mismatch is not the per-token rate math, reasoning-token handling, or estimation fallback; completed-request billing is correct. It was two mispriced mappings.

## Root cause (verified against granite prod usage logs)

**glm-5.2 was on z.ai reference rates** (`$1.4 / $0.26 / $4.4`), which mispriced every field:
- **Input `$0.77/M` and output `$2.695/M`** are the upstream's actual rates (a higher-output log — 79,331 in / 3,949 out / 78,464 cache, billed `$0.0868` — isolates these; `$2.695/M` output is the only value consistent with the cache rate across all logs).
- **Cache read is billed at `~$0.96/M`** — 5x the upstream's advertised `$0.192/M`. Coding-agent traffic is ~99% cache reads at 200k context, so this term dominates. The old `$0.26/M` under-billed it ~3.6x.

These rates reproduce the upstream's per-request charges to **<1%**, and reconcile the 30-day aggregate (991.4M tokens, 90.3% cache, spend consistent only at ~$0.96/M cache; the advertised $0.192/M would imply ~1/4 of the real spend).

**qwen3.7-max was on Alibaba list** (`$2.5 / $7.5`); the upstream bills novita-tier `~$1.25 / $3.75` (a 16-in/486-out row billed `$0.0017` → ~$3.46/M output), so the mapping over-billed ~2x.

## Changes

- granite glm-5.2: `0.77e-6 / 0.96e-6(cache) / 2.695e-6`
- granite qwen3.7-max: `1.25e-6 / 3.75e-6`, cache fields scaled to match

## Notes

- No billing-code changes: per-request accounting (streamed + non-streamed, reasoning included in `completion_tokens`) was verified correct.
- The upstream's public cache-read rate does not match what it actually bills (5x higher); these mappings follow actual billed cost, not the advertised page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pricing for selected AI models to better reflect verified Granite billing rates.
  * Corrected input/output and cached input/output pricing for additional Granite provider models.
  * Aligned cached cache-read/cache-write pricing with the latest verified charges, including where prior list-rate values were mismatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->