### PR TITLE
fix(gateway): 400 on malformed tool_call arguments

### DIFF
--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./transform-anthropic-messages.js";
 export * from "./parse-data-url.js";
+export * from "./parse-tool-call-arguments.js";
+export * from "./request-error.js";
 export * from "./process-image-url.js";
 export * from "./transform-google-messages.js";
 export * from "./get-provider-headers.js";

--- a/packages/actions/src/parse-tool-call-arguments.spec.ts
+++ b/packages/actions/src/parse-tool-call-arguments.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+
+import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
+import { RequestError } from "./request-error.js";
+
+import type { ToolCall } from "@llmgateway/models";
+
+function makeToolCall(args: string): ToolCall {
+	return {
+		id: "call_123",
+		type: "function",
+		function: {
+			name: "get_weather",
+			arguments: args,
+		},
+	};
+}
+
+describe("parseToolCallArguments", () => {
+	test("parses a valid JSON object", () => {
+		expect(parseToolCallArguments(makeToolCall('{"city":"Berlin"}'))).toEqual({
+			city: "Berlin",
+		});
+	});
+
+	test("returns an empty object for empty or whitespace arguments", () => {
+		expect(parseToolCallArguments(makeToolCall(""))).toEqual({});
+		expect(parseToolCallArguments(makeToolCall("  "))).toEqual({});
+		expect(
+			parseToolCallArguments(makeToolCall(undefined as unknown as string)),
+		).toEqual({});
+	});
+
+	test("throws a RequestError for malformed JSON", () => {
+		let thrown: unknown;
+		try {
+			parseToolCallArguments(makeToolCall('{"city":"Berlin"'));
+		} catch (e) {
+			thrown = e;
+		}
+		expect(thrown).toBeInstanceOf(RequestError);
+		expect((thrown as RequestError).statusCode).toBe(400);
+		expect((thrown as RequestError).message).toContain("get_weather");
+		expect((thrown as RequestError).message).toContain("call_123");
+	});
+
+	test("throws a RequestError for non-object JSON values", () => {
+		for (const args of ["42", '"text"', "[1,2]", "null", "true"]) {
+			expect(() => parseToolCallArguments(makeToolCall(args))).toThrow(
+				RequestError,
+			);
+		}
+	});
+});

