### PR TITLE
test(api): expect 201 from master IAM rule create

### DIFF
--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -257,7 +257,7 @@ describe("v1/master cache invalidation", () => {
 				ruleValue: { models: ["openai/gpt-4o-mini"] },
 			}),
 		});
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(201);
 
 		await assertSwrCleared(`iamRules:${apiKeyId}`);
 		const directRules = await cdb


### PR DESCRIPTION
## Summary

Fixes the unit-test failure that has turned main's `ci / test` job red on every push and merge-group run since #3149 merged (first failing run: `ff255fb` at 11:47 UTC today).

`POST /v1/master/keys/{id}/iam` returns `201` — its only declared OpenAPI response, and consistent with the other v1/master create routes (`POST /projects`, `POST /keys`). The cache-invalidation spec added in #3149 asserted `200`, so the test fails deterministically, not flakily. The mismatch landed unnoticed because the PR's head commit never ran the CI test job (it only has a "title" check and CodeRabbit — the `ci` workflow run appears to have required approval and was never approved).

This PR fixes the assertion to `201`. The rest of the test (SWR mirror eviction + fresh `cdb` read) is unchanged and passes.

## Verification

`vitest run apps/api/src/routes/v1-master.spec.ts` — 7/7 passing across 3 consecutive runs (it failed 1/7 deterministically before the fix).

## Preventing a recurrence

The process gap that let this land: a PR whose CI workflow never ran (fork approval pending) was still mergeable. That's a repo-settings fix, not a code fix — consider requiring the `ci / test` check via branch protection / merge-queue required checks so a PR can't merge while the check is missing rather than failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015afLuMRfBGnq8zupY9c5hv

---
_Generated by [Claude Code](https://claude.ai/code/session_015afLuMRfBGnq8zupY9c5hv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated API test expectations to reflect the endpoint’s correct `201 Created` response status.
  * Preserved existing cache invalidation and stale-while-revalidate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->