### PR TITLE
docs: reflect full-charge upgrade model in copy

### DIFF
--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -135,10 +135,8 @@ describe("dev plan tier changes", () => {
 			// Full new-tier price charged today, not a prorated slice.
 			amountDueCents: 7900,
 			currency: "USD",
-			remainingFraction: 0.5,
 			currentCreditsLimit: 87,
 			// Allowance resets to the new tier's full allotment (79 * 3 = 237).
-			proratedCreditDelta: 150,
 			newCreditsLimit: 237,
 			billingPeriodStart: new Date((nowSeconds - 500) * 1000).toISOString(),
 			billingPeriodEnd: new Date((nowSeconds + 500) * 1000).toISOString(),

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -153,21 +153,6 @@ function getInvoicePaymentIntentId(invoice: Stripe.Invoice) {
 	return getStripeId(invoiceWithPaymentIntent.payment_intent);
 }
 
-function getRemainingBillingPeriodFraction(
-	subscriptionItem: Stripe.SubscriptionItem,
-) {
-	const nowSeconds = Date.now() / 1000;
-	const periodStart = subscriptionItem.current_period_start;
-	const periodEnd = subscriptionItem.current_period_end;
-	const periodSeconds = periodEnd - periodStart;
-
-	if (periodSeconds <= 0) {
-		return 0;
-	}
-
-	return Math.min(1, Math.max(0, (periodEnd - nowSeconds) / periodSeconds));
-}
-
 // The full price of a tier charged on an upgrade. Reads the Stripe price's
 // unit amount so it stays correct for both monthly and legacy annual cadences
 // (DEV_PLAN_PRICES only tracks the monthly dollar figure).
@@ -809,9 +794,7 @@ const tierChangePreviewResponseSchema = z.object({
 	isUpgrade: z.boolean(),
 	amountDueCents: z.number().int().nonnegative(),
 	currency: z.literal("USD"),
-	remainingFraction: z.number(),
 	currentCreditsLimit: z.number(),
-	proratedCreditDelta: z.number(),
 	newCreditsLimit: z.number(),
 	billingPeriodStart: z.string(),
 	billingPeriodEnd: z.string(),
@@ -892,8 +875,6 @@ devPlans.openapi(changeTierPreview, async (c) => {
 		});
 	}
 
-	const remainingFraction = getRemainingBillingPeriodFraction(subscriptionItem);
-
 	// Upgrades charge the full new-tier price today and start a fresh billing
 	// cycle (no proration); downgrades stay deferred to renewal, so nothing is
 	// due today. Credits reset to the new tier's full allowance on an upgrade.
@@ -919,9 +900,7 @@ devPlans.openapi(changeTierPreview, async (c) => {
 		isUpgrade,
 		amountDueCents,
 		currency: "USD" as const,
-		remainingFraction,
 		currentCreditsLimit,
-		proratedCreditDelta: newCreditsLimit - currentCreditsLimit,
 		newCreditsLimit,
 		billingPeriodStart: new Date(
 			subscriptionItem.current_period_start * 1000,

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -1,7 +1,7 @@
 import Stripe from "stripe";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { db, tables } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
 import {
@@ -482,6 +482,150 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 			where: { id: { eq: ORG_ID } },
 		});
 		expect(org?.devPlanCreditsUsed).toBe("150");
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(1);
+	});
+});
+
+describe("handleInvoicePaymentSucceeded — chat plan upgrade invoice", () => {
+	beforeEach(async () => {
+		await deleteAll();
+		sendEmailMock.mockClear();
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	async function seedChatPlanOrg(opts: {
+		chatPlan: "starter" | "plus" | "pro";
+		creditsLimit: string;
+		creditsUsed: string;
+	}) {
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			chatPlan: opts.chatPlan,
+			chatPlanCreditsLimit: opts.creditsLimit,
+			chatPlanCreditsUsed: opts.creditsUsed,
+			chatPlanStripeSubscriptionId: SUB_ID,
+		});
+	}
+
+	test("leaves credits untouched when the endpoint already applied the upgrade", async () => {
+		// Normal flow: the change-tier endpoint already flipped the org to the new
+		// tier and reset the cycle before this webhook arrived. Usage consumed
+		// since then must not be re-zeroed.
+		await seedChatPlanOrg({
+			chatPlan: "plus",
+			creditsLimit: "47.5",
+			creditsUsed: "12",
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUB_ID,
+			metadata: { chatPlan: "plus" },
+		});
+
+		await handleInvoicePaymentSucceeded(
+			makeInvoiceEvent({
+				billingReason: "subscription_update",
+				amountPaid: 1900,
+				invoiceId: "in_chat_upgrade_applied",
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.chatPlan).toBe("plus");
+		expect(org?.chatPlanCreditsUsed).toBe("12");
+		expect(org?.chatPlanCreditsLimit).toBe("47.5");
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(1);
+		expect(txns[0].type).toBe("chat_plan_upgrade");
+		expect(txns[0].amount).toBe("19");
+		expect(txns[0].creditAmount).toBe("47.5");
+		expect(txns[0].description).toBe("Chat Plan PLUS upgrade");
+	});
+
+	test("resets to a fresh new-tier cycle when the endpoint never completed (webhook fallback)", async () => {
+		// Crash window: Stripe collected the full new-tier charge but the endpoint
+		// died before updating the org. The webhook must reproduce the fresh-cycle
+		// reset — full new allowance, usage zeroed. The old cycle's unused credits
+		// (18 - 10 = 8 here) are discarded, not rolled over into the new limit.
+		await seedChatPlanOrg({
+			chatPlan: "starter",
+			creditsLimit: "18",
+			creditsUsed: "10",
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUB_ID,
+			metadata: { chatPlan: "plus" },
+		});
+
+		await handleInvoicePaymentSucceeded(
+			makeInvoiceEvent({
+				billingReason: "subscription_update",
+				amountPaid: 1900,
+				invoiceId: "in_chat_upgrade_fallback",
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.chatPlan).toBe("plus");
+		expect(org?.chatPlanCreditsUsed).toBe("0");
+		expect(org?.chatPlanCreditsLimit).toBe("47.5");
+		expect(org?.chatPlanBillingCycleStart).not.toBeNull();
+
+		const txns = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(txns).toHaveLength(1);
+		expect(txns[0].type).toBe("chat_plan_upgrade");
+		expect(txns[0].creditAmount).toBe("47.5");
+		expect(txns[0].description).toBe("Chat Plan PLUS upgrade");
+	});
+
+	test("does not re-apply the reset on a Stripe retry of the same invoice", async () => {
+		await seedChatPlanOrg({
+			chatPlan: "starter",
+			creditsLimit: "18",
+			creditsUsed: "10",
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUB_ID,
+			metadata: { chatPlan: "plus" },
+		});
+
+		const event = makeInvoiceEvent({
+			billingReason: "subscription_update",
+			amountPaid: 1900,
+			invoiceId: "in_chat_upgrade_retry",
+		});
+		await handleInvoicePaymentSucceeded(event);
+
+		// Usage accrues on the fresh cycle before the retry lands.
+		await db
+			.update(tables.organization)
+			.set({ chatPlanCreditsUsed: "5" })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		await handleInvoicePaymentSucceeded(event);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.chatPlanCreditsUsed).toBe("5");
 
 		const txns = await db.query.transaction.findMany({
 			where: { organizationId: { eq: ORG_ID } },

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3374,12 +3374,12 @@ export async function handleInvoicePaymentSucceeded(event: {
 		isDevPlanSubscription && invoice.billing_reason === "subscription_update";
 
 	// Same billing-reason gate as dev plans: only reset chat plan credits on a
-	// true cycle renewal, not on mid-cycle tier-change proration invoices.
+	// true cycle renewal, not on mid-cycle tier-change invoices.
 	const isChatPlanRenewal =
 		isChatPlanSubscription && invoice.billing_reason === "subscription_cycle";
-	// Mid-cycle chat plan tier change: the change-tier endpoint charges the
-	// prorated upgrade with `always_invoice`, which Stripe bills as a
-	// `subscription_update` invoice.
+	// Mid-cycle chat plan tier upgrade: the change-tier endpoint resets the
+	// billing cycle (`billing_cycle_anchor: "now"`) and charges the full
+	// new-tier price, which Stripe bills as a `subscription_update` invoice.
 	const isChatPlanUpgradeInvoice =
 		isChatPlanSubscription && invoice.billing_reason === "subscription_update";
 
@@ -3804,30 +3804,55 @@ export async function handleInvoicePaymentSucceeded(event: {
 			`Skipping non-renewal dev plan invoice for organization ${organizationId} (billingReason: ${invoice.billing_reason})`,
 		);
 	} else if (isChatPlanUpgradeInvoice) {
-		// Invoice from a mid-cycle chat plan upgrade. The change-tier endpoint
-		// already applied the new tier/limit synchronously; this webhook records
-		// the charge and emails the invoice. onConflictDoNothing on the unique
-		// stripeInvoiceId index keeps it idempotent against Stripe retries, so the
-		// row and email are produced at most once. Credits are left untouched — an
-		// upgrade must not reset the cycle's usage.
-		const creditsLimit = getChatPlanCreditsLimit(
-			organization.chatPlan as ChatPlanTier,
-		);
-		const [upgradeTransaction] = await db
-			.insert(tables.transaction)
-			.values({
-				organizationId,
-				type: "chat_plan_upgrade",
-				amount: (invoice.amount_paid / 100).toString(),
-				creditAmount: creditsLimit.toString(),
-				currency: invoice.currency.toUpperCase(),
-				status: "completed",
-				stripePaymentIntentId: (invoice as any).payment_intent,
-				stripeInvoiceId: invoice.id,
-				description: `Chat Plan ${organization.chatPlan?.toUpperCase()} upgrade`,
-			})
-			.onConflictDoNothing()
-			.returning();
+		// Immediate invoice from a mid-cycle chat plan upgrade. The change-tier
+		// endpoint normally applies the fresh-cycle reset synchronously (new tier's
+		// full allowance, usage zeroed), so by the time this webhook arrives the
+		// org is already on the new tier and credits must be left untouched —
+		// re-zeroing usage here would grant free usage for anything consumed since
+		// the endpoint ran. If that process died after Stripe collected payment but
+		// before the local update, the org is still on the old tier: reproduce the
+		// same fresh-cycle reset here, reading the target tier from the
+		// subscription metadata the update set. The old cycle's unused credits are
+		// discarded, never rolled over. onConflictDoNothing on the unique
+		// stripeInvoiceId index keeps the row, email, and fallback reset at-most-
+		// once against Stripe retries.
+		const upgradeSubscription =
+			await getStripe().subscriptions.retrieve(subscriptionId);
+		const toTier = (upgradeSubscription.metadata?.chatPlan ??
+			organization.chatPlan) as ChatPlanTier;
+		const creditsLimit = getChatPlanCreditsLimit(toTier);
+
+		const upgradeTransaction = await db.transaction(async (tx) => {
+			const [created] = await tx
+				.insert(tables.transaction)
+				.values({
+					organizationId,
+					type: "chat_plan_upgrade",
+					amount: (invoice.amount_paid / 100).toString(),
+					creditAmount: creditsLimit.toString(),
+					currency: invoice.currency.toUpperCase(),
+					status: "completed",
+					stripePaymentIntentId: (invoice as any).payment_intent,
+					stripeInvoiceId: invoice.id,
+					description: `Chat Plan ${toTier.toUpperCase()} upgrade`,
+				})
+				.onConflictDoNothing()
+				.returning();
+
+			if (created && organization.chatPlan !== toTier) {
+				await tx
+					.update(tables.organization)
+					.set({
+						chatPlan: toTier,
+						chatPlanCreditsLimit: creditsLimit.toString(),
+						chatPlanCreditsUsed: "0",
+						chatPlanBillingCycleStart: new Date(),
+					})
+					.where(eq(tables.organization.id, organizationId));
+			}
+
+			return created;
+		});
 
 		if (upgradeTransaction) {
 			try {
@@ -3841,7 +3866,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 					...billingDetails,
 					lineItems: [
 						{
-							description: `Chat Plan ${organization.chatPlan?.toUpperCase()} upgrade`,
+							description: `Chat Plan ${toTier.toUpperCase()} upgrade`,
 							amount: invoice.amount_paid / 100,
 						},
 					],
@@ -3854,7 +3879,7 @@ export async function handleInvoicePaymentSucceeded(event: {
 				);
 			}
 			logger.info(
-				`Recorded chat plan upgrade invoice for organization ${organizationId}; credits used left unchanged`,
+				`Recorded chat plan upgrade invoice for organization ${organizationId}`,
 			);
 		} else {
 			logger.info(

--- a/apps/code/src/app/claude-code-alternative/page.tsx
+++ b/apps/code/src/app/claude-code-alternative/page.tsx
@@ -439,8 +439,8 @@ export default function ClaudeCodeAlternativePage() {
 							Keep the CLI. Swap the subscription.
 						</h2>
 						<p className="mb-8 text-muted-foreground">
-							Start on Pro — most developers ship from there. Switch tiers any
-							time, prorated.
+							Start on Pro — most developers ship from there. Upgrade any time
+							and your new allowance kicks in instantly.
 						</p>
 						<div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
 							<GetDevPassButton

--- a/apps/code/src/app/compare/[slug]/page.tsx
+++ b/apps/code/src/app/compare/[slug]/page.tsx
@@ -320,8 +320,8 @@ export default async function ComparePage({ params }: ComparePageProps) {
 							One key. Every model.
 						</h2>
 						<p className="mb-8 text-muted-foreground">
-							Start on Pro — most developers ship from there. Switch tiers any
-							time, prorated.
+							Start on Pro — most developers ship from there. Upgrade any time
+							and your new allowance kicks in instantly.
 						</p>
 						<div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
 							<CodeCTATracker cta="get_started" location="compare_bottom_cta">

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -16,7 +16,7 @@ export default function TermsPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> June 26, 2026
+				<strong>Last Updated:</strong> July 15, 2026
 			</p>
 			<p>
 				<strong>DevPass</strong> is a service operated by{" "}
@@ -111,6 +111,20 @@ export default function TermsPage() {
 				fees are non-refundable except where required by law. You may cancel at
 				any time; your plan remains active until the end of the current billing
 				period.
+			</p>
+			<p>
+				<strong>Plan changes.</strong> You may change tiers at any time from
+				your dashboard. <strong>Upgrades</strong> take effect immediately: we
+				charge the full price of the new tier at the time of the upgrade, your
+				billing cycle restarts on that day, and you receive the new tier&rsquo;s
+				full monthly allowance. Any unused allowance from the cycle being
+				replaced is forfeited — it does <strong>not</strong> roll over, and it
+				is not refunded, credited, or deducted from the upgrade price.{" "}
+				<strong>Downgrades</strong> are scheduled for your next renewal: you
+				keep your current tier and its allowance until the end of the period you
+				have already paid for, the lower tier is billed from the next renewal
+				onward, and no charge or refund is issued when you schedule the
+				downgrade.
 			</p>
 			<p>
 				DevPass is intended for individual developer use. We may rate-limit,

--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -173,7 +173,7 @@ const includedInEveryPlan = [
 	"DevPass Code, Claude Code, OpenCode, SoulForge",
 	"Any OpenAI/Anthropic-compatible tool",
 	"Real-time dashboard with per-request cost & latency",
-	"Switch tiers anytime — prorated, no cancellation fee",
+	"Switch tiers anytime — no lock-in, no cancellation fee",
 	"7-day first-month guarantee",
 ];
 
@@ -437,8 +437,8 @@ export default function PricingPage() {
 							Still deciding?
 						</h2>
 						<p className="mb-8 text-muted-foreground">
-							Start on Pro — most developers ship from there. Switch tiers any
-							time, prorated.
+							Start on Pro — most developers ship from there. Upgrade any time
+							and your new allowance kicks in instantly.
 						</p>
 						<div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
 							<GetDevPassButton

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -65,20 +65,20 @@ const faqData: FaqItem[] = [
 	{
 		question: "What happens if I hit my monthly limit?",
 		answer:
-			"Requests pause until your allowance resets at the start of the next billing cycle. You can upgrade to a higher tier at any time for an immediate, prorated boost to your available usage.",
+			"Requests pause until your allowance resets at the start of the next billing cycle. Or upgrade to a higher tier at any time: you pay the new tier's full price, your billing cycle restarts, and you get the new tier's full monthly allowance immediately.",
 		content: (
 			<>
 				Requests pause until your allowance resets at the start of the next
-				billing cycle. You can{" "}
-				<strong>upgrade to a higher tier at any time</strong> for an immediate,
-				prorated boost to your available usage.
+				billing cycle. Or <strong>upgrade to a higher tier at any time</strong>:
+				you pay the new tier&apos;s full price, your billing cycle restarts, and
+				you get the new tier&apos;s full monthly allowance immediately.
 			</>
 		),
 	},
 	{
 		question: "Can I change plans anytime?",
 		answer:
-			"Yes. Upgrade or downgrade whenever you like — changes are prorated and take effect immediately. There's no lock-in and no cancellation fee.",
+			"Yes. Upgrades take effect immediately: you're charged the new tier's full price, your billing cycle restarts, and you get the new tier's full allowance right away (unspent credits from the old cycle don't carry over). Downgrades take effect at your next renewal. There's no lock-in and no cancellation fee.",
 	},
 	{
 		question: "Do I need a subscription, or is there pay-as-you-go?",
@@ -133,7 +133,7 @@ const faqData: FaqItem[] = [
 	{
 		question: "Can I get a refund?",
 		answer:
-			"Yes — DevPass comes with a first-month guarantee. Cancel within 7 days of your first purchase and email contact@llmgateway.io: we'll refund your first month minus the usage you consumed at provider rates. Plan changes are prorated, and there's no cancellation fee.",
+			"Yes — DevPass comes with a first-month guarantee. Cancel within 7 days of your first purchase and email contact@llmgateway.io: we'll refund your first month minus the usage you consumed at provider rates. There's no cancellation fee.",
 		content: (
 			<>
 				Yes — DevPass comes with a <strong>first-month guarantee</strong>.
@@ -142,8 +142,7 @@ const faqData: FaqItem[] = [
 					contact@llmgateway.io
 				</Link>
 				: we&apos;ll refund your first month minus the usage you consumed at
-				provider rates. Plan changes are prorated, and there&apos;s no
-				cancellation fee.
+				provider rates. There&apos;s no cancellation fee.
 			</>
 		),
 	},

--- a/apps/docs/content/learn/chat-plans.mdx
+++ b/apps/docs/content/learn/chat-plans.mdx
@@ -43,4 +43,6 @@ The credit multiplier is tapered: the larger the plan, the more usage value each
 
 - Open the **Pricing** page from the chat playground sidebar to compare tiers and subscribe.
 - Your active plan appears in the playground sidebar with a badge, alongside how many credits remain for the cycle.
-- You can upgrade, downgrade, or cancel at any time. Cancelling takes effect at the end of the period you've already paid for — you keep access until then.
+- **Upgrading** takes effect immediately: you're charged the new tier's full price, your billing cycle restarts, and your credits reset to the new tier's full monthly allowance. Unspent credits from the old cycle don't carry over.
+- **Downgrading** also takes effect immediately: you move to the lower tier's allowance right away, and the unused portion of what you already paid for the higher tier is credited against your next invoice.
+- **Cancelling** takes effect at the end of the period you've already paid for — you keep access until then.

--- a/apps/playground/src/components/pricing/chat-pricing-plans.tsx
+++ b/apps/playground/src/components/pricing/chat-pricing-plans.tsx
@@ -42,7 +42,7 @@ const plans: PlanContent[] = [
 			"Claude Sonnet plus fast models like Haiku & Gemini Flash",
 			"Chat, image, video & audio studios",
 			"Real-time usage and per-message cost",
-			"Upgrade to frontier models anytime — prorated",
+			"Upgrade to frontier models anytime — takes effect instantly",
 		],
 	},
 	{


### PR DESCRIPTION
## Summary

PR #2913 replaced prorated DevPass/Chat tier upgrades with a **full-charge, fresh-cycle** model, but user-facing copy, one API response shape, and the chat upgrade webhook still reflected the old prorated flow. This PR updates everything to match the actual behavior and hardens the no-rollover guarantee:

- Upgrades charge the new tier's **full price** immediately, **restart the billing cycle**, and grant the **full new allowance**; unspent credits from the old cycle are **discarded, never rolled over**.
- DevPass downgrades take effect at the next renewal; Chat downgrades are immediate with the unused higher-tier time credited on the next invoice.

## Changes

### Copy
- **DevPass FAQ** (`apps/code/src/components/Faq.tsx`): rewrote the monthly-limit and change-plans answers (including the FAQPage JSON-LD text) to describe the full-charge model; dropped the "plan changes are prorated" claim from the refund answer.
- **DevPass pricing page**: "Switch tiers anytime — prorated" → "no lock-in, no cancellation fee"; bottom CTA now says upgrades kick in instantly.
- **Compare + Claude Code alternative pages**: same bottom-CTA fix.
- **Playground chat pricing** (`chat-pricing-plans.tsx`): Starter feature bullet no longer claims prorated upgrades.
- **Docs** (`learn/chat-plans.mdx`): expanded "Managing your plan" into explicit upgrade/downgrade/cancel bullets matching the implementation.

### API cleanup
- **`POST /dev-plans/change-tier-preview`**: removed the proration-era response fields `remainingFraction` and `proratedCreditDelta` (misleadingly named — it held the full credit delta since #2913) and the now-unused `getRemainingBillingPeriodFraction` helper. Neither field had any consumer; OpenAPI spec and typed clients regenerated (gitignored artifacts).

### No-rollover hardening (chat plan upgrade webhook)
Audited every path that applies an upgrade or renewal. DevPass endpoint + webhook fallback and the chat endpoint all correctly discard the old cycle's unused credits. The one gap was the **chat plan upgrade invoice webhook** (`stripe.ts`):
- It carried a stale proration-era comment ("an upgrade must not reset the cycle's usage") contradicting the endpoint, and derived tier/credits from the org's current `chatPlan`.
- Unlike the DevPass handler, it had **no crash-window fallback**: if the change-tier endpoint died after Stripe collected the full charge but before the local update, the org kept its old tier and old credits.
- Now it reads the target tier from the subscription metadata and reproduces the endpoint's fresh-cycle reset (full new allowance, usage zeroed — old unused credits discarded) when the org tier doesn't match, gated on winning the unique `stripeInvoiceId` insert so Stripe retries can't re-zero usage accrued since.
- Three new webhook tests: normal flow leaves credits untouched, fallback resets without rollover, retry doesn't re-apply.

## Legal
- **DevPass Supplemental Terms** (`apps/code/src/app/legal/terms/page.tsx`): Section 2 was silent on tier changes — added an explicit **Plan changes** clause: upgrades are immediate, charge the new tier's full price, restart the billing cycle, and forfeit the replaced cycle's unused allowance (no rollover, refund, or credit); downgrades apply at the next renewal with no charge or refund today. Bumped Last Updated to July 15, 2026. Base Terms make no tier-change claims, so no change needed there.

## Testing
- `dev-plans.spec.ts`: 14/14 pass (existing tests already assert upgrades wipe prior usage and grant exactly the new-tier allowance).
- `stripe.spec.ts`: 30/30 pass (3 new).
- Full `turbo build` across affected apps passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded “Managing your plan” guidance with clearer timing for upgrades, downgrades, and cancellations.
* **FAQ**
  * Updated monthly limit and refund answers (including structured fallback and rich content) to remove proration wording and emphasize instant upgrade behavior, plus “no cancellation fee.”
* **Pricing & Plan Updates**
  * Refreshed pricing, comparison, and pricing CTAs to say “Start on Pro” and that upgrades apply instantly (no lock-in, no cancellation fee).
  * Updated Starter-plan messaging to match instant, non-prorated upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->