### PR TITLE
feat: support LLM_OPENAI_BASE_URL env override

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -840,9 +840,10 @@ export async function beforeAllHook() {
 	for (const provider of providers) {
 		const envVarName = getProviderEnvVar(provider.id);
 		const envVarValue = envVarName ? process.env[envVarName] : undefined;
-		const baseUrlEnvName = (
-			provider.env.required as Record<string, string | undefined>
-		).baseUrl;
+		const baseUrlEnvName =
+			(provider.env.required as Record<string, string | undefined>).baseUrl ??
+			(provider.env.optional as Record<string, string | undefined> | undefined)
+				?.baseUrl;
 		const baseUrlValue = baseUrlEnvName
 			? process.env[baseUrlEnvName]
 			: undefined;

--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -12,6 +12,7 @@ const originalAzureFoundryResource = process.env.LLM_AZURE_AI_FOUNDRY_RESOURCE;
 const originalAzureFoundryApiVersion =
 	process.env.LLM_AZURE_AI_FOUNDRY_API_VERSION;
 const originalXiaomiBaseUrl = process.env.LLM_XIAOMI_BASE_URL;
+const originalOpenaiBaseUrl = process.env.LLM_OPENAI_BASE_URL;
 const originalBedrockBaseUrl = process.env.LLM_AWS_BEDROCK_BASE_URL;
 const originalBedrockRegion = process.env.LLM_AWS_BEDROCK_REGION;
 
@@ -71,6 +72,12 @@ afterEach(() => {
 		process.env.LLM_XIAOMI_BASE_URL = originalXiaomiBaseUrl;
 	}
 
+	if (originalOpenaiBaseUrl === undefined) {
+		delete process.env.LLM_OPENAI_BASE_URL;
+	} else {
+		process.env.LLM_OPENAI_BASE_URL = originalOpenaiBaseUrl;
+	}
+
 	if (originalBedrockBaseUrl === undefined) {
 		delete process.env.LLM_AWS_BEDROCK_BASE_URL;
 	} else {
@@ -107,6 +114,22 @@ describe("getProviderEndpoint", () => {
 		expect(() => getProviderEndpoint("glacier")).toThrow(
 			"Glacier provider requires LLM_GLACIER_BASE_URL environment variable",
 		);
+	});
+
+	it("uses the OpenAI base URL override when configured", () => {
+		process.env.LLM_OPENAI_BASE_URL = "http://localhost:8787/openai";
+
+		const endpoint = getProviderEndpoint("openai", undefined, "gpt-4o");
+
+		expect(endpoint).toBe("http://localhost:8787/openai/v1/chat/completions");
+	});
+
+	it("defaults to api.openai.com when no OpenAI base URL is configured", () => {
+		delete process.env.LLM_OPENAI_BASE_URL;
+
+		const endpoint = getProviderEndpoint("openai", undefined, "gpt-4o");
+
+		expect(endpoint).toBe("https://api.openai.com/v1/chat/completions");
 	});
 
 	it("uses the AI Studio base URL override when configured", () => {
@@ -461,6 +484,8 @@ describe("getProviderEndpoint", () => {
 		});
 
 		it("uses hardcoded default for openai regardless of skipEnvVars", () => {
+			process.env.LLM_OPENAI_BASE_URL = "http://localhost:8787/openai";
+
 			const endpoint = getProviderEndpoint(
 				"openai",
 				undefined,

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -177,7 +177,9 @@ export function getProviderEndpoint(
 				}
 				break;
 			case "openai":
-				url = "https://api.openai.com";
+				url =
+					envValueOrDefault("openai", "baseUrl", "https://api.openai.com") ??
+					"https://api.openai.com";
 				break;
 			case "anthropic":
 				url = "https://api.anthropic.com";

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -201,6 +201,9 @@ export const providers: ProviderDefinition[] = [
 			required: {
 				apiKey: "LLM_OPENAI_API_KEY",
 			},
+			optional: {
+				baseUrl: "LLM_OPENAI_BASE_URL",
+			},
 		},
 		streaming: true,
 		cancellation: true,


### PR DESCRIPTION
## Summary

- Add an optional `baseUrl` env var (`LLM_OPENAI_BASE_URL`) to the `openai` provider definition.
- `getProviderEndpoint` now honors the override when building OpenAI endpoints (chat completions, responses, images), falling back to `https://api.openai.com`. BYOK mode (`skipEnvVars`) keeps ignoring the env var, matching the existing `google-ai-studio` override semantics.
- The e2e harness now also picks up a provider's *optional* `baseUrl` env var (previously only *required* ones) when creating provider keys, so an env-configured base URL override is exercised by the e2e suite.

## Tests

- New unit specs: override applied, default without override, override ignored in BYOK mode (`packages/actions/src/get-provider-endpoint.spec.ts`, 48 pass).
- `TEST_MODELS="openai/gpt-5.6-sol,openai/gpt-5.6-terra,openai/gpt-5.6-luna" pnpm test:e2e` → 122 passed against a local OpenAI-compatible proxy configured via `LLM_OPENAI_BASE_URL`.
- `pnpm build` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a custom OpenAI base URL.
  - OpenAI connections now use the configured endpoint when available, while retaining the standard endpoint by default.
- **Bug Fixes**
  - Improved provider setup for configurations where the base URL is optional.
- **Tests**
  - Added coverage for custom endpoints, default behavior, and isolated environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->