### PR TITLE
fix(gateway): flatten xiaomi tool result content to plain string

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -4186,3 +4186,222 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 		expect(a).not.toContain("sess-1");
 	});
 });
+
+describe("prepareRequestBody - Xiaomi", () => {
+	test("flattens tool message with array content (text + image) to plain string", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{ role: "user", content: "describe this" },
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: [
+						{ type: "text", text: "screenshot taken" },
+						{
+							type: "image_url",
+							image_url: { url: "data:image/png;base64,abc" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(2);
+		expect(requestBody.messages[0].content).toBe("describe this");
+		expect(requestBody.messages[1].role).toBe("tool");
+		expect(requestBody.messages[1].content).toBe("screenshot taken");
+	});
+
+	test("leaves tool message with plain string content unchanged", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{ role: "user", content: "What is the weather?" },
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: "sunny, 22°C",
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(2);
+		expect(requestBody.messages[1].content).toBe("sunny, 22°C");
+	});
+
+	test("leaves user message array content unchanged (images still work)", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "describe this image" },
+						{
+							type: "image_url",
+							image_url: { url: "https://example.com/photo.jpg" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(1);
+		expect(requestBody.messages[0].role).toBe("user");
+		expect(Array.isArray(requestBody.messages[0].content)).toBe(true);
+		expect(requestBody.messages[0].content).toHaveLength(2);
+		expect(requestBody.messages[0].content[0]).toEqual({
+			type: "text",
+			text: "describe this image",
+		});
+		expect(requestBody.messages[0].content[1]).toEqual({
+			type: "image_url",
+			image_url: { url: "https://example.com/photo.jpg" },
+		});
+	});
+
+	test("handles tool message with multiple text blocks", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: [
+						{ type: "text", text: "part one " },
+						{ type: "text", text: "part two" },
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages[0].content).toBe("part one \npart two");
+	});
+
+	test("handles tool message with only images, no text (empty string)", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: [
+						{
+							type: "image_url",
+							image_url: { url: "data:image/png;base64,abc" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages[0].content).toBe("");
+	});
+
+	test("applies standard default params (stream_options, temperature, etc.)", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[{ role: "user", content: "Hello" }],
+			true,
+			0.7,
+			1024,
+			0.9,
+			0.5,
+			0.5,
+			{ type: "json_object" },
+			undefined,
+			undefined,
+			"medium",
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.stream_options).toEqual({ include_usage: true });
+		expect(requestBody.response_format).toEqual({ type: "json_object" });
+		expect(requestBody.temperature).toBe(0.7);
+		expect(requestBody.max_tokens).toBe(1024);
+		expect(requestBody.top_p).toBe(0.9);
+		expect(requestBody.frequency_penalty).toBe(0.5);
+		expect(requestBody.presence_penalty).toBe(0.5);
+		expect(requestBody.reasoning_effort).toBe("medium");
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -3208,6 +3208,51 @@ export async function prepareRequestBody(
 			}
 			break;
 		}
+		case "xiaomi": {
+			// Xiaomi expects tool message content as a plain string — flatten
+			// array content blocks to text, dropping image blocks.
+			requestBody.messages = requestBody.messages.map((m) =>
+				m.role === "tool" && Array.isArray(m.content)
+					? {
+							...m,
+							content: m.content
+								.filter((c) => c.type === "text" && c.text)
+								.map((c) => c.text)
+								.join("\n"),
+						}
+					: m,
+			);
+
+			if (stream) {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+			if (response_format) {
+				requestBody.response_format = response_format;
+			}
+
+			// Add optional parameters if they are provided
+			if (temperature !== undefined) {
+				requestBody.temperature = temperature;
+			}
+			if (max_tokens !== undefined) {
+				requestBody.max_tokens = max_tokens;
+			}
+			if (top_p !== undefined) {
+				requestBody.top_p = top_p;
+			}
+			if (frequency_penalty !== undefined) {
+				requestBody.frequency_penalty = frequency_penalty;
+			}
+			if (presence_penalty !== undefined) {
+				requestBody.presence_penalty = presence_penalty;
+			}
+			if (reasoning_effort !== undefined) {
+				requestBody.reasoning_effort = reasoning_effort;
+			}
+			break;
+		}
 		default: {
 			if (stream) {
 				requestBody.stream_options = {


### PR DESCRIPTION
## Problem

MiMo V2.5 (Xiaomi) on LLM Gateway returns HTTP 400 `Param Incorrect: text is not set` when a tool result message contains OpenAI-format array content blocks.

Example **failing** payload:

```json
{
  "role": "tool",
  "tool_call_id": "call_xxx",
  "content": [
    { "type": "text", "text": "screenshot taken" },
    { "type": "image_url", "image_url": { "url": "data:image/png;base64,..." } }
  ]
}
```

Example **successful** payload (after fix — array flattened to plain string, image blocks dropped):

```json
{
  "role": "tool",
  "tool_call_id": "call_xxx",
  "content": "screenshot taken"
}
```

## Root Cause

`prepare-request-body.ts` has no `case "xiaomi":` — the provider falls through to `default:`, which passes the request body through unchanged. Xiaomi's API validator requires tool message content to be a **plain string**. It looks for a top-level `text` field on the message object and does not traverse content arrays, hence `"text is not set"`.

MiMo V2.5 **does support images** (`vision: true`), and processes them correctly in user messages. The restriction is specific to tool-role messages. Xiaomi's API documentation has no documented format for multimodal content in tool results.

## Changes

Added `case "xiaomi":` to the provider switch in `prepare-request-body.ts` that:

1. **Flattens tool message array content to a plain string** — extracts text blocks, drops image blocks
2. **Applies standard default parameters** — `stream_options`, `temperature`, `max_tokens`, `reasoning_effort`, etc.

Before: array content passes through → 400 error
After: array flattened to string → request succeeds

## Limitations

Images in tool results are dropped — MiMo receives text only. This is a gap in Xiaomi's API implementation (the model processes images fine in user messages — the restriction is specific to tool results). Two complementary approaches exist for preserving image context, neither in scope for this PR:

- **Gateway-side (future work):** Convert image-bearing tool results into synthetic user messages where MiMo can process them. This requires careful message-list manipulation with edge cases around multi-turn tool call ordering.
- **Caller-side (already implemented in some agents):** Provider capability detection to route vision through auxiliary models when the primary provider rejects multimodal tool results.

## Verification

Tested against Xiaomi API with `mimo-v2.5`:
- **Before:** 400 `"Param Incorrect: text is not set"` on any tool call returning mixed text+image content
- **After:** 200 OK, model receives text content from tool result and continues conversation normally

User messages with images are unaffected — only tool-role messages are modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-specific Xiaomi request handling, including improved streaming include-usage behavior and forwarding of response formatting and generation parameters (with reasoning effort when available).
* **Bug Fixes**
  * Normalized Xiaomi tool message array content into plain text (newline-separated for multiple text blocks), preserved user array content unchanged, and returned empty tool text when only images are provided.
* **Tests**
  * Added Xiaomi-focused test coverage to verify message normalization and parameter forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->