### PR TITLE
feat: raise provider listing fee to $1000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -316,7 +316,7 @@ STRIPE_WEBHOOK_SECRET_TEST=whsec_your_stripe_sandbox_webhook_secret
 STRIPE_PRO_MONTHLY_PRICE_ID=price_your_pro_plan_price_id
 STRIPE_PRO_YEARLY_PRICE_ID=price_your_pro_plan_price_id
 
-# One-time $500 provider listing fee (used by the public /add-provider form)
+# One-time $1000 provider listing fee (used by the public /add-provider form)
 STRIPE_PROVIDER_LISTING_PRICE_ID=price_your_provider_listing_price_id
 
 # Dev Plans Stripe Price IDs (for devpass.llmgateway.io) — monthly billing only

--- a/apps/api/src/routes/public-contact.ts
+++ b/apps/api/src/routes/public-contact.ts
@@ -694,7 +694,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 
 	const compliance = complianceSummary(validatedData);
 
-	// Create the Stripe checkout session for the $500 listing fee up front so the
+	// Create the Stripe checkout session for the $1000 listing fee up front so the
 	// payment link is returned to the client even if the confirmation email can't
 	// be sent. The fee is refunded in full if we don't end up listing the provider.
 	let checkoutUrl: string | null = null;

--- a/apps/ui/src/components/add-provider/add-provider-form.tsx
+++ b/apps/ui/src/components/add-provider/add-provider-form.tsx
@@ -199,7 +199,7 @@ export function AddProviderForm({
 							<Info className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
 							<p className="text-sm text-muted-foreground">
 								There is a{" "}
-								<span className="font-semibold text-foreground">$500</span> fee
+								<span className="font-semibold text-foreground">$1000</span> fee
 								to list a provider, collected securely via Stripe right after
 								you submit. It is refunded in full if we don't end up listing
 								your provider.
@@ -211,7 +211,7 @@ export function AddProviderForm({
 						<div className="mb-8 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-400">
 							Payment was canceled, so your provider isn't queued for listing
 							yet. Your details were saved — submit the form again to retry the
-							$500 listing fee whenever you're ready.
+							$1000 listing fee whenever you're ready.
 						</div>
 					)}
 
@@ -225,7 +225,7 @@ export function AddProviderForm({
 									Payment received!
 								</h3>
 								<p className="text-muted-foreground">
-									Thanks — we've received your $500 listing fee and your
+									Thanks — we've received your $1000 listing fee and your
 									provider details. Our team will review your provider and
 									follow up. The fee is refunded in full if we don't end up
 									listing it.


### PR DESCRIPTION
## Summary

Raises the one-time provider listing fee from **$500** to **$1000** everywhere it appears in the codebase:

- `apps/ui/src/components/add-provider/add-provider-form.tsx` — fee notice, payment-canceled banner, and payment-success confirmation copy
- `apps/api/src/routes/public-contact.ts` — comment on the Stripe checkout session creation
- `.env.example` — comment for `STRIPE_PROVIDER_LISTING_PRICE_ID`

## Note

The amount actually charged comes from the Stripe price object behind `STRIPE_PROVIDER_LISTING_PRICE_ID`, so the price must also be updated to $1000 in the Stripe dashboard (and the env var pointed at the new price) for the charge to match this copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqmwjny7ahijX98zQ6Dupb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fqmwjny7ahijX98zQ6Dupb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the provider listing fee displayed throughout the provider submission and payment flow from $500 to $1,000.
  * Updated related fee descriptions to consistently reflect the $1,000 amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->