### PR TITLE
feat(gateway): add verbosity param for gpt-5.6 models

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1453,6 +1453,7 @@ chat.openapi(completions, async (c) => {
 		sensitive_word_check,
 		image_config,
 		effort,
+		verbosity,
 		service_tier,
 		web_search,
 		plugins,
@@ -2498,6 +2499,7 @@ chat.openapi(completions, async (c) => {
 			response_format,
 			reasoning_effort,
 			reasoning_max_tokens,
+			verbosity,
 			tools,
 			tool_choice,
 			webSearchTool,
@@ -6109,6 +6111,7 @@ chat.openapi(completions, async (c) => {
 				service_tier,
 				configIndex,
 			),
+			verbosity,
 		);
 	} catch (e) {
 		// Surface typed pre-upstream input errors in the activity feed as a
@@ -6316,6 +6319,7 @@ chat.openapi(completions, async (c) => {
 				n,
 				providerCacheControlEnabled,
 				service_tier,
+				verbosity,
 			},
 		);
 	}

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -304,6 +304,16 @@ export const completionsRequestSchema = z.object({
 				"Controls the computational effort for supported models (currently only claude-opus-4-5-20251101)",
 			example: "medium",
 		}),
+	verbosity: z
+		.enum(["low", "medium", "high"])
+		.nullable()
+		.optional()
+		.transform((val) => (val === null ? undefined : val))
+		.openapi({
+			description:
+				"Controls how detailed the model's responses are. Only supported by OpenAI GPT-5.6 and later models; requests to models without verbosity support return a 400 error.",
+			example: "low",
+		}),
 	service_tier: z
 		.enum(["auto", "default", "flex", "priority"])
 		.optional()

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -140,6 +140,7 @@ export interface ProviderContextOptions {
 	n?: number;
 	providerCacheControlEnabled: boolean;
 	service_tier?: "auto" | "default" | "flex" | "priority";
+	verbosity?: "low" | "medium" | "high";
 }
 
 interface ProjectInfo {
@@ -643,6 +644,7 @@ export async function resolveProviderContext(
 		options.providerCacheControlEnabled,
 		options.n,
 		options.service_tier,
+		options.verbosity,
 	);
 
 	// Post-validation of max_tokens in request body

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -132,6 +132,50 @@ describe("validateModelCapabilities - vision", () => {
 	});
 });
 
+describe("validateModelCapabilities - verbosity", () => {
+	const verbosityModel = getModel("gpt-5.6-terra");
+
+	it("allows verbosity for models that support it", () => {
+		expect(() =>
+			validateModelCapabilities(verbosityModel, "gpt-5.6-terra", undefined, {
+				verbosity: "low",
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects verbosity for models without support", () => {
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "deepseek-v4-flash", undefined, {
+				verbosity: "low",
+			}),
+		).toThrow(HTTPException);
+	});
+
+	it("skips the verbosity check for auto and custom models", () => {
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "auto", undefined, {
+				verbosity: "low",
+			}),
+		).not.toThrow();
+		expect(() =>
+			validateModelCapabilities(noVisionModel, "custom", undefined, {
+				verbosity: "low",
+			}),
+		).not.toThrow();
+	});
+
+	it("does not check verbosity when it is not specified", () => {
+		expect(() =>
+			validateModelCapabilities(
+				noVisionModel,
+				"deepseek-v4-flash",
+				undefined,
+				{},
+			),
+		).not.toThrow();
+	});
+});
+
 describe("validateModelCapabilities - custom providers", () => {
 	it("skips all capability checks when the provider is custom", () => {
 		expect(() =>

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -17,6 +17,7 @@ export interface ValidateModelCapabilitiesOptions {
 	};
 	reasoning_effort?: string;
 	reasoning_max_tokens?: number;
+	verbosity?: string;
 	tools?: unknown[];
 	tool_choice?: unknown;
 	webSearchTool?: WebSearchTool;
@@ -42,6 +43,7 @@ export function validateModelCapabilities(
 		response_format,
 		reasoning_effort,
 		reasoning_max_tokens,
+		verbosity,
 		tools,
 		tool_choice,
 		webSearchTool,
@@ -185,6 +187,30 @@ export function validateModelCapabilities(
 
 			throw new HTTPException(400, {
 				message: `Model ${requestedModel} does not support reasoning. Remove the reasoning_effort parameter or use a reasoning-capable model.`,
+			});
+		}
+	}
+
+	// Check if verbosity is specified but model doesn't support it
+	// Skip this check for "auto" and "custom" models as they will be resolved dynamically
+	if (
+		verbosity !== undefined &&
+		requestedModel !== "auto" &&
+		requestedModel !== "custom"
+	) {
+		const providersToCheck = requestedProvider
+			? modelInfo.providers.filter(
+					(p) => (p as ProviderModelMapping).providerId === requestedProvider,
+				)
+			: modelInfo.providers;
+
+		const supportsVerbosity = providersToCheck.some(
+			(provider) => (provider as ProviderModelMapping).verbosity === true,
+		);
+
+		if (!supportsVerbosity) {
+			throw new HTTPException(400, {
+				message: `Model ${requestedModel} does not support the verbosity parameter. Remove the verbosity parameter or use a model that supports it (OpenAI GPT-5.6 and later).`,
 			});
 		}
 	}

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -324,6 +324,9 @@ responses.post("/", async (c) => {
 	if (req.reasoning?.effort) {
 		chatRequest.reasoning_effort = req.reasoning.effort;
 	}
+	if (req.text?.verbosity !== undefined) {
+		chatRequest.verbosity = req.text.verbosity;
+	}
 	if (req.prompt_cache_key !== undefined) {
 		chatRequest.prompt_cache_key = req.prompt_cache_key;
 	}

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -51,6 +51,7 @@ async function prepareOpenAITextRequest(options: {
 	promptCacheKey?: string;
 	promptCacheRetention?: "in_memory" | "24h";
 	serviceTier?: "flex" | "priority";
+	verbosity?: "low" | "medium" | "high";
 }) {
 	const model = options.model ?? "gpt-5.5";
 	return await prepareRequestBody(
@@ -85,6 +86,7 @@ async function prepareOpenAITextRequest(options: {
 		true,
 		undefined,
 		options.serviceTier,
+		options.verbosity,
 	);
 }
 
@@ -619,6 +621,86 @@ describe("prepareRequestBody - OpenAI service tiers", () => {
 		})) as { service_tier?: string };
 
 		expect(requestBody.service_tier).toBeUndefined();
+	});
+});
+
+describe("prepareRequestBody - verbosity", () => {
+	test("forwards verbosity to gpt-5.6 chat completions", async () => {
+		const requestBody = (await prepareOpenAITextRequest({
+			model: "gpt-5.6-terra",
+			verbosity: "low",
+		})) as { verbosity?: string };
+
+		expect(requestBody.verbosity).toBe("low");
+	});
+
+	test("forwards verbosity as text.verbosity to gpt-5.6 Responses API", async () => {
+		const requestBody = (await prepareOpenAITextRequest({
+			model: "gpt-5.6-sol",
+			useResponsesApi: true,
+			verbosity: "high",
+		})) as { text?: { verbosity?: string } };
+
+		expect(requestBody.text?.verbosity).toBe("high");
+	});
+
+	test("keeps text.format when verbosity is combined with response_format", async () => {
+		const requestBody = (await prepareRequestBody(
+			"openai",
+			"gpt-5.6-luna",
+			null,
+			"gpt-5.6-luna",
+			[{ role: "user", content: "Hello!" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ type: "json_object" },
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+			20,
+			null,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			true, // useResponsesApi
+			undefined,
+			undefined,
+			true,
+			undefined,
+			undefined,
+			"medium", // verbosity
+		)) as { text?: { format?: { type: string }; verbosity?: string } };
+
+		expect(requestBody.text?.format?.type).toBe("json_object");
+		expect(requestBody.text?.verbosity).toBe("medium");
+	});
+
+	test("strips verbosity for models without verbosity support", async () => {
+		const requestBody = (await prepareOpenAITextRequest({
+			model: "gpt-4o",
+			verbosity: "low",
+		})) as { verbosity?: string };
+
+		expect(requestBody.verbosity).toBeUndefined();
+	});
+
+	test("strips verbosity from the Responses API body for unsupported models", async () => {
+		const requestBody = (await prepareOpenAITextRequest({
+			model: "gpt-5.5",
+			useResponsesApi: true,
+			verbosity: "low",
+		})) as { text?: { verbosity?: string } };
+
+		expect(requestBody.text?.verbosity).toBeUndefined();
 	});
 });
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -891,6 +891,7 @@ export async function prepareRequestBody(
 	providerCacheControlEnabled = true,
 	n?: number,
 	service_tier?: "auto" | "default" | "flex" | "priority",
+	verbosity?: "low" | "medium" | "high",
 ): Promise<ProviderRequestBody | FormData> {
 	tools = normalizeToolParameters(tools);
 	const modelDef = models.find((m) => m.id === usedInternalModel);
@@ -926,6 +927,17 @@ export async function prepareRequestBody(
 		providerMappingForOptions?.apiFormat === "openai-chat-completions";
 	if (reasoning_effort === "none" && !handlesNoneNatively) {
 		reasoning_effort = undefined;
+	}
+
+	// `verbosity` is only understood by OpenAI GPT-5.6+ models. Capability
+	// validation rejects unsupported pinned models upfront, but auto routing and
+	// retry fallbacks can still land on a mapping without verbosity support, so
+	// strip it here instead of forwarding an unknown parameter upstream.
+	if (
+		verbosity !== undefined &&
+		providerMappingForOptions?.verbosity !== true
+	) {
+		verbosity = undefined;
 	}
 
 	// `max` is Anthropic's top effort tier (above `xhigh`). Providers without a
@@ -1632,6 +1644,13 @@ export async function prepareRequestBody(
 					}
 				}
 
+				if (verbosity !== undefined) {
+					responsesBody.text = {
+						...responsesBody.text,
+						verbosity,
+					};
+				}
+
 				return responsesBody;
 			} else {
 				// Use regular chat completions format
@@ -1730,6 +1749,9 @@ export async function prepareRequestBody(
 					} else {
 						requestBody.reasoning_effort = genericReasoningEffort;
 					}
+				}
+				if (verbosity !== undefined) {
+					requestBody.verbosity = verbosity;
 				}
 				if (n !== undefined && n > 1) {
 					requestBody.n = n;

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -330,6 +330,11 @@ export interface ProviderModelMapping {
 	 */
 	reasoning?: boolean;
 	/**
+	 * Whether this model supports the OpenAI `verbosity` parameter
+	 * (low/medium/high response detail control, GPT-5.6 and later)
+	 */
+	verbosity?: boolean;
+	/**
 	 * Whether the provider returns reasoning inside tagged content (e.g. &lt;think&gt;...&lt;/think&gt;)
 	 * that needs to be split into separate reasoning and content fields
 	 */

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1751,6 +1751,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01",
 				reasoning: true,
 				reasoningOutput: "omit",
+				verbosity: true,
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
 				supportedParameters: [
@@ -1759,6 +1760,7 @@ export const openaiModels = [
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1790,6 +1792,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01",
 				reasoning: true,
 				reasoningOutput: "omit",
+				verbosity: true,
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
 				supportedParameters: [
@@ -1798,6 +1801,7 @@ export const openaiModels = [
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1829,6 +1833,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01",
 				reasoning: true,
 				reasoningOutput: "omit",
+				verbosity: true,
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
 				supportedParameters: [
@@ -1837,6 +1842,7 @@ export const openaiModels = [
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -248,6 +248,7 @@ export interface OpenAIRequestBody extends BaseRequestBody {
 		include_usage: boolean;
 	};
 	reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	verbosity?: "low" | "medium" | "high";
 	n?: number;
 	extra_body?: Record<string, unknown>;
 }
@@ -291,7 +292,7 @@ export interface OpenAIResponsesRequestBody {
 	temperature?: number;
 	max_output_tokens?: number;
 	text?: {
-		format:
+		format?:
 			| { type: "text" }
 			| { type: "json_object" }
 			| {
@@ -300,6 +301,7 @@ export interface OpenAIResponsesRequestBody {
 					schema: Record<string, unknown>;
 					strict?: boolean;
 			  };
+		verbosity?: "low" | "medium" | "high";
 	};
 }
 


### PR DESCRIPTION
## Summary

Adds support for OpenAI's new `verbosity` parameter (`low` / `medium` / `high`) for the GPT-5.6 model family (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`), controlling how detailed model responses are.

## Changes

- **Request schemas**: accept top-level `verbosity` on `/v1/chat/completions` and `text.verbosity` on `/v1/responses` (mirroring OpenAI's shapes for each API).
- **Capability gating**: new `verbosity?: boolean` flag on provider mappings; `validateModelCapabilities` returns a 400 when `verbosity` is sent to a model without support (skipped for `auto`/`custom`, matching `reasoning_effort` behavior).
- **Forwarding** (`prepareRequestBody`): sent as `text.verbosity` on the Responses API (merged with `text.format` when `response_format` is also set) and as top-level `verbosity` on Chat Completions. Stripped when auto routing or retry fallback lands on a mapping without support, so an unknown param is never forwarded upstream.
- **Model catalog**: `verbosity: true` + `"verbosity"` in `supportedParameters` on all three gpt-5.6 OpenAI mappings.

## Testing

- Unit tests: forwarding for both API shapes, coexistence with `response_format`, stripping for unsupported models, and capability validation (139 tests pass across the two touched spec files; full `pnpm test:unit` has one pre-existing, unrelated google-vertex routing failure that also fails on a clean tree).
- Scoped e2e: `TEST_MODELS="openai/gpt-5.6-luna" pnpm test:e2e` — 85 passed.
- Live verification through a local gateway against the real OpenAI API:
  - `verbosity: "low"` vs `"high"` on the same prompt produced 299 vs 20,069 chars of output, confirming upstream honors the forwarded value.
  - `gpt-4o` + `verbosity` → clean 400 with actionable message.
  - `/v1/responses` with `text.verbosity` → works.
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional low, medium, or high verbosity controls to Chat Completions and Responses API requests.
  * Forwarded verbosity settings for supported GPT-5.6 models across chat and Responses API requests.
  * Added validation with clear errors when verbosity is requested for unsupported models.
  * Preserved verbosity alongside response formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->