### PR TITLE
feat: add reset pass sales KPI to admin devpass

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -10173,6 +10173,8 @@ const devpassKpisSchema = z.object({
 	netNewThisMonth: z.number(),
 	refundsThisMonth: z.number(),
 	refundedAmountThisMonth: z.number(),
+	resetPassesSold: z.number(),
+	resetPassRevenue: z.number(),
 	weightedAvgUtilization: z.number(),
 	totalRealCostCycle: z.number(),
 	totalMrrCycle: z.number(),
@@ -10948,6 +10950,57 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const refundsThisMonth = Number(refundsRow?.count ?? 0);
 	const refundedAmountThisMonth = Number(refundsRow?.total ?? 0);
 
+	// All-time Reset Pass sales on DevPass orgs. These are one-time
+	// PaymentIntent purchases (no invoice), so no invoice dedup is needed;
+	// revenue is netted against completed refunds whose original transaction
+	// is a Reset Pass purchase, mirroring the all-time revenue subquery.
+	const [resetPassRow] = await db
+		.select({
+			count: sql<number>`COUNT(*)`,
+			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "dev_plan_reset_pass"),
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+			),
+		);
+	const resetPassesSold = Number(resetPassRow?.count ?? 0);
+
+	const resetPassRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"reset_pass_refund_original_tx",
+	);
+	const [resetPassRefundRow] = await db
+		.select({
+			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			resetPassRefundOriginalTx,
+			eq(tables.transaction.relatedTransactionId, resetPassRefundOriginalTx.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				eq(resetPassRefundOriginalTx.type, "dev_plan_reset_pass"),
+			),
+		);
+	const resetPassRevenue =
+		Number(resetPassRow?.total ?? 0) - Number(resetPassRefundRow?.total ?? 0);
+
 	// Weighted utilization across active subscribers
 	const [utilRow] = await db
 		.select({
@@ -11087,6 +11140,8 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			netNewThisMonth: startsThisMonth - endsThisMonth,
 			refundsThisMonth,
 			refundedAmountThisMonth,
+			resetPassesSold,
+			resetPassRevenue,
 			weightedAvgUtilization,
 			totalRealCostCycle,
 			totalMrrCycle,

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -8,6 +8,7 @@ import {
 	Info,
 	RotateCcw,
 	Search,
+	Ticket,
 	TrendingDown,
 	TrendingUp,
 	Users,
@@ -480,7 +481,7 @@ export default async function DevpassPage({
 				</Suspense>
 			</header>
 
-			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
+			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
 				<div className="rounded-lg border border-border/60 bg-card p-4">
 					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
 						<Users className="h-3.5 w-3.5" />
@@ -591,6 +592,18 @@ export default async function DevpassPage({
 					<div className="mt-1 text-xs text-muted-foreground">
 						{kpis.refundsThisMonth} refund
 						{kpis.refundsThisMonth === 1 ? "" : "s"} processed
+					</div>
+				</div>
+				<div className="rounded-lg border border-border/60 bg-card p-4">
+					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+						<Ticket className="h-3.5 w-3.5" />
+						Reset passes sold
+					</div>
+					<div className="mt-2 text-2xl font-semibold tabular-nums">
+						{kpis.resetPassesSold}
+					</div>
+					<div className="mt-1 text-xs text-muted-foreground">
+						{currencyFormatter.format(kpis.resetPassRevenue)} all-time revenue
 					</div>
 				</div>
 				<div className="rounded-lg border border-border/60 bg-card p-4">


### PR DESCRIPTION
Adds resetPassesSold and resetPassRevenue (net of refunds) to the
/admin/devpass KPI payload and surfaces them as a card on the admin
DevPass page.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019HjjgHDqCFFLHuXbZ4T9YN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Reset passes sold” KPI to the DevPass admin dashboard.
  * Displayed all-time revenue generated from reset pass sales.
  * Expanded the dashboard layout to accommodate the new KPI card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->