### PR TITLE
fix(devpass): make devPlanAllowAllModels toggle actually unlock all models

### DIFF
--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -297,16 +297,18 @@ export default function DevPlanSettings({
 
 					{advancedOpen && (
 						<div className="border-t p-5 space-y-4">
-							<div className="flex items-center justify-between gap-4">
-								<div className="space-y-0.5">
+							<div className="flex items-start justify-between gap-4">
+								<div className="space-y-1">
 									<Label
 										htmlFor="allow-all-models"
-										className="text-sm font-medium"
+										className="text-sm font-semibold"
 									>
 										Allow all models
 									</Label>
 									<p className="text-xs text-muted-foreground">
-										Enable access beyond the curated coding model list
+										Use any model from any provider, including provider-prefixed
+										IDs (e.g. <code>deepseek/deepseek-v4-flash</code>
+										). Prompt caching and cost predictability may be lost.
 									</p>
 								</div>
 								<Switch
@@ -318,16 +320,17 @@ export default function DevPlanSettings({
 							</div>
 
 							{allowAllModels && (
-								<div className="flex gap-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-3.5">
-									<AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
-									<p className="text-xs leading-relaxed text-muted-foreground">
-										<span className="font-medium text-yellow-600 dark:text-yellow-400">
+								<div className="flex gap-3 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
+									<AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+									<div className="text-xs text-muted-foreground space-y-1">
+										<p className="font-semibold text-amber-600 dark:text-amber-400">
 											Prompt caching may not be available.
-										</span>{" "}
-										Coding models are selected because they support prompt
-										caching, which reduces costs and latency. Non-curated models
-										may cost more.
-									</p>
+										</p>
+										<p>
+											Non-curated models and uncached providers may cost
+											significantly more. You are responsible for the costs.
+										</p>
+									</div>
 								</div>
 							)}
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2435,11 +2435,8 @@ chat.openapi(completions, async (c) => {
 			message: `Image generation is not available for coding plans. Coding plans only include text-based inference.`,
 		});
 	}
-
-	// Coding plans only allow models/provider mappings with cached input pricing.
-	// The model-level check denies models with no cached mapping at all.
-	// The specific-provider check denies a request like `groq/gpt-oss-120b` where the
-	// model qualifies as coding overall but the named mapping itself is uncached.
+	// Coding plans only allow models with cached input pricing. The toggle lifts
+	// this restriction so any model from any provider is available.
 	const isDevPlanRestricted = Boolean(
 		isDevPlan && !organization?.devPlanAllowAllModels,
 	);
@@ -2459,27 +2456,26 @@ chat.openapi(completions, async (c) => {
 		});
 	}
 
-	// Provider-targeting model strings (`provider/model`, `custom/model`) are
-	// never allowed on dev plans — only canonical root model ids. This is
-	// independent of allow-all-models: that flag only relaxes the model-level
-	// coding/cached-input restrictions below, it does not unlock direct or
-	// custom provider routing.
-	if (isDevPlan) {
-		if (
-			requestedProvider &&
-			requestedProvider !== "llmgateway" &&
-			requestedProvider !== "custom"
-		) {
+	// Provider-targeting model strings (`provider/model`) are restricted on
+	// dev plans that haven't enabled allow-all-models. Users who toggle
+	// "Enable access beyond the curated coding model list" accept the cost
+	// implications of bypassing smart routing and provider curation.
+	if (isDevPlanRestricted) {
+		if (requestedProvider && requestedProvider !== "llmgateway") {
 			throw new HTTPException(403, {
-				message: `Direct provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing.`,
+				message: `Direct provider routing is not available on restricted coding plans. Enable "access beyond the curated coding model list" in your dashboard settings, or use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix.`,
 			});
 		}
+	}
 
-		if (requestedProvider === "custom") {
-			throw new HTTPException(403, {
-				message: `Custom provider routing is not available on coding plans. Use the root model id (e.g. \`${modelInfo.id}\`) without a provider prefix and let the gateway handle routing.`,
-			});
-		}
+	// Custom provider routing (`custom/model`) is not a supported LLMGateway
+	// feature — it requires a real provider prefix from the models catalog
+	// (e.g. `deepseek/deepseek-v4-flash`, `anthropic/claude-sonnet-5`).
+	// This is independent of the allow-all-models toggle.
+	if (isDevPlan && requestedProvider === "custom") {
+		throw new HTTPException(403, {
+			message: `Custom provider routing is not supported. Use an existing provider prefix from the models catalog (e.g. \`deepseek/deepseek-v4-flash\`) or the root model id without a prefix.`,
+		});
 	}
 
 	if (isDevPlanRestricted) {


### PR DESCRIPTION
## Summary

The DevPass dashboard toggle "Allow all models" (`devPlanAllowAllModels`)
promises unrestricted model access but was only applied to the model-filtering
gate. The provider-prefix gate still used the raw `isDevPlan` flag, blocking
`provider/model` strings even when the toggle was ON.

This change swaps the provider-prefix gate from `isDevPlan` to
`isDevPlanRestricted`. With the toggle ON:

| | Allowed | Blocked |
|---|---|---|
| **Text & multimodal models** (any model with `output: ["text"]` or `["text","image"]`) | ✅ | |
| **Non-curated models** (models outside the curated coding list) | ✅ | |
| **Provider-prefixed model IDs** (`deepseek/deepseek-v4-flash`, `alibaba/qwen3.7-plus:us-virginia`) | ✅ | |
| **Image generation only models** (`seedance`, `kling`, `wan`, `gemini-*-image`) | | ❌ |
| **Custom provider** (`custom/…`) | | ❌ |
| **Throughput/latency routing** | | ❌ |

### Before

![Advanced section — original Allow all models toggle](https://i.imgur.com/dZzUNAA.png)

### After

![Advanced section — toggle ON with expanded warnings in dark theme](https://i.imgur.com/x78sUbh.png)

## What changed

- **Provider-prefix gate** (`chat.ts` ~line 2467): `isDevPlan` → `isDevPlanRestricted`. Toggle ON = `provider/model` strings pass instead of 403.
- **Custom provider gate**: stays on `isDevPlan` — `custom/…` remains blocked (not a real provider).
- **Dashboard UI**: tightened the toggle description and added a compact amber warning when ON. Toggle stays in the Advanced section with the label "Allow all models".

## Testing

- [ ] **⚠️ MANUAL TESTING REQUIRED** — this changes authorization gates on live DevPass traffic. Verify the following against a DevPass org before and after toggling `devPlanAllowAllModels`.

### Toggle ON (`devPlanAllowAllModels=true`)

All of these should return 200:

```bash
# Provider-prefixed model — was 403, should now be 200
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}'

# Another real provider prefix
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"anthropic/claude-sonnet-5","messages":[{"role":"user","content":"hi"}]}'

# Provider prefix + non-curated model
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"alibaba/qwen3.6-flash","messages":[{"role":"user","content":"hi"}]}'

# Model with region suffix (the : is parsed separately from the prefix gate)
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"alibaba/qwen3.7-plus:us-virginia","messages":[{"role":"user","content":"hi"}]}'
```

### Toggle OFF (`devPlanAllowAllModels=false`)

All of these should return 403:

```bash
# Provider-prefixed model blocked
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"deepseek/deepseek-v4-flash","messages":[{"role":"user","content":"hi"}]}'

# Non-curated model blocked
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"qwen3.6-flash","messages":[{"role":"user","content":"hi"}]}'
```

### Always blocked (regardless of toggle)

```bash
# Custom provider — not a real LLMGateway feature, always 403 on dev plans
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"custom/my-model","messages":[{"role":"user","content":"hi"}]}'

# Image generation — permanently blocked on dev plans
curl -s https://api.llmgateway.io/v1/chat/completions \
  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
  -d '{"model":"google/gemini-3-pro-image-preview","messages":[{"role":"user","content":"hi"}]}'

```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Advanced settings now clarify that allowing all models supports provider-prefixed model IDs.
  - Added warnings about potentially reduced prompt caching, less predictable costs, and increased spending responsibility.
  - Coding plans can access models from supported providers when expanded model access is enabled.

- **Bug Fixes**
  - Improved validation and messaging for provider-prefixed model requests.
  - Custom provider routing remains clearly identified as unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->