### PR TITLE
fix(shared): compare budget rates with exact decimals

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -74,6 +74,7 @@
 		"clsx": "^2.1.1",
 		"cmdk": "^1.1.1",
 		"date-fns": "4.1.0",
+		"decimal.js": "10.5.0",
 		"embla-carousel-react": "8.6.0",
 		"lucide-react": "0.561.0",
 		"next-themes": "^0.4.6",

--- a/packages/shared/src/member-budget-limits.spec.ts
+++ b/packages/shared/src/member-budget-limits.spec.ts
@@ -103,6 +103,29 @@ describe("validateApiKeyLimitsWithinMemberBudget", () => {
 		).toBeNull();
 	});
 
+	it("allows equal rates across different windows despite float division", () => {
+		// $30/month (720h) and $1/day (24h) are the same $/hour rate, but
+		// 30/720 and 1/24 differ in binary floating point. Exact cross-
+		// multiplication (1*720 === 30*24) treats them as equal → allowed.
+		const member: ApiKeyLimitConstraints = {
+			usageLimit: null,
+			periodUsageLimit: "30",
+			periodUsageDurationValue: 1,
+			periodUsageDurationUnit: "month",
+		};
+		expect(
+			validateApiKeyLimitsWithinMemberBudget(
+				{
+					usageLimit: null,
+					periodUsageLimit: "1",
+					periodUsageDurationValue: 1,
+					periodUsageDurationUnit: "day",
+				},
+				member,
+			),
+		).toBeNull();
+	});
+
 	it("requires a recurring key limit when the member has one", () => {
 		expect(
 			validateApiKeyLimitsWithinMemberBudget(NO_LIMITS, {

--- a/packages/shared/src/member-budget-limits.ts
+++ b/packages/shared/src/member-budget-limits.ts
@@ -4,6 +4,8 @@
  * pulling in the database driver.
  */
 
+import { Decimal } from "decimal.js";
+
 export type ApiKeyPeriodDurationUnitValue = "hour" | "day" | "week" | "month";
 
 /** The subset of limit fields shared by an API key and a member budget. */
@@ -52,13 +54,12 @@ function periodWindowLabel(
 	return `${value} ${unit}${value === 1 ? "" : "s"}`;
 }
 
-/** Spend rate normalized to $/hour, so windows of different length compare fairly. */
-function periodHourlyRate(
-	limit: string | number,
+/** Length of a period window in hours, so windows of different length compare fairly. */
+function periodWindowHours(
 	value: number,
 	unit: ApiKeyPeriodDurationUnitValue,
 ): number {
-	return Number(limit) / (value * PERIOD_UNIT_HOURS[unit]);
+	return value * PERIOD_UNIT_HOURS[unit];
 }
 
 /**
@@ -101,18 +102,25 @@ export function validateApiKeyLimitsWithinMemberBudget(
 		) {
 			return `Set a recurring usage limit at or below your organization limit of ${formatBudgetUsd(memberBudget.periodUsageLimit)} per ${memberWindow}.`;
 		}
-		const memberRate = periodHourlyRate(
-			memberBudget.periodUsageLimit,
+		const memberWindowHours = periodWindowHours(
 			memberBudget.periodUsageDurationValue,
 			memberBudget.periodUsageDurationUnit,
 		);
-		const keyRate = periodHourlyRate(
-			keyLimits.periodUsageLimit,
+		const keyWindowHours = periodWindowHours(
 			keyLimits.periodUsageDurationValue,
 			keyLimits.periodUsageDurationUnit,
 		);
-		// Tolerate float-division noise so identical rates aren't rejected.
-		if (keyRate > memberRate * (1 + 1e-9)) {
+		// Compare hourly spend rates via exact cross-multiplication (both windows
+		// are positive), so equal rates stay equal without float-division noise:
+		//   keyLimit / keyWindow > memberLimit / memberWindow
+		//   ⟺ keyLimit * memberWindow > memberLimit * keyWindow
+		const keyScaled = new Decimal(keyLimits.periodUsageLimit).times(
+			memberWindowHours,
+		);
+		const memberScaled = new Decimal(memberBudget.periodUsageLimit).times(
+			keyWindowHours,
+		);
+		if (keyScaled.greaterThan(memberScaled)) {
 			return `Recurring usage limit can't exceed your organization limit of ${formatBudgetUsd(memberBudget.periodUsageLimit)} per ${memberWindow}.`;
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
         version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.7(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.7))(zod@3.25.76)
@@ -934,10 +934,10 @@ importers:
         version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(better-auth@1.6.18(@opentelemetry/api@1.9.0)(next@16.2.7(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.6(zod@3.25.75))
       '@content-collections/core':
         specifier: 0.15.0
-        version: 0.15.0(typescript@5.9.2)
+        version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.2))(next@16.2.7(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.7(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.7))(zod@3.25.75)
@@ -1163,7 +1163,7 @@ importers:
         version: 10.4.21(postcss@8.5.10)
       openapi-typescript:
         specifier: 7.10.1
-        version: 7.10.1(typescript@5.9.2)
+        version: 7.10.1(typescript@5.9.3)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -1644,6 +1644,9 @@ importers:
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
+      decimal.js:
+        specifier: 10.5.0
+        version: 10.5.0
       embla-carousel-react:
         specifier: 8.6.0
         version: 8.6.0(react@19.2.7)
@@ -13026,21 +13029,6 @@ snapshots:
       conventional-commits-parser: 6.4.0
       picocolors: 1.1.1
 
-  '@content-collections/core@0.15.0(typescript@5.9.2)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      camelcase: 8.0.0
-      chokidar: 4.0.3
-      esbuild: 0.28.1
-      gray-matter: 4.0.3(patch_hash=5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc)
-      p-limit: 6.2.0
-      picomatch: 4.0.4
-      pluralize: 8.0.0
-      serialize-javascript: 7.0.5
-      tinyglobby: 0.2.16
-      typescript: 5.9.2
-      yaml: 2.8.3
-
   '@content-collections/core@0.15.0(typescript@5.9.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -13056,21 +13044,11 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.3
 
-  '@content-collections/integrations@0.5.0(@content-collections/core@0.15.0(typescript@5.9.2))':
-    dependencies:
-      '@content-collections/core': 0.15.0(typescript@5.9.2)
-
   '@content-collections/integrations@0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
 
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.2))(next@16.2.7(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
-    dependencies:
-      '@content-collections/core': 0.15.0(typescript@5.9.2)
-      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.2))
-      next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.7(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))
@@ -21940,16 +21918,6 @@ snapshots:
   openapi-types@12.1.3: {}
 
   openapi-typescript-helpers@0.0.15: {}
-
-  openapi-typescript@7.10.1(typescript@5.9.2):
-    dependencies:
-      '@redocly/openapi-core': 1.34.5(supports-color@10.2.2)
-      ansi-colors: 4.1.3
-      change-case: 5.4.4
-      parse-json: 8.3.0
-      supports-color: 10.2.2
-      typescript: 5.9.2
-      yargs-parser: 21.1.1
 
   openapi-typescript@7.10.1(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

The member-budget check normalized recurring spend limits to a `$/hour` rate using plain JavaScript float division (`Number(limit) / (value * hours)`), then compared with a hand-rolled `1e-9` tolerance so that identical rates weren't spuriously rejected by binary-float noise.

This replaces the division with **exact `Decimal` cross-multiplication**, following the repo's `decimal.js` convention (already used in `apps/gateway/src/lib/costs.ts` and `packages/actions`):

```
keyLimit / keyWindow > memberLimit / memberWindow
⟺ keyLimit * memberWindow > memberLimit * keyWindow   (both windows positive)
```

Both window lengths are positive integers, so the cross-multiplied comparison preserves the inequality direction and is exact — no epsilon fudge needed.

## Changes

- `periodHourlyRate` → `periodWindowHours` (returns the exact window length in hours).
- Comparison now uses `Decimal(...).times(...).greaterThan(...)`; dropped the `* (1 + 1e-9)` tolerance and its comment.
- Added `decimal.js` to `@llmgateway/shared` deps (browser-safe, matches existing pin `10.5.0`).
- Added a regression test: `$30/month` and `$1/day` are the same hourly rate but differ in binary float — cross-multiplication treats them as equal → allowed.

## Testing

- `pnpm vitest run packages/shared/src/member-budget-limits.spec.ts` — 8/8 pass
- `pnpm build` — all 17 tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for recurring budget limits so equivalent rates are handled accurately, even when different time windows are used.
  * Fixed an issue where floating-point rounding could incorrectly reject valid limit combinations.
  * Added coverage for cases where monthly and daily limits represent the same effective rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->