### PR TITLE
fix(bedrock): drop empty messages in Converse builder

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -3511,6 +3511,45 @@ describe("prepareRequestBody - max_tokens forwarding", () => {
 			// replaced by the model maxOutput.
 			expect(requestBody.inferenceConfig?.maxTokens).toBe(5000);
 		});
+
+		test("drops messages whose content resolves to empty", async () => {
+			// Bedrock's Converse API 400s on messages with an empty content array
+			// ("The content field in the Message object at messages.N is empty"),
+			// while the Anthropic API accepts empty assistant turns and the
+			// Anthropic transform drops empty messages entirely. The Bedrock
+			// builder must drop them too.
+			const requestBody = (await prepareRequestBody(
+				"aws-bedrock",
+				"claude-sonnet-4-6",
+				null,
+				"anthropic.claude-sonnet-4-6",
+				[
+					{ role: "user", content: "say hi" },
+					{ role: "assistant", content: "" },
+					{ role: "user", content: [{ type: "text", text: "" }] as any },
+					{ role: "assistant", content: [] as any },
+					{ role: "assistant", content: "", tool_calls: [] },
+					{ role: "user", content: "say hi again" },
+				],
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+			)) as any;
+
+			expect(requestBody.messages).toEqual([
+				{ role: "user", content: [{ text: "say hi" }] },
+				{ role: "user", content: [{ text: "say hi again" }] },
+			]);
+		});
 	});
 
 	describe("openai (Chat Completions)", () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2839,7 +2839,7 @@ export async function prepareRequestBody(
 				};
 
 				// Handle assistant messages with tool calls
-				if (msg.role === "assistant" && msg.tool_calls) {
+				if (msg.role === "assistant" && msg.tool_calls?.length) {
 					// Add text content if present
 					if (msg.content) {
 						bedrockMessage.content.push({
@@ -2958,6 +2958,15 @@ export async function prepareRequestBody(
 							}
 						}
 					}
+				}
+
+				// Bedrock's Converse API rejects messages whose content array is
+				// empty ("The content field in the Message object at messages.N is
+				// empty"), while the Anthropic API accepts empty assistant turns.
+				// Mirror transformAnthropicMessages and drop such messages —
+				// Bedrock accepts the resulting consecutive same-role messages.
+				if (bedrockMessage.content.length === 0) {
+					continue;
 				}
 
 				bedrockMessages.push(bedrockMessage);


### PR DESCRIPTION
## Problem

Prod is seeing a 38.5% error rate on `aws-bedrock/claude-opus-4-8:global`:

> 400: The content field in the Message object at messages.355 is empty. Add a ContentBlock object to the content field and try again.

When an incoming conversation contains a message whose content resolves to nothing (e.g. an assistant turn with `content: ""`, `content: []`, or only empty/whitespace text parts), the Bedrock Converse builder in `prepareRequestBody` still emitted the message with an empty `content` array, which Bedrock rejects.

## Upstream behavior (verified against real APIs)

- **Anthropic `/v1/messages`**: accepts empty assistant turns (`""` and `[]`) mid-conversation; rejects empty **user** messages and whitespace-only text blocks.
- **Bedrock Converse**: rejects any message with an empty content array for either role (the exact prod error), but **accepts** the conversation with the empty message dropped — consecutive same-role messages are fine.
- The gateway's Anthropic transform (`transformAnthropicMessages`) already drops content-less messages, which is why the same conversations succeed on the `anthropic` provider and only fail on `aws-bedrock`.

## Fix

Mirror the Anthropic transform in the Bedrock Converse builder: skip any message whose built `content` array ends up empty (also treating an empty `tool_calls: []` array as no tool calls so such messages fall through to the same guard).

## Testing

- Reproduced the exact 400 through the local gateway pinned to `aws-bedrock/claude-haiku-4-5` with `x-no-fallback`, and confirmed the fix returns 200 against the **real Bedrock upstream** (non-streaming + streaming with tool-use history).
- Confirmed the `anthropic` provider path is unchanged and still succeeds.
- Added a unit test covering empty-string / empty-array / empty-text-part / empty-`tool_calls` messages.
- `pnpm test:unit` (2845 passed), `pnpm build`, `pnpm format` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS Bedrock requests that included empty messages, preventing empty-content validation errors.
  * Improved handling of assistant messages so tool-call processing occurs only when actual tool calls are present.
  * Ensured empty assistant and user messages are excluded from generated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->