### PR TITLE
fix(dev-plans): handle resume of fully-ended sub

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -791,6 +791,25 @@ devPlans.openapi(resume, async (c) => {
 			personalOrg.devPlanStripeSubscriptionId,
 		);
 
+		// A subscription Stripe has fully ended (`canceled`, or expired before its
+		// first payment) can no longer be resumed by clearing `cancel_at_period_end`:
+		// Stripe rejects the update with `invalid_canceled_subscription_fields`
+		// ("A canceled subscription can only update its cancellation_details and
+		// metadata"), which previously surfaced as a generic 500. This state is
+		// normally transient — the `customer.subscription.deleted` webhook resets the
+		// org's dev plan to "none" — but a resume reaching Stripe before that webhook
+		// lands, or if it was missed, would hit the rejected update. Bail out early
+		// with a clear message telling the user to subscribe again.
+		if (
+			subscription.status === "canceled" ||
+			subscription.status === "incomplete_expired"
+		) {
+			throw new HTTPException(409, {
+				message:
+					"Your dev plan subscription has ended. Subscribe again to choose a new plan.",
+			});
+		}
+
 		if (!subscription.cancel_at_period_end) {
 			throw new HTTPException(400, {
 				message: "Subscription is not cancelled",
@@ -824,6 +843,9 @@ devPlans.openapi(resume, async (c) => {
 			success: true,
 		});
 	} catch (error) {
+		if (error instanceof HTTPException) {
+			throw error;
+		}
 		logger.error(
 			"Stripe dev plan resume error",
 			error instanceof Error ? error : new Error(String(error)),


### PR DESCRIPTION
## Problem

Production surfaced repeated `Stripe dev plan resume error` 500s from `POST /dev-plans/resume`:

> A canceled subscription can only update its cancellation_details and metadata.
> (`invalid_canceled_subscription_fields`)

When a dev plan subscription has been **fully ended** by Stripe (`status: "canceled"`, or `incomplete_expired` when it never took a first payment), the resume handler still reached `subscriptions.update({ cancel_at_period_end: false })`. Stripe rejects any such update on an ended subscription, and it bubbled up as a generic 500.

This state is normally transient — the `customer.subscription.deleted` webhook resets the org's dev plan to `none` — but a resume request racing ahead of that webhook (or a missed webhook) hits the rejected update.

## Fix

Mirror the existing `change-tier` handler:

1. **Guard on subscription status** after retrieve — if `canceled` / `incomplete_expired`, bail out early with a `409` and a clear message: *"Your dev plan subscription has ended. Subscribe again to choose a new plan."*
2. **Rethrow `HTTPException` from the catch** so the guard (and the pre-existing `"Subscription is not cancelled"` 400) is no longer swallowed into a generic 500.

## Testing

- `pnpm format` ✅
- `pnpm turbo run build --filter=api` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription resume handling for plans that can’t be reactivated directly, returning a clear “subscribe again” response instead of a failed resume attempt.
  * Existing error responses are now preserved more consistently, helping prevent unexpected changes to returned error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->