### PR TITLE
fix(cache): retry queue publishes on Redis blips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - In `packages/models`, ALWAYS express per-token prices (`inputPrice`, `outputPrice`, `cachedInputPrice`, and any other per-token price field) using `e-6` notation so the coefficient reads directly as USD per million tokens (e.g. `"1.4e-6"` for $1.40/M — the exact number providers publish). Never use `e-3` or other exponents for per-token prices. This does NOT apply to `requestPrice`, which is a flat USD amount charged per request (e.g. `"0.035"`), nor to `perSecondPrice`.
 - No unnecessary code comments
 - Do not use broad try/catch in API handlers unless to check for specific errors; instead, let errors propagate and be handled by the global error handler
+- Never use `insertLog`'s `syncInsert: true` (synchronous per-request DB insert) as a general, default, or fallback logging path — a per-request DB insert bypasses the Redis queue + batch worker and will immediately kill production DB performance. Request logs must always go through `publishToQueue`/`LOG_QUEUE`. `syncInsert` is reserved exclusively for the Responses API stored-response path (which requires read-after-write of the log row) and tests; never propose it as a resilience fallback for Redis outages either — harden the queue path instead (e.g. retry buffers).
 
 ### Testing and Quality Assurance
 

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 
-import { redisClient } from "@llmgateway/cache";
+import { closeRedisClient } from "@llmgateway/cache";
 import { closeDatabase, setQueryTags } from "@llmgateway/db";
 import {
 	initializeInstrumentation,
@@ -130,7 +130,7 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 		logger.info("Database connection closed");
 
 		logger.info("Closing Redis connection");
-		await redisClient.quit();
+		await closeRedisClient();
 		logger.info("Redis connection closed");
 
 		// Shutdown instrumentation last to ensure all spans are flushed

--- a/packages/cache/src/redis.spec.ts
+++ b/packages/cache/src/redis.spec.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	flushPendingQueueMessages,
+	pendingQueueMessageCount,
+	publishToQueue,
+	redisClient,
+} from "./redis.js";
+
+const TEST_QUEUE = "test_pending_retry_queue";
+
+// Note: other spec files (e.g. swr.spec.ts) run flushdb() against the shared
+// Redis instance concurrently, so these tests never assert on real Redis
+// state — lpush is always mocked.
+describe("publishToQueue retry buffer", () => {
+	async function drainPendingBuffer(): Promise<void> {
+		const spy = vi.spyOn(redisClient, "lpush").mockResolvedValue(0);
+		await flushPendingQueueMessages();
+		spy.mockRestore();
+	}
+
+	beforeEach(async () => {
+		vi.restoreAllMocks();
+		await drainPendingBuffer();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await drainPendingBuffer();
+	});
+
+	it("publishes directly when Redis is available", async () => {
+		const spy = vi.spyOn(redisClient, "lpush").mockResolvedValue(1);
+
+		await publishToQueue(TEST_QUEUE, { requestId: "direct" });
+
+		expect(pendingQueueMessageCount()).toBe(0);
+		expect(spy).toHaveBeenCalledWith(
+			TEST_QUEUE,
+			JSON.stringify({ requestId: "direct" }),
+		);
+	});
+
+	it("buffers messages on connection errors instead of throwing, then flushes on recovery", async () => {
+		const spy = vi
+			.spyOn(redisClient, "lpush")
+			.mockRejectedValue(new Error("Connection is closed."));
+
+		await expect(
+			publishToQueue(TEST_QUEUE, { requestId: "r1" }),
+		).resolves.toBeUndefined();
+		await expect(
+			publishToQueue(TEST_QUEUE, { requestId: "r2" }),
+		).resolves.toBeUndefined();
+		expect(pendingQueueMessageCount()).toBe(2);
+
+		spy.mockResolvedValue(1);
+
+		const flushed = await flushPendingQueueMessages();
+		expect(flushed).toBe(2);
+		expect(pendingQueueMessageCount()).toBe(0);
+		expect(spy).toHaveBeenCalledWith(
+			TEST_QUEUE,
+			JSON.stringify({ requestId: "r1" }),
+		);
+		expect(spy).toHaveBeenCalledWith(
+			TEST_QUEUE,
+			JSON.stringify({ requestId: "r2" }),
+		);
+	});
+
+	it("buffers messages on ECONNREFUSED-style errors", async () => {
+		const error = new Error("connect ECONNREFUSED 127.0.0.1:6379");
+		(error as NodeJS.ErrnoException).code = "ECONNREFUSED";
+		vi.spyOn(redisClient, "lpush").mockRejectedValue(error);
+
+		await expect(
+			publishToQueue(TEST_QUEUE, { requestId: "r3" }),
+		).resolves.toBeUndefined();
+		expect(pendingQueueMessageCount()).toBe(1);
+	});
+
+	it("rethrows non-connection errors without buffering", async () => {
+		vi.spyOn(redisClient, "lpush").mockRejectedValue(
+			new Error(
+				"WRONGTYPE Operation against a key holding the wrong kind of value",
+			),
+		);
+
+		await expect(
+			publishToQueue(TEST_QUEUE, { requestId: "r4" }),
+		).rejects.toThrow("WRONGTYPE");
+		expect(pendingQueueMessageCount()).toBe(0);
+	});
+
+	it("keeps buffered messages when the flush attempt fails", async () => {
+		vi.spyOn(redisClient, "lpush").mockRejectedValue(
+			new Error("Connection is closed."),
+		);
+
+		await publishToQueue(TEST_QUEUE, { requestId: "r5" });
+		expect(pendingQueueMessageCount()).toBe(1);
+
+		const flushed = await flushPendingQueueMessages();
+		expect(flushed).toBe(0);
+		expect(pendingQueueMessageCount()).toBe(1);
+	});
+});

