### PR TITLE
fix(gateway): hash prompt_cache_key before forwarding

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	clampPromptCacheKey,
 	hashSessionCacheKey,
 	prepareRequestBody,
 	RequestError,
@@ -4619,6 +4620,48 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 		expect(a).not.toBe(hashSessionCacheKey("sess-2"));
 		expect(a).toHaveLength(32);
 		expect(a).not.toContain("sess-1");
+	});
+
+	test("clampPromptCacheKey passes through keys within the 64-char limit", () => {
+		const key = "a".repeat(64);
+		expect(clampPromptCacheKey(key)).toBe(key);
+		expect(clampPromptCacheKey("tenant-a")).toBe("tenant-a");
+	});
+
+	test("clampPromptCacheKey hashes over-length keys to a stable 32-char digest", () => {
+		const key = "x".repeat(72);
+		const clamped = clampPromptCacheKey(key);
+		expect(clamped).toHaveLength(32);
+		expect(clamped).toBe(clampPromptCacheKey(key));
+		expect(clampPromptCacheKey("y".repeat(72))).not.toBe(clamped);
+	});
+
+	test("openai chat completions: clamps an over-length caller key to <= 64 chars", async () => {
+		const requestBody = await prepareCacheKeyRequest(
+			"openai",
+			"gpt-4o-mini",
+			conversation,
+			{ promptCacheKey: "z".repeat(72) },
+		);
+
+		expect(requestBody.prompt_cache_key).toBe(
+			clampPromptCacheKey("z".repeat(72)),
+		);
+		expect(requestBody.prompt_cache_key?.length).toBeLessThanOrEqual(64);
+	});
+
+	test("openai responses API: clamps an over-length caller key to <= 64 chars", async () => {
+		const requestBody = await prepareCacheKeyRequest(
+			"openai",
+			"gpt-5-mini",
+			conversation,
+			{ promptCacheKey: "z".repeat(72) },
+		);
+
+		expect(requestBody.prompt_cache_key).toBe(
+			clampPromptCacheKey("z".repeat(72)),
+		);
+		expect(requestBody.prompt_cache_key?.length).toBeLessThanOrEqual(64);
 	});
 });
 

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
-	clampPromptCacheKey,
+	hashPromptCacheKey,
 	hashSessionCacheKey,
 	prepareRequestBody,
 	RequestError,
@@ -544,7 +544,7 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 			promptCacheRetention: "24h",
 		})) as any;
 
-		expect(requestBody.prompt_cache_key).toBe("tenant-a");
+		expect(requestBody.prompt_cache_key).toBe(hashPromptCacheKey("tenant-a"));
 		expect(requestBody.prompt_cache_retention).toBe("24h");
 	});
 
@@ -555,7 +555,7 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 			promptCacheRetention: "in_memory",
 		})) as any;
 
-		expect(requestBody.prompt_cache_key).toBe("tenant-a");
+		expect(requestBody.prompt_cache_key).toBe(hashPromptCacheKey("tenant-a"));
 		expect(requestBody.prompt_cache_retention).toBe("in_memory");
 	});
 
@@ -613,7 +613,7 @@ describe("prepareRequestBody - OpenAI prompt caching", () => {
 			promptCacheRetention: "24h",
 		})) as any;
 
-		expect(requestBody.prompt_cache_key).toBe("tenant-a");
+		expect(requestBody.prompt_cache_key).toBe(hashPromptCacheKey("tenant-a"));
 		expect(requestBody.prompt_cache_retention).toBeUndefined();
 	});
 
@@ -4510,7 +4510,9 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 			{ promptCacheKey: "caller-session-key", sessionId: "sess-123" },
 		);
 
-		expect(requestBody.prompt_cache_key).toBe("caller-session-key");
+		expect(requestBody.prompt_cache_key).toBe(
+			hashPromptCacheKey("caller-session-key"),
+		);
 	});
 
 	test("meta: session id beats the conversation-derived key and is hashed", async () => {
@@ -4622,21 +4624,16 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 		expect(a).not.toContain("sess-1");
 	});
 
