### PR TITLE
fix(api): handle ended dev plan on resume

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -791,6 +791,24 @@ devPlans.openapi(resume, async (c) => {
 			personalOrg.devPlanStripeSubscriptionId,
 		);
 
+		// A subscription Stripe has fully ended (`canceled`, or expired before its
+		// first payment) can no longer be reactivated: Stripe rejects the update
+		// with `invalid_canceled_subscription_fields` ("A canceled subscription can
+		// only update its cancellation_details and metadata."), which previously
+		// surfaced as a generic 500. This state is normally transient — the
+		// `customer.subscription.deleted` webhook resets the org's dev plan to
+		// "none" — but a resume reaching Stripe before that webhook lands, or if it
+		// was missed, hits the rejected update. Bail out early with a clear message.
+		if (
+			subscription.status === "canceled" ||
+			subscription.status === "incomplete_expired"
+		) {
+			throw new HTTPException(409, {
+				message:
+					"Your dev plan subscription has ended. Subscribe again to start a new plan.",
+			});
+		}
+
 		if (!subscription.cancel_at_period_end) {
 			throw new HTTPException(400, {
 				message: "Subscription is not cancelled",
@@ -824,6 +842,9 @@ devPlans.openapi(resume, async (c) => {
 			success: true,
 		});
 	} catch (error) {
+		if (error instanceof HTTPException) {
+			throw error;
+		}
 		logger.error(
 			"Stripe dev plan resume error",
 			error instanceof Error ? error : new Error(String(error)),


### PR DESCRIPTION
## What

The production error `Stripe dev plan resume error: A canceled subscription can only update its cancellation_details and metadata.` (`invalid_canceled_subscription_fields`) came from the dev plan **resume** handler.

The handler only checked `cancel_at_period_end` before calling `subscriptions.update({ cancel_at_period_end: false })`. When a subscription has been fully **ended** by Stripe (status `canceled`, or `incomplete_expired` for one that expired before its first payment), Stripe rejects any item update. This surfaced as a generic 500 and noisy error logs.

## Fix

- Guard for the terminally-ended state (`canceled` / `incomplete_expired`) before the `cancel_at_period_end` check and return a **409** with a clear "subscribe again" message — mirroring the existing guard in the `changeTier` handler.
- Re-throw `HTTPException`s from the `catch` block so intentional 4xx responses (this new 409 and the existing 400) surface correctly instead of being swallowed into a 500.

This state is normally transient — the `customer.subscription.deleted` webhook resets the org's dev plan to "none" — but a resume request racing ahead of that webhook (or a missed webhook) would previously hit the rejected update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The resume flow now blocks attempts to reactivate subscriptions that have fully ended, returning a clear “subscribe again” response instead of failing later.
  * HTTP errors are now preserved as-is, so users see the correct response code and message instead of a generic server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->