### PR TITLE
fix(gateway): classify cached finish reason as OpenAI format

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -3860,6 +3860,106 @@ describe("api", () => {
 		expect(Number(cachedLog?.promptTokens)).toBeGreaterThan(0);
 	});
 
+	// Non-streaming responses are cached in OpenAI format, so the stored
+	// finish_reason is normalized (e.g. "stop"). The cache-hit log must classify
+	// it using the OpenAI mapping, not the upstream provider's native format —
+	// anthropic never emits "stop", so mapping against "anthropic" would resolve
+	// to UNKNOWN and log a spurious "Unknown finish reason encountered" error.
+	test("/v1/chat/completions cached anthropic response classifies finish reason", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-cache-anthropic",
+			token: "real-token-cache-anthropic",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-cache-anthropic",
+			token: "sk-test-key",
+			provider: "anthropic",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db
+			.update(tables.project)
+			.set({ cachingEnabled: true })
+			.where(eq(tables.project.id, "project-id"));
+
+		const originalFetch = globalThis.fetch;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url.includes(`${mockServerUrl}/v1/messages`)) {
+					return new Response(
+						JSON.stringify({
+							id: "msg_cache",
+							type: "message",
+							role: "assistant",
+							model: "claude-opus-4-8",
+							content: [{ type: "text", text: "Cached anthropic reply" }],
+							stop_reason: "end_turn",
+							stop_sequence: null,
+							usage: { input_tokens: 100, output_tokens: 20 },
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		const body = JSON.stringify({
+			model: "anthropic/claude-opus-4-8",
+			messages: [{ role: "user", content: "Cache this anthropic response!" }],
+		});
+
+		const makeRequest = () =>
+			app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-cache-anthropic",
+					"x-no-fallback": "true",
+				},
+				body,
+			});
+
+		const originalNodeEnv = process.env.NODE_ENV;
+		try {
+			// First request primes the cache (setCache is a no-op under NODE_ENV=test).
+			process.env.NODE_ENV = "development";
+			const firstRes = await makeRequest();
+			expect(firstRes.status).toBe(200);
+			process.env.NODE_ENV = originalNodeEnv;
+
+			// Second identical request is served entirely from the gateway cache.
+			const secondRes = await makeRequest();
+			expect(secondRes.status).toBe(200);
+			const secondJson = await secondRes.json();
+			expect(secondJson.choices[0].finish_reason).toBe("stop");
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+			fetchSpy.mockRestore();
+		}
+
+		const logs = await waitForLogs(2);
+		const cachedLog = logs.find((log) => log.cached);
+		expect(cachedLog).toBeTruthy();
+		// The cache stores the OpenAI-normalized "stop"; it must classify as
+		// completed rather than the UNKNOWN it would resolve to under anthropic.
+		expect(cachedLog?.finishReason).toBe("stop");
+		expect(cachedLog?.unifiedFinishReason).toBe("completed");
+	});
+
 	// test for model with multiple providers (llama-3.3-70b-instruct)
 	test.skip("/v1/chat/completions with model that has multiple providers", async () => {
 		await db.insert(tables.apiKey).values({

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -5748,6 +5748,16 @@ chat.openapi(completions, async (c) => {
 					content: cachedContent ?? null,
 					reasoningContent: cachedReasoningContent ?? null,
 					finishReason: cachedResponse.choices?.[0]?.finish_reason ?? null,
+					// Non-streaming responses are cached in OpenAI format, so the
+					// stored finish_reason is already normalized (e.g. "stop"). Map it
+					// with the OpenAI (default) branch by passing a null provider —
+					// mapping it against the upstream provider's native format (e.g.
+					// "anthropic", which never emits "stop") would resolve to UNKNOWN
+					// and log a spurious "Unknown finish reason encountered" error.
+					unifiedFinishReason: getUnifiedFinishReason(
+						cachedResponse.choices?.[0]?.finish_reason ?? null,
+						null,
+					),
 					promptTokens:
 						(
 							cachedCosts.promptTokens ?? cachedResponse.usage?.prompt_tokens


### PR DESCRIPTION
## Problem

Production is emitting spurious `ERROR` logs like:

```
"finishReason":"stop","level":50,"model":"anthropic/claude-haiku-4-5-free",
"msg":"Unknown finish reason encountered","provider":"anthropic"
```

Anthropic's native API never returns `stop` (it returns `end_turn`, `stop_sequence`, `tool_use`, etc.). So how does an `anthropic`-provider row get `finishReason: "stop"`?

**Root cause:** the non-streaming gateway response cache stores the *transformed* response, which is in OpenAI format. On a cache hit, `apps/gateway/src/chat/chat.ts` recorded `finishReason` from `cachedResponse.choices[0].finish_reason` — already normalized to `"stop"` — but left `unifiedFinishReason` unset. `insertLog` then recomputed it via `getUnifiedFinishReason("stop", "anthropic")`, which has no `"stop"` case for the anthropic branch, resolved to `UNKNOWN`, and logged the error. This fired on *every* anthropic-family non-streaming cache hit.

The streaming cache path is unaffected — it stores the raw provider `stop_reason` from `metadata.finishReason`, so `insertLog` maps it correctly.

## Fix

Set `unifiedFinishReason` explicitly on the non-streaming cache-hit log entry, mapping the (already OpenAI-normalized) `finish_reason` with the OpenAI default branch by passing a `null` provider. This yields `completed` instead of `UNKNOWN` and removes the bogus error log. No behavioral/billing change — `UNKNOWN` and `completed` both produce no error-type metric.

## Test

Added a regression test in `api.spec.ts`: an anthropic model returns `stop_reason: "end_turn"`, the response is cached, and the cache-hit log is asserted to classify as `completed` (not `unknown`). Verified it fails without the fix (`expected 'unknown' to be 'completed'`) and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cached chat completion responses so finish reasons are normalized consistently, even when the original upstream response came from a different provider.
  * Fixed gateway logging for cache hits to record the correct unified completion status.
  * Added coverage to verify cached non-streaming chat responses return the expected finish reason and cache metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->