### PR TITLE
test: deflake cancellation spec with mock sync

### DIFF
--- a/apps/gateway/src/cancellation.spec.ts
+++ b/apps/gateway/src/cancellation.spec.ts
@@ -12,8 +12,10 @@ import { db, tables } from "@llmgateway/db";
 
 import { app } from "./app.js";
 import {
+	resetMockCheckpoints,
 	startMockServer,
 	stopMockServer,
+	waitForMockCheckpoint,
 } from "./test-utils/mock-openai-server.js";
 import { clearCache, waitForLogs } from "./test-utils/test-helpers.js";
 
@@ -112,9 +114,18 @@ describe("client cancellation logging", () => {
 	});
 
 	beforeEach(async () => {
+		resetMockCheckpoints();
 		await resetState();
 		await setupFixtures();
 	});
+
+	// Give the gateway a beat to move past the checkpoint (e.g. from the fetch
+	// settling into res.text()/res.json()) before aborting. Any earlier or later
+	// abort ordering still logs `canceled: true`, so this only biases toward the
+	// specific path each test targets — it is not load-bearing for correctness.
+	function settle() {
+		return new Promise((resolve) => setTimeout(resolve, 50));
+	}
 
 	function postChat(content: string, signal: AbortSignal) {
 		return fetch(`${gatewayUrl}/v1/chat/completions`, {
@@ -134,12 +145,16 @@ describe("client cancellation logging", () => {
 	test("abort before the upstream responds is logged as canceled, not an error", async () => {
 		const controller = new AbortController();
 		// Mock delays 5s before sending any response; abort lands while the
-		// gateway is awaiting the upstream fetch.
+		// gateway is awaiting the upstream fetch. The checkpoint resolves once
+		// the mock has received the gateway's upstream request and started its
+		// delay, so the abort verifiably lands mid-fetch instead of racing a
+		// fixed sleep against slow CI runners.
+		const upstreamRequestReceived = waitForMockCheckpoint("TRIGGER_TIMEOUT");
 		const requestPromise = postChat(
 			`TRIGGER_TIMEOUT_5000 ${Math.random()}`,
 			controller.signal,
 		);
-		await new Promise((resolve) => setTimeout(resolve, 500));
+		await upstreamRequestReceived;
 		controller.abort();
 
 		await expect(requestPromise).rejects.toThrow();
@@ -157,12 +172,17 @@ describe("client cancellation logging", () => {
 		const controller = new AbortController();
 		// Mock returns 200 headers + a partial body, then hangs without
 		// finishing it. The abort lands while the gateway is awaiting
-		// res.json(), exercising the body-read cancellation path.
+		// res.json(), exercising the body-read cancellation path. The
+		// checkpoint resolves once the mock has flushed the partial body, so
+		// the gateway verifiably has the upstream request in flight before the
+		// abort fires.
+		const partialBodyFlushed = waitForMockCheckpoint("TRIGGER_BODY_HANG");
 		const requestPromise = postChat(
 			`TRIGGER_BODY_HANG ${Math.random()}`,
 			controller.signal,
 		);
-		await new Promise((resolve) => setTimeout(resolve, 500));
+		await partialBodyFlushed;
+		await settle();
 		controller.abort();
 
 		await expect(requestPromise).rejects.toThrow();
@@ -180,12 +200,17 @@ describe("client cancellation logging", () => {
 		const controller = new AbortController();
 		// Mock returns a 500 status + a partial error body, then hangs without
 		// finishing it. The abort lands while the gateway is awaiting res.text()
-		// on the error path, exercising the error-body cancellation path.
+		// on the error path, exercising the error-body cancellation path. The
+		// checkpoint resolves once the mock has flushed the partial error body,
+		// so the gateway verifiably has the upstream request in flight before
+		// the abort fires.
+		const partialBodyFlushed = waitForMockCheckpoint("TRIGGER_5XX_BODY_HANG");
 		const requestPromise = postChat(
 			`TRIGGER_5XX_BODY_HANG ${Math.random()}`,
 			controller.signal,
 		);
-		await new Promise((resolve) => setTimeout(resolve, 500));
+		await partialBodyFlushed;
+		await settle();
 		controller.abort();
 
 		await expect(requestPromise).rejects.toThrow();

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -332,6 +332,35 @@ let failOnceCounter = 0;
 let currentMockServerUrl = "";
 let videoCounter = 0;
 
+// Checkpoint waiters let tests synchronize with the mock reaching a specific
+// point inside a request (e.g. the partial body of a hang trigger has been
+// flushed to the socket) instead of guessing with fixed sleeps, which flake on
+// slow CI runners. Register the waiter BEFORE issuing the request, then await
+// it to know the gateway's upstream request has verifiably reached that point.
+const mockCheckpointWaiters = new Map<string, Array<() => void>>();
+
+export function waitForMockCheckpoint(name: string): Promise<void> {
+	return new Promise((resolve) => {
+		const waiters = mockCheckpointWaiters.get(name) ?? [];
+		waiters.push(resolve);
+		mockCheckpointWaiters.set(name, waiters);
+	});
+}
+
+function notifyMockCheckpoint(name: string) {
+	const waiters = mockCheckpointWaiters.get(name);
+	if (waiters) {
+		mockCheckpointWaiters.delete(name);
+		for (const resolve of waiters) {
+			resolve();
+		}
+	}
+}
+
+export function resetMockCheckpoints() {
+	mockCheckpointWaiters.clear();
+}
+
 interface MockVideoJobState {
 	id: string;
 	object: "video";
@@ -842,6 +871,7 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 	// Check if this request should trigger a timeout (delay response)
 	const timeoutDelay = extractTimeoutDelay(userMessage);
 	if (timeoutDelay) {
+		notifyMockCheckpoint("TRIGGER_TIMEOUT");
 		await delay(timeoutDelay);
 	}
 
@@ -1129,6 +1159,7 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 					controller.enqueue(
 						encoder.encode('{"id":"chatcmpl-123","object":"chat.completion"'),
 					);
+					notifyMockCheckpoint("TRIGGER_BODY_HANG");
 					return;
 				}
 				// Never enqueue more and never close: the body read hangs until the
@@ -1157,6 +1188,7 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 					sentPartialBody = true;
 					// Flush a partial JSON body so headers are written first.
 					controller.enqueue(encoder.encode('{"error":{"message":"partial'));
+					notifyMockCheckpoint("TRIGGER_5XX_BODY_HANG");
 					return;
 				}
 				// Never enqueue more and never close: the body read hangs until the


### PR DESCRIPTION
## Summary

Fixes the flaky `cancellation.spec.ts` suite (most recently seen failing the unrelated PR #3063: `abort while reading a non-OK error body is logged as canceled, not an error` timed out in `waitForLogs` after 10s).

### Root cause

Each test aborted the client after a **fixed 500ms sleep**, racing the abort against the gateway's request lifecycle. On a slow CI runner the abort can fire before the request has even reached the gateway (or before the gateway's upstream request reached the mock server), so no handler runs far enough to write a log row — `waitForLogs(1)` then times out with zero logs.

The gateway's error-body cancellation path itself is sound: once the upstream request is in flight, every abort ordering (mid-fetch, in the gap before `res.text()` via the `signal.aborted` re-check, or mid-body-read via `AbortError`) writes exactly one `canceled: true` log row. Only the "abort before anything happened" ordering produces no log, and that's purely a test-timing artifact.

### Fix

Replace the fixed sleeps with deterministic synchronization points:

- `mock-openai-server.ts` gains a small checkpoint mechanism (`waitForMockCheckpoint` / `resetMockCheckpoints`). The mock signals when it has **received the upstream request** (`TRIGGER_TIMEOUT`) or **flushed the partial hanging body** (`TRIGGER_BODY_HANG`, `TRIGGER_5XX_BODY_HANG`).
- `cancellation.spec.ts` registers the checkpoint before issuing the request and only aborts once it resolves, so the gateway verifiably has the upstream request in flight before the abort fires. The two body-hang tests add a short 50ms settle so the abort lands on the intended `res.json()`/`res.text()` read path (any other ordering still logs `canceled: true`, so this isn't load-bearing for correctness).

As a bonus the suite got faster (~4.7s vs ~7.5s) since tests no longer sleep a fixed 500ms each.

### Testing

- `vitest run apps/gateway/src/cancellation.spec.ts` — 3/3 passing, 5/5 consecutive runs green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yFNLANCC2jNC5HXz2GwMz

---
_Generated by [Claude Code](https://claude.ai/code/session_015yFNLANCC2jNC5HXz2GwMz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cancellation test reliability by synchronizing checks with specific request-processing stages.
  * Added coverage for cancellations during upstream requests and response-body processing.
  * Confirmed canceled requests are logged as cancellations rather than errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->