### PR TITLE
fix(worker): count premium usage for prefixed usedModel

### DIFF
--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -189,6 +189,48 @@ describe("Log Processing", () => {
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.01);
 		});
 
+		test("should accrue premium weekly usage for provider-prefixed premium models on dev plans", async () => {
+			await db
+				.update(organization)
+				.set({
+					devPlan: "pro",
+					devPlanCreditsLimit: "237",
+					devPlanCreditsUsed: "0",
+					devPlanPremiumCreditsUsed: "0",
+					devPlanPremiumWeekStart: null,
+				})
+				.where(eq(organization.id, testOrg.id));
+
+			// usedModel is stored as `provider/model[:region]`, not the bare
+			// catalog id — the premium classification must handle that shape.
+			await db.insert(log).values({
+				requestId: "test-request-premium",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.5,
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "anthropic/claude-fable-5",
+				requestedProvider: "anthropic",
+				usedModel: "anthropic/claude-fable-5",
+				usedProvider: "anthropic",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.devPlanCreditsUsed)).toBe(0.5);
+			expect(Number(updatedOrg!.devPlanPremiumCreditsUsed)).toBe(0.5);
+			expect(updatedOrg!.devPlanPremiumWeekStart).toBeInstanceOf(Date);
+		});
+
 		test("should not deduct credits for api-keys mode logs (no BYOK fee)", async () => {
 			const initialCredits = Number(testOrg.credits);
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -37,7 +37,7 @@ import {
 	assertSafeWebhookUrl,
 	calculateFees,
 	isCreditTopUpAmountInRange,
-	isPremiumModel,
+	isPremiumUsedModel,
 	isPremiumWeekExpired,
 	isPrivateOrReservedIp,
 } from "@llmgateway/shared";
@@ -1088,7 +1088,7 @@ export async function batchProcessLogs(): Promise<number> {
 					if (row.used_mode === "credits") {
 						addToBucket(
 							apiKeyCost,
-							Boolean(row.used_model && isPremiumModel(row.used_model)),
+							Boolean(row.used_model && isPremiumUsedModel(row.used_model)),
 						);
 					} else if (row.used_mode === "api-keys") {
 						if (row.data_storage_cost) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -52,6 +52,7 @@ export {
 	HIGH_COST_INPUT_PRICE,
 	HIGH_COST_OUTPUT_PRICE,
 	isPremiumModel,
+	isPremiumUsedModel,
 	type ModelCategory,
 } from "./model-categories.js";
 

--- a/packages/shared/src/model-categories.spec.ts
+++ b/packages/shared/src/model-categories.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getModelCategory, isPremiumModel } from "./model-categories.js";
+import {
+	getModelCategory,
+	isPremiumModel,
+	isPremiumUsedModel,
+} from "./model-categories.js";
 
 describe("model-categories", () => {
 	it("classifies a known premium model as premium", () => {
@@ -31,5 +35,25 @@ describe("model-categories", () => {
 	it("classifies a known standard model as standard", () => {
 		expect(isPremiumModel("gpt-4o-mini")).toBe(false);
 		expect(getModelCategory("gpt-4o-mini")).toBe("standard");
+	});
+
+	it("classifies provider-prefixed usedModel values as premium", () => {
+		expect(isPremiumUsedModel("anthropic/claude-fable-5")).toBe(true);
+		expect(isPremiumUsedModel("anthropic/claude-opus-4-8")).toBe(true);
+	});
+
+	it("classifies region-suffixed usedModel values as premium", () => {
+		expect(isPremiumUsedModel("aws-bedrock/claude-fable-5:global")).toBe(true);
+		expect(isPremiumUsedModel("aws-bedrock/claude-fable-5:us")).toBe(true);
+	});
+
+	it("classifies standard usedModel values as standard", () => {
+		expect(isPremiumUsedModel("openai/gpt-4o-mini")).toBe(false);
+		expect(isPremiumUsedModel("custom/some-unknown-model")).toBe(false);
+	});
+
+	it("accepts a bare model id in usedModel form", () => {
+		expect(isPremiumUsedModel("claude-fable-5")).toBe(true);
+		expect(isPremiumUsedModel("gpt-4o-mini")).toBe(false);
 	});
 });

--- a/packages/shared/src/model-categories.ts
+++ b/packages/shared/src/model-categories.ts
@@ -48,3 +48,19 @@ export function isPremiumModel(modelId: string): boolean {
 export function getModelCategory(modelId: string): ModelCategory {
 	return isPremiumModel(modelId) ? "premium" : "standard";
 }
+
+/**
+ * Variant of {@link isPremiumModel} for the log `usedModel` column, which
+ * stores `provider/model` optionally suffixed with a region
+ * (e.g. `anthropic/claude-fable-5` or `aws-bedrock/claude-fable-5:global`),
+ * not the bare catalog model id.
+ */
+export function isPremiumUsedModel(usedModel: string): boolean {
+	const slashIndex = usedModel.indexOf("/");
+	const withoutProvider =
+		slashIndex === -1 ? usedModel : usedModel.slice(slashIndex + 1);
+	const colonIndex = withoutProvider.indexOf(":");
+	const baseModelId =
+		colonIndex === -1 ? withoutProvider : withoutProvider.slice(0, colonIndex);
+	return isPremiumModel(baseModelId);
+}


### PR DESCRIPTION
## Problem

A DevPass user was able to burn ~$200 of virtual credits in a single day on Claude Fable 5, even though Fable 5 ($10/M in, $50/M out) is a premium-tier model that should be capped by the weekly DevPass fair-use allowance ($10/$50/$140 per week for lite/pro/max).

## Root cause

The weekly cap has two halves:

1. **Gateway (request time)**: `assertDevPlanPremiumCapNotExceeded` blocks premium requests once `devPlanPremiumCreditsUsed` exceeds the weekly limit. This works — it passes the bare catalog id (`claude-fable-5`) to `isPremiumModel`.
2. **Worker (deduction time)**: `batchProcessLogs` classifies each log as premium via `isPremiumModel(row.used_model)`. But the log's `usedModel` column stores the display format `provider/model[:region]` (e.g. `anthropic/claude-fable-5`, `aws-bedrock/claude-fable-5:global`), and `isPremiumModel` matches bare catalog ids only.

The lookup never matched, so `devPlanPremiumCreditsUsed` never accrued for **any** model, and the gateway check always saw ~0 premium usage. Premium spend was only bounded by the monthly plan credit limit (e.g. $237 on pro), which is exactly what the affected user hit.

## Fix

- Add `isPremiumUsedModel()` in `@llmgateway/shared`, which strips the `provider/` prefix and `:region` suffix before the premium price lookup, and use it in the worker's deduction path.
- Unit tests for the new helper covering prefixed, region-suffixed, bare, and unknown/custom model shapes.
- Worker regression test asserting a `provider/model`-shaped premium log accrues `devPlanPremiumCreditsUsed` and stamps `devPlanPremiumWeekStart` (verified it fails against the old code).

Note: already-processed logs are not retroactively re-counted; affected orgs start accruing premium usage from the next processed log onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)