### PR TITLE
fix(auth): address SSO/SCIM review feedback

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -33,19 +33,44 @@ const isHosted = process.env.HOSTED === "true";
 async function isSSOEnforcedForEmail(
 	email: string | null | undefined,
 ): Promise<boolean> {
+	// Keep enforcement tied to the same flag that surfaces the SSO sign-in entry
+	// point: with SSO_ENABLED off there's no way to sign in via SSO, so blocking
+	// password/social/passkey would just lock the domain out entirely.
+	if (process.env.SSO_ENABLED !== "true") {
+		return false;
+	}
+
 	const domain = email?.trim().toLowerCase().split("@")[1];
 	if (!domain) {
 		return false;
 	}
 	const providers = await db.query.ssoProvider.findMany({
 		where: { enforced: { eq: true } },
-		columns: { domain: true },
+		columns: { domain: true, organizationId: true },
 	});
-	return providers.some((provider) =>
-		provider.domain
-			.split(",")
-			.map((d) => d.trim().toLowerCase())
-			.includes(domain),
+	const matching = providers.filter(
+		(provider) =>
+			provider.organizationId &&
+			provider.domain
+				.split(",")
+				.map((d) => d.trim().toLowerCase())
+				.includes(domain),
+	);
+	if (!matching.length) {
+		return false;
+	}
+
+	// Only an active, enterprise org can enforce SSO. A soft-deleted org can no
+	// longer be managed to turn enforcement off, so a stale enforced row must not
+	// keep blocking a domain's users forever.
+	const orgs = await db.query.organization.findMany({
+		where: {
+			id: { in: [...new Set(matching.map((p) => p.organizationId as string))] },
+		},
+		columns: { status: true, plan: true },
+	});
+	return orgs.some(
+		(org) => org.status !== "deleted" && org.plan === "enterprise",
 	);
 }
 
@@ -1060,9 +1085,12 @@ The LLM Gateway Team`.trim();
 						!ctx.path.startsWith("/sso/") &&
 						(await isSSOEnforcedForEmail(dbUser?.email))
 					) {
+						// Delete only the session this blocked attempt just created — not
+						// every session for the user — so a rejected social/passkey login
+						// doesn't also sign them out of valid SSO sessions elsewhere.
 						await db
 							.delete(tables.session)
-							.where(eq(tables.session.userId, userId));
+							.where(eq(tables.session.id, newSession.session.id));
 						return ssoRequiredResponse();
 					}
 

--- a/apps/api/src/auth/handler.spec.ts
+++ b/apps/api/src/auth/handler.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+
+// Better Auth's sso() plugin mounts its own provider-management endpoints under
+// the /auth/* catch-all. They only require a session, so `handler.ts` blocks
+// direct HTTP access to them (see BLOCKED_SSO_PLUGIN_PATHS) — our own
+// enterprise/admin-gated wrapper lives at /sso and calls the plugin via
+// `apiAuth.api.*`, which bypasses this handler entirely.
+const BLOCKED_PATHS = [
+	"/auth/sso/register",
+	"/auth/sso/update-provider",
+	"/auth/sso/delete-provider",
+	"/auth/sso/get-provider",
+	"/auth/sso/providers",
+	"/auth/sso/request-domain-verification",
+	"/auth/sso/verify-domain",
+];
+
+// Paths the login flow needs must NOT be blocked by us; they pass through to
+// Better Auth's handler.
+const ALLOWED_PATHS = [
+	"/auth/sign-in/sso",
+	"/auth/sso/callback",
+	"/auth/sso/saml2/sp/metadata",
+];
+
+const BLOCK_BODY = { error: "not_found", message: "Not found" };
+
+// Our block responds with exactly this 404 JSON, distinct from any 404 Better
+// Auth itself might return, so allowed paths can be told apart from blocked.
+function isOurBlock(status: number, body: unknown): boolean {
+	return (
+		status === 404 &&
+		!!body &&
+		typeof body === "object" &&
+		(body as { error?: string }).error === "not_found" &&
+		(body as { message?: string }).message === "Not found"
+	);
+}
+
+describe("SSO plugin management endpoint blocking", () => {
+	test.each(BLOCKED_PATHS)("blocks POST %s with 404", async (path) => {
+		const response = await app.request(path, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "{}",
+		});
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual(BLOCK_BODY);
+	});
+
+	test.each(BLOCKED_PATHS)("blocks GET %s with 404", async (path) => {
+		const response = await app.request(path, { method: "GET" });
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual(BLOCK_BODY);
+	});
+
+	test("blocks even with a query string", async () => {
+		const response = await app.request(
+			"/auth/sso/get-provider?providerId=acme",
+			{ method: "GET" },
+		);
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual(BLOCK_BODY);
+	});
+
+	test("does not block an unrelated /auth path", async () => {
+		const response = await app.request("/auth/ok", { method: "GET" });
+		const body = await response.json().catch(() => null);
+
+		expect(isOurBlock(response.status, body)).toBe(false);
+	});
+
+	test.each(ALLOWED_PATHS)(
+		"does not block the login-flow path %s",
+		async (path) => {
+			const response = await app.request(path, { method: "GET" });
+			const body = await response.json().catch(() => null);
+
+			// Reached Better Auth (any status/body) rather than our 404 sentinel.
+			expect(isOurBlock(response.status, body)).toBe(false);
+		},
+	);
+});

--- a/apps/api/src/auth/handler.ts
+++ b/apps/api/src/auth/handler.ts
@@ -7,6 +7,25 @@ import type { ServerTypes } from "@/vars.js";
 // Create a Hono app for auth routes
 export const authHandler = new OpenAPIHono<ServerTypes>();
 
+// Better Auth's sso() plugin mounts its own provider-management endpoints under
+// the /auth/* catch-all. They only require a session (any authenticated user),
+// so exposing them would let a user bypass the enterprise/admin-gated /sso
+// wrapper and register a provider — claiming any email domain — with no
+// organization scoping. Block direct HTTP access to them here; our server-side
+// registration calls `apiAuth.api.registerSSOProvider` directly and never goes
+// through this handler, so it is unaffected. The SAML sign-in/callback/metadata
+// endpoints (/auth/sso/saml2/*, /auth/sso/callback, /auth/sign-in/sso) are left
+// reachable because the login flow needs them.
+const BLOCKED_SSO_PLUGIN_PATHS = new Set([
+	"/auth/sso/register",
+	"/auth/sso/update-provider",
+	"/auth/sso/delete-provider",
+	"/auth/sso/get-provider",
+	"/auth/sso/providers",
+	"/auth/sso/request-domain-verification",
+	"/auth/sso/verify-domain",
+]);
+
 authHandler.use("*", async (c, next) => {
 	const session = await apiAuth.api.getSession({ headers: c.req.raw.headers });
 
@@ -22,5 +41,8 @@ authHandler.use("*", async (c, next) => {
 });
 
 authHandler.on(["POST", "GET"], "/auth/*", (c) => {
+	if (BLOCKED_SSO_PLUGIN_PATHS.has(new URL(c.req.url).pathname)) {
+		return c.json({ error: "not_found", message: "Not found" }, 404);
+	}
 	return apiAuth.handler(c.req.raw);
 });

--- a/apps/api/src/lib/sso-roles.ts
+++ b/apps/api/src/lib/sso-roles.ts
@@ -1,0 +1,111 @@
+import { db, eq, tables } from "@llmgateway/db";
+
+export type OrgRole = "owner" | "admin" | "developer";
+
+export interface RoleChange {
+	old: OrgRole;
+	new: OrgRole;
+}
+
+const ROLE_RANK: Record<OrgRole, number> = {
+	developer: 1,
+	admin: 2,
+	owner: 3,
+};
+
+// Recompute an org member's role from their SCIM group memberships and the
+// org's group->role mappings. The highest-precedence mapped role wins; the
+// default is `developer`. Owners are never auto-demoted — owner is only ever
+// assigned manually (or by an explicit owner mapping), so an admin who set up
+// SSO can't be locked out by a group that maps to a lower role.
+//
+// Returns the {old,new} role change when it updated the membership, or null
+// when nothing changed, so callers (e.g. SCIM) can audit the transition.
+export async function recomputeUserRole(
+	userId: string,
+	organizationId: string,
+): Promise<RoleChange | null> {
+	const membership = await db.query.userOrganization.findFirst({
+		where: {
+			userId: { eq: userId },
+			organizationId: { eq: organizationId },
+		},
+		columns: { id: true, role: true },
+	});
+	if (!membership) {
+		return null;
+	}
+
+	const groupMemberships = await db.query.scimGroupMember.findMany({
+		where: { userId: { eq: userId } },
+		columns: { scimGroupId: true },
+	});
+	const groupIds = groupMemberships.map((m) => m.scimGroupId);
+
+	let mappedRole: OrgRole = "developer";
+	if (groupIds.length) {
+		const groups = await db.query.scimGroup.findMany({
+			where: {
+				id: { in: groupIds },
+				organizationId: { eq: organizationId },
+			},
+			columns: { displayName: true },
+		});
+		const names = groups.map((g) => g.displayName);
+		if (names.length) {
+			const mappings = await db.query.ssoRoleMapping.findMany({
+				where: {
+					organizationId: { eq: organizationId },
+					groupName: { in: names },
+				},
+				columns: { role: true },
+			});
+			for (const mapping of mappings) {
+				if (ROLE_RANK[mapping.role] > ROLE_RANK[mappedRole]) {
+					mappedRole = mapping.role;
+				}
+			}
+		}
+	}
+
+	if (membership.role === "owner" && ROLE_RANK[mappedRole] < ROLE_RANK.owner) {
+		return null;
+	}
+	if (membership.role !== mappedRole) {
+		await db
+			.update(tables.userOrganization)
+			.set({ role: mappedRole })
+			.where(eq(tables.userOrganization.id, membership.id));
+		return { old: membership.role, new: mappedRole };
+	}
+	return null;
+}
+
+// Recompute the role of every member of the SCIM group(s) with `groupName` in
+// this org. Used when a role mapping is added or removed after the IdP has
+// already pushed the group and its members, so existing members pick up (or
+// lose) the mapped role without waiting for a later SCIM membership event.
+export async function recomputeRoleForGroupName(
+	organizationId: string,
+	groupName: string,
+) {
+	const groups = await db.query.scimGroup.findMany({
+		where: {
+			organizationId: { eq: organizationId },
+			displayName: { eq: groupName },
+		},
+		columns: { id: true },
+	});
+	if (!groups.length) {
+		return;
+	}
+
+	const members = await db.query.scimGroupMember.findMany({
+		where: { scimGroupId: { in: groups.map((g) => g.id) } },
+		columns: { userId: true },
+	});
+	const userIds = [...new Set(members.map((m) => m.userId))];
+	for (const userId of userIds) {
+		await recomputeUserRole(userId, organizationId);
+	}
+}

--- a/apps/api/src/routes/scim.ts
+++ b/apps/api/src/routes/scim.ts
@@ -3,10 +3,12 @@ import { Hono } from "hono";
 import { getApiBaseUrl } from "@/lib/api-url.js";
 import { revokeMemberApiKeys } from "@/lib/revoke-member-api-keys.js";
 import { resolveDefaultProjectIds } from "@/lib/sso-default-projects.js";
+import { recomputeUserRole as applyUserRole } from "@/lib/sso-roles.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
 	and,
+	count,
 	db,
 	eq,
 	tables,
@@ -290,41 +292,74 @@ function parseEqFilter(
 scim.get("/Users", async (c) => {
 	const orgId = c.get("scimOrgId");
 	const startIndex = Math.max(1, Number(c.req.query("startIndex")) || 1);
-	const count = Math.min(200, Math.max(0, Number(c.req.query("count")) || 100));
+	const perPage = Math.min(
+		200,
+		Math.max(0, Number(c.req.query("count")) || 100),
+	);
 	const filter = c.req.query("filter");
 	const emailFilter = parseEqFilter(filter, "userName");
 	const externalIdFilter = parseEqFilter(filter, "externalId");
 
+	// IdPs poll with an `eq` filter to check whether a specific user already
+	// exists; resolve that with a single targeted lookup instead of scanning the
+	// whole directory.
+	if (emailFilter || externalIdFilter) {
+		const membership = await db.query.userOrganization.findFirst({
+			where: {
+				organizationId: { eq: orgId },
+				...(externalIdFilter
+					? { scimExternalId: { eq: externalIdFilter } }
+					: {}),
+			},
+			columns: { scimExternalId: true },
+			with: { user: { columns: { id: true, email: true, name: true } } },
+		});
+		const match =
+			membership?.user &&
+			(!emailFilter ||
+				membership.user.email.toLowerCase() === emailFilter.toLowerCase())
+				? membership
+				: null;
+		const resources =
+			match && match.user
+				? [toScimUser(match.user, true, match.scimExternalId)]
+				: [];
+		return scimJson({
+			schemas: [SCHEMA_LIST],
+			totalResults: resources.length,
+			startIndex,
+			itemsPerPage: resources.length,
+			Resources: resources,
+		});
+	}
+
+	const [{ total }] = await db
+		.select({ total: count() })
+		.from(tables.userOrganization)
+		.where(eq(tables.userOrganization.organizationId, orgId));
+
 	const memberships = await db.query.userOrganization.findMany({
 		where: { organizationId: { eq: orgId } },
-		columns: { id: true, scimExternalId: true },
-		with: {
-			user: { columns: { id: true, email: true, name: true } },
-		},
+		columns: { scimExternalId: true },
+		with: { user: { columns: { id: true, email: true, name: true } } },
+		orderBy: { createdAt: "asc" },
+		limit: perPage,
+		offset: startIndex - 1,
 	});
 
-	let rows = memberships
+	const rows = memberships
 		.filter((m) => m.user)
 		.map((m) => ({
 			user: m.user as ScimUserRow,
 			externalId: m.scimExternalId,
 		}));
 
-	if (emailFilter) {
-		const needle = emailFilter.toLowerCase();
-		rows = rows.filter((r) => r.user.email.toLowerCase() === needle);
-	} else if (externalIdFilter) {
-		rows = rows.filter((r) => r.externalId === externalIdFilter);
-	}
-
-	const page = rows.slice(startIndex - 1, startIndex - 1 + count);
-
 	return scimJson({
 		schemas: [SCHEMA_LIST],
-		totalResults: rows.length,
+		totalResults: total,
 		startIndex,
-		itemsPerPage: page.length,
-		Resources: page.map((r) => toScimUser(r.user, true, r.externalId)),
+		itemsPerPage: rows.length,
+		Resources: rows.map((r) => toScimUser(r.user, true, r.externalId)),
 	});
 });
 
@@ -337,12 +372,14 @@ scim.get("/Users/:id", async (c) => {
 		columns: { id: true, email: true, name: true },
 	});
 
-	if (!user) {
+	// Scope to the token's org: a user outside this org isn't a resource this
+	// token can see, so don't leak their email/name.
+	const membership = user ? await getMembership(user.id, orgId) : null;
+	if (!user || !membership) {
 		return scimError(404, "User not found");
 	}
 
-	const membership = await getMembership(user.id, orgId);
-	return scimJson(toScimUser(user, !!membership, membership?.scimExternalId));
+	return scimJson(toScimUser(user, true, membership.scimExternalId));
 });
 
 interface ScimUserPayload {
@@ -426,30 +463,38 @@ scim.post("/Users", async (c) => {
 		// sign-in instead.
 	}
 
-	const [membership] = await db
-		.insert(tables.userOrganization)
-		.values({
-			userId: user.id,
-			organizationId: orgId,
-			role: "developer",
-			scimExternalId: payload.externalId ?? null,
-		})
-		.returning({ id: tables.userOrganization.id });
+	// Okta can create a user with `active: false` (a staged/suspended
+	// assignment). Since deactivation is modeled by removing org membership, an
+	// inactive create must not grant membership (and thus SSO eligibility) until
+	// a later activation.
+	const active =
+		payload.active === undefined ? true : parseScimBoolean(payload.active);
+	if (active) {
+		const [membership] = await db
+			.insert(tables.userOrganization)
+			.values({
+				userId: user.id,
+				organizationId: orgId,
+				role: "developer",
+				scimExternalId: payload.externalId ?? null,
+			})
+			.returning({ id: tables.userOrganization.id });
 
-	await grantDefaultProjects(membership.id, orgId);
+		await grantDefaultProjects(membership.id, orgId);
 
-	await logScimAudit(c, {
-		action: "scim.user.provision",
-		resourceType: "scim_user",
-		resourceId: user.id,
-		targetUser: user,
-		metadata: { resourceName: user.email },
-	});
+		await logScimAudit(c, {
+			action: "scim.user.provision",
+			resourceType: "scim_user",
+			resourceId: user.id,
+			targetUser: user,
+			metadata: { resourceName: user.email },
+		});
 
-	// Apply any role mapping in case the user is already referenced by a group.
-	await recomputeUserRole(c, user.id, orgId);
+		// Apply any role mapping in case the user is already referenced by a group.
+		await recomputeUserRole(c, user.id, orgId);
+	}
 
-	return scimJson(toScimUser(user, true, payload.externalId), 201);
+	return scimJson(toScimUser(user, active, payload.externalId), 201);
 });
 
 // Grant a freshly-created membership the org's default project access. Owners/
@@ -470,7 +515,39 @@ async function grantDefaultProjects(
 		.onConflictDoNothing();
 }
 
-async function removeMembership(userId: string, organizationId: string) {
+// Returns true when the membership was removed, false when it was skipped
+// (last owner) so callers don't record a deactivation that didn't happen.
+async function removeMembership(
+	userId: string,
+	organizationId: string,
+): Promise<boolean> {
+	// Mirror the team-removal guard: never let SCIM deprovisioning delete the
+	// org's last owner, which would leave nobody able to manage billing, SSO or
+	// team settings. Skip (rather than error) so the IdP sync doesn't loop.
+	const membership = await db.query.userOrganization.findFirst({
+		where: {
+			userId: { eq: userId },
+			organizationId: { eq: organizationId },
+		},
+		columns: { role: true },
+	});
+	if (membership?.role === "owner") {
+		const owners = await db.query.userOrganization.findMany({
+			where: {
+				organizationId: { eq: organizationId },
+				role: { eq: "owner" },
+			},
+			columns: { id: true },
+		});
+		if (owners.length <= 1) {
+			logger.warn("SCIM: refusing to remove the last owner", {
+				organizationId,
+				userId,
+			});
+			return false;
+		}
+	}
+
 	await db
 		.delete(tables.userOrganization)
 		.where(
@@ -482,6 +559,7 @@ async function removeMembership(userId: string, organizationId: string) {
 	// Revoke the deprovisioned member's API keys so access actually stops; the
 	// gateway does not re-check org membership on each request.
 	await revokeMemberApiKeys(userId, organizationId);
+	return true;
 }
 
 // Returns true when a new org membership was created (the member was
@@ -514,89 +592,32 @@ async function ensureMembership(
 	return false;
 }
 
-type OrgRole = "owner" | "admin" | "developer";
-const ROLE_RANK: Record<OrgRole, number> = {
-	developer: 1,
-	admin: 2,
-	owner: 3,
-};
-
-// Recompute an org member's role from their SCIM group memberships and the
-// org's group->role mappings. The highest-precedence mapped role wins; the
-// default is `developer`. Owners are never auto-demoted — owner is only ever
-// assigned manually (or by an explicit owner mapping), so an admin who set up
-// SSO can't be locked out by a group that maps to a lower role.
+// Recompute an org member's role from their SCIM group→role mappings (shared
+// with the SSO management routes) and, when it actually changes the role, log
+// the transition against the SCIM request context.
 async function recomputeUserRole(
 	c: Context<ScimVars>,
 	userId: string,
 	organizationId: string,
 ) {
-	const membership = await db.query.userOrganization.findFirst({
-		where: {
-			userId: { eq: userId },
-			organizationId: { eq: organizationId },
+	const change = await applyUserRole(userId, organizationId);
+	if (!change) {
+		return;
+	}
+
+	const target = await db.query.user.findFirst({
+		where: { id: { eq: userId } },
+		columns: { id: true, email: true },
+	});
+	await logScimAudit(c, {
+		action: "scim.user.role_change",
+		resourceType: "scim_user",
+		resourceId: userId,
+		targetUser: target ?? { id: userId },
+		metadata: {
+			changes: { role: { old: change.old, new: change.new } },
 		},
-		columns: { id: true, role: true },
 	});
-	if (!membership) {
-		return;
-	}
-
-	const groupMemberships = await db.query.scimGroupMember.findMany({
-		where: { userId: { eq: userId } },
-		columns: { scimGroupId: true },
-	});
-	const groupIds = groupMemberships.map((m) => m.scimGroupId);
-
-	let mappedRole: OrgRole = "developer";
-	if (groupIds.length) {
-		const groups = await db.query.scimGroup.findMany({
-			where: {
-				id: { in: groupIds },
-				organizationId: { eq: organizationId },
-			},
-			columns: { displayName: true },
-		});
-		const names = groups.map((g) => g.displayName);
-		if (names.length) {
-			const mappings = await db.query.ssoRoleMapping.findMany({
-				where: {
-					organizationId: { eq: organizationId },
-					groupName: { in: names },
-				},
-				columns: { role: true },
-			});
-			for (const mapping of mappings) {
-				if (ROLE_RANK[mapping.role] > ROLE_RANK[mappedRole]) {
-					mappedRole = mapping.role;
-				}
-			}
-		}
-	}
-
-	if (membership.role === "owner" && ROLE_RANK[mappedRole] < ROLE_RANK.owner) {
-		return;
-	}
-	if (membership.role !== mappedRole) {
-		await db
-			.update(tables.userOrganization)
-			.set({ role: mappedRole })
-			.where(eq(tables.userOrganization.id, membership.id));
-
-		const target = await db.query.user.findFirst({
-			where: { id: { eq: userId } },
-			columns: { id: true, email: true },
-		});
-		await logScimAudit(c, {
-			action: "scim.user.role_change",
-			resourceType: "scim_user",
-			resourceId: userId,
-			targetUser: target ?? { id: userId },
-			metadata: {
-				changes: { role: { old: membership.role, new: mappedRole } },
-			},
-		});
-	}
 }
 
 scim.put("/Users/:id", async (c) => {
@@ -617,6 +638,40 @@ scim.put("/Users/:id", async (c) => {
 		return scimError(404, "User not found");
 	}
 
+	const active =
+		payload.active === undefined ? true : parseScimBoolean(payload.active);
+
+	// Deactivation targets an existing member; reject unknown users so a token
+	// can't probe or mutate users outside its org.
+	if (!active) {
+		if (!(await isMember(user.id, orgId))) {
+			return scimError(404, "User not found");
+		}
+		if (await removeMembership(user.id, orgId)) {
+			await logScimAudit(c, {
+				action: "scim.user.deactivate",
+				resourceType: "scim_user",
+				resourceId: user.id,
+				targetUser: user,
+				metadata: { resourceName: user.email },
+			});
+		}
+		return scimJson(toScimUser(user, false));
+	}
+
+	// Activation provisions (or keeps) membership in this org — only then is it
+	// safe to mutate the shared user row, so a foreign token can't rename users
+	// in other orgs.
+	if (await ensureMembership(user.id, orgId, payload.externalId)) {
+		await logScimAudit(c, {
+			action: "scim.user.activate",
+			resourceType: "scim_user",
+			resourceId: user.id,
+			targetUser: user,
+			metadata: { resourceName: user.email },
+		});
+	}
+
 	const oldName = user.name;
 	const name = resolveName(payload);
 	if (name && name !== user.name) {
@@ -634,31 +689,12 @@ scim.put("/Users/:id", async (c) => {
 		});
 	}
 
-	const active =
-		payload.active === undefined ? true : parseScimBoolean(payload.active);
-	if (active) {
-		if (await ensureMembership(user.id, orgId, payload.externalId)) {
-			await logScimAudit(c, {
-				action: "scim.user.activate",
-				resourceType: "scim_user",
-				resourceId: user.id,
-				targetUser: user,
-				metadata: { resourceName: user.email },
-			});
-		}
-	} else if (await isMember(user.id, orgId)) {
-		await removeMembership(user.id, orgId);
-		await logScimAudit(c, {
-			action: "scim.user.deactivate",
-			resourceType: "scim_user",
-			resourceId: user.id,
-			targetUser: user,
-			metadata: { resourceName: user.email },
-		});
-	}
+	// Reactivation via ensureMembership creates a fresh `developer` membership;
+	// re-apply group mappings so a user in an admin/owner group isn't downgraded.
+	await recomputeUserRole(c, user.id, orgId);
 
-	const membership = active ? await getMembership(user.id, orgId) : null;
-	return scimJson(toScimUser(user, active, membership?.scimExternalId));
+	const membership = await getMembership(user.id, orgId);
+	return scimJson(toScimUser(user, true, membership?.scimExternalId));
 });
 
 interface ScimPatchOp {
@@ -713,6 +749,12 @@ scim.patch("/Users/:id", async (c) => {
 		}
 	}
 
+	// A PATCH that neither targets a member nor activates one shouldn't reveal
+	// the user to a foreign token.
+	if (!wasMember && !active) {
+		return scimError(404, "User not found");
+	}
+
 	if (active) {
 		if (await ensureMembership(user.id, orgId)) {
 			await logScimAudit(c, {
@@ -723,15 +765,18 @@ scim.patch("/Users/:id", async (c) => {
 				metadata: { resourceName: user.email },
 			});
 		}
+		// New/reactivated membership defaults to `developer`; re-apply mappings.
+		await recomputeUserRole(c, user.id, orgId);
 	} else if (wasMember) {
-		await removeMembership(user.id, orgId);
-		await logScimAudit(c, {
-			action: "scim.user.deactivate",
-			resourceType: "scim_user",
-			resourceId: user.id,
-			targetUser: user,
-			metadata: { resourceName: user.email },
-		});
+		if (await removeMembership(user.id, orgId)) {
+			await logScimAudit(c, {
+				action: "scim.user.deactivate",
+				resourceType: "scim_user",
+				resourceId: user.id,
+				targetUser: user,
+				metadata: { resourceName: user.email },
+			});
+		}
 	}
 
 	const membership = active ? await getMembership(user.id, orgId) : null;
@@ -752,14 +797,15 @@ scim.delete("/Users/:id", async (c) => {
 	}
 
 	if (await isMember(user.id, orgId)) {
-		await removeMembership(user.id, orgId);
-		await logScimAudit(c, {
-			action: "scim.user.deprovision",
-			resourceType: "scim_user",
-			resourceId: user.id,
-			targetUser: user,
-			metadata: { resourceName: user.email },
-		});
+		if (await removeMembership(user.id, orgId)) {
+			await logScimAudit(c, {
+				action: "scim.user.deprovision",
+				resourceType: "scim_user",
+				resourceId: user.id,
+				targetUser: user,
+				metadata: { resourceName: user.email },
+			});
+		}
 	}
 	return new Response(null, { status: 204 });
 });
@@ -812,11 +858,10 @@ async function addGroupMembers(
 	userIds: string[],
 ) {
 	for (const userId of userIds) {
-		const exists = await db.query.user.findFirst({
-			where: { id: { eq: userId } },
-			columns: { id: true },
-		});
-		if (!exists) {
+		// Only add users who belong to this org: a token for one org must not add
+		// another org's user to a group (which would then leak their email via
+		// toScimGroup).
+		if (!(await isMember(userId, orgId))) {
 			continue;
 		}
 		const present = await db.query.scimGroupMember.findFirst({
@@ -833,6 +878,36 @@ async function addGroupMembers(
 		}
 		await recomputeUserRole(c, userId, orgId);
 	}
+}
+
+// Role mappings match on group displayName, so renaming a group changes which
+// mapping (if any) its members resolve to. Recompute every current member.
+async function recomputeGroupMembers(
+	c: Context<ScimVars>,
+	groupId: string,
+	orgId: string,
+) {
+	for (const userId of await groupMemberUserIds(groupId)) {
+		await recomputeUserRole(c, userId, orgId);
+	}
+}
+
+// displayName must stay unique within an org: role mappings key off it, so a
+// duplicate would make the mapped role for that name ambiguous. `excludeId`
+// skips the group being renamed.
+async function displayNameTaken(
+	orgId: string,
+	displayName: string,
+	excludeId?: string,
+): Promise<boolean> {
+	const existing = await db.query.scimGroup.findFirst({
+		where: {
+			organizationId: { eq: orgId },
+			displayName: { eq: displayName },
+		},
+		columns: { id: true },
+	});
+	return !!existing && existing.id !== excludeId;
 }
 
 async function removeGroupMembers(
@@ -882,29 +957,51 @@ function memberValues(members: { value?: string }[] | undefined): string[] {
 scim.get("/Groups", async (c) => {
 	const orgId = c.get("scimOrgId");
 	const startIndex = Math.max(1, Number(c.req.query("startIndex")) || 1);
-	const count = Math.min(200, Math.max(0, Number(c.req.query("count")) || 100));
+	const perPage = Math.min(
+		200,
+		Math.max(0, Number(c.req.query("count")) || 100),
+	);
 	const filter = c.req.query("filter");
 	const nameMatch = filter?.match(/displayName\s+eq\s+"([^"]+)"/i);
 
-	let groups = await db.query.scimGroup.findMany({
+	// Okta resolves a group by displayName before pushing membership; answer that
+	// with a single targeted lookup rather than scanning every group.
+	if (nameMatch) {
+		const group = await db.query.scimGroup.findFirst({
+			where: {
+				organizationId: { eq: orgId },
+				displayName: { eq: nameMatch[1] },
+			},
+			columns: { id: true, displayName: true, externalId: true },
+		});
+		return scimJson({
+			schemas: [SCHEMA_LIST],
+			totalResults: group ? 1 : 0,
+			startIndex,
+			itemsPerPage: group ? 1 : 0,
+			Resources: group ? [await toScimGroup(group)] : [],
+		});
+	}
+
+	const [{ total }] = await db
+		.select({ total: count() })
+		.from(tables.scimGroup)
+		.where(eq(tables.scimGroup.organizationId, orgId));
+
+	const groups = await db.query.scimGroup.findMany({
 		where: { organizationId: { eq: orgId } },
 		columns: { id: true, displayName: true, externalId: true },
 		orderBy: { createdAt: "desc" },
+		limit: perPage,
+		offset: startIndex - 1,
 	});
-
-	if (nameMatch) {
-		const needle = nameMatch[1].toLowerCase();
-		groups = groups.filter((g) => g.displayName.toLowerCase() === needle);
-	}
-
-	const page = groups.slice(startIndex - 1, startIndex - 1 + count);
 
 	return scimJson({
 		schemas: [SCHEMA_LIST],
-		totalResults: groups.length,
+		totalResults: total,
 		startIndex,
-		itemsPerPage: page.length,
-		Resources: await Promise.all(page.map((g) => toScimGroup(g))),
+		itemsPerPage: groups.length,
+		Resources: await Promise.all(groups.map((g) => toScimGroup(g))),
 	});
 });
 
@@ -931,14 +1028,7 @@ scim.post("/Groups", async (c) => {
 		return scimError(400, "displayName is required");
 	}
 
-	const existing = await db.query.scimGroup.findFirst({
-		where: {
-			organizationId: { eq: orgId },
-			displayName: { eq: payload.displayName },
-		},
-		columns: { id: true },
-	});
-	if (existing) {
+	if (await displayNameTaken(orgId, payload.displayName)) {
 		return scimError(409, "Group already exists");
 	}
 
@@ -987,7 +1077,10 @@ scim.put("/Groups/:id", async (c) => {
 	}
 
 	if (payload.displayName) {
-		await renameGroup(c, group, payload.displayName);
+		const conflict = await renameGroup(c, group, payload.displayName);
+		if (conflict) {
+			return conflict;
+		}
 	}
 
 	await replaceGroupMembers(c, group.id, orgId, memberValues(payload.members));
@@ -1016,13 +1109,19 @@ function patchMemberValues(value: unknown): string[] {
 	return [];
 }
 
+// Renames a group after checking displayName uniqueness. Returns a 409 SCIM
+// error Response when the target name is taken, otherwise null.
 async function renameGroup(
 	c: Context<ScimVars>,
 	group: ScimGroupRow,
 	displayName: string,
-) {
+): Promise<Response | null> {
 	if (displayName === group.displayName) {
-		return;
+		return null;
+	}
+	const orgId = c.get("scimOrgId");
+	if (await displayNameTaken(orgId, displayName, group.id)) {
+		return scimError(409, "A group with this displayName already exists");
 	}
 	const oldName = group.displayName;
 	await db
@@ -1039,6 +1138,9 @@ async function renameGroup(
 			changes: { displayName: { old: oldName, new: displayName } },
 		},
 	});
+	// A rename changes which mapping current members resolve to; recompute them.
+	await recomputeGroupMembers(c, group.id, orgId);
+	return null;
 }
 
 scim.patch("/Groups/:id", async (c) => {
@@ -1091,18 +1193,24 @@ scim.patch("/Groups/:id", async (c) => {
 					patchMemberValues(op.value),
 				);
 			} else if (path === "displayName" && typeof op.value === "string") {
-				await renameGroup(c, group, op.value);
+				const conflict = await renameGroup(c, group, op.value);
+				if (conflict) {
+					return conflict;
+				}
 			} else if (
 				op.value &&
 				typeof op.value === "object" &&
 				"displayName" in op.value &&
 				typeof (op.value as { displayName: unknown }).displayName === "string"
 			) {
-				await renameGroup(
+				const conflict = await renameGroup(
 					c,
 					group,
 					(op.value as { displayName: string }).displayName,
 				);
+				if (conflict) {
+					return conflict;
+				}
 			}
 		}
 	}

--- a/apps/api/src/routes/scim.ts
+++ b/apps/api/src/routes/scim.ts
@@ -303,27 +303,40 @@ scim.get("/Users", async (c) => {
 	// IdPs poll with an `eq` filter to check whether a specific user already
 	// exists; resolve that with a single targeted lookup instead of scanning the
 	// whole directory.
-	if (emailFilter || externalIdFilter) {
+	if (emailFilter) {
+		// Resolve the user by email (provisioned emails are stored lowercased),
+		// then confirm they belong to this org — filtering must key off the email,
+		// not an arbitrary member row.
+		const user = await db.query.user.findFirst({
+			where: { email: { eq: emailFilter.toLowerCase() } },
+			columns: { id: true, email: true, name: true },
+		});
+		const membership = user ? await getMembership(user.id, orgId) : null;
+		const resources =
+			user && membership
+				? [toScimUser(user, true, membership.scimExternalId)]
+				: [];
+		return scimJson({
+			schemas: [SCHEMA_LIST],
+			totalResults: resources.length,
+			startIndex,
+			itemsPerPage: resources.length,
+			Resources: resources,
+		});
+	}
+
+	if (externalIdFilter) {
 		const membership = await db.query.userOrganization.findFirst({
 			where: {
 				organizationId: { eq: orgId },
-				...(externalIdFilter
-					? { scimExternalId: { eq: externalIdFilter } }
-					: {}),
+				scimExternalId: { eq: externalIdFilter },
 			},
 			columns: { scimExternalId: true },
 			with: { user: { columns: { id: true, email: true, name: true } } },
 		});
-		const match =
-			membership?.user &&
-			(!emailFilter ||
-				membership.user.email.toLowerCase() === emailFilter.toLowerCase())
-				? membership
-				: null;
-		const resources =
-			match && match.user
-				? [toScimUser(match.user, true, match.scimExternalId)]
-				: [];
+		const resources = membership?.user
+			? [toScimUser(membership.user, true, membership.scimExternalId)]
+			: [];
 		return scimJson({
 			schemas: [SCHEMA_LIST],
 			totalResults: resources.length,

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -7,6 +7,7 @@ import { apiAuth } from "@/auth/config.js";
 import { getApiBaseUrl } from "@/lib/api-url.js";
 import { maskToken } from "@/lib/maskToken.js";
 import { getOrgProjectsOldestFirst } from "@/lib/sso-default-projects.js";
+import { recomputeRoleForGroupName } from "@/lib/sso-roles.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import { and, db, eq, isNull, shortid, tables } from "@llmgateway/db";
@@ -317,6 +318,24 @@ sso.openapi(register, async (c) => {
 			createdAt: tables.ssoProvider.createdAt,
 		});
 
+	// The org-stamping update matched no row: the plugin didn't persist the
+	// provider as expected. Clean up any orphaned, unassigned row it may have
+	// left (organizationId still null) so a failed registration can't linger,
+	// and fail loudly instead of crashing on `provider.id` below.
+	if (!provider) {
+		await db
+			.delete(tables.ssoProvider)
+			.where(
+				and(
+					eq(tables.ssoProvider.providerId, providerId),
+					isNull(tables.ssoProvider.organizationId),
+				),
+			);
+		throw new HTTPException(500, {
+			message: "Failed to register SSO provider",
+		});
+	}
+
 	// Seed a reasonable default per-developer API key cap for the org. Only set
 	// it when the org hasn't already configured its own default developer budget,
 	// so we never clobber an explicit admin choice.
@@ -612,7 +631,19 @@ sso.openapi(createRoleMapping, async (c) => {
 
 	const { organizationId, groupName, role } = c.req.valid("json");
 
-	await assertEnterpriseOrgAccess(user.id, organizationId);
+	const { role: callerRole } = await assertEnterpriseOrgAccess(
+		user.id,
+		organizationId,
+	);
+
+	// Mirror the team-role boundary: admins can't grant owner. Since group
+	// mappings drive SCIM role recomputation, an owner mapping would otherwise
+	// let an admin promote members (or themselves) to owner.
+	if (role === "owner" && callerRole !== "owner") {
+		throw new HTTPException(403, {
+			message: "Only owners can create an owner role mapping",
+		});
+	}
 
 	const existing = await db.query.ssoRoleMapping.findFirst({
 		where: {
@@ -635,6 +666,11 @@ sso.openapi(createRoleMapping, async (c) => {
 			groupName: tables.ssoRoleMapping.groupName,
 			role: tables.ssoRoleMapping.role,
 		});
+
+	// If the IdP already pushed this group and its members (the usual onboarding
+	// order), apply the new mapping to them now instead of waiting for a later
+	// SCIM membership event.
+	await recomputeRoleForGroupName(organizationId, groupName);
 
 	await logAuditEvent({
 		organizationId,
@@ -690,6 +726,10 @@ sso.openapi(removeRoleMapping, async (c) => {
 	await db
 		.delete(tables.ssoRoleMapping)
 		.where(eq(tables.ssoRoleMapping.id, id));
+
+	// Members elevated by this mapping keep the role until a later SCIM event
+	// otherwise; recompute them now so removing the mapping revokes the access.
+	await recomputeRoleForGroupName(organizationId, existing.groupName);
 
 	await logAuditEvent({
 		organizationId,
@@ -969,6 +1009,16 @@ sso.openapi(revokeScim, async (c) => {
 
 	await assertEnterpriseOrgAccess(user.id, organizationId);
 
+	// Resolve the active token first so the audit event identifies the revoked
+	// token (id + masked value), consistent with creation, rather than the org.
+	const active = await db.query.scimToken.findFirst({
+		where: {
+			organizationId: { eq: organizationId },
+			status: { eq: "active" },
+		},
+		columns: { id: true, maskedToken: true },
+	});
+
 	await db
 		.update(tables.scimToken)
 		.set({ status: "deleted" })
@@ -984,7 +1034,10 @@ sso.openapi(revokeScim, async (c) => {
 		userId: user.id,
 		action: "scim_token.revoke",
 		resourceType: "scim_token",
-		resourceId: organizationId,
+		resourceId: active?.id ?? organizationId,
+		metadata: active?.maskedToken
+			? { resourceName: active.maskedToken }
+			: undefined,
 	});
 
 	return c.json({ message: "SCIM token revoked successfully" });

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -218,12 +218,19 @@ export default function Login() {
 		WebAuthnAbortService.cancelCeremony();
 		try {
 			const origin = location.protocol + "//" + location.host;
+			// Carry the validated `?redirect=` target through the error path too, so a
+			// failed SSO attempt returns to /login with the intended destination and a
+			// retry still lands the user there.
+			const errorUrl = new URL("/login", origin);
+			if (redirectTarget !== "/dashboard") {
+				errorUrl.searchParams.set("redirect", redirectTarget);
+			}
 			const res = await signIn.sso({
 				email: parsed.data,
 				// Honor the same validated `?redirect=` target as the other sign-in
 				// methods so SSO users also land on their intended post-login route.
 				callbackURL: origin + redirectTarget,
-				errorCallbackURL: origin + "/login",
+				errorCallbackURL: errorUrl.toString(),
 			});
 			if (res?.error) {
 				toast({

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -217,10 +217,13 @@ export default function Login() {
 		// native passkey/biometric prompt after the SSO redirect.
 		WebAuthnAbortService.cancelCeremony();
 		try {
+			const origin = location.protocol + "//" + location.host;
 			const res = await signIn.sso({
 				email: parsed.data,
-				callbackURL: location.protocol + "//" + location.host + "/dashboard",
-				errorCallbackURL: location.protocol + "//" + location.host + "/login",
+				// Honor the same validated `?redirect=` target as the other sign-in
+				// methods so SSO users also land on their intended post-login route.
+				callbackURL: origin + redirectTarget,
+				errorCallbackURL: origin + "/login",
 			});
 			if (res?.error) {
 				toast({
@@ -230,6 +233,11 @@ export default function Login() {
 					variant: "destructive",
 				});
 			}
+		} catch (error: unknown) {
+			toast({
+				title: (error as Error)?.message || "Failed to sign in with SSO",
+				variant: "destructive",
+			});
 		} finally {
 			setIsLoading(false);
 		}

--- a/apps/ui/src/components/sso/sso-client.tsx
+++ b/apps/ui/src/components/sso/sso-client.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { Building2, Copy, HelpCircle, Trash2 } from "lucide-react";
+import { Building2, Copy, HelpCircle, Loader2, Trash2 } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useState } from "react";
 
 import { ProjectMultiSelect } from "@/components/projects/project-multi-select";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/lib/components/alert-dialog";
 import { Button } from "@/lib/components/button";
 import {
 	Card,
@@ -45,9 +55,19 @@ import { useApi } from "@/lib/fetch-client";
 
 import type React from "react";
 
-function copy(value: string, label: string) {
-	void navigator.clipboard.writeText(value);
-	toast({ title: `${label} copied to clipboard` });
+async function copy(value: string, label: string) {
+	try {
+		await navigator.clipboard.writeText(value);
+		toast({ title: `${label} copied to clipboard` });
+	} catch {
+		// Clipboard writes reject in insecure contexts or when permission is denied
+		// — don't claim success the user can't see.
+		toast({
+			title: `Failed to copy ${label}`,
+			description: "Copy it manually instead.",
+			variant: "destructive",
+		});
+	}
 }
 
 // Turn an org name into a URL-safe a-z0-9 slug used as the SSO connection id.
@@ -102,7 +122,7 @@ function ReadOnlyField({ label, value }: { label: string; value: string }) {
 					type="button"
 					variant="outline"
 					size="icon"
-					onClick={() => copy(value, label)}
+					onClick={() => void copy(value, label)}
 				>
 					<Copy className="h-4 w-4" />
 					<span className="sr-only">Copy {label}</span>
@@ -142,6 +162,15 @@ export function SsoClient() {
 	// the displayed selection derives from the server value (or the fallback
 	// project). Reset to `null` after a successful save to re-sync with the server.
 	const [projectDraft, setProjectDraft] = useState<string[] | null>(null);
+	// Confirmation for destructive actions (delete connection, revoke/rotate SCIM
+	// token) — each has organization-wide blast radius, so a single misclick
+	// shouldn't fire immediately.
+	const [confirmAction, setConfirmAction] = useState<{
+		title: string;
+		description: string;
+		actionLabel: string;
+		run: () => void | Promise<void>;
+	} | null>(null);
 
 	// Slug the admin pastes into the IdP (part of the SP URLs). Suggested as the
 	// recommended `<org-slug>-<provider>` format until the admin overrides it; must
@@ -392,7 +421,18 @@ export function SsoClient() {
 		}
 	}
 
-	if (selectedOrganization && !isEnterprise) {
+	// Wait for the org (and thus its plan) to load before deciding what to show,
+	// otherwise the full management UI briefly flashes for non-enterprise orgs
+	// before the upsell card replaces it.
+	if (!selectedOrganization) {
+		return (
+			<div className="flex items-center justify-center p-8">
+				<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+
+	if (!isEnterprise) {
 		return (
 			<div className="flex flex-col space-y-4 p-4 pt-6 md:p-8">
 				<Card>
@@ -459,7 +499,14 @@ export function SsoClient() {
 										<Button
 											variant="outline"
 											size="icon"
-											onClick={() => handleDelete(provider.providerId)}
+											onClick={() =>
+												setConfirmAction({
+													title: "Delete SSO connection?",
+													description: `This removes the SAML connection for ${provider.domain}. If Require SSO is on, users on that domain won't be able to sign in until you add a new connection.`,
+													actionLabel: "Delete connection",
+													run: () => handleDelete(provider.providerId),
+												})
+											}
 											disabled={deleteMutation.isPending}
 										>
 											<Trash2 className="h-4 w-4" />
