### PR TITLE
fix(ui): hide stealth providers from key config

### DIFF
--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -8,6 +8,7 @@ import { db, tables } from "@llmgateway/db";
 import {
 	getProviderEnvVar,
 	getTestOptions,
+	isStealthProvider,
 	models,
 	providers,
 } from "@llmgateway/models";
@@ -116,8 +117,22 @@ describe(
 			return { token, orgId };
 		}
 
+		// Stealth providers have no default base URL and are rejected by
+		// POST /keys/provider, so exclude them from the happy-path table (their
+		// rejection is asserted separately below). Otherwise a CI-provided stealth
+		// key (e.g. LLM_GRANITE_API_KEY) would make the 200 expectation fail.
 		const testProviders = providers
-			.filter((provider) => provider.id !== "llmgateway")
+			.filter(
+				(provider) =>
+					provider.id !== "llmgateway" && !isStealthProvider(provider),
+			)
+			.map((provider) => ({
+				providerId: provider.id,
+				name: provider.name,
+			}));
+
+		const stealthProviders = providers
+			.filter((provider) => isStealthProvider(provider))
 			.map((provider) => ({
 				providerId: provider.id,
 				name: provider.name,
@@ -188,6 +203,40 @@ describe(
 				expect(providerKey).not.toBeNull();
 				expect(providerKey?.provider).toBe(providerId);
 				expect(providerKey?.token).toBe(envVarValue);
+			},
+		);
+
+		test.each(stealthProviders)(
+			"POST /keys/provider rejects stealth $name key",
+			async ({ providerId }) => {
+				const { token, orgId } = await setupTestData();
+
+				const res = await app.request("/keys/provider", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Cookie: token,
+					},
+					body: JSON.stringify({
+						provider: providerId,
+						token: "stealth-test-token",
+						organizationId: orgId,
+					}),
+				});
+
+				expect(res.status).toBe(400);
+
+				const providerKey = await db.query.providerKey.findFirst({
+					where: {
+						provider: {
+							eq: providerId,
+						},
+						organizationId: {
+							eq: orgId,
+						},
+					},
+				});
+				expect(providerKey).toBeUndefined();
 			},
 		);
 

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -161,6 +161,34 @@ describe("provider keys route", () => {
 		expect(res.status).toBe(400);
 	});
 
