### PR TITLE
refactor: drop service tier upstream URL map

### DIFF
--- a/packages/actions/src/apply-google-service-tier.spec.ts
+++ b/packages/actions/src/apply-google-service-tier.spec.ts
@@ -181,4 +181,13 @@ describe("providerKeyBaseUrlSupportsServiceTier", () => {
 			),
 		).toBe(true);
 	});
+
+	it("allows a custom base URL on glacier (no static default upstream)", () => {
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"glacier",
+				"https://glacier.internal/v1beta",
+			),
+		).toBe(true);
+	});
 });

--- a/packages/actions/src/apply-google-service-tier.ts
+++ b/packages/actions/src/apply-google-service-tier.ts
@@ -1,3 +1,5 @@
+import { getProviderDefaultBaseUrl } from "./get-provider-endpoint.js";
+
 import type { ProviderId, ProviderRequestBody } from "@llmgateway/models";
 
 /**
@@ -31,18 +33,18 @@ export function applyGoogleServiceTier(
 }
 
 /**
- * Canonical upstream base URLs for the Google providers that honor the
- * OpenAI-compatible `service_tier` (Flex / Priority). A premium tier is only
- * guaranteed to apply when the request reaches Google directly: a provider key
- * pointing at a proxy / custom base URL may silently drop the tier header (Vertex)
- * or body field (AI Studio), so the gateway would bill and report the standard
- * tier even though the caller asked for Flex/Priority. Service-tier routing is
- * therefore restricted to keys that target these endpoints.
+ * The Google providers the gateway forwards premium tiers to via Google's
+ * transports: the `service_tier` body field (BODY_TIER_PROVIDERS) or the
+ * Vertex request headers. A premium tier is only guaranteed to apply when the
+ * request reaches Google's real upstream — a key pointing at a proxy / custom
+ * base URL may silently drop the tier and the request is served (and billed)
+ * as standard, never at the tier the caller asked for. Service-tier routing
+ * is therefore restricted to keys targeting the provider's default base URL.
  */
