### PR TITLE
feat(gateway): exact reset time in premium cap error

### DIFF
--- a/apps/gateway/src/chat/tools/resolve-provider-context.spec.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { formatUsedModelForDisplay } from "./resolve-provider-context.js";
+import {
+	formatTimeUntilReset,
+	formatUsedModelForDisplay,
+} from "./resolve-provider-context.js";
 
 describe("formatUsedModelForDisplay", () => {
 	it("uses the provider id for built-in providers", () => {
@@ -25,5 +28,36 @@ describe("formatUsedModelForDisplay", () => {
 		expect(
 			formatUsedModelForDisplay("alibaba", "glm-4.6", undefined, undefined),
 		).toBe("alibaba/glm-4.6");
+	});
+});
+
+describe("formatTimeUntilReset", () => {
+	const HOUR = 60 * 60 * 1000;
+	const DAY = 24 * HOUR;
+
+	it("formats days and hours", () => {
+		// 147h = 6 days and 3 hours
+		expect(formatTimeUntilReset(147 * HOUR)).toBe("6 days and 3 hours");
+	});
+
+	it("rounds partial hours up", () => {
+		expect(formatTimeUntilReset(146.5 * HOUR)).toBe("6 days and 3 hours");
+	});
+
+	it("drops the hours component when it is zero", () => {
+		expect(formatTimeUntilReset(7 * DAY)).toBe("7 days");
+	});
+
+	it("drops the days component when under a day", () => {
+		expect(formatTimeUntilReset(5 * HOUR)).toBe("5 hours");
+	});
+
+	it("uses singular units", () => {
+		expect(formatTimeUntilReset(DAY + HOUR)).toBe("1 day and 1 hour");
+	});
+
+	it("reports less than an hour for sub-hour durations", () => {
+		expect(formatTimeUntilReset(30 * 60 * 1000)).toBe("less than an hour");
+		expect(formatTimeUntilReset(0)).toBe("less than an hour");
 	});
 });

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -206,13 +206,30 @@ export function assertDevPlanPremiumCapNotExceeded(
 		weekStart.getTime() + DEV_PLAN_PREMIUM_WEEK_LENGTH_MS,
 	);
 	const msUntilReset = Math.max(0, resetAt.getTime() - Date.now());
-	const daysUntilReset = Math.max(
-		1,
-		Math.ceil(msUntilReset / (24 * 60 * 60 * 1000)),
-	);
 	throw new HTTPException(402, {
-		message: `You've used your weekly allowance for premium-tier models on the ${tier} plan. Upgrade for a higher allowance, or use any standard model now. Resets in ${daysUntilReset} day${daysUntilReset === 1 ? "" : "s"}.`,
+		message: `You've used your weekly allowance for premium-tier models on the ${tier} plan. Upgrade for a higher allowance, or use any standard model now. Resets in ${formatTimeUntilReset(msUntilReset)}.`,
 	});
+}
+
+/**
+ * Formats a duration as "N days and M hours", dropping zero components and
+ * rounding up to the next hour so the wait is never understated.
+ */
+export function formatTimeUntilReset(ms: number): string {
+	if (ms < 60 * 60 * 1000) {
+		return "less than an hour";
+	}
+	const totalHours = Math.ceil(ms / (60 * 60 * 1000));
+	const days = Math.floor(totalHours / 24);
+	const hours = totalHours % 24;
+	const parts: string[] = [];
+	if (days > 0) {
+		parts.push(`${days} day${days === 1 ? "" : "s"}`);
+	}
+	if (hours > 0) {
+		parts.push(`${hours} hour${hours === 1 ? "" : "s"}`);
+	}
+	return parts.join(" and ");
 }
 
 // Mirrors the initial credit gate in chat.ts so retry/fallback paths that


### PR DESCRIPTION
## Summary

Follow-up to #3074. The DevPass weekly premium-cap 402 error rounded the remaining wait up to whole days: 6 days and a few hours displayed as "Resets in 7 days", and even a 20-minute wait showed "Resets in 1 day".

The message now shows the remaining time as days and hours, e.g. "Resets in 6 days and 3 hours.":

- Rounds up to the next hour so the wait is never understated.
- Drops zero components ("7 days", "5 hours") and pluralizes correctly ("1 day and 1 hour").
- Sub-hour waits display as "Resets in less than an hour."

## Changes

- `apps/gateway/src/chat/tools/resolve-provider-context.ts`: replaced the whole-day ceil with a `formatTimeUntilReset()` helper used in the 402 message.
- `apps/gateway/src/chat/tools/resolve-provider-context.spec.ts`: unit tests for the formatter (rounding, zero components, singular/plural, sub-hour).

## Testing

- `vitest run apps/gateway/src/chat/tools/resolve-provider-context.spec.ts` — 10/10 passing
- `turbo run build --filter=gateway` — builds clean

https://claude.ai/code/session_01NeqtWHWHmyug3BXUv3JmV9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved premium usage limit messages with more accurate reset wait times.
  * Reset times now display days and hours when applicable, use correct singular/plural wording, and clearly identify waits under one hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->