### PR TITLE
feat: gate provider listing behind verified email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - In `packages/models`, ALWAYS express per-token prices (`inputPrice`, `outputPrice`, `cachedInputPrice`, and any other per-token price field) using `e-6` notation so the coefficient reads directly as USD per million tokens (e.g. `"1.4e-6"` for $1.40/M — the exact number providers publish). Never use `e-3` or other exponents for per-token prices. This does NOT apply to `requestPrice`, which is a flat USD amount charged per request (e.g. `"0.035"`), nor to `perSecondPrice`.
 - No unnecessary code comments
 - Do not use broad try/catch in API handlers unless to check for specific errors; instead, let errors propagate and be handled by the global error handler
+- Security gating must be enforced server-side, never in the UI alone. Client-side gates (disabling a form, hiding a button, gating on `user.emailVerified`) are UX conveniences, not security boundaries — the underlying API endpoint must independently verify auth/verification/permissions and reject unauthorized requests. For example, the provider-listing form (`apps/ui/src/components/add-provider/add-provider-form.tsx`) is gated in the UI, but the real enforcement lives in the `POST /public/contact/provider` handler (`apps/api/src/routes/public-contact.ts`), which requires an authenticated, email-verified session and derives the stored email from the session rather than trusting the request body.
 
 ### Testing and Quality Assurance
 

