### PR TITLE
fix(ui): surface OAuth errors landing on /dashboard

### DIFF
--- a/apps/ui/src/middleware.ts
+++ b/apps/ui/src/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+import type { NextRequest } from "next/server";
+
+// Better Auth appends `?error=<code>` (and sometimes `?error_description=`) to
+// the post-OAuth callback URL when a social sign-in fails (e.g.
+// `account_not_linked`). If that lands on `/dashboard`, the dashboard layout
+// redirects unauthenticated users straight to `/login` and drops the query, so
+// the error is never shown. Catch it here first and forward the code to the
+// login page, which renders it as a toast.
+export function middleware(request: NextRequest) {
+	const { pathname, searchParams } = request.nextUrl;
+	const error = searchParams.get("error");
+
+	if (!error || !pathname.startsWith("/dashboard")) {
+		return NextResponse.next();
+	}
+
+	const url = request.nextUrl.clone();
+	url.pathname = "/login";
+
+	const preserved = new URLSearchParams();
+	preserved.set("error", error);
+	const description = searchParams.get("error_description");
+	if (description) {
+		preserved.set("error_description", description);
+	}
+	url.search = preserved.toString();
+
+	return NextResponse.redirect(url);
+}
+
+export const config = {
+	matcher: ["/dashboard", "/dashboard/:path*"],
+};


### PR DESCRIPTION
## Problem

Better Auth appends `?error=<code>` (e.g. `account_not_linked`) to the OAuth callback URL when a social sign-in fails. If that error ever lands on `https://llmgateway.io/dashboard?error=account_not_linked`, no error message is rendered: the `/dashboard` layout runs `getUser()`, finds no session (login failed), and `redirect("/login")` — **dropping the `?error=` query param**. The user ends up on a bare `/login` with no indication of what went wrong.

Next.js layouts can't read `searchParams`, so the layout redirect can't preserve the code itself.

## Fix

Add `apps/ui/src/middleware.ts` that intercepts any request to `/dashboard` (or subpaths) carrying an `?error=` param and reroutes it to `/login`, preserving `error` and `error_description`. The login page already reads the `error` param and renders it as a toast via `getAuthErrorMessage`, so the user now sees a clear message (e.g. "An account with this email already exists. Please sign in with your email and password…") instead of a silent redirect.

This is a safety net: social sign-in already sets `errorCallbackURL` to `/login` / `/signup`, but this guarantees an auth error on `/dashboard` is never swallowed by the dashboard's auth redirect.

## Testing

- `pnpm turbo run build --filter=ui` succeeds; build output registers `ƒ Proxy (Middleware)`.
- `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in flow for dashboard pages by redirecting users to the login screen when an OAuth error is detected.
  * Preserves error details in the redirected URL so the login page can display a more helpful message.
  * Applies this behavior only to the dashboard and its subpages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->