### PR TITLE
feat(admin): show error classification in mappings

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8485,6 +8485,12 @@ const unstableMappingErrorDetailSchema = z.object({
 	statusText: z.string().nullable(),
 	responseText: z.string().nullable(),
 	cause: z.string().nullable(),
+	// The gateway's internal classification stored on the log
+	// (`unified_finish_reason`, e.g. `client_error`, `gateway_error`,
+	// `upstream_error`, `content_filter`). Surfaced because the HTTP status
+	// alone is misleading: some 4xx responses are classified as gateway or
+	// upstream errors.
+	classification: z.string().nullable(),
 	count: z.number(),
 });
 
@@ -8535,11 +8541,13 @@ admin.openapi(getUnstableMappingErrors, async (c) => {
 		status_text: string | null;
 		response_text: string | null;
 		cause: string | null;
+		classification: string | null;
 		count: string;
 		sampled_errors: string;
 	}>(sql`
 		WITH recent_errors AS (
-			SELECT ${tables.log.errorDetails} AS error_details
+			SELECT ${tables.log.errorDetails} AS error_details,
+				${tables.log.unifiedFinishReason} AS classification
 			FROM ${tables.log}
 			WHERE ${tables.log.hasError} = true
 				AND ${tables.log.usedModel} = ${model}
@@ -8553,10 +8561,11 @@ admin.openapi(getUnstableMappingErrors, async (c) => {
 			error_details->>'statusText' AS status_text,
 			LEFT(error_details->>'responseText', 2000) AS response_text,
 			error_details->>'cause' AS cause,
+			classification,
 			COUNT(*) AS count,
 			(SELECT COUNT(*) FROM recent_errors) AS sampled_errors
 		FROM recent_errors
-		GROUP BY status_code, status_text, response_text, cause
+		GROUP BY status_code, status_text, response_text, cause, classification
 		ORDER BY count DESC
 		LIMIT 10
 	`);
@@ -8570,6 +8579,7 @@ admin.openapi(getUnstableMappingErrors, async (c) => {
 			statusText: r.status_text,
 			responseText: r.response_text,
 			cause: r.cause,
+			classification: r.classification,
 			count: Number(r.count),
 		})),
 		sampledErrors,

--- a/ee/admin/src/components/unstable-mappings-table.tsx
+++ b/ee/admin/src/components/unstable-mappings-table.tsx
@@ -36,6 +36,50 @@ const percentFormatter = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 1,
 });
 
+// Human-readable labels and badge styling for the gateway's internal error
+// classification (the log's `unified_finish_reason`). Shown next to the HTTP
+// status because the status alone is misleading — some 4xx responses are
+// classified as gateway or upstream errors.
+const classificationBadges: Record<string, { label: string; class: string }> = {
+	client_error: {
+		label: "Client error",
+		class: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+	},
+	gateway_error: {
+		label: "Gateway error",
+		class: "bg-orange-500/15 text-orange-600 dark:text-orange-400",
+	},
+	upstream_error: {
+		label: "Upstream error",
+		class: "bg-red-500/15 text-red-600 dark:text-red-400",
+	},
+	content_filter: {
+		label: "Content filter",
+		class: "bg-purple-500/15 text-purple-600 dark:text-purple-400",
+	},
+	canceled: {
+		label: "Canceled",
+		class: "bg-muted text-muted-foreground",
+	},
+};
+
+function ClassificationBadge({
+	classification,
+}: {
+	classification: string | null;
+}) {
+	if (!classification) {
+		return null;
+	}
+	const badge = classificationBadges[classification] ?? {
+		label: classification,
+		class: "bg-muted text-muted-foreground",
+	};
+	return (
+		<Badge className={cn("font-medium", badge.class)}>{badge.label}</Badge>
+	);
+}
+
 function errorRateClass(rate: number): string {
 	if (rate >= 0.5) {
 		return "bg-red-500/15 text-red-600 dark:text-red-400";
@@ -128,6 +172,7 @@ function ErrorDetails({
 										{error.statusText}
 									</span>
 								)}
+								<ClassificationBadge classification={error.classification} />
 							</div>
 							<span className="shrink-0 text-sm font-semibold tabular-nums">
 								{error.count.toLocaleString()}×


### PR DESCRIPTION
## Summary

The unstable mappings error drilldown currently only shows the HTTP status of each sampled error (e.g. `404 Not Found`), which can be misleading: some 4xx responses are actually classified internally as gateway or upstream errors (e.g. a 404 `DeploymentNotFound` from Azure is treated as an upstream error, a 402 as a gateway error).

This PR surfaces the gateway's internal error classification next to the status code so it's immediately clear how each error is mapped.

## Changes

- **API** (`GET /admin/unstable-mappings/errors`): the error grouping now includes the log's stored `unified_finish_reason` (the classification computed by the gateway at request time via `getFinishReasonFromError`) and returns it as a new nullable `classification` field on each error group.
- **Admin UI** (unstable mappings table): a color-coded badge next to the status code shows the classification — Client error (blue), Gateway error (orange), Upstream error (red), Content filter (purple), Canceled (muted); unrecognized values are shown as-is with muted styling. Errors with no stored classification render no badge.

## Notes

- The classification comes from the log column rather than being recomputed, so it reflects what the gateway actually decided at request time.
- Adding the column to the `GROUP BY` can split a previously merged group when the same status/body was classified differently over time, which is intentional — that distinction is exactly what the page should show.
- `openapi.json` / generated client types are gitignored and regenerate at build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GE2FfC3Xk8mkpbfqxusf3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01GE2FfC3Xk8mkpbfqxusf3r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error classification details to unstable mapping error responses.
  * Error details now display readable classification badges, including client, gateway, upstream, content filter, and canceled statuses.
  * Unknown classifications receive a fallback label and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->