### PR TITLE
fix: mark flaky provider mappings as unstable

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -651,6 +651,9 @@ export const alibabaModels = [
 			{
 				providerId: "deepinfra",
 				externalId: "Qwen/Qwen3.5-9B",
+				// deepinfra hangs on reasoning + streaming requests
+				// (e2e 180s timeouts, verified 2026-07-21)
+				stability: "unstable",
 				inputPrice: "0.1e-6",
 				outputPrice: "0.15e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2191,6 +2191,9 @@ export const googleModels = [
 			{
 				providerId: "novita",
 				externalId: "google/gemma-4-26b-a4b-it",
+				// novita streams empty content for JSON output requests
+				// (e2e JSON output streaming failures, verified 2026-07-21)
+				stability: "unstable",
 				inputPrice: "0.07e-6",
 				outputPrice: "0.34e-6",
 				requestPrice: "0",


### PR DESCRIPTION
## Summary

Marks two provider mappings as `stability: "unstable"` due to recurring e2e failures:

- **`novita/gemma-4-26b-a4b-it`** (`packages/models/src/models/google.ts`) — novita streams empty content for JSON output requests, failing the `JSON output streaming` e2e assertion (`hasContent` is false).
- **`deepinfra/qwen3.5-9b`** (`packages/models/src/models/alibaba.ts`) — deepinfra hangs on reasoning + streaming requests, causing the `reasoning + streaming` e2e test to hit its 180s timeout.

Both failures were verified on 2026-07-21 and are noted in comments on the respective mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGxRfDBxDu5p3Lddwiz47j

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGxRfDBxDu5p3Lddwiz47j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider reliability guidance for Qwen 3.5 9B and Gemma 4 26B A4B IT.
  * Identified streaming limitations when using reasoning or JSON output with select providers.
  * Marked affected provider configurations as unstable to help set accurate expectations for supported usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->