### PR TITLE
fix(dev-plans): let users resubscribe after sub ends

### DIFF
--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -597,6 +597,62 @@ describe("dev plan tier changes", () => {
 		expect(org?.devPlanLastTierChangeCycleStart).toBeNull();
 	});
 
+	it("self-heals an ended subscription on resume instead of failing", async () => {
+		// The org still references a subscription Stripe has fully canceled (the
+		// `customer.subscription.deleted` webhook was delayed or missed). Resuming
+		// by clearing `cancel_at_period_end` would be rejected with
+		// `invalid_canceled_subscription_fields`, so the handler must instead reset
+		// the org to "none" and signal `ended` so the UI prompts a fresh subscribe.
+		await db
+			.update(tables.organization)
+			.set({ devPlanCancelled: true })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			customer: "cus_dev_plan",
+			status: "canceled",
+			cancel_at_period_end: false,
+			metadata: {
+				organizationId: ORG_ID,
+				subscriptionType: "dev_plan",
+				devPlan: "lite",
+				devPlanCycle: "monthly",
+			},
+			items: {
+				data: [
+					{
+						id: "si_dev_plan",
+						current_period_start: nowSeconds - 500,
+						current_period_end: nowSeconds + 500,
+						price: { id: "price_lite" },
+					},
+				],
+			},
+		});
+
+		const res = await app.request("/dev-plans/resume", {
+			method: "POST",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: false, ended: true });
+		// Never attempt the update Stripe would reject.
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlan).toBe("none");
+		expect(org?.devPlanCancelled).toBe(false);
+		expect(org?.devPlanStripeSubscriptionId).toBeNull();
+	});
+
 	it("schedules a downgrade for renewal instead of applying it immediately", async () => {
 		// Start on pro so switching to lite is a downgrade. The lower tier must not
 		// take effect until renewal: devPlan stays pro, the current cycle's credits

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -366,6 +366,33 @@ devPlans.openapi(getPersonalOrg, async (c) => {
 	});
 });
 
