### PR TITLE
fix(gateway): rewrite developer role for opted-out mappings

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -4867,8 +4867,8 @@ describe("prepareRequestBody - developer role normalization", () => {
 		)) as any;
 	}
 
-	test("maps developer role to system for non-OpenAI providers", async () => {
-		const requestBody = await prepare("zai", "glm-5.2");
+	test("rewrites developer to system for a mapping with supportsDeveloperRole: false (granite/glm-5.2)", async () => {
+		const requestBody = await prepare("granite", "glm-5.2");
 		expect(requestBody.messages[0].role).toBe("system");
 		expect(requestBody.messages[0].content).toBe(
 			"You are a helpful assistant.",
@@ -4876,9 +4876,9 @@ describe("prepareRequestBody - developer role normalization", () => {
 		expect(requestBody.messages[1].role).toBe("user");
 	});
 
-	test("maps developer role to system for alibaba (glm-5.2)", async () => {
-		const requestBody = await prepare("alibaba", "glm-5.2");
-		expect(requestBody.messages[0].role).toBe("system");
+	test("preserves developer role for a mapping that supports it (zai/glm-5.2)", async () => {
+		const requestBody = await prepare("zai", "glm-5.2");
+		expect(requestBody.messages[0].role).toBe("developer");
 	});
 
 	test("preserves developer role for OpenAI", async () => {

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -4842,11 +4842,15 @@ describe("prepareRequestBody - Xiaomi", () => {
 });
 
 describe("prepareRequestBody - developer role normalization", () => {
-	async function prepare(provider: string, model: string) {
+	async function prepare(
+		provider: string,
+		model: string,
+		region: string | null = null,
+	) {
 		return (await prepareRequestBody(
 			provider,
 			model,
-			null,
+			region,
 			model,
 			[
 				{ role: "developer", content: "You are a helpful assistant." },
@@ -4873,6 +4877,18 @@ describe("prepareRequestBody - developer role normalization", () => {
 		expect(requestBody.messages[0].content).toBe(
 			"You are a helpful assistant.",
 		);
+		expect(requestBody.messages[1].role).toBe("user");
+	});
+
+	test("rewrites developer to system for alibaba/glm-5.2 (supportsDeveloperRole: false)", async () => {
+		const requestBody = await prepare("alibaba", "glm-5.2");
+		expect(requestBody.messages[0].role).toBe("system");
+		expect(requestBody.messages[1].role).toBe("user");
+	});
+
+	test("resolves the flag through region expansion for alibaba/glm-5.2 (singapore)", async () => {
+		const requestBody = await prepare("alibaba", "glm-5.2", "singapore");
+		expect(requestBody.messages[0].role).toBe("system");
 		expect(requestBody.messages[1].role).toBe("user");
 	});
 

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -4840,3 +4840,49 @@ describe("prepareRequestBody - Xiaomi", () => {
 		expect(requestBody.reasoning_effort).toBe("medium");
 	});
 });
+
+describe("prepareRequestBody - developer role normalization", () => {
+	async function prepare(provider: string, model: string) {
+		return (await prepareRequestBody(
+			provider,
+			model,
+			null,
+			model,
+			[
+				{ role: "developer", content: "You are a helpful assistant." },
+				{ role: "user", content: "Hello" },
+			] as any,
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+	}
+
+	test("maps developer role to system for non-OpenAI providers", async () => {
+		const requestBody = await prepare("zai", "glm-5.2");
+		expect(requestBody.messages[0].role).toBe("system");
+		expect(requestBody.messages[0].content).toBe(
+			"You are a helpful assistant.",
+		);
+		expect(requestBody.messages[1].role).toBe("user");
+	});
+
+	test("maps developer role to system for alibaba (glm-5.2)", async () => {
+		const requestBody = await prepare("alibaba", "glm-5.2");
+		expect(requestBody.messages[0].role).toBe("system");
+	});
+
+	test("preserves developer role for OpenAI", async () => {
+		const requestBody = await prepare("openai", "gpt-4o-mini");
+		expect(requestBody.messages[0].role).toBe("developer");
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1383,11 +1383,11 @@ export async function prepareRequestBody(
 	// not one of ['system', 'assistant', 'user', 'tool', 'function']"). Mappings
 	// default to accepting `developer`, so this only rewrites where explicitly
 	// opted out.
-	const developerRoleMapping = modelDef?.providers.find(
-		(p) =>
-			p.providerId === usedProvider &&
-			((p as ProviderModelMapping).region ?? null) === usedRegion,
-	) as ProviderModelMapping | undefined;
+	const developerRoleMapping = getProviderMapping(
+		modelDef,
+		usedProvider,
+		usedRegion,
+	);
 	if (developerRoleMapping?.supportsDeveloperRole === false) {
 		processedMessages = transformDeveloperRole(processedMessages);
 	}

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -740,6 +740,20 @@ function transformMessagesForNoSystemRole(messages: any[]): any[] {
 }
 
 /**
+ * Maps the OpenAI-only `developer` role to `system`. Only OpenAI's own Chat
+ * Completions / Responses surfaces (and Azure OpenAI) accept the `developer`
+ * role; other OpenAI-compatible providers reject it with a 400 ("developer is
+ * not one of ['system', 'assistant', 'user', 'tool', 'function']"). `developer`
+ * is semantically a system instruction, so downgrading it to `system` is safe
+ * everywhere it isn't natively supported.
+ */
+function transformDeveloperRole(messages: any[]): any[] {
+	return messages.map((message) =>
+		message.role === "developer" ? { ...message, role: "system" } : message,
+	);
+}
+
+/**
  * Transforms message content types for OpenAI's Responses API.
  * The Responses API uses different content type identifiers:
  * - "text" -> "input_text" (for user/system/tool messages) or "output_text" (for assistant messages)
@@ -1362,10 +1376,20 @@ export async function prepareRequestBody(
 	const supportsSystemRole =
 		(modelDef as ModelDefinition)?.supportsSystemRole !== false;
 
-	// Transform messages if model doesn't support system role
 	let processedMessages = messages;
+
+	// Normalize the OpenAI-only `developer` role to `system` for every provider
+	// except OpenAI/Azure OpenAI, which accept it natively. Other
+	// OpenAI-compatible providers reject `developer` with a 400.
+	const providerSupportsDeveloperRole =
+		usedProvider === "openai" || usedProvider === "azure";
+	if (!providerSupportsDeveloperRole) {
+		processedMessages = transformDeveloperRole(processedMessages);
+	}
+
+	// Transform messages if model doesn't support system role
 	if (!supportsSystemRole) {
-		processedMessages = transformMessagesForNoSystemRole(messages);
+		processedMessages = transformMessagesForNoSystemRole(processedMessages);
 	}
 
 	// Strip Anthropic-style cache_control markers from caller-supplied content

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -740,12 +740,11 @@ function transformMessagesForNoSystemRole(messages: any[]): any[] {
 }
 
 /**
- * Maps the OpenAI-only `developer` role to `system`. Only OpenAI's own Chat
- * Completions / Responses surfaces (and Azure OpenAI) accept the `developer`
- * role; other OpenAI-compatible providers reject it with a 400 ("developer is
- * not one of ['system', 'assistant', 'user', 'tool', 'function']"). `developer`
- * is semantically a system instruction, so downgrading it to `system` is safe
- * everywhere it isn't natively supported.
+ * Maps the OpenAI-only `developer` role to `system`. Applied only for mappings
+ * that declare `supportsDeveloperRole: false`, i.e. upstreams that reject
+ * `developer` with a 400 ("developer is not one of ['system', 'assistant',
+ * 'user', 'tool', 'function']"). `developer` is semantically a system
+ * instruction, so downgrading it to `system` is safe on those upstreams.
  */
 function transformDeveloperRole(messages: any[]): any[] {
 	return messages.map((message) =>
@@ -1378,12 +1377,18 @@ export async function prepareRequestBody(
 
 	let processedMessages = messages;
 
-	// Normalize the OpenAI-only `developer` role to `system` for every provider
-	// except OpenAI/Azure OpenAI, which accept it natively. Other
-	// OpenAI-compatible providers reject `developer` with a 400.
-	const providerSupportsDeveloperRole =
-		usedProvider === "openai" || usedProvider === "azure";
-	if (!providerSupportsDeveloperRole) {
+	// Rewrite the OpenAI-only `developer` role to `system` for mappings that
+	// declare they don't accept it (`supportsDeveloperRole: false`). Some
+	// OpenAI-compatible upstreams reject `developer` with a 400 ("developer is
+	// not one of ['system', 'assistant', 'user', 'tool', 'function']"). Mappings
+	// default to accepting `developer`, so this only rewrites where explicitly
+	// opted out.
+	const developerRoleMapping = modelDef?.providers.find(
+		(p) =>
+			p.providerId === usedProvider &&
+			((p as ProviderModelMapping).region ?? null) === usedRegion,
+	) as ProviderModelMapping | undefined;
+	if (developerRoleMapping?.supportsDeveloperRole === false) {
 		processedMessages = transformDeveloperRole(processedMessages);
 	}
 

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -495,6 +495,14 @@ export interface ProviderModelMapping {
 	 */
 	supportedToolChoices?: ToolChoiceMode[];
 	/**
+	 * Whether this mapping's upstream accepts the OpenAI-only `developer` message
+	 * role. Defaults to `true` (assumed supported). When set to `false`, the
+	 * gateway rewrites `developer` messages to `system` before forwarding, since
+	 * some OpenAI-compatible providers reject `developer` with a 400 ("developer
+	 * is not one of ['system', 'assistant', 'user', 'tool', 'function']").
+	 */
+	supportsDeveloperRole?: boolean;
+	/**
 	 * Test skip/only functionality
 	 */
 	test?: "skip" | "only";

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -94,6 +94,7 @@ export const zaiModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				supportsDeveloperRole: false,
 			},
 			{
 				providerId: "bytedance",

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -129,6 +129,7 @@ export const zaiModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				supportsDeveloperRole: false,
 			},
 		],
 	},


### PR DESCRIPTION
## Problem

The granite and alibaba `glm-5.2` mappings reject the OpenAI-only `developer` message role with a 400:

```
{"error":{"message":"developer is not one of ['system', 'assistant', 'user', 'tool', 'function']","type":"invalid_request_error","code":"invalid_parameter_error"}}
```

The `developer` role is an OpenAI-ism (its newer replacement for `system` on reasoning models). Some OpenAI-compatible upstreams accept it; others reject it. This is per-provider-mapping, not model-wide — the same `glm-5.2` model works on mappings that accept `developer` (e.g. zai) and 400s on granite/alibaba.

## Fix

Track support per mapping with a new `supportsDeveloperRole` field on `ProviderModelMapping` (defaults to `true`). In `prepareRequestBody`, only mappings explicitly marked `supportsDeveloperRole: false` get their `developer` messages rewritten to `system` before forwarding. `developer` is semantically a system instruction, so the downgrade is safe on those upstreams. The rewrite runs before the existing no-system-role transform, so on a model that doesn't support `system` either, `developer` correctly collapses to `user` as well.

The mapping lookup uses the region-aware `getProviderMapping` helper (region-expanded, with fallbacks) rather than a raw `find` — the alibaba mapping declares `regions`, so a raw match on `region` would miss it when a request is bound to `singapore`.

Flagged so far: granite/glm-5.2 and alibaba/glm-5.2. Other mappings keep forwarding `developer` unchanged and can opt out as they're found to reject it.

## Verification (live provider calls)

- **granite/glm-5.2** (`api.aisa.one`) with `developer` → **400** (reproduces the exact reported error); with the rewritten `system` message → **200**, instruction honored ("Bonjour.").
- **alibaba/glm-5.2** (dashscope compatible-mode) with `developer` → **400**; with `system` → **200**.
- **OpenAI** gpt-4o-mini accepts both `developer + system` and `system + system` shapes (200) — mappings that support `developer` are left untouched.

## Tests

`prepare-request-body.spec.ts` → `developer role normalization`:
- rewrites `developer` → `system` for granite/glm-5.2 and alibaba/glm-5.2 (`supportsDeveloperRole: false`), including via region expansion (`singapore`)
- preserves `developer` for zai/glm-5.2 (supports it) and for OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with providers that do not accept OpenAI’s `developer` message role.
  - Developer messages are now automatically converted to `system` messages when required, while preserving their content.
  - Providers supporting the `developer` role continue to receive it unchanged.
  - Regional provider configurations now apply the same role handling consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->