### PR TITLE
fix(gateway): support service_tier in responses API

### DIFF
--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -39,6 +39,10 @@ request `flex` or `priority` for a provider/model mapping that does not support
 that tier, the gateway returns a 400 `unsupported_service_tier` error and logs
 the request as a client error.
 
+The parameter works the same on the OpenAI-compatible **Responses API**
+(`/v1/responses`): the tier is forwarded to the provider and the response's
+`service_tier` field echoes the tier that was actually served.
+
 ## Supported providers
 
 Service tiers are explicit per provider/model mapping. Check the model page for

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1000,6 +1000,127 @@ describe("api", () => {
 		expect(logs[0].usedServiceTier).toBeNull();
 	});
 
+	test("/v1/responses forwards the requested service tier", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-responses-service-tier",
+			token: "real-token-responses-service-tier",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-responses-service-tier",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/responses", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-responses-service-tier",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.5",
+				service_tier: "priority",
+				input: "Hello!",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		// The echoed tier is the one the provider actually served, not a static
+		// "default" — the tier must survive the internal chat-completions hop.
+		expect(json.service_tier).toBe("priority");
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].requestedServiceTier).toBe("priority");
+		expect(logs[0].usedServiceTier).toBe("priority");
+	});
+
+	test("/v1/responses rejects unsupported service tiers", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-responses-bad-service-tier",
+			token: "real-token-responses-bad-service-tier",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/responses", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-responses-bad-service-tier",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o",
+				service_tier: "priority",
+				input: "Hello!",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error).toMatchObject({
+			param: "service_tier",
+			code: "unsupported_service_tier",
+		});
+	});
+
+	test("/v1/responses streams the served service tier", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-responses-service-tier-stream",
+			token: "real-token-responses-service-tier-stream",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-responses-service-tier-stream",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/responses", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-responses-service-tier-stream",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.5",
+				service_tier: "priority",
+				stream: true,
+				input: "Hello!",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const raw = await res.text();
+		const completedLine = raw
+			.split("\n")
+			.find(
+				(line) =>
+					line.startsWith("data: ") && line.includes('"response.completed"'),
+			);
+		expect(completedLine).toBeDefined();
+		const completed = JSON.parse(completedLine!.slice(6));
+		expect(completed.response.service_tier).toBe("priority");
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].requestedServiceTier).toBe("priority");
+		expect(logs[0].usedServiceTier).toBe("priority");
+	});
+
 	test("/v1/chat/completions forwards generated request id upstream", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-generated-request-id",

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1032,6 +1032,9 @@ export function transformStreamingToOpenai(
 								},
 							],
 							usage,
+							...(typeof data.response?.service_tier === "string" && {
+								service_tier: data.response.service_tier,
+							}),
 						};
 						break;
 					}
@@ -1074,6 +1077,9 @@ export function transformStreamingToOpenai(
 								},
 							],
 							usage,
+							...(typeof data.response?.service_tier === "string" && {
+								service_tier: data.response.service_tier,
+							}),
 						};
 						break;
 					}

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -109,6 +109,31 @@ describe("responsesRequestSchema", () => {
 		expect(result.data?.reasoning?.effort).toBe("high");
 	});
 
