### PR TITLE
feat: automatic cache busting for og images

### DIFF
--- a/apps/code/src/app/claude-code-alternative/page.tsx
+++ b/apps/code/src/app/claude-code-alternative/page.tsx
@@ -15,6 +15,7 @@ import {
 	getDevPlanCreditsLimit,
 	MARKETING_STATS,
 } from "@llmgateway/shared";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -29,12 +30,20 @@ export const metadata: Metadata = {
 	description: DESCRIPTION,
 	alternates: { canonical: PAGE_PATH },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/claude-code-alternative/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: TITLE,
 		description: DESCRIPTION,
 		type: "article",
 		url: `${BASE_URL}${PAGE_PATH}`,
 	},
 	twitter: {
+		images: [withDeployVersion("/claude-code-alternative/opengraph-image")],
 		card: "summary_large_image",
 		title: TITLE,
 		description: DESCRIPTION,

--- a/apps/code/src/app/claude-code-alternative/page.tsx
+++ b/apps/code/src/app/claude-code-alternative/page.tsx
@@ -15,7 +15,7 @@ import {
 	getDevPlanCreditsLimit,
 	MARKETING_STATS,
 } from "@llmgateway/shared";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -30,20 +30,14 @@ export const metadata: Metadata = {
 	description: DESCRIPTION,
 	alternates: { canonical: PAGE_PATH },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/claude-code-alternative/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/claude-code-alternative")],
 		title: TITLE,
 		description: DESCRIPTION,
 		type: "article",
 		url: `${BASE_URL}${PAGE_PATH}`,
 	},
 	twitter: {
-		images: [withDeployVersion("/claude-code-alternative/opengraph-image")],
+		images: [versionedOgImage("/claude-code-alternative")],
 		card: "summary_large_image",
 		title: TITLE,
 		description: DESCRIPTION,

--- a/apps/code/src/app/compare/[slug]/page.tsx
+++ b/apps/code/src/app/compare/[slug]/page.tsx
@@ -12,7 +12,7 @@ import { SwitchIn60 } from "@/components/SwitchIn60";
 import { Button } from "@/components/ui/button";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import { allComparisons } from "content-collections";
 
@@ -59,19 +59,13 @@ export async function generateMetadata({
 			description: entry.description,
 			type: "article",
 			url: `${BASE_URL}/compare/${entry.slug}`,
-			images: [
-				{
-					url: withDeployVersion(`/compare/${entry.slug}/opengraph-image`),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`/compare/${entry.slug}`)],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: entry.metaTitle ?? entry.title,
 			description: entry.description,
-			images: [withDeployVersion(`/compare/${entry.slug}/opengraph-image`)],
+			images: [versionedOgImage(`/compare/${entry.slug}`)],
 		},
 	};
 }

--- a/apps/code/src/app/compare/[slug]/page.tsx
+++ b/apps/code/src/app/compare/[slug]/page.tsx
@@ -12,6 +12,8 @@ import { SwitchIn60 } from "@/components/SwitchIn60";
 import { Button } from "@/components/ui/button";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import { allComparisons } from "content-collections";
 
 import type { Comparison } from "content-collections";
@@ -57,11 +59,19 @@ export async function generateMetadata({
 			description: entry.description,
 			type: "article",
 			url: `${BASE_URL}/compare/${entry.slug}`,
+			images: [
+				{
+					url: withDeployVersion(`/compare/${entry.slug}/opengraph-image`),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: entry.metaTitle ?? entry.title,
 			description: entry.description,
+			images: [withDeployVersion(`/compare/${entry.slug}/opengraph-image`)],
 		},
 	};
 }

--- a/apps/code/src/app/compare/page.tsx
+++ b/apps/code/src/app/compare/page.tsx
@@ -5,6 +5,8 @@ import { BrandTile } from "@/components/brand-logos";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import { allComparisons } from "content-collections";
 
 import type { Comparison } from "content-collections";
@@ -16,6 +18,13 @@ export const metadata: Metadata = {
 		"How DevPass compares to Cursor, OpenCode, FirePass, the z.ai GLM Coding Plan, and Alibaba's Qwen plan. Pricing, model catalogs, and limits side by side.",
 	alternates: { canonical: "/compare" },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/compare/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "DevPass vs the Alternatives — Coding Plan Comparisons",
 		description:
 			"How DevPass compares to Cursor, OpenCode, FirePass, z.ai and Alibaba Qwen. Pricing, models, and limits side by side.",

--- a/apps/code/src/app/compare/page.tsx
+++ b/apps/code/src/app/compare/page.tsx
@@ -5,7 +5,7 @@ import { BrandTile } from "@/components/brand-logos";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import { allComparisons } from "content-collections";
 
@@ -18,13 +18,7 @@ export const metadata: Metadata = {
 		"How DevPass compares to Cursor, OpenCode, FirePass, the z.ai GLM Coding Plan, and Alibaba's Qwen plan. Pricing, model catalogs, and limits side by side.",
 	alternates: { canonical: "/compare" },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/compare/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/compare")],
 		title: "DevPass vs the Alternatives — Coding Plan Comparisons",
 		description:
 			"How DevPass compares to Cursor, OpenCode, FirePass, z.ai and Alibaba Qwen. Pricing, models, and limits side by side.",

--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { GoogleTag } from "@/components/google-tag";
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import "./globals.css";
 
 import type { Metadata } from "next";
@@ -55,7 +57,7 @@ export const metadata: Metadata = {
 		title: "DevPass by LLM Gateway - All-Access Dev Plans for AI Coding",
 		description:
 			"One subscription, every coding model. Fixed-price dev plans for Claude Code, Cursor, Cline, and any OpenAI-compatible tool.",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		type: "website",
 		url: "https://devpass.llmgateway.io",
 		siteName: "DevPass by LLM Gateway",
@@ -66,7 +68,7 @@ export const metadata: Metadata = {
 		title: "DevPass by LLM Gateway - All-Access Dev Plans for AI Coding",
 		description:
 			"One subscription, every coding model. Fixed-price dev plans for Claude Code, Cursor, and 200+ models.",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		creator: "@llmgateway",
 	},
 };

--- a/apps/code/src/app/profiles/[username]/page.tsx
+++ b/apps/code/src/app/profiles/[username]/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/profile/ProfileView";
 import { fetchPublicProfile } from "@/lib/public-profile";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -40,13 +40,9 @@ export async function generateMetadata({
 			type: "profile",
 			url: `/profiles/${profile.username}`,
 			images: [
-				{
-					url: withDeployVersion(
-						`/profiles/${encodeURIComponent(profile.username ?? username)}/opengraph-image`,
-					),
-					width: 1200,
-					height: 630,
-				},
+				versionedOgImage(
+					`/profiles/${encodeURIComponent(profile.username ?? username)}`,
+				),
 			],
 		},
 		twitter: {
@@ -54,8 +50,8 @@ export async function generateMetadata({
 			title,
 			description,
 			images: [
-				withDeployVersion(
-					`/profiles/${encodeURIComponent(profile.username ?? username)}/opengraph-image`,
+				versionedOgImage(
+					`/profiles/${encodeURIComponent(profile.username ?? username)}`,
 				),
 			],
 		},

--- a/apps/code/src/app/profiles/[username]/page.tsx
+++ b/apps/code/src/app/profiles/[username]/page.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/components/profile/ProfileView";
 import { fetchPublicProfile } from "@/lib/public-profile";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 interface PageProps {
@@ -37,11 +39,25 @@ export async function generateMetadata({
 			description,
 			type: "profile",
 			url: `/profiles/${profile.username}`,
+			images: [
+				{
+					url: withDeployVersion(
+						`/profiles/${encodeURIComponent(profile.username ?? username)}/opengraph-image`,
+					),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
+			images: [
+				withDeployVersion(
+					`/profiles/${encodeURIComponent(profile.username ?? username)}/opengraph-image`,
+				),
+			],
 		},
 	};
 }

--- a/apps/playground/src/app/compare/[slug]/page.tsx
+++ b/apps/playground/src/app/compare/[slug]/page.tsx
@@ -12,6 +12,8 @@ import {
 	US,
 } from "@/lib/comparisons";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 interface PageProps {
@@ -40,11 +42,19 @@ export async function generateMetadata({
 			description: comparison.metaDescription,
 			type: "article",
 			url: `https://chat.llmgateway.io${canonical}`,
+			images: [
+				{
+					url: withDeployVersion(`${canonical}/opengraph-image`),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: comparison.metaTitle,
 			description: comparison.metaDescription,
+			images: [withDeployVersion(`${canonical}/opengraph-image`)],
 		},
 	};
 }

--- a/apps/playground/src/app/compare/[slug]/page.tsx
+++ b/apps/playground/src/app/compare/[slug]/page.tsx
@@ -12,7 +12,7 @@ import {
 	US,
 } from "@/lib/comparisons";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -42,19 +42,13 @@ export async function generateMetadata({
 			description: comparison.metaDescription,
 			type: "article",
 			url: `https://chat.llmgateway.io${canonical}`,
-			images: [
-				{
-					url: withDeployVersion(`${canonical}/opengraph-image`),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`${canonical}`)],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: comparison.metaTitle,
 			description: comparison.metaDescription,
-			images: [withDeployVersion(`${canonical}/opengraph-image`)],
+			images: [versionedOgImage(`${canonical}`)],
 		},
 	};
 }

--- a/apps/playground/src/app/compare/page.tsx
+++ b/apps/playground/src/app/compare/page.tsx
@@ -5,7 +5,7 @@ import { FaceOff, ThemTile, UsTile } from "@/components/compare/logo-faceoff";
 import { Button } from "@/components/ui/button";
 import { comparisons, US } from "@/lib/comparisons";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -15,13 +15,7 @@ export const metadata: Metadata = {
 		"Compare LLM Gateway Chat to ChatGPT, Claude, Gemini, Poe, Perplexity and OpenRouter — every frontier model on one $19/mo subscription.",
 	alternates: { canonical: "/compare" },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/compare/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/compare")],
 		title: "Compare LLM Gateway Chat — vs ChatGPT, Claude, Gemini & more",
 		description:
 			"One subscription, every frontier model. See how LLM Gateway Chat stacks up against the AI chat apps you're evaluating.",
@@ -29,7 +23,7 @@ export const metadata: Metadata = {
 		url: "https://chat.llmgateway.io/compare",
 	},
 	twitter: {
-		images: [withDeployVersion("/compare/opengraph-image")],
+		images: [versionedOgImage("/compare")],
 		card: "summary_large_image",
 		title: "Compare LLM Gateway Chat — vs ChatGPT, Claude, Gemini & more",
 		description:

--- a/apps/playground/src/app/compare/page.tsx
+++ b/apps/playground/src/app/compare/page.tsx
@@ -5,6 +5,8 @@ import { FaceOff, ThemTile, UsTile } from "@/components/compare/logo-faceoff";
 import { Button } from "@/components/ui/button";
 import { comparisons, US } from "@/lib/comparisons";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -13,6 +15,13 @@ export const metadata: Metadata = {
 		"Compare LLM Gateway Chat to ChatGPT, Claude, Gemini, Poe, Perplexity and OpenRouter — every frontier model on one $19/mo subscription.",
 	alternates: { canonical: "/compare" },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/compare/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "Compare LLM Gateway Chat — vs ChatGPT, Claude, Gemini & more",
 		description:
 			"One subscription, every frontier model. See how LLM Gateway Chat stacks up against the AI chat apps you're evaluating.",
@@ -20,6 +29,7 @@ export const metadata: Metadata = {
 		url: "https://chat.llmgateway.io/compare",
 	},
 	twitter: {
+		images: [withDeployVersion("/compare/opengraph-image")],
 		card: "summary_large_image",
 		title: "Compare LLM Gateway Chat — vs ChatGPT, Claude, Gemini & more",
 		description:

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter, Geist_Mono } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import "./globals.css";
 
 import type { Metadata } from "next";
@@ -48,7 +50,7 @@ export const metadata: Metadata = {
 		title: "AI Playground — Chat with 200+ Models (GPT, Claude, Gemini)",
 		description:
 			"Test and compare 200+ AI models from one account. Chat, generate images and videos, and run multi-model group chats — pay-as-you-go.",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		type: "website",
 		url: "https://chat.llmgateway.io",
 		siteName: "LLM Gateway Playground",
@@ -59,7 +61,7 @@ export const metadata: Metadata = {
 		title: "AI Playground — Chat with 200+ Models (GPT, Claude, Gemini)",
 		description:
 			"Test and compare 200+ AI models from one account. Chat, generate images and videos, and run multi-model group chats — pay-as-you-go.",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		creator: "@llmgateway",
 	},
 };

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -7,6 +7,8 @@ import { Logo } from "@/components/ui/logo";
 import { getConfig } from "@/lib/config-server";
 import { parsePlaygroundMessageMetadata } from "@/lib/message-metadata";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { UIMessage } from "ai";
 import type { Metadata } from "next";
 
@@ -171,11 +173,25 @@ export async function generateMetadata({
 			url,
 			type: "article",
 			siteName: "LLM Gateway Playground",
+			images: [
+				{
+					url: withDeployVersion(
+						`/share/${encodeURIComponent(shareId)}/opengraph-image`,
+					),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
+			images: [
+				withDeployVersion(
+					`/share/${encodeURIComponent(shareId)}/opengraph-image`,
+				),
+			],
 		},
 	};
 }

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -7,7 +7,7 @@ import { Logo } from "@/components/ui/logo";
 import { getConfig } from "@/lib/config-server";
 import { parsePlaygroundMessageMetadata } from "@/lib/message-metadata";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { UIMessage } from "ai";
 import type { Metadata } from "next";
@@ -173,25 +173,13 @@ export async function generateMetadata({
 			url,
 			type: "article",
 			siteName: "LLM Gateway Playground",
-			images: [
-				{
-					url: withDeployVersion(
-						`/share/${encodeURIComponent(shareId)}/opengraph-image`,
-					),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`/share/${encodeURIComponent(shareId)}`)],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
-			images: [
-				withDeployVersion(
-					`/share/${encodeURIComponent(shareId)}/opengraph-image`,
-				),
-			],
+			images: [versionedOgImage(`/share/${encodeURIComponent(shareId)}`)],
 		},
 	};
 }

--- a/apps/ui/src/app/agents/page.tsx
+++ b/apps/ui/src/app/agents/page.tsx
@@ -2,6 +2,8 @@ import { AgentCards } from "@/components/agents/agent-cards";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -10,6 +12,13 @@ export const metadata: Metadata = {
 		"Pre-built tool-calling AI agents ready to integrate — weather, search, and more, powered by LLM Gateway.",
 	alternates: { canonical: "/agents" },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/agents/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "AI Agents — Pre-built Tool-Calling Agents",
 		description:
 			"Pre-built tool-calling AI agents ready to integrate — weather, search, and more, powered by LLM Gateway.",

--- a/apps/ui/src/app/agents/page.tsx
+++ b/apps/ui/src/app/agents/page.tsx
@@ -2,7 +2,7 @@ import { AgentCards } from "@/components/agents/agent-cards";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -12,13 +12,7 @@ export const metadata: Metadata = {
 		"Pre-built tool-calling AI agents ready to integrate — weather, search, and more, powered by LLM Gateway.",
 	alternates: { canonical: "/agents" },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/agents/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/agents")],
 		title: "AI Agents — Pre-built Tool-Calling Agents",
 		description:
 			"Pre-built tool-calling AI agents ready to integrate — weather, search, and more, powered by LLM Gateway.",

--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -8,6 +8,8 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { CopyMarkdownButton } from "./copy-markdown-button";
 
 import type { Blog } from "content-collections";
@@ -58,7 +60,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 				"@type": "ImageObject",
 				url: entry.image.src.startsWith("http")
 					? entry.image.src
-					: `https://llmgateway.io${entry.image.src}`,
+					: `https://llmgateway.io${withAssetVersion(entry.image.src)}`,
 				width: entry.image.width,
 				height: entry.image.height,
 			},
@@ -195,13 +197,13 @@ export async function generateMetadata({
 			images: entry.image
 				? [
 						{
-							url: entry.image.src,
+							url: withAssetVersion(entry.image.src),
 							width: entry.image.width ?? 800,
 							height: entry.image.height ?? 400,
 							alt: entry.image.alt ?? entry.title,
 						},
 					]
-				: ["/opengraph.png"],
+				: [withAssetVersion("/opengraph.png")],
 		},
 		twitter: {
 			card: "summary_large_image",

--- a/apps/ui/src/app/blog/category/[category]/page.tsx
+++ b/apps/ui/src/app/blog/category/[category]/page.tsx
@@ -4,6 +4,8 @@ import { BlogList } from "@/components/blog/list";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { slugify } from "@/lib/slugify";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { allBlogs } from "content-collections";
 
 import type { Metadata } from "next";
@@ -99,7 +101,7 @@ export async function generateMetadata({
 			description,
 			url: `https://llmgateway.io/blog/category/${slug}`,
 			type: "website",
-			images: ["/opengraph.png?v=2"],
+			images: [withAssetVersion("/opengraph.png")],
 		},
 	};
 }

--- a/apps/ui/src/app/blog/category/page.tsx
+++ b/apps/ui/src/app/blog/category/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { slugify } from "@/lib/slugify";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { allBlogs } from "content-collections";
 
 import type { Metadata } from "next";
@@ -18,7 +20,7 @@ export const metadata: Metadata = {
 			"Browse LLM Gateway blog posts by category — product updates, tutorials, deep-dives, and more.",
 		url: "https://llmgateway.io/blog/category",
 		type: "website",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 	},
 };
 

--- a/apps/ui/src/app/brand/page.tsx
+++ b/apps/ui/src/app/brand/page.tsx
@@ -3,6 +3,8 @@ import { Download } from "lucide-react";
 import { Card } from "@/lib/components/card";
 import Logo from "@/lib/icons/Logo";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,7 +13,7 @@ export const metadata: Metadata = {
 		"Download official LLM Gateway logos, marks, and brand assets. SVG files in light and dark variants, plus usage guidelines for partners.",
 	openGraph: {
 		title: "Brand Assets — Logos & Guidelines | LLM Gateway",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		description:
 			"Download official LLM Gateway logos, marks, and brand assets. SVG files in light and dark variants.",
 		type: "website",

--- a/apps/ui/src/app/changelog/[slug]/page.tsx
+++ b/apps/ui/src/app/changelog/[slug]/page.tsx
@@ -8,6 +8,8 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { CopyMarkdownButton } from "./copy-markdown-button";
 
 import type { Changelog } from "content-collections";
@@ -60,7 +62,7 @@ export default async function ChangelogEntryPage({
 				"@type": "ImageObject",
 				url: entry.image.src.startsWith("http")
 					? entry.image.src
-					: `https://llmgateway.io${entry.image.src}`,
+					: `https://llmgateway.io${withAssetVersion(entry.image.src)}`,
 				width: entry.image.width,
 				height: entry.image.height,
 			},
@@ -200,13 +202,13 @@ export async function generateMetadata({
 			images: entry.image
 				? [
 						{
-							url: entry.image.src,
+							url: withAssetVersion(entry.image.src),
 							width: entry.image.width ?? 800,
 							height: entry.image.height ?? 400,
 							alt: entry.image.alt ?? entry.title,
 						},
 					]
-				: ["/opengraph.png"],
+				: [withAssetVersion("/opengraph.png")],
 		},
 		twitter: {
 			card: "summary_large_image",

--- a/apps/ui/src/app/compare/github-copilot/page.tsx
+++ b/apps/ui/src/app/compare/github-copilot/page.tsx
@@ -3,7 +3,7 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonGitHubCopilot } from "@/components/landing/comparison-github-copilot";
 import Footer from "@/components/landing/footer";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
@@ -87,13 +87,7 @@ export async function generateMetadata() {
 			"Copilot now bills chat and agents by usage-based AI Credits. Compare it with LLM Gateway: zero token markup, hard budget caps, prompt caching, and 200+ models for any coding agent.",
 		alternates: { canonical: "/compare/github-copilot" },
 		openGraph: {
-			images: [
-				{
-					url: withDeployVersion("/compare/github-copilot/opengraph-image"),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage("/compare/github-copilot")],
 			title: "LLM Gateway vs GitHub Copilot — Costs Compared (2026)",
 			description:
 				"Copilot bills chat and agents by usage-based AI Credits. LLM Gateway: zero token markup, hard budget caps, and 200+ models for any coding agent.",
@@ -101,7 +95,7 @@ export async function generateMetadata() {
 			url: "https://llmgateway.io/compare/github-copilot",
 		},
 		twitter: {
-			images: [withDeployVersion("/compare/github-copilot/opengraph-image")],
+			images: [versionedOgImage("/compare/github-copilot")],
 			card: "summary_large_image",
 			title: "LLM Gateway vs GitHub Copilot — Costs Compared (2026)",
 			description:

--- a/apps/ui/src/app/compare/github-copilot/page.tsx
+++ b/apps/ui/src/app/compare/github-copilot/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonGitHubCopilot } from "@/components/landing/comparison-github-copilot";
 import Footer from "@/components/landing/footer";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const copilotFaqs: CompareFaqItem[] = [
@@ -85,6 +87,13 @@ export async function generateMetadata() {
 			"Copilot now bills chat and agents by usage-based AI Credits. Compare it with LLM Gateway: zero token markup, hard budget caps, prompt caching, and 200+ models for any coding agent.",
 		alternates: { canonical: "/compare/github-copilot" },
 		openGraph: {
+			images: [
+				{
+					url: withDeployVersion("/compare/github-copilot/opengraph-image"),
+					width: 1200,
+					height: 630,
+				},
+			],
 			title: "LLM Gateway vs GitHub Copilot — Costs Compared (2026)",
 			description:
 				"Copilot bills chat and agents by usage-based AI Credits. LLM Gateway: zero token markup, hard budget caps, and 200+ models for any coding agent.",
@@ -92,6 +101,7 @@ export async function generateMetadata() {
 			url: "https://llmgateway.io/compare/github-copilot",
 		},
 		twitter: {
+			images: [withDeployVersion("/compare/github-copilot/opengraph-image")],
 			card: "summary_large_image",
 			title: "LLM Gateway vs GitHub Copilot — Costs Compared (2026)",
 			description:

--- a/apps/ui/src/app/copilot-cost-calculator/page.tsx
+++ b/apps/ui/src/app/copilot-cost-calculator/page.tsx
@@ -4,6 +4,8 @@ import { COPILOT_CALCULATOR_FAQ } from "@/components/copilot-cost-calculator/faq
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 const PAGE_URL = "https://llmgateway.io/copilot-cost-calculator";
@@ -32,14 +34,14 @@ export const metadata: Metadata = {
 		title: "GitHub Copilot Cost Calculator (2026 AI Credits) | LLM Gateway",
 		description:
 			"Model your team's Copilot AI Credits bill after the June 2026 change and compare the same workload routed through LLM Gateway.",
-		images: [{ url: "/opengraph.png?v=1" }],
+		images: [{ url: withAssetVersion("/opengraph.png") }],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "GitHub Copilot Cost Calculator (2026 AI Credits) | LLM Gateway",
 		description:
 			"Estimate your team's Copilot AI Credits bill and see what the same usage costs at pass-through token prices with caching.",
-		images: ["/opengraph.png?v=1"],
+		images: [withAssetVersion("/opengraph.png")],
 	},
 };
 

--- a/apps/ui/src/app/enterprise/page.tsx
+++ b/apps/ui/src/app/enterprise/page.tsx
@@ -17,7 +17,7 @@ import { HeroRSC } from "@/components/landing/hero-rsc";
 import { Testimonials } from "@/components/landing/testimonials";
 import { fetchServerData } from "@/lib/server-api";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -27,13 +27,7 @@ export const metadata: Metadata = {
 		"SOC 2 Type II LLM infrastructure with SAML SSO, audit logs, prompt-injection guardrails, per-project routing, and white-label chat for regulated teams.",
 	alternates: { canonical: "/enterprise" },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/enterprise/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/enterprise")],
 		title: "Enterprise LLM Gateway",
 		description:
 			"SAML SSO, audit logs, guardrails, per-project routing, and white-label chat for regulated teams putting LLMs in production.",
@@ -41,7 +35,7 @@ export const metadata: Metadata = {
 		url: "https://llmgateway.io/enterprise",
 	},
 	twitter: {
-		images: [withDeployVersion("/enterprise/opengraph-image")],
+		images: [versionedOgImage("/enterprise")],
 		card: "summary_large_image",
 		title: "Enterprise LLM Gateway",
 		description:

--- a/apps/ui/src/app/enterprise/page.tsx
+++ b/apps/ui/src/app/enterprise/page.tsx
@@ -17,6 +17,8 @@ import { HeroRSC } from "@/components/landing/hero-rsc";
 import { Testimonials } from "@/components/landing/testimonials";
 import { fetchServerData } from "@/lib/server-api";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -25,6 +27,13 @@ export const metadata: Metadata = {
 		"SOC 2 Type II LLM infrastructure with SAML SSO, audit logs, prompt-injection guardrails, per-project routing, and white-label chat for regulated teams.",
 	alternates: { canonical: "/enterprise" },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/enterprise/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "Enterprise LLM Gateway",
 		description:
 			"SAML SSO, audit logs, guardrails, per-project routing, and white-label chat for regulated teams putting LLMs in production.",
@@ -32,6 +41,7 @@ export const metadata: Metadata = {
 		url: "https://llmgateway.io/enterprise",
 	},
 	twitter: {
+		images: [withDeployVersion("/enterprise/opengraph-image")],
 		card: "summary_large_image",
 		title: "Enterprise LLM Gateway",
 		description:

--- a/apps/ui/src/app/features/[slug]/page.tsx
+++ b/apps/ui/src/app/features/[slug]/page.tsx
@@ -23,7 +23,10 @@ import { Button } from "@/lib/components/button";
 import { getConfig } from "@/lib/config-server";
 import { features, getFeatureBySlug } from "@/lib/features";
 
-import { withAssetVersion } from "@llmgateway/shared/asset-version";
+import {
+	withAssetVersion,
+	withDeployVersion,
+} from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -292,6 +295,9 @@ export async function generateMetadata({
 
 	const title = feature.title;
 	const description = feature.description;
+	const ogImageUrl = withDeployVersion(
+		`/features/${feature.slug}/opengraph-image`,
+	);
 
 	return {
 		title,
@@ -304,11 +310,13 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `https://llmgateway.io/features/${feature.slug}`,
+			images: [{ url: ogImageUrl, width: 1200, height: 630 }],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
+			images: [ogImageUrl],
 		},
 	};
 }

--- a/apps/ui/src/app/features/[slug]/page.tsx
+++ b/apps/ui/src/app/features/[slug]/page.tsx
@@ -23,6 +23,8 @@ import { Button } from "@/lib/components/button";
 import { getConfig } from "@/lib/config-server";
 import { features, getFeatureBySlug } from "@/lib/features";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 interface PageProps {
@@ -85,7 +87,7 @@ export default async function FeaturePage({ params }: PageProps) {
 		name: feature.title,
 		description: feature.longDescription,
 		url: `https://llmgateway.io/features/${slug}`,
-		image: "https://llmgateway.io/opengraph.png?v=1",
+		image: `https://llmgateway.io${withAssetVersion("/opengraph.png")}`,
 		isPartOf: {
 			"@type": "WebSite",
 			name: "LLM Gateway",

--- a/apps/ui/src/app/features/[slug]/page.tsx
+++ b/apps/ui/src/app/features/[slug]/page.tsx
@@ -25,7 +25,7 @@ import { features, getFeatureBySlug } from "@/lib/features";
 
 import {
 	withAssetVersion,
-	withDeployVersion,
+	versionedOgImage,
 } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
@@ -295,9 +295,7 @@ export async function generateMetadata({
 
 	const title = feature.title;
 	const description = feature.description;
-	const ogImageUrl = withDeployVersion(
-		`/features/${feature.slug}/opengraph-image`,
-	);
+	const ogImage = versionedOgImage(`/features/${feature.slug}`);
 
 	return {
 		title,
@@ -310,13 +308,13 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `https://llmgateway.io/features/${feature.slug}`,
-			images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+			images: [ogImage],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
-			images: [ogImageUrl],
+			images: [ogImage],
 		},
 	};
 }

--- a/apps/ui/src/app/guides/[slug]/page.tsx
+++ b/apps/ui/src/app/guides/[slug]/page.tsx
@@ -8,7 +8,10 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
-import { withAssetVersion } from "@llmgateway/shared/asset-version";
+import {
+	withAssetVersion,
+	withDeployVersion,
+} from "@llmgateway/shared/asset-version";
 
 import { CopyMarkdownButton } from "./copy-markdown-button";
 
@@ -189,11 +192,19 @@ export async function generateMetadata({
 			description: guide.description ?? "LLM Gateway integration guide",
 			type: "article",
 			url: `https://llmgateway.io/guides/${guide.slug}`,
+			images: [
+				{
+					url: withDeployVersion(`/guides/${guide.slug}/opengraph-image`),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${guide.title} - Guides | LLM Gateway`,
 			description: guide.description ?? "LLM Gateway integration guide",
+			images: [withDeployVersion(`/guides/${guide.slug}/opengraph-image`)],
 		},
 	};
 }

--- a/apps/ui/src/app/guides/[slug]/page.tsx
+++ b/apps/ui/src/app/guides/[slug]/page.tsx
@@ -10,7 +10,7 @@ import { getMarkdownOptions } from "@/lib/utils/markdown";
 
 import {
 	withAssetVersion,
-	withDeployVersion,
+	versionedOgImage,
 } from "@llmgateway/shared/asset-version";
 
 import { CopyMarkdownButton } from "./copy-markdown-button";
@@ -192,19 +192,13 @@ export async function generateMetadata({
 			description: guide.description ?? "LLM Gateway integration guide",
 			type: "article",
 			url: `https://llmgateway.io/guides/${guide.slug}`,
-			images: [
-				{
-					url: withDeployVersion(`/guides/${guide.slug}/opengraph-image`),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`/guides/${guide.slug}`)],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${guide.title} - Guides | LLM Gateway`,
 			description: guide.description ?? "LLM Gateway integration guide",
-			images: [withDeployVersion(`/guides/${guide.slug}/opengraph-image`)],
+			images: [versionedOgImage(`/guides/${guide.slug}`)],
 		},
 	};
 }

--- a/apps/ui/src/app/guides/[slug]/page.tsx
+++ b/apps/ui/src/app/guides/[slug]/page.tsx
@@ -8,6 +8,8 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { CopyMarkdownButton } from "./copy-markdown-button";
 
 import type { Guide } from "content-collections";
@@ -58,7 +60,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
 				"@type": "ImageObject",
 				url: guide.image.src.startsWith("http")
 					? guide.image.src
-					: `https://llmgateway.io${guide.image.src}`,
+					: `https://llmgateway.io${withAssetVersion(guide.image.src)}`,
 				width: guide.image.width,
 				height: guide.image.height,
 			},

--- a/apps/ui/src/app/guides/page.tsx
+++ b/apps/ui/src/app/guides/page.tsx
@@ -3,7 +3,7 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { JsonLd } from "@/components/seo/json-ld";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import { allGuides } from "content-collections";
 
@@ -12,13 +12,7 @@ export const metadata = {
 	description:
 		"Step-by-step guides for integrating LLM Gateway with Claude Code, Cursor, Cline, n8n, and more.",
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/guides/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/guides")],
 		title: "Guides — Integrate with Claude Code, Cursor, Cline",
 		description:
 			"Step-by-step guides for integrating LLM Gateway with Claude Code, Cursor, Cline, n8n, and more.",

--- a/apps/ui/src/app/guides/page.tsx
+++ b/apps/ui/src/app/guides/page.tsx
@@ -3,6 +3,8 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { JsonLd } from "@/components/seo/json-ld";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import { allGuides } from "content-collections";
 
 export const metadata = {
@@ -10,6 +12,13 @@ export const metadata = {
 	description:
 		"Step-by-step guides for integrating LLM Gateway with Claude Code, Cursor, Cline, n8n, and more.",
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/guides/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "Guides — Integrate with Claude Code, Cursor, Cline",
 		description:
 			"Step-by-step guides for integrating LLM Gateway with Claude Code, Cursor, Cline, n8n, and more.",

--- a/apps/ui/src/app/integrations/page.tsx
+++ b/apps/ui/src/app/integrations/page.tsx
@@ -2,6 +2,8 @@ import dynamic from "next/dynamic";
 
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 const IntegrationCards = dynamic(() =>
 	import("@/components/integrations/integration-cards").then(
 		(mod) => mod.IntegrationCards,
@@ -14,6 +16,13 @@ export const metadata = {
 	description:
 		"Connect LLM Gateway with your favorite tools. Integrate with Claude Code, Cursor, Cline, n8n, and more.",
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/integrations/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "Integrations — Claude Code, Cursor, Cline, n8n",
 		description:
 			"Connect LLM Gateway with your favorite tools. Integrate with Claude Code, Cursor, Cline, n8n, and more.",

--- a/apps/ui/src/app/integrations/page.tsx
+++ b/apps/ui/src/app/integrations/page.tsx
@@ -2,7 +2,7 @@ import dynamic from "next/dynamic";
 
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 const IntegrationCards = dynamic(() =>
 	import("@/components/integrations/integration-cards").then(
@@ -16,13 +16,7 @@ export const metadata = {
 	description:
 		"Connect LLM Gateway with your favorite tools. Integrate with Claude Code, Cursor, Cline, n8n, and more.",
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/integrations/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/integrations")],
 		title: "Integrations — Claude Code, Cursor, Cline, n8n",
 		description:
 			"Connect LLM Gateway with your favorite tools. Integrate with Claude Code, Cursor, Cline, n8n, and more.",

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter, Geist_Mono, Plus_Jakarta_Sans } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import "./globals.css";
 
 import type { Metadata } from "next";
@@ -64,7 +66,7 @@ export const metadata: Metadata = {
 		title: "LLM Gateway - Unified API for Multiple LLM Providers",
 		description:
 			"Route, manage, and analyze LLM requests across OpenAI, Anthropic, Google, and 40+ providers through one unified API.",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		type: "website",
 		url: "https://llmgateway.io",
 		siteName: "LLM Gateway",
@@ -75,7 +77,7 @@ export const metadata: Metadata = {
 		title: "LLM Gateway - Unified API for Multiple LLM Providers",
 		description:
 			"Route, manage, and analyze LLM requests across 40+ providers through one unified API.",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		creator: "@llmgateway",
 	},
 	robots: {

--- a/apps/ui/src/app/mcp/page.tsx
+++ b/apps/ui/src/app/mcp/page.tsx
@@ -2,20 +2,14 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { McpContent } from "@/components/mcp/mcp-content";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 export const metadata = {
 	title: "MCP Server — 200+ Models for Claude Code & Cursor",
 	description:
 		"Use LLM Gateway as an MCP server for Claude Code, Cursor, and other AI assistants. Access 200+ models from OpenAI, Anthropic, Google, and more.",
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/mcp/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/mcp")],
 		title: "MCP Server — 200+ Models for Claude Code & Cursor",
 		description:
 			"Use LLM Gateway as an MCP server for Claude Code, Cursor, and other AI assistants. Access 200+ models from OpenAI, Anthropic, Google, and more.",

--- a/apps/ui/src/app/mcp/page.tsx
+++ b/apps/ui/src/app/mcp/page.tsx
@@ -2,11 +2,20 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { McpContent } from "@/components/mcp/mcp-content";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 export const metadata = {
 	title: "MCP Server — 200+ Models for Claude Code & Cursor",
 	description:
 		"Use LLM Gateway as an MCP server for Claude Code, Cursor, and other AI assistants. Access 200+ models from OpenAI, Anthropic, Google, and more.",
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/mcp/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "MCP Server — 200+ Models for Claude Code & Cursor",
 		description:
 			"Use LLM Gateway as an MCP server for Claude Code, Cursor, and other AI assistants. Access 200+ models from OpenAI, Anthropic, Google, and more.",

--- a/apps/ui/src/app/migration/[slug]/page.tsx
+++ b/apps/ui/src/app/migration/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { notFound } from "next/navigation";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import { allMigrations } from "content-collections";
 
 import type { Metadata } from "next";
@@ -140,11 +142,23 @@ export async function generateMetadata({
 			description: migration.description ?? "Migration guide for LLM Gateway",
 			type: "article",
 			url: `https://llmgateway.io/migration/${migration.slug}`,
+			images: [
+				{
+					url: withDeployVersion(
+						`/migration/${migration.slug}/opengraph-image`,
+					),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${migration.title} - Migration Guides | LLM Gateway`,
 			description: migration.description ?? "Migration guide for LLM Gateway",
+			images: [
+				withDeployVersion(`/migration/${migration.slug}/opengraph-image`),
+			],
 		},
 	};
 }

--- a/apps/ui/src/app/migration/[slug]/page.tsx
+++ b/apps/ui/src/app/migration/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from "next/navigation";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import { allMigrations } from "content-collections";
 
@@ -142,23 +142,13 @@ export async function generateMetadata({
 			description: migration.description ?? "Migration guide for LLM Gateway",
 			type: "article",
 			url: `https://llmgateway.io/migration/${migration.slug}`,
-			images: [
-				{
-					url: withDeployVersion(
-						`/migration/${migration.slug}/opengraph-image`,
-					),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`/migration/${migration.slug}`)],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${migration.title} - Migration Guides | LLM Gateway`,
 			description: migration.description ?? "Migration guide for LLM Gateway",
-			images: [
-				withDeployVersion(`/migration/${migration.slug}/opengraph-image`),
-			],
+			images: [versionedOgImage(`/migration/${migration.slug}`)],
 		},
 	};
 }

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -35,7 +35,7 @@ import {
 	type StabilityLevel,
 	type ModelDefinition,
 } from "@llmgateway/models";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -503,8 +503,8 @@ export async function generateMetadata({
 	const title = `${model.name ?? model.id} on ${providerName}`;
 	const description = `Pricing, latency, and capabilities for ${model.name ?? model.id} via ${providerName} on LLM Gateway.`;
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
-	const ogImageUrl = withDeployVersion(
-		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(decodedProvider)}/opengraph-image`,
+	const ogImage = versionedOgImage(
+		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(decodedProvider)}`,
 	);
 
 	return {
@@ -520,9 +520,7 @@ export async function generateMetadata({
 			url: canonical,
 			images: [
 				{
-					url: ogImageUrl,
-					width: 1200,
-					height: 630,
+					...ogImage,
 					alt: `${model.name ?? model.id} on ${providerName} model card`,
 				},
 			],
@@ -531,7 +529,7 @@ export async function generateMetadata({
 			card: "summary_large_image",
 			title,
 			description,
-			images: [ogImageUrl],
+			images: [ogImage],
 		},
 	};
 }

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -35,6 +35,7 @@ import {
 	type StabilityLevel,
 	type ModelDefinition,
 } from "@llmgateway/models";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -502,7 +503,9 @@ export async function generateMetadata({
 	const title = `${model.name ?? model.id} on ${providerName}`;
 	const description = `Pricing, latency, and capabilities for ${model.name ?? model.id} via ${providerName} on LLM Gateway.`;
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
-	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(decodedProvider)}/opengraph-image`;
+	const ogImageUrl = withDeployVersion(
+		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(decodedProvider)}/opengraph-image`,
+	);
 
 	return {
 		title,

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -43,7 +43,7 @@ import {
 	type StabilityLevel,
 	type ModelDefinition,
 } from "@llmgateway/models";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -605,8 +605,8 @@ export async function generateMetadata({
 			: (model.description ?? pitch);
 
 	const primaryProvider = model.providers[0]?.providerId || "default";
-	const ogImageUrl = withDeployVersion(
-		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`,
+	const ogImage = versionedOgImage(
+		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}`,
 	);
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
 
@@ -621,20 +621,13 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: canonical,
-			images: [
-				{
-					url: ogImageUrl,
-					width: 1200,
-					height: 630,
-					alt: `${model.name ?? model.id} model card`,
-				},
-			],
+			images: [{ ...ogImage, alt: `${model.name ?? model.id} model card` }],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
-			images: [ogImageUrl],
+			images: [ogImage],
 		},
 	};
 }

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -43,6 +43,7 @@ import {
 	type StabilityLevel,
 	type ModelDefinition,
 } from "@llmgateway/models";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -604,7 +605,9 @@ export async function generateMetadata({
 			: (model.description ?? pitch);
 
 	const primaryProvider = model.providers[0]?.providerId || "default";
-	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`;
+	const ogImageUrl = withDeployVersion(
+		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`,
+	);
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
 
 	return {

--- a/apps/ui/src/app/models/[name]/uptime/page.tsx
+++ b/apps/ui/src/app/models/[name]/uptime/page.tsx
@@ -27,6 +27,7 @@ import {
 	expandAllProviderRegions,
 	type ModelDefinition,
 } from "@llmgateway/models";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -381,7 +382,9 @@ export async function generateMetadata({
 
 	const canonical = `/models/${encodeURIComponent(decodedName)}/uptime`;
 	const primaryProvider = model.providers[0]?.providerId || "default";
-	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`;
+	const ogImageUrl = withDeployVersion(
+		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`,
+	);
 
 	return {
 		title,

--- a/apps/ui/src/app/models/[name]/uptime/page.tsx
+++ b/apps/ui/src/app/models/[name]/uptime/page.tsx
@@ -27,7 +27,7 @@ import {
 	expandAllProviderRegions,
 	type ModelDefinition,
 } from "@llmgateway/models";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -382,8 +382,8 @@ export async function generateMetadata({
 
 	const canonical = `/models/${encodeURIComponent(decodedName)}/uptime`;
 	const primaryProvider = model.providers[0]?.providerId || "default";
-	const ogImageUrl = withDeployVersion(
-		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`,
+	const ogImage = versionedOgImage(
+		`/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}`,
 	);
 
 	return {
@@ -406,20 +406,13 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: canonical,
-			images: [
-				{
-					url: ogImageUrl,
-					width: 1200,
-					height: 630,
-					alt: `${modelLabel} uptime status`,
-				},
-			],
+			images: [{ ...ogImage, alt: `${modelLabel} uptime status` }],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
-			images: [ogImageUrl],
+			images: [ogImage],
 		},
 		robots: {
 			index: true,

--- a/apps/ui/src/app/models/page.tsx
+++ b/apps/ui/src/app/models/page.tsx
@@ -6,6 +6,8 @@ import { AllModels } from "@/components/models/all-models";
 import { JsonLd } from "@/components/seo/json-ld";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 const CATEGORY_LINKS: ReadonlyArray<{ href: string; label: string }> = [
 	{ href: "/models/coding", label: "Best models for coding" },
 	{ href: "/models/reasoning", label: "Reasoning models" },
@@ -35,6 +37,13 @@ export const metadata = {
 	description:
 		"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and more. Filter by capabilities, pricing, and context size.",
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/models/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "AI Models Directory — Compare 200+ LLM Models",
 		description:
 			"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and more. Filter by capabilities, pricing, and context size.",
@@ -42,6 +51,7 @@ export const metadata = {
 		url: "https://llmgateway.io/models",
 	},
 	twitter: {
+		images: [withDeployVersion("/models/opengraph-image")],
 		card: "summary_large_image",
 		title: "AI Models Directory — Compare 200+ LLM Models",
 		description:

--- a/apps/ui/src/app/models/page.tsx
+++ b/apps/ui/src/app/models/page.tsx
@@ -6,7 +6,7 @@ import { AllModels } from "@/components/models/all-models";
 import { JsonLd } from "@/components/seo/json-ld";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 const CATEGORY_LINKS: ReadonlyArray<{ href: string; label: string }> = [
 	{ href: "/models/coding", label: "Best models for coding" },
@@ -37,13 +37,7 @@ export const metadata = {
 	description:
 		"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and more. Filter by capabilities, pricing, and context size.",
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/models/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/models")],
 		title: "AI Models Directory — Compare 200+ LLM Models",
 		description:
 			"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and more. Filter by capabilities, pricing, and context size.",
@@ -51,7 +45,7 @@ export const metadata = {
 		url: "https://llmgateway.io/models",
 	},
 	twitter: {
-		images: [withDeployVersion("/models/opengraph-image")],
+		images: [versionedOgImage("/models")],
 		card: "summary_large_image",
 		title: "AI Models Directory — Compare 200+ LLM Models",
 		description:

--- a/apps/ui/src/app/nano-banana-simulator/[discount]/page.tsx
+++ b/apps/ui/src/app/nano-banana-simulator/[discount]/page.tsx
@@ -5,7 +5,7 @@ import { PricingBreakdown } from "@/components/nano-banana-simulator/pricing-bre
 import { SimulatorCta } from "@/components/nano-banana-simulator/simulator-cta";
 import { SimulatorHero } from "@/components/nano-banana-simulator/simulator-hero";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -41,15 +41,7 @@ export async function generateMetadata({
 			description: `See how much you save on Gemini 3 Pro image generation. ${discount}% savings vs Google AI Studio pricing.`,
 			url: `https://llmgateway.io/nano-banana-simulator/${discount}`,
 			type: "website",
-			images: [
-				{
-					url: withDeployVersion(
-						`/nano-banana-simulator/${discount}/opengraph-image`,
-					),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`/nano-banana-simulator/${discount}`)],
 		},
 	};
 }

--- a/apps/ui/src/app/nano-banana-simulator/[discount]/page.tsx
+++ b/apps/ui/src/app/nano-banana-simulator/[discount]/page.tsx
@@ -5,6 +5,8 @@ import { PricingBreakdown } from "@/components/nano-banana-simulator/pricing-bre
 import { SimulatorCta } from "@/components/nano-banana-simulator/simulator-cta";
 import { SimulatorHero } from "@/components/nano-banana-simulator/simulator-hero";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 interface PageProps {
@@ -39,6 +41,15 @@ export async function generateMetadata({
 			description: `See how much you save on Gemini 3 Pro image generation. ${discount}% savings vs Google AI Studio pricing.`,
 			url: `https://llmgateway.io/nano-banana-simulator/${discount}`,
 			type: "website",
+			images: [
+				{
+					url: withDeployVersion(
+						`/nano-banana-simulator/${discount}/opengraph-image`,
+					),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 	};
 }

--- a/apps/ui/src/app/providers/[id]/page.tsx
+++ b/apps/ui/src/app/providers/[id]/page.tsx
@@ -12,7 +12,7 @@ import {
 	type ModelDefinition,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type {
 	ApiModel,
@@ -279,13 +279,7 @@ export async function generateMetadata({
 			type: "website",
 			url: `https://llmgateway.io/providers/${provider.id}`,
 			images: [
-				{
-					url: withDeployVersion(
-						`/providers/${encodeURIComponent(provider.id)}/opengraph-image`,
-					),
-					width: 1200,
-					height: 630,
-				},
+				versionedOgImage(`/providers/${encodeURIComponent(provider.id)}`),
 			],
 		},
 		twitter: {
@@ -293,9 +287,7 @@ export async function generateMetadata({
 			title: `${provider.name} API — Models & Pricing | LLM Gateway`,
 			description,
 			images: [
-				withDeployVersion(
-					`/providers/${encodeURIComponent(provider.id)}/opengraph-image`,
-				),
+				versionedOgImage(`/providers/${encodeURIComponent(provider.id)}`),
 			],
 		},
 	};

--- a/apps/ui/src/app/providers/[id]/page.tsx
+++ b/apps/ui/src/app/providers/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
 	type ModelDefinition,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type {
 	ApiModel,
@@ -277,11 +278,25 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `https://llmgateway.io/providers/${provider.id}`,
+			images: [
+				{
+					url: withDeployVersion(
+						`/providers/${encodeURIComponent(provider.id)}/opengraph-image`,
+					),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${provider.name} API — Models & Pricing | LLM Gateway`,
 			description,
+			images: [
+				withDeployVersion(
+					`/providers/${encodeURIComponent(provider.id)}/opengraph-image`,
+				),
+			],
 		},
 	};
 }

--- a/apps/ui/src/app/providers/country/[country]/page.tsx
+++ b/apps/ui/src/app/providers/country/[country]/page.tsx
@@ -10,6 +10,7 @@ import {
 	models as modelDefinitions,
 	providers as providerDefinitions,
 } from "@llmgateway/models";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -145,11 +146,19 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `https://llmgateway.io${canonical}`,
+			images: [
+				{
+					url: withDeployVersion("/providers/opengraph-image"),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `AI Providers in ${country.name} | LLM Gateway`,
 			description,
+			images: [withDeployVersion("/providers/opengraph-image")],
 		},
 	};
 }

--- a/apps/ui/src/app/providers/country/[country]/page.tsx
+++ b/apps/ui/src/app/providers/country/[country]/page.tsx
@@ -10,7 +10,7 @@ import {
 	models as modelDefinitions,
 	providers as providerDefinitions,
 } from "@llmgateway/models";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -146,19 +146,13 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `https://llmgateway.io${canonical}`,
-			images: [
-				{
-					url: withDeployVersion("/providers/opengraph-image"),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage("/providers")],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `AI Providers in ${country.name} | LLM Gateway`,
 			description,
-			images: [withDeployVersion("/providers/opengraph-image")],
+			images: [versionedOgImage("/providers")],
 		},
 	};
 }

--- a/apps/ui/src/app/providers/page.tsx
+++ b/apps/ui/src/app/providers/page.tsx
@@ -4,7 +4,7 @@ import { ProvidersGrid } from "@/components/providers/providers-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 
 import { providers as providerDefinitions } from "@llmgateway/models";
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -14,13 +14,7 @@ export const metadata: Metadata = {
 		"Browse 40+ LLM providers on LLM Gateway — OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, and more. One API for all of them.",
 	alternates: { canonical: "/providers" },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/providers/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/providers")],
 		title: "LLM Providers | LLM Gateway",
 		description:
 			"Browse 40+ LLM providers on LLM Gateway — OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, and more.",

--- a/apps/ui/src/app/providers/page.tsx
+++ b/apps/ui/src/app/providers/page.tsx
@@ -4,6 +4,7 @@ import { ProvidersGrid } from "@/components/providers/providers-grid";
 import { JsonLd } from "@/components/seo/json-ld";
 
 import { providers as providerDefinitions } from "@llmgateway/models";
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -13,6 +14,13 @@ export const metadata: Metadata = {
 		"Browse 40+ LLM providers on LLM Gateway — OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, and more. One API for all of them.",
 	alternates: { canonical: "/providers" },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/providers/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "LLM Providers | LLM Gateway",
 		description:
 			"Browse 40+ LLM providers on LLM Gateway — OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, and more.",

--- a/apps/ui/src/app/reliability/page.tsx
+++ b/apps/ui/src/app/reliability/page.tsx
@@ -6,6 +6,8 @@ import { ReliabilityFailover } from "@/components/reliability/failover";
 import { ReliabilityFeatures } from "@/components/reliability/features";
 import { ReliabilityHero } from "@/components/reliability/hero";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -15,7 +17,7 @@ export const metadata: Metadata = {
 	alternates: { canonical: "/reliability" },
 	openGraph: {
 		title: "Reliability & 99.9999% Uptime | LLM Gateway",
-		images: ["/opengraph.png?v=2"],
+		images: [withAssetVersion("/opengraph.png")],
 		description:
 			"Automatic failover across providers, real-time health monitoring, and intelligent routing. Never go down, even when your providers do.",
 		url: "https://llmgateway.io/reliability",

--- a/apps/ui/src/app/ship/page.tsx
+++ b/apps/ui/src/app/ship/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -13,13 +13,7 @@ export const metadata: Metadata = {
 		"Clone a production-ready AI template, connect to 200+ models, and deploy. Ship your AI app in minutes with LLM Gateway.",
 	alternates: { canonical: "/ship" },
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/ship/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/ship")],
 		title: "Ship an AI App in 10 Minutes | LLM Gateway",
 		description:
 			"Clone a production-ready AI template, connect to 200+ models, and deploy. Ship your AI app in minutes with LLM Gateway.",

--- a/apps/ui/src/app/ship/page.tsx
+++ b/apps/ui/src/app/ship/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,6 +13,13 @@ export const metadata: Metadata = {
 		"Clone a production-ready AI template, connect to 200+ models, and deploy. Ship your AI app in minutes with LLM Gateway.",
 	alternates: { canonical: "/ship" },
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/ship/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "Ship an AI App in 10 Minutes | LLM Gateway",
 		description:
 			"Clone a production-ready AI template, connect to 200+ models, and deploy. Ship your AI app in minutes with LLM Gateway.",

--- a/apps/ui/src/app/templates/page.tsx
+++ b/apps/ui/src/app/templates/page.tsx
@@ -5,6 +5,8 @@ import { HeroRSC } from "@/components/landing/hero-rsc";
 import { TemplateCards } from "@/components/templates/template-cards";
 import { Button } from "@/lib/components/button";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -12,6 +14,13 @@ export const metadata: Metadata = {
 	description:
 		"Production-ready templates to jumpstart your AI applications — image generation, chatbots, end-user monetization, and more.",
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/templates/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "AI App Templates — Production-Ready Starters",
 		description:
 			"Production-ready templates to jumpstart your AI applications — image generation, chatbots, end-user monetization, and more.",

--- a/apps/ui/src/app/templates/page.tsx
+++ b/apps/ui/src/app/templates/page.tsx
@@ -5,7 +5,7 @@ import { HeroRSC } from "@/components/landing/hero-rsc";
 import { TemplateCards } from "@/components/templates/template-cards";
 import { Button } from "@/lib/components/button";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -14,13 +14,7 @@ export const metadata: Metadata = {
 	description:
 		"Production-ready templates to jumpstart your AI applications — image generation, chatbots, end-user monetization, and more.",
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/templates/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/templates")],
 		title: "AI App Templates — Production-Ready Starters",
 		description:
 			"Production-ready templates to jumpstart your AI applications — image generation, chatbots, end-user monetization, and more.",

--- a/apps/ui/src/app/timeline/[year]/page.tsx
+++ b/apps/ui/src/app/timeline/[year]/page.tsx
@@ -20,7 +20,7 @@ import {
 	modelsForYear,
 } from "@/lib/timeline-data";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -53,19 +53,13 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `${BASE_URL}/timeline/${year}`,
-			images: [
-				{
-					url: withDeployVersion(`/timeline/${year}/opengraph-image`),
-					width: 1200,
-					height: 630,
-				},
-			],
+			images: [versionedOgImage(`/timeline/${year}`)],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
-			images: [withDeployVersion(`/timeline/${year}/opengraph-image`)],
+			images: [versionedOgImage(`/timeline/${year}`)],
 		},
 	};
 }

--- a/apps/ui/src/app/timeline/[year]/page.tsx
+++ b/apps/ui/src/app/timeline/[year]/page.tsx
@@ -20,6 +20,8 @@ import {
 	modelsForYear,
 } from "@/lib/timeline-data";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 const BASE_URL = "https://llmgateway.io";
@@ -51,11 +53,19 @@ export async function generateMetadata({
 			description,
 			type: "website",
 			url: `${BASE_URL}/timeline/${year}`,
+			images: [
+				{
+					url: withDeployVersion(`/timeline/${year}/opengraph-image`),
+					width: 1200,
+					height: 630,
+				},
+			],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title,
 			description,
+			images: [withDeployVersion(`/timeline/${year}/opengraph-image`)],
 		},
 	};
 }

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -18,7 +18,7 @@ import {
 	recentModels,
 } from "@/lib/timeline-data";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
@@ -32,13 +32,7 @@ export const metadata: Metadata = {
 		canonical: "/timeline",
 	},
 	openGraph: {
-		images: [
-			{
-				url: withDeployVersion("/timeline/opengraph-image"),
-				width: 1200,
-				height: 630,
-			},
-		],
+		images: [versionedOgImage("/timeline")],
 		title: "LLM Release Timeline — Model Release Dates",
 		description:
 			"Release dates for every major LLM — GPT, Claude, Gemini, Llama, Mistral and DeepSeek — with the date each model was added to LLM Gateway.",
@@ -46,7 +40,7 @@ export const metadata: Metadata = {
 		url: `${BASE_URL}/timeline`,
 	},
 	twitter: {
-		images: [withDeployVersion("/timeline/opengraph-image")],
+		images: [versionedOgImage("/timeline")],
 		card: "summary_large_image",
 		title: "LLM Release Timeline — Model Release Dates",
 		description:

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -18,6 +18,8 @@ import {
 	recentModels,
 } from "@/lib/timeline-data";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 const BASE_URL = "https://llmgateway.io";
@@ -30,6 +32,13 @@ export const metadata: Metadata = {
 		canonical: "/timeline",
 	},
 	openGraph: {
+		images: [
+			{
+				url: withDeployVersion("/timeline/opengraph-image"),
+				width: 1200,
+				height: 630,
+			},
+		],
 		title: "LLM Release Timeline — Model Release Dates",
 		description:
 			"Release dates for every major LLM — GPT, Claude, Gemini, Llama, Mistral and DeepSeek — with the date each model was added to LLM Gateway.",
@@ -37,6 +46,7 @@ export const metadata: Metadata = {
 		url: `${BASE_URL}/timeline`,
 	},
 	twitter: {
+		images: [withDeployVersion("/timeline/opengraph-image")],
 		card: "summary_large_image",
 		title: "LLM Release Timeline — Model Release Dates",
 		description:

--- a/apps/ui/src/app/token-cost-calculator/page.tsx
+++ b/apps/ui/src/app/token-cost-calculator/page.tsx
@@ -4,6 +4,8 @@ import { CALCULATOR_FAQ } from "@/components/token-cost-calculator/faq-data";
 import { TokenCostCalculatorClient } from "@/components/token-cost-calculator/token-cost-calculator-client";
 import { TokenCostCalculatorContent } from "@/components/token-cost-calculator/token-cost-calculator-content";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 const PAGE_URL = "https://llmgateway.io/token-cost-calculator";
@@ -35,14 +37,14 @@ export const metadata: Metadata = {
 		title: "LLM Token Cost Calculator & Tokenizer | LLM Gateway",
 		description:
 			"Paste a prompt to count tokens, then compare cost across GPT-5, Claude, Gemini, and 200+ models at zero markup.",
-		images: [{ url: "/opengraph.png?v=1" }],
+		images: [{ url: withAssetVersion("/opengraph.png") }],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "LLM Token Cost Calculator & Tokenizer | LLM Gateway",
 		description:
 			"Count your prompt's exact tokens and compare the cost across 200+ LLMs with LLM Gateway.",
-		images: ["/opengraph.png?v=1"],
+		images: [withAssetVersion("/opengraph.png")],
 	},
 };
 

--- a/apps/ui/src/app/use-cases/[slug]/page.tsx
+++ b/apps/ui/src/app/use-cases/[slug]/page.tsx
@@ -9,6 +9,8 @@ import { AuthLink } from "@/components/shared/auth-link";
 import { Button } from "@/lib/components/button";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { allUseCases } from "content-collections";
 
 import type { UseCase } from "content-collections";
@@ -46,7 +48,7 @@ export async function generateMetadata({
 			description: entry.description,
 			type: "article",
 			url: `${BASE_URL}/use-cases/${entry.slug}`,
-			images: ["/opengraph.png"],
+			images: [withAssetVersion("/opengraph.png")],
 		},
 		twitter: {
 			card: "summary_large_image",

--- a/apps/ui/src/app/use-cases/page.tsx
+++ b/apps/ui/src/app/use-cases/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 
+import { withAssetVersion } from "@llmgateway/shared/asset-version";
+
 import { allUseCases } from "content-collections";
 
 import type { UseCase } from "content-collections";
@@ -20,7 +22,7 @@ export const metadata: Metadata = {
 			"Coding agents, AI support, RAG, and cost optimization on one API for 200+ models with fallback, caching, and analytics.",
 		type: "website",
 		url: "https://llmgateway.io/use-cases",
-		images: ["/opengraph.png"],
+		images: [withAssetVersion("/opengraph.png")],
 	},
 };
 

--- a/apps/ui/src/components/models/category-page.tsx
+++ b/apps/ui/src/components/models/category-page.tsx
@@ -11,10 +11,13 @@ import {
 } from "@/lib/model-category-content";
 import { applyCategoryFilter } from "@/lib/model-category-filters";
 
+import { withDeployVersion } from "@llmgateway/shared/asset-version";
+
 import type { Metadata } from "next";
 
 export function buildCategoryMetadata(slug: ModelCategorySlug): Metadata {
 	const content = modelCategoryContent[slug];
+	const ogImageUrl = withDeployVersion(`/models/${slug}/opengraph-image`);
 	return {
 		alternates: {
 			canonical: `https://llmgateway.io/models/${slug}`,
@@ -25,11 +28,13 @@ export function buildCategoryMetadata(slug: ModelCategorySlug): Metadata {
 			title: content.metaTitle,
 			description: content.metaDescription,
 			type: "website",
+			images: [{ url: ogImageUrl, width: 1200, height: 630 }],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: content.metaTitle,
 			description: content.metaDescription,
+			images: [ogImageUrl],
 		},
 	};
 }

--- a/apps/ui/src/components/models/category-page.tsx
+++ b/apps/ui/src/components/models/category-page.tsx
@@ -11,13 +11,13 @@ import {
 } from "@/lib/model-category-content";
 import { applyCategoryFilter } from "@/lib/model-category-filters";
 
-import { withDeployVersion } from "@llmgateway/shared/asset-version";
+import { versionedOgImage } from "@llmgateway/shared/asset-version";
 
 import type { Metadata } from "next";
 
 export function buildCategoryMetadata(slug: ModelCategorySlug): Metadata {
 	const content = modelCategoryContent[slug];
-	const ogImageUrl = withDeployVersion(`/models/${slug}/opengraph-image`);
+	const ogImage = versionedOgImage(`/models/${slug}`);
 	return {
 		alternates: {
 			canonical: `https://llmgateway.io/models/${slug}`,
@@ -28,13 +28,13 @@ export function buildCategoryMetadata(slug: ModelCategorySlug): Metadata {
 			title: content.metaTitle,
 			description: content.metaDescription,
 			type: "website",
-			images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+			images: [ogImage],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: content.metaTitle,
 			description: content.metaDescription,
-			images: [ogImageUrl],
+			images: [ogImage],
 		},
 	};
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,6 +29,10 @@
 			"types": "./dist/api-key-hash.d.ts",
 			"import": "./dist/api-key-hash.js"
 		},
+		"./asset-version": {
+			"types": "./dist/asset-version.d.ts",
+			"import": "./dist/asset-version.js"
+		},
 		"./routing-config": {
 			"types": "./dist/routing-config.d.ts",
 			"import": "./dist/routing-config.js"

--- a/packages/shared/src/asset-version.spec.ts
+++ b/packages/shared/src/asset-version.spec.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { withAssetVersion } from "./asset-version.js";
+
+describe("withAssetVersion", () => {
+	const publicDir = mkdtempSync(path.join(tmpdir(), "asset-version-"));
+
+	afterAll(() => {
+		rmSync(publicDir, { recursive: true, force: true });
+	});
+
+	it("appends a stable content-hash query param", () => {
+		writeFileSync(path.join(publicDir, "opengraph.png"), "image-content-v1");
+
+		const versioned = withAssetVersion("/opengraph.png", publicDir);
+
+		expect(versioned).toMatch(/^\/opengraph\.png\?v=[0-9a-f]{10}$/);
+		expect(withAssetVersion("/opengraph.png", publicDir)).toBe(versioned);
+	});
+
+	it("produces different hashes for different file contents", () => {
+		writeFileSync(path.join(publicDir, "a.png"), "content-a");
+		writeFileSync(path.join(publicDir, "b.png"), "content-b");
+
+		const a = withAssetVersion("/a.png", publicDir);
+		const b = withAssetVersion("/b.png", publicDir);
+
+		expect(a).not.toBe("/a.png");
+		expect(a.split("?v=")[1]).not.toBe(b.split("?v=")[1]);
+	});
+
+	it("returns external URLs unchanged", () => {
+		expect(withAssetVersion("https://example.com/og.png", publicDir)).toBe(
+			"https://example.com/og.png",
+		);
+	});
+
+	it("returns URLs with an existing query string unchanged", () => {
+		writeFileSync(path.join(publicDir, "versioned.png"), "content");
+
+		expect(withAssetVersion("/versioned.png?v=1", publicDir)).toBe(
+			"/versioned.png?v=1",
+		);
+	});
+
+	it("returns missing files unchanged", () => {
+		expect(withAssetVersion("/does-not-exist.png", publicDir)).toBe(
+			"/does-not-exist.png",
+		);
+	});
+});

--- a/packages/shared/src/asset-version.spec.ts
+++ b/packages/shared/src/asset-version.spec.ts
@@ -2,9 +2,9 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 
-import { withAssetVersion } from "./asset-version.js";
+import { withAssetVersion, withDeployVersion } from "./asset-version.js";
 
 describe("withAssetVersion", () => {
 	const publicDir = mkdtempSync(path.join(tmpdir(), "asset-version-"));
@@ -51,5 +51,45 @@ describe("withAssetVersion", () => {
 		expect(withAssetVersion("/does-not-exist.png", publicDir)).toBe(
 			"/does-not-exist.png",
 		);
+	});
+});
+
+describe("withDeployVersion", () => {
+	const originalVersion = process.env.APP_VERSION;
+
+	afterEach(() => {
+		if (originalVersion === undefined) {
+			delete process.env.APP_VERSION;
+		} else {
+			process.env.APP_VERSION = originalVersion;
+		}
+	});
+
+	it("appends the deployment version as a query param", () => {
+		process.env.APP_VERSION = "v1.2.3";
+
+		expect(withDeployVersion("/providers/opengraph-image")).toBe(
+			"/providers/opengraph-image?v=v1.2.3",
+		);
+	});
+
+	it("URL-encodes the version", () => {
+		process.env.APP_VERSION = "feature/x";
+
+		expect(withDeployVersion("/og")).toBe("/og?v=feature%2Fx");
+	});
+
+	it("returns the URL unchanged without APP_VERSION", () => {
+		delete process.env.APP_VERSION;
+
+		expect(withDeployVersion("/providers/opengraph-image")).toBe(
+			"/providers/opengraph-image",
+		);
+	});
+
+	it("returns URLs with an existing query string unchanged", () => {
+		process.env.APP_VERSION = "v1.2.3";
+
+		expect(withDeployVersion("/og?v=1")).toBe("/og?v=1");
 	});
 });

--- a/packages/shared/src/asset-version.spec.ts
+++ b/packages/shared/src/asset-version.spec.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 
 import { afterAll, afterEach, describe, expect, it } from "vitest";
 
-import { withAssetVersion, withDeployVersion } from "./asset-version.js";
+import {
+	versionedOgImage,
+	withAssetVersion,
+	withDeployVersion,
+} from "./asset-version.js";
 
 describe("withAssetVersion", () => {
 	const publicDir = mkdtempSync(path.join(tmpdir(), "asset-version-"));
@@ -91,5 +95,15 @@ describe("withDeployVersion", () => {
 		process.env.APP_VERSION = "v1.2.3";
 
 		expect(withDeployVersion("/og?v=1")).toBe("/og?v=1");
+	});
+
+	it("versionedOgImage builds a versioned 1200x630 descriptor", () => {
+		process.env.APP_VERSION = "v1.2.3";
+
+		expect(versionedOgImage("/providers")).toEqual({
+			url: "/providers/opengraph-image?v=v1.2.3",
+			width: 1200,
+			height: 630,
+		});
 	});
 });

--- a/packages/shared/src/asset-version.ts
+++ b/packages/shared/src/asset-version.ts
@@ -1,0 +1,41 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const versionedUrlCache = new Map<string, string>();
+
+/**
+ * Appends a content-hash query param (`?v=<hash>`) to a root-relative URL of
+ * an asset in the app's `public/` directory, so browsers and social-media
+ * crawlers automatically re-fetch the asset whenever its file content
+ * changes (e.g. OpenGraph images). Server-only: reads the file from disk.
+ *
+ * External URLs, URLs that already carry a query string, and paths that
+ * don't resolve to an existing file are returned unchanged.
+ */
+export function withAssetVersion(
+	assetUrl: string,
+	publicDir: string = path.join(process.cwd(), "public"),
+): string {
+	if (!assetUrl.startsWith("/") || assetUrl.includes("?")) {
+		return assetUrl;
+	}
+
+	const filePath = path.join(publicDir, assetUrl);
+	const cached = versionedUrlCache.get(filePath);
+	if (cached) {
+		return cached;
+	}
+
+	if (!existsSync(filePath)) {
+		return assetUrl;
+	}
+
+	const hash = createHash("sha256")
+		.update(readFileSync(filePath))
+		.digest("hex")
+		.slice(0, 10);
+	const versionedUrl = `${assetUrl}?v=${hash}`;
+	versionedUrlCache.set(filePath, versionedUrl);
+	return versionedUrl;
+}

--- a/packages/shared/src/asset-version.ts
+++ b/packages/shared/src/asset-version.ts
@@ -5,6 +5,24 @@ import path from "node:path";
 const versionedUrlCache = new Map<string, string>();
 
 /**
+ * Appends the deployment version (`?v=<APP_VERSION>`) to a URL of a
+ * dynamically generated image route (e.g. Next.js `opengraph-image`
+ * routes), so browsers and social-media crawlers re-fetch the image after
+ * every deploy. Next.js only busts these URLs when the route file itself
+ * changes, not when an imported template or the model catalogue changes,
+ * so a per-deploy version is the only stamp that always tracks the
+ * rendered output. Without APP_VERSION set (local dev), or when the URL
+ * already carries a query string, the URL is returned unchanged.
+ */
+export function withDeployVersion(url: string): string {
+	const version = process.env.APP_VERSION;
+	if (!version || url.includes("?")) {
+		return url;
+	}
+	return `${url}?v=${encodeURIComponent(version)}`;
+}
+
+/**
  * Appends a content-hash query param (`?v=<hash>`) to a root-relative URL of
  * an asset in the app's `public/` directory, so browsers and social-media
  * crawlers automatically re-fetch the asset whenever its file content

--- a/packages/shared/src/asset-version.ts
+++ b/packages/shared/src/asset-version.ts
@@ -23,6 +23,26 @@ export function withDeployVersion(url: string): string {
 }
 
 /**
+ * Builds the OpenGraph/Twitter image descriptor for a page's
+ * `opengraph-image` route, deploy-versioned via withDeployVersion. All
+ * dynamically generated OG images share the standard 1200x630 card size,
+ * so pages only pass their own path:
+ *
+ *   openGraph: { images: [versionedOgImage("/providers")] }
+ */
+export function versionedOgImage(pagePath: string): {
+	url: string;
+	width: number;
+	height: number;
+} {
+	return {
+		url: withDeployVersion(`${pagePath}/opengraph-image`),
+		width: 1200,
+		height: 630,
+	};
+}
+
+/**
  * Appends a content-hash query param (`?v=<hash>`) to a root-relative URL of
  * an asset in the app's `public/` directory, so browsers and social-media
  * crawlers automatically re-fetch the asset whenever its file content


### PR DESCRIPTION
## Problem

OG image URLs in the generated HTML were static, so browsers and social crawlers (X, Slack, Discord, Facebook) kept serving stale cached cards after an image changed:

- **Static images** in `public/` (`/opengraph.png`, blog/changelog images) relied on manually bumped `?v=1`/`?v=2` params that nobody remembers to bump.
- **Dynamic `opengraph-image.tsx` routes**: Next.js appends a hash, but it's derived only from the route file's own source bytes. Verified empirically: changing the shared `ogImage()` template altered the rendered PNG while the URL hash stayed identical. Changes to `lib/og.tsx` or the model catalogue therefore never busted crawler caches. (`deploymentId`/`?dpl=` was also tested — Next applies it to `_next/static` assets but deliberately not to metadata image URLs.)
- The `/models/*` pages referenced their OG routes explicitly with **no** version at all.

## Solution

New helpers in `@llmgateway/shared/asset-version`:

- **`withAssetVersion(url)`** — for static `public/` assets: appends `?v=<sha256-prefix>` of the file contents, so the URL changes exactly when the file does. Used by the root layouts, blog/changelog metadata (frontmatter images + fallbacks), and JSON-LD image URLs.
- **`versionedOgImage(pagePath)`** — for dynamic OG routes: returns the standard `{ url, width: 1200, height: 630 }` descriptor with `?v=<APP_VERSION>` appended, so URLs rotate every deploy (any change affecting a rendered OG image ships via a deploy). Declaring the image explicitly in page metadata overrides the convention-generated tag — verified the HTML emits exactly one `og:image`. Applied to every page with an `opengraph-image.tsx` sibling across `ui`, `code`, and `playground` (one edit to `buildCategoryMetadata` covers all 18 model-category pages).

`APP_VERSION` is already set in the runtime containers and all three frontends render dynamically, so no infra changes needed. Without it (local dev) URLs are returned unchanged.

Side benefits: pages with `twitter` metadata blocks now show their custom per-page card on X instead of the inherited generic image, and the previously unversioned `/models/*` OG references now rotate per deploy.

## Verification

- Built standalone server with `APP_VERSION=v2.0.0`: `/templates`, `/models/gpt-4o`, `/models/coding`, `/providers/*`, `/features/*`, `/timeline` all emit `...opengraph-image?v=v2.0.0` (single tag, versioned URL serves `200 image/png`); homepage/blog emit content-hashed static URLs matching independently computed sha256 prefixes.
- Unit tests for both helpers (10 specs); full `packages/shared` suite green.
- `pnpm format` and full `turbo run build` for `ui`, `playground`, `code` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDq1oaVNH5zF5CuNdvhsGY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDq1oaVNH5zF5CuNdvhsGY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Graph and Twitter preview images across key pages, including models, providers, guides, comparisons, blog content, and shared pages.
  * Added route-specific preview images for more relevant social sharing cards.
  * Added automatic asset versioning to ensure updated images are displayed reliably.

* **Bug Fixes**
  * Improved cache invalidation for preview and public asset images, reducing stale social previews after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->