### PR TITLE
feat(models): declare reasoning efforts for xai

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -705,6 +705,7 @@ export const xaiModels = [
 				streaming: true,
 				vision: true,
 				reasoning: true,
+				reasoningEfforts: ["none", "low", "medium", "high"],
 				tools: true,
 				jsonOutput: true,
 				supportedParameters: xaiSupportedParamsNoFreqPresence,
@@ -915,6 +916,7 @@ export const xaiModels = [
 				streaming: true,
 				vision: true,
 				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high"],
 				tools: true,
 				jsonOutput: true,
 				supportedParameters: [


### PR DESCRIPTION
## Summary

Declares `reasoningEfforts` for xAI's direct mappings in `packages/models/src/models/xai.ts`, per #3028.

## Changes

- `grok-4.5` → `["low", "medium", "high"]`
  Source: [xAI Reasoning docs](https://docs.x.ai/developers/model-capabilities/text/reasoning) — states default is high, reasoning can't be disabled, lists exactly low/medium/high.
- `grok-4.3` → `["none", "low", "medium", "high"]`
  Source: [xAI Retirement docs](https://docs.x.ai/developers/migration/may-15-retirement) — states Grok 4.3 has "4 reasoning effort levels (none, low, medium, and high)."

## Not changed

- `grok-4-fast-reasoning`, `grok-4-1-fast-reasoning` — retired May 15, 2026, now redirect to grok-4.3. Flagging instead of patching a dead slug.
- `grok-4.20-multi-agent-beta-0309` — real xAI model is named `grok-4.20-multi-agent` (no suffix), confirmed via [xAI Multi-Agent docs](https://docs.x.ai/developers/model-capabilities/text/multi-agent). This externalId doesn't match and looks like a stale/deactivated entry — needs a maintainer look, not a guess from me.
- `grok-4.20-beta-0309-reasoning`, `grok-build-0.1` — no documented reasoning_effort values found.
- `grok-4-1-fast-reasoning` (azure-ai-foundry), `grok-4.3` (aws-bedrock, azure-ai-foundry), `grok-4.20-reasoning` (vertex-openai) — cloud-reseller entries, need checking against Azure/AWS/Vertex docs separately.

## Testing

- `pnpm format` — only `xai.ts` changed, 2 lines.