### PR TITLE
fix(videos): allow up to 9 reference images on Seedance 2.0

### DIFF
--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -2029,6 +2029,37 @@ mockOpenAIServer.post("/contents/generations/tasks", async (c) => {
 		};
 	};
 
+	const referenceImages: Array<{
+		mimeType: string;
+		bytesBase64Encoded: string;
+		referenceType: string;
+	}> = [];
+	for (const entry of content) {
+		if (
+			!entry ||
+			typeof entry !== "object" ||
+			(entry as Record<string, unknown>).role !== "reference_image"
+		) {
+			continue;
+		}
+		const imageUrl = (entry as Record<string, unknown>).image_url;
+		const url =
+			typeof imageUrl === "object" &&
+			imageUrl !== null &&
+			typeof (imageUrl as Record<string, unknown>).url === "string"
+				? ((imageUrl as Record<string, unknown>).url as string)
+				: undefined;
+		const match = url?.match(/^data:([^;]+);base64,(.*)$/);
+		if (!match) {
+			continue;
+		}
+		referenceImages.push({
+			mimeType: match[1],
+			bytesBase64Encoded: match[2],
+			referenceType: "reference_image",
+		});
+	}
+
 	videoCounter++;
 	const id = `bytedance_task_${videoCounter}`;
 	const job: MockVideoJobState = {
@@ -2039,6 +2070,7 @@ mockOpenAIServer.post("/contents/generations/tasks", async (c) => {
 		progress: 0,
 		firstFrame: parseFrameByRole("first_frame"),
 		lastFrame: parseFrameByRole("last_frame"),
+		referenceImages: referenceImages.length > 0 ? referenceImages : undefined,
 		duration: typeof body.duration === "number" ? body.duration : undefined,
 		ratio: typeof body.ratio === "string" ? body.ratio : undefined,
 		resolution:

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -805,6 +805,126 @@ describe("videos", () => {
 		expect(JSON.stringify(json)).toContain("Seedance 2.0");
 	});
 
+	test("/v1/videos forwards up to nine reference images to Seedance 2.0 Fast", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-bytedance-key",
+			provider: "bytedance",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const referenceImages = Array.from({ length: 9 }, (_, index) => ({
+			image_url: `data:image/png;base64,${Buffer.from(`ref-${index}`).toString("base64")}`,
+		}));
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0-fast",
+				prompt: "Combine these references into one clip",
+				size: "1280x720",
+				seconds: 5,
+				reference_images: referenceImages,
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const created = await createRes.json();
+
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: created.id } },
+		});
+		expect(videoJob?.usedProvider).toBe("bytedance");
+
+		const mockVideo = getMockVideo(videoJob!.upstreamId);
+		expect(mockVideo?.referenceImages).toHaveLength(9);
+	});
+
+	test("/v1/videos rejects more than nine reference images on Seedance 2.0 Fast", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const referenceImages = Array.from({ length: 10 }, (_, index) => ({
+			image_url: `data:image/png;base64,${Buffer.from(`ref-${index}`).toString("base64")}`,
+		}));
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-0-fast",
+				prompt: "Too many references",
+				size: "1280x720",
+				seconds: 5,
+				reference_images: referenceImages,
+			}),
+		});
+
+		expect(res.status).toBe(400);
+	});
+
+	test("/v1/videos rejects more than three reference images on veo", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-google-vertex-key",
+			provider: "google-vertex",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const referenceImages = Array.from({ length: 4 }, (_, index) => ({
+			image_url: `data:image/png;base64,${Buffer.from(`ref-${index}`).toString("base64")}`,
+		}));
+
+		const res = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "google-vertex/veo-3.1-generate-preview",
+				prompt: "Too many references for veo",
+				size: "1280x720",
+				seconds: 8,
+				reference_images: referenceImages,
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("at most 3 reference images");
+	});
+
 	test("/v1/videos uses routing metrics to pick the best eligible provider", async () => {
 		const originalGoogleCloudProject = process.env.LLM_GOOGLE_CLOUD_PROJECT;
 		const originalRuntimeGoogleCloudProject = process.env.GOOGLE_CLOUD_PROJECT;

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -229,7 +229,13 @@ const videoImageInputSchema = z
 		},
 	});
 
