### PR TITLE
fix(docs): canonicalize shared guides to main site

### DIFF
--- a/apps/docs/app/(home)/[[...slug]]/page.tsx
+++ b/apps/docs/app/(home)/[[...slug]]/page.tsx
@@ -14,6 +14,7 @@ import { EnterpriseCTA } from "@/components/enterprise-cta";
 import { Feedback } from "@/components/feedback";
 import { JsonLd } from "@/components/json-ld";
 import { docsBaseUrl } from "@/lib/base-url";
+import { marketingGuideCanonical } from "@/lib/guide-canonical";
 import { source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
 
@@ -33,7 +34,8 @@ export async function generateMetadata({
 	}
 
 	const path = page.url === "/" ? "" : page.url;
-	const canonicalUrl = `${docsBaseUrl}${path}`;
+	const canonicalUrl =
+		marketingGuideCanonical(page.url) ?? `${docsBaseUrl}${path}`;
 	const image = ["/docs-og", ...slug, "image.png"].join("/");
 
 	return {
@@ -88,7 +90,7 @@ export default async function Page(props: {
 		"@type": "TechArticle",
 		headline: page.data.title,
 		description: page.data.description,
-		url: `${docsBaseUrl}${path}`,
+		url: marketingGuideCanonical(page.url) ?? `${docsBaseUrl}${path}`,
 		...(time ? { dateModified: new Date(time).toISOString() } : {}),
 		author: {
 			"@type": "Organization",

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { docsBaseUrl } from "@/lib/base-url";
+import { marketingGuideCanonical } from "@/lib/guide-canonical";
 import { source } from "@/lib/source";
 
 import type { MetadataRoute } from "next";
@@ -13,12 +14,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
 	// sitemap as freshly changed on each deploy, which trains crawlers to
 	// ignore the field. Omitting it is the truthful option until real
 	// per-page modification dates are available.
-	return source.getPages().map((page) => {
-		const path = page.url === "/" ? "" : page.url;
-		return {
-			url: `${docsBaseUrl}${path}`,
-			changeFrequency: page.url === "/" ? "weekly" : "monthly",
-			priority: page.url === "/" ? 1 : 0.7,
-		};
-	});
+	// Guides that canonicalize cross-domain to llmgateway.io are excluded:
+	// a sitemap must only list canonical URLs, and listing an alternate here
+	// contradicts its canonical tag.
+	return source
+		.getPages()
+		.filter((page) => marketingGuideCanonical(page.url) === null)
+		.map((page) => {
+			const path = page.url === "/" ? "" : page.url;
+			return {
+				url: `${docsBaseUrl}${path}`,
+				changeFrequency: page.url === "/" ? "weekly" : "monthly",
+				priority: page.url === "/" ? 1 : 0.7,
+			};
+		});
 }

--- a/apps/docs/lib/guide-canonical.ts
+++ b/apps/docs/lib/guide-canonical.ts
@@ -1,0 +1,16 @@
+// Guides are published on both hosts with the same content:
+// docs.llmgateway.io/guides/* and llmgateway.io/guides/*. The marketing site
+// is the primary copy (indexed, in its sitemap, receives the traffic), so
+// shared guides canonicalize cross-domain to it instead of competing with it.
+// Docs-only guides without a marketing-site counterpart stay self-canonical —
+// add new docs-only guide slugs here, otherwise their canonical points at a
+// 404 on the marketing site.
+const docsOnlyGuideSlugs = new Set(["agent-skills", "cli"]);
+
+export function marketingGuideCanonical(pageUrl: string): string | null {
+	const match = /^\/guides\/([^/]+)$/.exec(pageUrl);
+	if (!match || docsOnlyGuideSlugs.has(match[1])) {
+		return null;
+	}
+	return `https://llmgateway.io/guides/${match[1]}`;
+}


### PR DESCRIPTION
## Summary

Follow-up to the GSC **"Alternate page with proper canonical tag"** coverage drilldown (2026-07-18 export, 411 URLs). A full audit of every URL shape in the export against the codebase confirmed the bucket is overwhelmingly working-as-designed (provider sub-pages → base model page, filter/utm/ref param URLs → clean URL, `chat.llmgateway.io/?model=` → chat root, etc. — Google confirming our canonical strategy, same conclusion as the June audit).

The audit surfaced **one real regression**: since #2954 flipped docs `metadataBase` to `docs.llmgateway.io`, the 17 guides published on **both** hosts (`docs.llmgateway.io/guides/*` and `llmgateway.io/guides/*`, same content) became *competing self-canonical duplicates*. Before #2954 they (accidentally) cross-canonicalized to the marketing site — which is why they appear in this GSC bucket. Left as-is, they'd resurface as "Duplicate, Google chose different canonical than user" errors and split ranking signals between hosts.

## Changes

- New `apps/docs/lib/guide-canonical.ts`: shared guides on docs now **deliberately** canonicalize cross-domain to `https://llmgateway.io/guides/<slug>` (marketing site is the primary copy — indexed, in its sitemap, self-canonical). Docs-only guides (`agent-skills`, `cli`) stay self-canonical via an explicit exception set.
- Docs page metadata + TechArticle JSON-LD `url` use the same canonical.
- Docs sitemap excludes cross-canonicalized guides (a sitemap must only list canonical URLs; listing an alternate contradicts its canonical tag).

## Verification (built standalone server)

- `/guides/kilo-code` → `<link rel="canonical" href="https://llmgateway.io/guides/kilo-code"/>`
- `/guides/agent-skills` → self-canonical on docs
- `/quick-start` → self-canonical on docs (non-guide pages unchanged)
- `/sitemap.xml` → only `guides/agent-skills` + `guides/cli` remain under `/guides/`

## Notes on the rest of the GSC export

No code change needed — verified correct: model provider sub-pages (canonical → base model page, already excluded from sitemap), `/models` + `/models/compare` + `/token-cost-calculator` param URLs, `?ref=`/`?utm_*` on ui, `chat.llmgateway.io/?model=`/`?ref=` (canonical `/`), `devpass.llmgateway.io/?v=`/`?ref=` (canonical `/`). `status.llmgateway.io` is third-party hosted. This GSC category never needs to reach zero — it grows with the model catalogue by design.

## Test plan

- [x] `turbo run build --filter=docs` passes
- [x] Canonicals + sitemap verified against the built server (above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Improved canonical URLs for guide documentation pages across supported domains.
  * Updated structured metadata to use the correct canonical guide URL.
  * Excluded documentation-only guides from the sitemap when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->