### PR TITLE
fix(gateway): support thinking:disabled for DeepSeek and GLM

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1287,6 +1287,156 @@ describe("prepareRequestBody - Xiaomi thinking", () => {
 	});
 });
 
+describe("prepareRequestBody - DeepSeek thinking", () => {
+	async function prepare(options: {
+		model: string;
+		reasoningEffort?:
+			| "none"
+			| "minimal"
+			| "low"
+			| "medium"
+			| "high"
+			| "xhigh"
+			| "max";
+		supportsReasoning?: boolean;
+	}) {
+		return (await prepareRequestBody(
+			"deepseek",
+			options.model,
+			null,
+			options.model,
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			options.reasoningEffort, // reasoning_effort
+			options.supportsReasoning ?? true, // supportsReasoning
+		)) as unknown as Record<string, unknown>;
+	}
+
+	test("maps none to thinking disabled and never forwards reasoning_effort", async () => {
+		const requestBody = await prepare({
+			model: "deepseek-v4-pro",
+			reasoningEffort: "none",
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("forwards native effort tiers verbatim without a thinking parameter", async () => {
+		const requestBody = await prepare({
+			model: "deepseek-v4-pro",
+			reasoningEffort: "high",
+		});
+		expect(requestBody.reasoning_effort).toBe("high");
+		expect(requestBody.thinking).toBeUndefined();
+	});
+
+	test("forwards max natively", async () => {
+		const requestBody = await prepare({
+			model: "deepseek-v4-pro",
+			reasoningEffort: "max",
+		});
+		expect(requestBody.reasoning_effort).toBe("max");
+		expect(requestBody.thinking).toBeUndefined();
+	});
+
+	test("keeps the provider default when no reasoning_effort is requested", async () => {
+		const requestBody = await prepare({ model: "deepseek-v4-pro" });
+		expect(requestBody.thinking).toBeUndefined();
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("forwards unsupported tiers verbatim so the provider rejects them", async () => {
+		const requestBody = await prepare({
+			model: "deepseek-v4-pro",
+			reasoningEffort: "xhigh",
+		});
+		expect(requestBody.reasoning_effort).toBe("xhigh");
+		expect(requestBody.thinking).toBeUndefined();
+	});
+
+	test("drops none for models that do not declare it in reasoningEfforts", async () => {
+		// deepseek-v3.2 on the deepseek provider has reasoning: false
+		// and no reasoningEfforts, so supportsReasoning is false
+		const requestBody = await prepare({
+			model: "deepseek-v3.2",
+			reasoningEffort: "none",
+			supportsReasoning: false,
+		});
+		expect(requestBody.thinking).toBeUndefined();
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+});
+
+describe("prepareRequestBody - Z.ai thinking", () => {
+	async function prepare(options: {
+		model: string;
+		reasoningEffort?:
+			| "none"
+			| "minimal"
+			| "low"
+			| "medium"
+			| "high"
+			| "xhigh"
+			| "max";
+	}) {
+		return (await prepareRequestBody(
+			"zai",
+			options.model,
+			null,
+			options.model,
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			options.reasoningEffort, // reasoning_effort
+			true, // supportsReasoning
+		)) as unknown as Record<string, unknown>;
+	}
+
+	test("maps none to thinking disabled", async () => {
+		const requestBody = await prepare({
+			model: "glm-4.7",
+			reasoningEffort: "none",
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+
+	test("enables thinking for explicit effort tiers", async () => {
+		const requestBody = await prepare({
+			model: "glm-4.7",
+			reasoningEffort: "high",
+		});
+		expect(requestBody.thinking).toEqual({ type: "enabled" });
+	});
+
+	test("disables thinking by default when no effort is requested", async () => {
+		const requestBody = await prepare({ model: "glm-4.7" });
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+
+	test("treats minimal as disabled", async () => {
+		const requestBody = await prepare({
+			model: "glm-4.7",
+			reasoningEffort: "minimal",
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+});
+
 describe("prepareRequestBody - reasoning_effort max", () => {
 	async function prepare(options: {
 		provider: Parameters<typeof prepareRequestBody>[0];

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1386,6 +1386,8 @@ describe("prepareRequestBody - Z.ai thinking", () => {
 			| "high"
 			| "xhigh"
 			| "max";
+		responseFormat?: Parameters<typeof prepareRequestBody>[11];
+		tools?: Parameters<typeof prepareRequestBody>[12];
 	}) {
 		return (await prepareRequestBody(
 			"zai",
@@ -1399,8 +1401,8 @@ describe("prepareRequestBody - Z.ai thinking", () => {
 			undefined, // top_p
 			undefined, // frequency_penalty
 			undefined, // presence_penalty
-			undefined, // response_format
-			undefined, // tools
+			options.responseFormat, // response_format
+			options.tools, // tools
 			undefined, // tool_choice
 			options.reasoningEffort, // reasoning_effort
 			true, // supportsReasoning
@@ -1434,6 +1436,42 @@ describe("prepareRequestBody - Z.ai thinking", () => {
 			reasoningEffort: "minimal",
 		});
 		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+
+	test("none disables thinking even when tools are present", async () => {
+		const requestBody = await prepare({
+			model: "glm-4.7",
+			reasoningEffort: "none",
+			tools: [
+				{
+					type: "function",
+					function: { name: "get_weather" },
+				},
+			],
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+
+	test("none disables thinking even with a response_format", async () => {
+		const requestBody = await prepare({
+			model: "glm-4.7",
+			reasoningEffort: "none",
+			responseFormat: { type: "json_object" },
+		});
+		expect(requestBody.thinking).toEqual({ type: "disabled" });
+	});
+
+	test("leaves thinking on provider default for tool requests without an effort", async () => {
+		const requestBody = await prepare({
+			model: "glm-4.7",
+			tools: [
+				{
+					type: "function",
+					function: { name: "get_weather" },
+				},
+			],
+		});
+		expect(requestBody.thinking).toBeUndefined();
 	});
 });
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1032,11 +1032,11 @@ export async function prepareRequestBody(
 
 	// `none` reasoning effort is handled natively by a few providers:
 	// OpenAI/Azure forward it (their newer models accept it to turn reasoning
-	// off), and Google, Moonshot, Alibaba, MiniMax, and Xiaomi reason by
-	// default so they must explicitly disable thinking when asked. Every other
-	// provider treats the absence of reasoning_effort as "off" already, so
-	// normalize `none` away for them to avoid forwarding an unsupported enum
-	// value.
+	// off), and Google, Moonshot, Alibaba, MiniMax, Xiaomi, and DeepSeek
+	// reason by default so they must explicitly disable thinking when asked.
+	// Every other provider treats
+	// the absence of reasoning_effort as "off" already, so normalize `none`
+	// away for them to avoid forwarding an unsupported enum value.
 	const handlesNoneNatively =
 		usedProvider === "openai" ||
 		usedProvider === "azure" ||
@@ -1048,6 +1048,8 @@ export async function prepareRequestBody(
 		usedProvider === "alibaba" ||
 		usedProvider === "minimax" ||
 		usedProvider === "xiaomi" ||
+		usedProvider === "deepseek" ||
+		usedProvider === "zai" ||
 		providerMappingForOptions?.apiFormat === "openai-chat-completions";
 	if (reasoning_effort === "none" && !handlesNoneNatively) {
 		reasoning_effort = undefined;
@@ -2031,19 +2033,24 @@ export async function prepareRequestBody(
 			}
 			// ZAI/GLM models use a `thinking` parameter instead of `reasoning_effort`.
 			// Mirror the OpenAI/Anthropic/Google contract: thinking is opt-in via
-			// `reasoning_effort`. Unset or `minimal` => disabled, anything else => enabled.
-			// Exception: disabling thinking corrupts GLM structured output
-			// (verified live: glm-4.5 emits tool calls as raw <tool_call> text,
-			// glm-4.6v-flashx appends a stray "End" token after JSON output), so
-			// for requests with tools or a response_format leave the provider
-			// default (enabled) rather than disabling.
+			// `reasoning_effort`. "none" explicitly disables thinking, "minimal" and
+			// unset also disable, anything else enables. Exception: disabling
+			// thinking corrupts GLM structured output (verified live: glm-4.5 emits
+			// tool calls as raw <tool_call> text, glm-4.6v-flashx appends a stray
+			// "End" token after JSON output), so for requests with tools or a
+			// response_format leave the provider default rather than disabling —
+			// unless the caller explicitly asked for "none".
 			if (supportsReasoning) {
-				const wantsThinking =
-					reasoning_effort !== undefined && reasoning_effort !== "minimal";
-				if (wantsThinking || (!requestBody.tools && !response_format)) {
-					requestBody.thinking = {
-						type: wantsThinking ? "enabled" : "disabled",
-					};
+				if (reasoning_effort === "none") {
+					requestBody.thinking = { type: "disabled" };
+				} else {
+					const wantsThinking =
+						reasoning_effort !== undefined && reasoning_effort !== "minimal";
+					if (wantsThinking || (!requestBody.tools && !response_format)) {
+						requestBody.thinking = {
+							type: wantsThinking ? "enabled" : "disabled",
+						};
+					}
 				}
 			}
 			// Add sensitive_word_check if provided (Z.ai specific)
@@ -3609,6 +3616,52 @@ export async function prepareRequestBody(
 			}
 			break;
 		}
+
+		case "deepseek": {
+			if (stream) {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+			if (response_format) {
+				requestBody.response_format = response_format;
+			}
+
+			// Add optional parameters if they are provided
+			if (temperature !== undefined) {
+				requestBody.temperature = temperature;
+			}
+			if (max_tokens !== undefined) {
+				requestBody.max_tokens = max_tokens;
+			}
+			if (top_p !== undefined) {
+				requestBody.top_p = top_p;
+			}
+			if (frequency_penalty !== undefined) {
+				requestBody.frequency_penalty = frequency_penalty;
+			}
+			if (presence_penalty !== undefined) {
+				requestBody.presence_penalty = presence_penalty;
+			}
+
+			// DeepSeek V4 models think by default. Translate reasoning_effort "none"
+			// to the documented binary disable (thinking: { type: "disabled" },
+			// verified to zero out reasoning tokens). Mappings that can turn thinking
+			// off declare none in reasoningEfforts; elsewhere none sends
+			// nothing and the provider default is kept.
+			if (reasoning_effort === "none") {
+				const canDisableThinking =
+					providerMappingForOptions?.reasoningEfforts?.includes("none") ??
+					false;
+				if (supportsReasoning && canDisableThinking) {
+					requestBody.thinking = { type: "disabled" };
+				}
+			} else if (reasoning_effort !== undefined) {
+				requestBody.reasoning_effort = reasoning_effort;
+			}
+			break;
+		}
+
 		default: {
 			if (stream) {
 				requestBody.stream_options = {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1032,11 +1032,11 @@ export async function prepareRequestBody(
 
 	// `none` reasoning effort is handled natively by a few providers:
 	// OpenAI/Azure forward it (their newer models accept it to turn reasoning
-	// off), and Google, Moonshot, Alibaba, MiniMax, Xiaomi, and DeepSeek
-	// reason by default so they must explicitly disable thinking when asked.
-	// Every other provider treats
-	// the absence of reasoning_effort as "off" already, so normalize `none`
-	// away for them to avoid forwarding an unsupported enum value.
+	// off), and Google, Moonshot, Alibaba, MiniMax, Xiaomi, DeepSeek, and
+	// Z.ai reason by default so they must explicitly disable thinking when
+	// asked. Every other provider treats the absence of reasoning_effort as
+	// "off" already, so normalize `none` away for them to avoid forwarding an
+	// unsupported enum value.
 	const handlesNoneNatively =
 		usedProvider === "openai" ||
 		usedProvider === "azure" ||

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -264,7 +264,7 @@ export const deepseekModels = [
 				jsonOutput: true,
 				streaming: true,
 				reasoning: true,
-				reasoningEfforts: ["high", "max"],
+				reasoningEfforts: ["none", "high", "max"],
 				vision: false,
 				tools: true,
 				supportedParameters: [
@@ -277,6 +277,7 @@ export const deepseekModels = [
 					"stream",
 					"response_format",
 					"tools",
+					"reasoning_effort",
 				],
 			},
 			{
@@ -379,7 +380,7 @@ export const deepseekModels = [
 				jsonOutput: true,
 				streaming: true,
 				reasoning: true,
-				reasoningEfforts: ["high", "max"],
+				reasoningEfforts: ["none", "high", "max"],
 				vision: false,
 				tools: true,
 				supportedParameters: [
@@ -392,6 +393,7 @@ export const deepseekModels = [
 					"stream",
 					"response_format",
 					"tools",
+					"reasoning_effort",
 				],
 			},
 			{

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -20,7 +20,7 @@ export const zaiModels = [
 				maxOutput: 128000,
 				streaming: true,
 				reasoning: true,
-				reasoningEfforts: ["high", "max"],
+				reasoningEfforts: ["none", "high", "max"],
 				vision: false,
 				tools: true,
 				webSearch: true,


### PR DESCRIPTION
## Summary

- **DeepSeek**: new `case "deepseek"` translates `reasoning_effort="none"` → `thinking: { type: "disabled" }`, matching the [DeepSeek API](https://api-docs.deepseek.com/guides/thinking_mode). Native effort tiers (`high`, `max`) are forwarded verbatim.
- **GLM (Z.ai)**: fix `case "zai"` — `"none"` was incorrectly mapping to `thinking: { type: "enabled" }`; now correctly sets `"disabled"`, matching the [Z.ai docs](https://docs.z.ai/guides/capabilities/thinking-mode). Caller-explicit `"none"` bypasses the structured-output safety guard.
- **MiMo (Xiaomi)**: already handled ✅, unchanged.

## Why

DeepSeek V4 and GLM 4.5+ models **think by default**. Without an explicit disable, every request burns reasoning tokens — even when the caller passes `reasoning_effort="none"`. The gateway was either stripping the parameter upstream (DeepSeek) or mapping it to the wrong toggle value (GLM). These providers expose a binary `thinking` toggle rather than the OpenAI-style effort enum, so `"none"` needs a provider-specific translation.

## Per-provider

| Provider | Models | Before | After |
|---|---|---|---|
| `deepseek` | v4-pro, v4-flash | ❌ `none` ignored (stripped upstream) | ✅ `thinking: { type: "disabled" }` |
| `zai` | GLM 4.5+ | ❌ `none` mapped to `"enabled"` (bug) | ✅ `thinking: { type: "disabled" }` |

MiMo (Xiaomi) already handled `none` → `thinking: { type: "disabled" }` correctly in its existing switch case and is unchanged.

## Reference

- [DeepSeek thinking mode](https://api-docs.deepseek.com/guides/thinking_mode) — `thinking: { type: "disabled" }`, do not send `reasoning_effort` alongside
- [Z.ai GLM thinking mode](https://docs.z.ai/guides/capabilities/thinking-mode) — `thinking: { type: "disabled" }`, supported on GLM 4.5+
- [MiMo deep thinking](https://mimo.mi.com/docs/en-US/quick-start/usage-guide/text-generation/deep-thinking?target=thinking-disabled) — same toggle format, already working

🤖 Generated with [Claude Code](https://claude.com/claude-code)