### PR TITLE
feat: growth nav, blog CTAs, analytics fixes

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -7,6 +7,7 @@ import {
 	executeSelfRefund,
 	isSelfRefundCandidateType,
 } from "@/lib/self-refund.js";
+import { posthog } from "@/posthog.js";
 import {
 	ensureStripeCustomer,
 	finalizeDevPlanSetupSession,
@@ -3213,6 +3214,17 @@ devPlans.openapi(redeemResetPass, async (c) => {
 			tier,
 			source,
 			premiumCreditsUsedBeforeReset: personalOrg.devPlanPremiumCreditsUsed,
+		},
+	});
+
+	posthog.capture({
+		distinctId: user.id,
+		event: "reset_pass_redeemed",
+		groups: { organization: personalOrg.id },
+		properties: {
+			devPlan: tier,
+			source,
+			organization: personalOrg.id,
 		},
 	});
 

--- a/apps/code/src/app/dashboard/components/UsageOverview.tsx
+++ b/apps/code/src/app/dashboard/components/UsageOverview.tsx
@@ -2,7 +2,10 @@
 
 import { format, formatDistanceToNowStrict } from "date-fns";
 import { Activity, Coins, Cpu, Gem, TrendingUp } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useEffect } from "react";
 
+import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
 
 import { AgentModelUsageChart } from "./AgentModelUsageChart";
