### PR TITLE
fix(dev-plans): reprice drafted renewal on tier change

### DIFF
--- a/apps/api/src/lib/pending-renewal.ts
+++ b/apps/api/src/lib/pending-renewal.ts
@@ -68,3 +68,109 @@ export async function voidPendingCycleRenewalInvoices(
 		}
 	}
 }
+
+function resolveCustomerId(
+	customer: string | { id?: string } | null | undefined,
+): string | null {
+	if (!customer) {
+		return null;
+	}
+	return typeof customer === "string" ? customer : (customer.id ?? null);
+}
+
+// A scheduled tier change (a downgrade, or an upgrade deferred to renewal) swaps
+// the subscription item's price with proration suppressed and no cycle re-anchor,
+// expecting the upcoming renewal invoice to bill the new tier. But Stripe drafts
+// that `subscription_cycle` invoice up to ~an hour before finalizing it, so a
+// change landing inside that window leaves an already-drafted invoice billing the
+// OLD price — which then charges while the renewal webhook applies the new tier
+// and its credit allotment (e.g. a pro→lite downgrade billed $79 but granted lite
+// credits, or a deferred lite→pro upgrade billed $29 while granting pro credits).
+//
+// Re-price the draft with an adjustment invoice item so the upcoming charge
+// matches the tier taking effect at renewal. The adjustment targets the draft's
+// net plan amount (its subscription lines plus any adjustment lines from earlier
+// changes in the same window), keeping it idempotent and correct across
+// consecutive changes (downgrade → upgrade, downgrade → cancel-downgrade) and a
+// no-op when the draft was created after the swap already at the new price.
+//
+// Best-effort: a failure only reverts to the pre-existing near-boundary mismatch,
+// so it must never fail the tier change itself.
+export async function repriceDraftRenewalInvoice(params: {
+	subscriptionId: string;
+	customer: string | { id?: string } | null | undefined;
+	newPriceId: string;
+	newTier: string;
+}): Promise<void> {
+	const stripe = getStripe();
+	try {
+		const customerId = resolveCustomerId(params.customer);
+		if (!customerId) {
+			logger.warn(
+				"Skipping draft renewal invoice re-price: subscription customer not found",
+				{ subscriptionId: params.subscriptionId },
+			);
+			return;
+		}
+
+		const drafts = await stripe.invoices.list({
+			subscription: params.subscriptionId,
+			status: "draft",
+			limit: 10,
+		});
+		const draft = drafts.data.find(
+			(invoice) => invoice.billing_reason === "subscription_cycle",
+		);
+		if (!draft?.id) {
+			return;
+		}
+
+		const newPrice = await stripe.prices.retrieve(params.newPriceId);
+		if (typeof newPrice.unit_amount !== "number") {
+			logger.warn(
+				"Skipping draft renewal invoice re-price: new price has no unit_amount",
+				{ subscriptionId: params.subscriptionId, priceId: params.newPriceId },
+			);
+			return;
+		}
+
+		const billedCents = draft.lines.data.reduce((sum, line) => {
+			if (line.parent?.type === "subscription_item_details") {
+				return sum + line.amount;
+			}
+			if (
+				line.parent?.type === "invoice_item_details" &&
+				line.metadata?.devPlanRenewalReprice === "true"
+			) {
+				return sum + line.amount;
+			}
+			return sum;
+		}, 0);
+
+		const adjustmentCents = newPrice.unit_amount - billedCents;
+		if (adjustmentCents === 0) {
+			return;
+		}
+
+		await stripe.invoiceItems.create({
+			customer: customerId,
+			invoice: draft.id,
+			amount: adjustmentCents,
+			currency: draft.currency,
+			description: `Dev Plan renewal adjusted to ${params.newTier.toUpperCase()} pricing`,
+			metadata: {
+				subscriptionType: "dev_plan",
+				devPlanRenewalReprice: "true",
+			},
+		});
+
+		logger.info(
+			`Re-priced draft renewal invoice ${draft.id} for subscription ${params.subscriptionId}: ${adjustmentCents} cent adjustment to ${params.newTier}`,
+		);
+	} catch (error) {
+		logger.error(
+			"Failed to re-price draft renewal invoice after dev plan tier change",
+			error instanceof Error ? error : new Error(String(error)),
+		);
+	}
+}

