### PR TITLE
feat(error-handler): handle upstream gateway errors

### DIFF
--- a/apps/api/src/error-handler.spec.ts
+++ b/apps/api/src/error-handler.spec.ts
@@ -1,0 +1,81 @@
+import { APICallError } from "ai";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+app.get("/test-errors/upstream-4xx", () => {
+	throw new APICallError({
+		message: "Organization org-id has insufficient credits",
+		url: "https://api.llmgateway.io/v1/chat/completions",
+		requestBodyValues: { messages: [{ role: "user", content: "hi" }] },
+		statusCode: 402,
+		responseHeaders: {},
+		responseBody: "",
+		isRetryable: false,
+		data: {
+			error: {
+				code: "billing_error",
+				message: "Organization org-id has insufficient credits",
+				param: null,
+				type: "invalid_request_error",
+			},
+		},
+	});
+});
+
+app.get("/test-errors/upstream-5xx", () => {
+	throw new APICallError({
+		message: "Internal provider failure",
+		url: "https://api.llmgateway.io/v1/chat/completions",
+		requestBodyValues: {},
+		statusCode: 500,
+		responseHeaders: {},
+		responseBody: "",
+		isRetryable: true,
+	});
+});
+
+describe("global error handler - upstream gateway errors", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("forwards upstream 4xx errors to the client", async () => {
+		const res = await app.request("/test-errors/upstream-4xx", {
+			headers: { Cookie: token },
+		});
+		expect(res.status).toBe(402);
+		const json = await res.json();
+		expect(json).toMatchObject({
+			error: true,
+			status: 402,
+			message: "Organization org-id has insufficient credits",
+			details: {
+				error: {
+					code: "billing_error",
+					type: "invalid_request_error",
+				},
+			},
+		});
+	});
+
+	test("maps upstream 5xx errors to a 502 without leaking details", async () => {
+		const res = await app.request("/test-errors/upstream-5xx", {
+			headers: { Cookie: token },
+		});
+		expect(res.status).toBe(502);
+		const json = await res.json();
+		expect(json).toEqual({
+			error: true,
+			status: 502,
+			message: "Upstream gateway request failed",
+		});
+	});
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import "dotenv/config";
 
 import { swaggerUI } from "@hono/swagger-ui";
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { APICallError } from "ai";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
@@ -44,6 +45,7 @@ import { v1Master } from "./routes/v1-master.js";
 import { stripeRoutes } from "./stripe.js";
 
 import type { ServerTypes } from "./vars.js";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 export const config = {
 	servers: [
@@ -129,6 +131,44 @@ app.onError((error, c) => {
 				...(error.res ? { details: error.res } : {}),
 			},
 			status,
+		);
+	}
+
+	// Upstream gateway call failures from the AI SDK (e.g. skill generation,
+	// memory extraction). 4xx statuses are expected user-facing conditions
+	// (insufficient credits, rate limits), not backend bugs — forward them to
+	// the client instead of logging an internal error.
+	if (APICallError.isInstance(error)) {
+		const status = error.statusCode;
+		if (status && status >= 400 && status < 500) {
+			logger.warn("Upstream gateway client error", {
+				status,
+				message: error.message,
+				path: c.req.path,
+				method: c.req.method,
+			});
+			return c.json(
+				{
+					error: true,
+					status,
+					message: error.message,
+					...(error.data !== undefined ? { details: error.data } : {}),
+				},
+				status as ContentfulStatusCode,
+			);
+		}
+		logger.error("Upstream gateway error", error, {
+			status,
+			path: c.req.path,
+			method: c.req.method,
+		});
+		return c.json(
+			{
+				error: true,
+				status: 502,
+				message: "Upstream gateway request failed",
+			},
+			502,
 		);
 	}
 


### PR DESCRIPTION
## Summary
Add comprehensive error handling for upstream gateway failures from the AI SDK (e.g., skill generation, memory extraction) in the global error handler. This distinguishes between client errors (4xx) that should be forwarded to users and server errors (5xx) that should be masked.

## Changes
- **Error classification**: Detect `APICallError` instances from the AI SDK and handle them separately from other application errors
- **4xx error forwarding**: Client errors (insufficient credits, rate limits, etc.) are logged as warnings and forwarded to the client with their original status code and error details
- **5xx error masking**: Server errors are logged as errors but returned to the client as generic 502 "Upstream gateway request failed" responses without leaking internal details
- **Test coverage**: Add comprehensive test suite (`error-handler.spec.ts`) validating both 4xx and 5xx error handling paths

## Implementation Details
- Uses `APICallError.isInstance()` to safely detect AI SDK errors
- Preserves error data in 4xx responses via optional `details` field for debugging
- Maps all 5xx upstream errors to 502 status code for consistent client-side handling
- Includes structured logging with request context (path, method, status) for observability

https://claude.ai/code/session_01Eonm2fJgDjuUYWkSDpR4YW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upstream gateway errors.
  * Client-side upstream failures now preserve their status and relevant error details.
  * Server-side upstream failures now return a safe 502 response with a generic message, preventing internal details from being exposed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->