### PR TITLE
feat(code): add 3D passport to DevPass profiles

### DIFF
--- a/apps/api/src/utils/profile.spec.ts
+++ b/apps/api/src/utils/profile.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createTestUser, deleteAll } from "@/testing.js";
+import { computeProfileData } from "@/utils/profile.js";
+
+import { db, projectHourlyModelStats, tables } from "@llmgateway/db";
+
+const ORG_ID = "test-profile-org";
+const PROJECT_ID = "test-profile-project";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe("computeProfileData passport fields", () => {
+	beforeEach(async () => {
+		await createTestUser();
+	});
+
+	afterEach(async () => {
+		await db.delete(projectHourlyModelStats);
+		await deleteAll();
+	});
+
+	async function insertOrg(devPlan: "none" | "pro") {
+		const startedAt = new Date("2026-07-05T00:00:00.000Z");
+		const expiresAt = new Date("2026-08-05T00:00:00.000Z");
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Personal Org",
+			billingEmail: "admin@example.com",
+			kind: "devpass",
+			devPlan,
+			devPlanBillingCycleStart: devPlan === "none" ? null : startedAt,
+			devPlanExpiresAt: devPlan === "none" ? null : expiresAt,
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORG_ID,
+			role: "owner",
+		});
+		await db.insert(tables.project).values({
+			id: PROJECT_ID,
+			name: "Default Project",
+			organizationId: ORG_ID,
+		});
+		return { startedAt, expiresAt };
+	}
+
+	it("exposes the dev plan as the visa validity window", async () => {
+		const { startedAt, expiresAt } = await insertOrg("pro");
+
+		const profile = await computeProfileData("test-user-id");
+		expect(profile?.plan).toEqual({
+			tier: "pro",
+			startedAt: startedAt.toISOString(),
+			expiresAt: expiresAt.toISOString(),
+		});
+	});
+
+	it("reports no plan when the org has no active dev plan", async () => {
+		await insertOrg("none");
+
+		const profile = await computeProfileData("test-user-id");
+		expect(profile?.plan).toBeNull();
+	});
+
+	it("returns first/last used timestamps per model for stamps", async () => {
+		await insertOrg("pro");
+
+		const early = new Date("2026-06-01T10:00:00.000Z");
+		const late = new Date("2026-07-10T15:00:00.000Z");
+		await db.insert(projectHourlyModelStats).values([
+			{
+				projectId: PROJECT_ID,
+				hourTimestamp: early,
+				usedModel: "gpt-4o",
+				usedProvider: "openai",
+				requestCount: 3,
+				totalTokens: "300",
+			},
+			{
+				projectId: PROJECT_ID,
+				hourTimestamp: late,
+				usedModel: "gpt-4o",
+				usedProvider: "openai",
+				requestCount: 5,
+				totalTokens: "500",
+			},
+			{
+				projectId: PROJECT_ID,
+				hourTimestamp: new Date(late.getTime() + HOUR_MS),
+				usedModel: "claude-opus-4-8",
+				usedProvider: "anthropic",
+				requestCount: 2,
+				totalTokens: "200",
+			},
+		]);
+
+		const profile = await computeProfileData("test-user-id");
+		const gpt = profile?.models.find((m) => m.id === "gpt-4o");
+		expect(gpt?.requestCount).toBe(8);
+		expect(gpt?.firstUsed).toBe(early.toISOString());
+		expect(gpt?.lastUsed).toBe(late.toISOString());
+
+		const opus = profile?.models.find((m) => m.id === "claude-opus-4-8");
+		expect(opus?.firstUsed).toBe(opus?.lastUsed);
+	});
+});

--- a/apps/api/src/utils/profile.spec.ts
+++ b/apps/api/src/utils/profile.spec.ts
@@ -97,11 +97,16 @@ describe("computeProfileData passport fields", () => {
 
 		const profile = await computeProfileData("test-user-id");
 		const gpt = profile?.models.find((m) => m.id === "gpt-4o");
+		expect(gpt).toBeDefined();
 		expect(gpt?.requestCount).toBe(8);
 		expect(gpt?.firstUsed).toBe(early.toISOString());
 		expect(gpt?.lastUsed).toBe(late.toISOString());
 
+		// A single hour bucket collapses to identical first/last timestamps.
+		const opusHour = new Date(late.getTime() + HOUR_MS).toISOString();
 		const opus = profile?.models.find((m) => m.id === "claude-opus-4-8");
-		expect(opus?.firstUsed).toBe(opus?.lastUsed);
+		expect(opus).toBeDefined();
+		expect(opus?.firstUsed).toBe(opusHour);
+		expect(opus?.lastUsed).toBe(opusHour);
 	});
 });

--- a/apps/api/src/utils/profile.ts
+++ b/apps/api/src/utils/profile.ts
@@ -34,12 +34,25 @@ export const profileSchema = z.object({
 			totalTokens: z.number(),
 		}),
 	),
+	// The DevPass "visa": current plan tier with the validity window of the
+	// running subscription period. Null when the user has no active dev plan.
+	plan: z
+		.object({
+			tier: z.enum(["lite", "pro", "max"]),
+			startedAt: z.string().nullable(),
+			expiresAt: z.string().nullable(),
+		})
+		.nullable(),
 	models: z.array(
 		z.object({
 			id: z.string(),
 			provider: z.string(),
 			requestCount: z.number(),
 			totalTokens: z.number(),
+			// First/last hour the model served a request — the profile
+			// passport renders these as entry/exit stamp dates.
+			firstUsed: z.string().nullable(),
+			lastUsed: z.string().nullable(),
 		}),
 	),
 	providers: z.array(
@@ -163,6 +176,7 @@ export async function computeProfileData(
 			longestStreak: 0,
 			activeDays: 0,
 		},
+		plan: null,
 		activity: [],
 		models: [],
 		providers: [],
@@ -180,6 +194,14 @@ export async function computeProfileData(
 
 	if (!personalOrg) {
 		return base;
+	}
+
+	if (personalOrg.devPlan !== "none") {
+		base.plan = {
+			tier: personalOrg.devPlan,
+			startedAt: personalOrg.devPlanBillingCycleStart?.toISOString() ?? null,
+			expiresAt: personalOrg.devPlanExpiresAt?.toISOString() ?? null,
+		};
 	}
 
 	const projectIds = personalOrg.projects
@@ -228,6 +250,14 @@ export async function computeProfileData(
 					sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
+				// mapWith applies the column's own decoder so the naive
+				// timestamp is interpreted as UTC, matching normal column reads.
+				firstUsed: sql`MIN(${projectHourlyModelStats.hourTimestamp})`
+					.mapWith(projectHourlyModelStats.hourTimestamp)
+					.as("firstUsed"),
+				lastUsed: sql`MAX(${projectHourlyModelStats.hourTimestamp})`
+					.mapWith(projectHourlyModelStats.hourTimestamp)
+					.as("lastUsed"),
 			})
 			.from(projectHourlyModelStats)
 			.where(inArray(projectHourlyModelStats.projectId, projectIds))
@@ -277,6 +307,8 @@ export async function computeProfileData(
 			provider: r.usedProvider,
 			requestCount: Number(r.requestCount),
 			totalTokens: Number(r.totalTokens),
+			firstUsed: r.firstUsed?.toISOString() ?? null,
+			lastUsed: r.lastUsed?.toISOString() ?? null,
 		}))
 		.filter((m) => m.id && m.id !== "unknown" && m.requestCount > 0)
 		.sort((a, b) => b.requestCount - a.requestCount);

--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -35,6 +35,7 @@
 		"@radix-ui/react-switch": "1.2.6",
 		"@radix-ui/react-tabs": "^1.1.13",
 		"@radix-ui/react-tooltip": "^1.2.8",
+		"@react-three/fiber": "9.6.1",
 		"@simplewebauthn/browser": "13.3.0",
 		"@stripe/react-stripe-js": "5.2.0",
 		"@stripe/stripe-js": "8.1.0",
@@ -60,7 +61,8 @@
 		"react-hook-form": "7.65.0",
 		"recharts": "^2.15.4",
 		"sonner": "^2.0.7",
-		"tailwind-merge": "3.3.1"
+		"tailwind-merge": "3.3.1",
+		"three": "0.185.1"
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.1",
@@ -69,6 +71,7 @@
 		"@types/node": "^25.3.0",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
+		"@types/three": "0.185.1",
 		"eslint": "^9.38.0",
 		"eslint-config-next": "16.0.0",
 		"openapi-typescript": "7.10.1",

--- a/apps/code/src/components/profile/ProfileView.tsx
+++ b/apps/code/src/components/profile/ProfileView.tsx
@@ -8,6 +8,7 @@ import {
 	formatTokens,
 	type AgentDefinition,
 } from "@/app/dashboard/components/coding-agents-shared";
