### PR TITLE
fix(models): enable 1h cache TTL for fable-5 on bedrock

### DIFF
--- a/apps/gateway/src/lib/anthropic-pricing.spec.ts
+++ b/apps/gateway/src/lib/anthropic-pricing.spec.ts
@@ -169,6 +169,7 @@ describe("AWS Bedrock Anthropic model pricing", () => {
 	);
 
 	const ONE_HOUR_BEDROCK_PREFIXES = [
+		"anthropic.claude-fable-5",
 		"anthropic.claude-opus-4-5",
 		"anthropic.claude-opus-4-6",
 		"anthropic.claude-opus-4-7",

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -38,6 +38,7 @@ export const anthropicModels = [
 				outputPrice: "50.0e-6",
 				cachedInputPrice: "1.0e-6",
 				cacheWriteInputPrice: "12.5e-6",
+				cacheWriteInputPrice1h: "20.0e-6",
 				minCacheableTokens: 1024,
 				requestPrice: "0",
 				contextSize: 1000000,


### PR DESCRIPTION
## Problem

A user reported that requesting prompt caching with `ttl: "1h"` works on Opus 4.7/4.8 (tokens land in `cache_creation.ephemeral_1h_input_tokens`) but on Claude Fable 5 the exact same request lands in `ephemeral_5m_input_tokens`.

## Cause

The gateway gates 1h TTL forwarding for AWS Bedrock on the model mapping's `cacheWriteInputPrice1h` field (`bedrockSupports1hTtl` in `packages/actions/src/prepare-request-body.ts`), silently downgrading `ttl: "1h"` cachePoints to the 5m default when the field is absent. Fable 5's `aws-bedrock` mapping was missing the field (the direct `anthropic` mapping has it), so any Fable 5 request routed through Bedrock lost the 1h TTL — Opus 4.7/4.8 have the field on both mappings, which is why they behaved correctly.

## Fix

- Add `cacheWriteInputPrice1h: "20.0e-6"` (2× input price, matching the direct Anthropic mapping) to Fable 5's `aws-bedrock` provider mapping. [AWS's Fable 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html) documents prompt caching with 5m **and** 1h TTLs.
- Allowlist `anthropic.claude-fable-5` in the Bedrock 1h pricing spec guard.

This also fixes billing for Fable 5 Bedrock 1h cache writes (the price was previously undefined). Geo-region (`us`) pricing gets the ×1.1 premium automatically via region expansion.

## Testing

- `pnpm test:unit` passes (the previously failing `chat-projects` specs were a stale local test-DB schema, fixed by `pnpm push-test`)
- `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new model option in AWS Bedrock pricing, including 1-hour cache write pricing.
* **Bug Fixes**
  * Updated eligibility checks so pricing details are only shown for models that support 1-hour cache TTLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->