### PR TITLE
fix: skip drizzle update on empty PATCH body

### DIFF
--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -2468,12 +2468,16 @@ keysApi.openapi(updateIamRule, async (c) => {
 		apiKey.project.organization?.plan,
 	);
 
-	// Update the IAM rule
-	const [updatedRule] = await cdb
-		.update(tables.apiKeyIamRule)
-		.set(updateData)
-		.where(eq(tables.apiKeyIamRule.id, ruleId))
-		.returning();
+	// An empty PATCH body is a valid no-op; drizzle throws "No values to set"
+	// on an empty update, so skip the query and return the rule unchanged.
+	let updatedRule = existingRule;
+	if (Object.keys(updateData).length > 0) {
+		[updatedRule] = await cdb
+			.update(tables.apiKeyIamRule)
+			.set(updateData)
+			.where(eq(tables.apiKeyIamRule.id, ruleId))
+			.returning();
+	}
 
 	if (!updatedRule) {
 		throw new HTTPException(404, {

--- a/apps/api/src/routes/organization.spec.ts
+++ b/apps/api/src/routes/organization.spec.ts
@@ -136,6 +136,25 @@ describe("organization route", () => {
 		).toBe(true);
 	});
 
+	test("PATCH /orgs/{id} with an empty body is a no-op", async () => {
+		const response = await app.request("/orgs/test-org-id", {
+			method: "PATCH",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({}),
+		});
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			organization: { id: string; name: string };
+		};
+		expect(body.organization.id).toBe("test-org-id");
+		expect(body.organization.name).toBe("Test Organization");
+	});
+
 	test("PATCH /orgs/{id} logs top-up setting changes separately from organization updates", async () => {
 		const response = await app.request("/orgs/test-org-id", {
 			method: "PATCH",

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -676,23 +676,29 @@ organization.openapi(updateOrganization, async (c) => {
 		updateData.autoTopUpAmount = autoTopUpAmount.toString();
 	}
 
+	// An empty PATCH body is a valid no-op; drizzle throws "No values to set"
+	// on an empty update, so skip the query and return the org unchanged.
 	let updatedOrganization;
-	try {
-		[updatedOrganization] = await db
-			.update(tables.organization)
-			.set(updateData)
-			.where(eq(tables.organization.id, id))
-			.returning();
-	} catch (err) {
-		const code =
-			(err as { code?: string; cause?: { code?: string } })?.code ??
-			(err as { cause?: { code?: string } })?.cause?.code;
-		if (code === "23505" && normalizedSsoDomain) {
-			throw new HTTPException(409, {
-				message: "This domain is already configured by another organization.",
-			});
+	if (Object.keys(updateData).length === 0) {
+		updatedOrganization = userOrganization.organization!;
+	} else {
+		try {
+			[updatedOrganization] = await db
+				.update(tables.organization)
+				.set(updateData)
+				.where(eq(tables.organization.id, id))
+				.returning();
+		} catch (err) {
+			const code =
+				(err as { code?: string; cause?: { code?: string } })?.code ??
+				(err as { cause?: { code?: string } })?.cause?.code;
+			if (code === "23505" && normalizedSsoDomain) {
+				throw new HTTPException(409, {
+					message: "This domain is already configured by another organization.",
+				});
+			}
+			throw err;
 		}
-		throw err;
 	}
 
 	// Build changes metadata for audit log


### PR DESCRIPTION
## Summary

Production logs showed an unhandled `Error: No values to set` from drizzle's `mapUpdateSet` in `PATCH /orgs/{id}` (`apps/api/src/routes/organization.ts`). When a PATCH request contains no updatable fields, the handler built an empty `updateData` object and passed it to `.set()`, which drizzle rejects — resulting in a 500.

## Changes

- **`apps/api/src/routes/organization.ts`**: when `updateData` is empty, skip the `UPDATE` query and return the organization unchanged (same pattern already used in the projects route).
- **`apps/api/src/routes/keys-api.ts`**: the IAM rule update route accepts a fully-partial body (`createIamRuleSchema.partial()`), so an empty PATCH hit the same crash — added the same guard, falling back to the existing rule.
- **`apps/api/src/routes/organization.spec.ts`**: regression test asserting an empty-body `PATCH /orgs/{id}` returns 200 with the unchanged organization.

Audited the remaining `.set(updateData)` call sites (`projects.ts`, `dev-plans.ts`) — they already guard against empty updates.

## Testing

- `pnpm exec vitest run apps/api/src/routes/organization.spec.ts` — 4 passed (incl. new test)
- `pnpm exec vitest run apps/api/src/routes/keys-api.spec.ts` — 31 passed
- `turbo run build --filter=api` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Ks3mo9zjzQ55M2MqRwjvq

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ks3mo9zjzQ55M2MqRwjvq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty organization updates now succeed without changing existing details.
  * Empty IAM rule updates are treated as valid no-ops instead of producing an error.
  * Domain conflict checks now apply only when organization details are actually changed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->