--- a/apps/api/src/routes/public-contact.ts
+++ b/apps/api/src/routes/public-contact.ts
@@ -1,7 +1,7 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
-import { redisClient } from "@/auth/config.js";
+import { apiAuth, redisClient } from "@/auth/config.js";
 import {
 	notifyEnterpriseContact,
 	notifyProviderContact,
@@ -514,6 +514,22 @@ const submitProviderContact = createRoute({
 			},
 			description: "Submission rejected by validation or spam checks",
 		},
+		401: {
+			content: {
+				"application/json": {
+					schema: contactResponseSchema,
+				},
+			},
+			description: "Authentication required to submit a provider listing",
+		},
+		403: {
+			content: {
+				"application/json": {
+					schema: contactResponseSchema,
+				},
+			},
+			description: "A verified email is required to submit a listing",
+		},
 		429: {
 			content: {
 				"application/json": {
@@ -534,7 +550,35 @@ const submitProviderContact = createRoute({
 });
 
 publicContact.openapi(submitProviderContact, async (c) => {
+	// Server-side spam gate: only authenticated users with a verified email may
+	// submit a provider listing. This mirrors the UI gate but is the real
+	// enforcement point — the UI check is a convenience, not a security boundary.
+	const session = await apiAuth.api.getSession({ headers: c.req.raw.headers });
+	if (!session?.user) {
+		return c.json(
+			{
+				success: false,
+				message: "You must be signed in to submit a provider listing.",
+			},
+			401,
+		);
+	}
+	if (!session.user.emailVerified) {
+		return c.json(
+			{
+				success: false,
+				message:
+					"Please verify your email address before submitting a provider listing.",
+			},
+			403,
+		);
+	}
+
 	const validatedData = c.req.valid("json");
+	// Tie the submission to the authenticated, verified account email rather than
+	// trusting the client-supplied value, so a listing can't be attributed to an
+	// address the submitter doesn't own.
+	const email = session.user.email;
 	const ipAddress = extractClientIP(c);
 	const userAgent = c.req.header("User-Agent") ?? null;
 
@@ -544,7 +588,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 			.insert(tables.providerListingRequest)
 			.values({
 				providerName: validatedData.providerName,
-				email: validatedData.email,
+				email,
 				url: validatedData.url,
 				country: validatedData.country,
 				complianceSoc2Type2: validatedData.complianceSoc2Type2,
@@ -599,7 +643,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 		}
 	}
 
-	const rateLimitKey = ipAddress ?? `email:${validatedData.email}`;
+	const rateLimitKey = ipAddress ?? `user:${session.user.id}`;
 	const canSubmit = await checkRateLimit(rateLimitKey);
 	if (!canSubmit) {
 		await updateProviderRequestStatus(
@@ -617,7 +661,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 		);
 	}
 
-	if (isDisposableEmail(validatedData.email)) {
+	if (isDisposableEmail(email)) {
 		await updateProviderRequestStatus(
 			submission.id,
 			"rejected",
@@ -667,7 +711,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 			const checkoutSession = await getStripe().checkout.sessions.create({
 				mode: "payment",
 				line_items: [{ price: providerListingPriceId, quantity: 1 }],
-				customer_email: validatedData.email,
+				customer_email: email,
 				success_url: `${uiUrl}/add-provider?payment=success`,
 				cancel_url: `${uiUrl}/add-provider?payment=canceled`,
 				metadata: {
@@ -724,7 +768,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 
 					<div class="field">
 						<div class="label">Contact Email:</div>
-						<div class="value">${escapeHtml(validatedData.email)}</div>
+						<div class="value">${escapeHtml(email)}</div>
 					</div>
 
 					<div class="field">
@@ -760,7 +804,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 		const { error } = await resend.emails.send({
 			from: fromEmail,
 			to: [replyToEmail],
-			replyTo: validatedData.email,
+			replyTo: email,
 			subject: `Provider Listing Request: ${validatedData.providerName}`,
 			html: htmlContent,
 		});
@@ -793,7 +837,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 
 	void notifyProviderContact({
 		providerName: validatedData.providerName,
-		email: validatedData.email,
+		email,
 		url: validatedData.url,
 		country: validatedData.country,
 		compliance,

--- a/apps/ui/src/components/add-provider/add-provider-form.tsx
+++ b/apps/ui/src/components/add-provider/add-provider-form.tsx
@@ -8,13 +8,18 @@ import {
 	ChevronsUpDown,
 	Info,
 	Loader2,
+	LogIn,
+	MailWarning,
 } from "lucide-react";
+import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { useUser } from "@/hooks/useUser";
+import { useAuth } from "@/lib/auth-client";
 import { Button } from "@/lib/components/button";
 import { Checkbox } from "@/lib/components/checkbox";
 import {
@@ -78,11 +83,16 @@ export function AddProviderForm({
 }) {
 	const api = useApi();
 	const posthog = usePostHog();
+	const { user, isLoading: isUserLoading } = useUser();
+	const { sendVerificationEmail } = useAuth();
 	const submitProvider = api.useMutation("post", "/public/contact/provider");
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isSuccess, setIsSuccess] = useState(false);
 	const [countryOpen, setCountryOpen] = useState(false);
+	const [isResending, setIsResending] = useState(false);
 	const [formLoadTime] = useState(() => Date.now());
+
+	const canFillForm = !!user && user.emailVerified;
 
 	const form = useForm<ProviderFormData>({
 		resolver: zodResolver(providerFormSchema),
@@ -104,6 +114,33 @@ export function AddProviderForm({
 	useEffect(() => {
 		form.setValue("timestamp", formLoadTime);
 	}, [form, formLoadTime]);
+
+	useEffect(() => {
+		if (canFillForm && user) {
+			form.setValue("email", user.email);
+		}
+	}, [canFillForm, user, form]);
+
+	const handleResendVerification = async () => {
+		if (!user) {
+			return;
+		}
+		setIsResending(true);
+		const { error } = await sendVerificationEmail({
+			email: user.email,
+			callbackURL: `${window.location.origin}/add-provider`,
+		});
+		if (error) {
+			toast.error("Failed to send verification email", {
+				description: error.message ?? "Please try again later.",
+			});
+		} else {
+			toast.success("Verification email sent", {
+				description: "Please check your inbox for the verification link.",
+			});
+		}
+		setIsResending(false);
+	};
 
 	const onSubmit = async (data: ProviderFormData) => {
 		posthog.capture("provider_request_submitted", {
@@ -216,6 +253,74 @@ export function AddProviderForm({
 									</Button>
 								</div>
 							</div>
+						) : isUserLoading ? (
+							<div className="flex items-center justify-center py-10">
+								<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+							</div>
+						) : !user ? (
+							<div className="py-4 text-center">
+								<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 mb-6">
+									<LogIn className="w-8 h-8 text-primary" />
+								</div>
+								<h3 className="text-2xl font-semibold mb-2">
+									Sign in to add a provider
+								</h3>
+								<p className="text-muted-foreground text-balance">
+									To keep listings genuine and prevent spam, you need a
+									LLMGateway account with a verified email before submitting a
+									provider. Create your account to get started.
+								</p>
+								<div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">
+									<Button asChild size="lg" className="w-full sm:w-auto">
+										<Link href="/signup">
+											Sign up
+											<ArrowRight className="ml-2 h-4 w-4" />
+										</Link>
+									</Button>
+									<Button
+										asChild
+										size="lg"
+										variant="outline"
+										className="w-full sm:w-auto"
+									>
+										<Link href="/login">Log in</Link>
+									</Button>
+								</div>
+							</div>
+						) : !user.emailVerified ? (
+							<div className="py-4 text-center">
+								<div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber-100 dark:bg-amber-900/20 mb-6">
+									<MailWarning className="w-8 h-8 text-amber-600 dark:text-amber-400" />
+								</div>
+								<h3 className="text-2xl font-semibold mb-2">
+									Verify your email first
+								</h3>
+								<p className="text-muted-foreground text-balance">
+									To prevent spam, the provider form is only available once
+									you've verified your email. We sent a verification link to{" "}
+									<span className="font-medium text-foreground">
+										{user.email}
+									</span>
+									. Click it, then reload this page.
+								</p>
+								<div className="mt-6">
+									<Button
+										onClick={handleResendVerification}
+										variant="outline"
+										size="lg"
+										disabled={isResending}
+									>
+										{isResending ? (
+											<>
+												<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+												Sending...
+											</>
+										) : (
+											"Resend verification email"
+										)}
+									</Button>
+								</div>
+							</div>
 						) : (
 							<Form {...form}>
 								<form
@@ -280,9 +385,13 @@ export function AddProviderForm({
 															type="email"
 															placeholder="team@acme.ai"
 															{...field}
-															className="bg-background h-11"
+															readOnly
+															className="bg-muted h-11 cursor-not-allowed"
 														/>
 													</FormControl>
+													<FormDescription>
+														Your verified account email.
+													</FormDescription>
 													<FormMessage />
 												</FormItem>
 											)}


### PR DESCRIPTION
## Summary

Gates the "Add a Provider" listing form behind an authenticated, email-verified account to prevent spam. Enforcement is done **server-side** (the real boundary), with the UI mirroring it for a clear experience.

## Changes

### UI (`apps/ui/src/components/add-provider/add-provider-form.tsx`)
- The form now resolves the current user via `useUser()` and renders one of these states inside the card:
  - **Loading** — spinner while the session resolves.
  - **Not signed in** — the form is not rendered; instead a message explains an account with a verified email is required to prevent spam, plus **Sign up** / **Log in** buttons.
  - **Signed in but email unverified** — the form is not rendered; a "Verify your email first" panel shows the account email and a **Resend verification email** button (via `sendVerificationEmail`, callback returns to `/add-provider`).
  - **Signed in + verified** — the full form renders.
- The **Contact Email** field is prefilled from the authenticated user and made read-only, so submissions are tied to the verified account.

### API (`apps/api/src/routes/public-contact.ts`)
- `POST /public/contact/provider` now requires an authenticated session (`401` otherwise) with a verified email (`403` otherwise) before doing any work.
- The stored/notified/checkout email is derived from the session's verified account email rather than the request body, so a listing can't be attributed to an address the submitter doesn't own.
- Rate-limit fallback key switched from client email to the authenticated user id.
- Added `401`/`403` responses to the OpenAPI route definition.

### Docs (`AGENTS.md`)
- Added a standing note that security gating must be enforced server-side, with the provider-listing flow cited as the reference example.

## Testing
- `pnpm exec turbo run build --filter=api` — passes
- `pnpm exec turbo run build --filter=ui` — passes
- `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R23YfVXvknBKCjoAk5EokU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider submissions now require a signed-in account with a verified email address.
  * Added clear loading, sign-in, and email-verification states to the provider form.
  * Users can resend verification emails directly from the form.
  * The contact email is automatically populated from the verified account and cannot be edited.

* **Bug Fixes**
  * Provider submissions now consistently use the verified account email for processing and notifications.
  * Added clear authentication and verification error responses for blocked submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->