### PR TITLE
fix(code): align premium fair-use copy

### DIFF
--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -21,6 +21,8 @@ import {
 	DEV_PLAN_PREMIUM_WEEKLY_PERCENT,
 	DEV_PLAN_PRICES,
 	getDevPlanCreditsLimit,
+	HIGH_COST_INPUT_PRICE,
+	HIGH_COST_OUTPUT_PRICE,
 } from "@llmgateway/shared";
 
 import type { Metadata } from "next";
@@ -48,6 +50,9 @@ interface UsageRow {
 const liteCredits = getDevPlanCreditsLimit("lite");
 const proCredits = getDevPlanCreditsLimit("pro");
 const maxCredits = getDevPlanCreditsLimit("max");
+
+const premiumInputPerM = Math.round(HIGH_COST_INPUT_PRICE * 1_000_000);
+const premiumOutputPerM = Math.round(HIGH_COST_OUTPUT_PRICE * 1_000_000);
 
 const productSchema = {
 	"@context": "https://schema.org",
@@ -136,7 +141,7 @@ const usageRows: UsageRow[] = [
 		emphasis: true,
 	},
 	{
-		label: "Frontier flagship fair-use (Opus, GPT Pro, Gemini Pro, Grok)",
+		label: `Premium model fair-use ($${premiumInputPerM}+/M input or $${premiumOutputPerM}+/M output)`,
 		lite: `${Math.round(DEV_PLAN_PREMIUM_WEEKLY_PERCENT.lite * 100)}% of credits`,
 		pro: `${Math.round(DEV_PLAN_PREMIUM_WEEKLY_PERCENT.pro * 100)}% of credits`,
 		max: `${Math.round(DEV_PLAN_PREMIUM_WEEKLY_PERCENT.max * 100)}% of credits`,
@@ -278,7 +283,7 @@ export default function PricingPage() {
 							</h2>
 							<p className="mt-3 text-muted-foreground">
 								Every tier ships with the full model catalog. Three dials
-								change: your monthly usage allowance, the weekly frontier
+								change: your monthly usage allowance, the weekly premium-model
 								fair-use, and support.
 							</p>
 						</div>

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -9,7 +9,11 @@ import {
 	AccordionItem,
 } from "@/components/ui/accordion";
 
-import { MARKETING_STATS } from "@llmgateway/shared";
+import {
+	HIGH_COST_INPUT_PRICE,
+	HIGH_COST_OUTPUT_PRICE,
+	MARKETING_STATS,
+} from "@llmgateway/shared";
 
 import type { ReactNode } from "react";
 
@@ -20,6 +24,9 @@ interface FaqItem {
 	answer: string;
 	content?: ReactNode;
 }
+
+const premiumInputPerM = Math.round(HIGH_COST_INPUT_PRICE * 1_000_000);
+const premiumOutputPerM = Math.round(HIGH_COST_OUTPUT_PRICE * 1_000_000);
 
 const faqData: FaqItem[] = [
 	{
@@ -89,14 +96,14 @@ const faqData: FaqItem[] = [
 	},
 	{
 		question: "Are there limits on premium models?",
-		answer:
-			"Premium frontier models — Anthropic Opus, OpenAI Pro/reasoning, Gemini Pro, and Grok 4 — are subject to a weekly fair-use allowance in addition to your monthly allowance: 12% of your monthly credits on Lite, 15% on Pro, and 18% on Max. Every other model draws on your full monthly allowance. The exact numbers are published on the plan cards — no hidden throttling.",
+		answer: `Premium models — any model priced at $${premiumInputPerM}+ per million input tokens or $${premiumOutputPerM}+ per million output tokens — are subject to a weekly fair-use allowance in addition to your monthly allowance: 12% of your monthly credits on Lite, 15% on Pro, and 18% on Max. Every other model draws on your full monthly allowance. The exact numbers are published on the plan cards — no hidden throttling.`,
 		content: (
 			<>
 				<p>
-					Premium frontier models — Anthropic Opus, OpenAI Pro/reasoning, Gemini
-					Pro, and Grok 4 — are subject to a weekly fair-use allowance in
-					addition to your monthly allowance:
+					Premium models — any model priced at ${premiumInputPerM}+ per million
+					input tokens or ${premiumOutputPerM}+ per million output tokens — are
+					subject to a weekly fair-use allowance in addition to your monthly
+					allowance:
 				</p>
 				<ul className="list-disc pl-6 mt-2 space-y-1">
 					<li>
@@ -111,7 +118,14 @@ const faqData: FaqItem[] = [
 				</ul>
 				<p className="mt-3">
 					Every other model draws on your full monthly allowance. The exact
-					numbers are published on the plan cards — no hidden throttling.
+					numbers are published on the plan cards — no hidden throttling. See{" "}
+					<Link
+						href="https://docs.llmgateway.io/learn/model-categories"
+						className="underline"
+					>
+						model categories &amp; fair use
+					</Link>{" "}
+					for how models are classified.
 				</p>
 			</>
 		),

--- a/apps/code/src/components/PricingPlans.tsx
+++ b/apps/code/src/components/PricingPlans.tsx
@@ -12,6 +12,8 @@ import { formatUsageRatio } from "@/lib/utils";
 import {
 	DEV_PLAN_PREMIUM_WEEKLY_PERCENT,
 	DEV_PLAN_PRICES,
+	HIGH_COST_INPUT_PRICE,
+	HIGH_COST_OUTPUT_PRICE,
 	MARKETING_STATS,
 	type DevPlanTier,
 } from "@llmgateway/shared";
@@ -209,8 +211,10 @@ export function PricingPlans({ credits, paygoUrl }: PricingPlansProps) {
 			</div>
 
 			<p className="mx-auto mt-6 max-w-3xl text-center text-xs leading-relaxed text-muted-foreground">
-				Frontier fair-use covers Anthropic Opus, OpenAI Pro/reasoning-tier,
-				Gemini Pro, and Grok — a weekly allowance on top of your monthly usage,
+				Frontier fair-use covers premium models — any model priced at $
+				{Math.round(HIGH_COST_INPUT_PRICE * 1_000_000)}+ per million input
+				tokens or ${Math.round(HIGH_COST_OUTPUT_PRICE * 1_000_000)}+ per million
+				output tokens — as a weekly allowance on top of your monthly usage,
 				published right on the card. Every other model draws on your full
 				monthly allowance. No hidden throttling.
 			</p>


### PR DESCRIPTION
## Summary
The DevPass pricing/FAQ copy named Gemini Pro and Grok as premium fair-use models, but the backend (`isPremiumModel` in `packages/shared/src/model-categories.ts`) classifies premium purely by price: ≥ $5/M input or ≥ $15/M output tokens. Gemini 3.1 Pro ($2/$12) and Grok 4.5 ($2/$6) don't qualify, so the copy was inaccurate. Replace the hardcoded model lists with the pricing-threshold rule, derived from the shared `HIGH_COST_*` constants so the copy stays in sync automatically.

## Changes
- Import `HIGH_COST_INPUT_PRICE` and `HIGH_COST_OUTPUT_PRICE` from `@llmgateway/shared` and compute per-million values in:
  - `apps/code/src/app/pricing/page.tsx`
  - `apps/code/src/components/PricingPlans.tsx`
  - `apps/code/src/components/Faq.tsx`
- Comparison-table row "Frontier flagship fair-use (Opus, GPT Pro, Gemini Pro, Grok)" → "Premium model fair-use ($5+/M input or $15+/M output)"
- PricingPlans footnote and FAQ answer (both JSON-LD string and rendered JSX) now describe premium models by pricing threshold instead of naming models
- FAQ links to the [model categories & fair use](https://docs.llmgateway.io/learn/model-categories) docs page

## Notes
- This also aligns with the repo convention of not hardcoding catalog-derived model lists in marketing copy
- The docs page (`apps/docs/content/learn/model-categories.mdx`) already stated the correct thresholds and is unchanged
- No backend changes: Grok 4 ($3/$15 output) remains premium; Grok 4.5 and Gemini 3.1 Pro remain standard

https://claude.ai/code/session_01D6RRcgfnD4JyEgvTJqAmUA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated pricing plan comparisons to describe weekly fair-use limits for premium models.
  * Premium model eligibility is now based on published input and output pricing thresholds rather than a fixed list of model names.
  * Added clearer per-million token pricing details to fair-use explanations.
  * Updated the FAQ with the new premium-model criteria and a link to documentation on model categories and fair use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->