### PR TITLE
fix: treat minimax abort finish reason as upstream error

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -393,6 +393,28 @@ describe("parseProviderResponse", () => {
 		});
 	});
 
+	describe("openai-format finish reason mapping", () => {
+		it("maps 'abort' finish reason to 'canceled' for minimax", () => {
+			const json = {
+				choices: [
+					{
+						message: { content: "Hello", role: "assistant" },
+						finish_reason: "abort",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse("minimax", "MiniMax-M3", json);
+
+			expect(result.finishReason).toBe("canceled");
+		});
+	});
+
 	describe("refusal finish reason", () => {
 		it("preserves the raw 'refusal' stop reason for aws-bedrock", () => {
 			const json = {

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -352,7 +352,7 @@ describe("parseProviderResponse", () => {
 	});
 
 	describe("novita finish reason mapping", () => {
-		it("maps 'abort' finish reason to 'canceled'", () => {
+		it("maps 'abort' finish reason to 'upstream_error'", () => {
 			const json = {
 				choices: [
 					{
@@ -369,7 +369,7 @@ describe("parseProviderResponse", () => {
 
 			const result = parseProviderResponse("novita", "glm-4", json);
 
-			expect(result.finishReason).toBe("canceled");
+			expect(result.finishReason).toBe("upstream_error");
 		});
 
 		it("maps 'end_turn' finish reason to 'stop'", () => {
@@ -394,7 +394,7 @@ describe("parseProviderResponse", () => {
 	});
 
 	describe("openai-format finish reason mapping", () => {
-		it("maps 'abort' finish reason to 'canceled' for minimax", () => {
+		it("maps 'abort' finish reason to 'upstream_error' for minimax", () => {
 			const json = {
 				choices: [
 					{
@@ -411,7 +411,7 @@ describe("parseProviderResponse", () => {
 
 			const result = parseProviderResponse("minimax", "MiniMax-M3", json);
 
-			expect(result.finishReason).toBe("canceled");
+			expect(result.finishReason).toBe("upstream_error");
 		});
 	});
 

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -574,7 +574,9 @@ export function parseProviderResponse(
 					nativeFinishReason: json.choices?.[0]?.native_finish_reason,
 					usage: json.usage,
 				});
-				finishReason = "canceled";
+				// "abort" is an upstream-initiated interruption, not a client
+				// cancellation, so it counts as an upstream error.
+				finishReason = "upstream_error";
 			} else if (finishReason === "tool_use") {
 				finishReason = "tool_calls";
 			}
@@ -944,7 +946,9 @@ export function parseProviderResponse(
 						nativeFinishReason: json.choices?.[0]?.native_finish_reason,
 						usage: json.usage,
 					});
-					finishReason = "canceled";
+					// "abort" is an upstream-initiated interruption, not a client
+					// cancellation, so it counts as an upstream error.
+					finishReason = "upstream_error";
 				}
 
 				// ZAI-specific fix for incorrect finish_reason in tool response scenarios

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -944,6 +944,7 @@ export function parseProviderResponse(
 						nativeFinishReason: json.choices?.[0]?.native_finish_reason,
 						usage: json.usage,
 					});
+					finishReason = "canceled";
 				}
 
 				// ZAI-specific fix for incorrect finish_reason in tool response scenarios

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1392,7 +1392,9 @@ export function transformStreamingToOpenai(
 					model: usedModel,
 					chunk: data,
 				});
-				transformedData.choices[0].finish_reason = "canceled";
+				// "abort" is an upstream-initiated interruption, not a client
+				// cancellation, so it counts as an upstream error.
+				transformedData.choices[0].finish_reason = "upstream_error";
 			} else if (transformedData?.choices?.[0]?.finish_reason === "tool_use") {
 				transformedData.choices[0].finish_reason = "tool_calls";
 			}

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -23,6 +23,15 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
+	it("maps 'abort' to canceled regardless of provider", () => {
+		expect(getUnifiedFinishReason("abort", "minimax")).toBe(
+			UnifiedFinishReason.CANCELED,
+		);
+		expect(getUnifiedFinishReason("abort", "novita")).toBe(
+			UnifiedFinishReason.CANCELED,
+		);
+	});
+
 	it("maps Anthropic finish reasons correctly", () => {
 		expect(getUnifiedFinishReason("stop_sequence", "anthropic")).toBe(
 			UnifiedFinishReason.COMPLETED,

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -23,12 +23,12 @@ describe("getUnifiedFinishReason", () => {
 		);
 	});
 
-	it("maps 'abort' to canceled regardless of provider", () => {
+	it("maps upstream 'abort' to upstream error regardless of provider", () => {
 		expect(getUnifiedFinishReason("abort", "minimax")).toBe(
-			UnifiedFinishReason.CANCELED,
+			UnifiedFinishReason.UPSTREAM_ERROR,
 		);
 		expect(getUnifiedFinishReason("abort", "novita")).toBe(
-			UnifiedFinishReason.CANCELED,
+			UnifiedFinishReason.UPSTREAM_ERROR,
 		);
 	});
 

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -49,6 +49,13 @@ export function getUnifiedFinishReason(
 	if (finishReason === "canceled") {
 		return UnifiedFinishReason.CANCELED;
 	}
+	// Some OpenAI-compatible providers (e.g. MiniMax) emit "abort" when
+	// generation is interrupted upstream. The response/streaming transforms
+	// normalize it to "canceled" for clients, but the streaming log path
+	// records the provider's raw finish reason, so classify it here too.
+	if (finishReason === "abort") {
+		return UnifiedFinishReason.CANCELED;
+	}
 	if (finishReason === "gateway_error") {
 		return UnifiedFinishReason.GATEWAY_ERROR;
 	}

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -49,12 +49,13 @@ export function getUnifiedFinishReason(
 	if (finishReason === "canceled") {
 		return UnifiedFinishReason.CANCELED;
 	}
-	// Some OpenAI-compatible providers (e.g. MiniMax) emit "abort" when
-	// generation is interrupted upstream. The response/streaming transforms
-	// normalize it to "canceled" for clients, but the streaming log path
-	// records the provider's raw finish reason, so classify it here too.
+	// Some OpenAI-compatible providers (e.g. MiniMax) emit "abort" when they
+	// interrupt generation on their side. CANCELED is reserved for requests
+	// canceled by the gateway's own client, so an upstream-initiated abort is
+	// an upstream error. The streaming log path records the provider's raw
+	// finish reason, so classify the raw value here as well.
 	if (finishReason === "abort") {
-		return UnifiedFinishReason.CANCELED;
+		return UnifiedFinishReason.UPSTREAM_ERROR;
 	}
 	if (finishReason === "gateway_error") {
 		return UnifiedFinishReason.GATEWAY_ERROR;


### PR DESCRIPTION
## Summary

MiniMax emits `finish_reason: "abort"` when it interrupts generation on its side, which caused spurious `Unknown finish reason encountered` ERROR logs in production (provider `minimax`, model `minimax/minimax-m3`).

`abort` is an upstream-initiated interruption, not a client cancellation — `CANCELED` is reserved for requests canceled by the gateway's own client — so it is now classified as an **upstream error** everywhere. This also corrects the pre-existing mistral/novita parse branch and the streaming transform, which conflated `abort` with `canceled`.

Two paths previously let the raw `abort` reach `insertLog`, where it resolved to `UNKNOWN` and fired the error log:

1. **Streaming**: the log path captures the raw provider chunk's `finish_reason`, so the raw `abort` bypassed the streaming transform's normalization.
2. **Non-streaming**: the default OpenAI-format parse branch only logged a warning for `abort` without mapping it, so both the log record and the client response kept the raw value.

## Changes

- `apps/gateway/src/lib/logs.ts`: classify `abort` as `UPSTREAM_ERROR` in `getUnifiedFinishReason` at the top level, covering the streaming log path (which records the raw provider finish reason) regardless of provider.
- `apps/gateway/src/chat/tools/parse-provider-response.ts`: map `abort` → `upstream_error` in the default OpenAI-format branch and in the mistral/novita branch (previously `canceled`).
- `apps/gateway/src/chat/tools/transform-streaming-to-openai.ts`: streaming chunks now surface `abort` as `upstream_error` (previously `canceled`).
- Added unit tests for the unified-reason and parse mappings.

These requests now show up as upstream errors rather than unknown/canceled in metrics and the dashboard. The pre-existing WARN `Upstream sent abort finish_reason` is retained for visibility into how often MiniMax does this.

## Testing

- `pnpm vitest run` on logs, parse-provider-response, and both streaming-transform spec files — 92 tests pass
- `turbo run build --filter=gateway` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkjBDx4sA1Rs9v4ixVUjh5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated finish-reason handling so upstream `abort` is classified as an upstream error (`upstream_error`) rather than treated as canceled.
  * Improved consistent status classification and logging/metrics for interrupted generations across supported providers.
* **Tests**
  * Expanded unit tests to cover OpenAI-style `finish_reason: "abort"` mapping for all relevant provider variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->