### PR TITLE
feat: handle together-ai minimax-m2.7 deprecation

### DIFF
--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -25,6 +25,23 @@ export const minimaxModels = [
 				tools: true,
 				jsonOutput: true,
 			},
+			{
+				providerId: "together-ai",
+				externalId: "MiniMaxAI/MiniMax-M3",
+				inputPrice: "0.3e-6",
+				cachedInputPrice: "0.06e-6",
+				outputPrice: "1.2e-6",
+				requestPrice: "0",
+				contextSize: 524288,
+				maxOutput: 131072,
+				quantization: "fp4",
+				streaming: true,
+				reasoning: true,
+				vision: false,
+				tools: false,
+				jsonOutput: true,
+				jsonOutputSchema: true,
+			},
 		],
 	},
 	{
@@ -68,6 +85,9 @@ export const minimaxModels = [
 				jsonOutput: true,
 			},
 			{
+				// Together AI deprecates this serverless model on 2026-07-27,
+				// recommending MiniMaxAI/MiniMax-M3 as the replacement.
+				deactivatedAt: new Date("2026-07-27"),
 				providerId: "together-ai",
 				externalId: "MiniMaxAI/MiniMax-M2.7",
 				inputPrice: "0.3e-6",


### PR DESCRIPTION
## Summary

Together AI announced the deprecation of the `MiniMaxAI/MiniMax-M2.7` serverless model, effective **2026-07-27**, recommending `MiniMaxAI/MiniMax-M3` as the replacement.

## Changes

- **Deactivate** the `together-ai` provider mapping on `minimax-m2.7` with `deactivatedAt: 2026-07-27`. Since deactivation checks use `currentDate > deactivatedAt`, the mapping keeps serving until Together's actual shutoff date and then auto-deactivates — same approach as the earlier `together-ai` deactivation on `minimax-m2.5` (2026-04-27).
- **Add** a `together-ai` provider mapping to `minimax-m3` (the recommended replacement), per Together's published serverless specs: model ID `MiniMaxAI/MiniMax-M3`, 524,288-token context, fp4 quantization, $0.30/M input, $0.06/M cached input, $1.20/M output. Behavior flags (`tools: false`, `vision: false`, `jsonOutput`/`jsonOutputSchema: true`) mirror the proven MiniMax-M2.7-on-Together mapping conservatively until verified against the live endpoint.

The `minimax` and `novita` mappings for `minimax-m2.7` are unaffected — only Together's serverless endpoint is being retired.

## Testing

- `pnpm build` — all 17 tasks pass
- `pnpm vitest run apps/gateway/src/models/models.spec.ts` — 21/21 pass
- `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ha9J4ToLfHuRd2J1ro1GSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha9J4ToLfHuRd2J1ro1GSL)_