### PR TITLE
fix: track chat plan refunds like devpass

### DIFF
--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -944,4 +944,111 @@ describe("handleChargeRefunded — dev plan refund tracking", () => {
 		});
 		expect(refunds).toHaveLength(1);
 	});
+
+	test("records a refund for a chat_plan_start that stored only the invoice id", async () => {
+		// Chat plan checkout records chat_plan_start with the invoice id but no
+		// payment intent, exactly like DevPass. The handler must resolve the invoice
+		// and record the refund instead of logging "Original transaction not found".
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			stripeCustomerId: "cus_chat_refund",
+			chatPlan: "pro",
+			chatPlanCreditsLimit: "100",
+			chatPlanStripeSubscriptionId: SUB_ID,
+		});
+		const [original] = await db
+			.insert(tables.transaction)
+			.values({
+				organizationId: ORG_ID,
+				type: "chat_plan_start",
+				amount: "20",
+				creditAmount: "100",
+				currency: "USD",
+				status: "completed",
+				stripeInvoiceId: "in_chat_refund",
+				description: "Chat Plan PRO started via Stripe Checkout",
+			})
+			.returning();
+
+		stripeMock.invoicePayments.list.mockResolvedValue({
+			data: [{ invoice: "in_chat_refund" }],
+		});
+		stripeMock.refunds.list.mockResolvedValue({
+			data: [{ id: "re_chat_refund", amount: 2000, reason: null }],
+		});
+
+		await handleChargeRefunded(
+			makeChargeRefundedEvent({
+				paymentIntentId: "pi_chat_refund",
+				customer: "cus_chat_refund",
+			}),
+		);
+
+		const refund = await db.query.transaction.findFirst({
+			where: { stripeRefundId: { eq: "re_chat_refund" } },
+		});
+		expect(refund?.type).toBe("credit_refund");
+		expect(refund?.amount).toBe("20");
+		expect(refund?.relatedTransactionId).toBe(original.id);
+
+		// Chat plans use virtual plan credits, so the refund must not deduct from the
+		// org's pay-as-you-go credit balance.
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.credits).toBe("0");
+	});
+
+	test("records a refund for a chat_plan_upgrade paid mid-cycle charge", async () => {
+		// A mid-cycle chat plan upgrade is recorded by the invoice.payment_succeeded
+		// webhook with the proration invoice's payment intent and invoice id, so a
+		// refund of that charge resolves directly by payment intent.
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			stripeCustomerId: "cus_chat_upgrade_refund",
+			chatPlan: "pro",
+			chatPlanCreditsLimit: "100",
+			chatPlanStripeSubscriptionId: SUB_ID,
+		});
+		const [original] = await db
+			.insert(tables.transaction)
+			.values({
+				organizationId: ORG_ID,
+				type: "chat_plan_upgrade",
+				amount: "10",
+				currency: "USD",
+				status: "completed",
+				stripeInvoiceId: "in_chat_upgrade",
+				stripePaymentIntentId: "pi_chat_upgrade",
+				description: "Chat Plan PRO upgrade",
+			})
+			.returning();
+
+		stripeMock.refunds.list.mockResolvedValue({
+			data: [{ id: "re_chat_upgrade", amount: 1000, reason: null }],
+		});
+
+		await handleChargeRefunded(
+			makeChargeRefundedEvent({
+				paymentIntentId: "pi_chat_upgrade",
+				customer: "cus_chat_upgrade_refund",
+			}),
+		);
+
+		const refund = await db.query.transaction.findFirst({
+			where: { stripeRefundId: { eq: "re_chat_upgrade" } },
+		});
+		expect(refund?.type).toBe("credit_refund");
+		expect(refund?.amount).toBe("10");
+		expect(refund?.relatedTransactionId).toBe(original.id);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.credits).toBe("0");
+	});
 });

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -2842,12 +2842,18 @@ export async function handleChargeRefunded(
 		| "dev_plan_start"
 		| "dev_plan_renewal"
 		| "dev_plan_upgrade"
+		| "chat_plan_start"
+		| "chat_plan_renewal"
+		| "chat_plan_upgrade"
 		| "subscription_start"
 	)[] = [
 		"credit_topup",
 		"dev_plan_start",
 		"dev_plan_renewal",
 		"dev_plan_upgrade",
+		"chat_plan_start",
+		"chat_plan_renewal",
+		"chat_plan_upgrade",
 		"subscription_start",
 	];
 
@@ -2934,9 +2940,10 @@ export async function handleChargeRefunded(
 	);
 
 	// Only credit_topup purchases add to organization.credits, so only those
-	// refunds should deduct credits back. Dev plan and subscription refunds
-	// are recorded for revenue reporting only — the subscription cancel/end
-	// webhooks handle the plan state changes separately.
+	// refunds should deduct credits back. Dev plan, chat plan, and subscription
+	// refunds are recorded for revenue reporting only — those plans use virtual
+	// plan credits, and the subscription cancel/end webhooks handle the plan
+	// state changes separately.
 	const isCreditTopup = originalTransaction.type === "credit_topup";
 
 	// Calculate proportional credit refund


### PR DESCRIPTION
## Problem

Production logged:

> `Original transaction not found for payment intent: pi_… (invoice: in_…)`

Chat plan refunds were never recorded. When a `charge.refunded` webhook arrives for a chat plan invoice, `handleChargeRefunded` looks up the original transaction — but its `refundableTypes` allowlist (which gates both the payment-intent lookup and the invoice-id fallback) only contained credit top-up, DevPass, and subscription types, **not** `chat_plan_*`. So the chat plan transaction was filtered out of both lookups, the handler bailed with the error above, and no `credit_refund` row was written.

## Fix

Add `chat_plan_start`, `chat_plan_renewal`, and `chat_plan_upgrade` to the `refundableTypes` allowlist, mirroring the DevPass set. All three chat plan payment transactions already persist the Stripe invoice id / payment intent:

- `chat_plan_start` — recorded on `checkout.session.completed` with the invoice id
- `chat_plan_renewal` — recorded on `invoice.payment_succeeded` with payment intent + invoice id
- `chat_plan_upgrade` — recorded on `invoice.payment_succeeded` (the `isChatPlanUpgradeInvoice` branch) with payment intent + invoice id

so the existing lookup resolves them once the types are on the allowlist — no other changes needed. Chat plans use virtual plan credits (not `organization.credits`), so like DevPass/subscription refunds these are recorded for revenue reporting only and don't deduct from the pay-as-you-go balance (guarded by the existing `isCreditTopup` check).

## Testing

- Added unit tests for a `chat_plan_start` refund (resolved via invoice id) and a `chat_plan_upgrade` refund (resolved via payment intent): each records a `credit_refund` linked to the original transaction and leaves `organization.credits` untouched.
- `pnpm vitest run apps/api/src/stripe.spec.ts -t "refund"` — 4 passed.
- `pnpm format` and `pnpm turbo run build --filter=api` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refunds for chat plan charges are now tracked correctly, including start, renewal, and upgrade payments.
  * Refund events can now be matched even when only invoice details are available, helping ensure the correct original charge is found.
  * Chat plan refunds are recorded without changing the org’s credit balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->