### PR TITLE
feat(gateway): add /v1/key plan status endpoint

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -28,6 +28,7 @@ import { extractErrorCause } from "./chat/tools/extract-error-cause.js";
 import { isUpstreamTermination } from "./chat/tools/normalize-streaming-error.js";
 import { embeddingsRoute } from "./embeddings/route.js";
 import { imagesRoute } from "./images/route.js";
+import { keyRoute } from "./key/route.js";
 import {
 	buildAnthropicErrorBody,
 	buildOpenAIErrorBody,
@@ -341,6 +342,7 @@ const v1 = new OpenAPIHono<ServerTypes>();
 v1.route("/chat", chat);
 v1.route("/embeddings", embeddingsRoute);
 v1.route("/images", imagesRoute);
+v1.route("/key", keyRoute);
 v1.route("/models", models);
 v1.route("/moderations", moderationsRoute);
 v1.route("/ocr", ocrRoute);

--- a/apps/gateway/src/key/key.spec.ts
+++ b/apps/gateway/src/key/key.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
+
+import { db, tables } from "@llmgateway/db";
+import {
+	DEV_PLAN_PREMIUM_WEEK_LENGTH_MS,
+	getDevPlanPremiumWeeklyLimit,
+} from "@llmgateway/shared";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): Date {
+	const offsetMs = days * DAY_MS;
+	return new Date(Date.now() - offsetMs);
+}
+
+describe("/v1/key", () => {
+	const harness = createGatewayApiTestHarness();
+
+	async function insertApiKey(
+		values: Partial<typeof tables.apiKey.$inferInsert> = {},
+	) {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+			...values,
+		});
+	}
+
+	function getKey(token?: string) {
+		return app.request("/v1/key", {
+			headers: token ? { Authorization: `Bearer ${token}` } : {},
+		});
+	}
+
+	test("401 without an API key", async () => {
+		const res = await getKey();
+		expect(res.status).toBe(401);
+	});
+
+	test("401 for an unknown token", async () => {
+		const res = await getKey("unknown-token");
+		expect(res.status).toBe(401);
+	});
+
+	test("401 for an inactive key", async () => {
+		await insertApiKey({ status: "inactive" });
+		const res = await getKey("real-token");
+		expect(res.status).toBe(401);
+	});
+
+	test("403 for non-user key types", async () => {
+		await insertApiKey({ keyType: "platform_publishable" });
+		const res = await getKey("real-token");
+		expect(res.status).toBe(403);
+	});
+
+	test("returns key info with devPlan none for PAYG orgs", async () => {
+		await insertApiKey({ usage: "12.5", usageLimit: "50" });
+
+		const res = await getKey("real-token");
+		expect(res.status).toBe(200);
+		const { data } = await res.json();
+		expect(data).toEqual({
+			label: "Test API Key",
+			usage: "12.5",
+			limit: "50",
+			devPlan: "none",
+			devPlanCreditsUsed: "0",
+			devPlanCreditsLimit: "0",
+			devPlanCreditsRemaining: "0",
+			devPlanPremiumWeeklyLimit: "0",
+			devPlanPremiumCreditsUsed: "0",
+			devPlanPremiumWeekResetsAt: null,
+		});
+	});
+
+	test("returns plan status for a dev-plan org with an active premium week", async () => {
+		await insertApiKey();
+		const premiumWeekStart = daysAgo(3);
+		await harness.setDevPlan({
+			devPlan: "pro",
+			creditsUsed: "25",
+			creditsLimit: "237",
+			premiumCreditsUsed: "5",
+			premiumWeekStart,
+		});
+
+		const res = await getKey("real-token");
+		expect(res.status).toBe(200);
+		const { data } = await res.json();
+		expect(data.label).toBe("Test API Key");
+		expect(data.usage).toBe("0");
+		expect(data.limit).toBeNull();
+		expect(data.devPlan).toBe("pro");
+		expect(data.devPlanCreditsUsed).toBe("25");
+		expect(data.devPlanCreditsLimit).toBe("237");
+		expect(data.devPlanCreditsRemaining).toBe("212.00");
+		expect(data.devPlanPremiumWeeklyLimit).toBe(
+			getDevPlanPremiumWeeklyLimit("pro").toFixed(2),
+		);
+		expect(data.devPlanPremiumCreditsUsed).toBe("5.00");
+		expect(data.devPlanPremiumWeekResetsAt).toBe(
+			new Date(
+				premiumWeekStart.getTime() + DEV_PLAN_PREMIUM_WEEK_LENGTH_MS,
+			).toISOString(),
+		);
+	});
+
+	test("reports zero premium usage when the weekly window has expired", async () => {
+		await insertApiKey();
+		await harness.setDevPlan({
+			devPlan: "max",
+			creditsUsed: "600",
+			creditsLimit: "537",
+			premiumCreditsUsed: "12",
+			premiumWeekStart: daysAgo(8),
+		});
+
+		const res = await getKey("real-token");
+		expect(res.status).toBe(200);
+		const { data } = await res.json();
+		expect(data.devPlan).toBe("max");
+		// Over-limit usage clamps remaining to zero rather than going negative.
+		expect(data.devPlanCreditsRemaining).toBe("0.00");
+		expect(data.devPlanPremiumCreditsUsed).toBe("0.00");
+		expect(data.devPlanPremiumWeekResetsAt).toBeNull();
+	});
+
+	test("does not echo the key token", async () => {
+		await insertApiKey();
+		await harness.setDevPlan({ devPlan: "lite" });
+
+		const res = await getKey("real-token");
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).not.toContain("real-token");
+	});
+});

