### PR TITLE
fix(anthropic): don't spend cache_control budget on tool results

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -304,6 +304,81 @@ describe("prepareRequestBody - Anthropic", () => {
 		expect(totalCacheControlBlocks).toBe(4);
 	});
 
+	test("does not spend cache_control budget on tool-result messages", async () => {
+		// A tool-result message's text content is rebuilt into a tool_result
+		// block (which carries no cache_control), so the long tool outputs below
+		// must not consume any of the 4 cache_control slots — the real cacheable
+		// user turns after them should still receive markers.
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+						{
+							id: "call_2",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+						{
+							id: "call_3",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+						{
+							id: "call_4",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+					],
+				},
+				{ role: "tool", tool_call_id: "call_1", content: longContent },
+				{ role: "tool", tool_call_id: "call_2", content: longContent },
+				{ role: "tool", tool_call_id: "call_3", content: longContent },
+				{ role: "tool", tool_call_id: "call_4", content: longContent },
+				{ role: "user", content: longContent },
+				{ role: "user", content: longContent },
+			],
+			false,
+			undefined,
+			1024,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as AnthropicRequestBody;
+
+		let totalCacheControlBlocks = 0;
+		for (const msg of requestBody.messages) {
+			if (Array.isArray(msg.content)) {
+				for (const block of msg.content) {
+					if (getCacheControl(block)) {
+						totalCacheControlBlocks++;
+					}
+				}
+			}
+		}
+
+		// Both trailing user turns get a marker; without the fix the four tool
+		// results exhaust the budget and this is 0.
+		expect(totalCacheControlBlocks).toBe(2);
+	});
+
 	test("strips caller-supplied cache_control when providerCacheControlEnabled is false", async () => {
 		const longContent = "A".repeat(5000);
 		const requestBody = (await prepareRequestBody(

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -94,6 +94,16 @@ export async function transformAnthropicMessages(
 	for (const m of groupedMessages) {
 		let content: MessageContent[] = [];
 
+		// A tool-result message has its content rebuilt into a tool_result block
+		// below, discarding whatever we assemble here. Skip cache_control
+		// accounting for it — otherwise auto-injecting (or counting a
+		// caller-supplied marker on) a text block that gets thrown away still
+		// consumes one of Anthropic's 4 cache_control slots, starving the real
+		// cacheable blocks (and the turn boundary) of markers.
+		const originalRole = m.role === "user" && m.tool_call_id ? "tool" : m.role;
+		const isDiscardedToolResult =
+			originalRole === "tool" && !!m.tool_call_id && m.content !== undefined;
+
 		// Handle existing content
 		if (Array.isArray(m.content)) {
 			// Process all images in parallel for better performance
@@ -126,7 +136,7 @@ export async function transformAnthropicMessages(
 							} as TextContent;
 						}
 					}
-					if (isTextContent(part) && part.text) {
+					if (!isDiscardedToolResult && isTextContent(part) && part.text) {
 						if (part.cache_control) {
 							// Count caller-supplied markers toward Anthropic's 4-block
 							// cap so subsequent auto-injection and the turn-boundary
@@ -154,6 +164,7 @@ export async function transformAnthropicMessages(
 		} else if (m.content && typeof m.content === "string") {
 			// Handle string content - automatically add cache_control for long prompts
 			const shouldCache =
+				!isDiscardedToolResult &&
 				shouldApplyCacheControl &&
 				m.content.length >= minCacheableChars &&
 				cacheControlCount < maxCacheControlBlocks;
@@ -212,8 +223,7 @@ export async function transformAnthropicMessages(
 		}
 
 		// Handle OpenAI-style tool role messages by converting them to Anthropic tool_result content blocks
-		// Use the original role since the mapped role will be "user"
-		const originalRole = m.role === "user" && m.tool_call_id ? "tool" : m.role;
+		// (originalRole was computed above, since the mapped role will be "user")
 		if (originalRole === "tool" && m.tool_call_id && m.content !== undefined) {
 			// For tool results, we need to check if content is JSON string and parse it appropriately
 			let toolResultContent: string;


### PR DESCRIPTION
When a tool-result message goes through `transformAnthropicMessages`, the content we assemble in the first pass is thrown away and rebuilt into a `tool_result` block, which never carries `cache_control`. But the cache_control accounting still ran on that soon-discarded text — auto-injecting a marker on it, or counting a caller-supplied one — so each such message quietly ate one of Anthropic's 4 cache_control slots.

A handful of long tool outputs (≥ the cacheable threshold) is enough to exhaust the budget, and then the actually-cacheable user turns after them, plus the turn-boundary marker, get nothing. So the prompt caching silently degrades in exactly the agentic, long-tool-output conversations the turn-boundary logic is meant to optimize.

The fix just skips cache_control accounting for messages that become tool_result blocks; non-tool messages are untouched, and tool_result output was already markerless, so there's no behavior change beyond freeing up the slots.

Added a test in `prepare-request-body.spec.ts`: four long tool results followed by two long user turns — both user turns keep their markers (before the fix the tool results exhaust the budget and it's 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic message processing so discarded tool results no longer consume available cache-control slots.
  * Ensured cache-control markers are applied to eligible later user messages as expected.
* **Tests**
  * Added coverage verifying cache-control budgeting remains correct when conversations contain multiple tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->