### PR TITLE
fix(api): remove stray null byte in admin route

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1493,7 +1493,7 @@ admin.openapi(getGlobalStats, async (c) => {
 				row as (typeof timeseriesBreakdownRows)[number] & { source: string }
 			).source;
 		}
-		const mapKey = `${row.date} ${key}`;
+		const mapKey = `${row.date}:${key}`;
 		const existing = timeseriesBreakdownMap.get(mapKey);
 		if (existing) {
 			existing.requestCount += Number(row.requestCount);


### PR DESCRIPTION
## Problem

`apps/api/src/routes/admin.ts` contained a stray `NUL` (`\x00`) byte at offset 38727, embedded in the timeseries-breakdown composite map key:

```ts
const mapKey = `${row.date}\x00${key}`;
```

A single null byte makes `grep`/`ripgrep` classify the whole file as binary and silently skip it — so searches for symbols in this file returned nothing unless `rg --text` was used.

## Fix

`row.date` is always a fixed-format `YYYY-MM-DD` string (built via `DATE(...)` / `to_char(..., 'YYYY-MM-DD')`), so it never contains a `:`. Replacing the NUL delimiter with a colon keeps the composite key collision-free, matches the codebase's existing `${a}:${b}` key convention, and restores plain text-searchability of the file.

## Testing

- `pnpm format` — clean, no changes beyond the one line
- `turbo run build --filter=api` — passes
- `grep -n mapKey apps/api/src/routes/admin.ts` now works without `--text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the consistency of global stats time series breakdown data so datapoints are grouped and merged correctly in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->