### PR TITLE
feat: prefer recent models in key validation

### DIFF
--- a/packages/actions/src/validate-provider-key.spec.ts
+++ b/packages/actions/src/validate-provider-key.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { models } from "@llmgateway/models";
 
-import { getValidationModel } from "./validate-provider-key.js";
+import {
+	getValidationModel,
+	pickCheapestRecentModel,
+} from "./validate-provider-key.js";
 
 describe("getValidationModel", () => {
 	it("never selects an OCR model for provider key validation", () => {
@@ -18,5 +21,67 @@ describe("getValidationModel", () => {
 			(p) => p.providerId === "mistral" && (p as { ocr?: boolean }).ocr,
 		);
 		expect(usesOcr).toBeFalsy();
+	});
+
+	it("selects a model from the newer half of the provider's releases", () => {
+		const selected = getValidationModel("openai");
+		expect(selected).not.toBeNull();
+
+		const selectedDef = models.find((m) => m.id === selected?.modelId);
+		const releasedAt =
+			selectedDef && "releasedAt" in selectedDef
+				? (selectedDef.releasedAt as Date | undefined)
+				: undefined;
+		expect(releasedAt).toBeDefined();
+
+		const datedReleases = models
+			.filter((m) => "releasedAt" in m && m.releasedAt !== undefined)
+			.filter((m) =>
+				m.providers.some(
+					(p) =>
+						p.providerId === "openai" &&
+						!("deprecatedAt" in p && p.deprecatedAt) &&
+						!("deactivatedAt" in p && p.deactivatedAt),
+				),
+			)
+			.map((m) => (m.releasedAt as Date).getTime());
+		const olderOrSame = datedReleases.filter(
+			(t) => t <= releasedAt!.getTime(),
+		).length;
+		// The pick must not be in the older half of the catalog
+		expect(olderOrSame * 2).toBeGreaterThanOrEqual(datedReleases.length);
+	});
+});
+
+describe("pickCheapestRecentModel", () => {
+	it("returns undefined for an empty list", () => {
+		expect(pickCheapestRecentModel([])).toBeUndefined();
+	});
+
+	it("picks the cheapest recent model over a cheaper outdated one", () => {
+		const picked = pickCheapestRecentModel([
+			{ id: "old-cheap", price: 0.1, releasedAt: new Date("2024-01-01") },
+			{ id: "older", price: 0.5, releasedAt: new Date("2023-06-01") },
+			{ id: "new-cheap", price: 0.3, releasedAt: new Date("2025-05-01") },
+			{ id: "new-pricey", price: 2, releasedAt: new Date("2025-06-01") },
+		]);
+		expect(picked?.id).toBe("new-cheap");
+	});
+
+	it("falls back to the cheapest model when release dates are unknown", () => {
+		const picked = pickCheapestRecentModel([
+			{ id: "pricey", price: 2 },
+			{ id: "cheap", price: 0.1 },
+		]);
+		expect(picked?.id).toBe("cheap");
+	});
+
+	it("ignores undated models when dated candidates exist", () => {
+		const picked = pickCheapestRecentModel([
+			{ id: "undated-cheap", price: 0.01 },
+			{ id: "new", price: 1, releasedAt: new Date("2025-05-01") },
+			{ id: "old", price: 0.5, releasedAt: new Date("2023-01-01") },
+		]);
+		expect(picked?.id).toBe("new");
 	});
 });

--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -15,6 +15,29 @@ import { prepareRequestBody } from "./prepare-request-body.js";
 
 import type { ProviderKeyOptions } from "@llmgateway/db";
 
+/**
+ * Pick the cheapest candidate among the newer half of the provider's releases,
+ * so key validation uses a cheap but current model instead of an outdated one
+ * that happens to be the cheapest. The cutoff is the median release date of
+ * the dated candidates, i.e. relative to the provider's own catalog rather
+ * than any absolute age threshold. Candidates without a release date are
+ * treated as old; they only win when fewer than two candidates are dated.
+ */
+export function pickCheapestRecentModel<
+	T extends { price: number; releasedAt?: Date },
+>(candidates: T[]): T | undefined {
+	const byPrice = [...candidates].sort((a, b) => a.price - b.price);
+	const dated = byPrice.filter((c) => c.releasedAt !== undefined);
+	if (dated.length < 2) {
+		return byPrice[0];
+	}
+	const releaseTimes = dated
+		.map((c) => c.releasedAt!.getTime())
+		.sort((a, b) => a - b);
+	const medianReleaseTime = releaseTimes[Math.floor(releaseTimes.length / 2)];
+	return dated.find((c) => c.releasedAt!.getTime() >= medianReleaseTime);
+}
+
 export function getValidationModel(
 	provider: ProviderId,
 	providerKeyOptions?: ProviderKeyOptions,
@@ -37,73 +60,75 @@ export function getValidationModel(
 
 	const currentDate = new Date();
 	const collectModels = (restrictToRegion: boolean) =>
-		models
-			.flatMap((model) => {
-				const providerMapping = model.providers.find(
-					(p) => p.providerId === provider,
-				) as ProviderModelMapping | undefined;
-				if (!providerMapping) {
+		models.flatMap((model) => {
+			const providerMapping = model.providers.find(
+				(p) => p.providerId === provider,
+			) as ProviderModelMapping | undefined;
+			if (!providerMapping) {
+				return [];
+			}
+
+			// If a region is selected, only consider models available in that region
+			if (restrictToRegion && selectedRegion && providerMapping.regions) {
+				if (!providerMapping.regions.some((r) => r.id === selectedRegion)) {
 					return [];
 				}
+			}
 
-				// If a region is selected, only consider models available in that region
-				if (restrictToRegion && selectedRegion && providerMapping.regions) {
-					if (!providerMapping.regions.some((r) => r.id === selectedRegion)) {
-						return [];
-					}
-				}
+			const providerStability =
+				"stability" in providerMapping
+					? (providerMapping.stability as string | undefined)
+					: undefined;
+			const modelStability =
+				"stability" in model
+					? (model.stability as string | undefined)
+					: undefined;
+			const effectiveStability = providerStability ?? modelStability;
+			const isStable =
+				effectiveStability !== "unstable" &&
+				effectiveStability !== "experimental";
 
-				const providerStability =
-					"stability" in providerMapping
-						? (providerMapping.stability as string | undefined)
-						: undefined;
-				const modelStability =
-					"stability" in model
-						? (model.stability as string | undefined)
-						: undefined;
-				const effectiveStability = providerStability ?? modelStability;
-				const isStable =
-					effectiveStability !== "unstable" &&
-					effectiveStability !== "experimental";
+			const isDeprecated =
+				providerMapping.deprecatedAt &&
+				currentDate >= providerMapping.deprecatedAt;
+			const isDeactivated =
+				providerMapping.deactivatedAt &&
+				currentDate >= providerMapping.deactivatedAt;
 
-				const isDeprecated =
-					providerMapping.deprecatedAt &&
-					currentDate >= providerMapping.deprecatedAt;
-				const isDeactivated =
-					providerMapping.deactivatedAt &&
-					currentDate >= providerMapping.deactivatedAt;
+			if (
+				!isStable ||
+				isDeprecated ||
+				isDeactivated ||
+				providerMapping.imageGenerations ||
+				providerMapping.videoGenerations ||
+				providerMapping.embeddings ||
+				providerMapping.speechGenerations ||
+				providerMapping.ocr
+			) {
+				return [];
+			}
 
-				if (
-					!isStable ||
-					isDeprecated ||
-					isDeactivated ||
-					providerMapping.imageGenerations ||
-					providerMapping.videoGenerations ||
-					providerMapping.embeddings ||
-					providerMapping.speechGenerations ||
-					providerMapping.ocr
-				) {
-					return [];
-				}
+			const hasPricing =
+				providerMapping.inputPrice !== undefined &&
+				providerMapping.outputPrice !== undefined;
+			const inputPrice = Number(providerMapping.inputPrice ?? "0");
+			const outputPrice = Number(providerMapping.outputPrice ?? "0");
+			const averagePrice = hasPricing
+				? (inputPrice + outputPrice) / 2
+				: Number.MAX_VALUE;
 
-				const hasPricing =
-					providerMapping.inputPrice !== undefined &&
-					providerMapping.outputPrice !== undefined;
-				const inputPrice = Number(providerMapping.inputPrice ?? "0");
-				const outputPrice = Number(providerMapping.outputPrice ?? "0");
-				const averagePrice = hasPricing
-					? (inputPrice + outputPrice) / 2
-					: Number.MAX_VALUE;
-
-				return [
-					{
-						modelId: model.id,
-						externalId: providerMapping.externalId,
-						price: averagePrice,
-					},
-				];
-			})
-			.sort((a, b) => a.price - b.price);
+			return [
+				{
+					modelId: model.id,
+					externalId: providerMapping.externalId,
+					price: averagePrice,
+					releasedAt:
+						"releasedAt" in model
+							? (model.releasedAt as Date | undefined)
+							: undefined,
+				},
+			];
+		});
 
 	// Prefer a model available in the selected region. If none is declared for
 	// that region (e.g. a data-residency AWS region that no model lists), fall
@@ -113,7 +138,7 @@ export function getValidationModel(
 		? regionModels
 		: collectModels(false);
 
-	const best = providerModels[0];
+	const best = pickCheapestRecentModel(providerModels);
 	return best ? { modelId: best.modelId, externalId: best.externalId } : null;
 }
 


### PR DESCRIPTION
## Summary

Provider key validation previously picked the **cheapest** eligible model outright, which could select a model that is over a year old (e.g. `qwen-turbo` from Feb 2025 for Alibaba, `sonar` from Jan 2025 for Perplexity). Old models are more likely to be retired upstream or unavailable to new keys, and validation should exercise a current model anyway.

`getValidationModel` now picks the cheapest model among the **newer half of the provider's releases**: the cutoff is the median `releasedAt` of the eligible candidates, so it is fully relative to each provider's own catalog — no hardcoded age thresholds or model names. As providers ship new models, the pick automatically moves forward.

- New pure helper `pickCheapestRecentModel()` in `validate-provider-key.ts`, unit-tested with synthetic data
- Candidates without a `releasedAt` are treated as old; they only win when fewer than two candidates are dated (so providers with undated catalogs still fall back to plain cheapest)
- All existing eligibility filters (stability, deprecation, region, modality, pricing) are unchanged

### Before → after (selected examples)

| Provider | Before | After |
|---|---|---|
| alibaba | qwen-turbo (2025-02) | qwen3-vl-flash (2025-10) |
| google-ai-studio | gemini-2.5-flash-lite (2025-07) | gemini-3.1-flash-lite (2026-05) |
| perplexity | sonar (2025-01) | sonar-reasoning-pro (2025-03) |
| zai | glm-4-32b-0414-128k (2025-04) | glm-4.6v-flashx (2025-12) |
| anthropic | claude-haiku-4-5-free (2025-10) | claude-sonnet-5 (2026-06) |
| moonshot | kimi-k2.5 (2026-01) | kimi-k2.7-code (2026-06) |

Validation requests cap at 10 output tokens, so the marginally pricier picks cost fractions of a cent.

## Testing

- `pnpm test:unit` — 2566 passed
- New unit tests for `pickCheapestRecentModel` plus a data-driven test asserting the OpenAI pick is not in the older half of the catalog
- `pnpm build` and `pnpm format` pass
- Verified per-provider picks before/after with a script over the real catalog (no provider lost its validation model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Validation now selects a cost-effective model from among newer available provider releases.
  * Deprecated and deactivated models remain excluded from validation.
  * When release dates are unavailable, validation falls back to selecting the lowest-cost eligible model.
  * Updated selection behavior helps ensure provider key checks use more current models while managing validation costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->