### PR TITLE
fix(models): correct gpt-5.1 reasoning effort tiers

### DIFF
--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1104,7 +1104,7 @@ export const openaiModels = [
 				webSearch: true,
 				webSearchPrice: "0.01", // $10 per 1000 searches for reasoning models
 				reasoning: true,
-				reasoningEfforts: ["none", "low", "medium", "high"],
+				reasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
 				reasoningOutput: "omit",
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
@@ -1133,7 +1133,7 @@ export const openaiModels = [
 				vision: true,
 				tools: true,
 				reasoning: true,
-				reasoningEfforts: ["none", "low", "medium", "high"],
+				reasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
 				supportsResponsesApi: true,
 				jsonOutputSchema: true,
 				supportedParameters: [


### PR DESCRIPTION
## Summary

A raw API request sending `reasoning_effort: "max"` to `gpt-5.1` gets an OpenAI `400`:

```
Invalid value: 'max'. Supported values are: 'none', 'minimal', 'low', 'medium', 'high', and 'xhigh'.
```

This is expected: `max` is only supported by Anthropic models and OpenAI GPT-5.6 (per the `reasoning_effort` schema docs), and the gateway deliberately forwards effort values unchanged rather than clamping them — so an unsupported value surfaces as a provider error. gpt-5.1's top tier is `xhigh`, not `max`.

While investigating, I found a genuine data bug: gpt-5.1's mapping advertised `reasoningEfforts: ["none", "low", "medium", "high"]`, omitting `minimal` and `xhigh` that OpenAI actually supports (as its own error message confirms). Because the playground builds its effort selector from `reasoningEfforts` and `/v1/models` exposes the list, `xhigh` was hidden from users even though it works.

## Change

Update the `openai` and `azure` gpt-5.1 mappings to advertise the full set OpenAI supports: `["none", "minimal", "low", "medium", "high", "xhigh"]`.

This does not change the `max` behavior — sending `max` to gpt-5.1 still (correctly) returns a provider error, consistent with the gateway's documented no-clamp policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for “minimal” and “xhigh” reasoning effort levels when using the GPT-5.1 model with supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->