### PR TITLE
feat(code): track OAuth signups in analytics

### DIFF
--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -33,7 +33,10 @@ import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
-import { trackPurchaseConversion } from "@/lib/google-tag";
+import {
+	trackPurchaseConversion,
+	trackSignupConversion,
+} from "@/lib/google-tag";
 import { useStripe } from "@/lib/stripe";
 import { cn } from "@/lib/utils";
 
@@ -129,7 +132,8 @@ export default function DashboardShell({
 	const posthog = usePostHog();
 	const { signOut } = useAuth();
 	const config = useAppConfig();
-	const { posthogKey, googleAdsPurchaseConversion } = config;
+	const { posthogKey, googleAdsPurchaseConversion, googleAdsSignupConversion } =
+		config;
 	const api = useApi();
 	const { stripe, isLoading: stripeLoading } = useStripe();
 	const queryClient = useQueryClient();
@@ -146,6 +150,43 @@ export default function DashboardShell({
 	const subscribeMutation = api.useMutation("post", "/dev-plans/subscribe");
 	const finalizeMutation = api.useMutation("post", "/dev-plans/finalize");
 	const setupSessionId = searchParams.get("setup_session_id");
+	const signupMethod = searchParams.get("signup_method");
+	const signupTracked = useRef(false);
+
+	// OAuth signups redirect away from /signup before it can capture anything,
+	// so better-auth sends brand-new accounts here with ?signup_method=<provider>
+	// (see SocialAuthButtons) and we fire the same analytics as the email path.
+	useEffect(() => {
+		if (!signupMethod || !user || signupTracked.current) {
+			return;
+		}
+		signupTracked.current = true;
+		if (posthogKey) {
+			posthog.capture("user_signed_up", {
+				email: user.email,
+				name: user.name,
+				method: signupMethod,
+			});
+		}
+		trackSignupConversion({
+			email: user.email,
+			method: signupMethod,
+			sendTo: googleAdsSignupConversion,
+		});
+		const params = new URLSearchParams(searchParams.toString());
+		params.delete("signup_method");
+		const query = params.toString();
+		router.replace((query ? `${pathname}?${query}` : pathname) as Route);
+	}, [
+		signupMethod,
+		user,
+		posthog,
+		posthogKey,
+		googleAdsSignupConversion,
+		searchParams,
+		router,
+		pathname,
+	]);
 
 	const [subscribingTier, setSubscribingTier] = useState<PlanTier | null>(null);
 	const [duplicateCardError, setDuplicateCardError] = useState<string | null>(

--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -394,6 +394,7 @@ function LoginForm() {
 							setIsLoading={setIsLoading}
 							callbackPath={returnUrl}
 							errorCallbackPath="/login"
+							newUserCallbackPath={returnUrl}
 						/>
 
 						<Button

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -99,6 +99,7 @@ function SignupForm() {
 							email: values.email,
 							name: values.name,
 							plan: selectedPlan,
+							method: "email",
 						});
 					}
 					trackSignupConversion({
@@ -339,6 +340,7 @@ function SignupForm() {
 							setIsLoading={setIsLoading}
 							callbackPath={returnUrl}
 							errorCallbackPath="/signup"
+							newUserCallbackPath={returnUrl}
 						/>
 					</div>
 

--- a/apps/code/src/components/social-auth-buttons.tsx
+++ b/apps/code/src/components/social-auth-buttons.tsx
@@ -13,6 +13,7 @@ interface SocialAuthButtonsProps {
 	setIsLoading: (loading: boolean) => void;
 	callbackPath: string;
 	errorCallbackPath: string;
+	newUserCallbackPath?: string;
 }
 
 export function SocialAuthButtons({
@@ -20,6 +21,7 @@ export function SocialAuthButtons({
 	setIsLoading,
 	callbackPath,
 	errorCallbackPath,
+	newUserCallbackPath,
 }: SocialAuthButtonsProps) {
 	const { signIn } = useAuth();
 	const { githubAuth, googleAuth } = useAppConfig();
@@ -34,11 +36,21 @@ export function SocialAuthButtons({
 		// native passkey/biometric prompt after a successful social sign-in + redirect.
 		WebAuthnAbortService.cancelCeremony();
 		try {
+			const origin = location.protocol + "//" + location.host;
 			const res = await signIn.social({
 				provider,
-				callbackURL: location.protocol + "//" + location.host + callbackPath,
-				errorCallbackURL:
-					location.protocol + "//" + location.host + errorCallbackPath,
+				callbackURL: origin + callbackPath,
+				errorCallbackURL: origin + errorCallbackPath,
+				// New accounts land with a signup_method param so DashboardShell can
+				// fire the signup analytics + ads conversion that the email path
+				// fires inline (OAuth redirects away before we could capture here).
+				newUserCallbackURL: newUserCallbackPath
+					? origin +
+						newUserCallbackPath +
+						(newUserCallbackPath.includes("?") ? "&" : "?") +
+						"signup_method=" +
+						provider
+					: undefined,
 			});
 			if (res?.error) {
 				toast.error(res.error.message ?? `Failed to sign in with ${provider}`, {


### PR DESCRIPTION
## Problem

OAuth (GitHub/Google) signups on devpass.llmgateway.io fire neither the PostHog `user_signed_up` event nor the Google Ads signup conversion — only the email+password path does. Since devs mostly sign up via GitHub, the Google Ads test campaign (`GOOG_Search_DevPass_Test_2026Q3`) and the PostHog attribution funnel undercount signups on both platforms. Confirmed while auditing the campaign's 0-conversion report on Jul 12.

## Solution

- `SocialAuthButtons` now passes better-auth's `newUserCallbackURL` (only **newly created** accounts are redirected there) with a `signup_method=<provider>` query param appended to the return URL. Existing users signing in via OAuth keep the plain `callbackURL`, so no false positives.
- `DashboardShell` consumes the param once: captures `user_signed_up` (with `method`) in PostHog and fires `trackSignupConversion` (enhanced-conversion user_data + `GOOGLE_ADS_SIGNUP_CONVERSION` send_to), then strips the param from the URL.
- Both `/signup` and `/login` pages opt in (an OAuth click on the login page that creates a new account is still a signup).
- Email signup path now also tags `user_signed_up` with `method: "email"` for symmetric breakdowns.

Caveat: if a new user's `returnUrl` points outside the dashboard shell, the event won't fire — the ad funnel (landing → /signup → /dashboard) is fully covered. The same OAuth gap exists in `apps/ui`/`apps/playground`; this PR scopes to `apps/code` where the ad campaign lands.

## Testing

- `turbo run build --filter=code` passes (validates `newUserCallbackURL` against better-auth 1.6.18 types).
- `pnpm format` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved social sign-up flows so new users return to their intended destination after authentication.
  - Sign-up methods are now captured for both social and email registration, improving conversion reporting.
  - Preserved existing redirect parameters during authentication and sign-up navigation.

- **Bug Fixes**
  - Removed temporary sign-up tracking parameters from the address bar after successful processing to keep URLs clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->