### PR TITLE
fix(worker): log auto top-up card declines at warn

### DIFF
--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -571,12 +571,22 @@ export async function processAutoTopUp(): Promise<void> {
 							.where(eq(tables.transaction.id, pendingTransaction.id));
 					}
 				} catch (stripeError) {
-					logger.error(
-						`Stripe error for organization ${org.id}`,
+					const errObj =
 						stripeError instanceof Error
 							? stripeError
-							: new Error(String(stripeError)),
-					);
+							: new Error(String(stripeError));
+					// Card declines (insufficient funds, generic_decline, expired
+					// cards, etc.) are an expected outcome of an off-session auto
+					// top-up, not a server error, so log them at warn level to avoid
+					// noisy error alerts.
+					if (stripeError instanceof Stripe.errors.StripeCardError) {
+						logger.warn(
+							`Auto top-up card declined for organization ${org.id}`,
+							errObj,
+						);
+					} else {
+						logger.error(`Stripe error for organization ${org.id}`, errObj);
+					}
 					// Mark transaction as failed
 					await db
 						.update(tables.transaction)


### PR DESCRIPTION
## Problem

An off-session auto top-up charge that Stripe declines (`code: card_declined`, `decline_code: generic_decline`, etc.) was surfacing in the worker as a `logger.error` — ERROR severity — which fired production error alerts:

```
llmgateway-worker … ERROR Error in default
{"err":{"charge":"ch_…","code":"card_declined","decline_code":"generic_decline", …}}
```

A card decline is an **expected** outcome of charging a saved card off-session, not a server error.

## Fix

In `processAutoTopUp()`'s catch block, detect `Stripe.errors.StripeCardError` (insufficient funds, generic_decline, expired card, etc.) and log it at `logger.warn` instead of `logger.error`. Genuine, unexpected Stripe failures still log at error level and continue to alert.

This mirrors the existing pattern already used in `apps/api/src/routes/payments.ts` and the webhook failure handler, which log payment declines at warn level.

## Notes

- No behavior change beyond log level: the pending transaction is still marked `failed` exactly as before.
- `pnpm build` (worker) and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe payment error handling during auto top-ups.
  * Card-decline issues are now logged as warnings, while unexpected payment errors still appear as errors.
  * Error details are now normalized for more consistent diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->