### PR TITLE
feat: add rename action to API key options menu

### DIFF
--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -1610,6 +1610,14 @@ keysApi.openapi(updateStatus, async (c) => {
 		});
 	}
 
+	// A regular key must not take on the reserved playground description,
+	// or it would collide with the playground key's fixed-description lookup.
+	if (descriptionInput === PLAYGROUND_API_KEY_DESCRIPTION) {
+		throw new HTTPException(403, {
+			message: "This name is reserved for the playground API key.",
+		});
+	}
+
 	// Check user role and permissions
 	const projectOrgId = apiKey.project.organizationId;
 	const userOrg = userOrgs.find((org) => org.organizationId === projectOrgId);

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -380,12 +380,15 @@ const listApiKeysQuerySchema = z.object({
 	}),
 });
 
-// Schema for updating an API key status
+// Schema for updating an API key status and/or metadata
 const updateApiKeyStatusSchema = z.object({
-	status: z.enum(["active", "inactive"]),
+	status: z.enum(["active", "inactive"]).optional(),
 	expiresAt: z.string().datetime().nullable().optional().openapi({
 		description:
 			"ISO 8601 timestamp when the key expires (TTL). Required to reactivate a key whose TTL has already passed; pass null to remove the TTL. Omit to leave the existing expiry unchanged.",
+	}),
+	description: z.string().trim().min(1).max(255).optional().openapi({
+		description: "New display name for the API key. Omit to leave unchanged.",
 	}),
 });
 
