### PR TITLE
feat(models): declare reasoning efforts for glm-4.7 on cerebras

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -723,6 +723,7 @@ export const zaiModels = [
 				maxOutput: 128000,
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: ["none"],
 				vision: false,
 				tools: true,
 				jsonOutput: true,


### PR DESCRIPTION
## Summary
Declares `reasoningEfforts` for `glm-4.7` on `providerId: "cerebras"` in `packages/models/src/models/zai.ts`.

## Changes
- `glm-4.7` (cerebras, `zai-glm-4.7`) → `["none"]`

## Source
[Cerebras Reasoning guide](https://inference-docs.cerebras.ai/capabilities/reasoning#z-ai-glm-4-7-reasoning_effort-and-disable_reasoning) and [API reference](https://inference-docs.cerebras.ai/api-reference/chat-completions):
- Reasoning is enabled by default on `zai-glm-4.7`; `reasoning_effort="none"` is documented as the way to disable it.
- The API reference's global `reasoning_effort` enum (`low`/`medium`/`high`/`none`) is scoped per-model — GLM-4.7's note lists only `none`. By contrast, the same page's Gemma-4 note explicitly states all four values are accepted and behaviorally equivalent for that model — no such statement exists for GLM-4.7, indicating the omission is deliberate, not incomplete documentation.
- `disable_reasoning` (a deprecated boolean alternative) is being replaced specifically by `reasoning_effort="none"`, reinforcing that `none` is the complete, intended replacement for a binary toggle — not one tier among several.

## Not changed
- `glm-4.6`/cerebras — not documented anywhere on Cerebras, and already deactivated.
- Other hosts checked in this pass: `together-ai` (GLM-5/5.1/4.7 — binary toggle only or not listed), `novita` (GLM-4.5 has binary `enable_thinking`, but the existing `requiresEnableThinking` field's one prior usage was verified only for a differently-shaped parameter via live testing — not declared here without similar verification), `bytedance` (only GLM-5.2 has genuine `reasoning_effort`; GLM-4.7 has binary `thinking` only).

## Testing
- `pnpm format` — clean, only `zai.ts` changed. (Unrelated `pnpm-lock.yaml` drift from local `pnpm install` reviewed and excluded from this commit.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the GLM-4.7 model configuration to support the Cerebras provider with reasoning disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->