### PR TITLE
fix(api): attribute purchase events to users

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1157,7 +1157,10 @@ export async function finalizeDevPlanSetupSession(
 		properties: { name: organization.name },
 	});
 	posthog.capture({
-		distinctId: "organization",
+		distinctId: await resolvePurchaserDistinctId(
+			userEmail,
+			organization.billingEmail,
+		),
 		event: "dev_plan_started",
 		groups: { organization: organizationId },
 		properties: {
@@ -1405,7 +1408,10 @@ async function handleCheckoutSessionCompleted(
 				},
 			});
 			posthog.capture({
-				distinctId: "organization",
+				distinctId: await resolvePurchaserDistinctId(
+					metadata?.userEmail as string | undefined,
+					organization.billingEmail,
+				),
 				event: "chat_plan_started",
 				groups: {
 					organization: organizationId,
@@ -1527,7 +1533,10 @@ async function handleCheckoutSessionCompleted(
 				},
 			});
 			posthog.capture({
-				distinctId: "organization",
+				distinctId: await resolvePurchaserDistinctId(
+					metadata?.userEmail as string | undefined,
+					organization.billingEmail,
+				),
 				event: "dev_plan_started",
 				groups: {
 					organization: organizationId,
@@ -1756,6 +1765,31 @@ async function applyFirstTimeBonus({
 	return { finalCreditAmount, bonusAmount, bonusType };
 }
 
+/**
+ * Resolves the PostHog distinct id for a purchase conversion event. The
+ * frontends identify browser persons with the user's id, so capturing
+ * payments against that same id lets pageview journeys be joined to
+ * payments in analytics (e.g. the converting-URL sections of the traffic
+ * report). Falls back to the legacy "organization" pseudo-person when no
+ * user can be resolved.
+ */
+async function resolvePurchaserDistinctId(
+	...emails: (string | null | undefined)[]
+): Promise<string> {
+	for (const email of emails) {
+		if (!email) {
+			continue;
+		}
+		const purchaser = await db.query.user.findFirst({
+			where: { email: { eq: email } },
+		});
+		if (purchaser) {
+			return purchaser.id;
+		}
+	}
+	return "organization";
+}
+
 async function recordCreditTopUp({
 	organizationId,
 	finalCreditAmount,
@@ -1768,6 +1802,7 @@ async function recordCreditTopUp({
 	organization,
 	source,
 	bonusType,
+	purchaserUserId,
 }: {
 	organizationId: string;
 	finalCreditAmount: number;
@@ -1787,6 +1822,7 @@ async function recordCreditTopUp({
 	};
 	source: string;
 	bonusType?: BonusType | null;
+	purchaserUserId?: string | null;
 }) {
 	await db
 		.update(tables.organization)
@@ -1871,7 +1907,9 @@ async function recordCreditTopUp({
 		},
 	});
 	posthog.capture({
-		distinctId: "organization",
+		distinctId:
+			purchaserUserId ??
+			(await resolvePurchaserDistinctId(organization.billingEmail)),
 		event: "credits_purchased",
 		groups: {
 			organization: organizationId,
@@ -2005,6 +2043,7 @@ async function handleCreditTopUpCheckout(session: Stripe.Checkout.Session) {
 		organization,
 		source: "stripe_checkout",
 		bonusType,
+		purchaserUserId: resolvedUser?.id ?? null,
 	});
 
 	if (userEmail) {
@@ -2607,7 +2646,12 @@ export async function fulfillResetPassPurchase(
 	}
 
 	posthog.capture({
-		distinctId: "organization",
+		distinctId:
+			metadata.userId ??
+			(await resolvePurchaserDistinctId(
+				metadata.userEmail,
+				organization.billingEmail,
+			)),
 		event: "reset_pass_purchased",
 		groups: {
 			organization: organization.id,
@@ -2820,7 +2864,9 @@ async function handlePaymentIntentSucceeded(
 			},
 		});
 		posthog.capture({
-			distinctId: "organization",
+			distinctId:
+				resolvedUser?.id ??
+				(await resolvePurchaserDistinctId(organization.billingEmail)),
 			event: "credits_purchased",
 			groups: {
 				organization: organizationId,
@@ -2845,6 +2891,7 @@ async function handlePaymentIntentSucceeded(
 			organization,
 			source: "payment_intent",
 			bonusType,
+			purchaserUserId: resolvedUser?.id ?? null,
 		});
 	}
 
@@ -3719,7 +3766,10 @@ export async function handleInvoicePaymentSucceeded(event: {
 			properties: { name: organization.name },
 		});
 		posthog.capture({
-			distinctId: "organization",
+			distinctId: await resolvePurchaserDistinctId(
+				subscriptionMetadata.userEmail,
+				organization.billingEmail,
+			),
 			event: "dev_plan_started",
 			groups: { organization: organizationId },
 			properties: {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1409,7 +1409,7 @@ async function handleCheckoutSessionCompleted(
 			});
 			posthog.capture({
 				distinctId: await resolvePurchaserDistinctId(
-					metadata?.userEmail as string | undefined,
+					metadata?.userEmail,
 					organization.billingEmail,
 				),
 				event: "chat_plan_started",
@@ -1534,7 +1534,7 @@ async function handleCheckoutSessionCompleted(
 			});
 			posthog.capture({
 				distinctId: await resolvePurchaserDistinctId(
-					metadata?.userEmail as string | undefined,
+					metadata?.userEmail,
 					organization.billingEmail,
 				),
 				event: "dev_plan_started",
@@ -1776,10 +1776,10 @@ async function applyFirstTimeBonus({
 async function resolvePurchaserDistinctId(
 	...emails: (string | null | undefined)[]
 ): Promise<string> {
-	for (const email of emails) {
-		if (!email) {
-			continue;
-		}
+	const candidates = new Set(
+		emails.filter((email): email is string => Boolean(email)),
+	);
+	for (const email of candidates) {
 		const purchaser = await db.query.user.findFirst({
 			where: { email: { eq: email } },
 		});

--- a/packages/scripts/src/traffic-report.ts
+++ b/packages/scripts/src/traffic-report.ts
@@ -27,6 +27,25 @@ interface PeriodPair {
 	previous: number;
 }
 
+interface UrlTraffic {
+	url: string;
+	pageviews: number;
+	visitors: number;
+}
+
+interface ConvertingUrl {
+	url: string;
+	signups: number;
+	payers: number;
+}
+
+interface BlogConversion {
+	path: string;
+	readers: number;
+	signups: number;
+	payers: number;
+}
+
 interface ReportData {
 	products: Map<string, { current: ProductTraffic; previous: ProductTraffic }>;
 	overall: { current: ProductTraffic; previous: ProductTraffic };
@@ -34,6 +53,9 @@ interface ReportData {
 	sources: Array<{ source: string; visitors: number }>;
 	sourcesByProduct: Map<string, Array<{ source: string; visitors: number }>>;
 	traffic: Map<string, PeriodPair>; // bucket -> human/bot/ai
+	topPages: UrlTraffic[];
+	convertingPages: ConvertingUrl[];
+	blogConversions: BlogConversion[];
 }
 
 const PRODUCTS: ReadonlyArray<{ host: string; label: string }> = [
@@ -48,6 +70,7 @@ const EVENTS: ReadonlyArray<{ event: string; label: string }> = [
 	{ event: "credits_purchased", label: "Credit purchases" },
 	{ event: "dev_plan_started", label: "DevPass starts" },
 	{ event: "chat_plan_started", label: "Chat plan starts" },
+	{ event: "reset_pass_purchased", label: "Reset passes" },
 	{ event: "onboarding_completed", label: "Onboarding done" },
 	{ event: "playground_chat_sent", label: "Playground chats" },
 	{ event: "cta_clicked", label: "CTA clicks" },
@@ -56,6 +79,20 @@ const EVENTS: ReadonlyArray<{ event: string; label: string }> = [
 ];
 
 const HOST_LIST = PRODUCTS.map((p) => `'${p.host}'`).join(",");
+
+// Events that mean the person paid us money. Payment events are captured
+// server-side against the purchasing user's id (see apps/api/src/stripe.ts),
+// which is the same id the frontends pass to posthog.identify, so they share
+// a person with that user's pageview journey.
+const PAYMENT_EVENTS = [
+	"credits_purchased",
+	"dev_plan_started",
+	"chat_plan_started",
+] as const;
+const PAYMENT_EVENT_LIST = PAYMENT_EVENTS.map((e) => `'${e}'`).join(",");
+
+// How far before a conversion a pageview may occur and still get credit.
+const ATTRIBUTION_LOOKBACK_DAYS = 30;
 
 function nonEmpty(value: string | undefined): string | undefined {
 	if (!value || value.trim() === "") {
@@ -275,15 +312,84 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 			AND properties.$host IN (${HOST_LIST})
 		GROUP BY period, bucket`;
 
-	const [perHost, overall, events, sources, sourcesByHost, traffic] =
-		await Promise.all([
-			runHogql(perHostQuery),
-			runHogql(overallQuery),
-			runHogql(eventsQuery),
-			runHogql(sourcesQuery),
-			runHogql(sourcesByProductQuery),
-			runHogql(trafficQuery),
-		]);
+	const topPagesQuery = `
+		SELECT concat(properties.$host, properties.$pathname) AS url,
+			count() AS pageviews,
+			count(DISTINCT person_id) AS visitors
+		FROM events
+		WHERE event = '$pageview'
+			AND timestamp >= toDateTime('${curStart}') AND timestamp < toDateTime('${curEnd}')
+			AND properties.$host IN (${HOST_LIST})
+		GROUP BY url
+		ORDER BY pageviews DESC
+		LIMIT 10`;
+
+	// Persons who converted (signed up / paid) during the current period, with
+	// the timestamp of their first conversion of each kind.
+	const lookbackStart = hogqlTimestamp(
+		shiftDays(window.current.start, -ATTRIBUTION_LOOKBACK_DAYS),
+	);
+	const convertersSubquery = `
+		SELECT person_id,
+			min(if(event = 'user_signed_up', timestamp, NULL)) AS signed_up_at,
+			min(if(event IN (${PAYMENT_EVENT_LIST}), timestamp, NULL)) AS paid_at
+		FROM events
+		WHERE event IN ('user_signed_up',${PAYMENT_EVENT_LIST})
+			AND timestamp >= toDateTime('${curStart}') AND timestamp < toDateTime('${curEnd}')
+		GROUP BY person_id`;
+
+	// A page "converts" a person when they viewed it any time in the lookback
+	// window before their first signup/payment of the period.
+	const convertingPagesQuery = `
+		SELECT concat(e.properties.$host, e.properties.$pathname) AS url,
+			uniqIf(e.person_id, ifNull(e.timestamp <= c.paid_at, 0)) AS payers,
+			uniqIf(e.person_id, ifNull(e.timestamp <= c.signed_up_at, 0)) AS signups
+		FROM events AS e
+		JOIN (${convertersSubquery}) AS c ON e.person_id = c.person_id
+		WHERE e.event = '$pageview'
+			AND e.timestamp >= toDateTime('${lookbackStart}') AND e.timestamp < toDateTime('${curEnd}')
+			AND e.properties.$host IN (${HOST_LIST})
+		GROUP BY url
+		HAVING payers > 0 OR signups > 0
+		ORDER BY payers DESC, signups DESC
+		LIMIT 5`;
+
+	const blogConversionsQuery = `
+		SELECT e.properties.$pathname AS path,
+			uniqIf(e.person_id, e.timestamp >= toDateTime('${curStart}')) AS readers,
+			uniqIf(e.person_id, ifNull(e.timestamp <= c.signed_up_at, 0)) AS signups,
+			uniqIf(e.person_id, ifNull(e.timestamp <= c.paid_at, 0)) AS payers
+		FROM events AS e
+		LEFT JOIN (${convertersSubquery}) AS c ON e.person_id = c.person_id
+		WHERE e.event = '$pageview'
+			AND e.timestamp >= toDateTime('${lookbackStart}') AND e.timestamp < toDateTime('${curEnd}')
+			AND e.properties.$host = 'llmgateway.io'
+			AND e.properties.$pathname LIKE '/blog/%'
+		GROUP BY path
+		ORDER BY payers DESC, signups DESC, readers DESC
+		LIMIT 5`;
+
+	const [
+		perHost,
+		overall,
+		events,
+		sources,
+		sourcesByHost,
+		traffic,
+		topPages,
+		convertingPages,
+		blogConversions,
+	] = await Promise.all([
+		runHogql(perHostQuery),
+		runHogql(overallQuery),
+		runHogql(eventsQuery),
+		runHogql(sourcesQuery),
+		runHogql(sourcesByProductQuery),
+		runHogql(trafficQuery),
+		runHogql(topPagesQuery),
+		runHogql(convertingPagesQuery),
+		runHogql(blogConversionsQuery),
+	]);
 
 	const products = new Map<
 		string,
@@ -374,6 +480,25 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 		}
 	}
 
+	const topPagesData = topPages.map((row) => ({
+		url: String(row[0]),
+		pageviews: num(row[1]),
+		visitors: num(row[2]),
+	}));
+
+	const convertingPagesData = convertingPages.map((row) => ({
+		url: String(row[0]),
+		payers: num(row[1]),
+		signups: num(row[2]),
+	}));
+
+	const blogConversionsData = blogConversions.map((row) => ({
+		path: String(row[0]),
+		readers: num(row[1]),
+		signups: num(row[2]),
+		payers: num(row[3]),
+	}));
+
 	return {
 		products,
 		overall: overallData,
@@ -381,6 +506,9 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 		sources: sourcesData,
 		sourcesByProduct,
 		traffic: trafficData,
+		topPages: topPagesData,
+		convertingPages: convertingPagesData,
+		blogConversions: blogConversionsData,
 	};
 }
 
@@ -398,6 +526,10 @@ function formatDelta(current: number, previous: number): string {
 }
 
 type Align = "left" | "right";
+
+function truncatePath(value: string, max: number): string {
+	return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
 
 function renderTable(
 	headers: string[],
@@ -458,6 +590,37 @@ function buildEmbed(window: ReportWindow, data: ReportData) {
 		"right",
 	]);
 
+	const topPagesTable = renderTable(
+		["Page", "Views", "Visitors"],
+		data.topPages.map((p) => [
+			truncatePath(p.url, 40),
+			formatInt(p.pageviews),
+			formatInt(p.visitors),
+		]),
+		["left", "right", "right"],
+	);
+
+	const convertingTable = renderTable(
+		["Page", "Payers", "Signups"],
+		data.convertingPages.map((p) => [
+			truncatePath(p.url, 40),
+			formatInt(p.payers),
+			formatInt(p.signups),
+		]),
+		["left", "right", "right"],
+	);
+
+	const blogTable = renderTable(
+		["Post", "Readers", "Signups", "Payers"],
+		data.blogConversions.map((b) => [
+			truncatePath(b.path.replace(/^\/blog\//, ""), 34),
+			formatInt(b.readers),
+			formatInt(b.signups),
+			formatInt(b.payers),
+		]),
+		["left", "right", "right", "right"],
+	);
+
 	const sources = data.sources
 		.map((s) => `${s.source} (${formatInt(s.visitors)})`)
 		.join(" · ");
@@ -488,6 +651,18 @@ function buildEmbed(window: ReportWindow, data: ReportData) {
 		"**Conversions & engagement**",
 		"```",
 		eventTable,
+		"```",
+		"**Top pages**",
+		"```",
+		data.topPages.length > 0 ? topPagesTable : "no data",
+		"```",
+		"**Top converting pages** · viewed before signup/purchase",
+		"```",
+		data.convertingPages.length > 0 ? convertingTable : "no data",
+		"```",
+		"**Blog posts** · readers this period, conversions they drove",
+		"```",
+		data.blogConversions.length > 0 ? blogTable : "no data",
 		"```",
 		`**Top sources** · ${sources || "no data"}`,
 		"",

--- a/packages/scripts/src/traffic-report.ts
+++ b/packages/scripts/src/traffic-report.ts
@@ -80,6 +80,9 @@ const EVENTS: ReadonlyArray<{ event: string; label: string }> = [
 
 const HOST_LIST = PRODUCTS.map((p) => `'${p.host}'`).join(",");
 
+// The blog is served by the marketing site (apps/ui) only.
+const BLOG_HOST = "llmgateway.io";
+
 // Events that mean the person paid us money. Payment events are captured
 // server-side against the purchasing user's id (see apps/api/src/stripe.ts),
 // which is the same id the frontends pass to posthog.identify, so they share
@@ -88,6 +91,7 @@ const PAYMENT_EVENTS = [
 	"credits_purchased",
 	"dev_plan_started",
 	"chat_plan_started",
+	"reset_pass_purchased",
 ] as const;
 const PAYMENT_EVENT_LIST = PAYMENT_EVENTS.map((e) => `'${e}'`).join(",");
 
@@ -338,12 +342,15 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 			AND timestamp >= toDateTime('${curStart}') AND timestamp < toDateTime('${curEnd}')
 		GROUP BY person_id`;
 
-	// A page "converts" a person when they viewed it any time in the lookback
+	// A page "converts" a person when they viewed it within the lookback
 	// window before their first signup/payment of the period.
+	const attributedTo = (conversionColumn: string): string =>
+		`ifNull(e.timestamp <= ${conversionColumn} AND e.timestamp >= ${conversionColumn} - INTERVAL ${ATTRIBUTION_LOOKBACK_DAYS} DAY, 0)`;
+
 	const convertingPagesQuery = `
 		SELECT concat(e.properties.$host, e.properties.$pathname) AS url,
-			uniqIf(e.person_id, ifNull(e.timestamp <= c.paid_at, 0)) AS payers,
-			uniqIf(e.person_id, ifNull(e.timestamp <= c.signed_up_at, 0)) AS signups
+			uniqIf(e.person_id, ${attributedTo("c.paid_at")}) AS payers,
+			uniqIf(e.person_id, ${attributedTo("c.signed_up_at")}) AS signups
 		FROM events AS e
 		JOIN (${convertersSubquery}) AS c ON e.person_id = c.person_id
 		WHERE e.event = '$pageview'
@@ -357,13 +364,13 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 	const blogConversionsQuery = `
 		SELECT e.properties.$pathname AS path,
 			uniqIf(e.person_id, e.timestamp >= toDateTime('${curStart}')) AS readers,
-			uniqIf(e.person_id, ifNull(e.timestamp <= c.signed_up_at, 0)) AS signups,
-			uniqIf(e.person_id, ifNull(e.timestamp <= c.paid_at, 0)) AS payers
+			uniqIf(e.person_id, ${attributedTo("c.signed_up_at")}) AS signups,
+			uniqIf(e.person_id, ${attributedTo("c.paid_at")}) AS payers
 		FROM events AS e
 		LEFT JOIN (${convertersSubquery}) AS c ON e.person_id = c.person_id
 		WHERE e.event = '$pageview'
 			AND e.timestamp >= toDateTime('${lookbackStart}') AND e.timestamp < toDateTime('${curEnd}')
-			AND e.properties.$host = 'llmgateway.io'
+			AND e.properties.$host = '${BLOG_HOST}'
 			AND e.properties.$pathname LIKE '/blog/%'
 		GROUP BY path
 		ORDER BY payers DESC, signups DESC, readers DESC


### PR DESCRIPTION
PostHog payment conversion events (credits_purchased,
dev_plan_started, chat_plan_started, reset_pass_purchased) were all
captured against the literal distinct id "organization", piling every
purchase onto one pseudo-person. Capture them against the purchasing
user's id instead (the same id the frontends pass to
posthog.identify), resolved from checkout metadata or the org billing
email, so pageview journeys can be joined to payments in analytics.
Falls back to "organization" when no user can be resolved.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FZGskXGCobGxpJ6minAgpZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Improved PostHog attribution for purchase/conversion events by using the purchaser’s user identity when available (instead of a generic fallback).
  * Included reset-pass purchases in payment/conversion tracking.

* **Traffic Reports**
  * Reports now show top pages by views.
  * Added “top converting pages” (attributed signups/payers using a lookback window).
  * Added blog post readership plus attributed signup/payer metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->