### PR TITLE
feat(models): add qwen3.6-flash + Alibaba regions

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1309,6 +1309,7 @@ export const alibabaModels = [
 				cacheWriteInputPrice: "3.125e-6",
 				regions: [
 					{ id: "singapore" },
+					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",
 						inputPrice: "1.7232e-6",
@@ -1438,7 +1439,11 @@ export const alibabaModels = [
 						cacheWriteInputPrice: "1.5e-6",
 					},
 				],
-				regions: [{ id: "singapore" }],
+				regions: [
+					{ id: "singapore" },
+					{ id: "us-virginia" },
+					{ id: "cn-beijing" },
+				],
 				requestPrice: "0",
 				contextSize: 1000000,
 				maxOutput: 65536,
@@ -2729,6 +2734,48 @@ export const alibabaModels = [
 				reasoning: true,
 				streaming: true,
 				vision: true,
+				tools: true,
+				jsonOutput: true,
+				// Qwen thinking models reject tool_choice "required" or object
+				supportedParameters: [
+					"temperature",
+					"max_tokens",
+					"top_p",
+					"frequency_penalty",
+					"presence_penalty",
+					"stop",
+					"stream",
+					"response_format",
+					"tools",
+				],
+			},
+		],
+	},
+	{
+		id: "qwen3.6-flash",
+		name: "Qwen3.6 Flash",
+		description:
+			"Fast, cost-effective Qwen3.6 model with hybrid reasoning, tool calling, and a 262K context window for high-volume tasks.",
+		family: "alibaba",
+		releasedAt: new Date("2026-04-29"),
+		providers: [
+			{
+				providerId: "alibaba",
+				externalId: "qwen3.6-flash",
+				inputPrice: "0.15e-6",
+				outputPrice: "0.9e-6",
+				cachedInputPrice: "0.015e-6",
+				regions: [
+					{ id: "singapore" },
+					{ id: "us-virginia" },
+					{ id: "cn-beijing" },
+				],
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 65536,
+				reasoning: true,
+				streaming: true,
+				vision: false,
 				tools: true,
 				jsonOutput: true,
 				// Qwen thinking models reject tool_choice "required" or object

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -281,6 +281,7 @@ export const deepseekModels = [
 				outputPrice: "4.8e-6",
 				regions: [
 					{ id: "singapore" },
+					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",
 						inputPrice: "1.65e-6",
@@ -371,6 +372,7 @@ export const deepseekModels = [
 				outputPrice: "0.4e-6",
 				regions: [
 					{ id: "singapore" },
+					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",
 						inputPrice: "0.138e-6",


### PR DESCRIPTION
## Summary

Adds the **qwen3.6-flash** model on the Alibaba (DashScope) provider and expands regional coverage for several existing Alibaba mappings. Every DashScope region was probed directly with the real region keys — Singapore/intl (`dashscope-intl`), US-Virginia (`dashscope-us`), and CN-Beijing (`dashscope`) — and only regions that returned a working completion were added.

### Changes
| Model | externalId | Action | Regions verified |
|---|---|---|---|
| **Qwen3.6 Flash** (new) | `qwen3.6-flash` | New model + `alibaba` mapping | sg ✅ · virginia ✅ · beijing ✅ |
| Qwen3.7 Max | `qwen3.7-max` | Add **us-virginia** region | sg ✅ · virginia ✅ · beijing ✅ |
| Qwen3.7 Plus | `qwen3.7-plus` | Add **us-virginia** + **cn-beijing** regions | sg ✅ · virginia ✅ · beijing ✅ |
| DeepSeek V4 Pro | `deepseek-v4-pro` | Add **us-virginia** region | sg ✅ · virginia ✅ · beijing ✅ |
| DeepSeek V4 Flash | `deepseek-v4-flash` | Add **us-virginia** region | sg ✅ · virginia ✅ · beijing ✅ |

`qwen3.6-flash` was confirmed to support reasoning, tool calling, and `json_object` mode via direct probes and e2e.

### Note on "DeepSeek-v4"
A standalone `deepseek-v4` model was requested, but it **does not exist on DashScope** — `deepseek-v4` (and `-chat/-max/-plus/-reasoner/-turbo/.1`) return `model_not_found` (404) in all three regions. The DeepSeek V4 models that DO exist (`deepseek-v4-pro`, `deepseek-v4-flash`) already had Alibaba mappings, so their region coverage was extended to us-virginia instead.

New regions with no distinct published pricing inherit the model's base (international) price via bare `{ id }` entries; existing cn-beijing overrides are preserved.

## Testing
- Direct API probes: **200 in every region** for all added mappings.
- `pnpm test:e2e` scoped to the 5 mappings (basic, reasoning, streaming, tools, json, params): all configs pass. The only local failures were reasoning-model `json_object` nondeterminism (`{}` instead of the requested object), which is absorbed by the suite's CI retry (`retry: 5`) — confirmed green under `CI=true`.
- `pnpm build` (full), `pnpm format`, and model unit tests (41) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)