### PR TITLE
feat(models): declare reasoning efforts for meta

### DIFF
--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -21,6 +21,7 @@ export const metaModels = [
 				maxOutput: 131072,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
 				reasoningMode: "adaptive",
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,


### PR DESCRIPTION
## Summary
Declares `reasoningEfforts` for the `providerId: "meta"` mapping (`muse-spark-1.1`) in `packages/models/src/models/meta.ts`.

## Changes
- `muse-spark-1.1` → `["minimal", "low", "medium", "high", "xhigh"]`

Sources:
- [Meta Model API, Reasoning](https://dev.meta.ai/docs/features/reasoning), which documents the `reasoning_effort` parameter behavior per value:

  | Value | Behavior |
  |---|---|
  | `none` | Not supported by Muse Spark — returns HTTP 400 |
  | `minimal` | Shortest reasoning pass |
  | `low` | Light reasoning |
  | `medium` | Moderate depth |
  | `high` | Deep reasoning |
  | `xhigh` | Maximum reasoning depth |

`none` is explicitly excluded, Meta's docs state it is not supported for this model and the API returns HTTP 400 if it's passed, so it isn't a valid `reasoning_effort` value for `muse-spark-1.1`, not an oversight.

## Testing
- `pnpm format`, only `meta.ts` changed, 1 line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring reasoning effort levels—minimal, low, medium, high, and extra high—for the Muse Spark 1.1 model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->