### PR TITLE
fix(reset-pass): prevent double-refunding

### DIFF
--- a/apps/api/src/lib/self-refund.spec.ts
+++ b/apps/api/src/lib/self-refund.spec.ts
@@ -444,6 +444,128 @@ describe("computeSelfRefundEligibility", () => {
 		});
 	});
 
+	test("with one pass redeemed, only the newest of two purchases is refundable", async () => {
+		// Two pro passes bought, one redeemed → inventory 1. The remaining pass
+		// is attributed to the newest purchase; the older one counts as redeemed
+		// and must not be refundable against the newer purchase's pass.
+		await seedOrg({
+			kind: "devpass",
+			devPlan: "pro",
+			devPlanResetPassesPro: 1,
+		});
+		const older = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(2),
+			stripePaymentIntentId: "pi_test_older",
+		});
+		const newer = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(1),
+			stripePaymentIntentId: "pi_test_newer",
+		});
+
+		expect(await getEligibility(newer.id)).toEqual({ eligible: true });
+		expect(await getEligibility(older.id)).toEqual({
+			eligible: false,
+			reason: "pass_already_used",
+		});
+	});
+
+	test("both purchases are refundable while inventory covers both", async () => {
+		await seedOrg({
+			kind: "devpass",
+			devPlan: "pro",
+			devPlanResetPassesPro: 2,
+		});
+		const older = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(2),
+			stripePaymentIntentId: "pi_test_older",
+		});
+		const newer = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(1),
+			stripePaymentIntentId: "pi_test_newer",
+		});
+
+		expect(await getEligibility(newer.id)).toEqual({ eligible: true });
+		expect(await getEligibility(older.id)).toEqual({ eligible: true });
+	});
+
+	test("a refunded newer purchase no longer blocks the older one", async () => {
+		// The newer purchase was refunded (clawback already applied → inventory
+		// back to 1); the older purchase's pass is genuinely unredeemed.
+		await seedOrg({
+			kind: "devpass",
+			devPlan: "pro",
+			devPlanResetPassesPro: 1,
+		});
+		const older = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(2),
+			stripePaymentIntentId: "pi_test_older",
+		});
+		const newer = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(1),
+			stripePaymentIntentId: "pi_test_newer",
+		});
+		await seedTransaction({
+			type: "credit_refund",
+			amount: "29",
+			creditAmount: "0",
+			stripeRefundId: "re_test_newer",
+			relatedTransactionId: newer.id,
+			stripePaymentIntentId: null,
+		});
+
+		expect(await getEligibility(older.id)).toEqual({ eligible: true });
+	});
+
+	test("a redeemed lite pass can't be refunded against pro inventory", async () => {
+		// The attribution count is tier-bound both ways: a lite purchase whose
+		// pass was redeemed stays ineligible even with unrelated pro passes and
+		// a newer pro purchase present.
+		await seedOrg({
+			kind: "devpass",
+			devPlan: "pro",
+			devPlanResetPassesLite: 0,
+			devPlanResetPassesPro: 1,
+		});
+		const lite = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "9",
+			creditAmount: null,
+			createdAt: daysAgo(2),
+			stripePaymentIntentId: "pi_test_lite",
+		});
+		const pro = await seedTransaction({
+			type: "dev_plan_reset_pass",
+			amount: "29",
+			creditAmount: null,
+			createdAt: daysAgo(1),
+			stripePaymentIntentId: "pi_test_pro",
+		});
+
+		expect(await getEligibility(lite.id)).toEqual({
+			eligible: false,
+			reason: "pass_already_used",
+		});
+		expect(await getEligibility(pro.id)).toEqual({ eligible: true });
+	});
+
 	test("reset pass inventory is tier-bound: a lite purchase can't ride on pro passes", async () => {
 		// $9 maps to a lite pass; the held inventory is pro-only, so the lite
 		// purchase itself has already been redeemed.

--- a/apps/api/src/lib/self-refund.ts
+++ b/apps/api/src/lib/self-refund.ts
@@ -243,15 +243,23 @@ function checkPlanEligibility(
 }
 
 /**
- * A Reset Pass purchase is returnable while the pass itself is still unused:
- * the tier-bound inventory the purchase granted must still hold at least one
- * pass. The tier is recovered from the charged amount — fulfilment validated
- * it against the tier's fixed price, so the mapping is unambiguous. The
- * `charge.refunded` webhook performs the clawback, so a redeem racing the
- * refund can at worst leave the clamped-at-zero inventory, never a free pass.
+ * A Reset Pass purchase is returnable while the pass itself is still unused.
+ * Passes are fungible within a tier, so redemptions are attributed to the
+ * oldest un-refunded purchase first: a purchase is only refundable while it
+ * ranks within the newest `inventory` un-refunded purchases of its tier.
+ * Gating on the rank rather than just `inventory >= 1` stops a second
+ * purchase from being refunded against the same unredeemed pass — both
+ * outright (a redeemed older purchase never becomes refundable again) and
+ * during the window before the `charge.refunded` webhook records the first
+ * refund's clawback. The tier is recovered from the charged amount —
+ * fulfilment validated it against the tier's fixed price, so the mapping is
+ * unambiguous. The webhook performs the clawback clamped at zero, so a
+ * redeem racing the refund can at worst leave empty inventory, never a free
+ * pass.
  */
 function checkResetPassEligibility(
 	organization: OrganizationRow,
+	transactions: TransactionRow[],
 	transaction: TransactionRow,
 ): SelfRefundEligibility {
 	const amount = dec(transaction.amount);
@@ -262,12 +270,29 @@ function checkResetPassEligibility(
 		return ineligible("unsupported_type");
 	}
 	const inventory =
-		tier === "lite"
+		(tier === "lite"
 			? organization.devPlanResetPassesLite
 			: tier === "pro"
 				? organization.devPlanResetPassesPro
-				: organization.devPlanResetPassesMax;
-	if ((inventory ?? 0) < 1) {
+				: organization.devPlanResetPassesMax) ?? 0;
+
+	const refundedIds = new Set(
+		transactions
+			.filter((t) => t.type === "credit_refund" && t.relatedTransactionId)
+			.map((t) => t.relatedTransactionId),
+	);
+	const tierPrice = dec(DEV_PLAN_RESET_PASS_PRICES[tier]);
+	const newerUnrefundedSameTier = transactions.filter(
+		(t) =>
+			t.type === "dev_plan_reset_pass" &&
+			isCompleted(t) &&
+			!refundedIds.has(t.id) &&
+			dec(t.amount).eq(tierPrice) &&
+			(t.createdAt > transaction.createdAt ||
+				(t.createdAt.getTime() === transaction.createdAt.getTime() &&
+					t.id > transaction.id)),
+	).length;
+	if (newerUnrefundedSameTier >= inventory) {
 		return ineligible("pass_already_used");
 	}
 	return { eligible: true };
@@ -338,7 +363,7 @@ export function computeSelfRefundEligibility({
 				"dev",
 			);
 		case "dev_plan_reset_pass":
-			return checkResetPassEligibility(organization, transaction);
+			return checkResetPassEligibility(organization, transactions, transaction);
 		case "chat_plan_start":
 		case "chat_plan_renewal":
 			return checkPlanEligibility(


### PR DESCRIPTION
## Summary

Updates the Reset Pass refund eligibility logic to prevent multiple purchases from being refunded against the same unredeemed pass. Passes are now attributed to the oldest un-refunded purchase first, and a purchase is only refundable if it ranks within the newest `inventory` un-refunded purchases of its tier.

## Changes

- **Updated `checkResetPassEligibility` function** to accept the full transaction list and compute eligibility based on purchase rank rather than just inventory count
  - Builds a set of refunded transaction IDs to identify un-refunded purchases
  - Counts how many newer un-refunded purchases of the same tier exist
  - Returns `pass_already_used` if the count meets or exceeds available inventory
  - This prevents a second purchase from being refunded against the same unredeemed pass

- **Added comprehensive test coverage** for the new behavior:
  - "with one pass redeemed, only the newest of two purchases is refundable" — validates that older purchases are blocked when inventory is exhausted
  - "both purchases are refundable while inventory covers both" — confirms both can be refunded when inventory allows
  - "a refunded newer purchase no longer blocks the older one" — ensures clawback properly unblocks older purchases
  - "a redeemed lite pass can't be refunded against pro inventory" — verifies tier-bound attribution works correctly

## Implementation Details

The fix uses a rank-based approach: for each purchase, count how many newer un-refunded purchases of the same tier exist. If this count is >= available inventory, the purchase is ineligible. This handles both the steady-state case (preventing double-refunds) and the transient window before the `charge.refunded` webhook records a clawback.

https://claude.ai/code/session_015YhmLC9ModCS2f7AZ9BYSb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-refund eligibility for development plan reset passes.
  * Prevented refunds for passes already consumed by redeemed inventory.
  * Correctly handled partially redeemed, previously refunded, and tier-specific reset passes.
  * Ensured newer eligible purchases are evaluated accurately when determining refundability.

* **Tests**
  * Added coverage for reset-pass inventory, refund, redemption, and tier-boundary scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->