### PR TITLE
feat(models): declare reasoning effort for glm-5.2

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -20,6 +20,7 @@ export const zaiModels = [
 				maxOutput: 128000,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["high", "max"],
 				vision: false,
 				tools: true,
 				webSearch: true,


### PR DESCRIPTION
## Summary

Declares `reasoningEfforts` for `glm-5.2` in `packages/models/src/models/zai.ts`, per #3028. Investigated all 13 `reasoning: true` blocks for `providerId: 'zai'`, only `glm-5.2` has a confirmed, documented graduated effort scale.

## Changes

- `glm-5.2` → `["high", "max"]`
  Sources:
  - [Z.AI's own GLM-5.2 docs](https://docs.z.ai/guides/llm/glm-5.2), working curl example using `"reasoning_effort": "max"`.
  - [Z.AI's official GitHub (zai-org/GLM-5)](https://github.com/zai-org/GLM-5), states the reasoning_effort parameter "accepts two levels: max and high... max is the default."

## Not changed, 12 other GLM models

The rest of the GLM family (glm-5.1, glm-5, glm-4.5, glm-4.5v, glm-4.5-x, glm-4.7, glm-4.7-flashx, glm-4.7-flash, glm-4.6, glm-4.6v, glm-4.6v-flashx, glm-4.6v-flash) use a binary `thinking: {"type": "enabled"|"disabled"}` toggle, not a graded effort parameter, confirmed across multiple independent sources (a Hermes bug report, an OpenClaw provider doc, and a pi-mono fix, all describing the same on/off mechanic). A binary toggle doesn't map to this field's purpose, so left unchanged rather than force-fitting a value.

## Testing

- `pnpm format` — only `zai.ts` changed, 1 line.