### PR TITLE
fix(sso): silence samlify SLO-endpoint warning spam

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -6,6 +6,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { createAuthMiddleware } from "better-auth/api";
 import { Redis } from "ioredis";
 
+import { silenceSamlifySloWarning } from "@/auth/silence-samlify-warnings.js";
 import { getApiBaseUrl } from "@/lib/api-url.js";
 import { getOrCreateDefaultOrganization } from "@/utils/default-org.js";
 import { notifyUserSignup } from "@/utils/discord.js";
@@ -18,6 +19,8 @@ import { logAuditEvent } from "@llmgateway/audit";
 import { db, eq, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import { getResendClient, resendAudienceId } from "@llmgateway/shared/email";
+
+silenceSamlifySloWarning();
 
 const apiUrl = getApiBaseUrl();
 const cookieDomain = process.env.COOKIE_DOMAIN ?? "localhost";

--- a/apps/api/src/auth/silence-samlify-warnings.spec.ts
+++ b/apps/api/src/auth/silence-samlify-warnings.spec.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { silenceSamlifySloWarning } from "./silence-samlify-warnings.js";
+
+describe("silenceSamlifySloWarning", () => {
+	let original: typeof console.warn;
+
+	beforeEach(() => {
+		original = console.warn;
+	});
+
+	afterEach(() => {
+		console.warn = original;
+	});
+
+	it("drops the samlify warning but passes other warnings through", () => {
+		// The underlying sink stands in for stderr; the patch wraps it once.
+		const sink = vi.fn();
+		console.warn = sink;
+		silenceSamlifySloWarning();
+
+		console.warn(
+			"Construct identity  provider - missing endpoint of SingleLogoutService",
+		);
+		expect(sink).not.toHaveBeenCalled();
+
+		console.warn("something else entirely", 42);
+		expect(sink).toHaveBeenCalledTimes(1);
+		expect(sink).toHaveBeenCalledWith("something else entirely", 42);
+	});
+});

--- a/apps/api/src/auth/silence-samlify-warnings.ts
+++ b/apps/api/src/auth/silence-samlify-warnings.ts
@@ -1,0 +1,30 @@
+// samlify (used by the @better-auth/sso SAML flow) emits a hardcoded
+// `console.warn` every time it constructs an IdP from field config that has no
+// SingleLogoutService endpoint:
+//   "Construct identity  provider - missing endpoint of SingleLogoutService"
+// We register IdPs from `entryPoint`/`cert` fields and do not use SAML Single
+// Logout, so this fires on every SSO sign-in and every SP-metadata fetch. Node
+// writes `console.warn` to stderr, which Cloud Logging classifies as ERROR, so
+// the benign notice floods the error logs. Drop exactly that one message and
+// leave every other warning untouched.
+
+const SAMLIFY_SLO_WARNING = "missing endpoint of SingleLogoutService";
+
+let patched = false;
+
+export function silenceSamlifySloWarning(): void {
+	if (patched) {
+		return;
+	}
+	patched = true;
+
+	// eslint-disable-next-line no-console -- intentional interception of samlify's raw console.warn
+	const original = console.warn.bind(console);
+	// eslint-disable-next-line no-console -- see above
+	console.warn = (...args: unknown[]): void => {
+		if (typeof args[0] === "string" && args[0].includes(SAMLIFY_SLO_WARNING)) {
+			return;
+		}
+		original(...args);
+	};
+}


### PR DESCRIPTION
## Problem

The API pod floods Cloud Logging with `ERROR`-severity entries:

```
Construct identity  provider - missing endpoint of SingleLogoutService
```

on every SSO sign-in and every SP-metadata fetch — even though SSO itself works fine.

## Root cause

`samlify` (used by `@better-auth/sso` for the SAML flow) emits a hardcoded `console.warn` whenever it constructs an Identity Provider from **field config** that has no `SingleLogoutService` endpoint (`node_modules/samlify/build/src/metadata-idp.js:136`). We register IdPs from `entryPoint`/`cert` fields (`apps/api/src/routes/sso.ts`) and don't use SAML Single Logout, so the IdP object is always built without an SLO endpoint and the warning fires on every request that constructs it.

Node routes `console.warn` to **stderr**, which Cloud Logging classifies as **ERROR** — hence the error-log spam despite the notice being benign.

## Fix

Install a one-time `console.warn` filter (`silenceSamlifySloWarning()`) at auth-config load that drops exactly that one samlify message and passes every other warning through untouched. This covers both existing and future providers immediately, without requiring a data backfill or collecting an IdP SLO URL we never use.

## Testing

- New unit test `silence-samlify-warnings.spec.ts` verifies the target message is dropped and unrelated warnings pass through.
- `pnpm format` and `turbo run build --filter=api` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy authentication warnings in the API logs during sign-in flow.
  * Kept unrelated warning messages working as expected, so important alerts still appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->