### PR TITLE
fix(moderations): retry with next env key on auth error

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1622,6 +1622,122 @@ describe("api", () => {
 		expect(moderationLog?.content).toContain('"flagged":true');
 	});
 
+	test("/v1/moderations retries with next env key on invalid key", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await harness.setProjectMode("credits");
+
+		const previousOpenAIKey = process.env.LLM_OPENAI_API_KEY;
+		const requestId = "moderation-key-rotation-request-id";
+		const attemptedKeys: (string | null)[] = [];
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+				expect(url).toBe("https://api.openai.com/v1/moderations");
+
+				const headers = new Headers(init?.headers);
+				const auth = headers.get("authorization");
+				attemptedKeys.push(auth);
+
+				if (auth === "Bearer sk-bad-key") {
+					return new Response(
+						JSON.stringify({
+							error: {
+								message: "Incorrect API key provided: sk-bad-key.",
+								type: "invalid_request_error",
+								param: null,
+								code: "invalid_api_key",
+							},
+						}),
+						{
+							status: 401,
+							headers: { "Content-Type": "application/json" },
+						},
+					);
+				}
+
+				expect(auth).toBe("Bearer sk-good-key");
+				return new Response(
+					JSON.stringify({
+						id: "modr-456",
+						model: "omni-moderation-latest",
+						results: [
+							{
+								flagged: false,
+							},
+						],
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			});
+
+		resetKeyHealth();
+		try {
+			process.env.LLM_OPENAI_API_KEY = "sk-bad-key,sk-good-key";
+
+			const res = await app.request("/v1/moderations", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					input: "Just a harmless sentence.",
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const json = await res.json();
+			expect(json).toHaveProperty("id", "modr-456");
+			expect(json.results[0].flagged).toBe(false);
+			expect(attemptedKeys).toEqual([
+				"Bearer sk-bad-key",
+				"Bearer sk-good-key",
+			]);
+
+			const logs = await waitForLogs(2);
+			const moderationLogs = logs.filter((log) => log.requestId === requestId);
+			expect(moderationLogs).toHaveLength(2);
+
+			const failedAttempt = moderationLogs.find((log) => log.hasError);
+			const successAttempt = moderationLogs.find((log) => !log.hasError);
+
+			expect(failedAttempt).toBeTruthy();
+			expect(failedAttempt?.finishReason).toBe("gateway_error");
+			expect(failedAttempt?.retried).toBe(true);
+			expect(failedAttempt?.retriedByLogId).toBe(successAttempt?.id);
+
+			expect(successAttempt).toBeTruthy();
+			expect(successAttempt?.finishReason).toBe("stop");
+			expect(successAttempt?.content).toContain('"flagged":false');
+		} finally {
+			fetchSpy.mockRestore();
+			resetKeyHealth();
+			if (previousOpenAIKey === undefined) {
+				delete process.env.LLM_OPENAI_API_KEY;
+			} else {
+				process.env.LLM_OPENAI_API_KEY = previousOpenAIKey;
+			}
+		}
+	});
+
 	test("/v1/embeddings e2e success", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-embeddings",

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -5,6 +5,7 @@ import { createLogEntry } from "@/chat/tools/create-log-entry.js";
 import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
 import { getFinishReasonFromError } from "@/chat/tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "@/chat/tools/get-provider-env.js";
+import { shouldRetryAlternateKey } from "@/chat/tools/retry-with-fallback.js";
 import { validateSource } from "@/chat/tools/validate-source.js";
 import {
 	reportKeyError,
@@ -509,274 +510,327 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 	};
 	c.req.raw.signal.addEventListener("abort", onAbort);
 
-	let upstreamResponse: Response;
-	let upstreamText: string;
-	let duration: number;
-	let responseSize: number;
+	// An auth failure (or transient upstream failure) is often isolated to a
+	// single credential, so rotate through the remaining env keys instead of
+	// failing the request on the first bad key — mirroring the alternate-key
+	// retry in the chat completions route. Bounded by the number of configured
+	// keys: every tried index is excluded from re-selection.
+	const finalLogId = shortid();
+	const triedEnvIndices = new Set<number>();
+	const rotateToNextEnvKey = (): boolean => {
+		if (envVarName === undefined) {
+			return false;
+		}
+		triedEnvIndices.add(configIndex);
+		try {
+			const envResult = getProviderEnv("openai", {
+				selectionScope: upstreamModel,
+				excludedIndices: triedEnvIndices,
+			});
+			usedToken = envResult.token;
+			configIndex = envResult.configIndex;
+			envVarName = envResult.envVarName;
+			return true;
+		} catch {
+			return false;
+		}
+	};
 
 	try {
-		const fetchSignal = createCombinedSignal(controller);
-		upstreamResponse = await fetch(upstreamUrl, {
-			method: "POST",
-			// SSRF: never follow redirects on an authenticated provider request. A
-			// tenant-supplied baseUrl could 3xx to an internal host at request time,
-			// and a redirect would also leak the upstream token.
-			redirect: "error",
-			headers: {
-				"Content-Type": "application/json",
-				...getProviderHeaders("openai", usedToken, { requestId }),
-			},
-			body: JSON.stringify(requestBody),
-			signal: fetchSignal,
-		});
+		while (true) {
+			let upstreamResponse: Response;
+			let upstreamText: string;
+			let duration: number;
 
-		upstreamText = await upstreamResponse.text();
-		duration = Date.now() - startedAt;
-		responseSize = upstreamText.length;
-	} catch (error) {
-		duration = Date.now() - startedAt;
-		if (envVarName !== undefined) {
-			reportKeyError(envVarName, configIndex, 0);
-		}
-		if (providerKey?.id) {
-			reportTrackedKeyError(providerKey.id, 0);
-		}
-
-		const isCanceled = error instanceof Error && error.name === "AbortError";
-		const isTimeout = isTimeoutError(error);
-
-		await insertLog({
-			...baseLogEntry,
-			duration,
-			timeToFirstToken: null,
-			timeToFirstReasoningToken: null,
-			responseSize: 0,
-			content: null,
-			reasoningContent: null,
-			finishReason: isCanceled ? "canceled" : "upstream_error",
-			promptTokens: null,
-			completionTokens: null,
-			totalTokens: null,
-			reasoningTokens: null,
-			cachedTokens: null,
-			hasError: !isCanceled,
-			streamed: false,
-			canceled: isCanceled,
-			errorDetails: isCanceled
-				? null
-				: {
-						statusCode: 0,
-						statusText: error instanceof Error ? error.name : "FetchError",
-						responseText:
-							error instanceof Error ? error.message : String(error),
+			try {
+				const fetchSignal = createCombinedSignal(controller);
+				upstreamResponse = await fetch(upstreamUrl, {
+					method: "POST",
+					// SSRF: never follow redirects on an authenticated provider request. A
+					// tenant-supplied baseUrl could 3xx to an internal host at request time,
+					// and a redirect would also leak the upstream token.
+					redirect: "error",
+					headers: {
+						"Content-Type": "application/json",
+						...getProviderHeaders("openai", usedToken, { requestId }),
 					},
-			inputCost: 0,
-			outputCost: 0,
-			cachedInputCost: 0,
-			requestCost: 0,
-			webSearchCost: 0,
-			imageInputTokens: null,
-			imageOutputTokens: null,
-			imageInputCost: null,
-			imageOutputCost: null,
-			cost: 0,
-			estimatedCost: false,
-			discount: null,
-			pricingTier: null,
-			dataStorageCost: calculateDataStorageCost(
-				null,
-				null,
-				null,
-				null,
-				retentionLevel,
-			),
-			cached: false,
-			toolResults: null,
-		});
+					body: JSON.stringify(requestBody),
+					signal: fetchSignal,
+				});
 
-		if (isCanceled) {
-			return c.json(
-				{
-					error: {
-						message: "Request canceled by client",
-						type: "canceled",
-						param: null,
-						code: "request_canceled",
+				upstreamText = await upstreamResponse.text();
+				duration = Date.now() - startedAt;
+			} catch (error) {
+				duration = Date.now() - startedAt;
+				if (envVarName !== undefined) {
+					reportKeyError(envVarName, configIndex, 0);
+				}
+				if (providerKey?.id) {
+					reportTrackedKeyError(providerKey.id, 0);
+				}
+
+				const isCanceled =
+					error instanceof Error && error.name === "AbortError";
+				const isTimeout = isTimeoutError(error);
+				const willRetry = !isCanceled && rotateToNextEnvKey();
+
+				await insertLog({
+					...baseLogEntry,
+					duration,
+					timeToFirstToken: null,
+					timeToFirstReasoningToken: null,
+					responseSize: 0,
+					content: null,
+					reasoningContent: null,
+					finishReason: isCanceled ? "canceled" : "upstream_error",
+					promptTokens: null,
+					completionTokens: null,
+					totalTokens: null,
+					reasoningTokens: null,
+					cachedTokens: null,
+					hasError: !isCanceled,
+					streamed: false,
+					canceled: isCanceled,
+					errorDetails: isCanceled
+						? null
+						: {
+								statusCode: 0,
+								statusText: error instanceof Error ? error.name : "FetchError",
+								responseText:
+									error instanceof Error ? error.message : String(error),
+							},
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					webSearchCost: 0,
+					imageInputTokens: null,
+					imageOutputTokens: null,
+					imageInputCost: null,
+					imageOutputCost: null,
+					cost: 0,
+					estimatedCost: false,
+					discount: null,
+					pricingTier: null,
+					dataStorageCost: calculateDataStorageCost(
+						null,
+						null,
+						null,
+						null,
+						retentionLevel,
+					),
+					cached: false,
+					toolResults: null,
+					retried: willRetry,
+					retriedByLogId: willRetry ? finalLogId : null,
+				});
+
+				if (willRetry) {
+					continue;
+				}
+
+				if (isCanceled) {
+					return c.json(
+						{
+							error: {
+								message: "Request canceled by client",
+								type: "canceled",
+								param: null,
+								code: "request_canceled",
+							},
+						},
+						400,
+					);
+				}
+
+				return c.json(
+					{
+						error: {
+							message: isTimeout
+								? `Upstream provider timeout: ${
+										error instanceof Error ? error.message : String(error)
+									}`
+								: `Failed to connect to provider: ${
+										error instanceof Error ? error.message : String(error)
+									}`,
+							type: isTimeout ? "upstream_timeout" : "upstream_error",
+							param: null,
+							code: isTimeout ? "timeout" : "fetch_failed",
+						},
 					},
-				},
-				400,
-			);
-		}
+					isTimeout ? 504 : 502,
+				);
+			}
 
-		return c.json(
-			{
-				error: {
-					message: isTimeout
-						? `Upstream provider timeout: ${
-								error instanceof Error ? error.message : String(error)
-							}`
-						: `Failed to connect to provider: ${
-								error instanceof Error ? error.message : String(error)
-							}`,
-					type: isTimeout ? "upstream_timeout" : "upstream_error",
-					param: null,
-					code: isTimeout ? "timeout" : "fetch_failed",
-				},
-			},
-			isTimeout ? 504 : 502,
-		);
+			const responseSize = upstreamText.length;
+
+			let upstreamJson: unknown = null;
+			if (upstreamText) {
+				try {
+					upstreamJson = JSON.parse(upstreamText);
+				} catch {
+					upstreamJson = upstreamText;
+				}
+			}
+
+			if (!upstreamResponse.ok) {
+				if (envVarName !== undefined) {
+					reportKeyError(
+						envVarName,
+						configIndex,
+						upstreamResponse.status,
+						upstreamText,
+					);
+				}
+				if (providerKey?.id) {
+					reportTrackedKeyError(
+						providerKey.id,
+						upstreamResponse.status,
+						upstreamText,
+					);
+				}
+
+				const finishReason = getFinishReasonFromError(
+					upstreamResponse.status,
+					upstreamText,
+				);
+				const willRetry =
+					shouldRetryAlternateKey(
+						finishReason,
+						upstreamResponse.status,
+						upstreamText,
+					) && rotateToNextEnvKey();
+
+				await insertLog({
+					...baseLogEntry,
+					duration,
+					timeToFirstToken: null,
+					timeToFirstReasoningToken: null,
+					responseSize,
+					content: getResponseContent(upstreamJson),
+					reasoningContent: null,
+					finishReason,
+					promptTokens: null,
+					completionTokens: null,
+					totalTokens: null,
+					reasoningTokens: null,
+					cachedTokens: null,
+					hasError: true,
+					streamed: false,
+					canceled: false,
+					errorDetails: {
+						statusCode: upstreamResponse.status,
+						statusText: upstreamResponse.statusText,
+						responseText: upstreamText,
+					},
+					inputCost: 0,
+					outputCost: 0,
+					cachedInputCost: 0,
+					requestCost: 0,
+					webSearchCost: 0,
+					imageInputTokens: null,
+					imageOutputTokens: null,
+					imageInputCost: null,
+					imageOutputCost: null,
+					cost: 0,
+					estimatedCost: false,
+					discount: null,
+					pricingTier: null,
+					dataStorageCost: calculateDataStorageCost(
+						null,
+						null,
+						null,
+						null,
+						retentionLevel,
+					),
+					cached: false,
+					toolResults: null,
+					retried: willRetry,
+					retriedByLogId: willRetry ? finalLogId : null,
+				});
+
+				if (willRetry) {
+					continue;
+				}
+
+				return c.json(
+					(typeof upstreamJson === "string"
+						? buildOpenAIErrorBody({
+								message: upstreamJson,
+								status: upstreamResponse.status,
+							})
+						: upstreamJson) ??
+						buildOpenAIErrorBody({
+							message: "An error occurred",
+							status: upstreamResponse.status,
+						}),
+					upstreamResponse.status as
+						| 400
+						| 401
+						| 403
+						| 404
+						| 410
+						| 429
+						| 500
+						| 502
+						| 503
+						| 504,
+				);
+			}
+
+			if (envVarName !== undefined) {
+				reportKeySuccess(envVarName, configIndex);
+			}
+			if (providerKey?.id) {
+				reportTrackedKeySuccess(providerKey.id);
+			}
+
+			await insertLog({
+				...baseLogEntry,
+				id: finalLogId,
+				duration,
+				timeToFirstToken: null,
+				timeToFirstReasoningToken: null,
+				responseSize,
+				content: getResponseContent(upstreamJson),
+				reasoningContent: null,
+				finishReason: "stop",
+				promptTokens: null,
+				completionTokens: null,
+				totalTokens: null,
+				reasoningTokens: null,
+				cachedTokens: null,
+				hasError: false,
+				streamed: false,
+				canceled: false,
+				errorDetails: null,
+				inputCost: 0,
+				outputCost: 0,
+				cachedInputCost: 0,
+				requestCost: 0,
+				webSearchCost: 0,
+				imageInputTokens: null,
+				imageOutputTokens: null,
+				imageInputCost: null,
+				imageOutputCost: null,
+				cost: 0,
+				estimatedCost: false,
+				discount: null,
+				pricingTier: null,
+				dataStorageCost: calculateDataStorageCost(
+					null,
+					null,
+					null,
+					null,
+					retentionLevel,
+				),
+				cached: false,
+				toolResults: null,
+			});
+
+			return c.json(upstreamJson as any);
+		}
 	} finally {
 		c.req.raw.signal.removeEventListener("abort", onAbort);
 	}
-
-	let upstreamJson: unknown = null;
-	if (upstreamText) {
-		try {
-			upstreamJson = JSON.parse(upstreamText);
-		} catch {
-			upstreamJson = upstreamText;
-		}
-	}
-
-	if (!upstreamResponse.ok) {
-		if (envVarName !== undefined) {
-			reportKeyError(
-				envVarName,
-				configIndex,
-				upstreamResponse.status,
-				upstreamText,
-			);
-		}
-		if (providerKey?.id) {
-			reportTrackedKeyError(
-				providerKey.id,
-				upstreamResponse.status,
-				upstreamText,
-			);
-		}
-
-		await insertLog({
-			...baseLogEntry,
-			duration,
-			timeToFirstToken: null,
-			timeToFirstReasoningToken: null,
-			responseSize,
-			content: getResponseContent(upstreamJson),
-			reasoningContent: null,
-			finishReason: getFinishReasonFromError(
-				upstreamResponse.status,
-				upstreamText,
-			),
-			promptTokens: null,
-			completionTokens: null,
-			totalTokens: null,
-			reasoningTokens: null,
-			cachedTokens: null,
-			hasError: true,
-			streamed: false,
-			canceled: false,
-			errorDetails: {
-				statusCode: upstreamResponse.status,
-				statusText: upstreamResponse.statusText,
-				responseText: upstreamText,
-			},
-			inputCost: 0,
-			outputCost: 0,
-			cachedInputCost: 0,
-			requestCost: 0,
-			webSearchCost: 0,
-			imageInputTokens: null,
-			imageOutputTokens: null,
-			imageInputCost: null,
-			imageOutputCost: null,
-			cost: 0,
-			estimatedCost: false,
-			discount: null,
-			pricingTier: null,
-			dataStorageCost: calculateDataStorageCost(
-				null,
-				null,
-				null,
-				null,
-				retentionLevel,
-			),
-			cached: false,
-			toolResults: null,
-		});
-
-		return c.json(
-			(typeof upstreamJson === "string"
-				? buildOpenAIErrorBody({
-						message: upstreamJson,
-						status: upstreamResponse.status,
-					})
-				: upstreamJson) ??
-				buildOpenAIErrorBody({
-					message: "An error occurred",
-					status: upstreamResponse.status,
-				}),
-			upstreamResponse.status as
-				| 400
-				| 401
-				| 403
-				| 404
-				| 410
-				| 429
-				| 500
-				| 502
-				| 503
-				| 504,
-		);
-	}
-
-	if (envVarName !== undefined) {
-		reportKeySuccess(envVarName, configIndex);
-	}
-	if (providerKey?.id) {
-		reportTrackedKeySuccess(providerKey.id);
-	}
-
-	await insertLog({
-		...baseLogEntry,
-		duration,
-		timeToFirstToken: null,
-		timeToFirstReasoningToken: null,
-		responseSize,
-		content: getResponseContent(upstreamJson),
-		reasoningContent: null,
-		finishReason: "stop",
-		promptTokens: null,
-		completionTokens: null,
-		totalTokens: null,
-		reasoningTokens: null,
-		cachedTokens: null,
-		hasError: false,
-		streamed: false,
-		canceled: false,
-		errorDetails: null,
-		inputCost: 0,
-		outputCost: 0,
-		cachedInputCost: 0,
-		requestCost: 0,
-		webSearchCost: 0,
-		imageInputTokens: null,
-		imageOutputTokens: null,
-		imageInputCost: null,
-		imageOutputCost: null,
-		cost: 0,
-		estimatedCost: false,
-		discount: null,
-		pricingTier: null,
-		dataStorageCost: calculateDataStorageCost(
-			null,
-			null,
-			null,
-			null,
-			retentionLevel,
-		),
-		cached: false,
-		toolResults: null,
-	});
-
-	return c.json(upstreamJson as any);
 });


### PR DESCRIPTION
## Summary

The `/v1/moderations` route sent a single request with the selected provider key and returned upstream errors directly. When one key in the comma-separated OpenAI env key list is invalid, requests failed with a 401 `invalid_api_key` instead of retrying with the next key — unlike chat completions, which already rotates to an alternate key in this case:

```json
{
  "error": {
    "message": "Incorrect API key provided: sk***c2...",
    "code": "invalid_api_key"
  },
  "status": 401
}
```

## Changes

- Wrap the upstream moderation call in a retry loop that rotates to the next configured env key (via `getProviderEnv` with `excludedIndices`) when the attempt fails with an auth error or a retryable upstream error, using the same `shouldRetryAlternateKey` predicate as the chat completions route. The loop is bounded by the number of configured keys since every tried index is excluded from re-selection.
- Network errors and timeouts also rotate (mirroring chat); client cancellations do not.
- Each failed attempt is still logged and reported to key health tracking; retried attempts are marked `retried: true` with `retriedByLogId` linking to the final log entry.
- BYOK provider keys are unchanged (there is only a single tracked key per org/provider, so there is nothing to rotate to).

## Testing

- Added a spec test that configures `LLM_OPENAI_API_KEY` with a bad + good key, asserts the 401 attempt rotates to the good key and succeeds, and verifies both log entries including the `retried`/`retriedByLogId` link.
- `pnpm vitest run apps/gateway/src/api.spec.ts -t moderations` — 4 passed (including the existing success and timeout tests).
- `turbo run build --filter=gateway` passes; `pnpm format` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)