+import { ProfilePassport } from "@/components/profile/passport/ProfilePassport";
 import { ProfileHeatmap } from "@/components/profile/ProfileHeatmap";
 import { ProfileTokensChart } from "@/components/profile/ProfileTokensChart";
 import { ProfileViewerCta } from "@/components/profile/ProfileViewerCta";
@@ -160,6 +161,11 @@ export function ProfileView({ profile }: { profile: ProfileData }) {
 						<p className="text-sm text-muted-foreground">@{profile.username}</p>
 					)}
 				</div>
+			</div>
+
+			{/* Interactive 3D passport */}
+			<div className="mt-8">
+				<ProfilePassport profile={profile} />
 			</div>
 
 			{/* Wrapped card + share toolkit */}

--- a/apps/code/src/components/profile/passport/PassportBook.tsx
+++ b/apps/code/src/components/profile/passport/PassportBook.tsx
@@ -66,10 +66,12 @@ function Leaf({
 	spec,
 	index,
 	turned,
+	reducedMotion,
 }: {
 	spec: LeafSpec;
 	index: number;
 	turned: number;
+	reducedMotion: boolean;
 }) {
 	const group = useRef<THREE.Group>(null);
 	const rotSpring = useRef(new Spring(0, 80, 11));
@@ -87,6 +89,13 @@ function Leaf({
 			: -0.01 * (index - turned);
 		rotSpring.current.target = rotTarget;
 		zSpring.current.target = zTarget;
+		if (reducedMotion) {
+			// Snap pages straight to their spread instead of animating the flip.
+			rotSpring.current.position = rotTarget;
+			rotSpring.current.velocity = 0;
+			zSpring.current.position = zTarget;
+			zSpring.current.velocity = 0;
+		}
 		if (group.current) {
 			group.current.rotation.y = rotSpring.current.update(dt);
 			group.current.position.z = zSpring.current.update(dt);
@@ -181,14 +190,20 @@ function Book({
 		}
 		// Open books centre on the spine; a closed passport centres its cover.
 		xSpring.current.target = turned === 0 ? -PASSPORT_W / 2 : 0;
+		if (reducedMotion) {
+			xSpring.current.position = xSpring.current.target;
+			xSpring.current.velocity = 0;
+		}
 		group.current.position.x = xSpring.current.update(dt);
 
 		const t = state.clock.getElapsedTime();
+		// Reduced motion keeps the book perfectly still: no float, no invite
+		// wobble, and no pointer-follow tilt.
 		const float = reducedMotion ? 0 : 1;
 		group.current.position.y = Math.sin(t * 0.9) * 0.015 * float;
 		const invite = turned === 0 ? Math.sin(t * 0.7) * 0.05 * float : 0;
-		const targetRotY = pointer.current.x * 0.22 + invite;
-		const targetRotX = -0.1 - pointer.current.y * 0.14;
+		const targetRotY = pointer.current.x * 0.22 * float + invite;
+		const targetRotX = -0.1 - pointer.current.y * 0.14 * float;
 		group.current.rotation.y +=
 			(targetRotY - group.current.rotation.y) * Math.min(1, dt * 5);
 		group.current.rotation.x +=
@@ -222,7 +237,13 @@ function Book({
 			}}
 		>
 			{leaves.map((leaf, i) => (
-				<Leaf key={i} spec={leaf} index={i} turned={turned} />
+				<Leaf
+					key={i}
+					spec={leaf}
+					index={i}
+					turned={turned}
+					reducedMotion={reducedMotion}
+				/>
 			))}
 		</group>
 	);

--- a/apps/code/src/components/profile/passport/PassportBook.tsx
+++ b/apps/code/src/components/profile/passport/PassportBook.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+/* eslint-disable no-mixed-operators -- spring/tilt math mixes arithmetic
+ * operators, and prettier strips the clarifying parentheses the rule would
+ * otherwise require (same trade-off as packages/db/src/logs.ts). */
+import { Canvas, useFrame, type ThreeEvent } from "@react-three/fiber";
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+
+import { buildPassportModel } from "./passport-data";
+import {
+	drawAirlinesPage,
+	drawAirportsPage,
+	drawBackCoverInner,
+	drawBackCoverOuter,
+	drawCoverInner,
+	drawCoverOuter,
+	drawEndorsementsPage,
+	drawStampsPage,
+	drawVisaPage,
+} from "./passport-textures";
+
+import type { ProfileData } from "@/components/profile/ProfileView";
+
+const PASSPORT_W = 0.88;
+const PASSPORT_H = 1.25;
+const LEAF_GAP = 0.012;
+
+/** Under-damped spring (see threejs-animation skill) for lively page flips. */
+class Spring {
+	public position: number;
+	public velocity = 0;
+	public target: number;
+	public constructor(
+		initial: number,
+		private stiffness = 90,
+		private damping = 12,
+	) {
+		this.position = initial;
+		this.target = initial;
+	}
+	public update(dt: number): number {
+		const clamped = Math.min(dt, 1 / 30);
+		const force = -this.stiffness * (this.position - this.target);
+		const dampingForce = -this.damping * this.velocity;
+		this.velocity += (force + dampingForce) * clamped;
+		this.position += this.velocity * clamped;
+		return this.position;
+	}
+}
+
+function canvasTexture(canvas: HTMLCanvasElement): THREE.CanvasTexture {
+	const texture = new THREE.CanvasTexture(canvas);
+	texture.colorSpace = THREE.SRGBColorSpace;
+	texture.anisotropy = 8;
+	return texture;
+}
+
+interface LeafSpec {
+	front: THREE.CanvasTexture;
+	back: THREE.CanvasTexture;
+	isCover: boolean;
+}
+
+function Leaf({
+	spec,
+	index,
+	turned,
+}: {
+	spec: LeafSpec;
+	index: number;
+	turned: number;
+}) {
+	const group = useRef<THREE.Group>(null);
+	const rotSpring = useRef(new Spring(0, 80, 11));
+	const zSpring = useRef(new Spring(-index * LEAF_GAP, 120, 16));
+
+	useFrame((_, dt) => {
+		const flipped = index < turned;
+		// Left/right stack orders differ: the most recently turned leaf lies on
+		// top of the left stack, the next unturned leaf on top of the right.
+		const zTarget = flipped
+			? -(turned - 1 - index) * LEAF_GAP
+			: -(index - turned) * LEAF_GAP;
+		const rotTarget = flipped
+			? Math.max(-Math.PI, -Math.PI + 0.055 - 0.014 * (turned - 1 - index))
+			: -0.01 * (index - turned);
+		rotSpring.current.target = rotTarget;
+		zSpring.current.target = zTarget;
+		if (group.current) {
+			group.current.rotation.y = rotSpring.current.update(dt);
+			group.current.position.z = zSpring.current.update(dt);
+		}
+	});
+
+	const w = spec.isCover ? PASSPORT_W * 1.04 : PASSPORT_W;
+	const h = spec.isCover ? PASSPORT_H * 1.04 : PASSPORT_H;
+	const sheetOffset = spec.isCover ? 0.0035 : 0.0018;
+
+	return (
+		<group ref={group}>
+			<mesh position={[w / 2, 0, sheetOffset]}>
+				<planeGeometry args={[w, h]} />
+				<meshStandardMaterial
+					map={spec.front}
+					roughness={spec.isCover ? 0.62 : 0.88}
+					metalness={spec.isCover ? 0.18 : 0}
+				/>
+			</mesh>
+			<mesh position={[w / 2, 0, -sheetOffset]} rotation={[0, Math.PI, 0]}>
+				<planeGeometry args={[w, h]} />
+				<meshStandardMaterial
+					map={spec.back}
+					roughness={spec.isCover ? 0.62 : 0.88}
+					metalness={spec.isCover ? 0.18 : 0}
+				/>
+			</mesh>
+		</group>
+	);
+}
+
+function Book({
+	profile,
+	turned,
+	onAdvance,
+	reducedMotion,
+}: {
+	profile: ProfileData;
+	turned: number;
+	onAdvance: (direction: 1 | -1) => void;
+	reducedMotion: boolean;
+}) {
+	const group = useRef<THREE.Group>(null);
+	const xSpring = useRef(new Spring(PASSPORT_W / -2, 60, 11));
+	const pointer = useRef({ x: 0, y: 0 });
+
+	const leaves = useMemo<LeafSpec[]>(() => {
+		const data = buildPassportModel(profile);
+		return [
+			{
+				front: canvasTexture(drawCoverOuter()),
+				back: canvasTexture(drawCoverInner()),
+				isCover: true,
+			},
+			{
+				front: canvasTexture(drawVisaPage(data)),
+				back: canvasTexture(drawAirportsPage(data.airports)),
+				isCover: false,
+			},
+			{
+				front: canvasTexture(drawAirlinesPage(data.airlines)),
+				back: canvasTexture(drawStampsPage(data.stamps.slice(0, 3), 0)),
+				isCover: false,
+			},
+			{
+				front: canvasTexture(drawStampsPage(data.stamps.slice(3, 6), 1)),
+				back: canvasTexture(drawEndorsementsPage(data)),
+				isCover: false,
+			},
+			{
+				front: canvasTexture(drawBackCoverInner()),
+				back: canvasTexture(drawBackCoverOuter()),
+				isCover: true,
+			},
+		];
+	}, [profile]);
+
+	useEffect(() => {
+		const specs = leaves;
+		return () => {
+			for (const leaf of specs) {
+				leaf.front.dispose();
+				leaf.back.dispose();
+			}
+		};
+	}, [leaves]);
+
+	useFrame((state, dt) => {
+		if (!group.current) {
+			return;
+		}
+		// Open books centre on the spine; a closed passport centres its cover.
+		xSpring.current.target = turned === 0 ? -PASSPORT_W / 2 : 0;
+		group.current.position.x = xSpring.current.update(dt);
+
+		const t = state.clock.getElapsedTime();
+		const float = reducedMotion ? 0 : 1;
+		group.current.position.y = Math.sin(t * 0.9) * 0.015 * float;
+		const invite = turned === 0 ? Math.sin(t * 0.7) * 0.05 * float : 0;
+		const targetRotY = pointer.current.x * 0.22 + invite;
+		const targetRotX = -0.1 - pointer.current.y * 0.14;
+		group.current.rotation.y +=
+			(targetRotY - group.current.rotation.y) * Math.min(1, dt * 5);
+		group.current.rotation.x +=
+			(targetRotX - group.current.rotation.x) * Math.min(1, dt * 5);
+		group.current.rotation.z = Math.sin(t * 0.6) * 0.008 * float;
+	});
+
+	const handleClick = (event: ThreeEvent<MouseEvent>) => {
+		event.stopPropagation();
+		if (turned === 0) {
+			onAdvance(1);
+			return;
+		}
+		// Click the left page to flip back, the right page to move on.
+		onAdvance(event.point.x < 0 ? -1 : 1);
+	};
+
+	return (
+		<group
+			ref={group}
+			onClick={handleClick}
+			onPointerMove={(event) => {
+				pointer.current = { x: event.pointer.x, y: event.pointer.y };
+			}}
+			onPointerOver={() => {
+				document.body.style.cursor = "pointer";
+			}}
+			onPointerOut={() => {
+				pointer.current = { x: 0, y: 0 };
+				document.body.style.cursor = "auto";
+			}}
+		>
+			{leaves.map((leaf, i) => (
+				<Leaf key={i} spec={leaf} index={i} turned={turned} />
+			))}
+		</group>
+	);
+}
+
+export default function PassportCanvas({
+	profile,
+	turned,
+	onAdvance,
+}: {
+	profile: ProfileData;
+	turned: number;
+	onAdvance: (direction: 1 | -1) => void;
+}) {
+	const [reducedMotion, setReducedMotion] = useState(false);
+
+	useEffect(() => {
+		const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+		setReducedMotion(query.matches);
+		const listener = (event: MediaQueryListEvent) =>
+			setReducedMotion(event.matches);
+		query.addEventListener("change", listener);
+		return () => query.removeEventListener("change", listener);
+	}, []);
+
+	return (
+		<Canvas
+			camera={{ fov: 38, position: [0, 0.1, 2.75] }}
+			dpr={[1, 2]}
+			gl={{ antialias: true, alpha: true }}
+			style={{ touchAction: "pan-y" }}
+		>
+			<ambientLight intensity={1.15} />
+			<directionalLight position={[2.2, 3, 4]} intensity={1.5} />
+			<directionalLight position={[-3, -1, 2]} intensity={0.35} />
+			<Book
+				profile={profile}
+				turned={turned}
+				onAdvance={onAdvance}
+				reducedMotion={reducedMotion}
+			/>
+		</Canvas>
+	);
+}

--- a/apps/code/src/components/profile/passport/ProfilePassport.tsx
+++ b/apps/code/src/components/profile/passport/ProfilePassport.tsx
@@ -2,8 +2,12 @@
 
 import { BookOpen, ChevronLeft, ChevronRight } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
+import {
+	buildPassportModel,
+	spreadSummary,
+} from "@/components/profile/passport/passport-data";
 import { MAX_TURNED } from "@/components/profile/passport/passport-shared";
 import { Button } from "@/components/ui/button";
 
@@ -40,6 +44,13 @@ export function ProfilePassport({ profile }: { profile: ProfileData }) {
 		);
 	}, []);
 
+	// The canvas pages are invisible to assistive technology; announce each
+	// spread's content as it changes.
+	const summary = useMemo(
+		() => spreadSummary(buildPassportModel(profile), turned),
+		[profile, turned],
+	);
+
 	return (
 		<section aria-label="DevPass passport">
 			<div className="mb-3 flex items-center justify-between">
@@ -57,6 +68,14 @@ export function ProfilePassport({ profile }: { profile: ProfileData }) {
 				aria-roledescription="interactive 3D passport"
 				tabIndex={0}
 				onKeyDown={(event) => {
+					// The nav buttons handle their own Enter/Space; acting here
+					// too would advance twice per key press.
+					if (
+						event.target instanceof HTMLElement &&
+						event.target.closest("button")
+					) {
+						return;
+					}
 					if (event.key === "ArrowRight" || event.key === "Enter") {
 						event.preventDefault();
 						advance(1);
@@ -67,6 +86,9 @@ export function ProfilePassport({ profile }: { profile: ProfileData }) {
 					}
 				}}
 			>
+				<p className="sr-only" aria-live="polite">
+					{summary}
+				</p>
 				<div className="h-[420px] sm:h-[480px]">
 					<PassportCanvas
 						profile={profile}

--- a/apps/code/src/components/profile/passport/ProfilePassport.tsx
+++ b/apps/code/src/components/profile/passport/ProfilePassport.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { BookOpen, ChevronLeft, ChevronRight } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useCallback, useState } from "react";
+
+import { MAX_TURNED } from "@/components/profile/passport/passport-shared";
+import { Button } from "@/components/ui/button";
+
+import type { ProfileData } from "@/components/profile/ProfileView";
+
+// three.js is heavy; load the scene only on the client, when the section
+// actually renders.
+const PassportCanvas = dynamic(
+	() => import("@/components/profile/passport/PassportBook"),
+	{
+		ssr: false,
+		loading: () => (
+			<div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+				Fetching passport from the consulate…
+			</div>
+		),
+	},
+);
+
+const SPREAD_LABELS = [
+	"Cover",
+	"Visa",
+	"Ports of entry · Carriers",
+	"Entry & exit stamps",
+	"Endorsements",
+];
+
+export function ProfilePassport({ profile }: { profile: ProfileData }) {
+	const [turned, setTurned] = useState(0);
+
+	const advance = useCallback((direction: 1 | -1) => {
+		setTurned((current) =>
+			Math.max(0, Math.min(MAX_TURNED, current + direction)),
+		);
+	}, []);
+
+	return (
+		<section aria-label="DevPass passport">
+			<div className="mb-3 flex items-center justify-between">
+				<h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+					<BookOpen className="h-4 w-4" />
+					Passport
+				</h2>
+				<span className="text-xs text-muted-foreground">
+					{SPREAD_LABELS[turned]}
+				</span>
+			</div>
+			<div
+				className="relative overflow-hidden rounded-xl border bg-gradient-to-b from-muted/60 to-muted/20"
+				role="group"
+				aria-roledescription="interactive 3D passport"
+				tabIndex={0}
+				onKeyDown={(event) => {
+					if (event.key === "ArrowRight" || event.key === "Enter") {
+						event.preventDefault();
+						advance(1);
+					}
+					if (event.key === "ArrowLeft") {
+						event.preventDefault();
+						advance(-1);
+					}
+				}}
+			>
+				<div className="h-[420px] sm:h-[480px]">
+					<PassportCanvas
+						profile={profile}
+						turned={turned}
+						onAdvance={advance}
+					/>
+				</div>
+				<div className="pointer-events-none absolute inset-x-0 bottom-3 flex items-center justify-center gap-2">
+					<Button
+						size="sm"
+						variant="outline"
+						className="pointer-events-auto"
+						onClick={() => advance(-1)}
+						disabled={turned === 0}
+						aria-label="Previous page"
+					>
+						<ChevronLeft className="h-4 w-4" />
+					</Button>
+					<span className="pointer-events-auto rounded-md border bg-background/80 px-2.5 py-1 text-xs text-muted-foreground backdrop-blur">
+						{turned === 0
+							? "Tap the passport to open it"
+							: SPREAD_LABELS[turned]}
+					</span>
+					<Button
+						size="sm"
+						variant="outline"
+						className="pointer-events-auto"
+						onClick={() => advance(1)}
+						disabled={turned === MAX_TURNED}
+						aria-label="Next page"
+					>
+						<ChevronRight className="h-4 w-4" />
+					</Button>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/code/src/components/profile/passport/passport-data.ts
+++ b/apps/code/src/components/profile/passport/passport-data.ts
@@ -88,6 +88,58 @@ function airportCode(label: string): string {
 	return (letters + "XXX").slice(0, 3);
 }
 
+/** UTC date label shared by the page textures and the screen-reader summary. */
+export function formatPassportDate(iso: string | null): string {
+	if (!iso) {
+		return "—";
+	}
+	return new Date(iso)
+		.toLocaleDateString("en-GB", {
+			day: "2-digit",
+			month: "short",
+			year: "numeric",
+			timeZone: "UTC",
+		})
+		.toUpperCase();
+}
+
+/**
+ * Plain-text description of the currently visible spread for assistive
+ * technology — the canvas pages themselves are invisible to screen readers.
+ */
+export function spreadSummary(model: PassportModel, turned: number): string {
+	switch (turned) {
+		case 0:
+			return `Closed DevPass passport of ${model.holderName}. Press Enter or tap to open it.`;
+		case 1: {
+			const visa = model.visa
+				? `${model.visa.tier.toUpperCase()} visa, valid from ${formatPassportDate(model.visa.startedAt)} until ${formatPassportDate(model.visa.expiresAt)}`
+				: "no active visa";
+			return `Visa page for ${model.holderName}: ${visa}.`;
+		}
+		case 2: {
+			const ports =
+				model.airports.map((a) => `${a.label} (${a.code})`).join(", ") ||
+				"none visited yet";
+			const carriers =
+				model.airlines.map((a) => a.label).join(", ") || "none on record";
+			return `Ports of entry, model families: ${ports}. Carriers, harnesses: ${carriers}.`;
+		}
+		case 3: {
+			const stamps =
+				model.stamps
+					.map(
+						(s) =>
+							`${s.model}: entry ${formatPassportDate(s.entry)}, exit ${formatPassportDate(s.exit)}`,
+					)
+					.join("; ") || "awaiting first entry";
+			return `Entry and exit stamps: ${stamps}.`;
+		}
+		default:
+			return `Endorsements: ${model.totalRequests} requests across ${model.activeDays} active days.`;
+	}
+}
+
 export function buildPassportModel(profile: ProfileData): PassportModel {
 	const airportMap = new Map<string, PassportAirport>();
 	for (const row of profile.models) {

--- a/apps/code/src/components/profile/passport/passport-data.ts
+++ b/apps/code/src/components/profile/passport/passport-data.ts
@@ -1,0 +1,152 @@
+import {
+	AGENTS,
+	type AgentDefinition,
+} from "@/app/dashboard/components/coding-agents-shared";
+import { resolveCanonicalModel } from "@/lib/model-family";
+
+import type { ProfileData } from "@/components/profile/ProfileView";
+
+/** One "airport" on the ports-of-entry page: a model family. */
+export interface PassportAirport {
+	/** IATA-style three-letter code derived from the family name. */
+	code: string;
+	label: string;
+	requestCount: number;
+}
+
+/** One "airline" on the carriers page: a coding-agent harness. */
+export interface PassportAirline {
+	label: string;
+	requestCount: number;
+	totalTokens: number;
+}
+
+/** One entry/exit stamp: a model with its first and last use. */
+export interface PassportStampData {
+	model: string;
+	family: string;
+	entry: string | null;
+	exit: string | null;
+	requestCount: number;
+}
+
+export interface PassportVisa {
+	tier: "lite" | "pro" | "max";
+	startedAt: string | null;
+	expiresAt: string | null;
+}
+
+export interface PassportModel {
+	holderName: string;
+	username: string | null;
+	memberSince: string;
+	visa: PassportVisa | null;
+	airports: PassportAirport[];
+	airlines: PassportAirline[];
+	stamps: PassportStampData[];
+	totalRequests: number;
+	activeDays: number;
+}
+
+const AGENT_BY_SOURCE = new Map<string, AgentDefinition>();
+for (const agent of AGENTS) {
+	for (const source of agent.sources) {
+		AGENT_BY_SOURCE.set(source.toLowerCase(), agent);
+	}
+}
+
+// Human labels for model families whose icon key isn't display-ready.
+const FAMILY_LABELS: Record<string, string> = {
+	openai: "OpenAI",
+	anthropic: "Anthropic",
+	"google-ai-studio": "Google",
+	google: "Google",
+	alibaba: "Alibaba",
+	zai: "Z.ai",
+	deepseek: "DeepSeek",
+	meta: "Meta",
+	mistral: "Mistral",
+	moonshot: "Moonshot",
+	xai: "xAI",
+	minimax: "MiniMax",
+};
+
+function familyLabel(key: string): string {
+	const known = FAMILY_LABELS[key.toLowerCase()];
+	if (known) {
+		return known;
+	}
+	return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+/**
+ * Derive a stable IATA-style code from a family label, e.g. "Anthropic" ->
+ * "ANT", "OpenAI" -> "OPE", "Z.ai" -> "ZAI". Purely cosmetic.
+ */
+function airportCode(label: string): string {
+	const letters = label.toUpperCase().replace(/[^A-Z]/g, "");
+	return (letters + "XXX").slice(0, 3);
+}
+
+export function buildPassportModel(profile: ProfileData): PassportModel {
+	const airportMap = new Map<string, PassportAirport>();
+	for (const row of profile.models) {
+		const resolved = resolveCanonicalModel(row.id);
+		const key = resolved.known ? resolved.iconKey : row.provider;
+		const label = familyLabel(key);
+		const existing = airportMap.get(label);
+		if (existing) {
+			existing.requestCount += row.requestCount;
+		} else {
+			airportMap.set(label, {
+				code: airportCode(label),
+				label,
+				requestCount: row.requestCount,
+			});
+		}
+	}
+
+	const airlineMap = new Map<string, PassportAirline>();
+	for (const agent of profile.agents) {
+		const def = AGENT_BY_SOURCE.get(agent.source.toLowerCase());
+		const label = def?.label ?? agent.source;
+		const existing = airlineMap.get(label);
+		if (existing) {
+			existing.requestCount += agent.requestCount;
+			existing.totalTokens += agent.totalTokens;
+		} else {
+			airlineMap.set(label, {
+				label,
+				requestCount: agent.requestCount,
+				totalTokens: agent.totalTokens,
+			});
+		}
+	}
+
+	const stamps: PassportStampData[] = profile.models.slice(0, 6).map((row) => {
+		const resolved = resolveCanonicalModel(row.id);
+		return {
+			model: resolved.name,
+			family: familyLabel(resolved.known ? resolved.iconKey : row.provider),
+			entry: row.firstUsed,
+			exit: row.lastUsed,
+			requestCount: row.requestCount,
+		};
+	});
+
+	return {
+		holderName: profile.name?.trim() || profile.username || "Traveller",
+		username: profile.username,
+		memberSince: profile.createdAt,
+		visa: profile.plan,
+		airports: Array.from(airportMap.values()).sort(
+			(a, b) => b.requestCount - a.requestCount,
+		),
+		airlines: Array.from(airlineMap.values()).sort(
+			(a, b) => b.requestCount - a.requestCount,
+		),
+		stamps,
+		totalRequests: profile.stats.totalRequests,
+		activeDays: profile.stats.activeDays,
+	};
+}

--- a/apps/code/src/components/profile/passport/passport-shared.ts
+++ b/apps/code/src/components/profile/passport/passport-shared.ts
@@ -1,0 +1,3 @@
+// Kept apart from PassportBook so the wrapper can import the page count
+// without pulling three.js into the main bundle (the scene loads dynamically).
+export const MAX_TURNED = 4;

--- a/apps/code/src/components/profile/passport/passport-textures.ts
+++ b/apps/code/src/components/profile/passport/passport-textures.ts
@@ -1,0 +1,576 @@
+/* eslint-disable no-mixed-operators -- canvas layout math is dense with
+ * mixed arithmetic, and prettier strips the clarifying parentheses the rule
+ * would otherwise require (same trade-off as packages/db/src/logs.ts). */
+import type {
+	PassportAirline,
+	PassportAirport,
+	PassportModel,
+	PassportStampData,
+} from "./passport-data";
+
+/**
+ * Every passport face is drawn into an offscreen 2D canvas and mounted as a
+ * three.js CanvasTexture — pages are "printed" from live profile data, which
+ * a pre-modelled asset could never show.
+ */
+
+export const PAGE_W = 768;
+export const PAGE_H = 1092;
+
+const PAPER = "#f2ecdd";
+const PAPER_INK = "#3d3a2f";
+const PAPER_FAINT = "rgba(61,58,47,0.38)";
+const GUILLOCHE = "rgba(96,116,160,0.14)";
+const COVER_BG = "#141d38";
+const COVER_GOLD = "#c9a227";
+
+const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace";
+const SANS = "ui-sans-serif, system-ui, -apple-system, sans-serif";
+
+const TIER_INK: Record<string, string> = {
+	lite: "#3f6212",
+	pro: "#3730a3",
+	max: "#92400e",
+};
+
+function makeCanvas(): CanvasRenderingContext2D {
+	const canvas = document.createElement("canvas");
+	canvas.width = PAGE_W;
+	canvas.height = PAGE_H;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) {
+		throw new Error("2d canvas unavailable");
+	}
+	return ctx;
+}
+
+function formatDate(iso: string | null): string {
+	if (!iso) {
+		return "—";
+	}
+	return new Date(iso)
+		.toLocaleDateString("en-GB", {
+			day: "2-digit",
+			month: "short",
+			year: "numeric",
+		})
+		.toUpperCase();
+}
+
+function formatCompact(n: number): string {
+	return new Intl.NumberFormat("en", {
+		notation: "compact",
+		maximumFractionDigits: 1,
+	}).format(n);
+}
+
+/** Cream paper with faint guilloche waves and a hairline frame. */
+function drawPaper(ctx: CanvasRenderingContext2D): void {
+	ctx.fillStyle = PAPER;
+	ctx.fillRect(0, 0, PAGE_W, PAGE_H);
+
+	ctx.save();
+	ctx.strokeStyle = GUILLOCHE;
+	ctx.lineWidth = 1.4;
+	for (let i = 0; i < 26; i++) {
+		ctx.beginPath();
+		for (let x = -40; x <= PAGE_W + 40; x += 8) {
+			const y =
+				90 + i * 38 + Math.sin(x / 68 + i * 1.7) * 14 + Math.sin(x / 23) * 4;
+			if (x === -40) {
+				ctx.moveTo(x, y);
+			} else {
+				ctx.lineTo(x, y);
+			}
+		}
+		ctx.stroke();
+	}
+	ctx.restore();
+
+	ctx.strokeStyle = PAPER_FAINT;
+	ctx.lineWidth = 2;
+	ctx.strokeRect(26, 26, PAGE_W - 52, PAGE_H - 52);
+}
+
+function pageHeader(ctx: CanvasRenderingContext2D, title: string): void {
+	ctx.fillStyle = PAPER_INK;
+	ctx.font = `600 30px ${MONO}`;
+	ctx.textAlign = "center";
+	ctx.letterSpacing = "10px";
+	ctx.fillText(title, PAGE_W / 2, 92);
+	ctx.letterSpacing = "0px";
+	ctx.strokeStyle = PAPER_FAINT;
+	ctx.lineWidth = 1.5;
+	ctx.beginPath();
+	ctx.moveTo(80, 118);
+	ctx.lineTo(PAGE_W - 80, 118);
+	ctx.stroke();
+}
+
+function emptyNotice(ctx: CanvasRenderingContext2D, text: string): void {
+	ctx.fillStyle = PAPER_FAINT;
+	ctx.font = `500 26px ${MONO}`;
+	ctx.textAlign = "center";
+	ctx.letterSpacing = "6px";
+	ctx.fillText(text, PAGE_W / 2, PAGE_H / 2);
+	ctx.letterSpacing = "0px";
+}
+
+function drawEmblem(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	r: number,
+	color: string,
+): void {
+	ctx.save();
+	ctx.strokeStyle = color;
+	ctx.fillStyle = color;
+	ctx.lineWidth = Math.max(2.5, r * 0.045);
+	ctx.beginPath();
+	ctx.arc(x, y, r, 0, Math.PI * 2);
+	ctx.stroke();
+	ctx.beginPath();
+	ctx.arc(x, y, r * 0.82, 0, Math.PI * 2);
+	ctx.stroke();
+	// Latitude/longitude grid inside the ring — the "globe".
+	ctx.lineWidth = Math.max(1.6, r * 0.028);
+	for (const f of [-0.55, 0, 0.55]) {
+		const squeeze = Math.sqrt(1 - f * f);
+		ctx.beginPath();
+		ctx.ellipse(x, y, r * 0.62 * squeeze, r * 0.62, 0, 0, Math.PI * 2);
+		ctx.stroke();
+		ctx.beginPath();
+		ctx.ellipse(
+			x,
+			y + f * r * 0.62,
+			r * 0.62 * squeeze,
+			r * 0.2,
+			0,
+			0,
+			Math.PI * 2,
+		);
+		ctx.stroke();
+	}
+	// Code brackets flanking the globe.
+	ctx.font = `700 ${Math.round(r * 0.62)}px ${MONO}`;
+	ctx.textAlign = "center";
+	ctx.textBaseline = "middle";
+	ctx.fillText("<", x - r * 1.42, y);
+	ctx.fillText(">", x + r * 1.42, y);
+	ctx.restore();
+}
+
+export function drawCoverOuter(): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	ctx.fillStyle = COVER_BG;
+	ctx.fillRect(0, 0, PAGE_W, PAGE_H);
+
+	// Leather grain: deterministic speckle.
+	ctx.fillStyle = "rgba(255,255,255,0.02)";
+	for (let i = 0; i < 2600; i++) {
+		const x = (Math.sin(i * 12.9898) * 0.5 + 0.5) * PAGE_W;
+		const y = (Math.sin(i * 78.233) * 0.5 + 0.5) * PAGE_H;
+		ctx.fillRect(x, y, 2, 2);
+	}
+
+	ctx.strokeStyle = COVER_GOLD;
+	ctx.lineWidth = 3;
+	ctx.strokeRect(40, 40, PAGE_W - 80, PAGE_H - 80);
+
+	ctx.fillStyle = COVER_GOLD;
+	ctx.textAlign = "center";
+	ctx.font = `600 44px ${MONO}`;
+	ctx.letterSpacing = "18px";
+	ctx.fillText("DEVPASS", PAGE_W / 2, 220);
+	ctx.letterSpacing = "0px";
+
+	drawEmblem(ctx, PAGE_W / 2, PAGE_H / 2 - 30, 130, COVER_GOLD);
+
+	ctx.font = `600 58px ${MONO}`;
+	ctx.letterSpacing = "22px";
+	ctx.fillText("PASSPORT", PAGE_W / 2, PAGE_H - 260);
+	ctx.letterSpacing = "0px";
+	ctx.font = `500 24px ${MONO}`;
+	ctx.letterSpacing = "8px";
+	ctx.fillStyle = "rgba(201,162,39,0.75)";
+	ctx.fillText("LLM GATEWAY", PAGE_W / 2, PAGE_H - 190);
+	ctx.letterSpacing = "0px";
+	return ctx.canvas;
+}
+
+export function drawCoverInner(): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	drawEmblem(ctx, PAGE_W / 2, PAGE_H / 2 - 40, 150, "rgba(61,58,47,0.12)");
+	ctx.fillStyle = PAPER_FAINT;
+	ctx.textAlign = "center";
+	ctx.font = `500 22px ${MONO}`;
+	ctx.letterSpacing = "3px";
+	ctx.fillText("This passport records the bearer's", PAGE_W / 2, PAGE_H - 220);
+	ctx.fillText("AI coding travels on DevPass.", PAGE_W / 2, PAGE_H - 184);
+	ctx.letterSpacing = "0px";
+	return ctx.canvas;
+}
+
+export function drawVisaPage(data: PassportModel): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	pageHeader(ctx, "VISA");
+
+	ctx.textAlign = "left";
+
+	// Holder block.
+	const label = (text: string, x: number, y: number) => {
+		ctx.fillStyle = PAPER_FAINT;
+		ctx.font = `500 18px ${MONO}`;
+		ctx.letterSpacing = "3px";
+		ctx.fillText(text, x, y);
+		ctx.letterSpacing = "0px";
+	};
+	const value = (text: string, x: number, y: number, size = 30) => {
+		ctx.fillStyle = PAPER_INK;
+		ctx.font = `600 ${size}px ${SANS}`;
+		ctx.fillText(text, x, y);
+	};
+
+	label("SURNAME / GIVEN NAMES", 70, 180);
+	value(data.holderName.toUpperCase(), 70, 218);
+	label("CALLSIGN", 70, 280);
+	value(data.username ? `@${data.username}` : "—", 70, 318);
+	label("MEMBER SINCE", 400, 280);
+	value(formatDate(data.memberSince), 400, 318, 26);
+
+	// Visa sticker.
+	const vx = 70;
+	const vy = 380;
+	const vw = PAGE_W - 140;
+	const vh = 430;
+	if (data.visa) {
+		const ink = TIER_INK[data.visa.tier] ?? PAPER_INK;
+		ctx.save();
+		ctx.fillStyle = "rgba(255,255,255,0.55)";
+		ctx.fillRect(vx, vy, vw, vh);
+		ctx.strokeStyle = ink;
+		ctx.lineWidth = 3;
+		ctx.strokeRect(vx, vy, vw, vh);
+		ctx.strokeRect(vx + 8, vy + 8, vw - 16, vh - 16);
+
+		const stickerMidX = vx + vw / 2;
+		ctx.fillStyle = ink;
+		ctx.textAlign = "center";
+		ctx.font = `600 26px ${MONO}`;
+		ctx.letterSpacing = "8px";
+		ctx.fillText("DEVPASS VISA", stickerMidX, vy + 58);
+		ctx.letterSpacing = "0px";
+
+		ctx.font = `700 92px ${MONO}`;
+		ctx.fillText(data.visa.tier.toUpperCase(), stickerMidX, vy + 176);
+
+		ctx.textAlign = "left";
+		label("VALID FROM", vx + 40, vy + 250);
+		value(formatDate(data.visa.startedAt), vx + 40, vy + 288, 28);
+		label("DATE OF EXPIRY", stickerMidX + 20, vy + 250);
+		value(formatDate(data.visa.expiresAt), stickerMidX + 20, vy + 288, 28);
+
+		label("ENTRIES", vx + 40, vy + 344);
+		value("MULTIPLE", vx + 40, vy + 380, 26);
+		label("STATUS", stickerMidX + 20, vy + 344);
+		value("ACTIVE", stickerMidX + 20, vy + 380, 26);
+
+		// Round duty seal overlapping the sticker corner.
+		ctx.globalAlpha = 0.8;
+		ctx.translate(vx + vw - 74, vy + vh - 60);
+		ctx.rotate(-0.28);
+		ctx.strokeStyle = ink;
+		ctx.lineWidth = 3.5;
+		ctx.beginPath();
+		ctx.arc(0, 0, 62, 0, Math.PI * 2);
+		ctx.stroke();
+		ctx.beginPath();
+		ctx.arc(0, 0, 50, 0, Math.PI * 2);
+		ctx.stroke();
+		ctx.fillStyle = ink;
+		ctx.textAlign = "center";
+		ctx.font = `700 20px ${MONO}`;
+		ctx.fillText("DEVPASS", 0, -6);
+		ctx.font = `600 15px ${MONO}`;
+		ctx.fillText("IMMIGRATION", 0, 16);
+		ctx.restore();
+	} else {
+		ctx.save();
+		ctx.setLineDash([12, 10]);
+		ctx.strokeStyle = PAPER_FAINT;
+		ctx.lineWidth = 3;
+		ctx.strokeRect(vx, vy, vw, vh);
+		ctx.setLineDash([]);
+		const emptyMidX = vx + vw / 2;
+		const emptyMidY = vy + vh / 2;
+		ctx.fillStyle = PAPER_FAINT;
+		ctx.textAlign = "center";
+		ctx.font = `600 30px ${MONO}`;
+		ctx.letterSpacing = "6px";
+		ctx.fillText("NO ACTIVE VISA", emptyMidX, emptyMidY - 14);
+		ctx.font = `500 22px ${MONO}`;
+		ctx.letterSpacing = "2px";
+		ctx.fillText("APPLY AT DEVPASS.LLMGATEWAY.IO", emptyMidX, emptyMidY + 34);
+		ctx.letterSpacing = "0px";
+		ctx.restore();
+	}
+
+	// Machine-readable zone.
+	ctx.fillStyle = PAPER_INK;
+	ctx.textAlign = "left";
+	ctx.font = `600 26px ${MONO}`;
+	ctx.letterSpacing = "4px";
+	const tier = data.visa?.tier.toUpperCase() ?? "NONE";
+	const callsign = (data.username ?? "TRAVELLER")
+		.toUpperCase()
+		.replace(/[^A-Z0-9]/g, "");
+	const mrz1 = `P<DEVPASS<<${callsign}`.padEnd(34, "<").slice(0, 34);
+	const mrz2 = `${tier}<VISA<MULTIPLE<ENTRIES`.padEnd(34, "<").slice(0, 34);
+	ctx.fillText(mrz1, 58, PAGE_H - 120);
+	ctx.fillText(mrz2, 58, PAGE_H - 78);
+	ctx.letterSpacing = "0px";
+	return ctx.canvas;
+}
+
+export function drawAirportsPage(
+	airports: PassportAirport[],
+): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	pageHeader(ctx, "PORTS OF ENTRY");
+
+	ctx.fillStyle = PAPER_FAINT;
+	ctx.textAlign = "center";
+	ctx.font = `500 20px ${MONO}`;
+	ctx.letterSpacing = "5px";
+	ctx.fillText("MODEL FAMILIES VISITED", PAGE_W / 2, 156);
+	ctx.letterSpacing = "0px";
+
+	if (airports.length === 0) {
+		emptyNotice(ctx, "NO PORTS VISITED");
+		return ctx.canvas;
+	}
+
+	const rows = airports.slice(0, 7);
+	const top = 220;
+	const rowH = 108;
+	rows.forEach((airport, i) => {
+		const y = top + i * rowH;
+		ctx.strokeStyle = PAPER_FAINT;
+		ctx.lineWidth = 1;
+		ctx.beginPath();
+		ctx.moveTo(64, y + 70);
+		ctx.lineTo(PAGE_W - 64, y + 70);
+		ctx.stroke();
+
+		// Airport code plate.
+		ctx.fillStyle = PAPER_INK;
+		ctx.textAlign = "left";
+		ctx.font = `700 52px ${MONO}`;
+		ctx.fillText(airport.code, 72, y + 52);
+
+		ctx.font = `500 27px ${SANS}`;
+		ctx.fillText(airport.label, 240, y + 44);
+
+		ctx.textAlign = "right";
+		ctx.font = `600 24px ${MONO}`;
+		ctx.fillText(
+			`${formatCompact(airport.requestCount)} REQ`,
+			PAGE_W - 72,
+			y + 46,
+		);
+	});
+	return ctx.canvas;
+}
+
+export function drawAirlinesPage(
+	airlines: PassportAirline[],
+): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	pageHeader(ctx, "CARRIERS");
+
+	ctx.fillStyle = PAPER_FAINT;
+	ctx.textAlign = "center";
+	ctx.font = `500 20px ${MONO}`;
+	ctx.letterSpacing = "5px";
+	ctx.fillText("HARNESSES FLOWN", PAGE_W / 2, 156);
+	ctx.letterSpacing = "0px";
+
+	if (airlines.length === 0) {
+		emptyNotice(ctx, "NO CARRIERS ON RECORD");
+		return ctx.canvas;
+	}
+
+	const rows = airlines.slice(0, 6);
+	const top = 224;
+	const rowH = 128;
+	rows.forEach((airline, i) => {
+		const y = top + i * rowH;
+		ctx.fillStyle = "rgba(255,255,255,0.5)";
+		ctx.fillRect(64, y, PAGE_W - 128, 100);
+		ctx.strokeStyle = PAPER_FAINT;
+		ctx.lineWidth = 1.5;
+		ctx.strokeRect(64, y, PAGE_W - 128, 100);
+
+		// Winged mark.
+		ctx.strokeStyle = PAPER_INK;
+		ctx.lineWidth = 3;
+		ctx.beginPath();
+		ctx.moveTo(96, y + 56);
+		ctx.quadraticCurveTo(122, y + 26, 150, y + 50);
+		ctx.moveTo(96, y + 56);
+		ctx.quadraticCurveTo(122, y + 44, 150, y + 62);
+		ctx.stroke();
+
+		ctx.fillStyle = PAPER_INK;
+		ctx.textAlign = "left";
+		ctx.font = `600 30px ${SANS}`;
+		ctx.fillText(airline.label, 180, y + 46);
+		ctx.fillStyle = PAPER_FAINT;
+		ctx.font = `500 20px ${MONO}`;
+		ctx.fillText(
+			`${formatCompact(airline.totalTokens)} TOKENS CARRIED`,
+			180,
+			y + 78,
+		);
+
+		ctx.fillStyle = PAPER_INK;
+		ctx.textAlign = "right";
+		ctx.font = `600 24px ${MONO}`;
+		ctx.fillText(
+			`${formatCompact(airline.requestCount)} FLT`,
+			PAGE_W - 90,
+			y + 58,
+		);
+	});
+	return ctx.canvas;
+}
+
+const STAMP_INKS = ["#166534", "#3730a3", "#9f1239", "#92400e"];
+
+export function drawStampsPage(
+	stamps: PassportStampData[],
+	pageIndex: number,
+): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	pageHeader(ctx, pageIndex === 0 ? "ENTRIES · EXITS" : "ENTRIES · EXITS II");
+
+	if (stamps.length === 0) {
+		emptyNotice(
+			ctx,
+			pageIndex === 0 ? "AWAITING FIRST ENTRY" : "MORE TRAVELS AHEAD",
+		);
+		return ctx.canvas;
+	}
+
+	stamps.forEach((stamp, i) => {
+		const cx = PAGE_W / 2 + (i % 2 === 0 ? -74 : 88) + Math.sin(i * 7.3) * 26;
+		const cy = 300 + i * 260 + Math.sin(i * 3.1) * 18;
+		const rot =
+			(i % 2 === 0 ? -1 : 1) * (0.09 + 0.05 * Math.abs(Math.sin(i * 5)));
+		const ink = STAMP_INKS[(i + pageIndex) % STAMP_INKS.length];
+		const w = 460;
+		const h = 196;
+
+		ctx.save();
+		ctx.translate(cx, cy);
+		ctx.rotate(rot);
+		const left = -w / 2;
+		const top = -h / 2;
+		ctx.globalAlpha = 0.86;
+		ctx.strokeStyle = ink;
+		ctx.fillStyle = ink;
+		ctx.lineWidth = 4;
+		ctx.strokeRect(left, top, w, h);
+		ctx.lineWidth = 1.8;
+		ctx.strokeRect(left + 7, top + 7, w - 14, h - 14);
+
+		ctx.textAlign = "center";
+		ctx.font = `500 17px ${MONO}`;
+		ctx.letterSpacing = "4px";
+		ctx.fillText(stamp.family.toUpperCase(), 0, top + 38);
+		ctx.letterSpacing = "0px";
+
+		const name =
+			stamp.model.length > 24 ? stamp.model.slice(0, 23) + "…" : stamp.model;
+		ctx.font = `700 30px ${MONO}`;
+		ctx.fillText(name.toUpperCase(), 0, top + 78);
+
+		ctx.font = `600 19px ${MONO}`;
+		ctx.textAlign = "left";
+		ctx.fillText(`ENTRY  ${formatDate(stamp.entry)}`, left + 30, -top - 58);
+		ctx.fillText(`EXIT   ${formatDate(stamp.exit)}`, left + 30, -top - 28);
+		ctx.textAlign = "right";
+		ctx.font = `700 26px ${MONO}`;
+		ctx.fillText(formatCompact(stamp.requestCount), -left - 30, -top - 40);
+		ctx.font = `500 14px ${MONO}`;
+		ctx.fillText("REQUESTS", -left - 30, -top - 20);
+		ctx.restore();
+	});
+	return ctx.canvas;
+}
+
+export function drawEndorsementsPage(data: PassportModel): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	pageHeader(ctx, "ENDORSEMENTS");
+
+	ctx.fillStyle = PAPER_INK;
+	ctx.textAlign = "center";
+	ctx.font = `600 34px ${MONO}`;
+	ctx.fillText(
+		`${formatCompact(data.totalRequests)} REQUESTS`,
+		PAGE_W / 2,
+		300,
+	);
+	ctx.fillText(`${data.activeDays} ACTIVE DAYS`, PAGE_W / 2, 360);
+
+	drawEmblem(ctx, PAGE_W / 2, 620, 110, "rgba(61,58,47,0.25)");
+
+	// Barcode strip.
+	ctx.fillStyle = PAPER_INK;
+	for (let i = 0; i < 60; i++) {
+		const wBar = 3 + Math.floor((Math.sin(i * 9.7) * 0.5 + 0.5) * 8);
+		const x = 120 + i * 9;
+		if (x + wBar > PAGE_W - 120) {
+			break;
+		}
+		ctx.fillRect(x, PAGE_H - 260, wBar, 90);
+	}
+
+	ctx.fillStyle = PAPER_FAINT;
+	ctx.font = `500 22px ${MONO}`;
+	ctx.letterSpacing = "3px";
+	ctx.fillText(
+		data.username
+			? `DEVPASS.LLMGATEWAY.IO/PROFILES/${data.username.toUpperCase()}`
+			: "DEVPASS.LLMGATEWAY.IO",
+		PAGE_W / 2,
+		PAGE_H - 120,
+	);
+	ctx.letterSpacing = "0px";
+	return ctx.canvas;
+}
+
+export function drawBackCoverInner(): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	drawPaper(ctx);
+	drawEmblem(ctx, PAGE_W / 2, PAGE_H / 2, 130, "rgba(61,58,47,0.1)");
+	return ctx.canvas;
+}
+
+export function drawBackCoverOuter(): HTMLCanvasElement {
+	const ctx = makeCanvas();
+	ctx.fillStyle = COVER_BG;
+	ctx.fillRect(0, 0, PAGE_W, PAGE_H);
+	ctx.strokeStyle = "rgba(201,162,39,0.5)";
+	ctx.lineWidth = 3;
+	ctx.strokeRect(40, 40, PAGE_W - 80, PAGE_H - 80);
+	drawEmblem(ctx, PAGE_W / 2, PAGE_H / 2, 90, "rgba(201,162,39,0.35)");
+	return ctx.canvas;
+}

