### PR TITLE
feat(admin): split reset pass revenue, 2-row KPIs

### DIFF
--- a/apps/api/src/routes/admin-metrics-gross-revenue.spec.ts
+++ b/apps/api/src/routes/admin-metrics-gross-revenue.spec.ts
@@ -16,6 +16,7 @@ interface AdminMetricsResponse {
 	grossRevenue: number;
 	grossCreditsRevenue: number;
 	grossDevpassRevenue: number;
+	grossResetPassRevenue: number;
 	grossChatPlansRevenue: number;
 	grossProSubscriptionsRevenue: number;
 }
@@ -97,6 +98,16 @@ describe("admin /metrics — gross revenue splits", () => {
 				stripeInvoiceId: "inv_gross_dev_2",
 				createdAt: new Date("2026-02-04T00:00:00Z"),
 			},
+			// Reset Pass: one-time PaymentIntent purchase, no invoice. Counted in
+			// its own split, not in DevPass subscription revenue.
+			{
+				organizationId: DEVPASS_ORG_ID,
+				type: "dev_plan_reset_pass",
+				amount: "9",
+				creditAmount: null,
+				status: "completed",
+				createdAt: new Date("2026-01-07T00:00:00Z"),
+			},
 			// Chat Plan: $10 paid for a plan that includes $150 of virtual
 			// credits — the $150 allowance must never count as revenue.
 			{
@@ -134,12 +145,13 @@ describe("admin /metrics — gross revenue splits", () => {
 
 		// Gross = positive Stripe amounts, refunds ignored: $21 + $11 credits.
 		expect(body.grossCreditsRevenue).toBe(32);
-		// $20 start + $20 second-cycle renewal.
+		// $20 start + $20 second-cycle renewal — the Reset Pass is NOT in here.
 		expect(body.grossDevpassRevenue).toBe(40);
+		expect(body.grossResetPassRevenue).toBe(9);
 		expect(body.grossChatPlansRevenue).toBe(10);
 		// Legacy subscription on a non-devpass org.
 		expect(body.grossProSubscriptionsRevenue).toBe(50);
-		expect(body.grossRevenue).toBe(132);
+		expect(body.grossRevenue).toBe(141);
 
 		// The credits-economy metrics must exclude ALL plan rows: chat plan
 		// creditAmount ($150) is a virtual allowance, not revenue.

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -10,6 +10,7 @@ import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
 import {
 	CHAT_PLAN_TX_TYPES,
+	DEV_PLAN_SUBSCRIPTION_TX_TYPES,
 	DEV_PLAN_TX_TYPES,
 	firstRowPerInvoiceFilter,
 	LEGACY_DEV_PLAN_TX_TYPES,
@@ -105,6 +106,7 @@ const adminMetricsSchema = z.object({
 	grossRevenue: z.number(),
 	grossCreditsRevenue: z.number(),
 	grossDevpassRevenue: z.number(),
+	grossResetPassRevenue: z.number(),
 	grossChatPlansRevenue: z.number(),
 	grossProSubscriptionsRevenue: z.number(),
 });
@@ -846,8 +848,10 @@ admin.openapi(getMetrics, async (c) => {
 
 	const grossCreditsRevenue = Number(grossCreditsRow?.value ?? 0);
 
-	// DevPass: dev plan payments (+ legacy `subscription_*` rows on devpass
-	// orgs), deduplicated per Stripe invoice. Mirrors /admin/devpass/timeseries.
+	// DevPass: dev plan subscription payments (+ legacy `subscription_*` rows on
+	// devpass orgs), deduplicated per Stripe invoice. Mirrors
+	// /admin/devpass/timeseries. One-time Reset Pass purchases are reported as
+	// their own split below.
 	const [grossDevpassRow] = await db
 		.select({
 			value:
@@ -865,7 +869,7 @@ admin.openapi(getMetrics, async (c) => {
 				eq(tables.transaction.status, "completed"),
 				eq(tables.organization.kind, "devpass"),
 				inArray(tables.transaction.type, [
-					...DEV_PLAN_TX_TYPES,
+					...DEV_PLAN_SUBSCRIPTION_TX_TYPES,
 					...LEGACY_DEV_PLAN_TX_TYPES,
 				]),
 				firstRowPerInvoiceFilter([
@@ -877,6 +881,32 @@ admin.openapi(getMetrics, async (c) => {
 		);
 
 	const grossDevpassRevenue = Number(grossDevpassRow?.value ?? 0);
+
+	// Reset Passes: one-time PaymentIntent purchases on devpass orgs — no
+	// invoice, so no dedup needed. Gross like the other splits (refunds are
+	// separate `credit_refund` rows and not netted out here).
+	const [grossResetPassRow] = await db
+		.select({
+			value:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"value",
+				),
+		})
+		.from(tables.transaction)
+		.innerJoin(
+			tables.organization,
+			eq(tables.transaction.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.organization.kind, "devpass"),
+				eq(tables.transaction.type, "dev_plan_reset_pass"),
+				transactionDateFilter,
+			),
+		);
+
+	const grossResetPassRevenue = Number(grossResetPassRow?.value ?? 0);
 
 	// Chat Plans: plan payments on chat orgs, deduplicated per Stripe invoice.
 	// Mirrors /admin/chat-plans/timeseries.
@@ -936,6 +966,7 @@ admin.openapi(getMetrics, async (c) => {
 	const grossRevenue =
 		grossCreditsRevenue +
 		grossDevpassRevenue +
+		grossResetPassRevenue +
 		grossChatPlansRevenue +
 		grossProSubscriptionsRevenue;
 
@@ -960,6 +991,7 @@ admin.openapi(getMetrics, async (c) => {
 		grossRevenue,
 		grossCreditsRevenue,
 		grossDevpassRevenue,
+		grossResetPassRevenue,
 		grossChatPlansRevenue,
 		grossProSubscriptionsRevenue,
 	});

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -45,6 +45,15 @@ export const DEV_PLAN_TX_TYPES = [
 	"dev_plan_reset_pass",
 ] as const;
 
+// Subscription-billed dev plan rows only — excludes one-time Reset Pass
+// purchases so they can be reported as their own revenue split.
+export const DEV_PLAN_SUBSCRIPTION_TX_TYPES = [
+	"dev_plan_start",
+	"dev_plan_upgrade",
+	"dev_plan_downgrade",
+	"dev_plan_renewal",
+] as const;
+
 // Pre-rename rows for what is now a dev plan. The same `subscription_*` types
 // are STILL written today for non-personal org Pro subs, so always pair them
 // with `organization.kind = 'devpass'` to avoid counting org Pro revenue.

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -481,7 +481,7 @@ export default async function DevpassPage({
 				</Suspense>
 			</header>
 
-			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 				<div className="rounded-lg border border-border/60 bg-card p-4">
 					<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
 						<Users className="h-3.5 w-3.5" />

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -321,6 +321,12 @@ export default async function Page({
 									value: currencyFormatter.format(metrics.grossDevpassRevenue),
 								},
 								{
+									label: "Reset passes",
+									value: currencyFormatter.format(
+										metrics.grossResetPassRevenue,
+									),
+								},
+								{
 									label: "Chat plans",
 									value: currencyFormatter.format(
 										metrics.grossChatPlansRevenue,


### PR DESCRIPTION
## Summary

- **Reset Passes on the admin dashboard revenue card**: Reset Pass sales are now their own line in the Total Revenue breakdown (alongside Credits, DevPass, Chat plans, Pro subs). They were previously rolled into the DevPass split via `DEV_PLAN_TX_TYPES`; the DevPass split now covers subscription payments only (new `DEV_PLAN_SUBSCRIPTION_TX_TYPES`), so the splits stay disjoint and still sum to the gross revenue total — Reset Passes remain fully counted in total revenue.
- **New `grossResetPassRevenue` metric** on `GET /admin/metrics`: sum of completed one-time `dev_plan_reset_pass` purchases on DevPass orgs (PaymentIntent purchases, no invoice, so no invoice dedup needed), gross like the other splits.
- **DevPass KPI cards in 2 rows**: the six KPI cards on the admin DevPass page now render as a 3-column grid (2 rows) instead of stretching into a single 6-column row on wide screens.

## Testing

- Extended `admin-metrics-gross-revenue.spec.ts` with a Reset Pass purchase: asserts it lands in its own split, is excluded from the DevPass subscription split, and is included in the gross revenue sum.
- `turbo run build --filter=api --filter=admin` passes; OpenAPI spec + admin typed client regenerated.

https://claude.ai/code/session_017Xbd48rpcVQWW2kx4vFiJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Reset Pass revenue as a separate component of gross revenue metrics.
  * Added a “Reset passes” line to the admin Total Revenue dashboard.
* **UI Improvements**
  * Improved responsive layout for DevPass KPI cards across screen sizes.
* **Bug Fixes**
  * Corrected gross revenue calculations to distinguish subscription revenue from one-time Reset Pass purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->