### PR TITLE
fix: retry 405 responses with another key

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -36,6 +36,13 @@ describe("getFinishReasonFromError", () => {
 		).toBe("gateway_error");
 	});
 
+	it("returns gateway_error for 405 method not allowed", () => {
+		expect(getFinishReasonFromError(405)).toBe("gateway_error");
+		expect(getFinishReasonFromError(405, "Method Not Allowed")).toBe(
+			"gateway_error",
+		);
+	});
+
 	it("returns content_filter for Azure ResponsibleAIPolicyViolation", () => {
 		const azureError = JSON.stringify({
 			error: {

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -8,6 +8,7 @@ import { isContentFilterErrorText } from "@llmgateway/shared";
  * 429 status codes indicate upstream rate limiting (treated as upstream error)
  * 404 status codes indicate model/endpoint not found at provider (treated as upstream error)
  * 401/403 status codes indicate authentication/authorization issues (gateway configuration errors)
+ * 405 status codes indicate the upstream rejected the request method (gateway endpoint mapping error)
  * Other 4xx status codes indicate client errors
  * Special client errors (like JSON format validation) are classified as client_error
  *
@@ -38,6 +39,14 @@ export function getFinishReasonFromError(
 	// account problem, not a client error, so classify as gateway_error to allow
 	// fallback to another provider.
 	if (statusCode === 402) {
+		return "gateway_error";
+	}
+
+	// 405 Method Not Allowed means the upstream rejected the HTTP method the
+	// gateway used — a gateway-side endpoint/method mapping problem for the
+	// selected provider or key, never a client fault, so classify as
+	// gateway_error so the request can be retried with another key or provider.
+	if (statusCode === 405) {
 		return "gateway_error";
 	}
 


### PR DESCRIPTION
## Summary

Upstream `405 Method Not Allowed` responses (seen ~199× as a bare `Method Not Allowed` body) were falling through the generic 4xx branch in `getFinishReasonFromError` and being classified as `client_error`, which is non-retryable — the gateway passed the error straight through to the client instead of trying another key or provider.

A 405 from an upstream is a gateway-side endpoint/method mapping problem for the selected provider or key, never the client's fault (the client only ever calls our OpenAI-compatible API). This change classifies status 405 as `gateway_error`, which:

- makes `shouldRetryAlternateKey` rotate to another configured key for the same provider
- makes `shouldRetryRequest` eligible for cross-provider fallback

The classification is shared, so chat completions (streaming + non-streaming), embeddings, OCR, speech, and moderations all pick it up.

## Changes

- `apps/gateway/src/chat/tools/get-finish-reason-from-error.ts`: return `gateway_error` for status 405 before the generic 4xx → `client_error` fallthrough
- `apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts`: cover 405 with and without the `Method Not Allowed` body

## Testing

- `vitest run` on `get-finish-reason-from-error.spec.ts` and `retry-with-fallback.spec.ts` — 83 tests pass
- `turbo run build --filter=gateway` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaRyArvA9Dv3A8gzPPLyTN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaRyArvA9Dv3A8gzPPLyTN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for HTTP 405 “Method Not Allowed” responses.
  * These responses are now consistently reported as gateway errors, including when an error message is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->