### PR TITLE
fix: reset stale reasoning effort, clarify docs

### DIFF
--- a/apps/docs/content/features/reasoning.mdx
+++ b/apps/docs/content/features/reasoning.mdx
@@ -40,7 +40,7 @@ Add the `reasoning_effort` parameter directly to your request:
 - `medium` - Balanced reasoning for most tasks
 - `high` - Deep reasoning for complex problems
 - `xhigh` - Very deep reasoning for the most complex problems
-- `max` - Highest reasoning tier, above `xhigh`. Supported by Anthropic thinking models and OpenAI GPT-5.6 models. Effort values are forwarded to the provider as-is, so sending a value the target model doesn't support results in a provider error
+- `max` - Highest reasoning tier, above `xhigh`. Supported by Anthropic thinking models and OpenAI GPT-5.6 models. Effort tiers are never downgraded by the gateway: providers that accept an effort parameter receive the value unchanged (unsupported values result in a provider error), while providers that take a thinking budget instead (Anthropic, Google) have each tier translated to a native budget
 
 <Callout type="info">
 	OpenAI's reasoning models do not all accept the same effort values. The
@@ -78,7 +78,7 @@ Use the unified `reasoning` configuration object with an `effort` field:
 - `medium` - Balanced reasoning for most tasks
 - `high` - Deep reasoning for complex problems
 - `xhigh` - Very deep reasoning for the most complex problems
