### PR TITLE
feat(seo): implement seo and ai-seo audit fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ llmgateway_data
 !apps/ui/public/llms.txt
 !apps/code/public/llms.txt
 !apps/playground/public/llms.txt
+!apps/docs/app/llms.txt
+!apps/docs/app/llms-full.txt
 docker-compose-override-*.yml
 benchmark_results.json
 benchmark-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ llmgateway_data
 *.http
 *.txt
 !apps/ui/public/llms.txt
+!apps/code/public/llms.txt
+!apps/playground/public/llms.txt
 docker-compose-override-*.yml
 benchmark_results.json
 benchmark-*.json

--- a/apps/code/public/llms.txt
+++ b/apps/code/public/llms.txt
@@ -1,0 +1,23 @@
+# DevPass by LLM Gateway
+
+> DevPass is a flat-price subscription for AI coding tools. One API key unlocks 200+ models across 40+ providers in any OpenAI-compatible coding agent — DevPass Code, Claude Code, opencode, Cursor, Continue, and more — with a fixed monthly usage allowance instead of surprise token bills.
+
+## Plans
+
+- Lite: $29/month — includes $87 of model usage at standard provider rates.
+- Pro: $79/month — includes $237 of model usage.
+- Max: $179/month — includes $537 of model usage.
+- Every plan includes the newest frontier models as they are released and full cost tracking.
+
+## Key pages
+
+- [DevPass](https://devpass.llmgateway.io): Plans, supported coding agents, and setup.
+- [Docs & agent guides](https://docs.llmgateway.io/guides): Step-by-step setup for each coding agent.
+- [Models](https://llmgateway.io/models): Full catalog of supported models with pricing and capabilities.
+- [LLM Gateway](https://llmgateway.io): The open-source gateway platform DevPass runs on.
+- [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
+
+## Notes
+
+- DevPass works with any tool that speaks the OpenAI API format — point it at the gateway base URL.
+- Usage allowances are metered at provider list rates; there is no markup on tokens.

--- a/apps/docs/app/(home)/[[...slug]]/page.tsx
+++ b/apps/docs/app/(home)/[[...slug]]/page.tsx
@@ -12,6 +12,7 @@ import posthog from "posthog-js";
 import { LLMCopyButton, ViewOptions } from "@/components/ai/page-actions";
 import { EnterpriseCTA } from "@/components/enterprise-cta";
 import { Feedback } from "@/components/feedback";
+import { JsonLd } from "@/components/json-ld";
 import { docsBaseUrl } from "@/lib/base-url";
 import { source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
@@ -81,6 +82,26 @@ export default async function Page(props: {
 
 	const MDXContent = page.data.body;
 
+	const path = page.url === "/" ? "" : page.url;
+	const techArticleSchema = {
+		"@context": "https://schema.org",
+		"@type": "TechArticle",
+		headline: page.data.title,
+		description: page.data.description,
+		url: `${docsBaseUrl}${path}`,
+		...(time ? { dateModified: new Date(time).toISOString() } : {}),
+		author: {
+			"@type": "Organization",
+			name: "LLM Gateway",
+			url: "https://llmgateway.io",
+		},
+		publisher: {
+			"@type": "Organization",
+			name: "LLM Gateway",
+			url: "https://llmgateway.io",
+		},
+	};
+
 	return (
 		<DocsPage
 			toc={page.data.toc}
@@ -91,6 +112,7 @@ export default async function Page(props: {
 			}}
 			lastUpdate={time ? new Date(time) : new Date()}
 		>
+			<JsonLd data={techArticleSchema} />
 			<nav
 				aria-label="Page actions"
 				className="flex flex-row gap-2 items-center border-b pt-2 pb-6"

--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -6,7 +6,7 @@ export const revalidate = false;
 
 const HEADER = `# LLM Gateway — Full Documentation
 
-> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 35+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
+> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 40+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
 
 API base URL: https://api.llmgateway.io/v1 · Docs: https://docs.llmgateway.io · Site: https://llmgateway.io
 

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -53,11 +53,11 @@ export async function GET() {
 
 	const content = `# LLM Gateway
 
-> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 35+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
+> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 40+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
 
 ## Key facts
 
-- One OpenAI-compatible API for 35+ providers and 280+ models.
+- One OpenAI-compatible API for 40+ providers and 200+ models.
 - Migrate by changing only the base URL (\`https://api.llmgateway.io/v1\`) and your API key — no code rewrites.
 - Open source (AGPLv3 core) with a managed cloud option; self-hosting supported via Docker.
 - Built-in usage analytics, per-model/provider cost breakdowns, automatic routing, fallbacks, caching, and guardrails.
@@ -66,7 +66,7 @@ export async function GET() {
 ## Product pages
 
 - [Home](${SITE_URL}): Unified API for multiple LLM providers.
-- [Models](${SITE_URL}/models): Browse 280+ supported models with pricing and capabilities.
+- [Models](${SITE_URL}/models): Browse 200+ supported models with pricing and capabilities.
 - [Providers](${SITE_URL}/providers): All supported LLM providers.
 - [Pricing](${SITE_URL}/pricing): Plans and pricing.
 - [Enterprise](${SITE_URL}/enterprise): Self-hosting, SSO, and team features.

--- a/apps/docs/components/json-ld.tsx
+++ b/apps/docs/components/json-ld.tsx
@@ -1,0 +1,23 @@
+type JsonLdData = Record<string, unknown>;
+
+interface JsonLdProps {
+	data: JsonLdData | JsonLdData[];
+}
+
+/**
+ * Renders a JSON-LD structured data script tag. Works in server components
+ * and is included in the SSR HTML so crawlers can read it without JS.
+ */
+export function JsonLd({ data }: JsonLdProps) {
+	return (
+		<script
+			type="application/ld+json"
+			// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+			dangerouslySetInnerHTML={{
+				// Escape `<` so a `</script>` (or `<!--`) inside the data can't
+				// break out of the script tag.
+				__html: JSON.stringify(data).replace(/</g, "\\u003c"),
+			}}
+		/>
+	);
+}

--- a/apps/docs/content/guides/autohand.mdx
+++ b/apps/docs/content/guides/autohand.mdx
@@ -7,7 +7,7 @@ icon: AutohandCode
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-Autohand Code is an autonomous AI coding agent that works in your terminal, IDE, and Slack. With LLM Gateway, you can route all Autohand Code requests through a single gateway—use any of 280+ models from 35+ providers, with full cost tracking and smart routing.
+Autohand Code is an autonomous AI coding agent that works in your terminal, IDE, and Slack. With LLM Gateway, you can route all Autohand Code requests through a single gateway—use any of 200+ models from 40+ providers, with full cost tracking and smart routing.
 
 ## Setup
 
@@ -45,7 +45,7 @@ All requests will now be routed through LLM Gateway.
 
 ## Why Use LLM Gateway with Autohand Code
 
-- **280+ models** — GPT-5, Claude Opus, Gemini, Llama, and more from 35+ providers
+- **200+ models** — GPT-5, Claude Opus, Gemini, Llama, and more from 40+ providers
 - **Smart routing** — Automatically selects the best provider based on uptime, throughput, price, and latency
 - **Cost tracking** — Monitor exactly how much each autonomous agent costs
 - **Single bill** — No need to manage multiple API provider accounts

--- a/apps/docs/content/guides/codex-cli.mdx
+++ b/apps/docs/content/guides/codex-cli.mdx
@@ -7,7 +7,7 @@ icon: CodexCli
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-Codex CLI is OpenAI's open-source terminal coding agent. By default it connects to OpenAI's API, but with LLM Gateway you can route it through a single gateway—use GPT-5.3 Codex, Gemini, Claude, or any of 280+ models while keeping full cost visibility.
+Codex CLI is OpenAI's open-source terminal coding agent. By default it connects to OpenAI's API, but with LLM Gateway you can route it through a single gateway—use GPT-5.3 Codex, Gemini, Claude, or any of 200+ models while keeping full cost visibility.
 
 One config file. No code changes. Full cost tracking in your dashboard.
 

--- a/apps/docs/content/guides/continue.mdx
+++ b/apps/docs/content/guides/continue.mdx
@@ -1,13 +1,13 @@
 ---
 title: Continue CLI Integration
-description: Use any model with Continue CLI through LLM Gateway. One config file, 280+ models, full cost tracking.
+description: Use any model with Continue CLI through LLM Gateway. One config file, 200+ models, full cost tracking.
 icon: Continue
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[Continue](https://docs.continue.dev) is an open-source AI code assistant available as a CLI tool. By configuring it to use LLM Gateway, you get access to 280+ models from 35+ providers with unified cost tracking.
+[Continue](https://docs.continue.dev) is an open-source AI code assistant available as a CLI tool. By configuring it to use LLM Gateway, you get access to 200+ models from 40+ providers with unified cost tracking.
 
 One config file. Any model. Full cost visibility.
 
@@ -117,7 +117,7 @@ All requests now route through LLM Gateway. You'll see usage, costs, and logs in
 
 ## Why Use LLM Gateway with Continue
 
-- **280+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more
+- **200+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more
 - **One API key** — Stop managing separate keys for each provider
 - **Cost tracking** — See exactly what each session costs in your dashboard
 - **Response caching** — Repeated requests hit cache automatically

--- a/apps/docs/content/guides/cursor.mdx
+++ b/apps/docs/content/guides/cursor.mdx
@@ -8,7 +8,7 @@ icon: Cursor
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-Cursor is an AI-powered code editor built on VSCode. You can point Cursor's custom OpenAI base URL at LLM Gateway to use any of our 280+ models for **plan mode** (the chat / planning panel).
+Cursor is an AI-powered code editor built on VSCode. You can point Cursor's custom OpenAI base URL at LLM Gateway to use any of our 200+ models for **plan mode** (the chat / planning panel).
 
 <Callout type="warn">
 	**Plan mode only.** Cursor's coding agent (Composer, inline edit,

--- a/apps/docs/content/guides/hermes-agent.mdx
+++ b/apps/docs/content/guides/hermes-agent.mdx
@@ -1,13 +1,13 @@
 ---
 title: Hermes Agent Integration
-description: Use any model with Hermes Agent through LLM Gateway. One config change, full cost tracking, 280+ models.
+description: Use any model with Hermes Agent through LLM Gateway. One config change, full cost tracking, 200+ models.
 icon: Hermes
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[Hermes Agent](https://github.com/nousresearch/hermes-agent) is an open-source AI coding agent for your terminal built by Nous Research. It supports tool use, browser automation, multi-provider routing, skills, and MCP servers. By pointing it at LLM Gateway you get access to 280+ models from 35+ providers, all tracked in one dashboard.
+[Hermes Agent](https://github.com/nousresearch/hermes-agent) is an open-source AI coding agent for your terminal built by Nous Research. It supports tool use, browser automation, multi-provider routing, skills, and MCP servers. By pointing it at LLM Gateway you get access to 200+ models from 40+ providers, all tracked in one dashboard.
 
 One config change. No code changes. Full cost tracking.
 
@@ -73,7 +73,7 @@ Then paste your LLM Gateway API key (starts with `llmgtwy_`):
 <Step>
 ### Choose a Model
 
-The wizard presents a list of 280+ available models. Type a model name or select from the list. Popular choices include `claude-sonnet-4-6`, `gpt-5.5`, or `gemini-3.1-pro`:
+The wizard presents a list of 200+ available models. Type a model name or select from the list. Popular choices include `claude-sonnet-4-6`, `gpt-5.5`, or `gemini-3.1-pro`:
 
 ![Model Selection List](../../public/guides/hermes-agent/2-model-list.png)
 
@@ -171,7 +171,7 @@ hermes chat --model claude-opus-4-6
 
 ## Why Use LLM Gateway with Hermes Agent
 
-- **280+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more
+- **200+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more
 - **One API key** — Stop managing separate keys for each provider
 - **Cost tracking** — See exactly what each session costs in your dashboard
 - **Response caching** — Repeated requests hit cache automatically

--- a/apps/docs/content/guides/kilo-code.mdx
+++ b/apps/docs/content/guides/kilo-code.mdx
@@ -69,7 +69,7 @@ Once connected, select an LLM Gateway model from the model picker at the bottom 
 
 ## Why Use LLM Gateway with Kilo Code
 
-- **280+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more from 35+ providers
+- **200+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more from 40+ providers
 - **One API key** — Stop managing separate keys for each provider
 - **Cost tracking** — See exactly what each session costs in your dashboard
 - **Response caching** — Repeated requests hit cache automatically

--- a/apps/docs/content/guides/kimi-code.mdx
+++ b/apps/docs/content/guides/kimi-code.mdx
@@ -185,7 +185,7 @@ display_name = "Qwen3.7 Max"
 
 ## Why Use LLM Gateway with Kimi Code CLI
 
-- **280+ models** — Access GPT-5.5, Gemini, Llama, DeepSeek, and more in a single CLI configuration.
+- **200+ models** — Access GPT-5.5, Gemini, Llama, DeepSeek, and more in a single CLI configuration.
 - **Unified cost tracking** — Get a detailed breakdown of costs per prompt and session in your dashboard.
 - **Response caching** — Automatically cache repeated requests (such as parsing or building commands) to save API costs.
 - **Automatic fallback** — Keep coding even if a provider encounters temporary downtime.

--- a/apps/docs/content/guides/mcp.mdx
+++ b/apps/docs/content/guides/mcp.mdx
@@ -423,7 +423,7 @@ The MCP server respects your account's rate limits. If you're hitting limits:
 
 ## Benefits
 
-- **Unified Access** - Use 280+ models from 35+ providers through one interface
+- **Unified Access** - Use 200+ models from 40+ providers through one interface
 - **Cost Tracking** - Monitor usage and costs in the LLM Gateway dashboard
 - **Caching** - Automatic response caching reduces costs and latency
 - **Fallback** - Automatic provider failover ensures reliability

--- a/apps/docs/content/guides/mimocode.mdx
+++ b/apps/docs/content/guides/mimocode.mdx
@@ -158,7 +158,7 @@ Once registered, you can set them as your default model or small model using the
 
 ## Why Use LLM Gateway with MiMo Code
 
-- **280+ models** — Access GPT-5.5, Gemini, Llama, DeepSeek, and more in a single CLI configuration.
+- **200+ models** — Access GPT-5.5, Gemini, Llama, DeepSeek, and more in a single CLI configuration.
 - **Unified cost tracking** — Get a detailed breakdown of costs per prompt and session in your dashboard.
 - **Response caching** — Automatically cache repeated requests (such as parsing or building commands) to save API costs.
 - **Automatic fallback** — Keep coding even if a provider encounters temporary downtime.

--- a/apps/docs/content/guides/openclaw.mdx
+++ b/apps/docs/content/guides/openclaw.mdx
@@ -7,7 +7,7 @@ icon: OpenClaw
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[OpenClaw](https://docs.openclaw.ai/) is a self-hosted gateway that connects your favorite chat apps—WhatsApp, Telegram, Discord, iMessage, and more—to AI coding agents. With LLM Gateway as a custom provider, you can route all your OpenClaw traffic through a single API, use any of 280+ models, and keep full visibility into usage and costs.
+[OpenClaw](https://docs.openclaw.ai/) is a self-hosted gateway that connects your favorite chat apps—WhatsApp, Telegram, Discord, iMessage, and more—to AI coding agents. With LLM Gateway as a custom provider, you can route all your OpenClaw traffic through a single API, use any of 200+ models, and keep full visibility into usage and costs.
 
 ## Setup
 
@@ -87,7 +87,7 @@ Launch OpenClaw and start chatting across your connected channels. All requests 
 
 ## Why Use LLM Gateway with OpenClaw
 
-- **Model flexibility** — Switch between GPT-5.4, Claude Opus, Gemini, or any of 280+ models
+- **Model flexibility** — Switch between GPT-5.4, Claude Opus, Gemini, or any of 200+ models
 - **Cost tracking** — Monitor exactly how much your chat agents cost to run
 - **Single bill** — No need to manage multiple API provider accounts
 - **Response caching** — Repeated queries hit cache, reducing costs

--- a/apps/docs/content/guides/opencode-desktop.mdx
+++ b/apps/docs/content/guides/opencode-desktop.mdx
@@ -1,6 +1,6 @@
 ---
 title: OpenCode Desktop Integration
-description: Connect OpenCode Desktop to 280+ models through LLM Gateway. No config files — just open Settings, connect, and start building.
+description: Connect OpenCode Desktop to 200+ models through LLM Gateway. No config files — just open Settings, connect, and start building.
 icon: OpenCode
 ---
 
@@ -87,7 +87,7 @@ Select a model and start chatting. All requests route through LLM Gateway — yo
 
 ## Why Use LLM Gateway with OpenCode Desktop
 
-- **280+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more from 35+ providers
+- **200+ models** — Claude, GPT, Gemini, Llama, DeepSeek, and more from 40+ providers
 - **One API key** — Stop managing separate keys for each provider
 - **Cost tracking** — See exactly what each session costs in your dashboard
 - **Response caching** — Repeated requests hit cache automatically

--- a/apps/docs/content/guides/opencode.mdx
+++ b/apps/docs/content/guides/opencode.mdx
@@ -1,13 +1,13 @@
 ---
 title: OpenCode Integration
-description: Connect OpenCode to 280+ models through LLM Gateway's built-in provider. No config files needed — just select, authenticate, and code.
+description: Connect OpenCode to 200+ models through LLM Gateway's built-in provider. No config files needed — just select, authenticate, and code.
 icon: OpenCode
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[OpenCode](https://opencode.ai) is an open-source AI coding agent for your terminal, IDE, or desktop. LLM Gateway is a built-in provider in OpenCode, so setup takes under a minute — no config files or npm adapters required. You get access to 280+ models from 35+ providers, all tracked in one dashboard.
+[OpenCode](https://opencode.ai) is an open-source AI coding agent for your terminal, IDE, or desktop. LLM Gateway is a built-in provider in OpenCode, so setup takes under a minute — no config files or npm adapters required. You get access to 200+ models from 40+ providers, all tracked in one dashboard.
 
 ## Prerequisites
 
@@ -67,7 +67,7 @@ You're all set! OpenCode is now connected to LLM Gateway. You can start asking q
 
 ## Why Use LLM Gateway with OpenCode
 
-- **280+ models** — GPT-5, Claude, Gemini, Llama, and more from 35+ providers
+- **200+ models** — GPT-5, Claude, Gemini, Llama, and more from 40+ providers
 - **One API key** — Stop juggling credentials for every provider
 - **Cost tracking** — See what each coding agent costs in your dashboard
 - **Response caching** — Repeated requests hit cache automatically

--- a/apps/docs/content/guides/pi.mdx
+++ b/apps/docs/content/guides/pi.mdx
@@ -8,7 +8,7 @@ icon: PiAgent
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[Pi](https://pi.dev) is a minimal terminal-based coding agent that gives an AI full access to read, write, edit, and run shell commands in your project. By pointing Pi at LLM Gateway, you can use any of our 280+ models — GPT-5.5, Gemini 3.1 Pro, Claude Opus 4.7, DeepSeek V4, and more — with full cost tracking and caching.
+[Pi](https://pi.dev) is a minimal terminal-based coding agent that gives an AI full access to read, write, edit, and run shell commands in your project. By pointing Pi at LLM Gateway, you can use any of our 200+ models — GPT-5.5, Gemini 3.1 Pro, Claude Opus 4.7, DeepSeek V4, and more — with full cost tracking and caching.
 
 ## Prerequisites
 

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Introduction to LLM Gateway
 description: LLM Gateway is an open-source API gateway for Large Language Models. Route requests to multiple providers, manage API keys, track usage, and optimize costs.
 icon: BookOpen
 ---

--- a/apps/docs/lib/get-llm-text.ts
+++ b/apps/docs/lib/get-llm-text.ts
@@ -3,6 +3,34 @@ import type { InferPageType } from "fumadocs-core/source";
 
 const DOCS_URL = "https://docs.llmgateway.io";
 
+// Navigation-card components whose target pages are already concatenated in
+// full elsewhere in llms-full.txt; interactive embeds have no text value and
+// are dropped entirely.
+const MDX_COMPONENT_REPLACEMENTS: Record<string, string> = {
+	FeatureCards: `All features are documented under ${DOCS_URL}/features; each feature page is included in full in this file.`,
+	AIToolingCards: `AI tooling: ${DOCS_URL}/llms.txt (docs index for LLMs), ${DOCS_URL}/llms-full.txt (this file), ${DOCS_URL}/guides/mcp (MCP server), ${DOCS_URL}/guides/agent-skills (agent skills), and https://llmgateway.io/templates (templates and agents).`,
+	SelfHostCards: `Self-hosting guides are documented under ${DOCS_URL}/self-host and included in full in this file.`,
+};
+
+// Raw MDX component tags mean nothing to LLM readers; swap known navigation
+// components for text pointers and drop the rest instead of leaking JSX.
+// Fenced code blocks are left untouched so JSX code samples survive.
+function replaceMdxComponents(text: string): string {
+	return text
+		.split(/(```[\s\S]*?```)/)
+		.map((segment) =>
+			segment.startsWith("```")
+				? segment
+				: segment
+						.replace(
+							/^[ \t]*<([A-Z][A-Za-z0-9]*)(?:\s[^>]*)?\/>[ \t]*$/gm,
+							(_match, name: string) => MDX_COMPONENT_REPLACEMENTS[name] ?? "",
+						)
+						.replace(/\n{3,}/g, "\n\n"),
+		)
+		.join("");
+}
+
 export async function getLLMText(page: InferPageType<typeof source>) {
 	const processed = await page.data.getText("processed");
 	// Root-relative markdown links would be resolved against whatever domain
@@ -11,5 +39,5 @@ export async function getLLMText(page: InferPageType<typeof source>) {
 	const absolute = processed.replace(/\]\((\/[^)\s]*)\)/g, `](${DOCS_URL}$1)`);
 	return `# ${page.data.title}
 URL: ${DOCS_URL}${page.url}
-${absolute}`;
+${replaceMdxComponents(absolute)}`;
 }

--- a/apps/playground/public/llms.txt
+++ b/apps/playground/public/llms.txt
@@ -1,0 +1,22 @@
+# LLM Gateway Chat
+
+> LLM Gateway Chat (chat.llmgateway.io) is an AI chat playground for talking to 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers in one place. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files — on transparent provider-rate credits.
+
+## Plans
+
+- Starter: $9/month.
+- Plus: $19/month.
+- Pro: $49/month.
+- All plans are billed monthly and include a monthly credit allowance usable across every model; free to start with no credit card.
+
+## Key pages
+
+- [Chat](https://chat.llmgateway.io): The chat playground.
+- [Models](https://llmgateway.io/models): Every supported model with pricing and capabilities.
+- [LLM Gateway](https://llmgateway.io): The open-source gateway platform behind Chat.
+- [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
+
+## Notes
+
+- Switch models mid-conversation; run the same prompt against multiple models at once.
+- Image and video generation use the same credit balance as chat.

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
 		template: "%s | LLM Gateway Playground",
 	},
 	description:
-		"Test and compare 200+ AI models from one account. Chat with GPT, Claude, Gemini, generate images and videos, and run multi-model group chats — pay-as-you-go with a single balance.",
+		"Test and compare 200+ AI models from one account. Chat with GPT, Claude, and Gemini, generate images and video, and run multi-model group chats.",
 	icons: {
 		icon: "/favicon/favicon.ico?v=2",
 	},

--- a/apps/playground/src/app/manifest.ts
+++ b/apps/playground/src/app/manifest.ts
@@ -5,7 +5,7 @@ export default function manifest(): MetadataRoute.Manifest {
 		name: "LLM Gateway Playground",
 		short_name: "LLM Gateway",
 		description:
-			"Test and compare 280+ AI models in one playground. Chat, image, video, and group-chat across providers.",
+			"Test and compare 200+ AI models in one playground. Chat, image, video, and group-chat across providers.",
 		start_url: "/",
 		display: "standalone",
 		background_color: "#ffffff",

--- a/apps/playground/src/components/playground/auth-dialog.tsx
+++ b/apps/playground/src/components/playground/auth-dialog.tsx
@@ -45,7 +45,7 @@ const FEATURES: Feature[] = [
 	{
 		icon: MessageSquare,
 		title: "Chat",
-		description: "GPT, Claude, Gemini & 280+ models — switch mid-conversation",
+		description: "GPT, Claude, Gemini & 200+ models — switch mid-conversation",
 	},
 	{
 		icon: ImagePlus,
@@ -83,7 +83,7 @@ export function AuthDialog({
 	open,
 	returnUrl,
 	title = "Every model and studio — in one place",
-	description = "Chat, images, video, canvas and group chat across 280+ models. Free to start — no credit card required.",
+	description = "Chat, images, video, canvas and group chat across 200+ models. Free to start — no credit card required.",
 }: AuthDialogProps) {
 	if (!open) {
 		return null;

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -1937,9 +1937,9 @@ export default function ChatPageClient({
 
 	return (
 		<SidebarProvider>
-			<h1 className="sr-only">
-				LLM Gateway Playground - Chat with 280+ AI Models
-			</h1>
+			<h2 className="sr-only">
+				LLM Gateway Playground - Chat with 200+ AI Models
+			</h2>
 			<div className="flex h-svh bg-background w-full overflow-hidden">
 				{isTemporaryChat ? null : (
 					<ChatSidebar

--- a/apps/playground/src/components/seo/playground-seo-section.tsx
+++ b/apps/playground/src/components/seo/playground-seo-section.tsx
@@ -17,11 +17,11 @@ interface VariantContent {
 
 const variants: Record<SeoVariant, VariantContent> = {
 	chat: {
-		h1: "AI chat playground — talk to 280+ models in one place",
+		h1: "AI chat playground — talk to 200+ models in one place",
 		intro:
 			"Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time. Pay-as-you-go from a single credit balance — no per-provider billing setup.",
 		bullets: [
-			"Supports 280+ models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers.",
+			"Supports 200+ models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers.",
 			"Stream responses, fork past conversations, and share read-only chat snapshots via public links.",
 			"One credit balance covers every provider — top up once, route requests anywhere, get unified usage and cost analytics through LLM Gateway.",
 		],
@@ -89,7 +89,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 		intro:
 			"Send one prompt to multiple AI models simultaneously and compare their responses. Useful for evaluating quality, speed, and cost across GPT, Claude, Gemini, Grok, and other models.",
 		bullets: [
-			"Run the same prompt against any combination of 280+ supported models.",
+			"Run the same prompt against any combination of 200+ supported models.",
 			"See streamed responses side by side in real time.",
 			"Compare latency, token counts, and cost per response in a single view.",
 		],
@@ -107,7 +107,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"Generate, edit, and export interactive UI specs as JSON with live preview. Export the result as a PDF or image. Powered by LLM Gateway.",
 		bullets: [
 			"Iterate on UI layouts by editing a JSON spec with live preview.",
-			"Use any of 280+ supported models to generate or modify canvas specs.",
+			"Use any of 200+ supported models to generate or modify canvas specs.",
 			"Export the canvas to PDF or PNG for sharing.",
 		],
 		related: [

--- a/apps/playground/src/lib/comparisons.ts
+++ b/apps/playground/src/lib/comparisons.ts
@@ -105,7 +105,7 @@ function planFacts(tier: ChatPlanTier) {
 export const US = {
 	name: "LLM Gateway Chat",
 	url: "https://chat.llmgateway.io",
-	modelCount: "280+",
+	modelCount: "200+",
 	plans: {
 		starter: planFacts("starter"),
 		plus: planFacts("plus"),
@@ -131,7 +131,7 @@ export const comparisons: Comparison[] = [
 		table: [
 			{
 				label: "Models",
-				us: "280+ across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral and more",
+				us: "200+ across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral and more",
 				them: "OpenAI only (GPT-5.x family)",
 				usWins: true,
 			},
@@ -220,7 +220,7 @@ export const comparisons: Comparison[] = [
 		faq: [
 			{
 				q: "Is LLM Gateway Chat a ChatGPT alternative?",
-				a: "Yes. It's a multi-model chat app that includes OpenAI's GPT models alongside Claude, Gemini, Grok, and 280+ others, so a single $19/mo subscription replaces ChatGPT Plus plus the other AI subscriptions you'd otherwise stack on top.",
+				a: "Yes. It's a multi-model chat app that includes OpenAI's GPT models alongside Claude, Gemini, Grok, and 200+ others, so a single $19/mo subscription replaces ChatGPT Plus plus the other AI subscriptions you'd otherwise stack on top.",
 			},
 			{
 				q: "Can I still use GPT-5 on LLM Gateway Chat?",
@@ -254,7 +254,7 @@ export const comparisons: Comparison[] = [
 		table: [
 			{
 				label: "Models",
-				us: "Claude Opus, Sonnet, Haiku + GPT, Gemini, Grok and 280+ more",
+				us: "Claude Opus, Sonnet, Haiku + GPT, Gemini, Grok and 200+ more",
 				them: "Anthropic only (Opus, Sonnet, Haiku)",
 				usWins: true,
 			},
@@ -344,7 +344,7 @@ export const comparisons: Comparison[] = [
 		faq: [
 			{
 				q: "Does LLM Gateway Chat include Claude?",
-				a: "Yes. Claude Opus, Sonnet, and Haiku are available on the Plus and Pro plans, alongside GPT, Gemini, Grok, and 280+ other models on one credit balance.",
+				a: "Yes. Claude Opus, Sonnet, and Haiku are available on the Plus and Pro plans, alongside GPT, Gemini, Grok, and 200+ other models on one credit balance.",
 			},
 			{
 				q: "Why use LLM Gateway Chat instead of Claude Pro?",
@@ -378,7 +378,7 @@ export const comparisons: Comparison[] = [
 		table: [
 			{
 				label: "Models",
-				us: "Gemini + GPT, Claude, Grok and 280+ more",
+				us: "Gemini + GPT, Claude, Grok and 200+ more",
 				them: "Google only (Gemini family)",
 				usWins: true,
 			},
@@ -467,7 +467,7 @@ export const comparisons: Comparison[] = [
 		faq: [
 			{
 				q: "Is LLM Gateway Chat a Google Gemini alternative?",
-				a: "Yes. It includes Gemini's models alongside GPT, Claude, Grok, and 280+ others on one $19/mo balance, without tying your chats to a Google account.",
+				a: "Yes. It includes Gemini's models alongside GPT, Claude, Grok, and 200+ others on one $19/mo balance, without tying your chats to a Google account.",
 			},
 			{
 				q: "Do I still get Gemini's long context window?",
@@ -491,7 +491,7 @@ export const comparisons: Comparison[] = [
 		category: "aggregator",
 		metaTitle: "LLM Gateway Chat vs Poe — multi-model chat without points math",
 		metaDescription:
-			"Poe meters every model with confusing compute points. LLM Gateway Chat gives you 280+ models on transparent provider-rate credits for $19/mo.",
+			"Poe meters every model with confusing compute points. LLM Gateway Chat gives you 200+ models on transparent provider-rate credits for $19/mo.",
 		eyebrow: "Compute points vs transparent credits",
 		verdict:
 			"Poe pioneered multi-model chat and has huge breadth, including user-built bots and group chats. Its weak point, by far the most common complaint, is the compute-points system: every model costs a different, hard-to-predict number of points, nothing rolls over, and frontier models drain your balance fast. LLM Gateway Chat is also one balance across every model, but priced as transparent credits at provider rates.",
@@ -500,7 +500,7 @@ export const comparisons: Comparison[] = [
 		table: [
 			{
 				label: "Models",
-				us: "280+ across every major provider",
+				us: "200+ across every major provider",
 				them: "100+ models plus user-built bots",
 			},
 			{
@@ -559,7 +559,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				heading: "Breadth and bots",
-				us: "The focus is direct, fast access to 280+ first-party models with image, video, and audio generation and side-by-side comparison.",
+				us: "The focus is direct, fast access to 200+ first-party models with image, video, and audio generation and side-by-side comparison.",
 				them: "Poe's real edge is its ecosystem: millions of user-created bots, creator monetization, and large group chats. If that ecosystem is why you're there, it's a genuine strength.",
 				bottomLine:
 					"Want a bot marketplace? Poe wins. Want clean, predictable access to the models themselves? That's us.",
@@ -592,7 +592,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				q: "Does it have as many models as Poe?",
-				a: "It includes 280+ first-party models across every major provider. Poe adds a large catalog of user-built bots on top; if a creator bot ecosystem is what you want, Poe is stronger there.",
+				a: "It includes 200+ first-party models across every major provider. Poe adds a large catalog of user-built bots on top; if a creator bot ecosystem is what you want, Poe is stronger there.",
 			},
 			{
 				q: "Will I run out as fast as I do on Poe?",
@@ -613,7 +613,7 @@ export const comparisons: Comparison[] = [
 		metaTitle:
 			"LLM Gateway Chat vs T3 Chat — multi-model chat with a media studio",
 		metaDescription:
-			"T3 Chat is fast $8/mo multi-model chat with no media generation. LLM Gateway Chat adds image, video, audio and group chat across 280+ models.",
+			"T3 Chat is fast $8/mo multi-model chat with no media generation. LLM Gateway Chat adds image, video, audio and group chat across 200+ models.",
 		eyebrow: "Fast and minimal vs full studio",
 		verdict:
 			"T3 Chat is genuinely excellent at one thing: fast, clean multi-model chat for $8/mo, with bring-your-own-key support. It's also deliberately minimal — no native mobile app, no voice, no persistent memory, and no real media generation. LLM Gateway Chat costs more but adds image, video, and audio generation, group chat, and a transparent credit balance.",
@@ -627,7 +627,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				label: "Models",
-				us: "280+ across every major provider",
+				us: "200+ across every major provider",
 				them: "Dozens across major providers",
 			},
 			{
@@ -710,7 +710,7 @@ export const comparisons: Comparison[] = [
 		faq: [
 			{
 				q: "Is LLM Gateway Chat worth more than T3 Chat's $8?",
-				a: "It depends on what you need. T3 is cheaper and faster for pure text chat. LLM Gateway Chat costs $19 on Plus but adds image, video, and audio generation, side-by-side group chat, persistent shareable conversations, and 280+ models with transparent credits.",
+				a: "It depends on what you need. T3 is cheaper and faster for pure text chat. LLM Gateway Chat costs $19 on Plus but adds image, video, and audio generation, side-by-side group chat, persistent shareable conversations, and 200+ models with transparent credits.",
 			},
 			{
 				q: "Does it support bring-your-own-key like T3?",
@@ -748,7 +748,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				label: "Models",
-				us: "280+ — pick or switch any model per message",
+				us: "200+ — pick or switch any model per message",
 				them: "Frontier models per query, plus its own Sonar",
 			},
 			{
@@ -842,7 +842,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				q: "Is it cheaper than Perplexity Pro?",
-				a: "Plus is $19/mo versus Perplexity Pro at $20/mo, and it covers chat, coding, and media generation across 280+ models rather than search alone.",
+				a: "Plus is $19/mo versus Perplexity Pro at $20/mo, and it covers chat, coding, and media generation across 200+ models rather than search alone.",
 			},
 		],
 	},
@@ -869,7 +869,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				label: "Models",
-				us: "280+ across every major provider",
+				us: "200+ across every major provider",
 				them: "400+ models from many providers",
 			},
 			{
@@ -922,7 +922,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				heading: "Breadth",
-				us: "280+ first-party models with a polished, persistent, media-capable interface.",
+				us: "200+ first-party models with a polished, persistent, media-capable interface.",
 				them: "More raw models — 400+ — and zero inference markup, which genuinely matters if you're building software on the API.",
 				bottomLine:
 					"For sheer model count and API economics, OpenRouter leads; for the chat experience, LLM Gateway Chat does.",
@@ -955,7 +955,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				q: "Does it have more models than OpenRouter?",
-				a: "OpenRouter lists more raw models — 400+ versus 280+ — and has zero inference markup for API developers. For chatting, LLM Gateway Chat focuses on a polished experience across every major provider.",
+				a: "OpenRouter lists more raw models — 400+ versus 200+ — and has zero inference markup for API developers. For chatting, LLM Gateway Chat focuses on a polished experience across every major provider.",
 			},
 			{
 				q: "Why pay a subscription instead of OpenRouter's pay-as-you-go?",

--- a/apps/ui/public/llms.txt
+++ b/apps/ui/public/llms.txt
@@ -1,12 +1,13 @@
 # LLM Gateway
 
-> LLM Gateway is a unified API for routing requests across OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek and 35+ other LLM providers. Use one OpenAI-compatible API and one key to access every model, with usage analytics, cost tracking, caching, and automatic failover. Open source (AGPLv3) and self-hostable.
+> LLM Gateway is a unified API for routing requests across 40+ LLM providers, including OpenAI, Anthropic, Google, Meta, Mistral, and DeepSeek. Use one OpenAI-compatible API and one key to access 200+ models, with usage analytics, cost tracking, caching, and automatic failover. Open source (AGPLv3) and self-hostable.
 
 ## Key pages
 
 - [Models](https://llmgateway.io/models): Full catalog of supported LLMs with pricing, context windows, and capabilities.
 - [Model release timeline](https://llmgateway.io/timeline): When each LLM was released by its provider and when it was added to LLM Gateway — a reference for AI model release dates (GPT, Claude, Gemini, Llama, Mistral, DeepSeek).
-- [Pricing](https://llmgateway.io/pricing): Pay-as-you-go credits with a 5% platform fee, free Bring-Your-Own-Keys, and enterprise plans.
+- [Pricing](https://llmgateway.io/pricing): Per-token at provider rates. Pay-as-you-go credits carry a flat 5% platform fee; Bring-Your-Own-Keys is free; enterprise plans available.
+- [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing summary for AI agents.
 - [Providers](https://llmgateway.io/providers): Every supported provider and the models each offers.
 - [Docs](https://docs.llmgateway.io): API reference and integration guides.
 - [Compare](https://llmgateway.io/compare/open-router): How LLM Gateway compares to OpenRouter, LiteLLM, Portkey, and the Vercel AI Gateway.

--- a/apps/ui/public/pricing.md
+++ b/apps/ui/public/pricing.md
@@ -1,0 +1,37 @@
+# LLM Gateway — Pricing
+
+Last updated: 2026-07-10
+
+> One OpenAI-compatible API for 200+ models across 40+ providers. Per-token prices match each provider's published rates; LLM Gateway charges a flat 5% platform fee when you buy credits. Bringing your own provider keys is free, and self-hosting is free under AGPLv3.
+
+## Managed cloud — pay-as-you-go credits
+
+- Price: $0 subscription. Prepaid credits, $10 minimum / $5,000 maximum per top-up.
+- Platform fee: flat 5% added at credit purchase (plus 1.5% for international cards).
+- Token pricing: provider list rates per token — no markup on tokens. Live per-model prices: https://llmgateway.io/models
+- Includes: 200+ models, 40+ providers, automatic failover, response caching, usage analytics, and cost tracking.
+
+## Bring Your Own Keys (BYOK)
+
+- Price: free. Your provider bills you directly at its own rates.
+- Platform fee: none — the 5% fee applies only to credit purchases.
+
+## Self-hosted
+
+- Price: free and open source (AGPLv3): https://github.com/theopenco/llmgateway
+
+## Enterprise
+
+- Price: custom — volume discounts, custom routing, unlimited data retention, 99.9% uptime SLA.
+- Details: https://llmgateway.io/enterprise — contact contact@llmgateway.io
+
+## Related products
+
+- DevPass — flat-price dev plans for AI coding tools: Lite $29/month ($87 model usage included), Pro $79/month ($237 included), Max $179/month ($537 included). https://devpass.llmgateway.io
+- Chat — consumer AI chat plans, billed monthly: Starter $9, Plus $19, Pro $49. https://chat.llmgateway.io
+
+## Notes
+
+- The API is OpenAI-compatible: point your existing SDK at the gateway base URL.
+- Free models are available on the free tier without buying credits.
+- Human-readable pricing page: https://llmgateway.io/pricing

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -597,9 +597,11 @@ export async function generateMetadata({
 	}
 
 	const title = `${model.name ?? model.id} — Pricing, Providers & Benchmarks`;
+	const pitch = `Use ${model.name ?? model.id} via one OpenAI-compatible API with live per-token pricing across providers.`;
 	const description =
-		model.description ??
-		`Compare ${model.name ?? model.id} pricing across providers, with its context window, capabilities, and one OpenAI-compatible API.`;
+		model.description && model.description.length + pitch.length <= 250
+			? `${model.description} ${pitch}`
+			: (model.description ?? pitch);
 
 	const primaryProvider = model.providers[0]?.providerId || "default";
 	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`;

--- a/apps/ui/src/app/models/compare/page.tsx
+++ b/apps/ui/src/app/models/compare/page.tsx
@@ -3,16 +3,19 @@ import { Suspense } from "react";
 import Footer from "@/components/landing/footer";
 import { Navbar } from "@/components/landing/navbar";
 import { ModelComparison } from "@/components/models/model-comparison";
+import { JsonLd } from "@/components/seo/json-ld";
 
 export const metadata = {
 	title: "Compare AI Models Side by Side",
 	description:
 		"Select any two AI models to compare pricing, context window, and capabilities with our interactive model comparison tool.",
+	alternates: { canonical: "https://llmgateway.io/models/compare" },
 	openGraph: {
 		title: "AI Model Comparison Tool",
 		description:
 			"Compare LLM pricing, context, and features across providers in a side-by-side view.",
 		type: "website",
+		url: "https://llmgateway.io/models/compare",
 	},
 	twitter: {
 		card: "summary_large_image",
@@ -22,9 +25,51 @@ export const metadata = {
 	},
 };
 
+const webApplicationSchema = {
+	"@context": "https://schema.org",
+	"@type": "WebApplication",
+	name: "AI Model Comparison Tool",
+	url: "https://llmgateway.io/models/compare",
+	applicationCategory: "DeveloperApplication",
+	operatingSystem: "Web",
+	offers: {
+		"@type": "Offer",
+		price: "0",
+		priceCurrency: "USD",
+	},
+	description:
+		"Interactive tool to compare any two AI models side by side — per-token pricing, context window, and capabilities across providers.",
+};
+
+const breadcrumbSchema = {
+	"@context": "https://schema.org",
+	"@type": "BreadcrumbList",
+	itemListElement: [
+		{
+			"@type": "ListItem",
+			position: 1,
+			name: "Home",
+			item: "https://llmgateway.io",
+		},
+		{
+			"@type": "ListItem",
+			position: 2,
+			name: "Models",
+			item: "https://llmgateway.io/models",
+		},
+		{
+			"@type": "ListItem",
+			position: 3,
+			name: "Compare",
+			item: "https://llmgateway.io/models/compare",
+		},
+	],
+};
+
 export default function ModelsComparePage() {
 	return (
 		<>
+			<JsonLd data={[webApplicationSchema, breadcrumbSchema]} />
 			<Navbar />
 			<main className="min-h-screen bg-background pt-24 md:pt-32 pb-16">
 				<div className="container mx-auto px-4">
@@ -37,9 +82,14 @@ export default function ModelsComparePage() {
 							capabilities across providers.
 						</p>
 					</header>
-					<Suspense>
-						<ModelComparison />
-					</Suspense>
+					<section aria-labelledby="comparison-tool-heading">
+						<h2 id="comparison-tool-heading" className="sr-only">
+							Model comparison tool
+						</h2>
+						<Suspense>
+							<ModelComparison />
+						</Suspense>
+					</section>
 				</div>
 			</main>
 			<Footer />

--- a/apps/ui/src/app/models/page.tsx
+++ b/apps/ui/src/app/models/page.tsx
@@ -1,9 +1,31 @@
+import Link from "next/link";
 import { Suspense } from "react";
 
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { AllModels } from "@/components/models/all-models";
 import { JsonLd } from "@/components/seo/json-ld";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
+
+const CATEGORY_LINKS: ReadonlyArray<{ href: string; label: string }> = [
+	{ href: "/models/coding", label: "Best models for coding" },
+	{ href: "/models/reasoning", label: "Reasoning models" },
+	{ href: "/models/roleplay", label: "Best models for roleplay" },
+	{ href: "/models/creative-writing", label: "Creative writing models" },
+	{ href: "/models/translation", label: "Translation models" },
+	{ href: "/models/math", label: "Best models for math" },
+	{ href: "/models/long-context", label: "Long context models" },
+	{ href: "/models/cheapest", label: "Cheapest models" },
+	{ href: "/models/open-source", label: "Open source models" },
+	{ href: "/models/vision", label: "Vision models" },
+	{ href: "/models/tools", label: "Tool-calling models" },
+	{ href: "/models/web-search", label: "Web search models" },
+	{ href: "/models/embeddings", label: "Embedding models" },
+	{ href: "/models/text", label: "Text generation models" },
+	{ href: "/models/text-to-image", label: "Text-to-image models" },
+	{ href: "/models/image-to-image", label: "Image editing models" },
+	{ href: "/models/video", label: "Video generation models" },
+	{ href: "/models/discounted", label: "Discounted models" },
+];
 
 export const metadata = {
 	alternates: {
@@ -80,6 +102,25 @@ export default async function ModelsPage() {
 					providers={providers}
 					title="AI Models Directory"
 					description="Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and 40+ providers — filter by capabilities, pricing, and context size."
+					seoContent={
+						<section className="container mx-auto px-4 pb-16">
+							<h2 className="text-2xl font-bold mb-6">
+								Browse models by use case
+							</h2>
+							<ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-3 max-w-3xl">
+								{CATEGORY_LINKS.map((category) => (
+									<li key={category.href}>
+										<Link
+											href={category.href}
+											className="text-muted-foreground hover:text-foreground hover:underline underline-offset-4"
+										>
+											{category.label}
+										</Link>
+									</li>
+								))}
+							</ul>
+						</section>
+					}
 				>
 					<HeroRSC navbarOnly sticky={false} />
 				</AllModels>

--- a/apps/ui/src/app/pricing/page.tsx
+++ b/apps/ui/src/app/pricing/page.tsx
@@ -7,22 +7,22 @@ import { JsonLd } from "@/components/seo/json-ld";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "LLM API Pricing — Per-Token, No Markup",
+	title: "LLM API Pricing — Provider Rates, Free BYOK",
 	description:
-		"Pay per-token at provider rates with no markup. Free tier, volume discounts, and one bill across OpenAI, Anthropic, Google, and 40+ providers.",
+		"Pay per-token at provider rates with a flat 5% platform fee on credits — or free with your own keys (BYOK). Volume discounts and one bill across 40+ providers.",
 	alternates: { canonical: "/pricing" },
 	openGraph: {
-		title: "LLM API Pricing — Per-Token, No Markup",
+		title: "LLM API Pricing — Provider Rates, Free BYOK",
 		description:
-			"Pay per-token at provider rates with no markup. Free tier, volume discounts, and one bill across 40+ LLM providers.",
+			"Pay per-token at provider rates with a flat 5% platform fee on credits, or free with your own keys. One bill across 40+ LLM providers.",
 		type: "website",
 		url: "https://llmgateway.io/pricing",
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "LLM API Pricing — Per-Token, No Markup",
+		title: "LLM API Pricing — Provider Rates, Free BYOK",
 		description:
-			"Pay per-token at provider rates with no markup. Free tier, volume discounts, and one bill across 40+ LLM providers.",
+			"Pay per-token at provider rates with a flat 5% platform fee on credits, or free with your own keys. One bill across 40+ LLM providers.",
 	},
 };
 
@@ -31,7 +31,7 @@ const pricingSchema = {
 	"@type": "Product",
 	name: "LLM Gateway API",
 	description:
-		"Unified API for 200+ LLM models across 40+ providers. Pay per-token at provider rates with no markup, bring your own keys for free, or self-host under AGPLv3.",
+		"Unified API for 200+ LLM models across 40+ providers. Pay per-token at provider rates with a flat 5% platform fee on credits, bring your own keys for free, or self-host under AGPLv3.",
 	brand: {
 		"@type": "Brand",
 		name: "LLM Gateway",
@@ -49,7 +49,7 @@ const pricingSchema = {
 				price: "0",
 				priceCurrency: "USD",
 				description:
-					"Access all 200+ models with a 5% platform fee on credit usage, or bring your own provider keys for free.",
+					"Access all 200+ models with a flat 5% platform fee on credit purchases, or bring your own provider keys for free.",
 				url: "https://llmgateway.io/pricing",
 			},
 			{

--- a/apps/ui/src/app/providers/[id]/page.tsx
+++ b/apps/ui/src/app/providers/[id]/page.tsx
@@ -263,20 +263,25 @@ export async function generateMetadata({
 		return {};
 	}
 
+	const modelCount = modelDefinitions.filter((model) =>
+		model.providers.some((p) => p.providerId === provider.id),
+	).length;
+	const description = `Access ${modelCount} ${provider.name} models through LLM Gateway's OpenAI-compatible API with per-token pricing, automatic fallback, caching, and cost analytics.`;
+
 	return {
-		title: provider.name,
-		description: `Learn about ${provider.name} integration with LLM Gateway. Access ${provider.name} models through our unified API.`,
+		title: `${provider.name} API — Models & Pricing`,
+		description,
 		alternates: { canonical: `/providers/${provider.id}` },
 		openGraph: {
-			title: `${provider.name} | LLM Gateway`,
-			description: `Learn about ${provider.name} integration with LLM Gateway. Access ${provider.name} models through our unified API.`,
+			title: `${provider.name} API — Models & Pricing | LLM Gateway`,
+			description,
 			type: "website",
 			url: `https://llmgateway.io/providers/${provider.id}`,
 		},
 		twitter: {
 			card: "summary_large_image",
-			title: `${provider.name} | LLM Gateway`,
-			description: `Learn about ${provider.name} integration with LLM Gateway.`,
+			title: `${provider.name} API — Models & Pricing | LLM Gateway`,
+			description,
 		},
 	};
 }

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -23,14 +23,14 @@ import type { Metadata } from "next";
 const BASE_URL = "https://llmgateway.io";
 
 export const metadata: Metadata = {
-	title: "LLM Release Timeline — When Each AI Model Was Released",
+	title: "LLM Release Timeline — Model Release Dates",
 	description:
-		"Release dates for every major LLM. See when GPT, Claude, Gemini, Llama, Mistral and DeepSeek models shipped from their provider and when each was added to LLM Gateway. Browse by year.",
+		"Release dates for every major LLM — see when GPT, Claude, Gemini, Llama, Mistral, and DeepSeek models shipped and when each was added to LLM Gateway.",
 	alternates: {
 		canonical: "/timeline",
 	},
 	openGraph: {
-		title: "LLM Release Timeline — When Each AI Model Was Released",
+		title: "LLM Release Timeline — Model Release Dates",
 		description:
 			"Release dates for every major LLM — GPT, Claude, Gemini, Llama, Mistral and DeepSeek — with the date each model was added to LLM Gateway.",
 		type: "website",
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "LLM Release Timeline — When Each AI Model Was Released",
+		title: "LLM Release Timeline — Model Release Dates",
 		description:
 			"Release dates for every major LLM — GPT, Claude, Gemini, Llama, Mistral and DeepSeek — and when each was added to LLM Gateway.",
 	},

--- a/apps/ui/src/components/blog/list.tsx
+++ b/apps/ui/src/components/blog/list.tsx
@@ -102,7 +102,7 @@ export function BlogList({
 									)}
 								</Link>
 								<div className="p-5 space-y-3">
-									<h3 className="text-xl font-semibold leading-tight">
+									<h2 className="text-xl font-semibold leading-tight">
 										<Link
 											href={`/blog/${entry.slug}`}
 											prefetch={true}
@@ -110,7 +110,7 @@ export function BlogList({
 										>
 											{entry.title}
 										</Link>
-									</h3>
+									</h2>
 									{entry?.categories && entry.categories.length > 0 && (
 										<div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
 											{entry.categories.map((cat) => (

--- a/apps/ui/src/components/pricing/pricing-table.tsx
+++ b/apps/ui/src/components/pricing/pricing-table.tsx
@@ -215,6 +215,9 @@ export function PricingTable() {
 	return (
 		<section className="w-full pb-16 md:pb-24">
 			<div className="container mx-auto px-4 md:px-6">
+				<h2 className="text-2xl md:text-3xl font-bold tracking-tight text-center mb-8">
+					Compare plans
+				</h2>
 				<div className="overflow-x-auto">
 					<table className="w-full border-collapse min-w-[600px]">
 						{/* Header */}

--- a/apps/ui/src/content/blog/2026-07-08-litellm-alternatives.md
+++ b/apps/ui/src/content/blog/2026-07-08-litellm-alternatives.md
@@ -3,7 +3,7 @@ id: blog-litellm-alternatives
 slug: litellm-alternatives
 date: 2026-07-08
 title: "8 Best LiteLLM Alternatives in 2026 (Compared)"
-summary: "The best LiteLLM alternatives in 2026, compared honestly — open-source gateways, managed routers, and enterprise platforms — so you can stop babysitting a Python proxy and pick the right replacement."
+summary: "The best LiteLLM alternatives in 2026, compared honestly — open-source gateways, managed routers, and enterprise platforms — and how to pick the right one."
 categories: ["Guides"]
 image:
   src: "/blog/litellm-alternatives.png"

--- a/apps/ui/src/content/use-cases/ai-customer-support.md
+++ b/apps/ui/src/content/use-cases/ai-customer-support.md
@@ -4,7 +4,7 @@ slug: ai-customer-support
 date: 2026-06-02
 title: AI customer support
 metaTitle: "LLM Gateway for AI Customer Support & Chatbots"
-description: "Build AI support agents and chatbots that stay up. Route across providers with automatic fallback, cache common answers, and see cost per conversation — through one OpenAI-compatible API."
+description: "Build AI support agents and chatbots that stay up. Route across providers with automatic fallback, cache common answers, and track cost per conversation."
 headline: "Support bots that don't go down when a provider does — with caching and per-conversation cost visibility."
 summary: "Run reliable support agents on any model, with automatic failover, response caching for common questions, and cost tracking per conversation."
 benefits:

--- a/apps/ui/src/lib/features.ts
+++ b/apps/ui/src/lib/features.ts
@@ -40,7 +40,7 @@ export const features: FeatureDefinition[] = [
 		title: "Unified API Interface",
 		subtitle: "One API for all LLM providers",
 		description:
-			"Compatible with the OpenAI API format for seamless migration and integration.",
+			"Compatible with the OpenAI API format — migrate by changing the base URL, keep your SDK, and reach 200+ models across 40+ providers with no code changes.",
 		longDescription:
 			"LLM Gateway provides a unified API interface that's fully compatible with the OpenAI API format. This means you can easily migrate from OpenAI to any other provider without changing your code. Simply update the base URL and API key, and you're ready to go.",
 		icon: null,


### PR DESCRIPTION
## Summary

Implements every actionable finding from this month's SEO + AI-SEO audit (methodology from the marketing `seo-audit` / `ai-seo` skills; companion to the automated monthly audit in #2982).

### Pricing claim reconciliation (highest-impact finding)
- `/pricing` metadata said **"no markup"** while `llms.txt` said **"5% platform fee"** — AI engines extracted contradictory pricing. Both now state the same fact: per-token at provider rates, flat 5% platform fee on credit purchases, free BYOK.
- Product JSON-LD offer wording corrected ("on credit purchases", the fee applies at top-up).

### Count unification (35+/40+ providers, 200+/280+ models)
- All surfaces now match `MARKETING_STATS` (40+ providers / 200+ models): docs `llms.txt` + `llms-full.txt` routes, 13 docs guides, playground manifest/H1/auth dialog/comparisons, ui `llms.txt`. (Dated blog posts left as historical content.)

### Machine-readable layer for AI agents
- **New `/pricing.md`** on llmgateway.io — plain-markdown pricing (cloud credits + fee, BYOK, self-host, enterprise, DevPass + Chat plans), linked from `llms.txt`.
- **New `llms.txt` for DevPass and Chat hosts** (both previously 404).
- **`llms-full.txt` MDX leak fixed**: raw tags (`<FeatureCards />`, `<BuyCredits/>`, …) are now replaced with text pointers (nav components) or stripped (interactive embeds); fenced code blocks are preserved.
- `.gitignore`: public `llms.txt` files and docs llms route dirs un-ignored (root `*.txt` was swallowing them).

### Template metadata fixes
- **Provider pages (×39)**: 20-char titles ("OpenAI | LLM Gateway") → "{Provider} API — Models & Pricing" + description with live model count.
- **Model pages (×325)**: meta description now appends a value proposition to the raw model blurb (when it fits).
- **Timeline**: title 68→57 chars, description 183→150.
- **Chat landing**: duplicate H1 fixed (hidden sr-only H1 demoted to h2; the content-rich SEO-section H1 remains), meta description 179→146.
- Meta description lengths: litellm-alternatives blog post 199→156, ai-customer-support use case 187→155, unified-api-interface feature 77→154.

### Structure & schema
- `/models`: new server-rendered **"Browse models by use case"** H2 section linking all 18 category pages (internal-linking boost for the curated SEO pages).
- `/models/compare`: WebApplication + BreadcrumbList JSON-LD, explicit canonical, H2 landmark.
- `/pricing`: "Compare plans" H2 above the plan table.
- `/blog`: post card titles h3→h2 (fixes skipped heading level).
- **Docs**: TechArticle JSON-LD (with dateModified from git) on every docs page via new `JsonLd` component; homepage title "Introduction" → "Introduction to LLM Gateway".

### Explicitly not done
- No changes to `export const dynamic` / rendering strategy (internal requirement).
- Chat landing visible-copy expansion skipped: its SEO content lives in an `sr-only` block, and piling more hidden text (or FAQPage schema on hidden content) is against guidelines — a visible content section is a product/design decision, flagged as follow-up.
- Named blog authors (E-E-A-T) skipped — content-policy decision.

### Testing
- `turbo run build --filter=ui --filter=docs --filter=playground` ✓ (15/15 tasks)
- `pnpm format` ✓

https://claude.ai/code/session_014no5xA4LRMMTMgHpyLoDH2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public pricing and machine-readable documentation pages.
  * Added model browsing links organized by use case.
  * Added structured metadata to improve search results and sharing.
  * Added clearer pricing-plan comparison headings and model descriptions.

* **Documentation**
  * Updated Gateway availability information to 200+ models across 40+ providers.
  * Expanded integration guides, pricing details, and product documentation.
  * Improved generated documentation readability by removing unsupported formatting components.

* **Style**
  * Refined product messaging across pricing, playground, provider, and use-case pages.
  * Improved heading structure and accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->