### PR TITLE
fix(api): handle empty project update body

### DIFF
--- a/apps/api/src/routes/projects.spec.ts
+++ b/apps/api/src/routes/projects.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+describe("projects route", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: "test-org-id",
+			name: "Test Organization",
+			billingEmail: "test@example.com",
+		});
+
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: "test-org-id",
+			role: "owner",
+		});
+
+		await db.insert(tables.project).values({
+			id: "test-project-id",
+			name: "Test Project",
+			organizationId: "test-org-id",
+		});
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("PATCH /projects/{id} with an empty body is a no-op", async () => {
+		const response = await app.request("/projects/test-project-id", {
+			method: "PATCH",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({}),
+		});
+
+		expect(response.status).toBe(200);
+
+		const json = await response.json();
+		expect(json.project.id).toBe("test-project-id");
+		expect(json.project.name).toBe("Test Project");
+	});
+
+	test("PATCH /projects/{id} updates provided fields", async () => {
+		const response = await app.request("/projects/test-project-id", {
+			method: "PATCH",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({ name: "Renamed Project" }),
+		});
+
+		expect(response.status).toBe(200);
+
+		const json = await response.json();
+		expect(json.project.name).toBe("Renamed Project");
+
+		const project = await db.query.project.findFirst({
+			where: {
+				id: {
+					eq: "test-project-id",
+				},
+			},
+		});
+		expect(project?.name).toBe("Renamed Project");
+	});
+});

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -360,6 +360,15 @@ projects.openapi(updateProject, async (c) => {
 		updateData.allowedOrigins = normalizedAllowedOrigins;
 	}
 
+	// An empty PATCH body is a valid no-op; drizzle throws "No values to set"
+	// on an empty update, so skip the query and return the project unchanged.
+	if (Object.keys(updateData).length === 0) {
+		return c.json({
+			message: "Project settings updated successfully",
+			project,
+		});
+	}
+
 	// Roll through the cached client so its onMutate invalidates the gateway's
 	// cached project lookups (Drizzle cache + SWR mirror) for the project table.
 	// Otherwise settings like defaultRoutingStrategy/mode/caching would keep


### PR DESCRIPTION
## Summary

Production error (`Error: No values to set` at `apps/api/src/routes/projects.ts:369`, trace `601f5a31999e4a25a1ffb307b3060f47`): the `updateProjectSchema` for `PATCH /projects/{id}` has all-optional fields, so an empty request body passes validation, leaves `updateData` empty, and drizzle's `.set({})` throws an unhandled 500.

## Fix

Treat an empty update as a no-op: skip the DB update and return the already-fetched project unchanged with a 200, matching the existing guard pattern in `dev-plans.ts`.

## Tests

Added `apps/api/src/routes/projects.spec.ts`:
- empty `PATCH {}` returns 200 with the unchanged project (fails with a 500 without the fix — verified by stashing the fix)
- a normal field update still persists

`pnpm test:unit` (scoped to the new spec), `pnpm format`, and a full `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project updates with an empty request now complete successfully without changing project details.
  * Project renaming continues to update and return the revised project information correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->