### PR TITLE
feat(ui): redesign dashboard and activity filters

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
@@ -1,5 +1,4 @@
 import { RecentLogs } from "@/components/activity/recent-logs";
-import { Card, CardContent } from "@/lib/components/card";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -96,21 +95,19 @@ export default async function ActivityPage({
 	return (
 		<div className="flex flex-col">
 			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
-				<h2 className="text-3xl font-bold tracking-tight">Activity Logs</h2>
-				<p>Your recent API requests and system events</p>
-				<div className="space-y-4">
-					<Card>
-						<CardContent>
-							<RecentLogs
-								initialData={initialLogsData ?? undefined}
-								providerOptions={providerOptions}
-								modelOptions={modelOptions}
-								projectId={projectId}
-								orgId={orgId}
-							/>
-						</CardContent>
-					</Card>
+				<div>
+					<h2 className="text-3xl font-bold tracking-tight">Activity Logs</h2>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Your recent API requests and system events
+					</p>
 				</div>
+				<RecentLogs
+					initialData={initialLogsData ?? undefined}
+					providerOptions={providerOptions}
+					modelOptions={modelOptions}
+					projectId={projectId}
+					orgId={orgId}
+				/>
 			</div>
 		</div>
 	);

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
@@ -1,9 +1,7 @@
 import { subDays, format } from "date-fns";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { DashboardClient } from "@/components/dashboard/dashboard-client";
-import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { ActivitT } from "@/types/activity";
@@ -52,14 +50,7 @@ export default async function Dashboard({
 		},
 	);
 
-	const cookieStore = await cookies();
-	const devPassCollapsed =
-		cookieStore.get(DEVPASS_CARD_COLLAPSED_COOKIE)?.value === "1";
-
 	return (
-		<DashboardClient
-			initialActivityData={initialActivityData ?? undefined}
-			initialDevPassCollapsed={devPassCollapsed}
-		/>
+		<DashboardClient initialActivityData={initialActivityData ?? undefined} />
 	);
 }

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Check, ChevronsUpDown, RefreshCw, Sparkles, X } from "lucide-react";
+import {
+	Check,
+	ChevronsUpDown,
+	RefreshCw,
+	Search,
+	SlidersHorizontal,
+	Sparkles,
+	X,
+} from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
 	useCallback,
@@ -18,6 +26,7 @@ import {
 	type DateRange,
 	DateRangeSelect,
 } from "@/components/date-range-select";
