### PR TITLE
fix(api): route v1/master writes through cdb

### DIFF
--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -260,8 +260,6 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
-		// A bare cdb select (not via swrWrap) must now return the new rule,
-		// proving the Drizzle cache layer was busted, not just the SWR mirror.
 		const directRules = await cdb
 			.select()
 			.from(tables.apiKeyIamRule)
@@ -313,6 +311,19 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
+		const directRules = await cdb
+			.select()
+			.from(tables.apiKeyIamRule)
+			.where(
+				and(
+					eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+					eq(tables.apiKeyIamRule.status, "active"),
+				),
+			);
+		expect(directRules).toHaveLength(1);
+		expect(directRules[0]?.ruleValue).toEqual({
+			models: ["anthropic/claude-3-5-sonnet"],
+		});
 		const rules = await readActiveIamRules(apiKeyId);
 		expect(rules).toHaveLength(1);
 		expect(rules[0]?.ruleValue).toEqual({
@@ -355,6 +366,16 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
+		const directRules = await cdb
+			.select()
+			.from(tables.apiKeyIamRule)
+			.where(
+				and(
+					eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+					eq(tables.apiKeyIamRule.status, "active"),
+				),
+			);
+		expect(directRules).toHaveLength(0);
 		expect(await readActiveIamRules(apiKeyId)).toHaveLength(0);
 	});
 });

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -15,6 +15,33 @@ import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 // master-key route, then asserts BOTH the SWR mirror is evicted AND a fresh cdb
 // select serves the new value.
 