@@ -667,7 +714,19 @@ export function SsoClient() {
 					{scim && <ReadOnlyField label="SCIM base URL" value={scim.baseUrl} />}
 					<div className="flex items-center gap-3">
 						<Button
-							onClick={handleGenerateScim}
+							onClick={() => {
+								if (scim?.configured) {
+									setConfirmAction({
+										title: "Rotate SCIM token?",
+										description:
+											"The current token stops working immediately. Directory provisioning will fail until you update your identity provider with the new token.",
+										actionLabel: "Rotate token",
+										run: handleGenerateScim,
+									});
+								} else {
+									void handleGenerateScim();
+								}
+							}}
 							disabled={generateScim.isPending}
 						>
 							{scim?.configured ? "Rotate SCIM token" : "Generate SCIM token"}
@@ -675,7 +734,15 @@ export function SsoClient() {
 						{scim?.configured && (
 							<Button
 								variant="outline"
-								onClick={handleRevokeScim}
+								onClick={() =>
+									setConfirmAction({
+										title: "Revoke SCIM token?",
+										description:
+											"Directory provisioning stops working immediately. You'll need to generate a new token and update your identity provider to resume it.",
+										actionLabel: "Revoke token",
+										run: handleRevokeScim,
+									})
+								}
 								disabled={revokeScim.isPending}
 							>
 								Revoke
@@ -835,9 +902,11 @@ export function SsoClient() {
 						<Button
 							variant="outline"
 							size="icon"
-							onClick={() =>
-								generatedToken && copy(generatedToken, "SCIM token")
-							}
+							onClick={() => {
+								if (generatedToken) {
+									void copy(generatedToken, "SCIM token");
+								}
+							}}
 						>
 							<Copy className="h-4 w-4" />
 							<span className="sr-only">Copy SCIM token</span>
@@ -848,6 +917,35 @@ export function SsoClient() {
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
+
+			<AlertDialog
+				open={!!confirmAction}
+				onOpenChange={(open) => {
+					if (!open) {
+						setConfirmAction(null);
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>{confirmAction?.title}</AlertDialogTitle>
+						<AlertDialogDescription>
+							{confirmAction?.description}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								void confirmAction?.run();
+								setConfirmAction(null);
+							}}
+						>
+							{confirmAction?.actionLabel}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Follow-up to #2924 (SAML SSO + SCIM), which merged with a large batch of automated review comments (Copilot, CodeRabbit, Codex). This PR works through each one, keeps the ones worth having, and implements them.

## Security / correctness (SCIM — `apps/api/src/routes/scim.ts`)

- **Org-scope every by-id operation.** `GET`/`PUT`/`PATCH`/`DELETE /Users/:id` and group-member adds now require the target user to belong to the token's org, so a token for one tenant can no longer read or mutate another tenant's users (was leaking `email`/`name` and allowing cross-org renames).
- **Honor `active: false` on create.** A staged/suspended Okta assignment no longer gets an active org membership (and thus SSO eligibility) until a later activation.
- **Recompute roles on reactivation and group rename.** `PUT`/`PATCH active=true` and group `displayName` changes now re-apply group→role mappings, so an admin/owner-group member isn't silently left as `developer`.
- **Last-owner guard.** SCIM deprovisioning refuses to delete the org's only owner, mirroring the team-removal guard.
- **Link SSO account for existing users**, not only newly created ones — otherwise enforcing SSO could lock out a user who first signed up with a password.
- **Group `displayName` uniqueness** enforced on rename (`PUT`/`PATCH`), not just create.
- **DB-level filtering + pagination** for `GET /Users` and `GET /Groups` instead of loading the whole directory into memory and slicing.

## Security / correctness (SSO management — `apps/api/src/routes/sso.ts`, `apps/api/src/auth/handler.ts`)

- **Block the plugin bypass.** Better Auth's raw `/auth/sso/register|update-provider|delete-provider|…` endpoints only require a session, so any authenticated user could sidestep the enterprise/admin-gated `/sso` wrapper. They're now rejected at the HTTP handler; our server-side `apiAuth.api.registerSSOProvider` call bypasses the handler and is unaffected.
- **Privilege boundary:** admins (non-owners) can no longer create `owner` role mappings.
- **Recompute members** when a role mapping is added or removed (previously only SCIM membership events triggered it).
- **Registration robustness:** guard against a missing provider row after `registerSSOProvider` and clean up an orphaned unassigned row on failure.
- **Sever stale links:** clear SCIM tokens' `ssoProviderId` when the connection is deleted; derive the token's provider link from the org's connection when not supplied.
- **Audit:** SCIM revoke logs the token id (+ masked value), not the org id.

## Auth enforcement (`apps/api/src/auth/config.ts`)

- Gate SSO enforcement on `SSO_ENABLED` **and** on an active, enterprise org (a soft-deleted org can no longer be managed to turn enforcement off).
- On a blocked non-SSO login, delete only that session — not every session for the user, which previously turned a rejected attempt into a global logout.

## UI (`apps/ui`)

- Login: preserve the validated `?redirect=` target for SSO sign-in and surface thrown errors via toast.
- SSO settings: confirm before destructive actions (delete connection, rotate/revoke SCIM token); only toast on a successful clipboard copy; show a loading state until the org plan resolves so the management UI doesn't flash for non-enterprise orgs.

## Refactor

- Shared role-recompute logic extracted to `apps/api/src/lib/sso-roles.ts` and reused by both routers.

## Deliberately skipped

- **SCIM email updates on `PUT`** — the `user` row is shared across orgs by email; letting one org's SCIM rewrite the global email risks cross-tenant identity hijack.
- **`spMetadata` for Better Auth** — it's `.optional()` in `@better-auth/sso@1.6.18`; `issuer` already serves as the SP entityID that matches what admins paste. Not a defect in this version.
- **Renaming `scim_token.ssoProviderId`** — cosmetic; already documented; a rename needs a migration and ref churn for no behavior change.
- **DNS domain-ownership verification** — a large standalone feature; deferred. Mitigated by enterprise-plan + owner/admin gating and one-connection-per-org.

## Testing

- `pnpm turbo run build --filter=api --filter=ui`, `pnpm format`, `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs for sensitive SSO/SCIM actions and improved feedback during copy and failures in the SSO sign-in flow.
  * Role mapping now recomputes automatically for org/group changes to reflect updated access immediately.
  * Expanded SCIM provisioning with org-scoped filtering, pagination, and stricter member handling.

* **Bug Fixes**
  * Improved SSO enforcement to validate enterprise eligibility and prevent incorrect session handling.
  * Prevented accidental removal of the last org owner during deprovisioning.
  * Tightened access to auth management routes and fixed cleanup/audit details for tokens and providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->