### PR TITLE
feat: self-refund for credit and plan purchases

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,7 @@
 		"ai": "6.0.27",
 		"bcrypt-ts": "8.0.0",
 		"better-auth": "1.6.23",
+		"decimal.js": "10.5.0",
 		"disposable-email-domains-js": "1.20.0",
 		"dotenv": "17.4.2",
 		"drizzle-zod": "0.8.3",

--- a/apps/api/src/lib/self-refund.spec.ts
+++ b/apps/api/src/lib/self-refund.spec.ts
@@ -1,0 +1,530 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+import { computeSelfRefundEligibility } from "./self-refund.js";
+
+import type * as PaymentsModule from "@/routes/payments.js";
+
+const stripeMock = vi.hoisted(() => ({
+	refunds: { create: vi.fn(), list: vi.fn() },
+	subscriptions: { cancel: vi.fn() },
+	invoices: { retrieve: vi.fn() },
+	invoicePayments: { list: vi.fn() },
+	paymentIntents: { retrieve: vi.fn() },
+}));
+
+vi.mock("@/routes/payments.js", async (importOriginal) => {
+	const original = await importOriginal<typeof PaymentsModule>();
+	return {
+		...original,
+		getStripe: () => stripeMock,
+	};
+});
+
+const ORG_ID = "test-org-id";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): Date {
+	const offsetMs = days * DAY_MS;
+	return new Date(Date.now() - offsetMs);
+}
+
+async function seedOrg(overrides: Record<string, unknown> = {}) {
+	await db.insert(tables.organization).values({
+		id: ORG_ID,
+		name: "Test Organization",
+		billingEmail: "test@example.com",
+		...overrides,
+	});
+	await db.insert(tables.userOrganization).values({
+		userId: "test-user-id",
+		organizationId: ORG_ID,
+		role: "owner",
+	});
+}
+
+async function seedTransaction(overrides: Record<string, unknown> = {}) {
+	const [row] = await db
+		.insert(tables.transaction)
+		.values({
+			organizationId: ORG_ID,
+			type: "credit_topup",
+			amount: "100",
+			creditAmount: "100",
+			stripePaymentIntentId: "pi_test_1",
+			...overrides,
+		} as typeof tables.transaction.$inferInsert)
+		.returning();
+	return row;
+}
+
+async function getEligibility(transactionId: string, role = "owner") {
+	const organization = await db.query.organization.findFirst({
+		where: { id: { eq: ORG_ID } },
+	});
+	const transactions = await db.query.transaction.findMany({
+		where: { organizationId: { eq: ORG_ID } },
+	});
+	const transaction = transactions.find((t) => t.id === transactionId);
+	return computeSelfRefundEligibility({
+		organization: organization!,
+		role,
+		transactions,
+		transaction: transaction!,
+	});
+}
+
+describe("computeSelfRefundEligibility", () => {
+	beforeEach(async () => {
+		await createTestUser();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("first credit top-up with no usage is eligible", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction();
+
+		expect(await getEligibility(tx.id)).toEqual({ eligible: true });
+	});
+
+	test("first credit top-up with usage just under 10% is eligible", async () => {
+		await seedOrg({ credits: "91" });
+		const tx = await seedTransaction();
+
+		expect(await getEligibility(tx.id)).toEqual({ eligible: true });
+	});
+
+	test("first credit top-up with 10% usage is not eligible", async () => {
+		await seedOrg({ credits: "90" });
+		const tx = await seedTransaction();
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "usage_exceeded",
+		});
+	});
+
+	test("gift credit consumption counts against the first top-up threshold", async () => {
+		// 20 gift + 100 purchased, 15 consumed (all attributable to the gift):
+		// still ineligible because all consumption counts.
+		await seedOrg({ credits: "105" });
+		await seedTransaction({
+			type: "credit_gift",
+			amount: null,
+			creditAmount: "20",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: null,
+		});
+		const tx = await seedTransaction();
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "usage_exceeded",
+		});
+	});
+
+	test("negative balance disqualifies the first top-up", async () => {
+		await seedOrg({ credits: "-5" });
+		const tx = await seedTransaction();
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "usage_exceeded",
+		});
+	});
+
+	test("repeat top-up: only the latest purchase is refundable", async () => {
+		await seedOrg({ credits: "150" });
+		const older = await seedTransaction({
+			createdAt: daysAgo(5),
+		});
+		const latest = await seedTransaction({
+			amount: "50",
+			creditAmount: "50",
+			stripePaymentIntentId: "pi_test_2",
+		});
+
+		expect(await getEligibility(older.id)).toEqual({
+			eligible: false,
+			reason: "not_latest_purchase",
+		});
+		expect(await getEligibility(latest.id)).toEqual({ eligible: true });
+	});
+
+	test("repeat top-up: balance below 90% of the purchase is not eligible", async () => {
+		await seedOrg({ credits: "44" });
+		await seedTransaction({
+			createdAt: daysAgo(5),
+		});
+		const latest = await seedTransaction({
+			amount: "50",
+			creditAmount: "50",
+			stripePaymentIntentId: "pi_test_2",
+		});
+
+		expect(await getEligibility(latest.id)).toEqual({
+			eligible: false,
+			reason: "usage_exceeded",
+		});
+	});
+
+	test("purchases older than 14 days are not eligible", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction({
+			createdAt: daysAgo(15),
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "window_expired",
+		});
+	});
+
+	test("already refunded transactions are not eligible", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction();
+		await seedTransaction({
+			type: "credit_refund",
+			amount: "100",
+			creditAmount: "-100",
+			stripeRefundId: "re_test_1",
+			relatedTransactionId: tx.id,
+			stripePaymentIntentId: null,
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "already_refunded",
+		});
+	});
+
+	test("non-owners are not eligible", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction();
+
+		expect(await getEligibility(tx.id, "admin")).toEqual({
+			eligible: false,
+			reason: "not_owner",
+		});
+	});
+
+	test("unsupported transaction types are not eligible", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction({
+			type: "dev_plan_upgrade",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_upgrade",
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "unsupported_type",
+		});
+	});
+
+	test("first dev plan purchase under 10% of the credit allowance is eligible", async () => {
+		await seedOrg({
+			devPlan: "pro",
+			devPlanCreditsUsed: "23",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: "sub_test_1",
+		});
+		const tx = await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({ eligible: true });
+	});
+
+	test("first dev plan purchase at 10% of the allowance is not eligible", async () => {
+		await seedOrg({
+			devPlan: "pro",
+			devPlanCreditsUsed: "23.7",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: "sub_test_1",
+		});
+		const tx = await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "usage_exceeded",
+		});
+	});
+
+	test("dev plan renewal gates on the dollar price, not the virtual allowance", async () => {
+		await seedOrg({
+			devPlan: "pro",
+			// 7 < 10% of $79 but far under 10% of the 237-credit allowance either
+			// way; 8 > $7.90 while still < 23.7 credits — the dollar gate decides.
+			devPlanCreditsUsed: "8",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: "sub_test_1",
+		});
+		await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+			createdAt: daysAgo(10),
+		});
+		const renewal = await seedTransaction({
+			type: "dev_plan_renewal",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_2",
+		});
+
+		expect(await getEligibility(renewal.id)).toEqual({
+			eligible: false,
+			reason: "usage_exceeded",
+		});
+	});
+
+	test("dev plan renewal under 10% of the price is eligible; the start is no longer refundable", async () => {
+		await seedOrg({
+			devPlan: "pro",
+			devPlanCreditsUsed: "7",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: "sub_test_1",
+		});
+		const start = await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+			createdAt: daysAgo(10),
+		});
+		const renewal = await seedTransaction({
+			type: "dev_plan_renewal",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_2",
+		});
+
+		expect(await getEligibility(renewal.id)).toEqual({ eligible: true });
+		expect(await getEligibility(start.id)).toEqual({
+			eligible: false,
+			reason: "not_latest_purchase",
+		});
+	});
+
+	test("plan payments are not eligible once the plan is inactive", async () => {
+		await seedOrg({
+			devPlan: "none",
+			devPlanCreditsUsed: "0",
+			devPlanCreditsLimit: "0",
+		});
+		const tx = await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "plan_inactive",
+		});
+	});
+
+	test("frozen dev plan credits block the refund", async () => {
+		await seedOrg({
+			devPlan: "pro",
+			devPlanCreditsUsed: "0",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: "sub_test_1",
+			devPlanCreditsFrozen: true,
+		});
+		const tx = await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({
+			eligible: false,
+			reason: "credits_frozen",
+		});
+	});
+
+	test("first chat plan purchase under 10% of the allowance is eligible", async () => {
+		await seedOrg({
+			kind: "chat",
+			chatPlan: "plus",
+			chatPlanCreditsUsed: "4",
+			chatPlanCreditsLimit: "47.5",
+			chatPlanStripeSubscriptionId: "sub_test_chat",
+		});
+		const tx = await seedTransaction({
+			type: "chat_plan_start",
+			amount: "19",
+			creditAmount: "47.5",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_chat",
+		});
+
+		expect(await getEligibility(tx.id)).toEqual({ eligible: true });
+	});
+});
+
+describe("self-refund endpoints", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+		stripeMock.refunds.create.mockReset();
+		stripeMock.subscriptions.cancel.mockReset();
+		stripeMock.invoices.retrieve.mockReset();
+		stripeMock.invoicePayments.list.mockReset();
+		stripeMock.refunds.create.mockResolvedValue({ id: "re_new_1" });
+		stripeMock.subscriptions.cancel.mockResolvedValue({});
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("refunds an eligible credit top-up without touching subscriptions", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction();
+
+		const response = await app.request(
+			`/orgs/${ORG_ID}/transactions/${tx.id}/refund`,
+			{ method: "POST", headers: { Cookie: token } },
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			status: "refund_processing",
+			stripeRefundId: "re_new_1",
+		});
+		expect(stripeMock.refunds.create).toHaveBeenCalledWith(
+			{ payment_intent: "pi_test_1", reason: "requested_by_customer" },
+			{ idempotencyKey: `self-refund-${tx.id}` },
+		);
+		expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
+
+		const auditLogs = await db.query.auditLog.findMany({
+			where: {
+				organizationId: { eq: ORG_ID },
+				action: { eq: "payment.self_refund" },
+			},
+		});
+		expect(auditLogs).toHaveLength(1);
+		expect(auditLogs[0]?.resourceId).toBe(tx.id);
+	});
+
+	test("refunding a dev plan resolves the invoice payment and cancels the subscription", async () => {
+		await seedOrg({
+			devPlan: "pro",
+			devPlanCreditsUsed: "0",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: "sub_test_1",
+		});
+		const tx = await seedTransaction({
+			type: "dev_plan_start",
+			amount: "79",
+			creditAmount: "237",
+			stripePaymentIntentId: null,
+			stripeInvoiceId: "in_test_1",
+		});
+		stripeMock.invoices.retrieve.mockResolvedValue({
+			id: "in_test_1",
+			payments: {
+				data: [
+					{
+						payment: {
+							payment_intent: {
+								id: "pi_from_invoice",
+								object: "payment_intent",
+							},
+						},
+					},
+				],
+			},
+		});
+
+		const response = await app.request(
+			`/orgs/${ORG_ID}/transactions/${tx.id}/refund`,
+			{ method: "POST", headers: { Cookie: token } },
+		);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.refunds.create).toHaveBeenCalledWith(
+			{ payment_intent: "pi_from_invoice", reason: "requested_by_customer" },
+			{ idempotencyKey: `self-refund-${tx.id}` },
+		);
+		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith("sub_test_1");
+	});
+
+	test("rejects ineligible transactions with 400 and does not call Stripe", async () => {
+		await seedOrg({ credits: "50" });
+		const tx = await seedTransaction();
+
+		const response = await app.request(
+			`/orgs/${ORG_ID}/transactions/${tx.id}/refund`,
+			{ method: "POST", headers: { Cookie: token } },
+		);
+
+		expect(response.status).toBe(400);
+		expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+	});
+
+	test("rejects non-owners with 403", async () => {
+		await seedOrg({ credits: "100" });
+		await db
+			.update(tables.userOrganization)
+			.set({ role: "admin" })
+			.where(eq(tables.userOrganization.userId, "test-user-id"));
+		const tx = await seedTransaction();
+
+		const response = await app.request(
+			`/orgs/${ORG_ID}/transactions/${tx.id}/refund`,
+			{ method: "POST", headers: { Cookie: token } },
+		);
+
+		expect(response.status).toBe(403);
+		expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+	});
+
+	test("GET /orgs/{id}/transactions annotates refund candidates", async () => {
+		await seedOrg({ credits: "100" });
+		const tx = await seedTransaction();
+
+		const response = await app.request(`/orgs/${ORG_ID}/transactions`, {
+			headers: { Cookie: token },
+		});
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			transactions: { id: string; refund?: { eligible: boolean } }[];
+		};
+		const annotated = body.transactions.find((t) => t.id === tx.id);
+		expect(annotated?.refund).toEqual({ eligible: true });
+	});
+});

