### PR TITLE
test: cover each declared reasoning effort in e2e

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -626,12 +626,15 @@ export function getSupportedReasoningEffort(
 
 // One test case per (reasoning model, declared effort) so every effort tier a
 // mapping declares via `reasoningEfforts` is exercised against the endpoint.
-export const reasoningEffortModels = reasoningModels.flatMap((m) =>
-	(
-		m.providers.find((p: ProviderModelMapping) => p.reasoning === true)
-			?.reasoningEfforts ?? []
-	).map((effort) => ({ model: m.model, effort })),
-);
+// Only expanded in FULL_MODE — it multiplies each mapping by its effort count.
+export const reasoningEffortModels = fullMode
+	? reasoningModels.flatMap((m) =>
+			(
+				m.providers.find((p: ProviderModelMapping) => p.reasoning === true)
+					?.reasoningEfforts ?? []
+			).map((effort) => ({ model: m.model, effort })),
+		)
+	: [];
 
 export const verbosityModels = testModels.filter((m) =>
 	m.providers.some((p: ProviderModelMapping) => p.verbosity === true),

--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -624,6 +624,15 @@ export function getSupportedReasoningEffort(
 	return "medium";
 }
 
+// One test case per (reasoning model, declared effort) so every effort tier a
+// mapping declares via `reasoningEfforts` is exercised against the endpoint.
+export const reasoningEffortModels = reasoningModels.flatMap((m) =>
+	(
+		m.providers.find((p: ProviderModelMapping) => p.reasoning === true)
+			?.reasoningEfforts ?? []
+	).map((effort) => ({ model: m.model, effort })),
+);
+
 export const verbosityModels = testModels.filter((m) =>
 	m.providers.some((p: ProviderModelMapping) => p.verbosity === true),
 );

--- a/apps/gateway/src/chat-reasoning.e2e.ts
+++ b/apps/gateway/src/chat-reasoning.e2e.ts
@@ -10,6 +10,7 @@ import {
 	getSupportedReasoningEffort,
 	getTestOptions,
 	logMode,
+	reasoningEffortModels,
 	reasoningModels,
 	validateLogByRequestId,
 	validateResponse,
@@ -109,6 +110,44 @@ describe("e2e", getConcurrentTestOptions(), () => {
 			if (shouldCheckReasoning) {
 				expect(json.choices[0].message).toHaveProperty("reasoning");
 			}
+		},
+	);
+
+	test.each(reasoningEffortModels)(
+		"reasoning effort $effort $model",
+		getTestOptions(),
+		async ({ model, effort }) => {
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: model,
+					messages: [
+						{
+							role: "user",
+							content: "What is 2/3 + 1/4?",
+						},
+					],
+					reasoning_effort: effort,
+				}),
+			});
+
+			const json = await res.json();
+			if (logMode) {
+				console.log(
+					`reasoning effort ${effort} response:`,
+					JSON.stringify(json, null, 2),
+				);
+			}
+
+			expect(res.status).toBe(200);
+			validateResponse(json);
 		},
 	);
 });


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WixRYE3XSqm2cmMmjtyjwc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for models supporting configurable reasoning effort levels.
  * Added a parameterized set of end-to-end checks to verify chat completion succeeds for each supported model/effort combination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->