### PR TITLE
fix(billing): log declined tier-change cards as warn

### DIFF
--- a/apps/api/src/routes/chat-plans.ts
+++ b/apps/api/src/routes/chat-plans.ts
@@ -528,20 +528,26 @@ chatPlans.openapi(changeTier, async (c) => {
 		if (error instanceof HTTPException) {
 			throw error;
 		}
-		logger.error(
-			"Stripe chat plan tier change error",
-			error instanceof Error ? error : new Error(String(error)),
-		);
+		// A declined card / required invoice payment is an expected user-facing
+		// outcome, not a server fault: surface it as a 402 and log at warn — never
+		// error — to avoid noisy alerts for declined cards.
 		const errCode =
 			typeof error === "object" && error !== null && "code" in error
 				? String((error as { code?: unknown }).code)
 				: undefined;
 		if (errCode === "card_declined" || errCode === "invoice_payment_required") {
+			logger.warn("Chat plan tier change payment declined", {
+				code: errCode,
+			});
 			throw new HTTPException(402, {
 				message:
 					"Upgrade payment could not be collected. Update your payment method and try again.",
 			});
 		}
+		logger.error(
+			"Stripe chat plan tier change error",
+			error instanceof Error ? error : new Error(String(error)),
+		);
 		throw new HTTPException(500, {
 			message: "Failed to change chat plan tier",
 		});

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1310,24 +1310,29 @@ devPlans.openapi(changeTier, async (c) => {
 		if (error instanceof HTTPException) {
 			throw error;
 		}
-		logger.error(
-			"Stripe dev plan tier change error",
-			error instanceof Error ? error : new Error(String(error)),
-		);
 		// Stripe returns StripeCardError / StripeInvalidRequestError when an
 		// upgrade can't be collected (declined card, no payment method on file,
 		// etc.). Surface this to the caller as a 402 instead of a generic 500
-		// so the UI can prompt the user to update billing.
+		// so the UI can prompt the user to update billing. This is an expected
+		// user-facing outcome, not a server fault, so log it at warn — never
+		// error — to avoid noisy alerts for declined cards.
 		const errCode =
 			typeof error === "object" && error !== null && "code" in error
 				? String((error as { code?: unknown }).code)
 				: undefined;
 		if (errCode === "card_declined" || errCode === "invoice_payment_required") {
+			logger.warn("Dev plan tier change payment declined", {
+				code: errCode,
+			});
 			throw new HTTPException(402, {
 				message:
 					"Upgrade payment could not be collected. Update your payment method and try again.",
 			});
 		}
+		logger.error(
+			"Stripe dev plan tier change error",
+			error instanceof Error ? error : new Error(String(error)),
+		);
 		throw new HTTPException(500, {
 			message: "Failed to change dev plan tier",
 		});


### PR DESCRIPTION
## Problem

A declined card during a plan tier change was being logged as a **server error**, firing alerts like:

```
ERROR Error Alert
{"err":{"charge":"ch_...","code":"card_declined","decline_code":"insufficient_funds",...}}
```

This is an **expected** user-facing outcome (the user is shown a 402 asking them to update their payment method), not a server fault, so it should not page anyone.

## Cause

In both `changeTier` handlers (`dev-plans.ts` and `chat-plans.ts`), the catch block called `logger.error(...)` on the raw Stripe error **before** checking whether the error code was `card_declined` / `invoice_payment_required`. So even the expected-decline path that ends in a 402 first emitted an ERROR-severity log.

## Fix

Reorder each catch block so the decline check runs first: an expected decline logs at `warn` (with just the decline code, no full error dump) and throws 402; only genuinely unexpected Stripe failures fall through to `logger.error` + 500.

The synchronous credit top-up path (`payments.ts`) already handles this correctly — `StripeCardError` is caught and 402'd without logging — so it was left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment failure handling when changing plans.
  * Clearer responses are now shown for declined cards or payment collection issues.
  * These expected payment failures no longer appear as generic server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->