### PR TITLE
feat: harden chat support and ask ai rate limits

### DIFF
--- a/apps/api/src/routes/public-chat-support.spec.ts
+++ b/apps/api/src/routes/public-chat-support.spec.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
 
 const BURST_LIMIT_MAX = 5;
+const RATE_LIMIT_MAX = 20;
+const DAILY_LIMIT_MAX = 60;
+const GLOBAL_HOURLY_LIMIT_MAX = 300;
 const META_BURST_LIMIT_MAX = 30;
 
 // Unique identifiers per call so runs never collide with earlier state in
@@ -16,9 +20,19 @@ function uniqueClientId(): string {
 	return `spec-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-// Omits `messages` on purpose: requests that pass the rate limiter fail
-// validation with a 400, so these tests exercise the limiter without ever
-// touching the DB or the LLM.
+// Seeds a single limiter bucket to its threshold so the next request trips
+// exactly that limiter. Blocked requests are rejected before any DB or LLM
+// work, so the tests exercise the limiter and nothing else.
+async function seedLimit(
+	bucket: string,
+	identifier: string,
+	max: number,
+): Promise<string> {
+	const key = `chat_support_rate_limit:${bucket}:${identifier}`;
+	await redisClient.set(key, String(max), "EX", 60);
+	return key;
+}
+
 async function sendMessage(ip: string, clientId: string): Promise<Response> {
 	return await app.request("/public/chat-support", {
 		method: "POST",
@@ -26,53 +40,97 @@ async function sendMessage(ip: string, clientId: string): Promise<Response> {
 			"Content-Type": "application/json",
 			"CF-Connecting-IP": ip,
 		},
-		body: JSON.stringify({ clientId }),
+		body: JSON.stringify({
+			clientId,
+			messages: [
+				{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] },
+			],
+		}),
 	});
 }
 
 describe("public chat support rate limiting", () => {
-	it("blocks message bursts per IP", async () => {
+	it("blocks messages once the per-IP burst window is exhausted", async () => {
 		const ip = uniqueIp();
-		for (let i = 0; i < BURST_LIMIT_MAX; i++) {
-			const res = await sendMessage(ip, uniqueClientId());
-			expect(res.status).toBe(400);
-		}
+		await seedLimit("burst", `ip:${ip}`, BURST_LIMIT_MAX);
 		const blocked = await sendMessage(ip, uniqueClientId());
 		expect(blocked.status).toBe(429);
 		const json = await blocked.json();
 		expect(json.error).toContain("too quickly");
 	});
 
-	it("blocks message bursts per clientId across IPs", async () => {
+	it("blocks messages once the clientId burst window is exhausted", async () => {
 		const clientId = uniqueClientId();
-		for (let i = 0; i < BURST_LIMIT_MAX; i++) {
-			const res = await sendMessage(uniqueIp(), clientId);
-			expect(res.status).toBe(400);
-		}
+		await seedLimit("burst", `client:${clientId}`, BURST_LIMIT_MAX);
 		const blocked = await sendMessage(uniqueIp(), clientId);
 		expect(blocked.status).toBe(429);
 	});
 
+	it("blocks messages once the hourly per-IP quota is exhausted", async () => {
+		const ip = uniqueIp();
+		await seedLimit("hour", `ip:${ip}`, RATE_LIMIT_MAX);
+		const blocked = await sendMessage(ip, uniqueClientId());
+		expect(blocked.status).toBe(429);
+		const json = await blocked.json();
+		expect(json.error).toContain("20 per hour");
+	});
+
+	it("blocks messages once the daily per-IP quota is exhausted", async () => {
+		const ip = uniqueIp();
+		await seedLimit("day", `ip:${ip}`, DAILY_LIMIT_MAX);
+		const blocked = await sendMessage(ip, uniqueClientId());
+		expect(blocked.status).toBe(429);
+		const json = await blocked.json();
+		expect(json.error).toContain("Daily message limit");
+	});
+
+	it("blocks everyone once the global breaker trips", async () => {
+		const key = await seedLimit("global_hour", "all", GLOBAL_HOURLY_LIMIT_MAX);
+		try {
+			const blocked = await sendMessage(uniqueIp(), uniqueClientId());
+			expect(blocked.status).toBe(429);
+			const json = await blocked.json();
+			expect(json.error).toContain("high volume");
+		} finally {
+			await redisClient.del(key);
+		}
+	});
+
 	it("does not throttle other visitors when one is blocked", async () => {
 		const ip = uniqueIp();
-		const clientId = uniqueClientId();
-		for (let i = 0; i < BURST_LIMIT_MAX + 1; i++) {
-			await sendMessage(ip, clientId);
-		}
+		await seedLimit("burst", `ip:${ip}`, BURST_LIMIT_MAX);
+		const blocked = await sendMessage(ip, uniqueClientId());
+		expect(blocked.status).toBe(429);
 		const other = await sendMessage(uniqueIp(), uniqueClientId());
-		expect(other.status).toBe(400);
+		expect(other.status).not.toBe(429);
+	});
+
+	it("does not consume rate-limit buckets for malformed requests", async () => {
+		const ip = uniqueIp();
+		const res = await app.request("/public/chat-support", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": ip,
+			},
+			body: JSON.stringify({ clientId: uniqueClientId() }),
+		});
+		expect(res.status).toBe(400);
+		const burst = await redisClient.get(
+			`chat_support_rate_limit:burst:ip:${ip}`,
+		);
+		expect(burst).toBeNull();
 	});
 
 	it("throttles the cheap endpoints on a shared per-IP bucket", async () => {
 		const ip = uniqueIp();
-		for (let i = 0; i < META_BURST_LIMIT_MAX; i++) {
-			// Missing clientId: passes the limiter, fails validation with a 400.
-			const res = await app.request("/public/chat-support/conversation", {
-				headers: { "CF-Connecting-IP": ip },
-			});
-			expect(res.status).toBe(400);
-		}
-		const blocked = await app.request("/public/chat-support/reaction", {
+		await seedLimit("meta_burst", `ip:${ip}`, META_BURST_LIMIT_MAX);
+		const blockedGet = await app.request(
+			`/public/chat-support/conversation?clientId=${uniqueClientId()}`,
+			{ headers: { "CF-Connecting-IP": ip } },
+		);
+		expect(blockedGet.status).toBe(429);
+		const blockedPost = await app.request("/public/chat-support/reaction", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -80,6 +138,6 @@ describe("public chat support rate limiting", () => {
 			},
 			body: JSON.stringify({}),
 		});
-		expect(blocked.status).toBe(429);
+		expect(blockedPost.status).toBe(429);
 	});
 });

--- a/apps/api/src/routes/public-chat-support.spec.ts
+++ b/apps/api/src/routes/public-chat-support.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+
+const BURST_LIMIT_MAX = 5;
+const META_BURST_LIMIT_MAX = 30;
+
+// Unique identifiers per call so runs never collide with earlier state in
+// Redis (the rate-limit keys live for up to 24 hours).
+function uniqueIp(): string {
+	const octet = () => Math.floor(Math.random() * 256);
+	return `10.${octet()}.${octet()}.${octet()}`;
+}
+
+function uniqueClientId(): string {
+	return `spec-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+// Omits `messages` on purpose: requests that pass the rate limiter fail
+// validation with a 400, so these tests exercise the limiter without ever
+// touching the DB or the LLM.
+async function sendMessage(ip: string, clientId: string): Promise<Response> {
+	return await app.request("/public/chat-support", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"CF-Connecting-IP": ip,
+		},
+		body: JSON.stringify({ clientId }),
+	});
+}
+
+describe("public chat support rate limiting", () => {
+	it("blocks message bursts per IP", async () => {
+		const ip = uniqueIp();
+		for (let i = 0; i < BURST_LIMIT_MAX; i++) {
+			const res = await sendMessage(ip, uniqueClientId());
+			expect(res.status).toBe(400);
+		}
+		const blocked = await sendMessage(ip, uniqueClientId());
+		expect(blocked.status).toBe(429);
+		const json = await blocked.json();
+		expect(json.error).toContain("too quickly");
+	});
+
+	it("blocks message bursts per clientId across IPs", async () => {
+		const clientId = uniqueClientId();
+		for (let i = 0; i < BURST_LIMIT_MAX; i++) {
+			const res = await sendMessage(uniqueIp(), clientId);
+			expect(res.status).toBe(400);
+		}
+		const blocked = await sendMessage(uniqueIp(), clientId);
+		expect(blocked.status).toBe(429);
+	});
+
+	it("does not throttle other visitors when one is blocked", async () => {
+		const ip = uniqueIp();
+		const clientId = uniqueClientId();
+		for (let i = 0; i < BURST_LIMIT_MAX + 1; i++) {
+			await sendMessage(ip, clientId);
+		}
+		const other = await sendMessage(uniqueIp(), uniqueClientId());
+		expect(other.status).toBe(400);
+	});
+
+	it("throttles the cheap endpoints on a shared per-IP bucket", async () => {
+		const ip = uniqueIp();
+		for (let i = 0; i < META_BURST_LIMIT_MAX; i++) {
+			// Missing clientId: passes the limiter, fails validation with a 400.
+			const res = await app.request("/public/chat-support/conversation", {
+				headers: { "CF-Connecting-IP": ip },
+			});
+			expect(res.status).toBe(400);
+		}
+		const blocked = await app.request("/public/chat-support/reaction", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"CF-Connecting-IP": ip,
+			},
+			body: JSON.stringify({}),
+		});
+		expect(blocked.status).toBe(429);
+	});
+});

