### PR TITLE
docs: weekly premium reset at renewal, faq item

### DIFF
--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -140,6 +140,35 @@ const faqData: FaqItem[] = [
 		answer: `Redeem a Reset Pass: it instantly restores your full weekly premium allowance and starts a fresh 7-day window. A pass removes the weekly limit only — it doesn't add credits, so usage still draws from your monthly allowance. Pro includes ${DEV_PLAN_INCLUDED_RESET_PASSES.pro} pass per billing cycle and Max includes ${DEV_PLAN_INCLUDED_RESET_PASSES.max}; extra passes are a one-time purchase from your dashboard ($${DEV_PLAN_RESET_PASS_PRICES.lite} on Lite, $${DEV_PLAN_RESET_PASS_PRICES.pro} on Pro, $${DEV_PLAN_RESET_PASS_PRICES.max} on Max). Standard models keep working the whole time, and if you're resetting every week, upgrading a tier is usually the better deal.`,
 	},
 	{
+		question: "Does the weekly premium allowance reset when my plan renews?",
+		answer:
+			"Yes. Every monthly renewal resets everything at once: your monthly credits, your weekly premium allowance (a fresh 7-day window starts at renewal), and your included Reset Passes. Between renewals the window is rolling — when 7 days end, the next window starts with your next premium request, and redeeming a Reset Pass clears the window so the next request starts a fresh one. There's no reset schedule to manage and nothing carries into the next cycle. Purchased Reset Passes are separate: they persist until redeemed.",
+		content: (
+			<>
+				<p>
+					Yes. Every monthly renewal resets everything at once: your monthly
+					credits, your weekly premium allowance (a fresh 7-day window starts at
+					renewal), and your included Reset Passes.
+				</p>
+				<p className="mt-3">
+					Between renewals the window is rolling — when 7 days end, the next
+					window starts with your next premium request, and redeeming a Reset
+					Pass clears the window so the next request starts a fresh one.
+					There&apos;s no reset schedule to manage and nothing carries into the
+					next cycle. Purchased Reset Passes are separate: they persist until
+					redeemed. See{" "}
+					<Link
+						href="https://docs.llmgateway.io/learn/reset-passes"
+						className="underline"
+					>
+						Reset Passes
+					</Link>{" "}
+					for the full mechanics.
+				</p>
+			</>
+		),
+	},
+	{
 		question: "Can I get a refund?",
 		answer:
 			"Yes — DevPass comes with a first-month guarantee. Cancel within 7 days of your first purchase and email contact@llmgateway.io: we'll refund your first month minus the usage you consumed at provider rates. There's no cancellation fee.",

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -142,7 +142,7 @@ const faqData: FaqItem[] = [
 	{
 		question: "Does the weekly premium allowance reset when my plan renews?",
 		answer:
-			"Yes. Every monthly renewal resets everything at once: your monthly credits, your weekly premium allowance (a fresh 7-day window starts at renewal), and your included Reset Passes. Between renewals the window is rolling — when 7 days end, the next window starts with your next premium request, and redeeming a Reset Pass clears the window so the next request starts a fresh one. There's no reset schedule to manage and nothing carries into the next cycle. Purchased Reset Passes are separate: they persist until redeemed.",
+			"Yes. Every monthly renewal resets everything at once: your monthly credits, your weekly premium allowance (a fresh 7-day window starts at renewal), and your included Reset Passes. Between renewals the window is rolling — when 7 days end, the next window starts with your next premium request, and redeeming a Reset Pass clears the window so the next request starts a fresh one. There's no reset schedule to manage — neither the weekly window nor unused included passes carry into the next cycle. Purchased Reset Passes are separate: they persist until redeemed.",
 		content: (
 			<>
 				<p>
@@ -154,9 +154,9 @@ const faqData: FaqItem[] = [
 					Between renewals the window is rolling — when 7 days end, the next
 					window starts with your next premium request, and redeeming a Reset
 					Pass clears the window so the next request starts a fresh one.
-					There&apos;s no reset schedule to manage and nothing carries into the
-					next cycle. Purchased Reset Passes are separate: they persist until
-					redeemed. See{" "}
+					There&apos;s no reset schedule to manage — neither the weekly window
+					nor unused included passes carry into the next cycle. Purchased Reset
+					Passes are separate: they persist until redeemed. See{" "}
 					<Link
 						href="https://docs.llmgateway.io/learn/reset-passes"
 						className="underline"

--- a/apps/docs/content/learn/reset-passes.mdx
+++ b/apps/docs/content/learn/reset-passes.mdx
@@ -45,6 +45,19 @@ Click **Use a pass** on the card. Your premium usage for the week is zeroed imme
 
 Standard models are unaffected either way: they never count against the weekly cap.
 
+## Renewal and the weekly window
+
+Nothing about the weekly allowance carries over between billing cycles — every monthly renewal starts you completely fresh, all at once:
+
+- **The weekly premium allowance resets in full.** Renewal zeroes your premium usage and starts a new 7-day window at the renewal moment, alongside the monthly credit reset. You never begin a cycle mid-window or with a partially used allowance.
+- **Included passes replenish.** Pro's 1 and Max's 2 included passes are restored every cycle; unused ones don't roll over. Purchased passes are unaffected — they persist until redeemed.
+
+An immediate tier upgrade restarts your billing cycle and performs the same full reset.
+
+Between renewals the window is **rolling, not on a fixed schedule**. When a 7-day window ends, the next one starts with your next premium request — and a redeemed pass clears the window entirely, so your next premium request starts a fresh 7 days. There is no weekly reset schedule that redeeming late (or early) can shift into the next cycle.
+
+In practice, a 30-day cycle of steady premium usage fits about five weekly windows (starting around days 0, 7, 14, 21, and 28) before any passes. On Max, whose weekly cap is 18% of the monthly allowance, those five windows plus a single included pass already unlock more than the entire monthly credit pool — so even spending exclusively on premium models needs no front-loaded pass redemptions or timing strategy. Redeem when you actually hit the cap.
+
 If you hit the cap from a coding agent, the gateway's `402` response points here:
 
 ```json


### PR DESCRIPTION
## Summary

A MAX subscriber asked whether the Premium Models weekly allowance resets when the monthly billing cycle renews — they had traced the schema fields on GitHub and worried they'd need to front-load both included Reset Passes in the first days of each cycle to spend the full monthly allowance on premium models. The answer (renewal resets everything at once) only existed in code comments, so this documents it:

- **`apps/docs/content/learn/reset-passes.mdx`**: new *Renewal and the weekly window* section — monthly renewal zeroes premium usage and starts a fresh 7-day window alongside the credit reset, included passes replenish (purchased ones persist), immediate upgrades do the same full reset, and the window is rolling (re-anchors on next premium request; a redeemed pass clears it) so no timing debt can carry into the next cycle. Includes the five-windows-per-cycle arithmetic showing Max needs no front-loading.
- **`apps/code/src/components/Faq.tsx`**: matching FAQ item on the DevPass landing page (with FAQPage JSON-LD via the existing plain-text `answer`), linking to the learn page.

Behavior verified against `apps/api/src/stripe.ts` (renewal/upgrade resets), `apps/worker/src/worker.ts` (window re-anchoring on spend), and `apps/api/src/routes/dev-plans.ts` (pass redemption clearing the window).

https://claude.ai/code/session_01CHq6YUHyKc6Jv6ZaJddoZm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ entry explaining how weekly premium allowances reset on plan renewal, including the rolling 7-day window behavior and Reset Pass effects.
  * Clarified renewal timing, tier upgrade impact, and how included vs. purchased Reset Passes persist until redeemed.
  * Expanded the Reset Passes documentation with a dedicated section and renewal/window examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->