### PR TITLE
fix: address reasoning preservation review findings

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1549,6 +1549,7 @@ chat.openapi(completions, async (c) => {
 	// Extract reasoning.effort and reasoning.max_tokens for unified reasoning configuration
 	const reasoning_object_effort = validationResult.data.reasoning?.effort;
 	const reasoning_max_tokens = validationResult.data.reasoning?.max_tokens;
+	const reasoning_context = validationResult.data.reasoning?.context;
 
 	// Validate that reasoning_effort and reasoning.effort are not both specified
 	if (
@@ -6146,6 +6147,7 @@ chat.openapi(completions, async (c) => {
 			verbosity,
 			prompt_cache_options,
 			sessionId,
+			reasoning_context,
 		);
 	} catch (e) {
 		// Surface typed pre-upstream input errors in the activity feed as a
@@ -12822,6 +12824,29 @@ chat.openapi(completions, async (c) => {
 	) {
 		transformedResponse.choices[0].message.reasoning_details =
 			parsedResponse.reasoningDetails;
+	}
+	// Surface the OpenAI Responses assistant-message phase so stateless clients
+	// can replay it as part of complete conversation history.
+	if (
+		parsedResponse.messagePhase &&
+		transformedResponse.choices?.[0]?.message
+	) {
+		transformedResponse.choices[0].message.phase = parsedResponse.messagePhase;
+	}
+	// Mark pre-tool commentary (message item before the first function_call in
+	// the provider's output) so the Responses converter can rebuild the
+	// original item order.
+	if (
+		parsedResponse.messageBeforeToolCalls === true &&
+		transformedResponse.choices?.[0]?.message
+	) {
+		transformedResponse.choices[0].message.content_before_tool_calls = true;
+	}
+	// Surface the effective reasoning context the provider applied so the
+	// Responses layer reports the served mode rather than echoing the request.
+	if (parsedResponse.reasoningContext) {
+		(transformedResponse as Record<string, unknown>).reasoning_context =
+			parsedResponse.reasoningContext;
 	}
 	const transformedMetadata =
 		transformedResponse.metadata &&

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -12842,6 +12842,16 @@ chat.openapi(completions, async (c) => {
 	) {
 		transformedResponse.choices[0].message.content_before_tool_calls = true;
 	}
+	// Surface separate phased assistant message items (e.g. commentary and
+	// final_answer) so the Responses layer can rebuild every original item.
+	if (
+		parsedResponse.messageItems &&
+		parsedResponse.messageItems.length > 0 &&
+		transformedResponse.choices?.[0]?.message
+	) {
+		transformedResponse.choices[0].message.message_items =
+			parsedResponse.messageItems;
+	}
 	// Surface the effective reasoning context the provider applied so the
 	// Responses layer reports the served mode rather than echoing the request.
 	if (parsedResponse.reasoningContext) {

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -141,6 +141,14 @@ export const completionsRequestSchema = z.object({
 						.passthrough(),
 				)
 				.optional(),
+			phase: z.enum(["commentary", "final_answer"]).optional().openapi({
+				description:
+					"OpenAI Responses assistant-message phase. Replayed upstream for OpenAI Responses API models; stripped for other providers.",
+			}),
+			content_before_tool_calls: z.boolean().optional().openapi({
+				description:
+					"Marks assistant content that preceded the message's tool calls (pre-tool commentary on OpenAI Responses API models), so replay preserves the original item order. Stripped for other providers.",
+			}),
 		}),
 	),
 	temperature: z
@@ -325,6 +333,14 @@ export const completionsRequestSchema = z.object({
 					"Exact number of tokens to allocate for reasoning. When specified, overrides effort. Supported by Anthropic and Google thinking models.",
 				example: 4000,
 			}),
+			context: z
+				.enum(["auto", "current_turn", "all_turns"])
+				.optional()
+				.openapi({
+					description:
+						"How much replayed reasoning the model considers (OpenAI Responses API models only). Omitting the field is equivalent to 'auto'. Forwarded upstream as reasoning.context; ignored by other providers.",
+					example: "current_turn",
+				}),
 		})
 		.optional()
 		.openapi({

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -149,6 +149,19 @@ export const completionsRequestSchema = z.object({
 				description:
 					"Marks assistant content that preceded the message's tool calls (pre-tool commentary on OpenAI Responses API models), so replay preserves the original item order. Stripped for other providers.",
 			}),
+			message_items: z
+				.array(
+					z.object({
+						text: z.string(),
+						phase: z.enum(["commentary", "final_answer"]).optional(),
+						preceding_tool_calls: z.number().int().nonnegative().optional(),
+					}),
+				)
+				.optional()
+				.openapi({
+					description:
+						"Separate phased assistant message items (e.g. commentary and final_answer) emitted by OpenAI Responses API models in a single turn. preceding_tool_calls records how many of the message's tool calls came before each item. Replayed upstream as individual message items in their original order; stripped for other providers.",
+				}),
 		}),
 	),
 	temperature: z

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -115,6 +115,141 @@ describe("parseProviderResponse", () => {
 
 			expect(result.reasoningDetails).toBeNull();
 		});
+
+		it("preserves every phased message item instead of only the first", () => {
+			const json = {
+				id: "resp_123",
+				status: "completed",
+				output: [
+					{
+						type: "message",
+						id: "msg_1",
+						role: "assistant",
+						phase: "commentary",
+						content: [{ type: "output_text", text: "Checking the weather." }],
+					},
+					{
+						type: "function_call",
+						id: "fc_1",
+						call_id: "call_1",
+						name: "get_weather",
+						arguments: "{}",
+					},
+					{
+						type: "message",
+						id: "msg_2",
+						role: "assistant",
+						phase: "final_answer",
+						content: [{ type: "output_text", text: "It is sunny." }],
+					},
+				],
+				usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+			};
+
+			const result = parseProviderResponse("openai", "gpt-5.6", json);
+
+			// Chat surface keeps all text; structure lives in messageItems.
+			expect(result.content).toBe("Checking the weather.\n\nIt is sunny.");
+			expect(result.messageItems).toEqual([
+				{
+					text: "Checking the weather.",
+					phase: "commentary",
+					preceding_tool_calls: 0,
+				},
+				{
+					text: "It is sunny.",
+					phase: "final_answer",
+					preceding_tool_calls: 1,
+				},
+			]);
+			expect(result.messagePhase).toBeNull();
+		});
+
+		it("records the exact position of each message among multiple tool calls", () => {
+			const json = {
+				id: "resp_123",
+				status: "completed",
+				output: [
+					{
+						type: "message",
+						id: "msg_1",
+						role: "assistant",
+						phase: "commentary",
+						content: [{ type: "output_text", text: "Commentary A" }],
+					},
+					{
+						type: "function_call",
+						id: "fc_1",
+						call_id: "call_1",
+						name: "tool_one",
+						arguments: "{}",
+					},
+					{
+						type: "message",
+						id: "msg_2",
+						role: "assistant",
+						phase: "commentary",
+						content: [{ type: "output_text", text: "Commentary B" }],
+					},
+					{
+						type: "function_call",
+						id: "fc_2",
+						call_id: "call_2",
+						name: "tool_two",
+						arguments: "{}",
+					},
+				],
+				usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+			};
+
+			const result = parseProviderResponse("openai", "gpt-5.6", json);
+
+			expect(result.messageItems).toEqual([
+				{ text: "Commentary A", phase: "commentary", preceding_tool_calls: 0 },
+				{ text: "Commentary B", phase: "commentary", preceding_tool_calls: 1 },
+			]);
+		});
+
+		it("keeps the position of a single message between two tool calls", () => {
+			const json = {
+				id: "resp_123",
+				status: "completed",
+				output: [
+					{
+						type: "function_call",
+						id: "fc_1",
+						call_id: "call_1",
+						name: "tool_one",
+						arguments: "{}",
+					},
+					{
+						type: "message",
+						id: "msg_1",
+						role: "assistant",
+						phase: "commentary",
+						content: [{ type: "output_text", text: "Between the calls." }],
+					},
+					{
+						type: "function_call",
+						id: "fc_2",
+						call_id: "call_2",
+						name: "tool_two",
+						arguments: "{}",
+					},
+				],
+				usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+			};
+
+			const result = parseProviderResponse("openai", "gpt-5.6", json);
+
+			expect(result.messageItems).toEqual([
+				{
+					text: "Between the calls.",
+					phase: "commentary",
+					preceding_tool_calls: 1,
+				},
+			]);
+		});
 	});
 
 	describe("google reasoning output", () => {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -33,6 +33,11 @@ export function parseProviderResponse(
 	let reasoningDetails: ReasoningDetail[] | null = null;
 	let messagePhase: string | null = null;
 	let messageBeforeToolCalls: boolean | null = null;
+	let messageItems: Array<{
+		text: string;
+		phase?: string;
+		preceding_tool_calls: number;
+	}> | null = null;
 	let reasoningContext: string | null = null;
 	let finishReason = null;
 	let promptTokens = null;
@@ -795,15 +800,74 @@ export function parseProviderResponse(
 				const reasoningOutput = json.output.find(
 					(item: any) => item.type === "reasoning",
 				);
+				const firstFunctionCallIdx = json.output.findIndex(
+					(item: any) => item.type === "function_call",
+				);
 
-				// Extract message content
-				if (messageOutput?.content?.[0]?.text) {
+				// Collect ALL message items (models may emit separate phased
+				// assistant messages, e.g. commentary and final_answer) with
+				// their phase and exact position among the function_call items
+				// (how many calls precede each message), so the original
+				// interleaving can be reconstructed item-for-item.
+				let functionCallsSeen = 0;
+				const allMessageOutputs: Array<{
+					text: string;
+					phase?: string;
+					preceding_tool_calls: number;
+				}> = [];
+				for (const item of json.output) {
+					if (item.type === "function_call") {
+						functionCallsSeen++;
+					} else if (item.type === "message") {
+						allMessageOutputs.push({
+							text: Array.isArray(item.content)
+								? item.content
+										.map((part: any) =>
+											typeof part?.text === "string" ? part.text : "",
+										)
+										.join("")
+								: "",
+							...(typeof item.phase === "string" && {
+								phase: item.phase,
+							}),
+							preceding_tool_calls: functionCallsSeen,
+						});
+					}
+				}
+
+				// Extract message content. With multiple phased messages, join
+				// them so nothing is dropped from the chat-completions surface.
+				if (allMessageOutputs.length > 1) {
+					content = allMessageOutputs
+						.map((m: { text: string }) => m.text)
+						.filter(Boolean)
+						.join("\n\n");
+				} else if (messageOutput?.content?.[0]?.text) {
 					content = messageOutput.content[0].text;
 				}
 
+				// Preserve the per-item structure whenever position matters —
+				// multiple messages, or any message alongside function calls
+				// (a single message may sit BETWEEN two calls, which the flat
+				// chat shape cannot express otherwise). Empty-text messages are
+				// dropped, matching the converter's empty-message guard.
+				const positionedMessages = allMessageOutputs.filter(
+					(m) => m.text.trim() !== "",
+				);
+				if (
+					positionedMessages.length > 0 &&
+					(allMessageOutputs.length > 1 || functionCallsSeen > 0)
+				) {
+					messageItems = positionedMessages;
+				}
+
 				// Preserve the assistant-message phase (e.g. "final_answer") so
-				// clients can replay it in stateless Responses history.
-				if (typeof messageOutput?.phase === "string") {
+				// clients can replay it in stateless Responses history. With
+				// multiple messages the per-item phases live in messageItems.
+				if (
+					allMessageOutputs.length <= 1 &&
+					typeof messageOutput?.phase === "string"
+				) {
 					messagePhase = messageOutput.phase;
 				}
 
@@ -818,13 +882,11 @@ export function parseProviderResponse(
 
 				// Record whether the message item preceded the first function_call
 				// (pre-tool commentary) so the Responses converter can rebuild the
-				// output array in the provider's original item order.
-				{
+				// output array in the provider's original item order. With
+				// multiple messages the per-item flags live in messageItems.
+				if (allMessageOutputs.length <= 1) {
 					const messageIdx = json.output.findIndex(
 						(item: any) => item.type === "message",
-					);
-					const firstFunctionCallIdx = json.output.findIndex(
-						(item: any) => item.type === "function_call",
 					);
 					if (messageIdx !== -1 && firstFunctionCallIdx !== -1) {
 						messageBeforeToolCalls = messageIdx < firstFunctionCallIdx;
@@ -1129,6 +1191,7 @@ export function parseProviderResponse(
 		reasoningDetails,
 		messagePhase,
 		messageBeforeToolCalls,
+		messageItems,
 		reasoningContext,
 		finishReason,
 		promptTokens,

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -31,6 +31,9 @@ export function parseProviderResponse(
 	let content = null;
 	let reasoningContent = null;
 	let reasoningDetails: ReasoningDetail[] | null = null;
+	let messagePhase: string | null = null;
+	let messageBeforeToolCalls: boolean | null = null;
+	let reasoningContext: string | null = null;
 	let finishReason = null;
 	let promptTokens = null;
 	let completionTokens = null;
@@ -798,6 +801,36 @@ export function parseProviderResponse(
 					content = messageOutput.content[0].text;
 				}
 
+				// Preserve the assistant-message phase (e.g. "final_answer") so
+				// clients can replay it in stateless Responses history.
+				if (typeof messageOutput?.phase === "string") {
+					messagePhase = messageOutput.phase;
+				}
+
+				// Capture the effective reasoning context the provider applied
+				// (current_turn/all_turns) so the Responses layer can report it.
+				if (
+					json.reasoning?.context === "current_turn" ||
+					json.reasoning?.context === "all_turns"
+				) {
+					reasoningContext = json.reasoning.context;
+				}
+
+				// Record whether the message item preceded the first function_call
+				// (pre-tool commentary) so the Responses converter can rebuild the
+				// output array in the provider's original item order.
+				{
+					const messageIdx = json.output.findIndex(
+						(item: any) => item.type === "message",
+					);
+					const firstFunctionCallIdx = json.output.findIndex(
+						(item: any) => item.type === "function_call",
+					);
+					if (messageIdx !== -1 && firstFunctionCallIdx !== -1) {
+						messageBeforeToolCalls = messageIdx < firstFunctionCallIdx;
+					}
+				}
+
 				// Extract reasoning content from summary (may hold multiple parts)
 				if (Array.isArray(reasoningOutput?.summary)) {
 					const summaryText = reasoningOutput.summary
@@ -851,6 +884,13 @@ export function parseProviderResponse(
 					} else {
 						finishReason = "stop";
 					}
+				} else if (json.status === "incomplete") {
+					// Mirror the streaming path: surface content-filter truncation
+					// distinctly; everything else (max_output_tokens) is "incomplete".
+					finishReason =
+						json.incomplete_details?.reason === "content_filter"
+							? "content_filter"
+							: "incomplete";
 				} else {
 					finishReason = json.status;
 				}
@@ -1087,6 +1127,9 @@ export function parseProviderResponse(
 		content,
 		reasoningContent,
 		reasoningDetails,
+		messagePhase,
+		messageBeforeToolCalls,
+		reasoningContext,
 		finishReason,
 		promptTokens,
 		completionTokens,

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -8,6 +8,7 @@ import {
 } from "./extract-token-usage.js";
 import { dedupeGoogleCandidateParts } from "./google-candidates.js";
 import {
+	buildEncryptedReasoningDetail,
 	extractReasoningDetailsText,
 	splitReasoningFromTaggedContent,
 } from "./reasoning-details.js";
@@ -811,23 +812,18 @@ export function parseProviderResponse(
 				// Collect encrypted reasoning payloads (returned when the upstream
 				// request sets store:false + include:["reasoning.encrypted_content"])
 				// so clients can replay them on later turns to preserve reasoning
-				// without stored responses.
-				const encryptedReasoningItems = json.output.filter(
-					(item: any) =>
+				// without stored responses. Each detail keeps its item's position
+				// in json.output as its index.
+				const encryptedReasoningDetails = json.output.flatMap(
+					(item: any, index: number) =>
 						item.type === "reasoning" &&
 						typeof item.encrypted_content === "string" &&
-						item.encrypted_content.length > 0,
+						item.encrypted_content.length > 0
+							? [buildEncryptedReasoningDetail(item, index)]
+							: [],
 				);
-				if (encryptedReasoningItems.length > 0) {
-					reasoningDetails = encryptedReasoningItems.map(
-						(item: any, index: number) => ({
-							type: "reasoning.encrypted",
-							data: item.encrypted_content,
-							...(typeof item.id === "string" && { id: item.id }),
-							format: "openai-responses-v1",
-							index,
-						}),
-					);
+				if (encryptedReasoningDetails.length > 0) {
+					reasoningDetails = encryptedReasoningDetails;
 				}
 
 				// Extract tool calls (if any) from the output array and transform to OpenAI format

--- a/apps/gateway/src/chat/tools/reasoning-details.ts
+++ b/apps/gateway/src/chat/tools/reasoning-details.ts
@@ -11,6 +11,25 @@ const THINK_TAG_PAIRS = [
 	},
 ] as const;
 
+/**
+ * Build a "reasoning.encrypted" reasoning_details entry from an OpenAI
+ * Responses API reasoning output item that carries encrypted_content.
+ * `index` is the item's position in the Responses API output array so
+ * replayed items keep their original ordering.
+ */
+export function buildEncryptedReasoningDetail(
+	item: { encrypted_content: string; id?: unknown },
+	index: number,
+): ReasoningDetail {
+	return {
+		type: "reasoning.encrypted",
+		data: item.encrypted_content,
+		...(typeof item.id === "string" && { id: item.id }),
+		format: "openai-responses-v1",
+		index,
+	};
+}
+
 export interface TaggedStreamingReasoningState {
 	inReasoning: boolean;
 	pending: string;

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -827,8 +827,13 @@ export function transformStreamingToOpenai(
 										index: 0,
 										delta: {
 											role: "assistant",
-											// Surface the assistant-message phase so the Responses
-											// translator (and stateless clients) can preserve it.
+											// Mark the start of each upstream message output item so
+											// the Responses translator can preserve exact item
+											// boundaries (e.g. two commentary messages split by a
+											// tool call), along with the item's phase.
+											...(item?.type === "message" && {
+												message_start: true,
+											}),
 											...(item?.type === "message" &&
 												typeof item.phase === "string" && {
 													phase: item.phase,

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -8,6 +8,7 @@ import {
 	extractBedrockCacheCreationDetails,
 } from "./extract-token-usage.js";
 import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
+import { buildEncryptedReasoningDetail } from "./reasoning-details.js";
 import { transformOpenaiStreaming } from "./transform-openai-streaming.js";
 
 import type { Annotation, StreamingDelta } from "./types.js";
@@ -850,15 +851,10 @@ export function transformStreamingToOpenai(
 							typeof doneItem.encrypted_content === "string" &&
 							doneItem.encrypted_content.length > 0
 								? [
-										{
-											type: "reasoning.encrypted",
-											data: doneItem.encrypted_content,
-											...(typeof doneItem.id === "string" && {
-												id: doneItem.id,
-											}),
-											format: "openai-responses-v1",
-											index: data.output_index ?? 0,
-										},
+										buildEncryptedReasoningDetail(
+											doneItem,
+											data.output_index ?? 0,
+										),
 									]
 								: null;
 						transformedData = {

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -825,7 +825,15 @@ export function transformStreamingToOpenai(
 								choices: [
 									{
 										index: 0,
-										delta: { role: "assistant" },
+										delta: {
+											role: "assistant",
+											// Surface the assistant-message phase so the Responses
+											// translator (and stateless clients) can preserve it.
+											...(item?.type === "message" &&
+												typeof item.phase === "string" && {
+													phase: item.phase,
+												}),
+										},
 										finish_reason: null,
 									},
 								],
@@ -871,6 +879,11 @@ export function transformStreamingToOpenai(
 										...(encryptedReasoning && {
 											reasoning_details: encryptedReasoning,
 										}),
+										...(data.type === "response.output_item.done" &&
+											doneItem?.type === "message" &&
+											typeof doneItem.phase === "string" && {
+												phase: doneItem.phase,
+											}),
 									},
 									finish_reason: null,
 								},
@@ -1059,6 +1072,9 @@ export function transformStreamingToOpenai(
 							...(typeof data.response?.service_tier === "string" && {
 								service_tier: data.response.service_tier,
 							}),
+							...(typeof data.response?.reasoning?.context === "string" && {
+								reasoning_context: data.response.reasoning.context,
+							}),
 						};
 						break;
 					}
@@ -1103,6 +1119,9 @@ export function transformStreamingToOpenai(
 							usage,
 							...(typeof data.response?.service_tier === "string" && {
 								service_tier: data.response.service_tier,
+							}),
+							...(typeof data.response?.reasoning?.context === "string" && {
+								reasoning_context: data.response.reasoning.context,
 							}),
 						};
 						break;

--- a/apps/gateway/src/responses.e2e.ts
+++ b/apps/gateway/src/responses.e2e.ts
@@ -270,6 +270,21 @@ describe("e2e", getConcurrentTestOptions(), () => {
 			expect(secondRes.status).toBe(200);
 			const text = getOutputText(secondJson);
 			expect(text.toLowerCase()).toContain("ada");
+
+			// Prove the encrypted reasoning item actually reached the upstream
+			// request unchanged (the answer alone could come from the replayed
+			// plaintext input).
+			const secondLog = await validateLogByRequestId(secondRequestId);
+			const upstreamRequest = secondLog.upstreamRequest as {
+				input?: Array<{ type?: string; encrypted_content?: string }>;
+			} | null;
+			const upstreamReasoning = (upstreamRequest?.input ?? []).find(
+				(item) => item.type === "reasoning",
+			);
+			expect(upstreamReasoning).toBeDefined();
+			expect(upstreamReasoning!.encrypted_content).toBe(
+				reasoningItem.encrypted_content,
+			);
 		},
 	);
 

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -778,7 +778,150 @@ describe("convertChatResponseToResponses", () => {
 		expect(result.data?.reasoning?.context).toBe("auto");
 	});
 
-	it("echoes reasoning.context from the request", () => {
+	it("rebuilds separate phased message items in their original order", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "Checking the weather.\n\nIt is sunny.",
+						message_items: [
+							{
+								text: "Checking the weather.",
+								phase: "commentary",
+								preceding_tool_calls: 0,
+							},
+							{
+								text: "It is sunny.",
+								phase: "final_answer",
+								preceding_tool_calls: 1,
+							},
+						],
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "get_weather", arguments: "{}" },
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+			usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.6");
+
+		expect(result.output.map((o) => o.type)).toEqual([
+			"message",
+			"function_call",
+			"message",
+		]);
+		expect(result.output[0]!.phase).toBe("commentary");
+		expect(
+			(result.output[0]!.content as Array<{ text: string }>)[0]!.text,
+		).toBe("Checking the weather.");
+		expect(result.output[2]!.phase).toBe("final_answer");
+		expect(
+			(result.output[2]!.content as Array<{ text: string }>)[0]!.text,
+		).toBe("It is sunny.");
+	});
+
+	it("reconstructs messages interleaved between multiple tool calls", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "Commentary A\n\nCommentary B",
+						message_items: [
+							{
+								text: "Commentary A",
+								phase: "commentary",
+								preceding_tool_calls: 0,
+							},
+							{
+								text: "Commentary B",
+								phase: "commentary",
+								preceding_tool_calls: 1,
+							},
+						],
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "tool_one", arguments: "{}" },
+							},
+							{
+								id: "call_2",
+								type: "function",
+								function: { name: "tool_two", arguments: "{}" },
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+			usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.6");
+
+		expect(
+			result.output.map((o) =>
+				o.type === "function_call"
+					? (o.name as string)
+					: (o.content as Array<{ text: string }>)[0]!.text,
+			),
+		).toEqual(["Commentary A", "tool_one", "Commentary B", "tool_two"]);
+	});
+
+	it("keeps a single message positioned between two tool calls", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "Between the calls.",
+						message_items: [
+							{
+								text: "Between the calls.",
+								phase: "commentary",
+								preceding_tool_calls: 1,
+							},
+						],
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "tool_one", arguments: "{}" },
+							},
+							{
+								id: "call_2",
+								type: "function",
+								function: { name: "tool_two", arguments: "{}" },
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+			usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.6");
+
+		expect(
+			result.output.map((o) =>
+				o.type === "function_call"
+					? (o.name as string)
+					: (o.content as Array<{ text: string }>)[0]!.text,
+			),
+		).toEqual(["tool_one", "Between the calls.", "tool_two"]);
+	});
+
+	it("never reports a requested context the provider did not confirm", () => {
 		const chatResponse = {
 			choices: [
 				{
@@ -789,18 +932,16 @@ describe("convertChatResponseToResponses", () => {
 			usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
 		};
 
+		// No upstream effective value (e.g. a non-OpenAI model that ignored the
+		// setting): the requested value must not be echoed as if applied.
 		const result = convertChatResponseToResponses(
 			chatResponse,
-			"gpt-5.6",
+			"claude-sonnet-5",
 			undefined,
 			{ reasoning: { effort: "high", context: "current_turn" } },
 		);
 
-		expect(result.reasoning).toEqual({
-			effort: "high",
-			summary: null,
-			context: "current_turn",
-		});
+		expect(result.reasoning).toEqual({ effort: "high", summary: null });
 	});
 
 	it("preserves the assistant-message phase on message output items", () => {
@@ -1314,6 +1455,202 @@ describe("streaming conversion", () => {
 			"function_call",
 		]);
 		expect(finalOutput[0]!.phase).toBe("commentary");
+	});
+
+	it("emits separate message items for commentary and final_answer phases in streaming", () => {
+		const state = createStreamingState("gpt-5.6");
+		const events: Array<{ event: string; data: string }> = [];
+
+		events.push(
+			...processStreamChunk(
+				{ choices: [{ delta: { role: "assistant", phase: "commentary" } }] },
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: { content: "Checking the weather." } }] },
+				state,
+			),
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										id: "call_1",
+										function: { name: "get_weather", arguments: "{}" },
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{
+					choices: [{ delta: { role: "assistant", phase: "final_answer" } }],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: { content: "It is sunny." } }] },
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: {}, finish_reason: "stop" }] },
+				state,
+			),
+			...createCompletionEvents(state),
+		);
+
+		const added = events
+			.filter((e) => e.event === "response.output_item.added")
+			.map((e) => JSON.parse(e.data))
+			.map((d) => ({
+				type: d.item.type,
+				index: d.output_index,
+				phase: d.item.phase,
+			}));
+		expect(added).toEqual([
+			{ type: "message", index: 0, phase: "commentary" },
+			{ type: "function_call", index: 1, phase: undefined },
+			{ type: "message", index: 2, phase: "final_answer" },
+		]);
+
+		// Each message item closes with its own id/index/text.
+		const messageDones = events
+			.filter(
+				(e) =>
+					e.event === "response.output_item.done" &&
+					JSON.parse(e.data).item.type === "message",
+			)
+			.map((e) => JSON.parse(e.data));
+		expect(messageDones).toHaveLength(2);
+		expect(messageDones[0]!.output_index).toBe(0);
+		expect(messageDones[0]!.item.phase).toBe("commentary");
+		expect(messageDones[0]!.item.content[0].text).toBe("Checking the weather.");
+		expect(messageDones[1]!.output_index).toBe(2);
+		expect(messageDones[1]!.item.phase).toBe("final_answer");
+		expect(messageDones[1]!.item.content[0].text).toBe("It is sunny.");
+		expect(messageDones[0]!.item.id).not.toBe(messageDones[1]!.item.id);
+
+		// Final output keeps both items in stream order.
+		const finalOutput = buildFinalOutputItems(state);
+		expect(finalOutput.map((o) => ({ type: o.type, phase: o.phase }))).toEqual([
+			{ type: "message", phase: "commentary" },
+			{ type: "function_call", phase: undefined },
+			{ type: "message", phase: "final_answer" },
+		]);
+	});
+
+	it("keeps same-phase messages split by a tool call as separate streamed items", () => {
+		const state = createStreamingState("gpt-5.6");
+		const events: Array<{ event: string; data: string }> = [];
+
+		// Simulates the translator's chunks for:
+		// commentary A -> function_call 1 -> commentary B -> function_call 2
+		events.push(
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								role: "assistant",
+								message_start: true,
+								phase: "commentary",
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: { content: "Commentary A" } }] },
+				state,
+			),
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										id: "call_1",
+										function: { name: "tool_one", arguments: "{}" },
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								role: "assistant",
+								message_start: true,
+								phase: "commentary",
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: { content: "Commentary B" } }] },
+				state,
+			),
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								tool_calls: [
+									{
+										index: 1,
+										id: "call_2",
+										function: { name: "tool_two", arguments: "{}" },
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+				state,
+			),
+		);
+
+		const added = events
+			.filter((e) => e.event === "response.output_item.added")
+			.map((e) => JSON.parse(e.data))
+			.map((d) => ({ type: d.item.type, index: d.output_index }));
+		expect(added).toEqual([
+			{ type: "message", index: 0 },
+			{ type: "function_call", index: 1 },
+			{ type: "message", index: 2 },
+			{ type: "function_call", index: 3 },
+		]);
+
+		const finalOutput = buildFinalOutputItems(state);
+		expect(
+			finalOutput.map((o) =>
+				o.type === "function_call"
+					? (o.name as string)
+					: (o.content as Array<{ text: string }>)[0]!.text,
+			),
+		).toEqual(["Commentary A", "tool_one", "Commentary B", "tool_two"]);
+		expect(finalOutput[0]!.phase).toBe("commentary");
+		expect(finalOutput[2]!.phase).toBe("commentary");
 	});
 
 	it("reports the effective reasoning.context from the terminal chunk in streaming", () => {

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -381,13 +381,75 @@ describe("convertResponsesInputToMessages", () => {
 		expect(result[2]!.role).toBe("tool");
 	});
 
-	it("drops buffered reasoning when no assistant item follows it", () => {
+	it("preserves the phase of a folded trailing assistant message", () => {
+		const input = [
+			{
+				type: "function_call" as const,
+				call_id: "call_123",
+				name: "get_weather",
+				arguments: '{"location": "SF"}',
+			},
+			{
+				type: "message" as const,
+				role: "assistant" as const,
+				phase: "commentary" as const,
+				content: [{ type: "output_text" as const, text: "Checking..." }],
+			},
+			{
+				type: "function_call_output" as const,
+				call_id: "call_123",
+				output: '{"temp": 72}',
+			},
+		] as unknown[];
+		const result = convertResponsesInputToMessages(
+			input as Parameters<typeof convertResponsesInputToMessages>[0],
+		);
+		expect(result).toHaveLength(2);
+		expect(result[0]!.role).toBe("assistant");
+		expect(result[0]!.tool_calls).toHaveLength(1);
+		expect(result[0]!.content).toBe("Checking...");
+		expect(result[0]!.phase).toBe("commentary");
+		expect(result[1]!.role).toBe("tool");
+	});
+
+	it("emits an assistant carrier for encrypted reasoning followed by a user item (incomplete prior turn)", () => {
 		const input = [
 			{
 				type: "reasoning",
 				id: "rs_orphan",
 				summary: [{ type: "summary_text", text: "stale thinking" }],
 				encrypted_content: "gAAAA-stale",
+			},
+			{ role: "user" as const, content: "New question" },
+			{ role: "assistant" as const, content: "Answer" },
+		] as unknown[];
+		const result = convertResponsesInputToMessages(
+			input as Parameters<typeof convertResponsesInputToMessages>[0],
+		);
+		expect(result).toHaveLength(3);
+		expect(result[0]!.role).toBe("assistant");
+		expect(result[0]!.content).toBeNull();
+		expect(result[0]!.reasoning_details).toEqual([
+			{
+				type: "reasoning.encrypted",
+				data: "gAAAA-stale",
+				id: "rs_orphan",
+				format: "openai-responses-v1",
+				index: 0,
+			},
+		]);
+		expect(result[1]!.role).toBe("user");
+		expect(result[2]!.role).toBe("assistant");
+		expect(result[2]!.reasoning).toBeUndefined();
+		expect(result[2]!.reasoning_details).toBeUndefined();
+	});
+
+	it("drops buffered text-only reasoning when no assistant item follows it", () => {
+		const input = [
+			{
+				type: "reasoning",
+				id: "rs_orphan",
+				summary: [{ type: "summary_text", text: "stale thinking" }],
 			},
 			{ role: "user" as const, content: "New question" },
 			{ role: "assistant" as const, content: "Answer" },
@@ -568,6 +630,198 @@ describe("convertChatResponseToResponses", () => {
 		const result = convertChatResponseToResponses(chatResponse, "gpt-4o-mini");
 
 		expect(result.status).toBe("incomplete");
+	});
+
+	it("sets status to incomplete on incomplete finish_reason (Responses API upstream truncation)", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: { role: "assistant", content: null },
+					finish_reason: "incomplete",
+				},
+			],
+			usage: {
+				prompt_tokens: 10,
+				completion_tokens: 16,
+				total_tokens: 26,
+			},
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.4");
+
+		expect(result.status).toBe("incomplete");
+		expect(result.incomplete_details).toEqual({
+			reason: "max_output_tokens",
+		});
+		expect(result.completed_at).toBeNull();
+	});
+
+	it("sets status to incomplete with content_filter reason on content_filter finish_reason", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: { role: "assistant", content: "partial" },
+					finish_reason: "content_filter",
+				},
+			],
+			usage: {
+				prompt_tokens: 10,
+				completion_tokens: 5,
+				total_tokens: 15,
+			},
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-4o-mini");
+
+		expect(result.status).toBe("incomplete");
+		expect(result.incomplete_details).toEqual({ reason: "content_filter" });
+	});
+
+	it("emits pre-tool commentary before function_call items when marked", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "Let me check the weather.",
+						phase: "commentary",
+						content_before_tool_calls: true,
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "get_weather", arguments: "{}" },
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+			usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.6");
+
+		expect(result.output.map((o) => o.type)).toEqual([
+			"message",
+			"function_call",
+		]);
+		expect(result.output[0]!.phase).toBe("commentary");
+	});
+
+	it("emits the message after function_call items by default", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "Done.",
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "get_weather", arguments: "{}" },
+							},
+						],
+					},
+					finish_reason: "tool_calls",
+				},
+			],
+			usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.6");
+
+		expect(result.output.map((o) => o.type)).toEqual([
+			"function_call",
+			"message",
+		]);
+	});
+
+	it("reports the effective reasoning.context and never echoes auto", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: { role: "assistant", content: "Hi" },
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+		};
+
+		// Effective value from the provider wins over the requested one.
+		const effective = convertChatResponseToResponses(
+			{ ...chatResponse, reasoning_context: "all_turns" },
+			"gpt-5.6",
+			undefined,
+			{ reasoning: { effort: "high", context: "auto" } },
+		);
+		expect(effective.reasoning?.context).toBe("all_turns");
+
+		// Requested "auto" without an effective value is omitted.
+		const auto = convertChatResponseToResponses(
+			chatResponse,
+			"gpt-5.6",
+			undefined,
+			{ reasoning: { effort: "high", context: "auto" } },
+		);
+		expect(auto.reasoning?.context).toBeUndefined();
+	});
+
+	it("accepts reasoning.context auto in the request schema", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "gpt-5.6",
+			input: "hello",
+			reasoning: { context: "auto" },
+		});
+		expect(result.success).toBe(true);
+		expect(result.data?.reasoning?.context).toBe("auto");
+	});
+
+	it("echoes reasoning.context from the request", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: { role: "assistant", content: "Hi" },
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+		};
+
+		const result = convertChatResponseToResponses(
+			chatResponse,
+			"gpt-5.6",
+			undefined,
+			{ reasoning: { effort: "high", context: "current_turn" } },
+		);
+
+		expect(result.reasoning).toEqual({
+			effort: "high",
+			summary: null,
+			context: "current_turn",
+		});
+	});
+
+	it("preserves the assistant-message phase on message output items", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "The answer is 42",
+						phase: "final_answer",
+					},
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.6");
+
+		const messageOutput = result.output.find((o) => o.type === "message");
+		expect(messageOutput?.phase).toBe("final_answer");
 	});
 
 	it("includes reasoning output when present", () => {
@@ -948,7 +1202,7 @@ describe("streaming conversion", () => {
 		expect(JSON.parse(fcDone!.data).item.name).toBe("get_weather");
 	});
 
-	it("maps length finish_reason to incomplete status in streaming", () => {
+	it("maps length finish_reason to a response.incomplete terminal event in streaming", () => {
 		const state = createStreamingState("gpt-4o-mini");
 		processStreamChunk(
 			{ choices: [{ delta: { content: "Hello" }, finish_reason: "length" }] },
@@ -956,9 +1210,159 @@ describe("streaming conversion", () => {
 		);
 
 		const events = createCompletionEvents(state);
-		const completedEvent = events.find((e) => e.event === "response.completed");
-		const completedData = JSON.parse(completedEvent!.data);
-		expect(completedData.response.status).toBe("incomplete");
+		expect(
+			events.find((e) => e.event === "response.completed"),
+		).toBeUndefined();
+		const terminalEvent = events.find((e) => e.event === "response.incomplete");
+		expect(terminalEvent).toBeDefined();
+		const terminalData = JSON.parse(terminalEvent!.data);
+		expect(terminalData.type).toBe("response.incomplete");
+		expect(terminalData.response.status).toBe("incomplete");
+	});
+
+	it("maps incomplete finish_reason (Responses API upstream) to a response.incomplete terminal event", () => {
+		const state = createStreamingState("gpt-5.4");
+		processStreamChunk(
+			{ choices: [{ delta: {}, finish_reason: "incomplete" }] },
+			state,
+		);
+
+		const events = createCompletionEvents(state);
+		const terminalEvent = events.find((e) => e.event === "response.incomplete");
+		expect(terminalEvent).toBeDefined();
+		const terminalData = JSON.parse(terminalEvent!.data);
+		expect(terminalData.response.status).toBe("incomplete");
+		expect(terminalData.response.incomplete_details).toEqual({
+			reason: "max_output_tokens",
+		});
+	});
+
+	it("keeps stable output indices and order for pre-tool commentary followed by a tool call", () => {
+		const state = createStreamingState("gpt-5.6");
+		const addedEvents: Array<{ type: string; index: number }> = [];
+
+		const collect = (events: Array<{ event: string; data: string }>) => {
+			for (const e of events) {
+				if (e.event === "response.output_item.added") {
+					const parsed = JSON.parse(e.data);
+					addedEvents.push({
+						type: parsed.item.type,
+						index: parsed.output_index,
+					});
+				}
+			}
+		};
+
+		collect(
+			processStreamChunk(
+				{
+					choices: [{ delta: { role: "assistant", phase: "commentary" } }],
+				},
+				state,
+			),
+		);
+		collect(
+			processStreamChunk(
+				{ choices: [{ delta: { content: "Let me check." } }] },
+				state,
+			),
+		);
+		collect(
+			processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										id: "call_1",
+										function: { name: "get_weather", arguments: "{}" },
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+		);
+		processStreamChunk(
+			{ choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+			state,
+		);
+
+		// Each item claims its own index, in stream order.
+		expect(addedEvents).toEqual([
+			{ type: "message", index: 0 },
+			{ type: "function_call", index: 1 },
+		]);
+
+		const events = createCompletionEvents(state);
+		const messageDone = events.find(
+			(e) =>
+				e.event === "response.output_item.done" &&
+				JSON.parse(e.data).item.type === "message",
+		);
+		// The done event reuses the index from the added event.
+		expect(JSON.parse(messageDone!.data).output_index).toBe(0);
+
+		// Final output preserves the stream order: commentary before the call.
+		const finalOutput = buildFinalOutputItems(state);
+		expect(finalOutput.map((o) => o.type)).toEqual([
+			"message",
+			"function_call",
+		]);
+		expect(finalOutput[0]!.phase).toBe("commentary");
+	});
+
+	it("reports the effective reasoning.context from the terminal chunk in streaming", () => {
+		const state = createStreamingState("gpt-5.6", undefined, {
+			reasoning: { effort: "high", context: "auto" },
+		});
+		processStreamChunk({ choices: [{ delta: { content: "Hi" } }] }, state);
+		processStreamChunk(
+			{
+				choices: [{ delta: {}, finish_reason: "stop" }],
+				reasoning_context: "current_turn",
+			},
+			state,
+		);
+
+		const events = createCompletionEvents(state);
+		const completedData = JSON.parse(
+			events.find((e) => e.event === "response.completed")!.data,
+		);
+		expect(completedData.response.reasoning.context).toBe("current_turn");
+	});
+
+	it("echoes the assistant-message phase on streamed message items", () => {
+		const state = createStreamingState("gpt-5.6");
+		processStreamChunk(
+			{ choices: [{ delta: { role: "assistant", phase: "final_answer" } }] },
+			state,
+		);
+		processStreamChunk({ choices: [{ delta: { content: "Hello" } }] }, state);
+		processStreamChunk(
+			{ choices: [{ delta: {}, finish_reason: "stop" }] },
+			state,
+		);
+
+		const events = createCompletionEvents(state);
+		const messageDone = events.find(
+			(e) =>
+				e.event === "response.output_item.done" &&
+				JSON.parse(e.data).item.type === "message",
+		);
+		expect(messageDone).toBeDefined();
+		expect(JSON.parse(messageDone!.data).item.phase).toBe("final_answer");
+		const completedData = JSON.parse(
+			events.find((e) => e.event === "response.completed")!.data,
+		);
+		const messageOutput = completedData.response.output.find(
+			(o: { type: string }) => o.type === "message",
+		);
+		expect(messageOutput.phase).toBe("final_answer");
 	});
 
 	it("captures encrypted reasoning deltas and gates them on the include opt-in", () => {

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -633,6 +633,36 @@ describe("convertChatResponseToResponses", () => {
 		);
 	});
 
+	it("excludes foreign-format encrypted details from encrypted_content", () => {
+		const chatResponse = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						content: "The answer is 42",
+						reasoning_details: [
+							{
+								type: "reasoning.encrypted",
+								data: "foreign-blob",
+								id: "rs_foreign",
+								format: "anthropic-claude-v1",
+								index: 0,
+							},
+						],
+					},
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 10, completion_tokens: 50, total_tokens: 60 },
+		};
+
+		const result = convertChatResponseToResponses(chatResponse, "gpt-5.5");
+
+		expect(
+			result.output.some((o) => (o as any).encrypted_content !== undefined),
+		).toBe(false);
+	});
+
 	it("strips encrypted_content via stripEncryptedReasoningContent", () => {
 		const output = [
 			{
@@ -1000,6 +1030,101 @@ describe("streaming conversion", () => {
 		expect(storedReasoning!.encrypted_content).toBe("gAAAA-encrypted-blob");
 	});
 
+	it("keeps added/done lifecycles consistent per encrypted reasoning item", () => {
+		const state = createStreamingState("gpt-5.5");
+		// Summary text first: added is deferred until the upstream id arrives.
+		const summaryEvents = processStreamChunk(
+			{ choices: [{ delta: { reasoning: "thinking..." } }] },
+			state,
+		);
+		expect(
+			summaryEvents.some((e) => e.event === "response.output_item.added"),
+		).toBe(false);
+
+		// Two encrypted reasoning items arrive, each with its own upstream id.
+		const addedEvents = [
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							delta: {
+								reasoning_details: [
+									{
+										type: "reasoning.encrypted",
+										data: "blob-1",
+										id: "rs_up1",
+										format: "openai-responses-v1",
+									},
+									{
+										type: "reasoning.encrypted",
+										data: "blob-2",
+										id: "rs_up2",
+										format: "openai-responses-v1",
+									},
+									// Foreign formats must not become encrypted_content items.
+									{
+										type: "reasoning.encrypted",
+										data: "foreign-blob",
+										id: "rs_foreign",
+										format: "anthropic-claude-v1",
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{ choices: [{ delta: { content: "Hello" } }] },
+				state,
+			),
+		]
+			.filter((e) => e.event === "response.output_item.added")
+			.map((e) => JSON.parse(e.data));
+
+		const doneEvents = createCompletionEvents(state, true)
+			.filter((e) => e.event === "response.output_item.done")
+			.map((e) => JSON.parse(e.data));
+
+		const addedReasoning = addedEvents.filter(
+			(e) => e.item.type === "reasoning",
+		);
+		const doneReasoning = doneEvents.filter((e) => e.item.type === "reasoning");
+
+		// One added and one done per item, agreeing on id and output_index.
+		expect(
+			addedReasoning.map((e) => ({ id: e.item.id, index: e.output_index })),
+		).toEqual([
+			{ id: "rs_up1", index: 0 },
+			{ id: "rs_up2", index: 1 },
+		]);
+		expect(
+			doneReasoning.map((e) => ({ id: e.item.id, index: e.output_index })),
+		).toEqual([
+			{ id: "rs_up1", index: 0 },
+			{ id: "rs_up2", index: 1 },
+		]);
+		expect(doneReasoning[0]!.item.encrypted_content).toBe("blob-1");
+		expect(doneReasoning[1]!.item.encrypted_content).toBe("blob-2");
+		// Summary text rides on the first item only.
+		expect(doneReasoning[0]!.item.summary[0].text).toBe("thinking...");
+		expect(doneReasoning[1]!.item.summary).toEqual([]);
+
+		// The message item follows the reasoning items in both event streams
+		// and the terminal output array.
+		const addedMessage = addedEvents.find((e) => e.item.type === "message");
+		const doneMessage = doneEvents.find((e) => e.item.type === "message");
+		expect(addedMessage!.output_index).toBe(2);
+		expect(doneMessage!.output_index).toBe(2);
+		const stored = buildFinalOutputItems(state);
+		expect(stored.map((o) => o.type)).toEqual([
+			"reasoning",
+			"reasoning",
+			"message",
+		]);
+	});
+
 	it("starts the reasoning item from an encrypted-only delta (no summary text)", () => {
 		const state = createStreamingState("gpt-5.5");
 		const events = processStreamChunk(
@@ -1012,6 +1137,7 @@ describe("streaming conversion", () => {
 									type: "reasoning.encrypted",
 									data: "gAAAA-blob",
 									id: "rs_upstream",
+									format: "openai-responses-v1",
 								},
 							],
 						},

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -339,6 +339,9 @@ responses.post("/", async (c) => {
 	if (req.reasoning?.effort) {
 		chatRequest.reasoning_effort = req.reasoning.effort;
 	}
+	if (req.reasoning?.context) {
+		chatRequest.reasoning = { context: req.reasoning.context };
+	}
 	if (req.text?.verbosity !== undefined) {
 		chatRequest.verbosity = req.text.verbosity;
 	}
@@ -518,6 +521,9 @@ responses.post("/", async (c) => {
 								instructions: req.instructions,
 								model: req.model,
 								status: completedResponse?.status ?? "completed",
+								incomplete_details:
+									completedResponse?.incomplete_details ?? null,
+								reasoning: completedResponse?.reasoning ?? null,
 								usage: completedResponse?.usage,
 								created_at: completedResponse?.created_at,
 							},
@@ -629,6 +635,8 @@ responses.post("/", async (c) => {
 					| "completed"
 					| "incomplete"
 					| "failed",
+				incomplete_details: responsesResponse.incomplete_details,
+				reasoning: responsesResponse.reasoning,
 				usage: (responsesResponse.usage ?? undefined) as
 					| Record<string, unknown>
 					| undefined,
@@ -952,7 +960,9 @@ responses.get("/:response_id", async (c) => {
 		completed_at: status === "completed" ? createdAt : null,
 		status,
 		incomplete_details:
-			status === "incomplete" ? { reason: "max_output_tokens" } : null,
+			status === "incomplete"
+				? (stored.incomplete_details ?? { reason: "max_output_tokens" })
+				: null,
 		model: stored.model,
 		previous_response_id: null,
 		instructions: stored.instructions ?? null,
@@ -972,7 +982,7 @@ responses.get("/:response_id", async (c) => {
 		frequency_penalty: 0,
 		top_logprobs: 0,
 		temperature: 1,
-		reasoning: { effort: null, summary: null },
+		reasoning: stored.reasoning ?? { effort: null, summary: null },
 		usage,
 		max_output_tokens: null,
 		max_tool_calls: null,

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -212,6 +212,7 @@ export const responsesRequestSchema = z.object({
 				.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 				.optional(),
 			summary: z.enum(["detailed", "auto"]).optional(),
+			context: z.enum(["auto", "current_turn", "all_turns"]).optional(),
 		})
 		.nullable()
 		.optional()

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -20,12 +20,17 @@ interface ChatCompletionsResponse {
 			}>;
 			reasoning?: string | null;
 			reasoning_details?: Array<Record<string, unknown>>;
+			phase?: string | null;
+			content_before_tool_calls?: boolean;
 			refusal?: string | null;
 			annotations?: Array<Record<string, unknown>>;
 		};
 		finish_reason?: string | null;
 	}>;
 	service_tier?: string | null;
+	// Effective reasoning context the provider applied (current_turn/all_turns),
+	// surfaced by the gateway's chat layer for Responses-API upstreams.
+	reasoning_context?: string;
 	usage?: {
 		prompt_tokens?: number;
 		completion_tokens?: number;
@@ -120,7 +125,11 @@ export interface ResponsesApiResponse {
 	frequency_penalty: number;
 	top_logprobs: number;
 	temperature: number;
-	reasoning: { effort: string | null; summary: string | null } | null;
+	reasoning: {
+		effort: string | null;
+		summary: string | null;
+		context?: string;
+	} | null;
 	usage: ResponsesApiUsage | null;
 	max_output_tokens: number | null;
 	max_tool_calls: number | null;
@@ -150,7 +159,11 @@ export interface ResponsesEchoRequest {
 	frequency_penalty?: number;
 	top_logprobs?: number;
 	temperature?: number;
-	reasoning?: { effort?: string | null; summary?: string | null } | null;
+	reasoning?: {
+		effort?: string | null;
+		summary?: string | null;
+		context?: string | null;
+	} | null;
 	max_output_tokens?: number;
 	max_tool_calls?: number;
 	store?: boolean;
@@ -231,6 +244,24 @@ function resolveServedServiceTier(
 }
 
 /**
+ * Resolve the reasoning context to report on a response: the effective mode
+ * the provider applied when known, otherwise the requested value ("auto"
+ * resolves upstream to current_turn/all_turns, so it is never reported).
+ * Returns a spreadable `{ context }` fragment or undefined to omit the field.
+ */
+export function resolveReasoningContext(
+	effectiveContext: string | undefined,
+	requestedContext: string | null | undefined,
+): { context: string } | undefined {
+	const context =
+		effectiveContext ??
+		(requestedContext && requestedContext !== "auto"
+			? requestedContext
+			: undefined);
+	return context ? { context } : undefined;
+}
+
+/**
  * Normalize chat-completions-style annotations to the Responses API shape:
  * chat nests citation fields under `url_citation`, the Responses API flattens
  * them onto the annotation object.
@@ -307,6 +338,42 @@ export function convertChatResponseToResponses(
 		});
 	}
 
+	// Build message output. Skip if content is empty/whitespace-only — many
+	// providers return content: "" alongside tool_calls, and emitting an empty
+	// message item pollutes stored conversations: on replay via
+	// previous_response_id it becomes a stray assistant message that separates
+	// the tool_calls assistant from its tool result, causing strict providers
+	// (deepseek, bytedance, aws-bedrock, kimi, etc.) to reject the request.
+	let messageItem: ResponsesApiOutput | null = null;
+	if (
+		message?.content !== null &&
+		message?.content !== undefined &&
+		message.content.trim() !== ""
+	) {
+		messageItem = {
+			type: "message",
+			id: `msg_${shortid(24)}`,
+			role: "assistant",
+			content: [
+				{
+					type: "output_text",
+					text: message.content,
+					annotations: normalizeAnnotationsToResponses(message.annotations),
+				},
+			],
+			...(message.phase ? { phase: message.phase } : {}),
+			status: "completed",
+		};
+	}
+
+	// Pre-tool commentary (a message item the provider emitted before the
+	// first function_call) keeps its original position; otherwise the message
+	// follows the function calls, matching the provider's emission order.
+	if (messageItem && message?.content_before_tool_calls) {
+		output.push(messageItem);
+		messageItem = null;
+	}
+
 	// Add function calls if present
 	if (message?.tool_calls && message.tool_calls.length > 0) {
 		for (const toolCall of message.tool_calls) {
@@ -321,38 +388,24 @@ export function convertChatResponseToResponses(
 		}
 	}
 
-	// Add message output. Skip if content is empty/whitespace-only — many
-	// providers return content: "" alongside tool_calls, and emitting an empty
-	// message item pollutes stored conversations: on replay via
-	// previous_response_id it becomes a stray assistant message that separates
-	// the tool_calls assistant from its tool result, causing strict providers
-	// (deepseek, bytedance, aws-bedrock, kimi, etc.) to reject the request.
-	if (
-		message?.content !== null &&
-		message?.content !== undefined &&
-		message.content.trim() !== ""
-	) {
-		const contentParts: Array<Record<string, unknown>> = [
-			{
-				type: "output_text",
-				text: message.content,
-				annotations: normalizeAnnotationsToResponses(message.annotations),
-			},
-		];
-
-		output.push({
-			type: "message",
-			id: `msg_${shortid(24)}`,
-			role: "assistant",
-			content: contentParts,
-			status: "completed",
-		});
+	if (messageItem) {
+		output.push(messageItem);
 	}
 
-	// Map finish_reason to status
+	// Map finish_reason to status. Providers served via the OpenAI Responses
+	// API surface truncation as finish_reason "incomplete" (from the upstream
+	// response status) rather than "length".
 	let status: "completed" | "incomplete" | "failed" = "completed";
-	if (choice?.finish_reason === "length") {
+	let incompleteReason: string | null = null;
+	if (
+		choice?.finish_reason === "length" ||
+		choice?.finish_reason === "incomplete"
+	) {
 		status = "incomplete";
+		incompleteReason = "max_output_tokens";
+	} else if (choice?.finish_reason === "content_filter") {
+		status = "incomplete";
+		incompleteReason = "content_filter";
 	}
 
 	const usage: ResponsesApiUsage = {
@@ -385,7 +438,9 @@ export function convertChatResponseToResponses(
 		completed_at: status === "completed" ? created : null,
 		status,
 		incomplete_details:
-			status === "incomplete" ? { reason: "max_output_tokens" } : null,
+			status === "incomplete" && incompleteReason
+				? { reason: incompleteReason }
+				: null,
 		model: chatResponse.model ?? requestedModel,
 		previous_response_id: request?.previous_response_id ?? null,
 		instructions: request?.instructions ?? null,
@@ -406,6 +461,12 @@ export function convertChatResponseToResponses(
 		reasoning: {
 			effort: request?.reasoning?.effort ?? null,
 			summary: request?.reasoning?.summary ?? null,
+			// Report the effective mode the provider applied; fall back to the
+			// requested value ("auto" resolves upstream, so it is never echoed).
+			...(resolveReasoningContext(
+				chatResponse.reasoning_context,
+				request?.reasoning?.context,
+			) ?? {}),
 		},
 		usage,
 		max_output_tokens: request?.max_output_tokens ?? null,

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -22,6 +22,11 @@ interface ChatCompletionsResponse {
 			reasoning_details?: Array<Record<string, unknown>>;
 			phase?: string | null;
 			content_before_tool_calls?: boolean;
+			message_items?: Array<{
+				text: string;
+				phase?: string;
+				preceding_tool_calls?: number;
+			}>;
 			refusal?: string | null;
 			annotations?: Array<Record<string, unknown>>;
 		};
@@ -244,21 +249,18 @@ function resolveServedServiceTier(
 }
 
 /**
- * Resolve the reasoning context to report on a response: the effective mode
- * the provider applied when known, otherwise the requested value ("auto"
- * resolves upstream to current_turn/all_turns, so it is never reported).
+ * Resolve the reasoning context to report on a response. The field is defined
+ * as the mode the model actually used, so it is only emitted from a validated
+ * upstream effective value — never echoed from the request (a provider may
+ * ignore the setting entirely).
  * Returns a spreadable `{ context }` fragment or undefined to omit the field.
  */
 export function resolveReasoningContext(
 	effectiveContext: string | undefined,
-	requestedContext: string | null | undefined,
 ): { context: string } | undefined {
-	const context =
-		effectiveContext ??
-		(requestedContext && requestedContext !== "auto"
-			? requestedContext
-			: undefined);
-	return context ? { context } : undefined;
+	return effectiveContext === "current_turn" || effectiveContext === "all_turns"
+		? { context: effectiveContext }
+		: undefined;
 }
 
 /**
@@ -338,59 +340,96 @@ export function convertChatResponseToResponses(
 		});
 	}
 
-	// Build message output. Skip if content is empty/whitespace-only — many
-	// providers return content: "" alongside tool_calls, and emitting an empty
-	// message item pollutes stored conversations: on replay via
+	// Build message output. Providers may emit several phased assistant
+	// message items (e.g. commentary and a final_answer); each is rebuilt as
+	// its own item with its phase and exact position among the function calls
+	// (via preceding_tool_calls), reconstructing the original interleaving —
+	// including a commentary between two calls. Otherwise a single message
+	// item is built from `content` — skipped if empty/whitespace-only, since
+	// many providers return content: "" alongside tool_calls, and emitting an
+	// empty message item pollutes stored conversations: on replay via
 	// previous_response_id it becomes a stray assistant message that separates
 	// the tool_calls assistant from its tool result, causing strict providers
 	// (deepseek, bytedance, aws-bedrock, kimi, etc.) to reject the request.
-	let messageItem: ResponsesApiOutput | null = null;
-	if (
+	const toolCalls = message?.tool_calls ?? [];
+	const messageItems: Array<{
+		precedingToolCalls: number;
+		text: string;
+		phase?: string;
+	}> = [];
+	if (message?.message_items && message.message_items.length > 0) {
+		for (const item of message.message_items) {
+			messageItems.push({
+				precedingToolCalls: item.preceding_tool_calls ?? toolCalls.length,
+				text: item.text,
+				...(item.phase ? { phase: item.phase } : {}),
+			});
+		}
+	} else if (
 		message?.content !== null &&
 		message?.content !== undefined &&
 		message.content.trim() !== ""
 	) {
-		messageItem = {
-			type: "message",
-			id: `msg_${shortid(24)}`,
-			role: "assistant",
-			content: [
-				{
-					type: "output_text",
-					text: message.content,
-					annotations: normalizeAnnotationsToResponses(message.annotations),
-				},
-			],
+		messageItems.push({
+			precedingToolCalls: message.content_before_tool_calls
+				? 0
+				: toolCalls.length,
+			text: message.content,
 			...(message.phase ? { phase: message.phase } : {}),
-			status: "completed",
-		};
+		});
 	}
 
-	// Pre-tool commentary (a message item the provider emitted before the
-	// first function_call) keeps its original position; otherwise the message
-	// follows the function calls, matching the provider's emission order.
-	if (messageItem && message?.content_before_tool_calls) {
-		output.push(messageItem);
-		messageItem = null;
-	}
+	const buildMessageItem = (
+		item: { text: string; phase?: string },
+		isLast: boolean,
+	): ResponsesApiOutput => ({
+		type: "message",
+		id: `msg_${shortid(24)}`,
+		role: "assistant",
+		content: [
+			{
+				type: "output_text",
+				text: item.text,
+				// Annotations aren't attributable to a specific item on the chat
+				// surface; keep them on the last (final) message.
+				annotations: isLast
+					? normalizeAnnotationsToResponses(message?.annotations)
+					: [],
+			},
+		],
+		...(item.phase ? { phase: item.phase } : {}),
+		status: "completed",
+	});
 
-	// Add function calls if present
-	if (message?.tool_calls && message.tool_calls.length > 0) {
-		for (const toolCall of message.tool_calls) {
-			output.push({
-				type: "function_call",
-				id: `fc_${shortid(24)}`,
-				call_id: toolCall.id,
-				name: toolCall.function.name,
-				arguments: toolCall.function.arguments,
-				status: "completed",
-			});
+	// Interleave messages and function calls back into their original order.
+	let nextMessage = 0;
+	const emitMessagesUpTo = (callsEmitted: number) => {
+		while (
+			nextMessage < messageItems.length &&
+			messageItems[nextMessage]!.precedingToolCalls <= callsEmitted
+		) {
+			output.push(
+				buildMessageItem(
+					messageItems[nextMessage]!,
+					nextMessage === messageItems.length - 1,
+				),
+			);
+			nextMessage++;
 		}
-	}
+	};
 
-	if (messageItem) {
-		output.push(messageItem);
-	}
+	toolCalls.forEach((toolCall, callIndex) => {
+		emitMessagesUpTo(callIndex);
+		output.push({
+			type: "function_call",
+			id: `fc_${shortid(24)}`,
+			call_id: toolCall.id,
+			name: toolCall.function.name,
+			arguments: toolCall.function.arguments,
+			status: "completed",
+		});
+	});
+	emitMessagesUpTo(Number.MAX_SAFE_INTEGER);
 
 	// Map finish_reason to status. Providers served via the OpenAI Responses
 	// API surface truncation as finish_reason "incomplete" (from the upstream
@@ -461,12 +500,9 @@ export function convertChatResponseToResponses(
 		reasoning: {
 			effort: request?.reasoning?.effort ?? null,
 			summary: request?.reasoning?.summary ?? null,
-			// Report the effective mode the provider applied; fall back to the
-			// requested value ("auto" resolves upstream, so it is never echoed).
-			...(resolveReasoningContext(
-				chatResponse.reasoning_context,
-				request?.reasoning?.context,
-			) ?? {}),
+			// Only the validated effective mode the provider applied is reported;
+			// the requested value is never echoed.
+			...(resolveReasoningContext(chatResponse.reasoning_context) ?? {}),
 		},
 		usage,
 		max_output_tokens: request?.max_output_tokens ?? null,

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -274,11 +274,15 @@ export function convertChatResponseToResponses(
 	// attached as `encrypted_content` so the reasoning can be replayed on later
 	// turns; the caller strips them from the wire response unless the request
 	// asked for them via include:["reasoning.encrypted_content"].
+	// Only OpenAI-Responses-shaped payloads qualify: `encrypted_content` items
+	// are replayed upstream as OpenAI encrypted reasoning, so a foreign format
+	// (e.g. "anthropic-claude-v1") must not be relabeled by ending up here.
 	const encryptedDetails = (message?.reasoning_details ?? []).filter(
 		(detail) =>
 			detail.type === "reasoning.encrypted" &&
 			typeof detail.data === "string" &&
-			(detail.data as string).length > 0,
+			(detail.data as string).length > 0 &&
+			detail.format === "openai-responses-v1",
 	);
 	if (encryptedDetails.length > 0) {
 		encryptedDetails.forEach((detail, index) => {

--- a/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
+++ b/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
@@ -15,6 +15,7 @@ interface ChatMessage {
 	tool_call_id?: string;
 	reasoning?: string;
 	reasoning_details?: Array<Record<string, unknown>>;
+	phase?: "commentary" | "final_answer";
 }
 
 interface PendingReasoning {
@@ -138,6 +139,7 @@ export function convertResponsesInputToMessages(
 			// Fold trailing assistant message content (if any) into this same
 			// assistant message rather than emitting it as a separate message.
 			let foldedContent: string | null = null;
+			let foldedPhase: ChatMessage["phase"];
 			while (i < input.length) {
 				const next = input[i] as Record<string, unknown> | undefined;
 				if (
@@ -149,6 +151,9 @@ export function convertResponsesInputToMessages(
 					if (text) {
 						foldedContent = (foldedContent ?? "") + text;
 					}
+					if (next.phase === "commentary" || next.phase === "final_answer") {
+						foldedPhase = next.phase;
+					}
 					i++;
 					continue;
 				}
@@ -159,6 +164,7 @@ export function convertResponsesInputToMessages(
 				role: "assistant",
 				content: foldedContent,
 				tool_calls: toolCalls,
+				...(foldedPhase ? { phase: foldedPhase } : {}),
 				...takePendingReasoning(pendingReasoning),
 			});
 			continue;
@@ -190,6 +196,7 @@ export function convertResponsesInputToMessages(
 		// Regular message items
 		const msg = item as {
 			role: string;
+			phase?: "commentary" | "final_answer";
 			content?: string | Array<Record<string, unknown>> | null;
 			name?: string;
 			tool_calls?: Array<{
@@ -207,16 +214,27 @@ export function convertResponsesInputToMessages(
 				: (msg.role as ChatMessage["role"]);
 
 		// Reasoning belongs to the assistant items directly following it. A
-		// non-assistant message means the buffered reasoning has no owner —
-		// drop it rather than mis-attach it to a later turn.
+		// non-assistant message means the prior turn ended with reasoning only
+		// (e.g. it hit max_output_tokens before emitting a message). Emit an
+		// assistant carrier message so encrypted payloads are still replayed
+		// upstream; reasoning text alone has no replayable value and is dropped.
 		if (role !== "assistant") {
-			takePendingReasoning(pendingReasoning);
+			if (pendingReasoning.details.length > 0) {
+				messages.push({
+					role: "assistant",
+					content: null,
+					...takePendingReasoning(pendingReasoning),
+				});
+			} else {
+				takePendingReasoning(pendingReasoning);
+			}
 		}
 
 		const chatMsg: ChatMessage = {
 			role,
 			content: convertContent(msg.content),
 			...(role === "assistant" ? takePendingReasoning(pendingReasoning) : {}),
+			...(role === "assistant" && msg.phase ? { phase: msg.phase } : {}),
 		};
 
 		if (msg.name) {

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -3,6 +3,7 @@ import { shortid } from "@llmgateway/db";
 import {
 	normalizeAnnotationsToResponses,
 	normalizeEchoedTools,
+	resolveReasoningContext,
 	stripEncryptedReasoningContent,
 } from "./convert-chat-to-responses.js";
 
@@ -15,6 +16,11 @@ interface StreamingState {
 	outputItemIndex: number;
 	contentPartStarted: boolean;
 	outputItemStarted: boolean;
+	// Output index reserved by the message item when it is announced. Reserving
+	// (rather than reading outputItemIndex at event time) keeps the index stable
+	// when later items (e.g. tool calls after pre-tool commentary) claim the
+	// next indices.
+	messageOutputIndex?: number;
 	messageId: string;
 	reasoningId: string;
 	fullContent: string[];
@@ -30,6 +36,9 @@ interface StreamingState {
 	}>;
 	annotations: Record<string, unknown>[];
 	reasoningStarted: boolean;
+	// OpenAI Responses assistant-message phase (e.g. "final_answer"), surfaced
+	// by the streaming translator as a delta field and echoed on message items.
+	messagePhase?: string;
 	finishReason: string | null;
 	sequenceNumber: number;
 	toolCalls: Map<
@@ -44,6 +53,9 @@ interface StreamingState {
 	>;
 	request?: ResponsesEchoRequest;
 	servedServiceTier?: string;
+	// Effective reasoning context the provider applied, surfaced by the
+	// streaming translator on the terminal chunk.
+	usedReasoningContext?: string;
 	usage: {
 		input_tokens: number;
 		output_tokens: number;
@@ -137,7 +149,14 @@ function buildResponsePayload(
 		completed_at: status === "completed" ? state.createdAt : null,
 		status,
 		incomplete_details:
-			status === "incomplete" ? { reason: "max_output_tokens" } : null,
+			status === "incomplete"
+				? {
+						reason:
+							state.finishReason === "content_filter"
+								? "content_filter"
+								: "max_output_tokens",
+					}
+				: null,
 		model: state.model,
 		previous_response_id: req?.previous_response_id ?? null,
 		instructions: req?.instructions ?? null,
@@ -156,6 +175,10 @@ function buildResponsePayload(
 		reasoning: {
 			effort: req?.reasoning?.effort ?? null,
 			summary: req?.reasoning?.summary ?? null,
+			...(resolveReasoningContext(
+				state.usedReasoningContext,
+				req?.reasoning?.context,
+			) ?? {}),
 		},
 		usage,
 		max_output_tokens: req?.max_output_tokens ?? null,
@@ -213,6 +236,12 @@ export function processStreamChunk(
 	// rather than the requested one. OpenAI chunks carry a top-level
 	// service_tier; other providers surface it via the gateway's final usage
 	// chunk metadata (used_service_tier null there means downgraded to standard).
+	// Capture the effective reasoning context the provider applied (surfaced by
+	// the streaming translator on the terminal chunk).
+	if (typeof chunk.reasoning_context === "string") {
+		state.usedReasoningContext = chunk.reasoning_context;
+	}
+
 	if (typeof chunk.service_tier === "string") {
 		state.servedServiceTier = chunk.service_tier;
 	} else {
@@ -231,6 +260,7 @@ export function processStreamChunk(
 					content?: string | null;
 					reasoning?: string | null;
 					reasoning_details?: Array<Record<string, unknown>>;
+					phase?: string;
 					annotations?: Array<Record<string, unknown>>;
 					tool_calls?: Array<{
 						index: number;
@@ -287,6 +317,12 @@ export function processStreamChunk(
 			}
 		}
 		return events;
+	}
+
+	// Capture the assistant-message phase (surfaced by the streaming translator
+	// from the upstream message output item) so message items can echo it.
+	if (typeof delta.phase === "string" && delta.phase) {
+		state.messagePhase = delta.phase;
 	}
 
 	// Handle reasoning delta. The output_item.added event is deferred until the
@@ -399,15 +435,19 @@ export function processStreamChunk(
 			// If reasoning was streamed, announce and close its item first
 			flushPendingReasoningItem(state, events);
 
+			// Reserve this item's output index so later items (e.g. tool calls
+			// following pre-tool commentary) don't claim the same index.
+			state.messageOutputIndex = state.outputItemIndex++;
 			events.push(
 				emitEvent(state, "response.output_item.added", {
 					type: "response.output_item.added",
-					output_index: state.outputItemIndex,
+					output_index: state.messageOutputIndex,
 					item: {
 						type: "message",
 						id: state.messageId,
 						role: "assistant",
 						content: [],
+						...(state.messagePhase ? { phase: state.messagePhase } : {}),
 						status: "in_progress",
 					},
 				}),
@@ -420,7 +460,7 @@ export function processStreamChunk(
 				emitEvent(state, "response.content_part.added", {
 					type: "response.content_part.added",
 					item_id: state.messageId,
-					output_index: state.outputItemIndex,
+					output_index: state.messageOutputIndex,
 					content_index: 0,
 					part: { type: "output_text", text: "", annotations: [] },
 				}),
@@ -432,7 +472,7 @@ export function processStreamChunk(
 			emitEvent(state, "response.output_text.delta", {
 				type: "response.output_text.delta",
 				item_id: state.messageId,
-				output_index: state.outputItemIndex,
+				output_index: state.messageOutputIndex,
 				content_index: 0,
 				delta: delta.content,
 			}),
@@ -451,7 +491,7 @@ export function processStreamChunk(
 					emitEvent(state, "response.output_text.annotation.added", {
 						type: "response.output_text.annotation.added",
 						item_id: state.messageId,
-						output_index: state.outputItemIndex,
+						output_index: state.messageOutputIndex,
 						content_index: 0,
 						annotation_index: annotationIndex,
 						annotation,
@@ -570,38 +610,53 @@ function buildReasoningOutputItems(
 export function buildFinalOutputItems(
 	state: StreamingState,
 ): Record<string, unknown>[] {
-	const output: Record<string, unknown>[] = [
-		...buildReasoningOutputItems(state),
-	];
+	// Order items by the output index each claimed when it was announced, so
+	// the final array preserves the stream order (e.g. pre-tool commentary
+	// messages stay before the function calls that followed them).
+	const indexed: Array<{ index: number; item: Record<string, unknown> }> = [];
+
+	buildReasoningOutputItems(state).forEach((item, i) => {
+		indexed.push({
+			index: state.reasoningItems[i]?.outputIndex ?? i,
+			item,
+		});
+	});
 
 	for (const tc of state.toolCalls.values()) {
-		output.push({
-			type: "function_call",
-			id: tc.id,
-			call_id: tc.callId,
-			name: tc.name,
-			arguments: tc.arguments,
-			status: "completed",
+		indexed.push({
+			index: tc.outputIndex,
+			item: {
+				type: "function_call",
+				id: tc.id,
+				call_id: tc.callId,
+				name: tc.name,
+				arguments: tc.arguments,
+				status: "completed",
+			},
 		});
 	}
 
 	if (state.fullContent.length > 0) {
-		output.push({
-			type: "message",
-			id: state.messageId,
-			role: "assistant",
-			content: [
-				{
-					type: "output_text",
-					text: state.fullContent.join(""),
-					annotations: state.annotations,
-				},
-			],
-			status: "completed",
+		indexed.push({
+			index: state.messageOutputIndex ?? Number.MAX_SAFE_INTEGER,
+			item: {
+				type: "message",
+				id: state.messageId,
+				role: "assistant",
+				content: [
+					{
+						type: "output_text",
+						text: state.fullContent.join(""),
+						annotations: state.annotations,
+					},
+				],
+				...(state.messagePhase ? { phase: state.messagePhase } : {}),
+				status: "completed",
+			},
 		});
 	}
 
-	return output;
+	return indexed.sort((a, b) => a.index - b.index).map((entry) => entry.item);
 }
 
 /**
@@ -640,7 +695,7 @@ export function createCompletionEvents(
 			emitEvent(state, "response.output_text.done", {
 				type: "response.output_text.done",
 				item_id: state.messageId,
-				output_index: state.outputItemIndex,
+				output_index: state.messageOutputIndex,
 				content_index: 0,
 				text: state.fullContent.join(""),
 			}),
@@ -649,7 +704,7 @@ export function createCompletionEvents(
 			emitEvent(state, "response.content_part.done", {
 				type: "response.content_part.done",
 				item_id: state.messageId,
-				output_index: state.outputItemIndex,
+				output_index: state.messageOutputIndex,
 				content_index: 0,
 				part: {
 					type: "output_text",
@@ -665,7 +720,7 @@ export function createCompletionEvents(
 		events.push(
 			emitEvent(state, "response.output_item.done", {
 				type: "response.output_item.done",
-				output_index: state.outputItemIndex,
+				output_index: state.messageOutputIndex,
 				item: {
 					type: "message",
 					id: state.messageId,
@@ -677,6 +732,7 @@ export function createCompletionEvents(
 							annotations: state.annotations,
 						},
 					],
+					...(state.messagePhase ? { phase: state.messagePhase } : {}),
 					status: "completed",
 				},
 			}),
@@ -701,9 +757,15 @@ export function createCompletionEvents(
 		);
 	}
 
-	// Map finish_reason to status
+	// Map finish_reason to status. Providers served via the OpenAI Responses
+	// API surface truncation as finish_reason "incomplete" (from the upstream
+	// response status) rather than "length".
 	let status: "completed" | "incomplete" | "failed" = "completed";
-	if (state.finishReason === "length") {
+	if (
+		state.finishReason === "length" ||
+		state.finishReason === "incomplete" ||
+		state.finishReason === "content_filter"
+	) {
 		status = "incomplete";
 	}
 
@@ -713,9 +775,13 @@ export function createCompletionEvents(
 		? fullOutput
 		: stripEncryptedReasoningContent(fullOutput);
 
+	// A truncated response must terminate with response.incomplete, not
+	// response.completed (the payload status alone is not enough per the spec).
+	const terminalEvent =
+		status === "incomplete" ? "response.incomplete" : "response.completed";
 	events.push(
-		emitEvent(state, "response.completed", {
-			type: "response.completed",
+		emitEvent(state, terminalEvent, {
+			type: terminalEvent,
 			response: buildResponsePayload(state, { status, output }),
 		}),
 	);

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -19,7 +19,15 @@ interface StreamingState {
 	reasoningId: string;
 	fullContent: string[];
 	fullReasoning: string[];
-	encryptedReasoning: Array<{ data: string; id?: string }>;
+	// Reasoning output items announced via response.output_item.added. Each
+	// entry's id/outputIndex are reused verbatim by the matching
+	// response.output_item.done event and the final output array, so the
+	// streaming lifecycle stays consistent per item.
+	reasoningItems: Array<{
+		id: string;
+		outputIndex: number;
+		encryptedData?: string;
+	}>;
 	annotations: Record<string, unknown>[];
 	reasoningStarted: boolean;
 	finishReason: string | null;
@@ -78,7 +86,7 @@ export function createStreamingState(
 		reasoningId: `rs_${shortid(24)}`,
 		fullContent: [],
 		fullReasoning: [],
-		encryptedReasoning: [],
+		reasoningItems: [],
 		annotations: [],
 		reasoningStarted: false,
 		finishReason: null,
@@ -281,67 +289,64 @@ export function processStreamChunk(
 		return events;
 	}
 
-	// Handle reasoning delta
+	// Handle reasoning delta. The output_item.added event is deferred until the
+	// item's real id is known (it arrives with the encrypted payload) or until
+	// the next output item starts — see flushPendingReasoningItem. Emitting it
+	// eagerly with a generated id would make the later done event (which must
+	// carry the upstream id for stateless replay) disagree with it.
 	if (delta.reasoning) {
-		if (!state.reasoningStarted) {
-			state.reasoningStarted = true;
-			events.push(
-				emitEvent(state, "response.output_item.added", {
-					type: "response.output_item.added",
-					output_index: state.outputItemIndex,
-					item: {
-						type: "reasoning",
-						id: state.reasoningId,
-						summary: [],
-					},
-				}),
-			);
-		}
+		state.reasoningStarted = true;
 		state.fullReasoning.push(delta.reasoning);
 	}
 
 	// Capture encrypted reasoning payloads ("reasoning.encrypted" entries) so
-	// the completed reasoning output item can carry encrypted_content for
+	// the completed reasoning output items can carry encrypted_content for
 	// stateless replay. They arrive as a single delta when the provider's
 	// reasoning item completes, possibly before any summary text was streamed.
+	// Each payload is its own output item with its own id and output_index.
+	// Foreign formats are dropped: encrypted_content is replayed upstream as
+	// OpenAI encrypted reasoning, so only openai-responses-v1 payloads qualify.
 	if (delta.reasoning_details?.length) {
 		for (const detail of delta.reasoning_details) {
 			if (
 				detail.type === "reasoning.encrypted" &&
 				typeof detail.data === "string" &&
-				detail.data.length > 0
+				detail.data.length > 0 &&
+				detail.format === "openai-responses-v1"
 			) {
-				if (!state.reasoningStarted) {
-					state.reasoningStarted = true;
-					if (typeof detail.id === "string" && detail.id) {
-						state.reasoningId = detail.id;
-					}
-					events.push(
-						emitEvent(state, "response.output_item.added", {
-							type: "response.output_item.added",
-							output_index: state.outputItemIndex,
-							item: {
-								type: "reasoning",
-								id: state.reasoningId,
-								summary: [],
-							},
-						}),
-					);
-				}
-				state.encryptedReasoning.push({
-					data: detail.data,
-					...(typeof detail.id === "string" && detail.id && { id: detail.id }),
+				state.reasoningStarted = true;
+				const id =
+					typeof detail.id === "string" && detail.id
+						? detail.id
+						: state.reasoningItems.length === 0
+							? state.reasoningId
+							: `rs_${shortid(24)}`;
+				const outputIndex = state.outputItemIndex++;
+				state.reasoningItems.push({
+					id,
+					outputIndex,
+					encryptedData: detail.data,
 				});
+				events.push(
+					emitEvent(state, "response.output_item.added", {
+						type: "response.output_item.added",
+						output_index: outputIndex,
+						item: {
+							type: "reasoning",
+							id,
+							summary: [],
+						},
+					}),
+				);
 			}
 		}
 	}
 
 	// Handle tool_calls delta
 	if (delta.tool_calls) {
-		// If reasoning was streamed but tool calls arrive (no content), close reasoning index
-		if (state.reasoningStarted && !state.outputItemStarted) {
-			state.outputItemIndex++;
-		}
+		// If reasoning was streamed without an encrypted payload, announce and
+		// close its item before tool-call items claim the next output indexes.
+		flushPendingReasoningItem(state, events);
 
 		for (const tc of delta.tool_calls) {
 			const existing = state.toolCalls.get(tc.index);
@@ -391,10 +396,8 @@ export function processStreamChunk(
 	if (delta.content) {
 		if (!state.outputItemStarted) {
 			state.outputItemStarted = true;
-			// If reasoning was streamed, close it first
-			if (state.reasoningStarted) {
-				state.outputItemIndex++;
-			}
+			// If reasoning was streamed, announce and close its item first
+			flushPendingReasoningItem(state, events);
 
 			events.push(
 				emitEvent(state, "response.output_item.added", {
@@ -496,11 +499,40 @@ export function processStreamChunk(
 }
 
 /**
- * Build the reasoning output items for the final output array. Each captured
- * encrypted reasoning payload becomes its own reasoning item (mirroring the
- * provider's items, with their original ids when known); the aggregated
- * summary text rides on the first item. Without encrypted payloads a single
- * summary-only item is produced.
+ * Announce the summary-only reasoning item when reasoning text was streamed
+ * but no encrypted payload (which would have carried the item's real id and
+ * claimed an output index) ever arrived. Called before the next output item
+ * starts and again at completion, so every reasoning item gets exactly one
+ * response.output_item.added with the same id/output_index its done event and
+ * the final output array will use. No-op once any reasoning item exists.
+ */
+function flushPendingReasoningItem(
+	state: StreamingState,
+	events: SSEEvent[],
+): void {
+	if (!state.reasoningStarted || state.reasoningItems.length > 0) {
+		return;
+	}
+	const outputIndex = state.outputItemIndex++;
+	state.reasoningItems.push({ id: state.reasoningId, outputIndex });
+	events.push(
+		emitEvent(state, "response.output_item.added", {
+			type: "response.output_item.added",
+			output_index: outputIndex,
+			item: {
+				type: "reasoning",
+				id: state.reasoningId,
+				summary: [],
+			},
+		}),
+	);
+}
+
+/**
+ * Build the reasoning output items for the final output array, mirroring
+ * state.reasoningItems (one item per captured encrypted payload, with their
+ * original ids when known); the aggregated summary text rides on the first
+ * item. Without encrypted payloads a single summary-only item is produced.
  */
 function buildReasoningOutputItems(
 	state: StreamingState,
@@ -514,14 +546,18 @@ function buildReasoningOutputItems(
 			text: state.fullReasoning.join(""),
 		},
 	];
-	if (state.encryptedReasoning.length === 0) {
+	if (state.reasoningItems.length === 0) {
+		// Pending summary-only item not yet flushed; mirror what
+		// flushPendingReasoningItem will announce.
 		return [{ type: "reasoning", id: state.reasoningId, summary }];
 	}
-	return state.encryptedReasoning.map((entry, index) => ({
+	return state.reasoningItems.map((entry, index) => ({
 		type: "reasoning",
-		id: entry.id ?? (index === 0 ? state.reasoningId : `rs_${shortid(24)}`),
+		id: entry.id,
 		summary: index === 0 ? summary : [],
-		encrypted_content: entry.data,
+		...(entry.encryptedData !== undefined && {
+			encrypted_content: entry.encryptedData,
+		}),
 	}));
 }
 
@@ -577,20 +613,26 @@ export function createCompletionEvents(
 ): SSEEvent[] {
 	const events: SSEEvent[] = [];
 
-	// Close the reasoning item(s) if started. Encrypted payloads are only put
-	// on the wire when the request asked for them.
+	// A reasoning-only stream (summary text, no encrypted payload, no
+	// content/tool items) never triggered a flush; announce the item now so
+	// its done event below has a matching added.
+	flushPendingReasoningItem(state, events);
+
+	// Close the reasoning item(s) if started, reusing each item's own
+	// output_index from its added event. Encrypted payloads are only put on
+	// the wire when the request asked for them.
 	const reasoningItems = includeEncryptedReasoning
 		? buildReasoningOutputItems(state)
 		: stripEncryptedReasoningContent(buildReasoningOutputItems(state));
-	for (const item of reasoningItems) {
+	reasoningItems.forEach((item, index) => {
 		events.push(
 			emitEvent(state, "response.output_item.done", {
 				type: "response.output_item.done",
-				output_index: 0,
+				output_index: state.reasoningItems[index]?.outputIndex ?? index,
 				item,
 			}),
 		);
-	}
+	});
 
 	// Close content part if started
 	if (state.contentPartStarted) {

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -9,21 +9,36 @@ import {
 
 import type { ResponsesEchoRequest } from "./convert-chat-to-responses.js";
 
+// One assistant message output item in the stream. Providers may emit several
+// per turn (e.g. a commentary message before tool calls and a final_answer
+// message after); each keeps its own id, phase, text, and the output index it
+// reserved when announced, so indices stay stable and no item is collapsed.
+interface MessageItemState {
+	id: string;
+	outputIndex: number;
+	phase?: string;
+	parts: string[];
+	contentPartStarted: boolean;
+	annotations: Record<string, unknown>[];
+}
+
 interface StreamingState {
 	responseId: string;
 	model: string;
 	createdAt: number;
 	outputItemIndex: number;
-	contentPartStarted: boolean;
-	outputItemStarted: boolean;
-	// Output index reserved by the message item when it is announced. Reserving
-	// (rather than reading outputItemIndex at event time) keeps the index stable
-	// when later items (e.g. tool calls after pre-tool commentary) claim the
-	// next indices.
-	messageOutputIndex?: number;
+	// Assistant message items in stream order; the last entry is the one
+	// currently receiving content deltas.
+	messageItems: MessageItemState[];
+	// Set when a new message item was announced (via the translator's
+	// message_start boundary marker or a phase change) but has not started
+	// streaming content yet; the item is created on its first content delta.
+	pendingNewMessage?: boolean;
+	// Phase announced (via a delta) for a message item that has not started
+	// streaming content yet.
+	pendingMessagePhase?: string;
 	messageId: string;
 	reasoningId: string;
-	fullContent: string[];
 	fullReasoning: string[];
 	// Reasoning output items announced via response.output_item.added. Each
 	// entry's id/outputIndex are reused verbatim by the matching
@@ -34,11 +49,7 @@ interface StreamingState {
 		outputIndex: number;
 		encryptedData?: string;
 	}>;
-	annotations: Record<string, unknown>[];
 	reasoningStarted: boolean;
-	// OpenAI Responses assistant-message phase (e.g. "final_answer"), surfaced
-	// by the streaming translator as a delta field and echoed on message items.
-	messagePhase?: string;
 	finishReason: string | null;
 	sequenceNumber: number;
 	toolCalls: Map<
@@ -92,14 +103,11 @@ export function createStreamingState(
 		model,
 		createdAt: Math.floor(Date.now() / 1000),
 		outputItemIndex: 0,
-		contentPartStarted: false,
-		outputItemStarted: false,
+		messageItems: [],
 		messageId: `msg_${shortid(24)}`,
 		reasoningId: `rs_${shortid(24)}`,
-		fullContent: [],
 		fullReasoning: [],
 		reasoningItems: [],
-		annotations: [],
 		reasoningStarted: false,
 		finishReason: null,
 		sequenceNumber: 0,
@@ -175,10 +183,7 @@ function buildResponsePayload(
 		reasoning: {
 			effort: req?.reasoning?.effort ?? null,
 			summary: req?.reasoning?.summary ?? null,
-			...(resolveReasoningContext(
-				state.usedReasoningContext,
-				req?.reasoning?.context,
-			) ?? {}),
+			...(resolveReasoningContext(state.usedReasoningContext) ?? {}),
 		},
 		usage,
 		max_output_tokens: req?.max_output_tokens ?? null,
@@ -261,6 +266,7 @@ export function processStreamChunk(
 					reasoning?: string | null;
 					reasoning_details?: Array<Record<string, unknown>>;
 					phase?: string;
+					message_start?: boolean;
 					annotations?: Array<Record<string, unknown>>;
 					tool_calls?: Array<{
 						index: number;
@@ -319,10 +325,34 @@ export function processStreamChunk(
 		return events;
 	}
 
+	// The translator marks the start of each upstream message output item with
+	// a message_start boundary. A boundary after content has streamed means a
+	// NEW message item begins (created lazily on its first content delta) —
+	// this preserves exact item boundaries even when consecutive messages
+	// share the same phase (e.g. two commentary items split by a tool call).
+	if (delta.message_start === true) {
+		const current = state.messageItems[state.messageItems.length - 1];
+		if (current && current.parts.length > 0) {
+			state.pendingNewMessage = true;
+			state.pendingMessagePhase = undefined;
+		}
+	}
+
 	// Capture the assistant-message phase (surfaced by the streaming translator
-	// from the upstream message output item) so message items can echo it.
+	// from each upstream message output item). As a fallback for streams
+	// without boundary markers, a phase that differs from the current message
+	// item's phase after content has streamed also starts a new item.
 	if (typeof delta.phase === "string" && delta.phase) {
-		state.messagePhase = delta.phase;
+		const current = state.messageItems[state.messageItems.length - 1];
+		if (!current || state.pendingNewMessage) {
+			state.pendingMessagePhase = delta.phase;
+		} else if (current.phase === undefined) {
+			// Late phase for the item already streaming (or announced).
+			current.phase = delta.phase;
+		} else if (current.phase !== delta.phase) {
+			state.pendingNewMessage = true;
+			state.pendingMessagePhase = delta.phase;
+		}
 	}
 
 	// Handle reasoning delta. The output_item.added event is deferred until the
@@ -430,73 +460,96 @@ export function processStreamChunk(
 
 	// Handle content delta
 	if (delta.content) {
-		if (!state.outputItemStarted) {
-			state.outputItemStarted = true;
+		let current = state.messageItems[state.messageItems.length - 1];
+		// Start a new message item on first content, or when a boundary marker
+		// (or differing phase) announced that a new message item begins.
+		if (!current || state.pendingNewMessage) {
 			// If reasoning was streamed, announce and close its item first
 			flushPendingReasoningItem(state, events);
 
-			// Reserve this item's output index so later items (e.g. tool calls
-			// following pre-tool commentary) don't claim the same index.
-			state.messageOutputIndex = state.outputItemIndex++;
+			current = {
+				// Keep the pre-generated id for the first message item so it is
+				// stable from response.created onward.
+				id:
+					state.messageItems.length === 0
+						? state.messageId
+						: `msg_${shortid(24)}`,
+				// Reserve this item's output index so later items (e.g. tool calls
+				// following pre-tool commentary) don't claim the same index.
+				outputIndex: state.outputItemIndex++,
+				...(state.pendingMessagePhase
+					? { phase: state.pendingMessagePhase }
+					: {}),
+				parts: [],
+				contentPartStarted: false,
+				annotations: [],
+			};
+			state.messageItems.push(current);
+			state.pendingNewMessage = false;
+			state.pendingMessagePhase = undefined;
 			events.push(
 				emitEvent(state, "response.output_item.added", {
 					type: "response.output_item.added",
-					output_index: state.messageOutputIndex,
+					output_index: current.outputIndex,
 					item: {
 						type: "message",
-						id: state.messageId,
+						id: current.id,
 						role: "assistant",
 						content: [],
-						...(state.messagePhase ? { phase: state.messagePhase } : {}),
+						...(current.phase ? { phase: current.phase } : {}),
 						status: "in_progress",
 					},
 				}),
 			);
 		}
 
-		if (!state.contentPartStarted) {
-			state.contentPartStarted = true;
+		if (!current.contentPartStarted) {
+			current.contentPartStarted = true;
 			events.push(
 				emitEvent(state, "response.content_part.added", {
 					type: "response.content_part.added",
-					item_id: state.messageId,
-					output_index: state.messageOutputIndex,
+					item_id: current.id,
+					output_index: current.outputIndex,
 					content_index: 0,
 					part: { type: "output_text", text: "", annotations: [] },
 				}),
 			);
 		}
 
-		state.fullContent.push(delta.content);
+		current.parts.push(delta.content);
 		events.push(
 			emitEvent(state, "response.output_text.delta", {
 				type: "response.output_text.delta",
-				item_id: state.messageId,
-				output_index: state.messageOutputIndex,
+				item_id: current.id,
+				output_index: current.outputIndex,
 				content_index: 0,
 				delta: delta.content,
 			}),
 		);
 	}
 
-	// Handle annotations delta (url citations from native web search)
+	// Handle annotations delta (url citations from native web search); they
+	// attach to the message item currently receiving content.
 	if (delta.annotations?.length) {
-		for (const annotation of normalizeAnnotationsToResponses(
-			delta.annotations,
-		)) {
-			const annotationIndex = state.annotations.length;
-			state.annotations.push(annotation);
-			if (state.contentPartStarted) {
-				events.push(
-					emitEvent(state, "response.output_text.annotation.added", {
-						type: "response.output_text.annotation.added",
-						item_id: state.messageId,
-						output_index: state.messageOutputIndex,
-						content_index: 0,
-						annotation_index: annotationIndex,
-						annotation,
-					}),
-				);
+		const current = state.messageItems[state.messageItems.length - 1];
+		if (current) {
+			for (const annotation of normalizeAnnotationsToResponses(
+				delta.annotations,
+			)) {
+				const annotationIndex = current.annotations.length;
+				current.annotations.push(annotation);
+				if (current.contentPartStarted) {
+					events.push(
+						emitEvent(state, "response.output_text.annotation.added", {
+							type: "response.output_text.annotation.added",
+							item_id: current.id,
+							output_index: current.outputIndex,
+							content_index: 0,
+							annotation_index: annotationIndex,
+							annotation,
+						}),
+					);
+				}
 			}
 		}
 	}
@@ -636,21 +689,24 @@ export function buildFinalOutputItems(
 		});
 	}
 
-	if (state.fullContent.length > 0) {
+	for (const message of state.messageItems) {
+		if (message.parts.length === 0) {
+			continue;
+		}
 		indexed.push({
-			index: state.messageOutputIndex ?? Number.MAX_SAFE_INTEGER,
+			index: message.outputIndex,
 			item: {
 				type: "message",
-				id: state.messageId,
+				id: message.id,
 				role: "assistant",
 				content: [
 					{
 						type: "output_text",
-						text: state.fullContent.join(""),
-						annotations: state.annotations,
+						text: message.parts.join(""),
+						annotations: message.annotations,
 					},
 				],
-				...(state.messagePhase ? { phase: state.messagePhase } : {}),
+				...(message.phase ? { phase: message.phase } : {}),
 				status: "completed",
 			},
 		});
@@ -689,50 +745,50 @@ export function createCompletionEvents(
 		);
 	});
 
-	// Close content part if started
-	if (state.contentPartStarted) {
-		events.push(
-			emitEvent(state, "response.output_text.done", {
-				type: "response.output_text.done",
-				item_id: state.messageId,
-				output_index: state.messageOutputIndex,
-				content_index: 0,
-				text: state.fullContent.join(""),
-			}),
-		);
-		events.push(
-			emitEvent(state, "response.content_part.done", {
-				type: "response.content_part.done",
-				item_id: state.messageId,
-				output_index: state.messageOutputIndex,
-				content_index: 0,
-				part: {
-					type: "output_text",
-					text: state.fullContent.join(""),
-					annotations: state.annotations,
-				},
-			}),
-		);
-	}
-
-	// Close output item if started
-	if (state.outputItemStarted) {
+	// Close each message item that streamed (text done, part done, item done),
+	// reusing the id/output_index from its added event.
+	for (const message of state.messageItems) {
+		const text = message.parts.join("");
+		if (message.contentPartStarted) {
+			events.push(
+				emitEvent(state, "response.output_text.done", {
+					type: "response.output_text.done",
+					item_id: message.id,
+					output_index: message.outputIndex,
+					content_index: 0,
+					text,
+				}),
+			);
+			events.push(
+				emitEvent(state, "response.content_part.done", {
+					type: "response.content_part.done",
+					item_id: message.id,
+					output_index: message.outputIndex,
+					content_index: 0,
+					part: {
+						type: "output_text",
+						text,
+						annotations: message.annotations,
+					},
+				}),
+			);
+		}
 		events.push(
 			emitEvent(state, "response.output_item.done", {
 				type: "response.output_item.done",
-				output_index: state.messageOutputIndex,
+				output_index: message.outputIndex,
 				item: {
 					type: "message",
-					id: state.messageId,
+					id: message.id,
 					role: "assistant",
 					content: [
 						{
 							type: "output_text",
-							text: state.fullContent.join(""),
-							annotations: state.annotations,
+							text,
+							annotations: message.annotations,
 						},
 					],
-					...(state.messagePhase ? { phase: state.messagePhase } : {}),
+					...(message.phase ? { phase: message.phase } : {}),
 					status: "completed",
 				},
 			}),

--- a/apps/gateway/src/responses/tools/response-state.ts
+++ b/apps/gateway/src/responses/tools/response-state.ts
@@ -9,6 +9,12 @@ export interface StoredResponseData {
 	instructions?: string;
 	model: string;
 	status: "completed" | "incomplete" | "failed";
+	incomplete_details?: { reason: string } | null;
+	reasoning?: {
+		effort: string | null;
+		summary: string | null;
+		context?: string;
+	} | null;
 	usage?: Record<string, unknown>;
 	created_at?: number;
 }
@@ -226,6 +232,12 @@ export async function getStoredResponse(
 			instructions?: string;
 			model?: string;
 			status?: "completed" | "incomplete" | "failed";
+			incomplete_details?: { reason: string } | null;
+			reasoning?: {
+				effort: string | null;
+				summary: string | null;
+				context?: string;
+			} | null;
 			usage?: Record<string, unknown>;
 			created_at?: number;
 		};
@@ -237,6 +249,8 @@ export async function getStoredResponse(
 			instructions: data.instructions,
 			model: data.model ?? "",
 			status: data.status ?? "completed",
+			incomplete_details: data.incomplete_details ?? null,
+			reasoning: data.reasoning ?? null,
 			usage: data.usage,
 			created_at: data.created_at,
 		};

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1771,6 +1771,12 @@ export async function processLogQueue(): Promise<number> {
 					toolChoice: _toolChoice,
 					toolResults: _toolResults,
 					responsesApiData: _responsesApiData,
+					// Debug payloads (x-debug) contain full request/response bodies
+					// and must not survive a metadata-only retention policy.
+					rawRequest: _rawRequest,
+					rawResponse: _rawResponse,
+					upstreamRequest: _upstreamRequest,
+					upstreamResponse: _upstreamResponse,
 					...metadataOnly
 				} = data;
 				return metadataOnly;

--- a/packages/actions/src/prepare-request-body.responses.spec.ts
+++ b/packages/actions/src/prepare-request-body.responses.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "vitest";
+
+import { prepareRequestBody } from "./prepare-request-body.js";
+
+import type { BaseMessage } from "@llmgateway/models";
+
+interface ResponsesBody {
+	input: Array<Record<string, unknown>>;
+	reasoning?: { context?: string };
+}
+
+// Tests for the OpenAI Responses API request transform: encrypted reasoning
+// replay provenance and output-item ordering for tool-call turns.
+
+async function buildOpenAIResponsesBody(
+	messages: BaseMessage[],
+	opts: {
+		reasoning_context?: "auto" | "current_turn" | "all_turns";
+	} = {},
+): Promise<ResponsesBody> {
+	return (await prepareRequestBody(
+		"openai",
+		"gpt-4o",
+		null,
+		"gpt-4o",
+		messages,
+		false, // stream
+		undefined, // temperature
+		undefined, // max_tokens
+		undefined, // top_p
+		undefined, // frequency_penalty
+		undefined, // presence_penalty
+		undefined, // response_format
+		undefined, // tools
+		undefined, // tool_choice
+		undefined, // reasoning_effort
+		true, // supportsReasoning
+		false, // isProd
+		20, // maxImageSizeMB
+		null, // userPlan
+		undefined, // sensitive_word_check
+		undefined, // image_config
+		undefined, // effort
+		undefined, // imageGenerations
+		undefined, // webSearchTool
+		undefined, // reasoning_max_tokens
+		true, // useResponsesApi
+		undefined, // prompt_cache_key
+		undefined, // prompt_cache_retention
+		true, // providerCacheControlEnabled
+		undefined, // n
+		undefined, // service_tier
+		undefined, // verbosity
+		undefined, // prompt_cache_options
+		undefined, // session_id
+		opts.reasoning_context, // reasoning_context
+	)) as unknown as ResponsesBody;
+}
+
+describe("transform to OpenAI Responses API", () => {
+	test("replays only encrypted reasoning tagged openai-responses-v1 (untagged blobs are dropped)", async () => {
+		const body = await buildOpenAIResponsesBody([
+			{ role: "user", content: "hi" },
+			{
+				role: "assistant",
+				content: "hello",
+				reasoning_details: [
+					{ type: "reasoning.encrypted", data: "unlabelled-blob" },
+					{
+						type: "reasoning.encrypted",
+						data: "tagged-blob",
+						id: "rs_tagged",
+						format: "openai-responses-v1",
+					},
+					{
+						type: "reasoning.encrypted",
+						data: "foreign-blob",
+						format: "anthropic-claude-v1",
+					},
+				],
+			},
+			{ role: "user", content: "again" },
+		]);
+
+		const reasoningItems = body.input.filter(
+			(item) => item.type === "reasoning",
+		);
+		expect(reasoningItems).toHaveLength(1);
+		expect(reasoningItems[0]!.encrypted_content).toBe("tagged-blob");
+		expect(reasoningItems[0]!.id).toBe("rs_tagged");
+	});
+
+	test("emits function_call items before the assistant message by default", async () => {
+		const body = await buildOpenAIResponsesBody([
+			{ role: "user", content: "weather?" },
+			{
+				role: "assistant",
+				content: "Done, it is sunny.",
+				tool_calls: [
+					{
+						id: "call_1",
+						type: "function",
+						function: { name: "get_weather", arguments: "{}" },
+					},
+				],
+			},
+			{ role: "tool", content: "sunny", tool_call_id: "call_1" },
+		]);
+
+		const types = body.input.map((item) =>
+			item.type === "function_call" || item.type === "function_call_output"
+				? item.type
+				: `message:${item.role}`,
+		);
+		expect(types).toEqual([
+			"message:user",
+			"function_call",
+			"message:assistant",
+			"function_call_output",
+		]);
+	});
+
+	test("keeps pre-tool commentary before the function_call items when marked", async () => {
+		const body = await buildOpenAIResponsesBody([
+			{ role: "user", content: "weather?" },
+			{
+				role: "assistant",
+				content: "Let me check the weather.",
+				phase: "commentary",
+				content_before_tool_calls: true,
+				tool_calls: [
+					{
+						id: "call_1",
+						type: "function",
+						function: { name: "get_weather", arguments: "{}" },
+					},
+				],
+			},
+			{ role: "tool", content: "sunny", tool_call_id: "call_1" },
+		]);
+
+		const types = body.input.map((item) =>
+			item.type === "function_call" || item.type === "function_call_output"
+				? item.type
+				: `message:${item.role}`,
+		);
+		expect(types).toEqual([
+			"message:user",
+			"message:assistant",
+			"function_call",
+			"function_call_output",
+		]);
+		const assistantMessage = body.input.find(
+			(item) => item.role === "assistant",
+		);
+		expect(assistantMessage!.phase).toBe("commentary");
+		expect(assistantMessage!.content_before_tool_calls).toBeUndefined();
+	});
+
+	test("forwards reasoning.context (including auto) to OpenAI", async () => {
+		const withContext = await buildOpenAIResponsesBody(
+			[{ role: "user", content: "hi" }],
+			{ reasoning_context: "current_turn" },
+		);
+		expect(withContext.reasoning?.context).toBe("current_turn");
+
+		const withAuto = await buildOpenAIResponsesBody(
+			[{ role: "user", content: "hi" }],
+			{ reasoning_context: "auto" },
+		);
+		expect(withAuto.reasoning?.context).toBe("auto");
+
+		const without = await buildOpenAIResponsesBody([
+			{ role: "user", content: "hi" },
+		]);
+		expect(without.reasoning?.context).toBeUndefined();
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -17,6 +17,7 @@ import {
 	type PromptCacheOptions,
 	type PromptCacheRetention,
 	type ProviderRequestBody,
+	type ReasoningDetail,
 	supportsOpenAIExplicitPromptCache,
 	supportsOpenAIExtendedPromptCache,
 	supportsServiceTier,
@@ -790,20 +791,35 @@ function transformContentForResponsesApi(content: any, role: string): any {
  * Only OpenAI-Responses-shaped payloads are forwarded — opaque blobs from a
  * different provider/format would be rejected upstream.
  */
-function extractEncryptedReasoningItems(msg: any): any[] {
+interface OpenAIResponsesReasoningItem {
+	type: "reasoning";
+	id?: string;
+	summary: unknown[];
+	encrypted_content: string;
+}
+
+function isEncryptedReasoningDetail(
+	detail: ReasoningDetail,
+): detail is ReasoningDetail & { data: string } {
+	return (
+		detail !== null &&
+		typeof detail === "object" &&
+		detail.type === "reasoning.encrypted" &&
+		typeof detail.data === "string" &&
+		detail.data.length > 0 &&
+		(detail.format === undefined || detail.format === "openai-responses-v1")
+	);
+}
+
+function extractEncryptedReasoningItems(
+	msg: BaseMessage,
+): OpenAIResponsesReasoningItem[] {
 	if (msg.role !== "assistant" || !Array.isArray(msg.reasoning_details)) {
 		return [];
 	}
-	const items: any[] = [];
+	const items: OpenAIResponsesReasoningItem[] = [];
 	for (const detail of msg.reasoning_details) {
-		if (
-			detail &&
-			typeof detail === "object" &&
-			detail.type === "reasoning.encrypted" &&
-			typeof detail.data === "string" &&
-			detail.data.length > 0 &&
-			(detail.format === undefined || detail.format === "openai-responses-v1")
-		) {
+		if (isEncryptedReasoningDetail(detail)) {
 			items.push({
 				type: "reasoning",
 				...(typeof detail.id === "string" && { id: detail.id }),
@@ -1531,11 +1547,11 @@ export async function prepareRequestBody(
 	// it, and strict providers reject unknown message fields, so strip it from
 	// every path except the Responses API transform above.
 	processedMessages = processedMessages.map((m) => {
-		if ((m as any).reasoning_details === undefined) {
+		if (m.reasoning_details === undefined) {
 			return m;
 		}
-		const { reasoning_details: _ignored, ...rest } = m as any;
-		return rest as typeof m;
+		const { reasoning_details: _ignored, ...rest } = m;
+		return rest;
 	});
 
 	// Start with a base structure that can be modified for each provider

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -914,34 +914,61 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 		}
 
 		// Assistant messages with tool_calls: emit function_call items and the
-		// message in the provider's original order. By default the message
-		// follows the function calls (matching the order the Responses API
-		// emits and convertResponsesInputToMessages folded from); pre-tool
-		// commentary marked with content_before_tool_calls goes first.
+		// message(s) in the provider's original order. Separate phased message
+		// items (message_items) are replayed individually, interleaved with the
+		// calls per their preceding_tool_calls position; otherwise the single
+		// message follows the function calls by default (matching the order the
+		// Responses API emits and convertResponsesInputToMessages folded from),
+		// with pre-tool commentary marked via content_before_tool_calls going
+		// first.
 		if (
 			msg.role === "assistant" &&
 			msg.tool_calls &&
 			msg.tool_calls.length > 0
 		) {
-			// Assistant message content, if present (preserve empty strings)
-			const messageItem =
-				msg.content !== null && msg.content !== undefined
-					? {
+			const toolCallCount = msg.tool_calls.length;
+			const messageItems: Array<{
+				precedingToolCalls: number;
+				item: Record<string, unknown>;
+			}> = [];
+			if (Array.isArray(msg.message_items) && msg.message_items.length > 0) {
+				for (const item of msg.message_items) {
+					messageItems.push({
+						precedingToolCalls: item.preceding_tool_calls ?? toolCallCount,
+						item: {
 							role: "assistant",
-							content: transformContentForResponsesApi(
-								msg.content,
-								"assistant",
-							),
-							...(msg.phase ? { phase: msg.phase } : {}),
-						}
-					: null;
-
-			if (messageItem && msg.content_before_tool_calls) {
-				items.push(messageItem);
+							content: transformContentForResponsesApi(item.text, "assistant"),
+							...(item.phase ? { phase: item.phase } : {}),
+						},
+					});
+				}
+			} else if (msg.content !== null && msg.content !== undefined) {
+				// Single assistant message content (preserve empty strings)
+				messageItems.push({
+					precedingToolCalls: msg.content_before_tool_calls ? 0 : toolCallCount,
+					item: {
+						role: "assistant",
+						content: transformContentForResponsesApi(msg.content, "assistant"),
+						...(msg.phase ? { phase: msg.phase } : {}),
+					},
+				});
 			}
 
-			// Emit each tool call as a separate function_call item
-			for (const toolCall of msg.tool_calls) {
+			let nextMessage = 0;
+			const emitMessagesUpTo = (callsEmitted: number) => {
+				while (
+					nextMessage < messageItems.length &&
+					messageItems[nextMessage]!.precedingToolCalls <= callsEmitted
+				) {
+					items.push(messageItems[nextMessage]!.item);
+					nextMessage++;
+				}
+			};
+
+			// Emit each tool call as a separate function_call item, with any
+			// message items restored to their original positions between them.
+			msg.tool_calls.forEach((toolCall: any, callIndex: number) => {
+				emitMessagesUpTo(callIndex);
 				items.push({
 					type: "function_call",
 					call_id: toolCall.id,
@@ -952,10 +979,24 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 					callId: toolCall.id,
 					name: toolCall.function?.name,
 				});
-			}
+			});
+			emitMessagesUpTo(Number.MAX_SAFE_INTEGER);
+			continue;
+		}
 
-			if (messageItem && !msg.content_before_tool_calls) {
-				items.push(messageItem);
+		// Assistant messages carrying separate phased message items but no tool
+		// calls: replay each item individually.
+		if (
+			msg.role === "assistant" &&
+			Array.isArray(msg.message_items) &&
+			msg.message_items.length > 0
+		) {
+			for (const item of msg.message_items) {
+				items.push({
+					role: "assistant",
+					content: transformContentForResponsesApi(item.text, "assistant"),
+					...(item.phase ? { phase: item.phase } : {}),
+				});
 			}
 			continue;
 		}
@@ -1587,7 +1628,8 @@ export async function prepareRequestBody(
 		if (
 			m.reasoning_details === undefined &&
 			m.phase === undefined &&
-			m.content_before_tool_calls === undefined
+			m.content_before_tool_calls === undefined &&
+			m.message_items === undefined
 		) {
 			return [m];
 		}
@@ -1595,6 +1637,7 @@ export async function prepareRequestBody(
 			reasoning_details: reasoningDetails,
 			phase: _phase,
 			content_before_tool_calls: _contentBeforeToolCalls,
+			message_items: _messageItems,
 			...rest
 		} = m;
 		if (

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -807,7 +807,10 @@ function isEncryptedReasoningDetail(
 		detail.type === "reasoning.encrypted" &&
 		typeof detail.data === "string" &&
 		detail.data.length > 0 &&
-		(detail.format === undefined || detail.format === "openai-responses-v1")
+		// Require the explicit provenance tag the gateway stamps on every
+		// payload it emits — an untagged blob could be a foreign format that
+		// must not be relabeled as OpenAI encrypted reasoning.
+		detail.format === "openai-responses-v1"
 	);
 }
 
@@ -896,21 +899,45 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 		// Replay encrypted reasoning from prior turns ahead of the assistant
 		// items it preceded, mirroring the item order the Responses API emits.
 		if (msg.role === "assistant") {
-			items.push(...extractEncryptedReasoningItems(msg));
+			const reasoningItems = extractEncryptedReasoningItems(msg);
+			items.push(...reasoningItems);
+			// A reasoning-only carrier (a prior turn that ended before emitting a
+			// message, e.g. on max_output_tokens) has no message to emit — the
+			// reasoning items above are the whole turn.
+			if (
+				reasoningItems.length > 0 &&
+				(msg.content === null || msg.content === undefined) &&
+				(!msg.tool_calls || msg.tool_calls.length === 0)
+			) {
+				continue;
+			}
 		}
 
-		// Assistant messages with tool_calls: emit the message, then function_call items
+		// Assistant messages with tool_calls: emit function_call items and the
+		// message in the provider's original order. By default the message
+		// follows the function calls (matching the order the Responses API
+		// emits and convertResponsesInputToMessages folded from); pre-tool
+		// commentary marked with content_before_tool_calls goes first.
 		if (
 			msg.role === "assistant" &&
 			msg.tool_calls &&
 			msg.tool_calls.length > 0
 		) {
-			// Emit assistant message content if present (preserve empty strings)
-			if (msg.content !== null && msg.content !== undefined) {
-				items.push({
-					role: "assistant",
-					content: transformContentForResponsesApi(msg.content, "assistant"),
-				});
+			// Assistant message content, if present (preserve empty strings)
+			const messageItem =
+				msg.content !== null && msg.content !== undefined
+					? {
+							role: "assistant",
+							content: transformContentForResponsesApi(
+								msg.content,
+								"assistant",
+							),
+							...(msg.phase ? { phase: msg.phase } : {}),
+						}
+					: null;
+
+			if (messageItem && msg.content_before_tool_calls) {
+				items.push(messageItem);
 			}
 
 			// Emit each tool call as a separate function_call item
@@ -926,6 +953,10 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 					name: toolCall.function?.name,
 				});
 			}
+
+			if (messageItem && !msg.content_before_tool_calls) {
+				items.push(messageItem);
+			}
 			continue;
 		}
 
@@ -937,6 +968,7 @@ function transformMessagesForResponsesApi(messages: any[]): any[] {
 		items.push({
 			role: msg.role,
 			content: transformContentForResponsesApi(msg.content, msg.role),
+			...(msg.role === "assistant" && msg.phase ? { phase: msg.phase } : {}),
 		});
 	}
 
@@ -1003,6 +1035,7 @@ export async function prepareRequestBody(
 	verbosity?: "low" | "medium" | "high",
 	prompt_cache_options?: PromptCacheOptions,
 	session_id?: string,
+	reasoning_context?: "auto" | "current_turn" | "all_turns",
 ): Promise<ProviderRequestBody | FormData> {
 	tools = normalizeToolParameters(tools);
 	const modelDef = models.find((m) => m.id === usedInternalModel);
@@ -1543,15 +1576,36 @@ export async function prepareRequestBody(
 	const messagesWithReasoningDetails = processedMessages;
 
 	// `reasoning_details` is the gateway's carrier for opaque reasoning payloads
-	// (e.g. OpenAI encrypted reasoning). No chat-completions upstream understands
-	// it, and strict providers reject unknown message fields, so strip it from
-	// every path except the Responses API transform above.
-	processedMessages = processedMessages.map((m) => {
-		if (m.reasoning_details === undefined) {
-			return m;
+	// (e.g. OpenAI encrypted reasoning); `phase` and `content_before_tool_calls`
+	// are OpenAI Responses assistant-message markers. No chat-completions
+	// upstream understands them, and strict providers reject unknown message
+	// fields, so strip them from every path except the Responses API transform
+	// above. An assistant message that carried only reasoning (no
+	// content/tool_calls — an incomplete prior turn replayed for the Responses
+	// API) becomes empty here, so drop it.
+	processedMessages = processedMessages.flatMap((m) => {
+		if (
+			m.reasoning_details === undefined &&
+			m.phase === undefined &&
+			m.content_before_tool_calls === undefined
+		) {
+			return [m];
 		}
-		const { reasoning_details: _ignored, ...rest } = m;
-		return rest;
+		const {
+			reasoning_details: reasoningDetails,
+			phase: _phase,
+			content_before_tool_calls: _contentBeforeToolCalls,
+			...rest
+		} = m;
+		if (
+			reasoningDetails !== undefined &&
+			m.role === "assistant" &&
+			(m.content === null || m.content === undefined) &&
+			(!m.tool_calls || m.tool_calls.length === 0)
+		) {
+			return [];
+		}
+		return [rest];
 	});
 
 	// Start with a base structure that can be modified for each provider
@@ -1723,6 +1777,13 @@ export async function prepareRequestBody(
 							: {
 									effort: responsesReasoningEffort,
 									summary: "detailed",
+									// reasoning.context is only documented on OpenAI's
+									// Responses API surface; other providers reject
+									// unknown reasoning fields.
+									...(reasoning_context !== undefined &&
+										(usedProvider === "openai" || usedProvider === "azure") && {
+											context: reasoning_context,
+										}),
 								},
 				};
 

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -128,6 +128,17 @@ export interface BaseMessage {
 	// commentary), so Responses API replay preserves the original item order.
 	// Stripped for chat-completions upstreams.
 	content_before_tool_calls?: boolean;
+	// Separate phased assistant message items (e.g. commentary + final_answer)
+	// emitted by OpenAI Responses API models in one turn. `preceding_tool_calls`
+	// is how many of the message's tool calls came before the item, so the
+	// exact interleaving can be reconstructed. Replayed upstream as individual
+	// message items; stripped for chat-completions upstreams (the concatenated
+	// `content` carries the text there).
+	message_items?: Array<{
+		text: string;
+		phase?: "commentary" | "final_answer";
+		preceding_tool_calls?: number;
+	}>;
 }
 
 // Provider-specific message formats

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -121,6 +121,13 @@ export interface BaseMessage {
 	reasoning?: string;
 	reasoning_content?: string;
 	reasoning_details?: ReasoningDetail[];
+	// OpenAI Responses assistant-message phase, replayed upstream on the
+	// Responses API path and stripped for chat-completions upstreams.
+	phase?: "commentary" | "final_answer";
+	// Marks assistant content that preceded the message's tool calls (pre-tool
+	// commentary), so Responses API replay preserves the original item order.
+	// Stripped for chat-completions upstreams.
+	content_before_tool_calls?: boolean;
 }
 
 // Provider-specific message formats
@@ -323,6 +330,7 @@ export interface OpenAIResponsesRequestBody {
 	reasoning: {
 		effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 		summary: "detailed";
+		context?: "auto" | "current_turn" | "all_turns";
 	};
 	tools?: Array<{
 		type: "function";


### PR DESCRIPTION
## Summary

Fixes the issues found while verifying #3042 (encrypted reasoning preservation) against live OpenAI behavior, across three review rounds.

### Correctness of truncated responses
- Map upstream Responses status `incomplete` to `status: "incomplete"` with the right `incomplete_details` reason (`max_output_tokens` / `content_filter`) in both non-streaming and streaming conversion — previously reported as `completed`
- Emit `response.incomplete` as the streaming terminal event instead of `response.completed`, per the official streaming contract
- Persist `incomplete_details` on stored responses so retrieval no longer hardcodes `max_output_tokens`

### Stateless history preservation
- Replay orphaned encrypted reasoning (a turn truncated before any message was emitted) via an assistant carrier message instead of dropping it; the carrier is emitted upstream as a bare reasoning item and dropped for chat-completions providers
- Preserve the assistant message `phase` (`commentary`/`final_answer`) end-to-end: inbound replay, non-streaming and streaming outputs, and when folding/unfolding tool-call turns
- Preserve original output-item order for pre-tool commentary: streaming message items now reserve their `output_index` (fixes index collisions with subsequent tool calls), final/stored output is ordered by claimed index, and the non-streaming converter threads a `content_before_tool_calls` marker so mixed `[message, function_call]` histories round-trip exactly

### reasoning.context contract
- Accept `auto | current_turn | all_turns` (previously stripped entirely; then `auto` was rejected), forward to OpenAI/Azure, and report the *effective* mode from the upstream response instead of echoing the request (`auto` is never echoed)
- Persist the reasoning echo on stored responses and return it on GET

### Hardening
- Require the `openai-responses-v1` provenance tag on replayed encrypted reasoning payloads — untagged blobs can no longer be relabeled as OpenAI encrypted reasoning
- Strip raw debug payloads (`rawRequest`/`rawResponse`/`upstreamRequest`/`upstreamResponse`) under metadata-only retention, closing an `x-debug: true` leak of encrypted payloads

## Testing
- New spec `packages/actions/src/prepare-request-body.responses.spec.ts` exercising the real Responses request transform (provenance filtering, item ordering, context forwarding)
- 15+ new/updated unit tests in `responses.spec.ts` covering status mapping, terminal events, carrier replay, phase, ordering, and context
- Full unit suite passes (only known-flaky timezone-sensitive DB calendar test fails locally); full `pnpm build` and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)