+	it("accepts service_tier and normalizes explicit null to undefined", () => {
+		const withTier = responsesRequestSchema.safeParse({
+			model: "gpt-5.5",
+			input: "hello",
+			service_tier: "flex",
+		});
+		expect(withTier.success).toBe(true);
+		expect(withTier.data?.service_tier).toBe("flex");
+
+		const withNull = responsesRequestSchema.safeParse({
+			model: "gpt-5.5",
+			input: "hello",
+			service_tier: null,
+		});
+		expect(withNull.success).toBe(true);
+		expect(withNull.data?.service_tier).toBeUndefined();
+
+		const invalid = responsesRequestSchema.safeParse({
+			model: "gpt-5.5",
+			input: "hello",
+			service_tier: "turbo",
+		});
+		expect(invalid.success).toBe(false);
+	});
+
 	it("accepts item_reference items mixed with messages and outputs", () => {
 		const result = responsesRequestSchema.safeParse({
 			model: "gpt-5.5",
@@ -330,6 +355,75 @@ describe("convertChatResponseToResponses", () => {
 		expect(messageOutput).toBeDefined();
 		expect((messageOutput as any).content[0].type).toBe("output_text");
 		expect((messageOutput as any).content[0].text).toBe("Hello!");
+	});
+
+	it("echoes the served service tier from the chat response", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: { role: "assistant", content: "Hi" },
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+			service_tier: "flex",
+		};
+
+		const result = convertChatResponseToResponses(
+			chatResponse,
+			"openai/gpt-5.5",
+			undefined,
+			{ service_tier: "flex" },
+		);
+
+		expect(result.service_tier).toBe("flex");
+	});
+
+	it("falls back to metadata used_service_tier, then the requested tier", () => {
+		const baseChat = {
+			choices: [
+				{
+					message: { role: "assistant", content: "Hi" },
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+		};
+
+		// A downgraded premium request echoes the tier actually served.
+		const downgraded = convertChatResponseToResponses(
+			{
+				...baseChat,
+				metadata: { requested_service_tier: "flex", used_service_tier: null },
+			},
+			"google-vertex/gemini-3-pro",
+			undefined,
+			{ service_tier: "flex" },
+		);
+		expect(downgraded.service_tier).toBe("default");
+
+		const served = convertChatResponseToResponses(
+			{
+				...baseChat,
+				metadata: {
+					requested_service_tier: "flex",
+					used_service_tier: "flex",
+				},
+			},
+			"google-vertex/gemini-3-pro",
+			undefined,
+			{ service_tier: "flex" },
+		);
+		expect(served.service_tier).toBe("flex");
+
+		// Without tier info from the chat response, echo the requested tier.
+		const requestedOnly = convertChatResponseToResponses(
+			baseChat,
+			"openai/gpt-5.5",
+			undefined,
+			{ service_tier: "priority" },
+		);
+		expect(requestedOnly.service_tier).toBe("priority");
 	});
 
 	it("converts tool calls to function_call outputs", () => {
@@ -569,6 +663,58 @@ describe("streaming conversion", () => {
 		const completedEvent = events.find((e) => e.event === "response.completed");
 		const completedData = JSON.parse(completedEvent!.data);
 		expect(completedData.response.status).toBe("completed");
+	});
+
+	it("captures the served service tier from stream chunks", () => {
+		const state = createStreamingState("gpt-5.5", undefined, {
+			service_tier: "flex",
+		});
+		processStreamChunk({ choices: [{ delta: { content: "Hello" } }] }, state);
+		processStreamChunk(
+			{
+				choices: [],
+				usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+				service_tier: "flex",
+			},
+			state,
+		);
+
+		const events = createCompletionEvents(state);
+		const completedEvent = events.find((e) => e.event === "response.completed");
+		const completedData = JSON.parse(completedEvent!.data);
+		expect(completedData.response.service_tier).toBe("flex");
+	});
+
+	it("captures a downgraded tier from the final usage chunk metadata", () => {
+		const state = createStreamingState("gemini-3-pro", undefined, {
+			service_tier: "flex",
+		});
+		processStreamChunk({ choices: [{ delta: { content: "Hello" } }] }, state);
+		processStreamChunk(
+			{
+				choices: [],
+				usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+				metadata: { requested_service_tier: "flex", used_service_tier: null },
+			},
+			state,
+		);
+
+		const events = createCompletionEvents(state);
+		const completedEvent = events.find((e) => e.event === "response.completed");
+		const completedData = JSON.parse(completedEvent!.data);
+		expect(completedData.response.service_tier).toBe("default");
+	});
+
+	it("echoes the requested service tier when no served tier is reported", () => {
+		const state = createStreamingState("gpt-5.5", undefined, {
+			service_tier: "priority",
+		});
+		processStreamChunk({ choices: [{ delta: { content: "Hello" } }] }, state);
+
+		const events = createCompletionEvents(state);
+		const completedEvent = events.find((e) => e.event === "response.completed");
+		const completedData = JSON.parse(completedEvent!.data);
+		expect(completedData.response.service_tier).toBe("priority");
 	});
 
 	it("uses consistent IDs across streaming events", () => {

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -339,6 +339,9 @@ responses.post("/", async (c) => {
 	if (req.routing !== undefined) {
 		chatRequest.routing = req.routing;
 	}
+	if (req.service_tier !== undefined) {
+		chatRequest.service_tier = req.service_tier;
+	}
 	if (response_format) {
 		chatRequest.response_format = response_format;
 	}

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -148,6 +148,11 @@ export const responsesRequestSchema = z.object({
 		.optional()
 		.transform((val) => (val === null ? undefined : val)),
 	routing: z.enum(["auto", "price", "throughput", "latency"]).optional(),
+	service_tier: z
+		.enum(["auto", "default", "flex", "priority"])
+		.nullable()
+		.optional()
+		.transform((val) => (val === null ? undefined : val)),
 	temperature: z
 		.number()
 		.nullable()

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -24,6 +24,7 @@ interface ChatCompletionsResponse {
 		};
 		finish_reason?: string | null;
 	}>;
+	service_tier?: string | null;
 	usage?: {
 		prompt_tokens?: number;
 		completion_tokens?: number;
@@ -189,6 +190,28 @@ export function normalizeEchoedTools(tools: unknown[] | undefined): unknown[] {
 }
 
 /**
+ * Resolve the processing tier the provider actually served from a chat
+ * completions response. OpenAI echoes it as a top-level `service_tier`;
+ * other providers (e.g. Google flex/priority) surface it via the gateway's
+ * `metadata.used_service_tier` (null there means downgraded to standard).
+ * Returns undefined when the chat response carries no tier information.
+ */
+function resolveServedServiceTier(
+	chatResponse: ChatCompletionsResponse,
+): string | undefined {
+	if (typeof chatResponse.service_tier === "string") {
+		return chatResponse.service_tier;
+	}
+	const metadata = chatResponse.metadata;
+	if (metadata && typeof metadata.requested_service_tier === "string") {
+		return typeof metadata.used_service_tier === "string"
+			? metadata.used_service_tier
+			: "default";
+	}
+	return undefined;
+}
+
+/**
  * Converts a chat completions response to Responses API format.
  */
 export function convertChatResponseToResponses(
@@ -315,7 +338,10 @@ export function convertChatResponseToResponses(
 		max_tool_calls: request?.max_tool_calls ?? null,
 		store: request?.store ?? true,
 		background: request?.background ?? false,
-		service_tier: request?.service_tier ?? "default",
+		service_tier:
+			resolveServedServiceTier(chatResponse) ??
+			request?.service_tier ??
+			"default",
 		metadata: {
 			...(request?.metadata ?? {}),
 			...(chatResponse.metadata ?? {}),

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -29,6 +29,7 @@ interface StreamingState {
 		}
 	>;
 	request?: ResponsesEchoRequest;
+	servedServiceTier?: string;
 	usage: {
 		input_tokens: number;
 		output_tokens: number;
@@ -145,7 +146,7 @@ function buildResponsePayload(
 		max_tool_calls: req?.max_tool_calls ?? null,
 		store: req?.store ?? true,
 		background: req?.background ?? false,
-		service_tier: req?.service_tier ?? "default",
+		service_tier: state.servedServiceTier ?? req?.service_tier ?? "default",
 		metadata: req?.metadata ?? {},
 		safety_identifier: req?.safety_identifier ?? null,
 		prompt_cache_key: req?.prompt_cache_key ?? null,
@@ -190,6 +191,24 @@ export function processStreamChunk(
 	state: StreamingState,
 ): SSEEvent[] {
 	const events: SSEEvent[] = [];
+
+	// Capture the served processing tier so the completion events echo the tier
+	// the provider actually applied (e.g. a flex request downgraded to default)
+	// rather than the requested one. OpenAI chunks carry a top-level
+	// service_tier; other providers surface it via the gateway's final usage
+	// chunk metadata (used_service_tier null there means downgraded to standard).
+	if (typeof chunk.service_tier === "string") {
+		state.servedServiceTier = chunk.service_tier;
+	} else {
+		const metadata = chunk.metadata as Record<string, unknown> | undefined;
+		if (metadata && typeof metadata.requested_service_tier === "string") {
+			state.servedServiceTier =
+				typeof metadata.used_service_tier === "string"
+					? metadata.used_service_tier
+					: "default";
+		}
+	}
+
 	const choices = chunk.choices as
 		| Array<{
 				delta?: {


### PR DESCRIPTION
## Problem

`service_tier` was ignored on `/v1/responses` for all models (reported with gpt-5.x): even with `service_tier: "flex"`, the request log showed the tier as default. The parameter only worked on `/v1/chat/completions`.

## Root cause

- `responsesRequestSchema` had no `service_tier` field, so Zod stripped it from the parsed body.
- The /v1/responses handler never forwarded the tier on the internal `/v1/chat/completions` hop, so the chat pipeline neither requested flex/priority upstream nor recorded `requestedServiceTier`/`usedServiceTier` on the log.
- Both response converters hardcoded the echo to `request.service_tier ?? "default"`, which was always `"default"`.

## Fix

- Accept `service_tier` (`auto`/`default`/`flex`/`priority`, null-tolerant) in the Responses API request schema and forward it to the internal chat request. Tier validation (400 `unsupported_service_tier`) now applies to /v1/responses exactly like chat completions.
- Echo the tier the provider **actually served** on the response: top-level `service_tier` from the chat response (OpenAI), falling back to the gateway's `metadata.used_service_tier` (Google flex/priority, incl. downgrades), then the requested tier.
- Streaming: `response.completed`/`response.incomplete` chunks built from the upstream OpenAI Responses API now carry `service_tier`, and the streaming translator captures it (or the final usage chunk metadata) so `response.completed` events echo the served tier.

## Tests

- Unit specs for the schema, non-streaming echo (served / downgraded / requested-only), and streaming capture paths.
- Integration tests against the mock OpenAI server: /v1/responses forwards the tier (log records `requestedServiceTier`/`usedServiceTier`), rejects unsupported tiers with 400, and streams the served tier in `response.completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `service_tier` support to the Responses API.
  - Supported tiers include `auto`, `default`, `flex`, and `priority`.
  - Responses now report the tier actually used by the provider, including in streaming completion events.
  - Tier information is preserved when requests are converted between API formats.

- **Bug Fixes**
  - Unsupported service-tier values now return a clear validation error.
  - Downgraded or unavailable tiers correctly report `default`.

- **Documentation**
  - Clarified how service tiers work with the Responses API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->