### PR TITLE
feat(devpass): add raw revenue and cumulative view

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9975,6 +9975,7 @@ const getDevpassSubscriber = createRoute({
 const devpassTimeseriesPointSchema = z.object({
 	date: z.string(),
 	revenue: z.number(),
+	rawRevenue: z.number(),
 	cost: z.number(),
 	margin: z.number(),
 });
@@ -9983,6 +9984,7 @@ const devpassTimeseriesSchema = z.object({
 	data: z.array(devpassTimeseriesPointSchema),
 	totals: z.object({
 		revenue: z.number(),
+		rawRevenue: z.number(),
 		cost: z.number(),
 		margin: z.number(),
 	}),
@@ -11007,6 +11009,7 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	const data: Array<{
 		date: string;
 		revenue: number;
+		rawRevenue: number;
 		cost: number;
 		margin: number;
 	}> = [];
@@ -11025,15 +11028,20 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	);
 
 	let totalRevenue = 0;
+	let totalRawRevenue = 0;
 	let totalCost = 0;
 
+	// `rawRevenue` is the gross amount collected from dev plan payments that
+	// day; `revenue` nets refunds out of it. Margin stays net-based.
 	while (cursor.getTime() <= lastDay) {
 		const iso = cursor.toISOString().slice(0, 10);
-		const revenue = (revenueMap.get(iso) ?? 0) - (refundMap.get(iso) ?? 0);
+		const rawRevenue = revenueMap.get(iso) ?? 0;
+		const revenue = rawRevenue - (refundMap.get(iso) ?? 0);
 		const cost = costMap.get(iso) ?? 0;
 		const margin = revenue - cost;
-		data.push({ date: iso, revenue, cost, margin });
+		data.push({ date: iso, revenue, rawRevenue, cost, margin });
 		totalRevenue += revenue;
+		totalRawRevenue += rawRevenue;
 		totalCost += cost;
 		cursor.setUTCDate(cursor.getUTCDate() + 1);
 	}
@@ -11042,6 +11050,7 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 		data,
 		totals: {
 			revenue: totalRevenue,
+			rawRevenue: totalRawRevenue,
 			cost: totalCost,
 			margin: totalRevenue - totalCost,
 		},

--- a/ee/admin/src/components/devpass-timeseries-chart.tsx
+++ b/ee/admin/src/components/devpass-timeseries-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { format, parseISO } from "date-fns";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
 
 import {
@@ -16,6 +16,8 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@/components/ui/chart";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
@@ -25,6 +27,10 @@ const chartConfig = {
 	revenue: {
 		label: "Revenue",
 		color: "hsl(142 71% 45%)",
+	},
+	rawRevenue: {
+		label: "Raw revenue",
+		color: "hsl(258 90% 66%)",
 	},
 	cost: {
 		label: "Provider cost",
@@ -36,7 +42,9 @@ const chartConfig = {
 	},
 } satisfies ChartConfig;
 
-type ActiveSeries = keyof typeof chartConfig;
+type SeriesKey = keyof typeof chartConfig;
+
+const SERIES_KEYS = ["revenue", "rawRevenue", "cost", "margin"] as const;
 
 const compactCurrency = new Intl.NumberFormat("en-US", {
 	style: "currency",
@@ -59,7 +67,11 @@ export function DevpassTimeseriesChart({
 	from?: string;
 	to?: string;
 }) {
-	const [activeSeries, setActiveSeries] = useState<ActiveSeries>("revenue");
+	const [activeSeries, setActiveSeries] = useState<SeriesKey[]>([
+		"revenue",
+		"rawRevenue",
+	]);
+	const [cumulative, setCumulative] = useState(false);
 	const $api = useApi();
 	const { data, isLoading, isError } = $api.useQuery(
 		"get",
@@ -69,8 +81,34 @@ export function DevpassTimeseriesChart({
 		},
 	);
 
-	const chartData = data?.data ?? [];
 	const totals = data?.totals;
+
+	const chartData = useMemo(() => {
+		const rows = data?.data ?? [];
+		if (!cumulative) {
+			return rows;
+		}
+		let revenue = 0;
+		let rawRevenue = 0;
+		let cost = 0;
+		let margin = 0;
+		return rows.map((row) => {
+			revenue += row.revenue;
+			rawRevenue += row.rawRevenue;
+			cost += row.cost;
+			margin += row.margin;
+			return { date: row.date, revenue, rawRevenue, cost, margin };
+		});
+	}, [data, cumulative]);
+
+	const toggleSeries = (key: SeriesKey) => {
+		setActiveSeries((prev) => {
+			if (prev.includes(key)) {
+				return prev.length > 1 ? prev.filter((k) => k !== key) : prev;
+			}
+			return SERIES_KEYS.filter((k) => k === key || prev.includes(k));
+		});
+	};
 
 	return (
 		<Card>
@@ -78,27 +116,37 @@ export function DevpassTimeseriesChart({
 				<div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
 					<CardTitle>DevPass revenue & usage</CardTitle>
 					<CardDescription>
-						Daily revenue from DevPass transactions, real provider cost across
-						current and former subscribers, and the resulting margin. Totals
-						aggregate the selected date range — note these will not match the
-						KPI cards above, which always reflect the current billing cycle.
+						Daily revenue from DevPass transactions (net of refunds), raw gross
+						revenue from DevPass subscriptions, real provider cost across
+						current and former subscribers, and the resulting margin. Click the
+						totals to toggle series on the chart. Totals aggregate the selected
+						date range — note these will not match the KPI cards above, which
+						always reflect the current billing cycle.
 					</CardDescription>
 				</div>
-				<div className="flex">
-					{(["revenue", "cost", "margin"] as const).map((key) => {
+				<div className="flex flex-wrap">
+					{SERIES_KEYS.map((key) => {
 						const value = totals?.[key] ?? 0;
+						const active = activeSeries.includes(key);
 						return (
 							<button
 								key={key}
 								type="button"
-								aria-pressed={activeSeries === key}
-								data-active={activeSeries === key}
+								aria-pressed={active}
+								data-active={active}
 								className={cn(
 									"relative z-30 flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6",
 								)}
-								onClick={() => setActiveSeries(key)}
+								onClick={() => toggleSeries(key)}
 							>
-								<span className="text-xs text-muted-foreground">
+								<span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+									<span
+										className={cn(
+											"size-2 shrink-0 rounded-[2px]",
+											active ? "" : "opacity-30",
+										)}
+										style={{ backgroundColor: chartConfig[key].color }}
+									/>
 									{chartConfig[key].label}
 								</span>
 								<span
@@ -116,7 +164,20 @@ export function DevpassTimeseriesChart({
 					})}
 				</div>
 			</CardHeader>
-			<CardContent className="px-2 sm:p-6">
+			<CardContent className="px-2 pt-4 sm:p-6">
+				<div className="mb-4 flex items-center justify-end gap-2 px-4 sm:px-0">
+					<Label
+						htmlFor="devpass-cumulative"
+						className="text-xs font-normal text-muted-foreground"
+					>
+						Cumulative
+					</Label>
+					<Switch
+						id="devpass-cumulative"
+						checked={cumulative}
+						onCheckedChange={setCumulative}
+					/>
+				</div>
 				{isError ? (
 					<div className="flex h-[250px] items-center justify-center text-sm text-muted-foreground">
 						Failed to load DevPass timeseries.
@@ -150,23 +211,38 @@ export function DevpassTimeseriesChart({
 							<ChartTooltip
 								content={
 									<ChartTooltipContent
-										className="w-[170px]"
-										nameKey={activeSeries}
+										className="w-[190px]"
 										labelFormatter={(value: string) => {
 											const date = parseISO(value);
 											return format(date, "MMM d, yyyy");
 										}}
-										formatter={(value) => fullCurrency.format(Number(value))}
+										formatter={(value, name, item) => (
+											<>
+												<span
+													className="size-2 shrink-0 rounded-[2px]"
+													style={{ backgroundColor: item.color }}
+												/>
+												<span className="text-muted-foreground">
+													{chartConfig[name as SeriesKey]?.label ?? name}
+												</span>
+												<span className="ml-auto font-mono font-medium tabular-nums text-foreground">
+													{fullCurrency.format(Number(value))}
+												</span>
+											</>
+										)}
 									/>
 								}
 							/>
-							<Line
-								dataKey={activeSeries}
-								type="monotone"
-								stroke={`var(--color-${activeSeries})`}
-								strokeWidth={2}
-								dot={false}
-							/>
+							{activeSeries.map((key) => (
+								<Line
+									key={key}
+									dataKey={key}
+									type="monotone"
+									stroke={`var(--color-${key})`}
+									strokeWidth={2}
+									dot={false}
+								/>
+							))}
 						</LineChart>
 					</ChartContainer>
 				)}

--- a/ee/admin/src/components/ui/switch.tsx
+++ b/ee/admin/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+	className,
+	...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+	return (
+		<SwitchPrimitive.Root
+			data-slot="switch"
+			className={cn(
+				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		>
+			<SwitchPrimitive.Thumb
+				data-slot="switch-thumb"
+				className={cn(
+					"bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+				)}
+			/>
+		</SwitchPrimitive.Root>
+	);
+}
+
+export { Switch };


### PR DESCRIPTION
## Summary
Enhanced the DevPass timeseries chart to track and display raw (gross) revenue separately from net revenue, and added a cumulative view toggle for better trend analysis.

## Key Changes
- **Backend API**: Added `rawRevenue` field to DevPass timeseries endpoint to track gross subscription revenue before refunds are deducted
- **Chart UI**: 
  - Changed from single-series selection to multi-series toggle, allowing users to view multiple metrics simultaneously
  - Added "Raw revenue" as a new chart series (purple) alongside existing revenue, cost, and margin
  - Implemented cumulative view toggle via new Switch component to show running totals over time
  - Updated chart tooltip to display all active series with color indicators and proper formatting
- **UI Components**: Added new `Switch` component (Radix UI primitive) for the cumulative toggle
- **Chart Configuration**: Updated to include raw revenue with distinct color and label

## Implementation Details
- Raw revenue represents the gross amount collected from dev plan payments; net revenue subtracts refunds from this amount
- The cumulative calculation accumulates all four metrics (revenue, rawRevenue, cost, margin) when enabled
- Series toggling prevents deselecting all series (minimum one must remain active)
- Chart totals in the header now function as clickable toggles to show/hide individual series
- Updated chart description to clarify the distinction between raw and net revenue

https://claude.ai/code/session_01GpN6iFgh8QswpvRQe5iLA7