### PR TITLE
feat(gateway): enforce reasoning effort allowlist

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2552,13 +2552,19 @@ chat.openapi(completions, async (c) => {
 			hasDocuments,
 		});
 	} catch (capabilityError) {
+		// Some capability rejections should be surfaced in the activity feed as a
+		// client_error log — a plain HTTPException here otherwise returns a 400 with
+		// no history row, so the user never sees the rejected request. Determine the
+		// client-facing message and error cause for the cases we want logged.
+		let clientErrorMessage: string | undefined;
+		let clientErrorCause: string | undefined;
+
 		// The /v1/messages layer flags requests that used Anthropic's explicit-budget
 		// thinking API (`thinking.type: "enabled"`). On adaptive-only models the
 		// mapped reasoning.max_tokens is unsupported and validateModelCapabilities
-		// rejects it. Mirror Anthropic's own "use adaptive thinking" 400 and surface
-		// it in the activity feed as a client_error — the raw capability error is
-		// OpenAI-flavored (mentions a field the native client never sent) and isn't
-		// logged otherwise, so the user never sees the rejected request in history.
+		// rejects it. Mirror Anthropic's own "use adaptive thinking" 400 — the raw
+		// capability error is OpenAI-flavored (mentions a field the native client
+		// never sent).
 		const usedAnthropicBudgetThinking =
 			c.req.header("x-llmgateway-thinking-type") === "enabled";
 		if (
@@ -2579,9 +2585,21 @@ chat.openapi(completions, async (c) => {
 			const supportsAdaptiveThinking = providersForAdaptiveCheck.some(
 				(p) => (p as ProviderModelMapping).reasoningMode === "adaptive",
 			);
-			const message = supportsAdaptiveThinking
+			clientErrorMessage = supportsAdaptiveThinking
 				? `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`
 				: `"thinking" is not supported for this model. Remove the "thinking" parameter or use a model that supports extended thinking.`;
+			clientErrorCause = "unsupported_reasoning_budget";
+		} else if (
+			capabilityError instanceof HTTPException &&
+			capabilityError.cause === "unsupported_reasoning_effort"
+		) {
+			// The requested reasoning_effort is not in the mapping's declared
+			// allowlist. Surface the gateway's own 400 in history as a client_error.
+			clientErrorMessage = capabilityError.message;
+			clientErrorCause = "unsupported_reasoning_effort";
+		}
+
+		if (clientErrorMessage !== undefined) {
 			try {
 				// Use _insertLog directly (not insertLogEntry): the local insertLog
 				// wrapper is declared further down and would be in its temporal dead
@@ -2633,8 +2651,8 @@ chat.openapi(completions, async (c) => {
 						errorDetails: {
 							statusCode: 400,
 							statusText: "Bad Request",
-							responseText: message,
-							cause: "unsupported_reasoning_budget",
+							responseText: clientErrorMessage,
+							cause: clientErrorCause,
 						},
 						duration: 0,
 						timeToFirstToken: null,
@@ -2658,11 +2676,12 @@ chat.openapi(completions, async (c) => {
 					{ syncInsert: syncLogInsert, retentionLevel },
 				);
 			} catch (error) {
-				logger.error("Failed to log budget-thinking rejection", {
+				logger.error("Failed to log capability rejection", {
 					error: toError(error),
+					cause: clientErrorCause,
 				});
 			}
-			throw new HTTPException(400, { message });
+			throw new HTTPException(400, { message: clientErrorMessage });
 		}
 		throw capabilityError;
 	}

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -328,7 +328,7 @@ export const completionsRequestSchema = z.object({
 		.transform((val) => (val === null ? undefined : val))
 		.openapi({
 			description:
-				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. The gateway never downgrades effort tiers: providers that accept an effort parameter receive the value unchanged (an unsupported value results in a provider error), while providers that take a thinking budget instead (e.g. Anthropic, Google) translate each tier to a native budget. The exact values each provider mapping accepts are exposed as `reasoning_efforts` on `/v1/models`.",
+				"Controls the reasoning effort for reasoning-capable models. `none` is only supported by OpenAI's newer reasoning models (e.g. gpt-5.4 and later); for other providers it disables reasoning. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. The gateway never downgrades effort tiers. When a provider mapping declares its supported efforts (exposed as `reasoning_efforts` on `/v1/models`), requesting a value outside that list is rejected with a 400; when a mapping declares no list, the value is forwarded unchanged (and an unsupported value results in a provider error). Providers that accept an effort parameter receive the value unchanged, while providers that take a thinking budget instead (e.g. Anthropic, Google) translate each tier to a native budget.",
 			example: "medium",
 		}),
 	reasoning: z
@@ -338,7 +338,7 @@ export const completionsRequestSchema = z.object({
 				.optional()
 				.openapi({
 					description:
-						"Controls the reasoning effort. Alternative to top-level reasoning_effort. Cannot be used together with reasoning_effort. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. Tiers are never downgraded by the gateway: enum-based providers receive the value unchanged (unsupported values result in a provider error), while budget-based providers (e.g. Anthropic, Google) translate the tier to a native thinking budget. See `reasoning_efforts` on `/v1/models` for the values each mapping accepts.",
+						"Controls the reasoning effort. Alternative to top-level reasoning_effort. Cannot be used together with reasoning_effort. `max` is the highest tier (above `xhigh`), supported by Anthropic models and OpenAI GPT-5.6 models. Tiers are never downgraded by the gateway. When a mapping declares its supported efforts (see `reasoning_efforts` on `/v1/models`), a value outside that list is rejected with a 400; otherwise the value is forwarded unchanged (and an unsupported value results in a provider error). Enum-based providers receive the value unchanged, while budget-based providers (e.g. Anthropic, Google) translate the tier to a native thinking budget.",
 					example: "medium",
 				}),
 			max_tokens: z.number().int().positive().optional().openapi({

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -5,7 +5,11 @@ import { models } from "@llmgateway/models";
 
 import { validateModelCapabilities } from "./validate-model-capabilities.js";
 
-import type { ModelDefinition } from "@llmgateway/models";
+import type {
+	ModelDefinition,
+	ProviderModelMapping,
+	ReasoningEffort,
+} from "@llmgateway/models";
 
 function getModel(id: string): ModelDefinition {
 	const m = models.find((model) => model.id === id);
@@ -239,6 +243,139 @@ describe("validateModelCapabilities - embeddings", () => {
 		).not.toThrow();
 		expect(() =>
 			validateModelCapabilities(embeddingModel, "custom", undefined, {}),
+		).not.toThrow();
+	});
+});
+
+describe("validateModelCapabilities - reasoning effort allowlist", () => {
+	const ALL_EFFORTS: ReasoningEffort[] = [
+		"none",
+		"minimal",
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+		"max",
+	];
+
+	const reasoningProviders = (m: ModelDefinition) =>
+		(m.providers as ProviderModelMapping[]).filter((p) => p.reasoning === true);
+
+	// A model where every reasoning-capable provider declares a non-empty
+	// reasoningEfforts list AND at least one global tier is left out — lets us
+	// pick both a supported and an unsupported effort deterministically.
+	const declaredModel = (() => {
+		for (const m of models as readonly ModelDefinition[]) {
+			const rp = reasoningProviders(m);
+			if (!rp.length) {
+				continue;
+			}
+			if (!rp.every((p) => p.reasoningEfforts && p.reasoningEfforts.length)) {
+				continue;
+			}
+			const union = new Set(rp.flatMap((p) => p.reasoningEfforts ?? []));
+			if (ALL_EFFORTS.some((e) => !union.has(e))) {
+				return m;
+			}
+		}
+		throw new Error(
+			"Test fixture missing: no reasoning model declares reasoningEfforts on all providers with a missing tier",
+		);
+	})();
+
+	const declaredUnion = new Set(
+		reasoningProviders(declaredModel).flatMap((p) => p.reasoningEfforts ?? []),
+	);
+	const supportedEffort = [...declaredUnion][0];
+	const unsupportedEffort = ALL_EFFORTS.find((e) => !declaredUnion.has(e))!;
+	const pinnedProvider = reasoningProviders(declaredModel)[0].providerId;
+
+	// A reasoning model where at least one reasoning-capable provider declares no
+	// list at all, so every effort must pass through untouched (never a gateway
+	// 400 for a request that could have worked upstream).
+	const undeclaredModel = (() => {
+		for (const m of models as readonly ModelDefinition[]) {
+			const rp = reasoningProviders(m);
+			if (
+				rp.length &&
+				rp.some((p) => !p.reasoningEfforts || !p.reasoningEfforts.length)
+			) {
+				return m;
+			}
+		}
+		throw new Error(
+			"Test fixture missing: no reasoning model with an undeclared reasoningEfforts provider",
+		);
+	})();
+
+	it("allows a declared effort value", () => {
+		expect(() =>
+			validateModelCapabilities(declaredModel, declaredModel.id, undefined, {
+				reasoning_effort: supportedEffort,
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects an effort value outside the declared list", () => {
+		expect(() =>
+			validateModelCapabilities(declaredModel, declaredModel.id, undefined, {
+				reasoning_effort: unsupportedEffort,
+			}),
+		).toThrow(HTTPException);
+	});
+
+	it("tags the rejection with the unsupported_reasoning_effort cause", () => {
+		try {
+			validateModelCapabilities(declaredModel, declaredModel.id, undefined, {
+				reasoning_effort: unsupportedEffort,
+			});
+			throw new Error("expected a rejection");
+		} catch (error) {
+			expect(error).toBeInstanceOf(HTTPException);
+			expect((error as HTTPException).cause).toBe(
+				"unsupported_reasoning_effort",
+			);
+		}
+	});
+
+	it("rejects when the pinned provider excludes the effort", () => {
+		expect(() =>
+			validateModelCapabilities(
+				declaredModel,
+				declaredModel.id,
+				pinnedProvider,
+				{
+					reasoning_effort: unsupportedEffort,
+				},
+			),
+		).toThrow(HTTPException);
+	});
+
+	it("passes through any effort when no list is declared", () => {
+		for (const effort of ALL_EFFORTS) {
+			expect(() =>
+				validateModelCapabilities(
+					undeclaredModel,
+					undeclaredModel.id,
+					undefined,
+					{
+						reasoning_effort: effort,
+					},
+				),
+			).not.toThrow();
+		}
+	});
+
+	it("skips the effort allowlist for auto and custom models", () => {
+		expect(() =>
+			validateModelCapabilities(declaredModel, "auto", undefined, {
+				reasoning_effort: unsupportedEffort,
+			}),
+		).not.toThrow();
+		expect(() =>
+			validateModelCapabilities(declaredModel, "custom", undefined, {
+				reasoning_effort: unsupportedEffort,
+			}),
 		).not.toThrow();
 	});
 });

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -216,8 +216,7 @@ export function validateModelCapabilities(
 					reasoningProviders.flatMap(
 						(provider) =>
 							((provider as ProviderModelMapping).reasoningEfforts as
-								| string[]
-								| undefined) ?? [],
+								string[] | undefined) ?? [],
 					),
 				),
 			);

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -189,6 +189,53 @@ export function validateModelCapabilities(
 				message: `Model ${requestedModel} does not support reasoning. Remove the reasoning_effort parameter or use a reasoning-capable model.`,
 			});
 		}
+
+		// Enforce the declared reasoning-effort allowlist. A reasoning-capable
+		// provider mapping MAY declare `reasoningEfforts` (the tiers it accepts).
+		// A mapping that declares no list (or an empty list) allows all efforts —
+		// the value is forwarded upstream as-is and we must not risk a gateway 400
+		// on a request that could have succeeded. Only reject when EVERY
+		// reasoning-capable candidate declares a non-empty list and none include
+		// the requested effort.
+		const reasoningProviders = providersToCheck.filter(
+			(provider) => (provider as ProviderModelMapping).reasoning === true,
+		);
+
+		const anyProviderAllowsEffort = reasoningProviders.some((provider) => {
+			const efforts = (provider as ProviderModelMapping).reasoningEfforts;
+			return (
+				!efforts ||
+				efforts.length === 0 ||
+				(efforts as string[]).includes(reasoning_effort)
+			);
+		});
+
+		if (!anyProviderAllowsEffort) {
+			const declaredEfforts = Array.from(
+				new Set(
+					reasoningProviders.flatMap(
+						(provider) =>
+							((provider as ProviderModelMapping).reasoningEfforts as
+								| string[]
+								| undefined) ?? [],
+					),
+				),
+			);
+
+			logger.warn(`Unsupported reasoning effort for model: ${requestedModel}`, {
+				requestedModel,
+				requestedProvider,
+				reasoning_effort,
+				declaredEfforts,
+			});
+
+			throw new HTTPException(400, {
+				message: `Model ${requestedModel} does not support reasoning effort "${reasoning_effort}". Supported values: ${declaredEfforts.join(
+					", ",
+				)}. Use one of the supported values or remove the reasoning_effort parameter.`,
+				cause: "unsupported_reasoning_effort",
+			});
+		}
 	}
 
 	// Check if verbosity is specified but model doesn't support it

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -442,10 +442,13 @@ export interface ProviderModelMapping {
 	 * ascending order of effort. Effort tiers differ per model generation
 	 * (e.g. GPT-5 accepts `minimal`..`high`, GPT-5.6 accepts `none`..`max`,
 	 * Anthropic thinking models accept `low`..`max`), so each mapping declares
-	 * its own list. The gateway forwards effort values to the provider as-is
-	 * (unsupported values fail upstream); this metadata is exposed via the
+	 * its own list. When declared, the gateway rejects requests whose
+	 * `reasoning_effort` is outside this list with a 400 (and records a
+	 * client_error log); otherwise it forwards the value to the provider as-is
+	 * (unsupported values fail upstream). This metadata is also exposed via the
 	 * models APIs so clients can present valid options. When unset, the
-	 * supported values are not (yet) declared for this mapping.
+	 * supported values are not (yet) declared for this mapping and all efforts
+	 * are forwarded through.
 	 */
 	reasoningEfforts?: ReasoningEffort[];
 	/**


### PR DESCRIPTION
## What

When a request specifies a `reasoning_effort` (or `reasoning.effort`) that is **not** in a model mapping's declared `reasoningEfforts` list, the gateway now rejects it with a **400** and records a **`client_error`** log so the rejected request shows up in the activity feed. Previously the value was forwarded blindly and only failed upstream (for enum-based providers) or was silently translated (for budget-based providers) — the `reasoningEfforts` field was purely informational metadata.

## Behavior

- **Mapping declares a list** (e.g. `["low","medium","high"]`) and user requests `"xhigh"` → **400** + `client_error` log (cause `unsupported_reasoning_effort`).
- **Mapping declares no list** → all efforts pass through unchanged. We never assume defaults, so the gateway can't 400 a request that could have worked upstream.
- **Multiple candidate providers** (no pinned provider) → only reject when *every* reasoning-capable mapping declares a list that excludes the value. If any candidate has no list, or includes the value, it passes through.
- **Pinned provider** (`provider/model`) → checked against that provider's list only.
- `auto`/`custom` models and non-reasoning models keep their existing behavior.

## Changes

- `validate-model-capabilities.ts` — new allowlist check after the reasoning-support gate; throws `HTTPException(400, { cause: "unsupported_reasoning_effort" })`.
- `chat.ts` — generalized the existing capability-error catch so both the Anthropic budget-thinking case and the new effort case insert a `client_error` log via one shared `_insertLog` call.
- `completions.ts` / `models.ts` — updated the `reasoning_effort` schema docs and the `reasoningEfforts` field doc to describe the new enforcement.
- Added unit tests covering allow/reject/pass-through/pinned/auto cases (27 total in the spec, all passing).

`pnpm format` and a full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for requested reasoning-effort levels based on model and provider capabilities.
  * Unsupported reasoning-effort values now return clear HTTP 400 errors listing supported options.
  * Models without declared effort limits continue forwarding requested values unchanged.

* **Bug Fixes**
  * Improved client-visible errors and activity logs for unsupported reasoning and Anthropic budget-thinking configurations.

* **Documentation**
  * Clarified reasoning-effort behavior in API documentation and model capability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->