### PR TITLE
fix(playground): per-model reasoning efforts

### DIFF
--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -566,7 +566,14 @@ interface ChatRequestBody {
 		image_quality?: "auto" | "low" | "medium" | "high" | string;
 		n?: number;
 	};
-	reasoning_effort?: "minimal" | "low" | "medium" | "high";
+	reasoning_effort?:
+		| "none"
+		| "minimal"
+		| "low"
+		| "medium"
+		| "high"
+		| "xhigh"
+		| "max";
 	web_search?: boolean;
 	mcp_servers?: McpServerConfig[];
 	is_image_gen?: boolean;

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -52,6 +52,10 @@ import {
 	setModelPreferenceCookie,
 } from "@/lib/model-preferences";
 import { shouldDisableFallback } from "@/lib/no-fallback";
+import {
+	getReasoningEffortOptions,
+	type PlaygroundReasoningEffort,
+} from "@/lib/reasoning-efforts";
 import { getErrorMessage } from "@/lib/utils";
 
 import type {
@@ -332,9 +336,8 @@ export default function ChatPageClient({
 	};
 
 	const [selectedModel, setSelectedModel] = useState(() => getInitialModel());
-	const [reasoningEffort, setReasoningEffort] = useState<
-		"" | "minimal" | "low" | "medium" | "high"
-	>("");
+	const [reasoningEffort, setReasoningEffort] =
+		useState<PlaygroundReasoningEffort>("");
 	const [imageAspectRatio, setImageAspectRatio] = useState<
 		| "auto"
 		| "1:1"
@@ -713,6 +716,21 @@ export default function ChatPageClient({
 		const mapping = getSelectedMapping(def, providerId, region);
 		return !!mapping?.reasoning;
 	}, [models, selectedModel]);
+
+	const reasoningEffortOptions = useMemo(() => {
+		if (!selectedModel || !supportsReasoning) {
+			return [];
+		}
+		const { providerId, modelId } = parseModelSelectorValue(selectedModel);
+		const def = models.find((m) => m.id === modelId);
+		if (!def) {
+			return [];
+		}
+		const providerIds = providerId
+			? [providerId]
+			: def.mappings.map((p: ApiModelProviderMapping) => p.providerId);
+		return getReasoningEffortOptions(modelId, def.family, providerIds);
+	}, [models, selectedModel, supportsReasoning]);
 
 	const supportsWebSearch = useMemo(() => {
 		if (!selectedModel) {
@@ -1868,12 +1886,13 @@ export default function ChatPageClient({
 		setText(value);
 	};
 
-	// Reset reasoning effort when switching to a non-reasoning model
+	// Reset reasoning effort when the selected model doesn't support the
+	// current level (e.g. switching from Claude with "max" to an OpenAI model)
 	useEffect(() => {
-		if (!supportsReasoning && reasoningEffort) {
+		if (reasoningEffort && !reasoningEffortOptions.includes(reasoningEffort)) {
 			setReasoningEffort("");
 		}
-	}, [supportsReasoning, reasoningEffort]);
+	}, [reasoningEffortOptions, reasoningEffort]);
 
 	// Reset image size/quality only when the selected model changes and the
 	// current value is not valid for the new model. Including alibabaImageSize
@@ -2119,6 +2138,7 @@ export default function ChatPageClient({
 											reasoningEffort={reasoningEffort}
 											setReasoningEffort={setReasoningEffort}
 											supportsReasoning={supportsReasoning}
+											reasoningEffortOptions={reasoningEffortOptions}
 											imageAspectRatio={imageAspectRatio}
 											setImageAspectRatio={setImageAspectRatio}
 											imageSize={imageSize}
@@ -2179,6 +2199,7 @@ export default function ChatPageClient({
 										reasoningEffort={reasoningEffort}
 										setReasoningEffort={setReasoningEffort}
 										supportsReasoning={supportsReasoning}
+										reasoningEffortOptions={reasoningEffortOptions}
 										imageAspectRatio={imageAspectRatio}
 										setImageAspectRatio={setImageAspectRatio}
 										imageSize={imageSize}
@@ -2427,9 +2448,8 @@ function ExtraChatPanel({
 	);
 	const comparisonChatIdRef = useRef<string | null>(initialChatId);
 	const loadedComparisonChatIdRef = useRef<string | null>(null);
-	const [reasoningEffort, setReasoningEffort] = useState<
-		"" | "minimal" | "low" | "medium" | "high"
-	>("");
+	const [reasoningEffort, setReasoningEffort] =
+		useState<PlaygroundReasoningEffort>("");
 	const [imageAspectRatio, setImageAspectRatio] = useState<
 		| "auto"
 		| "1:1"
@@ -2640,6 +2660,29 @@ function ExtraChatPanel({
 		const mapping = getSelectedMapping(def, providerId, region);
 		return !!mapping?.reasoning;
 	}, [models, selectedModel]);
+
+	const reasoningEffortOptions = useMemo(() => {
+		if (!selectedModel || !supportsReasoning) {
+			return [];
+		}
+		const { providerId, modelId } = parseModelSelectorValue(selectedModel);
+		const def = models.find((m) => m.id === modelId);
+		if (!def) {
+			return [];
+		}
+		const providerIds = providerId
+			? [providerId]
+			: def.mappings.map((p: ApiModelProviderMapping) => p.providerId);
+		return getReasoningEffortOptions(modelId, def.family, providerIds);
+	}, [models, selectedModel, supportsReasoning]);
+
+	// Reset reasoning effort when the selected model doesn't support the
+	// current level (e.g. switching from Claude with "max" to an OpenAI model)
+	useEffect(() => {
+		if (reasoningEffort && !reasoningEffortOptions.includes(reasoningEffort)) {
+			setReasoningEffort("");
+		}
+	}, [reasoningEffortOptions, reasoningEffort]);
 
 	const supportsWebSearch = useMemo(() => {
 		if (!selectedModel) {
@@ -3011,6 +3054,7 @@ function ExtraChatPanel({
 					reasoningEffort={reasoningEffort}
 					setReasoningEffort={setReasoningEffort}
 					supportsReasoning={supportsReasoning}
+					reasoningEffortOptions={reasoningEffortOptions}
 					imageAspectRatio={imageAspectRatio}
 					setImageAspectRatio={setImageAspectRatio}
 					imageSize={imageSize}

--- a/apps/playground/src/components/playground/chat-ui.tsx
+++ b/apps/playground/src/components/playground/chat-ui.tsx
@@ -101,6 +101,11 @@ import {
 	parsePlaygroundMessageMetadata,
 	type PlaygroundMessageMetadata,
 } from "@/lib/message-metadata";
+import {
+	REASONING_EFFORT_LABELS,
+	type PlaygroundReasoningEffort,
+	type ReasoningEffortValue,
+} from "@/lib/reasoning-efforts";
 import { cn } from "@/lib/utils";
 
 import type { UIMessage, ChatRequestOptions, ChatStatus } from "ai";
@@ -170,11 +175,10 @@ interface ChatUIProps {
 	status: ChatStatus;
 	stop: () => void;
 	regenerate: () => void;
-	reasoningEffort: "" | "minimal" | "low" | "medium" | "high";
-	setReasoningEffort: (
-		value: "" | "minimal" | "low" | "medium" | "high",
-	) => void;
+	reasoningEffort: PlaygroundReasoningEffort;
+	setReasoningEffort: (value: PlaygroundReasoningEffort) => void;
 	supportsReasoning: boolean;
+	reasoningEffortOptions: ReasoningEffortValue[];
 	imageAspectRatio:
 		| "auto"
 		| "1:1"
@@ -1013,6 +1017,7 @@ export const ChatUI = ({
 	reasoningEffort,
 	setReasoningEffort,
 	supportsReasoning,
+	reasoningEffortOptions,
 	imageAspectRatio,
 	setImageAspectRatio,
 	imageSize,
@@ -1847,15 +1852,12 @@ export const ChatUI = ({
 									</SelectContent>
 								</Select>
 							)}
-							{supportsReasoning && (
+							{supportsReasoning && reasoningEffortOptions.length > 0 && (
 								<Select
 									value={reasoningEffort ? reasoningEffort : "off"}
 									onValueChange={(val) =>
 										setReasoningEffort(
-											val === "off"
-												? ""
-												: ((val as "minimal" | "low" | "medium" | "high") ??
-														""),
+											val === "off" ? "" : (val as ReasoningEffortValue),
 										)
 									}
 								>
@@ -1871,12 +1873,11 @@ export const ChatUI = ({
 									</SelectTrigger>
 									<SelectContent>
 										<SelectItem value="off">Auto</SelectItem>
-										{selectedModel.includes("gpt-5") && (
-											<SelectItem value="minimal">Minimal</SelectItem>
-										)}
-										<SelectItem value="low">Low</SelectItem>
-										<SelectItem value="medium">Medium</SelectItem>
-										<SelectItem value="high">High</SelectItem>
+										{reasoningEffortOptions.map((effort) => (
+											<SelectItem key={effort} value={effort}>
+												{REASONING_EFFORT_LABELS[effort]}
+											</SelectItem>
+										))}
 									</SelectContent>
 								</Select>
 							)}

--- a/apps/playground/src/lib/reasoning-efforts.spec.ts
+++ b/apps/playground/src/lib/reasoning-efforts.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { getReasoningEffortOptions } from "./reasoning-efforts";
+
+describe("getReasoningEffortOptions", () => {
+	it("returns the full anthropic tier list including xhigh and max", () => {
+		expect(
+			getReasoningEffortOptions("claude-opus-4-8", "anthropic", ["anthropic"]),
+		).toEqual(["low", "medium", "high", "xhigh", "max"]);
+		expect(
+			getReasoningEffortOptions("claude-sonnet-4-6", "anthropic", [
+				"anthropic",
+				"aws-bedrock",
+			]),
+		).toEqual(["low", "medium", "high", "xhigh", "max"]);
+	});
+
+	it("includes none and minimal for Gemini API models", () => {
+		expect(
+			getReasoningEffortOptions("gemini-3.5-flash", "google", [
+				"google-ai-studio",
+				"google-vertex",
+			]),
+		).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"]);
+	});
+
+	it("uses the default set for Gemma on generic hosts", () => {
+		expect(
+			getReasoningEffortOptions("gemma-4-31b-it", "google", [
+				"deepinfra",
+				"together-ai",
+				"cerebras",
+			]),
+		).toEqual(["low", "medium", "high"]);
+	});
+
+	it("keeps minimal for the original GPT-5 line without xhigh", () => {
+		expect(getReasoningEffortOptions("gpt-5.1", "openai", ["openai"])).toEqual([
+			"minimal",
+			"low",
+			"medium",
+			"high",
+		]);
+		expect(getReasoningEffortOptions("gpt-5.2", "openai", ["openai"])).toEqual([
+			"minimal",
+			"low",
+			"medium",
+			"high",
+		]);
+	});
+
+	it("replaces minimal with none and adds xhigh for GPT-5.4+", () => {
+		for (const id of ["gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.6-sol"]) {
+			expect(getReasoningEffortOptions(id, "openai", ["openai"])).toEqual([
+				"none",
+				"low",
+				"medium",
+				"high",
+				"xhigh",
+			]);
+		}
+	});
+
+	it("restricts pro variants", () => {
+		expect(
+			getReasoningEffortOptions("gpt-5.2-pro", "openai", ["openai"]),
+		).toEqual(["high"]);
+		expect(
+			getReasoningEffortOptions("gpt-5.4-pro", "openai", ["openai"]),
+		).toEqual(["medium", "high", "xhigh"]);
+		expect(
+			getReasoningEffortOptions("gpt-5.5-pro", "openai", ["openai"]),
+		).toEqual(["medium", "high", "xhigh"]);
+	});
+
+	it("uses the default set for o-series, gpt-oss and codex models", () => {
+		for (const id of ["o1", "o4-mini", "gpt-oss-120b", "gpt-5.3-codex"]) {
+			expect(getReasoningEffortOptions(id, "openai", ["openai"])).toEqual([
+				"low",
+				"medium",
+				"high",
+			]);
+		}
+	});
+
+	it("only offers high and xhigh for Fugu", () => {
+		expect(
+			getReasoningEffortOptions("fugu-ultra", "sakana", ["sakana"]),
+		).toEqual(["high", "xhigh"]);
+	});
+
+	it("falls back to low/medium/high for other families", () => {
+		expect(getReasoningEffortOptions("glm-5.2", "zai", ["zai"])).toEqual([
+			"low",
+			"medium",
+			"high",
+		]);
+		expect(
+			getReasoningEffortOptions("deepseek-v4-pro", "deepseek", ["deepseek"]),
+		).toEqual(["low", "medium", "high"]);
+	});
+});

--- a/apps/playground/src/lib/reasoning-efforts.ts
+++ b/apps/playground/src/lib/reasoning-efforts.ts
@@ -1,0 +1,85 @@
+export const REASONING_EFFORT_VALUES = [
+	"none",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+
+export type ReasoningEffortValue = (typeof REASONING_EFFORT_VALUES)[number];
+
+export type PlaygroundReasoningEffort = "" | ReasoningEffortValue;
+
+export const REASONING_EFFORT_LABELS: Record<ReasoningEffortValue, string> = {
+	none: "Off",
+	minimal: "Minimal",
+	low: "Low",
+	medium: "Medium",
+	high: "High",
+	xhigh: "xHigh",
+	max: "Max",
+};
+
+const DEFAULT_EFFORTS: ReasoningEffortValue[] = ["low", "medium", "high"];
+
+// Providers that speak the Gemini API, where the gateway maps each effort
+// level (incl. `minimal`/`xhigh`) to a distinct thinkingBudget and `none`
+// natively disables thinking. Gemma-family models served by generic OpenAI-
+// compatible hosts don't get that mapping and fall back to the default set.
+const GOOGLE_API_PROVIDERS = new Set([
+	"google-ai-studio",
+	"google-vertex",
+	"glacier",
+	"quartz",
+]);
+
+/**
+ * Returns the reasoning effort levels that are meaningful for a model, i.e.
+ * the values the gateway forwards or maps to distinct behavior upstream.
+ * Mirrors the per-provider handling in @llmgateway/actions prepareRequestBody:
+ *
+ * - Anthropic maps low→max onto thinking budgets / adaptive effort tiers
+ *   (`minimal` collapses onto `low`, so it is omitted).
+ * - Gemini maps minimal→xhigh onto thinking budgets and honors `none` as an
+ *   explicit off switch (`max` aliases `high`).
+ * - OpenAI forwards the raw value and the upstream rejects unsupported ones:
+ *   the original GPT-5 line accepts `minimal`, GPT-5.4+ replaces it with
+ *   `none` and adds `xhigh`, pro variants are restricted further, and the
+ *   o-series/gpt-oss/codex models accept low/medium/high.
+ * - Fugu (sakana) only accepts high/xhigh.
+ */
+export function getReasoningEffortOptions(
+	modelId: string,
+	family: string | undefined,
+	providerIds: string[],
+): ReasoningEffortValue[] {
+	switch (family) {
+		case "anthropic":
+			return ["low", "medium", "high", "xhigh", "max"];
+		case "google":
+			if (providerIds.some((id) => GOOGLE_API_PROVIDERS.has(id))) {
+				return ["none", "minimal", "low", "medium", "high", "xhigh"];
+			}
+			return DEFAULT_EFFORTS;
+		case "sakana":
+			return ["high", "xhigh"];
+		case "openai": {
+			const gpt5 = modelId.match(/^gpt-5(?:\.(\d+))?/);
+			if (!gpt5 || modelId.startsWith("gpt-oss") || modelId.includes("codex")) {
+				return DEFAULT_EFFORTS;
+			}
+			const minor = gpt5[1] ? parseInt(gpt5[1], 10) : 0;
+			const isPro = modelId.includes("-pro");
+			if (minor >= 4) {
+				return isPro
+					? ["medium", "high", "xhigh"]
+					: ["none", "low", "medium", "high", "xhigh"];
+			}
+			return isPro ? ["high"] : ["minimal", "low", "medium", "high"];
+		}
+		default:
+			return DEFAULT_EFFORTS;
+	}
+}


### PR DESCRIPTION
## Summary

The playground's reasoning effort picker offered a hard-coded **Minimal / Low / Medium / High** list for every reasoning model. That was wrong in both directions:

- **Errors**: OpenAI rejects unsupported values with `unsupported_value` — e.g. picking *Minimal* on GPT-5.4+ models (which replaced `minimal` with `none`) failed the request.
- **Missing tiers**: models with higher effort levels never exposed them — `xhigh` on GPT-5.4/5.5/5.6, Fugu Ultra, and Gemini; `xhigh` + `max` on Claude.

## Changes

- New `apps/playground/src/lib/reasoning-efforts.ts`: derives the effort option list per model from the gateway's actual effort handling in `prepareRequestBody` (family + model id + provider mappings):
  - **Anthropic**: Low → Max (all five tiers map to distinct thinking budgets / adaptive effort levels)
  - **Gemini API models**: Off (`none`, natively disables thinking) + Minimal → xHigh (distinct thinking budgets); Gemma on generic hosts keeps Low/Medium/High
  - **OpenAI**: GPT-5 line keeps Minimal/Low/Medium/High; GPT-5.4+ gets Off/Low/Medium/High/xHigh; pro variants restricted (`gpt-5.x-pro` < 5.4 → High only, ≥ 5.4 → Medium/High/xHigh); o-series/gpt-oss/codex → Low/Medium/High
  - **Fugu Ultra (sakana)**: High/xHigh only (upstream rejects everything lower)
  - everything else: Low/Medium/High as before
- `chat-ui.tsx` renders the per-model list (removes the `includes("gpt-5")` substring hack) and hides the picker when a model has no meaningful levels.
- Selection resets when switching to a model that doesn't support the current level (e.g. Claude *Max* → GPT-5 Mini).
- Widened the `reasoning_effort` union in the chat API route to pass `none`/`xhigh`/`max` through to the gateway.
- Unit tests for the option derivation (9 cases).

## Verification

Ran the playground against the local API and checked the dropdown per model:

| Model | Options shown |
|---|---|
| GPT-5 Mini | Auto, Minimal, Low, Medium, High |
| GPT-5.6 Sol | Auto, Off, Low, Medium, High, xHigh |
| Claude Opus 4.8 | Auto, Low, Medium, High, xHigh, Max |
| Fugu Ultra | Auto, High, xHigh |
| Gemini 3.5 Flash | Auto, Off, Minimal, Low, Medium, High, xHigh |

Also verified the effort resets to Auto when switching from Claude (Max selected) to GPT-5 Mini. `turbo run build --filter=playground` and playground unit tests pass.

https://claude.ai/code/session_01PWxE8tVU8wz6C5Vgxw33ov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-aware reasoning effort options in the Playground.
  * Supported additional effort levels, including None, Extra High, and Maximum.
  * Reasoning effort choices now adapt automatically to the selected model and provider.
  * Applied the same configuration to comparison chat panels.

* **Bug Fixes**
  * Reasoning effort selections now reset when unavailable for the selected model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->