--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -43,6 +43,24 @@ const RATE_LIMIT_WINDOW_SECONDS = 60 * 60; // 1 hour
 // the entire quota to be spent instantly).
 const BURST_LIMIT_MAX = 5;
 const BURST_LIMIT_WINDOW_SECONDS = 20;
+// Daily cap on top of the hourly one — 20/hour alone still allows 480 LLM
+// calls per day from a single address grinding the window all day.
+const DAILY_LIMIT_MAX = 60;
+const DAILY_LIMIT_WINDOW_SECONDS = 24 * 60 * 60;
+// Global circuit breakers across all visitors. Per-identifier limits are
+// defeated by rotating IPs (or spoofed forwarding headers on direct API
+// hits), so these bound the total LLM spend no matter how the per-IP and
+// per-client buckets are evaded.
+const GLOBAL_HOURLY_LIMIT_MAX = 300;
+const GLOBAL_DAILY_LIMIT_MAX = 1500;
+// Escalations send an email and a Discord ping each, so they get their own
+// daily per-IP cap plus a global cap to keep a flood from burying the inbox.
+const ESCALATE_DAILY_LIMIT_MAX = 10;
+const ESCALATE_GLOBAL_DAILY_LIMIT_MAX = 50;
+// Shared per-IP budget for the cheap DB-backed endpoints (conversation
+// restore, reactions, ratings) — generous for humans, stops hammering.
+const META_BURST_LIMIT_MAX = 30;
+const META_HOURLY_LIMIT_MAX = 300;
 const CONVERSATION_TTL_SECONDS = 60 * 60; // 1 hour
 const MAX_CONTEXT_MESSAGES = 30;
 
