### PR TITLE
fix(models): drop vertex flex tier on gemini-3.6

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -1185,7 +1185,9 @@ export const googleModels = [
 			{
 				providerId: "google-vertex",
 				externalId: "gemini-3.6-flash",
-				serviceTiers: ["flex", "priority"],
+				// Vertex rejects Flex for this model ("Flex API is not supported
+				// for model: gemini-3.6-flash"); Flex is served via AI Studio only.
+				serviceTiers: ["priority"],
 				serviceTierRegions: ["global"],
 				inputPrice: "1.5e-6",
 				outputPrice: "7.5e-6",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,6 +10,7 @@ export default defineConfig({
 			"**/dist/**",
 			"**/*.e2e.ts",
 			".conductor/**",
+			".claude/**",
 		],
 		environment: "node",
 		testTimeout: 30000, // Increased timeout for tests


### PR DESCRIPTION
## Problem

Flex was declared on both provider mappings for the new `gemini-3.6-flash` (#3164), but Google Vertex AI rejects it upstream:

```
400 INVALID_ARGUMENT: Flex API is not supported for model: gemini-3.6-flash.
```

Since routing deprioritizes AI Studio (priority 0.8), an unpinned `gemini-3.6-flash` + `service_tier: "flex"` request landed on Vertex first and hard-failed with that 400 (fatal with `x-no-fallback`, wasted roundtrip otherwise).

## Fix

Remove `"flex"` from the `google-vertex` mapping of `gemini-3.6-flash` (capability-flag correction, same pattern as `gemini-2.5-pro`'s priority-only Vertex mapping). Priority stays: verified served as `ON_DEMAND_PRIORITY` on Vertex.

Also adds `.claude/**` to the vitest exclude list — stale `.claude/worktrees/` copies were being collected and failing `pnpm test:unit` with import errors, same class of noise as the existing `.conductor/**` exclude.

## Verified live (through the local gateway, real upstreams)

| Request | Before | After |
|---|---|---|
| `gemini-3.6-flash` + flex (unpinned, no-fallback) | 400 from Vertex | routes to AI Studio, `used_service_tier: flex`, billed 0.5x |
| `google-ai-studio/gemini-3.6-flash` + flex | ✓ served flex | ✓ served flex (also streaming) |
| `google-vertex/gemini-3.6-flash` + flex | proxied Vertex 400 | clean `unsupported_service_tier` validation error |
| `google-ai-studio/gemini-3.5-flash-lite` + flex | ✓ served flex | ✓ unchanged |
| `google-vertex/gemini-3.5-flash-lite` + flex | ✓ `ON_DEMAND_FLEX` | ✓ unchanged |
| `google-vertex/{3.6-flash,3.5-flash-lite}` + priority | ✓ `ON_DEMAND_PRIORITY` | ✓ unchanged |

`pnpm test:unit` green (172 files / 2866 tests), full `pnpm build` green.

https://claude.ai/code/session_01WNfVNjJoNbVvrzurgZ5J78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Google Vertex configuration to use the supported Priority service tier for the Gemini 3.6 Flash model.

* **Tests**
  * Excluded Claude configuration files from automated test discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->