### PR TITLE
fix(ui): apply Inter font by moving font vars to <html>

### DIFF
--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -89,7 +89,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
 	return (
-		<html lang="en" suppressHydrationWarning>
+		<html
+			lang="en"
+			className={`${inter.variable} ${geistMono.variable} ${bricolage.variable}`}
+			suppressHydrationWarning
+		>
 			<head>
 				<script
 					type="application/ld+json"
@@ -99,9 +103,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 					}}
 				/>
 			</head>
-			<body
-				className={`${inter.variable} ${geistMono.variable} ${bricolage.variable} antialiased`}
-			>
+			<body className="antialiased">
 				<GoogleTag
 					googleTagId={config.googleTagId}
 					googleAdsSignupConversion={config.googleAdsSignupConversion}

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -98,7 +98,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
 	return (
-		<html lang="en" suppressHydrationWarning>
+		<html
+			lang="en"
+			className={`${inter.variable} ${geistMono.variable}`}
+			suppressHydrationWarning
+		>
 			<head>
 				<script
 					type="application/ld+json"
@@ -115,7 +119,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 					}}
 				/>
 			</head>
-			<body className={`${inter.variable} ${geistMono.variable} antialiased`}>
+			<body className="antialiased">
 				<Providers config={config}>{children}</Providers>
 			</body>
 		</html>

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -134,7 +134,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
 	return (
-		<html lang="en" suppressHydrationWarning>
+		<html
+			lang="en"
+			className={`${inter.variable} ${geistMono.variable} ${plusJakarta.variable}`}
+			suppressHydrationWarning
+		>
 			<head>
 				<link rel="preconnect" href="https://internal.llmgateway.io" />
 				<link rel="preconnect" href="https://docs.llmgateway.io" />
@@ -153,9 +157,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 					}}
 				/>
 			</head>
-			<body
-				className={`${inter.variable} ${geistMono.variable} ${plusJakarta.variable} min-h-screen antialiased`}
-			>
+			<body className="min-h-screen antialiased">
 				<Providers config={config}>{children}</Providers>
 			</body>
 		</html>


### PR DESCRIPTION
## Problem

Inter was never actually rendering on any of the frontends — not just in Playwright screenshots. The `next/font` CSS variables (`--font-inter`, `--font-mono`, `--font-display`) were set on `<body>`, but each app's `globals.css` reads them at `:root` (`<html>`) via `--font-sans: var(--font-inter)`. At `:root` those variables were undefined, so `--font-sans` never resolved to Inter and every element fell back to Tailwind's default `ui-sans-serif, system-ui, sans-serif` stack.

This looked fine to real users because on macOS `system-ui` resolves to San Francisco — but that means users were getting SF, not Inter. Headless Chromium (Playwright screenshots) has no macOS system UI font, so it rendered an ugly generic fallback, which is how this was noticed.

## Fix

Move the font-variable classNames from `<body>` to `<html>` in `ui`, `playground`, and `code` `layout.tsx`. This is also Next.js's recommended placement for `next/font` variables. With the variables at `:root`, `--font-sans` resolves to Inter and it renders identically everywhere.

**Verified** on the live site: injecting `--font-inter` onto `<html>` flipped the computed `font-family` on the hero heading from `ui-sans-serif, system-ui, …` → `Inter, "Inter Fallback"` instantly.

## Testing

- `turbo run build --filter=ui --filter=playground --filter=code` — 15/15 tasks pass
- `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved font application across the application, playground, and UI experiences.
  * Preserved anti-aliasing and full-screen layout behavior while ensuring typography styling is applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->