### PR TITLE
feat(devpass): notify Discord on Reset Pass buys

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -36,6 +36,7 @@ import {
 	notifyDevPlanCancelled,
 	notifyDevPlanRenewed,
 	notifyDevPlanSubscribed,
+	notifyResetPassPurchased,
 } from "./utils/discord.js";
 import {
 	generateDevPlanCancellationFeedbackEmailHtml,
@@ -2586,6 +2587,21 @@ export async function fulfillResetPassPurchase(
 		logger.error(
 			"Invoice email failed (Reset Pass invoice); suppressing failure",
 			e as Error,
+		);
+	}
+
+	// Notify the internal Discord channel, mirroring the other purchase
+	// notifications. Runs after the transaction insert (guarded by the
+	// payment-intent dedupe above), so webhook retries won't double-notify.
+	if (organization.billingEmail) {
+		const purchaseUser = await db.query.user.findFirst({
+			where: { email: { eq: organization.billingEmail } },
+		});
+		await notifyResetPassPurchased(
+			organization.billingEmail,
+			purchaseUser?.name,
+			tier,
+			amountPaid,
 		);
 	}
 

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -203,6 +203,47 @@ export async function notifyDevPlanSubscribed(
 	});
 }
 
+export async function notifyResetPassPurchased(
+	email: string,
+	name: string | null | undefined,
+	devPlan: string,
+	amount: number,
+): Promise<void> {
+	const displayName = name ?? "Unknown";
+
+	await sendDiscordNotification({
+		embeds: [
+			{
+				title: "Reset Pass Purchased",
+				color: 0x06b6d4, // Cyan
+				fields: [
+					{
+						name: "Email",
+						value: email,
+						inline: true,
+					},
+					{
+						name: "Name",
+						value: displayName,
+						inline: true,
+					},
+					{
+						name: "Tier",
+						value: devPlan.toUpperCase(),
+						inline: true,
+					},
+					{
+						name: "Amount",
+						value: `$${amount.toFixed(2)}`,
+						inline: true,
+					},
+				],
+				timestamp: new Date().toISOString(),
+			},
+		],
+	});
+}
+
 export async function notifyDevPlanCancelled(
 	email: string,
 	name: string | null | undefined,


### PR DESCRIPTION
## Summary

Reset Pass purchases (#3093) were the only paid flow with no internal Discord notification — credits, DevPass/chat plan subscribe/renew/cancel, and refunds all post to the billing channel, and a *refunded* Reset Pass already notified via the generic refund handler. This closes that gap.

- Add `notifyResetPassPurchased` to `apps/api/src/utils/discord.ts` (email, name, tier, amount — same embed pattern as the other purchase notifiers, posts to `DISCORD_NOTIFICATION_URL`)
- Call it from `fulfillResetPassPurchase` after the payment-intent dedupe guard, so the synchronous purchase route and the `payment_intent.succeeded` recovery webhook can't double-notify
- Resolves the recipient from `organization.billingEmail` + user lookup, mirroring the refund notification path

## Test plan

- `pnpm exec turbo run build --filter=api` passes
- Notification is best-effort: `sendDiscordNotification` already swallows webhook failures and skips when `DISCORD_NOTIFICATION_URL` is unset, so fulfilment is unaffected either way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of reset pass purchases to ensure completed transactions are recorded reliably.
  * Added more detailed purchase information to internal notifications, including the purchaser’s email, name, selected tier, and payment amount.
  * Duplicate purchase fulfillment remains prevented, and notification failures do not interrupt payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->