### PR TITLE
feat(models): add quantization to novita moonshot mappings

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -37,6 +37,7 @@ export const moonshotModels = [
 				requestPrice: "0",
 				contextSize: 131072,
 				maxOutput: 131072,
+				quantization: "fp8",
 				streaming: true,
 				vision: false,
 				tools: true,


### PR DESCRIPTION
Adds quantization to Novita provider mappings in packages/models/src/models/moonshot.ts, per #2946.
Checked every Novita mapping in this file against Novita's own model detail pages. Added the field only where precision was explicitly stated — no inference from model names.

[kimi-k2-instruct](https://novita.ai/models/model-detail/moonshotai-kimi-k2-instruct) → fp8

Left unchanged — kimi-k2.6 shows Quantization as - on Novita's own page (explicitly unstated), so left out rather than guess.
Ran pnpm format; only this file changed.