--- a/apps/api/src/routes/dev-plans-reprice.e2e.ts
+++ b/apps/api/src/routes/dev-plans-reprice.e2e.ts
@@ -1,0 +1,260 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { repriceDraftRenewalInvoice } from "@/lib/pending-renewal.js";
+import { getStripe } from "@/routes/payments.js";
+
+import type Stripe from "stripe";
+
+// Real-Stripe verification of the pre-renewal draft-invoice re-pricing fix.
+//
+// Reproduces the exact incident against a live Stripe sandbox using a Test
+// Clock: subscribe to PRO, advance to the renewal boundary so Stripe drafts the
+// `subscription_cycle` invoice, then downgrade to LITE mid-window. Without the
+// fix the drafted invoice keeps billing PRO ($79) while the org flips to LITE
+// credits; with the fix the draft is re-priced to LITE ($29) before it charges.
+//
+// Opt-in only — hits the network and consumes Stripe rate limit, so it is
+// skipped unless STRIPE_TESTCLOCK_E2E is set (never in normal CI). Requires a
+// test-mode STRIPE_SECRET_KEY and the three STRIPE_DEV_PLAN_*_PRICE_ID vars, the
+// same env the API reads.
+const ENABLED = !!process.env.STRIPE_TESTCLOCK_E2E;
+
+const PRO_PRICE_ID = process.env.STRIPE_DEV_PLAN_PRO_PRICE_ID ?? "";
+const LITE_PRICE_ID = process.env.STRIPE_DEV_PLAN_LITE_PRICE_ID ?? "";
+
+const HOUR = 3600;
+
+function amountDue(invoice: Stripe.Invoice) {
+	return invoice.amount_due;
+}
+
+function repriceLineTotal(invoice: Stripe.Invoice) {
+	return invoice.lines.data
+		.filter((line) => line.metadata?.devPlanRenewalReprice === "true")
+		.reduce((sum, line) => sum + line.amount, 0);
+}
+
+describe.skipIf(!ENABLED)(
+	"dev plan renewal re-price (real Stripe test clock)",
+	() => {
+		// Resolved in beforeAll — the describe body runs even when skipped, so
+		// getStripe() (which throws without STRIPE_SECRET_KEY) must not run at
+		// registration time in a keyless CI.
+		let stripe: Stripe;
+		let clockId: string;
+		let customerId: string;
+		let subscriptionId: string;
+		let subscriptionItemId: string;
+		let renewalStart: number;
+		let proUnit: number;
+		let liteUnit: number;
+
+		async function waitForClock(id: string) {
+			for (let i = 0; i < 60; i++) {
+				const clock = await stripe.testHelpers.testClocks.retrieve(id);
+				if (clock.status === "ready") {
+					return clock;
+				}
+				if (clock.status === "internal_failure") {
+					throw new Error(`Test clock ${id} entered internal_failure`);
+				}
+				await new Promise((r) => setTimeout(r, 2000));
+			}
+			throw new Error(`Test clock ${id} did not become ready in time`);
+		}
+
+		async function advanceTo(seconds: number) {
+			await stripe.testHelpers.testClocks.advance(clockId, {
+				frozen_time: seconds,
+			});
+			await waitForClock(clockId);
+		}
+
+		async function getDraftRenewal() {
+			const invoices = await stripe.invoices.list({
+				subscription: subscriptionId,
+				status: "draft",
+				limit: 10,
+			});
+			return invoices.data.find(
+				(inv) => inv.billing_reason === "subscription_cycle",
+			);
+		}
+
+		beforeAll(async () => {
+			if (!ENABLED) {
+				return;
+			}
+			stripe = getStripe();
+			expect(PRO_PRICE_ID, "STRIPE_DEV_PLAN_PRO_PRICE_ID must be set").not.toBe(
+				"",
+			);
+			expect(
+				LITE_PRICE_ID,
+				"STRIPE_DEV_PLAN_LITE_PRICE_ID must be set",
+			).not.toBe("");
+
+			proUnit = (await stripe.prices.retrieve(PRO_PRICE_ID)).unit_amount ?? 0;
+			liteUnit = (await stripe.prices.retrieve(LITE_PRICE_ID)).unit_amount ?? 0;
+			expect(proUnit).toBeGreaterThan(liteUnit);
+
+			const now = Math.floor(Date.now() / 1000);
+			const clock = await stripe.testHelpers.testClocks.create({
+				frozen_time: now,
+				name: "devpass-reprice-e2e",
+			});
+			clockId = clock.id;
+
+			const customer = await stripe.customers.create({
+				name: "DevPass reprice e2e",
+				test_clock: clockId,
+			});
+			customerId = customer.id;
+
+			const pm = await stripe.paymentMethods.attach("pm_card_visa", {
+				customer: customerId,
+			});
+			await stripe.customers.update(customerId, {
+				invoice_settings: { default_payment_method: pm.id },
+			});
+
+			const subscription = await stripe.subscriptions.create({
+				customer: customerId,
+				items: [{ price: PRO_PRICE_ID }],
+				default_payment_method: pm.id,
+				collection_method: "charge_automatically",
+				metadata: { subscriptionType: "dev_plan", devPlan: "pro" },
+				expand: ["latest_invoice"],
+			});
+			subscriptionId = subscription.id;
+			subscriptionItemId = subscription.items.data[0].id;
+			renewalStart = subscription.items.data[0].current_period_end;
+		}, 120000);
+
+		afterAll(async () => {
+			if (!ENABLED || !clockId) {
+				return;
+			}
+			// Deleting the test clock tears down the customer, subscription and all
+			// invoices created against it — nothing lingers in the sandbox.
+			await stripe.testHelpers.testClocks.del(clockId).catch(() => undefined);
+		}, 60000);
+
+		it("the initial PRO subscription invoice is paid at PRO price", async () => {
+			const invoices = await stripe.invoices.list({
+				subscription: subscriptionId,
+				limit: 5,
+			});
+			const paid = invoices.data.find((inv) => inv.status === "paid");
+			expect(paid, "initial invoice should be paid").toBeTruthy();
+			expect(amountDue(paid!)).toBe(proUnit);
+		}, 120000);
+
+		it("Stripe drafts the renewal invoice at PRO price before finalizing (root cause)", async () => {
+			// Land 30 minutes into the new period — inside Stripe's ~1h draft window
+			// before the renewal invoice auto-finalizes and charges.
+			await advanceTo(renewalStart + Math.round(HOUR * 0.5));
+
+			const draft = await getDraftRenewal();
+			expect(
+				draft,
+				"a draft subscription_cycle invoice should exist",
+			).toBeTruthy();
+			expect(draft!.status).toBe("draft");
+			// It bills the OUTGOING (pro) tier: this is the state the incident hit.
+			expect(amountDue(draft!)).toBe(proUnit);
+		}, 120000);
+
+		it("a mid-window downgrade leaves the draft billing PRO until we re-price it", async () => {
+			// Swap the subscription price to LITE exactly as change-tier does.
+			await stripe.subscriptions.update(subscriptionId, {
+				items: [{ id: subscriptionItemId, price: LITE_PRICE_ID }],
+				proration_behavior: "none",
+				payment_behavior: "allow_incomplete",
+			});
+
+			// Proves root cause: the price swap does NOT touch the existing draft.
+			const beforeFix = await getDraftRenewal();
+			expect(amountDue(beforeFix!)).toBe(proUnit);
+
+			// Run the actual production helper against the real draft.
+			await repriceDraftRenewalInvoice({
+				subscriptionId,
+				customer: customerId,
+				newPriceId: LITE_PRICE_ID,
+				newTier: "lite",
+			});
+
+			const afterFix = await getDraftRenewal();
+			expect(amountDue(afterFix!)).toBe(liteUnit);
+			expect(repriceLineTotal(afterFix!)).toBe(liteUnit - proUnit);
+		}, 120000);
+
+		it("re-pricing is idempotent — a second run adds no further adjustment", async () => {
+			await repriceDraftRenewalInvoice({
+				subscriptionId,
+				customer: customerId,
+				newPriceId: LITE_PRICE_ID,
+				newTier: "lite",
+			});
+			const draft = await getDraftRenewal();
+			expect(amountDue(draft!)).toBe(liteUnit);
+			expect(repriceLineTotal(draft!)).toBe(liteUnit - proUnit);
+		}, 120000);
+
+		it("cancel-downgrade re-prices the draft back to the PRO price", async () => {
+			// Reverting the swap the way cancel-downgrade does.
+			await stripe.subscriptions.update(subscriptionId, {
+				items: [{ id: subscriptionItemId, price: PRO_PRICE_ID }],
+				proration_behavior: "none",
+				payment_behavior: "allow_incomplete",
+			});
+
+			await repriceDraftRenewalInvoice({
+				subscriptionId,
+				customer: customerId,
+				newPriceId: PRO_PRICE_ID,
+				newTier: "pro",
+			});
+
+			const draft = await getDraftRenewal();
+			expect(amountDue(draft!)).toBe(proUnit);
+			// The earlier -delta and this +delta net out to zero.
+			expect(repriceLineTotal(draft!)).toBe(0);
+		}, 120000);
+
+		it("the finalized renewal charges the re-priced LITE amount end-to-end", async () => {
+			// Re-apply the downgrade + re-price, then let the clock finalize it.
+			await stripe.subscriptions.update(subscriptionId, {
+				items: [{ id: subscriptionItemId, price: LITE_PRICE_ID }],
+				proration_behavior: "none",
+				payment_behavior: "allow_incomplete",
+			});
+			await repriceDraftRenewalInvoice({
+				subscriptionId,
+				customer: customerId,
+				newPriceId: LITE_PRICE_ID,
+				newTier: "lite",
+			});
+
+			const draft = await getDraftRenewal();
+			const draftId = draft!.id!;
+
+			// Advance just past Stripe's own scheduled auto-finalization time so it
+			// finalizes and charges the draft the same way a real renewal would.
+			const finalizeAt =
+				draft!.automatically_finalizes_at ?? renewalStart + HOUR;
+			await advanceTo(finalizeAt + 60);
+
+			let finalized = await stripe.invoices.retrieve(draftId);
+			// Charging can lag finalization slightly under the test clock; poll.
+			for (let i = 0; i < 30 && finalized.status !== "paid"; i++) {
+				await new Promise((r) => setTimeout(r, 2000));
+				finalized = await stripe.invoices.retrieve(draftId);
+			}
+			expect(finalized.status).toBe("paid");
+			// Without the fix this would have charged proUnit ($79) for a LITE cycle.
+			expect(finalized.amount_paid).toBe(liteUnit);
+		}, 120000);
+	},
+);