-const videoReferenceImagesSchema = z.array(videoImageInputSchema).min(1).max(3);
+const SEEDANCE_2_MAX_REFERENCE_IMAGES = 9;
+const DEFAULT_MAX_REFERENCE_IMAGES = 3;
+
+const videoReferenceImagesSchema = z
+	.array(videoImageInputSchema)
+	.min(1)
+	.max(SEEDANCE_2_MAX_REFERENCE_IMAGES);
 
 const referenceVideoUrlSchema = z
 	.string()
@@ -340,7 +346,7 @@ const createVideoRequestSchema = z
 		image: videoImageInputSchema.optional(),
 		reference_images: videoReferenceImagesSchema.optional().openapi({
 			description:
-				"One to three reference images for provider-specific asset or material-guided video generation.",
+				"Reference images for provider-specific asset or material-guided video generation. ByteDance Seedance 2.0 models accept up to 9; other providers accept up to 3.",
 			example: [
 				{
 					image_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
@@ -1069,6 +1075,10 @@ function getVideoProviderConstraintReasons(
 				reasons.push(
 					"reference inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast, seedance-2-0-mini)",
 				);
+			} else if (inputImageCount > SEEDANCE_2_MAX_REFERENCE_IMAGES) {
+				reasons.push(
+					`Seedance 2.0 supports at most ${SEEDANCE_2_MAX_REFERENCE_IMAGES} reference images`,
+				);
 			}
 
 			return reasons;
@@ -1083,6 +1093,12 @@ function getVideoProviderConstraintReasons(
 		if (referenceAudioCount > 0) {
 			reasons.push(
 				"reference audio is currently only supported on bytedance Seedance 2.0 models",
+			);
+		}
+
+		if (inputImageCount > DEFAULT_MAX_REFERENCE_IMAGES) {
+			reasons.push(
+				`this provider mapping supports at most ${DEFAULT_MAX_REFERENCE_IMAGES} reference images`,
 			);
 		}
 


### PR DESCRIPTION
## Summary

A user reported that **Seedance 2.0 Fast** only accepted up to 3 reference images, while ByteDance's official Seedance 2.0 omni-reference documentation states it supports up to **9** reference images (alongside up to 3 reference videos and 3 reference audio clips).

This was **not** Fast-specific: the shared `reference_images` request schema in `apps/gateway/src/videos/videos.ts` was hard-capped at `.max(3)` for **every** video model, so all three Seedance 2.0 variants (`seedance-2-0`, `seedance-2-0-fast`, `seedance-2-0-mini`) were affected.

## Changes

- Raise the shared `videoReferenceImagesSchema` cap from 3 → 9 (the maximum any model supports).
- Enforce the real per-provider limits in `getVideoProviderConstraintReasons`:
  - **bytedance Seedance 2.0** → up to **9** reference images
  - **all other providers** (google-vertex / avalanche Veo, etc.) → keep the previous cap of **3** (no behavior change)
- Update the `reference_images` OpenAPI description to reflect the new range.
- Extend the mock server to capture ByteDance `reference_image` content items so forwarding can be asserted.

## Tests

New tests in `videos.spec.ts`:
- Seedance 2.0 Fast forwards all 9 reference images.
- Seedance 2.0 Fast rejects 10 (schema cap).
- Veo rejects more than 3 reference images (per-provider cap preserved).

The reference videos/audios `.max(3)` caps already matched the docs and were left unchanged. Full `videos.spec.ts` suite (45 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support up to nine reference images for Seedance 2.0 Fast video generation.
  * Updated reference-image guidance to reflect provider-specific limits.

* **Bug Fixes**
  * Added validation to reject requests exceeding supported reference-image limits.
  * Other video providers now allow up to three reference images, with clear error messages when exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->