### PR TITLE
fix: forward gateway 4xx errors in embedTexts

### DIFF
--- a/apps/api/src/lib/rag.spec.ts
+++ b/apps/api/src/lib/rag.spec.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { HTTPException } from "hono/http-exception";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
 	chunkText,
 	cosineSimilarity,
+	embedTexts,
 	MAX_CHUNK_CHARS,
 	CHUNK_OVERLAP_CHARS,
 } from "./rag.js";
@@ -74,5 +76,46 @@ describe("cosineSimilarity", () => {
 		expect(cosineSimilarity(query, related)).toBeGreaterThan(
 			cosineSimilarity(query, unrelated),
 		);
+	});
+});
+
+describe("embedTexts", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("forwards upstream 4xx statuses like 402 insufficient credits", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						error: { message: "Organization org-id has insufficient credits" },
+					}),
+					{ status: 402 },
+				),
+			),
+		);
+
+		const error = await embedTexts("token", ["hello"]).catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(HTTPException);
+		expect(error).toMatchObject({
+			status: 402,
+			message: "Organization org-id has insufficient credits",
+		});
+	});
+
+	it("maps upstream 5xx statuses to a 502", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response("oops", { status: 500 })),
+		);
+
+		const error = await embedTexts("token", ["hello"]).catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(HTTPException);
+		expect(error).toMatchObject({
+			status: 502,
+			message: "Embedding request failed with status 500",
+		});
 	});
 });

--- a/apps/api/src/lib/rag.ts
+++ b/apps/api/src/lib/rag.ts
@@ -2,6 +2,8 @@ import { HTTPException } from "hono/http-exception";
 
 import { getGatewayUrl } from "@/utils/playground-key.js";
 
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+
 export const EMBEDDING_MODEL = "openai/text-embedding-3-small";
 
 // Target chunk size in characters (~375 tokens), small enough that several
@@ -117,7 +119,14 @@ export async function embedTexts(
 			} catch {
 				// Keep the generic message when the error body isn't JSON.
 			}
-			throw new HTTPException(502, { message });
+			// Gateway 4xx responses (e.g. 402 insufficient credits) are expected
+			// user-facing conditions — forward the status instead of wrapping it
+			// as a 502, which the global error handler would log as an error.
+			const status: ContentfulStatusCode =
+				res.status >= 400 && res.status < 500
+					? (res.status as ContentfulStatusCode)
+					: 502;
+			throw new HTTPException(status, { message });
 		}
 
 		const json = (await res.json()) as EmbeddingResponse;


### PR DESCRIPTION
## Problem

Production error logs show `HTTPException` at level 50 (error) for expected user-facing conditions like:

```
Organization bjnGFOb2i1V6XCXqvlh3 has insufficient credits
    at embedTexts (/app/src/lib/rag.ts:120:10)
```

The gateway's `/embeddings` endpoint returns **402** for insufficient credits, but `embedTexts` in `apps/api/src/lib/rag.ts` wrapped every non-ok upstream response as a **502** `HTTPException`. The API's global error handler (`apps/api/src/index.ts`) logs any HTTPException with status ≥ 500 as an error, so this expected billing condition was reported as a backend error.

## Fix

Forward upstream 4xx statuses (e.g. 402 insufficient credits, dev-plan limits) as-is from `embedTexts`, and reserve 502 for genuine upstream failures (5xx responses and malformed embedding responses). With a 4xx status, the global error handler returns the error to the client without logging it as a backend error — matching how upstream AI SDK `APICallError` 4xxs are already handled there.

The caller in `apps/api/src/routes/chat-projects.ts` re-throws `HTTPException`s unchanged, so the forwarded status propagates to the client as well.

## Testing

- Added unit tests in `rag.spec.ts` covering both paths: an upstream 402 is forwarded with its message, and an upstream 5xx still maps to a 502.
- `pnpm exec vitest run apps/api/src/lib/rag.spec.ts` — 13 tests pass.
- `turbo run build --filter=api` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJvPvDUkyX1Rs1FH79kmYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJvPvDUkyX1Rs1FH79kmYz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for embedding requests.
  - Client-side errors, such as insufficient credits, now retain their original status and message.
  - Server-side failures continue to be reported as gateway errors with clearer failure information.
- **Tests**
  - Added coverage to verify correct handling of client and server error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->