--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -20,6 +20,9 @@ const stripeMock = vi.hoisted(() => ({
 		finalizeInvoice: vi.fn(),
 		voidInvoice: vi.fn(),
 	},
+	invoiceItems: {
+		create: vi.fn(),
+	},
 }));
 
 vi.mock("@/routes/payments.js", async (importOriginal) => {
@@ -1047,5 +1050,243 @@ describe("dev plan tier changes", () => {
 		});
 		expect(res.status).toBe(400);
 		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+	});
+
+	it("re-prices an already-drafted renewal invoice when scheduling a downgrade", async () => {
+		// Stripe drafts the renewal invoice up to an hour before charging it. A
+		// downgrade inside that window swaps the subscription price too late for
+		// the draft, so without an adjustment the renewal bills the old (higher)
+		// tier while the webhook grants the lower tier's credits.
+		process.env.STRIPE_DEV_PLAN_LITE_PRICE_ID = "price_lite";
+		await db
+			.update(tables.organization)
+			.set({ devPlan: "pro", devPlanCreditsLimit: "237" })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
+		stripeMock.subscriptions.update.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			customer: "cus_dev_plan",
+			status: "active",
+			items: { data: [{ id: "si_dev_plan" }] },
+		});
+		stripeMock.invoices.list.mockResolvedValue({
+			data: [
+				{
+					id: "in_renewal_draft",
+					billing_reason: "subscription_cycle",
+					currency: "usd",
+					lines: {
+						data: [
+							{
+								amount: 7900,
+								parent: { type: "subscription_item_details" },
+								metadata: {},
+							},
+						],
+					},
+				},
+			],
+		});
+		stripeMock.prices.retrieve.mockResolvedValue({
+			id: "price_lite",
+			unit_amount: 2900,
+		});
+
+		const res = await app.request("/dev-plans/change-tier", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({ newTier: "lite" }),
+		});
+
+		expect(res.status).toBe(200);
+		// The draft still bills pro ($79); the adjustment brings it down to the
+		// lite price ($29) the renewal webhook will apply.
+		expect(stripeMock.prices.retrieve).toHaveBeenCalledWith("price_lite");
+		expect(stripeMock.invoiceItems.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customer: "cus_dev_plan",
+				invoice: "in_renewal_draft",
+				amount: -5000,
+				currency: "usd",
+				metadata: expect.objectContaining({
+					devPlanRenewalReprice: "true",
+				}),
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlan).toBe("pro");
+		expect(org?.devPlanPendingTier).toBe("lite");
+	});
+
+	it("skips the draft adjustment when the draft already bills the new price", async () => {
+		// The draft can be created concurrently with (or after) the price swap, in
+		// which case it already bills the new tier and must not be adjusted again.
+		process.env.STRIPE_DEV_PLAN_LITE_PRICE_ID = "price_lite";
+		await db
+			.update(tables.organization)
+			.set({ devPlan: "pro", devPlanCreditsLimit: "237" })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
+		stripeMock.subscriptions.update.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			customer: "cus_dev_plan",
+			status: "active",
+			items: { data: [{ id: "si_dev_plan" }] },
+		});
+		stripeMock.invoices.list.mockResolvedValue({
+			data: [
+				{
+					id: "in_renewal_draft",
+					billing_reason: "subscription_cycle",
+					currency: "usd",
+					lines: {
+						data: [
+							{
+								amount: 2900,
+								parent: { type: "subscription_item_details" },
+								metadata: {},
+							},
+						],
+					},
+				},
+			],
+		});
+		stripeMock.prices.retrieve.mockResolvedValue({
+			id: "price_lite",
+			unit_amount: 2900,
+		});
+
+		const res = await app.request("/dev-plans/change-tier", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({ newTier: "lite" }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(stripeMock.invoiceItems.create).not.toHaveBeenCalled();
+	});
+
+	it("schedules the downgrade even if re-pricing the draft fails", async () => {
+		// Re-pricing is best-effort: a Stripe failure there must not leave the
+		// price swapped without the pending tier recorded (the reverse mismatch).
+		process.env.STRIPE_DEV_PLAN_LITE_PRICE_ID = "price_lite";
+		await db
+			.update(tables.organization)
+			.set({ devPlan: "pro", devPlanCreditsLimit: "237" })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
+		stripeMock.subscriptions.update.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			customer: "cus_dev_plan",
+			status: "active",
+			items: { data: [{ id: "si_dev_plan" }] },
+		});
+		stripeMock.invoices.list.mockRejectedValue(new Error("stripe unavailable"));
+
+		const res = await app.request("/dev-plans/change-tier", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({ newTier: "lite" }),
+		});
+
+		expect(res.status).toBe(200);
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlanPendingTier).toBe("lite");
+	});
+
+	it("re-prices the draft back to the current tier on cancel-downgrade", async () => {
+		// Scheduling the downgrade inside the pre-renewal window added a negative
+		// adjustment to the draft; cancelling must bring the draft back to the
+		// current tier's price, netting out the earlier adjustment.
+		process.env.STRIPE_DEV_PLAN_PRO_PRICE_ID = "price_pro";
+		await db
+			.update(tables.organization)
+			.set({ devPlan: "pro", devPlanPendingTier: "lite" })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				// Price was swapped to the lower (lite) tier when scheduling.
+				{ price: { id: "price_lite" } },
+			),
+		);
+		stripeMock.subscriptions.update.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			customer: "cus_dev_plan",
+			status: "active",
+			items: { data: [{ id: "si_dev_plan" }] },
+		});
+		stripeMock.invoices.list.mockResolvedValue({
+			data: [
+				{
+					id: "in_renewal_draft",
+					billing_reason: "subscription_cycle",
+					currency: "usd",
+					lines: {
+						data: [
+							{
+								amount: 7900,
+								parent: { type: "subscription_item_details" },
+								metadata: {},
+							},
+							{
+								amount: -5000,
+								parent: { type: "invoice_item_details" },
+								metadata: { devPlanRenewalReprice: "true" },
+							},
+						],
+					},
+				},
+			],
+		});
+		stripeMock.prices.retrieve.mockResolvedValue({
+			id: "price_pro",
+			unit_amount: 7900,
+		});
+
+		const res = await app.request("/dev-plans/cancel-downgrade", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		// Net billed is $29 (7900 - 5000); the counter-adjustment restores $79.
+		expect(stripeMock.prices.retrieve).toHaveBeenCalledWith("price_pro");
+		expect(stripeMock.invoiceItems.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customer: "cus_dev_plan",
+				invoice: "in_renewal_draft",
+				amount: 5000,
+				currency: "usd",
+				metadata: expect.objectContaining({
+					devPlanRenewalReprice: "true",
+				}),
+			}),
+		);
 	});
 });

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2,7 +2,10 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { voidPendingCycleRenewalInvoices } from "@/lib/pending-renewal.js";
+import {
+	repriceDraftRenewalInvoice,
+	voidPendingCycleRenewalInvoices,
+} from "@/lib/pending-renewal.js";
 import {
 	computeSelfRefundEligibility,
 	executeSelfRefund,
@@ -1446,6 +1449,16 @@ devPlans.openapi(changeTier, async (c) => {
 				},
 			});
 
