### PR TITLE
fix(gateway): flatten xiaomi tool result to string

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -4186,3 +4186,222 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 		expect(a).not.toContain("sess-1");
 	});
 });
+
+describe("prepareRequestBody - Xiaomi", () => {
+	test("flattens tool message with array content (text + image) to plain string", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{ role: "user", content: "describe this" },
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: [
+						{ type: "text", text: "screenshot taken" },
+						{
+							type: "image_url",
+							image_url: { url: "data:image/png;base64,abc" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(2);
+		expect(requestBody.messages[0].content).toBe("describe this");
+		expect(requestBody.messages[1].role).toBe("tool");
+		expect(requestBody.messages[1].content).toBe("screenshot taken");
+	});
+
+	test("leaves tool message with plain string content unchanged", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{ role: "user", content: "What is the weather?" },
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: "sunny, 22°C",
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(2);
+		expect(requestBody.messages[1].content).toBe("sunny, 22°C");
+	});
+
+	test("leaves user message array content unchanged (images still work)", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "describe this image" },
+						{
+							type: "image_url",
+							image_url: { url: "https://example.com/photo.jpg" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages).toHaveLength(1);
+		expect(requestBody.messages[0].role).toBe("user");
+		expect(Array.isArray(requestBody.messages[0].content)).toBe(true);
+		expect(requestBody.messages[0].content).toHaveLength(2);
+		expect(requestBody.messages[0].content[0]).toEqual({
+			type: "text",
+			text: "describe this image",
+		});
+		expect(requestBody.messages[0].content[1]).toEqual({
+			type: "image_url",
+			image_url: { url: "https://example.com/photo.jpg" },
+		});
+	});
+
+	test("handles tool message with multiple text blocks", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: [
+						{ type: "text", text: "part one " },
+						{ type: "text", text: "part two" },
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages[0].content).toBe("part one \npart two");
+	});
+
+	test("handles tool message with only images, no text (empty string)", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: [
+						{
+							type: "image_url",
+							image_url: { url: "data:image/png;base64,abc" },
+						},
+					],
+				},
+			],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.messages[0].content).toBe("");
+	});
+
+	test("applies standard default params (stream_options, temperature, etc.)", async () => {
+		const requestBody = (await prepareRequestBody(
+			"xiaomi",
+			"mimo-v2.5",
+			null,
+			"mimo-v2.5",
+			[{ role: "user", content: "Hello" }],
+			true,
+			0.7,
+			1024,
+			0.9,
+			0.5,
+			0.5,
+			{ type: "json_object" },
+			undefined,
+			undefined,
+			"medium",
+			false,
+			false,
+		)) as any;
+
+		expect(requestBody.stream_options).toEqual({ include_usage: true });
+		expect(requestBody.response_format).toEqual({ type: "json_object" });
+		expect(requestBody.temperature).toBe(0.7);
+		expect(requestBody.max_tokens).toBe(1024);
+		expect(requestBody.top_p).toBe(0.9);
+		expect(requestBody.frequency_penalty).toBe(0.5);
+		expect(requestBody.presence_penalty).toBe(0.5);
+		expect(requestBody.reasoning_effort).toBe("medium");
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -3211,13 +3211,14 @@ export async function prepareRequestBody(
 		case "xiaomi": {
 			// Xiaomi expects tool message content as a plain string — flatten
 			// array content blocks to text, dropping image blocks.
-			requestBody.messages = requestBody.messages.map((m) =>
+			requestBody.messages = requestBody.messages.map((m: BaseMessage) =>
 				m.role === "tool" && Array.isArray(m.content)
 					? {
 							...m,
 							content: m.content
-								.filter((c) => c.type === "text" && c.text)
+								.filter(isTextContent)
 								.map((c) => c.text)
+								.filter(Boolean)
 								.join("\n"),
 						}
 					: m,

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -3208,6 +3208,51 @@ export async function prepareRequestBody(
 			}
 			break;
 		}
+		case "xiaomi": {
+			// Xiaomi expects tool message content as a plain string — flatten
+			// array content blocks to text, dropping image blocks.
+			requestBody.messages = requestBody.messages.map((m) =>
+				m.role === "tool" && Array.isArray(m.content)
+					? {
+							...m,
+							content: m.content
+								.filter((c) => c.type === "text" && c.text)
+								.map((c) => c.text)
+								.join("\n"),
+						}
+					: m,
+			);
+
+			if (stream) {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+			if (response_format) {
+				requestBody.response_format = response_format;
+			}
+
+			// Add optional parameters if they are provided
+			if (temperature !== undefined) {
+				requestBody.temperature = temperature;
+			}
+			if (max_tokens !== undefined) {
+				requestBody.max_tokens = max_tokens;
+			}
+			if (top_p !== undefined) {
+				requestBody.top_p = top_p;
+			}
+			if (frequency_penalty !== undefined) {
+				requestBody.frequency_penalty = frequency_penalty;
+			}
+			if (presence_penalty !== undefined) {
+				requestBody.presence_penalty = presence_penalty;
+			}
+			if (reasoning_effort !== undefined) {
+				requestBody.reasoning_effort = reasoning_effort;
+			}
+			break;
+		}
 		default: {
 			if (stream) {
 				requestBody.stream_options = {


### PR DESCRIPTION
## Summary

Mergeable version of #3037 (by @vicovaro, cherry-picked with authorship preserved) plus a follow-up commit fixing the strict-TypeScript compile errors the original branch has (`TS7006` implicit `any` on the map callbacks — CI never ran the build on the fork PR, so it went unnoticed).

Xiaomi's API returns HTTP 400 `Param Incorrect: `text` is not set` when a **tool-role message** carries OpenAI-format array content that includes an image block. This adds a `case "xiaomi":` to `prepareRequestBody` that flattens tool-message array content to a plain string (text blocks joined with `\n`, image blocks dropped) and applies the standard default parameters.

## Verification (e2e)

Tested directly against upstream `api.xiaomimimo.com` with `mimo-v2.5` and through a local gateway build:

| Payload | Upstream | Unpatched gateway | Patched gateway |
| --- | --- | --- | --- |
| tool msg, array content w/ image | 400 `text is not set` | 400 `text is not set` | **200** |
| tool msg, plain string | 200 | — | 200 |
| tool msg, empty string (image-only result after flatten) | 200 | — | — |
| user msg w/ image (vision) | 200 | — | 200 (incl. streaming + usage chunk) |

One note from testing: Xiaomi actually accepts **text-only** arrays in tool messages — the 400 only triggers when an image block is present. Flattening all arrays is a harmless superset fix, so the PR's approach is kept as-is.

Images in tool results are dropped (MiMo receives text only); Xiaomi has no documented multimodal format for tool results. Same limitation as #3037 documents.

Closes #3037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Xiaomi provider support for normalized tool messages containing text and image content.
  * Preserves user message content, including image inputs.
  * Supports standard generation settings, response formatting, streaming usage details, and reasoning effort for Xiaomi requests.

* **Tests**
  * Added coverage for Xiaomi message normalization and parameter forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->