### PR TITLE
feat: add more unstable mappings time windows

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8311,13 +8311,28 @@ const UNSTABLE_MAPPINGS_MAX_LOG_LIMIT = 1000000;
 // Supported time windows for the rankings, mapping each selectable value to its
 // SQL interval bound and an hours count surfaced to the UI for the description.
 const UNSTABLE_MAPPINGS_WINDOWS = {
+	"1h": { interval: sql`now() - interval '1 hour'`, hours: 1 },
+	"2h": { interval: sql`now() - interval '2 hours'`, hours: 2 },
 	"4h": { interval: sql`now() - interval '4 hours'`, hours: 4 },
+	"8h": { interval: sql`now() - interval '8 hours'`, hours: 8 },
+	"12h": { interval: sql`now() - interval '12 hours'`, hours: 12 },
+	"16h": { interval: sql`now() - interval '16 hours'`, hours: 16 },
 	"24h": { interval: sql`now() - interval '24 hours'`, hours: 24 },
 	"3d": { interval: sql`now() - interval '3 days'`, hours: 72 },
 	"7d": { interval: sql`now() - interval '7 days'`, hours: 168 },
 } as const;
 
-const unstableMappingsWindowSchema = z.enum(["4h", "24h", "3d", "7d"]);
+const unstableMappingsWindowSchema = z.enum([
+	"1h",
+	"2h",
+	"4h",
+	"8h",
+	"12h",
+	"16h",
+	"24h",
+	"3d",
+	"7d",
+]);
 
 type UnstableMappingsWindow = keyof typeof UNSTABLE_MAPPINGS_WINDOWS;
 

--- a/ee/admin/src/lib/unstable-mappings-params.ts
+++ b/ee/admin/src/lib/unstable-mappings-params.ts
@@ -1,4 +1,13 @@
-export type UnstableWindow = "4h" | "24h" | "3d" | "7d";
+export type UnstableWindow =
+	| "1h"
+	| "2h"
+	| "4h"
+	| "8h"
+	| "12h"
+	| "16h"
+	| "24h"
+	| "3d"
+	| "7d";
 
 export const UNSTABLE_WINDOW_DEFAULT: UnstableWindow = "4h";
 
@@ -6,14 +15,24 @@ export const UNSTABLE_WINDOW_OPTIONS: {
 	value: UnstableWindow;
 	label: string;
 }[] = [
+	{ value: "1h", label: "1h" },
+	{ value: "2h", label: "2h" },
 	{ value: "4h", label: "4h" },
+	{ value: "8h", label: "8h" },
+	{ value: "12h", label: "12h" },
+	{ value: "16h", label: "16h" },
 	{ value: "24h", label: "24h" },
 	{ value: "3d", label: "3d" },
 	{ value: "7d", label: "7d" },
 ];
 
 export const UNSTABLE_WINDOW_LABELS: Record<UnstableWindow, string> = {
+	"1h": "1 hour",
+	"2h": "2 hours",
 	"4h": "4 hours",
+	"8h": "8 hours",
+	"12h": "12 hours",
+	"16h": "16 hours",
 	"24h": "24 hours",
 	"3d": "3 days",
 	"7d": "7 days",


### PR DESCRIPTION
## Summary

Adds 1h, 2h, 8h, 12h and 16h time window options to the admin Unstable Mappings rankings, alongside the existing 4h/24h/3d/7d. The default window stays at 4h.

## Changes

- `apps/api/src/routes/admin.ts`: extended `UNSTABLE_MAPPINGS_WINDOWS` and `unstableMappingsWindowSchema` with the new intervals for both the `/admin/unstable-mappings` and `/admin/unstable-mappings/errors` endpoints.
- `ee/admin/src/lib/unstable-mappings-params.ts`: extended the `UnstableWindow` type, toggle options, and labels so the new windows are selectable in the admin dashboard.

The regenerated OpenAPI spec / admin client types (gitignored) pick up the new enum values automatically.

## Testing

- `pnpm build` passes across all 17 tasks.
- Verified the regenerated admin client types include the full `"1h" | "2h" | "4h" | "8h" | "12h" | "16h" | "24h" | "3d" | "7d"` window enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca5PtfDwERck27diYWkFVN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca5PtfDwERck27diYWkFVN)_