### PR TITLE
feat(docs): expand Features section by default

### DIFF
--- a/apps/docs/content/features/meta.json
+++ b/apps/docs/content/features/meta.json
@@ -1,0 +1,5 @@
+{
+	"title": "Features",
+	"description": "Explore LLM Gateway features",
+	"defaultOpen": true
+}

--- a/apps/docs/content/self-host/meta.json
+++ b/apps/docs/content/self-host/meta.json
@@ -2,7 +2,6 @@
 	"title": "Self Host",
 	"description": "Deploy LLM Gateway on your own infrastructure",
 	"icon": "Server",
-	"defaultOpen": true,
 	"pages": [
 		"index",
 		"docker",


### PR DESCRIPTION
## Summary

Based on PostHog data for docs.llmgateway.io (last 30 days), the **Features** section is the most visited docs section (~1.6k pageviews, ~1.3k unique visitors), ahead of Self Host (~1.1k) and Guides (~1.0k).

This PR makes the sidebar open on the section users actually visit most:

- Add `apps/docs/content/features/meta.json` with `defaultOpen: true` (folder previously had no meta.json; title and page ordering are unchanged)
- Remove `defaultOpen: true` from `apps/docs/content/self-host/meta.json`, so Self Host now collapses by default like the other sections

All other sections were already collapsed by default (fumadocs `defaultOpenLevel` defaults to 0), so no further changes needed.

## Data (pageviews by section, last 30d)

| Section | Pageviews |
|---|---|
| Features | ~1,620 |
| Self Host | ~1,060 |
| Guides | ~1,020 |
| API reference | ~700 |
| Knowledge base | ~455 |
| Resources / Integrations / Migrations | ~100 each |

https://claude.ai/code/session_01TVV56TZkVrMeHeHDF3m6uk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added metadata for the Features documentation section, including its title, description, and default expanded state.
  * Updated the Self-host documentation section to remove its explicit default expanded setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->