### PR TITLE
fix(api): bust gateway cache on api key changes

### DIFF
--- a/apps/api/src/lib/revoke-member-api-keys.ts
+++ b/apps/api/src/lib/revoke-member-api-keys.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, inArray, ne, tables } from "@llmgateway/db";
+import { and, cdb, db, eq, inArray, ne, tables } from "@llmgateway/db";
 
 /**
  * Revoke the API keys a member created within an organization.
@@ -32,7 +32,7 @@ export async function revokeMemberApiKeys(
 		return 0;
 	}
 
-	const revoked = await db
+	const revoked = await cdb
 		.update(tables.apiKey)
 		.set({ status: "deleted" })
 		.where(

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -698,7 +698,10 @@ keysApi.openapi(deletePlatformKey, async (c) => {
 		platformKey.projectId,
 	);
 
-	await db
+	// Delete through the cached client so onMutate busts the gateway's cached
+	// token lookups; otherwise the deleted key keeps authenticating until the
+	// cache expires.
+	await cdb
 		.update(tables.apiKey)
 		.set({
 			status: "deleted",
@@ -1431,7 +1434,10 @@ keysApi.openapi(deleteKey, async (c) => {
 		});
 	}
 
-	await db
+	// Delete through the cached client so onMutate busts the gateway's cached
+	// token lookups; otherwise the deleted key keeps authenticating until the
+	// cache expires.
+	await cdb
 		.update(tables.apiKey)
 		.set({
 			status: "deleted",
@@ -1615,7 +1621,11 @@ keysApi.openapi(updateStatus, async (c) => {
 	}
 
 	// Update the API key status
-	const [updatedApiKey] = await db
+	// Update through the cached client so its onMutate invalidates the gateway's
+	// cached token lookups (Drizzle cache + SWR mirror) for the api_key table.
+	// Otherwise a deactivated key keeps authenticating (and a reactivated one
+	// stays rejected) until the cache expires, so the change is not instant.
+	const [updatedApiKey] = await cdb
 		.update(tables.apiKey)
 		.set({
 			status,
@@ -1997,8 +2007,9 @@ keysApi.openapi(updateUsageLimit, async (c) => {
 
 	const periodConfigChanged = hasPeriodConfigChanged(apiKey, nextLimitConfig);
 
-	// Update the API key usage limit
-	const [updatedApiKey] = await db
+	// Update the API key usage limit through the cached client so onMutate busts
+	// the gateway's cached token lookup and the new limits take effect instantly.
+	const [updatedApiKey] = await cdb
 		.update(tables.apiKey)
 		.set({
 			usageLimit: nextLimitConfig.usageLimit,


### PR DESCRIPTION
## Problem

Deactivating / reactivating an API key in the dashboard didn't take effect in real time — the gateway kept honoring the old status for up to a minute due to caching.

## Root cause

The gateway authenticates each request via `findApiKeyByToken`, which reads the full `api_key` row through the **cached** Drizzle client (`cdb`) — cached in Redis (Drizzle cache, default 60s TTL, plus the SWR mirror). That cache is only invalidated when a mutation runs through `cdb`, whose `onMutate` hook busts the `api_key` table entries.

But the API's status/delete/limit handlers mutated through the **uncached** `db` client, which has no cache attached and therefore never fires `onMutate`. So the gateway kept serving the stale cached row until the TTL expired.

The roll handler already got this right (it deliberately uses `cdb` and documents why); the other handlers were inconsistent.

## Fix

Route the `api_key` mutations that the gateway reads back through the cached client (`cdb`) so `onMutate` invalidates the Drizzle cache **and** the SWR mirror immediately:

- `PATCH` status (activate/deactivate) — the reported bug
- soft-delete (both the API-key and platform-key delete handlers)
- usage-limit / period-limit update
- `revokeMemberApiKeys` (its comment already claimed auto-invalidation, but it still used `db`)

The change is a client swap only — same SQL, plus cache invalidation — so deactivate/reactivate (and delete/revoke/limit changes) now take effect on the next gateway request instead of up to 60s later.

## Testing

- `pnpm turbo run build --filter=api` ✅
- `pnpm vitest run apps/api/src/routes/keys-api.spec.ts` — 30/30 ✅
- `pnpm format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key deletions and status changes now take effect immediately.
  * Updates to API key expiration and usage limits are reflected without waiting for cached information to expire.
  * Revoked member API keys stop authenticating promptly after deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->