### PR TITLE
feat(dev-plans): charge full price on tier upgrade

### DIFF
--- a/apps/api/src/routes/chat-plans.ts
+++ b/apps/api/src/routes/chat-plans.ts
@@ -431,58 +431,75 @@ chatPlans.openapi(changeTier, async (c) => {
 		const subscription = await getStripe().subscriptions.retrieve(
 			personalOrg.chatPlanStripeSubscriptionId,
 		);
-
-		// Same payment-behavior strategy as dev-plans: charge prorated upgrades
-		// synchronously and reject the upgrade if the card declines, so we don't
-		// leave the customer on the higher tier without collecting.
-		const updated = await getStripe().subscriptions.update(
-			personalOrg.chatPlanStripeSubscriptionId,
-			{
-				items: [
-					{
-						id: subscription.items.data[0].id,
-						price: newPriceId,
-					},
-				],
-				proration_behavior: isUpgrade ? "always_invoice" : "create_prorations",
-				payment_behavior: isUpgrade
-					? "error_if_incomplete"
-					: "allow_incomplete",
-				metadata: {
-					...subscription.metadata,
-					chatPlan: newTier,
-					chatPlanCycle: "monthly",
-				},
-			},
-		);
-
-		if (
-			isUpgrade &&
-			updated.status !== "active" &&
-			updated.status !== "trialing"
-		) {
-			throw new HTTPException(402, {
-				message:
-					"Upgrade payment could not be collected. Update your payment method and try again.",
-			});
-		}
-
+		const subscriptionItemId = subscription.items.data[0].id;
 		const newCreditsLimit = getChatPlanCreditsLimit(newTier);
 
-		await db
-			.update(tables.organization)
-			.set({
-				chatPlan: newTier,
-				chatPlanCreditsLimit: newCreditsLimit.toString(),
-			})
-			.where(eq(tables.organization.id, personalOrg.id));
+		if (isUpgrade) {
+			// Charge the full new-tier price today and start a fresh billing cycle
+			// (`billing_cycle_anchor: "now"`) with no proration
+			// (`proration_behavior: "none"`). `error_if_incomplete` makes the update
+			// atomic, so a declined card leaves the subscription on the old tier.
+			const updated = await getStripe().subscriptions.update(
+				personalOrg.chatPlanStripeSubscriptionId,
+				{
+					items: [{ id: subscriptionItemId, price: newPriceId }],
+					proration_behavior: "none",
+					billing_cycle_anchor: "now",
+					payment_behavior: "error_if_incomplete",
+					metadata: {
+						...subscription.metadata,
+						chatPlan: newTier,
+						chatPlanCycle: "monthly",
+					},
+				},
+			);
 
-		// Upgrades charge a prorated amount (`always_invoice`); the resulting
-		// `subscription_update` invoice is recorded and emailed by the webhook
-		// (handleInvoicePaymentSucceeded), keyed on its unique stripeInvoiceId, so
-		// we must not insert a duplicate upgrade transaction here. Downgrades issue
-		// no charge/invoice, so record the tier change now.
-		if (!isUpgrade) {
+			if (updated.status !== "active" && updated.status !== "trialing") {
+				throw new HTTPException(402, {
+					message:
+						"Upgrade payment could not be collected. Update your payment method and try again.",
+				});
+			}
+
+			// Fresh billing cycle: reset credits to the new tier's full allowance,
+			// zero out usage, and advance the cycle start. The resulting
+			// `subscription_update` invoice is recorded and emailed by the webhook
+			// (handleInvoicePaymentSucceeded), keyed on its unique stripeInvoiceId, so
+			// we don't insert an upgrade transaction here.
+			await db
+				.update(tables.organization)
+				.set({
+					chatPlan: newTier,
+					chatPlanCreditsLimit: newCreditsLimit.toString(),
+					chatPlanCreditsUsed: "0",
+					chatPlanBillingCycleStart: new Date(),
+				})
+				.where(eq(tables.organization.id, personalOrg.id));
+		} else {
+			// Downgrade: unchanged behavior. Take effect immediately with Stripe
+			// proration crediting the unused higher-tier time on the next invoice.
+			await getStripe().subscriptions.update(
+				personalOrg.chatPlanStripeSubscriptionId,
+				{
+					items: [{ id: subscriptionItemId, price: newPriceId }],
+					proration_behavior: "create_prorations",
+					payment_behavior: "allow_incomplete",
+					metadata: {
+						...subscription.metadata,
+						chatPlan: newTier,
+						chatPlanCycle: "monthly",
+					},
+				},
+			);
+
+			await db
+				.update(tables.organization)
+				.set({
+					chatPlan: newTier,
+					chatPlanCreditsLimit: newCreditsLimit.toString(),
+				})
+				.where(eq(tables.organization.id, personalOrg.id));
+
 			await db.insert(tables.transaction).values({
 				organizationId: personalOrg.id,
 				type: "chat_plan_downgrade",

--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -8,16 +8,8 @@ import { db, eq, tables } from "@llmgateway/db";
 import type * as PaymentsModule from "@/routes/payments.js";
 
 const stripeMock = vi.hoisted(() => ({
-	invoiceItems: {
-		create: vi.fn(),
-		del: vi.fn(),
-	},
-	invoices: {
-		create: vi.fn(),
-		finalizeInvoice: vi.fn(),
-		pay: vi.fn(),
-		del: vi.fn(),
-		voidInvoice: vi.fn(),
+	prices: {
+		retrieve: vi.fn(),
 	},
 	subscriptions: {
 		retrieve: vi.fn(),
@@ -37,6 +29,42 @@ const ORG_ID = "test-dev-plan-org";
 const SUBSCRIPTION_ID = "sub_dev_plan_upgrade";
 const originalProPriceId = process.env.STRIPE_DEV_PLAN_PRO_PRICE_ID;
 
+// A fresh 30-day period the mocked subscription update anchors to (billing cycle
+// resets to now on an upgrade).
+const THIRTY_DAYS = 30 * 24 * 60 * 60;
+
+// Set by beforeEach and read by the retrievedSubscription helper below.
+let nowSecondsValue: number;
+
+function retrievedSubscription(
+	overrides: Record<string, unknown> = {},
+	itemOverrides: Record<string, unknown> = {},
+) {
+	return {
+		id: SUBSCRIPTION_ID,
+		customer: "cus_dev_plan",
+		status: "active",
+		metadata: {
+			organizationId: ORG_ID,
+			subscriptionType: "dev_plan",
+			devPlan: "lite",
+			devPlanCycle: "monthly",
+		},
+		items: {
+			data: [
+				{
+					id: "si_dev_plan",
+					current_period_start: nowSecondsValue - 500,
+					current_period_end: nowSecondsValue + 500,
+					price: { id: "price_lite" },
+					...itemOverrides,
+				},
+			],
+		},
+		...overrides,
+	};
+}
+
 describe("dev plan tier changes", () => {
 	let token: string;
 	let nowSeconds: number;
@@ -47,6 +75,7 @@ describe("dev plan tier changes", () => {
 		process.env.STRIPE_DEV_PLAN_PRO_PRICE_ID = "price_pro";
 		token = await createTestUser();
 		nowSeconds = Math.floor(Date.now() / 1000);
+		nowSecondsValue = nowSeconds;
 		dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
 
 		await db.insert(tables.organization).values({
@@ -79,30 +108,12 @@ describe("dev plan tier changes", () => {
 		await deleteAll();
 	});
 
-	it("previews prorated upgrade charge and credit deltas", async () => {
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
+	it("previews the full upgrade charge and new-tier credits", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		// Full monthly price of the pro tier ($79).
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 7900 });
 
 		const res = await app.request("/dev-plans/change-tier-preview", {
 			method: "POST",
@@ -121,44 +132,25 @@ describe("dev plan tier changes", () => {
 			currentTier: "lite",
 			newTier: "pro",
 			isUpgrade: true,
-			amountDueCents: 2500,
+			// Full new-tier price charged today, not a prorated slice.
+			amountDueCents: 7900,
 			currency: "USD",
 			remainingFraction: 0.5,
 			currentCreditsLimit: 87,
-			proratedCreditDelta: 75,
-			newCreditsLimit: 162,
+			// Allowance resets to the new tier's full allotment (79 * 3 = 237).
+			proratedCreditDelta: 150,
+			newCreditsLimit: 237,
 			billingPeriodStart: new Date((nowSeconds - 500) * 1000).toISOString(),
 			billingPeriodEnd: new Date((nowSeconds + 500) * 1000).toISOString(),
 		});
 		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
-		expect(stripeMock.invoiceItems.create).not.toHaveBeenCalled();
-		expect(stripeMock.invoices.create).not.toHaveBeenCalled();
 	});
 
-	it("rejects upgrade if the expected charge no longer matches", async () => {
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
+	it("rejects an upgrade if the full price exceeds the confirmed amount", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 7900 });
 
 		const res = await app.request("/dev-plans/change-tier", {
 			method: "POST",
@@ -174,8 +166,6 @@ describe("dev plan tier changes", () => {
 
 		expect(res.status).toBe(409);
 		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
-		expect(stripeMock.invoiceItems.create).not.toHaveBeenCalled();
-		expect(stripeMock.invoices.create).not.toHaveBeenCalled();
 
 		// The per-cycle claim is released when the change aborts before Stripe, so
 		// the user isn't locked out of retrying this cycle.
@@ -185,60 +175,26 @@ describe("dev plan tier changes", () => {
 		expect(org?.devPlanLastTierChangeCycleStart).toBeNull();
 	});
 
-	it("allows the upgrade when the recomputed charge is lower than the previewed amount", async () => {
-		// `remainingFraction` decays with wall-clock time, so the charge recomputed
-		// at confirm time is typically a little lower than the value the user saw in
-		// the preview. That benign downward drift must not block the upgrade — the
-		// user is only ever charged the smaller recomputed amount.
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
-		stripeMock.invoiceItems.create.mockResolvedValue({
-			id: "ii_upgrade",
-		});
-		stripeMock.invoices.create.mockResolvedValue({
-			id: "in_upgrade",
-			status: "draft",
-		});
-		stripeMock.invoices.finalizeInvoice.mockResolvedValue({
-			id: "in_upgrade",
-			status: "open",
-		});
-		stripeMock.invoices.pay.mockResolvedValue({
-			id: "in_upgrade",
-			status: "paid",
-			payment_intent: {
-				id: "pi_upgrade",
-			},
-		});
+	it("charges the full price, resets usage, and grants full new-tier credits", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 7900 });
 		stripeMock.subscriptions.update.mockResolvedValue({
 			id: SUBSCRIPTION_ID,
 			customer: "cus_dev_plan",
 			status: "active",
+			metadata: { devPlan: "pro" },
+			latest_invoice: {
+				id: "in_upgrade",
+				amount_paid: 7900,
+				payment_intent: { id: "pi_upgrade" },
+			},
 			items: {
 				data: [
 					{
 						id: "si_dev_plan",
+						current_period_end: nowSeconds + THIRTY_DAYS,
 					},
 				],
 			},
@@ -252,110 +208,20 @@ describe("dev plan tier changes", () => {
 			},
 			body: JSON.stringify({
 				newTier: "pro",
-				expectedAmountDueCents: 2600,
+				expectedAmountDueCents: 7900,
 			}),
 		});
 
 		expect(res.status).toBe(200);
-		expect(stripeMock.invoiceItems.create).toHaveBeenCalledWith(
-			expect.objectContaining({
-				amount: 2500,
-			}),
-		);
-	});
-
-	it("charges and grants prorated upgrade deltas while preserving usage", async () => {
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
-		stripeMock.invoiceItems.create.mockResolvedValue({
-			id: "ii_upgrade",
-		});
-		stripeMock.invoices.create.mockResolvedValue({
-			id: "in_upgrade",
-			status: "draft",
-		});
-		stripeMock.invoices.finalizeInvoice.mockResolvedValue({
-			id: "in_upgrade",
-			status: "open",
-		});
-		stripeMock.invoices.pay.mockResolvedValue({
-			id: "in_upgrade",
-			status: "paid",
-			payment_intent: {
-				id: "pi_upgrade",
-			},
-		});
-		stripeMock.subscriptions.update.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-					},
-				],
-			},
-		});
-
-		const res = await app.request("/dev-plans/change-tier", {
-			method: "POST",
-			headers: {
-				Cookie: token,
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				newTier: "pro",
-				expectedAmountDueCents: 2500,
-			}),
-		});
-
-		expect(res.status).toBe(200);
-		expect(stripeMock.invoiceItems.create).toHaveBeenCalledWith(
-			expect.objectContaining({
-				customer: "cus_dev_plan",
-				subscription: SUBSCRIPTION_ID,
-				amount: 2500,
-				currency: "usd",
-				metadata: expect.objectContaining({
-					organizationId: ORG_ID,
-					devPlanChange: "upgrade",
-					fromTier: "lite",
-					toTier: "pro",
-					remainingFraction: "0.5",
-				}),
-			}),
-		);
-		expect(stripeMock.invoices.pay).toHaveBeenCalledWith("in_upgrade", {
-			off_session: true,
-			expand: ["payment_intent"],
-		});
+		// Upgrade resets the billing cycle to now, charges the full new price, and
+		// suppresses proration.
 		expect(stripeMock.subscriptions.update).toHaveBeenCalledWith(
 			SUBSCRIPTION_ID,
 			expect.objectContaining({
+				items: [{ id: "si_dev_plan", price: "price_pro" }],
 				proration_behavior: "none",
-				payment_behavior: "allow_incomplete",
+				billing_cycle_anchor: "now",
+				payment_behavior: "error_if_incomplete",
 			}),
 		);
 
@@ -367,8 +233,13 @@ describe("dev plan tier changes", () => {
 			},
 		});
 		expect(org?.devPlan).toBe("pro");
-		expect(org?.devPlanCreditsUsed).toBe("12.5");
-		expect(org?.devPlanCreditsLimit).toBe("162");
+		// Fresh cycle: usage wiped, limit reset to the full new-tier allowance.
+		expect(org?.devPlanCreditsUsed).toBe("0");
+		expect(org?.devPlanCreditsLimit).toBe("237");
+		expect(org?.devPlanBillingCycleStart).not.toBeNull();
+		expect(org?.devPlanExpiresAt).toEqual(
+			new Date((nowSeconds + THIRTY_DAYS) * 1000),
+		);
 
 		const transaction = await db.query.transaction.findFirst({
 			where: {
@@ -378,76 +249,40 @@ describe("dev plan tier changes", () => {
 			},
 		});
 		expect(transaction?.type).toBe("dev_plan_upgrade");
-		expect(transaction?.amount).toBe("25");
+		expect(transaction?.amount).toBe("79");
+		expect(transaction?.creditAmount).toBe("237");
 		expect(transaction?.stripeInvoiceId).toBe("in_upgrade");
 		expect(transaction?.stripePaymentIntentId).toBe("pi_upgrade");
 	});
 
-	it("adds the upgrade credit on top of a carried-over limit from an earlier mid-cycle change", async () => {
-		// Reproduces a downgrade-then-re-upgrade within the same period: the org is
-		// on lite but still carries the pro-era limit (237) and the usage it
-		// accumulated before downgrading (220.31). The upgrade must add the prorated
-		// delta on top of the carried-over limit (237 + 75 = 312), not overwrite it
-		// with the lite tier base + delta (87 + 75 = 162), which would leave the
-		// allowance below current usage and hide the granted credit.
+	it("wipes prior mid-cycle usage on upgrade (fresh cycle)", async () => {
+		// The org has heavy prior usage this period; an upgrade starts a brand-new
+		// cycle, so usage resets to 0 rather than carrying over.
 		await db
 			.update(tables.organization)
 			.set({
-				devPlanCreditsLimit: "237",
-				devPlanCreditsUsed: "220.31",
+				devPlanCreditsLimit: "87",
+				devPlanCreditsUsed: "80.42",
 			})
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
-		stripeMock.invoiceItems.create.mockResolvedValue({
-			id: "ii_upgrade",
-		});
-		stripeMock.invoices.create.mockResolvedValue({
-			id: "in_upgrade",
-			status: "draft",
-		});
-		stripeMock.invoices.finalizeInvoice.mockResolvedValue({
-			id: "in_upgrade",
-			status: "open",
-		});
-		stripeMock.invoices.pay.mockResolvedValue({
-			id: "in_upgrade",
-			status: "paid",
-			payment_intent: {
-				id: "pi_upgrade",
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 7900 });
 		stripeMock.subscriptions.update.mockResolvedValue({
 			id: SUBSCRIPTION_ID,
 			customer: "cus_dev_plan",
 			status: "active",
+			metadata: { devPlan: "pro" },
+			latest_invoice: {
+				id: "in_upgrade",
+				amount_paid: 7900,
+				payment_intent: { id: "pi_upgrade" },
+			},
 			items: {
 				data: [
-					{
-						id: "si_dev_plan",
-					},
+					{ id: "si_dev_plan", current_period_end: nowSeconds + THIRTY_DAYS },
 				],
 			},
 		});
@@ -460,7 +295,7 @@ describe("dev plan tier changes", () => {
 			},
 			body: JSON.stringify({
 				newTier: "pro",
-				expectedAmountDueCents: 2500,
+				expectedAmountDueCents: 7900,
 			}),
 		});
 
@@ -474,52 +309,24 @@ describe("dev plan tier changes", () => {
 			},
 		});
 		expect(org?.devPlan).toBe("pro");
-		expect(org?.devPlanCreditsUsed).toBe("220.31");
-		expect(org?.devPlanCreditsLimit).toBe("312");
-
-		const transaction = await db.query.transaction.findFirst({
-			where: {
-				organizationId: {
-					eq: ORG_ID,
-				},
-			},
-		});
-		expect(transaction?.creditAmount).toBe("75");
+		expect(org?.devPlanCreditsUsed).toBe("0");
+		expect(org?.devPlanCreditsLimit).toBe("237");
 	});
 
-	it("rejects a second tier change within the same billing cycle", async () => {
-		// A tier change was already claimed for this cycle (marker at the cycle's
-		// Stripe period start), so another change must be blocked before any Stripe
-		// call. current_period_start below is nowSeconds - 500.
+	it("blocks a concurrent duplicate upgrade for the same period", async () => {
+		// A double-clicked confirm: the current Stripe period was already claimed
+		// (marker at the period start), so the second request is rejected before any
+		// Stripe call, preventing a second full-price charge and cycle reset.
 		const claimedCycleStart = new Date((nowSeconds - 500) * 1000);
 		await db
 			.update(tables.organization)
 			.set({ devPlanLastTierChangeCycleStart: claimedCycleStart })
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 7900 });
 
 		const res = await app.request("/dev-plans/change-tier", {
 			method: "POST",
@@ -534,7 +341,6 @@ describe("dev plan tier changes", () => {
 
 		expect(res.status).toBe(409);
 		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
-		expect(stripeMock.invoiceItems.create).not.toHaveBeenCalled();
 
 		const org = await db.query.organization.findFirst({
 			where: { id: { eq: ORG_ID } },
@@ -551,29 +357,9 @@ describe("dev plan tier changes", () => {
 		// `customer.subscription.deleted` webhook hasn't reset the org yet. Stripe
 		// would reject the price update with `invalid_canceled_subscription_fields`,
 		// so bail out with a 409 before ever calling update.
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "canceled",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_lite",
-						},
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription({ status: "canceled" }),
+		);
 
 		const res = await app.request("/dev-plans/change-tier", {
 			method: "POST",
@@ -608,28 +394,12 @@ describe("dev plan tier changes", () => {
 			.set({ devPlanCancelled: true })
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "canceled",
-			cancel_at_period_end: false,
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "lite",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: { id: "price_lite" },
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription({
+				status: "canceled",
+				cancel_at_period_end: false,
+			}),
+		);
 
 		const res = await app.request("/dev-plans/resume", {
 			method: "POST",
@@ -667,29 +437,12 @@ describe("dev plan tier changes", () => {
 			})
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "pro",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: {
-							id: "price_pro",
-						},
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
 		stripeMock.subscriptions.update.mockResolvedValue({
 			id: SUBSCRIPTION_ID,
 			customer: "cus_dev_plan",
@@ -709,8 +462,8 @@ describe("dev plan tier changes", () => {
 		});
 
 		expect(res.status).toBe(200);
-		// Stripe price is swapped so the renewal invoice bills the lower tier, but
-		// no proration charge is collected for a downgrade.
+		// Stripe price is swapped so the renewal invoice bills the lower tier, but no
+		// charge is collected and the cycle is NOT reset for a downgrade.
 		expect(stripeMock.subscriptions.update).toHaveBeenCalledWith(
 			SUBSCRIPTION_ID,
 			expect.objectContaining({
@@ -718,7 +471,10 @@ describe("dev plan tier changes", () => {
 				proration_behavior: "none",
 			}),
 		);
-		expect(stripeMock.invoiceItems.create).not.toHaveBeenCalled();
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalledWith(
+			SUBSCRIPTION_ID,
+			expect.objectContaining({ billing_cycle_anchor: "now" }),
+		);
 
 		const org = await db.query.organization.findFirst({
 			where: { id: { eq: ORG_ID } },
@@ -736,7 +492,7 @@ describe("dev plan tier changes", () => {
 	});
 
 	it("allows a downgrade even after an upgrade already claimed the cycle", async () => {
-		// An upgrade earlier this cycle set the once-per-cycle marker. That must
+		// An upgrade earlier this cycle set the double-charge-guard marker. That must
 		// not block a downgrade, which only schedules the lower tier for renewal.
 		process.env.STRIPE_DEV_PLAN_LITE_PRICE_ID = "price_lite";
 		const claimedCycleStart = new Date((nowSeconds - 500) * 1000);
@@ -749,27 +505,12 @@ describe("dev plan tier changes", () => {
 			})
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "pro",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: { id: "price_pro" },
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
 		stripeMock.subscriptions.update.mockResolvedValue({
 			id: SUBSCRIPTION_ID,
 			customer: "cus_dev_plan",
@@ -800,27 +541,12 @@ describe("dev plan tier changes", () => {
 			.set({ devPlan: "pro", devPlanPendingTier: "lite" })
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "pro",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: { id: "price_pro" },
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
 
 		const downgrade = await app.request("/dev-plans/change-tier", {
 			method: "POST",
@@ -832,8 +558,8 @@ describe("dev plan tier changes", () => {
 	});
 
 	it("allows an upgrade while a downgrade is pending and clears the pending tier", async () => {
-		// An upgrade supersedes a scheduled downgrade: it applies immediately and
-		// clears devPlanPendingTier.
+		// An upgrade supersedes a scheduled downgrade: it applies immediately, starts
+		// a fresh cycle and clears devPlanPendingTier.
 		process.env.STRIPE_DEV_PLAN_MAX_PRICE_ID = "price_max";
 		await db
 			.update(tables.organization)
@@ -845,46 +571,28 @@ describe("dev plan tier changes", () => {
 			})
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "pro",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						price: { id: "price_pro" },
-					},
-				],
-			},
-		});
-		stripeMock.invoiceItems.create.mockResolvedValue({ id: "ii_upgrade" });
-		stripeMock.invoices.create.mockResolvedValue({
-			id: "in_upgrade",
-			status: "draft",
-		});
-		stripeMock.invoices.finalizeInvoice.mockResolvedValue({
-			id: "in_upgrade",
-			status: "open",
-		});
-		stripeMock.invoices.pay.mockResolvedValue({
-			id: "in_upgrade",
-			status: "paid",
-			payment_intent: { id: "pi_upgrade" },
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "pro" } },
+				{ price: { id: "price_pro" } },
+			),
+		);
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 17900 });
 		stripeMock.subscriptions.update.mockResolvedValue({
 			id: SUBSCRIPTION_ID,
 			customer: "cus_dev_plan",
 			status: "active",
-			items: { data: [{ id: "si_dev_plan" }] },
+			metadata: { devPlan: "max" },
+			latest_invoice: {
+				id: "in_max",
+				amount_paid: 17900,
+				payment_intent: { id: "pi_max" },
+			},
+			items: {
+				data: [
+					{ id: "si_dev_plan", current_period_end: nowSeconds + THIRTY_DAYS },
+				],
+			},
 		});
 
 		const res = await app.request("/dev-plans/change-tier", {
@@ -899,6 +607,8 @@ describe("dev plan tier changes", () => {
 		});
 		expect(org?.devPlan).toBe("max");
 		expect(org?.devPlanPendingTier).toBeNull();
+		expect(org?.devPlanCreditsUsed).toBe("0");
+		expect(org?.devPlanCreditsLimit).toBe("537");
 	});
 
 	it("cancels a scheduled downgrade and reverts the Stripe price to the current tier", async () => {
@@ -910,28 +620,13 @@ describe("dev plan tier changes", () => {
 			.set({ devPlan: "max", devPlanPendingTier: "pro" })
 			.where(eq(tables.organization.id, ORG_ID));
 
-		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: SUBSCRIPTION_ID,
-			customer: "cus_dev_plan",
-			status: "active",
-			metadata: {
-				organizationId: ORG_ID,
-				subscriptionType: "dev_plan",
-				devPlan: "max",
-				devPlanCycle: "monthly",
-			},
-			items: {
-				data: [
-					{
-						id: "si_dev_plan",
-						current_period_start: nowSeconds - 500,
-						current_period_end: nowSeconds + 500,
-						// Price was swapped to the lower (pro) tier when scheduling.
-						price: { id: "price_pro" },
-					},
-				],
-			},
-		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(
+				{ metadata: { devPlan: "max" } },
+				// Price was swapped to the lower (pro) tier when scheduling.
+				{ price: { id: "price_pro" } },
+			),
+		);
 		stripeMock.subscriptions.update.mockResolvedValue({
 			id: SUBSCRIPTION_ID,
 			customer: "cus_dev_plan",

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -20,7 +20,6 @@ import {
 	db,
 	tables,
 	eq,
-	sql,
 	and,
 	or,
 	lt,
@@ -30,7 +29,7 @@ import {
 import { logger } from "@llmgateway/logger";
 import {
 	DEV_PLAN_PRICES,
-	getProratedCreditDelta,
+	getDevPlanCreditsLimit,
 	type DevPlanCycle,
 	type DevPlanTier,
 } from "@llmgateway/shared";
@@ -142,174 +141,38 @@ function getRemainingBillingPeriodFraction(
 	return Math.min(1, Math.max(0, (periodEnd - nowSeconds) / periodSeconds));
 }
 
-function getDevPlanUpgradeAmountCents(
-	currentTier: DevPlanTier,
-	newTier: DevPlanTier,
-	remainingFraction: number,
-) {
-	const fullDeltaCents =
-		(DEV_PLAN_PRICES[newTier] - DEV_PLAN_PRICES[currentTier]) * 100;
-	return Math.max(0, Math.round(fullDeltaCents * remainingFraction));
+// The full price of a tier charged on an upgrade. Reads the Stripe price's
+// unit amount so it stays correct for both monthly and legacy annual cadences
+// (DEV_PLAN_PRICES only tracks the monthly dollar figure).
+async function getDevPlanFullPriceCents(priceId: string): Promise<number> {
+	const price = await getStripe().prices.retrieve(priceId);
+	return price.unit_amount ?? 0;
 }
 
-function getDevPlanTierChangeCreditPreview(
-	currentTier: DevPlanTier,
-	newTier: DevPlanTier,
-	remainingFraction: number,
-	currentCreditsLimit: number,
-) {
-	const isUpgrade = DEV_PLAN_PRICES[newTier] > DEV_PLAN_PRICES[currentTier];
-	const proratedCreditDelta = isUpgrade
-		? getProratedCreditDelta(currentTier, newTier, remainingFraction)
-		: 0;
-
-	return {
-		currentCreditsLimit,
-		proratedCreditDelta,
-		newCreditsLimit: currentCreditsLimit + proratedCreditDelta,
-	};
-}
-
-async function cleanupFailedUpgradeInvoice(params: {
-	invoiceId: string | null;
-	invoiceItemId: string | null;
-	finalized: boolean;
-}) {
-	const stripe = getStripe();
-	try {
-		if (params.invoiceId) {
-			if (params.finalized) {
-				await stripe.invoices.voidInvoice(params.invoiceId);
-			} else {
-				await stripe.invoices.del(params.invoiceId);
-			}
-			return;
+function getDevPlanChangeInvoiceId(subscription: Stripe.Subscription) {
+	const latestInvoice = (
+		subscription as Stripe.Subscription & {
+			latest_invoice?: string | Stripe.Invoice | null;
 		}
-
-		if (params.invoiceItemId) {
-			await stripe.invoiceItems.del(params.invoiceItemId);
-		}
-	} catch (cleanupError) {
-		logger.warn("Failed to clean up failed dev plan upgrade invoice", {
-			error:
-				cleanupError instanceof Error
-					? cleanupError.message
-					: String(cleanupError),
-			invoiceId: params.invoiceId,
-			invoiceItemId: params.invoiceItemId,
-		});
+	).latest_invoice;
+	if (!latestInvoice) {
+		return { invoiceId: null, paymentIntentId: null, amountPaid: null };
 	}
-}
-
-async function collectDevPlanUpgradeCharge(params: {
-	subscription: Stripe.Subscription;
-	organizationId: string;
-	currentTier: DevPlanTier;
-	newTier: DevPlanTier;
-	remainingFraction: number;
-}) {
-	const stripe = getStripe();
-	const customerId = getStripeId(params.subscription.customer);
-
-	if (!customerId) {
-		throw new HTTPException(500, {
-			message: "Subscription customer not found",
-		});
-	}
-
-	const amountCents = getDevPlanUpgradeAmountCents(
-		params.currentTier,
-		params.newTier,
-		params.remainingFraction,
-	);
-
-	if (amountCents <= 0) {
-		return null;
-	}
-
-	const metadata = {
-		organizationId: params.organizationId,
-		subscriptionType: "dev_plan",
-		devPlanChange: "upgrade",
-		fromTier: params.currentTier,
-		toTier: params.newTier,
-		remainingFraction: params.remainingFraction.toString(),
-	};
-
-	let invoiceItemId: string | null = null;
-	let invoiceId: string | null = null;
-	let finalized = false;
-
-	try {
-		const invoiceItem = await stripe.invoiceItems.create({
-			customer: customerId,
-			subscription: params.subscription.id,
-			amount: amountCents,
-			currency: "usd",
-			description: `Dev Plan upgrade from ${params.currentTier.toUpperCase()} to ${params.newTier.toUpperCase()}`,
-			metadata,
-		});
-		invoiceItemId = invoiceItem.id ?? null;
-
-		const invoice = await stripe.invoices.create({
-			customer: customerId,
-			subscription: params.subscription.id,
-			collection_method: "charge_automatically",
-			auto_advance: false,
-			metadata,
-			expand: ["payment_intent"],
-		});
-		if (!invoice.id) {
-			throw new HTTPException(500, {
-				message: "Upgrade invoice was not created",
-			});
-		}
-		invoiceId = invoice.id;
-
-		const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id, {
-			auto_advance: false,
-			expand: ["payment_intent"],
-		});
-		if (!finalizedInvoice.id) {
-			throw new HTTPException(500, {
-				message: "Upgrade invoice was not finalized",
-			});
-		}
-		finalized = true;
-
-		const paidInvoice = await stripe.invoices.pay(finalizedInvoice.id, {
-			off_session: true,
-			expand: ["payment_intent"],
-		});
-
-		if (paidInvoice.status !== "paid") {
-			throw new HTTPException(402, {
-				message:
-					"Upgrade payment could not be collected. Update your payment method and try again.",
-			});
-		}
-
+	if (typeof latestInvoice === "string") {
 		return {
-			amount: amountCents / 100,
-			invoiceId: paidInvoice.id ?? invoiceId,
-			paymentIntentId: getInvoicePaymentIntentId(paidInvoice),
+			invoiceId: latestInvoice,
+			paymentIntentId: null,
+			amountPaid: null,
 		};
-	} catch (error) {
-		await cleanupFailedUpgradeInvoice({
-			invoiceId,
-			invoiceItemId,
-			finalized,
-		});
-
-		if (error instanceof HTTPException) {
-			throw error;
-		}
-
-		throw new HTTPException(402, {
-			message:
-				"Upgrade payment could not be collected. Update your payment method and try again.",
-		});
 	}
+	return {
+		invoiceId: latestInvoice.id ?? null,
+		paymentIntentId: getInvoicePaymentIntentId(latestInvoice),
+		amountPaid:
+			typeof latestInvoice.amount_paid === "number"
+				? latestInvoice.amount_paid
+				: null,
+	};
 }
 
 // Get or create personal organization for user
@@ -990,6 +853,7 @@ devPlans.openapi(changeTierPreview, async (c) => {
 
 	const currentTier: DevPlanTier = personalOrg.devPlan;
 	const isUpgrade = DEV_PLAN_PRICES[newTier] > DEV_PLAN_PRICES[currentTier];
+	const existingCycle: DevPlanCycle = personalOrg.devPlanCycle;
 	const subscription = await getStripe().subscriptions.retrieve(
 		personalOrg.devPlanStripeSubscriptionId,
 	);
@@ -1002,15 +866,25 @@ devPlans.openapi(changeTierPreview, async (c) => {
 	}
 
 	const remainingFraction = getRemainingBillingPeriodFraction(subscriptionItem);
-	const amountDueCents = isUpgrade
-		? getDevPlanUpgradeAmountCents(currentTier, newTier, remainingFraction)
-		: 0;
-	const creditPreview = getDevPlanTierChangeCreditPreview(
-		currentTier,
-		newTier,
-		remainingFraction,
-		parseFloat(personalOrg.devPlanCreditsLimit),
-	);
+
+	// Upgrades charge the full new-tier price today and start a fresh billing
+	// cycle (no proration); downgrades stay deferred to renewal, so nothing is
+	// due today. Credits reset to the new tier's full allowance on an upgrade.
+	const currentCreditsLimit = parseFloat(personalOrg.devPlanCreditsLimit);
+	let amountDueCents = 0;
+	let newCreditsLimit = currentCreditsLimit;
+	if (isUpgrade) {
+		const newPriceId = getDevPlanPriceId(newTier, existingCycle);
+		if (!newPriceId) {
+			const envSuffix =
+				existingCycle === "annual" ? "_ANNUAL_PRICE_ID" : "_PRICE_ID";
+			throw new HTTPException(500, {
+				message: `STRIPE_DEV_PLAN_${newTier.toUpperCase()}${envSuffix} environment variable is not set`,
+			});
+		}
+		amountDueCents = await getDevPlanFullPriceCents(newPriceId);
+		newCreditsLimit = getDevPlanCreditsLimit(newTier);
+	}
 
 	return c.json({
 		currentTier,
@@ -1019,9 +893,9 @@ devPlans.openapi(changeTierPreview, async (c) => {
 		amountDueCents,
 		currency: "USD" as const,
 		remainingFraction,
-		currentCreditsLimit: creditPreview.currentCreditsLimit,
-		proratedCreditDelta: creditPreview.proratedCreditDelta,
-		newCreditsLimit: creditPreview.newCreditsLimit,
+		currentCreditsLimit,
+		proratedCreditDelta: newCreditsLimit - currentCreditsLimit,
+		newCreditsLimit,
 		billingPeriodStart: new Date(
 			subscriptionItem.current_period_start * 1000,
 		).toISOString(),
@@ -1175,9 +1049,7 @@ devPlans.openapi(changeTier, async (c) => {
 		// upgrade, which supersedes and clears the pending downgrade (the upgrade
 		// branch below sets devPlanPendingTier back to null). Only block scheduling
 		// *another* downgrade while one is already pending — to revert to the
-		// current tier the user uses the dedicated cancel-downgrade action. This
-		// still closes the credit-refresh abuse: an upgrade re-grants prorated
-		// credits only via the once-per-cycle-limited path below.
+		// current tier the user uses the dedicated cancel-downgrade action.
 		const cycleStart = new Date(subscriptionItem.current_period_start * 1000);
 		if (personalOrg.devPlanPendingTier && !isUpgrade) {
 			throw new HTTPException(409, {
@@ -1186,18 +1058,17 @@ devPlans.openapi(changeTier, async (c) => {
 			});
 		}
 
-		// Rate-limit UPGRADES to one per billing cycle. Repeatedly upgrading would
-		// re-charge and re-grant prorated credits (and a double-submit would double
-		// charge), so claim the cycle atomically *before* any Stripe call: a single
-		// conditional UPDATE advances the marker to this cycle's Stripe period start
-		// only if it hasn't been claimed yet (NULL or an earlier cycle). Anchoring
-		// to the Stripe period (stable across the mid-cycle price swap, since
-		// proration is suppressed) — rather than a transaction row's createdAt —
-		// both avoids a read-then-write race between concurrent requests and
-		// prevents misattributing a change near a renewal boundary to the wrong
-		// cycle. Downgrades are exempt: they only schedule the lower tier for
-		// renewal (no charge, no credit grant), so an earlier upgrade must not block
-		// a later downgrade.
+		// Guard UPGRADES against a double charge. An upgrade resets the billing
+		// cycle and charges the full new-tier price, so two racing requests (e.g. a
+		// double-clicked confirm) would each start a fresh cycle and charge again.
+		// Claim the current Stripe period atomically *before* any Stripe call: a
+		// single conditional UPDATE advances the marker to this cycle's period start
+		// only if it hasn't been claimed yet (NULL or an earlier cycle). Both racing
+		// requests read the same pre-reset period start, so only one wins the claim;
+		// the other gets 409. After the anchor reset a legitimate next upgrade sees a
+		// newer period start and is allowed. Downgrades are exempt: they only
+		// schedule the lower tier for renewal (no charge), so an earlier upgrade must
+		// not block a later downgrade.
 		if (isUpgrade) {
 			const claimed = await db
 				.update(tables.organization)
@@ -1218,25 +1089,21 @@ devPlans.openapi(changeTier, async (c) => {
 			if (claimed.length === 0) {
 				throw new HTTPException(409, {
 					message:
-						"You can only upgrade once per billing cycle. Your next upgrade takes effect at renewal.",
+						"An upgrade is already being processed. Please try again in a moment.",
 				});
 			}
 			claimedCycleThisCall = true;
 		}
 
-		const remainingFraction =
-			getRemainingBillingPeriodFraction(subscriptionItem);
+		// Upgrades charge the full new-tier price today; downgrades are deferred to
+		// renewal and cost nothing now.
 		const amountDueCents = isUpgrade
-			? getDevPlanUpgradeAmountCents(currentTier, newTier, remainingFraction)
+			? await getDevPlanFullPriceCents(newPriceId)
 			: 0;
 
-		// Guard against charging the user more than the preview they confirmed.
-		// Only reject an *increase*: `remainingFraction` decays with wall-clock
-		// time (it is derived from `Date.now()`), so the amount recomputed here is
-		// almost always slightly lower than the previewed value once any time has
-		// passed between opening the dialog and confirming. A strict `!==` check
-		// treated that benign downward drift as a mismatch and blocked legitimate
-		// upgrades; charging the smaller recomputed amount is always fine.
+		// Guard against charging the user more than the preview they confirmed. The
+		// full price is deterministic per tier, so this only trips if the Stripe
+		// price changed between the preview and the confirmation.
 		if (
 			typeof expectedAmountDueCents === "number" &&
 			amountDueCents > expectedAmountDueCents
@@ -1247,177 +1114,146 @@ devPlans.openapi(changeTier, async (c) => {
 			});
 		}
 
-		// Tier changes suppress Stripe's default proration invoice so we can
-		// charge the prorated upgrade amount with DevPass-specific metadata and
-		// grant the matching prorated credit delta. Downgrades issue no refund.
-		const updated = await getStripe().subscriptions.update(subscriptionId, {
-			items: [
-				{
-					id: subscriptionItemId,
-					price: newPriceId,
-				},
-			],
-			proration_behavior: "none",
-			payment_behavior: "allow_incomplete",
-			metadata: {
-				...subscription.metadata,
-				devPlan: newTier,
-				devPlanCycle: existingCycle,
-			},
-		});
-
-		if (
-			isUpgrade &&
-			updated.status !== "active" &&
-			updated.status !== "trialing"
-		) {
-			throw new HTTPException(402, {
-				message:
-					"Upgrade payment could not be collected. Update your payment method and try again.",
-			});
-		}
-
-		const paidUpgrade = isUpgrade
-			? await collectDevPlanUpgradeCharge({
-					subscription: updated,
-					organizationId: personalOrg.id,
-					currentTier,
-					newTier,
-					remainingFraction,
-				}).catch(async (error: unknown) => {
-					try {
-						await getStripe().subscriptions.update(subscriptionId, {
-							items: [
-								{
-									id: subscriptionItemId,
-									price: currentPriceId,
-								},
-							],
-							proration_behavior: "none",
-							payment_behavior: "allow_incomplete",
-							metadata: {
-								...subscription.metadata,
-								devPlan: currentTier,
-								devPlanCycle: existingCycle,
-							},
-						});
-					} catch (rollbackError) {
-						logger.error(
-							"Failed to roll back dev plan tier after upgrade payment failure",
-							rollbackError instanceof Error
-								? rollbackError
-								: new Error(String(rollbackError)),
-						);
-					}
-
-					throw error;
-				})
-			: null;
-
 		if (isUpgrade) {
-			const creditPreview = getDevPlanTierChangeCreditPreview(
-				currentTier,
-				newTier,
-				remainingFraction,
-				parseFloat(personalOrg.devPlanCreditsLimit),
-			);
-
-			// Reflect the new tier immediately, and persist Stripe's actual period
-			// end as the renewal date (a mid-cycle upgrade preserves the billing
-			// anchor, so the UI shouldn't project a fresh cycle from the upgrade
-			// date). The credit grant is applied separately below, gated on winning
-			// the transaction insert.
-			await db
-				.update(tables.organization)
-				.set({
+			// Swap to the new price, reset the billing cycle to now
+			// (`billing_cycle_anchor: "now"`) so Stripe immediately invoices the full
+			// new-tier price and starts a fresh period, and suppress proration
+			// (`proration_behavior: "none"`) so no partial credit or debit is applied.
+			// `error_if_incomplete` makes the update atomic: if the charge can't be
+			// collected Stripe throws and leaves the subscription on the old tier, so
+			// there's no half-applied upgrade to roll back.
+			const updated = await getStripe().subscriptions.update(subscriptionId, {
+				items: [
+					{
+						id: subscriptionItemId,
+						price: newPriceId,
+					},
+				],
+				proration_behavior: "none",
+				billing_cycle_anchor: "now",
+				payment_behavior: "error_if_incomplete",
+				expand: ["latest_invoice.payment_intent"],
+				metadata: {
+					...subscription.metadata,
 					devPlan: newTier,
-					devPlanExpiresAt: new Date(
-						subscriptionItem.current_period_end * 1000,
-					),
-					// An immediate upgrade supersedes any scheduled downgrade.
-					devPlanPendingTier: null,
-				})
-				.where(eq(tables.organization.id, personalOrg.id));
+					devPlanCycle: existingCycle,
+				},
+			});
 
-			if (paidUpgrade) {
-				// Insert the unique-stripeInvoiceId marker and apply the credit grant
-				// in one transaction so they commit together. onConflictDoNothing makes
-				// this idempotent against the webhook fallback: only the path that wins
-				// the insert grants the credits and emails the invoice, so a concurrent
-				// `invoice.payment_succeeded` webhook can't double-apply the credit
-				// delta, produce a second transaction row, or send a duplicate email.
-				// Atomicity matters because both paths short-circuit on the existing
-				// marker — a crash between insert and grant would otherwise leave the
-				// invoice recorded with the credit never applied.
-				const upgradeTransaction = await db.transaction(async (tx) => {
-					const [created] = await tx
-						.insert(tables.transaction)
-						.values({
-							organizationId: personalOrg.id,
-							type: "dev_plan_upgrade",
-							amount: paidUpgrade.amount.toString(),
-							creditAmount: creditPreview.proratedCreditDelta.toString(),
-							currency: "USD",
-							status: "completed",
-							stripePaymentIntentId: paidUpgrade.paymentIntentId,
-							stripeInvoiceId: paidUpgrade.invoiceId,
-							description: `Changed from ${currentTier} to ${newTier} plan`,
-						})
-						.onConflictDoNothing()
-						.returning();
-
-					if (created) {
-						// Add the prorated credit delta on top of the existing allowance.
-						// Never recompute the limit from the tier's base allotment: that
-						// discards credits carried into this period by earlier mid-cycle
-						// changes (e.g. a downgrade then re-upgrade), which would shrink the
-						// allowance below the user's accumulated usage and hide the granted
-						// credit.
-						await tx
-							.update(tables.organization)
-							.set({
-								devPlanCreditsLimit: sql`${tables.organization.devPlanCreditsLimit} + ${creditPreview.proratedCreditDelta}`,
-							})
-							.where(eq(tables.organization.id, personalOrg.id));
-					}
-
-					return created;
+			if (updated.status !== "active" && updated.status !== "trialing") {
+				throw new HTTPException(402, {
+					message:
+						"Upgrade payment could not be collected. Update your payment method and try again.",
 				});
+			}
 
-				if (upgradeTransaction) {
-					try {
-						const billingDetails =
-							await resolveDevPassBillingDetails(personalOrg);
-						await generateAndEmailInvoice({
-							invoiceNumber: upgradeTransaction.id,
-							invoiceDate: new Date(),
-							organizationName: personalOrg.name,
-							organizationId: personalOrg.id,
-							...billingDetails,
-							lineItems: [
-								{
-									description: `Dev Plan upgrade from ${currentTier.toUpperCase()} to ${newTier.toUpperCase()} ($${creditPreview.proratedCreditDelta} credits included)`,
-									amount: paidUpgrade.amount,
-								},
-							],
-							currency: "USD",
-						});
-					} catch (e) {
-						logger.error(
-							"Invoice email failed (DevPass upgrade invoice); suppressing failure",
-							e as Error,
-						);
-					}
+			const newExpiresAt = new Date(
+				updated.items.data[0].current_period_end * 1000,
+			);
+			const { invoiceId, paymentIntentId, amountPaid } =
+				getDevPlanChangeInvoiceId(updated);
+			const chargedAmount =
+				amountPaid !== null ? amountPaid / 100 : amountDueCents / 100;
+			const newCreditsLimit = getDevPlanCreditsLimit(newTier);
+
+			// Insert the unique-stripeInvoiceId marker and reset the org to the new
+			// tier's full allowance in one transaction so they commit together.
+			// onConflictDoNothing keeps this idempotent against the
+			// `invoice.payment_succeeded` webhook fallback: only the path that wins
+			// the insert resets org state and emails the invoice, so a concurrent
+			// webhook can't double-apply the reset, produce a second transaction row,
+			// or send a duplicate email.
+			const upgradeTransaction = await db.transaction(async (tx) => {
+				const [created] = await tx
+					.insert(tables.transaction)
+					.values({
+						organizationId: personalOrg.id,
+						type: "dev_plan_upgrade",
+						amount: chargedAmount.toString(),
+						creditAmount: newCreditsLimit.toString(),
+						currency: "USD",
+						status: "completed",
+						stripePaymentIntentId: paymentIntentId,
+						stripeInvoiceId: invoiceId,
+						description: `Changed from ${currentTier} to ${newTier} plan`,
+					})
+					.onConflictDoNothing()
+					.returning();
+
+				if (created) {
+					// Fresh billing cycle: reset the limit to the new tier's full
+					// allowance, zero out usage (including the premium weekly window),
+					// advance the cycle start, clear any pending downgrade and dunning
+					// freeze state, and persist the new period end as the renewal date.
+					await tx
+						.update(tables.organization)
+						.set({
+							devPlan: newTier,
+							devPlanCreditsLimit: newCreditsLimit.toString(),
+							devPlanCreditsUsed: "0",
+							devPlanPremiumCreditsUsed: "0",
+							devPlanPremiumWeekStart: new Date(),
+							devPlanCreditsFrozen: false,
+							devPlanCreditsLimitBeforeFreeze: null,
+							devPlanBillingCycleStart: new Date(),
+							devPlanExpiresAt: newExpiresAt,
+							devPlanPendingTier: null,
+						})
+						.where(eq(tables.organization.id, personalOrg.id));
+				}
+
+				return created;
+			});
+
+			if (upgradeTransaction) {
+				try {
+					const billingDetails =
+						await resolveDevPassBillingDetails(personalOrg);
+					await generateAndEmailInvoice({
+						invoiceNumber: upgradeTransaction.id,
+						invoiceDate: new Date(),
+						organizationName: personalOrg.name,
+						organizationId: personalOrg.id,
+						...billingDetails,
+						lineItems: [
+							{
+								description: `Dev Plan upgrade to ${newTier.toUpperCase()} ($${newCreditsLimit} credits included)`,
+								amount: chargedAmount,
+							},
+						],
+						currency: "USD",
+					});
+				} catch (e) {
+					logger.error(
+						"Invoice email failed (DevPass upgrade invoice); suppressing failure",
+						e as Error,
+					);
 				}
 			}
 		} else {
-			// Downgrade: the lower tier only takes effect at the next renewal, so
-			// keep `devPlan` (and the current cycle's credits, limit and used) on the
-			// current higher tier and record the target tier as pending. The Stripe
-			// price was already swapped above, so the renewal invoice bills the lower
-			// price; the renewal webhook then flips `devPlan` to the pending tier and
-			// resets credits to its allotment. No proration invoice is generated, so
-			// record the tier-change transaction here.
+			// Downgrade: unchanged. The lower tier takes effect at the next renewal,
+			// so keep `devPlan` (and the current cycle's credits) on the current
+			// higher tier and record the target tier as pending. Swap the Stripe
+			// price with no proration and no cycle reset, so the renewal invoice bills
+			// the lower price; the renewal webhook then flips `devPlan` to the pending
+			// tier and resets credits to its allotment. No invoice is generated now,
+			// so record the tier-change transaction here.
+			await getStripe().subscriptions.update(subscriptionId, {
+				items: [
+					{
+						id: subscriptionItemId,
+						price: newPriceId,
+					},
+				],
+				proration_behavior: "none",
+				payment_behavior: "allow_incomplete",
+				metadata: {
+					...subscription.metadata,
+					devPlan: newTier,
+					devPlanCycle: existingCycle,
+				},
+			});
+
 			await db
 				.update(tables.organization)
 				.set({

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -418,64 +418,44 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 		expect(org?.devPlanExpiresAt?.getTime()).toBe(periodEnd * 1000);
 	});
 
-	test("does NOT reset credits on a proration invoice from a tier change", async () => {
+	test("resets to a fresh new-tier cycle on a tier-change invoice (webhook fallback)", async () => {
+		// The change-tier endpoint normally resets state synchronously; this exercises
+		// the webhook fallback when that process died after Stripe collected payment.
+		// An upgrade invoice (`subscription_update`) starts a brand-new cycle, so the
+		// org resets to the new tier's full allowance with usage zeroed. The target
+		// tier is read from the subscription metadata the update set.
 		await seedUsedDevPlanOrg();
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUB_ID,
+			metadata: { devPlan: "max" },
+		});
 
+		const periodEnd = Math.floor(Date.now() / 1000) + SECONDS_IN_TWO_WEEKS;
 		await handleInvoicePaymentSucceeded(
 			makeInvoiceEvent({
 				billingReason: "subscription_update",
-				amountPaid: 9221,
-				invoiceId: "in_proration_001",
+				amountPaid: 17900,
+				invoiceId: "in_upgrade_001",
+				periodEnd,
 			}),
 		);
 
 		const org = await db.query.organization.findFirst({
 			where: { id: { eq: ORG_ID } },
 		});
-		// The credit usage must be preserved — otherwise a user could
-		// downgrade then upgrade to repeatedly refresh their full balance.
-		expect(org?.devPlanCreditsUsed).toBe("150");
+		expect(org?.devPlan).toBe("max");
+		expect(org?.devPlanCreditsUsed).toBe("0");
+		expect(org?.devPlanCreditsLimit).toBe("537");
+		expect(org?.devPlanExpiresAt?.getTime()).toBe(periodEnd * 1000);
 
 		const txns = await db.query.transaction.findMany({
 			where: { organizationId: { eq: ORG_ID } },
 		});
 		expect(txns).toHaveLength(1);
 		expect(txns[0].type).toBe("dev_plan_upgrade");
-		expect(txns[0].creditAmount).toBeNull();
-		expect(txns[0].amount).toBe("92.21");
-	});
-
-	test("records a manual upgrade invoice without resetting used credits", async () => {
-		await seedUsedDevPlanOrg();
-
-		await handleInvoicePaymentSucceeded(
-			makeInvoiceEvent({
-				billingReason: "manual",
-				amountPaid: 5000,
-				invoiceId: "in_manual_upgrade_001",
-				metadata: {
-					organizationId: ORG_ID,
-					subscriptionType: "dev_plan",
-					devPlanChange: "upgrade",
-					fromTier: "lite",
-					toTier: "pro",
-				},
-			}),
-		);
-
-		const org = await db.query.organization.findFirst({
-			where: { id: { eq: ORG_ID } },
-		});
-		expect(org?.devPlanCreditsUsed).toBe("150");
-
-		const txns = await db.query.transaction.findMany({
-			where: { organizationId: { eq: ORG_ID } },
-		});
-		expect(txns).toHaveLength(1);
-		expect(txns[0].type).toBe("dev_plan_upgrade");
-		expect(txns[0].creditAmount).toBeNull();
-		expect(txns[0].amount).toBe("50");
-		expect(txns[0].stripeInvoiceId).toBe("in_manual_upgrade_001");
+		expect(txns[0].creditAmount).toBe("537");
+		expect(txns[0].amount).toBe("179");
+		expect(txns[0].stripeInvoiceId).toBe("in_upgrade_001");
 	});
 
 	test("skips processing an invoice that was already recorded", async () => {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -16,7 +16,6 @@ import { logger } from "@llmgateway/logger";
 import {
 	getChatPlanCreditsLimit,
 	getDevPlanCreditsLimit,
-	getProratedCreditDelta,
 	type ChatPlanCycle,
 	type ChatPlanTier,
 	type DevPlanCycle,
@@ -3220,12 +3219,11 @@ export async function handleInvoicePaymentSucceeded(event: {
 	// gate the credit reset on the billing reason.
 	const isDevPlanRenewal =
 		isDevPlanSubscription && invoice.billing_reason === "subscription_cycle";
+	// A tier upgrade resets the billing cycle (`billing_cycle_anchor: "now"`) and
+	// charges the full new-tier price, so Stripe emits its immediate invoice with
+	// `billing_reason: "subscription_update"`.
 	const isDevPlanUpgradeInvoice =
-		isDevPlanSubscription &&
-		(invoice.billing_reason === "subscription_update" ||
-			(invoice.billing_reason === "manual" &&
-				metadata?.subscriptionType === "dev_plan" &&
-				metadata?.devPlanChange === "upgrade"));
+		isDevPlanSubscription && invoice.billing_reason === "subscription_update";
 
 	// Same billing-reason gate as dev plans: only reset chat plan credits on a
 	// true cycle renewal, not on mid-cycle tier-change proration invoices.
@@ -3550,35 +3548,29 @@ export async function handleInvoicePaymentSucceeded(event: {
 			);
 		}
 	} else if (isDevPlanUpgradeInvoice) {
-		// Invoice from a mid-cycle upgrade. The change-tier endpoint normally
-		// records the transaction (and emails the invoice) synchronously; this
-		// webhook path is the fallback if the process exits after Stripe collects
-		// payment but before the local insert. onConflictDoNothing on the unique
-		// stripeInvoiceId index makes it atomically idempotent with the sync path,
-		// so only the path that wins the insert reconciles org state and emails —
-		// a concurrent sync request can't yield a duplicate row or email. We do
-		// NOT reset `devPlanCreditsUsed`.
-		const fromTier = metadata?.fromTier as DevPlanTier | undefined;
-		const toTier = metadata?.toTier as DevPlanTier | undefined;
-		const remainingFraction = metadata?.remainingFraction
-			? Number(metadata.remainingFraction)
-			: undefined;
-		const proratedCreditDelta =
-			fromTier && toTier && remainingFraction !== undefined
-				? getProratedCreditDelta(fromTier, toTier, remainingFraction)
-				: undefined;
+		// Immediate invoice from a tier upgrade. An upgrade resets the billing
+		// cycle (`billing_cycle_anchor: "now"`) and charges the full new-tier
+		// price, so Stripe emits this with `billing_reason: "subscription_update"`.
+		// The change-tier endpoint normally resets org state, records the
+		// transaction and emails the invoice synchronously (and the early-return
+		// guard above then short-circuits this handler). This path is the fallback
+		// if that process exited after Stripe collected payment but before the
+		// local insert. It reproduces the same fresh-cycle reset, idempotently via
+		// onConflictDoNothing on the unique stripeInvoiceId, reading the target
+		// tier from the subscription metadata the update set.
+		const upgradeSubscription =
+			await getStripe().subscriptions.retrieve(subscriptionId);
+		const toTier = (upgradeSubscription.metadata?.devPlan ??
+			organization.devPlan) as DevPlanTier;
+		const creditsLimit = getDevPlanCreditsLimit(toTier);
 
-		// Insert the unique-stripeInvoiceId marker and reconcile org tier/limit in
-		// one transaction so they commit together. This handles the case where the
-		// sync path died after Stripe collected payment but before it applied the
-		// upgrade. Mirrors the sync path: add the prorated credit delta on top of
-		// the existing allowance rather than recomputing from the tier base (which
-		// would discard credits carried over from earlier mid-cycle changes).
-		// Winning the unique-invoice insert gates the reconcile, so the delta is
-		// applied exactly once across the sync and webhook paths. Atomicity matters
-		// because both paths short-circuit on the existing marker — a crash between
-		// insert and reconcile would otherwise leave the invoice recorded with the
-		// credit never applied.
+		// The invoice lines cover the new period, so the latest line end is the new
+		// current_period_end (= next renewal date).
+		const newPeriodEnd = invoice.lines.data.reduce(
+			(max, line) => Math.max(max, line.period?.end ?? 0),
+			0,
+		);
+
 		const upgradeTransaction = await db.transaction(async (tx) => {
 			const [created] = await tx
 				.insert(tables.transaction)
@@ -3586,25 +3578,36 @@ export async function handleInvoicePaymentSucceeded(event: {
 					organizationId,
 					type: "dev_plan_upgrade",
 					amount: (invoice.amount_paid / 100).toString(),
-					creditAmount: proratedCreditDelta?.toString(),
+					creditAmount: creditsLimit.toString(),
 					currency: invoice.currency.toUpperCase(),
 					status: "completed",
 					stripePaymentIntentId: (invoice as any).payment_intent,
 					stripeInvoiceId: invoice.id,
-					description:
-						fromTier && toTier
-							? `Changed from ${fromTier} to ${toTier} plan`
-							: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade`,
+					description: `Dev Plan ${toTier.toUpperCase()} upgrade`,
 				})
 				.onConflictDoNothing()
 				.returning();
 
-			if (created && fromTier && toTier && proratedCreditDelta !== undefined) {
+			if (created) {
+				// Fresh billing cycle: reset the limit to the new tier's full
+				// allowance, zero out usage (including the premium weekly window),
+				// advance the cycle start, clear any pending downgrade and dunning
+				// freeze state, and persist the new period end as the renewal date.
 				await tx
 					.update(tables.organization)
 					.set({
 						devPlan: toTier,
-						devPlanCreditsLimit: sql`${tables.organization.devPlanCreditsLimit} + ${proratedCreditDelta}`,
+						devPlanCreditsLimit: creditsLimit.toString(),
+						devPlanCreditsUsed: "0",
+						devPlanPremiumCreditsUsed: "0",
+						devPlanPremiumWeekStart: new Date(),
+						devPlanCreditsFrozen: false,
+						devPlanCreditsLimitBeforeFreeze: null,
+						devPlanBillingCycleStart: new Date(),
+						devPlanExpiresAt: newPeriodEnd
+							? new Date(newPeriodEnd * 1000)
+							: undefined,
+						devPlanPendingTier: null,
 					})
 					.where(eq(tables.organization.id, organizationId));
 			}
@@ -3623,10 +3626,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 					...billingDetails,
 					lineItems: [
 						{
-							description:
-								fromTier && toTier
-									? `Dev Plan upgrade from ${fromTier.toUpperCase()} to ${toTier.toUpperCase()}`
-									: `Dev Plan ${organization.devPlan?.toUpperCase()} upgrade`,
+							description: `Dev Plan upgrade to ${toTier.toUpperCase()} ($${creditsLimit} credits included)`,
 							amount: invoice.amount_paid / 100,
 						},
 					],
@@ -3640,7 +3640,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 			}
 
 			logger.info(
-				`Recorded dev plan upgrade invoice for organization ${organizationId}; credits used left unchanged`,
+				`Recorded dev plan upgrade invoice for organization ${organizationId}; reset to fresh ${toTier} cycle`,
 			);
 		} else {
 			logger.info(

--- a/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
+++ b/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
@@ -313,10 +313,10 @@ function TierChangePreviewCopy({
 			<span>
 				You&apos;ll be charged{" "}
 				<strong>{formatCurrencyFromCents(preview.amountDueCents)}</strong> today
-				for the rest of your current billing period, then ${plan.price}/mo going
-				forward. Your current-period allowance increases by{" "}
-				{formatUsageAmount(preview.proratedCreditDelta)} to{" "}
-				{formatUsageAmount(preview.newCreditsLimit)} in usage.
+				and your billing period restarts now, then ${plan.price}/mo going
+				forward. Your allowance resets to{" "}
+				{formatUsageAmount(preview.newCreditsLimit)} in usage for the new
+				period.
 			</span>
 		);
 	}

--- a/packages/shared/src/dev-plans.spec.ts
+++ b/packages/shared/src/dev-plans.spec.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { getDevPlanCreditsLimit, getProratedCreditDelta } from "./dev-plans.js";
+import { DEV_PLAN_PRICES, getDevPlanCreditsLimit } from "./dev-plans.js";
 
-describe("getProratedCreditDelta", () => {
+describe("getDevPlanCreditsLimit", () => {
 	const original = process.env.DEV_PLAN_CREDITS_MULTIPLIER;
 
 	beforeEach(() => {
@@ -17,33 +17,18 @@ describe("getProratedCreditDelta", () => {
 		}
 	});
 
-	it("grants the full tier difference when the whole period remains", () => {
-		const delta = getProratedCreditDelta("lite", "max", 1);
-		expect(delta).toBe(
-			getDevPlanCreditsLimit("max") - getDevPlanCreditsLimit("lite"),
+	it("multiplies the tier price by the credits multiplier", () => {
+		expect(getDevPlanCreditsLimit("lite")).toBe(DEV_PLAN_PRICES.lite * 3);
+		expect(getDevPlanCreditsLimit("pro")).toBe(DEV_PLAN_PRICES.pro * 3);
+		expect(getDevPlanCreditsLimit("max")).toBe(DEV_PLAN_PRICES.max * 3);
+	});
+
+	it("grants a higher tier a strictly larger allowance", () => {
+		expect(getDevPlanCreditsLimit("max")).toBeGreaterThan(
+			getDevPlanCreditsLimit("pro"),
 		);
-	});
-
-	it("prorates the upgrade credits by the remaining fraction", () => {
-		const full = getDevPlanCreditsLimit("max") - getDevPlanCreditsLimit("lite");
-		expect(getProratedCreditDelta("lite", "max", 0.5)).toBeCloseTo(full / 2);
-	});
-
-	it("returns a negative delta for a downgrade", () => {
-		const delta = getProratedCreditDelta("max", "lite", 1);
-		expect(delta).toBe(
-			getDevPlanCreditsLimit("lite") - getDevPlanCreditsLimit("max"),
+		expect(getDevPlanCreditsLimit("pro")).toBeGreaterThan(
+			getDevPlanCreditsLimit("lite"),
 		);
-		expect(delta).toBeLessThan(0);
-	});
-
-	it("grants nothing when no time remains in the period", () => {
-		expect(getProratedCreditDelta("lite", "max", 0)).toBe(0);
-	});
-
-	it("clamps out-of-range fractions to [0, 1]", () => {
-		const full = getDevPlanCreditsLimit("max") - getDevPlanCreditsLimit("lite");
-		expect(getProratedCreditDelta("lite", "max", 1.5)).toBe(full);
-		expect(getProratedCreditDelta("lite", "max", -0.5)).toBe(0);
 	});
 });

--- a/packages/shared/src/dev-plans.ts
+++ b/packages/shared/src/dev-plans.ts
@@ -71,24 +71,3 @@ export function getRemainingPremiumWeeklyAllowance(
 			: (creditsUsed ?? 0);
 	return Math.max(0, limit - used);
 }
-
-/**
- * Prorated credit delta for a mid-cycle tier change.
- *
- * Credits track prorated dollars: changing tier part-way through a billing
- * period grants (upgrade) or removes (downgrade) only the difference in the
- * tiers' credit allotments scaled by the fraction of the period that remains —
- * mirroring the prorated amount Stripe charges or credits back. Returns a
- * positive number for upgrades and a negative number for downgrades.
- */
-export function getProratedCreditDelta(
-	fromTier: DevPlanTier,
-	toTier: DevPlanTier,
-	remainingFraction: number,
-): number {
-	const normalized = Number.isFinite(remainingFraction) ? remainingFraction : 0;
-	const clamped = Math.min(1, Math.max(0, normalized));
-	const delta =
-		getDevPlanCreditsLimit(toTier) - getDevPlanCreditsLimit(fromTier);
-	return delta * clamped;
-}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,7 +30,6 @@ export {
 	getDevPlanCreditsLimit,
 	getDevPlanPremiumWeeklyLimit,
 	getRemainingPremiumWeeklyAllowance,
-	getProratedCreditDelta,
 	isPremiumWeekExpired,
 } from "./dev-plans.js";
 


### PR DESCRIPTION
## Summary

DevPass (and Chat) tier upgrades were **prorating both dollars and virtual credits**: a custom Stripe invoice charged only the prorated dollar delta, and only a prorated slice of the credit difference was granted mid-cycle. This was fiddly, error-prone (custom invoice → finalize → pay → manual rollback), and confusing ("your allowance increases by $75 to $312").

This PR replaces that with a **full-charge, fresh-cycle** model for upgrades:

- On upgrade we update the Stripe subscription with `billing_cycle_anchor: "now"` + `proration_behavior: "none"` + `payment_behavior: "error_if_incomplete"`. Stripe immediately charges the **full new-tier price**, starts a **fresh billing period**, and applies **no proration**. `error_if_incomplete` makes it atomic — a declined card leaves the subscription on the old tier, so the custom-invoice + manual-rollback code is gone.
- Credits reset to the new tier's **full allowance** with **usage zeroed** (a brand-new cycle).
- **Downgrades are unchanged** (DevPass: deferred to renewal, no charge today; Chat: immediate). Downgrades have no proration pain.

Feasibility confirmed against the Stripe docs ([update](https://docs.stripe.com/api/subscriptions/update), [billing cycle](https://docs.stripe.com/billing/subscriptions/billing-cycle), [prorations](https://docs.stripe.com/billing/subscriptions/prorations)) — a single `subscriptions.update` does it; no cancel/recreate needed.

## Changes

- **`apps/api/src/routes/dev-plans.ts`** — upgrade path rewritten (anchor reset + full reset); deleted `collectDevPlanUpgradeCharge` / `cleanupFailedUpgradeInvoice` / prorated helpers; preview now returns the full price + full new-tier credits. The per-cycle claim is kept, repurposed as a **double-charge guard** (two racing confirms would each reset the cycle + charge again).
- **`apps/api/src/stripe.ts`** — the tier-change invoice (`subscription_update`) webhook now **full-resets** to the new tier (read from subscription metadata), idempotent via the unique `stripeInvoiceId` (the sync route normally wins; this is the crash fallback). Added a **chat-subscription skip branch** so a chat `subscription_update` invoice can never fall through to the Pro handler and wrongly flip the org to `plan: "pro"`.
- **`apps/api/src/routes/chat-plans.ts`** — Chat upgrades mirror the model (anchor reset, reset credits/usage/cycle, record the invoice id); downgrade unchanged.
- **`packages/shared`** — removed now-unused `getProratedCreditDelta` (+ its export and spec).
- **`apps/code/.../ActivePlanChangeTier.tsx`** — upgrade dialog copy now reads "charged $X today, billing period restarts now, allowance resets to $Y."

## Testing

- `apps/api/src/routes/dev-plans.spec.ts` (13) — rewritten for the full-charge model: asserts `billing_cycle_anchor: "now"` + `proration_behavior: "none"`, credits reset to the full new-tier allowance with usage zeroed, fresh `devPlanBillingCycleStart`/`devPlanExpiresAt`; downgrade tests stay deferred; double-charge guard.
- `apps/api/src/stripe.spec.ts` (22) — added a webhook-fallback test for the `subscription_update` upgrade invoice (full reset, idempotent); genuine `subscription_cycle` renewal + pending-downgrade paths unchanged.
- `packages/shared/src/dev-plans.spec.ts` (2) — replaced proration tests with `getDevPlanCreditsLimit` coverage.
- `pnpm exec turbo run build --filter=api --filter=code` ✓ · lint ✓ · format ✓

> Note: the manual/local Stripe-test-mode verification from the plan was not run here (the Stripe MCP server needs interactive auth); the change is covered by unit tests exercising the mocked Stripe calls and webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrades now take effect immediately, restarting the billing period and resetting included credits to the new tier’s full allowance.
  * Downgrades remain scheduled for renewal, with updated tier-change handling.

* **Bug Fixes**
  * Improved billing, credit resets, and transaction recording for tier changes, including more reliable upgrade/downgrade flows.
  * Refined invoice processing to avoid incorrect chat-plan state changes during non-renewal cases.

* **Documentation**
  * Updated tier-change upgrade confirmation text to match the new “restart + reset credits” behavior.

* **Tests**
  * Revised and expanded tier-change and invoice-handling coverage to reflect the new billing semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->