@@ -115,37 +133,108 @@ async function checkRateLimit(
 	}
 }
 
-// Enforces both the short burst window and the hourly cap. The burst check runs
-// first so a request blocked by it doesn't also consume the hourly quota.
+// Enforces the burst, hourly and daily windows per IP and per clientId, then
+// the global circuit breakers. Narrower windows run first so a request they
+// block doesn't consume the wider quotas, and the global buckets run last so
+// per-identifier rejections don't eat into everyone else's budget. The
+// clientId is client-chosen, so it can't be the only key — but it catches
+// bots that rotate IPs while reusing a client identity, and the global caps
+// bound whatever rotates both.
 async function checkMessageRateLimit(
-	identifier: string,
+	ipAddress: string,
+	clientId: string,
 ): Promise<{ ok: true } | { ok: false; message: string }> {
-	const burstOk = await checkRateLimit(
-		identifier,
-		"burst",
-		BURST_LIMIT_MAX,
-		BURST_LIMIT_WINDOW_SECONDS,
+	const identifiers = [`ip:${ipAddress}`, `client:${clientId}`];
+
+	for (const identifier of identifiers) {
+		const burstOk = await checkRateLimit(
+			identifier,
+			"burst",
+			BURST_LIMIT_MAX,
+			BURST_LIMIT_WINDOW_SECONDS,
+		);
+		if (!burstOk) {
+			return {
+				ok: false,
+				message:
+					"You're sending messages too quickly. Please wait a few seconds and try again.",
+			};
+		}
+	}
+	for (const identifier of identifiers) {
+		const hourOk = await checkRateLimit(
+			identifier,
+			"hour",
+			RATE_LIMIT_MAX,
+			RATE_LIMIT_WINDOW_SECONDS,
+		);
+		if (!hourOk) {
+			return {
+				ok: false,
+				message: "Too many messages. Please try again later (max 20 per hour).",
+			};
+		}
+	}
+	for (const identifier of identifiers) {
+		const dayOk = await checkRateLimit(
+			identifier,
+			"day",
+			DAILY_LIMIT_MAX,
+			DAILY_LIMIT_WINDOW_SECONDS,
+		);
+		if (!dayOk) {
+			return {
+				ok: false,
+				message:
+					"Daily message limit reached. Please try again tomorrow or email contact@llmgateway.io.",
+			};
+		}
+	}
+
+	const globalHourOk = await checkRateLimit(
+		"all",
+		"global_hour",
+		GLOBAL_HOURLY_LIMIT_MAX,
+		RATE_LIMIT_WINDOW_SECONDS,
 	);
-	if (!burstOk) {
+	const globalDayOk =
+		globalHourOk &&
+		(await checkRateLimit(
+			"all",
+			"global_day",
+			GLOBAL_DAILY_LIMIT_MAX,
+			DAILY_LIMIT_WINDOW_SECONDS,
+		));
+	if (!globalDayOk) {
+		logger.warn("Chat support global rate limit reached", { ipAddress });
 		return {
 			ok: false,
 			message:
-				"You're sending messages too quickly. Please wait a few seconds and try again.",
+				"Chat support is experiencing unusually high volume. Please try again later or email contact@llmgateway.io.",
 		};
 	}
-	const hourOk = await checkRateLimit(
-		identifier,
-		"hour",
-		RATE_LIMIT_MAX,
+
+	return { ok: true };
+}
+
+// Shared limiter for the cheap DB-backed endpoints. One bucket across all of
+// them: none is expensive on its own, the goal is just to stop hammering.
+async function checkMetaRateLimit(ipAddress: string): Promise<boolean> {
+	const burstOk = await checkRateLimit(
+		`ip:${ipAddress}`,
+		"meta_burst",
+		META_BURST_LIMIT_MAX,
+		BURST_LIMIT_WINDOW_SECONDS,
+	);
+	if (!burstOk) {
+		return false;
+	}
+	return await checkRateLimit(
+		`ip:${ipAddress}`,
+		"meta_hour",
+		META_HOURLY_LIMIT_MAX,
 		RATE_LIMIT_WINDOW_SECONDS,
 	);
-	if (!hourOk) {
-		return {
-			ok: false,
-			message: "Too many messages. Please try again later (max 20 per hour).",
-		};
-	}
-	return { ok: true };
 }
 
 function getTextFromUIMessage(message: UIMessage): string {
@@ -304,11 +393,6 @@ export const publicChatSupport = new Hono<ServerTypes>();
 
 publicChatSupport.post("/", async (c) => {
 	const ipAddress = extractClientIP(c) ?? "unknown";
-	const rateLimit = await checkMessageRateLimit(ipAddress);
-
-	if (!rateLimit.ok) {
-		return c.json({ error: rateLimit.message }, 429);
-	}
 
 	const body = await c.req.json<{
 		messages: UIMessage[];
@@ -320,6 +404,11 @@ publicChatSupport.post("/", async (c) => {
 
 	if (!clientId || typeof clientId !== "string" || clientId.length > 64) {
 		return c.json({ error: "Missing or invalid clientId" }, 400);
+	}
+
+	const rateLimit = await checkMessageRateLimit(ipAddress, clientId);
+	if (!rateLimit.ok) {
+		return c.json({ error: rateLimit.message }, 429);
 	}
 
 	if (!messages || !Array.isArray(messages) || messages.length === 0) {
@@ -488,6 +577,10 @@ publicChatSupport.post("/", async (c) => {
 // can restore history across reloads and surface admin replies. Archived
 // conversations resolve to an empty result — they are hidden from the visitor.
 publicChatSupport.get("/conversation", async (c) => {
+	if (!(await checkMetaRateLimit(extractClientIP(c) ?? "unknown"))) {
+		return c.json({ error: "Too many requests. Please try again later." }, 429);
+	}
+
 	const clientId = c.req.query("clientId");
 	if (!clientId || clientId.length > 64) {
 		return c.json({ error: "Missing or invalid clientId" }, 400);
@@ -551,6 +644,10 @@ publicChatSupport.get("/conversation", async (c) => {
 
 // Records a thumbs up/down on a specific assistant message.
 publicChatSupport.post("/reaction", async (c) => {
+	if (!(await checkMetaRateLimit(extractClientIP(c) ?? "unknown"))) {
+		return c.json({ error: "Too many requests. Please try again later." }, 429);
+	}
+
 	const body = await c.req.json<{
 		clientId?: string;
 		sequence?: number;
@@ -595,6 +692,10 @@ publicChatSupport.post("/reaction", async (c) => {
 
 // Lets the visitor resolve their conversation and rate it from 0 to 5 stars.
 publicChatSupport.post("/resolve", async (c) => {
+	if (!(await checkMetaRateLimit(extractClientIP(c) ?? "unknown"))) {
+		return c.json({ error: "Too many requests. Please try again later." }, 429);
+	}
+
 	const body = await c.req.json<{
 		clientId?: string;
 		rating?: number;
@@ -629,16 +730,37 @@ publicChatSupport.post("/resolve", async (c) => {
 
 publicChatSupport.post("/escalate", async (c) => {
 	const ipAddress = extractClientIP(c) ?? "unknown";
-	// Throttle escalation on its own bucket — never the message bucket — so a
+	// Throttle escalation on its own buckets — never the message buckets — so a
 	// visitor who has used up their hourly message quota can still reach a human.
-	const canSubmit = await checkRateLimit(
-		ipAddress,
+	const hourOk = await checkRateLimit(
+		`ip:${ipAddress}`,
 		"escalate",
 		RATE_LIMIT_MAX,
 		RATE_LIMIT_WINDOW_SECONDS,
 	);
+	const dayOk =
+		hourOk &&
+		(await checkRateLimit(
+			`ip:${ipAddress}`,
+			"escalate_day",
+			ESCALATE_DAILY_LIMIT_MAX,
+			DAILY_LIMIT_WINDOW_SECONDS,
+		));
+	const globalOk =
+		dayOk &&
+		(await checkRateLimit(
+			"all",
+			"escalate_global_day",
+			ESCALATE_GLOBAL_DAILY_LIMIT_MAX,
+			DAILY_LIMIT_WINDOW_SECONDS,
+		));
 
-	if (!canSubmit) {
+	if (!globalOk) {
+		if (dayOk) {
+			logger.warn("Chat support global escalation limit reached", {
+				ipAddress,
+			});
+		}
 		return c.json({ error: "Too many requests. Please try again later." }, 429);
 	}
 

--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -406,11 +406,6 @@ publicChatSupport.post("/", async (c) => {
 		return c.json({ error: "Missing or invalid clientId" }, 400);
 	}
 
-	const rateLimit = await checkMessageRateLimit(ipAddress, clientId);
-	if (!rateLimit.ok) {
-		return c.json({ error: rateLimit.message }, 429);
-	}
-
 	if (!messages || !Array.isArray(messages) || messages.length === 0) {
 		return c.json({ error: "Missing messages" }, 400);
 	}
@@ -420,6 +415,14 @@ publicChatSupport.post("/", async (c) => {
 	if (messages.length > 100) {
 		return c.json({ error: "Too many messages in conversation" }, 400);
 	}
+
+	// Checked only after validation so malformed requests can't consume the
+	// per-identifier buckets — or worse, trip the global breaker for free.
+	const rateLimit = await checkMessageRateLimit(ipAddress, clientId);
+	if (!rateLimit.ok) {
+		return c.json({ error: rateLimit.message }, 429);
+	}
+
 	const contextMessages = messages.slice(-MAX_CONTEXT_MESSAGES);
 
 	const userAgent = c.req.header("User-Agent");
@@ -746,21 +749,8 @@ publicChatSupport.post("/escalate", async (c) => {
 			ESCALATE_DAILY_LIMIT_MAX,
 			DAILY_LIMIT_WINDOW_SECONDS,
 		));
-	const globalOk =
-		dayOk &&
-		(await checkRateLimit(
-			"all",
-			"escalate_global_day",
-			ESCALATE_GLOBAL_DAILY_LIMIT_MAX,
-			DAILY_LIMIT_WINDOW_SECONDS,
-		));
 
-	if (!globalOk) {
-		if (dayOk) {
-			logger.warn("Chat support global escalation limit reached", {
-				ipAddress,
-			});
-		}
+	if (!dayOk) {
 		return c.json({ error: "Too many requests. Please try again later." }, 429);
 	}
 
@@ -793,6 +783,22 @@ publicChatSupport.post("/escalate", async (c) => {
 
 	if (existing[0]?.escalatedAt) {
 		return c.json({ success: true, message: "Already escalated." });
+	}
+
+	// Checked only once we know a new escalation will actually be sent, so
+	// malformed requests and already-escalated retries don't spend the global
+	// cap. Each escalation past this point costs an email and a Discord ping.
+	const globalOk = await checkRateLimit(
+		"all",
+		"escalate_global_day",
+		ESCALATE_GLOBAL_DAILY_LIMIT_MAX,
+		DAILY_LIMIT_WINDOW_SECONDS,
+	);
+	if (!globalOk) {
+		logger.warn("Chat support global escalation limit reached", {
+			ipAddress,
+		});
+		return c.json({ error: "Too many requests. Please try again later." }, 429);
 	}
 
 	await db

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -15,6 +15,56 @@ import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 export const runtime = "nodejs";
 export const maxDuration = 300;
 
+// Ask AI is public, anonymous and spends LLM credits on every call, so it
+// gets per-IP limits plus a global circuit breaker (per-IP buckets alone are
+// defeated by rotating addresses). The docs app has no Redis and the
+// standalone Next server runs as a single instance, so an in-memory sliding
+// window is sufficient.
+const BURST_LIMIT_MAX = 3;
+const BURST_LIMIT_WINDOW_MS = 20_000;
+const HOURLY_LIMIT_MAX = 30;
+const HOURLY_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const GLOBAL_HOURLY_LIMIT_MAX = 300;
+const MAX_MESSAGES = 50;
+
+const rateLimitHits = new Map<string, number[]>();
+
+function isAllowed(key: string, max: number, windowMs: number): boolean {
+	const now = Date.now();
+	pruneRateLimitHits(now);
+	const hits = (rateLimitHits.get(key) ?? []).filter((t) => now - t < windowMs);
+	if (hits.length >= max) {
+		rateLimitHits.set(key, hits);
+		return false;
+	}
+	hits.push(now);
+	rateLimitHits.set(key, hits);
+	return true;
+}
+
+// Bounds memory when an attacker rotates IPs: once the map grows past the
+// threshold, drop every entry whose hits have all aged out of the widest
+// window.
+function pruneRateLimitHits(now: number): void {
+	if (rateLimitHits.size < 10_000) {
+		return;
+	}
+	for (const [key, hits] of rateLimitHits) {
+		if (hits.every((t) => now - t >= HOURLY_LIMIT_WINDOW_MS)) {
+			rateLimitHits.delete(key);
+		}
+	}
+}
+
+function extractClientIP(req: Request): string {
+	return (
+		req.headers.get("cf-connecting-ip") ??
+		req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+		req.headers.get("x-real-ip") ??
+		"unknown"
+	);
+}
+
 interface CustomDocument extends DocumentData {
 	url: string;
 	title: string;
@@ -111,6 +161,34 @@ export async function POST(req: Request) {
 		);
 	}
 
+	// Narrower windows first so a blocked request doesn't consume the wider
+	// quotas; the global bucket last so per-IP rejections don't eat into it.
+	const ip = extractClientIP(req);
+	if (!isAllowed(`burst:${ip}`, BURST_LIMIT_MAX, BURST_LIMIT_WINDOW_MS)) {
+		return Response.json(
+			{
+				error:
+					"You're sending messages too quickly. Please wait a few seconds and try again.",
+			},
+			{ status: 429 },
+		);
+	}
+	if (!isAllowed(`hour:${ip}`, HOURLY_LIMIT_MAX, HOURLY_LIMIT_WINDOW_MS)) {
+		return Response.json(
+			{ error: "Too many messages. Please try again later." },
+			{ status: 429 },
+		);
+	}
+	if (!isAllowed("global", GLOBAL_HOURLY_LIMIT_MAX, HOURLY_LIMIT_WINDOW_MS)) {
+		return Response.json(
+			{
+				error:
+					"Ask AI is experiencing unusually high volume. Please try again later.",
+			},
+			{ status: 429 },
+		);
+	}
+
 	const llmgateway = createLLMGateway({
 		apiKey,
 		baseURL: process.env.GATEWAY_URL ?? "https://api.llmgateway.io/v1",
@@ -120,6 +198,12 @@ export async function POST(req: Request) {
 	});
 
 	const reqJson = (await req.json()) as { messages?: ChatUIMessage[] };
+	if ((reqJson.messages ?? []).length > MAX_MESSAGES) {
+		return Response.json(
+			{ error: "Too many messages in conversation" },
+			{ status: 400 },
+		);
+	}
 
 	const result = streamText({
 		model: llmgateway.chat("auto"),

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -27,33 +27,48 @@ const HOURLY_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const GLOBAL_HOURLY_LIMIT_MAX = 300;
 const MAX_MESSAGES = 50;
 
+// Hard cap on tracked buckets so an attacker rotating IPs can't grow the map
+// with the attack rate: the least-recently-used bucket is evicted as soon as
+// the cap is exceeded (an evicted bucket simply starts fresh). Each check
+// re-inserts its key, so insertion order doubles as recency order.
+const MAX_TRACKED_KEYS = 10_000;
 const rateLimitHits = new Map<string, number[]>();
 
 function isAllowed(key: string, max: number, windowMs: number): boolean {
 	const now = Date.now();
-	pruneRateLimitHits(now);
 	const hits = (rateLimitHits.get(key) ?? []).filter((t) => now - t < windowMs);
+	rateLimitHits.delete(key);
+	rateLimitHits.set(key, hits);
 	if (hits.length >= max) {
-		rateLimitHits.set(key, hits);
 		return false;
 	}
 	hits.push(now);
-	rateLimitHits.set(key, hits);
+	while (rateLimitHits.size > MAX_TRACKED_KEYS) {
+		const oldest = rateLimitHits.keys().next().value;
+		if (oldest === undefined) {
+			break;
+		}
+		rateLimitHits.delete(oldest);
+	}
 	return true;
 }
 
-// Bounds memory when an attacker rotates IPs: once the map grows past the
-// threshold, drop every entry whose hits have all aged out of the widest
-// window.
-function pruneRateLimitHits(now: number): void {
-	if (rateLimitHits.size < 10_000) {
-		return;
+// The global bucket lives outside the evictable map so key churn can never
+// push it out. Timestamps are appended in order, so expiry trims the front.
+const globalHits: number[] = [];
+
+function isGlobalAllowed(max: number, windowMs: number): boolean {
+	const now = Date.now();
+	let first = globalHits[0];
+	while (first !== undefined && now - first >= windowMs) {
+		globalHits.shift();
+		first = globalHits[0];
 	}
-	for (const [key, hits] of rateLimitHits) {
-		if (hits.every((t) => now - t >= HOURLY_LIMIT_WINDOW_MS)) {
-			rateLimitHits.delete(key);
-		}
+	if (globalHits.length >= max) {
+		return false;
 	}
+	globalHits.push(now);
+	return true;
 }
 
 function extractClientIP(req: Request): string {
@@ -179,7 +194,7 @@ export async function POST(req: Request) {
 			{ status: 429 },
 		);
 	}
-	if (!isAllowed("global", GLOBAL_HOURLY_LIMIT_MAX, HOURLY_LIMIT_WINDOW_MS)) {
+	if (!isGlobalAllowed(GLOBAL_HOURLY_LIMIT_MAX, HOURLY_LIMIT_WINDOW_MS)) {
 		return Response.json(
 			{
 				error:


### PR DESCRIPTION
## Why

People are spamming the public support chat. The existing per-IP burst (5/20s) + hourly (20/h) limits don't hold up:

- Per-IP buckets are defeated by rotating IPs, and by spoofed `X-Forwarded-For`/`X-Real-IP` on requests that hit the API directly (the UI proxy strips those, but nothing forces traffic through it).
- 20/hour still allows 480 LLM calls/day from a single address grinding the window.
- `/conversation`, `/reaction` and `/resolve` had no limits at all.
- The docs **Ask AI** route (`apps/docs/app/api/chat`) — a second public endpoint spending LLM credits — had **zero** rate limiting.

## What

### `POST /public/chat-support` (widget messages)
| Layer | Limit |
|---|---|
| Burst per IP **and** per clientId | 5 / 20s (existing, now also keyed by clientId) |
| Hourly per IP and per clientId | 20 / hour (existing, now also keyed by clientId) |
| **Daily per IP and per clientId** | **60 / day** (new) |
| **Global circuit breaker** | **300 / hour, 1500 / day across all visitors** (new) |

The clientId bucket catches bots that rotate IPs while reusing a client identity; the global breakers bound total LLM spend no matter how per-identifier buckets are evaded. Global trips log a warning for visibility. Narrower windows are checked first so blocked requests don't consume wider quotas, and global runs last so per-identifier rejections don't eat everyone else's budget.

### `POST /public/chat-support/escalate`
Kept on its own buckets (so someone out of message quota can still reach a human), now with a daily per-IP cap (10/day) and a global daily cap (50/day) — each escalation sends an email + Discord ping, so a rotating-IP flood could bury the inbox.

### `/conversation`, `/reaction`, `/resolve`
New shared per-IP bucket: 30 / 20s burst + 300 / hour. Generous for humans, stops hammering.

### Docs Ask AI (`apps/docs/app/api/chat/route.ts`)
Per-IP burst (3/20s) + hourly (30/h) + global (300/h) limits, and a 50-message conversation cap. In-memory sliding window since the docs app has no Redis and the standalone Next server runs as a single instance.

## Verification

- New spec `public-chat-support.spec.ts` (4 tests, passing) exercises the limiter through `app.request` without touching DB/LLM.
- Drove the built API on an alternate port with curl: per-IP burst → 429, per-clientId bucket across rotating IPs → 429, unrelated visitors unaffected, rate-limited requests with real message payloads rejected before the LLM path, hourly/daily/global/escalate layers each return their distinct 429 message (verified by seeding Redis counters), meta endpoints 429 after 30 rapid hits on a shared bucket, Redis key TTLs correct (20s/1h/24h).
- Drove the built docs server: 3 requests then 429 on the 4th, per-IP isolation, 51-message conversation → 400.
- `turbo run build --filter=api --filter=docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stronger throttling for chat support and chat API requests, with separate burst, hourly, and daily limits per client and IP, plus global circuit breakers.
  * Added tailored rate limiting for conversation, reaction, resolve, and escalation actions.
  * Enforced a maximum message count for chat API requests.
* **Bug Fixes**
  * Improved handling so invalid requests (e.g., missing required fields) don’t consume rate-limit capacity.
* **Tests**
  * Expanded coverage for rate-limiting behavior across multiple scopes and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->