--- a/apps/gateway/src/key/key.spec.ts
+++ b/apps/gateway/src/key/key.spec.ts
@@ -60,6 +60,14 @@ describe("/v1/key", () => {
 		expect(res.status).toBe(403);
 	});
 
+	test("401 for platform_secret keys, which the gateway treats as nonexistent", async () => {
+		// findApiKeyByToken excludes platform_secret on every gateway route, so
+		// the response must not acknowledge that the token exists (401, not 403).
+		await insertApiKey({ keyType: "platform_secret" });
+		const res = await getKey("real-token");
+		expect(res.status).toBe(401);
+	});
+
 	test("returns key info with devPlan none for PAYG orgs", async () => {
 		await insertApiKey({ usage: "12.5", usageLimit: "50" });
 

--- a/apps/gateway/src/key/key.ts
+++ b/apps/gateway/src/key/key.ts
@@ -1,0 +1,195 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+
+import {
+	findApiKeyByToken,
+	findOrganizationById,
+	findProjectById,
+} from "@/lib/cached-queries.js";
+import { extractApiToken } from "@/lib/extract-api-token.js";
+
+import {
+	DEV_PLAN_PREMIUM_WEEK_LENGTH_MS,
+	getDevPlanPremiumWeeklyLimit,
+	isPremiumWeekExpired,
+} from "@llmgateway/shared";
+
+import type { ServerTypes } from "@/vars.js";
+
+export const key = new OpenAPIHono<ServerTypes>();
+
+const keyResponseSchema = z.object({
+	data: z.object({
+		label: z.string().openapi({
+			description: "Description of the API key used for the request.",
+		}),
+		usage: z.string().openapi({
+			description: "Total usage in USD accrued by this API key.",
+		}),
+		limit: z.string().nullable().openapi({
+			description: "Usage limit in USD set on this API key, if any.",
+		}),
+		devPlan: z.enum(["none", "lite", "pro", "max"]).openapi({
+			description:
+				"Dev plan tier of the organization this key belongs to. 'none' for pay-as-you-go organizations.",
+		}),
+		devPlanCreditsUsed: z.string().openapi({
+			description: "Plan credits used in the current billing cycle, in USD.",
+		}),
+		devPlanCreditsLimit: z.string().openapi({
+			description: "Plan credit allowance per billing cycle, in USD.",
+		}),
+		devPlanCreditsRemaining: z.string().openapi({
+			description: "Plan credits remaining in the current billing cycle.",
+		}),
+		devPlanPremiumWeeklyLimit: z.string().openapi({
+			description:
+				"Weekly fair-use allowance for premium models, in USD of plan credits.",
+		}),
+		devPlanPremiumCreditsUsed: z.string().openapi({
+			description:
+				"Premium-model plan credits used in the current weekly window.",
+		}),
+		devPlanPremiumWeekResetsAt: z.string().nullable().openapi({
+			description:
+				"When the current premium weekly window resets (ISO 8601), or null when no window is active.",
+		}),
+	}),
+});
+
+const getKey = createRoute({
+	operationId: "v1_key_retrieve",
+	summary: "Retrieve key status",
+	description:
+		"Returns usage information for the API key used to authenticate the request, including the organization's dev plan allowance and weekly premium-model usage. Lets clients that only hold an API key surface remaining quota without a dashboard session. Deliberately excludes billing details and the key token itself.",
+	method: "get",
+	path: "/",
+	security: [{ bearerAuth: [] }],
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: keyResponseSchema,
+				},
+			},
+			description: "Status of the API key and its organization's dev plan.",
+		},
+	},
+});
+
+key.openapi(getKey, async (c) => {
+	const token = extractApiToken(c);
+	const apiKey = await findApiKeyByToken(token);
+
+	if (!apiKey) {
+		throw new HTTPException(401, {
+			message:
+				"Unauthorized: Invalid LLMGateway API token. The token could not be found. Go to the LLMGateway 'API Keys' page to generate a new token.",
+		});
+	}
+
+	if (apiKey.status !== "active") {
+		throw new HTTPException(401, {
+			message:
+				"Unauthorized: This LLMGateway API token is not active (it may be disabled or deleted). Go to the LLMGateway 'API Keys' page to generate a new token.",
+		});
+	}
+
+	// Plan status is developer-key territory: embeddable-SDK principals
+	// (publishable keys, end-user sessions) must not read org-level plan state
+	// or the aggregate key's metadata.
+	if (apiKey.keyType !== "user" || apiKey.endUserSession) {
+		throw new HTTPException(403, {
+			message: "This endpoint is only available for regular API keys.",
+		});
+	}
+
+	const project = await findProjectById(apiKey.projectId);
+	if (!project) {
+		throw new HTTPException(500, {
+			message: "Could not find project",
+		});
+	}
+
+	if (project.status === "deleted") {
+		throw new HTTPException(410, {
+			message: "Project has been archived and is no longer accessible",
+		});
+	}
+
+	const organization = await findOrganizationById(project.organizationId);
+	if (!organization) {
+		throw new HTTPException(500, {
+			message: "Could not find organization",
+		});
+	}
+
+	if (organization.status === "deleted") {
+		throw new HTTPException(410, {
+			message: "Organization has been disabled and is no longer accessible",
+		});
+	}
+
+	// Per-key and per-member usage limits are deliberately NOT enforced here:
+	// a client most needs to read remaining quota exactly when the key is
+	// over its cap.
+
+	const devPlan =
+		organization.kind === "devpass" ? organization.devPlan : "none";
+
+	if (devPlan === "none") {
+		return c.json({
+			data: {
+				label: apiKey.description,
+				usage: apiKey.usage,
+				limit: apiKey.usageLimit,
+				devPlan: "none" as const,
+				devPlanCreditsUsed: "0",
+				devPlanCreditsLimit: "0",
+				devPlanCreditsRemaining: "0",
+				devPlanPremiumWeeklyLimit: "0",
+				devPlanPremiumCreditsUsed: "0",
+				devPlanPremiumWeekResetsAt: null,
+			},
+		});
+	}
+
+	const creditsUsed = parseFloat(organization.devPlanCreditsUsed);
+	const creditsLimit = parseFloat(organization.devPlanCreditsLimit);
+	const creditsRemaining = Math.max(0, creditsLimit - creditsUsed);
+
+	// Same semantics as GET /dev-plans/status on the API: an expired window
+	// reports zero usage and no reset date — the full allowance is already
+	// available again. The cached organization may round-trip timestamps as
+	// strings, so re-wrap before doing date math.
+	const premiumWeekStart = organization.devPlanPremiumWeekStart
+		? new Date(organization.devPlanPremiumWeekStart)
+		: null;
+	const premiumWeeklyLimit = getDevPlanPremiumWeeklyLimit(devPlan);
+	const premiumWeekExpired = isPremiumWeekExpired(premiumWeekStart);
+	const premiumCreditsUsed = premiumWeekExpired
+		? 0
+		: parseFloat(organization.devPlanPremiumCreditsUsed ?? "0");
+	const premiumWeekResetsAt =
+		!premiumWeekExpired && premiumWeekStart
+			? new Date(
+					premiumWeekStart.getTime() + DEV_PLAN_PREMIUM_WEEK_LENGTH_MS,
+				).toISOString()
+			: null;
+
+	return c.json({
+		data: {
+			label: apiKey.description,
+			usage: apiKey.usage,
+			limit: apiKey.usageLimit,
+			devPlan,
+			devPlanCreditsUsed: organization.devPlanCreditsUsed,
+			devPlanCreditsLimit: organization.devPlanCreditsLimit,
+			devPlanCreditsRemaining: creditsRemaining.toFixed(2),
+			devPlanPremiumWeeklyLimit: premiumWeeklyLimit.toFixed(2),
+			devPlanPremiumCreditsUsed: premiumCreditsUsed.toFixed(2),
+			devPlanPremiumWeekResetsAt: premiumWeekResetsAt,
+		},
+	});
+});

