### PR TITLE
feat: gross revenue splits on admin dashboard

### DIFF
--- a/apps/api/src/routes/admin-metrics-gross-revenue.spec.ts
+++ b/apps/api/src/routes/admin-metrics-gross-revenue.spec.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const ORG_ID = "gross-rev-default-org";
+const DEVPASS_ORG_ID = "gross-rev-devpass-org";
+const CHAT_ORG_ID = "gross-rev-chat-org";
+
+interface AdminMetricsResponse {
+	totalRevenue: number;
+	totalProcessed: number;
+	totalToppedUp: number;
+	grossRevenue: number;
+	grossCreditsRevenue: number;
+	grossDevpassRevenue: number;
+	grossChatPlansRevenue: number;
+	grossProSubscriptionsRevenue: number;
+}
+
+describe("admin /metrics — gross revenue splits", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: ORG_ID,
+				name: "Gross Revenue Default Org",
+				billingEmail: "gr-default@example.com",
+			},
+			{
+				id: DEVPASS_ORG_ID,
+				name: "Gross Revenue DevPass Org",
+				billingEmail: "gr-devpass@example.com",
+				kind: "devpass",
+			},
+			{
+				id: CHAT_ORG_ID,
+				name: "Gross Revenue Chat Org",
+				billingEmail: "gr-chat@example.com",
+				kind: "chat",
+			},
+		]);
+
+		await db.insert(tables.transaction).values([
+			// Org credit purchase: $21 gross, $20 credited.
+			{
+				organizationId: ORG_ID,
+				type: "credit_topup",
+				amount: "21",
+				creditAmount: "20",
+				status: "completed",
+				createdAt: new Date("2026-01-01T00:00:00Z"),
+			},
+			// End-user wallet top-up ($11 gross) and its refund reversal — the
+			// negative row must NOT reduce gross credits revenue.
+			{
+				organizationId: ORG_ID,
+				type: "end_user_topup",
+				amount: "11",
+				creditAmount: "10",
+				status: "completed",
+				createdAt: new Date("2026-01-02T00:00:00Z"),
+			},
+			{
+				organizationId: ORG_ID,
+				type: "end_user_topup",
+				amount: "-11",
+				creditAmount: "-10",
+				status: "completed",
+				createdAt: new Date("2026-01-03T00:00:00Z"),
+			},
+			// DevPass: a start and a second-cycle renewal, one invoice each.
+			// (Same-invoice start+renewal duplicates only exist historically —
+			// stripe_invoice_id is unique nowadays — so the invoice dedup guard
+			// itself can't be exercised through inserts here.)
+			{
+				organizationId: DEVPASS_ORG_ID,
+				type: "dev_plan_start",
+				amount: "20",
+				creditAmount: "40",
+				status: "completed",
+				stripeInvoiceId: "inv_gross_dev_1",
+				createdAt: new Date("2026-01-04T00:00:00Z"),
+			},
+			{
+				organizationId: DEVPASS_ORG_ID,
+				type: "dev_plan_renewal",
+				amount: "20",
+				creditAmount: "40",
+				status: "completed",
+				stripeInvoiceId: "inv_gross_dev_2",
+				createdAt: new Date("2026-02-04T00:00:00Z"),
+			},
+			// Chat Plan: $10 paid for a plan that includes $150 of virtual
+			// credits — the $150 allowance must never count as revenue.
+			{
+				organizationId: CHAT_ORG_ID,
+				type: "chat_plan_start",
+				amount: "10",
+				creditAmount: "150",
+				status: "completed",
+				stripeInvoiceId: "inv_gross_chat_1",
+				createdAt: new Date("2026-01-05T00:00:00Z"),
+			},
+			// Legacy org Pro subscription on a default org.
+			{
+				organizationId: ORG_ID,
+				type: "subscription_start",
+				amount: "50",
+				creditAmount: null,
+				status: "completed",
+				stripeInvoiceId: "inv_gross_pro_1",
+				createdAt: new Date("2026-01-06T00:00:00Z"),
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("splits gross revenue by product and keeps credits metrics plan-free", async () => {
+		const res = await app.request("/admin/metrics", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as AdminMetricsResponse;
+
+		// Gross = positive Stripe amounts, refunds ignored: $21 + $11 credits.
+		expect(body.grossCreditsRevenue).toBe(32);
+		// $20 start + $20 second-cycle renewal.
+		expect(body.grossDevpassRevenue).toBe(40);
+		expect(body.grossChatPlansRevenue).toBe(10);
+		// Legacy subscription on a non-devpass org.
+		expect(body.grossProSubscriptionsRevenue).toBe(50);
+		expect(body.grossRevenue).toBe(132);
+
+		// The credits-economy metrics must exclude ALL plan rows: chat plan
+		// creditAmount ($150) is a virtual allowance, not revenue.
+		expect(body.totalRevenue).toBe(20);
+		expect(body.totalProcessed).toBe(21);
+		expect(body.totalToppedUp).toBe(20);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9,9 +9,13 @@ import { parseReferralBonusPercent } from "@/lib/referral-bonus.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
 import {
-	notDevpassFilter,
+	CHAT_PLAN_TX_TYPES,
+	DEV_PLAN_TX_TYPES,
+	firstRowPerInvoiceFilter,
+	LEGACY_DEV_PLAN_TX_TYPES,
 	notEndUserNonRevenueFilter,
 	notEndUserWalletFilter,
+	notPlanFilter,
 	paidTransactionFilter,
 } from "@/utils/devpass-filter.js";
 import {
@@ -96,6 +100,13 @@ const adminMetricsSchema = z.object({
 	totalGiftedCredits: z.number(),
 	totalBonusCredits: z.number(),
 	totalRefunds: z.number(),
+	// Gross revenue across all products (Stripe `amount`, i.e. before Stripe
+	// fees; refunds not netted out), split by product.
+	grossRevenue: z.number(),
+	grossCreditsRevenue: z.number(),
+	grossDevpassRevenue: z.number(),
+	grossChatPlansRevenue: z.number(),
+	grossProSubscriptionsRevenue: z.number(),
 });
 
 const timeseriesRangeSchema = z.enum(["7d", "30d", "90d", "365d", "all"]);
@@ -622,8 +633,9 @@ admin.openapi(getMetrics, async (c) => {
 
 	// Total revenue: completed credit-purchase rows — org credit top-ups AND
 	// end-user wallet top-ups (`end_user_topup`, reversed on refund) — using
-	// creditAmount to exclude Stripe fees. Excludes gifts, DevPass subscription
-	// rows, and the non-revenue end-user rows (developer margin + funded bonus).
+	// creditAmount to exclude Stripe fees. Excludes gifts, all plan rows
+	// (DevPass/legacy subscription/Chat Plan), and the non-revenue end-user rows
+	// (developer margin + funded bonus).
 	const [revenueRow] = await db
 		.select({
 			value:
@@ -636,7 +648,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				transactionDateFilter,
 			),
@@ -655,11 +667,11 @@ admin.openapi(getMetrics, async (c) => {
 	const totalOrganizations = Number(orgsRow?.count ?? 0);
 
 	// Total topped up (credits from completed credit-purchase transactions).
-	// Excludes DevPass virtual credits — those are granted per cycle and reset,
-	// so they would inflate the topped-up / unused-credits numbers — and all
-	// end-user wallet rows, which live in their own balance economy (their spend
-	// is not in `totalSpent`, so counting their top-ups would inflate unused
-	// credits).
+	// Excludes DevPass and Chat Plan virtual credits — those are granted per
+	// cycle and reset, so they would inflate the topped-up / unused-credits
+	// numbers — and all end-user wallet rows, which live in their own balance
+	// economy (their spend is not in `totalSpent`, so counting their top-ups
+	// would inflate unused credits).
 	const [toppedUpRow] = await db
 		.select({
 			value:
@@ -671,7 +683,7 @@ admin.openapi(getMetrics, async (c) => {
 		.where(
 			and(
 				eq(tables.transaction.status, "completed"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserWalletFilter,
 				transactionDateFilter,
 			),
@@ -680,7 +692,7 @@ admin.openapi(getMetrics, async (c) => {
 	const totalToppedUp = Number(toppedUpRow?.value ?? 0);
 
 	// Total spent (usage cost from hourly stats). Excludes spend from projects
-	// belonging to orgs whose usage is/was on a DevPass plan, so the
+	// belonging to orgs whose usage is/was on a DevPass or Chat Plan, so the
 	// unusedCredits derivation (toppedUp - spent) only reflects the
 	// credit-purchase economy.
 	const [spentRow] = await db
@@ -703,11 +715,13 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				projectStatsDateFilter,
 				eq(tables.organization.devPlan, "none"),
+				eq(tables.organization.chatPlan, "none"),
 				sql`NOT EXISTS (
 					SELECT 1 FROM ${tables.transaction} t
 					WHERE t.organization_id = ${tables.organization.id}
 					AND (
 						t.type IN ('dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal')
+						OR t.type IN ('chat_plan_start', 'chat_plan_upgrade', 'chat_plan_downgrade', 'chat_plan_renewal')
 						OR (t.type IN ('subscription_start', 'subscription_cancel', 'subscription_end') AND ${tables.organization.kind} = 'devpass')
 					)
 				)`,
@@ -716,7 +730,7 @@ admin.openapi(getMetrics, async (c) => {
 
 	const totalSpent = Number(spentRow?.value ?? 0);
 
-	// Total processed (gross Stripe amounts from completed non-gift, non-DevPass transactions)
+	// Total processed (gross Stripe amounts from completed non-gift, non-plan transactions)
 	const [processedRow] = await db
 		.select({
 			value:
@@ -729,7 +743,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				transactionDateFilter,
 			),
@@ -799,6 +813,123 @@ admin.openapi(getMetrics, async (c) => {
 
 	const totalRefunds = Number(refundsRow?.value ?? 0);
 
+	// Gross revenue splits: actual dollars charged via Stripe (`amount`, so
+	// including Stripe fees), before netting refunds out.
+	//
+	// Credits: org credit top-ups + end-user wallet top-ups. Refund reversals
+	// are negative same-type rows, so only positive amounts count as gross.
+	const [grossCreditsRow] = await db
+		.select({
+			value:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"value",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.type, ["credit_topup", "end_user_topup"]),
+				sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
+				transactionDateFilter,
+			),
+		);
+
+	const grossCreditsRevenue = Number(grossCreditsRow?.value ?? 0);
+
+	// DevPass: dev plan payments (+ legacy `subscription_*` rows on devpass
+	// orgs), deduplicated per Stripe invoice. Mirrors /admin/devpass/timeseries.
+	const [grossDevpassRow] = await db
+		.select({
+			value:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"value",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				inArray(tables.transaction.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				transactionDateFilter,
+			),
+		);
+
+	const grossDevpassRevenue = Number(grossDevpassRow?.value ?? 0);
+
+	// Chat Plans: plan payments on chat orgs, deduplicated per Stripe invoice.
+	// Mirrors /admin/chat-plans/timeseries.
+	const [grossChatPlansRow] = await db
+		.select({
+			value:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"value",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "chat"),
+				inArray(tables.transaction.type, [...CHAT_PLAN_TX_TYPES]),
+				firstRowPerInvoiceFilter(CHAT_PLAN_TX_TYPES),
+				transactionDateFilter,
+			),
+		);
+
+	const grossChatPlansRevenue = Number(grossChatPlansRow?.value ?? 0);
+
+	// Org Pro subscriptions: `subscription_*` rows on non-devpass orgs (the same
+	// legacy types double as DevPass rows on devpass orgs, counted above).
+	const [grossProSubsRow] = await db
+		.select({
+			value:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"value",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				ne(tables.organization.kind, "devpass"),
+				inArray(tables.transaction.type, [...LEGACY_DEV_PLAN_TX_TYPES]),
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				transactionDateFilter,
+			),
+		);
+
+	const grossProSubscriptionsRevenue = Number(grossProSubsRow?.value ?? 0);
+
+	const grossRevenue =
+		grossCreditsRevenue +
+		grossDevpassRevenue +
+		grossChatPlansRevenue +
+		grossProSubscriptionsRevenue;
+
 	const rawBalance = totalToppedUp - totalSpent;
 	const unusedCredits = Math.max(0, rawBalance);
 	const overage = Math.max(0, -rawBalance);
@@ -817,6 +948,11 @@ admin.openapi(getMetrics, async (c) => {
 		totalGiftedCredits,
 		totalBonusCredits,
 		totalRefunds,
+		grossRevenue,
+		grossCreditsRevenue,
+		grossDevpassRevenue,
+		grossChatPlansRevenue,
+		grossProSubscriptionsRevenue,
 	});
 });
 
@@ -906,7 +1042,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
@@ -929,7 +1065,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
@@ -972,7 +1108,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),
@@ -991,7 +1127,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				notDevpassFilter,
+				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),
@@ -10054,22 +10190,6 @@ const getDevpassUsage = createRoute({
 	},
 });
 
-const DEV_PLAN_TX_TYPES = [
-	"dev_plan_start",
-	"dev_plan_upgrade",
-	"dev_plan_downgrade",
-	"dev_plan_renewal",
-] as const;
-
-// Pre-rename rows for what is now a dev plan. The same `subscription_*` types
-// are STILL written today for non-personal org Pro subs, so always pair them
-// with `organization.kind = 'devpass'` to avoid counting org Pro revenue.
-const LEGACY_DEV_PLAN_TX_TYPES = [
-	"subscription_start",
-	"subscription_cancel",
-	"subscription_end",
-] as const;
-
 function tierPriceOf(tier: string): number {
 	if (tier === "lite" || tier === "pro" || tier === "max") {
 		return DEV_PLAN_PRICES[tier];
@@ -10254,23 +10374,10 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 					...DEV_PLAN_TX_TYPES,
 					...LEGACY_DEV_PLAN_TX_TYPES,
 				]),
-				sql`NOT EXISTS (
-					SELECT 1 FROM ${tables.transaction} dup
-					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
-						AND dup.stripe_invoice_id IS NOT NULL
-						AND dup.organization_id = ${tables.transaction.organizationId}
-						AND dup.id <> ${tables.transaction.id}
-						AND dup.status = 'completed'
-						AND dup.amount IS NOT NULL
-						AND dup.type IN (
-							'dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal',
-							'subscription_start', 'subscription_cancel', 'subscription_end'
-						)
-						AND (
-							dup.created_at < ${tables.transaction.createdAt}
-							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
-						)
-				)`,
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
 			),
 		)
 		.groupBy(tables.transaction.organizationId)
@@ -10902,23 +11009,10 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 					...DEV_PLAN_TX_TYPES,
 					...LEGACY_DEV_PLAN_TX_TYPES,
 				]),
-				sql`NOT EXISTS (
-					SELECT 1 FROM ${tables.transaction} dup
-					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
-						AND dup.stripe_invoice_id IS NOT NULL
-						AND dup.organization_id = ${tables.transaction.organizationId}
-						AND dup.id <> ${tables.transaction.id}
-						AND dup.status = 'completed'
-						AND dup.amount IS NOT NULL
-						AND dup.type IN (
-							'dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal',
-							'subscription_start', 'subscription_cancel', 'subscription_end'
-						)
-						AND (
-							dup.created_at < ${tables.transaction.createdAt}
-							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
-						)
-				)`,
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
@@ -11333,23 +11427,10 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 				eq(tables.transaction.organizationId, orgId),
 				eq(tables.transaction.status, "completed"),
 				inArray(tables.transaction.type, allTimeRevenueTypes),
-				sql`NOT EXISTS (
-					SELECT 1 FROM ${tables.transaction} dup
-					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
-						AND dup.stripe_invoice_id IS NOT NULL
-						AND dup.organization_id = ${tables.transaction.organizationId}
-						AND dup.id <> ${tables.transaction.id}
-						AND dup.status = 'completed'
-						AND dup.amount IS NOT NULL
-						AND dup.type IN (
-							'dev_plan_start', 'dev_plan_upgrade', 'dev_plan_downgrade', 'dev_plan_renewal',
-							'subscription_start', 'subscription_cancel', 'subscription_end'
-						)
-						AND (
-							dup.created_at < ${tables.transaction.createdAt}
-							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
-						)
-				)`,
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
 			),
 		);
 
@@ -11783,13 +11864,6 @@ const getChatPlansUsage = createRoute({
 	},
 });
 
-const CHAT_PLAN_TX_TYPES = [
-	"chat_plan_start",
-	"chat_plan_upgrade",
-	"chat_plan_downgrade",
-	"chat_plan_renewal",
-] as const;
-
 function chatTierPriceOf(tier: string): number {
 	if (tier === "starter" || tier === "plus" || tier === "pro") {
 		return CHAT_PLAN_PRICES[tier];
@@ -11958,22 +12032,7 @@ admin.openapi(getChatPlansSubscribers, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				inArray(tables.transaction.type, [...CHAT_PLAN_TX_TYPES]),
-				sql`NOT EXISTS (
-					SELECT 1 FROM ${tables.transaction} dup
-					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
-						AND dup.stripe_invoice_id IS NOT NULL
-						AND dup.organization_id = ${tables.transaction.organizationId}
-						AND dup.id <> ${tables.transaction.id}
-						AND dup.status = 'completed'
-						AND dup.amount IS NOT NULL
-						AND dup.type IN (
-							'chat_plan_start', 'chat_plan_upgrade', 'chat_plan_downgrade', 'chat_plan_renewal'
-						)
-						AND (
-							dup.created_at < ${tables.transaction.createdAt}
-							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
-						)
-				)`,
+				firstRowPerInvoiceFilter(CHAT_PLAN_TX_TYPES),
 			),
 		)
 		.groupBy(tables.transaction.organizationId)
@@ -12542,22 +12601,7 @@ admin.openapi(getChatPlansTimeseries, async (c) => {
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
 				inArray(tables.transaction.type, [...CHAT_PLAN_TX_TYPES]),
-				sql`NOT EXISTS (
-					SELECT 1 FROM ${tables.transaction} dup
-					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
-						AND dup.stripe_invoice_id IS NOT NULL
-						AND dup.organization_id = ${tables.transaction.organizationId}
-						AND dup.id <> ${tables.transaction.id}
-						AND dup.status = 'completed'
-						AND dup.amount IS NOT NULL
-						AND dup.type IN (
-							'chat_plan_start', 'chat_plan_upgrade', 'chat_plan_downgrade', 'chat_plan_renewal'
-						)
-						AND (
-							dup.created_at < ${tables.transaction.createdAt}
-							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
-						)
-				)`,
+				firstRowPerInvoiceFilter(CHAT_PLAN_TX_TYPES),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
@@ -12959,22 +13003,7 @@ admin.openapi(getChatPlansSubscriber, async (c) => {
 				eq(tables.transaction.organizationId, orgId),
 				eq(tables.transaction.status, "completed"),
 				inArray(tables.transaction.type, [...CHAT_PLAN_TX_TYPES]),
-				sql`NOT EXISTS (
-					SELECT 1 FROM ${tables.transaction} dup
-					WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
-						AND dup.stripe_invoice_id IS NOT NULL
-						AND dup.organization_id = ${tables.transaction.organizationId}
-						AND dup.id <> ${tables.transaction.id}
-						AND dup.status = 'completed'
-						AND dup.amount IS NOT NULL
-						AND dup.type IN (
-							'chat_plan_start', 'chat_plan_upgrade', 'chat_plan_downgrade', 'chat_plan_renewal'
-						)
-						AND (
-							dup.created_at < ${tables.transaction.createdAt}
-							OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
-						)
-				)`,
+				firstRowPerInvoiceFilter(CHAT_PLAN_TX_TYPES),
 			),
 		);
 

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -1,6 +1,12 @@
 import { sql, tables } from "@llmgateway/db";
 
-export const devpassExcludedTypes = [
+// All plan/subscription transaction types (DevPass dev plans, legacy
+// subscriptions, Chat Plans). These are excluded from the credits-economy
+// metrics: dev/chat plan rows store `creditAmount` as the plan's included
+// (virtual) credit allowance — not dollars — so counting them would corrupt
+// revenue and topped-up figures. Plan revenue is reported separately via the
+// gross revenue split metrics.
+export const planExcludedTypes = [
 	"dev_plan_start",
 	"dev_plan_upgrade",
 	"dev_plan_downgrade",
@@ -13,12 +19,69 @@ export const devpassExcludedTypes = [
 	"subscription_upgrade",
 	"subscription_downgrade",
 	"subscription_renewal",
+	"chat_plan_start",
+	"chat_plan_upgrade",
+	"chat_plan_downgrade",
+	"chat_plan_renewal",
+	"chat_plan_cancel",
+	"chat_plan_end",
 ] as const;
 
-export const notDevpassFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
-	devpassExcludedTypes.map((t) => sql`${t}`),
+export const notPlanFilter = sql`${tables.transaction.type} NOT IN (${sql.join(
+	planExcludedTypes.map((t) => sql`${t}`),
 	sql`, `,
 )})`;
+
+// DevPass dev plan payment/lifecycle rows that can carry a Stripe `amount`.
+export const DEV_PLAN_TX_TYPES = [
+	"dev_plan_start",
+	"dev_plan_upgrade",
+	"dev_plan_downgrade",
+	"dev_plan_renewal",
+] as const;
+
+// Pre-rename rows for what is now a dev plan. The same `subscription_*` types
+// are STILL written today for non-personal org Pro subs, so always pair them
+// with `organization.kind = 'devpass'` to avoid counting org Pro revenue.
+export const LEGACY_DEV_PLAN_TX_TYPES = [
+	"subscription_start",
+	"subscription_cancel",
+	"subscription_end",
+] as const;
+
+export const CHAT_PLAN_TX_TYPES = [
+	"chat_plan_start",
+	"chat_plan_upgrade",
+	"chat_plan_downgrade",
+	"chat_plan_renewal",
+] as const;
+
+// Keeps exactly one transaction per (stripe_invoice_id, organization_id): the
+// FIRST invoice of a subscription triggers BOTH `checkout.session.completed`
+// and `invoice.payment_succeeded`, which insert two rows (e.g. a
+// `dev_plan_start` and a `dev_plan_renewal`, or a `chat_plan_start` and a
+// `chat_plan_renewal`) for the same invoice. Without this guard the initial
+// payment is counted twice. Keeps the earliest row per invoice (tie-broken by
+// id) so each Stripe invoice contributes exactly once.
+export function firstRowPerInvoiceFilter(dedupTypes: readonly string[]) {
+	return sql`NOT EXISTS (
+		SELECT 1 FROM ${tables.transaction} dup
+		WHERE dup.stripe_invoice_id = ${tables.transaction.stripeInvoiceId}
+			AND dup.stripe_invoice_id IS NOT NULL
+			AND dup.organization_id = ${tables.transaction.organizationId}
+			AND dup.id <> ${tables.transaction.id}
+			AND dup.status = 'completed'
+			AND dup.amount IS NOT NULL
+			AND dup.type IN (${sql.join(
+				dedupTypes.map((t) => sql`${t}`),
+				sql`, `,
+			)})
+			AND (
+				dup.created_at < ${tables.transaction.createdAt}
+				OR (dup.created_at = ${tables.transaction.createdAt} AND dup.id < ${tables.transaction.id})
+			)
+	)`;
+}
 
 // Transaction types that represent an actual customer payment: org credit
 // purchases, dev/chat plan charges (start/upgrade/renewal — cancel, end and

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -3,6 +3,7 @@ import {
 	CircleDollarSign,
 	Gift,
 	PiggyBank,
+	TrendingUp,
 	Users,
 } from "lucide-react";
 import Link from "next/link";
@@ -28,7 +29,7 @@ const numberFormatter = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 0,
 });
 
-type Accent = "green" | "blue" | "purple" | "red" | "amber";
+type Accent = "green" | "blue" | "purple" | "red" | "amber" | "teal";
 
 const accentRing: Record<Accent, string> = {
 	green: "border-emerald-500/30 bg-emerald-500/10 text-emerald-400",
@@ -36,6 +37,7 @@ const accentRing: Record<Accent, string> = {
 	purple: "border-violet-500/30 bg-violet-500/10 text-violet-400",
 	red: "border-red-500/30 bg-red-500/10 text-red-400",
 	amber: "border-amber-500/30 bg-amber-500/10 text-amber-400",
+	teal: "border-teal-500/30 bg-teal-500/10 text-teal-400",
 };
 
 function GroupedMetricCard({
@@ -161,7 +163,7 @@ export default async function Page({
 				</div>
 			</header>
 
-			<section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+			<section className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-5">
 				<GroupedMetricCard
 					label="Audience"
 					value={numberFormatter.format(metrics.totalSignups)}
@@ -184,11 +186,42 @@ export default async function Page({
 					]}
 				/>
 				<GroupedMetricCard
-					label="Revenue"
+					label="Total Revenue"
+					value={currencyFormatter.format(metrics.grossRevenue)}
+					subtitle="Gross, all products (before fees & refunds)"
+					icon={<TrendingUp className="h-4 w-4" />}
+					accent="teal"
+					stats={[
+						{
+							label: "Credits",
+							value: currencyFormatter.format(metrics.grossCreditsRevenue),
+						},
+						{
+							label: "DevPass",
+							value: currencyFormatter.format(metrics.grossDevpassRevenue),
+						},
+						{
+							label: "Chat plans",
+							value: currencyFormatter.format(metrics.grossChatPlansRevenue),
+						},
+						...(metrics.grossProSubscriptionsRevenue > 0
+							? [
+									{
+										label: "Pro subs",
+										value: currencyFormatter.format(
+											metrics.grossProSubscriptionsRevenue,
+										),
+									},
+								]
+							: []),
+					]}
+				/>
+				<GroupedMetricCard
+					label="Credits Revenue"
 					value={currencyFormatter.format(
 						metrics.totalRevenue - metrics.totalRefunds,
 					)}
-					subtitle="Net (excl. Stripe fees & refunds)"
+					subtitle="Net credits (excl. Stripe fees & refunds)"
 					icon={<CircleDollarSign className="h-4 w-4" />}
 					accent="green"
 					stats={[

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -74,15 +74,15 @@ export function RevenueChart({
 		<Card>
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
 				<div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
-					<CardTitle>Revenue</CardTitle>
+					<CardTitle>Credits Revenue</CardTitle>
 					<CardDescription>
 						Cumulative processed, revenue (after fees), and net (after fees &
-						refunds)
+						refunds) for credit purchases
 					</CardDescription>
 				</div>
 				<div className="flex">
 					<div className="flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left sm:border-l sm:border-t-0 sm:px-8 sm:py-6">
-						<span className="text-xs text-muted-foreground">Total Revenue</span>
+						<span className="text-xs text-muted-foreground">Net Revenue</span>
 						<span className="text-lg font-bold leading-none sm:text-3xl">
 							{currencyFormatter.format(totalNet)}
 						</span>


### PR DESCRIPTION
## Context

Question from the dashboard: does the admin **Revenue** card only include credits, and not DevPass / Chat Plan subscription revenue?

Answer: it was *meant* to be credits-only (all `dev_plan_*` and legacy `subscription_*` rows were excluded), but `chat_plan_*` rows were never added to the exclusion filter. Chat Plan transactions store `creditAmount` as the plan's included **virtual credit allowance** (e.g. $150 of credits on a cheaper plan), not dollars paid — so they were leaking into `totalRevenue` / `totalToppedUp` (inflating them) and their Stripe `amount` into `totalProcessed`.

## Changes

### Fix: make the credits metrics purely credits
- Added `chat_plan_*` types to the plan exclusion filter (`notDevpassFilter` → `notPlanFilter` in `devpass-filter.ts`), which cleans up `totalRevenue`, `totalProcessed`, `totalToppedUp`, and the dashboard revenue timeseries.
- `totalSpent` now also excludes usage from orgs that are/were on a Chat Plan (mirrors the existing DevPass handling), keeping the `unusedCredits` / `overage` derivation to the credit-purchase economy.

### New: gross revenue splits + Total Revenue card
`/admin/metrics` now returns gross revenue (Stripe `amount`, i.e. before fees, refunds not netted) split by product:
- `grossCreditsRevenue` — org credit top-ups + end-user wallet top-ups (positive amounts only, so refund reversals are ignored)
- `grossDevpassRevenue` — dev plan payments + legacy `subscription_*` rows on devpass orgs, deduped per Stripe invoice (mirrors `/admin/devpass/timeseries`)
- `grossChatPlansRevenue` — chat plan payments on chat orgs, deduped per Stripe invoice (mirrors `/admin/chat-plans/timeseries`)
- `grossProSubscriptionsRevenue` — legacy org Pro `subscription_*` rows on non-devpass orgs (a fourth stream that would otherwise be missing from any total)
- `grossRevenue` — sum of the above

The admin dashboard gets a new **Total Revenue** card showing `grossRevenue` with the Credits / DevPass / Chat plans split (Pro subs shown only when non-zero). The old card is relabeled **Credits Revenue** and the timeseries chart labels updated to match its credits-only scope.

### Refactor
- Shared `DEV_PLAN_TX_TYPES` / `LEGACY_DEV_PLAN_TX_TYPES` / `CHAT_PLAN_TX_TYPES` and the per-invoice dedup guard (`firstRowPerInvoiceFilter`) moved into `devpass-filter.ts`, replacing four duplicated inline `NOT EXISTS` blocks.

## Testing
- New `admin-metrics-gross-revenue.spec.ts` covering the splits, refund-reversal handling, and that chat plan `creditAmount` no longer counts toward the credits metrics — passes along with the existing `admin-metrics-bonus.spec.ts`.
- Full `pnpm build` passes (17/17 tasks), OpenAPI spec + admin client regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL6UnCWFJBsJcH6xi9cEGr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL6UnCWFJBsJcH6xi9cEGr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Total Revenue metric to the admin dashboard with gross revenue breakdowns for Credits, DevPass, Chat Plans, and Pro subscriptions.
  - Expanded the admin metrics API with product-specific gross revenue fields.

- **Bug Fixes**
  - Improved revenue calculations to prevent plan allowances, refunds, and duplicate invoice records from inflating totals.
  - Clarified credit revenue and net revenue labels throughout the dashboard.
  - Ensured credit economy metrics exclude plan-related transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->