### PR TITLE
ci(e2e): add shard job failure detection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,3 +142,10 @@ jobs:
           find ./e2e-results -name "*.blob" -exec mv {} .vitest-reports/ \;
           # Merge reports - this will fail if tests failed, providing the final status
           pnpm vitest run -c vitest/vitest.e2e.config.mts --merge-reports
+
+      - name: Fail if any e2e-shards matrix job did not succeed
+        if: always() && needs.e2e-shards.result != 'success'
+        run: |
+          echo "e2e-shards result was '${{ needs.e2e-shards.result }}', expected 'success'."
+          echo "At least one shard failed to run (e.g. before it could produce results), so the merged report above is incomplete."
+          exit 1


### PR DESCRIPTION
## Summary
Adds a safety check to the e2e CI workflow to detect when the e2e-shards matrix job fails to complete successfully, ensuring that incomplete test reports are not silently treated as passing.

## Changes
- Added a new workflow step that runs after all e2e-shards jobs complete
- The step checks if any shard job failed to succeed (e.g., due to infrastructure issues before producing results)
- If the e2e-shards job result is not 'success', the workflow explicitly fails with a clear error message
- This prevents the merged test report from being treated as complete when underlying shard jobs didn't run properly

## Implementation Details
- Uses `if: always()` to ensure the check runs regardless of previous step outcomes
- Checks `needs.e2e-shards.result` against the expected 'success' status
- Provides clear messaging about why the failure occurred (incomplete merged report)
- Exits with code 1 to fail the workflow when shards didn't succeed

https://claude.ai/code/session_01Ra48tj76UGFeMnEjtP7H4W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end testing reliability by ensuring the overall workflow fails when any test shard does not complete successfully.
  * Added clearer diagnostic output to help identify incomplete or failed test runs.
  * Prevents successful status reports from masking failures in parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->