### PR TITLE
fix: novita deepseek-v3.2 reasoning suppression

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -138,6 +138,21 @@ export const deepseekModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				// reasoning_effort must NOT be forwarded: Novita ignores it on its
+				// own and, sent alongside the `chat_template_kwargs.thinking` flag,
+				// it suppresses reasoning entirely (verified live 2026-07-16).
+				// Thinking is controlled solely via requiresEnableThinking.
+				supportedParameters: [
+					"temperature",
+					"max_tokens",
+					"top_p",
+					"frequency_penalty",
+					"presence_penalty",
+					"stop",
+					"stream",
+					"response_format",
+					"tools",
+				],
 			},
 			{
 				providerId: "alibaba",


### PR DESCRIPTION
## Summary

The `novita/deepseek-v3.2` reasoning e2e tests (`basic reasoning`, `reasoning + streaming`) have been failing the aggregate e2e check on every PR (seen on #3075, #3087, and others).

Root cause, verified live against Novita's API on 2026-07-16: Novita changed behavior so that sending `reasoning_effort` **alongside** the `chat_template_kwargs: { thinking: true }` flag suppresses reasoning entirely (0 reasoning tokens, no `reasoning_content`), while `reasoning_effort` on its own has no effect on this hybrid model. The gateway sends both: `requiresEnableThinking` adds the template flag, and the default OpenAI-compatible case forwards `reasoning_effort` raw because the mapping declared no `supportedParameters`.

## Fix

Declare `supportedParameters` (without `reasoning_effort`) on the novita mapping so the raw effort value is dropped and only the `chat_template_kwargs.thinking` flag — the one control the deployment actually honors — is forwarded. Metadata-only change, mirroring the sibling deepseek mappings.

## Testing

- `TEST_MODELS="novita/deepseek-v3.2" FULL_MODE=true pnpm test:e2e` — 88 passed, 0 failed (previously the two reasoning tests failed)
- Verified live: template flag alone → 804 reasoning chars; flag + `reasoning_effort` → 0
- models/actions unit suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the Novita provider by restricting requests to supported generation and control settings.
  * Prevented unsupported reasoning controls from being forwarded, ensuring reasoning behavior is handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->