-- `max` - Highest reasoning tier, above `xhigh`. Supported by Anthropic thinking models and OpenAI GPT-5.6 models. Effort values are forwarded to the provider as-is, so sending a value the target model doesn't support results in a provider error
+- `max` - Highest reasoning tier, above `xhigh`. Supported by Anthropic thinking models and OpenAI GPT-5.6 models. Effort tiers are never downgraded by the gateway: providers that accept an effort parameter receive the value unchanged (unsupported values result in a provider error), while providers that take a thinking budget instead (Anthropic, Google) have each tier translated to a native budget
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/chat/completions" \

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -215,7 +215,8 @@ const anthropicRequestSchema = z.object({
 		.object({
 			// Matches the chat completions reasoning-effort enum. Claude Code emits
 			// the full range (including `xhigh` and `max`), so accept all of them;
-			// values are forwarded to the provider as-is.
+			// tiers are never downgraded — downstream they map onto Anthropic's
+			// native thinking controls (adaptive effort or a budget).
 			effort: z
 				.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 				.optional(),

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -307,7 +307,7 @@ export const completionsRequestSchema = z.object({
 		.transform((val) => (val === null ? undefined : val))
 		.openapi({
 			description:
-				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. Values are forwarded to the provider as-is; sending a value the target model doesn't support results in a provider error. The exact values each provider mapping accepts are exposed as `reasoning_efforts` on `/v1/models`.",
+				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. The gateway never downgrades effort tiers: providers that accept an effort parameter receive the value unchanged (an unsupported value results in a provider error), while providers that take a thinking budget instead (e.g. Anthropic, Google) translate each tier to a native budget. The exact values each provider mapping accepts are exposed as `reasoning_efforts` on `/v1/models`.",
 			example: "medium",
 		}),
 	reasoning: z
@@ -317,7 +317,7 @@ export const completionsRequestSchema = z.object({
 				.optional()
 				.openapi({
 					description:
-						"Controls the reasoning effort. Alternative to top-level reasoning_effort. Cannot be used together with reasoning_effort. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. Values are forwarded to the provider as-is; unsupported values result in a provider error. See `reasoning_efforts` on `/v1/models` for the values each mapping accepts.",
+						"Controls the reasoning effort. Alternative to top-level reasoning_effort. Cannot be used together with reasoning_effort. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. Tiers are never downgraded by the gateway: enum-based providers receive the value unchanged (unsupported values result in a provider error), while budget-based providers (e.g. Anthropic, Google) translate the tier to a native thinking budget. See `reasoning_efforts` on `/v1/models` for the values each mapping accepts.",
 					example: "medium",
 				}),
 			max_tokens: z.number().int().positive().optional().openapi({

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -51,7 +51,10 @@ import {
 	getModelPreferenceCookie,
 	setModelPreferenceCookie,
 } from "@/lib/model-preferences";
-import { getReasoningEffortOptions } from "@/lib/model-utils";
+import {
+	getFallbackReasoningEffortOptions,
+	getReasoningEffortOptions,
+} from "@/lib/model-utils";
 import { shouldDisableFallback } from "@/lib/no-fallback";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -1889,20 +1892,19 @@ export default function ChatPageClient({
 		setText(value);
 	};
 
-	// Reset reasoning effort when switching to a non-reasoning model, or when
-	// the new model declares its supported efforts and the current value isn't
-	// among them.
+	// Reset reasoning effort when switching to a model that doesn't support
+	// it. The effective options mirror what the selector renders: the model's
+	// declared efforts, or the generic fallback set when undeclared.
 	useEffect(() => {
 		if (!reasoningEffort) {
 			return;
 		}
-		if (
-			!supportsReasoning ||
-			(reasoningEfforts && !reasoningEfforts.includes(reasoningEffort))
-		) {
+		const effortOptions =
+			reasoningEfforts ?? getFallbackReasoningEffortOptions(selectedModel);
+		if (!supportsReasoning || !effortOptions.includes(reasoningEffort)) {
 			setReasoningEffort("");
 		}
-	}, [supportsReasoning, reasoningEffort, reasoningEfforts]);
+	}, [supportsReasoning, reasoningEffort, reasoningEfforts, selectedModel]);
 
 	// Reset image size/quality only when the selected model changes and the
 	// current value is not valid for the new model. Including alibabaImageSize
@@ -2691,20 +2693,19 @@ function ExtraChatPanel({
 		return getReasoningEffortOptions(mapping ? [mapping] : []);
 	}, [models, selectedModel]);
 
-	// Reset reasoning effort when switching to a non-reasoning model, or when
-	// the new model declares its supported efforts and the current value isn't
-	// among them.
+	// Reset reasoning effort when switching to a model that doesn't support
+	// it. The effective options mirror what the selector renders: the model's
+	// declared efforts, or the generic fallback set when undeclared.
 	useEffect(() => {
 		if (!reasoningEffort) {
 			return;
 		}
-		if (
-			!supportsReasoning ||
-			(reasoningEfforts && !reasoningEfforts.includes(reasoningEffort))
-		) {
+		const effortOptions =
+			reasoningEfforts ?? getFallbackReasoningEffortOptions(selectedModel);
+		if (!supportsReasoning || !effortOptions.includes(reasoningEffort)) {
 			setReasoningEffort("");
 		}
-	}, [supportsReasoning, reasoningEffort, reasoningEfforts]);
+	}, [supportsReasoning, reasoningEffort, reasoningEfforts, selectedModel]);
 
 	const supportsWebSearch = useMemo(() => {
 		if (!selectedModel) {

--- a/apps/playground/src/components/playground/chat-ui.tsx
+++ b/apps/playground/src/components/playground/chat-ui.tsx
@@ -101,6 +101,7 @@ import {
 	parsePlaygroundMessageMetadata,
 	type PlaygroundMessageMetadata,
 } from "@/lib/message-metadata";
+import { getFallbackReasoningEffortOptions } from "@/lib/model-utils";
 import { cn } from "@/lib/utils";
 
 import type { ReasoningEffortOption } from "@/lib/fetch-models";
@@ -1888,11 +1889,7 @@ export const ChatUI = ({
 										<SelectItem value="off">Auto</SelectItem>
 										{(
 											reasoningEfforts ??
-											// Fallback for models that don't declare their
-											// supported efforts in the catalog yet.
-											((selectedModel.includes("gpt-5")
-												? ["minimal", "low", "medium", "high"]
-												: ["low", "medium", "high"]) as ReasoningEffortOption[])
+											getFallbackReasoningEffortOptions(selectedModel)
 										).map((effort) => (
 											<SelectItem key={effort} value={effort}>
 												{REASONING_EFFORT_LABELS[effort]}

--- a/apps/playground/src/lib/model-utils.ts
+++ b/apps/playground/src/lib/model-utils.ts
@@ -16,6 +16,19 @@ export const REASONING_EFFORT_ORDER: ReasoningEffortOption[] = [
 ];
 
 /**
+ * Generic effort options for models that don't declare their supported
+ * values in the catalog yet. Used for both rendering the selector and
+ * resetting a stale selection, so the two never disagree.
+ */
+export function getFallbackReasoningEffortOptions(
+	selectedModel: string,
+): ReasoningEffortOption[] {
+	return selectedModel.includes("gpt-5")
+		? ["minimal", "low", "medium", "high"]
+		: ["low", "medium", "high"];
+}
+
+/**
  * Union of the reasoning_effort values declared by the given provider
  * mappings, in ascending order of effort. Returns null when none of the
  * mappings declare their supported values, so callers can fall back to a


### PR DESCRIPTION
## Summary

Follow-up to #3028, addressing the CodeRabbit review comments that couldn't land there because the branch was locked in the merge queue.

- **Playground: reset uncatalogued reasoning efforts too.** A previously selected effort (e.g. `max` on gpt-5.6-sol) survived switching to a model with no declared `reasoningEfforts` in the catalog, leaving the selector with no matching item while still sending the unsupported `reasoning_effort` upstream — which now fails with a provider 4xx since #3028 removed the downgrade. Both reset effects (main chat and comparison panel) now validate against the same effective options the selector renders, via a shared `getFallbackReasoningEffortOptions` helper that also replaces the inline fallback in the dropdown.
- **Docs/API descriptions:** clarify that effort tiers are never downgraded by the gateway — enum-based providers receive the value unchanged (unsupported values result in a provider error), while budget-based providers (Anthropic, Google) translate each tier to a native thinking budget. Applied to both `reasoning_effort` descriptions in the chat completions schema, the Anthropic endpoint comment, and the reasoning docs page.

## Testing

- `turbo run build --filter=playground --filter=gateway` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPnpiisz8mM8nRGyVpWmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPnpiisz8mM8nRGyVpWmUh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent fallback reasoning-effort options for models without published support details.
  - Reasoning-effort selections now automatically adapt when switching models, clearing unsupported values.

- **Bug Fixes**
  - Prevented invalid reasoning-effort settings from remaining selected for unsupported models.
  - Clarified that reasoning tiers are not downgraded and are translated appropriately for providers using native thinking budgets.

- **Documentation**
  - Updated configuration and API descriptions to explain reasoning-effort handling and provider-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->