### PR TITLE
feat(ui): expandable details on model mapping card

### DIFF
--- a/apps/ui/src/components/models/adapt-model.ts
+++ b/apps/ui/src/components/models/adapt-model.ts
@@ -69,6 +69,7 @@ export function adaptProviderMapping(
 			streaming: p.streaming === "only" ? true : p.streaming,
 			vision: p.vision ?? null,
 			reasoning: p.reasoning ?? null,
+			reasoningEfforts: p.reasoningEfforts ?? null,
 			reasoningOutput: p.reasoningOutput ?? null,
 			reasoningMaxTokens: p.reasoningMaxTokens ?? null,
 			tools: p.tools ?? null,

--- a/apps/ui/src/components/models/model-card.tsx
+++ b/apps/ui/src/components/models/model-card.tsx
@@ -520,9 +520,13 @@ export function ProviderSection({
 }) {
 	const [activeRegionIdx, setActiveRegionIdx] = useState(0);
 	const [showTokenPricing, setShowTokenPricing] = useState(false);
+	const [showMappingDetails, setShowMappingDetails] = useState(false);
 	const [selectedServiceTierId, setSelectedServiceTierId] =
 		useState("standard");
 	const activeMapping = mappings[activeRegionIdx] ?? mappings[0];
+	const hasMappingDetails =
+		(activeMapping.reasoningEfforts?.length ?? 0) > 0 ||
+		(activeMapping.supportedParameters?.length ?? 0) > 0;
 	const supportedServiceTierIds = new Set(activeMapping.serviceTiers ?? []);
 	const serviceTiers = (providerInfo.serviceTiers ?? []).filter((tier) =>
 		supportedServiceTierIds.has(tier.id),
@@ -1312,6 +1316,72 @@ export function ProviderSection({
 							</>
 						)}
 					</button>
+				)}
+
+				{/* Reasoning efforts + supported parameters, collapsed by default */}
+				{hasMappingDetails && (
+					<>
+						{showMappingDetails && (
+							<div className="space-y-2.5">
+								{(activeMapping.reasoningEfforts?.length ?? 0) > 0 && (
+									<div className="rounded-md bg-muted/40 border border-border/30 p-2.5">
+										<div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-2">
+											Reasoning Efforts
+										</div>
+										<div className="flex flex-wrap gap-1">
+											{activeMapping.reasoningEfforts!.map((effort) => (
+												<Badge
+													key={effort}
+													variant="outline"
+													className="text-[10px] px-1.5 py-0 h-4 font-mono text-muted-foreground"
+												>
+													{effort}
+												</Badge>
+											))}
+										</div>
+									</div>
+								)}
+								{(activeMapping.supportedParameters?.length ?? 0) > 0 && (
+									<div className="rounded-md bg-muted/40 border border-border/30 p-2.5">
+										<div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 mb-2">
+											Supported Parameters
+										</div>
+										<div className="flex flex-wrap gap-1">
+											{activeMapping.supportedParameters!.map((param) => (
+												<Badge
+													key={param}
+													variant="outline"
+													className="text-[10px] px-1.5 py-0 h-4 font-mono text-muted-foreground"
+												>
+													{param}
+												</Badge>
+											))}
+										</div>
+									</div>
+								)}
+							</div>
+						)}
+						<button
+							type="button"
+							className="w-full flex items-center justify-center gap-1.5 py-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+							onClick={(e) => {
+								e.stopPropagation();
+								setShowMappingDetails((v) => !v);
+							}}
+						>
+							{showMappingDetails ? (
+								<>
+									<ChevronUp className="h-3 w-3" />
+									Hide details
+								</>
+							) : (
+								<>
+									<ChevronDown className="h-3 w-3" />
+									Show details
+								</>
+							)}
+						</button>
+					</>
 				)}
 			</div>
 		</div>

--- a/apps/ui/src/lib/fetch-models.ts
+++ b/apps/ui/src/lib/fetch-models.ts
@@ -49,6 +49,9 @@ export interface ApiModelProviderMapping {
 	streaming: boolean;
 	vision: boolean | null;
 	reasoning: boolean | null;
+	reasoningEfforts?:
+		| ("none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max")[]
+		| null;
 	reasoningOutput: string | null;
 	reasoningMaxTokens: boolean | null;
 	tools: boolean | null;


### PR DESCRIPTION
## Summary

Follow-up to #3028/#3030: surface the per-mapping reasoning effort values and supported parameters on the public model detail pages, without cluttering the card by default.

- The provider mapping detail card (`ProviderSection`) gains a **"Show details" section, collapsed by default**, mirroring the card's existing chevron expand/collapse pattern. When expanded it shows:
  - **Reasoning Efforts** — the mapping's declared `reasoningEfforts` values as badges, in ascending order (e.g. `none` → `max` for gpt-5.6-sol).
  - **Supported Parameters** — the mapping's `supportedParameters` as badges.
- The toggle only renders when the mapping actually declares at least one of the two, so cards without this metadata are unchanged.
- Plumbing: added `reasoningEfforts` to the UI's `ApiModelProviderMapping` type and to `adaptProviderMapping` (the model-definition → UI adapter used by the detail pages); `supportedParameters` was already plumbed through.

## Testing

- Verified against a locally running UI build on `/models/gpt-5.6-sol`: card renders identically to before when collapsed (just the "Show details" toggle), and expanding shows the Reasoning Efforts (`none, low, medium, high, xhigh, max`) and Supported Parameters badges; collapsing hides them again.
- `turbo run build --filter=ui` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPnpiisz8mM8nRGyVpWmUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPnpiisz8mM8nRGyVpWmUh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model provider mappings now include supported reasoning effort levels.
  * Added expandable mapping details to model cards, displaying supported reasoning efforts and parameters when available.
  * Added “Show details” and “Hide details” controls for reviewing model capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->