--- a/packages/actions/src/parse-tool-call-arguments.ts
+++ b/packages/actions/src/parse-tool-call-arguments.ts
@@ -1,0 +1,34 @@
+import { RequestError } from "./request-error.js";
+
+import type { ToolCall } from "@llmgateway/models";
+
+/**
+ * Parse the client-supplied `tool_calls[].function.arguments` string into the
+ * structured object required by providers with native tool_use blocks
+ * (Anthropic, Bedrock Converse). The string is opaque to request validation,
+ * so malformed JSON (e.g. a tool call truncated by max_tokens that the client
+ * echoed back into history) must be rejected as a client error, not crash the
+ * transform with an unhandled SyntaxError.
+ */
+export function parseToolCallArguments(
+	toolCall: ToolCall,
+): Record<string, unknown> {
+	const args = toolCall.function.arguments;
+	if (!args || !args.trim()) {
+		return {};
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(args);
+	} catch (e) {
+		throw new RequestError(
+			`Invalid JSON in tool_calls[].function.arguments for tool "${toolCall.function.name}" (id: ${toolCall.id}): ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new RequestError(
+			`tool_calls[].function.arguments for tool "${toolCall.function.name}" (id: ${toolCall.id}) must be a JSON object`,
+		);
+	}
+	return parsed as Record<string, unknown>;
+}

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -95,6 +95,46 @@ async function prepareOpenAITextRequest(options: {
 }
 
 describe("prepareRequestBody - Anthropic", () => {
+	test("should throw a typed RequestError for malformed tool_call arguments", async () => {
+		await expect(
+			prepareRequestBody(
+				"anthropic",
+				"claude-3-5-sonnet-20241022",
+				null,
+				"claude-3-5-sonnet-20241022",
+				[
+					{ role: "user", content: "Hello!" },
+					{
+						role: "assistant",
+						content: "",
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: {
+									name: "get_weather",
+									arguments: '{"city":"Berlin"',
+								},
+							},
+						],
+					},
+				],
+				false,
+				undefined,
+				1024,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+				false,
+			),
+		).rejects.toBeInstanceOf(RequestError);
+	});
+
 	test("should extract system messages to system field for caching", async () => {
 		const requestBody = (await prepareRequestBody(
 			"anthropic",
@@ -2021,6 +2061,46 @@ describe("prepareRequestBody - function tool parameter normalization", () => {
 });
 
 describe("prepareRequestBody - AWS Bedrock", () => {
+	test("should throw a typed RequestError for malformed tool_call arguments", async () => {
+		await expect(
+			prepareRequestBody(
+				"aws-bedrock",
+				"claude-sonnet-4-5",
+				null,
+				"anthropic.claude-sonnet-4-5-20250929-v1:0",
+				[
+					{ role: "user", content: "Hello!" },
+					{
+						role: "assistant",
+						content: "",
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: {
+									name: "get_weather",
+									arguments: '{"city":"Berlin"',
+								},
+							},
+						],
+					},
+				],
+				false,
+				undefined,
+				1024,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+				false,
+			),
+		).rejects.toBeInstanceOf(RequestError);
+	});
+
 	test("should keep Grok 4.3 as Bedrock Mantle OpenAI chat completions", async () => {
 		const requestBody = (await prepareRequestBody(
 			"aws-bedrock",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -24,28 +24,15 @@ import {
 import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import { parseDataUrl } from "./parse-data-url.js";
+import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
 import { processImageUrl } from "./process-image-url.js";
+import { RequestError } from "./request-error.js";
 import { transformAnthropicMessages } from "./transform-anthropic-messages.js";
 import { transformGoogleMessages } from "./transform-google-messages.js";
 
 type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
 
-/**
- * Generic typed error for invalid client requests detected before we hit the
- * upstream provider (e.g. malformed message shapes). The gateway maps this to
- * the carried `statusCode` (default 400) and writes a client_error log row so
- * the rejected request still shows up in the user's activity history instead
- * of surfacing as a generic 500 with no log. Reuse this for any similar
- * pre-upstream request validation failure.
- */
-export class RequestError extends Error {
-	public readonly statusCode: number;
-	public constructor(message: string, statusCode = 400) {
-		super(message);
-		this.name = "RequestError";
-		this.statusCode = statusCode;
-	}
-}
+export { RequestError } from "./request-error.js";
 
 function getProviderMapping(
 	modelDef: ModelDefinition | undefined,
@@ -2476,7 +2463,7 @@ export async function prepareRequestBody(
 							toolUse: {
 								toolUseId: toolCall.id,
 								name: toolCall.function.name,
-								input: JSON.parse(toolCall.function.arguments),
+								input: parseToolCallArguments(toolCall),
 							},
 						});
 					});

--- a/packages/actions/src/request-error.ts
+++ b/packages/actions/src/request-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Generic typed error for invalid client requests detected before we hit the
+ * upstream provider (e.g. malformed message shapes). The gateway maps this to
+ * the carried `statusCode` (default 400) and writes a client_error log row so
+ * the rejected request still shows up in the user's activity history instead
+ * of surfacing as a generic 500 with no log. Reuse this for any similar
+ * pre-upstream request validation failure.
+ */
+export class RequestError extends Error {
+	public readonly statusCode: number;
+	public constructor(message: string, statusCode = 400) {
+		super(message);
+		this.name = "RequestError";
+		this.statusCode = statusCode;
+	}
+}

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -10,6 +10,7 @@ import {
 	type ToolUseContent,
 } from "@llmgateway/models";
 
+import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
 import { processImageUrl } from "./process-image-url.js";
 
 /**
@@ -203,7 +204,7 @@ export async function transformAnthropicMessages(
 						type: "tool_use",
 						id: uniqueId,
 						name: toolCall.function.name,
-						input: JSON.parse(toolCall.function.arguments),
+						input: parseToolCallArguments(toolCall),
 					};
 				},
 			);


### PR DESCRIPTION
## Summary

Production was throwing unhandled 500s (`SyntaxError: Expected ',' or '}' after property value in JSON`) from `transform-anthropic-messages.ts` when a client's message history contained an assistant message whose `tool_calls[].function.arguments` string is not valid JSON — typically a tool call truncated by `max_tokens` that the client echoed back verbatim. Request validation only checks that `arguments` is a string, so the bad JSON detonated inside the Anthropic (and Bedrock Converse) transforms.

## Changes

- New `parseToolCallArguments()` helper parses client-supplied tool-call arguments and throws the existing typed `RequestError` on malformed JSON (or non-object values), which the gateway already maps to a **400**, logs at **warn** level (`Invalid request`), and records as a `client_error` row in the activity feed — instead of an unhandled 500 with no log row.
- Empty/whitespace argument strings are treated as `{}` (matching the Google transform's existing leniency for no-arg tools).
- Applied at both crash sites: the Anthropic transform (`transform-anthropic-messages.ts`) and the Bedrock Converse path (`prepare-request-body.ts`). The Google transform already fell back to `{}` and is unchanged.
- Moved `RequestError` into its own module (`request-error.ts`) so transforms can import it without a circular dependency; it's re-exported from `prepare-request-body.ts` so existing imports are unaffected.

## Testing

- New unit tests for the helper and `prepareRequestBody` integration tests for both the Anthropic and Bedrock paths.
- `pnpm test:unit` passes (one unrelated flaky gateway graceful-shutdown streaming test failed once, passed on re-run).
- `pnpm build` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool-call arguments across supported providers.
  * Malformed, empty, or invalid arguments now produce consistent, descriptive request errors instead of unexpected parsing failures.
  * Added validation to ensure tool-call arguments are valid JSON objects before processing.

* **New Features**
  * Added publicly available request error and tool-call argument parsing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->