### PR TITLE
test: fix flaky unit tests on main

### DIFF
--- a/apps/api/src/testing.ts
+++ b/apps/api/src/testing.ts
@@ -19,33 +19,48 @@ const credentials = {
 	password: "admin@example.com1A",
 };
 
+function isDeadlockError(error: unknown): boolean {
+	for (let current = error; current instanceof Error; current = current.cause) {
+		if ((current as Error & { code?: unknown }).code === "40P01") {
+			return true;
+		}
+	}
+	return false;
+}
+
 export async function deleteAll() {
 	// await redisClient.flushdb();
 
-	await Promise.all([
-		db.delete(tables.log),
-		db.delete(tables.auditLog),
-		db.delete(tables.apiKey),
-		db.delete(tables.providerKey),
-		db.delete(projectHourlyStats),
-		db.delete(projectHourlyModelStats),
-		db.delete(apiKeyHourlyStats),
-		db.delete(apiKeyHourlyModelStats),
-	]);
-
-	await Promise.all([
-		db.delete(tables.userOrganization),
-		db.delete(tables.organizationInvite),
-		db.delete(tables.project),
-	]);
-
-	await Promise.all([
-		db.delete(tables.organization),
-		db.delete(tables.user),
-		db.delete(tables.account),
-		db.delete(tables.session),
-		db.delete(tables.verification),
-	]);
+	// Delete sequentially, children before parents, so ON DELETE CASCADE from
+	// parent tables never races a concurrent delete on the same child rows.
+	// Concurrent deletes on cascade-linked tables (e.g. user -> account) lock
+	// the same rows in different orders and deadlock (postgres error 40P01).
+	// Test files share one database, so retry when two cleanups still collide.
+	for (let attempt = 1; ; attempt++) {
+		try {
+			await db.delete(tables.log);
+			await db.delete(tables.auditLog);
+			await db.delete(projectHourlyStats);
+			await db.delete(projectHourlyModelStats);
+			await db.delete(apiKeyHourlyStats);
+			await db.delete(apiKeyHourlyModelStats);
+			await db.delete(tables.apiKey);
+			await db.delete(tables.providerKey);
+			await db.delete(tables.organizationInvite);
+			await db.delete(tables.userOrganization);
+			await db.delete(tables.project);
+			await db.delete(tables.session);
+			await db.delete(tables.account);
+			await db.delete(tables.verification);
+			await db.delete(tables.organization);
+			await db.delete(tables.user);
+			return;
+		} catch (error) {
+			if (attempt >= 3 || !isDeadlockError(error)) {
+				throw error;
+			}
+		}
+	}
 }
 
 /**

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -4186,11 +4186,19 @@ describe("api", () => {
 		const previousVertexKey = process.env.LLM_GOOGLE_VERTEX_API_KEY;
 		const previousGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
 		const previousVertexBaseUrl = process.env.LLM_GOOGLE_VERTEX_BASE_URL;
+		// The escape must land on google-vertex, so google-ai-studio may not have
+		// an env credential to retry with. Locally, `import "dotenv/config"` in
+		// app.ts loads the repo .env, whose real LLM_GOOGLE_AI_STUDIO_API_KEY
+		// would otherwise let the retry loop call the real Google API.
+		const previousStudioKey = process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+		const previousStudioBaseUrl = process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
 
 		try {
 			process.env.LLM_GOOGLE_VERTEX_API_KEY = "vertex-test-token";
 			process.env.LLM_GOOGLE_CLOUD_PROJECT = "vertex-project";
 			process.env.LLM_GOOGLE_VERTEX_BASE_URL = mockServerUrl;
+			delete process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+			delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
 
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -4224,6 +4232,16 @@ describe("api", () => {
 				delete process.env.LLM_GOOGLE_VERTEX_BASE_URL;
 			} else {
 				process.env.LLM_GOOGLE_VERTEX_BASE_URL = previousVertexBaseUrl;
+			}
+			if (previousStudioKey === undefined) {
+				delete process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
+			} else {
+				process.env.LLM_GOOGLE_AI_STUDIO_API_KEY = previousStudioKey;
+			}
+			if (previousStudioBaseUrl === undefined) {
+				delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
+			} else {
+				process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL = previousStudioBaseUrl;
 			}
 		}
 	});

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -99,25 +99,19 @@ describe("fallback and error status code handling", () => {
 		await clearCache();
 		await db.delete(tables.modelProviderMappingHistory);
 
-		await Promise.all([
-			db.delete(tables.log),
-			db.delete(tables.apiKeyIamRule),
-			db.delete(tables.apiKey),
-			db.delete(tables.providerKey),
-		]);
-
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-
-		await Promise.all([
-			db.delete(tables.organization),
-			db.delete(tables.user),
-			db.delete(tables.account),
-			db.delete(tables.session),
-			db.delete(tables.verification),
-		]);
+		// Sequential, children before parents: concurrent deletes on
+		// cascade-linked tables (e.g. user -> account) deadlock in postgres.
+		await db.delete(tables.log);
+		await db.delete(tables.apiKeyIamRule);
+		await db.delete(tables.apiKey);
+		await db.delete(tables.providerKey);
+		await db.delete(tables.userOrganization);
+		await db.delete(tables.project);
+		await db.delete(tables.session);
+		await db.delete(tables.account);
+		await db.delete(tables.verification);
+		await db.delete(tables.organization);
+		await db.delete(tables.user);
 	}
 
 	beforeAll(async () => {


### PR DESCRIPTION
## Summary

Fixes two unit-test failures on `main` — the CI flake that broke the last two main builds, plus a local-only failure uncovered while reproducing it.

### 1. CI flake: `team-invites.spec.ts` deadlock (the failing main builds)

The last two `ci` runs on main failed in `team invites > expired invite is not accepted on sign-in` with postgres `deadlock detected` (40P01), always `while deleting tuple in relation "account"`, raised from `deleteAll()` in `apps/api/src/testing.ts`.

Root cause: `deleteAll()` ran `db.delete(user)` — which `ON DELETE CASCADE`s into `account` and `session` — in the same `Promise.all` as direct deletes of `account` and `session`. Each statement runs on its own pool connection, so the cascade and the direct delete lock the same rows in different orders and postgres kills one transaction. Timing-dependent, hence flaky (it passed on the PR, then failed on main).

Fix:
- Run the deletes sequentially, children before parents, so cascades always land on already-empty tables.
- Retry up to 3× on 40P01, since all spec files share one `test` database and vitest runs files in parallel, so two files' cleanups can still collide cross-process.
- Apply the same sequencing to the identical pattern in `apps/gateway/src/fallback.spec.ts`.

### 2. Local-only failure: hybrid escape test calls the real Google API

`api.spec.ts > hybrid escapes to credits provider when keyed provider fails` fails deterministically on any machine whose repo `.env` contains a real `LLM_GOOGLE_AI_STUDIO_API_KEY` (loaded into unit tests by `import "dotenv/config"` in `apps/gateway/src/app.ts`). After the keyed google-ai-studio provider fails, the retry loop finds the real env key and gets a genuine (billed!) Gemini response with `used_provider: google-ai-studio` instead of escaping to `google-vertex`. CI has no `.env`, which is why this only failed locally.

Fix: the test now saves + deletes `LLM_GOOGLE_AI_STUDIO_API_KEY`/`_BASE_URL` for its duration (same pattern it already uses for the vertex vars), restoring them in `finally`.

## Testing

- Full `pnpm test:unit`: **157 files / 2561 tests passed** (previously 1 failure per run).
- The hybrid escape test now passes in isolation with the real `.env` present (previously failed 4/4 attempts).
- `pnpm build` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test database cleanup to avoid deadlocks by deleting related records in a safe order and retrying when needed.
  * Prevented local Google AI Studio credentials from affecting provider fallback tests.

* **Tests**
  * Made test-state resets more deterministic by clearing related data sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->