+import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 import {
 	Command,
@@ -177,6 +186,7 @@ export function RecentLogs({
 	const searchParams = useSearchParams();
 	const [modelPickerOpen, setModelPickerOpen] = useState(false);
 	const [modelSearch, setModelSearch] = useState("");
+	const [dateRangeResetKey, setDateRangeResetKey] = useState(0);
 
 	// Initialize state from URL parameters
 	const [dateRange, setDateRange] = useState<DateRange | undefined>();
@@ -453,6 +463,42 @@ export function RecentLogs({
 		[model, modelOptions, updateUrlWithFilters],
 	);
 
+	const activeFilterCount = [
+		dateRange,
+		unifiedFinishReason,
+		provider,
+		model,
+		apiKeyId,
+		customHeaderKey.trim() || undefined,
+		customHeaderValue.trim() || undefined,
+		sessionId.trim() || undefined,
+	].filter(Boolean).length;
+
+	const clearAllFilters = useCallback(() => {
+		isFilteringRef.current = true;
+		scrollPositionRef.current = window.scrollY;
+		setDateRange(undefined);
+		setDateRangeResetKey((key) => key + 1);
+		setUnifiedFinishReason(undefined);
+		setProvider(undefined);
+		setModel(undefined);
+		setApiKeyId(undefined);
+		setCustomHeaderKey("");
+		setCustomHeaderValue("");
+		setSessionId("");
+		updateUrlWithFilters({
+			startDate: undefined,
+			endDate: undefined,
+			unifiedFinishReason: undefined,
+			provider: undefined,
+			model: undefined,
+			apiKeyId: undefined,
+			customHeaderKey: undefined,
+			customHeaderValue: undefined,
+			sessionId: undefined,
+		});
+	}, [updateUrlWithFilters]);
+
 	if (!projectId) {
 		return (
 			<div className="py-8 text-center text-muted-foreground">
@@ -466,190 +512,239 @@ export function RecentLogs({
 			className="space-y-4 max-w-full overflow-hidden"
 			style={{ scrollBehavior: "auto" }}
 		>
-			<div className="flex flex-wrap gap-2 mb-4 sticky top-0 bg-background z-10 py-2">
-				<DateRangeSelect onChange={handleDateRangeChange} />
-
-				<Select
-					onValueChange={handleFilterChange(
-						"unifiedFinishReason",
-						setUnifiedFinishReason,
-					)}
-					value={unifiedFinishReason ?? "all"}
-				>
-					<SelectTrigger className="w-[200px]">
-						<SelectValue placeholder="Filter by unified reason" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="all">All unified reasons</SelectItem>
-						{Object.entries(UnifiedFinishReason).map(([key, value]) => (
-							<SelectItem key={value} value={value}>
-								{key
-									.toLowerCase()
-									.replace(/_/g, " ")
-									.replace(/\b\w/g, (l) => l.toUpperCase())}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-
-				<Select onValueChange={handleProviderChange} value={provider ?? "all"}>
-					<SelectTrigger className="w-[160px]">
-						<SelectValue placeholder="Filter by provider" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="all">All providers</SelectItem>
-						{providerOptions.map((option) => (
-							<SelectItem key={option.id} value={option.id}>
-								{option.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-
-				<Select
-					onValueChange={handleFilterChange("apiKeyId", setApiKeyId)}
-					value={apiKeyId ?? "all"}
-				>
-					<SelectTrigger className="w-[200px]">
-						<SelectValue placeholder="Filter by API key" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="all">All API keys</SelectItem>
-						{apiKeyOptions.map((option) => (
-							<SelectItem key={option.id} value={option.id}>
-								{option.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-
-				<Popover open={modelPickerOpen} onOpenChange={setModelPickerOpen}>
-					<PopoverTrigger asChild>
-						<Button
-							variant="outline"
-							role="combobox"
-							aria-expanded={modelPickerOpen}
-							className="w-[260px] justify-between"
-						>
-							<span className="truncate">
-								{selectedModelOption?.label ?? model ?? "Filter by model"}
-							</span>
-							<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-						</Button>
-					</PopoverTrigger>
-					<PopoverContent className="w-[320px] p-0" align="start">
-						<Command shouldFilter={false}>
-							<CommandInput
-								placeholder="Search models..."
-								value={modelSearch}
-								onValueChange={setModelSearch}
-							/>
-							<CommandList>
-								<CommandEmpty>No models found.</CommandEmpty>
-								<CommandItem
-									value="all"
-									onSelect={() => {
-										handleFilterChange("model", setModel)("all");
-										setModelPickerOpen(false);
-										setModelSearch("");
-									}}
+			<div className="sticky top-0 z-10 pb-1 pt-1">
+				<div className="rounded-xl border bg-card/95 p-3 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/85">
+					<div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+						<div className="flex items-center gap-2">
+							<SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+							<span className="text-sm font-medium">Filters</span>
+							{activeFilterCount > 0 && (
+								<Badge
+									variant="secondary"
+									className="h-5 rounded-full px-2 text-xs font-normal"
 								>
-									<Check
-										className={cn(
-											"h-4 w-4",
-											!model ? "opacity-100" : "opacity-0",
-										)}
-									/>
-									All models
-								</CommandItem>
-								{filteredModelOptions.map((option) => (
-									<CommandItem
-										key={option.id}
-										value={`${option.id} ${option.label} ${option.aliases.join(" ")}`}
-										onSelect={() => {
-											handleFilterChange("model", setModel)(option.id);
-											setModelPickerOpen(false);
-											setModelSearch("");
-										}}
-									>
-										<Check
-											className={cn(
-												"h-4 w-4",
-												model === option.id ? "opacity-100" : "opacity-0",
-											)}
-										/>
-										<div className="flex min-w-0 flex-col">
-											<span className="truncate">{option.label}</span>
-											{option.label !== option.id ? (
-												<span className="truncate text-xs text-muted-foreground">
-													{option.id}
-												</span>
-											) : null}
-										</div>
-									</CommandItem>
+									{activeFilterCount} active
+								</Badge>
+							)}
+						</div>
+						<div className="flex items-center gap-1.5">
+							{activeFilterCount > 0 && (
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									onClick={clearAllFilters}
+									className="h-8 gap-1.5 text-muted-foreground"
+								>
+									<X className="h-3.5 w-3.5" />
+									Reset
+								</Button>
+							)}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => void refetch()}
+								disabled={isLoading || isRefetching || isFetchingNextPage}
+								className="h-8 gap-1.5"
+							>
+								<RefreshCw
+									className={cn("h-3.5 w-3.5", isRefetching && "animate-spin")}
+								/>
+								{isRefetching ? "Refreshing..." : "Refresh"}
+							</Button>
+						</div>
+					</div>
+
+					<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+						<DateRangeSelect
+							key={dateRangeResetKey}
+							onChange={handleDateRangeChange}
+							className="w-full"
+						/>
+
+						<Select
+							onValueChange={handleProviderChange}
+							value={provider ?? "all"}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Filter by provider" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All providers</SelectItem>
+								{providerOptions.map((option) => (
+									<SelectItem key={option.id} value={option.id}>
+										{option.label}
+									</SelectItem>
 								))}
-							</CommandList>
-						</Command>
-					</PopoverContent>
-				</Popover>
+							</SelectContent>
+						</Select>
 
-				<Input
-					placeholder="Custom header key (e.g., uid)"
-					value={customHeaderKey}
-					onChange={(e) => {
-						isFilteringRef.current = true;
-						scrollPositionRef.current = window.scrollY;
-						setCustomHeaderKey(e.target.value);
-						// Update URL immediately
-						updateUrlWithFilters({
-							customHeaderKey: e.target.value ?? undefined,
-						});
-					}}
-					className="w-[200px]"
-				/>
+						<Popover open={modelPickerOpen} onOpenChange={setModelPickerOpen}>
+							<PopoverTrigger asChild>
+								<Button
+									variant="outline"
+									role="combobox"
+									aria-expanded={modelPickerOpen}
+									className={cn(
+										"w-full justify-between font-normal",
+										!model && "text-muted-foreground",
+									)}
+								>
+									<span className="truncate">
+										{selectedModelOption?.label ?? model ?? "All models"}
+									</span>
+									<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+								</Button>
+							</PopoverTrigger>
+							<PopoverContent className="w-[320px] p-0" align="start">
+								<Command shouldFilter={false}>
+									<CommandInput
+										placeholder="Search models..."
+										value={modelSearch}
+										onValueChange={setModelSearch}
+									/>
+									<CommandList>
+										<CommandEmpty>No models found.</CommandEmpty>
+										<CommandItem
+											value="all"
+											onSelect={() => {
+												handleFilterChange("model", setModel)("all");
+												setModelPickerOpen(false);
+												setModelSearch("");
+											}}
+										>
+											<Check
+												className={cn(
+													"h-4 w-4",
+													!model ? "opacity-100" : "opacity-0",
+												)}
+											/>
+											All models
+										</CommandItem>
+										{filteredModelOptions.map((option) => (
+											<CommandItem
+												key={option.id}
+												value={`${option.id} ${option.label} ${option.aliases.join(" ")}`}
+												onSelect={() => {
+													handleFilterChange("model", setModel)(option.id);
+													setModelPickerOpen(false);
+													setModelSearch("");
+												}}
+											>
+												<Check
+													className={cn(
+														"h-4 w-4",
+														model === option.id ? "opacity-100" : "opacity-0",
+													)}
+												/>
+												<div className="flex min-w-0 flex-col">
+													<span className="truncate">{option.label}</span>
+													{option.label !== option.id ? (
+														<span className="truncate text-xs text-muted-foreground">
+															{option.id}
+														</span>
+													) : null}
+												</div>
+											</CommandItem>
+										))}
+									</CommandList>
+								</Command>
+							</PopoverContent>
+						</Popover>
 
-				<Input
-					placeholder="Custom header value (e.g., 12345)"
-					value={customHeaderValue}
-					onChange={(e) => {
-						isFilteringRef.current = true;
-						scrollPositionRef.current = window.scrollY;
-						setCustomHeaderValue(e.target.value);
-						// Update URL immediately
-						updateUrlWithFilters({
-							customHeaderValue: e.target.value ?? undefined,
-						});
-					}}
-					className="w-[200px]"
-				/>
+						<Select
+							onValueChange={handleFilterChange("apiKeyId", setApiKeyId)}
+							value={apiKeyId ?? "all"}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Filter by API key" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All API keys</SelectItem>
+								{apiKeyOptions.map((option) => (
+									<SelectItem key={option.id} value={option.id}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 
-				<Input
-					placeholder="Session ID"
-					value={sessionId}
-					onChange={(e) => {
-						isFilteringRef.current = true;
-						scrollPositionRef.current = window.scrollY;
-						setSessionId(e.target.value);
-						// Update URL immediately
-						updateUrlWithFilters({
-							sessionId: e.target.value ?? undefined,
-						});
-					}}
-					className="w-[200px]"
-				/>
+						<Select
+							onValueChange={handleFilterChange(
+								"unifiedFinishReason",
+								setUnifiedFinishReason,
+							)}
+							value={unifiedFinishReason ?? "all"}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Filter by unified reason" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All unified reasons</SelectItem>
+								{Object.entries(UnifiedFinishReason).map(([key, value]) => (
+									<SelectItem key={value} value={value}>
+										{key
+											.toLowerCase()
+											.replace(/_/g, " ")
+											.replace(/\b\w/g, (l) => l.toUpperCase())}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 
-				<Button
-					type="button"
-					variant="outline"
-					onClick={() => void refetch()}
-					disabled={isLoading || isRefetching || isFetchingNextPage}
-					className="gap-2"
-				>
-					<RefreshCw
-						className={cn("h-4 w-4", isRefetching && "animate-spin")}
-					/>
-					{isRefetching ? "Refreshing..." : "Refresh"}
-				</Button>
+						<div className="relative">
+							<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								placeholder="Header key (e.g. uid)"
+								value={customHeaderKey}
+								onChange={(e) => {
+									isFilteringRef.current = true;
+									scrollPositionRef.current = window.scrollY;
+									setCustomHeaderKey(e.target.value);
+									updateUrlWithFilters({
+										customHeaderKey: e.target.value ?? undefined,
+									});
+								}}
+								className="w-full pl-8"
+							/>
+						</div>
+
+						<div className="relative">
+							<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								placeholder="Header value (e.g. 12345)"
+								value={customHeaderValue}
+								onChange={(e) => {
+									isFilteringRef.current = true;
+									scrollPositionRef.current = window.scrollY;
+									setCustomHeaderValue(e.target.value);
+									updateUrlWithFilters({
+										customHeaderValue: e.target.value ?? undefined,
+									});
+								}}
+								className="w-full pl-8"
+							/>
+						</div>
+
+						<div className="relative">
+							<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								placeholder="Session ID"
+								value={sessionId}
+								onChange={(e) => {
+									isFilteringRef.current = true;
+									scrollPositionRef.current = window.scrollY;
+									setSessionId(e.target.value);
+									updateUrlWithFilters({
+										sessionId: e.target.value ?? undefined,
+									});
+								}}
+								className="w-full pl-8"
+							/>
+						</div>
+					</div>
+				</div>
 			</div>
 
 			{isLoading ? (

--- a/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
+++ b/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
@@ -361,10 +361,13 @@ export function ApiKeyLimitFields({
 					Current period usage resets when the configured window elapses.
 				</div>
 				{value.periodUsageLimitEnabled && (
-					<div className="grid gap-3 md:grid-cols-[1fr_132px_132px]">
+					<div className="grid items-end gap-3 md:grid-cols-[1fr_132px_132px]">
 						<div className="space-y-2">
-							<Label htmlFor={`${idPrefix}-period-limit`}>
-								Recurring usage limit
+							<Label
+								className="whitespace-nowrap"
+								htmlFor={`${idPrefix}-period-limit`}
+							>
+								Limit
 							</Label>
 							<div className="relative">
 								<span className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
@@ -399,30 +402,32 @@ export function ApiKeyLimitFields({
 						</div>
 						<div className="space-y-2">
 							<Label htmlFor={`${idPrefix}-duration-unit`}>Unit</Label>
-							<Select
-								value={value.periodUsageDurationUnit}
-								onValueChange={(nextValue) =>
-									updateValue(
-										"periodUsageDurationUnit",
-										nextValue as ApiKeyPeriodDurationUnit,
-									)
-								}
-							>
-								<SelectTrigger
-									id={`${idPrefix}-duration-unit`}
-									className="w-full"
+							<div>
+								<Select
+									value={value.periodUsageDurationUnit}
+									onValueChange={(nextValue) =>
+										updateValue(
+											"periodUsageDurationUnit",
+											nextValue as ApiKeyPeriodDurationUnit,
+										)
+									}
 								>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{apiKeyPeriodDurationUnits.map((unit) => (
-										<SelectItem key={unit} value={unit}>
-											{unit[0]?.toUpperCase()}
-											{unit.slice(1)}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+									<SelectTrigger
+										id={`${idPrefix}-duration-unit`}
+										className="w-full"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{apiKeyPeriodDurationUnits.map((unit) => (
+											<SelectItem key={unit} value={unit}>
+												{unit[0]?.toUpperCase()}
+												{unit.slice(1)}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
 						</div>
 					</div>
 				)}

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, subDays } from "date-fns";
+import { addDays, differenceInCalendarDays, format, subDays } from "date-fns";
 import {
 	CreditCard,
 	Zap,
@@ -19,6 +19,7 @@ import {
 	BookOpen,
 	FlaskConical,
 	MessageSquare,
+	Settings,
 	Wallet,
 	Gift,
 } from "lucide-react";
@@ -29,7 +30,6 @@ import { useEffect } from "react";
 import { CreateApiKeyDialog } from "@/components/api-keys/create-api-key-dialog";
 import { TopUpCreditsButton } from "@/components/credits/top-up-credits-dialog";
 import { CostBreakdownCard } from "@/components/dashboard/cost-breakdown-card";
-import { DevPassCard } from "@/components/dashboard/devpass-card";
 import { ErrorsReliabilityCard } from "@/components/dashboard/errors-reliability-card";
 import { MetricCard } from "@/components/dashboard/metric-card";
 import { Overview } from "@/components/dashboard/overview";
@@ -49,21 +49,15 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/lib/components/select";
+import { Skeleton } from "@/lib/components/skeleton";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { cn } from "@/lib/utils";
 
 import type { ActivitT } from "@/types/activity";
 
 interface DashboardClientProps {
 	initialActivityData?: ActivitT;
-	initialDevPassCollapsed?: boolean;
 }
 
 function formatCredits(credits: number) {
@@ -73,10 +67,134 @@ function formatCredits(credits: number) {
 	});
 }
 
-export function DashboardClient({
-	initialActivityData,
-	initialDevPassCollapsed,
-}: DashboardClientProps) {
+function formatTokens(tokens: number) {
+	if (tokens >= 1_000_000) {
+		return `${(tokens / 1_000_000).toFixed(1)}M`;
+	}
+	if (tokens >= 1_000) {
+		return `${(tokens / 1_000).toFixed(1)}k`;
+	}
+	return tokens.toString();
+}
+
+function pctChange(current: number, previous: number): number | null {
+	if (previous <= 0) {
+		return null;
+	}
+	return ((current - previous) / previous) * 100;
+}
+
+const quickActions = [
+	{
+		href: "api-keys",
+		icon: Key,
+		label: "API Keys",
+	},
+	{
+		href: "provider-keys",
+		icon: KeyRound,
+		label: "Provider Keys",
+	},
+	{
+		href: "activity",
+		icon: Activity,
+		label: "Activity",
+	},
+	{
+		href: "usage",
+		icon: BarChart3,
+		label: "Usage & Metrics",
+	},
+	{
+		href: "model-usage",
+		icon: ChartColumnBig,
+		label: "Model Usage",
+	},
+	{
+		href: "settings",
+		icon: Settings,
+		label: "Settings",
+	},
+] as const;
+
+function QuickActionsCard({
+	buildUrl,
+	buildOrgUrl,
+	className,
+}: {
+	buildUrl: (path?: string) => string;
+	buildOrgUrl: (path?: string) => string;
+	className?: string;
+}) {
+	return (
+		<Card className={className}>
+			<CardHeader>
+				<CardTitle>Quick Actions</CardTitle>
+				<CardDescription>Jump straight to common tasks</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="grid grid-cols-2 gap-2">
+					{quickActions.map((action) => (
+						<Link
+							key={action.href}
+							href={
+								action.href === "provider-keys"
+									? buildOrgUrl("org/provider-keys")
+									: buildUrl(action.href)
+							}
+							prefetch={true}
+							className="group flex items-center gap-3 rounded-lg border border-border/60 p-3 transition-colors hover:border-primary/40 hover:bg-accent/40"
+						>
+							<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground transition-colors group-hover:text-foreground">
+								<action.icon className="h-4 w-4" />
+							</div>
+							<span className="text-sm font-medium leading-tight">
+								{action.label}
+							</span>
+						</Link>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function StatCell({
+	icon: Icon,
+	label,
+	value,
+	sub,
+	isLoading,
+}: {
+	icon: React.ComponentType<{ className?: string }>;
+	label: string;
+	value: string;
+	sub?: string;
+	isLoading?: boolean;
+}) {
+	return (
+		<div className="min-w-0 lg:px-6 lg:first:pl-0 lg:last:pr-0">
+			<div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+				<Icon className="h-3.5 w-3.5" />
+				<span className="truncate">{label}</span>
+			</div>
+			{isLoading ? (
+				<Skeleton className="mt-2 h-6 w-20" />
+			) : (
+				<p className="mt-1.5 truncate text-lg font-semibold tabular-nums">
+					{value}
+				</p>
+			)}
+			{isLoading ? (
+				<Skeleton className="mt-1.5 h-3 w-24" />
+			) : sub ? (
+				<p className="mt-0.5 truncate text-xs text-muted-foreground">{sub}</p>
+			) : null}
+		</div>
+	);
+}
+
+export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const { buildUrl, buildOrgUrl } = useDashboardNavigation();
@@ -85,6 +203,10 @@ export function DashboardClient({
 	const { from, to } = getDateRangeFromParams(searchParams);
 	const fromStr = format(from, "yyyy-MM-dd");
 	const toStr = format(to, "yyyy-MM-dd");
+
+	const rangeDays = differenceInCalendarDays(to, from) + 1;
+	const prevFrom = subDays(from, rangeDays);
+	const prevTo = subDays(from, 1);
 
 	// Get metric type from URL params, default to "costs"
 	const metricParam = searchParams.get("metric");
@@ -128,6 +250,29 @@ export function DashboardClient({
 		},
 	);
 
+	// Previous period of the same length, used for trend deltas on the KPI
+	// cards. Skipped for very long ranges (e.g. "All time") where a
+	// comparison window is meaningless.
+	const { data: prevData } = api.useQuery(
+		"get",
+		"/activity",
+		{
+			params: {
+				query: {
+					from: format(prevFrom, "yyyy-MM-dd"),
+					to: format(prevTo, "yyyy-MM-dd"),
+					timezone: getBrowserTimeZone(),
+					...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
+				},
+			},
+		},
+		{
+			enabled: !!selectedProject?.id && rangeDays <= 366,
+			refetchOnWindowFocus: false,
+			staleTime: 1000 * 60 * 5, // 5 minutes
+		},
+	);
+
 	// Get API keys data to check plan limits
 	const { data: apiKeysData } = api.useQuery(
 		"get",
@@ -154,6 +299,7 @@ export function DashboardClient({
 	};
 
 	const activityData = data?.activity ?? [];
+	const prevActivityData = prevData?.activity ?? [];
 
 	const totalRequests =
 		activityData.reduce((sum, day) => sum + day.requestCount, 0) ?? 0;
@@ -183,6 +329,46 @@ export function DashboardClient({
 		activityData.reduce((sum, day) => sum + day.cachedTokens, 0) ?? 0;
 	const totalCachedInputCost =
 		activityData.reduce((sum, day) => sum + day.cachedInputCost, 0) ?? 0;
+	const totalErrors =
+		activityData.reduce((sum, day) => sum + day.errorCount, 0) ?? 0;
+	const totalCached =
+		activityData.reduce((sum, day) => sum + day.cacheCount, 0) ?? 0;
+
+	const prevRequests = prevActivityData.reduce(
+		(sum, day) => sum + day.requestCount,
+		0,
+	);
+	const prevCost = prevActivityData.reduce((sum, day) => sum + day.cost, 0);
+	const prevSavings = prevActivityData.reduce(
+		(sum, day) => sum + day.discountSavings,
+		0,
+	);
+
+	const cacheHitRate =
+		totalRequests > 0 ? (totalCached / totalRequests) * 100 : 0;
+	const avgCostPerRequest = totalRequests > 0 ? totalCost / totalRequests : 0;
+
+	// Day-by-day series for the KPI sparklines, with missing days filled as 0.
+	const { requestsTrend, costTrend } = (() => {
+		if (rangeDays > 400) {
+			const sorted = [...activityData].sort((a, b) =>
+				a.date < b.date ? -1 : 1,
+			);
+			return {
+				requestsTrend: sorted.map((day) => day.requestCount),
+				costTrend: sorted.map((day) => day.cost),
+			};
+		}
+		const byDate = new Map(activityData.map((day) => [day.date, day]));
+		const requests: number[] = [];
+		const costs: number[] = [];
+		for (let i = 0; i < rangeDays; i++) {
+			const day = byDate.get(format(addDays(from, i), "yyyy-MM-dd"));
+			requests.push(day?.requestCount ?? 0);
+			costs.push(day?.cost ?? 0);
+		}
+		return { requestsTrend: requests, costTrend: costs };
+	})();
 
 	const { mostUsedModel, mostUsedProvider } = (() => {
 		const modelCostMap = new Map<string, { cost: number; provider: string }>();
@@ -208,44 +394,6 @@ export function DashboardClient({
 		}
 		return { mostUsedModel: topModel, mostUsedProvider: topProvider };
 	})();
-
-	const quickActions = [
-		{
-			href: "api-keys",
-			icon: Key,
-			label: "Manage API Keys",
-		},
-		{
-			href: "provider-keys",
-			icon: KeyRound,
-			label: "Provider Keys",
-		},
-		{
-			href: "activity",
-			icon: Activity,
-			label: "View Activity",
-		},
-		{
-			href: "usage",
-			icon: BarChart3,
-			label: "Usage & Metrics",
-		},
-		{
-			href: "model-usage",
-			icon: ChartColumnBig,
-			label: "Model Usage",
-		},
-	] as const;
-
-	const formatTokens = (tokens: number) => {
-		if (tokens >= 1_000_000) {
-			return `${(tokens / 1_000_000).toFixed(1)}M`;
-		}
-		if (tokens >= 1_000) {
-			return `${(tokens / 1_000).toFixed(1)}k`;
-		}
-		return tokens.toString();
-	};
 
 	const isInitialLoading = !selectedOrganization;
 
@@ -336,12 +484,18 @@ export function DashboardClient({
 
 				<ReferralBanner />
 
-				<DevPassCard defaultCollapsed={initialDevPassCollapsed} />
-
-				<DateRangePicker buildUrl={buildUrl} />
+				<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+					<DateRangePicker buildUrl={buildUrl} />
+					{rangeDays <= 366 && (
+						<p className="text-xs text-muted-foreground">
+							Trends compare to {format(prevFrom, "MMM d")} –{" "}
+							{format(prevTo, "MMM d")}
+						</p>
+					)}
+				</div>
 
 				<div className="space-y-4">
-					<div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-4">
 						<MetricCard
 							label="Organization Credits"
 							value={`$${
@@ -355,31 +509,24 @@ export function DashboardClient({
 						/>
 						<MetricCard
 							label="Total Requests"
-							value={isLoading ? "Loading..." : totalRequests.toLocaleString()}
+							value={totalRequests.toLocaleString()}
 							subtitle={
-								isLoading
-									? "–"
-									: `${format(from, "MMM d")} - ${format(to, "MMM d")}${
-											activityData.length > 0
-												? ` • ${(
-														activityData.reduce(
-															(sum, day) => sum + day.cacheRate,
-															0,
-														) / activityData.length
-													).toFixed(1)}% cached`
-												: ""
-										}`
+								totalRequests > 0
+									? `${cacheHitRate.toFixed(1)}% cache hit rate • ${totalErrors.toLocaleString()} errors`
+									: `${format(from, "MMM d")} – ${format(to, "MMM d")}`
 							}
 							icon={<Zap className="h-4 w-4" />}
 							accent="purple"
+							delta={pctChange(totalRequests, prevRequests)}
+							trend={requestsTrend}
+							isLoading={isLoading}
 						/>
 						<MetricCard
-							label="Total Cost"
-							value={isLoading ? "Loading..." : `$${totalCost.toFixed(2)}`}
+							label="Total Spend"
+							value={`$${totalCost.toFixed(2)}`}
 							subtitle={
-								isLoading
-									? "–"
-									: `${format(from, "MMM d")} - ${format(to, "MMM d")}${
+								totalRequests > 0
+									? `avg $${avgCostPerRequest.toFixed(4)} per request${
 											totalRequestCost > 0
 												? ` • $${totalRequestCost.toFixed(2)} requests`
 												: ""
@@ -388,75 +535,60 @@ export function DashboardClient({
 												? ` • $${totalDataStorageCost.toFixed(4)} storage`
 												: ""
 										}`
+									: `${format(from, "MMM d")} – ${format(to, "MMM d")}`
 							}
 							icon={<CircleDollarSign className="h-4 w-4" />}
-							accent="purple"
+							accent="blue"
+							delta={pctChange(totalCost, prevCost)}
+							trend={costTrend}
+							isLoading={isLoading}
 						/>
 						<MetricCard
 							label="Total Savings"
-							value={isLoading ? "Loading..." : `$${totalSavings.toFixed(4)}`}
-							subtitle={
-								isLoading
-									? "–"
-									: `Discounts from ${format(from, "MMM d")} - ${format(to, "MMM d")}`
-							}
+							value={`$${totalSavings.toFixed(4)}`}
+							subtitle="Discounts this period"
 							icon={<TrendingDown className="h-4 w-4" />}
 							accent="green"
-						/>
-						<MetricCard
-							label="Input Tokens & Cost"
-							value={
-								isLoading
-									? "Loading..."
-									: `${formatTokens(totalInputTokens)} • $${totalInputCost.toFixed(2)}`
-							}
-							subtitle={isLoading ? "–" : "Prompt tokens and associated cost"}
-							icon={<ArrowDownToLine className="h-4 w-4" />}
-							accent="blue"
-						/>
-						<MetricCard
-							label="Output Tokens & Cost"
-							value={
-								isLoading
-									? "Loading..."
-									: `${formatTokens(totalOutputTokens)} • $${totalOutputCost.toFixed(2)}`
-							}
-							subtitle={
-								isLoading ? "–" : "Completion tokens and associated cost"
-							}
-							icon={<ArrowUpFromLine className="h-4 w-4" />}
-							accent="purple"
-						/>
-						<MetricCard
-							label="Cached Tokens & Cost"
-							value={
-								isLoading
-									? "Loading..."
-									: `${formatTokens(totalCachedTokens)} • $${totalCachedInputCost.toFixed(2)}`
-							}
-							subtitle={
-								isLoading
-									? "–"
-									: "Tokens and cost served from cache (if supported)"
-							}
-							icon={<Server className="h-4 w-4" />}
-							accent="green"
-							tooltip="Cached input tokens are already included in the Input Tokens & Cost total above. This card breaks them out so you can see how much of the input was served from cache."
-						/>
-						<MetricCard
-							label="Most Used Model"
-							value={isLoading ? "Loading..." : mostUsedModel || "—"}
-							subtitle={
-								isLoading
-									? "–"
-									: mostUsedProvider
-										? `Provider: ${mostUsedProvider}`
-										: `${format(from, "MMM d")} - ${format(to, "MMM d")}`
-							}
-							icon={<Crown className="h-4 w-4" />}
-							accent="blue"
+							delta={pctChange(totalSavings, prevSavings)}
+							isLoading={isLoading}
 						/>
 					</div>
+
+					<Card>
+						<CardContent className="grid grid-cols-2 gap-x-4 gap-y-5 lg:grid-cols-4 lg:gap-0 lg:divide-x lg:divide-border/60">
+							<StatCell
+								icon={ArrowDownToLine}
+								label="Input tokens"
+								value={formatTokens(totalInputTokens)}
+								sub={`$${totalInputCost.toFixed(2)} spend`}
+								isLoading={isLoading}
+							/>
+							<StatCell
+								icon={ArrowUpFromLine}
+								label="Output tokens"
+								value={formatTokens(totalOutputTokens)}
+								sub={`$${totalOutputCost.toFixed(2)} spend`}
+								isLoading={isLoading}
+							/>
+							<StatCell
+								icon={Server}
+								label="Cached tokens"
+								value={formatTokens(totalCachedTokens)}
+								sub={`$${totalCachedInputCost.toFixed(2)} • included in input`}
+								isLoading={isLoading}
+							/>
+							<StatCell
+								icon={Crown}
+								label="Top model"
+								value={mostUsedModel || "—"}
+								sub={
+									mostUsedProvider ? `via ${mostUsedProvider}` : "No usage yet"
+								}
+								isLoading={isLoading}
+							/>
+						</CardContent>
+					</Card>
+
 					{!isLoading && totalRequests < 5 ? (
 						<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
 							{(() => {
@@ -623,64 +755,42 @@ export function DashboardClient({
 									</Card>
 								);
 							})()}
-							<Card className="min-w-0 lg:col-span-3">
-								<CardHeader>
-									<CardTitle>Quick Actions</CardTitle>
-									<CardDescription>
-										Common tasks you might want to perform
-									</CardDescription>
-								</CardHeader>
-								<CardContent className="space-y-2">
-									{quickActions.map((action) => (
-										<Button
-											key={action.href}
-											asChild
-											variant="outline"
-											className="w-full justify-start"
-										>
-											<Link
-												href={
-													action.href === "provider-keys"
-														? buildOrgUrl("org/provider-keys")
-														: buildUrl(action.href)
-												}
-												prefetch={true}
-											>
-												<action.icon className="mr-2 h-4 w-4" />
-												{action.label}
-											</Link>
-										</Button>
-									))}
-								</CardContent>
-							</Card>
+							<QuickActionsCard
+								buildUrl={buildUrl}
+								buildOrgUrl={buildOrgUrl}
+								className="min-w-0 lg:col-span-3"
+							/>
 						</div>
 					) : (
 						<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
 							<Card className="min-w-0 lg:col-span-4">
 								<CardHeader>
-									<div className="flex items-start justify-between">
-										<div className="flex-1">
+									<div className="flex flex-wrap items-start justify-between gap-3">
+										<div>
 											<CardTitle>Usage Overview</CardTitle>
 											<CardDescription>
 												{metric === "costs"
-													? "Provider pricing for reference"
-													: "Total Requests"}
-												{selectedProject && (
-													<span className="block mt-1 text-sm">
-														Filtered by project: {selectedProject.name}
-													</span>
-												)}
+													? "Daily inference spend (provider list price)"
+													: "Daily request volume"}
 											</CardDescription>
 										</div>
-										<Select value={metric} onValueChange={updateMetricInUrl}>
-											<SelectTrigger className="w-[140px]">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value="costs">Costs</SelectItem>
-												<SelectItem value="requests">Requests</SelectItem>
-											</SelectContent>
-										</Select>
+										<div className="inline-flex items-center rounded-lg border border-border/60 bg-muted/40 p-0.5">
+											{(["costs", "requests"] as const).map((option) => (
+												<button
+													key={option}
+													type="button"
+													onClick={() => updateMetricInUrl(option)}
+													className={cn(
+														"rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors",
+														metric === option
+															? "bg-background text-foreground shadow-sm"
+															: "text-muted-foreground hover:text-foreground",
+													)}
+												>
+													{option}
+												</button>
+											))}
+										</div>
 									</div>
 								</CardHeader>
 								<CardContent className="pl-2">
@@ -691,36 +801,11 @@ export function DashboardClient({
 									/>
 								</CardContent>
 							</Card>
-							<Card className="min-w-0 lg:col-span-3">
-								<CardHeader>
-									<CardTitle>Quick Actions</CardTitle>
-									<CardDescription>
-										Common tasks you might want to perform
-									</CardDescription>
-								</CardHeader>
-								<CardContent className="space-y-2">
-									{quickActions.map((action) => (
-										<Button
-											key={action.href}
-											asChild
-											variant="outline"
-											className="w-full justify-start"
-										>
-											<Link
-												href={
-													action.href === "provider-keys"
-														? buildOrgUrl("org/provider-keys")
-														: buildUrl(action.href)
-												}
-												prefetch={true}
-											>
-												<action.icon className="mr-2 h-4 w-4" />
-												{action.label}
-											</Link>
-										</Button>
-									))}
-								</CardContent>
-							</Card>
+							<QuickActionsCard
+								buildUrl={buildUrl}
+								buildOrgUrl={buildOrgUrl}
+								className="min-w-0 lg:col-span-3"
+							/>
 						</div>
 					)}
 

--- a/apps/ui/src/components/dashboard/errors-reliability-card.tsx
+++ b/apps/ui/src/components/dashboard/errors-reliability-card.tsx
@@ -9,12 +9,57 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
+import { cn } from "@/lib/utils";
 
 import type { DailyActivity } from "@/types/activity";
 
 interface ErrorsReliabilityCardProps {
 	activityData: DailyActivity[];
 	isLoading: boolean;
+}
+
+function RateStat({
+	label,
+	rate,
+	detail,
+	tone,
+}: {
+	label: string;
+	rate: number;
+	detail: string;
+	tone: "good" | "warn" | "bad" | "neutral";
+}) {
+	const toneColors = {
+		good: "bg-emerald-500",
+		warn: "bg-amber-500",
+		bad: "bg-red-500",
+		neutral: "bg-sky-500",
+	} as const;
+
+	return (
+		<div className="rounded-lg border border-border/60 p-3">
+			<div className="flex items-center gap-1.5">
+				<span
+					className={cn("h-1.5 w-1.5 rounded-full", toneColors[tone])}
+					aria-hidden
+				/>
+				<p className="text-xs text-muted-foreground">{label}</p>
+			</div>
+			<p className="mt-1.5 text-2xl font-bold tabular-nums">
+				{rate.toFixed(2)}
+				<span className="text-sm font-normal text-muted-foreground"> %</span>
+			</p>
+			<div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
+				<div
+					className={cn("h-full rounded-full", toneColors[tone])}
+					style={{
+						width: `${Math.min(100, Math.max(rate, rate > 0 ? 2 : 0))}%`,
+					}}
+				/>
+			</div>
+			<p className="mt-2 text-xs text-muted-foreground">{detail}</p>
+		</div>
+	);
 }
 
 export function ErrorsReliabilityCard({
@@ -68,6 +113,10 @@ export function ErrorsReliabilityCard({
 
 	const errorRate = totalRequests > 0 ? (totalErrors / totalRequests) * 100 : 0;
 	const cacheRate = totalRequests > 0 ? (totalCached / totalRequests) * 100 : 0;
+	const successRate = 100 - errorRate;
+
+	const errorTone: "good" | "warn" | "bad" =
+		errorRate < 1 ? "good" : errorRate < 5 ? "warn" : "bad";
 
 	const worstErrorDays = [...activityData]
 		.filter((d) => d.errorCount > 0)
@@ -83,33 +132,39 @@ export function ErrorsReliabilityCard({
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
-				<div className="grid grid-cols-2 gap-4 text-sm">
-					<div className="rounded-md border p-3">
-						<p className="mb-1 text-xs text-muted-foreground">Error rate</p>
-						<p className="text-2xl font-bold">
-							{errorRate.toFixed(2)}
-							<span className="text-sm font-normal text-muted-foreground">
-								{" "}
-								%
-							</span>
-						</p>
-						<p className="mt-1 text-xs text-muted-foreground">
-							{totalErrors.toLocaleString()} failed of{" "}
-							{totalRequests.toLocaleString()} requests
+				<div className="grid grid-cols-2 gap-3 text-sm">
+					<RateStat
+						label="Error rate"
+						rate={errorRate}
+						detail={`${totalErrors.toLocaleString()} failed of ${totalRequests.toLocaleString()} requests`}
+						tone={errorTone}
+					/>
+					<RateStat
+						label="Cache hit rate"
+						rate={cacheRate}
+						detail={`${totalCached.toLocaleString()} cached responses`}
+						tone="neutral"
+					/>
+				</div>
+
+				<div className="rounded-lg border border-border/60 p-3">
+					<div className="flex items-center justify-between">
+						<p className="text-xs text-muted-foreground">Success rate</p>
+						<p className="text-sm font-semibold tabular-nums">
+							{successRate.toFixed(2)}%
 						</p>
 					</div>
-					<div className="rounded-md border p-3">
-						<p className="mb-1 text-xs text-muted-foreground">Cache hit rate</p>
-						<p className="text-2xl font-bold">
-							{cacheRate.toFixed(2)}
-							<span className="text-sm font-normal text-muted-foreground">
-								{" "}
-								%
-							</span>
-						</p>
-						<p className="mt-1 text-xs text-muted-foreground">
-							{totalCached.toLocaleString()} cached responses
-						</p>
+					<div className="mt-2 flex h-1.5 gap-px overflow-hidden rounded-full bg-muted">
+						<div
+							className="h-full rounded-l-full bg-emerald-500"
+							style={{ width: `${successRate}%` }}
+						/>
+						{errorRate > 0 && (
+							<div
+								className="h-full rounded-r-full bg-red-500"
+								style={{ width: `${Math.max(errorRate, 1)}%` }}
+							/>
+						)}
 					</div>
 				</div>
 
@@ -122,10 +177,19 @@ export function ErrorsReliabilityCard({
 							{worstErrorDays.map((day) => (
 								<div
 									key={day.date}
-									className="flex items-center justify-between rounded-md border px-2 py-1"
+									className="flex items-center justify-between rounded-md border border-border/60 px-2.5 py-1.5"
 								>
 									<span>{format(parseISO(day.date), "MMM d, yyyy")}</span>
-									<span className="font-semibold">
+									<span
+										className={cn(
+											"font-semibold tabular-nums",
+											day.errorRate >= 5
+												? "text-red-500"
+												: day.errorRate >= 1
+													? "text-amber-500"
+													: "text-muted-foreground",
+										)}
+									>
 										{day.errorRate.toFixed(2)}%
 									</span>
 								</div>

--- a/apps/ui/src/components/dashboard/metric-card.tsx
+++ b/apps/ui/src/components/dashboard/metric-card.tsx
@@ -1,5 +1,10 @@
-import { Info } from "lucide-react";
+"use client";
 
+import { ArrowDownRight, ArrowUpRight, Info } from "lucide-react";
+import { useId } from "react";
+import { Area, AreaChart, ResponsiveContainer } from "recharts";
+
+import { Skeleton } from "@/lib/components/skeleton";
 import {
 	Tooltip,
 	TooltipContent,
@@ -8,6 +13,42 @@ import {
 } from "@/lib/components/tooltip";
 import { cn } from "@/lib/utils";
 
+const accentColors: Record<"green" | "blue" | "purple", string> = {
+	green: "#10b981",
+	blue: "#3b82f6",
+	purple: "#8b5cf6",
+};
+
+function Sparkline({ trend, color }: { trend: number[]; color: string }) {
+	const gradientId = useId();
+	const chartData = trend.map((value, index) => ({ index, value }));
+
+	return (
+		<ResponsiveContainer width="100%" height="100%">
+			<AreaChart
+				data={chartData}
+				margin={{ top: 2, right: 0, left: 0, bottom: 0 }}
+			>
+				<defs>
+					<linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+						<stop offset="5%" stopColor={color} stopOpacity={0.35} />
+						<stop offset="95%" stopColor={color} stopOpacity={0.02} />
+					</linearGradient>
+				</defs>
+				<Area
+					type="monotone"
+					dataKey="value"
+					stroke={color}
+					strokeWidth={1.5}
+					fill={`url(#${gradientId})`}
+					isAnimationActive={false}
+					dot={false}
+				/>
+			</AreaChart>
+		</ResponsiveContainer>
+	);
+}
+
 export function MetricCard({
 	label,
 	value,
@@ -15,6 +56,10 @@ export function MetricCard({
 	icon,
 	accent,
 	tooltip,
+	delta,
+	deltaLabel = "vs previous period",
+	trend,
+	isLoading,
 }: {
 	label: string;
 	value: string;
@@ -22,10 +67,22 @@ export function MetricCard({
 	icon?: React.ReactNode;
 	accent?: "green" | "blue" | "purple";
 	tooltip?: string;
+	/** Percent change vs the previous period; null when not computable. */
+	delta?: number | null;
+	deltaLabel?: string;
+	/** Daily values for the selected period, rendered as a sparkline. */
+	trend?: number[];
+	isLoading?: boolean;
 }) {
+	const accentColor = accentColors[accent ?? "blue"];
+	const showTrend =
+		!isLoading && trend && trend.length > 1 && trend.some((v) => v !== 0);
+	const showDelta =
+		!isLoading && typeof delta === "number" && Number.isFinite(delta);
+
 	return (
-		<div className="bg-card text-card-foreground flex flex-col justify-between gap-3 rounded-xl border border-border/60 p-4 shadow-sm sm:p-5">
-			<div className="flex items-start justify-between gap-3">
+		<div className="bg-card text-card-foreground relative flex flex-col justify-between overflow-hidden rounded-xl border border-border/60 shadow-sm">
+			<div className="flex items-start justify-between gap-3 p-4 pb-0 sm:p-5 sm:pb-0">
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-1.5">
 						<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -50,10 +107,39 @@ export function MetricCard({
 							</TooltipProvider>
 						) : null}
 					</div>
-					<p className="mt-2 text-xl font-semibold tabular-nums break-all sm:text-2xl">
-						{value}
-					</p>
-					{subtitle ? (
+					{isLoading ? (
+						<Skeleton className="mt-2 h-7 w-24 sm:h-8" />
+					) : (
+						<div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+							<p className="text-xl font-semibold tabular-nums break-all sm:text-2xl">
+								{value}
+							</p>
+							{showDelta ? (
+								<span
+									title={deltaLabel}
+									className={cn(
+										"inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums",
+										delta >= 0
+											? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+											: "bg-red-500/10 text-red-600 dark:text-red-400",
+									)}
+								>
+									{delta >= 0 ? (
+										<ArrowUpRight className="h-3 w-3" />
+									) : (
+										<ArrowDownRight className="h-3 w-3" />
+									)}
+									{Math.abs(delta) >= 1000
+										? ">999"
+										: Math.abs(delta).toFixed(1)}
+									%
+								</span>
+							) : null}
+						</div>
+					)}
+					{isLoading ? (
+						<Skeleton className="mt-2 h-3 w-32" />
+					) : subtitle ? (
 						<p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
 					) : null}
 				</div>
@@ -72,6 +158,9 @@ export function MetricCard({
 						{icon}
 					</div>
 				) : null}
+			</div>
+			<div className={cn("h-10", !showTrend && "h-4 sm:h-5")}>
+				{showTrend ? <Sparkline trend={trend} color={accentColor} /> : null}
 			</div>
 		</div>
 	);

--- a/apps/ui/src/components/dashboard/recent-activity-card.tsx
+++ b/apps/ui/src/components/dashboard/recent-activity-card.tsx
@@ -56,6 +56,7 @@ export function RecentActivityCard({
 	const latestDays = [...activityData]
 		.sort((a, b) => (a.date < b.date ? 1 : -1))
 		.slice(0, 7);
+	const maxCost = Math.max(...latestDays.map((day) => day.cost), 0);
 
 	return (
 		<Card>
@@ -64,33 +65,43 @@ export function RecentActivityCard({
 				<CardDescription>Daily usage overview (last few days)</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<div className="space-y-3">
+				<div className="space-y-2">
 					{latestDays.map((day) => (
 						<div
 							key={day.date}
-							className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+							className="rounded-lg border border-border/60 px-3 py-2 text-sm"
 						>
-							<div>
-								<p className="font-medium">
-									{format(parseISO(day.date), "MMM d, yyyy")}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									{day.requestCount.toLocaleString()} requests •{" "}
-									{day.totalTokens.toLocaleString()} tokens
-								</p>
-							</div>
-							<div className="text-right">
-								<p className="font-semibold text-muted-foreground">
-									${day.cost.toFixed(4)}
-								</p>
-								<p className="text-xs text-muted-foreground">
-									inference (ref.)
-								</p>
-								{day.discountSavings > 0 && (
-									<p className="text-xs text-emerald-600">
-										-${day.discountSavings.toFixed(4)} saved
+							<div className="flex items-center justify-between gap-3">
+								<div className="min-w-0">
+									<p className="font-medium">
+										{format(parseISO(day.date), "MMM d, yyyy")}
 									</p>
-								)}
+									<p className="truncate text-xs text-muted-foreground">
+										{day.requestCount.toLocaleString()} requests •{" "}
+										{day.totalTokens.toLocaleString()} tokens
+									</p>
+								</div>
+								<div className="shrink-0 text-right">
+									<p className="font-semibold tabular-nums">
+										${day.cost.toFixed(4)}
+									</p>
+									{day.discountSavings > 0 && (
+										<p className="text-xs text-emerald-600 dark:text-emerald-400">
+											-${day.discountSavings.toFixed(4)} saved
+										</p>
+									)}
+								</div>
+							</div>
+							<div className="mt-2 h-1 overflow-hidden rounded-full bg-muted">
+								<div
+									className="h-full rounded-full bg-sky-500/70"
+									style={{
+										width:
+											maxCost > 0
+												? `${Math.max((day.cost / maxCost) * 100, 2)}%`
+												: "0%",
+									}}
+								/>
 							</div>
 						</div>
 					))}

--- a/apps/ui/src/components/date-range-select.tsx
+++ b/apps/ui/src/components/date-range-select.tsx
@@ -132,9 +132,14 @@ const RELATIVE_TIME_OPTIONS: RelativeTimeOption[] = [
 interface DateRangeSelectProps {
 	value?: string;
 	onChange: (value: string, range: DateRange) => void;
+	className?: string;
 }
 
-export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
+export function DateRangeSelect({
+	value,
+	onChange,
+	className,
+}: DateRangeSelectProps) {
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
 	const [selected, setSelected] = useState(value);
@@ -172,10 +177,16 @@ export function DateRangeSelect({ value, onChange }: DateRangeSelectProps) {
 			<PopoverTrigger asChild>
 				<button
 					type="button"
-					className="border-input hover:bg-accent hover:text-accent-foreground flex h-9 items-center gap-2 whitespace-nowrap rounded-md border px-3 py-2 text-sm transition-colors"
+					className={cn(
+						"border-input hover:bg-accent hover:text-accent-foreground flex h-9 items-center justify-between gap-2 whitespace-nowrap rounded-md border px-3 py-2 text-sm transition-colors",
+						!selectedOption && "text-muted-foreground",
+						className,
+					)}
 				>
-					{selectedOption?.label ?? "Select time range"}
-					<ChevronDownIcon className="h-4 w-4 opacity-50" />
+					<span className="truncate">
+						{selectedOption?.label ?? "Select time range"}
+					</span>
+					<ChevronDownIcon className="h-4 w-4 shrink-0 opacity-50" />
 				</button>
 			</PopoverTrigger>
 			<PopoverContent className="w-52 p-0" align="start">


### PR DESCRIPTION
## Summary

Redesigns the project dashboard and the Activity Logs filter bar, and fixes the recurring-usage-limit field alignment in the API key dialogs.

### Dashboard
- **Trend deltas**: KPI cards (Requests, Spend, Savings) now show percent change vs the previous period of the same length, powered by a second `/activity` query (skipped for ranges > 366 days); a caption next to the date picker states the comparison window
- **Sparklines**: Requests and Spend cards render a day-by-day mini area chart for the selected period
- **Skeleton loading** on metric cards instead of `"Loading..."` text values
- **Token stats strip**: Input/Output/Cached tokens and Top Model consolidated into one compact divided card (was 4 more full-size metric cards)
- **Chart card**: segmented Costs/Requests toggle replaces the select dropdown
- **Quick actions**: 2-column tile grid (adds Settings) instead of stacked full-width buttons, shared via one `QuickActionsCard` component
- **Errors & Reliability**: status-colored rates (green/amber/red) with progress bars plus a success-rate split bar; Recent Activity rows get relative cost-share bars
- **Removed the DevPass promo card** from the dashboard (still present on the Agents page)

### Activity Logs
- Filter bar rebuilt as a structured toolbar: header row with filter icon, active-filter count badge, Reset (shown when filters are active) and Refresh; controls sit in a responsive grid with consistent full widths
- Text filters (header key/value, session ID) get search-icon prefixes
- Removed the double-card nesting on the page; the toolbar is sticky with backdrop blur

### API key dialogs
- "Set recurring usage limit" fields now align on one row: shortened the wrapping label to "Limit", bottom-aligned the grid, and wrapped the unit Select so Radix's hidden native select no longer picks up the `space-y-2` margin

## Test plan
- `pnpm test:unit` — 158 files, 2569 tests pass
- `turbo run build --filter=ui` passes
- Verified in-browser (login → dashboard with data-rich org, activity filters incl. filter/reset flow, create-API-key dialog alignment measured pixel-equal)

https://claude.ai/code/session_01BSoziVsPo8yuWcMVibhi1E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard KPI comparisons with previous periods, including percentage changes and trend sparklines.
  * Improved usage metrics with selectable views and trend comparison messaging.
  * Enhanced error and reliability insights with clearer success, error, and cache-hit visualizations.
  * Added filter counts and a reset-all option to the activity feed filters.

* **UI Improvements**
  * Refined dashboard cards, recent activity charts, date-range controls, and API key limit fields.
  * Simplified activity feed and dashboard layouts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->