### PR TITLE
fix(admin): dashboard metrics and date ranges

### DIFF
--- a/apps/api/src/routes/admin-paid-customers.spec.ts
+++ b/apps/api/src/routes/admin-paid-customers.spec.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+import { paidTransactionTypes } from "@/utils/devpass-filter.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const allTransactionTypes = tables.transaction.type.enumValues;
+const nonPaidTransactionTypes = allTransactionTypes.filter(
+	(t) => !(paidTransactionTypes as readonly string[]).includes(t),
+);
+
+interface AdminMetricsResponse {
+	payingCustomers: number;
+}
+
+interface TimeseriesPoint {
+	date: string;
+	paidCustomers: number;
+	net: number;
+	dailySignups: number;
+	dailyPaidCustomers: number;
+	dailyNet: number;
+}
+
+interface TimeseriesResponse {
+	data: TimeseriesPoint[];
+	totals: { paidCustomers: number; net: number };
+}
+
+async function getMetrics(cookie: string): Promise<AdminMetricsResponse> {
+	const res = await app.request("/admin/metrics", {
+		headers: { Cookie: cookie },
+	});
+	expect(res.status).toBe(200);
+	return (await res.json()) as AdminMetricsResponse;
+}
+
+async function getTimeseries(
+	cookie: string,
+	query = "",
+): Promise<TimeseriesResponse> {
+	const res = await app.request(`/admin/metrics/timeseries${query}`, {
+		headers: { Cookie: cookie },
+	});
+	expect(res.status).toBe(200);
+	return (await res.json()) as TimeseriesResponse;
+}
+
+describe("admin paid customers — transaction type matrix", () => {
+	let cookie: string;
+
+	// One org per paid transaction type, all of them counting exactly once,
+	// plus orgs that must never count: one holding every non-paid type, one
+	// with only a pending payment, and one with multiple paid transactions
+	// (must not be double-counted).
+	const expectedPaidCustomers = paidTransactionTypes.length + 1;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			...paidTransactionTypes.map((type) => ({
+				id: `paid-${type}`,
+				name: `Paid ${type}`,
+				billingEmail: `${type}@example.com`,
+			})),
+			{
+				id: "non-paid-org",
+				name: "Non Paid Org",
+				billingEmail: "non-paid@example.com",
+			},
+			{
+				id: "pending-org",
+				name: "Pending Org",
+				billingEmail: "pending@example.com",
+			},
+			{
+				id: "multi-paid-org",
+				name: "Multi Paid Org",
+				billingEmail: "multi@example.com",
+			},
+		]);
+
+		await db.insert(tables.transaction).values([
+			// Each paid type on its own org — every one must count as a paid
+			// customer exactly once.
+			...paidTransactionTypes.map((type) => ({
+				organizationId: `paid-${type}`,
+				type,
+				amount: "10",
+				creditAmount: "10",
+				status: "completed" as const,
+			})),
+			// Every remaining enum value on a single org — none of these
+			// (gifts, refunds, cancel/end/downgrade bookkeeping, end-user margin
+			// rows) may qualify it as paying.
+			...nonPaidTransactionTypes.map((type) => ({
+				organizationId: "non-paid-org",
+				type,
+				amount: "10",
+				creditAmount: "10",
+				status: "completed" as const,
+			})),
+			// A real payment type that never completed must not count.
+			{
+				organizationId: "pending-org",
+				type: "credit_topup" as const,
+				amount: "10",
+				creditAmount: "10",
+				status: "pending" as const,
+			},
+			// Multiple paid transactions on one org count as one customer.
+			{
+				organizationId: "multi-paid-org",
+				type: "credit_topup" as const,
+				amount: "10",
+				creditAmount: "10",
+				status: "completed" as const,
+			},
+			{
+				organizationId: "multi-paid-org",
+				type: "dev_plan_renewal" as const,
+				amount: "10",
+				creditAmount: "10",
+				status: "completed" as const,
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("every transaction type is classified as paid or non-paid", () => {
+		for (const type of paidTransactionTypes) {
+			expect(allTransactionTypes).toContain(type);
+		}
+		expect(paidTransactionTypes.length + nonPaidTransactionTypes.length).toBe(
+			allTransactionTypes.length,
+		);
+	});
+
+	test("/admin/metrics payingCustomers counts only orgs with completed payments", async () => {
+		const body = await getMetrics(cookie);
+		expect(body.payingCustomers).toBe(expectedPaidCustomers);
+	});
+
+	test("/admin/metrics/timeseries paid customer totals add up", async () => {
+		const body = await getTimeseries(cookie);
+
+		expect(body.totals.paidCustomers).toBe(expectedPaidCustomers);
+		// The cumulative series must end at the total, and the per-day new paid
+		// customers must sum to it (nothing counted twice, nothing pre-range).
+		expect(body.data.at(-1)?.paidCustomers).toBe(expectedPaidCustomers);
+		const dailySum = body.data.reduce(
+			(sum, point) => sum + point.dailyPaidCustomers,
+			0,
+		);
+		expect(dailySum).toBe(expectedPaidCustomers);
+	});
+});
+
+describe("admin paid customers — bounded range baseline", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: "old-org",
+				name: "Old Org",
+				billingEmail: "old@example.com",
+			},
+			{
+				id: "recent-org",
+				name: "Recent Org",
+				billingEmail: "recent@example.com",
+			},
+			{
+				id: "gift-org",
+				name: "Gift Org",
+				billingEmail: "gift@example.com",
+			},
+		]);
+
+		// eslint-disable-next-line no-mixed-operators
+		const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+		await db.insert(tables.transaction).values([
+			// First payment well before the 7d range — belongs to the baseline.
+			{
+				organizationId: "old-org",
+				type: "credit_topup",
+				amount: "21",
+				creditAmount: "20",
+				status: "completed",
+				createdAt: sixtyDaysAgo,
+			},
+			// Second payment inside the range — must not re-count the org.
+			{
+				organizationId: "old-org",
+				type: "credit_topup",
+				amount: "6",
+				creditAmount: "5",
+				status: "completed",
+			},
+			// First payment inside the range — the only new paid customer.
+			{
+				organizationId: "recent-org",
+				type: "credit_topup",
+				amount: "11",
+				creditAmount: "10",
+				status: "completed",
+			},
+			// Gift inside the range — no paid customer, no revenue.
+			{
+				organizationId: "gift-org",
+				type: "credit_gift",
+				amount: "3",
+				creditAmount: "3",
+				status: "completed",
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("range=7d keeps pre-range customers in the baseline, not in day one", async () => {
+		const body = await getTimeseries(cookie, "?range=7d");
+		const todayStr = new Date().toISOString().split("T")[0];
+		const first = body.data[0];
+		const today = body.data.find((point) => point.date === todayStr);
+
+		// Both orgs are paid customers overall.
+		expect(body.totals.paidCustomers).toBe(2);
+		expect(body.data.at(-1)?.paidCustomers).toBe(2);
+
+		// The old org sits in the cumulative baseline of the first point but
+		// must not appear as a day-one delta (regression: the first sparkline
+		// bar used to show the whole pre-range total).
+		expect(first.paidCustomers).toBe(1);
+		expect(first.dailyPaidCustomers).toBe(0);
+		expect(first.dailySignups).toBe(0);
+		expect(first.dailyNet).toBe(0);
+		// Cumulative revenue also starts from the pre-range baseline.
+		expect(first.net).toBe(20);
+
+		// Only the recent org is a new paid customer within the range; the old
+		// org's in-range second payment must not re-count it.
+		const dailySum = body.data.reduce(
+			(sum, point) => sum + point.dailyPaidCustomers,
+			0,
+		);
+		expect(dailySum).toBe(1);
+		expect(today?.dailyPaidCustomers).toBe(1);
+
+		// Today's daily net = in-range payments (5 + 10); the gift is excluded.
+		expect(today?.dailyNet).toBe(15);
+		expect(body.totals.net).toBe(35);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,6 +12,7 @@ import {
 	notDevpassFilter,
 	notEndUserNonRevenueFilter,
 	notEndUserWalletFilter,
+	paidTransactionFilter,
 } from "@/utils/devpass-filter.js";
 import {
 	HOURLY_BUCKET_THRESHOLD_MINUTES,
@@ -107,6 +108,11 @@ const timeseriesDataPointSchema = z.object({
 	processed: z.number(),
 	refunds: z.number(),
 	net: z.number(),
+	// Per-day (non-cumulative) values. The cumulative series above start from a
+	// pre-range baseline, so clients cannot derive day-one deltas themselves.
+	dailySignups: z.number(),
+	dailyPaidCustomers: z.number(),
+	dailyNet: z.number(),
 });
 
 const adminTimeseriesSchema = z.object({
@@ -593,7 +599,9 @@ admin.openapi(getMetrics, async (c) => {
 
 	const verifiedUsers = Number(verifiedRow?.count ?? 0);
 
-	// Paying customers: organizations with at least one completed transaction
+	// Paying customers: organizations with at least one completed payment
+	// transaction (credit purchase, dev/chat plan charge, or end-user top-up —
+	// gifts and bookkeeping rows don't count)
 	const [payingRow] = await db
 		.select({
 			count:
@@ -603,7 +611,11 @@ admin.openapi(getMetrics, async (c) => {
 		})
 		.from(tables.transaction)
 		.where(
-			and(eq(tables.transaction.status, "completed"), transactionDateFilter),
+			and(
+				eq(tables.transaction.status, "completed"),
+				paidTransactionFilter,
+				transactionDateFilter,
+			),
 		);
 
 	const payingCustomers = Number(payingRow?.count ?? 0);
@@ -1014,7 +1026,12 @@ admin.openapi(getTimeseries, async (c) => {
 					organizationId: tables.transaction.organizationId,
 				})
 				.from(tables.transaction)
-				.where(eq(tables.transaction.status, "completed"))
+				.where(
+					and(
+						eq(tables.transaction.status, "completed"),
+						paidTransactionFilter,
+					),
+				)
 				.groupBy(tables.transaction.organizationId)
 				.having(sql`MIN(${tables.transaction.createdAt}) < ${startDate}`)
 				.as("pre_range_orgs"),
@@ -1035,7 +1052,12 @@ admin.openapi(getTimeseries, async (c) => {
 					),
 				})
 				.from(tables.transaction)
-				.where(eq(tables.transaction.status, "completed"))
+				.where(
+					and(
+						eq(tables.transaction.status, "completed"),
+						paidTransactionFilter,
+					),
+				)
 				.groupBy(tables.transaction.organizationId)
 				.having(
 					and(
@@ -1083,6 +1105,9 @@ admin.openapi(getTimeseries, async (c) => {
 		processed: number;
 		refunds: number;
 		net: number;
+		dailySignups: number;
+		dailyPaidCustomers: number;
+		dailyNet: number;
 	}> = [];
 	let cumulativePaid = preRangeCount;
 	let totalSignups = 0;
@@ -1101,7 +1126,8 @@ admin.openapi(getTimeseries, async (c) => {
 		const dailyRevenue = revenueMap.get(dateStr) ?? 0;
 		const dailyProcessed = processedMap.get(dateStr) ?? 0;
 		const dailyRefunds = refundsMap.get(dateStr) ?? 0;
-		cumulativePaid += newPaidMap.get(dateStr) ?? 0;
+		const dailyPaidCustomers = newPaidMap.get(dateStr) ?? 0;
+		cumulativePaid += dailyPaidCustomers;
 
 		totalSignups += dailySignups;
 		totalRevenue += dailyRevenue;
@@ -1116,6 +1142,9 @@ admin.openapi(getTimeseries, async (c) => {
 			processed: totalProcessed,
 			refunds: totalRefunds,
 			net: totalRevenue - totalRefunds,
+			dailySignups,
+			dailyPaidCustomers,
+			dailyNet: dailyRevenue - dailyRefunds,
 		});
 	}
 

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -20,6 +20,28 @@ export const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.joi
 	sql`, `,
 )})`;
 
+// Transaction types that represent an actual customer payment: org credit
+// purchases, dev/chat plan charges (start/upgrade/renewal — cancel, end and
+// downgrade rows are bookkeeping, not payments), legacy subscriptions, and
+// end-user wallet top-ups. Used to count "paid customers", so gifts, refunds
+// and margin bookkeeping never qualify an org as paying.
+export const paidTransactionTypes = [
+	"credit_topup",
+	"subscription_start",
+	"dev_plan_start",
+	"dev_plan_upgrade",
+	"dev_plan_renewal",
+	"chat_plan_start",
+	"chat_plan_upgrade",
+	"chat_plan_renewal",
+	"end_user_topup",
+] as const;
+
+export const paidTransactionFilter = sql`${tables.transaction.type} IN (${sql.join(
+	paidTransactionTypes.map((t) => sql`${t}`),
+	sql`, `,
+)})`;
+
 // All LLM SDK end-user wallet transaction types. These belong to the separate
 // end-user wallet economy (their own balances, not organization.credits), so
 // they are excluded from the org credit-purchase "topped up / unused credits"

--- a/ee/admin/src/app/chat-plans/page.tsx
+++ b/ee/admin/src/app/chat-plans/page.tsx
@@ -35,6 +35,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { resolveDateRange } from "@/lib/date-range";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
@@ -321,6 +322,7 @@ export default async function ChatPlansPage({
 		utilization?: string;
 		marginNegative?: string;
 		showChurned?: string;
+		range?: string;
 		from?: string;
 		to?: string;
 	}>;
@@ -328,8 +330,12 @@ export default async function ChatPlansPage({
 	await requireSession();
 
 	const params = await searchParams;
-	const from = typeof params?.from === "string" ? params?.from : undefined;
-	const to = typeof params?.to === "string" ? params?.to : undefined;
+	const range = typeof params?.range === "string" ? params?.range : undefined;
+	const { from, to } = resolveDateRange({
+		range,
+		from: params?.from,
+		to: params?.to,
+	});
 	const rawPage = parseInt(params?.page ?? "1", 10);
 	const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
 	const search = params?.search ?? "";
@@ -394,11 +400,15 @@ export default async function ChatPlansPage({
 	if (showChurned) {
 		queryParams.set("showChurned", "true");
 	}
-	if (from) {
-		queryParams.set("from", from);
-	}
-	if (to) {
-		queryParams.set("to", to);
+	if (range) {
+		queryParams.set("range", range);
+	} else {
+		if (from) {
+			queryParams.set("from", from);
+		}
+		if (to) {
+			queryParams.set("to", to);
+		}
 	}
 	queryParams.set("sortBy", sortBy);
 	queryParams.set("sortOrder", sortOrder);
@@ -414,6 +424,7 @@ export default async function ChatPlansPage({
 		const utilValue = formData.get("utilization") as string;
 		const marginValue = formData.get("marginNegative") as string;
 		const churnValue = formData.get("showChurned") as string;
+		const rangeValue = formData.get("range") as string;
 		const fromValue = formData.get("from") as string;
 		const toValue = formData.get("to") as string;
 		const sp = new URLSearchParams();
@@ -435,11 +446,15 @@ export default async function ChatPlansPage({
 		if (churnValue) {
 			sp.set("showChurned", "true");
 		}
-		if (fromValue) {
-			sp.set("from", fromValue);
-		}
-		if (toValue) {
-			sp.set("to", toValue);
+		if (rangeValue) {
+			sp.set("range", rangeValue);
+		} else {
+			if (fromValue) {
+				sp.set("from", fromValue);
+			}
+			if (toValue) {
+				sp.set("to", toValue);
+			}
 		}
 		sp.set("sortBy", sortByValue);
 		sp.set("sortOrder", sortOrderValue);
@@ -654,8 +669,9 @@ export default async function ChatPlansPage({
 					name="showChurned"
 					value={showChurned ? "true" : ""}
 				/>
-				<input type="hidden" name="from" value={from ?? ""} />
-				<input type="hidden" name="to" value={to ?? ""} />
+				<input type="hidden" name="range" value={range ?? ""} />
+				<input type="hidden" name="from" value={range ? "" : (from ?? "")} />
+				<input type="hidden" name="to" value={range ? "" : (to ?? "")} />
 				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
 					<div className="relative flex-1">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -35,6 +35,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { resolveDateRange } from "@/lib/date-range";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
@@ -321,6 +322,7 @@ export default async function DevpassPage({
 		utilization?: string;
 		marginNegative?: string;
 		showChurned?: string;
+		range?: string;
 		from?: string;
 		to?: string;
 	}>;
@@ -328,8 +330,12 @@ export default async function DevpassPage({
 	await requireSession();
 
 	const params = await searchParams;
-	const from = typeof params?.from === "string" ? params?.from : undefined;
-	const to = typeof params?.to === "string" ? params?.to : undefined;
+	const range = typeof params?.range === "string" ? params?.range : undefined;
+	const { from, to } = resolveDateRange({
+		range,
+		from: params?.from,
+		to: params?.to,
+	});
 	const rawPage = parseInt(params?.page ?? "1", 10);
 	const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
 	const search = params?.search ?? "";
@@ -394,11 +400,15 @@ export default async function DevpassPage({
 	if (showChurned) {
 		queryParams.set("showChurned", "true");
 	}
-	if (from) {
-		queryParams.set("from", from);
-	}
-	if (to) {
-		queryParams.set("to", to);
+	if (range) {
+		queryParams.set("range", range);
+	} else {
+		if (from) {
+			queryParams.set("from", from);
+		}
+		if (to) {
+			queryParams.set("to", to);
+		}
 	}
 	queryParams.set("sortBy", sortBy);
 	queryParams.set("sortOrder", sortOrder);
@@ -414,6 +424,7 @@ export default async function DevpassPage({
 		const utilValue = formData.get("utilization") as string;
 		const marginValue = formData.get("marginNegative") as string;
 		const churnValue = formData.get("showChurned") as string;
+		const rangeValue = formData.get("range") as string;
 		const fromValue = formData.get("from") as string;
 		const toValue = formData.get("to") as string;
 		const sp = new URLSearchParams();
@@ -435,11 +446,15 @@ export default async function DevpassPage({
 		if (churnValue) {
 			sp.set("showChurned", "true");
 		}
-		if (fromValue) {
-			sp.set("from", fromValue);
-		}
-		if (toValue) {
-			sp.set("to", toValue);
+		if (rangeValue) {
+			sp.set("range", rangeValue);
+		} else {
+			if (fromValue) {
+				sp.set("from", fromValue);
+			}
+			if (toValue) {
+				sp.set("to", toValue);
+			}
 		}
 		sp.set("sortBy", sortByValue);
 		sp.set("sortOrder", sortOrderValue);
@@ -652,8 +667,9 @@ export default async function DevpassPage({
 					name="showChurned"
 					value={showChurned ? "true" : ""}
 				/>
-				<input type="hidden" name="from" value={from ?? ""} />
-				<input type="hidden" name="to" value={to ?? ""} />
+				<input type="hidden" name="range" value={range ?? ""} />
+				<input type="hidden" name="from" value={range ? "" : (from ?? "")} />
+				<input type="hidden" name="to" value={range ? "" : (to ?? "")} />
 				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
 					<div className="relative flex-1">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -13,6 +13,7 @@ import { DateRangePicker } from "@/components/date-range-picker";
 import { RevenueChart } from "@/components/revenue-chart";
 import { SignupsChart } from "@/components/signups-chart";
 import { Button } from "@/components/ui/button";
+import { resolveDateRangeFromSearchParams } from "@/lib/date-range";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
@@ -122,8 +123,7 @@ export default async function Page({
 	await requireSession();
 
 	const params = await searchParams;
-	const from = typeof params.from === "string" ? params.from : undefined;
-	const to = typeof params.to === "string" ? params.to : undefined;
+	const { from, to } = resolveDateRangeFromSearchParams(params);
 
 	const $api = await createServerApiClient();
 	const [metricsRes, timeseriesRes] = await Promise.all([

--- a/ee/admin/src/components/date-range-picker.tsx
+++ b/ee/admin/src/components/date-range-picker.tsx
@@ -1,22 +1,6 @@
 "use client";
 
-import {
-	endOfMonth,
-	endOfQuarter,
-	endOfWeek,
-	endOfYear,
-	format,
-	getQuarter,
-	startOfMonth,
-	startOfQuarter,
-	startOfWeek,
-	startOfYear,
-	subDays,
-	subMonths,
-	subQuarters,
-	subWeeks,
-	subYears,
-} from "date-fns";
+import { endOfMonth, format, startOfMonth } from "date-fns";
 import { ChevronDownIcon, ChevronLeftIcon } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -27,13 +11,12 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+	RELATIVE_RANGE_PRESETS,
+	findRelativeRangePreset,
+	resolveDateRange,
+} from "@/lib/date-range";
 import { cn } from "@/lib/utils";
-
-interface DatePreset {
-	label: string;
-	value: string;
-	getRange: () => { from: Date; to: Date };
-}
 
 const MONTH_NAMES = [
 	"Jan",
@@ -50,155 +33,22 @@ const MONTH_NAMES = [
 	"Dec",
 ];
 
-function getQuarterLabel(date: Date): string {
-	return `Q${getQuarter(date)} ${format(date, "yyyy")}`;
-}
-
-function buildPresets(): DatePreset[] {
-	const today = new Date();
-	return [
-		{
-			label: "Custom",
-			value: "custom",
-			getRange: () => ({ from: subDays(today, 6), to: today }),
-		},
-		{
-			label: "Today",
-			value: "today",
-			getRange: () => ({ from: today, to: today }),
-		},
-		{
-			label: "This week",
-			value: "this_week",
-			getRange: () => ({
-				from: startOfWeek(today, { weekStartsOn: 1 }),
-				to: today,
-			}),
-		},
-		{
-			label: "This month",
-			value: "this_month",
-			getRange: () => ({ from: startOfMonth(today), to: today }),
-		},
-		{
-			label: "This year",
-			value: "this_year",
-			getRange: () => ({ from: startOfYear(today), to: today }),
-		},
-		{
-			label: "Last week",
-			value: "last_week",
-			getRange: () => {
-				const lw = subWeeks(today, 1);
-				return {
-					from: startOfWeek(lw, { weekStartsOn: 1 }),
-					to: endOfWeek(lw, { weekStartsOn: 1 }),
-				};
-			},
-		},
-		{
-			label: "Last month",
-			value: "last_month",
-			getRange: () => {
-				const lm = subMonths(today, 1);
-				return { from: startOfMonth(lm), to: endOfMonth(lm) };
-			},
-		},
-		{
-			label: "Last year",
-			value: "last_year",
-			getRange: () => {
-				const ly = subYears(today, 1);
-				return { from: startOfYear(ly), to: endOfYear(ly) };
-			},
-		},
-		{
-			label: "Last 30 days",
-			value: "last_30_days",
-			getRange: () => ({ from: subDays(today, 29), to: today }),
-		},
-		{
-			label: "Last 90 days",
-			value: "last_90_days",
-			getRange: () => ({ from: subDays(today, 89), to: today }),
-		},
-		{
-			label: "Last 6 months",
-			value: "last_6_months",
-			getRange: () => ({ from: subMonths(today, 6), to: today }),
-		},
-		{
-			label: `This quarter (${getQuarterLabel(today)})`,
-			value: "this_quarter",
-			getRange: () => ({ from: startOfQuarter(today), to: today }),
-		},
-		{
-			label: `Last quarter (${getQuarterLabel(subQuarters(today, 1))})`,
-			value: "last_quarter",
-			getRange: () => {
-				const lq = subQuarters(today, 1);
-				return { from: startOfQuarter(lq), to: endOfQuarter(lq) };
-			},
-		},
-		{
-			label: `2 quarters ago (${getQuarterLabel(subQuarters(today, 2))})`,
-			value: "2_quarters_ago",
-			getRange: () => {
-				const q = subQuarters(today, 2);
-				return { from: startOfQuarter(q), to: endOfQuarter(q) };
-			},
-		},
-		{
-			label: `3 quarters ago (${getQuarterLabel(subQuarters(today, 3))})`,
-			value: "3_quarters_ago",
-			getRange: () => {
-				const q = subQuarters(today, 3);
-				return { from: startOfQuarter(q), to: endOfQuarter(q) };
-			},
-		},
-		{
-			label: "All time",
-			value: "all_time",
-			getRange: () => ({ from: new Date(2020, 0, 1), to: today }),
-		},
-	];
-}
-
-function findMatchingPreset(
-	from: Date,
-	to: Date,
-	presets: DatePreset[],
-): string {
-	for (const preset of presets) {
-		// "all_time" is tracked via the absence of from/to in the URL, not
-		// by concrete range equality — skip it here.
-		if (preset.value === "custom" || preset.value === "all_time") {
-			continue;
-		}
-		const range = preset.getRange();
-		if (
-			format(from, "yyyy-MM-dd") === format(range.from, "yyyy-MM-dd") &&
-			format(to, "yyyy-MM-dd") === format(range.to, "yyyy-MM-dd")
-		) {
-			return preset.value;
-		}
-	}
-	return "custom";
-}
-
 export function getDateRangeFromParams(searchParams: URLSearchParams) {
-	const fromParam = searchParams.get("from");
-	const toParam = searchParams.get("to");
+	const resolved = resolveDateRange({
+		range: searchParams.get("range") ?? undefined,
+		from: searchParams.get("from") ?? undefined,
+		to: searchParams.get("to") ?? undefined,
+	});
 
-	if (fromParam && toParam) {
+	if (resolved.from && resolved.to) {
 		return {
-			from: new Date(fromParam + "T00:00:00"),
-			to: new Date(toParam + "T00:00:00"),
+			from: new Date(resolved.from + "T00:00:00"),
+			to: new Date(resolved.to + "T00:00:00"),
 			isAllTime: false,
 		};
 	}
 
-	// Default: no from/to in URL means "all time". Return concrete dates
+	// Default: no range/from/to in URL means "all time". Return concrete dates
 	// for calendar/display purposes only; callers that build API requests
 	// should rely on isAllTime (and omit from/to params) to let the backend
 	// use its native all-time aggregate path.
@@ -346,11 +196,27 @@ export function DateRangePicker() {
 	const [showCalendar, setShowCalendar] = useState(false);
 
 	const { from, to, isAllTime } = getDateRangeFromParams(searchParams);
-	const presets = useMemo(() => buildPresets(), []);
-	const activePreset = useMemo(
-		() => (isAllTime ? "all_time" : findMatchingPreset(from, to, presets)),
-		[from, to, presets, isAllTime],
+	const today = useMemo(() => new Date(), []);
+
+	const presets = useMemo(
+		() => [
+			{ label: "Custom", value: "custom" },
+			...RELATIVE_RANGE_PRESETS.map((p) => ({
+				label: p.getLabel(today),
+				value: p.value,
+			})),
+			{ label: "All time", value: "all_time" },
+		],
+		[today],
 	);
+
+	const activePreset = useMemo(() => {
+		const rangeParam = searchParams.get("range") ?? undefined;
+		if (findRelativeRangePreset(rangeParam)) {
+			return rangeParam as string;
+		}
+		return isAllTime ? "all_time" : "custom";
+	}, [searchParams, isAllTime]);
 
 	const filteredPresets = useMemo(
 		() =>
@@ -379,20 +245,25 @@ export function DateRangePicker() {
 		router.push(qs ? `${pathname}?${qs}` : pathname);
 	};
 
-	const handlePresetSelect = (preset: DatePreset) => {
-		if (preset.value === "custom") {
+	const handlePresetSelect = (value: string) => {
+		if (value === "custom") {
 			setShowCalendar(true);
 			return;
 		}
-		// "All time" leaves the URL without from/to so the API uses its
+		// "All time" leaves the URL without range/from/to so the API uses its
 		// native all-time aggregate path instead of a concrete 2020→today range.
-		if (preset.value === "all_time") {
+		if (value === "all_time") {
 			clearDateRange();
 			setOpen(false);
 			return;
 		}
-		const range = preset.getRange();
-		updateDateRange(range.from, range.to);
+		// Relative presets only store the preset value; the concrete dates are
+		// resolved against "today" on every request.
+		const params = new URLSearchParams(searchParams.toString());
+		params.delete("from");
+		params.delete("to");
+		params.set("range", value);
+		router.push(`${pathname}?${params.toString()}`);
 		setOpen(false);
 	};
 
@@ -403,9 +274,11 @@ export function DateRangePicker() {
 	};
 
 	const triggerLabel = useMemo(() => {
-		const preset = presets.find((p) => p.value === activePreset);
-		if (preset && preset.value !== "custom") {
-			return preset.label;
+		if (activePreset !== "custom") {
+			const preset = presets.find((p) => p.value === activePreset);
+			if (preset) {
+				return preset.label;
+			}
 		}
 		return `${format(from, "MMM d, yyyy")} – ${format(to, "MMM d, yyyy")}`;
 	}, [activePreset, from, to, presets]);
@@ -449,7 +322,7 @@ export function DateRangePicker() {
 								<button
 									key={preset.value}
 									type="button"
-									onClick={() => handlePresetSelect(preset)}
+									onClick={() => handlePresetSelect(preset.value)}
 									className={cn(
 										"w-full px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
 										activePreset === preset.value && "bg-accent/50",

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -63,9 +63,9 @@ export function RevenueChart({
 }) {
 	const dailyData = useMemo(
 		() =>
-			data.map((point, index) => ({
+			data.map((point) => ({
 				date: point.date,
-				dailyNet: point.net - (index > 0 ? data[index - 1].net : 0),
+				dailyNet: point.dailyNet,
 			})),
 		[data],
 	);

--- a/ee/admin/src/components/signups-chart.tsx
+++ b/ee/admin/src/components/signups-chart.tsx
@@ -50,10 +50,12 @@ export function SignupsChart({
 
 	const dailyData = useMemo(
 		() =>
-			data.map((point, index) => ({
+			data.map((point) => ({
 				date: point.date,
 				daily:
-					point[activeChart] - (index > 0 ? data[index - 1][activeChart] : 0),
+					activeChart === "signups"
+						? point.dailySignups
+						: point.dailyPaidCustomers,
 			})),
 		[data, activeChart],
 	);

--- a/ee/admin/src/lib/date-range.ts
+++ b/ee/admin/src/lib/date-range.ts
@@ -1,0 +1,177 @@
+import {
+	endOfMonth,
+	endOfQuarter,
+	endOfWeek,
+	endOfYear,
+	format,
+	getQuarter,
+	startOfMonth,
+	startOfQuarter,
+	startOfWeek,
+	startOfYear,
+	subDays,
+	subMonths,
+	subQuarters,
+	subWeeks,
+	subYears,
+} from "date-fns";
+
+export interface RelativeRangePreset {
+	value: string;
+	getLabel: (today: Date) => string;
+	getRange: (today: Date) => { from: Date; to: Date };
+}
+
+function getQuarterLabel(date: Date): string {
+	return `Q${getQuarter(date)} ${format(date, "yyyy")}`;
+}
+
+// Relative date-range presets. Selecting one stores its value in the `range`
+// query param so the URL stays relative ("this week" is resolved against
+// today on every request); concrete `from`/`to` params are only used for
+// custom spans.
+export const RELATIVE_RANGE_PRESETS: RelativeRangePreset[] = [
+	{
+		value: "today",
+		getLabel: () => "Today",
+		getRange: (today) => ({ from: today, to: today }),
+	},
+	{
+		value: "this_week",
+		getLabel: () => "This week",
+		getRange: (today) => ({
+			from: startOfWeek(today, { weekStartsOn: 1 }),
+			to: today,
+		}),
+	},
+	{
+		value: "this_month",
+		getLabel: () => "This month",
+		getRange: (today) => ({ from: startOfMonth(today), to: today }),
+	},
+	{
+		value: "this_year",
+		getLabel: () => "This year",
+		getRange: (today) => ({ from: startOfYear(today), to: today }),
+	},
+	{
+		value: "last_week",
+		getLabel: () => "Last week",
+		getRange: (today) => {
+			const lw = subWeeks(today, 1);
+			return {
+				from: startOfWeek(lw, { weekStartsOn: 1 }),
+				to: endOfWeek(lw, { weekStartsOn: 1 }),
+			};
+		},
+	},
+	{
+		value: "last_month",
+		getLabel: () => "Last month",
+		getRange: (today) => {
+			const lm = subMonths(today, 1);
+			return { from: startOfMonth(lm), to: endOfMonth(lm) };
+		},
+	},
+	{
+		value: "last_year",
+		getLabel: () => "Last year",
+		getRange: (today) => {
+			const ly = subYears(today, 1);
+			return { from: startOfYear(ly), to: endOfYear(ly) };
+		},
+	},
+	{
+		value: "last_30_days",
+		getLabel: () => "Last 30 days",
+		getRange: (today) => ({ from: subDays(today, 29), to: today }),
+	},
+	{
+		value: "last_90_days",
+		getLabel: () => "Last 90 days",
+		getRange: (today) => ({ from: subDays(today, 89), to: today }),
+	},
+	{
+		value: "last_6_months",
+		getLabel: () => "Last 6 months",
+		getRange: (today) => ({ from: subMonths(today, 6), to: today }),
+	},
+	{
+		value: "this_quarter",
+		getLabel: (today) => `This quarter (${getQuarterLabel(today)})`,
+		getRange: (today) => ({ from: startOfQuarter(today), to: today }),
+	},
+	{
+		value: "last_quarter",
+		getLabel: (today) =>
+			`Last quarter (${getQuarterLabel(subQuarters(today, 1))})`,
+		getRange: (today) => {
+			const lq = subQuarters(today, 1);
+			return { from: startOfQuarter(lq), to: endOfQuarter(lq) };
+		},
+	},
+	{
+		value: "2_quarters_ago",
+		getLabel: (today) =>
+			`2 quarters ago (${getQuarterLabel(subQuarters(today, 2))})`,
+		getRange: (today) => {
+			const q = subQuarters(today, 2);
+			return { from: startOfQuarter(q), to: endOfQuarter(q) };
+		},
+	},
+	{
+		value: "3_quarters_ago",
+		getLabel: (today) =>
+			`3 quarters ago (${getQuarterLabel(subQuarters(today, 3))})`,
+		getRange: (today) => {
+			const q = subQuarters(today, 3);
+			return { from: startOfQuarter(q), to: endOfQuarter(q) };
+		},
+	},
+];
+
+export function findRelativeRangePreset(
+	value: string | undefined,
+): RelativeRangePreset | undefined {
+	return value
+		? RELATIVE_RANGE_PRESETS.find((p) => p.value === value)
+		: undefined;
+}
+
+export interface DateRangeSearchParams {
+	range?: string;
+	from?: string;
+	to?: string;
+}
+
+// Resolves the URL query state into concrete `from`/`to` date strings for API
+// calls. A valid `range` preset wins and is resolved against today; `from`/`to`
+// are honored only as a custom span; neither means "all time" (both undefined
+// so the API uses its native all-time path).
+export function resolveDateRange(params: DateRangeSearchParams): {
+	from?: string;
+	to?: string;
+} {
+	const preset = findRelativeRangePreset(params.range);
+	if (preset) {
+		const { from, to } = preset.getRange(new Date());
+		return {
+			from: format(from, "yyyy-MM-dd"),
+			to: format(to, "yyyy-MM-dd"),
+		};
+	}
+	if (params.from && params.to) {
+		return { from: params.from, to: params.to };
+	}
+	return {};
+}
+
+export function resolveDateRangeFromSearchParams(
+	params: Record<string, string | string[] | undefined>,
+): { from?: string; to?: string } {
+	return resolveDateRange({
+		range: typeof params.range === "string" ? params.range : undefined,
+		from: typeof params.from === "string" ? params.from : undefined,
+		to: typeof params.to === "string" ? params.to : undefined,
+	});
+}


### PR DESCRIPTION
## Summary

Three fixes to the admin dashboard, plus unit tests locking in the paid-customer accounting:

### 1. "Paid Customers" now counts only real payments
Previously any org with at least one `completed` transaction of *any* type counted as a paid/paying customer — including `credit_gift` recipients and pure bookkeeping rows (cancel/end/downgrade, margin accrual/payout). Both the `/admin/metrics` "Paying" stat and the `/admin/metrics/timeseries` paid-customers series now require an actual payment transaction via a new `paidTransactionFilter` allowlist:

- `credit_topup` (org credit purchases)
- `dev_plan_start` / `dev_plan_upgrade` / `dev_plan_renewal`
- `chat_plan_start` / `chat_plan_upgrade` / `chat_plan_renewal`
- `subscription_start` (legacy)
- `end_user_topup` (real end-user payments, consistent with the revenue definition)

### 2. Per-day sparkline first bar no longer shows the pre-range total
The signups/paid-customers and revenue charts derived daily bars by diffing the cumulative series client-side. Since the cumulative series starts from a pre-range baseline, the first bar showed the entire all-time-before total when a smaller duration was selected. The timeseries endpoint now returns per-day values (`dailySignups`, `dailyPaidCustomers`, `dailyNet`) and both charts use them directly.

### 3. Relative date ranges live in the URL as `?range=`
Selecting a preset like "This week" or "Last 30 days" now stores `?range=this_week` in the query state, resolved against today on every request — so the selection stays relative and shareable. Concrete `from`/`to` params are only written when a custom span is picked; "All time" still clears everything. The dashboard, DevPass and Chat plans pages resolve `range` server-side and preserve it across pagination/filter/search navigation.

### 4. Unit tests (`admin-paid-customers.spec.ts`)
- Classifies **every** transaction enum type as paid or non-paid, derived from the schema at runtime — a newly added type is automatically exercised and the paid/non-paid split must stay exhaustive
- Asserts `/admin/metrics` `payingCustomers` counts one org per paid type, never counts gift/refund/bookkeeping/margin rows or pending payments, and never double-counts orgs with multiple payments
- Asserts the timeseries totals add up: cumulative series ends at the total and per-day `dailyPaidCustomers` values sum to it
- Regression test for the sparkline bug: with `range=7d`, a customer who first paid 60 days ago appears in the first point's cumulative baseline but with a day-one delta of 0, and an in-range second payment doesn't re-count them
- Mutation-verified: removing `paidTransactionFilter` makes 3 of 4 tests fail

## Testing

- `pnpm build` passes
- `pnpm test:unit`: 2535 passed; the single failure (`api.spec.ts` hybrid escape expecting `google-vertex`) is pre-existing and unrelated (fails on a clean tree with local env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added date-range presets for common periods, including weeks, months, quarters, and rolling timeframes.
  - Added support for selecting relative date ranges across admin dashboard pages and filters.
  - Admin metrics now include daily signups, paid-customer acquisitions, and net revenue changes.
  - Revenue and signup charts now display daily values directly and more accurately.

- **Bug Fixes**
  - Improved paid-customer reporting by excluding non-paid and pending transactions.
  - Ensured customers with multiple payments are counted only once.
  - Improved baseline and date-range metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->