### PR TITLE
feat(ui): allow reselecting auto theme in toggles

### DIFF
--- a/apps/docs/app/layout.config.tsx
+++ b/apps/docs/app/layout.config.tsx
@@ -8,6 +8,9 @@ import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
  * Docs Layout: app/docs/layout.tsx
  */
 export const baseOptions: BaseLayoutProps = {
+	themeSwitch: {
+		mode: "light-dark-system",
+	},
 	nav: {
 		url: "/",
 		title: (

--- a/apps/playground/src/components/landing/theme-toggle.tsx
+++ b/apps/playground/src/components/landing/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
+import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
@@ -11,129 +11,59 @@ interface ThemeToggleProps {
 	size?: "default" | "compact";
 }
 
+const THEME_OPTIONS = [
+	{ value: "light", label: "Light", Icon: Sun },
+	{ value: "dark", label: "Dark", Icon: Moon },
+	{ value: "system", label: "System (default)", Icon: Monitor },
+] as const;
+
 export function ThemeToggle({ className, size = "default" }: ThemeToggleProps) {
-	const { theme, setTheme, systemTheme } = useTheme();
+	const { theme, setTheme } = useTheme();
 	const [mounted, setMounted] = useState(false);
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const isDark = currentTheme === "dark";
-	const sizeClasses =
-		size === "compact"
-			? {
-					root: "h-7 w-14",
-					knob: "size-5",
-					icon: "size-3.5",
-					translate: "translate-x-7",
-					negativeTranslate: "-translate-x-7",
-				}
-			: {
-					root: "h-8 w-16",
-					knob: "size-6",
-					icon: "size-4",
-					translate: "translate-x-8",
-					negativeTranslate: "-translate-x-8",
-				};
 
 	useEffect(() => setMounted(true), []);
 
-	if (!mounted) {
-		return (
-			<div
-				aria-hidden="true"
-				className={cn(
-					"flex p-1 rounded-full cursor-pointer transition-all duration-300",
-					sizeClasses.root,
-					"bg-white border border-zinc-200",
-					className,
-				)}
-			>
-				<div className="flex justify-between items-center w-full">
-					<div
-						className={cn(
-							"flex justify-center items-center rounded-full transition-transform duration-300 transform bg-gray-200",
-							sizeClasses.knob,
-							sizeClasses.translate,
-						)}
-					>
-						<Sun
-							className={cn(sizeClasses.icon, "text-gray-700")}
-							strokeWidth={1.5}
-						/>
-					</div>
-					<div
-						className={cn(
-							"flex justify-center items-center rounded-full transition-transform duration-300 transform",
-							sizeClasses.knob,
-							sizeClasses.negativeTranslate,
-						)}
-					>
-						<Moon
-							className={cn(sizeClasses.icon, "text-black")}
-							strokeWidth={1.5}
-						/>
-					</div>
-				</div>
-			</div>
-		);
-	}
+	const sizeClasses =
+		size === "compact"
+			? { root: "h-7 gap-0.5 p-0.5", button: "size-6", icon: "size-3.5" }
+			: { root: "h-8 gap-1 p-1", button: "size-6", icon: "size-4" };
+
+	// Default to "system" until mounted to keep SSR markup stable.
+	const active = mounted ? (theme ?? "system") : "system";
 
 	return (
-		<button
-			aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
+		<div
+			aria-label="Theme"
 			className={cn(
-				"flex p-1 rounded-full cursor-pointer transition-all duration-300",
+				"inline-flex items-center rounded-full border border-zinc-200 bg-white transition-colors dark:border-zinc-800 dark:bg-zinc-950",
 				sizeClasses.root,
-				isDark
-					? "bg-zinc-950 border border-zinc-800"
-					: "bg-white border border-zinc-200",
 				className,
 			)}
-			onClick={() => setTheme(isDark ? "light" : "dark")}
-			type="button"
+			role="radiogroup"
 		>
-			<div className="flex justify-between items-center w-full">
-				<div
-					className={cn(
-						"flex justify-center items-center rounded-full transition-transform duration-300",
-						sizeClasses.knob,
-						isDark
-							? "transform translate-x-0 bg-zinc-800"
-							: `transform ${sizeClasses.translate} bg-gray-200`,
-					)}
-				>
-					{isDark ? (
-						<Moon
-							className={cn(sizeClasses.icon, "text-white")}
-							strokeWidth={1.5}
-						/>
-					) : (
-						<Sun
-							className={cn(sizeClasses.icon, "text-gray-700")}
-							strokeWidth={1.5}
-						/>
-					)}
-				</div>
-				<div
-					className={cn(
-						"flex justify-center items-center rounded-full transition-transform duration-300",
-						sizeClasses.knob,
-						isDark
-							? "bg-transparent"
-							: `transform ${sizeClasses.negativeTranslate}`,
-					)}
-				>
-					{isDark ? (
-						<Sun
-							className={cn(sizeClasses.icon, "text-gray-500")}
-							strokeWidth={1.5}
-						/>
-					) : (
-						<Moon
-							className={cn(sizeClasses.icon, "text-black")}
-							strokeWidth={1.5}
-						/>
-					)}
-				</div>
-			</div>
-		</button>
+			{THEME_OPTIONS.map(({ value, label, Icon }) => {
+				const isActive = mounted && active === value;
+				return (
+					<button
+						aria-checked={isActive}
+						aria-label={label}
+						className={cn(
+							"flex items-center justify-center rounded-full transition-colors",
+							sizeClasses.button,
+							isActive
+								? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-white"
+								: "text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
+						)}
+						key={value}
+						onClick={() => setTheme(value)}
+						role="radio"
+						title={label}
+						type="button"
+					>
+						<Icon className={sizeClasses.icon} strokeWidth={1.5} />
+					</button>
+				);
+			})}
+		</div>
 	);
 }

--- a/apps/playground/src/components/playground/audio-sidebar.tsx
+++ b/apps/playground/src/components/playground/audio-sidebar.tsx
@@ -16,7 +16,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { List, type RowComponentProps } from "react-window";
@@ -390,12 +389,6 @@ export function AudioSidebar({
 			},
 		});
 	};
-
-	const { theme, setTheme, systemTheme } = useTheme();
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const renameItem = useRenameAudioHistory();
 	const deleteItem = useDeleteAudioHistory();
@@ -780,10 +773,7 @@ export function AudioSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/canvas-sidebar.tsx
+++ b/apps/playground/src/components/playground/canvas-sidebar.tsx
@@ -13,9 +13,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
-import { useCallback } from "react";
 
 import { CreditsDisplay } from "@/components/credits/credits-display";
 import { ThemeToggle } from "@/components/landing/theme-toggle";
@@ -102,11 +100,6 @@ export function CanvasSidebar({
 	const orgIdParam = searchParams.get("orgId");
 	const withOrg = (path: string) =>
 		orgIdParam ? `${path}?orgId=${orgIdParam}` : path;
-	const { theme, setTheme, systemTheme } = useTheme();
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const isAuthenticated = !!user;
 
@@ -339,10 +332,7 @@ export function CanvasSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -23,7 +23,6 @@ import {
 // import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
 import {
 	useCallback,
@@ -509,7 +508,6 @@ export const ChatSidebar = function ChatSidebar({
 	const { user, isLoading: isUserLoading } = useUser();
 	const { signOut } = useAuth();
 	const { organization, isLoading: isOrgLoading } = useOrganization();
-	const { theme, setTheme, systemTheme } = useTheme();
 
 	// Resolve the org context for chat history: the selected org, or the
 	// dedicated Chat org (backing the "Chat plan" context) when none is selected.
@@ -547,10 +545,6 @@ export const ChatSidebar = function ChatSidebar({
 	}, []);
 
 	const chats = useMemo(() => chatsData?.chats ?? [], [chatsData?.chats]);
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const logout = async () => {
 		posthog.reset();
@@ -1090,10 +1084,7 @@ export const ChatSidebar = function ChatSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/image-sidebar.tsx
+++ b/apps/playground/src/components/playground/image-sidebar.tsx
@@ -16,7 +16,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { List, type RowComponentProps } from "react-window";
@@ -392,12 +391,6 @@ export function ImageSidebar({
 			},
 		});
 	};
-
-	const { theme, setTheme, systemTheme } = useTheme();
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const renameItem = useRenameImageHistory();
 	const deleteItem = useDeleteImageHistory();
@@ -782,10 +775,7 @@ export function ImageSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/org-sidebar.tsx
+++ b/apps/playground/src/components/playground/org-sidebar.tsx
@@ -17,7 +17,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { List, type RowComponentProps } from "react-window";
@@ -224,12 +223,6 @@ export function OrgSidebar({
 
 	const { data: orgSharesData, isLoading: isSharesLoading } =
 		useOrgShares(organizationId);
-
-	const { theme, setTheme, systemTheme } = useTheme();
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [isMac, setIsMac] = useState(false);
@@ -588,10 +581,7 @@ export function OrgSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/projects-sidebar.tsx
+++ b/apps/playground/src/components/playground/projects-sidebar.tsx
@@ -16,8 +16,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useTheme } from "next-themes";
-import { useCallback } from "react";
 
 import { CreditsDisplay } from "@/components/credits/credits-display";
 import { ThemeToggle } from "@/components/landing/theme-toggle";
@@ -79,12 +77,6 @@ export function ProjectsSidebar({
 	const { state: sidebarState, isMobile } = useSidebar();
 	const { user, isLoading: isUserLoading } = useUser();
 	const { signOut } = useAuth();
-	const { theme, setTheme, systemTheme } = useTheme();
-
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const isMac = useSidebarShortcut("j", onCreateOpen);
 
@@ -332,10 +324,7 @@ export function ProjectsSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/skills-sidebar.tsx
+++ b/apps/playground/src/components/playground/skills-sidebar.tsx
@@ -20,8 +20,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useTheme } from "next-themes";
-import { useCallback } from "react";
 
 import { CreditsDisplay } from "@/components/credits/credits-display";
 import { ThemeToggle } from "@/components/landing/theme-toggle";
@@ -87,12 +85,6 @@ export function SkillsSidebar({
 	const { state: sidebarState, isMobile } = useSidebar();
 	const { user, isLoading: isUserLoading } = useUser();
 	const { signOut } = useAuth();
-	const { theme, setTheme, systemTheme } = useTheme();
-
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
 
 	const isMac = useSidebarShortcut("j", onCreateOpen);
 
@@ -357,10 +349,7 @@ export function SkillsSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/playground/src/components/playground/video-sidebar.tsx
+++ b/apps/playground/src/components/playground/video-sidebar.tsx
@@ -16,7 +16,6 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useTheme } from "next-themes";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { List, type RowComponentProps } from "react-window";
@@ -403,12 +402,6 @@ export function VideoSidebar({
 		});
 	};
 
-	const { theme, setTheme, systemTheme } = useTheme();
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const toggleTheme = useCallback(() => {
-		setTheme(currentTheme === "dark" ? "light" : "dark");
-	}, [currentTheme, setTheme]);
-
 	const renameItem = useRenameVideoHistory();
 	const deleteItem = useDeleteVideoHistory();
 	const [editingId, setEditingId] = useState<string | null>(null);
@@ -792,10 +785,7 @@ export function VideoSidebar({
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="justify-between gap-3"
-									onSelect={(event) => {
-										event.preventDefault();
-										toggleTheme();
-									}}
+									onSelect={(event) => event.preventDefault()}
 								>
 									<span>Theme</span>
 									<div

--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -758,6 +758,9 @@ function ThemeSelect() {
 					<div className="flex items-center">
 						<ComputerIcon className="mr-2 h-4 w-4" />
 						System
+						<span className="ml-2 text-xs text-muted-foreground">
+							(Default)
+						</span>
 					</div>
 				</SelectItem>
 			</SelectContent>

--- a/apps/ui/src/components/landing/theme-toggle.tsx
+++ b/apps/ui/src/components/landing/theme-toggle.tsx
@@ -1,4 +1,6 @@
-import { Moon, Sun } from "lucide-react";
+"use client";
+
+import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
@@ -6,85 +8,62 @@ import { cn } from "@/lib/utils";
 
 interface ThemeToggleProps {
 	className?: string;
+	size?: "default" | "compact";
 }
 
-export function ThemeToggle({ className }: ThemeToggleProps) {
-	const { theme, setTheme, systemTheme } = useTheme();
+const THEME_OPTIONS = [
+	{ value: "light", label: "Light", Icon: Sun },
+	{ value: "dark", label: "Dark", Icon: Moon },
+	{ value: "system", label: "System (default)", Icon: Monitor },
+] as const;
+
+export function ThemeToggle({ className, size = "default" }: ThemeToggleProps) {
+	const { theme, setTheme } = useTheme();
 	const [mounted, setMounted] = useState(false);
 
-	// Use theme if available, fallback to systemTheme, then default to light
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const isDark = currentTheme === "dark";
+	useEffect(() => setMounted(true), []);
 
-	useEffect(() => {
-		setMounted(true);
-	}, []);
+	const sizeClasses =
+		size === "compact"
+			? { root: "h-7 gap-0.5 p-0.5", button: "size-6", icon: "size-3.5" }
+			: { root: "h-8 gap-1 p-1", button: "size-6", icon: "size-4" };
 
-	// Prevent hydration mismatch by showing a neutral state until mounted
-	if (!mounted) {
-		return (
-			<div
-				className={cn(
-					"flex w-16 h-8 p-1 rounded-full cursor-pointer transition-all duration-300",
-					"bg-white border border-zinc-200",
-					className,
-				)}
-				role="button"
-				tabIndex={0}
-			>
-				<div className="flex justify-between items-center w-full">
-					<div className="flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300 transform translate-x-8 bg-gray-200">
-						<Sun className="w-4 h-4 text-gray-700" strokeWidth={1.5} />
-					</div>
-					<div className="flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300 transform -translate-x-8">
-						<Moon className="w-4 h-4 text-black" strokeWidth={1.5} />
-					</div>
-				</div>
-			</div>
-		);
-	}
+	// Default to "system" until mounted to keep SSR markup stable.
+	const active = mounted ? (theme ?? "system") : "system";
 
 	return (
 		<div
+			aria-label="Theme"
 			className={cn(
-				"flex w-16 h-8 p-1 rounded-full cursor-pointer transition-all duration-300",
-				isDark
-					? "bg-zinc-950 border border-zinc-800"
-					: "bg-white border border-zinc-200",
+				"inline-flex items-center rounded-full border border-zinc-200 bg-white transition-colors dark:border-zinc-800 dark:bg-zinc-950",
+				sizeClasses.root,
 				className,
 			)}
-			onClick={() => setTheme(isDark ? "light" : "dark")}
-			role="button"
-			tabIndex={0}
+			role="radiogroup"
 		>
-			<div className="flex justify-between items-center w-full">
-				<div
-					className={cn(
-						"flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300",
-						isDark
-							? "transform translate-x-0 bg-zinc-800"
-							: "transform translate-x-8 bg-gray-200",
-					)}
-				>
-					{isDark ? (
-						<Moon className="w-4 h-4 text-white" strokeWidth={1.5} />
-					) : (
-						<Sun className="w-4 h-4 text-gray-700" strokeWidth={1.5} />
-					)}
-				</div>
-				<div
-					className={cn(
-						"flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300",
-						isDark ? "bg-transparent" : "transform -translate-x-8",
-					)}
-				>
-					{isDark ? (
-						<Sun className="w-4 h-4 text-gray-500" strokeWidth={1.5} />
-					) : (
-						<Moon className="w-4 h-4 text-black" strokeWidth={1.5} />
-					)}
-				</div>
-			</div>
+			{THEME_OPTIONS.map(({ value, label, Icon }) => {
+				const isActive = mounted && active === value;
+				return (
+					<button
+						aria-checked={isActive}
+						aria-label={label}
+						className={cn(
+							"flex items-center justify-center rounded-full transition-colors",
+							sizeClasses.button,
+							isActive
+								? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-white"
+								: "text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
+						)}
+						key={value}
+						onClick={() => setTheme(value)}
+						role="radio"
+						title={label}
+						type="button"
+					>
+						<Icon className={sizeClasses.icon} strokeWidth={1.5} />
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/ui/src/components/mode-toggle.tsx
+++ b/apps/ui/src/components/mode-toggle.tsx
@@ -42,6 +42,7 @@ export function ModeToggle({ className }: { className?: string }) {
 				<DropdownMenuItem onClick={() => setTheme("system")}>
 					<ComputerIcon className="mr-2 size-4" />
 					<span>System</span>
+					<span className="ml-auto text-xs text-muted-foreground">Default</span>
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/ee/admin/src/components/landing/theme-toggle.tsx
+++ b/ee/admin/src/components/landing/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
+import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
@@ -8,80 +8,62 @@ import { cn } from "@/lib/utils";
 
 interface ThemeToggleProps {
 	className?: string;
+	size?: "default" | "compact";
 }
 
-export function ThemeToggle({ className }: ThemeToggleProps) {
-	const { theme, setTheme, systemTheme } = useTheme();
+const THEME_OPTIONS = [
+	{ value: "light", label: "Light", Icon: Sun },
+	{ value: "dark", label: "Dark", Icon: Moon },
+	{ value: "system", label: "System (default)", Icon: Monitor },
+] as const;
+
+export function ThemeToggle({ className, size = "default" }: ThemeToggleProps) {
+	const { theme, setTheme } = useTheme();
 	const [mounted, setMounted] = useState(false);
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const isDark = currentTheme === "dark";
 
 	useEffect(() => setMounted(true), []);
 
-	if (!mounted) {
-		return (
-			<div
-				className={cn(
-					"flex w-16 h-8 p-1 rounded-full cursor-pointer transition-all duration-300",
-					"bg-white border border-zinc-200",
-					className,
-				)}
-				role="button"
-				tabIndex={0}
-			>
-				<div className="flex justify-between items-center w-full">
-					<div className="flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300 transform translate-x-8 bg-gray-200">
-						<Sun className="w-4 h-4 text-gray-700" strokeWidth={1.5} />
-					</div>
-					<div className="flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300 transform -translate-x-8">
-						<Moon className="w-4 h-4 text-black" strokeWidth={1.5} />
-					</div>
-				</div>
-			</div>
-		);
-	}
+	const sizeClasses =
+		size === "compact"
+			? { root: "h-7 gap-0.5 p-0.5", button: "size-6", icon: "size-3.5" }
+			: { root: "h-8 gap-1 p-1", button: "size-6", icon: "size-4" };
+
+	// Default to "system" until mounted to keep SSR markup stable.
+	const active = mounted ? (theme ?? "system") : "system";
 
 	return (
 		<div
+			aria-label="Theme"
 			className={cn(
-				"flex w-16 h-8 p-1 rounded-full cursor-pointer transition-all duration-300",
-				isDark
-					? "bg-zinc-950 border border-zinc-800"
-					: "bg-white border border-zinc-200",
+				"inline-flex items-center rounded-full border border-zinc-200 bg-white transition-colors dark:border-zinc-800 dark:bg-zinc-950",
+				sizeClasses.root,
 				className,
 			)}
-			onClick={() => setTheme(isDark ? "light" : "dark")}
-			role="button"
-			tabIndex={0}
+			role="radiogroup"
 		>
-			<div className="flex justify-between items-center w-full">
-				<div
-					className={cn(
-						"flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300",
-						isDark
-							? "transform translate-x-0 bg-zinc-800"
-							: "transform translate-x-8 bg-gray-200",
-					)}
-				>
-					{isDark ? (
-						<Moon className="w-4 h-4 text-white" strokeWidth={1.5} />
-					) : (
-						<Sun className="w-4 h-4 text-gray-700" strokeWidth={1.5} />
-					)}
-				</div>
-				<div
-					className={cn(
-						"flex justify-center items-center w-6 h-6 rounded-full transition-transform duration-300",
-						isDark ? "bg-transparent" : "transform -translate-x-8",
-					)}
-				>
-					{isDark ? (
-						<Sun className="w-4 h-4 text-gray-500" strokeWidth={1.5} />
-					) : (
-						<Moon className="w-4 h-4 text-black" strokeWidth={1.5} />
-					)}
-				</div>
-			</div>
+			{THEME_OPTIONS.map(({ value, label, Icon }) => {
+				const isActive = mounted && active === value;
+				return (
+					<button
+						aria-checked={isActive}
+						aria-label={label}
+						className={cn(
+							"flex items-center justify-center rounded-full transition-colors",
+							sizeClasses.button,
+							isActive
+								? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-white"
+								: "text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
+						)}
+						key={value}
+						onClick={() => setTheme(value)}
+						role="radio"
+						title={label}
+						type="button"
+					>
+						<Icon className={sizeClasses.icon} strokeWidth={1.5} />
+					</button>
+				);
+			})}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

The theme switchers across the sub-apps could not return to **System** (auto) once a user picked light or dark — even though `system` is the app default. This makes auto directly selectable everywhere and marks it as the default.

### Animated pill toggle (`apps/ui`, `apps/playground`, `ee/admin`)
The `landing/theme-toggle.tsx` pill was a two-position slider (Light ↔ Dark only). Rewrote it into a **three-segment control** (Sun / Moon / Monitor) so any theme, including System, is directly selectable. System is the last option and labeled the default (`aria-label`/`title` "System (default)"). Keeps the `size` (`default`/`compact`) and `className` props.

### Docs (`apps/docs`, Fumadocs)
The Fumadocs sidebar toggle only showed sun/moon. Enabled the three-way toggle via `themeSwitch: { mode: "light-dark-system" }` in the layout config, adding the System option.

### Existing dropdown switchers (`ModeToggle`, dashboard `ThemeSelect`)
Already had all three options; now visibly mark **System** as the default.

## Changes

- Rewrote `landing/theme-toggle.tsx` in `apps/ui`, `apps/playground`, `ee/admin` into a 3-segment radio-group.
- 8 Playground sidebars: removed the now-redundant binary `toggleTheme` row logic; cleaned up orphaned `useTheme`/`useCallback` imports.
- `apps/docs`: `themeSwitch.mode = "light-dark-system"`.
- `ModeToggle` + dashboard `ThemeSelect`: muted "Default" marker on the System option.

`apps/code` has no user-facing theme switcher, so nothing to change there.

## Testing

- `pnpm format` ✅
- `pnpm build` (ui, playground, admin, docs) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)