### PR TITLE
fix(devpass): skip card dedupe in local dev

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -7,7 +7,11 @@ import {
 	executeSelfRefund,
 	isSelfRefundCandidateType,
 } from "@/lib/self-refund.js";
-import { ensureStripeCustomer, finalizeDevPlanSetupSession } from "@/stripe.js";
+import {
+	ensureStripeCustomer,
+	finalizeDevPlanSetupSession,
+	isDevPlanCardDedupeEnforced,
+} from "@/stripe.js";
 import { findDefaultOrganization } from "@/utils/default-org.js";
 import {
 	buildInvoiceDataForTransaction,
@@ -2632,29 +2636,32 @@ devPlans.openapi(updatePaymentMethod, async (c) => {
 
 	// Enforce one card per DevPass account: reject a card already linked to a
 	// different org and detach it so it isn't silently left on this customer.
-	const conflictingOrg = await db.query.organization.findFirst({
-		where: {
-			devPlanCardFingerprint: { eq: fingerprint },
-			id: { ne: personalOrg.id },
-		},
-	});
-	if (conflictingOrg) {
-		try {
-			await getStripe().paymentMethods.detach(paymentMethodId);
-		} catch (err) {
-			logger.warn(
-				`Failed to detach duplicate dev plan card ${paymentMethodId}`,
-				{ error: err instanceof Error ? err.message : String(err) },
+	// Skipped in local development so the same Stripe test card can be reused.
+	if (isDevPlanCardDedupeEnforced()) {
+		const conflictingOrg = await db.query.organization.findFirst({
+			where: {
+				devPlanCardFingerprint: { eq: fingerprint },
+				id: { ne: personalOrg.id },
+			},
+		});
+		if (conflictingOrg) {
+			try {
+				await getStripe().paymentMethods.detach(paymentMethodId);
+			} catch (err) {
+				logger.warn(
+					`Failed to detach duplicate dev plan card ${paymentMethodId}`,
+					{ error: err instanceof Error ? err.message : String(err) },
+				);
+			}
+			return c.json(
+				{
+					error: "duplicate_card" as const,
+					message:
+						"This card is already associated with another DevPass account. Please use a different payment method.",
+				},
+				409,
 			);
 		}
-		return c.json(
-			{
-				error: "duplicate_card" as const,
-				message:
-					"This card is already associated with another DevPass account. Please use a different payment method.",
-			},
-			409,
-		);
 	}
 
 	// confirmCardSetup already attaches the card to the customer; attach again

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -819,6 +819,16 @@ async function resolvePaymentMethodFromSetupSession(
 }
 
 /**
+ * Whether the one-card-per-DevPass-account rule is enforced. Disabled in local
+ * development so the same Stripe test card (e.g. 4242 4242 4242 4242) can be
+ * reused across dev accounts without hitting `duplicate_card`. Stays enforced
+ * in test and production.
+ */
+export function isDevPlanCardDedupeEnforced(): boolean {
+	return process.env.NODE_ENV !== "development";
+}
+
+/**
  * Finalize a DevPass setup-mode checkout session: verify the card fingerprint
  * is not already in use by another organization, then create the Stripe
  * subscription server-side. Idempotent: safe to call from both the
@@ -881,7 +891,7 @@ export async function finalizeDevPlanSetupSession(
 			? (paymentMethod.card?.fingerprint ?? null)
 			: null;
 
-	if (fingerprint) {
+	if (fingerprint && isDevPlanCardDedupeEnforced()) {
 		const conflictingOrg = await db.query.organization.findFirst({
 			where: {
 				devPlanCardFingerprint: { eq: fingerprint },


### PR DESCRIPTION
## Summary

The DevPass one-card-per-account rule rejected the reused Stripe test card (`4242 4242 4242 4242`) with `duplicate_card` during local development, making it painful to activate multiple dev DevPass accounts.

This gates the card-fingerprint conflict check on `NODE_ENV`: it now only enforces in **test** and **production**, and is skipped in **development**.

## Changes

- Add `isDevPlanCardDedupeEnforced()` helper in `apps/api/src/stripe.ts` (`NODE_ENV !== "development"`).
- Gate the fingerprint conflict lookup in `finalizeDevPlanSetupSession` (checkout finalize / webhook path).
- Gate the conflict lookup in the `updatePaymentMethod` handler (`apps/api/src/routes/dev-plans.ts`).

Enforcement is unchanged in `test` (unit/e2e) and `production`; only local `development` skips the check. The fingerprint is still stored as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DevPass payment setup now allows card reuse in local development environments.
  * Duplicate-card enforcement remains active in test and production environments.
  * Payment updates proceed normally when duplicate-card checks are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->