### PR TITLE
fix(billing): drop invoice id from cancel/end txns

### DIFF
--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -116,6 +116,35 @@ describe("handleSubscriptionUpdated — dev plan cancellation feedback email", (
 		});
 		expect(txns).toHaveLength(1);
 		expect(txns[0].type).toBe("dev_plan_cancel");
+		expect(txns[0].stripeInvoiceId).toBeNull();
+	});
+
+	test("cancellation does not collide with the payment row's invoice id", async () => {
+		await seedDevPlanOrg();
+
+		// The initial checkout already recorded this invoice on the payment row,
+		// claiming the unique stripeInvoiceId slot. subscription.latest_invoice on
+		// the cancel event is that same invoice.
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			currency: "USD",
+			status: "completed",
+			stripeInvoiceId: "in_test_001",
+			description: "Dev Plan PRO started",
+		});
+
+		await handleSubscriptionUpdated(
+			makeUpdatedEvent({ cancelAtPeriodEnd: true }),
+		);
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(2);
+		const cancel = txns.find((t) => t.type === "dev_plan_cancel");
+		expect(cancel).toBeDefined();
+		expect(cancel?.stripeInvoiceId).toBeNull();
 	});
 
 	test("does not re-send feedback email on duplicate updated event", async () => {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3822,7 +3822,6 @@ export async function handleSubscriptionUpdated(
 				type: "chat_plan_cancel",
 				currency: "USD",
 				status: "completed",
-				stripeInvoiceId: subscription.latest_invoice as string,
 				description: `Chat Plan ${organization.chatPlan?.toUpperCase()} cancelled`,
 			});
 
@@ -3904,7 +3903,6 @@ export async function handleSubscriptionUpdated(
 				type: "dev_plan_cancel",
 				currency: "USD",
 				status: "completed",
-				stripeInvoiceId: subscription.latest_invoice as string,
 				description: `Dev Plan ${organization.devPlan?.toUpperCase()} cancelled`,
 			});
 
@@ -4006,7 +4004,6 @@ export async function handleSubscriptionUpdated(
 				type: "subscription_cancel",
 				currency: "USD",
 				status: "completed",
-				stripeInvoiceId: subscription.latest_invoice as string,
 				description: "Pro subscription cancelled",
 			});
 		}
@@ -4087,7 +4084,6 @@ async function handleSubscriptionDeleted(
 			type: "chat_plan_end",
 			currency: "USD",
 			status: "completed",
-			stripeInvoiceId: subscription.latest_invoice as string,
 			description: `Chat Plan ${previousChatPlan?.toUpperCase()} ended`,
 		});
 
@@ -4144,7 +4140,6 @@ async function handleSubscriptionDeleted(
 			type: "dev_plan_end",
 			currency: "USD",
 			status: "completed",
-			stripeInvoiceId: subscription.latest_invoice as string,
 			description: `Dev Plan ${previousDevPlan?.toUpperCase()} ended`,
 		});
 
@@ -4203,7 +4198,6 @@ async function handleSubscriptionDeleted(
 			type: "subscription_end",
 			currency: "USD",
 			status: "completed",
-			stripeInvoiceId: subscription.latest_invoice as string,
 			description: "Pro subscription ended",
 		});
 


### PR DESCRIPTION
## Problem

Production Stripe webhooks for `customer.subscription.updated` (and `.deleted`) are failing with HTTP 400 and being retried forever. Example live event `evt_1TodNC…` (Dev Plan LITE cancellation):

```
Webhook error: Failed query: insert into "transaction" (...)
params: …,dev_plan_cancel,USD,completed,in_1Tl84P…,Dev Plan LITE cancelled
```

## Root cause

`transaction.stripeInvoiceId` has a **unique partial index** (`transaction_stripe_invoice_id_unique`). Only one row may hold a given Stripe invoice id.

The six cancel/end handlers in `apps/api/src/stripe.ts` inserted their transaction row with `stripeInvoiceId: subscription.latest_invoice`. During a cancellation, `latest_invoice` is the last **paid** invoice — which the corresponding payment row (`dev_plan_start` / `*_renewal` / `*_upgrade` / `subscription_start`) already recorded, claiming the unique slot. The cancel/end insert therefore violated the constraint, the handler threw, the webhook returned 400, and Stripe kept retrying.

## Fix

Drop `stripeInvoiceId` from all six state-change inserts:

- `chat_plan_cancel`, `dev_plan_cancel`, `subscription_cancel`
- `chat_plan_end`, `dev_plan_end`, `subscription_end`

The invoice id is never read back for these types (refund matching only queries the `*_start`/`*_renewal`/`*_upgrade` payment rows), so nothing depends on it. Payment-recording rows are unchanged and still own the invoice id.

## Test

Added a regression test that seeds a `dev_plan_start` row holding `in_test_001`, then fires a cancel event whose `latest_invoice` is that same invoice. Before the fix this threw a unique-constraint violation; now the cancel row is written with a null `stripeInvoiceId`. Full `stripe.spec.ts` suite (18 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subscription cancellation billing records so they no longer reuse invoice IDs from the related payment entry.
  * This prevents duplicate invoice references when a plan is canceled after an earlier transaction already used the same invoice.
  * Added coverage to ensure cancellation transactions keep their invoice ID empty in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->