### PR TITLE
fix(ui): make dialog content scrollable when overflowing

### DIFF
--- a/apps/ui/src/lib/components/dialog.tsx
+++ b/apps/ui/src/lib/components/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
## Problem

On small / mobile viewports, dialogs whose content is taller than the screen (e.g. the **Create API Key** dialog with the recurring usage limit fields expanded) overflow off-screen with no way to scroll to the footer buttons.

The shared `DialogContent` is fixed and vertically centered (`top-[50%] translate-y-[-50%]`) but had no `max-height` or overflow handling, so the top and bottom of tall dialogs got clipped by the viewport.

## Fix

Add `max-h-[calc(100dvh-2rem)]` and `overflow-y-auto` to the shared `DialogContent` in `apps/ui/src/lib/components/dialog.tsx`. Any dialog taller than the viewport now scrolls internally instead of being clipped.

This is a single change at the root component, so it benefits every dialog in the UI app. Dialogs that already set their own `max-h`/overflow (via `cn()` / tailwind-merge) continue to override the default.

## Testing

- `pnpm format` — clean
- `turbo run build --filter=ui` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7pJYcDf1UxyobsvEjJeUR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog usability by constraining its height to the viewport and enabling vertical scrolling for longer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->