### PR TITLE
fix(code): align DevPass invoice table columns

### DIFF
--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
 import type { paths } from "@/lib/api/v1";
+import type { ReactNode } from "react";
 
 const PAGE_SIZE = 10;
 
@@ -40,6 +41,23 @@ function isInvoiceable(invoice: Invoice): boolean {
 		invoice.status === "completed" &&
 		invoice.amount !== null &&
 		Number(invoice.amount) > 0
+	);
+}
+
+// Invisible stand-in that reserves the exact footprint of an action button so
+// the Invoice/Refund columns stay aligned on rows missing one of the actions.
+function ActionButtonPlaceholder({ children }: { children: ReactNode }) {
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			disabled
+			aria-hidden="true"
+			tabIndex={-1}
+			className="invisible hidden sm:inline-flex"
+		>
+			{children}
+		</Button>
 	);
 }
 
@@ -139,7 +157,12 @@ function RefundButton({ invoice }: { invoice: Invoice }) {
 
 	const refund = invoice.refund;
 	if (!refund) {
-		return null;
+		return (
+			<ActionButtonPlaceholder>
+				<Undo2 className="h-4 w-4" />
+				<span className="sr-only sm:not-sr-only">Refund</span>
+			</ActionButtonPlaceholder>
+		);
 	}
 
 	if (!refund.eligible) {
@@ -254,8 +277,8 @@ export default function DevPassInvoices() {
 				usage credits granted for that billing period.
 			</p>
 
-			<div className="overflow-hidden rounded-xl border">
-				<div className="hidden grid-cols-[1fr_1fr_auto_auto_auto] gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:grid">
+			<div className="overflow-hidden rounded-xl border sm:grid sm:grid-cols-[1fr_1fr_auto_auto_auto]">
+				<div className="hidden grid-cols-subgrid gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:col-span-5 sm:grid">
 					<div>Date</div>
 					<div>Description</div>
 					<div className="text-right">Amount debited</div>
@@ -266,7 +289,7 @@ export default function DevPassInvoices() {
 				{pageInvoices.map((invoice) => (
 					<div
 						key={invoice.id}
-						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:grid-cols-[1fr_1fr_auto_auto_auto] sm:items-center"
+						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:col-span-5 sm:grid-cols-subgrid sm:items-center"
 					>
 						<div className="text-sm tabular-nums">
 							{format(new Date(invoice.date), "MMM d, yyyy")}
@@ -295,8 +318,13 @@ export default function DevPassInvoices() {
 							{formatCredits(invoice.creditAmount)}
 						</div>
 						<div className="col-span-2 mt-1 flex justify-end gap-2 sm:col-span-1 sm:mt-0">
-							{isInvoiceable(invoice) && (
+							{isInvoiceable(invoice) ? (
 								<InvoiceDownloadButton invoice={invoice} />
+							) : (
+								<ActionButtonPlaceholder>
+									<Download className="h-4 w-4" />
+									<span className="sr-only sm:not-sr-only">Invoice</span>
+								</ActionButtonPlaceholder>
 							)}
 							<RefundButton invoice={invoice} />
 						</div>


### PR DESCRIPTION
## Problem

Rows in the DevPass Invoices table (`/dashboard/billing`) were misaligned when a row had no Refund button. Each row was an independent CSS grid with `auto`-sized columns, so a row without a Refund button — e.g. plan upgrades, whose `dev_plan_upgrade` type is not in `SELF_REFUNDABLE_TYPES` and therefore gets no `refund` object — collapsed its actions column, shifting the amount, credits, and Invoice button out of line with the other rows.

**Before:**

The "Upgrade" row's Invoice button sits flush right and its amount/credits columns shift right relative to every other row.

## Fix

Two-part fix in `apps/code/src/app/dashboard/components/DevPassInvoices.tsx`:

1. **Shared column tracks via subgrid** — the table container is now a single grid (`sm:grid sm:grid-cols-[1fr_1fr_auto_auto_auto]`) and the header + each row use `grid-cols-subgrid`, so every row sizes its columns from the same shared tracks instead of independently.
2. **Reserved action-button slots** — when a row has no Invoice or Refund action, an invisible placeholder button (`ActionButtonPlaceholder`) reserves the exact footprint, so the Invoice buttons and Refund buttons each line up in their own column. Placeholders are `hidden` below the `sm` breakpoint, leaving the mobile card layout unchanged.

## Verification

- Reproduced against seeded data plus transactions mirroring the report (renewals with eligible/ineligible refunds, an upgrade with no refund, a plan start): before the fix the Upgrade row was shifted; after the fix all five columns align across all rows.
- Verified the mobile (390px) card layout still renders correctly with no blank space from placeholders.
- `turbo run build --filter=code` passes; `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vdcHUSBXoA6D73wzjRBh3

---
_Generated by [Claude Code](https://claude.ai/code/session_013vdcHUSBXoA6D73wzjRBh3)_