### PR TITLE
feat(models): add service tiers for gpt-5.1/5.2

### DIFF
--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1092,6 +1092,8 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5.1",
+				serviceTiers: ["flex", "priority"],
+				serviceTierMultipliers: { priority: 2 },
 				inputPrice: "1.25e-6",
 				outputPrice: "10.0e-6",
 				cachedInputPrice: "0.125e-6",
@@ -1191,6 +1193,8 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5.1-codex",
+				serviceTiers: ["priority"],
+				serviceTierMultipliers: { priority: 2 },
 				inputPrice: "1.25e-6",
 				outputPrice: "10e-6",
 				requestPrice: "0",
@@ -1284,6 +1288,8 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5.2",
+				serviceTiers: ["flex", "priority"],
+				serviceTierMultipliers: { priority: 2 },
 				inputPrice: "1.75e-6",
 				outputPrice: "14.0e-6",
 				cachedInputPrice: "0.175e-6",

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -90,6 +90,32 @@ describe("model service tier support", () => {
 			)?.multiplier,
 		).toBe(2);
 		expect(
+			getSupportedServiceTiers("gpt-5.1", "openai").map((tier) => tier.id),
+		).toEqual(["flex", "priority"]);
+		expect(
+			getSupportedServiceTiers("gpt-5.1", "openai").find(
+				(tier) => tier.id === "priority",
+			)?.multiplier,
+		).toBe(2);
+		expect(
+			getSupportedServiceTiers("gpt-5.2", "openai").map((tier) => tier.id),
+		).toEqual(["flex", "priority"]);
+		expect(
+			getSupportedServiceTiers("gpt-5.2", "openai").find(
+				(tier) => tier.id === "priority",
+			)?.multiplier,
+		).toBe(2);
+		expect(
+			getSupportedServiceTiers("gpt-5.1-codex", "openai").map(
+				(tier) => tier.id,
+			),
+		).toEqual(["priority"]);
+		expect(
+			getSupportedServiceTiers("gpt-5.1-codex", "openai").find(
+				(tier) => tier.id === "priority",
+			)?.multiplier,
+		).toBe(2);
+		expect(
 			getSupportedServiceTiers("gpt-5.5-pro", "openai").map((tier) => tier.id),
 		).toEqual(["flex"]);
 		expect(


### PR DESCRIPTION
## Summary

Adds OpenAI service tier support for the GPT-5.1/5.2 generation, matching OpenAI's published flex/priority pricing:

- **gpt-5.1**: `serviceTiers: ["flex", "priority"]` with priority at 2× (OpenAI: flex $0.625/$5.00, priority $2.50/$20.00 per 1M vs standard $1.25/$10.00)
- **gpt-5.2**: `serviceTiers: ["flex", "priority"]` with priority at 2× (OpenAI: flex $0.875/$7.00, priority $3.50/$28.00 per 1M vs standard $1.75/$14.00)
- **gpt-5.1-codex**: `serviceTiers: ["priority"]` at 2× (matches the existing gpt-5.2-codex mapping; OpenAI lists no flex row for codex models)

Flex uses the provider-level default 0.5× multiplier. Per OpenAI's pricing tables, gpt-5.1-codex-mini, gpt-5.2-pro, and gpt-5.2-chat-latest support neither tier, so they are intentionally left unchanged.

Sources: OpenAI pricing (developers.openai.com/api/docs/pricing), flex-processing and priority-processing guides.

## Verification

- Probed the OpenAI API directly: `service_tier: "flex"` and `"priority"` are accepted and echoed back as served for both gpt-5.1 and gpt-5.2.
- Live e2e through the local gateway (`x-no-fallback`, pinned `openai/gpt-5.1` and `openai/gpt-5.2`): all four tier/model combinations succeed and the response reports the requested tier as served.
- Queued log entries confirm billing applies the multipliers exactly (flex 0.5×, priority 2×) on input and output cost.
- Negative check: `service_tier: "flex"` on `openai/gpt-5.2-chat-latest` still rejects with `unsupported_service_tier`.
- Extended `packages/models/src/providers.spec.ts` with tier/multiplier assertions for the three models; catalog-related unit specs pass, `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-tier support for OpenAI’s GPT-5.1, GPT-5.1 Codex, and GPT-5.2 models.
  * Added flexible and priority tier options where available, including priority-tier pricing details.

* **Tests**
  * Expanded coverage to verify supported service tiers and priority multipliers for these models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->