### PR TITLE
fix: handle reasoning summary done streaming events

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -836,6 +836,8 @@ export function transformStreamingToOpenai(
 					case "response.output_item.done":
 					case "response.content_part.done":
 					case "response.output_text.done":
+					case "response.reasoning_summary_text.done":
+					case "response.reasoning_summary_part.done":
 					case "response.web_search_call.in_progress":
 					case "response.web_search_call.searching":
 					case "response.web_search_call.completed":


### PR DESCRIPTION
## Summary

The gateway logged this warning when streaming from providers that emit OpenAI Responses API reasoning summary events (seen with `meta/muse-spark-1.1`):

```
WARN [streaming] Unrecognized OpenAI event type
    eventType: "response.reasoning_summary_text.done"
```

`response.reasoning_summary_text.done` and `response.reasoning_summary_part.done` fell through to the `default` case in `transformOpenaiResponsesStreaming`, logging a warning on every occurrence.

## Fix

Add both `.done` events to the existing no-op passthrough case group (alongside `response.output_text.done`, `response.content_part.done`, etc.) in `apps/gateway/src/chat/tools/transform-streaming-to-openai.ts`. The reasoning text has already been streamed via the corresponding `.delta`/`.added` events, so the `.done` events (which carry the full accumulated text) must be no-ops — re-emitting their text would duplicate the reasoning output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuF9xmJq3zJ4Bkctovmfgr

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuF9xmJq3zJ4Bkctovmfgr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenAI Responses API streaming events.
  * Reasoning summary completion events are now handled correctly during streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->