+	test("POST /keys/provider rejects stealth providers", async () => {
+		const res = await app.request("/keys/provider", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({
+				provider: "granite",
+				token: "granite-test-token",
+				organizationId: "test-org-id",
+			}),
+		});
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.message).toContain("cannot be configured with a provider key");
+
+		// Verify no key was created
+		const providerKey = await db.query.providerKey.findFirst({
+			where: {
+				provider: {
+					eq: "granite",
+				},
+			},
+		});
+		expect(providerKey).toBeUndefined();
+	});
+
 	test("POST /keys/provider with duplicate provider", async () => {
 		const res = await app.request("/keys/provider", {
 			method: "POST",

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -10,7 +10,7 @@ import { logAuditEvent } from "@llmgateway/audit";
 import { invalidateSwrByTables } from "@llmgateway/cache";
 import { db, eq, getTableName, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
-import { providers } from "@llmgateway/models";
+import { isStealthProvider, providers } from "@llmgateway/models";
 import { assertSafeProviderUrl } from "@llmgateway/shared/url-safety-node";
 
 import type { ServerTypes } from "@/vars.js";
@@ -232,6 +232,15 @@ keysProvider.openapi(create, async (c) => {
 	if (provider === "custom" && (!name || !baseUrl)) {
 		throw new HTTPException(400, {
 			message: "Custom providers require both a name and base URL",
+		});
+	}
+
+	// Stealth providers have no default base URL and an undisclosed platform, so
+	// users can't self-configure a working key for them. They are hidden from the
+	// UI selector; reject here too as defense in depth against direct API calls.
+	if (provider !== "custom" && isStealthProvider(provider as ProviderId)) {
+		throw new HTTPException(400, {
+			message: `Provider ${provider} cannot be configured with a provider key`,
 		});
 	}
 

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -25,7 +25,11 @@ import {
 import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
 
-import { providers, type ProviderDefinition } from "@llmgateway/models";
+import {
+	providers,
+	isStealthProvider,
+	type ProviderDefinition,
+} from "@llmgateway/models";
 
 import { ProviderSelect } from "./provider-select";
 
@@ -80,8 +84,11 @@ export function CreateProviderKeyDialog({
 	const effectiveRegion =
 		(selectedRegion || selectedProviderDef?.regionConfig?.defaultRegion) ?? "";
 
+	// Exclude the gateway itself and stealth providers (no default base URL):
+	// users can't configure a stealth provider key because the platform behind
+	// it is undisclosed, so hide them from the selector entirely.
 	const availableProviders = providers.filter(
-		(provider) => provider.id !== "llmgateway",
+		(provider) => provider.id !== "llmgateway" && !isStealthProvider(provider),
 	);
 
 	// Update selectedProvider when preselectedProvider changes or dialog opens

--- a/apps/ui/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-list.tsx
@@ -32,7 +32,7 @@ import { StatusBadge } from "@/lib/components/status-badge";
 import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
 
-import { providers } from "@llmgateway/models";
+import { isStealthProvider, providers } from "@llmgateway/models";
 import { getProviderIcon } from "@llmgateway/shared/components";
 
 import { CreateProviderKeyDialog } from "./create-provider-key-dialog";
@@ -97,9 +97,15 @@ export function ProviderKeysList({
 	const deleteMutation = api.useMutation("delete", "/keys/provider/{id}");
 	const toggleMutation = api.useMutation("patch", "/keys/provider/{id}");
 
-	// Filter out LLM Gateway from the providers list
+	// Filter out LLM Gateway and stealth providers (no default base URL) from the
+	// providers list: users can't configure a stealth provider key because the
+	// platform behind it is undisclosed, so they must not appear as connectable.
 	const availableProviders = useMemo(
-		() => providers.filter((provider) => provider.id !== "llmgateway"),
+		() =>
+			providers.filter(
+				(provider) =>
+					provider.id !== "llmgateway" && !isStealthProvider(provider),
+			),
 		[],
 	);
 

--- a/packages/models/src/helpers.ts
+++ b/packages/models/src/helpers.ts
@@ -1,5 +1,10 @@
 import { models, type ProviderModelMapping } from "./models.js";
-import { providers, type ServiceTier } from "./providers.js";
+import {
+	providers,
+	type ProviderDefinition,
+	type ProviderId,
+	type ServiceTier,
+} from "./providers.js";
 import { expandAllProviderRegions } from "./region-helpers.js";
 
 /**
@@ -178,4 +183,21 @@ const OPENAI_EXTENDED_PROMPT_CACHE_MODELS = new Set<string>([
 
 export function supportsOpenAIExtendedPromptCache(modelName: string): boolean {
 	return OPENAI_EXTENDED_PROMPT_CACHE_MODELS.has(modelName);
+}
+
+/**
+ * Whether a provider is a "stealth" provider — one that has no default base URL
+ * and instead requires the base URL to be supplied via a `baseUrl` env var
+ * (`env.required.baseUrl`). Because the platform behind such a provider is
+ * undisclosed, users cannot self-configure a provider key for it (they can't
+ * know the endpoint), so these are hidden from the UI provider selector.
+ */
+export function isStealthProvider(
+	provider: ProviderId | ProviderDefinition,
+): boolean {
+	const def =
+		typeof provider === "string"
+			? providers.find((p) => p.id === provider)
+			: provider;
+	return Boolean(def?.env.required.baseUrl);
 }

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getSupportedServiceTiers, supportsServiceTier } from "./helpers.js";
+import {
+	getSupportedServiceTiers,
+	isStealthProvider,
+	supportsServiceTier,
+} from "./helpers.js";
 import { anthropicModels } from "./models/anthropic.js";
 import { models } from "./models.js";
 import {
@@ -187,6 +191,33 @@ describe("model service tier support", () => {
 				"flex",
 			),
 		).toBe(false);
+	});
+});
+
+describe("isStealthProvider", () => {
+	it("flags providers that require a baseUrl env var (no default endpoint)", () => {
+		for (const id of ["glacier", "granite", "quartz", "avalanche", "tundra"]) {
+			expect(isStealthProvider(id)).toBe(true);
+		}
+	});
+
+	it("does not flag providers with a default base URL", () => {
+		for (const id of [
+			"openai",
+			"anthropic",
+			"google-ai-studio",
+			"llmgateway",
+		]) {
+			expect(isStealthProvider(id)).toBe(false);
+		}
+	});
+
+	it("keeps stealth providers out of the definitions used for BYOK config", () => {
+		const stealth = providers.filter((provider) => isStealthProvider(provider));
+		expect(stealth.length).toBeGreaterThan(0);
+		for (const provider of stealth) {
+			expect(provider.env.required.baseUrl).toBeTruthy();
+		}
 	});
 });
 


### PR DESCRIPTION
## Problem

Stealth providers (`glacier`, `granite`, `quartz`, `avalanche`, `tundra`) have **no default base URL** — they require an `LLM_*_BASE_URL` env var and route to an undisclosed platform. They were still shown in the "Add Provider Key" selector, but a user can never configure a working key for one: they don't know the endpoint/platform, so any key they add would fail to route.

## Fix

- **`packages/models`**: add `isStealthProvider(provider)` helper that returns `true` when a provider's definition requires a `baseUrl` env var (`env.required.baseUrl`), i.e. it has no hardcoded default endpoint.
- **`apps/ui`**: exclude stealth providers from `availableProviders` in the create-provider-key dialog, so they no longer appear in the selector.
- **`apps/api`**: reject `POST /keys/provider` for stealth providers as defense in depth against direct API calls.
- **Tests**: cover `isStealthProvider` for the current stealth set and non-stealth providers.

## Verification

- `turbo run build --filter=@llmgateway/models --filter=api --filter=ui` — all green
- `vitest run packages/models/src/providers.spec.ts` — 31 passed
- `tsc --noEmit` in `packages/models` — clean
- `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “stealth” provider detection to determine which providers can’t be configured with a provider key.
* **Bug Fixes**
  * `POST /keys/provider` now rejects stealth providers with a clear `400` and prevents invalid provider-key records from being stored.
  * Provider-key creation UI now hides ineligible providers, including stealth providers and the excluded gateway provider.
* **Tests**
  * Added unit, API, and e2e coverage for stealth-provider detection and for rejecting stealth providers during provider-key creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->