@@ -219,12 +222,36 @@ export default function UsageOverview({
 	cycle = "monthly",
 }: UsageOverviewProps) {
 	const api = useApi();
+	const posthog = usePostHog();
+	const { posthogKey } = useAppConfig();
 
 	const tierKey = planName.toLowerCase();
 	// The monthly credit pool (not the weekly premium allowance) is the hard
 	// ceiling: once it's gone, Reset Passes can't unlock anything, so the pass
 	// card gives way to the upgrade/PAYG promo.
 	const monthlyExhausted = creditsLimit > 0 && creditsUsed >= creditsLimit;
+
+	// Top of the Reset Pass upsell funnel: the user sees the exhausted weekly
+	// premium meter. reset_pass_purchased/redeemed are captured server-side,
+	// so without this event the funnel has a bottom but no top.
+	const weeklyExhausted =
+		premiumWeeklyLimit > 0 && premiumCreditsUsed >= premiumWeeklyLimit;
+	useEffect(() => {
+		if (!posthogKey || !weeklyExhausted) {
+			return;
+		}
+		posthog.capture("devpass_weekly_cap_hit_viewed", {
+			tier: tierKey,
+			weeklyLimit: premiumWeeklyLimit,
+			weeklyUsed: premiumCreditsUsed,
+			resetsAt: premiumWeekResetsAt,
+			purchasedPasses: resetPasses,
+			includedPassesRemaining: includedResetPassesRemaining,
+			monthlyExhausted,
+		});
+		// Fire once per exhausted dashboard view, not on every prop tick.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [posthogKey, weeklyExhausted]);
 
 	const { data: activity } = api.useQuery(
 		"get",

--- a/apps/playground/next.config.ts
+++ b/apps/playground/next.config.ts
@@ -26,6 +26,21 @@ const nextConfig: NextConfig = {
 		"@json-render/react-pdf",
 		"@json-render/image",
 	],
+	async rewrites() {
+		return [
+			// First-party PostHog ingestion proxy — ad blockers block
+			// *.posthog.com directly, silently dropping client events. The
+			// client is configured with api_host: "/ingest" (providers.tsx).
+			{
+				source: "/ingest/static/:path*",
+				destination: "https://us-assets.i.posthog.com/static/:path*",
+			},
+			{
+				source: "/ingest/:path*",
+				destination: "https://us.i.posthog.com/:path*",
+			},
+		];
+	},
 	typescript: {
 		ignoreBuildErrors: true,
 	},

--- a/apps/playground/src/components/providers.tsx
+++ b/apps/playground/src/components/providers.tsx
@@ -41,16 +41,23 @@ export function Providers({ children, config }: ProvidersProps) {
 		const host = config.posthogHost;
 		const init = () => {
 			posthog.init(key, {
-				api_host: host,
+				// Ingest through our own origin (see the /ingest rewrites in
+				// next.config.ts) so ad blockers that block *.posthog.com don't
+				// silently drop client events.
+				api_host: "/ingest",
+				ui_host: host,
 				capture_pageview: "history_change",
 				autocapture: true,
 			});
 		};
+		// Captures fired before init() are dropped by posthog-js, so the idle
+		// deferral must be bounded — a busy main thread (e.g. the chat page)
+		// can starve requestIdleCallback long enough for a user to act.
 		if (typeof requestIdleCallback !== "undefined") {
-			const id = requestIdleCallback(init);
+			const id = requestIdleCallback(init, { timeout: 800 });
 			return () => cancelIdleCallback(id);
 		}
-		const timer = setTimeout(init, 1000);
+		const timer = setTimeout(init, 300);
 		return () => clearTimeout(timer);
 	}, [config.posthogKey, config.posthogHost]);
 

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -422,6 +422,17 @@ const nextConfig: NextConfig = {
 				source: "/docs-health",
 				destination: "https://docs.llmgateway.io/health",
 			},
+			// First-party PostHog ingestion proxy — ad blockers block
+			// *.posthog.com directly, silently dropping client events. The
+			// client is configured with api_host: "/ingest" (providers.tsx).
+			{
+				source: "/ingest/static/:path*",
+				destination: "https://us-assets.i.posthog.com/static/:path*",
+			},
+			{
+				source: "/ingest/:path*",
+				destination: "https://us.i.posthog.com/:path*",
+			},
 		];
 	},
 	typescript: {

--- a/apps/ui/src/components/blog/blog-cta.tsx
+++ b/apps/ui/src/components/blog/blog-cta.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+
+import { Button } from "@/lib/components/button";
+
+// Conversion card embeddable in markdown content via the `BlogCta` override in
+// getMarkdownOptions. The DevPass variant leans into the passport/boarding-pass
+// brand language used across DevPass surfaces.
+export function BlogCta({
+	variant = "devpass",
+	location = "inline",
+}: {
+	variant?: "devpass" | "gateway";
+	location?: string;
+}) {
+	const posthog = usePostHog();
+	const pathname = usePathname();
+	const post = pathname?.split("/").pop() ?? "unknown";
+
+	const track = (cta: string) => {
+		posthog.capture("cta_clicked", {
+			location: `blog_${location}`,
+			cta,
+			post,
+		});
+	};
+
+	if (variant === "gateway") {
+		return (
+			<div className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8">
+				<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
+					LLM Gateway
+				</div>
+				<h3 className="mt-3 text-2xl font-bold tracking-tight text-foreground">
+					One API key for every model.
+				</h3>
+				<p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+					Route to 200+ models with automatic failover, caching, and real-time
+					cost analytics. Free to start — no credit card required.
+				</p>
+				<div className="mt-5 flex flex-wrap items-center gap-3">
+					<Button
+						asChild
+						className="bg-zinc-900 font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-black dark:hover:bg-zinc-200"
+					>
+						<Link
+							href="/signup"
+							prefetch={true}
+							onClick={() => track("create_free_account")}
+						>
+							Create free account
+						</Link>
+					</Button>
+					<Link
+						href="/models"
+						prefetch={true}
+						onClick={() => track("browse_models")}
+						className="text-sm text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+					>
+						Browse all models
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="not-prose relative my-10 overflow-hidden rounded-xl border border-dashed border-stone-400/70 bg-stone-50/70 dark:border-stone-600/70 dark:bg-stone-900/30">
+			<div className="p-6 sm:p-8">
+				<div className="flex flex-wrap items-baseline justify-between gap-2">
+					<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-stone-500 dark:text-stone-400">
+						DevPass · Boarding pass
+					</div>
+					<div className="font-mono text-[9px] tracking-[0.25em] text-stone-400 dark:text-stone-500">
+						No. DP-{post.slice(0, 6).toUpperCase()}
+					</div>
+				</div>
+				<h3 className="mt-3 text-2xl font-bold tracking-tight text-foreground">
+					Every frontier model. One flat rate.
+				</h3>
+				<p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+					Run Claude, GPT-5.5, Gemini, and 200+ more through Claude Code,
+					Cursor, or whatever tool you already use. From $29/mo — no token math,
+					no surprise invoices.
+				</p>
+				<div className="mt-5 flex flex-wrap items-center gap-3">
+					<Button
+						asChild
+						className="bg-zinc-900 font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-black dark:hover:bg-zinc-200"
+					>
+						<a
+							href={`https://devpass.llmgateway.io/signup?utm_source=blog&utm_medium=cta&utm_campaign=${post}`}
+							onClick={() => track("get_devpass")}
+						>
+							Get DevPass — from $29/mo
+						</a>
+					</Button>
+					<a
+						href={`https://devpass.llmgateway.io/pricing?utm_source=blog&utm_medium=cta&utm_campaign=${post}`}
+						onClick={() => track("compare_devpass_plans")}
+						className="text-sm text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+					>
+						Compare plans
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/components/landing/navbar.tsx
+++ b/apps/ui/src/components/landing/navbar.tsx
@@ -30,6 +30,7 @@ import {
 	Zap,
 } from "lucide-react";
 import Link from "next/link";
+import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
 
 import { AuthLink } from "@/components/shared/auth-link";
@@ -70,8 +71,12 @@ function IconMenuItem({
 	gradient: string;
 	external?: boolean;
 }) {
+	const posthog = usePostHog();
 	const linkClassName = cn(
-		"group/product flex items-start gap-3 select-none rounded-lg p-3 no-underline outline-none transition-all duration-300 bg-linear-to-br from-transparent to-transparent",
+		// flex-row is load-bearing: NavigationMenuLink's base classes include
+		// flex-col and are concatenated onto this link via Radix Slot, so the
+		// direction must be asserted explicitly or the card stacks vertically.
+		"group/product flex flex-row items-start gap-3 select-none rounded-lg p-3 no-underline outline-none transition-all duration-300 bg-linear-to-br from-transparent to-transparent",
 		gradient,
 		"hover:shadow-lg focus:shadow-md",
 	);
@@ -96,6 +101,10 @@ function IconMenuItem({
 		</>
 	);
 
+	const handleClick = () => {
+		posthog.capture("nav_link_clicked", { link: title, area: "dropdown" });
+	};
+
 	return (
 		<li>
 			<NavigationMenuLink asChild>
@@ -105,11 +114,17 @@ function IconMenuItem({
 						target="_blank"
 						rel="noopener noreferrer"
 						className={linkClassName}
+						onClick={handleClick}
 					>
 						{inner}
 					</a>
 				) : (
-					<Link href={href as Route} prefetch={true} className={linkClassName}>
+					<Link
+						href={href as Route}
+						prefetch={true}
+						className={linkClassName}
+						onClick={handleClick}
+					>
 						{inner}
 					</Link>
 				)}
@@ -130,8 +145,13 @@ export const Navbar = ({
 	providers?: ApiProvider[];
 }) => {
 	const config = useAppConfig();
+	const posthog = usePostHog();
 	const { isAuthenticated: hasSession, isLoading } = useSessionStatus();
 	const isAuthenticated = hasSession && !isLoading;
+
+	const trackNav = (link: string) => {
+		posthog.capture("nav_link_clicked", { link, area: "navbar" });
+	};
 
 	const productsLinks: Array<{
 		title: string;
@@ -421,7 +441,7 @@ export const Navbar = ({
 								prefetch={true}
 							>
 								<Logo className="h-8 w-8 rounded-full text-black dark:text-white" />
-								<span className="text-xl font-bold tracking-tight text-zinc-900 dark:text-white">
+								<span className="text-xl font-bold tracking-tight text-zinc-900 dark:text-white whitespace-nowrap">
 									LLM Gateway
 								</span>
 							</Link>
@@ -437,18 +457,58 @@ export const Navbar = ({
 						</div>
 
 						{/* Desktop center nav */}
-						<div className="m-auto hidden items-center gap-2 nav:flex min-w-0">
-							<div className="w-[140px] lg:w-[160px]">
+						<div className="m-auto hidden items-center gap-1 nav:flex min-w-0">
+							<div className="w-[140px] xl:w-[160px]">
 								<ModelSearch models={models} providers={providers} />
 							</div>
 							<NavigationMenu viewport={false} delayDuration={300}>
-								<NavigationMenuList className="flex gap-1 text-sm">
+								<NavigationMenuList className="flex gap-0.5 text-sm">
+									{/* Most-clicked destinations surfaced as direct links —
+									    DevPass (top product) and Models (top resource) per
+									    PostHog page traffic; Chat joins on wider screens. */}
+									<NavigationMenuItem>
+										<NavigationMenuLink asChild>
+											<a
+												href="https://devpass.llmgateway.io"
+												onClick={() => trackNav("DevPass")}
+												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-3 py-2 whitespace-nowrap"
+											>
+												DevPass
+											</a>
+										</NavigationMenuLink>
+									</NavigationMenuItem>
+
+									<NavigationMenuItem className="hidden min-[1360px]:block">
+										<NavigationMenuLink asChild>
+											<a
+												href={config.playgroundUrl ?? "#"}
+												onClick={() => trackNav("Chat")}
+												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-3 py-2 whitespace-nowrap"
+											>
+												Chat
+											</a>
+										</NavigationMenuLink>
+									</NavigationMenuItem>
+
+									<NavigationMenuItem>
+										<NavigationMenuLink asChild>
+											<Link
+												href="/models"
+												prefetch={true}
+												onClick={() => trackNav("Models")}
+												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-3 py-2 whitespace-nowrap"
+											>
+												Models
+											</Link>
+										</NavigationMenuLink>
+									</NavigationMenuItem>
+
 									{/* Products dropdown */}
 									<NavigationMenuItem>
-										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-4 py-2 bg-transparent">
+										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-3 py-2 bg-transparent">
 											Products
 										</NavigationMenuTrigger>
-										<NavigationMenuContent>
+										<NavigationMenuContent className="md:left-1/2 md:-translate-x-1/2">
 											<ul className="grid grid-cols-2 gap-2 p-4 md:w-[520px] lg:w-[580px]">
 												{productsLinks.map((product) => (
 													<IconMenuItem
@@ -467,10 +527,10 @@ export const Navbar = ({
 
 									{/* Resources dropdown */}
 									<NavigationMenuItem>
-										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-4 py-2 bg-transparent">
+										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-3 py-2 bg-transparent">
 											Resources
 										</NavigationMenuTrigger>
-										<NavigationMenuContent>
+										<NavigationMenuContent className="md:left-1/2 md:-translate-x-1/2">
 											<ul className="grid grid-cols-2 gap-2 p-4 md:w-[680px] lg:w-[820px] lg:grid-cols-3">
 												{resourcesLinks.map((link) => (
 													<IconMenuItem
@@ -487,26 +547,12 @@ export const Navbar = ({
 										</NavigationMenuContent>
 									</NavigationMenuItem>
 
-									{/* Docs link */}
-									<NavigationMenuItem>
-										<NavigationMenuLink asChild>
-											<a
-												href={config.docsUrl ?? ""}
-												target="_blank"
-												rel="noopener noreferrer"
-												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-4 py-2"
-											>
-												Docs
-											</a>
-										</NavigationMenuLink>
-									</NavigationMenuItem>
-
 									{/* AI dropdown */}
 									<NavigationMenuItem>
-										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-4 py-2 bg-transparent">
+										<NavigationMenuTrigger className="text-muted-foreground hover:text-accent-foreground px-3 py-2 bg-transparent">
 											AI
 										</NavigationMenuTrigger>
-										<NavigationMenuContent>
+										<NavigationMenuContent className="md:left-1/2 md:-translate-x-1/2">
 											<ul className="grid grid-cols-2 gap-2 p-4 md:w-[520px] lg:w-[580px]">
 												{aiLinks.map((item) => (
 													<IconMenuItem
@@ -523,13 +569,29 @@ export const Navbar = ({
 										</NavigationMenuContent>
 									</NavigationMenuItem>
 
+									{/* Docs link */}
+									<NavigationMenuItem>
+										<NavigationMenuLink asChild>
+											<a
+												href={config.docsUrl ?? ""}
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={() => trackNav("Docs")}
+												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-3 py-2"
+											>
+												Docs
+											</a>
+										</NavigationMenuLink>
+									</NavigationMenuItem>
+
 									{/* Pricing link */}
 									<NavigationMenuItem>
 										<NavigationMenuLink asChild>
 											<Link
 												href="/pricing"
 												prefetch={true}
-												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-4 py-2"
+												onClick={() => trackNav("Pricing")}
+												className="text-muted-foreground hover:text-accent-foreground block duration-150 px-3 py-2"
 											>
 												Pricing
 											</Link>
@@ -547,6 +609,24 @@ export const Navbar = ({
 									<ModelSearch models={models} providers={providers} />
 								</div>
 								<ul className="text-base">
+									<li>
+										<a
+											href="https://devpass.llmgateway.io"
+											onClick={() => trackNav("DevPass")}
+											className="text-muted-foreground hover:text-accent-foreground block py-2.5 duration-150"
+										>
+											DevPass
+										</a>
+									</li>
+									<li>
+										<a
+											href={config.playgroundUrl ?? "#"}
+											onClick={() => trackNav("Chat")}
+											className="text-muted-foreground hover:text-accent-foreground block py-2.5 duration-150"
+										>
+											Chat
+										</a>
+									</li>
 									<li>
 										<Link
 											href="/pricing"
@@ -662,8 +742,10 @@ export const Navbar = ({
 							</div>
 
 							<div className="flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit items-center">
-								{/* GitHub stars (compact) + Discord */}
-								<div className="hidden nav:flex items-center gap-1">
+								{/* GitHub stars (compact) + Discord — hidden in the narrow
+								    band above the nav breakpoint so the promoted nav links
+								    don't collide with the right-side controls. */}
+								<div className="hidden min-[1280px]:flex items-center gap-1">
 									{children}
 									<a
 										href={config.discordUrl}

--- a/apps/ui/src/components/providers.tsx
+++ b/apps/ui/src/components/providers.tsx
@@ -71,16 +71,23 @@ export function Providers({ children, config }: ProvidersProps) {
 		const host = config.posthogHost;
 		const init = () => {
 			posthog.init(key, {
-				api_host: host,
+				// Ingest through our own origin (see the /ingest rewrites in
+				// next.config.ts) so ad blockers that block *.posthog.com don't
+				// silently drop client events.
+				api_host: "/ingest",
+				ui_host: host,
 				capture_pageview: "history_change",
 				autocapture: true,
 			});
 		};
+		// Captures fired before init() are dropped by posthog-js, so the idle
+		// deferral must be bounded — a busy main thread can starve
+		// requestIdleCallback long enough for a user to act.
 		if (typeof requestIdleCallback !== "undefined") {
-			const id = requestIdleCallback(init);
+			const id = requestIdleCallback(init, { timeout: 800 });
 			return () => cancelIdleCallback(id);
 		}
-		const timer = setTimeout(init, 1000);
+		const timer = setTimeout(init, 300);
 		return () => clearTimeout(timer);
 	}, [config.posthogKey, config.posthogHost]);
 

--- a/apps/ui/src/content/blog/2026-06-22-best-ai-coding-plans.md
+++ b/apps/ui/src/content/blog/2026-06-22-best-ai-coding-plans.md
@@ -50,6 +50,8 @@ export ANTHROPIC_API_KEY="$LLM_GATEWAY_API_KEY"
 # every one of the 200+ models is now a single switch away
 ```
 
+<BlogCta variant="devpass" location="after_ranking" />
+
 ---
 
 ## 2. Claude Code (Anthropic Max)
@@ -325,4 +327,6 @@ Switch to one flat rate for every model in under two minutes:
 
 No per-token math. No vendor lock-in. Just every model under one key.
 
-**[Get DevPass](https://devpass.llmgateway.io/signup?plan=pro)** | **[Compare DevPass vs Cursor](https://devpass.llmgateway.io/compare/cursor)** | **[Read the 7 best AI gateways](/blog/best-ai-gateways)**
+<BlogCta variant="devpass" location="bottom" />
+
+**[Compare DevPass vs Cursor](https://devpass.llmgateway.io/compare/cursor)** | **[Read the 7 best AI gateways](/blog/best-ai-gateways)**

--- a/apps/ui/src/lib/utils/markdown.tsx
+++ b/apps/ui/src/lib/utils/markdown.tsx
@@ -1,3 +1,5 @@
+import { BlogCta } from "@/components/blog/blog-cta";
+
 import { SyntaxHighlightedPre } from "./markdown-code-block";
 
 export interface ChangelogFrontmatter {
@@ -22,6 +24,9 @@ export interface ChangelogEntry extends ChangelogFrontmatter {
 export function getMarkdownOptions() {
 	return {
 		overrides: {
+			BlogCta: {
+				component: BlogCta,
+			},
 			h1: {
 				props: {
 					className:

--- a/packages/scripts/src/traffic-report.ts
+++ b/packages/scripts/src/traffic-report.ts
@@ -65,7 +65,14 @@ const PRODUCTS: ReadonlyArray<{ host: string; label: string }> = [
 	{ host: "docs.llmgateway.io", label: "Docs" },
 ];
 
-const EVENTS: ReadonlyArray<{ event: string; label: string }> = [
+// `unique: true` counts distinct persons instead of raw events. Click events
+// use it because a single bot hammering a page can otherwise dominate the
+// weekly number (e.g. 708 pricing clicks from one crawler on 2026-07-11).
+const EVENTS: ReadonlyArray<{
+	event: string;
+	label: string;
+	unique?: boolean;
+}> = [
 	{ event: "user_signed_up", label: "Signups" },
 	{ event: "credits_purchased", label: "Credit purchases" },
 	{ event: "dev_plan_started", label: "DevPass starts" },
@@ -73,8 +80,8 @@ const EVENTS: ReadonlyArray<{ event: string; label: string }> = [
 	{ event: "reset_pass_purchased", label: "Reset passes" },
 	{ event: "onboarding_completed", label: "Onboarding done" },
 	{ event: "playground_chat_sent", label: "Playground chats" },
-	{ event: "cta_clicked", label: "CTA clicks" },
-	{ event: "pricing_plan_clicked", label: "Pricing clicks" },
+	{ event: "cta_clicked", label: "CTA clickers", unique: true },
+	{ event: "pricing_plan_clicked", label: "Pricing clickers", unique: true },
 	{ event: "enterprise_contact_submitted", label: "Enterprise leads" },
 ];
 
@@ -268,7 +275,8 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 
 	const eventList = EVENTS.map((e) => `'${e.event}'`).join(",");
 	const eventsQuery = `
-		SELECT event, ${periodExpr} AS period, count() AS hits
+		SELECT event, ${periodExpr} AS period, count() AS hits,
+			count(DISTINCT person_id) AS unique_hits
 		FROM events
 		WHERE event IN (${eventList}) AND ${rangeExpr}
 		GROUP BY event, period`;
@@ -433,18 +441,23 @@ async function fetchReport(window: ReportWindow): Promise<ReportData> {
 	}
 
 	const eventsData = new Map<string, PeriodPair>();
+	const uniqueEvents = new Set(
+		EVENTS.filter((e) => e.unique).map((e) => e.event),
+	);
 	for (const { event } of EVENTS) {
 		eventsData.set(event, { current: 0, previous: 0 });
 	}
 	for (const row of events) {
-		const entry = eventsData.get(String(row[0]));
+		const event = String(row[0]);
+		const entry = eventsData.get(event);
 		if (!entry) {
 			continue;
 		}
+		const value = uniqueEvents.has(event) ? num(row[3]) : num(row[2]);
 		if (row[1] === "current") {
-			entry.current = num(row[2]);
+			entry.current = value;
 		} else {
-			entry.previous = num(row[2]);
+			entry.previous = value;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Four growth/measurement workstreams driven by last week's traffic report analysis:

### 1. Navbar: surface the most-clicked destinations (+ fix broken dropdowns)
- **DevPass**, **Chat**, and **Models** are now direct navbar links (per PostHog 30d traffic: DevPass home 2,949 visitors/mo, Models 2,352, Chat 926), no hover needed. Dropdowns remain for the long tail; mobile menu updated to match.
- Responsive budget at the 1192px `nav:` breakpoint: Chat shows ≥1360px, GitHub-stars/Discord cluster shows ≥1280px.
- All nav links (top-level + dropdown items) fire `nav_link_clicked`, so future nav decisions can use real click data.
- **Fixes a dropdown regression that is live on production**: `NavigationMenuLink`'s `flex-col` base class (concatenated via Radix Slot) stacked every dropdown card vertically, blowing panels up to ~650px tall. One load-bearing `flex-row` restores the layout (~430px). Panels also now center under their triggers instead of clipping off the right viewport edge on <1600px screens.

### 2. Blog → signup CTAs
- New `BlogCta` component with a passport/boarding-pass DevPass variant and a generic gateway variant, registered as a `markdown-to-jsx` override — any post can embed `<BlogCta variant="devpass" />`.
- Embedded twice in `best-ai-coding-plans` (top post: 328 readers/wk, 2 signups). Clicks fire `cta_clicked` with `location`/`cta`/`post`; links carry UTM params for per-post conversion attribution.

### 3. Analytics reliability
- **Bounded PostHog init** in ui + playground: captures fired before the previously-unbounded idle-deferred `init()` were silently dropped — the cause of `playground_chat_sent` zero-event days.
- **First-party `/ingest` proxy** (Next rewrites → `us.i.posthog.com`) so ad blockers stop eating client events. Expect a one-time step **up** in client-event counts after deploy — recovered data, not growth.
- **Weekly traffic report**: `cta_clicked`/`pricing_plan_clicked` now count unique persons ("CTA clickers"/"Pricing clickers") so one bot can't skew a week (708 pricing clicks from a single crawler on Jul 11).
- Payer attribution (0 payers on every page in the weekly report) needed no change here — root cause was fixed by #3151.

### 4. Reset Pass upsell funnel instrumentation
- `devpass_weekly_cap_hit_viewed` (dashboard, on exhausted weekly premium meter) with tier/usage/passes-available properties — the funnel top for `reset_pass_purchased`.
- `reset_pass_redeemed` captured server-side in the redeem route (previously emitted nothing).
- Follow-ups after deploy: build the cap-hit → purchase funnel + cap-hit trend insights in PostHog; SQL gap-check in ~2 weeks to size the never-visits-dashboard cohort before deciding on gateway-side capture + cap-hit lifecycle email.

## Testing
- `turbo run build` passes for ui, playground, code, api, and scripts.
- All 32 `dev-plans-reset-passes` unit tests pass.
- Navbar verified via Playwright screenshots at 1200/1440/1550px (light + dark); dropdown panel bounds verified on-screen for Products/Resources/AI at 1200px and 1550px; blog CTAs verified in light + dark.

https://claude.ai/code/session_01FYyCRLR4CU4FWoiSi7hd1K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reusable promotional cards to blog content, including links for creating an account, browsing models, and exploring DevPass plans.
  - Added contextual calls to action after rankings and near the end of relevant articles.
  - Improved navigation links across desktop and mobile layouts, including access to DevPass, Chat, Models, Docs, and Pricing.

- **Analytics**
  - Improved measurement of navigation, promotional interactions, usage-limit views, and plan activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->