--- a/apps/code/src/components/profile/passport/passport-textures.ts
+++ b/apps/code/src/components/profile/passport/passport-textures.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-mixed-operators -- canvas layout math is dense with
  * mixed arithmetic, and prettier strips the clarifying parentheses the rule
  * would otherwise require (same trade-off as packages/db/src/logs.ts). */
+import { formatPassportDate as formatDate } from "./passport-data";
+
 import type {
 	PassportAirline,
 	PassportAirport,
@@ -44,17 +46,27 @@ function makeCanvas(): CanvasRenderingContext2D {
 	return ctx;
 }
 
-function formatDate(iso: string | null): string {
-	if (!iso) {
-		return "—";
+/**
+ * Ellipsize `text` so it fits `maxWidth` with the CURRENT ctx.font — set the
+ * font before calling. Keeps user-provided strings (names, handles, model
+ * ids) from spilling over adjacent fields or the page edge.
+ */
+function fitText(
+	ctx: CanvasRenderingContext2D,
+	text: string,
+	maxWidth: number,
+): string {
+	if (ctx.measureText(text).width <= maxWidth) {
+		return text;
 	}
-	return new Date(iso)
-		.toLocaleDateString("en-GB", {
-			day: "2-digit",
-			month: "short",
-			year: "numeric",
-		})
-		.toUpperCase();
+	let trimmed = text;
+	while (
+		trimmed.length > 1 &&
+		ctx.measureText(trimmed + "…").width > maxWidth
+	) {
+		trimmed = trimmed.slice(0, -1);
+	}
+	return trimmed + "…";
 }
 
 function formatCompact(n: number): string {
@@ -228,16 +240,23 @@ export function drawVisaPage(data: PassportModel): HTMLCanvasElement {
 		ctx.fillText(text, x, y);
 		ctx.letterSpacing = "0px";
 	};
-	const value = (text: string, x: number, y: number, size = 30) => {
+	const value = (
+		text: string,
+		x: number,
+		y: number,
+		size = 30,
+		maxWidth = PAGE_W - 140,
+	) => {
 		ctx.fillStyle = PAPER_INK;
 		ctx.font = `600 ${size}px ${SANS}`;
-		ctx.fillText(text, x, y);
+		ctx.fillText(fitText(ctx, text, maxWidth), x, y);
 	};
 
 	label("SURNAME / GIVEN NAMES", 70, 180);
 	value(data.holderName.toUpperCase(), 70, 218);
 	label("CALLSIGN", 70, 280);
-	value(data.username ? `@${data.username}` : "—", 70, 318);
+	// The member-since column starts at x=400; keep the callsign clear of it.
+	value(data.username ? `@${data.username}` : "—", 70, 318, 30, 310);
 	label("MEMBER SINCE", 400, 280);
 	value(formatDate(data.memberSince), 400, 318, 26);
 
@@ -373,7 +392,7 @@ export function drawAirportsPage(
 		ctx.fillText(airport.code, 72, y + 52);
 
 		ctx.font = `500 27px ${SANS}`;
-		ctx.fillText(airport.label, 240, y + 44);
+		ctx.fillText(fitText(ctx, airport.label, 300), 240, y + 44);
 
 		ctx.textAlign = "right";
 		ctx.font = `600 24px ${MONO}`;
@@ -429,7 +448,7 @@ export function drawAirlinesPage(
 		ctx.fillStyle = PAPER_INK;
 		ctx.textAlign = "left";
 		ctx.font = `600 30px ${SANS}`;
-		ctx.fillText(airline.label, 180, y + 46);
+		ctx.fillText(fitText(ctx, airline.label, 360), 180, y + 46);
 		ctx.fillStyle = PAPER_FAINT;
 		ctx.font = `500 20px ${MONO}`;
 		ctx.fillText(
@@ -493,13 +512,11 @@ export function drawStampsPage(
 		ctx.textAlign = "center";
 		ctx.font = `500 17px ${MONO}`;
 		ctx.letterSpacing = "4px";
-		ctx.fillText(stamp.family.toUpperCase(), 0, top + 38);
+		ctx.fillText(fitText(ctx, stamp.family.toUpperCase(), w - 60), 0, top + 38);
 		ctx.letterSpacing = "0px";
 
-		const name =
-			stamp.model.length > 24 ? stamp.model.slice(0, 23) + "…" : stamp.model;
 		ctx.font = `700 30px ${MONO}`;
-		ctx.fillText(name.toUpperCase(), 0, top + 78);
+		ctx.fillText(fitText(ctx, stamp.model.toUpperCase(), w - 50), 0, top + 78);
 
 		ctx.font = `600 19px ${MONO}`;
 		ctx.textAlign = "left";
@@ -547,9 +564,13 @@ export function drawEndorsementsPage(data: PassportModel): HTMLCanvasElement {
 	ctx.font = `500 22px ${MONO}`;
 	ctx.letterSpacing = "3px";
 	ctx.fillText(
-		data.username
-			? `DEVPASS.LLMGATEWAY.IO/PROFILES/${data.username.toUpperCase()}`
-			: "DEVPASS.LLMGATEWAY.IO",
+		fitText(
+			ctx,
+			data.username
+				? `DEVPASS.LLMGATEWAY.IO/PROFILES/${data.username.toUpperCase()}`
+				: "DEVPASS.LLMGATEWAY.IO",
+			PAGE_W - 120,
+		),
 		PAGE_W / 2,
 		PAGE_H - 120,
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-three/fiber':
+        specifier: 9.6.1
+        version: 9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)
       '@simplewebauthn/browser':
         specifier: 13.3.0
         version: 13.3.0
@@ -425,6 +428,9 @@ importers:
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1
+      three:
+        specifier: 0.185.1
+        version: 0.185.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -444,6 +450,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/three':
+        specifier: 0.185.1
+        version: 0.185.1
       eslint:
         specifier: ^9.38.0
         version: 9.38.0(jiti@2.6.1)
@@ -2167,6 +2176,9 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -4880,6 +4892,31 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@react-three/fiber@9.6.1':
+    resolution: {integrity: sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@redis/bloom@5.9.0':
     resolution: {integrity: sha512-W9D8yfKTWl4tP8lkC3MRYkMz4OfbuzE/W8iObe0jFgoRmgMfkBV+Vj38gvIqZPImtY0WB34YZkX3amYuQebvRQ==}
     engines: {node: '>= 18'}
@@ -5660,6 +5697,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
@@ -5866,6 +5906,11 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
@@ -5878,8 +5923,14 @@ packages:
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
+  '@types/three@0.185.1':
+    resolution: {integrity: sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -5892,6 +5943,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.46.2':
     resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
@@ -9011,6 +9065,11 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
+
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
@@ -9580,6 +9639,9 @@ packages:
 
   mermaid@11.15.0:
     resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -10824,6 +10886,15 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-window@2.2.7:
     resolution: {integrity: sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==}
     peerDependencies:
@@ -11601,6 +11672,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   svg-pathdata@6.0.3:
     resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
     engines: {node: '>=12.0.0'}
@@ -11712,6 +11788,9 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -12479,6 +12558,24 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -13265,6 +13362,8 @@ snapshots:
       conventional-commits-parser: 6.4.0
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -16360,6 +16459,26 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-promise-suspense: 0.3.4
 
+  '@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-use-measure: 2.1.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.7)
+      three: 0.185.1
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@redis/bloom@5.9.0(@redis/client@5.9.0)':
     dependencies:
       '@redis/client': 5.9.0
@@ -17050,6 +17169,8 @@ snapshots:
   '@turbo/windows-arm64@2.9.14':
     optional: true
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
@@ -17294,6 +17415,10 @@ snapshots:
     dependencies:
       '@types/react': 19.2.17
 
+  '@types/react-reconciler@0.28.9(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
       '@types/react': 19.2.17
@@ -17313,9 +17438,20 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.6
 
+  '@types/stats.js@0.17.4': {}
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 25.3.0
+
+  '@types/three@0.185.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.2
+      meshoptimizer: 1.1.1
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -17325,6 +17461,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -19203,7 +19341,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.38.0(jiti@2.6.1))
@@ -19230,6 +19368,21 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.38.0(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19274,14 +19427,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.38.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19353,7 +19506,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@4.4.4)(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1)))(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -21010,6 +21163,13 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  its-fine@2.0.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.17)
+      react: 19.2.7
+    transitivePeerDependencies:
+      - '@types/react'
+
   java-properties@1.0.2: {}
 
   jiti@2.6.1: {}
@@ -21643,6 +21803,8 @@ snapshots:
       stylis: 4.3.6
       ts-dedent: 2.2.0
       uuid: 11.1.1
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -22959,6 +23121,12 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       swr: 2.3.6(react@19.2.7)
 
+  react-use-measure@2.1.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
   react-window@2.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -24019,6 +24187,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  suspend-react@0.1.3(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   svg-pathdata@6.0.3:
     optional: true
 
@@ -24151,6 +24323,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  three@0.185.1: {}
 
   throttleit@2.1.0: {}
 
@@ -24977,5 +25151,11 @@ snapshots:
   zod@4.3.6: {}
 
   zod@4.4.3: {}
+
+  zustand@5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

Public DevPass profiles (`/profiles/[username]`) now carry an **interactive three.js passport** — a navy booklet anyone can open and flip through, page by page, with the holder's AI coding travels printed on live canvas-textured pages.

The travel metaphor maps DevPass data onto a real passport:

| Passport | DevPass |
| --- | --- |
| Visa | The DevPass itself — tier sticker with **valid from** (subscription start) and **date of expiry** |
| Airports (ports of entry) | Model families visited, with IATA-style codes (ANT, OPE, …) |
| Airlines (carriers) | Harnesses flown (Claude Code, OpenCode, Cursor, …) with flight counts |
| Entry/exit stamps | Individual models, stamped with **first-used (entry)** and **last-used (exit)** dates |

Plus a cover with the DevPass emblem, an endorsements page (totals + profile URL barcode), and an MRZ strip on the visa page.

## Implementation

- **Scene**: procedural book built with `three` + `@react-three/fiber` — five leaves hinged on the spine, under-damped springs for page flips and cover opening, correct left/right stack reordering, pointer-follow tilt, idle float (disabled under `prefers-reduced-motion`). Loaded via `next/dynamic` (`ssr: false`) so three.js stays out of the main bundle.
- **Pages** are drawn into offscreen 2D canvases from live profile data and mounted as `CanvasTexture`s — guilloche paper, tier-colored visa sticker, rotated ink stamps.
- **API**: the public profile payload now exposes `plan` (tier + startedAt/expiresAt) and per-model `firstUsed`/`lastUsed` (MIN/MAX hour buckets decoded with `mapWith` so naive timestamps stay UTC). Covered by a new `profile.spec.ts`.
- **Interaction**: click the passport (or arrow buttons / keyboard arrows) to open and flip; click left page to go back. A11y: buttons + focusable wrapper + spread labels.

## Testing

- `apps/api/src/utils/profile.spec.ts`: visa window, no-plan case, first/last-used aggregation (3 tests).
- Verified end-to-end in the browser against the seeded dev DB: cover → visa (PRO, 05 JUL → 05 AUG 2026) → ports/carriers → stamps → endorsements.
- `pnpm build` green across all apps.

https://claude.ai/code/session_01ALMqWviMXjb4ZA6dXjRcgE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive 3D DevPass passport to user profiles.
  * Users can navigate passport pages with Previous/Next controls and keyboard support, with reduced-motion support.
  * Passport pages now display active plan details, model usage activity, and profile statistics.
  * Added first- and last-used timestamps for model usage and surfaced them in the passport experience.

* **Tests**
  * Added test coverage for active plan tier handling and per-model first/last usage timestamp computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->