### PR TITLE
feat(models): enable verbosity on older GPT-5 models

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -510,6 +510,10 @@ export const reasoningModels = testModels.filter((m) =>
 	m.providers.some((p: ProviderModelMapping) => p.reasoning === true),
 );
 
+export const verbosityModels = testModels.filter((m) =>
+	m.providers.some((p: ProviderModelMapping) => p.verbosity === true),
+);
+
 export const streamingReasoningModels = reasoningModels.filter((m) =>
 	m.providers.some((p: ProviderModelMapping) => {
 		// Check model-level streaming first, then fall back to provider-level

--- a/apps/gateway/src/chat-verbosity.e2e.ts
+++ b/apps/gateway/src/chat-verbosity.e2e.ts
@@ -1,0 +1,78 @@
+import "dotenv/config";
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import {
+	beforeAllHook,
+	beforeEachHook,
+	generateTestRequestId,
+	getConcurrentTestOptions,
+	getTestOptions,
+	logMode,
+	validateLogByRequestId,
+	validateResponse,
+	verbosityModels,
+} from "@/chat-helpers.e2e.js";
+
+const verbosityValues = ["low", "medium", "high"] as const;
+
+// Every model that advertises verbosity support must accept all three verbosity
+// levels upstream. Some OpenAI models (e.g. the codex snapshots) only accept
+// "medium" and are intentionally NOT flagged verbosity: true, so pinning the
+// provider with x-no-fallback here ensures a value the upstream rejects surfaces
+// as a 400 instead of silently falling back to a healthy provider.
+const verbosityTestCases = verbosityModels.flatMap((modelConfig) =>
+	verbosityValues.map((verbosity) => ({
+		...modelConfig,
+		verbosity,
+	})),
+);
+
+describe("e2e verbosity", getConcurrentTestOptions(), () => {
+	beforeAll(beforeAllHook);
+
+	beforeEach(beforeEachHook);
+
+	test("empty", () => {
+		expect(true).toBe(true);
+	});
+
+	test.each(verbosityTestCases)(
+		"verbosity $verbosity $model",
+		getTestOptions(),
+		async ({ model, verbosity }) => {
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: model,
+					messages: [
+						{
+							role: "user",
+							content: "Say 'OK'",
+						},
+					],
+					verbosity,
+				}),
+			});
+
+			const json = await res.json();
+			if (logMode) {
+				console.log(
+					`verbosity ${verbosity} response for ${model}:`,
+					JSON.stringify(json, null, 2),
+				);
+			}
+
+			expect(res.status).toBe(200);
+			validateResponse(json);
+			await validateLogByRequestId(requestId);
+		},
+	);
+});

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -348,7 +348,7 @@ export const completionsRequestSchema = z.object({
 		.transform((val) => (val === null ? undefined : val))
 		.openapi({
 			description:
-				"Controls how detailed the model's responses are. Only supported by OpenAI GPT-5.6 and later models; requests to models without verbosity support return a 400 error.",
+				"Controls how detailed the model's responses are. Only supported by OpenAI GPT-5 and later models; requests to models without verbosity support return a 400 error.",
 			example: "low",
 		}),
 	service_tier: z

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -143,6 +143,15 @@ describe("validateModelCapabilities - verbosity", () => {
 		).not.toThrow();
 	});
 
+	it("allows verbosity for older GPT-5 models that support it", () => {
+		const olderModel = getModel("gpt-5.1");
+		expect(() =>
+			validateModelCapabilities(olderModel, "gpt-5.1", undefined, {
+				verbosity: "high",
+			}),
+		).not.toThrow();
+	});
+
 	it("rejects verbosity for models without support", () => {
 		expect(() =>
 			validateModelCapabilities(noVisionModel, "deepseek-v4-flash", undefined, {

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -210,7 +210,7 @@ export function validateModelCapabilities(
 
 		if (!supportsVerbosity) {
 			throw new HTTPException(400, {
-				message: `Model ${requestedModel} does not support the verbosity parameter. Remove the verbosity parameter or use a model that supports it (OpenAI GPT-5.6 and later).`,
+				message: `Model ${requestedModel} does not support the verbosity parameter. Remove the verbosity parameter or use a model that supports it (OpenAI GPT-5 and later).`,
 			});
 		}
 	}

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -796,7 +796,7 @@ describe("prepareRequestBody - verbosity", () => {
 
 	test("strips verbosity from the Responses API body for unsupported models", async () => {
 		const requestBody = (await prepareOpenAITextRequest({
-			model: "gpt-5.5",
+			model: "gpt-5.1-codex",
 			useResponsesApi: true,
 			verbosity: "low",
 		})) as { text?: { verbosity?: string } };

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -940,7 +940,7 @@ export async function prepareRequestBody(
 		reasoning_effort = undefined;
 	}
 
-	// `verbosity` is only understood by OpenAI GPT-5.6+ models. Capability
+	// `verbosity` is only understood by OpenAI GPT-5+ models. Capability
 	// validation rejects unsupported pinned models upfront, but auto routing and
 	// retry fallbacks can still land on a mapping without verbosity support, so
 	// strip it here instead of forwarding an unknown parameter upstream.

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -331,7 +331,7 @@ export interface ProviderModelMapping {
 	reasoning?: boolean;
 	/**
 	 * Whether this model supports the OpenAI `verbosity` parameter
-	 * (low/medium/high response detail control, GPT-5.6 and later)
+	 * (low/medium/high response detail control, GPT-5 and later)
 	 */
 	verbosity?: boolean;
 	/**

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -851,6 +851,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01", // $10 per 1000 searches for reasoning models
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
@@ -859,6 +860,7 @@ export const openaiModels = [
 					"response_format",
 					"tools",
 					"tool_choice",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -918,6 +920,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01", // $10 per 1000 searches for reasoning models
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
@@ -926,6 +929,7 @@ export const openaiModels = [
 					"response_format",
 					"tools",
 					"tool_choice",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -985,6 +989,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01", // $10 per 1000 searches for reasoning models
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
@@ -993,6 +998,7 @@ export const openaiModels = [
 					"response_format",
 					"tools",
 					"tool_choice",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1084,12 +1090,14 @@ export const openaiModels = [
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1147,6 +1155,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01", // $10 per 1000 searches for reasoning models
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				jsonOutput: true,
 			},
 		],
@@ -1270,12 +1279,14 @@ export const openaiModels = [
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1332,6 +1343,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01", // $10 per 1000 searches for reasoning models
 				supportsResponsesApi: true,
 				jsonOutputSchema: false,
+				verbosity: true,
 				jsonOutput: true,
 			},
 			{
@@ -1433,12 +1445,14 @@ export const openaiModels = [
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1499,6 +1513,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01",
 				supportsResponsesApi: true,
 				jsonOutputSchema: false,
+				verbosity: true,
 				jsonOutput: true,
 			},
 			{
@@ -1551,6 +1566,7 @@ export const openaiModels = [
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				jsonOutput: true,
 			},
 			{
@@ -1603,6 +1619,7 @@ export const openaiModels = [
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				jsonOutput: true,
 			},
 			{
@@ -1655,12 +1672,14 @@ export const openaiModels = [
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
+				verbosity: true,
 				supportedParameters: [
 					"temperature",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",
 					"response_format",
+					"verbosity",
 				],
 				jsonOutput: true,
 			},
@@ -1721,6 +1740,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01",
 				supportsResponsesApi: true,
 				jsonOutputSchema: false,
+				verbosity: true,
 				jsonOutput: true,
 			},
 		],
@@ -1981,6 +2001,7 @@ export const openaiModels = [
 				webSearchPrice: "0.01",
 				supportsResponsesApi: true,
 				jsonOutputSchema: false,
+				verbosity: true,
 				jsonOutput: true,
 			},
 			{


### PR DESCRIPTION
## Summary

`verbosity` was previously only flagged on GPT-5.6 (`sol`/`terra`/`luna`), but OpenAI accepts the parameter across the whole GPT-5 reasoning family. I probed every `openai` GPT-5 mapping directly against the OpenAI Responses/Chat Completions APIs with all three levels (`low`/`medium`/`high`) and enabled `verbosity: true` on every mapping that accepts the full range:

`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-5.1`, `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5`, `gpt-5.5-pro`

### Intentionally excluded
- **Codex snapshots** (`gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.2-codex`) and **`gpt-5-chat-latest`** — OpenAI only accepts verbosity `"medium"` on these; flagging them would let `low`/`high` requests 400 upstream (the capability flag is a boolean while the type allows all three).
- **`gpt-5.2-chat-latest` / `gpt-5.3-chat-latest`** — already deprecated and deactivating 2026-08-10.

## Verification

Added `apps/gateway/src/chat-verbosity.e2e.ts`, which sends `low`/`medium`/`high` to every verbosity-flagged model and asserts a `200` (pinned provider + `x-no-fallback` so an upstream rejection surfaces instead of falling back). **44/44 passed** — no upstream rejections:

```
✓ apps/gateway/src/chat-verbosity.e2e.ts (44 tests)
    ✓ verbosity 'low'|'medium'|'high' × { gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.1,
      gpt-5.2, gpt-5.2-pro, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.5,
      gpt-5.3-codex, gpt-5.6-sol/terra/luna }
```

(`test: "skip"` mappings — `gpt-5-pro`, `gpt-5.4-pro`, `gpt-5.5-pro` — aren't run by e2e but were verified via the direct API probe.)

## Also
- Added a `verbosityModels` helper export and a unit assertion covering a newly-flagged older model.
- Updated the now-stale "GPT-5.6 and later" copy to "GPT-5 and later" in the request schema, capability-error message, and field doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verbosity support for additional OpenAI GPT-5 family models, including GPT-5.1, GPT-5.2, GPT-5.3 Codex, GPT-5.4, GPT-5.5, Mini, and Nano variants.
  * Supported models can now accept low, medium, and high verbosity settings.

* **Documentation**
  * Updated API guidance and validation messages to clarify that verbosity is supported by OpenAI GPT-5 and later models.

* **Bug Fixes**
  * Improved capability handling so unsupported models continue to reject or remove verbosity settings appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->