### PR TITLE
fix(models): declare reasoning effort tiers for deepseek v4

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -334,6 +334,7 @@ export const deepseekModels = [
 				quantization: "fp4",
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["none", "low", "medium", "high", "xhigh"],
 				vision: false,
 				tools: true,
 				jsonOutput: true,

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -460,6 +460,7 @@ export const deepseekModels = [
 				maxOutput: 393216,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["minimal", "low", "medium", "high", "max"],
 				reasoningOutput: "omit" as const,
 				vision: false,
 				tools: true,


### PR DESCRIPTION
## Problem

Two DeepSeek V4 provider mappings were erroring in production because they declared no `reasoningEfforts`, so the gateway forwarded the caller's effort tier verbatim (per the no-downgrade rule) and the provider rejected unsupported values:

**ByteDance `deepseek-v4-flash`** — 400 on `xhigh`:
```
Invalid reasoning_effort: 'xhigh'. Valid values are: ['high', 'low', 'max', 'medium', 'minimal']
```

**DeepInfra `deepseek-v4-pro`** — 422 on `max`:
```
Input should be 'low', 'medium', 'high', 'xhigh' or 'none'
```

## Fix

Declare the exact tiers each endpoint reports as valid, so the supported set is published in the model catalog (UI/playground/clients) and unsupported tiers are no longer offered:

- ByteDance `deepseek-v4-flash`: `["minimal", "low", "medium", "high", "max"]`
- DeepInfra `deepseek-v4-pro`: `["none", "low", "medium", "high", "xhigh"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)