### PR TITLE
feat(models): declare reasoning efforts for sakana fugu-ultra

### DIFF
--- a/packages/models/src/models/sakana.ts
+++ b/packages/models/src/models/sakana.ts
@@ -39,6 +39,7 @@ export const sakanaModels = [
 				contextSize: 1000000,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["high", "xhigh"],
 				// Fugu reasoning summaries are only exposed via the OpenAI Responses
 				// API, so route through it. Summaries are adaptive (omitted for
 				// simpler prompts), hence reasoningOutput is "omit".


### PR DESCRIPTION
## Summary
Declares `reasoningEfforts` for the `providerId: "sakana"` mapping (`fugu-ultra`) in `packages/models/src/models/sakana.ts`.

## Changes
- `fugu-ultra` → `["high", "xhigh"]`

Sources:
- [Sakana AI / On Note](https://console.sakana.ai/get-started#using-sakana-fugu-in-custom-workflows), which states Fugu models accept two reasoning effort levels, `high` and `xhigh`, set via the `reasoning.effort` parameter; any other value is rejected. `max` is also accepted but is explicitly a compatibility alias that currently maps to the same level as `xhigh`, not a distinct effort level.
- The same page's Codex model catalog config (`fugu.json`) independently lists `supported_reasoning_levels` for `fugu-ultra` as exactly `high` and `xhigh`, confirming the same two values from a second source on the same page.

`max` is excluded from `reasoningEfforts` since it doesn't produce behavior distinct from `xhigh`, same convention used for DeepSeek's `xhigh`→`max` aliasing. `none`, `low`, and `medium` are not documented as accepted values for this model and are excluded.

## Testing
- `pnpm format`, only `sakana.ts` changed, 1 line.