### PR TITLE
fix: use output tokens for model throughput

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -450,9 +450,9 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalDuration}), 0)`.as(
 					"totalDuration",
 				),
-			totalTokens:
-				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTokens}), 0)`.as(
-					"totalTokens",
+			totalOutputTokens:
+				sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalOutputTokens}), 0)`.as(
+					"totalOutputTokens",
 				),
 		})
 		.from(modelProviderMappingHistory)
@@ -474,7 +474,7 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 		const upstreamErrorsCount = Number(m.upstreamErrorsCount);
 		const cachedCount = Number(m.cachedCount);
 		const totalDuration = Number(m.totalDuration);
-		const totalTokens = Number(m.totalTokens);
+		const totalOutputTokens = Number(m.totalOutputTokens);
 		// Uptime only counts upstream/provider-side failures against the provider —
 		// client errors (4xx from user) or gateway errors aren't the provider's fault.
 		const uptime =
@@ -482,9 +482,12 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 				? Math.round(((logsCount - upstreamErrorsCount) / logsCount) * 1000) /
 					10
 				: null;
+		// Throughput = generated (output) tokens per second of request time.
+		// Prompt tokens must not be counted — they inflate the number by the
+		// prompt/output ratio, which is 30-60x for coding-agent traffic.
 		const tokensPerSecond =
-			totalDuration > 0 && totalTokens > 0
-				? Math.round(totalTokens / (totalDuration / 1000))
+			totalDuration > 0 && totalOutputTokens > 0
+				? Math.round(totalOutputTokens / (totalDuration / 1000))
 				: null;
 		return {
 			providerId: m.providerId,
@@ -655,6 +658,10 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTokens}), 0)`.as(
 						"total_tokens",
 					),
+				totalOutputTokens:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalOutputTokens}), 0)`.as(
+						"total_output_tokens",
+					),
 			})
 			.from(modelProviderMappingHistory)
 			.innerJoin(
@@ -691,6 +698,7 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 				totalDuration: number;
 				totalTimeToFirstToken: number;
 				totalTokens: number;
+				totalOutputTokens: number;
 			}>;
 		}
 	>();
@@ -724,6 +732,7 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			totalDuration: Number(r.totalDuration),
 			totalTimeToFirstToken: Number(r.totalTimeToFirstToken),
 			totalTokens: Number(r.totalTokens),
+			totalOutputTokens: Number(r.totalOutputTokens),
 		});
 		byProvider.set(key, entry);
 	}
@@ -735,7 +744,7 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 		let totalCached = 0;
 		let totalDuration = 0;
 		let totalTtft = 0;
-		let totalTokens = 0;
+		let totalOutputTokens = 0;
 
 		const points = p.points.map((pt) => {
 			totalLogs += pt.logsCount;
@@ -744,7 +753,7 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			totalCached += pt.cachedCount;
 			totalDuration += pt.totalDuration;
 			totalTtft += pt.totalTimeToFirstToken;
-			totalTokens += pt.totalTokens;
+			totalOutputTokens += pt.totalOutputTokens;
 			const nonCached = pt.logsCount - pt.cachedCount;
 			return {
 				timestamp: pt.timestamp,
@@ -770,9 +779,11 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 				? Math.round(((totalLogs - totalUpstreamErrors) / totalLogs) * 1000) /
 					10
 				: null;
+		// Output tokens only — including prompt tokens would inflate throughput
+		// by the prompt/output ratio (see the benchmarks endpoint above).
 		const tokensPerSecond =
 			totalDuration > 0
-				? Math.round(totalTokens / (totalDuration / 1000))
+				? Math.round(totalOutputTokens / (totalDuration / 1000))
 				: null;
 
 		return {

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -469,8 +469,8 @@ export function LogDetailClient({
 		Number(log.dataStorageCost) > 0;
 
 	const throughput =
-		log.duration && log.totalTokens
-			? (Number(log.totalTokens) / (log.duration / 1000)).toFixed(1)
+		log.duration && log.completionTokens
+			? (Number(log.completionTokens) / (log.duration / 1000)).toFixed(1)
 			: null;
 
 	return (


### PR DESCRIPTION
## Summary

Throughput (tok/s) on the model pages was wildly inflated — e.g. Sonnet 5 via AWS Bedrock showed **1,845 tok/s** while OpenRouter reports ~38 tps for the same model/provider.

Root cause: the calculation divided `totalTokens` (**prompt + completion**) by request duration. Since most Bedrock traffic is coding agents sending 30–100k-token prompts with small outputs, the number was inflated by the prompt/output ratio (~50x). Industry-standard throughput only counts generated output tokens.

## Changes

- `apps/api/src/routes/internal-models.ts`
  - `/models/{modelId}/benchmarks` (model page benchmark cards): compute `tokensPerSecond` from `totalOutputTokens`
  - `/models/{modelId}/uptime` (uptime page): same fix; the per-point token-volume chart still uses total tokens (correct for volume)
- `apps/ui/.../activity/[logId]/log-detail-client.tsx`: per-request throughput now uses `completionTokens` instead of `totalTokens`

The history table already stores `totalOutputTokens`, so no worker or schema changes are needed and the fix applies retroactively to existing data. The providers grid (`public-providers-stats.ts`) and routing metrics (`provider-metrics-history.ts`) already used output tokens and are untouched.

## Notes

Our denominator is total request duration (includes TTFT), so the corrected number reads slightly conservative vs OpenRouter's generation-only throughput. Tighter parity would need the worker to track a clean non-cached generation-time sum — possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjFaXtmU4er5ajjaSUbaqV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Throughput and tokens-per-second metrics now use output/completion tokens, which makes speed calculations more accurate and avoids inflated results from prompt tokens.
  * Updated model benchmark and uptime views to report these metrics consistently across providers and time windows.
  * Log details now show a corrected throughput value when viewing individual activity records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->