### PR TITLE
fix(alibaba): declare reasoningMaxTokens for kimi-k2.5

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1125,6 +1125,16 @@ describe("prepareRequestBody - Alibaba thinking", () => {
 		expect(requestBody.thinking_budget).toBe(24576);
 		expect(requestBody.reasoning_effort).toBeUndefined();
 	});
+
+	test("sends nothing for mappings without budget-controlled thinking", async () => {
+		const requestBody = await prepare({
+			model: "glm-5",
+			reasoningEffort: "high",
+		});
+		expect(requestBody.enable_thinking).toBeUndefined();
+		expect(requestBody.thinking_budget).toBeUndefined();
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
 });
 
 describe("prepareRequestBody - MiniMax thinking", () => {

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1116,13 +1116,13 @@ describe("prepareRequestBody - Alibaba thinking", () => {
 		expect(requestBody.max_tokens).toBe(100);
 	});
 
-	test("sends nothing for mappings without budget-controlled thinking", async () => {
+	test("sends enable_thinking and thinking_budget for kimi-k2.5 (budget-controlled thinking)", async () => {
 		const requestBody = await prepare({
 			model: "kimi-k2.5",
 			reasoningEffort: "high",
 		});
-		expect(requestBody.enable_thinking).toBeUndefined();
-		expect(requestBody.thinking_budget).toBeUndefined();
+		expect(requestBody.enable_thinking).toBe(true);
+		expect(requestBody.thinking_budget).toBe(24576);
 		expect(requestBody.reasoning_effort).toBeUndefined();
 	});
 });

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -307,6 +307,7 @@ export const moonshotModels = [
 				contextSize: 262144,
 				maxOutput: 98304,
 				reasoning: true,
+				reasoningMaxTokens: true,
 				streaming: true,
 				vision: true,
 				tools: true,


### PR DESCRIPTION
## Summary
Declares `reasoningMaxTokens: true` for `kimi-k2.5` on `providerId: "alibaba"`, and updates/restores the corresponding unit tests.

Replaces #3100, which included an incorrect `thinking_budget` gate — closed in favor of this minimal fix, per review feedback.

## Changes
- `moonshot.ts`: `kimi-k2.5` (alibaba) → `reasoningMaxTokens: true`
- `prepare-request-body.spec.ts`:
  - Updated the `kimi-k2.5` test to assert `enable_thinking: true`, `thinking_budget: 24576` for `reasoningEffort: "high"` (previously asserted `undefined`, which was stale once `reasoningMaxTokens` was added)
  - Restored the original "sends nothing for mappings without budget-controlled thinking" test, using `glm-5` instead of `kimi-k2.5` (an active `alibaba` mapping that still lacks `reasoningMaxTokens`), so that code path stays covered

## Source
[DashScope API reference](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-dashscope): `enable_thinking` applies to Kimi-K2.6/K2.5, Qwen, DeepSeek-V4, and GLM series. `thinking_budget` was live-verified (per review) to work correctly for Kimi as well — no gating needed.

## Not changed
- `prepare-request-body.ts` — untouched, no code logic change.

## Testing
- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts -t "Alibaba"` — 10 passed, 0 failed.
- CI checks: green.