### PR TITLE
feat: deactivate retiring Vertex MaaS endpoints

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -516,6 +516,7 @@ export const alibabaModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "qwen/qwen3-235b-a22b-instruct-2507-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				inputPrice: "0.22e-6",
 				outputPrice: "0.88e-6",
 				requestPrice: "0",
@@ -926,6 +927,7 @@ export const alibabaModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "qwen/qwen3-coder-480b-a35b-instruct-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				inputPrice: "0.22e-6",
 				cachedInputPrice: "0.022e-6",
 				outputPrice: "1.8e-6",
@@ -1185,6 +1187,7 @@ export const alibabaModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "qwen/qwen3-next-80b-a3b-thinking-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				// Vertex MaaS throttles this model's tiny concurrency quota (429
 				// RESOURCE_EXHAUSTED) even on single requests, flaking e2e
 				stability: "unstable",
@@ -1252,6 +1255,7 @@ export const alibabaModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "qwen/qwen3-next-80b-a3b-instruct-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				inputPrice: "0.15e-6",
 				outputPrice: "1.2e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -227,6 +227,7 @@ export const deepseekModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "deepseek-ai/deepseek-v3.2-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				// Vertex MaaS throttles this model's tiny concurrency quota (429
 				// RESOURCE_EXHAUSTED even for single spaced-out requests,
 				// verified 2026-07-14), flaking e2e

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -171,6 +171,7 @@ export const moonshotModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "moonshotai/kimi-k2-thinking-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				inputPrice: "0.6e-6",
 				cachedInputPrice: "0.06e-6",
 				outputPrice: "2.5e-6",

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -411,6 +411,7 @@ export const zaiModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "zai-org/glm-5-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				inputPrice: "1e-6",
 				cachedInputPrice: "0.1e-6",
 				outputPrice: "3.2e-6",
@@ -836,6 +837,7 @@ export const zaiModels = [
 			{
 				providerId: "vertex-openai",
 				externalId: "zai-org/glm-4.7-maas",
+				deactivatedAt: new Date("2026-10-21"),
 				inputPrice: "0.6e-6",
 				outputPrice: "2.2e-6",
 				requestPrice: "0",


### PR DESCRIPTION
## Summary

Google announced the retirement of several Vertex AI Open Model-as-a-Service (MaaS) endpoints effective **October 21, 2026**. This PR sets `deactivatedAt: new Date("2026-10-21")` on the affected `vertex-openai` provider mappings in `packages/models`, so they keep serving until the retirement date and are automatically excluded from routing afterwards.

## Deactivated mappings

- `zai-org/glm-5-maas` (glm-5)
- `zai-org/glm-4.7-maas` (glm-4.7)
- `deepseek-ai/deepseek-v3.2-maas` (deepseek-v3.2)
- `moonshotai/kimi-k2-thinking-maas` (kimi-k2-thinking)
- `qwen/qwen3-235b-a22b-instruct-2507-maas`
- `qwen/qwen3-coder-480b-a35b-instruct-maas`
- `qwen/qwen3-next-80b-a3b-thinking-maas`
- `qwen/qwen3-next-80b-a3b-instruct-maas`

## Notes

- The retirement notice also listed `gpt-oss-20b-maas`, `deepseek-v3.1-maas`, `deepseek-r1-0528-maas`, `qwen3-235b`-adjacent variants not in our catalogue, `minimax-m2-maas`, `deepseek-ocr-maas`, `multilingual-e5-large-instruct-maas`, `multilingual-e5-small-maas`, and `llama-3.3-70b-instruct-maas` — none of these have `vertex-openai` mappings in the catalogue, so no change is needed for them.
- The two `grok-4.20` `vertex-openai` mappings are not on the retirement list and remain unchanged.
- Mappings are deactivated, not removed, per repo policy (historical usage records reference them).
- `turbo run build --filter=@llmgateway/models` passes; `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JerZjamGmoxyKR1yKoZ91w

---
_Generated by [Claude Code](https://claude.ai/code/session_01JerZjamGmoxyKR1yKoZ91w)_