### PR TITLE
fix(api): don't error-log bogus Stripe webhook signatures

### DIFF
--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -1,6 +1,8 @@
+import Stripe from "stripe";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { db, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 
 import {
 	handleChargeRefunded,
@@ -8,12 +10,12 @@ import {
 	handlePaymentIntentFailed,
 	handleSubscriptionDeleted,
 	handleSubscriptionUpdated,
+	stripeRoutes,
 } from "./stripe.js";
 import { deleteAll } from "./testing.js";
 
 import type * as PaymentsModule from "./routes/payments.js";
 import type * as EmailModule from "./utils/email.js";
-import type Stripe from "stripe";
 
 const stripeMock = vi.hoisted(() => ({
 	refunds: { list: vi.fn() },
@@ -22,6 +24,7 @@ const stripeMock = vi.hoisted(() => ({
 	subscriptions: { retrieve: vi.fn() },
 	paymentIntents: { retrieve: vi.fn() },
 	paymentMethods: { retrieve: vi.fn() },
+	webhooks: { constructEvent: vi.fn() },
 }));
 
 vi.mock("./routes/payments.js", async (importOriginal) => {
@@ -1030,5 +1033,48 @@ describe("handleChargeRefunded — dev plan refund tracking", () => {
 			where: { id: { eq: ORG_ID } },
 		});
 		expect(org?.credits).toBe("0");
+	});
+});
+
+describe("webhook route — invalid signature", () => {
+	const realStripe = new Stripe("sk_test_dummy");
+
+	afterEach(() => {
+		stripeMock.webhooks.constructEvent.mockReset();
+	});
+
+	test("logs a warning and returns 400 for a bogus signature", async () => {
+		const previousSecret = process.env.STRIPE_WEBHOOK_SECRET;
+		process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_secret";
+		// Defer to the real Stripe SDK so an actual
+		// StripeSignatureVerificationError is thrown, exercising the handler's
+		// instanceof branch rather than a hand-rolled error.
+		stripeMock.webhooks.constructEvent.mockImplementation(
+			(body: string, sig: string, secret: string) =>
+				realStripe.webhooks.constructEvent(body, sig, secret),
+		);
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		try {
+			const res = await stripeRoutes.request("/webhook", {
+				method: "POST",
+				headers: { "stripe-signature": "fake_signature" },
+				body: JSON.stringify({ type: "checkout.session.completed" }),
+			});
+
+			expect(res.status).toBe(400);
+			expect(await res.text()).toContain("Invalid signature");
+			expect(warnSpy).toHaveBeenCalledWith(
+				"Ignoring Stripe webhook with invalid signature",
+				expect.objectContaining({ message: expect.any(String) }),
+			);
+		} finally {
+			warnSpy.mockRestore();
+			if (previousSecret === undefined) {
+				delete process.env.STRIPE_WEBHOOK_SECRET;
+			} else {
+				process.env.STRIPE_WEBHOOK_SECRET = previousSecret;
+			}
+		}
 	});
 });

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1,5 +1,6 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
+import Stripe from "stripe";
 import { z } from "zod";
 
 import {
@@ -48,7 +49,6 @@ import {
 } from "./utils/plan-billing.js";
 
 import type { ServerTypes } from "./vars.js";
-import type Stripe from "stripe";
 
 export async function ensureStripeCustomer(
 	organizationId: string,
@@ -389,6 +389,16 @@ stripeRoutes.openapi(webhookHandler, async (c) => {
 
 		return c.json({ received: true });
 	} catch (error) {
+		// Signature verification failures are almost always spoofed/bogus traffic
+		// hitting the public webhook endpoint (e.g. a `fake_signature` header). They
+		// are not actionable, so log at warn level and still return 400 rather than
+		// raising an error alert.
+		if (error instanceof Stripe.errors.StripeSignatureVerificationError) {
+			logger.warn("Ignoring Stripe webhook with invalid signature", {
+				message: error.message,
+			});
+			throw new HTTPException(400, { message: "Invalid signature" });
+		}
 		logger.error("Webhook error:", error as Error);
 		throw new HTTPException(400, {
 			message: `Webhook error: ${error instanceof Error ? error.message : "Unknown error"}`,


### PR DESCRIPTION
## Problem

Spoofed / bogus requests hitting the public Stripe webhook endpoint (e.g. a request with a `fake_signature` header and `{"type": "checkout.session.completed"}` body) fail Stripe signature verification. The resulting `StripeSignatureVerificationError` fell through to the generic catch block and was logged as `ERROR`, which fires error alerts for what is just untrusted internet noise.

```
ERROR Webhook error: Unable to extract timestamp and signatures from header
```

## Fix

Handle `Stripe.errors.StripeSignatureVerificationError` specifically in the webhook handler's catch block:

- Log at `warn` level instead of `error` (no more error alerts)
- Still return `400` so Stripe/spoofers get the same rejection as before

Real webhook-processing errors (anything other than a signature mismatch) continue to log at `error` level and return 400 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe webhook security by explicitly detecting invalid webhook signatures.
  * Invalid webhook signatures now return a clear HTTP 400 response (`{ message: "Invalid signature" }`) instead of falling back to generic error handling.
* **Tests**
  * Added coverage to verify the invalid-signature webhook behavior and associated warning logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->