### PR TITLE
fix(gateway): map reasoning_effort to Moonshot thinking

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -921,6 +921,81 @@ describe("prepareRequestBody - reasoning_effort none", () => {
 	});
 });
 
+describe("prepareRequestBody - Moonshot thinking", () => {
+	async function prepare(options: {
+		model: string;
+		reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high";
+	}) {
+		return (await prepareRequestBody(
+			"moonshot",
+			options.model,
+			null,
+			options.model,
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			options.reasoningEffort, // reasoning_effort
+			true, // supportsReasoning
+		)) as any;
+	}
+
+	test("maps reasoning_effort to thinking enabled and never forwards reasoning_effort", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k2.6",
+			reasoningEffort: "high",
+		});
+		expect(requestBody.thinking).toEqual({ type: "enabled" });
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("maps none to thinking disabled on models that can turn thinking off", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k2.6",
+			reasoningEffort: "none",
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("maps minimal to thinking disabled on models that can turn thinking off", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k2.5",
+			reasoningEffort: "minimal",
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+
+	test("keeps the provider default when no reasoning_effort is requested", async () => {
+		const requestBody = await prepare({ model: "kimi-k2.6" });
+		expect(requestBody.thinking).toBeUndefined();
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("never sends disabled to always-on models (kimi-k2.7-code)", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k2.7-code",
+			reasoningEffort: "none",
+		});
+		expect(requestBody.thinking).toBeUndefined();
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("sends thinking enabled to always-on models when effort is requested", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k2.7-code",
+			reasoningEffort: "medium",
+		});
+		expect(requestBody.thinking).toEqual({ type: "enabled" });
+	});
+});
+
 describe("prepareRequestBody - reasoning_effort max", () => {
 	async function prepare(options: {
 		provider: Parameters<typeof prepareRequestBody>[0];

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -955,10 +955,10 @@ export async function prepareRequestBody(
 
 	// `none` reasoning effort is handled natively by a few providers:
 	// OpenAI/Azure forward it (their newer models accept it to turn reasoning
-	// off), and Google reasons by default so it must explicitly disable thinking
-	// when asked. Every other provider treats the absence of reasoning_effort as
-	// "off" already, so normalize `none` away for them to avoid forwarding an
-	// unsupported enum value.
+	// off), and Google and Moonshot reason by default so they must explicitly
+	// disable thinking when asked. Every other provider treats the absence of
+	// reasoning_effort as "off" already, so normalize `none` away for them to
+	// avoid forwarding an unsupported enum value.
 	const handlesNoneNatively =
 		usedProvider === "openai" ||
 		usedProvider === "azure" ||
@@ -966,6 +966,7 @@ export async function prepareRequestBody(
 		usedProvider === "glacier" ||
 		usedProvider === "google-vertex" ||
 		usedProvider === "quartz" ||
+		usedProvider === "moonshot" ||
 		providerMappingForOptions?.apiFormat === "openai-chat-completions";
 	if (reasoning_effort === "none" && !handlesNoneNatively) {
 		reasoning_effort = undefined;
@@ -1944,6 +1945,54 @@ export async function prepareRequestBody(
 			// Add sensitive_word_check if provided (Z.ai specific)
 			if (sensitive_word_check) {
 				requestBody.sensitive_word_check = sensitive_word_check;
+			}
+			break;
+		}
+		case "moonshot": {
+			if (stream) {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+			if (response_format) {
+				requestBody.response_format = response_format;
+			}
+
+			// Add optional parameters if they are provided
+			if (temperature !== undefined) {
+				requestBody.temperature = temperature;
+			}
+			if (max_tokens !== undefined) {
+				requestBody.max_tokens = max_tokens;
+			}
+			if (top_p !== undefined) {
+				requestBody.top_p = top_p;
+			}
+			if (frequency_penalty !== undefined) {
+				requestBody.frequency_penalty = frequency_penalty;
+			}
+			if (presence_penalty !== undefined) {
+				requestBody.presence_penalty = presence_penalty;
+			}
+			// Moonshot's thinking models don't recognize `reasoning_effort`; they
+			// take a binary `thinking` parameter (`{ type: "enabled" | "disabled" }`)
+			// and think by default. Map `none`/`minimal` to an explicit disable and
+			// every other tier to an explicit enable; when no effort is requested,
+			// send nothing and keep the provider default (thinking on). Mappings
+			// that can turn thinking off declare `none` in `reasoningEfforts`;
+			// always-on models (kimi-k2.7-code*) reject `"disabled"` with a 400, so
+			// collapse disable requests onto their minimum (thinking stays on).
+			if (supportsReasoning && reasoning_effort !== undefined) {
+				const wantsThinking =
+					reasoning_effort !== "none" && reasoning_effort !== "minimal";
+				const canDisableThinking =
+					providerMappingForOptions?.reasoningEfforts?.includes("none") ??
+					false;
+				if (wantsThinking) {
+					requestBody.thinking = { type: "enabled" };
+				} else if (canDisableThinking) {
+					requestBody.thinking = { type: "disabled" };
+				}
 			}
 			break;
 		}

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -226,6 +226,17 @@ export const moonshotModels = [
 				contextSize: 262144,
 				maxOutput: 32768,
 				reasoning: true,
+				// Moonshot thinking is a binary toggle (`thinking.type`), not a
+				// graduated effort: none/minimal disable it, low..max enable it.
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
 				streaming: true,
 				vision: true,
 				tools: true,
@@ -235,6 +246,7 @@ export const moonshotModels = [
 					"response_format",
 					"tools",
 					"tool_choice",
+					"reasoning_effort",
 				],
 			},
 			{
@@ -357,6 +369,17 @@ export const moonshotModels = [
 				contextSize: 262144,
 				maxOutput: 262144,
 				reasoning: true,
+				// Moonshot thinking is a binary toggle (`thinking.type`), not a
+				// graduated effort: none/minimal disable it, low..max enable it.
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
 				streaming: true,
 				vision: true,
 				tools: true,
@@ -366,6 +389,7 @@ export const moonshotModels = [
 					"response_format",
 					"tools",
 					"tool_choice",
+					"reasoning_effort",
 				],
 			},
 			{
@@ -456,6 +480,9 @@ export const moonshotModels = [
 				contextSize: 262144,
 				maxOutput: 262144,
 				reasoning: true,
+				// Thinking is always on for kimi-k2.7-code; `thinking.type:
+				// "disabled"` errors upstream, so `none`/`minimal` are not offered.
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
 				streaming: true,
 				vision: true,
 				tools: true,
@@ -465,6 +492,7 @@ export const moonshotModels = [
 					"response_format",
 					"tools",
 					"tool_choice",
+					"reasoning_effort",
 				],
 			},
 		],
@@ -487,11 +515,19 @@ export const moonshotModels = [
 				contextSize: 262144,
 				maxOutput: 262144,
 				reasoning: true,
+				// Thinking is always on for kimi-k2.7-code-highspeed; `thinking.type:
+				// "disabled"` errors upstream, so `none`/`minimal` are not offered.
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
 				streaming: true,
 				vision: true,
 				tools: true,
 				jsonOutput: false,
-				supportedParameters: ["max_tokens", "tools", "tool_choice"],
+				supportedParameters: [
+					"max_tokens",
+					"tools",
+					"tool_choice",
+					"reasoning_effort",
+				],
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

Fixes #3061 — `reasoning_effort` was silently ignored for every model routed through the `moonshot` provider.

Moonshot's API doesn't recognize `reasoning_effort`; its thinking models take a binary `thinking` parameter (`{ type: "enabled" | "disabled" }`) and think by default ([docs](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#the-thinking-parameter)). The gateway routed moonshot through the default OpenAI-compatible case, where `reasoning_effort` was dropped because the moonshot mappings' `supportedParameters` don't list it — so the value passed capability validation and then vanished with no error.

## Changes

- **`prepare-request-body.ts`**: dedicated `moonshot` case that translates `reasoning_effort` into the `thinking` parameter:
  - `none` / `minimal` → `thinking: { type: "disabled" }` (mirrors the ZAI/GLM binary-thinking contract)
  - `low`–`max` → `thinking: { type: "enabled" }`
  - unset → nothing sent, keeping Moonshot's default (thinking on), which preserves current behavior
  - `none` is no longer normalized away for moonshot (it now translates to an explicit disable, like Google)
- **kimi-k2.7-code / -highspeed** always think and reject `"disabled"` with a 400 (verified live), so disable requests collapse onto their minimum (thinking stays on), gated by `reasoningEfforts` metadata: only mappings that can turn thinking off declare `none`.
- **`moonshot.ts` catalog**: declared `reasoningEfforts` and added `reasoning_effort` to `supportedParameters` on the four active moonshot mappings so the models API publishes the valid options.

## Testing

- New unit specs covering enabled/disabled/unset/always-on paths (`prepare-request-body.spec.ts`), full unit suite passes (one unrelated real-Stripe billing spec was flaky and passes in isolation)
- `TEST_MODELS="moonshot/kimi-k2.6" pnpm test:e2e` — 85 passed against the real Moonshot API
- Verified live against `api.moonshot.ai`: kimi-k2.6 accepts both `thinking` values (empty `reasoning_content` when disabled), kimi-k2.7-code rejects `disabled` with `invalid thinking: only type=enabled is allowed for this model`
- `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)