--- a/packages/cache/src/redis.ts
+++ b/packages/cache/src/redis.ts
@@ -45,12 +45,77 @@ redisClient.on("error", (err) => {
 
 export const LOG_QUEUE = "log_queue_" + process.env.NODE_ENV;
 
+// In-memory retry buffer for queue messages that could not be published while
+// Redis was unreachable. Messages are re-published when the connection comes
+// back (see the "ready" listener / retry interval below) instead of dropped.
+const MAX_PENDING_QUEUE_MESSAGES = 10_000;
+const PENDING_FLUSH_INTERVAL_MS = 5_000;
+const pendingQueueMessages: { queue: string; payload: string }[] = [];
+let flushingPendingQueueMessages = false;
+
+export function pendingQueueMessageCount(): number {
+	return pendingQueueMessages.length;
+}
+
+export async function flushPendingQueueMessages(): Promise<number> {
+	if (flushingPendingQueueMessages) {
+		return 0;
+	}
+	flushingPendingQueueMessages = true;
+	let flushed = 0;
+	try {
+		while (pendingQueueMessages.length > 0) {
+			const next = pendingQueueMessages[0];
+			await redisClient.lpush(next.queue, next.payload);
+			pendingQueueMessages.shift();
+			flushed++;
+		}
+	} catch (error) {
+		logger.warn("Failed to flush pending queue messages, will retry", error, {
+			flushed,
+			pending: pendingQueueMessages.length,
+		});
+	} finally {
+		flushingPendingQueueMessages = false;
+	}
+	if (flushed > 0) {
+		logger.info("Flushed pending queue messages to Redis", {
+			flushed,
+			pending: pendingQueueMessages.length,
+		});
+	}
+	return flushed;
+}
+
+function bufferPendingQueueMessage(queue: string, payload: string): void {
+	if (pendingQueueMessages.length >= MAX_PENDING_QUEUE_MESSAGES) {
+		pendingQueueMessages.shift();
+		logger.error("Pending queue buffer full, dropping oldest message", {
+			maxPending: MAX_PENDING_QUEUE_MESSAGES,
+		});
+	}
+	pendingQueueMessages.push({ queue, payload });
+}
+
+redisClient.on("ready", () => {
+	if (pendingQueueMessages.length > 0) {
+		void flushPendingQueueMessages();
+	}
+});
+
+setInterval(() => {
+	if (pendingQueueMessages.length > 0 && redisClient.status === "ready") {
+		void flushPendingQueueMessages();
+	}
+}, PENDING_FLUSH_INTERVAL_MS).unref();
+
 export async function publishToQueue(
 	queue: string,
 	message: unknown,
 ): Promise<void> {
+	const payload = JSON.stringify(message);
 	try {
-		await redisClient.lpush(queue, JSON.stringify(message));
+		await redisClient.lpush(queue, payload);
 	} catch (error) {
 		const msg = message as Record<string, unknown> | undefined;
 		const item = msg
@@ -62,15 +127,17 @@ export async function publishToQueue(
 					usedProvider: msg.usedProvider,
 				}
 			: undefined;
-		// Publishing request logs is best-effort telemetry. When Redis is briefly
-		// unreachable (deploy/failover) the command can't be queued; swallow it at
-		// warn level instead of throwing, so a transient blip doesn't turn an
-		// already-served request into an unhandled 500 or raise error alerts.
+		// When Redis is briefly unreachable (deploy/failover), buffer the message
+		// in memory and re-publish once the connection recovers, instead of
+		// throwing — a transient blip must not turn an already-served request
+		// into an unhandled 500 or raise error alerts.
 		if (isConnectionUnavailableError(error)) {
-			logger.warn("Skipped publishing to queue (Redis unavailable)", error, {
-				queue,
-				item,
-			});
+			bufferPendingQueueMessage(queue, payload);
+			logger.warn(
+				"Redis unavailable, buffered queue message for retry",
+				error,
+				{ queue, item, pending: pendingQueueMessages.length },
+			);
 			return;
 		}
 		logger.error("Error publishing to queue", error, { queue, item });
@@ -98,9 +165,17 @@ export async function consumeFromQueue(
 
 export async function closeRedisClient(): Promise<void> {
 	try {
-		await redisClient.disconnect();
+		// Drain any buffered queue messages before tearing down the connection so
+		// logs published during a Redis blip are not lost on shutdown.
+		await flushPendingQueueMessages();
+		await redisClient.quit();
 		logger.info("Redis client disconnected");
 	} catch (error) {
+		if (isConnectionUnavailableError(error)) {
+			logger.warn("Redis already disconnected during close", error);
+			redisClient.disconnect();
+			return;
+		}
 		logger.error("Error disconnecting Redis client", error);
 		throw error;
 	}

--- a/packages/cache/src/redis.ts
+++ b/packages/cache/src/redis.ts
@@ -8,7 +8,40 @@ export const redisClient = new Redis({
 	password: process.env.REDIS_PASSWORD,
 });
 
-redisClient.on("error", (err) => logger.error("Redis Client Error", err));
+/**
+ * Detects transient "Redis is not currently reachable" errors — e.g. a socket
+ * closed during a rolling deploy/failover or an in-flight command racing with
+ * graceful shutdown. ioredis auto-reconnects from these, so they are expected
+ * operational noise rather than application bugs.
+ */
+function isConnectionUnavailableError(error: unknown): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+	const code = (error as NodeJS.ErrnoException).code;
+	if (
+		code === "ECONNREFUSED" ||
+		code === "ECONNRESET" ||
+		code === "ETIMEDOUT" ||
+		code === "EPIPE" ||
+		code === "ENOTFOUND"
+	) {
+		return true;
+	}
+	return (
+		error.message.includes("Connection is closed") ||
+		error.message.includes("Stream isn't writeable") ||
+		error.message.includes("max retries per request")
+	);
+}
+
+redisClient.on("error", (err) => {
+	if (isConnectionUnavailableError(err)) {
+		logger.warn("Redis connection unavailable", err);
+		return;
+	}
+	logger.error("Redis Client Error", err);
+});
 
 export const LOG_QUEUE = "log_queue_" + process.env.NODE_ENV;
 
@@ -29,6 +62,17 @@ export async function publishToQueue(
 					usedProvider: msg.usedProvider,
 				}
 			: undefined;
+		// Publishing request logs is best-effort telemetry. When Redis is briefly
+		// unreachable (deploy/failover) the command can't be queued; swallow it at
+		// warn level instead of throwing, so a transient blip doesn't turn an
+		// already-served request into an unhandled 500 or raise error alerts.
+		if (isConnectionUnavailableError(error)) {
+			logger.warn("Skipped publishing to queue (Redis unavailable)", error, {
+				queue,
+				item,
+			});
+			return;
+		}
 		logger.error("Error publishing to queue", error, { queue, item });
 		throw error;
 	}


### PR DESCRIPTION
## Problem

The gateway spams `ERROR` logs (and raises error alerts) like:

```
Error: Connection is closed.
    at publishToQueue (@llmgateway/cache/src/redis.ts:20)
    at insertLog (apps/gateway/src/lib/logs.ts:336)
```

This happens when Redis is briefly unreachable — e.g. an in-flight request tries to publish its request log while the connection is closing during a rolling deploy / failover / shutdown. Because `publishToQueue` logged at `ERROR` **and rethrew**, a transient blip:

- turned already-served requests into unhandled `500`s via `app.onError`,
- generated noisy error-level alerts for an expected operational condition, and
- **dropped the request log entirely** — nothing ever retried the publish.

## Fix

`isConnectionUnavailableError()` detects connection-lost errors (`ECONNREFUSED`/`ECONNRESET`/`ETIMEDOUT`/`EPIPE`/`ENOTFOUND`, `"Connection is closed"`, `"Stream isn't writeable"`, max-retries). On such errors:

1. **Retry instead of drop** — the message is buffered in an in-memory retry buffer (capped at 10k, drop-oldest with an error log) and re-published when the connection recovers: on the client's `ready` event and via a 5s `unref`'d retry interval. Note ioredis's built-in offline queue already covers plain reconnects; this buffer covers commands that failed with a thrown error (e.g. terminal `end` state racing shutdown).
2. **No more 500s/alerts** — `publishToQueue` logs a `warn` and returns instead of rethrowing; the client-level `error` handler is likewise downgraded to `warn` for this error class. Genuinely unexpected errors still log at `ERROR` and rethrow.
3. **Shutdown drain** — `closeRedisClient()` now flushes the pending buffer before `quit()` (falling back to `disconnect()` if the connection is already gone), and the gateway's graceful shutdown calls `closeRedisClient()` instead of `redisClient.quit()` directly, so logs buffered during a blip survive shutdown. The worker already used `closeRedisClient()`.

Explicitly **not** using `insertLog`'s `syncInsert` as a fallback — per-request DB inserts would kill production performance; documented this in AGENTS.md so it isn't proposed again.

## Tests

- New `packages/cache/src/redis.spec.ts` (5 tests): direct publish, buffering + flush on recovery, ECONNREFUSED-style codes, rethrow of non-connection errors, buffer retained on failed flush. Fully mocked `lpush` since other cache specs `flushdb()` the shared Redis concurrently.
- `pnpm format`, `turbo run build --filter=gateway --filter=worker`, and the cache spec suite (3 consecutive runs) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for temporary Redis connection failures by buffering pending queue messages instead of dropping them.
  * Reduced log noise by downgrading transient Redis unavailability to warnings while still surfacing unexpected failures.
  * On shutdown, buffered messages are flushed before closing the Redis client to avoid message loss.
* **Tests**
  * Added Vitest coverage for publish buffering, retry/flush behavior during Redis recovery, and ensuring non-connection errors are still rethrown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->