--- a/apps/gateway/src/key/route.ts
+++ b/apps/gateway/src/key/route.ts
@@ -1,0 +1,9 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+import { key } from "./key.js";
+
+import type { ServerTypes } from "@/vars.js";
+
+export const keyRoute = new OpenAPIHono<ServerTypes>();
+
+keyRoute.route("/", key);

--- a/apps/gateway/src/test-utils/gateway-api-test-harness.ts
+++ b/apps/gateway/src/test-utils/gateway-api-test-harness.ts
@@ -178,6 +178,8 @@ export function createGatewayApiTestHarness() {
 			serviceTier?: "default" | "flex";
 			creditsUsed?: string;
 			creditsLimit?: string;
+			premiumCreditsUsed?: string;
+			premiumWeekStart?: Date | null;
 		}) {
 			await db
 				.update(tables.organization)
@@ -187,6 +189,8 @@ export function createGatewayApiTestHarness() {
 					devPlanServiceTier: options.serviceTier ?? "default",
 					devPlanCreditsUsed: options.creditsUsed ?? "0",
 					devPlanCreditsLimit: options.creditsLimit ?? "100",
+					devPlanPremiumCreditsUsed: options.premiumCreditsUsed ?? "0",
+					devPlanPremiumWeekStart: options.premiumWeekStart ?? null,
 				})
 				.where(eq(tables.organization.id, TEST_ORGANIZATION_ID));
 		},


