### PR TITLE
fix(seo): redirect GSC 404s, fix llms.txt links

### DIFF
--- a/apps/code/next.config.ts
+++ b/apps/code/next.config.ts
@@ -14,6 +14,21 @@ const nextConfig: NextConfig = {
 	experimental: {
 		serverSourceMaps: true,
 	},
+	async redirects() {
+		// Truncated pricing-toggle URLs ("/mo", "/yr") picked up by crawlers.
+		return [
+			{
+				source: "/mo",
+				destination: "/",
+				permanent: true,
+			},
+			{
+				source: "/yr",
+				destination: "/",
+				permanent: true,
+			},
+		];
+	},
 	typescript: {
 		ignoreBuildErrors: true,
 	},

--- a/apps/docs/content/features/data-retention.mdx
+++ b/apps/docs/content/features/data-retention.mdx
@@ -120,8 +120,8 @@ Storage costs appear in:
 - Billing invoices as a separate line item
 
 <Callout type="success">
-	Enable [auto top-up](/dashboard) in billing settings to ensure uninterrupted
-	service when storage costs accumulate.
+	Enable [auto top-up](https://llmgateway.io/dashboard) in billing settings to
+	ensure uninterrupted service when storage costs accumulate.
 </Callout>
 
 ## Self-Hosted Deployments

--- a/apps/docs/content/features/moderations.mdx
+++ b/apps/docs/content/features/moderations.mdx
@@ -16,7 +16,7 @@ Use it when you want to:
 - Apply the same moderation API shape you already use with OpenAI clients
 
 For the full request and response schema, see the
-[API reference](/v1/moderations).
+[API reference](/v1_moderations).
 
 ## Endpoint
 

--- a/apps/docs/content/features/ocr.mdx
+++ b/apps/docs/content/features/ocr.mdx
@@ -17,7 +17,7 @@ Use it when you want to:
 - Feed document contents into a downstream model or RAG pipeline
 
 For the full request and response schema, see the
-[API reference](/v1/ocr).
+[API reference](/v1_ocr).
 
 ## Endpoint
 

--- a/apps/docs/content/guides/continue.mdx
+++ b/apps/docs/content/guides/continue.mdx
@@ -175,7 +175,7 @@ models:
 
 <Callout type="warn">
 	Disabling fallback means requests will fail if the chosen provider is down.
-	See the [routing docs](/docs/features/routing) for details.
+	See the [routing docs](/features/routing) for details.
 </Callout>
 
 ## Troubleshooting

--- a/apps/docs/content/guides/hermes-agent.mdx
+++ b/apps/docs/content/guides/hermes-agent.mdx
@@ -126,7 +126,7 @@ Once you press `Y`, Hermes launches a full agent session connected to LLM Gatewa
 
 ## DevPass Compatibility
 
-Hermes Agent is fully compatible with [DevPass coding plans](/docs/features/coding-agents). The gateway automatically detects Hermes via multiple signals:
+Hermes Agent is fully compatible with [DevPass coding plans](/features/coding-agents). The gateway automatically detects Hermes via multiple signals:
 
 - **X-Source header** — Hermes sends `X-Source: https://hermes-agent.nousresearch.com` (auto-detected)
 - **User-Agent** — `HermesAgent/<version>` is recognized
@@ -213,7 +213,7 @@ By default, LLM Gateway automatically fails over to alternative providers if you
 
 <Callout type="warn">
 	Disabling fallback means requests will fail if the chosen provider is down.
-	See the [routing docs](/docs/features/routing) for details.
+	See the [routing docs](/features/routing) for details.
 </Callout>
 
 ## Troubleshooting

--- a/apps/docs/content/guides/opencode-desktop.mdx
+++ b/apps/docs/content/guides/opencode-desktop.mdx
@@ -118,7 +118,7 @@ By default, LLM Gateway automatically fails over to alternative providers if you
 
 <Callout type="warn">
 	Disabling fallback means requests will fail if the chosen provider is down.
-	See the [routing docs](/docs/features/routing) for details.
+	See the [routing docs](/features/routing) for details.
 </Callout>
 
 ## Troubleshooting

--- a/apps/docs/content/guides/opencode.mdx
+++ b/apps/docs/content/guides/opencode.mdx
@@ -128,7 +128,7 @@ By default, LLM Gateway automatically fails over to alternative providers if you
 
 <Callout type="warn">
 	Disabling fallback means requests will fail if the chosen provider is down.
-	See the [routing docs](/docs/features/routing) for details.
+	See the [routing docs](/features/routing) for details.
 </Callout>
 
 ## Switching Models

--- a/apps/docs/lib/get-llm-text.ts
+++ b/apps/docs/lib/get-llm-text.ts
@@ -5,7 +5,11 @@ const DOCS_URL = "https://docs.llmgateway.io";
 
 export async function getLLMText(page: InferPageType<typeof source>) {
 	const processed = await page.data.getText("processed");
+	// Root-relative markdown links would be resolved against whatever domain
+	// serves this text (llmgateway.io proxies /llms-full.txt), so make them
+	// absolute docs URLs.
+	const absolute = processed.replace(/\]\((\/[^)\s]*)\)/g, `](${DOCS_URL}$1)`);
 	return `# ${page.data.title}
 URL: ${DOCS_URL}${page.url}
-${processed}`;
+${absolute}`;
 }

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -40,6 +40,57 @@ const nextConfig: NextConfig = {
 				destination: "/features/caching/provider-cache-control",
 				permanent: true,
 			},
+			{
+				source: "/features/embeddable-sdk",
+				destination: "/features/embeddable-payments",
+				permanent: true,
+			},
+			{
+				source: "/docs/:path*",
+				destination: "/:path*",
+				permanent: true,
+			},
+			{
+				source: "/dashboard",
+				destination: "/learn/dashboard",
+				permanent: true,
+			},
+			{
+				source: "/api-reference",
+				destination: "/v1_chat_completions",
+				permanent: true,
+			},
+			{
+				source: "/providers",
+				destination: "https://llmgateway.io/providers",
+				permanent: true,
+			},
+			// Guessed REST-style API reference URLs.
+			{
+				source: "/v1/chat/completions",
+				destination: "/v1_chat_completions",
+				permanent: true,
+			},
+			{
+				source: "/v1/moderations",
+				destination: "/v1_moderations",
+				permanent: true,
+			},
+			{
+				source: "/v1/ocr",
+				destination: "/v1_ocr",
+				permanent: true,
+			},
+			{
+				source: "/v1/videos",
+				destination: "/v1_videos_create",
+				permanent: true,
+			},
+			{
+				source: "/v1/responses",
+				destination: "/v1_chat_completions",
+				permanent: true,
+			},
 		];
 	},
 };

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -345,3 +345,9 @@ registerMcpOAuthRoutes(app);
 app.doc("/json", config);
 
 app.get("/docs", swaggerUI({ url: "/json" }));
+
+// The gateway is an API, not a website: keep search engines from crawling and
+// indexing its endpoints (GSC keeps reporting api.llmgateway.io URLs).
+app.get("/robots.txt", (c) => {
+	return c.text("User-agent: *\nDisallow: /\n");
+});

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -17,6 +17,91 @@ const nextConfig: NextConfig = {
 		serverSourceMaps: true,
 	},
 	async redirects() {
+		// Docs pages that ended up indexed on llmgateway.io because the proxied
+		// llms-full.txt contained relative links. Redirect them to their real
+		// home on docs.llmgateway.io.
+		const docsFeatureSlugs = [
+			"anthropic-endpoint",
+			"api-keys",
+			"caching",
+			"caching/gateway-caching",
+			"caching/provider-cache-control",
+			"coding-agents",
+			"compliance",
+			"cost-breakdown",
+			"custom-providers",
+			"data-retention",
+			"documents",
+			"embeddable-payments",
+			"embeddings",
+			"image-generation",
+			"master-keys",
+			"metadata",
+			"moderations",
+			"ocr",
+			"reasoning",
+			"response-healing",
+			"routing",
+			"service-tiers",
+			"sessions",
+			"source",
+			"speech-generation",
+			"video-generation",
+			"vision",
+			"web-search",
+		];
+		const apiReferenceSlugs = [
+			"v1_audio_speech",
+			"v1_chat_completions",
+			"v1_embeddings",
+			"v1_images_edits",
+			"v1_images_generations",
+			"v1_messages",
+			"v1_models",
+			"v1_moderations",
+			"v1_ocr",
+			"v1_videos_content",
+			"v1_videos_create",
+			"v1_videos_log_content",
+			"v1_videos_retrieve",
+		];
+		// Models that were renamed: sub-pages (provider, uptime) exist at the
+		// new slug, so preserve the rest of the path.
+		const renamedModelRedirects: Record<string, string> = {
+			"qwen37-max": "qwen3.7-max",
+			"seedream-4.0": "seedream-4-0",
+			"grok-4-fast": "grok-4-fast-reasoning",
+			"grok-4-1-fast": "grok-4-1-fast-reasoning",
+		};
+		// Models that were removed before the "deactivate, never delete"
+		// policy existed. Their pages are indexed, so 301 them (including any
+		// sub-pages) to the closest surviving model page.
+		const removedModelRedirects: Record<string, string> = {
+			"gpt-oss-20b-free": "/models/gpt-oss-20b",
+			"gpt-4.1-free": "/models/gpt-4.1",
+			"glm-4.5-air-free": "/models/glm-4.5-air",
+			"llama-3.3-70b-instruct-free": "/models/llama-3.3-70b-instruct",
+			"llama-4-scout-free": "/models/llama-4-scout",
+			"llama-4-maverick-free": "/models/llama-4-maverick-17b-instruct",
+			"kimi-k2-0905-free": "/models/kimi-k2",
+			"kimi-k2-0905": "/models/kimi-k2",
+			"deepseek-r1t2-chimera-free": "/models/deepseek-r1-0528",
+			"mistral-7b-instruct-together": "/models",
+			"mixtral-8x7b-instruct-together": "/models",
+			"nemotron-nano-9b-v2": "/models",
+		};
+		// Providers that were removed entirely; their pages and backlinks are
+		// still indexed.
+		const removedProviderRedirects: Record<string, string> = {
+			"together.ai": "/providers/together-ai",
+			sherlock: "/providers/xai",
+			cloudrift: "/providers",
+			routeway: "/providers",
+			"routeway-discount": "/providers",
+			"anthropic-discount": "/providers",
+			bluestone: "/providers",
+			obsidian: "/providers",
+		};
 		return [
 			{
 				source: "/blog/embeddable-ai-credits-stripe-for-ai",
@@ -40,6 +125,11 @@ const nextConfig: NextConfig = {
 			},
 			{
 				source: "/chat",
+				destination: "https://chat.llmgateway.io",
+				permanent: true,
+			},
+			{
+				source: "/playground",
 				destination: "https://chat.llmgateway.io",
 				permanent: true,
 			},
@@ -116,6 +206,194 @@ const nextConfig: NextConfig = {
 			{
 				source: "/models/grok-4.3/azure-ai-foundry",
 				destination: "/models/grok-4-3/azure-ai-foundry",
+				permanent: true,
+			},
+			// Docs content indexed on the wrong domain (see comment above).
+			{
+				source: "/quick-start",
+				destination: "https://docs.llmgateway.io/quick-start",
+				permanent: true,
+			},
+			{
+				source: "/overview",
+				destination: "https://docs.llmgateway.io/overview",
+				permanent: true,
+			},
+			{
+				source: "/self-host",
+				destination: "https://docs.llmgateway.io/self-host",
+				permanent: true,
+			},
+			{
+				source: "/self-host/:path*",
+				destination: "https://docs.llmgateway.io/self-host/:path*",
+				permanent: true,
+			},
+			{
+				source: "/learn/:path*",
+				destination: "https://docs.llmgateway.io/learn/:path*",
+				permanent: true,
+			},
+			{
+				source: "/resources/:path*",
+				destination: "https://docs.llmgateway.io/resources/:path*",
+				permanent: true,
+			},
+			{
+				source: "/docs/:path*",
+				destination: "https://docs.llmgateway.io/:path*",
+				permanent: true,
+			},
+			{
+				source: "/health",
+				destination: "https://docs.llmgateway.io/health",
+				permanent: true,
+			},
+			{
+				source: "/metrics",
+				destination: "https://docs.llmgateway.io/learn/usage-metrics",
+				permanent: true,
+			},
+			{
+				source: "/guides/agent-skills",
+				destination: "https://docs.llmgateway.io/guides/agent-skills",
+				permanent: true,
+			},
+			{
+				source: "/guides/cli",
+				destination: "https://docs.llmgateway.io/guides/cli",
+				permanent: true,
+			},
+			{
+				source: "/integrations/aws-bedrock",
+				destination: "https://docs.llmgateway.io/integrations/aws-bedrock",
+				permanent: true,
+			},
+			{
+				source: "/integrations/azure",
+				destination: "https://docs.llmgateway.io/integrations/azure",
+				permanent: true,
+			},
+			{
+				source: "/integrations/vertex-anthropic",
+				destination: "https://docs.llmgateway.io/integrations/vertex-anthropic",
+				permanent: true,
+			},
+			...docsFeatureSlugs.map((slug) => ({
+				source: `/features/${slug}`,
+				destination: `https://docs.llmgateway.io/features/${slug}`,
+				permanent: true,
+			})),
+			{
+				source: "/features/auto-routing",
+				destination: "https://docs.llmgateway.io/features/routing",
+				permanent: true,
+			},
+			// API reference pages (fumadocs OpenAPI slugs) indexed on the
+			// marketing domain.
+			...apiReferenceSlugs.map((slug) => ({
+				source: `/${slug}`,
+				destination: `https://docs.llmgateway.io/${slug}`,
+				permanent: true,
+			})),
+			{
+				source: "/v1",
+				destination: "https://docs.llmgateway.io/v1_chat_completions",
+				permanent: true,
+			},
+			{
+				source: "/v1_videos",
+				destination: "https://docs.llmgateway.io/v1_videos_create",
+				permanent: true,
+			},
+			{
+				source: "/v1/chat/completions",
+				destination: "https://docs.llmgateway.io/v1_chat_completions",
+				permanent: true,
+			},
+			{
+				source: "/v1/images/generations",
+				destination: "https://docs.llmgateway.io/v1_images_generations",
+				permanent: true,
+			},
+			{
+				source: "/v1/images/edits",
+				destination: "https://docs.llmgateway.io/v1_images_edits",
+				permanent: true,
+			},
+			// Removed/renamed models and providers.
+			...Object.entries(renamedModelRedirects).flatMap(([slug, target]) => [
+				{
+					source: `/models/${slug}`,
+					destination: `/models/${target}`,
+					permanent: true,
+				},
+				{
+					source: `/models/${slug}/:path*`,
+					destination: `/models/${target}/:path*`,
+					permanent: true,
+				},
+			]),
+			...Object.entries(removedModelRedirects).flatMap(
+				([slug, destination]) => [
+					{
+						source: `/models/${slug}`,
+						destination,
+						permanent: true,
+					},
+					{
+						source: `/models/${slug}/:path*`,
+						destination,
+						permanent: true,
+					},
+				],
+			),
+			...Object.entries(removedProviderRedirects).map(
+				([slug, destination]) => ({
+					source: `/providers/${slug}`,
+					destination,
+					permanent: true,
+				}),
+			),
+			// Misc renamed or truncated URLs that picked up external links.
+			{
+				source: "/migrations/:path*",
+				destination: "/migration/:path*",
+				permanent: true,
+			},
+			{
+				source: "/migration/open-router",
+				destination: "/migration/openrouter",
+				permanent: true,
+			},
+			{
+				source: "/changelog/video-gen-sessions-content-filter",
+				destination: "/changelog/video-gen-sessions-and-more",
+				permanent: true,
+			},
+			{
+				source: "/changelog/claude-code-50-percent-off",
+				destination: "/changelog",
+				permanent: true,
+			},
+			{
+				source: "/changelog/routeway-free-models",
+				destination: "/changelog",
+				permanent: true,
+			},
+			{
+				source: "/mo",
+				destination: "/models",
+				permanent: true,
+			},
+			{
+				source: "/image",
+				destination: "/models/text-to-image",
+				permanent: true,
+			},
+			{
+				source: "/connect",
+				destination: "/connect/cli",
 				permanent: true,
 			},
 		];

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -9,7 +9,7 @@ import {
 	Braces,
 } from "lucide-react";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 
 import Footer from "@/components/landing/footer";
 import { Navbar } from "@/components/landing/navbar";
