### PR TITLE
fix(api): block rate-limit bypass via spoofed IP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,13 @@ TIMEOUT_MS=5000
 # Defaults: gateway=620s, api=60s
 # KEEP_ALIVE_TIMEOUT_S=620
 
+# Trust the X-Forwarded-For / X-Real-IP headers for abuse rate limiting on the
+# public contact and newsletter forms. Leave unset (default) when the API sits
+# behind Cloudflare — CF-Connecting-IP is used and these client-settable headers
+# are ignored so they cannot be spoofed to bypass rate limits. Only set to "true"
+# if you self-host behind a reverse proxy that strips/overwrites these headers.
+# TRUST_PROXY_HEADERS=true
+
 # Gateway request timeout in milliseconds - maximum time for end-to-end request
 # Defaults to 1500000ms (25 minutes)
 # GATEWAY_TIMEOUT_MS=1500000

--- a/apps/api/src/lib/client-ip.spec.ts
+++ b/apps/api/src/lib/client-ip.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getTrustedClientIp } from "./client-ip.js";
+
+import type { Context } from "hono";
+
+// Hono's c.req.header() is case-insensitive; mirror that with lowercase lookup.
+// No env/socket is attached, so getConnInfo() throws and the helper treats the
+// socket-peer fallback as unavailable — exactly the unit-test path.
+function mockContext(headers: Record<string, string>): Context {
+	const lower: Record<string, string> = {};
+	for (const [k, v] of Object.entries(headers)) {
+		lower[k.toLowerCase()] = v;
+	}
+	return {
+		req: {
+			header: (name: string) => lower[name.toLowerCase()],
+		},
+	} as unknown as Context;
+}
+
+describe("getTrustedClientIp", () => {
+	afterEach(() => {
+		delete process.env.TRUST_PROXY_HEADERS;
+	});
+
+	it("returns CF-Connecting-IP when present", () => {
+		const c = mockContext({ "CF-Connecting-IP": "203.0.113.9" });
+		expect(getTrustedClientIp(c)).toBe("203.0.113.9");
+	});
+
+	it("prefers CF-Connecting-IP over spoofable forwarding headers", () => {
+		const c = mockContext({
+			"CF-Connecting-IP": "203.0.113.9",
+			"X-Forwarded-For": "10.0.0.6",
+			"X-Real-IP": "10.0.0.7",
+		});
+		expect(getTrustedClientIp(c)).toBe("203.0.113.9");
+	});
+
+	it("ignores X-Forwarded-For by default (spoof cannot mint a bucket)", () => {
+		const c = mockContext({ "X-Forwarded-For": "10.0.0.6" });
+		expect(getTrustedClientIp(c)).toBeNull();
+	});
+
+	it("ignores X-Real-IP by default", () => {
+		const c = mockContext({ "X-Real-IP": "10.0.0.7" });
+		expect(getTrustedClientIp(c)).toBeNull();
+	});
+
+	it("does not distinguish rotated spoofed X-Forwarded-For values", () => {
+		// The abuse in the report: a new forged IP per request. All of them must
+		// resolve to the same (null) key so they share one rate-limit bucket.
+		const keys = ["10.0.0.6", "10.0.0.7", "10.0.0.8", "10.0.0.9"].map((ip) =>
+			getTrustedClientIp(mockContext({ "X-Forwarded-For": ip })),
+		);
+		expect(new Set(keys)).toEqual(new Set([null]));
+	});
+
+	it("honors X-Forwarded-For first hop when TRUST_PROXY_HEADERS=true", () => {
+		process.env.TRUST_PROXY_HEADERS = "true";
+		const c = mockContext({ "X-Forwarded-For": "198.51.100.1, 192.0.2.1" });
+		expect(getTrustedClientIp(c)).toBe("198.51.100.1");
+	});
+
+	it("honors X-Real-IP when TRUST_PROXY_HEADERS=true and no XFF", () => {
+		process.env.TRUST_PROXY_HEADERS = "true";
+		const c = mockContext({ "X-Real-IP": "198.51.100.2" });
+		expect(getTrustedClientIp(c)).toBe("198.51.100.2");
+	});
+
+	it("still prefers CF-Connecting-IP even when proxy headers are trusted", () => {
+		process.env.TRUST_PROXY_HEADERS = "true";
+		const c = mockContext({
+			"CF-Connecting-IP": "203.0.113.9",
+			"X-Forwarded-For": "10.0.0.6",
+		});
+		expect(getTrustedClientIp(c)).toBe("203.0.113.9");
+	});
+});

