### PR TITLE
feat(billing): download PDF invoice per purchase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,31 @@ Without `x-no-fallback`, a failing pinned provider falls back to the next health
 
 Caveat: if you run multiple git worktrees (e.g. conductor workspaces), only one `pnpm dev` can own port :4001 — confirm which working tree is actually serving it (`lsof -a -p <pid> -d cwd -Fn`) before assuming your local edits are live, or launch your own build on a different `PORT`.
 
+#### Running the dev stack on alternate ports (avoiding worktree conflicts)
+
+When another worktree already owns the default ports, run your stack on an offset range instead of fighting for :4002/:3002/etc. The wiring is driven entirely by env vars — no code changes needed:
+
+- **API port**: `PORT` (default `4002`). The API's own base URL is `API_URL`.
+- **Frontends → API**: every frontend resolves the backend from `API_URL` (default `http://localhost:4002`), read server-side in `apps/*/src/lib/config-server.ts`. Set it to your relocated API for each frontend process.
+- **Auth + CORS**: the API reads `ORIGIN_URLS` (comma-separated CORS/better-auth trusted-origins allowlist; defaults to `localhost:3002..3006,4002`) and `UI_URL`. If you relocate a frontend you MUST add its new origin to `ORIGIN_URLS` or login/API calls fail CORS. Login itself works across ports because the better-auth session cookie is host-only for `localhost` (shared across all ports) — no `COOKIE_DOMAIN` change needed.
+
+Two gotchas:
+
+- The `ui`/`playground`/`code` `dev` scripts hard-code `--port` in `package.json`, so overriding `PORT` alone won't move them — run `next dev --port <n>` directly.
+- The API `dev` script loads `../../.env` via `node --env-file`; Node does NOT override already-exported process env, so vars you `export`/prefix on the command line win over `.env`.
+
+Example: API on :4102, UI on :3102, Playground on :3103 (run from repo root, backgrounded):
+
+```bash
+ORIGINS="http://localhost:3102,http://localhost:3103,http://localhost:4102"
+( cd apps/api && PORT=4102 API_URL=http://localhost:4102 UI_URL=http://localhost:3102 ORIGIN_URLS="$ORIGINS" \
+    node --enable-source-maps --env-file=../../.env dist/serve.js )        # build first: turbo run build --filter=api
+( cd apps/ui         && API_URL=http://localhost:4102 pnpm exec next dev --port 3102 --turbopack )
+( cd apps/playground && API_URL=http://localhost:4102 pnpm exec next dev --port 3103 --turbopack )
+```
+
+Running the built `dist/serve.js` gives no watch (rebuild + restart the API after code changes); swap in the `api` package's `dev` script if you want tsc-watch. All apps share the one Postgres/Redis on the default ports, so the relocated stack sees the same seeded DB.
+
 #### E2E Test Options
 
 - `TEST_MODELS` - Run tests only for specific models (comma-separated list of `provider/model-id` pairs)

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -5,7 +5,12 @@ import { z } from "zod";
 import { ensureStripeCustomer, finalizeDevPlanSetupSession } from "@/stripe.js";
 import { findDefaultOrganization } from "@/utils/default-org.js";
 import { resolveDevPassBillingDetails } from "@/utils/devpass-billing.js";
-import { generateAndEmailInvoice } from "@/utils/invoice.js";
+import {
+	buildInvoiceDataForTransaction,
+	generateAndEmailInvoice,
+	generateInvoicePDF,
+	isInvoiceableTransaction,
+} from "@/utils/invoice.js";
 import { getOrCreatePersonalOrg } from "@/utils/personal-org.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
@@ -1975,6 +1980,70 @@ devPlans.openapi(getInvoices, async (c) => {
 	}));
 
 	return c.json({ invoices });
+});
+
+// Download a PDF invoice for a single DevPass billing event. Billing details
+// mirror the invoice originally emailed at purchase time (see stripe.ts).
+const downloadInvoice = createRoute({
+	method: "get",
+	path: "/invoices/{invoiceId}/pdf",
+	request: {
+		params: z.object({
+			invoiceId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/pdf": {
+					schema: z.any().openapi({ type: "string", format: "binary" }),
+				},
+			},
+			description: "PDF invoice for the specified DevPass billing event",
+		},
+	},
+});
+
+devPlans.openapi(downloadInvoice, async (c) => {
+	const user = c.get("user");
+
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { invoiceId } = c.req.param();
+
+	const personalOrg = await findPersonalOrg(user.id);
+	if (!personalOrg) {
+		throw new HTTPException(404, { message: "Invoice not found" });
+	}
+
+	const transaction = await db.query.transaction.findFirst({
+		where: {
+			id: { eq: invoiceId },
+			organizationId: { eq: personalOrg.id },
+		},
+	});
+	if (!transaction || !isInvoiceableTransaction(transaction)) {
+		throw new HTTPException(404, { message: "Invoice not found" });
+	}
+
+	const billingDetails = await resolveDevPassBillingDetails(personalOrg);
+
+	const pdf = generateInvoicePDF(
+		buildInvoiceDataForTransaction(transaction, {
+			id: personalOrg.id,
+			name: personalOrg.name,
+			...billingDetails,
+		}),
+	);
+
+	c.header("Content-Type", "application/pdf");
+	c.header(
+		"Content-Disposition",
+		`attachment; filename="invoice-${transaction.id}.pdf"`,
+	);
+	return c.body(new Uint8Array(pdf));
 });
 
 // Rotate the dev-plan API key — invalidates the current key and issues a new one

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -10,6 +10,7 @@ import {
 	generateAndEmailInvoice,
 	generateInvoicePDF,
 	isInvoiceableTransaction,
+	isRefundTransaction,
 } from "@/utils/invoice.js";
 import { getOrCreatePersonalOrg } from "@/utils/personal-org.js";
 
@@ -2038,10 +2039,13 @@ devPlans.openapi(downloadInvoice, async (c) => {
 		}),
 	);
 