### PR DESCRIPTION
Closes #3121

## What

Adds an API-key-authenticated `GET /v1/key` endpoint on the gateway (following OpenRouter's `GET /v1/key` precedent, the issue's preferred option) so third-party client integrations that only hold a DevPass API key (`llmgtwy_...`) can surface remaining plan allowance and weekly premium usage — the same way tools surface GitHub Copilot quota — without extracting a dashboard session cookie.

## Response shape

```json
{
  "data": {
    "label": "My API Key",
    "usage": "12.5",
    "limit": null,
    "devPlan": "pro",
    "devPlanCreditsUsed": "25",
    "devPlanCreditsLimit": "237",
    "devPlanCreditsRemaining": "212.00",
    "devPlanPremiumWeeklyLimit": "35.55",
    "devPlanPremiumCreditsUsed": "5.00",
    "devPlanPremiumWeekResetsAt": "2026-07-22T14:00:00.000Z"
  }
}
```

- The `devPlan*` fields use the same names, semantics, and string formatting as the session-authenticated `GET /dev-plans/status` (computed with the same `@llmgateway/shared` helpers: expired weekly window reports zero usage and a null reset date), so clients can share parsing logic between the two.
- `label`/`usage`/`limit` describe the bearer key itself (OpenRouter parity).
- Keys on non-DevPass (PAYG/chat) organizations get `devPlan: "none"` with zeroed plan fields, mirroring the session endpoint's fallback.

## Design decisions

- **Lower-privilege by design**: deliberately excludes billing details, invoices, payment method info, and the key echo that the session endpoint returns, per the issue.
- **Only regular developer keys**: embeddable-SDK principals (publishable keys, end-user sessions) get a 403 — they must not read org-level plan state.
- **No usage-limit enforcement on reads**: per-key/per-member budget asserts are intentionally skipped — a client most needs to read remaining quota exactly when the key is over its cap.
- Documented in the gateway's OpenAPI spec (`/docs` swagger) with `bearerAuth`.

## Tests

New `apps/gateway/src/key/key.spec.ts` (8 tests: auth failures, key-type restriction, PAYG fallback, active/expired premium week math, over-limit clamping, no token echo) using the shared gateway test harness, whose `setDevPlan` helper now accepts optional premium-week fields. Full `pnpm build` and the other harness-based gateway specs (api, embeddings, ocr, speech, videos — 191 tests) pass.

https://claude.ai/code/session_01NpGKvafA6XTymT4cWS2zfE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to retrieve API key status, usage, quota, and development-plan details.
  - Added authentication/authorization handling for missing, invalid, inactive, or unsupported API keys.
  - Added premium credit and weekly reset information, including correct behavior for expired windows.
  - Responses omit sensitive API tokens and billing details.

- **Tests**
  - Added endpoint tests covering auth/authorization outcomes and premium credit calculation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->