### PR TITLE
chore: gitignore .empryo local tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ generate-image-*.png
 scripts/*.jpg
 scripts/*.png
 .soulforge
+.empryo


### PR DESCRIPTION
## Summary
Adds `.empryo` to `.gitignore` — local tooling state directory (coding agent), not part of the project.

## Changes
- `.gitignore`: `+.empryo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude the `.empryo` file from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->