### PR TITLE
feat(models): add alibaba qwen-image-3.0-pro

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1885,6 +1885,38 @@ export const alibabaModels = [
 		],
 	},
 	{
+		id: "qwen-image-3.0-pro",
+		name: "Qwen Image 3.0 Pro",
+		description:
+			"Alibaba's third-generation Qwen image model with richer content, authentic details, and native text rendering in 12 languages, supporting prompts up to 4.5k tokens.",
+		family: "alibaba",
+		output: ["text", "image"],
+		releasedAt: new Date("2026-07-21"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "alibaba",
+				// Launch-day (2026-07-21) requests alternate between AccessDenied
+				// and Throttling.RateQuota in every region; re-verify and remove
+				// once Alibaba opens up access.
+				stability: "unstable",
+				externalId: "qwen-image-3.0-pro",
+				// Limited-time free at launch (2026-07-21) in both mainland and
+				// international regions; update prices once Alibaba publishes them.
+				inputPrice: "0",
+				outputPrice: "0",
+				requestPrice: "0",
+				contextSize: 4500,
+				maxOutput: 4096,
+				streaming: false,
+				vision: false,
+				tools: false,
+				jsonOutput: false,
+				imageGenerations: true,
+			},
+		],
+	},
+	{
 		id: "qwq-plus",
 		name: "QwQ Plus",
 		description:


### PR DESCRIPTION
## Summary

Adds Alibaba's **Qwen-Image-3.0** (released 2026-07-21) to the model catalogue as `alibaba/qwen-image-3.0-pro`.

- The only model id Alibaba exposes is `qwen-image-3.0-pro` — a bare `qwen-image-3.0` returns `Model not exist` on DashScope (verified against both the international and Beijing endpoints).
- Priced at zero (`inputPrice`/`outputPrice`/`requestPrice` = 0): Alibaba's pricing page lists the model as 限时免费 (limited-time free) in both mainland and international regions, with no post-promo price published yet. Not flagged `free: true` so it stays behind normal credit gating; prices should be updated once Alibaba publishes them.
- Marked `stability: "unstable"` + `test: "skip"`: launch-day requests alternate between `AccessDenied` and `Throttling.RateQuota` in every region (intl + Beijing, sync and async endpoints) while the account key generates fine with the existing `qwen-image` mapping. Re-verify and remove once Alibaba opens up access.

## Testing

- `packages/models` specs pass (62/62).
- `TEST_MODELS="alibaba/qwen-image-3.0-pro" FULL_MODE=true pnpm test:e2e`: routing/request wiring is correct (gateway builds the DashScope multimodal-generation request and surfaces the upstream error verbatim), but the 4 model-hitting tests currently fail with the upstream 403/429 above — provider-side launch gating, not a gateway bug.
- Verified through a locally running gateway build: pinned `alibaba/qwen-image-3.0-pro` with `x-no-fallback` reproduces the upstream 403/429; control run with `alibaba/qwen-image` on the same gateway generates an image successfully.
- `pnpm format` and full `pnpm build` (17/17) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Alibaba’s Qwen Image 3.0 Pro image-generation model.
  * The model supports image generation with text input and is currently marked as unstable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->