### PR TITLE
feat(gateway): read pi session-id headers

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -681,11 +681,16 @@ anthropic.openapi(messages, async (c) => {
 	// Get user-agent for forwarding
 	const userAgent = c.req.header("User-Agent") ?? "";
 
-	// Sticky-routing session id: prefer an explicit header, otherwise derive it
-	// from Anthropic's metadata.user_id (Claude Code embeds the session id here)
-	// and forward it to the chat completions endpoint, which routes on it.
+	// Sticky-routing session id: prefer an explicit header (x-session-id, or the
+	// session-affinity/session-id headers coding agents such as pi attach),
+	// otherwise derive it from Anthropic's metadata.user_id (Claude Code embeds
+	// the session id here) and forward it to the chat completions endpoint, which
+	// routes on it.
 	const sessionId =
 		c.req.header("x-session-id")?.trim() ||
+		c.req.header("x-session-affinity")?.trim() ||
+		c.req.header("session_id")?.trim() ||
+		c.req.header("session-id")?.trim() ||
 		extractAnthropicSessionId(anthropicRequest.metadata?.user_id);
 
 	// Make internal request to the existing chat completions endpoint using app.request()

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -4745,6 +4745,49 @@ describe("api", () => {
 		});
 	});
 
+	test("/v1/chat/completions records pi session_id header as sessionId", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+				// pi's OpenAI-completions session-affinity header set
+				session_id: "pi-session-42",
+				"x-client-request-id": "pi-session-42",
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				messages: [
+					{
+						role: "user",
+						content: "Hello from pi!",
+					},
+				],
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].sessionId).toBe("pi-session-42");
+	});
+
 	test("Deactivated provider falls back to active provider", async () => {
 		// Use fake timers to set the date between the two deactivation dates:
 		// google-ai-studio deactivatedAt: 2026-01-17

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1482,13 +1482,17 @@ chat.openapi(completions, async (c) => {
 	let servedServiceTier: "flex" | "priority" | null = null;
 
 	// Sticky-routing session key, in priority order: the explicit x-session-id
-	// header, then x-session-affinity (sent by coding agents such as opencode),
-	// then the OpenAI-native body fields (prompt_cache_key, then user). When
-	// present, provider selection pins this session to a single provider to keep
-	// upstream prompt caches warm.
+	// header, then the session-affinity/session-id headers coding agents attach
+	// to identify a conversation (opencode sends x-session-affinity; pi sends
+	// x-session-affinity plus session_id/session-id, all carrying the same
+	// session id), then the OpenAI-native body fields (prompt_cache_key, then
+	// user). When present, provider selection pins this session to a single
+	// provider to keep upstream prompt caches warm.
 	const sessionId =
 		c.req.header("x-session-id")?.trim() ||
 		c.req.header("x-session-affinity")?.trim() ||
+		c.req.header("session_id")?.trim() ||
+		c.req.header("session-id")?.trim() ||
 		prompt_cache_key ||
 		user ||
 		undefined;


### PR DESCRIPTION
## Summary

The [pi coding agent](https://github.com/earendil-works/pi) attaches session-affinity headers to identify a conversation so providers keep prompt caches warm across turns. Depending on the API path, pi sends these headers, all carrying the **same** session id (`options.sessionId`):

- **OpenAI-completions** (`/v1/chat/completions`, what LLM Gateway exposes): `session_id`, `x-client-request-id`, `x-session-affinity` — sent when the provider's `compat.sendSessionAffinityHeaders` is enabled ([pi-ai `openai-completions.ts`](https://github.com/earendil-works/pi/blob/main/packages/ai/src/api/openai-completions.ts)).
- **Codex responses**: `session-id`, `x-client-request-id`.
- **Anthropic messages**: `x-session-affinity`.

The gateway already reads `x-session-affinity`, but **not** `session_id` / `session-id`, so pi's session id went unrecognized on paths where only those were sent. This adds both to the sticky-routing session precedence in the chat completions and Anthropic entrypoints.

`x-client-request-id` is intentionally **not** consumed: its name is per-request semantics and other clients set it to a unique-per-request value, which would fragment sticky routing and analytics.

## Changes

- `apps/gateway/src/chat/chat.ts` — add `session_id` and `session-id` to the session-key precedence (after `x-session-id` / `x-session-affinity`, before the OpenAI body fields).
- `apps/gateway/src/anthropic/anthropic.ts` — recognize `x-session-affinity`, `session_id`, and `session-id` on the Anthropic-compatible entrypoint (it previously only read `x-session-id` + Claude Code metadata), and forward the resolved id as before.
- `apps/gateway/src/api.spec.ts` — new test asserting a request with pi's `session_id` header lands in `log.sessionId`.

## Notes for users

pi does **not** send these headers by default to a generic OpenAI-compatible provider (its bundled OpenRouter/custom-provider presets default `sendSessionAffinityHeaders: false`). To have pi emit them to LLM Gateway, either set `compat.sendSessionAffinityHeaders: true` on the provider config, or add the header via pi's `before_provider_headers` extension hook (`event.headers["x-session-id"] = ctx.sessionManager.getSessionId()`). This PR ensures the gateway captures the id once pi sends it. Pi is already recognized as a source (`pi-agent`) for attribution.

## Testing

- `pnpm turbo run build --filter=gateway` passes
- New + adjacent session/sticky-routing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)