+			// If Stripe already drafted the upcoming renewal invoice (this change
+			// landed inside the pre-renewal finalization window), it still bills the
+			// old price — re-price it to match the tier taking effect at renewal.
+			await repriceDraftRenewalInvoice({
+				subscriptionId,
+				customer: subscription.customer,
+				newPriceId,
+				newTier,
+			});
+
 			await db
 				.update(tables.organization)
 				.set({
@@ -1649,6 +1662,15 @@ devPlans.openapi(cancelDowngrade, async (c) => {
 				},
 			},
 		);
+
+		// Scheduling the change may have re-priced a drafted renewal invoice to the
+		// target tier; re-price it back so the renewal bills the current tier.
+		await repriceDraftRenewalInvoice({
+			subscriptionId: personalOrg.devPlanStripeSubscriptionId,
+			customer: subscription.customer,
+			newPriceId: currentTierPriceId,
+			newTier: currentTier,
+		});
 
 		await db
 			.update(tables.organization)


### PR DESCRIPTION
## Problem

A DevPass subscriber downgraded pro → lite at 06:37 PM and was renewed at 07:01 PM the same day — charged the **PRO price ($79)** but granted **LITE credits ($87)** with the transaction labeled "Dev Plan LITE renewed". Net effect: overcharged ~$50 for a lite cycle.

## Root cause

Stripe drafts the `subscription_cycle` renewal invoice up to ~an hour before finalizing and charging it. A tier change swaps the subscription item's price immediately (`proration_behavior: "none"`), but an **already-drafted renewal invoice keeps billing the price it was drafted with** — the swap lands too late. The renewal webhook then desyncs three ways: `amount` comes from Stripe's `invoice.amount_paid` (old tier), while credits, tier, and description follow `devPlanPendingTier` (new tier).

Any tier change (or cancel-downgrade) inside the pre-renewal finalization window hits this, in either direction.

## Fix

After every tier-change price swap (`change-tier`, both directions, and `cancel-downgrade`), look for a draft `subscription_cycle` invoice on the subscription and re-price it by adding an adjustment invoice item for the difference between the new tier's price and the draft's **net plan amount** (subscription lines + earlier tagged adjustment lines).

- Computing against the net amount makes it idempotent and correct across consecutive changes in the same window (downgrade → upgrade, downgrade → cancel) and a no-op when the draft was created after the swap already at the new price.
- Adjustment lines are tagged with `devPlanRenewalReprice` metadata so only our own adjustments are netted.
- Best-effort: a failure only reverts to today's (rare) near-boundary mismatch and never fails the tier change itself — failing after the swap but before recording the pending tier would create the reverse mismatch.
- For upgrades it runs only after the prorated charge succeeded, so a rolled-back upgrade never touches the draft.

## Tests

**Unit** (`dev-plans.spec.ts`, mocked Stripe, 18 passing): downgrade re-prices a drafted renewal (−$50), skips when the draft already bills the new price, downgrade still succeeds when re-pricing fails, cancel-downgrade nets the earlier adjustment back out (+$50).

**Real Stripe Test Clock e2e** (`dev-plans-reprice.e2e.ts`, opt-in via `STRIPE_TESTCLOCK_E2E`, skipped in CI): reproduces the incident against a live sandbox and runs the actual `repriceDraftRenewalInvoice` helper. All 6 pass:
- Initial PRO subscription invoice pays at $79.
- **Root cause confirmed:** Stripe drafts the renewal at $79 before finalizing; the mid-window price swap leaves that draft billing $79.
- The helper re-prices the draft to $29 with a −$50 adjustment line; idempotent on re-run.
- cancel-downgrade re-prices back to $79 (adjustments net to $0).
- **End-to-end:** after advancing the clock past finalization, the invoice **charges $29**, not $79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downgrade scheduling now keeps already-drafted upcoming renewal charges aligned with the selected tier.
  * If the drafted renewal invoice already reflects the new tier, no additional adjustment is applied.
  * If re-pricing a drafted renewal fails, the tier change/downgrade still proceeds and remains scheduled.
  * Canceling a scheduled downgrade now re-prices the drafted renewal back to the current tier.
* **Tests**
  * Added an end-to-end verification covering downgrade re-pricing, idempotency, and cancel-downgrade behavior against Stripe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->