### PR TITLE
fix(gateway): warn on upstream socket terminations

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -24,6 +24,8 @@ import { HealthChecker } from "@llmgateway/shared";
 
 import { anthropic } from "./anthropic/anthropic.js";
 import { chat } from "./chat/chat.js";
+import { extractErrorCause } from "./chat/tools/extract-error-cause.js";
+import { isUpstreamTermination } from "./chat/tools/normalize-streaming-error.js";
 import { embeddingsRoute } from "./embeddings/route.js";
 import { imagesRoute } from "./images/route.js";
 import {
@@ -213,6 +215,20 @@ app.onError((error, c) => {
 			method: c.req.method,
 		});
 		return renderGatewayError(c, 499, "Client Closed Request");
+	}
+
+	// An upstream-side socket close (e.g. undici "terminated: other side
+	// closed" / ECONNRESET) that escaped the chat handler's own classification
+	// is an expected provider/client disconnect, not a gateway bug. Log it at
+	// warn to avoid raising server-error alerts.
+	if (isUpstreamTermination(error)) {
+		logger.warn("Upstream connection terminated", {
+			message: error instanceof Error ? error.message : String(error),
+			cause: extractErrorCause(error),
+			path: c.req.path,
+			method: c.req.method,
+		});
+		return renderGatewayError(c, 502, "Upstream connection terminated");
 	}
 
 	// For any other errors (non-HTTPException), return 500 Internal Server Error

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -216,7 +216,10 @@ import {
 import { messagesContainDocuments } from "./tools/messages-contain-documents.js";
 import { messagesContainImages } from "./tools/messages-contain-images.js";
 import { mightBeCompleteJson } from "./tools/might-be-complete-json.js";
-import { normalizeStreamingError } from "./tools/normalize-streaming-error.js";
+import {
+	isUpstreamTermination,
+	normalizeStreamingError,
+} from "./tools/normalize-streaming-error.js";
 import { checkOpenAIContentFilter } from "./tools/openai-content-filter.js";
 import { convertAwsEventStreamToSSE } from "./tools/parse-aws-eventstream.js";
 import { parseModelInput } from "./tools/parse-model-input.js";
@@ -10769,6 +10772,15 @@ chat.openapi(completions, async (c) => {
 				} else if (error.name === "AbortError") {
 					logger.info("Streaming request aborted by client (escaped handler)", {
 						message: error.message,
+						path: c.req.path,
+					});
+				} else if (isUpstreamTermination(error)) {
+					// An upstream-side socket close (e.g. undici "terminated: other
+					// side closed" / ECONNRESET) is an expected provider/client
+					// disconnect, not a gateway fault. Log at warn to avoid alerts.
+					logger.warn("Upstream stream terminated (escaped handler)", {
+						message: error.message,
+						cause: extractErrorCause(error),
 						path: c.req.path,
 					});
 				} else {

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeStreamingError } from "./normalize-streaming-error.js";
+import {
+	isUpstreamTermination,
+	normalizeStreamingError,
+} from "./normalize-streaming-error.js";
 
 describe("normalizeStreamingError", () => {
 	it("classifies terminated undici stream reads as upstream termination", () => {
@@ -105,5 +108,40 @@ describe("normalizeStreamingError", () => {
 
 		expect(normalized.log.details.responseText).not.toBe("[object Object]");
 		expect(normalized.client.message).not.toContain("[object Object]");
+	});
+});
+
+describe("isUpstreamTermination", () => {
+	it("detects a bare undici terminated TypeError", () => {
+		expect(isUpstreamTermination(new TypeError("terminated"))).toBe(true);
+	});
+
+	it("detects an upstream socket close via the cause chain", () => {
+		const socketCloseError = new Error("other side closed") as Error & {
+			code?: string;
+		};
+		socketCloseError.name = "SocketError";
+		socketCloseError.code = "UND_ERR_SOCKET";
+
+		const error = new TypeError("terminated", { cause: socketCloseError });
+
+		expect(isUpstreamTermination(error)).toBe(true);
+	});
+
+	it("detects ECONNRESET surfaced through the cause chain", () => {
+		const reset = new Error("read ECONNRESET") as Error & { code?: string };
+		reset.code = "ECONNRESET";
+
+		expect(
+			isUpstreamTermination(new Error("fetch failed", { cause: reset })),
+		).toBe(true);
+	});
+
+	it("does not flag genuine gateway-side errors", () => {
+		expect(
+			isUpstreamTermination(new SyntaxError("Unexpected end of JSON input")),
+		).toBe(false);
+		expect(isUpstreamTermination("terminated")).toBe(false);
+		expect(isUpstreamTermination(undefined)).toBe(false);
 	});
 });

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.ts
@@ -125,13 +125,20 @@ function safeStringifyError(error: unknown): string {
 	return `[unserializable ${ctorName}]`;
 }
 
-function isUpstreamTermination(error: unknown, cause?: string): boolean {
+/**
+ * True when the failure is an expected upstream-side socket close (the provider
+ * or client closed the connection mid-request, e.g. undici's
+ * "terminated: other side closed" / ECONNRESET), rather than a gateway bug.
+ * Callers use this to log such disconnects at warn severity instead of raising
+ * server-error alerts.
+ */
+export function isUpstreamTermination(error: unknown): boolean {
 	if (!(error instanceof Error)) {
 		return false;
 	}
 
 	const normalizedMessage = error.message.trim().toLowerCase();
-	const normalizedCause = cause?.toLowerCase() ?? "";
+	const normalizedCause = extractErrorCause(error)?.toLowerCase() ?? "";
 
 	return (
 		(error.name === "TypeError" && normalizedMessage === "terminated") ||
@@ -159,7 +166,7 @@ export function normalizeStreamingError(
 	const cause = extractErrorCause(error);
 	const errorCode = getErrorCode(error);
 
-	const terminated = isUpstreamTermination(error, cause);
+	const terminated = isUpstreamTermination(error);
 	const statusCode = terminated ? 502 : 500;
 	const statusText = terminated
 		? "Upstream Stream Terminated"


### PR DESCRIPTION
## What

The alert below is being logged at **ERROR** severity:

```
{"err":{"message":"terminated: other side closed","stack":"TypeError: terminated\n    at Fetch.onAborted (node:internal/deps/undici/undici...)\n    ... at TLSSocket.onHttpSocketClose"}}
```

This is undici's (Node's built-in `fetch`) way of reporting that the **socket was closed by the other side** mid-request — i.e. the upstream LLM provider (or the client) dropped the TCP/TLS connection while the gateway was reading/writing. For a streaming proxy this is a routine operational event, **not a gateway bug**.

## Why it was logging as ERROR

The gateway already recognizes this in its main streaming-read and body-read paths and downgrades it to `warn` (see `normalize-streaming-error.ts` + `chat.ts`). But when a `terminated` error *escaped* those paths and bubbled up to:

- the **global `app.onError` handler** (`app.ts` → `"Unhandled error"`), or
- the **streaming escaped handler** (`chat.ts` → `"Streaming request error (escaped handler)"`)

…neither classified it, so it hit `logger.error` → GCP `ERROR` severity → alert noise.

## Change

- Export the existing termination predicate as `isUpstreamTermination(error)` (now derives the cause chain itself; behavior of `normalizeStreamingError` unchanged).
- Reuse it in both fallback handlers so an upstream socket close logs at `warn` and returns `502` instead of logging `error` / returning `500`.
- Add unit coverage for the exported predicate (bare `terminated` TypeError, socket-close via cause chain, ECONNRESET, and negative cases).

No behavior change for genuine gateway-side faults — those still log at `error`.

## Test

- `pnpm exec vitest run apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts` — 9 passed
- `turbo run build --filter=gateway` — green
- `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upstream connection terminations during requests and streaming responses.
  * Returns a clearer “Upstream connection terminated” gateway error instead of a generic failure.
  * Logs expected upstream disconnects at warning level for improved diagnostics.
  * Added coverage for socket closures, connection resets, nested causes, and unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->