### PR TITLE
fix(api): validate chat support body with zod

### DIFF
--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -238,10 +238,16 @@ async function checkMetaRateLimit(ipAddress: string): Promise<boolean> {
 }
 
 function getTextFromUIMessage(message: UIMessage): string {
-	return message.parts
-		.filter((p): p is { type: "text"; text: string } => p.type === "text")
-		.map((p) => p.text)
-		.join("");
+	// `message` is cast from an untrusted request body, so `parts` may be absent
+	// (e.g. older clients sending a plain `content` string). Guard both shapes.
+	if (Array.isArray(message.parts)) {
+		return message.parts
+			.filter((p): p is { type: "text"; text: string } => p.type === "text")
+			.map((p) => p.text)
+			.join("");
+	}
+	const content = (message as { content?: unknown }).content;
+	return typeof content === "string" ? content : "";
 }
 
 // Redis is a best-effort cache for clientId → conversationId. If it's

--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -238,16 +238,10 @@ async function checkMetaRateLimit(ipAddress: string): Promise<boolean> {
 }
 
 function getTextFromUIMessage(message: UIMessage): string {
-	// `message` is cast from an untrusted request body, so `parts` may be absent
-	// (e.g. older clients sending a plain `content` string). Guard both shapes.
-	if (Array.isArray(message.parts)) {
-		return message.parts
-			.filter((p): p is { type: "text"; text: string } => p.type === "text")
-			.map((p) => p.text)
-			.join("");
-	}
-	const content = (message as { content?: unknown }).content;
-	return typeof content === "string" ? content : "";
+	return message.parts
+		.filter((p): p is { type: "text"; text: string } => p.type === "text")
+		.map((p) => p.text)
+		.join("");
 }
 
 // Redis is a best-effort cache for clientId → conversationId. If it's
@@ -395,32 +389,46 @@ async function persistMessage(
 	}
 }
 
+// The endpoint is public and unauthenticated, so the body is fully untrusted.
+// A UIMessage's `parts` array is required by both getTextFromUIMessage and the
+// AI SDK's convertToModelMessages downstream, so validate the whole shape up
+// front and reject anything malformed instead of crashing deeper in the flow.
+const chatSupportMessageSchema = z.object({
+	id: z.string().optional(),
+	role: z.string(),
+	parts: z.array(z.object({ type: z.string() }).passthrough()),
+	metadata: z.unknown().optional(),
+});
+
+const chatSupportRequestSchema = z.object({
+	// Longer histories are allowed now that conversations persist across
+	// sessions, but only the most recent messages are fed to the model to bound
+	// token usage (see MAX_CONTEXT_MESSAGES below).
+	messages: z
+		.array(chatSupportMessageSchema)
+		.min(1, "Missing messages")
+		.max(100, "Too many messages in conversation"),
+	name: z.string().max(200).optional(),
+	email: z.string().max(320).optional(),
+	clientId: z.string().min(1).max(64),
+});
+
 export const publicChatSupport = new Hono<ServerTypes>();
 
 publicChatSupport.post("/", async (c) => {
 	const ipAddress = extractClientIP(c) ?? "unknown";
 
-	const body = await c.req.json<{
-		messages: UIMessage[];
-		name?: string;
-		email?: string;
-		clientId?: string;
-	}>();
-	const { messages, name, email, clientId } = body;
-
-	if (!clientId || typeof clientId !== "string" || clientId.length > 64) {
-		return c.json({ error: "Missing or invalid clientId" }, 400);
+	const parsed = chatSupportRequestSchema.safeParse(
+		await c.req.json().catch(() => null),
+	);
+	if (!parsed.success) {
+		return c.json(
+			{ error: parsed.error.issues[0]?.message ?? "Invalid request body" },
+			400,
+		);
 	}
-
-	if (!messages || !Array.isArray(messages) || messages.length === 0) {
-		return c.json({ error: "Missing messages" }, 400);
-	}
-
-	// Allow longer histories now that conversations persist across sessions, but
-	// only feed the most recent messages to the model to bound token usage.
-	if (messages.length > 100) {
-		return c.json({ error: "Too many messages in conversation" }, 400);
-	}
+	const { name, email, clientId } = parsed.data;
+	const messages = parsed.data.messages as unknown as UIMessage[];
 
 	// Checked only after validation so malformed requests can't consume the
 	// per-identifier buckets — or worse, trip the global breaker for free.


### PR DESCRIPTION
## Problem

The public chat support endpoint crashed in production with:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at getTextFromUIMessage (/app/src/routes/public-chat-support.ts:242:4)
```

`/public/chat-support` is **public and unauthenticated**, so its body is fully untrusted. The handler only checked that `messages` was a non-empty array — never the shape of each message. A caller sending a message object without a `parts` array (e.g. an OpenAI-style `{ role, content }` payload from a bot/scanner or custom client) made `message.parts.filter(...)` throw. The same malformed shape would also break the AI SDK's `convertToModelMessages(...)` further down the flow, so a lenient fallback wouldn't have been enough.

## Fix

Validate the entire request body with a single zod schema parsed at request time, replacing the ad-hoc `clientId`/`messages` checks:

- Requires each message to have a `parts` array (the shape `getTextFromUIMessage` and `convertToModelMessages` both depend on).
- Enforces `messages` length (1–100), `clientId` (1–64 chars), and optional `name`/`email` bounds.
- Malformed payloads are rejected with a `400` up front — before rate limits, DB writes, or the LLM call — instead of crashing deeper in the handler.

With the shape guaranteed by validation, `getTextFromUIMessage` reverts to its simple form.

## Testing

- `turbo run build --filter=api` passes
- `turbo run format --filter=api` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of chat support submissions by enforcing a consistent message format before processing.
  * Invalid requests are now rejected with a clear 400 response indicating the first validation issue.
  * Ensures message content is handled safely and consistently, including cases where parts are missing or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->