### PR TITLE
feat(models): add glm-5.2 via alibaba

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -111,6 +111,23 @@ export const zaiModels = [
 				jsonOutput: true,
 				healStreamingJsonOutput: true,
 			},
+			{
+				providerId: "alibaba",
+				externalId: "glm-5.2",
+				inputPrice: "1.4e-6",
+				// implicit cache hits bill at 20% of the input price
+				cachedInputPrice: "0.28e-6",
+				outputPrice: "4.4e-6",
+				regions: [{ id: "singapore" }],
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 131072,
+				streaming: true,
+				reasoning: true,
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 	{


### PR DESCRIPTION
## Summary

Adds a new `alibaba` provider mapping for **GLM-5.2**, now available on Alibaba Cloud Model Studio's International (Singapore) deployment.

Specs verified against the [Model Studio docs](https://www.alibabacloud.com/help/en/model-studio/glm) and confirmed live against the `dashscope-intl` endpoint:

- **Pricing**: $1.40/M input, $4.40/M output (flat rate, per the international pricing table); implicit cache hits bill at 20% of input price → `cachedInputPrice: 0.28e-6` (`cached_tokens` confirmed in live responses)
- **Context**: 1M tokens; **max output**: 131072 (probed live — upstream reports `Range of max_tokens should be [1, 131072]`)
- **Regions**: `singapore` only — the model is listed under the International deployment scope, and only the intl endpoint serves it with our key (US/Beijing endpoints are separate key scopes)
- **Reasoning**: thinking mode is on by default upstream and returns `reasoning_content`; `reasoning_effort` is accepted; forced `tool_choice` works with thinking enabled (kept on via the existing `reasoning: true` gate in `prepare-request-body.ts`)
- **JSON output**: works (verified live, including with thinking enabled)
- No web search support on Alibaba for this model, so `webSearch` is omitted

## Testing

- `TEST_MODELS="alibaba/glm-5.2" pnpm test:e2e` — **97 passed, 0 failed** (covers both `alibaba/glm-5.2` and `alibaba/glm-5.2:singapore`, incl. streaming, reasoning, tool calls, JSON output)
- `pnpm test:unit` (models) — 2687 passed
- `pnpm build` + `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)