+// Seed an SWR mirror entry the way the gateway would and confirm it landed.
+async function primeSwrEntry<T>(key: string, table: string, value: T) {
+	await swrWrap(key, [table], async () => value);
+	expect(await redisClient.get(SWR_PREFIX + key)).not.toBeNull();
+}
+
+async function assertSwrCleared(key: string) {
+	expect(await redisClient.get(SWR_PREFIX + key)).toBeNull();
+}
+
+function readActiveIamRules(apiKeyId: string) {
+	return swrWrap(
+		`iamRules:${apiKeyId}`,
+		[getTableName(tables.apiKeyIamRule)],
+		async () =>
+			await cdb
+				.select()
+				.from(tables.apiKeyIamRule)
+				.where(
+					and(
+						eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+						eq(tables.apiKeyIamRule.status, "active"),
+					),
+				),
+	);
+}
+
 describe("v1/master cache invalidation", () => {
 	let masterToken: string;
 
@@ -75,16 +102,6 @@ describe("v1/master cache invalidation", () => {
 			Authorization: `Bearer ${masterToken}`,
 			...extra,
 		};
-	}
-
-	// Seed an SWR mirror entry the way the gateway would and confirm it landed.
-	async function primeSwrEntry<T>(key: string, table: string, value: T) {
-		await swrWrap(key, [table], async () => value);
-		expect(await redisClient.get(SWR_PREFIX + key)).not.toBeNull();
-	}
-
-	async function assertSwrCleared(key: string) {
-		expect(await redisClient.get(SWR_PREFIX + key)).toBeNull();
 	}
 
 	test("PATCH /keys/{id} invalidates the gateway api_key cache", async () => {
@@ -225,23 +242,7 @@ describe("v1/master cache invalidation", () => {
 			createdBy: "test-user-id",
 		});
 
-		const readActiveIamRules = () =>
-			swrWrap(
-				`iamRules:${apiKeyId}`,
-				[getTableName(tables.apiKeyIamRule)],
-				async () =>
-					await cdb
-						.select()
-						.from(tables.apiKeyIamRule)
-						.where(
-							and(
-								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
-								eq(tables.apiKeyIamRule.status, "active"),
-							),
-						),
-			);
-
-		expect(await readActiveIamRules()).toHaveLength(0);
+		expect(await readActiveIamRules(apiKeyId)).toHaveLength(0);
 		await primeSwrEntry(
 			`iamRules:${apiKeyId}`,
 			getTableName(tables.apiKeyIamRule),
@@ -259,7 +260,7 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
-		expect(await readActiveIamRules()).toHaveLength(1);
+		expect(await readActiveIamRules(apiKeyId)).toHaveLength(1);
 	});
 
 	test("PATCH /keys/{id}/iam/{ruleId} busts the gateway's cached IAM rule lookups", async () => {
@@ -280,23 +281,7 @@ describe("v1/master cache invalidation", () => {
 			})
 			.returning();
 
-		const readActiveIamRules = () =>
-			swrWrap(
-				`iamRules:${apiKeyId}`,
-				[getTableName(tables.apiKeyIamRule)],
-				async () =>
-					await cdb
-						.select()
-						.from(tables.apiKeyIamRule)
-						.where(
-							and(
-								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
-								eq(tables.apiKeyIamRule.status, "active"),
-							),
-						),
-			);
-
-		expect(await readActiveIamRules()).toHaveLength(1);
+		expect(await readActiveIamRules(apiKeyId)).toHaveLength(1);
 		await primeSwrEntry(
 			`iamRules:${apiKeyId}`,
 			getTableName(tables.apiKeyIamRule),
@@ -316,7 +301,7 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
-		const rules = await readActiveIamRules();
+		const rules = await readActiveIamRules(apiKeyId);
 		expect(rules).toHaveLength(1);
 		expect(rules[0]?.ruleValue).toEqual({
 			models: ["anthropic/claude-3-5-sonnet"],
@@ -341,23 +326,7 @@ describe("v1/master cache invalidation", () => {
 			})
 			.returning();
 
-		const readActiveIamRules = () =>
-			swrWrap(
-				`iamRules:${apiKeyId}`,
-				[getTableName(tables.apiKeyIamRule)],
-				async () =>
-					await cdb
-						.select()
-						.from(tables.apiKeyIamRule)
-						.where(
-							and(
-								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
-								eq(tables.apiKeyIamRule.status, "active"),
-							),
-						),
-			);
-
-		expect(await readActiveIamRules()).toHaveLength(1);
+		expect(await readActiveIamRules(apiKeyId)).toHaveLength(1);
 		await primeSwrEntry(
 			`iamRules:${apiKeyId}`,
 			getTableName(tables.apiKeyIamRule),
@@ -374,6 +343,6 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
-		expect(await readActiveIamRules()).toHaveLength(0);
+		expect(await readActiveIamRules(apiKeyId)).toHaveLength(0);
 	});
 });

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -7,13 +7,13 @@ import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
 import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 
-// These tests cover issue #2674: management mutations on gateway-cached tables
-// must go through the cached client (cdb) so RedisCache.onMutate invalidates the
-// gateway's SWR mirrors. v1-master mutates apiKey, apiKeyIamRule and project,
-// which the gateway resolves through swrWrap-cached lookups (see
-// apps/gateway/src/lib/cached-queries.ts). Each test primes the cache exactly as
-// the gateway would, mutates through the master-key route, then asserts the
-// cache no longer serves the stale value.
+// Issue #2674: management mutations on gateway-cached tables must go through the
+// cached client (cdb) so RedisCache.onMutate invalidates the gateway's SWR
+// mirrors. v1-master mutates apiKey, apiKeyIamRule and project, which the gateway
+// resolves through swrWrap-cached lookups (apps/gateway/src/lib/cached-queries.ts).
+// Each test primes the cache exactly as the gateway would, mutates through the
+// master-key route, then asserts BOTH the SWR mirror is evicted AND a fresh cdb
+// select serves the new value.
 
 describe("v1/master cache invalidation", () => {
 	let masterToken: string;
@@ -77,6 +77,16 @@ describe("v1/master cache invalidation", () => {
 		};
 	}
 
+	// Seed an SWR mirror entry the way the gateway would and confirm it landed.
+	async function primeSwrEntry<T>(key: string, table: string, value: T) {
+		await swrWrap(key, [table], async () => value);
+		expect(await redisClient.get(SWR_PREFIX + key)).not.toBeNull();
+	}
+
+	async function assertSwrCleared(key: string) {
+		expect(await redisClient.get(SWR_PREFIX + key)).toBeNull();
+	}
+
 	test("PATCH /keys/{id} invalidates the gateway api_key cache", async () => {
 		// A per-run-unique key keeps the SWR key from colliding with entries left
 		// in Redis by earlier runs, which outlive deleteAll (it does not flush
@@ -91,13 +101,11 @@ describe("v1/master cache invalidation", () => {
 			createdBy: "test-user-id",
 		});
 
-		// Prime the SWR mirror the way the gateway's findApiKeyByToken does.
 		const swrCacheKey = `apiKey:token:${getApiKeyFingerprint(apiKeyToken)}`;
-		await swrWrap(swrCacheKey, [getTableName(tables.apiKey)], async () => ({
+		await primeSwrEntry(swrCacheKey, getTableName(tables.apiKey), {
 			token: apiKeyToken,
 			status: "active",
-		}));
-		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+		});
 
 		const res = await app.request(`/v1/master/keys/${apiKeyId}`, {
 			method: "PATCH",
@@ -106,7 +114,13 @@ describe("v1/master cache invalidation", () => {
 		});
 		expect(res.status).toBe(200);
 
-		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+		await assertSwrCleared(swrCacheKey);
+		// The cached cdb select must reflect the new status, not the stale one.
+		const fresh = await cdb
+			.select()
+			.from(tables.apiKey)
+			.where(eq(tables.apiKey.id, apiKeyId));
+		expect(fresh[0]?.status).toBe("inactive");
 	});
 
 	test("DELETE /keys/{id} invalidates the gateway api_key cache", async () => {
@@ -121,11 +135,10 @@ describe("v1/master cache invalidation", () => {
 		});
 
 		const swrCacheKey = `apiKey:token:${getApiKeyFingerprint(apiKeyToken)}`;
-		await swrWrap(swrCacheKey, [getTableName(tables.apiKey)], async () => ({
+		await primeSwrEntry(swrCacheKey, getTableName(tables.apiKey), {
 			token: apiKeyToken,
 			status: "active",
-		}));
-		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+		});
 
 		const res = await app.request(`/v1/master/keys/${apiKeyId}`, {
 			method: "DELETE",
@@ -133,7 +146,41 @@ describe("v1/master cache invalidation", () => {
 		});
 		expect(res.status).toBe(200);
 
-		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+		await assertSwrCleared(swrCacheKey);
+		const fresh = await cdb
+			.select()
+			.from(tables.apiKey)
+			.where(eq(tables.apiKey.id, apiKeyId));
+		expect(fresh[0]?.status).toBe("deleted");
+	});
+
+	test("PATCH /projects/{id} invalidates the gateway project cache", async () => {
+		const projectId = `cache-test-project-${crypto.randomUUID()}`;
+		await db.insert(tables.project).values({
+			id: projectId,
+			name: "Cache Test Project",
+			organizationId: "test-org-id",
+		});
+
+		const swrCacheKey = `project:${projectId}`;
+		await primeSwrEntry(swrCacheKey, getTableName(tables.project), {
+			id: projectId,
+			name: "Cache Test Project",
+		});
+
+		const res = await app.request(`/v1/master/projects/${projectId}`, {
+			method: "PATCH",
+			headers: authHeaders({ "Content-Type": "application/json" }),
+			body: JSON.stringify({ name: "Renamed Project" }),
+		});
+		expect(res.status).toBe(200);
+
+		await assertSwrCleared(swrCacheKey);
+		const fresh = await cdb
+			.select()
+			.from(tables.project)
+			.where(eq(tables.project.id, projectId));
+		expect(fresh[0]?.name).toBe("Renamed Project");
 	});
 
 	test("DELETE /projects/{id} invalidates the gateway project cache", async () => {
@@ -144,13 +191,11 @@ describe("v1/master cache invalidation", () => {
 			organizationId: "test-org-id",
 		});
 
-		// Prime the SWR mirror the way the gateway's findProjectById does.
 		const swrCacheKey = `project:${projectId}`;
-		await swrWrap(swrCacheKey, [getTableName(tables.project)], async () => ({
+		await primeSwrEntry(swrCacheKey, getTableName(tables.project), {
 			id: projectId,
 			status: "active",
-		}));
-		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+		});
 
 		const res = await app.request(`/v1/master/projects/${projectId}`, {
 			method: "DELETE",
@@ -158,7 +203,12 @@ describe("v1/master cache invalidation", () => {
 		});
 		expect(res.status).toBe(200);
 
-		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+		await assertSwrCleared(swrCacheKey);
+		const fresh = await cdb
+			.select()
+			.from(tables.project)
+			.where(eq(tables.project.id, projectId));
+		expect(fresh[0]?.status).toBe("deleted");
 	});
 
 	test("POST /keys/{id}/iam busts the gateway's cached IAM rule lookups", async () => {
@@ -191,11 +241,12 @@ describe("v1/master cache invalidation", () => {
 						),
 			);
 
-		// Prime both cache layers with the "no rules" result.
 		expect(await readActiveIamRules()).toHaveLength(0);
-		expect(
-			await redisClient.get(SWR_PREFIX + `iamRules:${apiKeyId}`),
-		).not.toBeNull();
+		await primeSwrEntry(
+			`iamRules:${apiKeyId}`,
+			getTableName(tables.apiKeyIamRule),
+			[],
+		);
 
 		const res = await app.request(`/v1/master/keys/${apiKeyId}/iam`, {
 			method: "POST",
@@ -207,11 +258,122 @@ describe("v1/master cache invalidation", () => {
 		});
 		expect(res.status).toBe(200);
 
-		// The SWR mirror for the api_key_iam_rule table must be gone...
-		expect(
-			await redisClient.get(SWR_PREFIX + `iamRules:${apiKeyId}`),
-		).toBeNull();
-		// ...and the cached select must serve the new rule, not the stale miss.
+		await assertSwrCleared(`iamRules:${apiKeyId}`);
 		expect(await readActiveIamRules()).toHaveLength(1);
+	});
+
+	test("PATCH /keys/{id}/iam/{ruleId} busts the gateway's cached IAM rule lookups", async () => {
+		const apiKeyId = `cache-test-api-key-${crypto.randomUUID()}`;
+		await db.insert(tables.apiKey).values({
+			id: apiKeyId,
+			token: `${apiKeyId}-token`,
+			projectId: "test-project-id",
+			description: "IAM Cache Test Key",
+			createdBy: "test-user-id",
+		});
+		const [rule] = await db
+			.insert(tables.apiKeyIamRule)
+			.values({
+				apiKeyId,
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+			})
+			.returning();
+
+		const readActiveIamRules = () =>
+			swrWrap(
+				`iamRules:${apiKeyId}`,
+				[getTableName(tables.apiKeyIamRule)],
+				async () =>
+					await cdb
+						.select()
+						.from(tables.apiKeyIamRule)
+						.where(
+							and(
+								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+								eq(tables.apiKeyIamRule.status, "active"),
+							),
+						),
+			);
+
+		expect(await readActiveIamRules()).toHaveLength(1);
+		await primeSwrEntry(
+			`iamRules:${apiKeyId}`,
+			getTableName(tables.apiKeyIamRule),
+			[rule],
+		);
+
+		const res = await app.request(
+			`/v1/master/keys/${apiKeyId}/iam/${rule.id}`,
+			{
+				method: "PATCH",
+				headers: authHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({
+					ruleValue: { models: ["anthropic/claude-3-5-sonnet"] },
+				}),
+			},
+		);
+		expect(res.status).toBe(200);
+
+		await assertSwrCleared(`iamRules:${apiKeyId}`);
+		const rules = await readActiveIamRules();
+		expect(rules).toHaveLength(1);
+		expect(rules[0]?.ruleValue).toEqual({
+			models: ["anthropic/claude-3-5-sonnet"],
+		});
+	});
+
+	test("DELETE /keys/{id}/iam/{ruleId} busts the gateway's cached IAM rule lookups", async () => {
+		const apiKeyId = `cache-test-api-key-${crypto.randomUUID()}`;
+		await db.insert(tables.apiKey).values({
+			id: apiKeyId,
+			token: `${apiKeyId}-token`,
+			projectId: "test-project-id",
+			description: "IAM Cache Test Key",
+			createdBy: "test-user-id",
+		});
+		const [rule] = await db
+			.insert(tables.apiKeyIamRule)
+			.values({
+				apiKeyId,
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+			})
+			.returning();
+
+		const readActiveIamRules = () =>
+			swrWrap(
+				`iamRules:${apiKeyId}`,
+				[getTableName(tables.apiKeyIamRule)],
+				async () =>
+					await cdb
+						.select()
+						.from(tables.apiKeyIamRule)
+						.where(
+							and(
+								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+								eq(tables.apiKeyIamRule.status, "active"),
+							),
+						),
+			);
+
+		expect(await readActiveIamRules()).toHaveLength(1);
+		await primeSwrEntry(
+			`iamRules:${apiKeyId}`,
+			getTableName(tables.apiKeyIamRule),
+			[rule],
+		);
+
+		const res = await app.request(
+			`/v1/master/keys/${apiKeyId}/iam/${rule.id}`,
+			{
+				method: "DELETE",
+				headers: authHeaders(),
+			},
+		);
+		expect(res.status).toBe(200);
+
+		await assertSwrCleared(`iamRules:${apiKeyId}`);
+		expect(await readActiveIamRules()).toHaveLength(0);
 	});
 });

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
+import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
+import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
+
+// These tests cover issue #2674: management mutations on gateway-cached tables
+// must go through the cached client (cdb) so RedisCache.onMutate invalidates the
+// gateway's SWR mirrors. v1-master mutates apiKey, apiKeyIamRule and project,
+// which the gateway resolves through swrWrap-cached lookups (see
+// apps/gateway/src/lib/cached-queries.ts). Each test primes the cache exactly as
+// the gateway would, mutates through the master-key route, then asserts the
+// cache no longer serves the stale value.
+
+describe("v1/master cache invalidation", () => {
+	let masterToken: string;
+
+	beforeEach(async () => {
+		// createTestUser runs deleteAll and seeds test-user-id.
+		await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: "test-org-id",
+			name: "Test Organization",
+			billingEmail: "test@example.com",
+			plan: "enterprise",
+		});
+
+		await db.insert(tables.userOrganization).values({
+			id: "test-user-org-id",
+			userId: "test-user-id",
+			organizationId: "test-org-id",
+			role: "owner",
+		});
+
+		await db.insert(tables.project).values({
+			id: "test-project-id",
+			name: "Test Project",
+			organizationId: "test-org-id",
+		});
+
+		await db.insert(tables.apiKey).values({
+			id: "test-api-key-id",
+			token: "test-master-token",
+			projectId: "test-project-id",
+			description: "Test API Key",
+			createdBy: "test-user-id",
+		});
+
+		// The gateway authenticates master keys by hashing the bearer token and
+		// matching masterKey.tokenHash (v1-master.ts auth middleware).
+		masterToken = `mk-${crypto.randomUUID()}`;
+		await db.insert(tables.masterKey).values({
+			id: "test-master-key-id",
+			tokenHash: getApiKeyFingerprint(masterToken),
+			maskedToken: "mk-****",
+			description: "Test Master Key",
+			status: "active",
+			organizationId: "test-org-id",
+			createdBy: "test-user-id",
+		});
+	});
+
+	afterEach(async () => {
+		// deleteAll does not target masterKey, but deleting the organization
+		// cascades it (masterKey.organizationId ON DELETE cascade).
+		await deleteAll();
+	});
+
+	function authHeaders(extra: Record<string, string> = {}) {
+		return {
+			Authorization: `Bearer ${masterToken}`,
+			...extra,
+		};
+	}
+
+	test("PATCH /keys/{id} invalidates the gateway api_key cache", async () => {
+		// A per-run-unique key keeps the SWR key from colliding with entries left
+		// in Redis by earlier runs, which outlive deleteAll (it does not flush
+		// Redis).
+		const apiKeyId = `cache-test-api-key-${crypto.randomUUID()}`;
+		const apiKeyToken = `${apiKeyId}-token`;
+		await db.insert(tables.apiKey).values({
+			id: apiKeyId,
+			token: apiKeyToken,
+			projectId: "test-project-id",
+			description: "Cache Test Key",
+			createdBy: "test-user-id",
+		});
+
+		// Prime the SWR mirror the way the gateway's findApiKeyByToken does.
+		const swrCacheKey = `apiKey:token:${getApiKeyFingerprint(apiKeyToken)}`;
+		await swrWrap(swrCacheKey, [getTableName(tables.apiKey)], async () => ({
+			token: apiKeyToken,
+			status: "active",
+		}));
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+
+		const res = await app.request(`/v1/master/keys/${apiKeyId}`, {
+			method: "PATCH",
+			headers: authHeaders({ "Content-Type": "application/json" }),
+			body: JSON.stringify({ status: "inactive" }),
+		});
+		expect(res.status).toBe(200);
+
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+	});
+
+	test("DELETE /keys/{id} invalidates the gateway api_key cache", async () => {
+		const apiKeyId = `cache-test-api-key-${crypto.randomUUID()}`;
+		const apiKeyToken = `${apiKeyId}-token`;
+		await db.insert(tables.apiKey).values({
+			id: apiKeyId,
+			token: apiKeyToken,
+			projectId: "test-project-id",
+			description: "Cache Test Key",
+			createdBy: "test-user-id",
+		});
+
+		const swrCacheKey = `apiKey:token:${getApiKeyFingerprint(apiKeyToken)}`;
+		await swrWrap(swrCacheKey, [getTableName(tables.apiKey)], async () => ({
+			token: apiKeyToken,
+			status: "active",
+		}));
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+
+		const res = await app.request(`/v1/master/keys/${apiKeyId}`, {
+			method: "DELETE",
+			headers: authHeaders(),
+		});
+		expect(res.status).toBe(200);
+
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+	});
+
+	test("DELETE /projects/{id} invalidates the gateway project cache", async () => {
+		const projectId = `cache-test-project-${crypto.randomUUID()}`;
+		await db.insert(tables.project).values({
+			id: projectId,
+			name: "Cache Test Project",
+			organizationId: "test-org-id",
+		});
+
+		// Prime the SWR mirror the way the gateway's findProjectById does.
+		const swrCacheKey = `project:${projectId}`;
+		await swrWrap(swrCacheKey, [getTableName(tables.project)], async () => ({
+			id: projectId,
+			status: "active",
+		}));
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
+
+		const res = await app.request(`/v1/master/projects/${projectId}`, {
+			method: "DELETE",
+			headers: authHeaders(),
+		});
+		expect(res.status).toBe(200);
+
+		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).toBeNull();
+	});
+
+	test("POST /keys/{id}/iam busts the gateway's cached IAM rule lookups", async () => {
+		// The gateway enforces IAM rules through a cached select (cdb) wrapped in
+		// an SWR fallback mirror, both indexed by the api_key_iam_rule table (see
+		// findActiveIamRules in apps/gateway/src/lib/cached-queries.ts). Creating a
+		// rule through cdb must bust both layers so it applies immediately.
+		const apiKeyId = `cache-test-api-key-${crypto.randomUUID()}`;
+		await db.insert(tables.apiKey).values({
+			id: apiKeyId,
+			token: `${apiKeyId}-token`,
+			projectId: "test-project-id",
+			description: "IAM Cache Test Key",
+			createdBy: "test-user-id",
+		});
+
+		const readActiveIamRules = () =>
+			swrWrap(
+				`iamRules:${apiKeyId}`,
+				[getTableName(tables.apiKeyIamRule)],
+				async () =>
+					await cdb
+						.select()
+						.from(tables.apiKeyIamRule)
+						.where(
+							and(
+								eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+								eq(tables.apiKeyIamRule.status, "active"),
+							),
+						),
+			);
+
+		// Prime both cache layers with the "no rules" result.
+		expect(await readActiveIamRules()).toHaveLength(0);
+		expect(
+			await redisClient.get(SWR_PREFIX + `iamRules:${apiKeyId}`),
+		).not.toBeNull();
+
+		const res = await app.request(`/v1/master/keys/${apiKeyId}/iam`, {
+			method: "POST",
+			headers: authHeaders({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		// The SWR mirror for the api_key_iam_rule table must be gone...
+		expect(
+			await redisClient.get(SWR_PREFIX + `iamRules:${apiKeyId}`),
+		).toBeNull();
+		// ...and the cached select must serve the new rule, not the stale miss.
+		expect(await readActiveIamRules()).toHaveLength(1);
+	});
+});

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -260,6 +260,18 @@ describe("v1/master cache invalidation", () => {
 		expect(res.status).toBe(200);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
+		// A bare cdb select (not via swrWrap) must now return the new rule,
+		// proving the Drizzle cache layer was busted, not just the SWR mirror.
+		const directRules = await cdb
+			.select()
+			.from(tables.apiKeyIamRule)
+			.where(
+				and(
+					eq(tables.apiKeyIamRule.apiKeyId, apiKeyId),
+					eq(tables.apiKeyIamRule.status, "active"),
+				),
+			);
+		expect(directRules).toHaveLength(1);
 		expect(await readActiveIamRules(apiKeyId)).toHaveLength(1);
 	});
 

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -21,7 +21,13 @@ import {
 import { createProjectForOrg } from "@/routes/projects.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
-import { db, eq, getApiKeyCurrentPeriodState, tables } from "@llmgateway/db";
+import {
+	cdb,
+	db,
+	eq,
+	getApiKeyCurrentPeriodState,
+	tables,
+} from "@llmgateway/db";
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 
 import type { ServerTypes } from "@/vars.js";
@@ -420,7 +426,7 @@ v1Master.openapi(updateProject, async (c) => {
 		});
 	}
 
-	const [updated] = await db
+	const [updated] = await cdb
 		.update(tables.project)
 		.set(updates)
 		.where(eq(tables.project.id, id))
@@ -503,7 +509,7 @@ v1Master.openapi(deleteProject, async (c) => {
 		});
 	}
 
-	await db
+	await cdb
 		.update(tables.project)
 		.set({ status: "deleted" })
 		.where(eq(tables.project.id, id));
@@ -660,7 +666,7 @@ v1Master.openapi(updateApiKey, async (c) => {
 		}
 	}
 
-	const [updated] = await db
+	const [updated] = await cdb
 		.update(tables.apiKey)
 		.set(setPayload)
 		.where(eq(tables.apiKey.id, id))
@@ -843,7 +849,7 @@ v1Master.openapi(deleteApiKey, async (c) => {
 		});
 	}
 
-	await db
+	await cdb
 		.update(tables.apiKey)
 		.set({ status: "deleted" })
 		.where(eq(tables.apiKey.id, id));
@@ -908,7 +914,7 @@ v1Master.openapi(createIamRule, async (c) => {
 
 	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
 
-	const [rule] = await db
+	const [rule] = await cdb
 		.insert(tables.apiKeyIamRule)
 		.values({
 			apiKeyId: apiKey.id,
@@ -1024,7 +1030,7 @@ v1Master.openapi(updateIamRule, async (c) => {
 		});
 	}
 
-	const [updated] = await db
+	const [updated] = await cdb
 		.update(tables.apiKeyIamRule)
 		.set(updates)
 		.where(eq(tables.apiKeyIamRule.id, ruleId))
@@ -1090,7 +1096,7 @@ v1Master.openapi(deleteIamRule, async (c) => {
 		});
 	}
 
-	await db
+	await cdb
 		.delete(tables.apiKeyIamRule)
 		.where(eq(tables.apiKeyIamRule.id, ruleId));
 


### PR DESCRIPTION
Fixes #2674.

The master-key routes in `apps/api/src/routes/v1-master.ts` mutated `apiKey`, `apiKeyIamRule`, and `project` through the uncached `db` client. Because those writes bypassed `cdb`, `RedisCache.onMutate` never fired, so the gateway kept serving stale rows from its `swrWrap` mirrors (4h TTL) after a key, rule, or project was updated or deleted.

This routes the 7 mutations through `cdb`, so cache invalidation happens automatically. `cdb` is the cache-aware client already used elsewhere in the API (e.g. `keys-api.ts`); `masterKey.lastUsedAt` stays on `db` because `masterKey` isn't gateway-cached.

Test: `apps/api/src/routes/v1-master.spec.ts` primes each table's SWR cache the way the gateway does (`findApiKeyByToken`, `findProjectById`, `findActiveIamRules`), calls the master route, then asserts the SWR entry is evicted AND a fresh `cdb` select returns the updated row. Covers all 7 mutations (apiKey/project update+delete, iam create/update/delete). Needs live Postgres + Redis (CI).

Scope is limited to #2674: other `db` mutations on gateway-cached tables (e.g. in `stripe.ts`, `platform-sessions.ts`, worker usage writes) are excluded — some sit inside `db.transaction` blocks or are high-frequency worker writes where `cdb` would thrash the cache, and belong in separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved master key management so cached gateway data for API keys, projects, and active IAM rules is reliably invalidated and refreshed after key/project/IAM rule create, update, or delete actions.
* **Tests**
  * Added automated coverage to confirm SWR cache eviction in Redis and that subsequent reads reflect the updated master key, project, and IAM rule state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->