### PR TITLE
fix(stripe): ignore deletion of superseded subs

### DIFF
--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -6,6 +6,7 @@ import {
 	handleChargeRefunded,
 	handleInvoicePaymentSucceeded,
 	handlePaymentIntentFailed,
+	handleSubscriptionDeleted,
 	handleSubscriptionUpdated,
 } from "./stripe.js";
 import { deleteAll } from "./testing.js";
@@ -632,6 +633,102 @@ describe("handleSubscriptionUpdated — dev plan credit freeze/restore", () => {
 		// The stale event must not touch the active subscription's expiry/cancel
 		// flags either.
 		expect(org?.devPlanCancelled).toBe(false);
+	});
+});
+
+function makeDeletedEvent(overrides?: {
+	subscriptionId?: string;
+	metadata?: Record<string, string>;
+}): Stripe.CustomerSubscriptionDeletedEvent {
+	return {
+		id: "evt_test_deleted",
+		type: "customer.subscription.deleted",
+		data: {
+			object: {
+				id: overrides?.subscriptionId ?? SUB_ID,
+				customer: "cus_test_feedback",
+				status: "canceled",
+				metadata: overrides?.metadata ?? {
+					organizationId: ORG_ID,
+					subscriptionType: "dev_plan",
+				},
+				items: { data: [] },
+			},
+		},
+	} as unknown as Stripe.CustomerSubscriptionDeletedEvent;
+}
+
+describe("handleSubscriptionDeleted — superseded subscription", () => {
+	beforeEach(async () => {
+		await deleteAll();
+		sendEmailMock.mockClear();
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	test("ignores deletion of a superseded dev-plan subscription", async () => {
+		// Repro of the production incident: the customer cancelled their old plan
+		// at period end, then started a NEW Lite plan before the old period
+		// elapsed. Stripe's deletion event for the old subscription arrived hours
+		// after the new checkout and wiped the fresh plan back to `none`.
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			devPlan: "lite",
+			devPlanCreditsLimit: "87",
+			devPlanCreditsUsed: "0",
+			devPlanStripeSubscriptionId: SUB_ID,
+			devPlanCancelled: false,
+		});
+
+		await handleSubscriptionDeleted(
+			makeDeletedEvent({ subscriptionId: "sub_old_cancelled_plan" }),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlan).toBe("lite");
+		expect(org?.devPlanCreditsLimit).toBe("87");
+		expect(org?.devPlanStripeSubscriptionId).toBe(SUB_ID);
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(0);
+		expect(sendEmailMock).not.toHaveBeenCalled();
+	});
+
+	test("still ends the dev plan when the active subscription is deleted", async () => {
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			devPlan: "lite",
+			devPlanCreditsLimit: "87",
+			devPlanCreditsUsed: "10",
+			devPlanStripeSubscriptionId: SUB_ID,
+			devPlanCancelled: true,
+		});
+
+		await handleSubscriptionDeleted(makeDeletedEvent());
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlan).toBe("none");
+		expect(org?.devPlanStripeSubscriptionId).toBeNull();
+		expect(org?.devPlanCreditsLimit).toBe("0");
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(1);
+		expect(txns[0].type).toBe("dev_plan_end");
 	});
 });
 

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -4083,7 +4083,7 @@ export async function handleSubscriptionUpdated(
 	}
 }
 
