### PR TITLE
feat(models): add kimi-k3

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -924,7 +924,8 @@ describe("prepareRequestBody - reasoning_effort none", () => {
 describe("prepareRequestBody - Moonshot thinking", () => {
 	async function prepare(options: {
 		model: string;
-		reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high";
+		reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "max";
+		maxTokens?: number;
 	}) {
 		return (await prepareRequestBody(
 			"moonshot",
@@ -934,7 +935,7 @@ describe("prepareRequestBody - Moonshot thinking", () => {
 			[{ role: "user", content: "Hello!" }],
 			false, // stream
 			undefined, // temperature
-			undefined, // max_tokens
+			options.maxTokens, // max_tokens
 			undefined, // top_p
 			undefined, // frequency_penalty
 			undefined, // presence_penalty
@@ -993,6 +994,33 @@ describe("prepareRequestBody - Moonshot thinking", () => {
 			reasoningEffort: "medium",
 		});
 		expect(requestBody.thinking).toEqual({ type: "enabled" });
+	});
+
+	test("forwards reasoning_effort natively for kimi-k3 (no thinking toggle)", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k3",
+			reasoningEffort: "max",
+		});
+		expect(requestBody.reasoning_effort).toBe("max");
+		expect(requestBody.thinking).toBeUndefined();
+	});
+
+	test("collapses disable requests onto the provider default for kimi-k3", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k3",
+			reasoningEffort: "none",
+		});
+		expect(requestBody.reasoning_effort).toBeUndefined();
+		expect(requestBody.thinking).toBeUndefined();
+	});
+
+	test("sends max_completion_tokens instead of max_tokens for kimi-k3", async () => {
+		const requestBody = await prepare({
+			model: "kimi-k3",
+			maxTokens: 4096,
+		});
+		expect(requestBody.max_completion_tokens).toBe(4096);
+		expect(requestBody.max_tokens).toBeUndefined();
 	});
 });
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2006,6 +2006,11 @@ export async function prepareRequestBody(
 			break;
 		}
 		case "moonshot": {
+			// Kimi K3 has its own parameter surface: output length is capped via
+			// `max_completion_tokens` (the K2-era `max_tokens` is not documented
+			// for it), and thinking is configured through the native top-level
+			// `reasoning_effort` field instead of the binary `thinking` toggle.
+			const isKimiK3 = usedInternalModel === "kimi-k3";
 			if (stream) {
 				requestBody.stream_options = {
 					include_usage: true,
@@ -2020,7 +2025,11 @@ export async function prepareRequestBody(
 				requestBody.temperature = temperature;
 			}
 			if (max_tokens !== undefined) {
-				requestBody.max_tokens = max_tokens;
+				if (isKimiK3) {
+					requestBody.max_completion_tokens = max_tokens;
+				} else {
+					requestBody.max_tokens = max_tokens;
+				}
 			}
 			if (top_p !== undefined) {
 				requestBody.top_p = top_p;
@@ -2031,24 +2040,34 @@ export async function prepareRequestBody(
 			if (presence_penalty !== undefined) {
 				requestBody.presence_penalty = presence_penalty;
 			}
-			// Moonshot's thinking models don't recognize `reasoning_effort`; they
-			// take a binary `thinking` parameter (`{ type: "enabled" | "disabled" }`)
-			// and think by default. Map `none`/`minimal` to an explicit disable and
-			// every other tier to an explicit enable; when no effort is requested,
-			// send nothing and keep the provider default (thinking on). Mappings
-			// that can turn thinking off declare `none` in `reasoningEfforts`;
-			// always-on models (kimi-k2.7-code*) reject `"disabled"` with a 400, so
-			// collapse disable requests onto their minimum (thinking stays on).
+			// Moonshot's K2-era thinking models don't recognize `reasoning_effort`;
+			// they take a binary `thinking` parameter (`{ type: "enabled" |
+			// "disabled" }`) and think by default. Map `none`/`minimal` to an
+			// explicit disable and every other tier to an explicit enable; when no
+			// effort is requested, send nothing and keep the provider default
+			// (thinking on). Mappings that can turn thinking off declare `none` in
+			// `reasoningEfforts`; always-on models (kimi-k2.7-code*) reject
+			// `"disabled"` with a 400, so collapse disable requests onto their
+			// minimum (thinking stays on). Kimi K3 instead takes the top-level
+			// `reasoning_effort` field natively (currently only "max") and always
+			// thinks, so forward the effort as-is and collapse disable requests
+			// onto the provider default.
 			if (supportsReasoning && reasoning_effort !== undefined) {
 				const wantsThinking =
 					reasoning_effort !== "none" && reasoning_effort !== "minimal";
-				const canDisableThinking =
-					providerMappingForOptions?.reasoningEfforts?.includes("none") ??
-					false;
-				if (wantsThinking) {
-					requestBody.thinking = { type: "enabled" };
-				} else if (canDisableThinking) {
-					requestBody.thinking = { type: "disabled" };
+				if (isKimiK3) {
+					if (wantsThinking) {
+						requestBody.reasoning_effort = reasoning_effort;
+					}
+				} else {
+					const canDisableThinking =
+						providerMappingForOptions?.reasoningEfforts?.includes("none") ??
+						false;
+					if (wantsThinking) {
+						requestBody.thinking = { type: "enabled" };
+					} else if (canDisableThinking) {
+						requestBody.thinking = { type: "disabled" };
+					}
 				}
 			}
 			break;

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -557,4 +557,40 @@ export const moonshotModels = [
 			},
 		],
 	},
+	{
+		id: "kimi-k3",
+		name: "Kimi K3",
+		description:
+			"Kimi's flagship model for long-horizon coding and end-to-end knowledge work with a 1M-token context window.",
+		family: "moonshot",
+		releasedAt: new Date("2026-07-16"),
+		providers: [
+			{
+				providerId: "moonshot",
+				externalId: "kimi-k3",
+				inputPrice: "3.0e-6",
+				cachedInputPrice: "0.3e-6",
+				outputPrice: "15.0e-6",
+				requestPrice: "0",
+				contextSize: 1048576,
+				maxOutput: 1048576,
+				reasoning: true,
+				// K3 always thinks; the effort level is set via the native
+				// top-level `reasoning_effort` field (no K2-era `thinking`
+				// toggle), which currently accepts only "max".
+				reasoningEfforts: ["max"],
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+				supportedParameters: [
+					"max_tokens",
+					"response_format",
+					"tools",
+					"tool_choice",
+					"reasoning_effort",
+				],
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];

--- a/packages/shared/src/components/models-directory/model-category-filters.ts
+++ b/packages/shared/src/components/models-directory/model-category-filters.ts
@@ -70,6 +70,7 @@ export const curatedCategoryModelIds: Record<
 		"gemini-3.5-flash",
 		"grok-build-0-1",
 		"grok-4-3",
+		"kimi-k3",
 		"kimi-k2.7-code",
 		"kimi-k2.7-code-highspeed",
 		"kimi-k2.6",
@@ -195,6 +196,8 @@ export const OPEN_SOURCE_MODEL_IDS: ReadonlySet<string> = new Set([
 // API-only Muse Spark models alongside the open Llama family)
 export const CLOSED_SOURCE_MODEL_IDS: ReadonlySet<string> = new Set([
 	"muse-spark-1.1",
+	// API-only at launch; no open weights published (unlike the K2 family)
+	"kimi-k3",
 ]);
 
 export function isTextOutput(output: string[] | null | undefined): boolean {


### PR DESCRIPTION
## Summary

Adds Moonshot's **Kimi K3** flagship model to the catalogue, released today (2026-07-16). Docs: [pricing](https://platform.kimi.ai/docs/pricing/chat-k3.md), [quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart.md), [thinking effort](https://platform.kimi.ai/docs/guide/use-thinking-effort.md), [tool choice](https://platform.kimi.ai/docs/guide/use-tool-choice.md).

### Model definition (`packages/models`)

- `kimi-k3` on the `moonshot` provider (same `api.moonshot.ai/v1` endpoint)
- 1,048,576-token context window and max output (per docs, `max_completion_tokens` can be set up to 1048576)
- $3.00/M input (cache miss), $0.30/M cached input (cache hit), $15.00/M output — lands in the premium fair-use category automatically via the $15/M output threshold
- `reasoning: true` with `reasoningEfforts: ["max"]` — K3 always thinks; effort is set via the top-level `reasoning_effort` field which currently accepts only `"max"` (more levels announced as coming)
- Vision (images + video input), tools with all `tool_choice` modes (`auto`/`none`/`required`/named function — K3 lifts the K2-era forced-tool-choice restriction), strict JSON schema output, streaming with separate `reasoning_content` deltas
- `supportedParameters` excludes temperature/top_p/penalties (K3 fixes them at 1.0/0.95/0), so the gateway strips them instead of forwarding

### Gateway request mapping (`packages/actions`)

K3's API differs from the K2 generation in two ways, handled in the `moonshot` case of `prepareRequestBody`:

- `reasoning_effort` is forwarded natively for K3 (K2-era models get the binary `thinking: { type }` toggle, which K3 does not accept); disable requests (`none`/`minimal`) collapse onto the provider default since K3 cannot turn thinking off
- `max_tokens` is translated to `max_completion_tokens` (the only output-cap parameter K3 documents)

Unit tests added for all three behaviors.

### Models directory (`packages/shared`)

- Added `kimi-k3` to the curated **coding** category
- Marked closed-source: API-only at launch with no published weights, while the `moonshot` family otherwise defaults to open-source

## Testing

- `pnpm exec vitest run packages/actions packages/models packages/shared/src/model-categories.spec.ts` — all pass (including 3 new K3 tests)
- `pnpm build` — 17/17 tasks successful
- Live verification not possible locally (no `LLM_MOONSHOT_API_KEY` in local env); behavior is per the official K3 docs and should be smoke-tested once deployed with a key

https://claude.ai/code/session_01XETTwBHG4TF4gHDFR4VU2G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi K3 model, including a 1M-token context window, vision, tools, streaming, JSON output, and reasoning capabilities.
  * Added Kimi K3 to the coding model category.
  * Added native reasoning controls and optimized token handling for Kimi K3.
* **Bug Fixes**
  * Corrected token limit mapping for Kimi K3 requests.
  * Ensured disabled or unspecified reasoning uses provider defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->