--- a/apps/api/src/lib/self-refund.spec.ts
+++ b/apps/api/src/lib/self-refund.spec.ts
@@ -439,7 +439,7 @@ describe("self-refund endpoints", () => {
 		expect(auditLogs[0]?.resourceId).toBe(tx.id);
 	});
 
-	test("refunding a dev plan resolves the invoice payment and cancels the subscription", async () => {
+	test("refunding a dev plan resolves the invoice payment and issues the refund", async () => {
 		await seedOrg({
 			devPlan: "pro",
 			devPlanCreditsUsed: "0",
@@ -479,7 +479,10 @@ describe("self-refund endpoints", () => {
 			{ payment_intent: "pi_from_invoice", reason: "requested_by_customer" },
 			{ idempotencyKey: `self-refund-${tx.id}` },
 		);
-		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith("sub_test_1");
+		// The endpoint only issues the refund; the subscription is cancelled by the
+		// charge.refunded webhook (handleChargeRefunded), covering every refund
+		// source, not just this endpoint.
+		expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
 	});
 
 	test("rejects ineligible transactions with 400 and does not call Stripe", async () => {

--- a/apps/api/src/lib/self-refund.ts
+++ b/apps/api/src/lib/self-refund.ts
@@ -1,3 +1,4 @@
+import { Decimal } from "decimal.js";
 import { HTTPException } from "hono/http-exception";
 
 import { getStripe } from "@/routes/payments.js";
@@ -21,13 +22,20 @@ export const SELF_REFUND_WINDOW_DAYS = 14;
 
 const SELF_REFUND_WINDOW_MS = SELF_REFUND_WINDOW_DAYS * 24 * 60 * 60 * 1000;
 
-// Usage at or above 10% of the purchased credits denies the self-refund
-// (equivalently, repeat top-ups require the balance to still cover 90%).
-// Compared as used*10 >= total rather than used >= 0.1*total: multiplying the
-// decimal total by 0.1 picks up float noise right at the boundary
-// (0.1*237 === 23.700000000000003), while *10 stays exact.
-function usageExceedsThreshold(used: number, total: number): boolean {
-	return used * 10 >= total;
+// Usage at or above 10% of the purchased credits denies the self-refund;
+// equivalently, repeat top-ups require the balance to still cover the
+// remaining 90%.
+const SELF_REFUND_USAGE_THRESHOLD = new Decimal("0.1");
+const SELF_REFUND_BALANCE_FLOOR = new Decimal(1).minus(
+	SELF_REFUND_USAGE_THRESHOLD,
+);
+
+function dec(value: string | number | null | undefined): Decimal {
+	return new Decimal(value ?? 0);
+}
+
+function usageExceedsThreshold(used: Decimal, total: Decimal): boolean {
+	return used.gte(total.times(SELF_REFUND_USAGE_THRESHOLD));
 }
 
 export type SelfRefundIneligibilityReason =
@@ -91,8 +99,8 @@ function latestOf(rows: TransactionRow[]): TransactionRow | undefined {
 function computeUsedCredits(
 	organization: OrganizationRow,
 	transactions: TransactionRow[],
-): number {
-	let granted = Number(organization.referralEarnings ?? "0");
+): Decimal {
+	let granted = dec(organization.referralEarnings);
 	for (const t of transactions) {
 		if (!isCompleted(t)) {
 			continue;
@@ -104,13 +112,13 @@ function computeUsedCredits(
 		) {
 			// credit_refund rows carry a negative creditAmount, netting out the
 			// refunded grant.
-			granted += Number(t.creditAmount ?? "0");
+			granted = granted.plus(dec(t.creditAmount));
 		} else if (t.type === "end_user_bonus") {
 			// End-user signup bonuses are funded from the org balance.
-			granted -= Number(t.amount ?? "0");
+			granted = granted.minus(dec(t.amount));
 		}
 	}
-	return granted - Number(organization.credits);
+	return granted.minus(dec(organization.credits));
 }
 
 function checkCreditTopupEligibility(
@@ -118,8 +126,8 @@ function checkCreditTopupEligibility(
 	transactions: TransactionRow[],
 	transaction: TransactionRow,
 ): SelfRefundEligibility {
-	const creditAmount = Number(transaction.creditAmount ?? "0");
-	if (!(creditAmount > 0)) {
+	const creditAmount = dec(transaction.creditAmount);
+	if (!creditAmount.gt(0)) {
 		return ineligible("unsupported_type");
 	}
 
@@ -145,7 +153,9 @@ function checkCreditTopupEligibility(
 	if (latestTopup?.id !== transaction.id) {
 		return ineligible("not_latest_purchase");
 	}
-	if (Number(organization.credits) * 10 < creditAmount * 9) {
+	if (
+		dec(organization.credits).lt(creditAmount.times(SELF_REFUND_BALANCE_FLOOR))
+	) {
 		return ineligible("usage_exceeded");
 	}
 	return { eligible: true };
@@ -162,10 +172,10 @@ function checkPlanEligibility(
 	const subscriptionId = isDev
 		? organization.devPlanStripeSubscriptionId
 		: organization.chatPlanStripeSubscriptionId;
-	const creditsUsed = Number(
+	const creditsUsed = dec(
 		isDev ? organization.devPlanCreditsUsed : organization.chatPlanCreditsUsed,
 	);
-	const creditsLimit = Number(
+	const creditsLimit = dec(
 		isDev
 			? organization.devPlanCreditsLimit
 			: organization.chatPlanCreditsLimit,
@@ -202,7 +212,7 @@ function checkPlanEligibility(
 		// First-ever plan purchase: threshold on the virtual credit allowance
 		// (deliberately more lenient, as a first-purchase guarantee).
 		if (
-			!(creditsLimit > 0) ||
+			!creditsLimit.gt(0) ||
 			usageExceedsThreshold(creditsUsed, creditsLimit)
 		) {
 			return ineligible("usage_exceeded");
@@ -217,7 +227,7 @@ function checkPlanEligibility(
 	const price = isDev
 		? DEV_PLAN_PRICES[plan as DevPlanTier]
 		: CHAT_PLAN_PRICES[plan as ChatPlanTier];
-	if (!price || usageExceedsThreshold(creditsUsed, price)) {
+	if (!price || usageExceedsThreshold(creditsUsed, dec(price))) {
 		return ineligible("usage_exceeded");
 	}
 	return { eligible: true };
@@ -248,7 +258,7 @@ export function computeSelfRefundEligibility({
 		return ineligible("not_completed");
 	}
 	if (
-		!(Number(transaction.amount ?? "0") > 0) ||
+		!dec(transaction.amount).gt(0) ||
 		(!transaction.stripePaymentIntentId && !transaction.stripeInvoiceId)
 	) {
 		return ineligible("unsupported_type");

--- a/apps/api/src/lib/self-refund.ts
+++ b/apps/api/src/lib/self-refund.ts
@@ -1,0 +1,379 @@
+import { HTTPException } from "hono/http-exception";
+
+import { getStripe } from "@/routes/payments.js";
+import { getPaymentIntentFromInvoicePayments } from "@/stripe.js";
+
+import { logAuditEvent } from "@llmgateway/audit";
+import { logger } from "@llmgateway/logger";
+import {
+	CHAT_PLAN_PRICES,
+	DEV_PLAN_PRICES,
+	type ChatPlanTier,
+	type DevPlanTier,
+} from "@llmgateway/shared";
+
+import type { tables } from "@llmgateway/db";
+
+type OrganizationRow = typeof tables.organization.$inferSelect;
+type TransactionRow = typeof tables.transaction.$inferSelect;
+
+export const SELF_REFUND_WINDOW_DAYS = 14;
+
+const SELF_REFUND_WINDOW_MS = SELF_REFUND_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+// Usage at or above 10% of the purchased credits denies the self-refund
+// (equivalently, repeat top-ups require the balance to still cover 90%).
+// Compared as used*10 >= total rather than used >= 0.1*total: multiplying the
+// decimal total by 0.1 picks up float noise right at the boundary
+// (0.1*237 === 23.700000000000003), while *10 stays exact.
+function usageExceedsThreshold(used: number, total: number): boolean {
+	return used * 10 >= total;
+}
+
+export type SelfRefundIneligibilityReason =
+	| "unsupported_type"
+	| "not_completed"
+	| "already_refunded"
+	| "window_expired"
+	| "not_owner"
+	| "not_latest_purchase"
+	| "plan_inactive"
+	| "credits_frozen"
+	| "usage_exceeded";
+
+export interface SelfRefundEligibility {
+	eligible: boolean;
+	reason?: SelfRefundIneligibilityReason;
+}
+
+export const SELF_REFUNDABLE_TYPES = [
+	"credit_topup",
+	"dev_plan_start",
+	"dev_plan_renewal",
+	"chat_plan_start",
+	"chat_plan_renewal",
+] as const;
+
+export type SelfRefundableType = (typeof SELF_REFUNDABLE_TYPES)[number];
+
+export function isSelfRefundCandidateType(
+	type: string,
+): type is SelfRefundableType {
+	return (SELF_REFUNDABLE_TYPES as readonly string[]).includes(type);
+}
+
+function ineligible(
+	reason: SelfRefundIneligibilityReason,
+): SelfRefundEligibility {
+	return { eligible: false, reason };
+}
+
+function isCompleted(t: TransactionRow): boolean {
+	return t.status === "completed";
+}
+
+function latestOf(rows: TransactionRow[]): TransactionRow | undefined {
+	return rows.reduce<TransactionRow | undefined>(
+		(latest, row) =>
+			!latest || row.createdAt > latest.createdAt ? row : latest,
+		undefined,
+	);
+}
+
+/**
+ * Total credits ever consumed by the org, reconstructed from the pooled
+ * balance: every credit grant and drain besides gateway usage is recorded
+ * either as a transaction row (topups, gifts, refunds, end-user bonuses) or on
+ * the org row itself (referral earnings, which are only ever incremented), so
+ * usage = grants − balance. Referral-bonus reversals aren't reconstructed,
+ * which only over-counts usage — erring toward denying the refund.
+ */
+function computeUsedCredits(
+	organization: OrganizationRow,
+	transactions: TransactionRow[],
+): number {
+	let granted = Number(organization.referralEarnings ?? "0");
+	for (const t of transactions) {
+		if (!isCompleted(t)) {
+			continue;
+		}
+		if (
+			t.type === "credit_topup" ||
+			t.type === "credit_gift" ||
+			t.type === "credit_refund"
+		) {
+			// credit_refund rows carry a negative creditAmount, netting out the
+			// refunded grant.
+			granted += Number(t.creditAmount ?? "0");
+		} else if (t.type === "end_user_bonus") {
+			// End-user signup bonuses are funded from the org balance.
+			granted -= Number(t.amount ?? "0");
+		}
+	}
+	return granted - Number(organization.credits);
+}
+
+function checkCreditTopupEligibility(
+	organization: OrganizationRow,
+	transactions: TransactionRow[],
+	transaction: TransactionRow,
+): SelfRefundEligibility {
+	const creditAmount = Number(transaction.creditAmount ?? "0");
+	if (!(creditAmount > 0)) {
+		return ineligible("unsupported_type");
+	}
+
+	const completedTopups = transactions.filter(
+		(t) => t.type === "credit_topup" && isCompleted(t),
+	);
+
+	if (completedTopups.length <= 1) {
+		// First-ever top-up: all consumption counts, including gift/signup
+		// credits, so free credits can't be burned and the paid top-up refunded
+		// in full afterwards.
+		const usedCredits = computeUsedCredits(organization, transactions);
+		if (usageExceedsThreshold(usedCredits, creditAmount)) {
+			return ineligible("usage_exceeded");
+		}
+		return { eligible: true };
+	}
+
+	// Repeat top-ups: only the most recent purchase is refundable, and only
+	// while the remaining balance still covers at least 90% of it (the
+	// remaining pool is attributed to the newest purchase first).
+	const latestTopup = latestOf(completedTopups);
+	if (latestTopup?.id !== transaction.id) {
+		return ineligible("not_latest_purchase");
+	}
+	if (Number(organization.credits) * 10 < creditAmount * 9) {
+		return ineligible("usage_exceeded");
+	}
+	return { eligible: true };
+}
+
+function checkPlanEligibility(
+	organization: OrganizationRow,
+	transactions: TransactionRow[],
+	transaction: TransactionRow,
+	product: "dev" | "chat",
+): SelfRefundEligibility {
+	const isDev = product === "dev";
+	const plan = isDev ? organization.devPlan : organization.chatPlan;
+	const subscriptionId = isDev
+		? organization.devPlanStripeSubscriptionId
+		: organization.chatPlanStripeSubscriptionId;
+	const creditsUsed = Number(
+		isDev ? organization.devPlanCreditsUsed : organization.chatPlanCreditsUsed,
+	);
+	const creditsLimit = Number(
+		isDev
+			? organization.devPlanCreditsLimit
+			: organization.chatPlanCreditsLimit,
+	);
+
+	// Refunding a plan payment cancels the subscription; without an active
+	// subscription there is nothing to refund against.
+	if (plan === "none" || !subscriptionId) {
+		return ineligible("plan_inactive");
+	}
+	if (isDev && organization.devPlanCreditsFrozen) {
+		return ineligible("credits_frozen");
+	}
+
+	const paymentTypes: string[] = isDev
+		? ["dev_plan_start", "dev_plan_renewal", "dev_plan_upgrade"]
+		: ["chat_plan_start", "chat_plan_renewal", "chat_plan_upgrade"];
+	const planPayments = transactions.filter(
+		(t) => paymentTypes.includes(t.type) && isCompleted(t),
+	);
+
+	// Only the latest plan payment corresponds to the current billing cycle's
+	// usage counters; older starts/renewals can't be checked against usage.
+	const latestPayment = latestOf(planPayments);
+	if (latestPayment?.id !== transaction.id) {
+		return ineligible("not_latest_purchase");
+	}
+
+	const isFirstPurchase =
+		transaction.type === (isDev ? "dev_plan_start" : "chat_plan_start") &&
+		planPayments.length === 1;
+
+	if (isFirstPurchase) {
+		// First-ever plan purchase: threshold on the virtual credit allowance
+		// (deliberately more lenient, as a first-purchase guarantee).
+		if (
+			!(creditsLimit > 0) ||
+			usageExceedsThreshold(creditsUsed, creditsLimit)
+		) {
+			return ineligible("usage_exceeded");
+		}
+		return { eligible: true };
+	}
+
+	// Renewals and re-subscribes: threshold on the dollar price instead of the
+	// virtual allowance. Virtual credits track provider cost, so at a 3x
+	// multiplier 10% of the allowance would leak up to 30% of the payment in
+	// provider cost; gating on dollars caps the leak at 10% of revenue.
+	const price = isDev
+		? DEV_PLAN_PRICES[plan as DevPlanTier]
+		: CHAT_PLAN_PRICES[plan as ChatPlanTier];
+	if (!price || usageExceedsThreshold(creditsUsed, price)) {
+		return ineligible("usage_exceeded");
+	}
+	return { eligible: true };
+}
+
+/**
+ * Decide whether a transaction can be self-refunded by the org owner.
+ * `transactions` must be the org's complete transaction list (any order); the
+ * same list the transactions endpoints already fetch.
+ */
+export function computeSelfRefundEligibility({
+	organization,
+	role,
+	transactions,
+	transaction,
+	now = new Date(),
+}: {
+	organization: OrganizationRow;
+	role: string | null | undefined;
+	transactions: TransactionRow[];
+	transaction: TransactionRow;
+	now?: Date;
+}): SelfRefundEligibility {
+	if (!isSelfRefundCandidateType(transaction.type)) {
+		return ineligible("unsupported_type");
+	}
+	if (!isCompleted(transaction)) {
+		return ineligible("not_completed");
+	}
+	if (
+		!(Number(transaction.amount ?? "0") > 0) ||
+		(!transaction.stripePaymentIntentId && !transaction.stripeInvoiceId)
+	) {
+		return ineligible("unsupported_type");
+	}
+	if (
+		transactions.some(
+			(t) =>
+				t.type === "credit_refund" && t.relatedTransactionId === transaction.id,
+		)
+	) {
+		return ineligible("already_refunded");
+	}
+	if (
+		now.getTime() - new Date(transaction.createdAt).getTime() >
+		SELF_REFUND_WINDOW_MS
+	) {
+		return ineligible("window_expired");
+	}
+	if (role !== "owner") {
+		return ineligible("not_owner");
+	}
+
+	switch (transaction.type) {
+		case "credit_topup":
+			return checkCreditTopupEligibility(
+				organization,
+				transactions,
+				transaction,
+			);
+		case "dev_plan_start":
+		case "dev_plan_renewal":
+			return checkPlanEligibility(
+				organization,
+				transactions,
+				transaction,
+				"dev",
+			);
+		case "chat_plan_start":
+		case "chat_plan_renewal":
+			return checkPlanEligibility(
+				organization,
+				transactions,
+				transaction,
+				"chat",
+			);
+	}
+}
+
+/**
+ * Issue the Stripe refund for an already-eligibility-checked transaction and,
+ * for plan payments, cancel the subscription immediately. Bookkeeping (the
+ * credit_refund row, credit deduction, plan-field reset) is left to the
+ * charge.refunded and customer.subscription.deleted webhooks, which are
+ * already idempotent and order-independent.
+ */
+export async function executeSelfRefund({
+	organization,
+	transaction,
+	userId,
+}: {
+	organization: OrganizationRow;
+	transaction: TransactionRow;
+	userId: string;
+}): Promise<{ stripeRefundId: string }> {
+	const stripe = getStripe();
+
+	let paymentIntentId = transaction.stripePaymentIntentId;
+	if (!paymentIntentId && transaction.stripeInvoiceId) {
+		// Plan payments record only the invoice id; resolve the payment intent
+		// through the invoice's payments (stripe 18.x dropped invoice.payment_intent).
+		const invoice = await stripe.invoices.retrieve(transaction.stripeInvoiceId);
+		const paymentIntent = await getPaymentIntentFromInvoicePayments(invoice);
+		paymentIntentId = paymentIntent?.id ?? null;
+	}
+	if (!paymentIntentId) {
+		throw new HTTPException(400, {
+			message: "No refundable payment found for this transaction",
+		});
+	}
+
+	// The idempotency key makes double-clicks and races return the same refund
+	// instead of issuing a second one.
+	const refund = await stripe.refunds.create(
+		{
+			payment_intent: paymentIntentId,
+			reason: "requested_by_customer",
+		},
+		{ idempotencyKey: `self-refund-${transaction.id}` },
+	);
+
+	// Refunding a plan payment ends the plan: cancel the subscription
+	// immediately so the customer isn't left with a refunded-but-active plan.
+	// The refund already succeeded, so a cancel failure is logged and surfaced
+	// to ops instead of failing the request — support can cancel manually.
+	const subscriptionId =
+		transaction.type === "dev_plan_start" ||
+		transaction.type === "dev_plan_renewal"
+			? organization.devPlanStripeSubscriptionId
+			: transaction.type === "chat_plan_start" ||
+				  transaction.type === "chat_plan_renewal"
+				? organization.chatPlanStripeSubscriptionId
+				: null;
+	if (subscriptionId) {
+		try {
+			await stripe.subscriptions.cancel(subscriptionId);
+		} catch (error) {
+			logger.error(
+				`Self-refund ${refund.id} succeeded but cancelling subscription ${subscriptionId} failed for organization ${organization.id}`,
+				error as Error,
+			);
+		}
+	}
+
+	await logAuditEvent({
+		organizationId: organization.id,
+		userId,
+		action: "payment.self_refund",
+		resourceType: "payment",
+		resourceId: transaction.id,
+		metadata: {
+			stripeRefundId: refund.id,
+			transactionType: transaction.type,
+			amount: transaction.amount,
+		},
+	});
+
+	return { stripeRefundId: refund.id };
+}

--- a/apps/api/src/lib/self-refund.ts
+++ b/apps/api/src/lib/self-refund.ts
@@ -5,7 +5,6 @@ import { getStripe } from "@/routes/payments.js";
 import { getPaymentIntentFromInvoicePayments } from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
-import { logger } from "@llmgateway/logger";
 import {
 	CHAT_PLAN_PRICES,
 	DEV_PLAN_PRICES,
@@ -308,11 +307,12 @@ export function computeSelfRefundEligibility({
 }
 
 /**
- * Issue the Stripe refund for an already-eligibility-checked transaction and,
- * for plan payments, cancel the subscription immediately. Bookkeeping (the
- * credit_refund row, credit deduction, plan-field reset) is left to the
- * charge.refunded and customer.subscription.deleted webhooks, which are
- * already idempotent and order-independent.
+ * Issue the Stripe refund for an already-eligibility-checked transaction. All
+ * bookkeeping is left to the webhooks: charge.refunded records the credit_refund
+ * row (and, for a dev/chat plan payment, cancels the Stripe subscription), and
+ * the resulting customer.subscription.deleted resets the plan fields. Keeping
+ * the cancellation in the webhook means it fires for every refund source, not
+ * just this endpoint.
  */
 export async function executeSelfRefund({
 	organization,
@@ -348,29 +348,6 @@ export async function executeSelfRefund({
 		},
 		{ idempotencyKey: `self-refund-${transaction.id}` },
 	);
-
-	// Refunding a plan payment ends the plan: cancel the subscription
-	// immediately so the customer isn't left with a refunded-but-active plan.
-	// The refund already succeeded, so a cancel failure is logged and surfaced
-	// to ops instead of failing the request — support can cancel manually.
-	const subscriptionId =
-		transaction.type === "dev_plan_start" ||
-		transaction.type === "dev_plan_renewal"
-			? organization.devPlanStripeSubscriptionId
-			: transaction.type === "chat_plan_start" ||
-				  transaction.type === "chat_plan_renewal"
-				? organization.chatPlanStripeSubscriptionId
-				: null;
-	if (subscriptionId) {
-		try {
-			await stripe.subscriptions.cancel(subscriptionId);
-		} catch (error) {
-			logger.error(
-				`Self-refund ${refund.id} succeeded but cancelling subscription ${subscriptionId} failed for organization ${organization.id}`,
-				error as Error,
-			);
-		}
-	}
 
 	await logAuditEvent({
 		organizationId: organization.id,

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -2,6 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import {
+	computeSelfRefundEligibility,
+	executeSelfRefund,
+	isSelfRefundCandidateType,
+} from "@/lib/self-refund.js";
 import { ensureStripeCustomer, finalizeDevPlanSetupSession } from "@/stripe.js";
 import { findDefaultOrganization } from "@/utils/default-org.js";
 import {
@@ -2002,6 +2007,24 @@ const getInvoices = createRoute({
 								currency: z.string(),
 								status: z.enum(["pending", "completed", "failed"]),
 								description: z.string().nullable(),
+								refund: z
+									.object({
+										eligible: z.boolean(),
+										reason: z
+											.enum([
+												"unsupported_type",
+												"not_completed",
+												"already_refunded",
+												"window_expired",
+												"not_owner",
+												"not_latest_purchase",
+												"plan_inactive",
+												"credits_frozen",
+												"usage_exceeded",
+											])
+											.optional(),
+									})
+									.optional(),
 							}),
 						),
 					}),
@@ -2024,28 +2047,134 @@ devPlans.openapi(getInvoices, async (c) => {
 		return c.json({ invoices: [] });
 	}
 
+	// Eligibility needs the full transaction list (refund rows, ordering across
+	// types); the dev-plan billing events are filtered out of it for display.
 	const transactions = await db.query.transaction.findMany({
 		where: {
 			organizationId: { eq: personalOrg.id },
-			type: { in: ["dev_plan_start", "dev_plan_renewal", "dev_plan_upgrade"] },
 		},
 		orderBy: {
 			createdAt: "desc",
 		},
 	});
 
-	const invoices = transactions.map((t) => ({
-		id: t.id,
-		type: t.type as "dev_plan_start" | "dev_plan_renewal" | "dev_plan_upgrade",
-		date: t.createdAt.toISOString(),
-		amount: t.amount,
-		creditAmount: t.creditAmount,
-		currency: t.currency,
-		status: t.status,
-		description: t.description,
-	}));
+	const membership = await db.query.userOrganization.findFirst({
+		where: {
+			userId: { eq: user.id },
+			organizationId: { eq: personalOrg.id },
+		},
+	});
+
+	const invoices = transactions
+		.filter((t) =>
+			["dev_plan_start", "dev_plan_renewal", "dev_plan_upgrade"].includes(
+				t.type,
+			),
+		)
+		.map((t) => ({
+			id: t.id,
+			type: t.type as
+				| "dev_plan_start"
+				| "dev_plan_renewal"
+				| "dev_plan_upgrade",
+			date: t.createdAt.toISOString(),
+			amount: t.amount,
+			creditAmount: t.creditAmount,
+			currency: t.currency,
+			status: t.status,
+			description: t.description,
+			refund: isSelfRefundCandidateType(t.type)
+				? computeSelfRefundEligibility({
+						organization: personalOrg,
+						role: membership?.role,
+						transactions,
+						transaction: t,
+					})
+				: undefined,
+		}));
 
 	return c.json({ invoices });
+});
+
+// Self-service refund for a DevPass billing event. Only the first (or latest)
+// barely-used payment qualifies; refunding also cancels the DevPass
+// immediately. See lib/self-refund.ts for the eligibility rules.
+const selfRefundInvoice = createRoute({
+	method: "post",
+	path: "/invoices/{invoiceId}/refund",
+	request: {
+		params: z.object({
+			invoiceId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						status: z.literal("refund_processing"),
+						stripeRefundId: z.string(),
+					}),
+				},
+			},
+			description:
+				"Refund created; the DevPass is cancelled immediately and bookkeeping is applied when Stripe confirms via webhook",
+		},
+	},
+});
+
+devPlans.openapi(selfRefundInvoice, async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { invoiceId } = c.req.param();
+
+	const personalOrg = await findPersonalOrg(user.id);
+	if (!personalOrg) {
+		throw new HTTPException(404, { message: "No DevPass organization found" });
+	}
+
+	const transactions = await db.query.transaction.findMany({
+		where: {
+			organizationId: { eq: personalOrg.id },
+		},
+	});
+	const transaction = transactions.find((t) => t.id === invoiceId);
+	if (!transaction) {
+		throw new HTTPException(404, { message: "Invoice not found" });
+	}
+
+	const membership = await db.query.userOrganization.findFirst({
+		where: {
+			userId: { eq: user.id },
+			organizationId: { eq: personalOrg.id },
+		},
+	});
+
+	const eligibility = computeSelfRefundEligibility({
+		organization: personalOrg,
+		role: membership?.role,
+		transactions,
+		transaction,
+	});
+	if (!eligibility.eligible) {
+		throw new HTTPException(400, {
+			message: `This payment is not eligible for a self-service refund: ${eligibility.reason}`,
+		});
+	}
+
+	const { stripeRefundId } = await executeSelfRefund({
+		organization: personalOrg,
+		transaction,
+		userId: user.id,
+	});
+
+	return c.json({
+		status: "refund_processing" as const,
+		stripeRefundId,
+	});
 });
 
 // Download a PDF invoice for a single DevPass billing event. Billing details

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -3,6 +3,11 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import {
+	computeSelfRefundEligibility,
+	executeSelfRefund,
+	isSelfRefundCandidateType,
+} from "@/lib/self-refund.js";
+import {
 	getUserProjectIds,
 	userHasOrganizationAccess,
 } from "@/utils/authorization.js";
@@ -172,6 +177,23 @@ const AUTO_TOP_UP_AUDIT_FIELDS = [
 	"autoTopUpAmount",
 ] as const;
 
+const refundEligibilitySchema = z.object({
+	eligible: z.boolean(),
+	reason: z
+		.enum([
+			"unsupported_type",
+			"not_completed",
+			"already_refunded",
+			"window_expired",
+			"not_owner",
+			"not_latest_purchase",
+			"plan_inactive",
+			"credits_frozen",
+			"usage_exceeded",
+		])
+		.optional(),
+});
+
 const transactionSchema = z.object({
 	id: z.string(),
 	createdAt: z.date(),
@@ -211,6 +233,8 @@ const transactionSchema = z.object({
 	description: z.string().nullable(),
 	relatedTransactionId: z.string().nullable(),
 	refundReason: z.string().nullable(),
+	// Self-refund eligibility, present only on refund-candidate purchase types.
+	refund: refundEligibilitySchema.optional(),
 });
 
 const getOrganizations = createRoute({
@@ -954,8 +978,16 @@ organization.openapi(getTransactions, async (c) => {
 
 	const { id } = c.req.param();
 
-	const hasAccess = await userHasOrganizationAccess(user.id, id);
-	if (!hasAccess) {
+	const userOrganization = await db.query.userOrganization.findFirst({
+		where: {
+			userId: { eq: user.id },
+			organizationId: { eq: id },
+		},
+		with: {
+			organization: true,
+		},
+	});
+	if (!userOrganization?.organization) {
 		throw new HTTPException(403, {
 			message: "You do not have access to this organization",
 		});
@@ -972,8 +1004,112 @@ organization.openapi(getTransactions, async (c) => {
 		},
 	});
 
+	const org = userOrganization.organization;
 	return c.json({
+		transactions: transactions.map((t) =>
+			isSelfRefundCandidateType(t.type)
+				? {
+						...t,
+						refund: computeSelfRefundEligibility({
+							organization: org,
+							role: userOrganization.role,
+							transactions,
+							transaction: t,
+						}),
+					}
+				: t,
+		),
+	});
+});
+
+const selfRefundTransaction = createRoute({
+	method: "post",
+	path: "/{id}/transactions/{transactionId}/refund",
+	request: {
+		params: z.object({
+			id: z.string(),
+			transactionId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						status: z.literal("refund_processing"),
+						stripeRefundId: z.string(),
+					}),
+				},
+			},
+			description:
+				"Refund created; the transaction and credit adjustments are applied when Stripe confirms via webhook",
+		},
+	},
+});
+
+organization.openapi(selfRefundTransaction, async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, {
+			message: "Unauthorized",
+		});
+	}
+
+	const { id, transactionId } = c.req.param();
+
+	const userOrganization = await db.query.userOrganization.findFirst({
+		where: {
+			userId: { eq: user.id },
+			organizationId: { eq: id },
+		},
+		with: {
+			organization: true,
+		},
+	});
+	if (!userOrganization?.organization) {
+		throw new HTTPException(403, {
+			message: "You do not have access to this organization",
+		});
+	}
+
+	const transactions = await db.query.transaction.findMany({
+		where: {
+			organizationId: { eq: id },
+		},
+	});
+	const transaction = transactions.find((t) => t.id === transactionId);
+	if (!transaction) {
+		throw new HTTPException(404, {
+			message: "Transaction not found",
+		});
+	}
+
+	const eligibility = computeSelfRefundEligibility({
+		organization: userOrganization.organization,
+		role: userOrganization.role,
 		transactions,
+		transaction,
+	});
+	if (!eligibility.eligible) {
+		if (eligibility.reason === "not_owner") {
+			throw new HTTPException(403, {
+				message: "Only the organization owner can request a refund",
+			});
+		}
+		throw new HTTPException(400, {
+			message: `This transaction is not eligible for a self-service refund: ${eligibility.reason}`,
+		});
+	}
+
+	const { stripeRefundId } = await executeSelfRefund({
+		organization: userOrganization.organization,
+		transaction,
+		userId: user.id,
+	});
+
+	return c.json({
+		status: "refund_processing" as const,
+		stripeRefundId,
 	});
 });
 

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -19,7 +19,7 @@ const stripeMock = vi.hoisted(() => ({
 	refunds: { list: vi.fn() },
 	invoices: { list: vi.fn() },
 	invoicePayments: { list: vi.fn() },
-	subscriptions: { retrieve: vi.fn() },
+	subscriptions: { retrieve: vi.fn(), cancel: vi.fn() },
 	paymentIntents: { retrieve: vi.fn() },
 	paymentMethods: { retrieve: vi.fn() },
 }));
@@ -800,6 +800,7 @@ describe("handlePaymentIntentFailed — subscription invoice vs credit top-up", 
 function makeChargeRefundedEvent(overrides: {
 	paymentIntentId: string;
 	customer: string;
+	refunded?: boolean;
 }): Stripe.ChargeRefundedEvent {
 	return {
 		id: "evt_test_charge_refunded",
@@ -809,6 +810,8 @@ function makeChargeRefundedEvent(overrides: {
 				id: "ch_test_refund_001",
 				payment_intent: overrides.paymentIntentId,
 				customer: overrides.customer,
+				// true when the charge is fully refunded; false for a partial refund.
+				refunded: overrides.refunded ?? false,
 				// Current Stripe API versions omit the invoice link on the charge.
 				invoice: null,
 			},
@@ -884,6 +887,80 @@ describe("handleChargeRefunded — dev plan refund tracking", () => {
 			where: { id: { eq: ORG_ID } },
 		});
 		expect(org?.credits).toBe("0");
+	});
+
+	test("cancels the subscription on a full dev plan refund", async () => {
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			stripeCustomerId: "cus_devpass_refund",
+			devPlan: "pro",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: SUB_ID,
+		});
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			amount: "79",
+			currency: "USD",
+			status: "completed",
+			stripeInvoiceId: "in_devpass_refund",
+		});
+
+		stripeMock.invoicePayments.list.mockResolvedValue({
+			data: [{ invoice: "in_devpass_refund" }],
+		});
+		stripeMock.refunds.list.mockResolvedValue({
+			data: [{ id: "re_devpass_refund", amount: 7900, reason: null }],
+		});
+
+		await handleChargeRefunded(
+			makeChargeRefundedEvent({
+				paymentIntentId: "pi_devpass_refund",
+				customer: "cus_devpass_refund",
+				refunded: true,
+			}),
+		);
+
+		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith(SUB_ID);
+	});
+
+	test("does not cancel the subscription on a partial dev plan refund", async () => {
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			stripeCustomerId: "cus_devpass_refund",
+			devPlan: "pro",
+			devPlanCreditsLimit: "237",
+			devPlanStripeSubscriptionId: SUB_ID,
+		});
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			amount: "79",
+			currency: "USD",
+			status: "completed",
+			stripeInvoiceId: "in_devpass_refund",
+		});
+
+		stripeMock.invoicePayments.list.mockResolvedValue({
+			data: [{ invoice: "in_devpass_refund" }],
+		});
+		stripeMock.refunds.list.mockResolvedValue({
+			data: [{ id: "re_devpass_partial", amount: 1000, reason: null }],
+		});
+
+		await handleChargeRefunded(
+			makeChargeRefundedEvent({
+				paymentIntentId: "pi_devpass_refund",
+				customer: "cus_devpass_refund",
+				refunded: false,
+			}),
+		);
+
+		expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
 	});
 
 	test("does not double-record when the same refund is delivered twice", async () => {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3043,6 +3043,35 @@ export async function handleChargeRefunded(
 			.where(eq(tables.organization.id, originalTransaction.organizationId));
 	}
 
+	// A full refund of a dev/chat plan payment ends the plan — cancel the Stripe
+	// subscription so the customer isn't left refunded-but-still-subscribed.
+	// Handling it here (rather than only in the self-refund endpoint) covers every
+	// refund source: the self-service dashboard, the admin panel, and manual
+	// refunds issued straight from the Stripe dashboard. Cancelling emits
+	// customer.subscription.deleted, which resets the plan fields and records the
+	// *_plan_end transaction. Gated on a full refund so a partial refund doesn't
+	// tear down the whole plan.
+	if (charge.refunded) {
+		const planSubscriptionId = originalTransaction.type.startsWith("dev_plan")
+			? organization.devPlanStripeSubscriptionId
+			: originalTransaction.type.startsWith("chat_plan")
+				? organization.chatPlanStripeSubscriptionId
+				: null;
+		if (planSubscriptionId) {
+			try {
+				await getStripe().subscriptions.cancel(planSubscriptionId);
+				logger.info(
+					`Cancelled subscription ${planSubscriptionId} after full refund of ${originalTransaction.type} for organization ${organization.id}`,
+				);
+			} catch (error) {
+				logger.error(
+					`Refund recorded but cancelling subscription ${planSubscriptionId} failed for organization ${organization.id}`,
+					error as Error,
+				);
+			}
+		}
+	}
+
 	// Notify the internal Discord channel, mirroring the purchase notification.
 	// Runs after the transaction insert (which is guarded by the stripeRefundId
 	// dedupe check above), so webhook retries won't double-notify.

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -527,7 +527,7 @@ function getInvoiceConfirmationClientSecret(
 	return confirmationSecret?.client_secret ?? null;
 }
 
-async function getPaymentIntentFromInvoicePayments(
+export async function getPaymentIntentFromInvoicePayments(
 	invoice: Stripe.Invoice,
 ): Promise<Stripe.PaymentIntent | null> {
 	let invoicePayments = invoice.payments?.data ?? [];

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -30,6 +30,7 @@ import {
 	notifyChatPlanRenewed,
 	notifyChatPlanSubscribed,
 	notifyCreditsPurchased,
+	notifyRefund,
 	notifyDevPlanCancelled,
 	notifyDevPlanRenewed,
 	notifyDevPlanSubscribed,
@@ -2833,6 +2834,21 @@ async function resolveRefundInvoiceId(
 	return typeof invoice === "string" ? invoice : (invoice.id ?? undefined);
 }
 
+// Human-readable product name for a refunded purchase, used in the internal
+// Discord refund notification.
+function refundProductLabel(type: string): string {
+	if (type === "credit_topup") {
+		return "Credits";
+	}
+	if (type.startsWith("dev_plan")) {
+		return "DevPass";
+	}
+	if (type.startsWith("chat_plan")) {
+		return "Chat Plan";
+	}
+	return "Subscription";
+}
+
 export async function handleChargeRefunded(
 	event: Stripe.ChargeRefundedEvent,
 	options: { endUserOnly?: boolean } = {},
@@ -3025,6 +3041,21 @@ export async function handleChargeRefunded(
 				credits: sql`${tables.organization.credits} - ${creditRefundAmount}`,
 			})
 			.where(eq(tables.organization.id, originalTransaction.organizationId));
+	}
+
+	// Notify the internal Discord channel, mirroring the purchase notification.
+	// Runs after the transaction insert (which is guarded by the stripeRefundId
+	// dedupe check above), so webhook retries won't double-notify.
+	if (organization.billingEmail) {
+		const refundUser = await db.query.user.findFirst({
+			where: { email: { eq: organization.billingEmail } },
+		});
+		await notifyRefund(
+			organization.billingEmail,
+			refundUser?.name,
+			refundAmountInDollars,
+			refundProductLabel(originalTransaction.type),
+		);
 	}
 
 	// Track in PostHog

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -126,6 +126,47 @@ export async function notifyCreditsPurchased(
 	});
 }
 
+export async function notifyRefund(
+	email: string,
+	name: string | null | undefined,
+	refundAmount: number,
+	product: string,
+): Promise<void> {
+	const displayName = name ?? "Unknown";
+
+	await sendDiscordNotification({
+		embeds: [
+			{
+				title: "Refund Processed",
+				color: 0xf97316, // Orange
+				fields: [
+					{
+						name: "Email",
+						value: email,
+						inline: true,
+					},
+					{
+						name: "Name",
+						value: displayName,
+						inline: true,
+					},
+					{
+						name: "Product",
+						value: product,
+						inline: true,
+					},
+					{
+						name: "Amount",
+						value: `$${refundAmount.toFixed(2)}`,
+						inline: true,
+					},
+				],
+				timestamp: new Date().toISOString(),
+			},
+		],
+	});
+}
+
 export async function notifyDevPlanSubscribed(
 	email: string,
 	name: string | null | undefined,

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -1,10 +1,28 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { ChevronLeft, ChevronRight, Download, Loader2 } from "lucide-react";
+import {
+	ChevronLeft,
+	ChevronRight,
+	Download,
+	Loader2,
+	Undo2,
+} from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
@@ -73,6 +91,108 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			)}
 			<span className="sr-only sm:not-sr-only">Invoice</span>
 		</Button>
+	);
+}
+
+const REFUND_INELIGIBILITY_COPY: Record<string, string> = {
+	unsupported_type: "This payment cannot be refunded",
+	not_completed: "Only completed payments can be refunded",
+	already_refunded: "This payment has already been refunded",
+	window_expired: "Refunds are available for 14 days after purchase",
+	not_owner: "Only the organization owner can request a refund",
+	not_latest_purchase: "Only your most recent payment can be self-refunded",
+	plan_inactive: "Your DevPass is no longer active",
+	credits_frozen: "Refunds are unavailable while credits are frozen",
+	usage_exceeded: "More than 10% of this period's credits have been used",
+};
+
+function RefundButton({ invoice }: { invoice: Invoice }) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+
+	const refundMutation = api.useMutation(
+		"post",
+		"/dev-plans/invoices/{invoiceId}/refund",
+		{
+			onSuccess: () => {
+				toast.success(
+					"Refund processing. Your DevPass has been cancelled and the refund will arrive within a few business days.",
+				);
+				void queryClient.invalidateQueries({
+					predicate: (query) => {
+						const key = query.queryKey;
+						return (
+							Array.isArray(key) &&
+							(key[1] === "/dev-plans/invoices" ||
+								key[1] === "/dev-plans/status")
+						);
+					},
+				});
+			},
+			onError: () => {
+				toast.error(
+					"Could not process the refund. Please try again later or contact support.",
+				);
+			},
+		},
+	);
+
+	const refund = invoice.refund;
+	if (!refund) {
+		return null;
+	}
+
+	if (!refund.eligible) {
+		return (
+			<span
+				title={
+					REFUND_INELIGIBILITY_COPY[refund.reason ?? "unsupported_type"] ??
+					"This payment cannot be refunded"
+				}
+			>
+				<Button variant="outline" size="sm" disabled>
+					<Undo2 className="h-4 w-4" />
+					<span className="sr-only sm:not-sr-only">Refund</span>
+				</Button>
+			</span>
+		);
+	}
+
+	return (
+		<AlertDialog>
+			<AlertDialogTrigger asChild>
+				<Button variant="outline" size="sm" disabled={refundMutation.isPending}>
+					{refundMutation.isPending ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Undo2 className="h-4 w-4" />
+					)}
+					<span className="sr-only sm:not-sr-only">Refund</span>
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Refund this payment?</AlertDialogTitle>
+					<AlertDialogDescription>
+						{formatAmount(invoice.amount, invoice.currency)} will be refunded to
+						your payment method and your DevPass will be cancelled immediately.
+						This cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Keep my DevPass</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={() =>
+							refundMutation.mutate({
+								params: { path: { invoiceId: invoice.id } },
+							})
+						}
+					>
+						Refund and cancel
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
 	);
 }
 
@@ -174,10 +294,11 @@ export default function DevPassInvoices() {
 							<span className="text-xs sm:hidden">Credits </span>
 							{formatCredits(invoice.creditAmount)}
 						</div>
-						<div className="col-span-2 mt-1 flex justify-end sm:col-span-1 sm:mt-0">
+						<div className="col-span-2 mt-1 flex justify-end gap-2 sm:col-span-1 sm:mt-0">
 							{isInvoiceable(invoice) && (
 								<InvoiceDownloadButton invoice={invoice} />
 							)}
+							<RefundButton invoice={invoice} />
 						</div>
 					</div>
 				))}

--- a/apps/playground/src/components/pricing/chat-billing-history.tsx
+++ b/apps/playground/src/components/pricing/chat-billing-history.tsx
@@ -1,12 +1,29 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { Download, Loader2 } from "lucide-react";
+import { Download, Loader2, Undo2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
 import type { paths } from "@/lib/api/v1";
@@ -123,6 +140,131 @@ function InvoiceDownloadButton({
 	);
 }
 
+const REFUND_INELIGIBILITY_COPY: Record<string, string> = {
+	unsupported_type: "This payment cannot be refunded",
+	not_completed: "Only completed payments can be refunded",
+	already_refunded: "This payment has already been refunded",
+	window_expired: "Refunds are available for 14 days after purchase",
+	not_owner: "Only the organization owner can request a refund",
+	not_latest_purchase: "Only your most recent payment can be self-refunded",
+	plan_inactive: "The plan for this payment is no longer active",
+	credits_frozen: "Refunds are unavailable while credits are frozen",
+	usage_exceeded: "More than 10% of these credits have been used",
+};
+
+function isPlanPayment(type: Transaction["type"]): boolean {
+	return type === "chat_plan_start" || type === "chat_plan_renewal";
+}
+
+function RefundButton({
+	orgId,
+	transaction,
+}: {
+	orgId: string;
+	transaction: Transaction;
+}) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+
+	const refundMutation = api.useMutation(
+		"post",
+		"/orgs/{id}/transactions/{transactionId}/refund",
+		{
+			onSuccess: () => {
+				toast.success(
+					isPlanPayment(transaction.type)
+						? "Refund processing. Your chat plan has been cancelled and the refund will arrive within a few business days."
+						: "Refund processing. It will appear in your billing history shortly.",
+				);
+				void queryClient.invalidateQueries({
+					predicate: (query) => {
+						const key = query.queryKey;
+						return (
+							Array.isArray(key) &&
+							(key[1] === "/orgs/{id}/transactions" ||
+								key[1] === "/chat-plans/status")
+						);
+					},
+				});
+			},
+			onError: () => {
+				toast.error(
+					"Could not process the refund. Please try again later or contact support.",
+				);
+			},
+		},
+	);
+
+	const refund = transaction.refund;
+	if (!refund) {
+		return null;
+	}
+
+	if (!refund.eligible) {
+		return (
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						{/* span wrapper so the tooltip works on a disabled button */}
+						<span tabIndex={0}>
+							<Button variant="outline" size="sm" disabled>
+								<Undo2 className="h-4 w-4" />
+								<span className="sr-only sm:not-sr-only">Refund</span>
+							</Button>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent>
+						{REFUND_INELIGIBILITY_COPY[refund.reason ?? "unsupported_type"] ??
+							"This payment cannot be refunded"}
+					</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	return (
+		<AlertDialog>
+			<AlertDialogTrigger asChild>
+				<Button variant="outline" size="sm" disabled={refundMutation.isPending}>
+					{refundMutation.isPending ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Undo2 className="h-4 w-4" />
+					)}
+					<span className="sr-only sm:not-sr-only">Refund</span>
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Refund this payment?</AlertDialogTitle>
+					<AlertDialogDescription>
+						{formatAmount(transaction.amount, transaction.currency)} will be
+						refunded to your payment method.{" "}
+						{isPlanPayment(transaction.type)
+							? "Your chat plan will be cancelled immediately. "
+							: "The purchased credits will be removed from your balance. "}
+						This cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={() =>
+							refundMutation.mutate({
+								params: {
+									path: { id: orgId, transactionId: transaction.id },
+								},
+							})
+						}
+					>
+						Request refund
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}
+
 export function ChatBillingHistory() {
 	const api = useApi();
 
@@ -190,13 +332,14 @@ export function ChatBillingHistory() {
 							</span>
 							{formatAmount(transaction.amount, transaction.currency)}
 						</div>
-						<div className="col-span-2 mt-1 flex justify-end sm:col-span-1 sm:mt-0">
+						<div className="col-span-2 mt-1 flex justify-end gap-2 sm:col-span-1 sm:mt-0">
 							{isInvoiceable(transaction) && (
 								<InvoiceDownloadButton
 									orgId={orgId}
 									transaction={transaction}
 								/>
 							)}
+							<RefundButton orgId={orgId} transaction={transaction} />
 						</div>
 					</div>
 				))}

--- a/apps/playground/src/components/pricing/chat-billing-history.tsx
+++ b/apps/playground/src/components/pricing/chat-billing-history.tsx
@@ -78,6 +78,15 @@ function formatAmount(amount: string | null, currency: string): string {
 	return `${value.toFixed(2)} ${currency}`;
 }
 
+// Refunds move money back to the customer, so show the amount as negative in the
+// history. The stored `amount` stays positive (it feeds invoice generation).
+function amountCell(transaction: Transaction): string {
+	const formatted = formatAmount(transaction.amount, transaction.currency);
+	return isRefund(transaction.type) && transaction.amount !== null
+		? `-${formatted}`
+		: formatted;
+}
+
 function InvoiceDownloadButton({
 	orgId,
 	transaction,
@@ -330,7 +339,7 @@ export function ChatBillingHistory() {
 							<span className="text-xs text-muted-foreground sm:hidden">
 								Amount{" "}
 							</span>
-							{formatAmount(transaction.amount, transaction.currency)}
+							{amountCell(transaction)}
 						</div>
 						<div className="col-span-2 mt-1 flex justify-end gap-2 sm:col-span-1 sm:mt-0">
 							{isInvoiceable(transaction) && (

--- a/apps/ui/src/app/dashboard/[orgId]/org/transactions/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/transactions/page.tsx
@@ -13,6 +13,19 @@ interface Transaction {
 	amount: string | null;
 	status: "pending" | "completed" | "failed";
 	description: string | null;
+	refund?: {
+		eligible: boolean;
+		reason?:
+			| "unsupported_type"
+			| "not_completed"
+			| "already_refunded"
+			| "window_expired"
+			| "not_owner"
+			| "not_latest_purchase"
+			| "plan_inactive"
+			| "credits_frozen"
+			| "usage_exceeded";
+	};
 }
 
 interface TransactionsData {

--- a/apps/ui/src/components/billing/transactions-client.tsx
+++ b/apps/ui/src/components/billing/transactions-client.tsx
@@ -1,10 +1,22 @@
 "use client";
 
 import { format } from "date-fns";
-import { Download, Loader2 } from "lucide-react";
+import { Download, Loader2, Undo2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/lib/components/alert-dialog";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 import {
@@ -14,8 +26,28 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/lib/components/tooltip";
 import { useToast } from "@/lib/components/use-toast";
 import { useFetchClient } from "@/lib/fetch-client";
+
+interface RefundEligibility {
+	eligible: boolean;
+	reason?:
+		| "unsupported_type"
+		| "not_completed"
+		| "already_refunded"
+		| "window_expired"
+		| "not_owner"
+		| "not_latest_purchase"
+		| "plan_inactive"
+		| "credits_frozen"
+		| "usage_exceeded";
+}
 
 interface Transaction {
 	id: string;
@@ -31,6 +63,122 @@ interface Transaction {
 	amount: string | null;
 	status: "pending" | "completed" | "failed";
 	description: string | null;
+	refund?: RefundEligibility;
+}
+
+const REFUND_INELIGIBILITY_COPY: Record<
+	NonNullable<RefundEligibility["reason"]>,
+	string
+> = {
+	unsupported_type: "This transaction cannot be refunded",
+	not_completed: "Only completed payments can be refunded",
+	already_refunded: "This purchase has already been refunded",
+	window_expired: "Refunds are available for 14 days after purchase",
+	not_owner: "Only the organization owner can request a refund",
+	not_latest_purchase: "Only your most recent purchase can be self-refunded",
+	plan_inactive: "The plan for this payment is no longer active",
+	credits_frozen: "Refunds are unavailable while credits are frozen",
+	usage_exceeded: "More than 10% of these credits have been used",
+};
+
+function RefundButton({
+	orgId,
+	transaction,
+}: {
+	orgId: string;
+	transaction: Transaction;
+}) {
+	const fetchClient = useFetchClient();
+	const router = useRouter();
+	const { toast } = useToast();
+	const [loading, setLoading] = useState(false);
+
+	const refund = transaction.refund;
+	if (!refund) {
+		return null;
+	}
+
+	async function handleRefund() {
+		setLoading(true);
+		try {
+			const { response } = await fetchClient.POST(
+				"/orgs/{id}/transactions/{transactionId}/refund",
+				{
+					params: { path: { id: orgId, transactionId: transaction.id } },
+				},
+			);
+			if (!response.ok) {
+				throw new Error("Refund request failed");
+			}
+			toast({
+				title: "Refund processing",
+				description:
+					"Your refund has been submitted and will appear in your transaction history shortly.",
+			});
+			router.refresh();
+		} catch {
+			toast({
+				title: "Could not process refund",
+				description: "Please try again later or contact support.",
+				variant: "destructive",
+			});
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	if (!refund.eligible) {
+		return (
+			<TooltipProvider>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						{/* span wrapper so the tooltip works on a disabled button */}
+						<span tabIndex={0}>
+							<Button variant="outline" size="sm" disabled>
+								<Undo2 className="h-4 w-4" />
+								Refund
+							</Button>
+						</span>
+					</TooltipTrigger>
+					<TooltipContent>
+						{REFUND_INELIGIBILITY_COPY[refund.reason ?? "unsupported_type"]}
+					</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
+		);
+	}
+
+	return (
+		<AlertDialog>
+			<AlertDialogTrigger asChild>
+				<Button variant="outline" size="sm" disabled={loading}>
+					{loading ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Undo2 className="h-4 w-4" />
+					)}
+					Refund
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Refund this purchase?</AlertDialogTitle>
+					<AlertDialogDescription>
+						${Number(transaction.amount ?? 0).toFixed(2)} will be refunded to
+						your original payment method and{" "}
+						{Number(transaction.creditAmount ?? 0).toFixed(2)} credits will be
+						removed from your balance. This cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction onClick={handleRefund}>
+						Request refund
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
 }
 
 interface TransactionsData {
@@ -199,9 +347,10 @@ function TransactionCard({
 					</div>
 				)}
 
-				{isInvoiceable(transaction) && (
-					<div className="pt-1">
+				{(isInvoiceable(transaction) || transaction.refund) && (
+					<div className="pt-1 flex gap-2">
 						<InvoiceDownloadButton orgId={orgId} transaction={transaction} />
+						<RefundButton orgId={orgId} transaction={transaction} />
 					</div>
 				)}
 			</div>
@@ -329,11 +478,17 @@ export function TransactionsClient({
 													{transaction.description ?? "—"}
 												</td>
 												<td className="p-4 align-middle whitespace-nowrap text-right">
-													{isInvoiceable(transaction) ? (
-														<InvoiceDownloadButton
-															orgId={orgId}
-															transaction={transaction}
-														/>
+													{isInvoiceable(transaction) || transaction.refund ? (
+														<div className="flex justify-end gap-2">
+															<InvoiceDownloadButton
+																orgId={orgId}
+																transaction={transaction}
+															/>
+															<RefundButton
+																orgId={orgId}
+																transaction={transaction}
+															/>
+														</div>
 													) : (
 														"—"
 													)}

--- a/apps/ui/src/components/billing/transactions-client.tsx
+++ b/apps/ui/src/components/billing/transactions-client.tsx
@@ -200,6 +200,18 @@ function isRefund(type: Transaction["type"]): boolean {
 	return type === "credit_refund";
 }
 
+// Refunds move money back to the customer, so show the paid amount as negative
+// — matching the already-signed Credits column. The stored `amount` stays
+// positive (it feeds invoice/credit-note generation).
+function paidAmountDisplay(transaction: Transaction): string {
+	if (transaction.amount === null) {
+		return "—";
+	}
+	return isRefund(transaction.type)
+		? `-${transaction.amount}`
+		: transaction.amount;
+}
+
 function InvoiceDownloadButton({
 	orgId,
 	transaction,
@@ -335,7 +347,7 @@ function TransactionCard({
 					{transaction.amount && (
 						<div>
 							<p className="text-muted-foreground text-xs">Total Paid</p>
-							<p className="font-medium">{transaction.amount}</p>
+							<p className="font-medium">{paidAmountDisplay(transaction)}</p>
 						</div>
 					)}
 				</div>
@@ -459,7 +471,7 @@ export function TransactionsClient({
 													{transaction.creditAmount ?? "—"}
 												</td>
 												<td className="p-4 align-middle whitespace-nowrap">
-													{transaction.amount ?? "—"}
+													{paidAmountDisplay(transaction)}
 												</td>
 												<td className="p-4 align-middle whitespace-nowrap">
 													<Badge

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2801,6 +2801,7 @@ export const auditLogActions = [
 	"payment.credit_topup",
 	"payment.auto_topup.update",
 	"payment.auto_topup.disable",
+	"payment.self_refund",
 	// Credits
 	"credits.gift",
 	// Referral

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,7 +169,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.6.23
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.4.0)
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.16.3)(sql.js@1.13.0))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.4.0)
       '@better-auth/sso':
         specifier: 1.6.23
         version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))
@@ -233,6 +233,9 @@ importers:
       better-auth:
         specifier: 1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.16.3)(sql.js@1.13.0))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
+      decimal.js:
+        specifier: 10.5.0
+        version: 10.5.0
       disposable-email-domains-js:
         specifier: 1.20.0
         version: 1.20.0
@@ -295,7 +298,7 @@ importers:
         version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.7))(zod@3.25.76)
@@ -928,16 +931,16 @@ importers:
         version: 3.0.29(react@19.2.7)(zod@3.25.75)
       '@better-auth/passkey':
         specifier: 1.6.23
-        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.4.0)
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.16.3)(sql.js@1.13.0))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.4.0)
       '@better-auth/sso':
         specifier: 1.6.23
         version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))
       '@content-collections/core':
         specifier: 0.15.0
-        version: 0.15.0(typescript@5.9.2)
+        version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.2))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.7))(zod@3.25.75)
@@ -1163,7 +1166,7 @@ importers:
         version: 10.4.21(postcss@8.5.10)
       openapi-typescript:
         specifier: 7.10.1
-        version: 7.10.1(typescript@5.9.2)
+        version: 7.10.1(typescript@5.9.3)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -13016,7 +13019,7 @@ snapshots:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.4.0)':
+  '@better-auth/passkey@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.16.3)(sql.js@1.13.0))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.16.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.4.0)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
@@ -13224,21 +13227,6 @@ snapshots:
       conventional-commits-parser: 6.4.0
       picocolors: 1.1.1
 
-  '@content-collections/core@0.15.0(typescript@5.9.2)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      camelcase: 8.0.0
-      chokidar: 4.0.3
-      esbuild: 0.28.1
-      gray-matter: 4.0.3(patch_hash=5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc)
-      p-limit: 6.2.0
-      picomatch: 4.0.4
-      pluralize: 8.0.0
-      serialize-javascript: 7.0.5
-      tinyglobby: 0.2.16
-      typescript: 5.9.2
-      yaml: 2.8.3
-
   '@content-collections/core@0.15.0(typescript@5.9.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -13254,21 +13242,11 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.3
 
-  '@content-collections/integrations@0.5.0(@content-collections/core@0.15.0(typescript@5.9.2))':
-    dependencies:
-      '@content-collections/core': 0.15.0(typescript@5.9.2)
-
   '@content-collections/integrations@0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
 
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.2))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
-    dependencies:
-      '@content-collections/core': 0.15.0(typescript@5.9.2)
-      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.2))
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.2.10(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))
@@ -22330,16 +22308,6 @@ snapshots:
   openapi-types@12.1.3: {}
 
   openapi-typescript-helpers@0.0.15: {}
-
-  openapi-typescript@7.10.1(typescript@5.9.2):
-    dependencies:
-      '@redocly/openapi-core': 1.34.5(supports-color@10.2.2)
-      ansi-colors: 4.1.3
-      change-case: 5.4.4
-      parse-json: 8.3.0
-      supports-color: 10.2.2
-      typescript: 5.9.2
-      yargs-parser: 21.1.1
 
   openapi-typescript@7.10.1(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

Adds a self-service **Refund** button for credit top-ups and DevPass/Chat plan payments, shown in the dashboard transactions page (apps/ui), the DevPass invoices list (apps/code), and the chat billing history (apps/playground). The button is greyed out with a tooltip explaining why when the purchase isn't eligible.

## Eligibility rules

Computed in `apps/api/src/lib/self-refund.ts` and annotated as an optional `refund: { eligible, reason }` object on `GET /orgs/{id}/transactions` and `GET /dev-plans/invoices` (no extra client round-trips).

Common guards: completed positive payment, org **owner only**, **14-day window**, not already refunded.

Per product:
- **First credit top-up**: total consumption < 10% of the purchased credits — reconstructed from the pooled balance (grants incl. gifts, refunds, end-user bonuses, referral earnings), so burning free gift credits and then refunding the paid top-up in full is not possible.
- **Repeat top-ups**: only the latest purchase, and only while the balance still covers ≥ 90% of it (remaining pool attributed to the newest purchase first).
- **First dev/chat plan purchase**: plan usage < 10% of the virtual credit allowance (first-purchase guarantee, per the original spec).
- **Plan renewals / re-subscribes**: current-cycle usage < 10% of the **dollar** price instead — at a 3x credit multiplier, 10% of the virtual allowance would leak up to 30% of the payment in provider cost, so renewals gate on dollars.
- **Upgrades** stay support-only (prorated partial charges).

## Refund execution

`POST /orgs/{id}/transactions/{transactionId}/refund` (plus a DevPass wrapper `POST /dev-plans/invoices/{invoiceId}/refund`) re-checks eligibility server-side, then:
1. Resolves the payment intent — directly for top-ups, via `getPaymentIntentFromInvoicePayments` for plan invoices (stripe 18.x drops `invoice.payment_intent`).
2. Creates the Stripe refund with an idempotency key (`self-refund-{txId}`), so double-clicks/races can't double-refund.
3. For plan payments, cancels the subscription immediately (refund first; a cancel failure is logged, not surfaced as a request failure).
4. Writes a `payment.self_refund` audit event.

Bookkeeping (the `credit_refund` row, credit deduction, plan-field reset) is intentionally left to the existing idempotent `charge.refunded` and `customer.subscription.deleted` webhook handlers — no schema migration needed.

## Tests

`apps/api/src/lib/self-refund.spec.ts` (23 tests): eligibility matrix (first vs repeat top-ups, gift-credit accounting, negative balance, plan start vs renewal thresholds incl. the exact-10% float boundary, window, refunded, roles, frozen/inactive plans) plus endpoint tests asserting the Stripe calls, idempotency key, subscription-cancel behavior, audit logging, and the GET annotation.

- `pnpm test:unit apps/api/src/lib/self-refund.spec.ts` — 23/23 passing
- `pnpm format` + `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-service refund flow for eligible credit top-ups and DevPass plan payments, including “why not eligible” reason details.
  * Added refund eligibility to invoice and transaction listings.
  * Added Refund actions to dashboard and transactions UI with confirmation dialogs, tooltips, loading states, and success/error toasts.
* **Bug Fixes**
  * Strengthened eligibility enforcement (ownership, completion, refund window, already-refunded, unsupported types, plan/credit constraints, and latest-payment checks).
* **Audit**
  * Records self-refund events via `payment.self_refund`.
* **Chores**
  * Sends a Discord notification when refunds are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->