### PR TITLE
fix(api): route cached mutations through cdb

### DIFF
--- a/apps/api/src/routes/custom-models.ts
+++ b/apps/api/src/routes/custom-models.ts
@@ -5,22 +5,16 @@ import { z } from "zod";
 import { getAdminOrganizationIds } from "@/utils/authorization.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
-import { invalidateSwrByTables } from "@llmgateway/cache";
-import { db, eq, getTableName, tables } from "@llmgateway/db";
+import { cdb, db, eq, tables } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
 export const customModels = new OpenAPIHono<ServerTypes>();
 
-const customModelTableName = getTableName(tables.customModel);
-
-// The gateway reads custom models through its SWR cache (keyed on the
-// custom_model table). The API writes go through the uncached client, so we
-// must explicitly invalidate after mutations or the gateway can serve stale
-// pricing/limits/rejections until the cache expires.
-async function invalidateCustomModelCache(): Promise<void> {
-	await invalidateSwrByTables([customModelTableName]);
-}
+// The gateway reads custom models through a cached select (cdb) wrapped in an
+// SWR fallback mirror, both keyed on the custom_model table. Mutations below
+// write through cdb so its onMutate busts both layers; otherwise the gateway
+// can serve stale pricing/limits/rejections until the cache expires.
 
 const priceField = z
 	.string()
@@ -248,7 +242,7 @@ customModels.openapi(create, async (c) => {
 		});
 	}
 
-	const [customModel] = await db
+	const [customModel] = await cdb
 		.insert(tables.customModel)
 		.values({
 			providerKeyId,
@@ -268,8 +262,6 @@ customModels.openapi(create, async (c) => {
 			modelName: fields.modelName,
 		},
 	});
-
-	await invalidateCustomModelCache();
 
 	return c.json({ customModel });
 });
@@ -350,7 +342,7 @@ customModels.openapi(update, async (c) => {
 		}
 	}
 
-	const [customModel] = await db
+	const [customModel] = await cdb
 		.update(tables.customModel)
 		.set(fields)
 		.where(eq(tables.customModel.id, id))
@@ -367,8 +359,6 @@ customModels.openapi(update, async (c) => {
 			modelName: customModel.modelName,
 		},
 	});
-
-	await invalidateCustomModelCache();
 
 	return c.json({ customModel }, 200);
 });
@@ -423,7 +413,7 @@ customModels.openapi(deleteCustomModel, async (c) => {
 
 	await getManageableProviderKey(user.id, existing.providerKeyId);
 
-	await db
+	await cdb
 		.update(tables.customModel)
 		.set({ status: "deleted" })
 		.where(eq(tables.customModel.id, id));
@@ -439,8 +429,6 @@ customModels.openapi(deleteCustomModel, async (c) => {
 			modelName: existing.modelName,
 		},
 	});
-
-	await invalidateCustomModelCache();
 
 	return c.json({ message: "Custom model deleted successfully" });
 });

--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -4,7 +4,7 @@ import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
 import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
-import { db, eq, getTableName, tables } from "@llmgateway/db";
+import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
 
 const ONE_MINUTE_MS = 60 * 1000;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
@@ -375,6 +375,66 @@ describe("keys route", () => {
 
 		// The cached lookup for the old token must be gone after the roll.
 		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+	});