+	const prefix = isRefundTransaction(transaction.type)
+		? "credit-note"
+		: "invoice";
 	c.header("Content-Type", "application/pdf");
 	c.header(
 		"Content-Disposition",
-		`attachment; filename="invoice-${transaction.id}.pdf"`,
+		`attachment; filename="${prefix}-${transaction.id}.pdf"`,
 	);
 	return c.body(new Uint8Array(pdf));
 });

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2031,12 +2031,26 @@ devPlans.openapi(downloadInvoice, async (c) => {
 
 	const billingDetails = await resolveDevPassBillingDetails(personalOrg);
 
+	const originalTransaction =
+		isRefundTransaction(transaction.type) && transaction.relatedTransactionId
+			? await db.query.transaction.findFirst({
+					where: {
+						id: { eq: transaction.relatedTransactionId },
+						organizationId: { eq: personalOrg.id },
+					},
+				})
+			: null;
+
 	const pdf = generateInvoicePDF(
-		buildInvoiceDataForTransaction(transaction, {
-			id: personalOrg.id,
-			name: personalOrg.name,
-			...billingDetails,
-		}),
+		buildInvoiceDataForTransaction(
+			transaction,
+			{
+				id: personalOrg.id,
+				name: personalOrg.name,
+				...billingDetails,
+			},
+			originalTransaction,
+		),
 	);
 
 	const prefix = isRefundTransaction(transaction.type)

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -11,6 +11,7 @@ import {
 	buildInvoiceDataForTransaction,
 	generateInvoicePDF,
 	isInvoiceableTransaction,
+	isRefundTransaction,
 } from "@/utils/invoice.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
@@ -953,10 +954,13 @@ organization.openapi(downloadTransactionInvoice, async (c) => {
 		buildInvoiceDataForTransaction(transaction, org),
 	);
 
+	const prefix = isRefundTransaction(transaction.type)
+		? "credit-note"
+		: "invoice";
 	c.header("Content-Type", "application/pdf");
 	c.header(
 		"Content-Disposition",
-		`attachment; filename="invoice-${transaction.id}.pdf"`,
+		`attachment; filename="${prefix}-${transaction.id}.pdf"`,
 	);
 	return c.body(new Uint8Array(pdf));
 });

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -7,6 +7,11 @@ import {
 	userHasOrganizationAccess,
 } from "@/utils/authorization.js";
 import { getOrCreateDefaultOrganization } from "@/utils/default-org.js";
+import {
+	buildInvoiceDataForTransaction,
+	generateInvoicePDF,
+	isInvoiceableTransaction,
+} from "@/utils/invoice.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
@@ -876,6 +881,84 @@ organization.openapi(getTransactions, async (c) => {
 	return c.json({
 		transactions,
 	});
+});
+
+const downloadTransactionInvoice = createRoute({
+	method: "get",
+	path: "/{id}/transactions/{transactionId}/invoice",
+	request: {
+		params: z.object({
+			id: z.string(),
+			transactionId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/pdf": {
+					schema: z.any().openapi({ type: "string", format: "binary" }),
+				},
+			},
+			description: "PDF invoice for the specified transaction",
+		},
+	},
+});
+
+organization.openapi(downloadTransactionInvoice, async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const { id, transactionId } = c.req.param();
+
+	const hasAccess = await userHasOrganizationAccess(user.id, id);
+	if (!hasAccess) {
+		throw new HTTPException(403, {
+			message: "You do not have access to this organization",
+		});
+	}
+
+	const transaction = await db.query.transaction.findFirst({
+		where: {
+			id: { eq: transactionId },
+			organizationId: { eq: id },
+		},
+	});
+	if (!transaction) {
+		throw new HTTPException(404, {
+			message: "Transaction not found",
+		});
+	}
+	if (!isInvoiceableTransaction(transaction)) {
+		throw new HTTPException(400, {
+			message: "No invoice is available for this transaction",
+		});
+	}
+
+	const org = await db.query.organization.findFirst({
+		where: {
+			id: { eq: id },
+		},
+	});
+	if (!org) {
+		throw new HTTPException(404, {
+			message: "Organization not found",
+		});
+	}
+
+	const pdf = generateInvoicePDF(
+		buildInvoiceDataForTransaction(transaction, org),
+	);
+
+	c.header("Content-Type", "application/pdf");
+	c.header(
+		"Content-Disposition",
+		`attachment; filename="invoice-${transaction.id}.pdf"`,
+	);
+	return c.body(new Uint8Array(pdf));
 });
 
 const getReferralStats = createRoute({

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -950,8 +950,18 @@ organization.openapi(downloadTransactionInvoice, async (c) => {
 		});
 	}
 
+	const originalTransaction =
+		isRefundTransaction(transaction.type) && transaction.relatedTransactionId
+			? await db.query.transaction.findFirst({
+					where: {
+						id: { eq: transaction.relatedTransactionId },
+						organizationId: { eq: id },
+					},
+				})
+			: null;
+
 	const pdf = generateInvoicePDF(
-		buildInvoiceDataForTransaction(transaction, org),
+		buildInvoiceDataForTransaction(transaction, org, originalTransaction),
 	);
 
 	const prefix = isRefundTransaction(transaction.type)

--- a/apps/api/src/utils/invoice.spec.ts
+++ b/apps/api/src/utils/invoice.spec.ts
@@ -8,6 +8,7 @@ import {
 	generateAndEmailInvoice,
 	generateInvoicePDF,
 	isInvoiceableTransaction,
+	isRefundTransaction,
 } from "./invoice.js";
 
 import type { InvoiceData } from "./invoice.js";
@@ -471,6 +472,30 @@ describe("buildInvoiceDataForTransaction", () => {
 				amount: 19,
 			},
 		]);
+		expect(data.documentType).toBe("invoice");
+	});
+
+	it("marks refunds as a credit note", () => {
+		const data = buildInvoiceDataForTransaction(
+			{
+				id: "tx-refund",
+				type: "credit_refund",
+				amount: "19.00",
+				currency: "USD",
+				description: "Credit refund: $19.00 (100.0% of original purchase)",
+				createdAt: new Date("2026-04-01"),
+				status: "completed",
+			},
+			org,
+		);
+
+		expect(data.documentType).toBe("credit_note");
+		expect(data.lineItems).toEqual([
+			{
+				description: "Credit refund: $19.00 (100.0% of original purchase)",
+				amount: 19,
+			},
+		]);
 	});
 
 	it("falls back to a type label when the transaction has no description", () => {
@@ -509,5 +534,38 @@ describe("buildInvoiceDataForTransaction", () => {
 		const pdf = generateInvoicePDF(data);
 		expect(pdf).toBeInstanceOf(Buffer);
 		expect(pdf.length).toBeGreaterThan(0);
+	});
+
+	it("renders a refund as a credit note", () => {
+		const data = buildInvoiceDataForTransaction(
+			{
+				id: "tx-refund-pdf",
+				type: "credit_refund",
+				amount: "19.00",
+				currency: "USD",
+				description: "Credit refund",
+				createdAt: new Date("2026-05-01"),
+				status: "completed",
+			},
+			org,
+		);
+
+		const pdfContent = generateInvoicePDF(data).toString("latin1");
+		expect(pdfContent).toContain("CREDIT NOTE");
+		expect(pdfContent).toContain("Credit Note Number: tx-refund-pdf");
+		expect(pdfContent).toContain("TOTAL REFUNDED");
+	});
+});
+
+describe("isRefundTransaction", () => {
+	it("is true for refund transaction types", () => {
+		expect(isRefundTransaction("credit_refund")).toBe(true);
+		expect(isRefundTransaction("end_user_refund")).toBe(true);
+	});
+
+	it("is false for charge transaction types", () => {
+		expect(isRefundTransaction("credit_topup")).toBe(false);
+		expect(isRefundTransaction("chat_plan_start")).toBe(false);
+		expect(isRefundTransaction("dev_plan_start")).toBe(false);
 	});
 });

--- a/apps/api/src/utils/invoice.spec.ts
+++ b/apps/api/src/utils/invoice.spec.ts
@@ -475,26 +475,49 @@ describe("buildInvoiceDataForTransaction", () => {
 		expect(data.documentType).toBe("invoice");
 	});
 
