### PR TITLE
fix: prevent duplicate Stripe customers in top-ups

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -53,36 +53,60 @@ import type Stripe from "stripe";
 export async function ensureStripeCustomer(
 	organizationId: string,
 ): Promise<string> {
-	const organization = await db.query.organization.findFirst({
-		where: {
-			id: organizationId,
+	// Claim the row under a lock so two concurrent callers (e.g. the
+	// setup_intent.succeeded webhook racing a payment-intent request) can't
+	// each create a Stripe customer. Losing that race orphans one customer
+	// and strands any payment method attached to it, which later breaks
+	// off-session charges with "PaymentMethod does not belong to the
+	// Customer". The second caller blocks until the first commits, then
+	// sees the persisted id.
+	const { stripeCustomerId, created, billingEmail } = await db.transaction(
+		async (tx) => {
+			const [organization] = await tx
+				.select()
+				.from(tables.organization)
+				.where(eq(tables.organization.id, organizationId))
+				.for("update")
+				.limit(1);
+
+			if (!organization) {
+				throw new Error(`Organization not found: ${organizationId}`);
+			}
+
+			if (organization.stripeCustomerId) {
+				return {
+					stripeCustomerId: organization.stripeCustomerId,
+					created: false,
+					billingEmail: organization.billingEmail,
+				};
+			}
+
+			const customer = await getStripe().customers.create({
+				email: organization.billingEmail,
+				metadata: {
+					organizationId,
+				},
+			});
+
+			await tx
+				.update(tables.organization)
+				.set({
+					stripeCustomerId: customer.id,
+				})
+				.where(eq(tables.organization.id, organizationId));
+
+			return {
+				stripeCustomerId: customer.id,
+				created: true,
+				billingEmail: organization.billingEmail,
+			};
 		},
-	});
+	);
 
-	if (!organization) {
-		throw new Error(`Organization not found: ${organizationId}`);
-	}
-
-	let stripeCustomerId = organization.stripeCustomerId;
-	if (!stripeCustomerId) {
-		const customer = await getStripe().customers.create({
-			email: organization.billingEmail,
-			metadata: {
-				organizationId,
-			},
-		});
-		stripeCustomerId = customer.id;
-
-		await db
-			.update(tables.organization)
-			.set({
-				stripeCustomerId,
-			})
-			.where(eq(tables.organization.id, organizationId));
-	} else {
+	if (!created) {
 		// Update existing customer email if billingEmail has changed
 		await getStripe().customers.update(stripeCustomerId, {
-			email: organization.billingEmail,
+			email: billingEmail,
 		});
 	}
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -292,6 +292,21 @@ async function releaseLock(key: string): Promise<void> {
 	await db.delete(tables.lock).where(eq(tables.lock.key, key));
 }
 
+async function recordAutoTopUpFailure(org: {
+	id: string;
+	paymentFailureCount: number | null;
+	paymentFailureStartedAt: Date | null;
+}): Promise<void> {
+	await db
+		.update(tables.organization)
+		.set({
+			paymentFailureCount: (org.paymentFailureCount ?? 0) + 1,
+			lastPaymentFailureAt: new Date(),
+			paymentFailureStartedAt: org.paymentFailureStartedAt ?? new Date(),
+		})
+		.where(eq(tables.organization.id, org.id));
+}
+
 export async function processAutoTopUp(): Promise<void> {
 	const lockAcquired = await acquireLock(AUTO_TOPUP_LOCK_KEY);
 	if (!lockAcquired) {
@@ -484,6 +499,24 @@ export async function processAutoTopUp(): Promise<void> {
 					const stripePaymentMethod = await getStripe().paymentMethods.retrieve(
 						defaultPaymentMethod.stripePaymentMethodId,
 					);
+
+					const paymentMethodCustomer =
+						typeof stripePaymentMethod.customer === "string"
+							? stripePaymentMethod.customer
+							: (stripePaymentMethod.customer?.id ?? null);
+
+					// A payment method can only be charged against the customer it
+					// is attached to; a mismatch (e.g. from a historical duplicate
+					// Stripe customer) would be rejected on every attempt, so track
+					// the failure for backoff/auto-disable instead of charging.
+					if (paymentMethodCustomer !== org.stripeCustomerId) {
+						logger.error(
+							`Default payment method ${defaultPaymentMethod.stripePaymentMethodId} for organization ${org.id} is attached to Stripe customer ${paymentMethodCustomer}, but the organization's Stripe customer is ${org.stripeCustomerId}; skipping auto top-up`,
+						);
+						await recordAutoTopUpFailure(org);
+						continue;
+					}
+
 					const country = stripePaymentMethod.card?.country;
 					isInternational = Boolean(country) && country !== "US";
 				} catch (err) {
@@ -586,6 +619,13 @@ export async function processAutoTopUp(): Promise<void> {
 						);
 					} else {
 						logger.error(`Stripe error for organization ${org.id}`, errObj);
+					}
+					// A rejected paymentIntents.create never produces a
+					// payment_intent.payment_failed webhook (unlike card declines),
+					// so record the failure here or backoff/auto-disable never
+					// engage and the same doomed charge retries every cycle.
+					if (stripeError instanceof Stripe.errors.StripeInvalidRequestError) {
+						await recordAutoTopUpFailure(org);
 					}
 					// Mark transaction as failed
 					await db


### PR DESCRIPTION
## Problem

Production auto top-ups for an organization were failing every worker cycle with:

> The PaymentMethod pm_… does not belong to the Customer you supplied cus_…

Root cause: `ensureStripeCustomer` had an unguarded check-then-create race. Two concurrent callers (e.g. the `setup_intent.succeeded` webhook racing a payment-intent/checkout request) could each create a Stripe customer for the same organization. One DB write wins, the other customer is orphaned — and the saved card gets attached to the orphan. Every subsequent off-session charge that combines the saved default payment method with `organization.stripeCustomerId` is then rejected by Stripe.

This is exactly what happened in production: two customers created seconds apart with the same `metadata.organizationId`, the card on one, the org record pointing at the other.

The failure also retried forever: a rejected `paymentIntents.create` never produces a `payment_intent.payment_failed` webhook, so `paymentFailureCount` / `lastPaymentFailureAt` were never bumped, meaning the worker's exponential backoff and 7-day auto-disable never engaged.

## Changes

- **`apps/api/src/stripe.ts`**: `ensureStripeCustomer` now claims the organization row with `SELECT … FOR UPDATE` inside a transaction before creating a Stripe customer, so concurrent callers serialize and the second one sees the persisted id. This mirrors the pattern `ensureEndCustomerStripeCustomer` already uses for the same race. The email-sync behavior for existing customers is preserved.
- **`apps/worker/src/worker.ts`**:
  - Before charging, the auto top-up loop verifies the default payment method is actually attached to the org's Stripe customer (it already retrieves the PM for the international-fee check). On mismatch it logs, records the failure, and skips instead of creating a doomed pending transaction.
  - `StripeInvalidRequestError` from `paymentIntents.create` now records the payment failure, so backoff and the 7-day auto-disable apply to persistent non-card errors. Card declines are unchanged — those are still tracked via the `payment_intent.payment_failed` webhook, avoiding double counting.

## Testing

- `turbo run build --filter=api --filter=worker` passes
- `apps/worker/src/worker.spec.ts` and `apps/api/src/stripe.spec.ts` pass (32 tests)

Note: orgs already in the corrupted state need a one-time manual repair (point `organization.stripe_customer_id` at the Stripe customer the card is attached to). With this change they stop hard-erroring every cycle and instead back off and eventually auto-disable with an audit log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Dix3yNabRPNVkdvhUGCAw

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dix3yNabRPNVkdvhUGCAw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate billing customer records during simultaneous billing operations.
  * Improved handling of auto top-up failures by recording payment failure details.
  * Prevented charges when the selected payment method is not linked to the correct billing customer.
  * Reduced repeated unsuccessful auto top-up attempts after certain payment errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->