### PR TITLE
feat: group unstable mapping errors by streaming

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -8553,6 +8553,10 @@ const unstableMappingErrorDetailSchema = z.object({
 	// alone is misleading: some 4xx responses are classified as gateway or
 	// upstream errors.
 	classification: z.string().nullable(),
+	// Whether the failed request was a streaming request. Streaming and
+	// non-streaming failures often have different causes, so the drilldown
+	// groups errors by this flag.
+	streamed: z.boolean(),
 	count: z.number(),
 });
 
@@ -8614,12 +8618,14 @@ admin.openapi(getUnstableMappingErrors, async (c) => {
 		response_text: string | null;
 		cause: string | null;
 		classification: string | null;
+		streamed: boolean;
 		count: string;
 		sampled_errors: string;
 	}>(sql`
 		WITH recent_errors AS (
 			SELECT ${tables.log.errorDetails} AS error_details,
-				${tables.log.unifiedFinishReason} AS classification
+				${tables.log.unifiedFinishReason} AS classification,
+				COALESCE(${tables.log.streamed}, false) AS streamed
 			FROM ${tables.log}
 			WHERE ${tables.log.hasError} = true
 				AND ${tables.log.usedModel} = ${model}
@@ -8635,10 +8641,11 @@ admin.openapi(getUnstableMappingErrors, async (c) => {
 			LEFT(error_details->>'responseText', 2000) AS response_text,
 			error_details->>'cause' AS cause,
 			classification,
+			streamed,
 			COUNT(*) AS count,
 			(SELECT COUNT(*) FROM recent_errors) AS sampled_errors
 		FROM recent_errors
-		GROUP BY status_code, status_text, response_text, cause, classification
+		GROUP BY status_code, status_text, response_text, cause, classification, streamed
 		ORDER BY count DESC
 		LIMIT 10
 	`);
@@ -8653,6 +8660,7 @@ admin.openapi(getUnstableMappingErrors, async (c) => {
 			responseText: r.response_text,
 			cause: r.cause,
 			classification: r.classification,
+			streamed: r.streamed,
 			count: Number(r.count),
 		})),
 		sampledErrors,

--- a/ee/admin/src/components/unstable-mappings-table.tsx
+++ b/ee/admin/src/components/unstable-mappings-table.tsx
@@ -151,49 +151,83 @@ function ErrorDetails({
 		);
 	}
 
+	// Streaming and non-streaming requests often fail differently, so split
+	// the drilldown into one section per mode to make debugging easier.
+	const groups = [
+		{
+			label: "Streaming",
+			badgeClass: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400",
+			errors: errors.filter((error) => error.streamed),
+		},
+		{
+			label: "Non-streaming",
+			badgeClass: "bg-muted text-muted-foreground",
+			errors: errors.filter((error) => !error.streamed),
+		},
+	].filter((group) => group.errors.length > 0);
+
 	return (
-		<div className="space-y-3 p-4">
+		<div className="space-y-4 p-4">
 			<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
 				Top {errors.length} error{errors.length === 1 ? "" : "s"} ·{" "}
 				{data?.sampledErrors.toLocaleString()} sampled
 			</p>
-			<ul className="space-y-2">
-				{errors.map((error, i) => (
-					<li
-						key={i}
-						className="rounded-md border border-border/60 bg-background/60 p-3"
-					>
-						<div className="flex items-center justify-between gap-3">
-							<div className="flex items-center gap-2">
-								{error.statusCode !== null && (
-									<Badge variant="outline" className="font-mono">
-										{error.statusCode}
-									</Badge>
-								)}
-								{error.statusText && (
-									<span className="text-sm font-medium">
-										{error.statusText}
+			{groups.map((group) => (
+				<div key={group.label} className="space-y-2">
+					<div className="flex items-center gap-2">
+						<Badge className={cn("font-medium", group.badgeClass)}>
+							{group.label}
+						</Badge>
+						<span className="text-xs text-muted-foreground">
+							{group.errors.length} error
+							{group.errors.length === 1 ? "" : "s"} ·{" "}
+							{group.errors
+								.reduce((sum, error) => sum + error.count, 0)
+								.toLocaleString()}
+							× total
+						</span>
+					</div>
+					<ul className="space-y-2">
+						{group.errors.map((error, i) => (
+							<li
+								key={i}
+								className="rounded-md border border-border/60 bg-background/60 p-3"
+							>
+								<div className="flex items-center justify-between gap-3">
+									<div className="flex items-center gap-2">
+										{error.statusCode !== null && (
+											<Badge variant="outline" className="font-mono">
+												{error.statusCode}
+											</Badge>
+										)}
+										{error.statusText && (
+											<span className="text-sm font-medium">
+												{error.statusText}
+											</span>
+										)}
+										<ClassificationBadge
+											classification={error.classification}
+										/>
+									</div>
+									<span className="shrink-0 text-sm font-semibold tabular-nums">
+										{error.count.toLocaleString()}×
 									</span>
+								</div>
+								{error.responseText && (
+									<pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-2 text-xs text-muted-foreground">
+										{error.responseText}
+									</pre>
 								)}
-								<ClassificationBadge classification={error.classification} />
-							</div>
-							<span className="shrink-0 text-sm font-semibold tabular-nums">
-								{error.count.toLocaleString()}×
-							</span>
-						</div>
-						{error.responseText && (
-							<pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-2 text-xs text-muted-foreground">
-								{error.responseText}
-							</pre>
-						)}
-						{error.cause && (
-							<p className="mt-1 text-xs text-muted-foreground">
-								Cause: {error.cause}
-							</p>
-						)}
-					</li>
-				))}
-			</ul>
+								{error.cause && (
+									<p className="mt-1 text-xs text-muted-foreground">
+										Cause: {error.cause}
+									</p>
+								)}
+							</li>
+						))}
+					</ul>
+				</div>
+			))}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

The unstable-mappings admin drilldown previously showed a flat list of sampled errors with no indication of whether each failure came from a streaming or non-streaming request — which matters, since the two modes often fail differently.

- **API** (`GET /admin/unstable-mappings/errors`): the sampled-error aggregation now also groups by the log's `streamed` flag (`COALESCE`d to `false`) and returns it as `streamed` on each error detail.
- **Admin UI** (unstable-mappings table drilldown): the error list is now split into **Streaming** and **Non-streaming** sections, each with a labeled badge and a subtotal (distinct error count and total occurrences), so it's immediately clear which mode each error belongs to.

## Testing

- `turbo run build --filter=api --filter=admin` passes (regenerates the OpenAPI spec and admin client types).
- `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xo5YhhQ7dG2tAPxEpotK3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo5YhhQ7dG2tAPxEpotK3p)_