+
+	test("POST /keys/api/{id}/iam busts the gateway's cached IAM rule lookups", async () => {
+		// The gateway enforces IAM rules through a cached select (cdb) wrapped in
+		// an SWR fallback mirror, both indexed by the api_key_iam_rule table (see
+		// findActiveIamRules in apps/gateway/src/lib/cached-queries.ts). Creating
+		// a rule through cdb must bust both layers so it applies immediately.
+		//
+		// A per-run unique API key keeps the cache keys (SWR key and Drizzle query
+		// hash, which includes the bind params) from colliding with cached entries
+		// left in Redis by earlier runs, which outlive deleteAll().
+		const apiKeyId = `cache-test-api-key-${crypto.randomUUID()}`;
+		await db.insert(tables.apiKey).values({
+			id: apiKeyId,
+			token: `${apiKeyId}-token`,
+			projectId: "test-project-id",
+			description: "IAM Cache Test Key",
+			createdBy: "test-user-id",
+		});
+		const readActiveIamRules = () =>
+			swrWrap(
+				`iamRules:${apiKeyId}`,
+				[getTableName(tables.apiKeyIamRule)],
+				async () =>
+					await cdb
+						.select()
+						.from(tables.apiKeyIamRule)
+						.where(
+							and(
+								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+								eq(tables.apiKeyIamRule.status, "active"),
+							),
+						),
+			);
+
+		// Prime both cache layers with the "no rules" result.
+		expect(await readActiveIamRules()).toHaveLength(0);
+		expect(
+			await redisClient.get(SWR_PREFIX + `iamRules:${apiKeyId}`),
+		).not.toBeNull();
+
+		const res = await app.request(`/keys/api/${apiKeyId}/iam`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		// The SWR mirror for the api_key_iam_rule table must be gone...
+		expect(
+			await redisClient.get(SWR_PREFIX + `iamRules:${apiKeyId}`),
+		).toBeNull();
+		// ...and the cached select must serve the new rule, not the stale miss.
+		expect(await readActiveIamRules()).toHaveLength(1);
 	});
 
 	test("POST /keys/api creates a period usage limit", async () => {

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -610,7 +610,7 @@ keysApi.openapi(createPlatformKey, async (c) => {
 	});
 	const token = `sk_${test ? "test" : "live"}_${shortid(40)}`;
 
-	const [platformKey] = await db
+	const [platformKey] = await cdb
 		.insert(tables.apiKey)
 		.values({
 			token,
@@ -1063,7 +1063,7 @@ export async function createApiKeyForProject(
 		process.env.NODE_ENV === "development" ? `llmgdev_` : "llmgtwy_";
 	const token = prefix + shortid(40);
 
-	const [apiKey] = await db
+	const [apiKey] = await cdb
 		.insert(tables.apiKey)
 		.values({
 			token,
@@ -2210,7 +2210,7 @@ keysApi.openapi(createIamRule, async (c) => {
 	);
 
 	// Create the IAM rule
-	const [rule] = await db
+	const [rule] = await cdb
 		.insert(tables.apiKeyIamRule)
 		.values({
 			apiKeyId: id,
@@ -2469,7 +2469,7 @@ keysApi.openapi(updateIamRule, async (c) => {
 	);
 
 	// Update the IAM rule
-	const [updatedRule] = await db
+	const [updatedRule] = await cdb
 		.update(tables.apiKeyIamRule)
 		.set(updateData)
 		.where(eq(tables.apiKeyIamRule.id, ruleId))
@@ -2609,7 +2609,7 @@ keysApi.openapi(deleteIamRule, async (c) => {
 	}
 
 	// Delete the IAM rule
-	const result = await db
+	const result = await cdb
 		.delete(tables.apiKeyIamRule)
 		.where(eq(tables.apiKeyIamRule.id, ruleId))
 		.returning();

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -3,7 +3,8 @@ import { expect, test, beforeEach, describe, afterEach } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { db, tables } from "@llmgateway/db";
+import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
+import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
 
 describe("provider keys route", () => {
 	let token: string;
@@ -292,5 +293,120 @@ describe("provider keys route", () => {
 		});
 		expect(providerKey).not.toBeNull();
 		expect(providerKey?.status).toBe("deleted");
+	});
+
+	// The gateway resolves provider keys through a cached select (cdb) wrapped
+	// in an SWR fallback mirror, both indexed by the provider_key table (see
+	// apps/gateway/src/lib/cached-queries.ts). Mutations must go through cdb so
+	// its onMutate busts both layers; otherwise the gateway serves stale keys
+	// until the cache TTL expires.
+	//
+	// Each test uses its own org so the cache keys (SWR key and Drizzle query
+	// hash, which includes the bind params) are unique per run — cached entries
+	// in Redis outlive deleteAll() and would otherwise leak between runs.
+	async function createCacheTestOrg() {
+		const orgId = `cache-test-org-${crypto.randomUUID()}`;
+		await db.insert(tables.organization).values({
+			id: orgId,
+			name: "Cache Test Organization",
+			billingEmail: "cache-test@example.com",
+			plan: "pro",
+		});
+		await db.insert(tables.userOrganization).values({
+			id: `${orgId}-membership`,
+			userId: "test-user-id",
+			organizationId: orgId,
+			role: "owner",
+		});
+		await db.insert(tables.project).values({
+			id: `${orgId}-project`,
+			name: "Cache Test Project",
+			organizationId: orgId,
+		});
+		return orgId;
+	}
+
+	function readActiveProviderKeys(orgId: string, provider: string) {
+		return swrWrap(
+			`providerKey:${orgId}:${provider}`,
+			[getTableName(tables.providerKey)],
+			async () =>
+				await cdb
+					.select()
+					.from(tables.providerKey)
+					.where(
+						and(
+							eq(tables.providerKey.status, "active"),
+							eq(tables.providerKey.organizationId, orgId),
+							eq(tables.providerKey.provider, provider),
+						),
+					),
+		);
+	}
+
+	test("POST /keys/provider makes the new key visible to cached lookups", async () => {
+		const orgId = await createCacheTestOrg();
+
+		// Prime both cache layers with the "no key" result.
+		expect(await readActiveProviderKeys(orgId, "anthropic")).toHaveLength(0);
+		expect(
+			await redisClient.get(SWR_PREFIX + `providerKey:${orgId}:anthropic`),
+		).not.toBeNull();
+
+		const res = await app.request("/keys/provider", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({
+				provider: "anthropic",
+				token: "anthropic-test-token",
+				organizationId: orgId,
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		// The SWR mirror for the provider_key table must be gone...
+		expect(
+			await redisClient.get(SWR_PREFIX + `providerKey:${orgId}:anthropic`),
+		).toBeNull();
+		// ...and the cached select must serve the new key, not the stale miss.
+		expect(await readActiveProviderKeys(orgId, "anthropic")).toHaveLength(1);
+	});
+
+	test("PATCH /keys/provider/{id} busts cached lookups of the key", async () => {
+		const orgId = await createCacheTestOrg();
+		await db.insert(tables.providerKey).values({
+			id: `${orgId}-provider-key`,
+			token: "cache-test-provider-token",
+			provider: "openai",
+			organizationId: orgId,
+		});
+
+		// Prime both cache layers with the key still active.
+		expect(await readActiveProviderKeys(orgId, "openai")).toHaveLength(1);
+		expect(
+			await redisClient.get(SWR_PREFIX + `providerKey:${orgId}:openai`),
+		).not.toBeNull();
+
+		const res = await app.request(`/keys/provider/${orgId}-provider-key`, {
+			method: "PATCH",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({
+				status: "inactive",
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		// The SWR mirror for the provider_key table must be gone...
+		expect(
+			await redisClient.get(SWR_PREFIX + `providerKey:${orgId}:openai`),
+		).toBeNull();
+		// ...and the cached select must reflect the deactivation immediately.
+		expect(await readActiveProviderKeys(orgId, "openai")).toHaveLength(0);
 	});
 });

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -7,8 +7,7 @@ import { getAdminOrganizationIds } from "@/utils/authorization.js";
 
 import { validateProviderKey } from "@llmgateway/actions";
 import { logAuditEvent } from "@llmgateway/audit";
-import { invalidateSwrByTables } from "@llmgateway/cache";
-import { db, eq, getTableName, tables } from "@llmgateway/db";
+import { cdb, db, eq, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import { isStealthProvider, providers } from "@llmgateway/models";
 import { assertSafeProviderUrl } from "@llmgateway/shared/url-safety-node";
@@ -17,8 +16,6 @@ import type { ServerTypes } from "@/vars.js";
 import type { ProviderId } from "@llmgateway/models";
 
 export const keysProvider = new OpenAPIHono<ServerTypes>();
-
-const providerKeyTableName = getTableName(tables.providerKey);
 
 // Create a schema for provider key responses
 // Using z.object directly instead of createSelectSchema due to compatibility issues
@@ -342,7 +339,7 @@ keysProvider.openapi(create, async (c) => {
 
 	// Use the user-provided token
 	// Create the provider key
-	const [providerKey] = await db
+	const [providerKey] = await cdb
 		.insert(tables.providerKey)
 		.values({
 			token: userToken,
@@ -365,10 +362,6 @@ keysProvider.openapi(create, async (c) => {
 			hasCustomBaseUrl: !!baseUrl,
 		},
 	});
-
-	// The gateway caches provider keys via SWR; invalidate so a newly added key
-	// is usable immediately.
-	await invalidateSwrByTables([providerKeyTableName]);
 
 	return c.json({
 		providerKey: {
@@ -570,7 +563,7 @@ keysProvider.openapi(deleteKey, async (c) => {
 		});
 	}
 
-	await db
+	await cdb
 		.update(tables.providerKey)
 		.set({
 			status: "deleted",
@@ -587,10 +580,6 @@ keysProvider.openapi(deleteKey, async (c) => {
 			provider: providerKey.provider,
 		},
 	});
-
-	// The gateway caches provider keys via SWR; invalidate so a deleted key
-	// stops being used immediately.
-	await invalidateSwrByTables([providerKeyTableName]);
 
 	return c.json({
 		message: "Provider key deleted successfully",
@@ -714,7 +703,7 @@ keysProvider.openapi(updateStatus, async (c) => {
 	}
 
 	// Update the provider key
-	const [updatedProviderKey] = await db
+	const [updatedProviderKey] = await cdb
 		.update(tables.providerKey)
 		.set(updates)
 		.where(eq(tables.providerKey.id, id))
@@ -746,9 +735,6 @@ keysProvider.openapi(updateStatus, async (c) => {
 				changes,
 			},
 		});
-		// The gateway caches provider keys (incl. customModelsOnly) via SWR;
-		// invalidate so status/restriction changes take effect promptly.
-		await invalidateSwrByTables([providerKeyTableName]);
 	}
 
 	return c.json({

--- a/apps/api/src/routes/routing-config.ts
+++ b/apps/api/src/routes/routing-config.ts
@@ -2,8 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { invalidateSwrByTables } from "@llmgateway/cache";
-import { db, eq, getTableName, tables } from "@llmgateway/db";
+import { cdb, db, eq, tables } from "@llmgateway/db";
 import {
 	buildProviderPriorityDefaults,
 	DEFAULT_ROUTING_HISTORY,
@@ -30,12 +29,6 @@ import type {
 } from "@llmgateway/db";
 
 export const routingConfig = new OpenAPIHono<ServerTypes>();
-
-const routingConfigTableName = getTableName(tables.routingConfig);
-
-async function invalidateRoutingConfigCache(): Promise<void> {
-	await invalidateSwrByTables([routingConfigTableName]);
-}
 
 async function checkProjectEnterpriseAccess(
 	userId: string,
@@ -355,7 +348,10 @@ routingConfig.openapi(updateConfig, async (c) => {
 			null) as ProviderPriorityOverrides | null,
 	};
 
-	const builder = db.insert(tables.routingConfig).values(insertValues);
+	// Write through the cached client so onMutate busts the gateway's cached
+	// routing-config lookups (Drizzle cache + SWR mirror); otherwise changes
+	// only take effect once the cache expires.
+	const builder = cdb.insert(tables.routingConfig).values(insertValues);
 	const [row] =
 		Object.keys(conflictSet).length === 0
 			? await builder
@@ -377,7 +373,6 @@ routingConfig.openapi(updateConfig, async (c) => {
 			where: { projectId: { eq: projectId } },
 		}));
 
-	await invalidateRoutingConfigCache();
 	return c.json(result);
 });
 
@@ -403,11 +398,10 @@ routingConfig.openapi(resetConfig, async (c) => {
 	const { projectId } = c.req.param();
 	await checkProjectEnterpriseAccess(user.id, projectId);
 
-	await db
+	await cdb
 		.delete(tables.routingConfig)
 		.where(eq(tables.routingConfig.projectId, projectId));
 
-	await invalidateRoutingConfigCache();
 	return c.json({ ok: true });
 });
 


### PR DESCRIPTION
## Summary

Routes all mutations of gateway-cached tables through the cached database client (`cdb`) instead of the plain `db` client, so the gateway stops serving stale data after a mutation. Covers credentials (API keys, provider keys, IAM rules) plus the two remaining manual-invalidation holdouts (routing config, custom models).

The gateway resolves these tables through `cdb.select()` lookups wrapped in an SWR fallback mirror (`apps/gateway/src/lib/cached-queries.ts`, `routing-config-loader.ts`). Writing through `cdb` triggers `RedisCache.onMutate` (`packages/db/src/redis-cache.ts`), which busts **both** cache layers for the affected tables:

- the Drizzle Redis cache entries (60s TTL) — previously left stale, so e.g. a deleted API key kept authenticating and a disabled provider key kept being used until the TTL expired
- the SWR fallback mirrors (`invalidateSwrByTables`) — this is why the explicit `invalidateSwrByTables` calls are removed: they are now redundant with the central `onMutate` wiring, which covers the same tables plus the Drizzle layer the explicit calls missed

## Changes

- `keys-api.ts`: platform key create/delete, API key create/delete/status/limit updates, and IAM rule create/update/delete now write via `cdb` (some paths were already migrated on main; this covers the rest)
- `keys-provider.ts`: provider key create/delete/status-update now write via `cdb`; redundant explicit SWR invalidation removed
- `routing-config.ts`, `custom-models.ts`: same migration for the last two callers that still wrote via plain `db` and manually invalidated only the SWR mirror, leaving the Drizzle cache stale
- Regression tests (`keys-api.spec.ts`, `keys-provider.spec.ts`): prime both cache layers the way the gateway does, mutate through the API, and assert the SWR mirror is dropped **and** the cached select serves fresh data. Verified they fail when the mutation is reverted to the plain `db` client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of key-management updates by persisting platform, API key, and IAM rule changes through a consistent cached write path.
  * Improved cache freshness for provider keys, custom-models, and routing-config by relying on the cached write mechanism instead of separate invalidation steps.
* **Tests**
  * Expanded route specs to verify cache behavior after creating IAM rules and provider keys (including ensuring cached misses are cleared and reads reflect the latest state).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->