@@ -1525,7 +1528,11 @@ keysApi.openapi(updateStatus, async (c) => {
 	}
 
 	const { id } = c.req.param();
-	const { status, expiresAt: expiresAtInput } = c.req.valid("json");
+	const {
+		status,
+		expiresAt: expiresAtInput,
+		description: descriptionInput,
+	} = c.req.valid("json");
 
 	// Get the user's projects
 	const userOrgs = await db.query.userOrganization.findMany({
@@ -1577,11 +1584,29 @@ keysApi.openapi(updateStatus, async (c) => {
 		});
 	}
 
+	if (
+		status === undefined &&
+		expiresAtInput === undefined &&
+		descriptionInput === undefined
+	) {
+		throw new HTTPException(400, {
+			message: "No changes provided",
+		});
+	}
+
 	// Prevent deactivation of the auto-generated playground key
 	if (isPlaygroundApiKey(apiKey) && status === "inactive") {
 		throw new HTTPException(403, {
 			message:
 				"Cannot deactivate the playground API key. This key is required for the playground to function.",
+		});
+	}
+
+	// Renaming the auto-generated playground key would break the UI's lookup
+	// of it by its fixed description.
+	if (isPlaygroundApiKey(apiKey) && descriptionInput !== undefined) {
+		throw new HTTPException(403, {
+			message: "Cannot rename the playground API key.",
 		});
 	}
 
@@ -1628,19 +1653,24 @@ keysApi.openapi(updateStatus, async (c) => {
 	const [updatedApiKey] = await cdb
 		.update(tables.apiKey)
 		.set({
-			status,
+			...(status !== undefined ? { status } : {}),
 			...(expiresAtProvided ? { expiresAt: nextExpiresAt } : {}),
+			...(descriptionInput !== undefined
+				? { description: descriptionInput }
+				: {}),
 		})
 		.where(eq(tables.apiKey.id, id))
 		.returning();
 
-	const statusChanged = apiKey.status !== status;
+	const statusChanged = status !== undefined && apiKey.status !== status;
 	const expiryChanged =
 		expiresAtProvided &&
 		(apiKey.expiresAt?.getTime() ?? null) !==
 			(nextExpiresAt?.getTime() ?? null);
+	const descriptionChanged =
+		descriptionInput !== undefined && apiKey.description !== descriptionInput;
 
-	if (statusChanged || expiryChanged) {
+	if (statusChanged || expiryChanged || descriptionChanged) {
 		const changes: Record<string, { old: unknown; new: unknown }> = {};
 		if (statusChanged) {
 			changes.status = { old: apiKey.status, new: status };
@@ -1649,6 +1679,12 @@ keysApi.openapi(updateStatus, async (c) => {
 			changes.expiresAt = {
 				old: apiKey.expiresAt?.toISOString() ?? null,
 				new: nextExpiresAt?.toISOString() ?? null,
+			};
+		}
+		if (descriptionChanged) {
+			changes.description = {
+				old: apiKey.description,
+				new: descriptionInput,
 			};
 		}
 
@@ -1666,7 +1702,10 @@ keysApi.openapi(updateStatus, async (c) => {
 	}
 
 	return c.json({
-		message: `API key status updated to ${status}`,
+		message:
+			status !== undefined
+				? `API key status updated to ${status}`
+				: "API key updated",
 		apiKey: {
 			...serializeApiKey(updatedApiKey),
 			maskedToken: maskToken(updatedApiKey.token),

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -4,6 +4,7 @@ import {
 	EditIcon,
 	KeyIcon,
 	MoreHorizontal,
+	PencilIcon,
 	PlusIcon,
 	RefreshCwIcon,
 	Shield,
@@ -63,6 +64,7 @@ import { ApiKeyLimitsDialog } from "./api-key-limits-dialog";
 import { formatApiKeyExpiry } from "./api-key-ttl-fields";
 import { CreateApiKeyDialog } from "./create-api-key-dialog";
 import { ReactivateApiKeyDialog } from "./reactivate-api-key-dialog";
+import { RenameApiKeyDialog } from "./rename-api-key-dialog";
 import { RollApiKeyDialog } from "./roll-api-key-dialog";
 
 import type { ApiKey, Project } from "@/lib/types";
@@ -94,6 +96,7 @@ export function ApiKeysList({
 	const [creatorFilter, setCreatorFilter] = useState<CreatorFilter>("all");
 	const [reactivateKey, setReactivateKey] = useState<ApiKey | null>(null);
 	const [rollKey, setRollKey] = useState<ApiKey | null>(null);
+	const [renameKey, setRenameKey] = useState<ApiKey | null>(null);
 
 	const getIamRulesUrl = (keyId: string) =>
 		`/dashboard/${orgId}/${projectId}/api-keys/${keyId}/iam` as Route;
@@ -149,6 +152,9 @@ export function ApiKeysList({
 
 	const { mutateAsync: rollKeyAsync, isPending: isRollPending } =
 		api.useMutation("post", "/keys/api/{id}/roll");
+
+	const { mutateAsync: renameKeyAsync, isPending: isRenamePending } =
+		api.useMutation("patch", "/keys/api/{id}");
 
 	const allKeys = data?.apiKeys.filter((key) => key.status !== "deleted") ?? [];
 	const activeKeys = allKeys.filter((key) => key.status === "active");
@@ -351,6 +357,36 @@ export function ApiKeysList({
 				variant: "destructive",
 			});
 			return undefined;
+		}
+	};
+
+	const handleRename = async (description: string) => {
+		if (!renameKey) {
+			return;
+		}
+
+		try {
+			await renameKeyAsync({
+				params: {
+					path: { id: renameKey.id },
+				},
+				body: {
+					description,
+				},
+			});
+
+			invalidateApiKeys();
+			setRenameKey(null);
+
+			toast({
+				title: "API Key Renamed",
+				description: "The API key has been renamed.",
+			});
+		} catch {
+			toast({
+				title: "Failed to rename API key.",
+				variant: "destructive",
+			});
 		}
 	};
 
@@ -711,6 +747,10 @@ export function ApiKeysList({
 											{key.description !== "Auto-generated playground key" && (
 												<>
 													<DropdownMenuSeparator />
+													<DropdownMenuItem onClick={() => setRenameKey(key)}>
+														<PencilIcon className="mr-2 h-4 w-4" />
+														Rename Key
+													</DropdownMenuItem>
 													<DropdownMenuItem onClick={() => toggleStatus(key)}>
 														{key.status === "active"
 															? "Deactivate"
@@ -967,6 +1007,18 @@ export function ApiKeysList({
 				}}
 				onConfirm={handleRoll}
 				isPending={isRollPending}
+			/>
+
+			<RenameApiKeyDialog
+				apiKey={renameKey}
+				open={renameKey !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setRenameKey(null);
+					}
+				}}
+				onConfirm={handleRename}
+				isPending={isRenamePending}
 			/>
 		</>
 	);

--- a/apps/ui/src/components/api-keys/rename-api-key-dialog.tsx
+++ b/apps/ui/src/components/api-keys/rename-api-key-dialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/lib/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/lib/components/dialog";
+import { Input } from "@/lib/components/input";
+import { Label } from "@/lib/components/label";
+import { toast } from "@/lib/components/use-toast";
+
+import type { ApiKey } from "@/lib/types";
+
+interface RenameApiKeyDialogProps {
+	apiKey: ApiKey | null;
+	isPending?: boolean;
+	onConfirm: (description: string) => Promise<void> | void;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+}
+
+export function RenameApiKeyDialog({
+	apiKey,
+	isPending = false,
+	onConfirm,
+	onOpenChange,
+	open,
+}: RenameApiKeyDialogProps) {
+	const [description, setDescription] = useState("");
+
+	useEffect(() => {
+		if (open) {
+			setDescription(apiKey?.description ?? "");
+		}
+	}, [open, apiKey?.description]);
+
+	const handleConfirm = async () => {
+		const trimmed = description.trim();
+		if (!trimmed) {
+			toast({
+				title: "Enter a name for the API key.",
+				variant: "destructive",
+			});
+			return;
+		}
+
+		await onConfirm(trimmed);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[500px]">
+				<DialogHeader>
+					<DialogTitle>Rename API Key</DialogTitle>
+					<DialogDescription>
+						Choose a new name for this API key. This does not affect the key's
+						secret, stats, limits, or IAM rules.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-2 py-4">
+					<Label htmlFor="rename-api-key-description">Name</Label>
+					<Input
+						id="rename-api-key-description"
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+						maxLength={255}
+						autoFocus
+					/>
+				</div>
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={isPending}
+					>
+						Cancel
+					</Button>
+					<Button type="button" onClick={handleConfirm} disabled={isPending}>
+						{isPending ? "Renaming..." : "Save"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
## Summary
- Add a "Rename Key" action to the API key row's dropdown menu (desktop and mobile) on the API keys page, backed by a new `RenameApiKeyDialog`.
- Extend `PATCH /keys/api/{id}` to accept an optional `description` field so a key's name can be updated (status is now also optional, so a request can update either field independently). Renaming the auto-generated playground key is blocked, and the change is recorded in the audit log.

## Test plan
- [x] `pnpm test:unit` (full suite, 2620 passed)
- [x] `turbo run build --filter=api` and `turbo run build --filter=ui`
- [x] `pnpm format`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Muhm7AXz1PTVDkmcBJEhBw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API key renaming from the API keys list, including a rename dialog with validation and loading feedback.
  * API key update requests now allow changing the key description independently of status and expiration.
* **Bug Fixes**
  * Prevented changing the automatically generated playground API key’s description.
  * Added validation to reject update requests that contain no changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->