### PR TITLE
fix(gateway): map content_filter to refusal stop

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -1373,7 +1373,7 @@ anthropic.openapi(messages, async (c) => {
 
 function determineStopReason(
 	finishReason: string | undefined,
-): "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | null {
+): "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | "refusal" | null {
 	switch (finishReason) {
 		case "stop":
 			return "end_turn";
@@ -1381,6 +1381,12 @@ function determineStopReason(
 			return "max_tokens";
 		case "tool_calls":
 			return "tool_use";
+		case "content_filter":
+			return "refusal";
+		// Unknown finish reasons fall back to "end_turn" rather than null:
+		// a null stopReason would suppress the terminal message_delta and
+		// message_stop events in the streaming path, leaving clients with a
+		// malformed stream.
 		default:
 			return "end_turn";
 	}


### PR DESCRIPTION
## Summary

- The Anthropic-compat `/v1/messages` endpoint's `determineStopReason` returned `"end_turn"` for any unrecognized OpenAI finish reason, including `"content_filter"` — so content-filtered responses looked like normal completions to Anthropic SDK clients.
- Map `content_filter` → `"refusal"`, which Anthropic's API now supports as a stop reason (and which the endpoint's response schema already allows).
- Unknown finish reasons intentionally still fall back to `"end_turn"` rather than `null`: in the streaming path a `null` `stopReason` suppresses the terminal `message_delta`/`message_stop` events, which would leave clients with a malformed stream.

Extracted from #1994; the prompt-caching portion of that PR was superseded by work already on main.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test:unit` passes (152 files, 2485 tests)
- [ ] Send a request that triggers content filtering through `/v1/messages` and verify `stop_reason` is `"refusal"`
- [ ] Verify normal completions still return `"end_turn"`, `length` → `"max_tokens"`, `tool_calls` → `"tool_use"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of certain model completion outcomes by mapping content-filtered responses to a user-visible refusal state.
  * Prevented malformed streaming termination events by ensuring an unknown finish reason still falls back to a valid stop reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->