### PR TITLE
feat(models): add grok-4.5

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -894,6 +894,34 @@ export const xaiModels = [
 		],
 	},
 	{
+		id: "grok-4-5",
+		name: "Grok 4.5",
+		description:
+			"xAI's flagship reasoning model with a 500K context window, vision, and tool support.",
+		aliases: ["grok-4.5-latest", "grok-build-latest"],
+		family: "xai",
+		releasedAt: new Date("2026-07-08"),
+		providers: [
+			{
+				providerId: "xai",
+				contentFilterPrice: 0.05,
+				externalId: "grok-4.5",
+				inputPrice: "2.0e-6",
+				cachedInputPrice: "0.5e-6",
+				outputPrice: "6.0e-6",
+				requestPrice: "0",
+				contextSize: 500_000,
+				maxOutput: undefined,
+				streaming: true,
+				vision: true,
+				reasoning: true,
+				tools: true,
+				jsonOutput: true,
+				supportedParameters: xaiSupportedParamsNoFreqPresence,
+			},
+		],
+	},
+	{
 		id: "grok-build-0-1",
 		name: "Grok Build 0.1",
 		description:


### PR DESCRIPTION
## Summary

Adds xAI's **grok-4.5** to the models catalog (`packages/models/src/models/xai.ts`), following the existing `grok-4-3` pattern (dashed gateway id `grok-4-5`, dotted `externalId: "grok-4.5"`).

- **Modalities:** text + image → text (`vision: true`)
- **Context window:** 500,000 tokens
- **Capabilities:** reasoning, tools/function calling, structured outputs, streaming
- **Pricing:** $2.00/M input, $0.50/M cached input, $6.00/M output
- **Aliases:** `grok-4.5-latest`, `grok-build-latest`

Rate limits and xAI datacenter regions (us-east-1/us-west-2) aren't modeled in the catalog, so those spec items have no corresponding fields.

## Testing

- `pnpm vitest run packages/models` — 42 tests pass
- `pnpm build` — full build green (17/17 tasks)
- `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFpvSqQbW4TaAqeYJ75xGV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new XAI model, including its latest aliases.
  * The model is available with a large context window, streaming, vision, reasoning, tools, and JSON output support.
  * Pricing and supported parameters are now defined for this model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->