### PR TITLE
fix(admin): drop cents in dashboard metric cards

### DIFF
--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -22,7 +22,8 @@ import { cn } from "@/lib/utils";
 const currencyFormatter = new Intl.NumberFormat("en-US", {
 	style: "currency",
 	currency: "USD",
-	maximumFractionDigits: 2,
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 0,
 });
 
 const numberFormatter = new Intl.NumberFormat("en-US", {


### PR DESCRIPTION
## Summary

The top metric cards on the admin dashboard home page rendered currency values with cents (e.g. `$1.05`), which takes up more space and is harder to scan. This changes the shared `currencyFormatter` in `ee/admin/src/app/page.tsx` to whole dollars (`minimumFractionDigits: 0`, `maximumFractionDigits: 0`), so all card values (and the overage banner on the same page) now render as e.g. `$1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYXWoLoomZskiwnGKwRw7f

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYXWoLoomZskiwnGKwRw7f)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Currency amounts in the dashboard now display as rounded whole-dollar values without fractional digits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->