### PR TITLE
fix(stripe): don't let cancel rows block paid retries

### DIFF
--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -389,6 +389,45 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 		expect(txns[0].stripeInvoiceId).toBe("in_manual_upgrade_001");
 	});
 
+	test("processes a successful retry on the invoice a prior cancel referenced", async () => {
+		// Failed payment during dunning marks the plan cancelled; the retry then
+		// succeeds on the SAME invoice ("in_test_001", the sub's latest_invoice).
+		// The cancel row must not claim that unique invoice id, or the success
+		// below is silently skipped and the paid plan stays cancelled.
+		await seedUsedDevPlanOrg();
+
+		await handleSubscriptionUpdated(
+			makeUpdatedEvent({ cancelAtPeriodEnd: true }),
+		);
+
+		const cancelled = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(cancelled?.devPlanCancelled).toBe(true);
+
+		await handleInvoicePaymentSucceeded(
+			makeInvoiceEvent({
+				billingReason: "subscription_cycle",
+				amountPaid: 7900,
+				invoiceId: "in_test_001",
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlanCancelled).toBe(false);
+		expect(org?.devPlanCreditsUsed).toBe("0");
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns.map((t) => t.type).sort()).toEqual([
+			"dev_plan_cancel",
+			"dev_plan_renewal",
+		]);
+	});
+
 	test("skips processing an invoice that was already recorded", async () => {
 		await seedUsedDevPlanOrg();
 		await db.insert(tables.transaction).values({

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3822,7 +3822,6 @@ export async function handleSubscriptionUpdated(
 				type: "chat_plan_cancel",
 				currency: "USD",
 				status: "completed",
-				stripeInvoiceId: subscription.latest_invoice as string,
 				description: `Chat Plan ${organization.chatPlan?.toUpperCase()} cancelled`,
 			});
 
@@ -3897,14 +3896,19 @@ export async function handleSubscriptionUpdated(
 		// Handle dev plan subscription update
 		const wasDevPlanCancelled = organization.devPlanCancelled;
 
-		// Create transaction record for dev plan cancellation if it was cancelled
+		// Create transaction record for dev plan cancellation if it was cancelled.
+		// State-change rows must NOT carry the invoice id: stripeInvoiceId is
+		// UNIQUE and `latest_invoice` is often the same invoice that is still
+		// being paid (dunning retries reuse it). Stamping it here would let a
+		// cancel row claim that invoice's slot, so the later successful
+		// `invoice.payment_succeeded` bails on the "already recorded" guard and
+		// the paid plan never gets reactivated / its credits reset.
 		if (!isSubscriptionActive && !wasDevPlanCancelled) {
 			await db.insert(tables.transaction).values({
 				organizationId,
 				type: "dev_plan_cancel",
 				currency: "USD",
 				status: "completed",
-				stripeInvoiceId: subscription.latest_invoice as string,
 				description: `Dev Plan ${organization.devPlan?.toUpperCase()} cancelled`,
 			});
 
@@ -4006,7 +4010,6 @@ export async function handleSubscriptionUpdated(
 				type: "subscription_cancel",
 				currency: "USD",
 				status: "completed",
-				stripeInvoiceId: subscription.latest_invoice as string,
 				description: "Pro subscription cancelled",
 			});
 		}
@@ -4087,7 +4090,6 @@ async function handleSubscriptionDeleted(
 			type: "chat_plan_end",
 			currency: "USD",
 			status: "completed",
-			stripeInvoiceId: subscription.latest_invoice as string,
 			description: `Chat Plan ${previousChatPlan?.toUpperCase()} ended`,
 		});
 
@@ -4138,13 +4140,14 @@ async function handleSubscriptionDeleted(
 		// Handle dev plan subscription deletion
 		const previousDevPlan = organization.devPlan;
 
-		// Create transaction record for dev plan end
+		// Create transaction record for dev plan end. As with the cancel row
+		// above, do not stamp the (unique) invoice id — `latest_invoice` already
+		// belongs to the paid dev_plan_start/renewal transaction.
 		await db.insert(tables.transaction).values({
 			organizationId,
 			type: "dev_plan_end",
 			currency: "USD",
 			status: "completed",
-			stripeInvoiceId: subscription.latest_invoice as string,
 			description: `Dev Plan ${previousDevPlan?.toUpperCase()} ended`,
 		});
 
@@ -4203,7 +4206,6 @@ async function handleSubscriptionDeleted(
 			type: "subscription_end",
 			currency: "USD",
 			status: "completed",
-			stripeInvoiceId: subscription.latest_invoice as string,
 			description: "Pro subscription ended",
 		});
 


### PR DESCRIPTION
## Problem

A customer paid \$179 for **Dev Plan MAX** — Stripe shows the payment succeeded — but the app's activity log shows a **"Dev Plan MAX cancelled"** event and the plan was left cancelled with credits not reset. There were **3 payment attempts on the same invoice (2 failed, 1 succeeded)**, and the final successful one "was not considered."

## Root cause

`handleSubscriptionUpdated` / `handleSubscriptionDeleted` stamped their **state-change** transactions (`*_cancel` / `*_end`) with `stripeInvoiceId: subscription.latest_invoice`.

- `transaction.stripeInvoiceId` has a **UNIQUE index** (`packages/db/src/schema.ts`).
- During dunning, Stripe **retries the same invoice** until it succeeds, so `latest_invoice` is the very invoice still being paid.
- A cancel event fired mid-dunning writes a `dev_plan_cancel` row that **claims that invoice's unique id**.
- When the retry finally succeeds, `handleInvoicePaymentSucceeded` runs its idempotency guard ("bail if a row already exists for this invoice, regardless of type"), finds the cancel row, and **returns early** — so the plan is never reactivated, credits never reset, and no renewal/receipt is recorded.

This exactly matches the report: the successful payment was *not considered* and *didn't reset the plan*.

## Fix

Stop stamping `stripeInvoiceId` on the state-change rows (`dev/chat/pro` `cancel` + `end`). That id is never read back for those types — refund matching only looks at `*_start` / `renewal` / `upgrade` — and occupying the unique slot is what breaks the paid-retry path (and was a latent unique-violation risk on the `*_end` inserts too).

Added a regression test: a cancel followed by a successful `invoice.payment_succeeded` on the **same** invoice now reactivates the plan (`devPlanCancelled=false`), resets credits, and records `dev_plan_renewal`.

## Note on the affected customer

This is the code fix. The already-affected account (Stripe customer `cus_UohjSNar77ZCZI`) still needs a **one-off manual reconciliation** — its Dev Plan MAX should be re-activated and credits reset to reflect the collected \$179, since the original webhook was skipped. That can't be done from here (Stripe access required).

## Testing
- `apps/api/src/stripe.spec.ts` — 18 tests pass (incl. new regression test)
- `pnpm format`, `turbo run build --filter=api` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription and invoice handling so plan cancellations no longer interfere with later successful renewal payments.
  * Prevented duplicate or conflicting transaction records during plan state changes, helping credits and cancellation status update correctly.
  * Fixed an issue where a renewed payment after cancellation could fail to restore the expected plan state.

* **Tests**
  * Added coverage for a cancellation-then-payment retry scenario to verify credits and renewal status are restored as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->