### PR TITLE
feat: add devpass toggle to revenue chart

### DIFF
--- a/apps/api/src/routes/admin-paid-customers.spec.ts
+++ b/apps/api/src/routes/admin-paid-customers.spec.ts
@@ -19,14 +19,24 @@ interface TimeseriesPoint {
 	date: string;
 	paidCustomers: number;
 	net: number;
+	devpassRevenue: number;
+	devpassRefunds: number;
+	devpassNet: number;
 	dailySignups: number;
 	dailyPaidCustomers: number;
 	dailyNet: number;
+	dailyDevpassNet: number;
 }
 
 interface TimeseriesResponse {
 	data: TimeseriesPoint[];
-	totals: { paidCustomers: number; net: number };
+	totals: {
+		paidCustomers: number;
+		net: number;
+		devpassRevenue: number;
+		devpassRefunds: number;
+		devpassNet: number;
+	};
 }
 
 async function getMetrics(cookie: string): Promise<AdminMetricsResponse> {
@@ -263,5 +273,95 @@ describe("admin paid customers — bounded range baseline", () => {
 		// Today's daily net = in-range payments (5 + 10); the gift is excluded.
 		expect(today?.dailyNet).toBe(15);
 		expect(body.totals.net).toBe(35);
+	});
+});
+
+describe("admin timeseries — devpass revenue series", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: "devpass-org",
+				name: "DevPass Org",
+				billingEmail: "devpass@example.com",
+				kind: "devpass",
+			},
+			{
+				id: "pro-org",
+				name: "Pro Org",
+				billingEmail: "pro@example.com",
+			},
+		]);
+
+		// eslint-disable-next-line no-mixed-operators
+		const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+		await db.insert(tables.transaction).values([
+			// Pre-range dev plan payment — belongs to the cumulative baseline.
+			{
+				organizationId: "devpass-org",
+				type: "dev_plan_start",
+				amount: "20",
+				creditAmount: "40",
+				status: "completed",
+				stripeInvoiceId: "inv_pre",
+				createdAt: sixtyDaysAgo,
+			},
+			// In-range dev plan payment.
+			{
+				id: "devpass-start-tx",
+				organizationId: "devpass-org",
+				type: "dev_plan_start",
+				amount: "10",
+				creditAmount: "20",
+				status: "completed",
+				stripeInvoiceId: "inv_1",
+			},
+			// In-range refund against a dev plan payment — netted out.
+			{
+				organizationId: "devpass-org",
+				type: "credit_refund",
+				amount: "4",
+				creditAmount: "0",
+				status: "completed",
+				relatedTransactionId: "devpass-start-tx",
+			},
+			// Legacy `subscription_*` row on a NON-devpass org is org Pro revenue,
+			// never DevPass revenue.
+			{
+				organizationId: "pro-org",
+				type: "subscription_start",
+				amount: "99",
+				creditAmount: "0",
+				status: "completed",
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("range=7d devpass series nets refunds and keeps baseline", async () => {
+		const body = await getTimeseries(cookie, "?range=7d");
+		const todayStr = new Date().toISOString().split("T")[0];
+		const first = body.data[0];
+		const today = body.data.find((point) => point.date === todayStr);
+
+		// 20 pre-range + 10 in-range (org Pro subscription excluded).
+		expect(body.totals.devpassRevenue).toBe(30);
+		expect(body.totals.devpassRefunds).toBe(4);
+		expect(body.totals.devpassNet).toBe(26);
+		expect(body.data.at(-1)?.devpassNet).toBe(26);
+
+		// Pre-range payment sits in the cumulative baseline, not in day one.
+		expect(first.devpassNet).toBe(20);
+		expect(first.dailyDevpassNet).toBe(0);
+
+		// Today's delta: 10 gross - 4 refund.
+		expect(today?.dailyDevpassNet).toBe(6);
 	});
 });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -119,11 +119,17 @@ const timeseriesDataPointSchema = z.object({
 	processed: z.number(),
 	refunds: z.number(),
 	net: z.number(),
+	// DevPass plan revenue (gross Stripe amount, deduplicated per invoice) and
+	// net (after refunds), cumulative like the credits series above.
+	devpassRevenue: z.number(),
+	devpassRefunds: z.number(),
+	devpassNet: z.number(),
 	// Per-day (non-cumulative) values. The cumulative series above start from a
 	// pre-range baseline, so clients cannot derive day-one deltas themselves.
 	dailySignups: z.number(),
 	dailyPaidCustomers: z.number(),
 	dailyNet: z.number(),
+	dailyDevpassNet: z.number(),
 });
 
 const adminTimeseriesSchema = z.object({
@@ -136,6 +142,9 @@ const adminTimeseriesSchema = z.object({
 		processed: z.number(),
 		refunds: z.number(),
 		net: z.number(),
+		devpassRevenue: z.number(),
+		devpassRefunds: z.number(),
+		devpassNet: z.number(),
 	}),
 });
 
@@ -1095,6 +1104,80 @@ admin.openapi(getTimeseries, async (c) => {
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
 
+	// DevPass revenue per day: dev plan payments (+ legacy `subscription_*` rows
+	// on devpass orgs), gross Stripe `amount` deduplicated per invoice. Mirrors
+	// /admin/devpass/timeseries.
+	const devpassRevenuePerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				inArray(tables.transaction.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
+	// DevPass refunds per day: `credit_refund` rows linked back to a dev plan
+	// payment via `relatedTransactionId`. Mirrors /admin/devpass/timeseries.
+	const devpassRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"devpass_refund_original_tx",
+	);
+	const devpassRefundsPerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			devpassRefundOriginalTx,
+			eq(tables.transaction.relatedTransactionId, devpassRefundOriginalTx.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				inArray(devpassRefundOriginalTx.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
 	// Pre-range totals for cumulative chart
 	const [preRangeRevenueRow] = await db
 		.select({
@@ -1150,6 +1233,65 @@ admin.openapi(getTimeseries, async (c) => {
 			),
 		);
 	const preRangeRefunds = Number(preRangeRefundsRow?.total ?? 0);
+
+	const [preRangeDevpassRevenueRow] = await db
+		.select({
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				inArray(tables.transaction.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				firstRowPerInvoiceFilter([
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				sql`${tables.transaction.createdAt} < ${startDate}`,
+			),
+		);
+	const preRangeDevpassRevenue = Number(preRangeDevpassRevenueRow?.total ?? 0);
+
+	const [preRangeDevpassRefundsRow] = await db
+		.select({
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			devpassRefundOriginalTx,
+			eq(tables.transaction.relatedTransactionId, devpassRefundOriginalTx.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				inArray(devpassRefundOriginalTx.type, [
+					...DEV_PLAN_TX_TYPES,
+					...LEGACY_DEV_PLAN_TX_TYPES,
+				]),
+				sql`${tables.transaction.createdAt} < ${startDate}`,
+			),
+		);
+	const preRangeDevpassRefunds = Number(preRangeDevpassRefundsRow?.total ?? 0);
 
 	// Count of orgs that became paying before the range (bounded SQL query)
 	const [preRangeRow] = await db
@@ -1227,6 +1369,16 @@ admin.openapi(getTimeseries, async (c) => {
 		refundsMap.set(row.date, Number(row.total));
 	}
 
+	const devpassRevenueMap = new Map<string, number>();
+	for (const row of devpassRevenuePerDay) {
+		devpassRevenueMap.set(row.date, Number(row.total));
+	}
+
+	const devpassRefundsMap = new Map<string, number>();
+	for (const row of devpassRefundsPerDay) {
+		devpassRefundsMap.set(row.date, Number(row.total));
+	}
+
 	const newPaidMap = new Map<string, number>();
 	for (const row of firstTransactionPerOrg) {
 		newPaidMap.set(row.date, Number(row.count));
@@ -1241,15 +1393,21 @@ admin.openapi(getTimeseries, async (c) => {
 		processed: number;
 		refunds: number;
 		net: number;
+		devpassRevenue: number;
+		devpassRefunds: number;
+		devpassNet: number;
 		dailySignups: number;
 		dailyPaidCustomers: number;
 		dailyNet: number;
+		dailyDevpassNet: number;
 	}> = [];
 	let cumulativePaid = preRangeCount;
 	let totalSignups = 0;
 	let totalRevenue = preRangeRevenue;
 	let totalProcessed = preRangeProcessed;
 	let totalRefunds = preRangeRefunds;
+	let totalDevpassRevenue = preRangeDevpassRevenue;
+	let totalDevpassRefunds = preRangeDevpassRefunds;
 
 	const totalDays = Math.ceil(
 		(endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000),
@@ -1262,6 +1420,8 @@ admin.openapi(getTimeseries, async (c) => {
 		const dailyRevenue = revenueMap.get(dateStr) ?? 0;
 		const dailyProcessed = processedMap.get(dateStr) ?? 0;
 		const dailyRefunds = refundsMap.get(dateStr) ?? 0;
+		const dailyDevpassRevenue = devpassRevenueMap.get(dateStr) ?? 0;
+		const dailyDevpassRefunds = devpassRefundsMap.get(dateStr) ?? 0;
 		const dailyPaidCustomers = newPaidMap.get(dateStr) ?? 0;
 		cumulativePaid += dailyPaidCustomers;
 
@@ -1269,6 +1429,8 @@ admin.openapi(getTimeseries, async (c) => {
 		totalRevenue += dailyRevenue;
 		totalProcessed += dailyProcessed;
 		totalRefunds += dailyRefunds;
+		totalDevpassRevenue += dailyDevpassRevenue;
+		totalDevpassRefunds += dailyDevpassRefunds;
 
 		data.push({
 			date: dateStr,
@@ -1278,9 +1440,13 @@ admin.openapi(getTimeseries, async (c) => {
 			processed: totalProcessed,
 			refunds: totalRefunds,
 			net: totalRevenue - totalRefunds,
+			devpassRevenue: totalDevpassRevenue,
+			devpassRefunds: totalDevpassRefunds,
+			devpassNet: totalDevpassRevenue - totalDevpassRefunds,
 			dailySignups,
 			dailyPaidCustomers,
 			dailyNet: dailyRevenue - dailyRefunds,
+			dailyDevpassNet: dailyDevpassRevenue - dailyDevpassRefunds,
 		});
 	}
 
@@ -1294,6 +1460,9 @@ admin.openapi(getTimeseries, async (c) => {
 			processed: totalProcessed,
 			refunds: totalRefunds,
 			net: totalRevenue - totalRefunds,
+			devpassRevenue: totalDevpassRevenue,
+			devpassRefunds: totalDevpassRefunds,
+			devpassNet: totalDevpassRevenue - totalDevpassRefunds,
 		},
 	});
 });

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -472,7 +472,10 @@ export default async function Page({
 						<div className="reveal" style={revealAt(9)}>
 							<RevenueChart
 								data={timeseries.data}
-								totalNet={timeseries.totals.net}
+								totals={{
+									credits: timeseries.totals.net,
+									devpass: timeseries.totals.devpassNet,
+								}}
 							/>
 						</div>
 					</div>

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { format, parseISO } from "date-fns";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
 	Bar,
 	BarChart,
@@ -41,7 +41,32 @@ const chartConfig = {
 		label: "Net",
 		color: "hsl(38 92% 50%)",
 	},
+	devpassRevenue: {
+		label: "Gross",
+		color: "hsl(217 91% 60%)",
+	},
+	devpassNet: {
+		label: "Net",
+		color: "hsl(142 71% 45%)",
+	},
 } satisfies ChartConfig;
+
+const revenueViews = {
+	credits: {
+		label: "Credits Net",
+		description:
+			"Cumulative processed, revenue (after fees), and net (after fees & refunds) for credit purchases",
+		lines: ["processed", "revenue", "net"],
+	},
+	devpass: {
+		label: "DevPass Net",
+		description:
+			"Cumulative gross and net (after refunds) DevPass plan revenue",
+		lines: ["devpassRevenue", "devpassNet"],
+	},
+} as const;
+
+type ActiveView = keyof typeof revenueViews;
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
 	style: "currency",
@@ -56,18 +81,21 @@ const NEGATIVE_COLOR = "hsl(0 72% 51%)";
 
 export function RevenueChart({
 	data,
-	totalNet,
+	totals,
 }: {
 	data: TimeseriesDataPoint[];
-	totalNet: number;
+	totals: { credits: number; devpass: number };
 }) {
+	const [activeView, setActiveView] = useState<ActiveView>("credits");
+
 	const dailyData = useMemo(
 		() =>
 			data.map((point) => ({
 				date: point.date,
-				dailyNet: point.dailyNet,
+				dailyNet:
+					activeView === "credits" ? point.dailyNet : point.dailyDevpassNet,
 			})),
-		[data],
+		[data, activeView],
 	);
 
 	return (
@@ -75,22 +103,28 @@ export function RevenueChart({
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
 				<div className="flex flex-1 flex-col justify-center gap-1.5 px-6 py-5 sm:py-6">
 					<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-						Credits Revenue
+						Credits & DevPass Revenue
 					</CardTitle>
 					<CardDescription className="text-xs">
-						Cumulative processed, revenue (after fees), and net (after fees &
-						refunds) for credit purchases
+						{revenueViews[activeView].description}
 					</CardDescription>
 				</div>
 				<div className="flex">
-					<div className="flex flex-1 flex-col justify-center gap-1.5 border-t px-6 py-4 text-left sm:border-l sm:border-t-0 sm:px-8 sm:py-6">
-						<span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-							Net Revenue
-						</span>
-						<span className="font-mono text-lg font-medium leading-none tabular-nums tracking-tight sm:text-3xl">
-							{currencyFormatter.format(totalNet)}
-						</span>
-					</div>
+					{(["credits", "devpass"] as const).map((key) => (
+						<button
+							key={key}
+							data-active={activeView === key}
+							className="relative z-30 flex flex-1 flex-col justify-center gap-1.5 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6"
+							onClick={() => setActiveView(key)}
+						>
+							<span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+								{revenueViews[key].label}
+							</span>
+							<span className="font-mono text-lg font-medium leading-none tabular-nums tracking-tight sm:text-3xl">
+								{currencyFormatter.format(totals[key])}
+							</span>
+						</button>
+					))}
 				</div>
 			</CardHeader>
 			<CardContent className="px-2 sm:p-6">
@@ -133,27 +167,16 @@ export function RevenueChart({
 								/>
 							}
 						/>
-						<Line
-							dataKey="processed"
-							type="monotone"
-							stroke="var(--color-processed)"
-							strokeWidth={2}
-							dot={false}
-						/>
-						<Line
-							dataKey="revenue"
-							type="monotone"
-							stroke="var(--color-revenue)"
-							strokeWidth={2}
-							dot={false}
-						/>
-						<Line
-							dataKey="net"
-							type="monotone"
-							stroke="var(--color-net)"
-							strokeWidth={2}
-							dot={false}
-						/>
+						{revenueViews[activeView].lines.map((key) => (
+							<Line
+								key={key}
+								dataKey={key}
+								type="monotone"
+								stroke={`var(--color-${key})`}
+								strokeWidth={2}
+								dot={false}
+							/>
+						))}
 					</LineChart>
 				</ChartContainer>
 				<div className="mt-2 px-2 sm:px-0">


### PR DESCRIPTION
## Summary

The admin dashboard's "Credits Revenue" card now toggles between **Credits** and **DevPass** revenue, using the same button-toggle pattern as the "Signups & Paid Customers" card.

## Changes

### API (`apps/api/src/routes/admin.ts`)
- `/admin/metrics/timeseries` now also returns a DevPass revenue series: cumulative `devpassRevenue` (gross Stripe amount), `devpassRefunds`, `devpassNet`, and per-day `dailyDevpassNet`, plus matching `totals`.
- The queries mirror the existing `/admin/devpass/timeseries` definitions: dev plan payments (+ legacy `subscription_*` rows on devpass orgs) deduplicated per Stripe invoice, with `credit_refund` rows linked via `relatedTransactionId` netted out.
- Like the credits series, the cumulative DevPass series starts from a pre-range baseline so bounded ranges (e.g. 7d) don't dump prior revenue into day one.

### Admin UI (`ee/admin`)
- `RevenueChart` gets Credits Net / DevPass Net toggle buttons in the card header (same interaction as the signups chart). Credits shows the existing processed/revenue/net lines; DevPass shows gross and net (after refunds) lines. The daily net-gain bar chart follows the active view.
- Card title updated to "Credits & DevPass Revenue" with a per-view description.

### Tests
- Added a spec covering the DevPass series: refunds netted out, pre-range baseline handling, and exclusion of legacy org Pro `subscription_*` rows on non-devpass orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZAC5ZsGdCkMx4xWjck7mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZAC5ZsGdCkMx4xWjck7mh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DevPass revenue metrics to the admin timeseries data, including daily net revenue, cumulative revenue, and refunds.
  * Updated the Growth & Revenue chart to switch between Credits and DevPass views.
  * Added separate totals and daily trend visualizations for each revenue stream.

* **Bug Fixes**
  * Improved revenue calculations to account for refunds, legacy transactions, and payments made before the selected reporting period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->