### PR TITLE
fix(gateway): keep session-sticky retries on pinned provider

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -251,6 +251,7 @@ import { resolveReasoningTokens } from "./tools/resolve-reasoning-tokens.js";
 import {
 	type RoutingAttempt,
 	getErrorType,
+	getSameKeyMaxRetries,
 	isRetryableErrorType,
 	providerRetryKey,
 	sameKeyRetryDelay,
@@ -6890,7 +6891,7 @@ chat.openapi(completions, async (c) => {
 										routingMetadata?.providerScores ?? []
 									).some((s) => s.providerId !== usedProvider),
 									retryCount: sameKeyRetryCount,
-									maxRetries: routingCfg.retry.maxRetries,
+									maxRetries: getSameKeyMaxRetries(),
 								}) &&
 								// Same-key retries re-hit the provider, so consume a rate-limit
 								// slot like fallback retries do and skip the retry when limited.
@@ -7006,7 +7007,7 @@ chat.openapi(completions, async (c) => {
 								// failed attempt) so a client disconnect during the
 								// retried upstream call still cancels.
 								c.req.raw.signal.addEventListener("abort", onAbort);
-								await sameKeyRetryDelay();
+								await sameKeyRetryDelay(sameKeyRetryCount);
 								routingAttempts.push(
 									buildRoutingAttempt(
 										usedProvider,
@@ -7283,7 +7284,7 @@ chat.openapi(completions, async (c) => {
 										routingMetadata?.providerScores ?? []
 									).some((s) => s.providerId !== usedProvider),
 									retryCount: sameKeyRetryCount,
-									maxRetries: routingCfg.retry.maxRetries,
+									maxRetries: getSameKeyMaxRetries(),
 								}) &&
 								// Same-key retries re-hit the provider, so consume a rate-limit
 								// slot like fallback retries do and skip the retry when limited.
@@ -7418,7 +7419,7 @@ chat.openapi(completions, async (c) => {
 								// failed attempt) so a client disconnect during the
 								// retried upstream call still cancels.
 								c.req.raw.signal.addEventListener("abort", onAbort);
-								await sameKeyRetryDelay();
+								await sameKeyRetryDelay(sameKeyRetryCount);
 								routingAttempts.push(
 									buildRoutingAttempt(
 										usedProvider,
@@ -7581,7 +7582,7 @@ chat.openapi(completions, async (c) => {
 									(s) => s.providerId !== usedProvider,
 								),
 								retryCount: sameKeyRetryCount,
-								maxRetries: routingCfg.retry.maxRetries,
+								maxRetries: getSameKeyMaxRetries(),
 							}) &&
 							// Same-key retries re-hit the provider, so consume a rate-limit
 							// slot like fallback retries do and skip the retry when limited.
@@ -7757,7 +7758,7 @@ chat.openapi(completions, async (c) => {
 							// failed attempt) so a client disconnect during the
 							// retried upstream call still cancels.
 							c.req.raw.signal.addEventListener("abort", onAbort);
-							await sameKeyRetryDelay();
+							await sameKeyRetryDelay(sameKeyRetryCount);
 							routingAttempts.push(
 								buildRoutingAttempt(
 									usedProvider,
@@ -7953,7 +7954,7 @@ chat.openapi(completions, async (c) => {
 									(s) => s.providerId !== usedProvider,
 								),
 								retryCount: sameKeyRetryCount,
-								maxRetries: routingCfg.retry.maxRetries,
+								maxRetries: getSameKeyMaxRetries(),
 							}) &&
 							// Same-key retries re-hit the provider, so consume a rate-limit
 							// slot like fallback retries do and skip the retry when limited.
@@ -8091,7 +8092,7 @@ chat.openapi(completions, async (c) => {
 							// failed attempt) so a client disconnect during the
 							// retried upstream call still cancels.
 							c.req.raw.signal.addEventListener("abort", onAbort);
-							await sameKeyRetryDelay();
+							await sameKeyRetryDelay(sameKeyRetryCount);
 							routingAttempts.push(
 								buildRoutingAttempt(
 									usedProvider,
@@ -11282,7 +11283,7 @@ chat.openapi(completions, async (c) => {
 						(s) => s.providerId !== usedProvider,
 					),
 					retryCount: sameKeyRetryCount,
-					maxRetries: routingCfg.retry.maxRetries,
+					maxRetries: getSameKeyMaxRetries(),
 				}) &&
 				// Same-key retries re-hit the provider, so consume a rate-limit
 				// slot like fallback retries do and skip the retry when limited.
@@ -11418,7 +11419,7 @@ chat.openapi(completions, async (c) => {
 				// a client disconnect during the retried upstream call still
 				// cancels.
 				c.req.raw.signal.addEventListener("abort", onAbort);
-				await sameKeyRetryDelay();
+				await sameKeyRetryDelay(sameKeyRetryCount);
 				routingAttempts.push(
 					buildRoutingAttempt(
 						usedProvider,
@@ -11723,7 +11724,7 @@ chat.openapi(completions, async (c) => {
 						(s) => s.providerId !== usedProvider,
 					),
 					retryCount: sameKeyRetryCount,
-					maxRetries: routingCfg.retry.maxRetries,
+					maxRetries: getSameKeyMaxRetries(),
 				}) &&
 				// Same-key retries re-hit the provider, so consume a rate-limit
 				// slot like fallback retries do and skip the retry when limited.
@@ -11918,7 +11919,7 @@ chat.openapi(completions, async (c) => {
 				// a client disconnect during the retried upstream call still
 				// cancels.
 				c.req.raw.signal.addEventListener("abort", onAbort);
-				await sameKeyRetryDelay();
+				await sameKeyRetryDelay(sameKeyRetryCount);
 				routingAttempts.push(
 					buildRoutingAttempt(
 						usedProvider,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6865,6 +6865,7 @@ chat.openapi(completions, async (c) => {
 							const willRetryTimeout = shouldRetryRequest({
 								requestedProvider,
 								noFallback,
+								sessionSticky: sessionStickyEnabled,
 								errorType: "upstream_timeout",
 								retryCount: retryAttempt,
 								remainingProviders:
@@ -6880,6 +6881,7 @@ chat.openapi(completions, async (c) => {
 								!willRetryTimeout &&
 								shouldRetrySameKey({
 									usedProvider,
+									sessionSticky: sessionStickyEnabled,
 									errorType: "upstream_timeout",
 									statusCode: 0,
 									envVarName,
@@ -7256,6 +7258,7 @@ chat.openapi(completions, async (c) => {
 							const willRetryFetch = shouldRetryRequest({
 								requestedProvider,
 								noFallback,
+								sessionSticky: sessionStickyEnabled,
 								errorType: "network_error",
 								retryCount: retryAttempt,
 								remainingProviders:
@@ -7271,6 +7274,7 @@ chat.openapi(completions, async (c) => {
 								!willRetryFetch &&
 								shouldRetrySameKey({
 									usedProvider,
+									sessionSticky: sessionStickyEnabled,
 									errorType: "network_error",
 									statusCode: 0,
 									envVarName,
@@ -7552,6 +7556,7 @@ chat.openapi(completions, async (c) => {
 						const willRetryHttpError = shouldRetryRequest({
 							requestedProvider,
 							noFallback,
+							sessionSticky: sessionStickyEnabled,
 							errorType: finishReason,
 							retryCount: retryAttempt,
 							remainingProviders:
@@ -7567,6 +7572,7 @@ chat.openapi(completions, async (c) => {
 							!willRetryHttpError &&
 							shouldRetrySameKey({
 								usedProvider,
+								sessionSticky: sessionStickyEnabled,
 								errorType: finishReason,
 								statusCode: res.status,
 								envVarName,
@@ -7922,6 +7928,7 @@ chat.openapi(completions, async (c) => {
 						const willRetryStreamingError = shouldRetryRequest({
 							requestedProvider,
 							noFallback,
+							sessionSticky: sessionStickyEnabled,
 							errorType,
 							retryCount: retryAttempt,
 							remainingProviders:
@@ -7937,6 +7944,7 @@ chat.openapi(completions, async (c) => {
 							!willRetryStreamingError &&
 							shouldRetrySameKey({
 								usedProvider,
+								sessionSticky: sessionStickyEnabled,
 								errorType,
 								statusCode: inferredStatusCode,
 								envVarName,
@@ -11249,6 +11257,7 @@ chat.openapi(completions, async (c) => {
 			const willRetryFetchNonStreaming = shouldRetryRequest({
 				requestedProvider,
 				noFallback,
+				sessionSticky: sessionStickyEnabled,
 				errorType: "network_error",
 				retryCount: retryAttempt,
 				remainingProviders:
@@ -11264,6 +11273,7 @@ chat.openapi(completions, async (c) => {
 				!willRetryFetchNonStreaming &&
 				shouldRetrySameKey({
 					usedProvider,
+					sessionSticky: sessionStickyEnabled,
 					errorType: "network_error",
 					statusCode: 0,
 					envVarName,
@@ -11688,6 +11698,7 @@ chat.openapi(completions, async (c) => {
 			const willRetryHttpNonStreaming = shouldRetryRequest({
 				requestedProvider,
 				noFallback,
+				sessionSticky: sessionStickyEnabled,
 				errorType: finishReason,
 				retryCount: retryAttempt,
 				remainingProviders:
@@ -11703,6 +11714,7 @@ chat.openapi(completions, async (c) => {
 				!willRetryHttpNonStreaming &&
 				shouldRetrySameKey({
 					usedProvider,
+					sessionSticky: sessionStickyEnabled,
 					errorType: finishReason,
 					statusCode: res.status,
 					envVarName,

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 import {
 	isRetryableErrorType,
 	sameKeyRetryDelay,
 	SAME_KEY_RETRY_DELAY_MS,
+	getSameKeyMaxRetries,
+	DEFAULT_SAME_KEY_MAX_RETRIES,
 	shouldRetryAlternateKey,
 	shouldRetrySameKey,
 	shouldRetryRequest,
@@ -369,11 +371,11 @@ describe("shouldRetrySameKey", () => {
 });
 
 describe("sameKeyRetryDelay", () => {
-	it("resolves after the fixed delay", async () => {
+	it("resolves after the first-attempt delay", async () => {
 		vi.useFakeTimers();
 		try {
 			let resolved = false;
-			const pending = sameKeyRetryDelay().then(() => {
+			const pending = sameKeyRetryDelay(1).then(() => {
 				resolved = true;
 			});
 
@@ -386,6 +388,65 @@ describe("sameKeyRetryDelay", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("backs off exponentially per attempt (1s, 2s, 4s)", async () => {
+		vi.useFakeTimers();
+		try {
+			for (const [attempt, expectedMs] of [
+				[1, 1000],
+				[2, 2000],
+				[3, 4000],
+			] as const) {
+				let resolved = false;
+				const pending = sameKeyRetryDelay(attempt).then(() => {
+					resolved = true;
+				});
+
+				await vi.advanceTimersByTimeAsync(expectedMs - 1);
+				expect(resolved).toBe(false);
+
+				await vi.advanceTimersByTimeAsync(1);
+				await pending;
+				expect(resolved).toBe(true);
+			}
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
+describe("getSameKeyMaxRetries", () => {
+	const original = process.env.SAME_KEY_MAX_RETRIES;
+	afterEach(() => {
+		if (original === undefined) {
+			delete process.env.SAME_KEY_MAX_RETRIES;
+		} else {
+			process.env.SAME_KEY_MAX_RETRIES = original;
+		}
+	});
+
+	it("defaults to 2 when unset", () => {
+		delete process.env.SAME_KEY_MAX_RETRIES;
+		expect(getSameKeyMaxRetries()).toBe(DEFAULT_SAME_KEY_MAX_RETRIES);
+		expect(DEFAULT_SAME_KEY_MAX_RETRIES).toBe(2);
+	});
+
+	it("honors a valid override", () => {
+		process.env.SAME_KEY_MAX_RETRIES = "5";
+		expect(getSameKeyMaxRetries()).toBe(5);
+	});
+
+	it("allows disabling retries with 0", () => {
+		process.env.SAME_KEY_MAX_RETRIES = "0";
+		expect(getSameKeyMaxRetries()).toBe(0);
+	});
+
+	it("falls back to the default for invalid values", () => {
+		process.env.SAME_KEY_MAX_RETRIES = "not-a-number";
+		expect(getSameKeyMaxRetries()).toBe(DEFAULT_SAME_KEY_MAX_RETRIES);
+		process.env.SAME_KEY_MAX_RETRIES = "-1";
+		expect(getSameKeyMaxRetries()).toBe(DEFAULT_SAME_KEY_MAX_RETRIES);
 	});
 });
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -127,6 +127,15 @@ describe("shouldRetryRequest", () => {
 			shouldRetryRequest({ ...defaultOpts, errorType: "upstream_timeout" }),
 		).toBe(true);
 	});
+
+	it("does not fall back to another provider for session-sticky requests", () => {
+		// Sticky sessions pin to one provider to keep the upstream prompt cache
+		// warm; switching providers mid-session would break the pin. Same-provider
+		// retries handle transient failures instead.
+		expect(shouldRetryRequest({ ...defaultOpts, sessionSticky: true })).toBe(
+			false,
+		);
+	});
 });
 
 describe("shouldRetryAlternateKey", () => {
@@ -176,6 +185,48 @@ describe("shouldRetrySameKey", () => {
 		expect(shouldRetrySameKey({ ...defaultOpts, hasOtherProvider: true })).toBe(
 			false,
 		);
+	});
+
+	it("retries the pinned provider for session-sticky requests even when others exist", () => {
+		// Cross-provider fallback is disabled for sticky sessions, so the pinned
+		// provider is retried on the same key even when alternatives exist.
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				hasOtherProvider: true,
+				sessionSticky: true,
+			}),
+		).toBe(true);
+	});
+
+	it("still excludes deterministic failures for session-sticky requests", () => {
+		// The sticky bypass only relaxes the hasOtherProvider gate — auth, 4xx and
+		// rate-limit failures remain non-retryable on the same key.
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				hasOtherProvider: true,
+				sessionSticky: true,
+				errorType: "gateway_error",
+				statusCode: 401,
+			}),
+		).toBe(false);
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				hasOtherProvider: true,
+				sessionSticky: true,
+				statusCode: 400,
+			}),
+		).toBe(false);
+		expect(
+			shouldRetrySameKey({
+				...defaultOpts,
+				hasOtherProvider: true,
+				sessionSticky: true,
+				retryCount: 2,
+			}),
+		).toBe(false);
 	});
 
 	it("retries on upstream timeouts", () => {

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -4,6 +4,23 @@ import { DEFAULT_ROUTING_RETRY } from "@llmgateway/shared/routing-config";
 
 export const MAX_RETRIES = DEFAULT_ROUTING_RETRY.maxRetries;
 
+/**
+ * Number of same-key retries against the pinned/only provider before giving up
+ * (session-sticky and single-provider transient failures). Overridable via the
+ * `SAME_KEY_MAX_RETRIES` env var; defaults to 2. A value of 0 disables same-key
+ * retries entirely.
+ */
+export const DEFAULT_SAME_KEY_MAX_RETRIES = 2;
+
+export function getSameKeyMaxRetries(): number {
+	const raw = process.env.SAME_KEY_MAX_RETRIES;
+	if (!raw) {
+		return DEFAULT_SAME_KEY_MAX_RETRIES;
+	}
+	const v = parseInt(raw, 10);
+	return Number.isFinite(v) && v >= 0 ? v : DEFAULT_SAME_KEY_MAX_RETRIES;
+}
+
 export type RetryableErrorType =
 	| "network_error"
 	| "provider_error"
@@ -60,17 +77,23 @@ export function shouldRetryAlternateKey(
 }
 
 /**
- * Fixed delay before a same-key retry. Cross-provider fallback switches to a
+ * Backoff before a same-key retry. Cross-provider fallback switches to a
  * different upstream and retries immediately, but a same-key retry re-hits
  * the upstream that just failed — a short pause gives transient faults a
  * moment to clear instead of immediately adding pressure. The added latency
  * is acceptable since the upstream is already slow or erroring.
+ *
+ * The delay grows exponentially with the 1-based attempt number so successive
+ * retries back off further: 1s before the first retry, 2s before the second,
+ * 4s before the third, and so on.
  */
 export const SAME_KEY_RETRY_DELAY_MS = 1000;
 
-export function sameKeyRetryDelay(): Promise<void> {
+export function sameKeyRetryDelay(attempt: number): Promise<void> {
+	const multiplier = 2 ** (attempt - 1);
+	const delayMs = multiplier * SAME_KEY_RETRY_DELAY_MS;
 	return new Promise((resolve) => {
-		setTimeout(resolve, SAME_KEY_RETRY_DELAY_MS);
+		setTimeout(resolve, delayMs);
 	});
 }
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -96,6 +96,12 @@ export function sameKeyRetryDelay(): Promise<void> {
  * request on the identical key will almost certainly fail the same way
  * (and re-firing a 429 would amplify rate-limit pressure). BYOK/custom
  * providers (envVarName unset) are also excluded.
+ *
+ * Session-sticky requests are the exception to the `hasOtherProvider` gate:
+ * they pin the conversation to a single provider to keep the upstream prompt
+ * cache warm, and cross-provider fallback is disabled for them (see
+ * `shouldRetryRequest`), so the pinned provider is retried on the same key even
+ * when other providers exist.
  */
 export function shouldRetrySameKey(opts: {
 	usedProvider: string;
@@ -106,11 +112,12 @@ export function shouldRetrySameKey(opts: {
 	hasOtherProvider: boolean;
 	retryCount: number;
 	maxRetries: number;
+	sessionSticky?: boolean;
 }): boolean {
 	if (opts.retryCount >= opts.maxRetries) {
 		return false;
 	}
-	if (opts.hasOtherProvider) {
+	if (opts.hasOtherProvider && !opts.sessionSticky) {
 		return false;
 	}
 	if (opts.usedProvider === "custom" || opts.usedProvider === "llmgateway") {
@@ -145,6 +152,12 @@ export function shouldRetrySameKey(opts: {
  * Determines whether a failed request should be retried with a different provider.
  * Only retries when no specific provider was requested, the error is retryable,
  * retry count hasn't been exceeded, and alternative providers are available.
+ *
+ * Cross-provider fallback is disabled for session-sticky requests: they pin the
+ * conversation to a single provider so the upstream prompt cache stays warm, and
+ * switching providers mid-session would break that pin. Transient failures on a
+ * sticky request are instead retried against the pinned provider (via the
+ * alternate-key and same-key retry paths).
  */
 export function shouldRetryRequest(opts: {
 	requestedProvider: string | undefined;
@@ -154,11 +167,15 @@ export function shouldRetryRequest(opts: {
 	remainingProviders: number;
 	usedProvider: string;
 	maxRetries?: number;
+	sessionSticky?: boolean;
 }): boolean {
 	if (opts.requestedProvider) {
 		return false;
 	}
 	if (opts.noFallback) {
+		return false;
+	}
+	if (opts.sessionSticky) {
 		return false;
 	}
 	if (!isRetryableErrorType(opts.errorType)) {


### PR DESCRIPTION
## What

For session-sticky requests, retry the **pinned** provider on transient failures instead of falling back to a different provider. Same-key retries back off exponentially and the retry count is configurable via an env var.

## Why

Session-sticky routing pins a conversation to a single upstream provider so the provider-side prompt cache stays warm across turns (`x-session-id` / Claude Code's `metadata.user_id` / `prompt_cache_key`, etc.). Double-checking the retry path revealed the pin was **not** protected on failure:

- `shouldRetryRequest` (cross-provider fallback) had no knowledge of session stickiness, so a transient error on a sticky-pinned provider fell back to a *different* provider — breaking the pin and discarding the warm cache.
- `shouldRetrySameKey` is gated off whenever other providers exist (`hasOtherProvider`), so the pinned provider was **not** retried. The specific gap: a sticky session on a model with multiple providers but a single env key jumped straight to another provider on the first transient failure, with zero same-provider retries.

## Change

**Keep sticky retries on the pinned provider**
- `shouldRetryRequest`: return `false` for session-sticky requests — cross-provider fallback would break the pin.
- `shouldRetrySameKey`: relax the `hasOtherProvider` gate for session-sticky requests so the pinned provider is retried on the same key even when alternatives exist. All other guards stay (transient errors only; auth/4xx/rate-limit/`gateway_error` excluded; BYOK/custom excluded).
- Thread `sessionSticky: sessionStickyEnabled` into all 6 retry decision sites (streaming + non-streaming).

**Exponential backoff**
- `sameKeyRetryDelay(attempt)` now scales with the 1-based attempt number: **1s** before the first retry, **2s** before the second, **4s** before the third, etc. (was a fixed 1s).

**Configurable retry count**
- New `SAME_KEY_MAX_RETRIES` env var (default **2**) controls how many times the pinned/only provider is retried on the same key. `0` disables same-key retries. Replaces the routing-config retry budget for the same-key path.

Multi-key pinned providers already stay on the same provider via the existing alternate-key rotation path, so this fills the single-key gap. Persistent provider outages are still handled across requests: the session uptime threshold re-pins to a healthy provider on the next request. Non-sticky requests and video generation are unaffected.

## Tests

Added unit coverage in `retry-with-fallback.spec.ts`:
- sticky requests don't cross-provider fall back; they retry the pinned provider even when other providers exist; deterministic failures remain excluded
- exponential backoff (1s / 2s / 4s per attempt)
- `getSameKeyMaxRetries` default (2), valid override, `0` to disable, and invalid-value fallback

`turbo run build --filter=gateway`, `pnpm format`, and the full `retry-with-fallback` spec (59 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for session-sticky conversations so requests stay pinned to the selected provider when eligible.
  * Added consistent session-sticky handling across both streaming and non-streaming retry paths, while still respecting non-retryable failures.
* **New Features**
  * Introduced configurable same-key retry budgeting with a default limit and optional disabling.
  * Same-key retries now use exponential backoff with attempt-based delays.
* **Tests**
  * Expanded timing/config tests, added coverage for sticky pinning and same-key retry limits (including disable and invalid env handling).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->