### PR TITLE
fix(gateway): stop false-negative on large structured SSE JSON

### DIFF
--- a/apps/gateway/src/chat/tools/might-be-complete-json.spec.ts
+++ b/apps/gateway/src/chat/tools/might-be-complete-json.spec.ts
@@ -112,11 +112,48 @@ describe("mightBeCompleteJson", () => {
 			expect(mightBeCompleteJson(json)).toBe(true);
 		});
 
-		it("returns false for large nested object with unbalanced braces", () => {
+		it("defers to JSON.parse for beyond-window structural imbalance (never a false negative)", () => {
 			const base64Data = "A".repeat(LARGE_SIZE);
-			// Extra opening brace
+			// Extra opening brace. The imbalance cannot be proven cheaply once the
+			// structure extends past the bounded scan window, so the heuristic must
+			// NOT return a false negative here — it returns true and lets JSON.parse
+			// make the final (correct) rejection. Returning false would make the SSE
+			// scanner over-consume and merge two events.
 			const json = `{"outer":{{"inner":{"data":"${base64Data}"}}}`;
-			expect(mightBeCompleteJson(json)).toBe(false);
+			expect(mightBeCompleteJson(json)).toBe(true);
+			expect(() => JSON.parse(json)).toThrow();
+		});
+
+		it("returns true for large, densely-structured valid JSON (OpenAI response.created regression)", () => {
+			// A 100KB+ payload whose bulk is nested structure (a big tools array),
+			// not one opaque string. The old skeleton heuristic returned a false
+			// negative here, causing the gateway SSE scanner to merge two events and
+			// throw "Unexpected non-whitespace character after JSON".
+			const tools = [];
+			for (let i = 0; i < 400; i++) {
+				tools.push({
+					type: "function",
+					description: `Apply a patch to files number ${i}`,
+					name: `tool_${i}`,
+					parameters: {
+						$schema: "https://json-schema.org/draft/2020-12/schema",
+						type: "object",
+						properties: {
+							patchText: { type: "string", description: "The full patch text" },
+						},
+						required: ["patchText"],
+						additionalProperties: false,
+					},
+					strict: true,
+				});
+			}
+			const json = JSON.stringify({
+				type: "response.created",
+				response: { id: "resp_x", object: "response", output: [], tools },
+			});
+			expect(json.length).toBeGreaterThan(100 * 1024);
+			expect(mightBeCompleteJson(json)).toBe(true);
+			expect(() => JSON.parse(json)).not.toThrow();
 		});
 
 		it("handles large payload performance efficiently", () => {

--- a/apps/gateway/src/chat/tools/might-be-complete-json.ts
+++ b/apps/gateway/src/chat/tools/might-be-complete-json.ts
@@ -89,20 +89,30 @@ export function mightBeCompleteJson(str: string): boolean {
 /**
  * Optimized heuristic for large JSON payloads (100KB+).
  *
- * Instead of scanning the entire string, we scan from the start until we
- * enter a string value that extends beyond our scan window, then scan backward
- * from the end until we enter the same string. The structural depth counted
- * from each end should match for the JSON to be balanced.
+ * This function must honor the same contract as `mightBeCompleteJson`: it may
+ * only return `false` when the payload is *definitely* incomplete. Returning a
+ * false negative here is not merely a wasted `JSON.parse` — the SSE scanner in
+ * chat.ts uses this result to decide where an event ends, so a spurious `false`
+ * makes it over-consume and merge two SSE events into one string, which then
+ * throws a `json_parse_error` ("Unexpected non-whitespace character after JSON").
  *
- * This turns an O(n) scan into O(k) where k is the size of the structural
- * JSON skeleton (typically a few hundred bytes even for multi-MB payloads).
+ * We scan a bounded window from the start. The common large-payload case is a
+ * single opaque string value (e.g. a base64 image): a *truncated* one ends
+ * mid-string, so its last char is not `}`/`]` and the caller's cheap first/last
+ * char check already rejects it before we get here. That means anything reaching
+ * this function already *looks* complete. Rather than trying to prove balance
+ * cheaply — which is unsound for large, densely-structured JSON (e.g. an OpenAI
+ * `response.created` event with a big `tools` array), where the structural depth
+ * lives across the whole payload and not just at the ends — we defer the final
+ * decision to `JSON.parse` and return `true`. We still return an exact answer
+ * for payloads whose structure fits inside the scan window.
  */
 function mightBeCompleteJsonLarge(trimmed: string): boolean {
-	const SCAN_LIMIT = 8192; // scan at most 8KB from each end
+	const SCAN_LIMIT = 8192; // scan at most 8KB from the start
 
-	// Forward scan: count structural depth until we enter a long string
-	let fBraces = 0;
-	let fBrackets = 0;
+	// Forward scan: count structural depth until we run out of window
+	let braces = 0;
+	let brackets = 0;
 	let inString = false;
 	let i = 0;
 	const forwardEnd = Math.min(trimmed.length, SCAN_LIMIT);
@@ -120,84 +130,26 @@ function mightBeCompleteJsonLarge(trimmed: string): boolean {
 			if (c === '"') {
 				inString = true;
 			} else if (c === "{") {
-				fBraces++;
+				braces++;
 			} else if (c === "}") {
-				fBraces--;
+				braces--;
 			} else if (c === "[") {
-				fBrackets++;
+				brackets++;
 			} else if (c === "]") {
-				fBrackets--;
+				brackets--;
 			}
 		}
 		i++;
 	}
 
-	// If we finished scanning the entire string (unlikely given >100KB), use result directly
+	// If the whole payload fit inside the window, we have an exact answer.
 	if (i >= trimmed.length) {
-		return !inString && fBraces === 0 && fBrackets === 0;
+		return !inString && braces === 0 && brackets === 0;
 	}
 
-	// If we're NOT in a string at the forward scan limit, the structural content
-	// extends beyond our window in a non-string context. This is unusual for large
-	// payloads. Use a conservative approach: the first/last char check already passed.
-	if (!inString) {
-		return true;
-	}
-
-	// We entered a large string value in the forward scan.
-	// Now scan backward from the end. The reverse scan counts structural depth
-	// from the end until it enters a string going backward (which should be the
-	// same string the forward scan entered).
-	//
-	// For the JSON to be balanced:
-	//   - Forward opened fBraces braces before the string
-	//   - Reverse should see the same number of closing braces after the string
-	//   - Same for brackets
-	let rBraces = 0;
-	let rBrackets = 0;
-	let rInString = false;
-	let j = trimmed.length - 1;
-	const reverseEnd = Math.max(0, trimmed.length - SCAN_LIMIT);
-
-	while (j >= reverseEnd) {
-		const c = trimmed[j];
-		if (rInString) {
-			// Inside a string scanning backward - check for unescaped quote
-			if (c === '"') {
-				let backslashes = 0;
-				let k = j - 1;
-				while (k >= 0 && trimmed[k] === "\\") {
-					backslashes++;
-					k--;
-				}
-				if (backslashes % 2 === 0) {
-					rInString = false;
-				}
-			}
-			// Once we enter the large string going backward, we've accounted for
-			// all the closing structure. Stop scanning.
-			if (rInString && j < trimmed.length - SCAN_LIMIT + 1) {
-				// We're deep in the string and past our scan limit - stop
-				break;
-			}
-		} else {
-			if (c === '"') {
-				rInString = true;
-			} else if (c === "}") {
-				rBraces++;
-			} else if (c === "{") {
-				rBraces--;
-			} else if (c === "]") {
-				rBrackets++;
-			} else if (c === "[") {
-				rBrackets--;
-			}
-		}
-		j--;
-	}
-
-	// Forward scan opened fBraces/fBrackets before entering the string.
-	// Reverse scan should have closed the same number after the string.
-	// rBraces counts '}' as +1 and '{' as -1, so for balance: fBraces === rBraces
-	return fBraces === rBraces && fBrackets === rBrackets;
+	// The structure extends beyond our scan window. We cannot cheaply prove the
+	// payload is unbalanced (a mismatch measured only at the ends is unsound for
+	// densely-structured JSON), so we must not return a false negative here.
+	// The first/last char check already passed, so let JSON.parse decide.
+	return true;
 }


### PR DESCRIPTION
## Problem

Streaming requests to OpenAI's Responses API (e.g. `gpt-5-nano`) intermittently failed with:

```
Unexpected non-whitespace character after JSON at position 103198 (line 3 column 1)
type: json_parse_error
```

on a `response.created` event.

## Root cause

OpenAI Responses API SSE frames look like:

```
event: response.created
data: {…103KB JSON…}

event: response.in_progress
data: {…}
```

The gateway's SSE scanner (`apps/gateway/src/chat/chat.ts`) uses `mightBeCompleteJson()` to decide where the `response.created` event ends — cut at the first newline (correct) or extend to the next `data:` (wrong). For payloads over 100KB it delegated to `mightBeCompleteJsonLarge`, whose forward/reverse "skeleton" heuristic **assumes the huge middle is one opaque string** (a base64 image).

A `response.created` event is instead **densely structured** (a big `tools` array), so its structural depth is spread across the whole payload and the forward/reverse bracket counts don't match → the heuristic returned a **false negative** for valid, complete JSON.

Because the scanner trusts that result to place event boundaries, the false `false` made it over-consume and merge the `response.created` event with the following `response.in_progress` event into one string. `JSON.parse` then choked on the second object at line 3 column 1.

## Fix

`mightBeCompleteJson`'s contract is that it may only return `false` when the payload is **definitely** incomplete — `false` is an optimization, `true` is always safe (JSON.parse is the final arbiter). A bracket-count mismatch measured only at the two ends does not prove imbalance for densely-structured JSON, so `mightBeCompleteJsonLarge` no longer returns `false` in that case. Once structure extends past the bounded scan window it returns `true` and defers to `JSON.parse`.

Performance is preserved:
- Truncated large payloads (streaming base64) end mid-string, so their last char isn't `}`/`]` and the existing cheap first/last-char check rejects them before this function runs.
- The 5MB base64 fast path still returns `true` after only an 8KB forward scan (now even cheaper — the reverse scan is gone).

## Tests

- Added a regression test for a 100KB+ densely-structured `response.created`-shaped payload (returns `true`, is parseable).
- Updated the beyond-window unbalanced-braces test to assert the safe behavior (returns `true`, and `JSON.parse` performs the correct rejection).
- All 25 tests in `might-be-complete-json.spec.ts` pass; gateway build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)