--- a/apps/api/src/lib/client-ip.ts
+++ b/apps/api/src/lib/client-ip.ts
@@ -1,0 +1,50 @@
+import { getConnInfo } from "@hono/node-server/conninfo";
+
+import type { Context } from "hono";
+
+// Returns a client IP suitable for use as an abuse / rate-limit key: a value the
+// caller cannot forge in this deployment. This is deliberately stricter than a
+// best-effort "who is this" lookup — a spoofable value here lets an attacker
+// rotate the apparent IP and mint a fresh rate-limit bucket per request.
+//
+// Trust model (matches the rest of the API, e.g. apps/api/src/auth/config.ts):
+//   1. CF-Connecting-IP — set by Cloudflare at the edge and overwritten on every
+//      request, so a client cannot spoof it as long as the origin only accepts
+//      Cloudflare traffic. Primary trusted source in production.
+//   2. The real TCP peer address (getConnInfo). This is the actual socket
+//      source; in a direct-to-origin request (no Cloudflare) it is the caller's
+//      real IP and is likewise unspoofable.
+//   3. X-Forwarded-For / X-Real-IP — client-settable headers, trusted ONLY when
+//      the operator opts in via TRUST_PROXY_HEADERS=true (self-hosters who front
+//      the API with a proxy that strips/overwrites these). Never trusted by
+//      default: these were the vector used to bypass the provider-listing rate
+//      limit by sending a different forged IP on each request.
+export function getTrustedClientIp(c: Context): string | null {
+	const cfConnectingIp = c.req.header("CF-Connecting-IP")?.trim();
+	if (cfConnectingIp) {
+		return cfConnectingIp;
+	}
+
+	if (process.env.TRUST_PROXY_HEADERS === "true") {
+		const forwarded = c.req.header("X-Forwarded-For")?.split(",")[0]?.trim();
+		if (forwarded) {
+			return forwarded;
+		}
+		const realIp = c.req.header("X-Real-IP")?.trim();
+		if (realIp) {
+			return realIp;
+		}
+	}
+
+	try {
+		const address = getConnInfo(c).remote.address?.trim();
+		if (address) {
+			return address;
+		}
+	} catch {
+		// getConnInfo throws when there is no underlying Node socket (e.g. unit
+		// tests that call app.request() directly). Fall through to null.
+	}
+
+	return null;
+}

--- a/apps/api/src/routes/public-contact.ts
+++ b/apps/api/src/routes/public-contact.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
 import { redisClient } from "@/auth/config.js";
+import { getTrustedClientIp } from "@/lib/client-ip.js";
 import {
 	notifyEnterpriseContact,
 	notifyProviderContact,
@@ -132,26 +133,6 @@ const submitEnterpriseContact = createRoute({
 	},
 });
 