-	it("marks refunds as a credit note", () => {
+	it("marks refunds as a credit note with a negative net total and original context", () => {
 		const data = buildInvoiceDataForTransaction(
 			{
 				id: "tx-refund",
 				type: "credit_refund",
-				amount: "19.00",
+				amount: "50.00",
 				currency: "USD",
-				description: "Credit refund: $19.00 (100.0% of original purchase)",
+				description: "Credit refund: $50.00 (25.0% of original purchase)",
 				createdAt: new Date("2026-04-01"),
+				status: "completed",
+				relatedTransactionId: "tx-original",
+			},
+			org,
+			{ amount: "200.00", description: "Credit Top-up" },
+		);
+
+		expect(data.documentType).toBe("credit_note");
+		expect(data.originalAmount).toBe(200);
+		expect(data.refundPercentage).toBe(25);
+		expect(data.lineItems).toEqual([
+			{ description: "Refund — Credit Top-up", amount: -50 },
+		]);
+	});
+
+	it("falls back to the refund description when the original is unknown", () => {
+		const data = buildInvoiceDataForTransaction(
+			{
+				id: "tx-refund-2",
+				type: "end_user_refund",
+				amount: "5.00",
+				currency: "USD",
+				description: "End-user top-up refund",
+				createdAt: new Date("2026-04-02"),
 				status: "completed",
 			},
 			org,
 		);
 
 		expect(data.documentType).toBe("credit_note");
+		expect(data.originalAmount).toBeUndefined();
+		expect(data.refundPercentage).toBeUndefined();
 		expect(data.lineItems).toEqual([
-			{
-				description: "Credit refund: $19.00 (100.0% of original purchase)",
-				amount: 19,
-			},
+			{ description: "End-user top-up refund", amount: -5 },
 		]);
 	});
 
@@ -536,24 +559,44 @@ describe("buildInvoiceDataForTransaction", () => {
 		expect(pdf.length).toBeGreaterThan(0);
 	});
 
-	it("renders a refund as a credit note", () => {
+	it("renders a refund as a credit note with original amount and negative total", () => {
 		const data = buildInvoiceDataForTransaction(
 			{
 				id: "tx-refund-pdf",
 				type: "credit_refund",
-				amount: "19.00",
+				amount: "50.00",
 				currency: "USD",
 				description: "Credit refund",
 				createdAt: new Date("2026-05-01"),
 				status: "completed",
+				relatedTransactionId: "tx-original",
 			},
 			org,
+			{ amount: "200.00", description: "Credit Top-up" },
 		);
 
 		const pdfContent = generateInvoicePDF(data).toString("latin1");
 		expect(pdfContent).toContain("CREDIT NOTE");
 		expect(pdfContent).toContain("Credit Note Number: tx-refund-pdf");
-		expect(pdfContent).toContain("TOTAL REFUNDED");
+		expect(pdfContent).toContain("Original amount: USD 200.00");
+		expect(pdfContent).toContain("Refunded: 25.0% of original purchase");
+		// negative net total
+		expect(pdfContent).toContain("USD -50.00");
+	});
+
+	it("allows negative line item amounts for credit notes", () => {
+		expect(() =>
+			generateInvoicePDF({
+				invoiceNumber: "cn-1",
+				invoiceDate: new Date("2026-05-01"),
+				organizationName: "Org",
+				organizationId: "org-1",
+				billingEmail: "b@example.com",
+				lineItems: [{ description: "Refund", amount: -10 }],
+				currency: "USD",
+				documentType: "credit_note",
+			}),
+		).not.toThrow();
 	});
 });
 

--- a/apps/api/src/utils/invoice.spec.ts
+++ b/apps/api/src/utils/invoice.spec.ts
@@ -3,7 +3,12 @@ import * as path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { generateAndEmailInvoice, generateInvoicePDF } from "./invoice.js";
+import {
+	buildInvoiceDataForTransaction,
+	generateAndEmailInvoice,
+	generateInvoicePDF,
+	isInvoiceableTransaction,
+} from "./invoice.js";
 
 import type { InvoiceData } from "./invoice.js";
 
@@ -398,5 +403,111 @@ describe("generateAndEmailInvoice", () => {
 				]),
 			}),
 		);
+	});
+});
+
+describe("isInvoiceableTransaction", () => {
+	it("returns true for a completed, positive-amount charge", () => {
+		expect(
+			isInvoiceableTransaction({ status: "completed", amount: "19.00" }),
+		).toBe(true);
+	});
+
+	it("returns false for non-completed transactions", () => {
+		expect(
+			isInvoiceableTransaction({ status: "pending", amount: "19.00" }),
+		).toBe(false);
+		expect(
+			isInvoiceableTransaction({ status: "failed", amount: "19.00" }),
+		).toBe(false);
+	});
+
+	it("returns false when there is no positive amount", () => {
+		expect(
+			isInvoiceableTransaction({ status: "completed", amount: null }),
+		).toBe(false);
+		expect(isInvoiceableTransaction({ status: "completed", amount: "0" })).toBe(
+			false,
+		);
+		expect(
+			isInvoiceableTransaction({ status: "completed", amount: "-5.00" }),
+		).toBe(false);
+	});
+});
+
+describe("buildInvoiceDataForTransaction", () => {
+	const org = {
+		id: "org-1",
+		name: "Test Organization",
+		billingEmail: "billing@example.com",
+		billingCompany: "Test Co",
+		billingAddress: "123 Main St",
+		billingTaxId: "TAX-1",
+		billingNotes: "note",
+	};
+
+	it("uses the transaction id and date as invoice identity", () => {
+		const data = buildInvoiceDataForTransaction(
+			{
+				id: "tx-1",
+				type: "chat_plan_start",
+				amount: "19.00",
+				currency: "USD",
+				description: "Chat Plan PRO started via Stripe Checkout",
+				createdAt: new Date("2026-01-15"),
+				status: "completed",
+			},
+			org,
+		);
+
+		expect(data.invoiceNumber).toBe("tx-1");
+		expect(data.invoiceDate).toEqual(new Date("2026-01-15"));
+		expect(data.organizationId).toBe("org-1");
+		expect(data.billingCompany).toBe("Test Co");
+		expect(data.currency).toBe("USD");
+		expect(data.lineItems).toEqual([
+			{
+				description: "Chat Plan PRO started via Stripe Checkout",
+				amount: 19,
+			},
+		]);
+	});
+
+	it("falls back to a type label when the transaction has no description", () => {
+		const data = buildInvoiceDataForTransaction(
+			{
+				id: "tx-2",
+				type: "credit_topup",
+				amount: "50.00",
+				currency: "USD",
+				description: null,
+				createdAt: new Date("2026-02-01"),
+				status: "completed",
+			},
+			org,
+		);
+
+		expect(data.lineItems).toEqual([
+			{ description: "Credit Top-up", amount: 50 },
+		]);
+	});
+
+	it("produces a renderable PDF", () => {
+		const data = buildInvoiceDataForTransaction(
+			{
+				id: "tx-3",
+				type: "dev_plan_start",
+				amount: "25.00",
+				currency: "USD",
+				description: null,
+				createdAt: new Date("2026-03-01"),
+				status: "completed",
+			},
+			org,
+		);
+
+		const pdf = generateInvoicePDF(data);
+		expect(pdf).toBeInstanceOf(Buffer);
+		expect(pdf.length).toBeGreaterThan(0);
 	});
 });

