### PR TITLE
fix(devpass): surface refunds in billing history

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -13959,6 +13959,9 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 					"dev_plan_reset_pass_gift",
 					// PAYG overflow top-ups are DevPass billing events too.
 					"credit_topup",
+					// Refunds against DevPass payments — shown as a line item so the
+					// history matches the net revenue reported in the KPIs/detail.
+					"credit_refund",
 					// Legacy types — pre dev_plan_* rename, still in DB for older
 					// dev plan subscribers; without these their history reads as empty.
 					"subscription_start",

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12305,6 +12305,9 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 					"dev_plan_renewal",
 					"dev_plan_reset_pass",
 					"dev_plan_reset_pass_gift",
+					// Refunds against DevPass payments — shown as a line item so the
+					// history matches the net revenue reported in the KPIs/detail.
+					"credit_refund",
 					// Legacy types — pre dev_plan_* rename, still in DB for older
 					// dev plan subscribers; without these their history reads as empty.
 					"subscription_start",

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2408,6 +2408,7 @@ const getInvoices = createRoute({
 									"dev_plan_reset_pass",
 									// PAYG overflow credits purchases (manual and auto-reload).
 									"credit_topup",
+									"credit_refund",
 								]),
 								date: z.string(),
 								amount: z.string().nullable(),