-function extractClientIP(c: {
-	req: { header: (name: string) => string | undefined };
-}): string | null {
-	// CF-Connecting-IP is set by Cloudflare and cannot be spoofed by clients.
-	// This is the only fully trusted header when deployed behind Cloudflare.
-	const cfConnectingIP = c.req.header("CF-Connecting-IP");
-	if (cfConnectingIP) {
-		return cfConnectingIP;
-	}
-
-	// X-Forwarded-For is spoofable unless stripped by a trusted reverse proxy.
-	// Only use as a fallback (e.g. non-Cloudflare environments like local dev).
-	const xForwardedFor = c.req.header("X-Forwarded-For");
-	if (xForwardedFor) {
-		return xForwardedFor.split(",")[0]?.trim() ?? null;
-	}
-
-	return c.req.header("X-Real-IP") ?? null;
-}
-
 function checkForSpam(text: string): boolean {
 	const lowerText = text.toLowerCase();
 	return spamKeywords.some((keyword) => lowerText.includes(keyword));
@@ -219,7 +200,7 @@ async function updateProviderRequestStatus(
 
 publicContact.openapi(submitEnterpriseContact, async (c) => {
 	const validatedData = c.req.valid("json");
-	const ipAddress = extractClientIP(c);
+	const ipAddress = getTrustedClientIp(c);
 	const userAgent = c.req.header("User-Agent") ?? null;
 
 	let submission: { id: string };
@@ -280,8 +261,9 @@ publicContact.openapi(submitEnterpriseContact, async (c) => {
 		}
 	}
 
-	// Use IP when available; fall back to email so unknown-IP requests don't
-	// share a single rate-limit bucket that any client can exhaust.
+	// Key on the trusted client IP (getTrustedClientIp), which the caller cannot
+	// forge, so rotating X-Forwarded-For no longer mints a fresh bucket per
+	// request. Fall back to email only when no IP can be resolved at all.
 	const rateLimitKey = ipAddress ?? `email:${validatedData.email}`;
 	const canSubmit = await checkRateLimit(rateLimitKey);
 	if (!canSubmit) {
@@ -535,7 +517,7 @@ const submitProviderContact = createRoute({
 
 publicContact.openapi(submitProviderContact, async (c) => {
 	const validatedData = c.req.valid("json");
-	const ipAddress = extractClientIP(c);
+	const ipAddress = getTrustedClientIp(c);
 	const userAgent = c.req.header("User-Agent") ?? null;
 
 	let submission: { id: string };
@@ -599,6 +581,9 @@ publicContact.openapi(submitProviderContact, async (c) => {
 		}
 	}
 
+	// Key on the trusted client IP (getTrustedClientIp), which the caller cannot
+	// forge, so rotating X-Forwarded-For no longer mints a fresh bucket per
+	// request. Fall back to email only when no IP can be resolved at all.
 	const rateLimitKey = ipAddress ?? `email:${validatedData.email}`;
 	const canSubmit = await checkRateLimit(rateLimitKey);
 	if (!canSubmit) {

--- a/apps/api/src/routes/public-newsletter.ts
+++ b/apps/api/src/routes/public-newsletter.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
 import { redisClient } from "@/auth/config.js";
+import { getTrustedClientIp } from "@/lib/client-ip.js";
 
 import { logger } from "@llmgateway/logger";
 
@@ -15,22 +16,6 @@ const RESEND_TIMEOUT_MS = 10_000;
 
 const resendApiKey = process.env.RESEND_API_KEY;
 const resendNewsletterTopicId = process.env.RESEND_NEWSLETTER_TOPIC_ID;
-
-function extractClientIP(c: {
-	req: { header: (name: string) => string | undefined };
-}): string | null {
-	const cfConnectingIP = c.req.header("CF-Connecting-IP");
-	if (cfConnectingIP) {
-		return cfConnectingIP;
-	}
-
-	const xForwardedFor = c.req.header("X-Forwarded-For");
-	if (xForwardedFor) {
-		return xForwardedFor.split(",")[0]?.trim() ?? null;
-	}
-
-	return c.req.header("X-Real-IP") ?? null;
-}
 
 async function checkRateLimit(identifier: string): Promise<boolean> {
 	const key = `newsletter_rate_limit:${identifier}`;
@@ -102,8 +87,10 @@ const subscribeRoute = createRoute({
 
 publicNewsletter.openapi(subscribeRoute, async (c) => {
 	const { email } = c.req.valid("json");
-	const ipAddress = extractClientIP(c);
+	const ipAddress = getTrustedClientIp(c);
 
+	// Key on the trusted client IP so a spoofed X-Forwarded-For cannot mint a
+	// fresh rate-limit bucket per request; fall back to email when absent.
 	const rateLimitKey = ipAddress ?? `email:${email}`;
 	const canSubmit = await checkRateLimit(rateLimitKey);
 	if (!canSubmit) {


### PR DESCRIPTION
## The abuse

The public **provider-listing** form (`POST /public/contact/provider`) — plus the enterprise-contact and newsletter-subscribe routes — gate spam with a per-IP rate limit (max 3/hour). But `extractClientIP()` resolved the client IP from the **client-controlled** `X-Forwarded-For` / `X-Real-IP` headers, and the rate-limit key was `ipAddress ?? email` — i.e. it *preferred* that spoofable value.

So an attacker just sends a different forged `X-Forwarded-For` on each request (`10.0.0.6`, `10.0.0.7`, …), gets a **fresh rate-limit bucket every time**, and bypasses the limit entirely — flooding the endpoint with unpaid listing requests, team emails, and Discord pings.

This is exactly what the report screenshot shows:
- `SpamProvider1-5` share one real IP → the limiter correctly **rejects** 4 of them.
- `SpamXFF6-10` each carry a forged `10.0.0.x` IP → all sail through as **Delivered**.

The listing fee is a separate Stripe checkout, so an evaded rate limit also means uncapped *unpaid* submissions (`Fee: unpaid`).

## The fix

New `apps/api/src/lib/client-ip.ts` → `getTrustedClientIp(c)` that only returns values the caller cannot forge in this deployment:

1. **`CF-Connecting-IP`** — set/overwritten by Cloudflare at the edge (the codebase's established trusted header, see `apps/api/src/auth/config.ts`).
2. **Real TCP peer address** via `@hono/node-server`'s `getConnInfo` — the actual socket source; in a direct-to-origin request this is the attacker's real IP and is unspoofable.
3. **`X-Forwarded-For` / `X-Real-IP`** — trusted **only** when the operator opts in with `TRUST_PROXY_HEADERS=true` (self-hosters who front the API with a header-sanitizing proxy). Never trusted by default.

The contact and newsletter rate limiters now key on this trusted IP, so rotating a forged header collapses to a single bucket and the limit holds. Storing it also means the admin table shows the real source instead of the spoofed `10.0.0.x`.

## Scope note

`apps/gateway`'s IAM `client-ip.ts` and `public-chat-support.ts` share the same header-trust pattern, but chat-support already has a global hourly backstop (300/hr) that a rotating-IP attack can't bypass, so it's far less exposed. Migrating those to the shared helper is a sensible follow-up; kept out of this PR to stay focused and low-risk.

## Testing

- `apps/api/src/lib/client-ip.spec.ts` (8 tests) — proves spoofable headers are ignored by default, that rotated forged `X-Forwarded-For` values all resolve to the same key, `CF-Connecting-IP` always wins, and `TRUST_PROXY_HEADERS` opt-in behaves.
- `turbo run build --filter=api` — typecheck/build clean.
- `pnpm format` clean.

https://claude.ai/code/session_01CU87R448HGmpmcfMhLj7U1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client IP detection for contact and newsletter rate limiting.
  - Prioritizes trusted Cloudflare client IP information and safely falls back when no reliable IP is available.
  - Prevents spoofed proxy headers from affecting rate-limit tracking by default.
  - Added optional configuration for deployments that securely manage proxy headers.

- **Tests**
  - Added coverage for trusted IP precedence, proxy-header handling, fallback behavior, and case-insensitive headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->