+// Reset a personal org's dev-plan fields after its Stripe subscription has
+// fully ended (`canceled` / `incomplete_expired`). This mirrors the reset the
+// `customer.subscription.deleted` webhook performs, so the dashboard falls back
+// to the plan chooser and the user can subscribe again. It exists as a
+// self-heal for the case where that webhook was delayed or missed: without it
+// the org is stuck holding a reference to a dead subscription — resume is
+// rejected by Stripe and a fresh subscribe is blocked as "already active".
+async function resetEndedDevPlan(organizationId: string): Promise<void> {
+	await db
+		.update(tables.organization)
+		.set({
+			devPlan: "none",
+			devPlanPendingTier: null,
+			devPlanCreditsLimit: "0",
+			devPlanCreditsUsed: "0",
+			devPlanPremiumCreditsUsed: "0",
+			devPlanPremiumWeekStart: null,
+			devPlanCreditsFrozen: false,
+			devPlanCreditsLimitBeforeFreeze: null,
+			devPlanStripeSubscriptionId: null,
+			devPlanExpiresAt: null,
+			devPlanCancelled: false,
+			devPlanBillingCycleStart: null,
+		})
+		.where(eq(tables.organization.id, organizationId));
+}
+
 // Subscribe to a dev plan
 const subscribe = createRoute({
 	method: "post",
@@ -419,15 +446,28 @@ devPlans.openapi(subscribe, async (c) => {
 	// Get or create personal org
 	const personalOrg = await getOrCreatePersonalOrg(user);
 
-	// Check if already has an active dev plan subscription
+	// Check if already has an active dev plan subscription. A stale reference to
+	// a subscription Stripe has already ended (deletion webhook delayed/missed)
+	// would otherwise permanently block resubscribing, so verify the recorded
+	// subscription is really live before rejecting — and self-heal if it isn't.
 	if (
 		personalOrg.devPlan !== "none" &&
 		personalOrg.devPlanStripeSubscriptionId
 	) {
-		throw new HTTPException(400, {
-			message:
-				"Already have an active dev plan. Please upgrade or cancel first.",
-		});
+		const existing = await getStripe().subscriptions.retrieve(
+			personalOrg.devPlanStripeSubscriptionId,
+		);
+		if (
+			existing.status === "canceled" ||
+			existing.status === "incomplete_expired"
+		) {
+			await resetEndedDevPlan(personalOrg.id);
+		} else {
+			throw new HTTPException(400, {
+				message:
+					"Already have an active dev plan. Please upgrade or cancel first.",
+			});
+		}
 	}
 
 	const priceId = getDevPlanPriceId(tier, cycle);
@@ -750,6 +790,10 @@ const resume = createRoute({
 				"application/json": {
 					schema: z.object({
 						success: z.boolean(),
+						// True when the subscription had already fully ended and could
+						// not be resumed — the org was reset to "none" and the user
+						// should subscribe again via the plan chooser.
+						ended: z.boolean().optional(),
 					}),
 				},
 			},
@@ -801,19 +845,18 @@ devPlans.openapi(resume, async (c) => {
 		// first payment) can no longer be resumed by clearing `cancel_at_period_end`:
 		// Stripe rejects the update with `invalid_canceled_subscription_fields`
 		// ("A canceled subscription can only update its cancellation_details and
-		// metadata"), which previously surfaced as a generic 500. This state is
-		// normally transient — the `customer.subscription.deleted` webhook resets the
-		// org's dev plan to "none" — but a resume reaching Stripe before that webhook
-		// lands, or if it was missed, would hit the rejected update. Bail out early
-		// with a clear message telling the user to subscribe again.
+		// metadata"). This state is normally transient — the
+		// `customer.subscription.deleted` webhook resets the org's dev plan to
+		// "none" — but a resume reaching Stripe before that webhook lands, or if it
+		// was missed, would hit the rejected update. Self-heal the stale row so the
+		// dashboard falls back to the plan chooser, and tell the client the
+		// subscription has ended so it can prompt a fresh subscribe.
 		if (
 			subscription.status === "canceled" ||
 			subscription.status === "incomplete_expired"
 		) {
-			throw new HTTPException(409, {
-				message:
-					"Your dev plan subscription has ended. Subscribe again to choose a new plan.",
-			});
+			await resetEndedDevPlan(personalOrg.id);
+			return c.json({ success: false, ended: true }, 200);
 		}
 
 		if (!subscription.cancel_at_period_end) {

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -168,7 +168,18 @@ export default function BillingClient({
 	const handleResume = async (): Promise<void> => {
 		setIsResuming(true);
 		try {
-			await resumeMutation.mutateAsync({});
+			const result = await resumeMutation.mutateAsync({});
+			// The subscription had already fully ended, so it can't be resumed — the
+			// server reset the plan to "none". Refresh status so the dashboard swaps
+			// to the plan chooser and the user can subscribe again.
+			if (result.ended) {
+				await invalidateStatus();
+				toast.info("Your subscription has ended", {
+					description: "Choose a plan to subscribe again.",
+				});
+				return;
+			}
+			await invalidateStatus();
 			if (posthogKey) {
 				posthog.capture("dev_plan_resumed");
 			}


### PR DESCRIPTION
## Problem

A DevPass user whose subscription has **fully ended** in Stripe (`canceled` / `incomplete_expired`) can get permanently stuck and unable to resubscribe.

This happens when the org still holds a reference to the dead subscription because the `customer.subscription.deleted` webhook was **delayed or missed** (exactly the failed webhook events seen for the reported account). In that state:

- **Resume** ("Continue subscription") → Stripe rejects the `cancel_at_period_end: false` update with `invalid_canceled_subscription_fields` ("A canceled subscription can only update its cancellation_details and metadata").
- **Subscribe** (resubscribe) → blocked with `400 "Already have an active dev plan"` because `devPlanStripeSubscriptionId` is still set.

The dashboard only ever offers "Resume subscription" (because `hasActivePlan` is still true), so the user never reaches the plan chooser. #2901 improved the resume error message but didn't unblock resubscribing.

## Fix

Both paths now **self-heal** by resetting the org's dev-plan fields (mirroring what the deletion webhook does), so the dashboard falls back to the plan chooser and a fresh subscribe works:

- **`POST /dev-plans/resume`** — on a `canceled`/`incomplete_expired` sub, reset the org and return `{ success: false, ended: true }` instead of throwing. The UI refreshes status (swapping to the plan chooser) and shows "Your subscription has ended — choose a plan to subscribe again."
- **`POST /dev-plans/subscribe`** — before rejecting as "already active", verify the recorded subscription is really live; if it has ended, reset and continue to checkout.

The genuinely-active "cancelling at period end" resume path is unchanged.

## Verification

Reproduced and verified end-to-end against the **Stripe sandbox** with the local stack (`pnpm dev`, `sk_test`):

1. Confirmed the sandbox reproduces the exact reported error (`invalid_canceled_subscription_fields`) on a real canceled subscription.
2. Wired a devpass org to a real canceled test subscription, then via the live API:
   - `resume` → `{ success: false, ended: true }`, org reset to `none` (no Stripe 400). ✅
   - `subscribe` → real Stripe Checkout URL. ✅
   - `subscribe` directly on the stuck state (no prior resume) → self-heals + returns Checkout URL. ✅
3. Regression check: an active sub with `cancel_at_period_end=true` still resumes normally (`{ success: true }`, Stripe `cape=false`). ✅

Added a regression test (`self-heals an ended subscription on resume instead of failing`); full `dev-plans.spec.ts` passes (14/14). `pnpm build` and `pnpm format` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved subscription resume handling so ended subscriptions are detected automatically and users are prompted to choose a new plan.
  * Added support for returning an “ended” state when a resume attempt finds the plan is no longer active.

* **Bug Fixes**
  * Fixed cases where resume could fail on canceled or expired subscriptions by resetting the account state instead of showing an error.
  * Ensured billing status refreshes correctly after an ended subscription is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->