-async function handleSubscriptionDeleted(
+export async function handleSubscriptionDeleted(
 	event: Stripe.CustomerSubscriptionDeletedEvent,
 ) {
 	const subscription = event.data.object;
@@ -4110,6 +4110,46 @@ async function handleSubscriptionDeleted(
 	const isDevPlan =
 		metadata?.subscriptionType === "dev_plan" ||
 		organization.devPlanStripeSubscriptionId === subscription.id;
+
+	// A deletion event can target a *superseded* subscription — e.g. the user
+	// cancelled at period end, then started a NEW plan before the old one's
+	// period actually elapsed. The old subscription's metadata still carries
+	// `subscriptionType: dev_plan`/`chat_plan`, so the metadata-based detection
+	// above would let its deletion wipe the org's fresh plan (tier, credits,
+	// subscription id) hours after the new checkout completed. Once the org has
+	// activated a different subscription, its deletion events must be ignored.
+	// (handleSubscriptionUpdated applies the same guard.)
+	if (
+		isDevPlan &&
+		organization.devPlanStripeSubscriptionId &&
+		organization.devPlanStripeSubscriptionId !== subscription.id
+	) {
+		logger.info(
+			`Ignoring stale dev-plan subscription.deleted ${subscription.id} for org ${organizationId} (active sub: ${organization.devPlanStripeSubscriptionId})`,
+		);
+		return;
+	}
+	if (
+		isChatPlan &&
+		organization.chatPlanStripeSubscriptionId &&
+		organization.chatPlanStripeSubscriptionId !== subscription.id
+	) {
+		logger.info(
+			`Ignoring stale chat-plan subscription.deleted ${subscription.id} for org ${organizationId} (active sub: ${organization.chatPlanStripeSubscriptionId})`,
+		);
+		return;
+	}
+	if (
+		!isDevPlan &&
+		!isChatPlan &&
+		organization.stripeSubscriptionId &&
+		organization.stripeSubscriptionId !== subscription.id
+	) {
+		logger.info(
+			`Ignoring stale subscription.deleted ${subscription.id} for org ${organizationId} (active sub: ${organization.stripeSubscriptionId})`,
+		);
+		return;
+	}
 
 	if (isChatPlan) {
 		const previousChatPlan = organization.chatPlan;


### PR DESCRIPTION
## Summary

Fixes a customer-facing billing bug (org `nmS7qOY49mXvA2DKGHaP`, chan020401@gmail.com): a user who cancelled their dev plan at period end and then **resubscribed before the old period elapsed** got their brand-new plan wiped.

### Timeline of the incident
1. Jun 2 — Lite plan started (sub A), Jun 13 upgraded to Pro, later cancelled at period end
2. Jul 3, 22:26 — user starts a **new** Lite plan via Stripe Checkout (sub B); `devPlanStripeSubscriptionId` now points to B, $87 credits granted
3. Jul 4, 02:56 — Stripe delivers `customer.subscription.deleted` for the **old** sub A; its metadata still carries `subscriptionType: dev_plan`, so `handleSubscriptionDeleted` reset the org to `devPlan: none`, zeroed the fresh credits, and nulled the subscription id — admin dashboard then shows "Tier: none / churned" despite an active Stripe subscription

### Fix
`handleSubscriptionUpdated` already guards against events targeting a *superseded* subscription; `handleSubscriptionDeleted` did not. This mirrors the same guard: once the org has activated a different subscription id, deletion events for old subscriptions are logged and ignored — for dev plans, chat plans, and regular pro subscriptions alike.

### Tests
- New: stale dev-plan deletion leaves the new plan/credits/sub id untouched (repro of the incident, no `dev_plan_end` transaction, no cancellation email)
- New: deletion of the *matching* active subscription still ends the plan as before
- `apps/api/src/stripe.spec.ts`: 23/23 pass; full `pnpm build` passes

### Note for ops
This PR only prevents future occurrences. The affected org still needs a manual repair: restore `devPlan='lite'`, `devPlanCreditsLimit='87'`, `devPlanStripeSubscriptionId` (the active sub id from Stripe), `devPlanExpiresAt`/`devPlanBillingCycleStart` from the Jul 3 subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled subscription events so outdated webhook updates no longer overwrite an organization’s current plan or credits.
  * When the active dev plan is deleted, the plan now ends correctly and the related subscription and credit limits are cleared.

* **Tests**
  * Added coverage for subscription-deletion scenarios to verify stale events are ignored and active deletions are processed properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->