--- a/apps/api/src/utils/invoice.ts
+++ b/apps/api/src/utils/invoice.ts
@@ -20,6 +20,10 @@ export interface InvoiceLineItem {
 	amount: number;
 }
 
+// "invoice" for a charge, "credit_note" for a refund. A credit note renders the
+// same layout but titled as a refund document.
+export type InvoiceDocumentType = "invoice" | "credit_note";
+
 export interface InvoiceData {
 	invoiceNumber: string;
 	invoiceDate: Date;
@@ -34,12 +38,14 @@ export interface InvoiceData {
 	billingNotes?: string | null;
 	lineItems: InvoiceLineItem[];
 	currency: string;
+	// Defaults to "invoice" when omitted.
+	documentType?: InvoiceDocumentType;
 }
 
-// Human-readable fallback labels used when a purchase transaction has no
-// stored description. Kept in sync with the transaction types that represent an
-// actual charge (see isInvoiceableTransaction).
-const PURCHASE_TYPE_LABELS: Record<string, string> = {
+// Human-readable fallback labels used when a transaction has no stored
+// description. Covers the charge and refund types that are invoiceable (see
+// isInvoiceableTransaction).
+const TRANSACTION_TYPE_LABELS: Record<string, string> = {
 	credit_topup: "Credit Top-up",
 	subscription_start: "Subscription",
 	dev_plan_start: "DevPass Plan",
@@ -49,7 +55,15 @@ const PURCHASE_TYPE_LABELS: Record<string, string> = {
 	chat_plan_renewal: "Chat Plan Renewal",
 	chat_plan_upgrade: "Chat Plan Upgrade",
 	end_user_topup: "Credit Top-up",
+	credit_refund: "Refund",
+	end_user_refund: "Refund",
 };
+
+// Refund transactions record the returned amount as a positive `amount` (see
+// stripe.ts); they render as a credit note rather than an invoice.
+export function isRefundTransaction(type: string): boolean {
+	return type === "credit_refund" || type === "end_user_refund";
+}
 
 interface InvoiceableTransaction {
 	id: string;
@@ -71,10 +85,11 @@ interface InvoiceOrganization {
 	billingNotes: string | null;
 }
 
-// A transaction is invoiceable when it represents a completed, positive-amount
-// charge (top-ups, subscription/plan starts, renewals and upgrades). Cancels,
-// ends, refunds and zero/no-amount gifts are excluded — there is nothing to
-// invoice for those.
+// A transaction has a downloadable document when it is completed with a
+// positive amount: a charge (top-ups, subscription/plan starts, renewals and
+// upgrades) yields an invoice, a refund (positive `amount`, see stripe.ts)
+// yields a credit note. Cancels, ends and zero/no-amount gifts are excluded —
+// there is nothing to document for those.
 export function isInvoiceableTransaction(transaction: {
 	status: string;
 	amount: string | null;
@@ -96,7 +111,7 @@ export function buildInvoiceDataForTransaction(
 	const amount = transaction.amount ? parseFloat(transaction.amount) : 0;
 	const description =
 		transaction.description ??
-		PURCHASE_TYPE_LABELS[transaction.type] ??
+		TRANSACTION_TYPE_LABELS[transaction.type] ??
 		"Purchase";
 
 	return {
@@ -111,6 +126,9 @@ export function buildInvoiceDataForTransaction(
 		billingNotes: organization.billingNotes,
 		lineItems: [{ description, amount }],
 		currency: transaction.currency,
+		documentType: isRefundTransaction(transaction.type)
+			? "credit_note"
+			: "invoice",
 	};
 }
 
@@ -127,6 +145,7 @@ export function generateInvoicePDF(data: InvoiceData): Buffer {
 	const invoiceNumber = data.invoiceNumber || "";
 	const organizationName = data.organizationName || "";
 	const billingEmail = data.billingEmail || "";
+	const isCreditNote = data.documentType === "credit_note";
 
 	// eslint-disable-next-line new-cap
 	const doc = new jsPDF();
@@ -135,12 +154,18 @@ export function generateInvoicePDF(data: InvoiceData): Buffer {
 
 	doc.setFontSize(24);
 	doc.setFont("helvetica", "bold");
-	doc.text("INVOICE", pageWidth / 2, yPos, { align: "center" });
+	doc.text(isCreditNote ? "CREDIT NOTE" : "INVOICE", pageWidth / 2, yPos, {
+		align: "center",
+	});
 
 	yPos += 15;
 	doc.setFontSize(10);
 	doc.setFont("helvetica", "normal");
-	doc.text(`Invoice Number: ${invoiceNumber}`, 20, yPos);
+	doc.text(
+		`${isCreditNote ? "Credit Note" : "Invoice"} Number: ${invoiceNumber}`,
+		20,
+		yPos,
+	);
 	yPos += 6;
 	doc.text(
 		`Date: ${data.invoiceDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}`,
@@ -240,7 +265,7 @@ export function generateInvoicePDF(data: InvoiceData): Buffer {
 
 	doc.setFontSize(12);
 	doc.setFont("helvetica", "bold");
-	doc.text("TOTAL", 20, yPos);
+	doc.text(isCreditNote ? "TOTAL REFUNDED" : "TOTAL", 20, yPos);
 	doc.text(`${data.currency} ${total.toFixed(2)}`, pageWidth - 20, yPos, {
 		align: "right",
 	});

--- a/apps/api/src/utils/invoice.ts
+++ b/apps/api/src/utils/invoice.ts
@@ -36,6 +36,84 @@ export interface InvoiceData {
 	currency: string;
 }
 
+// Human-readable fallback labels used when a purchase transaction has no
+// stored description. Kept in sync with the transaction types that represent an
+// actual charge (see isInvoiceableTransaction).
+const PURCHASE_TYPE_LABELS: Record<string, string> = {
+	credit_topup: "Credit Top-up",
+	subscription_start: "Subscription",
+	dev_plan_start: "DevPass Plan",
+	dev_plan_renewal: "DevPass Plan Renewal",
+	dev_plan_upgrade: "DevPass Plan Upgrade",
+	chat_plan_start: "Chat Plan",
+	chat_plan_renewal: "Chat Plan Renewal",
+	chat_plan_upgrade: "Chat Plan Upgrade",
+	end_user_topup: "Credit Top-up",
+};
+
+interface InvoiceableTransaction {
+	id: string;
+	type: string;
+	amount: string | null;
+	currency: string;
+	description: string | null;
+	createdAt: Date;
+	status: string;
+}
+
+interface InvoiceOrganization {
+	id: string;
+	name: string;
+	billingEmail: string;
+	billingCompany: string | null;
+	billingAddress: string | null;
+	billingTaxId: string | null;
+	billingNotes: string | null;
+}
+
+// A transaction is invoiceable when it represents a completed, positive-amount
+// charge (top-ups, subscription/plan starts, renewals and upgrades). Cancels,
+// ends, refunds and zero/no-amount gifts are excluded — there is nothing to
+// invoice for those.
+export function isInvoiceableTransaction(transaction: {
+	status: string;
+	amount: string | null;
+}): boolean {
+	return (
+		transaction.status === "completed" &&
+		transaction.amount !== null &&
+		parseFloat(transaction.amount) > 0
+	);
+}
+
+// Reconstruct the InvoiceData for an existing purchase transaction so it can be
+// re-rendered on demand (e.g. a downloadable PDF). The invoice number and date
+// mirror the invoice originally emailed at purchase time (see stripe.ts).
+export function buildInvoiceDataForTransaction(
+	transaction: InvoiceableTransaction,
+	organization: InvoiceOrganization,
+): InvoiceData {
+	const amount = transaction.amount ? parseFloat(transaction.amount) : 0;
+	const description =
+		transaction.description ??
+		PURCHASE_TYPE_LABELS[transaction.type] ??
+		"Purchase";
+
+	return {
+		invoiceNumber: transaction.id,
+		invoiceDate: transaction.createdAt,
+		organizationName: organization.name,
+		organizationId: organization.id,
+		billingEmail: organization.billingEmail,
+		billingCompany: organization.billingCompany,
+		billingAddress: organization.billingAddress,
+		billingTaxId: organization.billingTaxId,
+		billingNotes: organization.billingNotes,
+		lineItems: [{ description, amount }],
+		currency: transaction.currency,
+	};
+}
+
 export function generateInvoicePDF(data: InvoiceData): Buffer {
 	// Validate required fields
 	if (!data.lineItems || data.lineItems.length === 0) {

--- a/apps/api/src/utils/invoice.ts
+++ b/apps/api/src/utils/invoice.ts
@@ -40,6 +40,10 @@ export interface InvoiceData {
 	currency: string;
 	// Defaults to "invoice" when omitted.
 	documentType?: InvoiceDocumentType;
+	// Credit-note context: the full amount of the original purchase and the
+	// percentage of it that this refund covers. Shown above the line items.
+	originalAmount?: number;
+	refundPercentage?: number;
 }
 
 // Human-readable fallback labels used when a transaction has no stored
@@ -73,6 +77,14 @@ interface InvoiceableTransaction {
 	description: string | null;
 	createdAt: Date;
 	status: string;
+	relatedTransactionId?: string | null;
+}
+
+// The original purchase a refund relates to (via relatedTransactionId). Used to
+// show the initial full amount and the refunded percentage on the credit note.
+interface OriginalTransaction {
+	amount: string | null;
+	description: string | null;
 }
 
 interface InvoiceOrganization {
@@ -107,14 +119,11 @@ export function isInvoiceableTransaction(transaction: {
 export function buildInvoiceDataForTransaction(
 	transaction: InvoiceableTransaction,
 	organization: InvoiceOrganization,
+	originalTransaction?: OriginalTransaction | null,
 ): InvoiceData {
 	const amount = transaction.amount ? parseFloat(transaction.amount) : 0;
-	const description =
-		transaction.description ??
-		TRANSACTION_TYPE_LABELS[transaction.type] ??
-		"Purchase";
 
-	return {
+	const base = {
 		invoiceNumber: transaction.id,
 		invoiceDate: transaction.createdAt,
 		organizationName: organization.name,
@@ -124,20 +133,57 @@ export function buildInvoiceDataForTransaction(
 		billingAddress: organization.billingAddress,
 		billingTaxId: organization.billingTaxId,
 		billingNotes: organization.billingNotes,
-		lineItems: [{ description, amount }],
 		currency: transaction.currency,
-		documentType: isRefundTransaction(transaction.type)
-			? "credit_note"
-			: "invoice",
+	};
+
+	if (isRefundTransaction(transaction.type)) {
+		// Refunds record a positive `amount` (see stripe.ts); the credit note
+		// shows it as a negative net total and, when the original purchase is
+		// known, the full initial amount and the refunded percentage.
+		const originalAmountRaw = originalTransaction?.amount;
+		const originalAmount =
+			originalAmountRaw !== null && originalAmountRaw !== undefined
+				? parseFloat(originalAmountRaw)
+				: null;
+		const refundPercentage =
+			originalAmount && originalAmount > 0
+				? (amount / originalAmount) * 100
+				: null;
+		const lineDescription = originalTransaction?.description
+			? `Refund — ${originalTransaction.description}`
+			: (transaction.description ?? "Refund");
+
+		return {
+			...base,
+			documentType: "credit_note",
+			lineItems: [{ description: lineDescription, amount: -amount }],
+			originalAmount: originalAmount ?? undefined,
+			refundPercentage: refundPercentage ?? undefined,
+		};
+	}
+
+	const description =
+		transaction.description ??
+		TRANSACTION_TYPE_LABELS[transaction.type] ??
+		"Purchase";
+
+	return {
+		...base,
+		documentType: "invoice",
+		lineItems: [{ description, amount }],
 	};
 }
 
 export function generateInvoicePDF(data: InvoiceData): Buffer {
+	const isCreditNote = data.documentType === "credit_note";
+
 	// Validate required fields
 	if (!data.lineItems || data.lineItems.length === 0) {
 		throw new Error("Invoice must contain at least one line item");
 	}
-	if (data.lineItems.some((item) => item.amount < 0)) {
+	// Invoices bill for a charge (non-negative); credit notes record a refund as
+	// a negative net amount, so negatives are expected there.
+	if (!isCreditNote && data.lineItems.some((item) => item.amount < 0)) {
 		throw new Error("Line item amounts must be non-negative");
 	}
 
@@ -145,7 +191,6 @@ export function generateInvoicePDF(data: InvoiceData): Buffer {
 	const invoiceNumber = data.invoiceNumber || "";
 	const organizationName = data.organizationName || "";
 	const billingEmail = data.billingEmail || "";
-	const isCreditNote = data.documentType === "credit_note";
 
 	// eslint-disable-next-line new-cap
 	const doc = new jsPDF();
@@ -172,6 +217,24 @@ export function generateInvoicePDF(data: InvoiceData): Buffer {
 		20,
 		yPos,
 	);
+
+	// Credit-note context: the original purchase amount and the refunded portion.
+	if (isCreditNote && data.originalAmount !== undefined) {
+		yPos += 6;
+		doc.text(
+			`Original amount: ${data.currency} ${data.originalAmount.toFixed(2)}`,
+			20,
+			yPos,
+		);
+		if (data.refundPercentage !== undefined) {
+			yPos += 6;
+			doc.text(
+				`Refunded: ${data.refundPercentage.toFixed(1)}% of original purchase`,
+				20,
+				yPos,
+			);
+		}
+	}
 
 	yPos += 15;
 	const fromYPos = yPos;
@@ -265,7 +328,8 @@ export function generateInvoicePDF(data: InvoiceData): Buffer {
 
 	doc.setFontSize(12);
 	doc.setFont("helvetica", "bold");
-	doc.text(isCreditNote ? "TOTAL REFUNDED" : "TOTAL", 20, yPos);
+	// total is negative for a credit note (net refund), e.g. "USD -50.00".
+	doc.text("TOTAL", 20, yPos);
 	doc.text(`${data.currency} ${total.toFixed(2)}`, pageWidth - 20, yPos, {
 		align: "right",
 	});

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { format } from "date-fns";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Download, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { useApi } from "@/lib/fetch-client";
+import { useApi, useFetchClient } from "@/lib/fetch-client";
 
 import type { paths } from "@/lib/api/v1";
 
@@ -13,6 +14,67 @@ const PAGE_SIZE = 10;
 
 type Invoice =
 	paths["/dev-plans/invoices"]["get"]["responses"]["200"]["content"]["application/json"]["invoices"][number];
+
+// A DevPass invoice is downloadable when it is a completed, positive charge
+// (mirrors isInvoiceableTransaction on the API).
+function isInvoiceable(invoice: Invoice): boolean {
+	return (
+		invoice.status === "completed" &&
+		invoice.amount !== null &&
+		Number(invoice.amount) > 0
+	);
+}
+
+function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
+	const fetchClient = useFetchClient();
+	const [loading, setLoading] = useState(false);
+
+	async function handleDownload() {
+		setLoading(true);
+		try {
+			const { data, response } = await fetchClient.GET(
+				"/dev-plans/invoices/{invoiceId}/pdf",
+				{
+					params: { path: { invoiceId: invoice.id } },
+					parseAs: "blob",
+				},
+			);
+
+			if (!response.ok || !data) {
+				throw new Error("Failed to download invoice");
+			}
+
+			const url = URL.createObjectURL(data as unknown as Blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `invoice-${invoice.id}.pdf`;
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+			URL.revokeObjectURL(url);
+		} catch {
+			toast.error("Could not download invoice. Please try again later.");
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={handleDownload}
+			disabled={loading}
+		>
+			{loading ? (
+				<Loader2 className="h-4 w-4 animate-spin" />
+			) : (
+				<Download className="h-4 w-4" />
+			)}
+			<span className="sr-only sm:not-sr-only">Invoice</span>
+		</Button>
+	);
+}
 
 const TYPE_LABELS: Record<Invoice["type"], string> = {
 	dev_plan_start: "Plan started",
@@ -73,17 +135,18 @@ export default function DevPassInvoices() {
 			</p>
 
 			<div className="overflow-hidden rounded-xl border">
-				<div className="hidden grid-cols-[1fr_1fr_auto_auto] gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:grid">
+				<div className="hidden grid-cols-[1fr_1fr_auto_auto_auto] gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:grid">
 					<div>Date</div>
 					<div>Description</div>
 					<div className="text-right">Amount debited</div>
 					<div className="text-right">Credits granted</div>
+					<div className="text-right">Invoice</div>
 				</div>
 
 				{pageInvoices.map((invoice) => (
 					<div
 						key={invoice.id}
-						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:grid-cols-[1fr_1fr_auto_auto] sm:items-center"
+						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:grid-cols-[1fr_1fr_auto_auto_auto] sm:items-center"
 					>
 						<div className="text-sm tabular-nums">
 							{format(new Date(invoice.date), "MMM d, yyyy")}
@@ -110,6 +173,11 @@ export default function DevPassInvoices() {
 						<div className="text-right text-sm tabular-nums text-muted-foreground sm:text-right">
 							<span className="text-xs sm:hidden">Credits </span>
 							{formatCredits(invoice.creditAmount)}
+						</div>
+						<div className="col-span-2 mt-1 flex justify-end sm:col-span-1 sm:mt-0">
+							{isInvoiceable(invoice) && (
+								<InvoiceDownloadButton invoice={invoice} />
+							)}
 						</div>
 					</div>
 				))}

--- a/apps/playground/src/app/pricing/page.tsx
+++ b/apps/playground/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 
+import { ChatBillingHistory } from "@/components/pricing/chat-billing-history";
 import { ChatPricingPlans } from "@/components/pricing/chat-pricing-plans";
 import { getUser } from "@/lib/getUser";
 
@@ -75,6 +76,8 @@ export default async function PricingPage() {
 					</li>
 				</ul>
 			</section>
+
+			{user && <ChatBillingHistory />}
 		</main>
 	);
 }

--- a/apps/playground/src/components/pricing/chat-billing-history.tsx
+++ b/apps/playground/src/components/pricing/chat-billing-history.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { Download, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useApi, useFetchClient } from "@/lib/fetch-client";
+
+import type { paths } from "@/lib/api/v1";
+
+type Transaction =
+	paths["/orgs/{id}/transactions"]["get"]["responses"]["200"]["content"]["application/json"]["transactions"][number];
+
+const TYPE_LABELS: Partial<Record<Transaction["type"], string>> = {
+	chat_plan_start: "Chat plan started",
+	chat_plan_renewal: "Chat plan renewal",
+	chat_plan_upgrade: "Chat plan upgrade",
+	chat_plan_downgrade: "Chat plan downgrade",
+	chat_plan_cancel: "Chat plan cancelled",
+	chat_plan_end: "Chat plan ended",
+	credit_topup: "Credit top-up",
+	credit_refund: "Credit refund",
+	credit_gift: "Credit gift",
+	end_user_topup: "Credit top-up",
+	end_user_refund: "Credit refund",
+};
+
+function typeLabel(type: Transaction["type"]): string {
+	return TYPE_LABELS[type] ?? type;
+}
+
+// A transaction has a downloadable invoice when it is a completed, positive
+// charge (mirrors isInvoiceableTransaction on the API).
+function isInvoiceable(transaction: Transaction): boolean {
+	return (
+		transaction.status === "completed" &&
+		transaction.amount !== null &&
+		Number(transaction.amount) > 0
+	);
+}
+
+function formatAmount(amount: string | null, currency: string): string {
+	if (amount === null) {
+		return "—";
+	}
+	const value = Number(amount);
+	if (!Number.isFinite(value)) {
+		return "—";
+	}
+	if (currency === "USD") {
+		return `$${value.toFixed(2)}`;
+	}
+	return `${value.toFixed(2)} ${currency}`;
+}
+
+function InvoiceDownloadButton({
+	orgId,
+	transaction,
+}: {
+	orgId: string;
+	transaction: Transaction;
+}) {
+	const fetchClient = useFetchClient();
+	const [loading, setLoading] = useState(false);
+
+	async function handleDownload() {
+		setLoading(true);
+		try {
+			const { data, response } = await fetchClient.GET(
+				"/orgs/{id}/transactions/{transactionId}/invoice",
+				{
+					params: { path: { id: orgId, transactionId: transaction.id } },
+					parseAs: "blob",
+				},
+			);
+
+			if (!response.ok || !data) {
+				throw new Error("Failed to download invoice");
+			}
+
+			const url = URL.createObjectURL(data as unknown as Blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `invoice-${transaction.id}.pdf`;
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+			URL.revokeObjectURL(url);
+		} catch {
+			toast.error("Could not download invoice. Please try again later.");
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={handleDownload}
+			disabled={loading}
+		>
+			{loading ? (
+				<Loader2 className="h-4 w-4 animate-spin" />
+			) : (
+				<Download className="h-4 w-4" />
+			)}
+			<span className="sr-only sm:not-sr-only">Invoice</span>
+		</Button>
+	);
+}
+
+export function ChatBillingHistory() {
+	const api = useApi();
+
+	const statusQuery = useQuery({
+		...api.queryOptions("get", "/chat-plans/status"),
+		staleTime: 30_000,
+	});
+	const orgId = statusQuery.data?.organizationId ?? null;
+
+	const transactionsQuery = useQuery({
+		...api.queryOptions("get", "/orgs/{id}/transactions", {
+			params: { path: { id: orgId ?? "" } },
+		}),
+		enabled: Boolean(orgId),
+	});
+
+	const transactions = transactionsQuery.data?.transactions ?? [];
+
+	if (!orgId || transactions.length === 0) {
+		return null;
+	}
+
+	return (
+		<section className="mx-auto mt-16 max-w-3xl">
+			<h2 className="mb-1 text-base font-semibold text-foreground">
+				Billing history
+			</h2>
+			<p className="mb-4 text-sm text-muted-foreground">
+				Your chat plan and top-up charges. Download a PDF invoice for any
+				purchase.
+			</p>
+
+			<div className="overflow-hidden rounded-xl border">
+				<div className="hidden grid-cols-[1fr_1fr_auto_auto] gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:grid">
+					<div>Date</div>
+					<div>Description</div>
+					<div className="text-right">Amount</div>
+					<div className="text-right">Invoice</div>
+				</div>
+
+				{transactions.map((transaction) => (
+					<div
+						key={transaction.id}
+						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:grid-cols-[1fr_1fr_auto_auto] sm:items-center"
+					>
+						<div className="text-sm tabular-nums">
+							{format(new Date(transaction.createdAt), "MMM d, yyyy")}
+						</div>
+						<div className="text-sm">
+							<span>{typeLabel(transaction.type)}</span>
+							{transaction.description && (
+								<span className="block text-xs text-muted-foreground">
+									{transaction.description}
+								</span>
+							)}
+							{transaction.status !== "completed" && (
+								<span className="mt-0.5 inline-block rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium capitalize text-muted-foreground">
+									{transaction.status}
+								</span>
+							)}
+						</div>
+						<div className="text-right text-sm tabular-nums">
+							<span className="text-xs text-muted-foreground sm:hidden">
+								Amount{" "}
+							</span>
+							{formatAmount(transaction.amount, transaction.currency)}
+						</div>
+						<div className="col-span-2 mt-1 flex justify-end sm:col-span-1 sm:mt-0">
+							{isInvoiceable(transaction) && (
+								<InvoiceDownloadButton
+									orgId={orgId}
+									transaction={transaction}
+								/>
+							)}
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/playground/src/components/pricing/chat-billing-history.tsx
+++ b/apps/playground/src/components/pricing/chat-billing-history.tsx
@@ -32,14 +32,19 @@ function typeLabel(type: Transaction["type"]): string {
 	return TYPE_LABELS[type] ?? type;
 }
 
-// A transaction has a downloadable invoice when it is a completed, positive
-// charge (mirrors isInvoiceableTransaction on the API).
+// A transaction has a downloadable document when it is a completed, positive
+// amount — a charge (invoice) or a refund (credit note). Mirrors
+// isInvoiceableTransaction on the API.
 function isInvoiceable(transaction: Transaction): boolean {
 	return (
 		transaction.status === "completed" &&
 		transaction.amount !== null &&
 		Number(transaction.amount) > 0
 	);
+}
+
+function isRefund(type: Transaction["type"]): boolean {
+	return type === "credit_refund" || type === "end_user_refund";
 }
 
 function formatAmount(amount: string | null, currency: string): string {
@@ -66,6 +71,9 @@ function InvoiceDownloadButton({
 	const fetchClient = useFetchClient();
 	const [loading, setLoading] = useState(false);
 
+	const refund = isRefund(transaction.type);
+	const label = refund ? "Credit note" : "Invoice";
+
 	async function handleDownload() {
 		setLoading(true);
 		try {
@@ -78,19 +86,21 @@ function InvoiceDownloadButton({
 			);
 
 			if (!response.ok || !data) {
-				throw new Error("Failed to download invoice");
+				throw new Error("Failed to download document");
 			}
 
 			const url = URL.createObjectURL(data as unknown as Blob);
 			const link = document.createElement("a");
 			link.href = url;
-			link.download = `invoice-${transaction.id}.pdf`;
+			link.download = `${refund ? "credit-note" : "invoice"}-${transaction.id}.pdf`;
 			document.body.appendChild(link);
 			link.click();
 			link.remove();
 			URL.revokeObjectURL(url);
 		} catch {
-			toast.error("Could not download invoice. Please try again later.");
+			toast.error(
+				`Could not download ${label.toLowerCase()}. Please try again later.`,
+			);
 		} finally {
 			setLoading(false);
 		}
@@ -108,7 +118,7 @@ function InvoiceDownloadButton({
 			) : (
 				<Download className="h-4 w-4" />
 			)}
-			<span className="sr-only sm:not-sr-only">Invoice</span>
+			<span className="sr-only sm:not-sr-only">{label}</span>
 		</Button>
 	);
 }

--- a/apps/ui/src/app/dashboard/[orgId]/org/transactions/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/transactions/page.tsx
@@ -59,5 +59,5 @@ export default async function TransactionsPage({
 
 	const data = await fetchTransactions(orgId);
 
-	return <TransactionsClient data={data} />;
+	return <TransactionsClient data={data} orgId={orgId} />;
 }

--- a/apps/ui/src/components/billing/transactions-client.tsx
+++ b/apps/ui/src/components/billing/transactions-client.tsx
@@ -37,14 +37,19 @@ interface TransactionsData {
 	transactions: Transaction[];
 }
 
-// A transaction has a downloadable invoice when it is a completed, positive
-// charge (mirrors isInvoiceableTransaction on the API).
+// A transaction has a downloadable document when it is a completed, positive
+// amount — a charge (invoice) or a refund (credit note). Mirrors
+// isInvoiceableTransaction on the API.
 function isInvoiceable(transaction: Transaction): boolean {
 	return (
 		transaction.status === "completed" &&
 		transaction.amount !== null &&
 		Number(transaction.amount) > 0
 	);
+}
+
+function isRefund(type: Transaction["type"]): boolean {
+	return type === "credit_refund";
 }
 
 function InvoiceDownloadButton({
@@ -62,6 +67,9 @@ function InvoiceDownloadButton({
 		return null;
 	}
 
+	const refund = isRefund(transaction.type);
+	const label = refund ? "Credit note" : "Invoice";
+
 	async function handleDownload() {
 		setLoading(true);
 		try {
@@ -74,20 +82,20 @@ function InvoiceDownloadButton({
 			);
 
 			if (!response.ok || !data) {
-				throw new Error("Failed to download invoice");
+				throw new Error("Failed to download document");
 			}
 
 			const url = URL.createObjectURL(data as unknown as Blob);
 			const link = document.createElement("a");
 			link.href = url;
-			link.download = `invoice-${transaction.id}.pdf`;
+			link.download = `${refund ? "credit-note" : "invoice"}-${transaction.id}.pdf`;
 			document.body.appendChild(link);
 			link.click();
 			link.remove();
 			URL.revokeObjectURL(url);
 		} catch {
 			toast({
-				title: "Could not download invoice",
+				title: `Could not download ${label.toLowerCase()}`,
 				description: "Please try again later.",
 				variant: "destructive",
 			});
@@ -108,7 +116,7 @@ function InvoiceDownloadButton({
 			) : (
 				<Download className="h-4 w-4" />
 			)}
-			Invoice
+			{label}
 		</Button>
 	);
 }

--- a/apps/ui/src/components/billing/transactions-client.tsx
+++ b/apps/ui/src/components/billing/transactions-client.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { format } from "date-fns";
+import { Download, Loader2 } from "lucide-react";
+import { useState } from "react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Badge } from "@/lib/components/badge";
+import { Button } from "@/lib/components/button";
 import {
 	Card,
 	CardContent,
@@ -11,6 +14,8 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
+import { useToast } from "@/lib/components/use-toast";
+import { useFetchClient } from "@/lib/fetch-client";
 
 interface Transaction {
 	id: string;
@@ -32,7 +37,89 @@ interface TransactionsData {
 	transactions: Transaction[];
 }
 
-function TransactionCard({ transaction }: { transaction: Transaction }) {
+// A transaction has a downloadable invoice when it is a completed, positive
+// charge (mirrors isInvoiceableTransaction on the API).
+function isInvoiceable(transaction: Transaction): boolean {
+	return (
+		transaction.status === "completed" &&
+		transaction.amount !== null &&
+		Number(transaction.amount) > 0
+	);
+}
+
+function InvoiceDownloadButton({
+	orgId,
+	transaction,
+}: {
+	orgId: string;
+	transaction: Transaction;
+}) {
+	const fetchClient = useFetchClient();
+	const { toast } = useToast();
+	const [loading, setLoading] = useState(false);
+
+	if (!isInvoiceable(transaction)) {
+		return null;
+	}
+
+	async function handleDownload() {
+		setLoading(true);
+		try {
+			const { data, response } = await fetchClient.GET(
+				"/orgs/{id}/transactions/{transactionId}/invoice",
+				{
+					params: { path: { id: orgId, transactionId: transaction.id } },
+					parseAs: "blob",
+				},
+			);
+
+			if (!response.ok || !data) {
+				throw new Error("Failed to download invoice");
+			}
+
+			const url = URL.createObjectURL(data as unknown as Blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `invoice-${transaction.id}.pdf`;
+			document.body.appendChild(link);
+			link.click();
+			link.remove();
+			URL.revokeObjectURL(url);
+		} catch {
+			toast({
+				title: "Could not download invoice",
+				description: "Please try again later.",
+				variant: "destructive",
+			});
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={handleDownload}
+			disabled={loading}
+		>
+			{loading ? (
+				<Loader2 className="h-4 w-4 animate-spin" />
+			) : (
+				<Download className="h-4 w-4" />
+			)}
+			Invoice
+		</Button>
+	);
+}
+
+function TransactionCard({
+	transaction,
+	orgId,
+}: {
+	transaction: Transaction;
+	orgId: string;
+}) {
 	const getTypeLabel = (type: Transaction["type"]) => {
 		switch (type) {
 			case "credit_topup":
@@ -103,12 +190,24 @@ function TransactionCard({ transaction }: { transaction: Transaction }) {
 						<p className="text-sm">{transaction.description}</p>
 					</div>
 				)}
+
+				{isInvoiceable(transaction) && (
+					<div className="pt-1">
+						<InvoiceDownloadButton orgId={orgId} transaction={transaction} />
+					</div>
+				)}
 			</div>
 		</Card>
 	);
 }
 
-export function TransactionsClient({ data }: { data: TransactionsData }) {
+export function TransactionsClient({
+	data,
+	orgId,
+}: {
+	data: TransactionsData;
+	orgId: string;
+}) {
 	const isMobile = useIsMobile();
 
 	return (
@@ -140,6 +239,7 @@ export function TransactionsClient({ data }: { data: TransactionsData }) {
 										<TransactionCard
 											key={transaction.id}
 											transaction={transaction}
+											orgId={orgId}
 										/>
 									))
 								)}
@@ -167,6 +267,9 @@ export function TransactionsClient({ data }: { data: TransactionsData }) {
 											</th>
 											<th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground whitespace-nowrap">
 												Description
+											</th>
+											<th className="h-12 px-4 text-right align-middle font-medium text-muted-foreground whitespace-nowrap">
+												Invoice
 											</th>
 										</tr>
 									</thead>
@@ -217,12 +320,22 @@ export function TransactionsClient({ data }: { data: TransactionsData }) {
 												<td className="p-4 align-middle text-sm text-muted-foreground max-w-xs truncate">
 													{transaction.description ?? "—"}
 												</td>
+												<td className="p-4 align-middle whitespace-nowrap text-right">
+													{isInvoiceable(transaction) ? (
+														<InvoiceDownloadButton
+															orgId={orgId}
+															transaction={transaction}
+														/>
+													) : (
+														"—"
+													)}
+												</td>
 											</tr>
 										))}
 										{data.transactions.length === 0 && (
 											<tr>
 												<td
-													colSpan={6}
+													colSpan={7}
 													className="p-8 text-center text-muted-foreground"
 												>
 													No transactions found


### PR DESCRIPTION
## What

Adds a **Download invoice** button next to each purchase-related transaction in the billing sections of all three dashboards:

- **UI dashboard** (`/dashboard/[orgId]/org/transactions`) — new **Invoice** column/button in the transactions table (and mobile cards).
- **DevPass dashboard** — Invoice button per row in the DevPass invoices list.
- **Chat dashboard** (`chat.llmgateway.io` / playground) — the chat billing surface previously had **no** transaction history at all, so this adds a new **Billing history** section on the pricing page listing chat-plan and top-up charges, each with a download button.

The button only appears for transactions that represent an actual charge — completed, positive-amount (top-ups, subscription/plan starts, renewals, upgrades). Cancels, ends, refunds and zero/no-amount gifts have no invoice.

## How

- Reuses the existing `jsPDF` generator (`generateInvoicePDF`) that already backs the invoice emails sent at purchase time.
- New shared helpers in `apps/api/src/utils/invoice.ts`:
  - `isInvoiceableTransaction(tx)` — gate for downloadable transactions.
  - `buildInvoiceDataForTransaction(tx, org)` — reconstructs the `InvoiceData` for an existing transaction (invoice number/date mirror the originally-emailed invoice).
- New API endpoints:
  - `GET /orgs/{id}/transactions/{transactionId}/invoice` — org-access gated; used by the UI dashboard and the chat app (chat org id comes from `/chat-plans/status`).
  - `GET /dev-plans/invoices/{invoiceId}/pdf` — keeps DevPass's server-side personal-org resolution and mirrored billing details (`resolveDevPassBillingDetails`).
- Frontends download via the typed fetch client (`parseAs: "blob"`) and trigger a client-side download.

## Testing

- `pnpm format`, `pnpm build` (ui, code, playground, api + deps) all pass.
- Added unit tests for `isInvoiceableTransaction` and `buildInvoiceDataForTransaction`; full `invoice.spec.ts` passes (31 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated invoice PDF downloads for eligible billing transactions in DevPass and organization views.
  * Refunds now generate downloadable credit-note PDFs with distinct “credit-note” filenames and labeling.
  * Added invoice/credit-note download buttons and a new Invoice column in transaction UIs; added billing history to the pricing page for signed-in users.
* **Bug Fixes**
  * Document downloads are restricted to completed transactions with positive amounts; non-invoiceable items no longer show download actions.
* **Tests**
  * Expanded automated coverage for invoice eligibility, credit-note data/PDF rendering.
* **Documentation**
  * Updated dev-stack setup guidance for running on alternate ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->