### PR TITLE
feat(models): declare reasoning efforts for xai grok-4.3 on aws-bedrock

### DIFF
--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -726,6 +726,7 @@ export const xaiModels = [
 				streaming: true,
 				vision: true,
 				reasoning: true,
+				reasoningEfforts: ["none", "low", "medium", "high"],
 				reasoningOutput: "omit",
 				tools: true,
 				jsonOutput: true,


### PR DESCRIPTION
## Summary
Declares `reasoningEfforts` for the `grok-4.3` mapping on `providerId: "aws-bedrock"` in `packages/models/src/models/xai.ts`.

## Changes
- `grok-4.3` (aws-bedrock, `xai.grok-4.3`) → `["none", "low", "medium", "high"]`

## Sources
Confirmed independently across four first-party sources:
- [AWS What's New — Grok on Amazon Bedrock](https://aws.amazon.com/about-aws/whats-new/2026/06/grok-amazon-bedrock/): *"Grok 4.3 is a reasoning-first model that offers configurable reasoning effort (none, low, medium, high)."*
- [AWS Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html): confirms always-on, configurable reasoning with the same four values, and model ID `xai.grok-4.3` (matches this mapping's `externalId`).
- [AWS ML Blog — Introducing Grok on Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/introducing-grok-on-amazon-bedrock/)
- [xAI's own announcement](https://x.ai/news/grok-amazon-bedrock), including a sample request using `"reasoning": {"effort": "low"}`.

`minimal` is explicitly not a valid value for this model on Bedrock (confirmed via third-party eval tooling docs noting the API rejects it) — the four-value set is exact, not rounded up.

## Not changed
- `prepare-request-body.ts` — untouched, no code changes, catalog-only PR.
- Other `xai.ts` mappings checked but excluded (native `xai` grok-4, grok-4.20-beta-0309-reasoning, grok-build-0.1; `azure-ai-foundry` grok-4-1-fast-reasoning/grok-4.3; `vertex-openai` grok-4.20-reasoning) — none have documented graduated `reasoning_effort` support at the host level; some are also already deactivated.

## Testing
- `pnpm format` — clean, only `xai.ts` changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reasoning effort levels for the Grok 4.3 model when accessed through AWS Bedrock.
  * Supported levels include none, low, medium, and high.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->