-const SERVICE_TIER_UPSTREAM_BASE_URLS: Partial<Record<ProviderId, string>> = {
-	"google-ai-studio": "https://generativelanguage.googleapis.com",
-	"google-vertex": "https://aiplatform.googleapis.com",
-};
+const GOOGLE_TIER_PROVIDERS: ReadonlySet<ProviderId> = new Set<ProviderId>([
+	...BODY_TIER_PROVIDERS,
+	"google-vertex",
+]);
 
 /**
  * The OpenAI-compatible processing tiers that select premium (Flex / Priority)
@@ -68,20 +70,22 @@ function normalizeServiceTierBaseUrl(baseUrl: string): string {
 
 /**
  * Whether a provider key's base URL is eligible to carry a Flex/Priority
- * service-tier request. Eligible when the provider has no upstream-only rule, or
- * when the key uses the managed default (no custom base URL), or when the custom
- * base URL exactly matches the provider's canonical upstream. A custom base URL
- * on google-ai-studio / google-vertex is the only case this rejects.
+ * service-tier request. Eligible when the provider is not one of the Google
+ * tier providers, when the key uses the managed default (no custom base URL),
+ * or when the custom base URL exactly matches the provider's default base URL
+ * (its real upstream). A custom base URL on google-ai-studio / google-vertex
+ * is the only case this rejects — glacier has no static default base URL
+ * (env-defined deployment), so there is no canonical upstream to enforce.
  */
 export function providerKeyBaseUrlSupportsServiceTier(
 	provider: ProviderId,
 	baseUrl: string | null | undefined,
 ): boolean {
-	const upstream = SERVICE_TIER_UPSTREAM_BASE_URLS[provider];
-	if (!upstream) {
+	if (!GOOGLE_TIER_PROVIDERS.has(provider) || !baseUrl) {
 		return true;
 	}
-	if (!baseUrl) {
+	const upstream = getProviderDefaultBaseUrl(provider);
+	if (!upstream) {
 		return true;
 	}
 	return (

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -87,6 +87,50 @@ function buildVertexCompatibleEndpoint(
 }
 
 /**
+ * Static default base URLs for providers whose canonical upstream is a fixed
+ * host. Single source of truth for "the provider's default base URL":
+ * getProviderEndpoint falls back to these when no key base URL or env
+ * override is configured, and service-tier key eligibility compares custom
+ * base URLs against them. Providers absent from this map derive their
+ * endpoint from env vars, key options (e.g. the Azure resource), or region
+ * maps and have no static default.
+ */
+const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<ProviderId, string>> = {
+	openai: "https://api.openai.com",
+	anthropic: "https://api.anthropic.com",
+	"google-ai-studio": "https://generativelanguage.googleapis.com",
+	"google-vertex": "https://aiplatform.googleapis.com",
+	"inference.net": "https://api.inference.net",
+	"together-ai": "https://api.together.ai",
+	mistral: "https://api.mistral.ai",
+	xai: "https://api.x.ai",
+	groq: "https://api.groq.com/openai",
+	cerebras: "https://api.cerebras.ai",
+	deepseek: "https://api.deepseek.com",
+	perplexity: "https://api.perplexity.ai",
+	novita: "https://api.novita.ai/v3/openai",
+	moonshot: "https://api.moonshot.ai",
+	meta: "https://api.meta.ai",
+	nebius: "https://api.tokenfactory.nebius.com",
+	zai: "https://api.z.ai",
+	nanogpt: "https://nano-gpt.com/api",
+	bytedance: "https://ark.ap-southeast.bytepluses.com/api/v3",
+	minimax: "https://api.minimax.io",
+	sakana: "https://api.sakana.ai",
+	reve: "https://api.reve.com",
+	xiaomi: "https://api.xiaomimimo.com",
+	canopywave: "https://inference.canopywave.io",
+	embercloud: "https://api.embercloud.ai",
+	deepinfra: "https://api.deepinfra.com/v1/openai",
+};
+
+export function getProviderDefaultBaseUrl(
+	provider: ProviderId,
+): string | undefined {
+	return PROVIDER_DEFAULT_BASE_URLS[provider];
+}
+
+/**
  * Get the endpoint URL for a provider API call.
  *
  * @param model - The upstream model id sent in the URL path (e.g. for Google
@@ -177,20 +221,15 @@ export function getProviderEndpoint(
 				}
 				break;
 			case "openai":
-				url =
-					envValueOrDefault("openai", "baseUrl", "https://api.openai.com") ??
-					"https://api.openai.com";
-				break;
-			case "anthropic":
-				url = "https://api.anthropic.com";
-				break;
 			case "google-ai-studio":
+			case "google-vertex":
+			case "xiaomi":
 				url =
 					envValueOrDefault(
-						"google-ai-studio",
+						provider,
 						"baseUrl",
-						"https://generativelanguage.googleapis.com",
-					) ?? "https://generativelanguage.googleapis.com";
+						getProviderDefaultBaseUrl(provider),
+					) ?? getProviderDefaultBaseUrl(provider);
 				break;
 			case "glacier":
 				url = skipEnvVars
@@ -211,14 +250,6 @@ export function getProviderEndpoint(
 						"Granite provider requires LLM_GRANITE_BASE_URL environment variable",
 					);
 				}
-				break;
-			case "google-vertex":
-				url =
-					envValueOrDefault(
-						"google-vertex",
-						"baseUrl",
-						"https://aiplatform.googleapis.com",
-					) ?? "https://aiplatform.googleapis.com";
 				break;
 			case "vertex-openai": {
 				const vertexOpenaiDefaultHost =
@@ -270,39 +301,6 @@ export function getProviderEndpoint(
 					);
 				}
 				break;
-			case "inference.net":
-				url = "https://api.inference.net";
-				break;
-			case "together-ai":
-				url = "https://api.together.ai";
-				break;
-			case "mistral":
-				url = "https://api.mistral.ai";
-				break;
-			case "xai":
-				url = "https://api.x.ai";
-				break;
-			case "groq":
-				url = "https://api.groq.com/openai";
-				break;
-			case "cerebras":
-				url = "https://api.cerebras.ai";
-				break;
-			case "deepseek":
-				url = "https://api.deepseek.com";
-				break;
-			case "perplexity":
-				url = "https://api.perplexity.ai";
-				break;
-			case "novita":
-				url = "https://api.novita.ai/v3/openai";
-				break;
-			case "moonshot":
-				url = "https://api.moonshot.ai";
-				break;
-			case "meta":
-				url = "https://api.meta.ai";
-				break;
 			case "alibaba": {
 				const alibabaBaseUrl =
 					regionBaseUrl ?? "https://dashscope-intl.aliyuncs.com";
@@ -314,35 +312,6 @@ export function getProviderEndpoint(
 				}
 				break;
 			}
-			case "nebius":
-				url = "https://api.tokenfactory.nebius.com";
-				break;
-			case "zai":
-				url = "https://api.z.ai";
-				break;
-			case "nanogpt":
-				url = "https://nano-gpt.com/api";
-				break;
-			case "bytedance":
-				url = "https://ark.ap-southeast.bytepluses.com/api/v3";
-				break;
-			case "minimax":
-				url = "https://api.minimax.io";
-				break;
-			case "sakana":
-				url = "https://api.sakana.ai";
-				break;
-			case "reve":
-				url = "https://api.reve.com";
-				break;
-			case "xiaomi":
-				url =
-					envValueOrDefault(
-						"xiaomi",
-						"baseUrl",
-						"https://api.xiaomimimo.com",
-					) ?? "https://api.xiaomimimo.com";
-				break;
 			case "aws-bedrock": {
 				// Precedence: explicit baseUrl arg (handled above) > env baseUrl >
 				// region-derived endpoint > hardcoded default. An explicitly
@@ -395,23 +364,20 @@ export function getProviderEndpoint(
 				url = `https://${resource}.services.ai.azure.com`;
 				break;
 			}
-			case "canopywave":
-				url = "https://inference.canopywave.io";
-				break;
-			case "embercloud":
-				url = "https://api.embercloud.ai";
-				break;
-			case "deepinfra":
-				url = "https://api.deepinfra.com/v1/openai";
-				break;
 			case "custom":
 				if (!baseUrl) {
 					throw new Error(`Custom provider requires a baseUrl`);
 				}
 				url = baseUrl;
 				break;
-			default:
-				throw new Error(`Provider ${provider} requires a baseUrl`);
+			default: {
+				const staticDefault = getProviderDefaultBaseUrl(provider);
+				if (!staticDefault) {
+					throw new Error(`Provider ${provider} requires a baseUrl`);
+				}
+				url = staticDefault;
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Removes the bespoke `SERVICE_TIER_UPSTREAM_BASE_URLS` constant from the service-tier key eligibility filter and derives the canonical upstream from the provider's default base URL instead, so the filter and the endpoint builder can never drift apart.

- **New single source of truth**: `getProviderDefaultBaseUrl()` in `packages/actions/src/get-provider-endpoint.ts` holds the static default base URLs for all fixed-host providers. `getProviderEndpoint()` now consumes it too: the ~25 hardcoded literal cases in its switch collapsed into a `default` branch, and the four env-overridable cases (`openai`, `google-ai-studio`, `google-vertex`, `xiaomi`) share one case.
- **`providerKeyBaseUrlSupportsServiceTier()`** now scopes the upstream-only rule behaviorally via `GOOGLE_TIER_PROVIDERS` (the `BODY_TIER_PROVIDERS` set plus `google-vertex`) — the providers where the gateway injects the premium tier via Google's transports — and compares custom base URLs against the provider's default base URL. Glacier is nominally in scope but has no static default (env-defined deployment), so it stays exempt, matching current behavior.
- **Comment fix**: the old rationale claimed a proxy dropping the tier would cause premium-tier billing for standard service. Billing actually keys off the *served* tier (`resolveServedServiceTier`), so the real problem is silent delivery downgrade — the request is served (and billed) as standard, never at the tier the caller asked for. The comment now says that.

No behavior change: the resolved URLs are byte-identical to the old map, OpenAI (body-transported tier that survives proxies) remains ungated, and all existing spec expectations pass unchanged.

## Testing

- `packages/actions` specs pass (67 tests, including all 48 `get-provider-endpoint` cases validating the switch refactor), plus a new spec case for the glacier exemption
- Full unit suite: 171 files, 2854 tests passed
- `pnpm build` and `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)