@@ -2483,7 +2484,10 @@ devPlans.openapi(getInvoices, async (c) => {
 				// billing event the user should see.
 				(t.type === "credit_topup" &&
 					t.amount !== null &&
-					parseFloat(t.amount) > 0),
+					parseFloat(t.amount) > 0) ||
+				// Refunds against DevPass payments — shown as a line item so the
+				// history matches the net revenue reported in the KPIs/detail.
+				t.type === "credit_refund",
 		)
 		.map((t) => ({
 			id: t.id,
@@ -2492,7 +2496,8 @@ devPlans.openapi(getInvoices, async (c) => {
 				| "dev_plan_renewal"
 				| "dev_plan_upgrade"
 				| "dev_plan_reset_pass"
-				| "credit_topup",
+				| "credit_topup"
+				| "credit_refund",
 			date: t.createdAt.toISOString(),
 			amount: t.amount,
 			creditAmount: t.creditAmount,

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2260,6 +2260,7 @@ const getInvoices = createRoute({
 									"dev_plan_renewal",
 									"dev_plan_upgrade",
 									"dev_plan_reset_pass",
+									"credit_refund",
 								]),
 								date: z.string(),
 								amount: z.string().nullable(),
@@ -2333,6 +2334,9 @@ devPlans.openapi(getInvoices, async (c) => {
 				"dev_plan_renewal",
 				"dev_plan_upgrade",
 				"dev_plan_reset_pass",
+				// Refunds against DevPass payments — shown as a line item so the
+				// history matches the net revenue reported in the KPIs/detail.
+				"credit_refund",
 			].includes(t.type),
 		)
 		.map((t) => ({
@@ -2341,7 +2345,8 @@ devPlans.openapi(getInvoices, async (c) => {
 				| "dev_plan_start"
 				| "dev_plan_renewal"
 				| "dev_plan_upgrade"
-				| "dev_plan_reset_pass",
+				| "dev_plan_reset_pass"
+				| "credit_refund",
 			date: t.createdAt.toISOString(),
 			amount: t.amount,
 			creditAmount: t.creditAmount,

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -40,8 +40,9 @@ const PAGE_SIZE = 10;
 type Invoice =
 	paths["/dev-plans/invoices"]["get"]["responses"]["200"]["content"]["application/json"]["invoices"][number];
 
-// A DevPass invoice is downloadable when it is a completed, positive charge
-// (mirrors isInvoiceableTransaction on the API).
+// A DevPass invoice has a downloadable document when it is completed with a
+// positive amount (mirrors isInvoiceableTransaction on the API): a charge
+// yields an invoice, a refund yields a credit note.
 function isInvoiceable(invoice: Invoice): boolean {
 	return (
 		invoice.status === "completed" &&
@@ -70,6 +71,8 @@ function ActionButtonPlaceholder({ children }: { children: ReactNode }) {
 function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 	const fetchClient = useFetchClient();
 	const [loading, setLoading] = useState(false);
+	const isRefund = invoice.type === "credit_refund";
+	const documentLabel = isRefund ? "Credit note" : "Invoice";
 
 	async function handleDownload() {
 		setLoading(true);
@@ -89,7 +92,7 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			const url = URL.createObjectURL(data as unknown as Blob);
 			const link = document.createElement("a");
 			link.href = url;
-			link.download = `invoice-${invoice.id}.pdf`;
+			link.download = `${isRefund ? "credit-note" : "invoice"}-${invoice.id}.pdf`;
 			document.body.appendChild(link);
 			link.click();
 			link.remove();
@@ -113,7 +116,7 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			) : (
 				<Download className="h-4 w-4" />
 			)}
-			<span className="sr-only sm:not-sr-only">Invoice</span>
+			<span className="sr-only sm:not-sr-only">{documentLabel}</span>
 		</Button>
 	);
 }
@@ -285,6 +288,7 @@ const TYPE_LABELS: Record<Invoice["type"], string> = {
 	dev_plan_upgrade: "Upgrade",
 	dev_plan_reset_pass: "Reset Pass",
 	credit_topup: "Credits top-up",
+	credit_refund: "Refund",
 };
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -292,14 +296,21 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 	currency: "USD",
 });
 
-function formatAmount(amount: string | null, currency: string): string {
+function formatAmount(
+	amount: string | null,
+	currency: string,
+	isRefund = false,
+): string {
 	if (amount === null) {
 		return "—";
 	}
-	const value = Number(amount);
-	if (!Number.isFinite(value)) {
+	const parsed = Number(amount);
+	if (!Number.isFinite(parsed)) {
 		return "—";
 	}
+	// Refund amounts are stored as positive dollars; show money returned as a
+	// negative so the history reads as a credit rather than another charge.
+	const value = isRefund ? -Math.abs(parsed) : parsed;
 	if (currency === "USD") {
 		return currencyFormatter.format(value);
 	}
@@ -335,8 +346,8 @@ export default function DevPassInvoices() {
 		<div>
 			<h2 className="mb-1 font-semibold">Invoices</h2>
 			<p className="mb-4 text-sm text-muted-foreground">
-				A record of every DevPass charge, including the amount debited and the
-				usage credits granted for that billing period.
+				A record of every DevPass charge and refund, including the amount
+				debited and the usage credits granted for that billing period.
 			</p>
 
 			<div className="overflow-hidden rounded-xl border sm:grid sm:grid-cols-[1fr_1fr_auto_auto_auto]">
@@ -373,7 +384,11 @@ export default function DevPassInvoices() {
 							<span className="text-xs text-muted-foreground sm:hidden">
 								Amount{" "}
 							</span>
-							{formatAmount(invoice.amount, invoice.currency)}
+							{formatAmount(
+								invoice.amount,
+								invoice.currency,
+								invoice.type === "credit_refund",
+							)}
 						</div>
 						<div className="text-right text-sm tabular-nums text-muted-foreground sm:text-right">
 							<span className="text-xs sm:hidden">Credits </span>

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -40,8 +40,9 @@ const PAGE_SIZE = 10;
 type Invoice =
 	paths["/dev-plans/invoices"]["get"]["responses"]["200"]["content"]["application/json"]["invoices"][number];
 
-// A DevPass invoice is downloadable when it is a completed, positive charge
-// (mirrors isInvoiceableTransaction on the API).
+// A DevPass invoice has a downloadable document when it is completed with a
+// positive amount (mirrors isInvoiceableTransaction on the API): a charge
+// yields an invoice, a refund yields a credit note.
 function isInvoiceable(invoice: Invoice): boolean {
 	return (
 		invoice.status === "completed" &&
@@ -70,6 +71,8 @@ function ActionButtonPlaceholder({ children }: { children: ReactNode }) {
 function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 	const fetchClient = useFetchClient();
 	const [loading, setLoading] = useState(false);
+	const isRefund = invoice.type === "credit_refund";
+	const documentLabel = isRefund ? "Credit note" : "Invoice";
 
 	async function handleDownload() {
 		setLoading(true);
@@ -89,7 +92,7 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			const url = URL.createObjectURL(data as unknown as Blob);
 			const link = document.createElement("a");
 			link.href = url;
-			link.download = `invoice-${invoice.id}.pdf`;
+			link.download = `${isRefund ? "credit-note" : "invoice"}-${invoice.id}.pdf`;
 			document.body.appendChild(link);
 			link.click();
 			link.remove();
@@ -113,7 +116,7 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			) : (
 				<Download className="h-4 w-4" />
 			)}
-			<span className="sr-only sm:not-sr-only">Invoice</span>
+			<span className="sr-only sm:not-sr-only">{documentLabel}</span>
 		</Button>
 	);
 }
@@ -267,6 +270,7 @@ const TYPE_LABELS: Record<Invoice["type"], string> = {
 	dev_plan_renewal: "Renewal",
 	dev_plan_upgrade: "Upgrade",
 	dev_plan_reset_pass: "Reset Pass",
+	credit_refund: "Refund",
 };
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -274,14 +278,21 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 	currency: "USD",
 });
 
-function formatAmount(amount: string | null, currency: string): string {
+function formatAmount(
+	amount: string | null,
+	currency: string,
+	isRefund = false,
+): string {
 	if (amount === null) {
 		return "—";
 	}
-	const value = Number(amount);
-	if (!Number.isFinite(value)) {
+	const parsed = Number(amount);
+	if (!Number.isFinite(parsed)) {
 		return "—";
 	}
+	// Refund amounts are stored as positive dollars; show money returned as a
+	// negative so the history reads as a credit rather than another charge.
+	const value = isRefund ? -Math.abs(parsed) : parsed;
 	if (currency === "USD") {
 		return currencyFormatter.format(value);
 	}
@@ -317,8 +328,8 @@ export default function DevPassInvoices() {
 		<div>
 			<h2 className="mb-1 font-semibold">Invoices</h2>
 			<p className="mb-4 text-sm text-muted-foreground">
-				A record of every DevPass charge, including the amount debited and the
-				usage credits granted for that billing period.
+				A record of every DevPass charge and refund, including the amount
+				debited and the usage credits granted for that billing period.
 			</p>
 
 			<div className="overflow-hidden rounded-xl border sm:grid sm:grid-cols-[1fr_1fr_auto_auto_auto]">
@@ -355,7 +366,11 @@ export default function DevPassInvoices() {
 							<span className="text-xs text-muted-foreground sm:hidden">
 								Amount{" "}
 							</span>
-							{formatAmount(invoice.amount, invoice.currency)}
+							{formatAmount(
+								invoice.amount,
+								invoice.currency,
+								invoice.type === "credit_refund",
+							)}
 						</div>
 						<div className="text-right text-sm tabular-nums text-muted-foreground sm:text-right">
 							<span className="text-xs sm:hidden">Credits </span>

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -71,7 +71,11 @@ function formatTransactionType(type: string) {
 function getTransactionTypeBadgeVariant(
 	type: string,
 ): "default" | "secondary" | "outline" | "destructive" {
-	if (type.includes("cancel") || type.includes("end")) {
+	if (
+		type.includes("cancel") ||
+		type.includes("end") ||
+		type.includes("refund")
+	) {
 		return "destructive";
 	}
 	if (
@@ -524,7 +528,10 @@ export default async function DevpassDetailPage({
 											</TableCell>
 											<TableCell className="tabular-nums">
 												{t.amount
-													? currencyFormatter.format(parseFloat(t.amount))
+													? currencyFormatter.format(
+															(t.type === "credit_refund" ? -1 : 1) *
+																parseFloat(t.amount),
+														)
 													: "—"}
 											</TableCell>
 											<TableCell className="tabular-nums">

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -68,7 +68,11 @@ function formatTransactionType(type: string) {
 function getTransactionTypeBadgeVariant(
 	type: string,
 ): "default" | "secondary" | "outline" | "destructive" {
-	if (type.includes("cancel") || type.includes("end")) {
+	if (
+		type.includes("cancel") ||
+		type.includes("end") ||
+		type.includes("refund")
+	) {
 		return "destructive";
 	}
 	if (
@@ -472,7 +476,10 @@ export default async function DevpassDetailPage({
 											</TableCell>
 											<TableCell className="tabular-nums">
 												{t.amount
-													? currencyFormatter.format(parseFloat(t.amount))
+													? currencyFormatter.format(
+															(t.type === "credit_refund" ? -1 : 1) *
+																parseFloat(t.amount),
+														)
 													: "—"}
 											</TableCell>
 											<TableCell className="tabular-nums">

--- a/packages/scripts/src/backfill-stripe-refunds.ts
+++ b/packages/scripts/src/backfill-stripe-refunds.ts
@@ -1,21 +1,30 @@
 /* eslint-disable no-console */
 /**
- * One-time backfill: reconcile legacy credit_refund rows whose amount was
- * stored as the cumulative `charge.amount_refunded` (pre-fix in
- * apps/api/src/stripe.ts) and which therefore have no stripe_refund_id.
+ * One-time backfill for DevPass refunds that never made it into the
+ * `transaction` table correctly. Two independent problems are reconciled:
  *
- * For each affected DevPass payment intent, pulls the actual succeeded refunds
- * from Stripe, deletes the DevPass legacy NULL-refund-id rows, and inserts one
- * correct row per Stripe refund delta — keyed on stripe_refund_id so the run is
- * idempotent. Regular credit top-up refunds are intentionally skipped.
+ *   Phase 1 — legacy malformed rows: `credit_refund` rows whose amount was
+ *   stored as the cumulative `charge.amount_refunded` (pre-fix in
+ *   apps/api/src/stripe.ts) and which therefore have no `stripe_refund_id`.
+ *   These are deleted and rewritten from the actual Stripe refunds.
+ *
+ *   Phase 2 — missing rows: DevPass payments that were refunded in Stripe but
+ *   for which NO `credit_refund` row exists at all (the `charge.refunded`
+ *   webhook wasn't delivered/handled, or the refund predates refund tracking).
+ *   For every DevPass payment we pull the succeeded Stripe refunds and insert
+ *   any that aren't already recorded.
+ *
+ * Both phases key on `stripe_refund_id` so the run is idempotent, and regular
+ * credit top-up refunds are intentionally skipped (DevPass only).
  *
  * Usage:
  *   pnpm --filter @llmgateway/scripts backfill-stripe-refunds                       # dry run
  *   pnpm --filter @llmgateway/scripts backfill-stripe-refunds --commit              # apply
  *   pnpm --filter @llmgateway/scripts backfill-stripe-refunds --payment-intent=pi_x # scope to one PI
+ *   pnpm --filter @llmgateway/scripts backfill-stripe-refunds --org=org_x           # scope to one org
  *
  * Environment:
- *   STRIPE_SECRET_KEY - required
+ *   STRIPE_SECRET_KEY - required (use the LIVE key in production)
  *   DATABASE_URL      - defaults to local postgres if unset
  */
 
@@ -34,6 +43,15 @@ const LEGACY_DEV_PLAN_TX_TYPES = [
 	"subscription_start",
 	"subscription_cancel",
 	"subscription_end",
+] as const;
+// The payment transaction types a DevPass refund can be attributed to. A refund
+// links back to the original charge (start/renewal/upgrade), never to a
+// cancel/end/downgrade marker row.
+const REFUNDABLE_ORIGINAL_TYPES = [
+	"dev_plan_start",
+	"dev_plan_renewal",
+	"dev_plan_upgrade",
+	"subscription_start",
 ] as const;
 
 function getStripe(): Stripe {
@@ -56,17 +74,95 @@ function hasFlag(name: string): boolean {
 	return process.argv.includes(`--${name}`);
 }
 
-async function main(): Promise<void> {
-	const stripe = getStripe();
-	const commit = hasFlag("commit");
-	const scopePI = parseFlag("payment-intent");
-
-	console.log(
-		`Mode: ${commit ? "COMMIT (writes enabled)" : "DRY RUN (no writes)"}`,
-	);
-	if (scopePI) {
-		console.log(`Scoped to payment intent: ${scopePI}`);
+// All succeeded refunds for a payment intent, oldest first. Non-succeeded
+// attempts (pending/failed/canceled) never move money, so they're excluded.
+async function listSucceededRefunds(
+	stripe: Stripe,
+	paymentIntentId: string,
+): Promise<Stripe.Refund[]> {
+	const attempts: Stripe.Refund[] = [];
+	for await (const r of stripe.refunds.list({
+		payment_intent: paymentIntentId,
+		limit: 100,
+	})) {
+		attempts.push(r);
 	}
+	return attempts
+		.filter((r) => r.status === "succeeded")
+		.sort((a, b) => a.created - b.created);
+}
+
+// Resolve the payment intent(s) that settled a given invoice. DevPass
+// `dev_plan_*` transactions store the invoice id rather than the payment
+// intent, so this is how we map an invoice back to a refundable charge.
+async function resolveInvoicePaymentIntents(
+	stripe: Stripe,
+	invoiceId: string,
+): Promise<string[]> {
+	const ids = new Set<string>();
+	for await (const p of stripe.invoicePayments.list({
+		invoice: invoiceId,
+		limit: 100,
+	})) {
+		const payment = p.payment as
+			| { type?: string; payment_intent?: string | { id?: string } | null }
+			| undefined;
+		const pi = payment?.payment_intent;
+		const piId = typeof pi === "string" ? pi : (pi?.id ?? undefined);
+		if (piId) {
+			ids.add(piId);
+		}
+	}
+	return [...ids];
+}
+
+type TransactionRow = typeof tables.transaction.$inferSelect;
+
+function refundDescription(
+	refundDollars: number,
+	originalAmount: number,
+): string {
+	const ratio = originalAmount > 0 ? refundDollars / originalAmount : 0;
+	return `Credit refund: $${refundDollars.toFixed(2)} (${(ratio * 100).toFixed(1)}% of original purchase) [backfilled]`;
+}
+
+async function insertRefundRow(
+	tx: Pick<typeof db, "insert">,
+	params: {
+		paymentIntentId: string;
+		refund: Stripe.Refund;
+		original: TransactionRow;
+	},
+): Promise<void> {
+	const { paymentIntentId, refund, original } = params;
+	const refundDollars = refund.amount / 100;
+	const originalAmount = Number.parseFloat(original.amount ?? "0");
+	await tx.insert(tables.transaction).values({
+		createdAt: new Date(refund.created * 1000),
+		updatedAt: new Date(refund.created * 1000),
+		organizationId: original.organizationId,
+		type: "credit_refund",
+		amount: refundDollars.toString(),
+		// DevPass plan payments don't add to org.credits, so their refunds don't
+		// deduct credits — mirrors handleChargeRefunded for non-credit_topup rows.
+		creditAmount: "0",
+		currency: original.currency ?? "USD",
+		status: "completed",
+		stripePaymentIntentId: paymentIntentId,
+		stripeRefundId: refund.id,
+		relatedTransactionId: original.id,
+		refundReason: refund.reason ?? null,
+		description: refundDescription(refundDollars, originalAmount),
+	});
+}
+
+// Phase 1: reconcile legacy credit_refund rows that have no stripe_refund_id.
+async function reconcileLegacyRows(
+	stripe: Stripe,
+	opts: { commit: boolean; scopePI?: string; scopeOrg?: string },
+): Promise<{ inserted: number; deleted: number; skippedPIs: number }> {
+	const { commit, scopePI, scopeOrg } = opts;
+	console.log(`\n=== Phase 1: reconcile legacy rows (no stripe_refund_id) ===`);
 
 	const legacyRows = await db
 		.select()
@@ -78,26 +174,25 @@ async function main(): Promise<void> {
 				...(scopePI
 					? [eq(tables.transaction.stripePaymentIntentId, scopePI)]
 					: []),
+				...(scopeOrg ? [eq(tables.transaction.organizationId, scopeOrg)] : []),
 			),
 		);
 
 	console.log(
-		`\nFound ${legacyRows.length} legacy credit_refund row(s) without stripe_refund_id`,
+		`Found ${legacyRows.length} legacy credit_refund row(s) without stripe_refund_id`,
 	);
 	if (legacyRows.length === 0) {
-		console.log("Nothing to backfill.");
-		process.exit(0);
+		return { inserted: 0, deleted: 0, skippedPIs: 0 };
 	}
 
-	const devpassRows: typeof legacyRows = [];
-	const originalAmountByRefundId = new Map<string, number>();
+	const devpassRows: TransactionRow[] = [];
+	const originalByRowId = new Map<string, TransactionRow>();
 	let nonDevpassRows = 0;
 	for (const row of legacyRows) {
 		if (!row.relatedTransactionId) {
 			nonDevpassRows += 1;
 			continue;
 		}
-
 		const original = await db.query.transaction.findFirst({
 			where: { id: { eq: row.relatedTransactionId } },
 		});
@@ -105,7 +200,6 @@ async function main(): Promise<void> {
 			nonDevpassRows += 1;
 			continue;
 		}
-
 		const isDevPlan = (DEV_PLAN_TX_TYPES as readonly string[]).includes(
 			original.type,
 		);
@@ -121,31 +215,24 @@ async function main(): Promise<void> {
 				continue;
 			}
 		}
-
 		if (!isDevPlan && !isLegacyDevPlan) {
 			nonDevpassRows += 1;
 			continue;
 		}
-
 		devpassRows.push(row);
-		originalAmountByRefundId.set(
-			row.id,
-			Number.parseFloat(original.amount ?? "0"),
-		);
+		originalByRowId.set(row.id, original);
 	}
 
 	if (nonDevpassRows > 0) {
-		console.log(
-			`Skipping ${nonDevpassRows} non-DevPass legacy refund row(s).`,
-		);
+		console.log(`Skipping ${nonDevpassRows} non-DevPass legacy refund row(s).`);
 	}
 	if (devpassRows.length === 0) {
-		console.log("No DevPass refund rows to backfill.");
-		process.exit(0);
+		console.log("No DevPass legacy refund rows to reconcile.");
+		return { inserted: 0, deleted: 0, skippedPIs: 0 };
 	}
 
-	const byPI = new Map<string, typeof devpassRows>();
-	const noPI: typeof legacyRows = [];
+	const byPI = new Map<string, TransactionRow[]>();
+	const noPI: TransactionRow[] = [];
 	for (const row of devpassRows) {
 		if (!row.stripePaymentIntentId) {
 			noPI.push(row);
@@ -169,85 +256,43 @@ async function main(): Promise<void> {
 
 	console.log(`\nGrouped into ${byPI.size} unique payment intent(s)\n`);
 
-	let totalInsert = 0;
-	let totalDelete = 0;
-	let totalSkippedPI = 0;
+	let inserted = 0;
+	let deleted = 0;
+	let skippedPIs = 0;
 
 	for (const [pi, rows] of byPI) {
-		console.log(`=== ${pi} (${rows.length} legacy row(s)) ===`);
-
+		console.log(`--- ${pi} (${rows.length} legacy row(s)) ---`);
 		const legacyTotal = rows.reduce(
 			(s, r) => s + Number.parseFloat(r.amount ?? "0"),
 			0,
 		);
 		console.log(`  Legacy rows sum: $${legacyTotal.toFixed(2)}`);
-		for (const r of rows) {
-			console.log(
-				`    - id=${r.id} amount=$${Number.parseFloat(r.amount ?? "0").toFixed(2)} created=${r.createdAt.toISOString()}`,
-			);
-		}
 
-		let refundAttempts: Stripe.Refund[] = [];
+		let refunds: Stripe.Refund[];
 		try {
-			for await (const r of stripe.refunds.list({
-				payment_intent: pi,
-				limit: 100,
-			})) {
-				refundAttempts.push(r);
-			}
+			refunds = await listSucceededRefunds(stripe, pi);
 		} catch (err) {
 			console.warn(
 				`  Failed to list Stripe refunds: ${(err as Error).message}`,
 			);
-			totalSkippedPI += 1;
+			skippedPIs += 1;
 			continue;
 		}
-
-		if (refundAttempts.length === 0) {
-			console.warn(
-				`  No Stripe refunds found for this PI — leaving legacy rows in place`,
-			);
-			totalSkippedPI += 1;
-			continue;
-		}
-
-		refundAttempts = refundAttempts.sort((a, b) => a.created - b.created);
-		const skippedAttempts = refundAttempts.filter((r) => r.status !== "succeeded");
-		if (skippedAttempts.length > 0) {
-			console.log(
-				`  Ignoring ${skippedAttempts.length} non-succeeded Stripe refund attempt(s):`,
-			);
-			for (const r of skippedAttempts) {
-				console.log(
-					`    - ${r.id} $${(r.amount / 100).toFixed(2)} status=${r.status ?? "unknown"} created=${new Date(r.created * 1000).toISOString()} reason=${r.reason ?? "—"}`,
-				);
-			}
-		}
-
-		const refunds = refundAttempts.filter((r) => r.status === "succeeded");
 		if (refunds.length === 0) {
 			console.warn(
-				`  No succeeded Stripe refunds found for this PI — leaving legacy rows in place`,
+				`  No succeeded Stripe refunds for this PI — leaving legacy rows in place`,
 			);
-			totalSkippedPI += 1;
+			skippedPIs += 1;
 			continue;
 		}
 
 		const stripeTotal = refunds.reduce((s, r) => s + r.amount / 100, 0);
 		console.log(
-			`  Succeeded Stripe refunds (${refunds.length}, sum $${stripeTotal.toFixed(2)}):`,
+			`  Succeeded Stripe refunds (${refunds.length}, sum $${stripeTotal.toFixed(2)})`,
 		);
-		for (const r of refunds) {
-			console.log(
-				`    - ${r.id} $${(r.amount / 100).toFixed(2)} status=${r.status ?? "unknown"} created=${new Date(r.created * 1000).toISOString()} reason=${r.reason ?? "—"}`,
-			);
-		}
 
 		const existingForPI = await db
-			.select({
-				id: tables.transaction.id,
-				refundId: tables.transaction.stripeRefundId,
-			})
+			.select({ refundId: tables.transaction.stripeRefundId })
 			.from(tables.transaction)
 			.where(
 				and(
@@ -261,15 +306,7 @@ async function main(): Promise<void> {
 				.filter((id): id is string => id !== null),
 		);
 		const toInsert = refunds.filter((r) => !existingRefundIds.has(r.id));
-
-		if (toInsert.length < refunds.length) {
-			console.log(
-				`  ${refunds.length - toInsert.length} refund(s) already correctly stored — skipping those`,
-			);
-		}
-
-		const sample = rows[0];
-		const originalAmount = originalAmountByRefundId.get(sample.id) ?? 0;
+		const original = originalByRowId.get(rows[0].id)!;
 
 		console.log(
 			`  Plan: delete ${rows.length} legacy row(s), insert ${toInsert.length} correct row(s) — net change to refund total: $${(stripeTotal - legacyTotal).toFixed(2)}`,
@@ -277,50 +314,197 @@ async function main(): Promise<void> {
 
 		if (commit) {
 			await db.transaction(async (tx) => {
-				await tx
-					.delete(tables.transaction)
-					.where(
-						inArray(
-							tables.transaction.id,
-							rows.map((row) => row.id),
-						),
-					);
-
+				await tx.delete(tables.transaction).where(
+					inArray(
+						tables.transaction.id,
+						rows.map((row) => row.id),
+					),
+				);
 				for (const r of toInsert) {
-					const refundDollars = r.amount / 100;
-					const ratio = originalAmount > 0 ? refundDollars / originalAmount : 0;
-					await tx.insert(tables.transaction).values({
-						createdAt: new Date(r.created * 1000),
-						updatedAt: new Date(r.created * 1000),
-						organizationId: sample.organizationId,
-						type: "credit_refund",
-						amount: refundDollars.toString(),
-						creditAmount: "0",
-						currency: sample.currency ?? "USD",
-						status: "completed",
-						stripePaymentIntentId: pi,
-						stripeRefundId: r.id,
-						relatedTransactionId: sample.relatedTransactionId,
-						refundReason: r.reason ?? null,
-						description: `Credit refund: $${refundDollars.toFixed(2)} (${(ratio * 100).toFixed(1)}% of original purchase) [backfilled]`,
+					await insertRefundRow(tx, {
+						paymentIntentId: pi,
+						refund: r,
+						original,
 					});
 				}
 			});
 			console.log(`  Applied`);
 		}
-
-		totalDelete += rows.length;
-		totalInsert += toInsert.length;
+		deleted += rows.length;
+		inserted += toInsert.length;
 	}
+
+	return { inserted, deleted, skippedPIs };
+}
+
+// Phase 2: discover DevPass refunds that exist in Stripe but have no
+// credit_refund row at all, and insert them.
+async function backfillMissingRefunds(
+	stripe: Stripe,
+	opts: { commit: boolean; scopePI?: string; scopeOrg?: string },
+): Promise<{ inserted: number; scannedPIs: number; skippedNoPI: number }> {
+	const { commit, scopePI, scopeOrg } = opts;
+	console.log(`\n=== Phase 2: backfill missing refunds (no row at all) ===`);
+
+	// DevPass payment transactions that could have been refunded.
+	const originals = await db
+		.select()
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			and(
+				eq(tables.transaction.organizationId, tables.organization.id),
+				eq(tables.organization.kind, "devpass"),
+			),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.type, [...REFUNDABLE_ORIGINAL_TYPES]),
+				...(scopeOrg ? [eq(tables.transaction.organizationId, scopeOrg)] : []),
+			),
+		);
+
+	const originalRows = originals.map((r) => r.transaction);
+	console.log(`Scanning ${originalRows.length} DevPass payment transaction(s)`);
+
+	// Map each unique payment intent to the earliest original it settled (the
+	// first invoice can back both a dev_plan_start and dev_plan_renewal — either
+	// is a valid refund anchor for revenue attribution, so pick deterministically).
+	const originalByPI = new Map<string, TransactionRow>();
+	let skippedNoPI = 0;
+	for (const original of originalRows) {
+		let paymentIntentIds: string[] = [];
+		if (original.stripePaymentIntentId) {
+			paymentIntentIds = [original.stripePaymentIntentId];
+		} else if (original.stripeInvoiceId) {
+			try {
+				paymentIntentIds = await resolveInvoicePaymentIntents(
+					stripe,
+					original.stripeInvoiceId,
+				);
+			} catch (err) {
+				console.warn(
+					`  Failed to resolve PI for invoice ${original.stripeInvoiceId}: ${(err as Error).message}`,
+				);
+			}
+		}
+		if (paymentIntentIds.length === 0) {
+			skippedNoPI += 1;
+			continue;
+		}
+		for (const pi of paymentIntentIds) {
+			if (scopePI && pi !== scopePI) {
+				continue;
+			}
+			const existing = originalByPI.get(pi);
+			if (!existing || original.createdAt < existing.createdAt) {
+				originalByPI.set(pi, original);
+			}
+		}
+	}
+
+	if (skippedNoPI > 0) {
+		console.log(
+			`Skipped ${skippedNoPI} payment transaction(s) with no resolvable payment intent.`,
+		);
+	}
+	console.log(`Resolved ${originalByPI.size} unique payment intent(s)\n`);
+
+	let inserted = 0;
+	let scannedPIs = 0;
+	for (const [pi, original] of originalByPI) {
+		scannedPIs += 1;
+		let refunds: Stripe.Refund[];
+		try {
+			refunds = await listSucceededRefunds(stripe, pi);
+		} catch (err) {
+			console.warn(
+				`  Failed to list Stripe refunds for ${pi}: ${(err as Error).message}`,
+			);
+			continue;
+		}
+		if (refunds.length === 0) {
+			continue;
+		}
+
+		const missing: Stripe.Refund[] = [];
+		for (const r of refunds) {
+			const already = await db.query.transaction.findFirst({
+				where: {
+					stripeRefundId: { eq: r.id },
+					type: { eq: "credit_refund" },
+				},
+			});
+			if (!already) {
+				missing.push(r);
+			}
+		}
+		if (missing.length === 0) {
+			continue;
+		}
+
+		console.log(
+			`--- ${pi} (org ${original.organizationId}, original ${original.type} $${original.amount}) ---`,
+		);
+		for (const r of missing) {
+			console.log(
+				`  MISSING refund ${r.id} $${(r.amount / 100).toFixed(2)} created=${new Date(r.created * 1000).toISOString()} reason=${r.reason ?? "—"}`,
+			);
+		}
+
+		if (commit) {
+			await db.transaction(async (tx) => {
+				for (const r of missing) {
+					await insertRefundRow(tx, {
+						paymentIntentId: pi,
+						refund: r,
+						original,
+					});
+				}
+			});
+			console.log(`  Inserted ${missing.length} refund row(s)`);
+		}
+		inserted += missing.length;
+	}
+
+	return { inserted, scannedPIs, skippedNoPI };
+}
+
+async function main(): Promise<void> {
+	const stripe = getStripe();
+	const commit = hasFlag("commit");
+	const scopePI = parseFlag("payment-intent");
+	const scopeOrg = parseFlag("org");
+
+	console.log(
+		`Mode: ${commit ? "COMMIT (writes enabled)" : "DRY RUN (no writes)"}`,
+	);
+	if (scopePI) {
+		console.log(`Scoped to payment intent: ${scopePI}`);
+	}
+	if (scopeOrg) {
+		console.log(`Scoped to organization: ${scopeOrg}`);
+	}
+
+	const phase1 = await reconcileLegacyRows(stripe, {
+		commit,
+		scopePI,
+		scopeOrg,
+	});
+	const phase2 = await backfillMissingRefunds(stripe, {
+		commit,
+		scopePI,
+		scopeOrg,
+	});
 
 	console.log(`\n=== Summary ===`);
 	console.log(
-		`  ${totalDelete} legacy row(s) ${commit ? "deleted" : "would be deleted"}`,
+		`  Phase 1 (legacy): ${phase1.deleted} row(s) ${commit ? "deleted" : "would be deleted"}, ${phase1.inserted} ${commit ? "inserted" : "would be inserted"}, ${phase1.skippedPIs} PI(s) skipped`,
 	);
 	console.log(
-		`  ${totalInsert} correct row(s) ${commit ? "inserted" : "would be inserted"}`,
+		`  Phase 2 (missing): ${phase2.inserted} row(s) ${commit ? "inserted" : "would be inserted"} across ${phase2.scannedPIs} PI(s) scanned`,
 	);
-	console.log(`  ${totalSkippedPI} payment intent(s) skipped`);
 
 	if (!commit) {
 		console.log(`\n(Dry run — re-run with --commit to apply)`);


### PR DESCRIPTION
## Problem

A DevPass subscriber was refunded in prod, but the refund was **invisible** in the billing history — the admin org-detail page and the user's DevPass billing page both showed only the original charge, while the subscriber's **all-time revenue read $0.00** (`$29 − $29 refund`).

Root cause: the refund **is** recorded as a `credit_refund` transaction and already nets out of the reported revenue/margin, but **both** transaction-list queries filtered `credit_refund` out:

- Admin per-org detail — `GET /admin/devpass/{orgId}` (`apps/api/src/routes/admin.ts`)
- User DevPass billing — `GET /dev-plans/invoices` (`apps/api/src/routes/dev-plans.ts`)

So refunds affected the aggregates but never appeared as a line item. (The API already had credit-note PDF support for refunds — `isInvoiceableTransaction`/`isRefundTransaction` — confirming refunds were always meant to be listed.)

## Changes

**Show refunds in both histories**
- Add `credit_refund` to both transaction-list queries.
- Admin detail (`ee/admin`): refund renders with a destructive badge and a **negative** amount.
- User billing (`apps/code`): refund renders as a **Refund** line with a negative amount and a downloadable **credit note**.

**Backfill missing refunds** (`packages/scripts/src/backfill-stripe-refunds.ts`)
- New **Phase 2** discovers DevPass refunds that exist in Stripe but have **no `credit_refund` row at all** (webhook missed/undelivered) and inserts them — resolving the invoice → payment-intent → succeeded-refunds chain.
- **Phase 1** (reconcile legacy rows with `NULL stripe_refund_id`) is preserved.
- New `--org=<id>` scope flag. Both phases are idempotent on `stripe_refund_id`.

## Screenshots

DevPass billing page (`apps/code`) — the refund now appears as a **Refund** line with a negative amount (`-$15.00`) and a downloadable **credit note**, alongside the original renewal charge. Light and dark:

<img width="992" alt="DevPass invoices — refund line item (light)" src="https://raw.githubusercontent.com/theopenco/llmgateway/6f6f2a04899da3125e4839403747338c944fbd5e/devpass-invoices-light.png" />

<img width="992" alt="DevPass invoices — refund line item (dark)" src="https://raw.githubusercontent.com/theopenco/llmgateway/6f6f2a04899da3125e4839403747338c944fbd5e/devpass-invoices-dark.png" />

## Verification (local, against the running stack)

- Reproduced the exact prod state: a real Stripe test refund with **no** DB row → the enhanced script's Phase 2 discovered it (via invoice→PI resolution) and inserted the correct `credit_refund` row; re-run is a no-op (idempotent).
- Confirmed `GET /admin/devpass/{orgId}` and `GET /dev-plans/invoices` now return the `credit_refund` row.
- Confirmed the refund credit-note PDF downloads (`application/pdf`).
- `pnpm format` + full `pnpm build` (17/17) pass.

## Follow-up (not in this PR)

Run the backfill in prod (dry-run → `--commit`), e.g. scoped first: `--org=2t6ZtQyGpTEohmrJXEgX`, with the **live** `STRIPE_SECRET_KEY` and prod `DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Refund transactions now appear in DevPass invoices and subscriber transaction history.
  * Refunds are clearly labeled, displayed as negative amounts, and available for download as credit notes.

* **Bug Fixes**
  * Billing views now display charges and refunds consistently.
  * Historical refund records can be restored more reliably, including previously missing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