-	test("clampPromptCacheKey passes through keys within the 64-char limit", () => {
-		const key = "a".repeat(64);
-		expect(clampPromptCacheKey(key)).toBe(key);
-		expect(clampPromptCacheKey("tenant-a")).toBe("tenant-a");
+	test("hashPromptCacheKey always hashes to a stable 32-char digest", () => {
+		expect(hashPromptCacheKey("tenant-a")).toHaveLength(32);
+		expect(hashPromptCacheKey("tenant-a")).toBe(hashPromptCacheKey("tenant-a"));
+		expect(hashPromptCacheKey("tenant-a")).not.toBe(
+			hashPromptCacheKey("tenant-b"),
+		);
+		expect(hashPromptCacheKey("tenant-a")).not.toContain("tenant-a");
 	});
 
-	test("clampPromptCacheKey hashes over-length keys to a stable 32-char digest", () => {
-		const key = "x".repeat(72);
-		const clamped = clampPromptCacheKey(key);
-		expect(clamped).toHaveLength(32);
-		expect(clamped).toBe(clampPromptCacheKey(key));
-		expect(clampPromptCacheKey("y".repeat(72))).not.toBe(clamped);
-	});
-
-	test("openai chat completions: clamps an over-length caller key to <= 64 chars", async () => {
+	test("openai chat completions: hashes the caller key within the 64-char limit", async () => {
 		const requestBody = await prepareCacheKeyRequest(
 			"openai",
 			"gpt-4o-mini",
@@ -4645,12 +4642,12 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 		);
 
 		expect(requestBody.prompt_cache_key).toBe(
-			clampPromptCacheKey("z".repeat(72)),
+			hashPromptCacheKey("z".repeat(72)),
 		);
 		expect(requestBody.prompt_cache_key?.length).toBeLessThanOrEqual(64);
 	});
 
-	test("openai responses API: clamps an over-length caller key to <= 64 chars", async () => {
+	test("openai responses API: hashes the caller key within the 64-char limit", async () => {
 		const requestBody = await prepareCacheKeyRequest(
 			"openai",
 			"gpt-5-mini",
@@ -4659,7 +4656,7 @@ describe("prepareRequestBody - upstream prompt_cache_key", () => {
 		);
 
 		expect(requestBody.prompt_cache_key).toBe(
-			clampPromptCacheKey("z".repeat(72)),
+			hashPromptCacheKey("z".repeat(72)),
 		);
 		expect(requestBody.prompt_cache_key?.length).toBeLessThanOrEqual(64);
 	});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -56,6 +56,22 @@ export function hashSessionCacheKey(sessionId: string): string {
 }
 
 /**
+ * OpenAI, Azure, and Meta cap `prompt_cache_key` at 64 characters and reject
+ * anything longer with a 400 (`string_above_max_length`). Callers can supply an
+ * over-length key (e.g. a coding agent that concatenates several ids), so hash
+ * any key that exceeds the limit down to a stable 32-char digest — cache
+ * routing only needs the key to be stable per conversation, and the digest
+ * stays well within the limit. Keys within the limit pass through unchanged.
+ */
+const MAX_PROMPT_CACHE_KEY_LENGTH = 64;
+export function clampPromptCacheKey(key: string): string {
+	if (key.length <= MAX_PROMPT_CACHE_KEY_LENGTH) {
+		return key;
+	}
+	return createHash("sha256").update(key).digest("hex").slice(0, 32);
+}
+
+/**
  * Meta only routes prompt-cache lookups by `prompt_cache_key`: identical
  * prefixes sent without a key land on different backends and report
  * `cached_tokens: 0` every time (verified live), while the same requests with
@@ -1718,7 +1734,8 @@ export async function prepareRequestBody(
 							? deriveConversationCacheKey(processedMessages)
 							: undefined);
 					if (upstreamCacheKey !== undefined) {
-						responsesBody.prompt_cache_key = upstreamCacheKey;
+						responsesBody.prompt_cache_key =
+							clampPromptCacheKey(upstreamCacheKey);
 					}
 				}
 
@@ -1813,7 +1830,8 @@ export async function prepareRequestBody(
 							? hashSessionCacheKey(session_id)
 							: undefined);
 					if (upstreamCacheKey !== undefined) {
-						requestBody.prompt_cache_key = upstreamCacheKey;
+						requestBody.prompt_cache_key =
+							clampPromptCacheKey(upstreamCacheKey);
 					}
 					if (
 						prompt_cache_retention !== undefined &&

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -56,19 +56,17 @@ export function hashSessionCacheKey(sessionId: string): string {
 }
 
 /**
- * OpenAI, Azure, and Meta cap `prompt_cache_key` at 64 characters and reject
- * anything longer with a 400 (`string_above_max_length`). Callers can supply an
- * over-length key (e.g. a coding agent that concatenates several ids), so hash
- * any key that exceeds the limit down to a stable 32-char digest — cache
- * routing only needs the key to be stable per conversation, and the digest
- * stays well within the limit. Keys within the limit pass through unchanged.
+ * Hash a caller-supplied `prompt_cache_key` before forwarding it upstream.
+ * OpenAI, Azure, and Meta cap the field at 64 characters and reject anything
+ * longer with a 400 (`string_above_max_length`). Rather than only clamping
+ * over-length keys, always hash to a stable 32-char digest: every upstream
+ * cache key the gateway sends (this, the session-id hash, the conversation
+ * prefix hash) is then a uniform 32-char value, and raw caller values are never
+ * exposed to providers. Keyed and domain-separated exactly like
+ * `hashSessionCacheKey`, so cache routing stays stable per key.
  */
-const MAX_PROMPT_CACHE_KEY_LENGTH = 64;
-export function clampPromptCacheKey(key: string): string {
-	if (key.length <= MAX_PROMPT_CACHE_KEY_LENGTH) {
-		return key;
-	}
-	return createHash("sha256").update(key).digest("hex").slice(0, 32);
+export function hashPromptCacheKey(key: string): string {
+	return hashSessionCacheKey(key);
 }
 
 /**
@@ -1726,7 +1724,9 @@ export async function prepareRequestBody(
 					usedProvider === "meta"
 				) {
 					const upstreamCacheKey =
-						prompt_cache_key ??
+						(prompt_cache_key !== undefined
+							? hashPromptCacheKey(prompt_cache_key)
+							: undefined) ??
 						(session_id !== undefined
 							? hashSessionCacheKey(session_id)
 							: undefined) ??
@@ -1734,8 +1734,7 @@ export async function prepareRequestBody(
 							? deriveConversationCacheKey(processedMessages)
 							: undefined);
 					if (upstreamCacheKey !== undefined) {
-						responsesBody.prompt_cache_key =
-							clampPromptCacheKey(upstreamCacheKey);
+						responsesBody.prompt_cache_key = upstreamCacheKey;
 					}
 				}
 
@@ -1825,13 +1824,14 @@ export async function prepareRequestBody(
 					// may hit a legacy deployment-based api-version that rejects
 					// unknown body fields, and the deployment type isn't known here.
 					const upstreamCacheKey =
-						prompt_cache_key ??
+						(prompt_cache_key !== undefined
+							? hashPromptCacheKey(prompt_cache_key)
+							: undefined) ??
 						(session_id !== undefined
 							? hashSessionCacheKey(session_id)
 							: undefined);
 					if (upstreamCacheKey !== undefined) {
-						requestBody.prompt_cache_key =
-							clampPromptCacheKey(upstreamCacheKey);
+						requestBody.prompt_cache_key = upstreamCacheKey;
 					}
 					if (
 						prompt_cache_retention !== undefined &&


### PR DESCRIPTION
## Problem

Requests were failing with a 400 from OpenAI:

```
{
  "error": {
    "message": "Invalid 'prompt_cache_key': string too long. Expected a string with maximum length 64, but got a string with length 72 instead.",
    "type": "invalid_request_error",
    "param": "prompt_cache_key",
    "code": "string_above_max_length"
  }
}
```

OpenAI, Azure, and Meta cap `prompt_cache_key` at **64 characters**. The gateway forwarded a caller-supplied `prompt_cache_key` verbatim, so any key longer than 64 chars (e.g. a coding agent that concatenates several ids) was rejected upstream.

## Fix

Added `hashPromptCacheKey()` in `packages/actions/src/prepare-request-body.ts` and always hash the caller-supplied key before forwarding (keyed and domain-separated exactly like `hashSessionCacheKey`). This means **every** upstream cache key the gateway sends — the caller key hash, the session-id hash, and the conversation-prefix hash — is now a uniform 32-char digest that always fits the limit, and raw caller values are never exposed to providers.

Applied at both forwarding sites — the Responses API path and the Chat Completions path — which covers OpenAI, Azure, and Meta. Cache routing only needs the key to be stable per conversation, which hashing preserves.

## Tests

Updated `prepare-request-body.spec.ts` so cache-key assertions expect the hashed value, and added coverage for the always-hash helper plus end-to-end hashing of an over-length caller key on both the chat-completions and responses paths. All prompt_cache_key / prompt caching tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt caching keys are now consistently transformed before being sent to supported providers.
  * Generated keys are stable, non-reversible, and remain within provider character limits.
  * Updated behavior applies across OpenAI Chat Completions, Responses, Azure, and Meta integrations.
* **Tests**
  * Added coverage for deterministic key generation, input protection, length limits, and model-specific retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->