### PR TITLE
feat(code): track DevPass purchase conversions

### DIFF
--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -33,6 +33,7 @@ import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
+import { trackPurchaseConversion } from "@/lib/google-tag";
 import { useStripe } from "@/lib/stripe";
 import { cn } from "@/lib/utils";
 
@@ -128,7 +129,7 @@ export default function DashboardShell({
 	const posthog = usePostHog();
 	const { signOut } = useAuth();
 	const config = useAppConfig();
-	const { posthogKey } = config;
+	const { posthogKey, googleAdsPurchaseConversion } = config;
 	const api = useApi();
 	const { stripe, isLoading: stripeLoading } = useStripe();
 	const queryClient = useQueryClient();
@@ -154,10 +155,21 @@ export default function DashboardShell({
 		useState<SetupActivationStatus | null>(null);
 	const activeSetupSession = useRef<string | null>(null);
 	const finalizeDevPlanRef = useRef(finalizeMutation.mutateAsync);
+	const purchaseTrackedSession = useRef<string | null>(null);
+	const devPlanStatusRef = useRef(devPlanStatus);
+	const userEmailRef = useRef(user?.email);
 
 	useEffect(() => {
 		finalizeDevPlanRef.current = finalizeMutation.mutateAsync;
 	}, [finalizeMutation.mutateAsync]);
+
+	useEffect(() => {
+		devPlanStatusRef.current = devPlanStatus;
+	}, [devPlanStatus]);
+
+	useEffect(() => {
+		userEmailRef.current = user?.email;
+	}, [user?.email]);
 
 	useEffect(() => {
 		const sessionId = setupSessionId;
@@ -239,6 +251,21 @@ export default function DashboardShell({
 				if (result?.status === "ok" || result?.status === "already_processed") {
 					setSetupActivationStatus("success");
 					toast.success("DevPass activated");
+					if (purchaseTrackedSession.current !== sessionId) {
+						purchaseTrackedSession.current = sessionId;
+						const tier = devPlanStatusRef.current?.devPlan;
+						const planData =
+							tier && tier !== "none"
+								? plans.find((plan) => plan.tier === tier)
+								: undefined;
+						trackPurchaseConversion({
+							email: userEmailRef.current ?? "",
+							value: planData?.price,
+							currency: "USD",
+							transactionId: sessionId,
+							sendTo: googleAdsPurchaseConversion,
+						});
+					}
 					void queryClient.invalidateQueries({
 						predicate: (query) => {
 							const key = query.queryKey;
@@ -305,6 +332,7 @@ export default function DashboardShell({
 		router,
 		stripe,
 		stripeLoading,
+		googleAdsPurchaseConversion,
 	]);
 
 	const handleSubscribe = async (tier: PlanTier): Promise<void> => {

--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -105,6 +105,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 				<GoogleTag
 					googleTagId={config.googleTagId}
 					googleAdsSignupConversion={config.googleAdsSignupConversion}
+					googleAdsPurchaseConversion={config.googleAdsPurchaseConversion}
 				/>
 				<Providers config={config}>{children}</Providers>
 			</body>

--- a/apps/code/src/components/google-tag.tsx
+++ b/apps/code/src/components/google-tag.tsx
@@ -3,14 +3,17 @@ import Script from "next/script";
 interface GoogleTagProps {
 	googleTagId?: string;
 	googleAdsSignupConversion?: string;
+	googleAdsPurchaseConversion?: string;
 }
 
 export function GoogleTag({
 	googleTagId,
 	googleAdsSignupConversion,
+	googleAdsPurchaseConversion,
 }: GoogleTagProps) {
-	const adsTagId = googleAdsSignupConversion?.split("/")[0];
-	const tagIds = [googleTagId, adsTagId].filter(
+	const signupAdsTagId = googleAdsSignupConversion?.split("/")[0];
+	const purchaseAdsTagId = googleAdsPurchaseConversion?.split("/")[0];
+	const tagIds = [googleTagId, signupAdsTagId, purchaseAdsTagId].filter(
 		(id, index, ids): id is string => Boolean(id) && ids.indexOf(id) === index,
 	);
 

--- a/apps/code/src/lib/config-server.ts
+++ b/apps/code/src/lib/config-server.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
 	posthogHost?: string;
 	googleTagId?: string;
 	googleAdsSignupConversion?: string;
+	googleAdsPurchaseConversion?: string;
 	stripePublishableKey?: string;
 	githubAuth: boolean;
 	googleAuth: boolean;
@@ -34,6 +35,7 @@ export function getConfig(): AppConfig {
 		posthogHost: process.env.POSTHOG_HOST,
 		googleTagId: process.env.GOOGLE_TAG_ID,
 		googleAdsSignupConversion: process.env.GOOGLE_ADS_SIGNUP_CONVERSION,
+		googleAdsPurchaseConversion: process.env.GOOGLE_ADS_PURCHASE_CONVERSION,
 		stripePublishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
 		githubAuth: !!process.env.GITHUB_CLIENT_ID,
 		googleAuth: !!process.env.GOOGLE_CLIENT_ID,

--- a/apps/code/src/lib/google-tag.ts
+++ b/apps/code/src/lib/google-tag.ts
@@ -27,3 +27,37 @@ export function trackSignupConversion({
 		window.gtag("event", "conversion", { send_to: sendTo });
 	}
 }
+
+export interface PurchaseConversionOptions {
+	email: string;
+	value?: number;
+	currency?: string;
+	transactionId?: string;
+	sendTo?: string;
+}
+
+export function trackPurchaseConversion({
+	email,
+	value,
+	currency = "USD",
+	transactionId,
+	sendTo,
+}: PurchaseConversionOptions): void {
+	if (typeof window === "undefined" || typeof window.gtag !== "function") {
+		return;
+	}
+	window.gtag("set", "user_data", { email });
+	window.gtag("event", "purchase", {
+		value,
+		currency,
+		transaction_id: transactionId,
+	});
+	if (sendTo) {
+		window.gtag("event", "conversion", {
+			send_to: sendTo,
+			value,
+			currency,
+			transaction_id: transactionId,
+		});
+	}
+}


### PR DESCRIPTION
## What

Fire a Google Ads / GA4 **purchase conversion** when a DevPass subscription finalizes, mirroring the existing signup conversion (commits `87660698a` / `067827c11`).

## Why

We already track `sign_up` conversions in the DevPass app, but purchases — the actual revenue event — weren't reported to Google Ads, so smart bidding / ROAS had no purchase signal to optimize against.

## How

- **`lib/google-tag.ts`** — new `trackPurchaseConversion({ email, value, currency, transactionId, sendTo })` helper: sets `user_data` (email, for enhanced conversions), fires a GA4 `purchase` event, and — when `sendTo` is set — a Google Ads `conversion` event with the same value/currency/transaction_id.
- **`lib/config-server.ts`** — exposes `googleAdsPurchaseConversion` from the new `GOOGLE_ADS_PURCHASE_CONVERSION` env var (same `AW-XXXX/label` shape as the signup var).
- **`components/google-tag.tsx` + `layout.tsx`** — the `AW-` account derived from the purchase conversion is added as a gtag destination too, so the conversion reaches Google Ads even when `GOOGLE_TAG_ID` is a GA4-only measurement id.
- **`dashboard/DashboardShell.tsx`** — fires at the finalization success branch (`status === "ok" | "already_processed"`), i.e. where a DevPass purchase completes on return from Stripe Checkout:
  - **value** looked up from `plans.ts` via the newly-active tier (this flow only creates monthly subscriptions, so the monthly price is correct; best-effort — omitted if status hasn't refetched yet)
  - **transaction_id** = the checkout `setup_session_id`, giving Google Ads dedup across reloads
  - a `purchaseTrackedSession` ref guards against double-firing within a session

## Config

Set `GOOGLE_ADS_PURCHASE_CONVERSION` (e.g. `AW-123456789/PurchaseLabel...`) in the `code` app environment. If unset, the GA4 `purchase` event still fires (when `GOOGLE_TAG_ID` is set) but no Ads conversion is sent.

## Testing

- `turbo run build --filter=code` passes
- `pnpm format` / lint-staged clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added purchase conversion tracking when DevPass activation completes successfully.
  * Purchase events now include transaction details, plan value, currency, and customer email.
  * Added support for configuring a dedicated Google Ads purchase conversion.
  * Prevented duplicate purchase tracking for the same setup session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->