### PR TITLE
fix: idempotency keys for Stripe customer creation

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -81,12 +81,20 @@ export async function ensureStripeCustomer(
 				};
 			}
 
-			const customer = await getStripe().customers.create({
-				email: organization.billingEmail,
-				metadata: {
-					organizationId,
+			// Deterministic idempotency key: if Stripe creates the customer but
+			// the surrounding DB transaction fails to commit, the retry returns
+			// the already-created customer instead of minting a duplicate.
+			const customer = await getStripe().customers.create(
+				{
+					email: organization.billingEmail,
+					metadata: {
+						organizationId,
+					},
 				},
-			});
+				{
+					idempotencyKey: `ensure-stripe-customer:${organizationId}`,
+				},
+			);
 
 			await tx
 				.update(tables.organization)
@@ -140,15 +148,23 @@ export async function ensureEndCustomerStripeCustomer(
 			return endCustomer.stripeCustomerId;
 		}
 
-		const customer = await getStripe(mode).customers.create({
-			email: endCustomer.email ?? undefined,
-			name: endCustomer.name ?? undefined,
-			metadata: {
-				endCustomerId,
-				projectId: endCustomer.projectId,
-				organizationId: endCustomer.organizationId,
+		// Deterministic idempotency key: if Stripe creates the customer but
+		// the surrounding DB transaction fails to commit, the retry returns
+		// the already-created customer instead of minting a duplicate.
+		const customer = await getStripe(mode).customers.create(
+			{
+				email: endCustomer.email ?? undefined,
+				name: endCustomer.name ?? undefined,
+				metadata: {
+					endCustomerId,
+					projectId: endCustomer.projectId,
+					organizationId: endCustomer.organizationId,
+				},
 			},
-		});
+			{
+				idempotencyKey: `ensure-end-customer-stripe-customer:${endCustomerId}`,
+			},
+		);
 
 		await tx
 			.update(tables.endCustomer)


### PR DESCRIPTION
## Problem

Follow-up to the CodeRabbit review feedback on #3033, which merged before the feedback was addressed.

The `SELECT … FOR UPDATE` row lock added in #3033 serializes concurrent callers of `ensureStripeCustomer`, but there is still a duplicate-customer window: if `customers.create` succeeds on Stripe's side and the surrounding DB transaction then fails to commit (crash, connection loss, rollback), the persisted `stripeCustomerId` is never written — so the next call creates a second Stripe customer and orphans the first.

## Changes

- `ensureStripeCustomer`: pass a deterministic idempotency key (`ensure-stripe-customer:${organizationId}`) to `customers.create`, so a retry within Stripe's idempotency window returns the already-created customer instead of minting a duplicate.
- `ensureEndCustomerStripeCustomer`: same fix (`ensure-end-customer-stripe-customer:${endCustomerId}`) — it has the identical transaction-commit failure window.

## Testing

- `turbo run build --filter=api` passes
- `apps/api/src/stripe.spec.ts` passes (24 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Dix3yNabRPNVkdvhUGCAw

---
_Generated by [Claude Code](https://claude.ai/code/session_016Dix3yNabRPNVkdvhUGCAw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Stripe customer records when account creation transactions are retried or encounter failures.
  * Improved reliability of customer setup while preserving existing customer metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->