### PR TITLE
feat(models): declare reasoning effort for deepseek

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -244,6 +244,7 @@ export const deepseekModels = [
 				jsonOutput: true,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["high", "max"],
 				vision: false,
 				tools: true,
 				supportedParameters: [
@@ -354,6 +355,7 @@ export const deepseekModels = [
 				jsonOutput: true,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["high", "max"],
 				vision: false,
 				tools: true,
 				supportedParameters: [


### PR DESCRIPTION
## Summary

Declares `reasoningEfforts` for both `providerId: "deepseek"` mappings (`deepseek-v4-pro`, `deepseek-v4-flash`) in `packages/models/src/models/deepseek.ts`, per #3028.

## Changes

- `deepseek-v4-pro` → `["high", "max"]`
- `deepseek-v4-flash` → `["high", "max"]`

Sources:
- [DeepSeek Thinking Mode guide](https://api-docs.deepseek.com/guides/thinking_mode/), summary table explicitly lists the Thinking Effort Control parameter as accepting `"high/max"` for `reasoning_effort`. Footnotes clarify `low`/`medium` are silently mapped to `high`, and `xhigh` is silently mapped to `max`, accepted without erroring, but producing identical behavior to `high`/`max` respectively.
- [DeepSeek API Reference, Create Chat Completion](https://api-docs.deepseek.com/api/create-chat-completion/), describes the same behavior for the `reasoning_effort` field, confirming this isn't isolated to one doc page.

`none` is not part of `reasoning_effort` for DeepSeek, thinking on/off is a separate parameter (`thinking: {"type": "enabled"|"disabled"}`), outside the scope of this field. Only listing the two values that produce genuinely distinct model behavior, rather than every string the API happens to accept without erroring.

## Testing

- `pnpm format`, only `deepseek.ts` changed, 2 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting high and maximum reasoning effort when using DeepSeek V4 Pro and V4 Flash models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->