### PR TITLE
docs: fix premium weekly cap window wording

### DIFF
--- a/apps/docs/content/learn/model-categories.mdx
+++ b/apps/docs/content/learn/model-categories.mdx
@@ -32,7 +32,7 @@ You can browse the full catalog on the [**Supported Models**](https://llmgateway
 	limited only by your credit balance, with no weekly cap.
 </Callout>
 
-Premium models are the most expensive to run, so DevPass plans apply a **weekly fair-use cap** on premium usage. This is a rolling 7-day window that resets continuously — it sits on top of the plan's normal monthly credit allowance. The cap scales with each plan: it's a share of that plan's total monthly credits, so higher tiers get a larger weekly premium allowance.
+Premium models are the most expensive to run, so DevPass plans apply a **weekly fair-use cap** on premium usage. The cap works on a fixed 7-day window: the window opens with your first premium-model request, all premium usage during those 7 days counts against the cap, and the full allowance resets at once when the window ends. It sits on top of the plan's normal monthly credit allowance. The cap scales with each plan: it's a share of that plan's total monthly credits, so higher tiers get a larger weekly premium allowance.
 
 | DevPass plan | Premium fair-use cap (per week) |
 | ------------ | ------------------------------- |
@@ -46,4 +46,4 @@ Premium models are the most expensive to run, so DevPass plans apply a **weekly 
 	window.
 </Callout>
 
-Once a DevPass plan reaches its weekly premium cap, premium requests are paused until the rolling window frees up, while standard models keep working normally. Upgrading the DevPass plan raises the weekly cap.
+Once a DevPass plan reaches its weekly premium cap, premium requests are paused until the current 7-day window ends — usage does not gradually free up over time. The reset countdown runs from when the window opened, not from when you hit the cap, so the full allowance can return anywhere from moments to 7 days after you reach the limit. Standard models keep working normally the whole time. Upgrading the DevPass plan raises the weekly cap.


### PR DESCRIPTION
## Summary

A Discord user asked whether the DevPass weekly premium allowance is a truly rolling 7-day window (usage gradually freeing up) or a full reset. The docs said "a rolling 7-day window that resets continuously," but the implementation (`isPremiumWeekExpired` / `getRemainingPremiumWeeklyAllowance` in `packages/shared/src/dev-plans.ts`, reset logic in `apps/worker/src/worker.ts`) uses a **fixed 7-day window anchored to the first premium request**, with the full allowance returning at once when the window ends.

This updates `apps/docs/content/learn/model-categories.mdx` to describe the actual behavior:
- The window opens with the first premium-model request; all premium usage during those 7 days counts against the cap.
- Usage does not gradually become available again — the full allowance resets at once when the window ends.
- The reset countdown ("Resets in N days" in the 402 error) runs from the window start, not from when the cap is hit.

No behavior changes, docs only.

https://claude.ai/code/session_01NeqtWHWHmyug3BXUv3JmV9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the premium-model fair-use cap uses a fixed 7-day window starting with the first premium request.
  * Explained that the cap fully resets when the window ends and premium requests remain paused until then.
  * Confirmed that upgrading the DevPass plan increases the weekly premium allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->