@@ -66,7 +66,9 @@ export default async function ModelProviderPage({ params }: PageProps) {
 	);
 
 	if (providerMappings.length === 0) {
-		notFound();
+		// The model exists but this provider mapping was removed; send crawlers
+		// and old links to the model page instead of a 404.
+		permanentRedirect(`/models/${encodeURIComponent(decodedName)}`);
 	}
 
 	const staticProviderMapping = providerMappings[0];

--- a/apps/ui/src/content/guides/cline.md
+++ b/apps/ui/src/content/guides/cline.md
@@ -1,0 +1,68 @@
+---
+id: cline
+slug: cline
+title: Cline Integration
+description: Run Cline, the autonomous VS Code coding agent, on any of 280+ models through LLM Gateway. One OpenAI-compatible endpoint, unified billing, full cost tracking.
+date: 2026-07-03
+---
+
+[Cline](https://cline.bot) is an autonomous AI coding assistant that lives in VS Code. It creates and edits files, runs terminal commands, and works through multi-step tasks on its own. Unlike Cursor, Cline routes **everything** through the endpoint you give it — so with LLM Gateway you get a full coding agent on any model in our catalog, with every request tracked and billed in one place.
+
+## Quick Start
+
+### 1. Install the Cline extension
+
+Search for "Cline" in the VS Code Extensions view (Cmd/Ctrl + Shift + X) and install it.
+
+![Install Cline Extension](https://docs.llmgateway.io/guides/cline/clineinstall.webp)
+
+### 2. Configure the API provider
+
+Open the Cline panel, click the settings gear, and set:
+
+- **API Provider**: `OpenAI Compatible`
+- **Base URL**: `https://api.llmgateway.io/v1`
+- **API Key**: your key from the [LLM Gateway dashboard](/dashboard)
+- **Model ID**: any model from the [catalog](https://llmgateway.io/models), e.g. `claude-sonnet-4-6`, `gpt-5.2`, or `deepseek-v3.2`
+
+![Configure API Provider](https://docs.llmgateway.io/guides/cline/modelsetup.webp)
+
+### 3. Test it
+
+Ask Cline to do something concrete — "Create a hello world function in Python". It should respond and offer to create the file.
+
+![Test Cline](https://docs.llmgateway.io/guides/cline/clineexec.webp)
+
+All requests — planning, edits, terminal commands — now route through LLM Gateway.
+
+## Picking the right model
+
+Cline works the codebase hard: long contexts, lots of tool calls. A few tips:
+
+- **Frontier coding models** (`claude-sonnet-4-6`, `gpt-5.2`, `gemini-3-pro-preview`) give the best autonomous results
+- **Discounted models**: check the [discounted list](https://llmgateway.io/models?view=grid&filters=1&discounted=true) — same models, lower price through partner providers
+- **Provider pinning**: prefix with a provider (e.g. `openai/gpt-5.2`) to pin routing; otherwise LLM Gateway picks the best available provider with automatic failover
+- **Free models**: try [free models](https://llmgateway.io/models?view=grid&filters=1&free=true) for low-stakes tasks
+
+## Switching models mid-project
+
+Because Cline just sees one OpenAI-compatible endpoint, swapping models is a one-line change in its settings — no new accounts or API keys. Use a fast, cheap model for boilerplate and switch to a frontier model for the hard parts, keeping one bill and one usage dashboard the whole time.
+
+## Troubleshooting
+
+**Authentication errors** — Double-check the key and that the base URL is exactly `https://api.llmgateway.io/v1`.
+
+**Model not found** — Copy the model ID exactly from the [models page](https://llmgateway.io/models).
+
+**Context overflow on big tasks** — Switch to a model with a larger context window; the catalog lists context sizes per model.
+
+Need help? Join our [Discord](https://llmgateway.io/discord).
+
+## Why route Cline through LLM Gateway
+
+- **Full agent support** — unlike Cursor, every Cline feature works through the gateway
+- **Any model, one key** — OpenAI, Anthropic, Google, Meta, DeepSeek, and open-source models
+- **Cost control** — per-request cost tracking and spend limits in the [dashboard](/dashboard)
+- **Caching and failover** — repeated requests hit cache; failing providers fall over automatically
+
+[Get started for free](/signup) — no credit card required.

--- a/apps/ui/src/content/guides/cursor.md
+++ b/apps/ui/src/content/guides/cursor.md
@@ -1,0 +1,78 @@
+---
+id: cursor
+slug: cursor
+title: Cursor Integration
+description: Point Cursor's chat at any of 280+ models through LLM Gateway. One base URL override, full cost tracking — with an honest look at what Cursor does and doesn't allow.
+date: 2026-07-03
+---
+
+Cursor is an AI-powered code editor built on VS Code. It supports a custom OpenAI base URL, which means you can point its chat panel at LLM Gateway and use any model from our catalog — GPT-5, Claude, Gemini, DeepSeek, or 280+ others — with every request tracked in your dashboard.
+
+One thing up front, because most guides skip it: **the base URL override only applies to Cursor's chat / plan mode.** Composer, inline edit (Cmd/Ctrl + K), and autocomplete are locked to Cursor's own backend and will not route through any external endpoint. If you want a full coding agent running through LLM Gateway, use [Claude Code](/guides/claude-code), [Codex CLI](/guides/codex-cli), [Cline](/guides/cline), or [OpenCode](/guides/opencode) instead.
+
+## Quick Start
+
+### 1. Get your API key
+
+Create an API key in your [LLM Gateway dashboard](/dashboard) under **API Keys**.
+
+### 2. Add the key to Cursor
+
+Open **Cursor Settings → Models**, then add your LLM Gateway key under **OpenAI API Key**.
+
+![Cursor Settings](https://docs.llmgateway.io/guides/cursor/settings-1.png)
+
+### 3. Override the base URL
+
+In the same Models settings, enable **Override OpenAI Base URL** and set it to:
+
+```
+https://api.llmgateway.io/v1
+```
+
+![Cursor API Key Input](https://docs.llmgateway.io/guides/cursor/settings-2.png)
+
+### 4. Pick your models
+
+Add any model ID from the [models catalog](https://llmgateway.io/models) — for example `gpt-5`, `claude-sonnet-4-5`, or `deepseek-v3.2`.
+
+![Cursor Model Selection](https://docs.llmgateway.io/guides/cursor/model-selection.png)
+
+Open the chat panel (Cmd/Ctrl + L) and every request now routes through LLM Gateway.
+
+## What works and what doesn't
+
+| Cursor feature                  | Routes through LLM Gateway |
+| ------------------------------- | -------------------------- |
+| Chat / plan mode (Cmd/Ctrl + L) | ✅ Yes                     |
+| Composer / coding agent         | ❌ Cursor backend only     |
+| Inline edit (Cmd/Ctrl + K)      | ❌ Cursor backend only     |
+| Autocomplete / tab              | ❌ Cursor backend only     |
+
+This is a Cursor limitation, not an LLM Gateway one — external OpenAI-compatible endpoints are only honored by the chat panel.
+
+## Model selection tips
+
+- **Provider pinning**: prefix the model with a provider to pin it, e.g. `openai/gpt-5`
+- **Discounted models**: browse the [discounted models](https://llmgateway.io/models?view=grid&filters=1&discounted=true) and copy the ID
+- **Free models**: browse the [free models](https://llmgateway.io/models?view=grid&filters=1&free=true)
+- **Reasoning models**: browse [reasoning models](https://llmgateway.io/models?view=grid&filters=1&reasoning=true) for planning-heavy work
+
+## Troubleshooting
+
+**Authentication errors** — Verify the API key and that the base URL is exactly `https://api.llmgateway.io/v1`, and check that your account has credits.
+
+**Model not found** — Confirm the model ID exists in the [catalog](https://llmgateway.io/models) and is spelled exactly as shown.
+
+**Composer or autocomplete still uses Cursor's models** — Expected; see the table above.
+
+Need help? Join our [Discord](https://llmgateway.io/discord).
+
+## Why route Cursor through LLM Gateway
+
+- **Any model in the chat panel** — OpenAI, Anthropic, Google, Meta, DeepSeek, and open-source models through one key
+- **Cost tracking** — every chat request appears in your [dashboard](/dashboard) with per-model cost breakdowns
+- **Caching** — repeated prompts hit the cache instead of the provider
+- **One bill** — no juggling separate provider accounts
+
+[Get started for free](/signup) — no credit card required.

--- a/apps/ui/src/content/guides/mcp.md
+++ b/apps/ui/src/content/guides/mcp.md
@@ -1,0 +1,99 @@
+---
+id: mcp
+slug: mcp
+title: MCP Server Integration
+description: Use LLM Gateway's built-in MCP server to give Claude Code, Codex, Cursor, or any MCP client access to 280+ models — chat, image generation, and model discovery as tools.
+date: 2026-07-03
+---
+
+LLM Gateway ships a hosted [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server at `https://api.llmgateway.io/mcp`. Connect it to Claude Code, Codex, Cursor, or any MCP-compatible client and your AI assistant gets tools to call **any model in our catalog** — ask GPT-5 for a second opinion from inside Claude Code, generate images mid-session, or look up model pricing without leaving your editor.
+
+## What you get
+
+The MCP server exposes four tools:
+
+- **`chat`** — send messages to any supported LLM (`model`, `messages`, optional `temperature` / `max_tokens`)
+- **`generate-image`** — text-to-image with models like Qwen Image (`prompt`, optional `model`, `size`, `n`)
+- **`generate-nano-banana`** — image generation with Gemini 3 Pro Image Preview, with optional save-to-disk
+- **`list-models`** / **`list-image-models`** — browse available models with capabilities and pricing
+
+## Setup
+
+You'll need an API key from the [LLM Gateway dashboard](/dashboard) (**API Keys** section).
+
+### Claude Code
+
+```bash
+claude mcp add --transport http --scope user llmgateway https://api.llmgateway.io/mcp \
+  --header "Authorization: Bearer your-api-key-here"
+```
+
+Or add it manually to `~/.claude.json` (user scope) or `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "llmgateway": {
+      "url": "https://api.llmgateway.io/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+### Codex CLI
+
+```bash
+export LLM_GATEWAY_API_KEY="your-api-key-here"
+codex mcp add llmgateway --url https://api.llmgateway.io/mcp \
+  --bearer-token-env-var LLM_GATEWAY_API_KEY
+```
+
+Or in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.llmgateway]
+url = "https://api.llmgateway.io/mcp"
+bearer_token_env_var = "LLM_GATEWAY_API_KEY"
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "llmgateway": {
+      "url": "https://api.llmgateway.io/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+Any other MCP client works the same way: streamable HTTP transport, `https://api.llmgateway.io/mcp`, bearer auth.
+
+## Try it
+
+Once connected, ask your assistant things like:
+
+- "Use the chat tool to ask GPT-5 about TypeScript best practices"
+- "Generate an image of a futuristic city with the generate-image tool"
+- "List all available Anthropic models with pricing"
+
+Every tool call is a normal LLM Gateway request — it shows up in your [dashboard](/dashboard) with cost and token counts, hits the cache when repeated, and uses the same credits as your API traffic.
+
+## Why use it
+
+- **Cross-model workflows** — your coding agent can consult a different model without you switching tools
+- **Image generation anywhere** — any MCP client becomes an image studio
+- **One key, one bill** — MCP traffic and API traffic share credits, caching, and analytics
+
+For the full tool parameter reference, see the [MCP docs](https://docs.llmgateway.io/guides/mcp).
+
+[Get started for free](/signup) — no credit card required.

--- a/apps/ui/src/content/guides/n8n.md
+++ b/apps/ui/src/content/guides/n8n.md
@@ -1,0 +1,61 @@
+---
+id: n8n
+slug: n8n
+title: n8n Integration
+description: Power n8n AI workflows with any of 280+ models through LLM Gateway. One OpenAI credential, every provider, full cost visibility per workflow.
+date: 2026-07-03
+---
+
+n8n is a workflow automation platform with first-class AI nodes. Point its OpenAI credential at LLM Gateway and every AI Agent, Chat Model, and LLM node in your workflows can use any model from our catalog — GPT-5, Claude, Gemini, DeepSeek, or 280+ others — with one credential and one bill.
+
+![n8n workflow with LLM Gateway](https://docs.llmgateway.io/guides/n8n/overview.png)
+
+## Quick Start
+
+### 1. Add an OpenAI credential
+
+In n8n, go to **Settings → Credentials → Add Credential → OpenAI** and set:
+
+- **API Key**: your key from the [LLM Gateway dashboard](/dashboard)
+- **Base URL**: `https://api.llmgateway.io/v1`
+- **Organization ID**: leave blank
+
+![n8n credential setup](https://docs.llmgateway.io/guides/n8n/credential-3.png)
+
+### 2. Wire up an AI Agent node
+
+Add an **AI Agent** node to your workflow and attach a **Chat Model** using the credential you just created.
+
+![n8n AI Agent node](https://docs.llmgateway.io/guides/n8n/node-1.png)
+
+**Important:** toggle **off** the Responses API option on the chat model node — n8n's Responses API mode is not supported; LLM Gateway uses the standard chat completions API here.
+
+![Responses API toggle](https://docs.llmgateway.io/guides/n8n/responses-api.png)
+
+### 3. Pick a model and run
+
+Set the model to any [LLM Gateway model ID](https://llmgateway.io/models) (e.g. `gpt-5`) and execute the workflow with a test prompt.
+
+![n8n test run](https://docs.llmgateway.io/guides/n8n/test.png)
+
+## Why this beats a direct provider credential
+
+Automation workflows are exactly where gateway routing pays off:
+
+- **Swap models without touching workflows** — change the model ID, keep the credential; or let LLM Gateway's routing pick the best-value provider automatically
+- **Per-workflow cost visibility** — every n8n execution shows up in your [dashboard](/dashboard) with token counts and cost, so you know what each automation actually costs
+- **Failover for unattended runs** — scheduled workflows keep running when a provider has an outage; the gateway retries on a healthy provider
+- **Caching** — workflows that re-process similar inputs hit the cache instead of paying twice
+- **Free and discounted models** — batch or low-stakes steps can run on [free models](https://llmgateway.io/models?view=grid&filters=1&free=true) or [discounted models](https://llmgateway.io/models?view=grid&filters=1&discounted=true)
+
+## Troubleshooting
+
+**Credential test fails** — Verify the base URL is exactly `https://api.llmgateway.io/v1` and the key is valid.
+
+**Errors on the chat model node** — Make sure the Responses API toggle is off (see step 2).
+
+**Model not found** — Use the exact model ID from the [models page](https://llmgateway.io/models); prefix with a provider (e.g. `openai/gpt-5`) to pin routing.
+
+Need help? Join our [Discord](https://llmgateway.io/discord).
+
+[Get started for free](/signup) — no credit card required.


### PR DESCRIPTION
## Summary

GSC reports ~150 indexed URLs returning 404. Root cause for most of them: `llmgateway.io/llms-full.txt` proxies the docs' `llms-full.txt`, which contained **root-relative links** (`(/features/routing)`, `(/guides/cursor)`, `(/v1_models)`, …). Crawlers resolved those against `llmgateway.io`, indexing docs paths on the marketing domain. The rest are removed/renamed models & providers, deleted changelog entries, and junk/truncated URLs.

### Root-cause fixes

- **`apps/docs/lib/get-llm-text.ts`**: root-relative markdown links in `llms-full.txt` / `.mdx` output are now rewritten to absolute `https://docs.llmgateway.io/...` URLs, so proxying the file on another domain can no longer leak bad paths.
- Fixed wrong in-content docs links: `(/docs/features/*` → `(/features/*` (4 guides), `(/v1/moderations)` → `(/v1_moderations)`, `(/v1/ocr)` → `(/v1_ocr)`, `(/dashboard)` → absolute UI URL.
- **`apps/gateway`**: added `robots.txt` (`Disallow: /`) so search engines stop crawling/indexing `api.llmgateway.io` endpoints.

### Redirects (apps/ui)

- Docs content indexed on the marketing domain → 301 to `docs.llmgateway.io`: `/quick-start`, `/overview`, `/self-host(/*)`, `/learn/*`, `/resources/*`, `/docs/*`, `/health`, `/metrics`, `/integrations/{aws-bedrock,azure,vertex-anthropic}`, `/guides/{agent-skills,cli}`, 28 `/features/*` slugs (+ `auto-routing` → `routing`), all 13 `/v1_*` API-reference slugs (+ `/v1`, `/v1_videos`, `/v1/images/*`, `/v1/chat/completions`).
- Renamed models keep their sub-paths: `qwen37-max` → `qwen3.7-max`, `seedream-4.0` → `seedream-4-0`, `grok-4-fast` → `grok-4-fast-reasoning`, `grok-4-1-fast` → `grok-4-1-fast-reasoning` (covers `/xai`, `/azure-ai-foundry`, `/uptime` sub-pages).
- Removed models → closest surviving model page: all the `-free` Routeway models, `kimi-k2-0905`, `deepseek-r1t2-chimera-free`, `mistral-7b/mixtral-8x7b-instruct-together`, `nemotron-nano-9b-v2`.
- Removed providers: `together.ai` → `together-ai`, `sherlock` → `xai`, and `cloudrift`/`routeway(-discount)`/`anthropic-discount`/`bluestone`/`obsidian` → `/providers`.
- Misc: `/migrations/*` → `/migration/*`, `/migration/open-router` → `/migration/openrouter`, deleted changelog slugs → `/changelog`, `video-gen-sessions-content-filter` → real slug, `/playground` → chat, `/mo` → `/models`, `/image` → `/models/text-to-image`, `/connect` → `/connect/cli`.

### Code-level fix (apps/ui)

- `/models/[name]/[provider]`: when the model exists but the provider mapping was removed, the page now issues a **permanent redirect to the model page** instead of a 404. This fixes the whole class of `/models/*/canopywave|obsidian|cloudrift|together.ai|anthropic-discount|…` URLs and is self-maintaining for future removals.

### Redirects (apps/docs)

`/features/embeddable-sdk` → `embeddable-payments`, `/docs/*` → `/*`, `/dashboard` → `/learn/dashboard`, `/api-reference` → `/v1_chat_completions`, `/providers` → marketing providers page, REST-style guesses `/v1/{chat/completions,moderations,ocr,videos,responses}` → the real `v1_*` pages.

### Redirects (apps/code)

Truncated pricing URLs `devpass.llmgateway.io/mo|/yr` → `/`.

### New pages (apps/ui)

Four new marketing guides using the existing `/guides/[slug]` template, covering indexed-but-missing URLs with real search demand:

- `/guides/cursor` — honest about Cursor's plan-mode-only base-URL support
- `/guides/cline`
- `/guides/n8n`
- `/guides/mcp`

### Intentionally left 404

Old OG-image endpoints (`/api/og/*`, `/models/*/opengraph-image`), Cloudflare `/cdn-cgi/*`, stale `_next/static` font URLs, and `status.llmgateway.io` maintenance pages (external) — not indexable content, Google will drop them.

Also note: the "Alternate page with proper canonical tag" GSC list needs **no action** — model/provider sub-pages intentionally canonicalize to the parent model page, and `chat.llmgateway.io/?model=` params canonicalize to root (working as designed).

## Test plan

- `turbo run build --filter=ui --filter=docs --filter=code --filter=gateway`
- Verified all 146 listed URLs currently 404 in production and each redirect target exists (checked model/provider IDs against `packages/models`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu489MzZqcHvrwPLzXaYVb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new integration guides for Cursor, Cline, MCP, and n8n.
  * Expanded documentation coverage for redirected and updated API routes.

* **Bug Fixes**
  * Redirected outdated pricing, docs, API, model, and provider URLs to the correct destinations.
  * Improved model pages so missing provider variants now send visitors to the main model page.
  * Added crawling prevention for the gateway.

* **Documentation**
  * Updated internal links across guides and feature pages to match the latest site structure.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->