### PR TITLE
fix(gateway): settle body reads on client abort

### DIFF
--- a/apps/gateway/src/cancellation.spec.ts
+++ b/apps/gateway/src/cancellation.spec.ts
@@ -133,7 +133,12 @@ describe("client cancellation logging", () => {
 	// Pin the gateway's request id (it honors x-request-id) so each test can
 	// wait for exactly its own log row instead of counting all rows in the
 	// table, which is brittle against any stray row from another request.
-	function postChat(content: string, signal: AbortSignal, requestId: string) {
+	function postChat(
+		content: string,
+		signal: AbortSignal,
+		requestId: string,
+		options?: { stream?: boolean },
+	) {
 		return fetch(`${gatewayUrl}/v1/chat/completions`, {
 			method: "POST",
 			headers: {
@@ -144,6 +149,7 @@ describe("client cancellation logging", () => {
 			body: JSON.stringify({
 				model: "llmgateway/custom",
 				messages: [{ role: "user", content }],
+				...(options?.stream ? { stream: true } : {}),
 			}),
 			signal,
 		});
@@ -244,6 +250,35 @@ describe("client cancellation logging", () => {
 			controller.abort();
 
 			await expect(requestPromise).rejects.toThrow();
+
+			await expectCanceledLog(requestId);
+		},
+	);
+
+	test(
+		"abort while reading a non-OK error body during streaming is logged as canceled",
+		{ timeout: 90000 },
+		async () => {
+			const controller = new AbortController();
+			const requestId = `cancel-stream-error-body-${crypto.randomUUID()}`;
+			// Same 500 + hanging error body as the non-streaming test, but with
+			// stream: true so the abort lands in the streaming handler's wrapped
+			// error-body res.text() instead of the non-streaming one.
+			const partialBodyFlushed = waitForMockCheckpoint("TRIGGER_5XX_BODY_HANG");
+			const requestPromise = postChat(
+				`TRIGGER_5XX_BODY_HANG ${Math.random()}`,
+				controller.signal,
+				requestId,
+				{ stream: true },
+			);
+			await partialBodyFlushed;
+			await settle();
+			controller.abort();
+
+			// The gateway may already have started the SSE response, in which case
+			// the fetch promise resolved and the abort tears down the body read
+			// instead of rejecting the promise. Either way the request is finished.
+			await requestPromise.catch(() => {});
 
 			await expectCanceledLog(requestId);
 		},

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6018,6 +6018,18 @@ chat.openapi(completions, async (c) => {
 	let requestCanBeCanceled =
 		providers.find((p) => p.id === usedProvider)?.cancellation === true;
 
+	// Classify a failed upstream body read as a client cancellation. A client
+	// disconnect usually surfaces as an AbortError (raceClientAbort guarantees
+	// one when cancellation is supported), but the abort can also surface as a
+	// generic failure (undici "terminated" TypeError, or a TimeoutError when
+	// the abort never reached the body read), so any read failure after the
+	// client already disconnected counts as canceled too.
+	// requestCanBeCanceled is read at call time: retries can switch providers,
+	// flipping whether cancellation is supported.
+	const isClientAbortError = (bodyError: Error): boolean =>
+		bodyError.name === "AbortError" ||
+		(requestCanBeCanceled && c.req.raw.signal.aborted);
+
 	// For Google providers, enrich messages with cached thought_signatures
 	// This is needed for multi-turn tool call conversations with Gemini 3+
 	if (isGoogleCompatibleProvider(usedProvider)) {
@@ -6641,6 +6653,183 @@ chat.openapi(completions, async (c) => {
 				// Add event listener for the abort event on the connection
 				c.req.raw.signal.addEventListener("abort", onAbort);
 
+				// Streaming twin of the non-streaming readBodyWithClientAbort: settle
+				// an upstream body read immediately on client disconnect instead of
+				// relying on the fetch AbortSignal to propagate into undici's
+				// in-flight body machinery, where a late abort can be missed.
+				const readBodyWithClientAbort = <T>(
+					bodyPromise: Promise<T>,
+				): Promise<T> =>
+					raceClientAbort(
+						bodyPromise,
+						c.req.raw.signal,
+						requestCanBeCanceled ? controller : undefined,
+					);
+
+				// Build and persist the canceled-request log, then emit the canceled
+				// SSE events. Shared by the in-loop fetch-cancellation path and the
+				// error-body-read cancellation path so a client disconnect is always
+				// recorded as canceled rather than escaping as a stream error.
+				const respondCanceledStreaming = async (
+					perAttemptStartTime: number,
+				) => {
+					// Extract plugin IDs for logging (canceled request)
+					const canceledPluginIds = plugins?.map((p) => p.id) ?? [];
+
+					// Calculate costs for cancelled request if billing is enabled
+					const billCancelled = shouldBillCancelledRequests();
+					let cancelledCosts: Awaited<
+						ReturnType<typeof calculateCosts>
+					> | null = null;
+					let estimatedPromptTokens: number | null = null;
+
+					if (billCancelled) {
+						// Estimate prompt tokens from messages
+						const tokenEstimation = estimateTokens(
+							usedProvider!,
+							messages,
+							null,
+							null,
+							null,
+						);
+						estimatedPromptTokens = tokenEstimation.calculatedPromptTokens;
+
+						// Calculate costs based on prompt tokens only (no completion yet)
+						// If web search tool was enabled, count it as 1 search for billing
+						cancelledCosts = await calculateCosts(
+							usedInternalModel,
+							usedProvider!,
+							usedRegion ?? null,
+							estimatedPromptTokens,
+							0, // No completion tokens yet
+							null, // No cached tokens
+							{
+								prompt: messages
+									.map((m) => messageContentToString(m.content))
+									.join("\n"),
+								completion: "",
+							},
+							null, // No reasoning tokens
+							0, // No output images
+							undefined,
+							inputImageCount,
+							webSearchTool ? 1 : null, // Bill for web search if it was enabled
+							project.organizationId,
+							undefined, // imageQuality
+							null, // reportedImageInputTokens
+							null, // reportedImageOutputTokens
+							{ servedServiceTier, customPricing: customPricingMapping },
+						);
+					}
+
+					const baseLogEntry = createLogEntry(
+						requestId,
+						project,
+						apiKey,
+						providerKey?.id,
+						usedModelFormatted!,
+						usedModelMapping!,
+						usedProvider!,
+						initialRequestedModel,
+						requestedProvider,
+						messages,
+						temperature,
+						max_tokens,
+						top_p,
+						frequency_penalty,
+						presence_penalty,
+						reasoning_effort,
+						reasoning_max_tokens,
+						effort,
+						response_format,
+						tools,
+						tool_choice,
+						source,
+						customHeaders,
+						debugMode,
+						userAgent,
+						image_config,
+						routingMetadata,
+						rawBody,
+						null, // No response for canceled request
+						requestBody, // The request that was sent before cancellation
+						null, // No upstream response for canceled request
+						canceledPluginIds,
+						undefined, // No plugin results for canceled request
+					);
+
+					await insertLogEntry({
+						...baseLogEntry,
+						duration: Date.now() - perAttemptStartTime,
+						timeToFirstToken: null, // Not applicable for canceled request
+						timeToFirstReasoningToken: null, // Not applicable for canceled request
+						responseSize: 0,
+						content: null,
+						reasoningContent: null,
+						finishReason: "canceled",
+						promptTokens: billCancelled
+							? (
+									cancelledCosts?.promptTokens ?? estimatedPromptTokens
+								)?.toString()
+							: null,
+						completionTokens: billCancelled ? "0" : null,
+						totalTokens: billCancelled
+							? (
+									cancelledCosts?.promptTokens ?? estimatedPromptTokens
+								)?.toString()
+							: null,
+						reasoningTokens: null,
+						cachedTokens: null,
+						hasError: false,
+						streamed: true,
+						canceled: true,
+						errorDetails: null,
+						inputCost: cancelledCosts?.inputCost ?? null,
+						outputCost: cancelledCosts?.outputCost ?? null,
+						cachedInputCost: cancelledCosts?.cachedInputCost ?? null,
+						requestCost: cancelledCosts?.requestCost ?? null,
+						webSearchCost: cancelledCosts?.webSearchCost ?? null,
+						imageInputTokens:
+							cancelledCosts?.imageInputTokens?.toString() ?? null,
+						imageOutputTokens:
+							cancelledCosts?.imageOutputTokens?.toString() ?? null,
+						imageInputCost: cancelledCosts?.imageInputCost ?? null,
+						imageOutputCost: cancelledCosts?.imageOutputCost ?? null,
+						audioInputTokens:
+							cancelledCosts?.audioInputTokens?.toString() ?? null,
+						audioInputCost: cancelledCosts?.audioInputCost ?? null,
+						cost: cancelledCosts?.totalCost ?? null,
+						estimatedCost: cancelledCosts?.estimatedCost ?? false,
+						discount: cancelledCosts?.discount ?? null,
+						dataStorageCost: billCancelled
+							? calculateDataStorageCost(
+									cancelledCosts?.promptTokens ?? estimatedPromptTokens,
+									null,
+									0,
+									null,
+									retentionLevel,
+								)
+							: "0",
+						cached: false,
+						toolResults: null,
+					});
+
+					// Send a cancellation event to the client
+					await writeSSEAndCache({
+						event: "canceled",
+						data: JSON.stringify({
+							message: "Request canceled by client",
+						}),
+						id: String(eventId++),
+					});
+					await writeSSEAndCache({
+						event: "done",
+						data: "[DONE]",
+						id: String(eventId++),
+					});
+					clearKeepalive();
+				};
+
 				// --- Retry loop for provider fallback ---
 				const routingAttempts: RoutingAttempt[] = [];
 				const failedProviderIds = new Set<string>();
@@ -7033,162 +7222,7 @@ chat.openapi(completions, async (c) => {
 							});
 							return;
 						} else if (error instanceof Error && error.name === "AbortError") {
-							// Log the canceled request
-							// Extract plugin IDs for logging (canceled request)
-							const canceledPluginIds = plugins?.map((p) => p.id) ?? [];
-
-							// Calculate costs for cancelled request if billing is enabled
-							const billCancelled = shouldBillCancelledRequests();
-							let cancelledCosts: Awaited<
-								ReturnType<typeof calculateCosts>
-							> | null = null;
-							let estimatedPromptTokens: number | null = null;
-
-							if (billCancelled) {
-								// Estimate prompt tokens from messages
-								const tokenEstimation = estimateTokens(
-									usedProvider,
-									messages,
-									null,
-									null,
-									null,
-								);
-								estimatedPromptTokens = tokenEstimation.calculatedPromptTokens;
-
-								// Calculate costs based on prompt tokens only (no completion yet)
-								// If web search tool was enabled, count it as 1 search for billing
-								cancelledCosts = await calculateCosts(
-									usedInternalModel,
-									usedProvider,
-									usedRegion ?? null,
-									estimatedPromptTokens,
-									0, // No completion tokens yet
-									null, // No cached tokens
-									{
-										prompt: messages
-											.map((m) => messageContentToString(m.content))
-											.join("\n"),
-										completion: "",
-									},
-									null, // No reasoning tokens
-									0, // No output images
-									undefined,
-									inputImageCount,
-									webSearchTool ? 1 : null, // Bill for web search if it was enabled
-									project.organizationId,
-									undefined, // imageQuality
-									null, // reportedImageInputTokens
-									null, // reportedImageOutputTokens
-									{ servedServiceTier, customPricing: customPricingMapping },
-								);
-							}
-
-							const baseLogEntry = createLogEntry(
-								requestId,
-								project,
-								apiKey,
-								providerKey?.id,
-								usedModelFormatted,
-								usedModelMapping,
-								usedProvider,
-								initialRequestedModel,
-								requestedProvider,
-								messages,
-								temperature,
-								max_tokens,
-								top_p,
-								frequency_penalty,
-								presence_penalty,
-								reasoning_effort,
-								reasoning_max_tokens,
-								effort,
-								response_format,
-								tools,
-								tool_choice,
-								source,
-								customHeaders,
-								debugMode,
-								userAgent,
-								image_config,
-								routingMetadata,
-								rawBody,
-								null, // No response for canceled request
-								requestBody, // The request that was sent before cancellation
-								null, // No upstream response for canceled request
-								canceledPluginIds,
-								undefined, // No plugin results for canceled request
-							);
-
-							await insertLogEntry({
-								...baseLogEntry,
-								duration: Date.now() - perAttemptStartTime,
-								timeToFirstToken: null, // Not applicable for canceled request
-								timeToFirstReasoningToken: null, // Not applicable for canceled request
-								responseSize: 0,
-								content: null,
-								reasoningContent: null,
-								finishReason: "canceled",
-								promptTokens: billCancelled
-									? (
-											cancelledCosts?.promptTokens ?? estimatedPromptTokens
-										)?.toString()
-									: null,
-								completionTokens: billCancelled ? "0" : null,
-								totalTokens: billCancelled
-									? (
-											cancelledCosts?.promptTokens ?? estimatedPromptTokens
-										)?.toString()
-									: null,
-								reasoningTokens: null,
-								cachedTokens: null,
-								hasError: false,
-								streamed: true,
-								canceled: true,
-								errorDetails: null,
-								inputCost: cancelledCosts?.inputCost ?? null,
-								outputCost: cancelledCosts?.outputCost ?? null,
-								cachedInputCost: cancelledCosts?.cachedInputCost ?? null,
-								requestCost: cancelledCosts?.requestCost ?? null,
-								webSearchCost: cancelledCosts?.webSearchCost ?? null,
-								imageInputTokens:
-									cancelledCosts?.imageInputTokens?.toString() ?? null,
-								imageOutputTokens:
-									cancelledCosts?.imageOutputTokens?.toString() ?? null,
-								imageInputCost: cancelledCosts?.imageInputCost ?? null,
-								imageOutputCost: cancelledCosts?.imageOutputCost ?? null,
-								audioInputTokens:
-									cancelledCosts?.audioInputTokens?.toString() ?? null,
-								audioInputCost: cancelledCosts?.audioInputCost ?? null,
-								cost: cancelledCosts?.totalCost ?? null,
-								estimatedCost: cancelledCosts?.estimatedCost ?? false,
-								discount: cancelledCosts?.discount ?? null,
-								dataStorageCost: billCancelled
-									? calculateDataStorageCost(
-											cancelledCosts?.promptTokens ?? estimatedPromptTokens,
-											null,
-											0,
-											null,
-											retentionLevel,
-										)
-									: "0",
-								cached: false,
-								toolResults: null,
-							});
-
-							// Send a cancellation event to the client
-							await writeSSEAndCache({
-								event: "canceled",
-								data: JSON.stringify({
-									message: "Request canceled by client",
-								}),
-								id: String(eventId++),
-							});
-							await writeSSEAndCache({
-								event: "done",
-								data: "[DONE]",
-								id: String(eventId++),
-							});
-							clearKeepalive();
+							await respondCanceledStreaming(perAttemptStartTime);
 							return;
 						} else if (error instanceof Error) {
 							// Handle fetch errors (timeout, connection failures, etc.)
@@ -7457,7 +7491,24 @@ chat.openapi(completions, async (c) => {
 					}
 
 					if (!res.ok) {
-						const rawErrorResponseText = await res.text();
+						let rawErrorResponseText: string;
+						try {
+							rawErrorResponseText = await readBodyWithClientAbort(res.text());
+						} catch (bodyError) {
+							// Re-throw non-Error values (mirrors the fetch catch above).
+							if (!(bodyError instanceof Error)) {
+								throw bodyError;
+							}
+							// A client disconnect aborts the in-flight error-body read;
+							// record it as a canceled request (same log shape as the
+							// fetch-cancellation path) instead of escaping as a stream
+							// error.
+							if (isClientAbortError(bodyError)) {
+								await respondCanceledStreaming(perAttemptStartTime);
+								return;
+							}
+							throw bodyError;
+						}
 						const errorResponseText = usesAwsBedrockConverse()
 							? extractAwsBedrockHttpError(res, rawErrorResponseText)
 							: rawErrorResponseText;
@@ -11494,14 +11545,8 @@ chat.openapi(completions, async (c) => {
 				// A client disconnect aborts the in-flight error-body read; record
 				// it as a canceled request (same log shape as the fetch-
 				// cancellation path) instead of misreporting it as an upstream
-				// failure or a bare 499. The abort can also surface as a generic
-				// failure (undici "terminated" TypeError, or a TimeoutError when
-				// the abort never reached the body read), so any read failure
-				// after the client already disconnected counts as canceled too.
-				if (
-					bodyError.name === "AbortError" ||
-					(requestCanBeCanceled && c.req.raw.signal.aborted)
-				) {
+				// failure or a bare 499.
+				if (isClientAbortError(bodyError)) {
 					return await respondCanceled();
 				}
 				// A read timeout or a mid-body socket failure (e.g. undici
@@ -12375,14 +12420,7 @@ chat.openapi(completions, async (c) => {
 		// A client disconnect aborts the in-flight body read; record it as a
 		// canceled request (same log shape as the fetch-cancellation path)
 		// instead of misreporting it as an upstream failure or a bare 499.
-		// The abort can also surface as a generic failure (undici "terminated"
-		// TypeError, or a TimeoutError when the abort never reached the body
-		// read), so any read failure after the client already disconnected
-		// counts as canceled too.
-		if (
-			bodyError.name === "AbortError" ||
-			(requestCanBeCanceled && c.req.raw.signal.aborted)
-		) {
+		if (isClientAbortError(bodyError)) {
 			// The post-loop success append already recorded this provider as a
 			// succeeded routing attempt. Drop it before logging the cancellation
 			// so a client disconnect isn't counted as a provider success in the

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -29,6 +29,7 @@ import {
 	findProviderKeysByProviders,
 	type CustomModel,
 } from "@/lib/cached-queries.js";
+import { raceClientAbort } from "@/lib/client-abort.js";
 import { getClientIpFromRequest } from "@/lib/client-ip.js";
 import {
 	isCodingModel,
@@ -11002,6 +11003,20 @@ chat.openapi(completions, async (c) => {
 		); // Using 400 status code for client closed request
 	};
 
+	// Wrap an upstream body read (res.text()/res.json()) so a client disconnect
+	// settles it immediately instead of relying on the fetch AbortSignal to
+	// propagate into undici's in-flight body machinery — a late abort can be
+	// missed there, leaving the read blocked until the fetch timeout and the
+	// request mislogged as an upstream error instead of canceled.
+	// requestCanBeCanceled is read at call time: retries can switch providers,
+	// flipping whether cancellation is supported.
+	const readBodyWithClientAbort = <T>(bodyPromise: Promise<T>): Promise<T> =>
+		raceClientAbort(
+			bodyPromise,
+			c.req.raw.signal,
+			requestCanBeCanceled ? controller : undefined,
+		);
+
 	// --- Retry loop for provider fallback ---
 	const routingAttempts: RoutingAttempt[] = [];
 	const failedProviderIds = new Set<string>();
@@ -11467,7 +11482,7 @@ chat.openapi(completions, async (c) => {
 				onAbort();
 			}
 			try {
-				const rawErrorResponseText = await res.text();
+				const rawErrorResponseText = await readBodyWithClientAbort(res.text());
 				errorResponseText = usesAwsBedrockConverse()
 					? extractAwsBedrockHttpError(res, rawErrorResponseText)
 					: rawErrorResponseText;
@@ -11479,8 +11494,14 @@ chat.openapi(completions, async (c) => {
 				// A client disconnect aborts the in-flight error-body read; record
 				// it as a canceled request (same log shape as the fetch-
 				// cancellation path) instead of misreporting it as an upstream
-				// failure or a bare 499.
-				if (bodyError.name === "AbortError") {
+				// failure or a bare 499. The abort can also surface as a generic
+				// failure (undici "terminated" TypeError, or a TimeoutError when
+				// the abort never reached the body read), so any read failure
+				// after the client already disconnected counts as canceled too.
+				if (
+					bodyError.name === "AbortError" ||
+					(requestCanBeCanceled && c.req.raw.signal.aborted)
+				) {
 					return await respondCanceled();
 				}
 				// A read timeout or a mid-body socket failure (e.g. undici
@@ -12112,7 +12133,7 @@ chat.openapi(completions, async (c) => {
 		if (forceStream && res.body) {
 			// Stream-only model: upstream returned SSE but client expects JSON.
 			// Read the full stream and assemble a non-streaming response.
-			const text = await res.text();
+			const text = await readBodyWithClientAbort(res.text());
 			const lines = text.split("\n");
 			let content = "";
 			const toolCalls: any[] = [];
@@ -12196,7 +12217,7 @@ chat.openapi(completions, async (c) => {
 			// Upstream is openai/azure gpt-image-* and we forced stream=true
 			// to dodge the 122s sync wall. Collapse the SSE back into the
 			// normal { data: [{ b64_json }], usage } shape.
-			const text = await res.text();
+			const text = await readBodyWithClientAbort(res.text());
 			const collapsed = collapseImageGenSse(text);
 			if ("error" in collapsed) {
 				const sseErrorText = JSON.stringify(collapsed.error);
@@ -12344,7 +12365,7 @@ chat.openapi(completions, async (c) => {
 			}
 			json = collapsed.json;
 		} else {
-			json = await res.json();
+			json = await readBodyWithClientAbort(res.json());
 		}
 	} catch (bodyError) {
 		// Re-throw non-Error values (mirrors the fetch catch above).
@@ -12354,7 +12375,14 @@ chat.openapi(completions, async (c) => {
 		// A client disconnect aborts the in-flight body read; record it as a
 		// canceled request (same log shape as the fetch-cancellation path)
 		// instead of misreporting it as an upstream failure or a bare 499.
-		if (bodyError.name === "AbortError") {
+		// The abort can also surface as a generic failure (undici "terminated"
+		// TypeError, or a TimeoutError when the abort never reached the body
+		// read), so any read failure after the client already disconnected
+		// counts as canceled too.
+		if (
+			bodyError.name === "AbortError" ||
+			(requestCanBeCanceled && c.req.raw.signal.aborted)
+		) {
 			// The post-loop success append already recorded this provider as a
 			// succeeded routing attempt. Drop it before logging the cancellation
 			// so a client disconnect isn't counted as a provider success in the

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -29,6 +29,7 @@ import {
 	findProjectById,
 	findProviderKey,
 } from "@/lib/cached-queries.js";
+import { raceClientAbort } from "@/lib/client-abort.js";
 import { getClientIpFromRequest } from "@/lib/client-ip.js";
 import { assertProviderCompliant } from "@/lib/compliance.js";
 import {
@@ -996,6 +997,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			});
 
 			let upstreamResponse: Response;
+			let upstreamText = "";
 			let fetchError: Error | null = null;
 			try {
 				const fetchSignal = createCombinedSignal(controller);
@@ -1015,9 +1017,22 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					body: JSON.stringify(attempt.requestBody),
 					signal: fetchSignal,
 				});
+				// Settle the body read immediately on a client disconnect instead of
+				// relying on the fetch AbortSignal to propagate into undici's
+				// in-flight body machinery, where a late abort can be missed.
+				upstreamText = await raceClientAbort(
+					upstreamResponse.text(),
+					c.req.raw.signal,
+					controller,
+				);
 			} catch (error) {
+				// The abort can also surface as a generic failure (undici
+				// "terminated" TypeError, or a TimeoutError when the abort never
+				// reached the read), so any failure after the client already
+				// disconnected counts as canceled too.
 				const isCanceled =
-					error instanceof Error && error.name === "AbortError";
+					error instanceof Error &&
+					(error.name === "AbortError" || c.req.raw.signal.aborted);
 				const isTimeout = isTimeoutError(error);
 				const isNetworkError = error instanceof TypeError;
 				if (!isCanceled && !isTimeout && !isNetworkError) {
@@ -1028,7 +1043,8 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			}
 
 			if (fetchError !== null) {
-				const isCanceled = fetchError.name === "AbortError";
+				const isCanceled =
+					fetchError.name === "AbortError" || c.req.raw.signal.aborted;
 				const isTimeout = isTimeoutError(fetchError);
 
 				const duration = Date.now() - startedAt;
@@ -1165,7 +1181,6 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				);
 			}
 
-			const upstreamText = await upstreamResponse.text();
 			const duration = Date.now() - startedAt;
 			const responseSize = upstreamText.length;
 

--- a/apps/gateway/src/lib/client-abort.spec.ts
+++ b/apps/gateway/src/lib/client-abort.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+
+import { raceClientAbort } from "./client-abort.js";
+
+describe("raceClientAbort", () => {
+	test("resolves with the body value when the client stays connected", async () => {
+		const client = new AbortController();
+		const upstream = new AbortController();
+
+		await expect(
+			raceClientAbort(Promise.resolve("body"), client.signal, upstream),
+		).resolves.toBe("body");
+		expect(upstream.signal.aborted).toBe(false);
+	});
+
+	test("passes body read failures through unchanged", async () => {
+		const client = new AbortController();
+		const upstream = new AbortController();
+		const failure = new TypeError("terminated");
+
+		await expect(
+			raceClientAbort(Promise.reject(failure), client.signal, upstream),
+		).rejects.toBe(failure);
+	});
+
+	test("rejects with AbortError when the client aborts mid-read and aborts the upstream controller", async () => {
+		const client = new AbortController();
+		const upstream = new AbortController();
+		const hangingBody = new Promise<string>(() => {});
+
+		const race = raceClientAbort(hangingBody, client.signal, upstream);
+		client.abort();
+
+		await expect(race).rejects.toMatchObject({ name: "AbortError" });
+		expect(upstream.signal.aborted).toBe(true);
+	});
+
+	test("rejects immediately when the client signal is already aborted", async () => {
+		const client = new AbortController();
+		client.abort();
+		const upstream = new AbortController();
+		const hangingBody = new Promise<string>(() => {});
+
+		await expect(
+			raceClientAbort(hangingBody, client.signal, upstream),
+		).rejects.toMatchObject({ name: "AbortError" });
+		expect(upstream.signal.aborted).toBe(true);
+	});
+
+	test("returns the body read unchanged when cancellation is not supported", async () => {
+		const client = new AbortController();
+		client.abort();
+
+		// No upstream controller: a disconnect must not interrupt the read, the
+		// gateway finishes consuming the upstream response for logging/billing.
+		await expect(
+			raceClientAbort(Promise.resolve("body"), client.signal, undefined),
+		).resolves.toBe("body");
+	});
+
+	test("consumes the body promise's late rejection after the abort already won", async () => {
+		let rejectBody!: (error: Error) => void;
+		const body = new Promise<string>((_, reject) => {
+			rejectBody = reject;
+		});
+		const client = new AbortController();
+		const upstream = new AbortController();
+
+		const race = raceClientAbort(body, client.signal, upstream);
+		client.abort();
+		await expect(race).rejects.toMatchObject({ name: "AbortError" });
+
+		// The upstream teardown rejects the losing body read afterwards; vitest
+		// fails the run if this surfaces as an unhandled rejection.
+		rejectBody(new Error("late upstream teardown"));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	});
+
+	test("resolves when the body settles before a later client abort", async () => {
+		const client = new AbortController();
+		const upstream = new AbortController();
+
+		const value = await raceClientAbort(
+			Promise.resolve("body"),
+			client.signal,
+			upstream,
+		);
+		client.abort();
+
+		// The abort listener was removed when the body settled, so a later
+		// disconnect no longer tears down the upstream controller.
+		expect(value).toBe("body");
+		expect(upstream.signal.aborted).toBe(false);
+	});
+});

--- a/apps/gateway/src/lib/client-abort.ts
+++ b/apps/gateway/src/lib/client-abort.ts
@@ -15,6 +15,11 @@
  * When `upstreamController` is undefined (the provider does not support
  * cancellation), the read is returned unchanged: the gateway deliberately
  * finishes reading the upstream response so it can be logged and billed.
+ *
+ * Aborting `upstreamController` here may overlap a caller's own client-abort
+ * listener aborting the same controller; the double abort is intentional
+ * (AbortController.abort() is idempotent) so the helper stays safe to use
+ * without any external listener wiring.
  */
 export function raceClientAbort<T>(
 	bodyPromise: Promise<T>,

--- a/apps/gateway/src/lib/client-abort.ts
+++ b/apps/gateway/src/lib/client-abort.ts
@@ -1,0 +1,51 @@
+/**
+ * Await an upstream body read (res.text()/res.json()) but settle immediately
+ * when the client disconnects, instead of relying on the fetch AbortSignal to
+ * propagate into undici's in-flight body machinery.
+ *
+ * The abort chain for a body read is long: client socket close -> request
+ * signal abort event -> AbortController.abort() -> undici erroring the body
+ * stream. The last hop is timing-sensitive: a late abort can be missed
+ * entirely (the read then blocks until the fetch timeout fires tens of
+ * seconds later) or surface as a generic "terminated" TypeError rather than
+ * an AbortError. Racing the read against the client signal directly
+ * guarantees a prompt AbortError so a disconnect is always recorded as
+ * canceled.
+ *
+ * When `upstreamController` is undefined (the provider does not support
+ * cancellation), the read is returned unchanged: the gateway deliberately
+ * finishes reading the upstream response so it can be logged and billed.
+ */
+export function raceClientAbort<T>(
+	bodyPromise: Promise<T>,
+	clientSignal: AbortSignal,
+	upstreamController: AbortController | undefined,
+): Promise<T> {
+	if (!upstreamController) {
+		return bodyPromise;
+	}
+
+	let removeListener = () => {};
+	const clientAborted = new Promise<never>((_, reject) => {
+		const onClientAbort = () => {
+			// Tear down the upstream connection too: the losing body read stays
+			// pending otherwise and would hold the socket until the fetch timeout.
+			upstreamController.abort();
+			reject(new DOMException("This operation was aborted", "AbortError"));
+		};
+
+		if (clientSignal.aborted) {
+			onClientAbort();
+			return;
+		}
+		clientSignal.addEventListener("abort", onClientAbort, { once: true });
+		removeListener = () =>
+			clientSignal.removeEventListener("abort", onClientAbort);
+	});
+
+	// Promise.race keeps handlers attached to the body promise even when the
+	// abort wins, so its eventual rejection (e.g. the upstream teardown
+	// triggered by upstreamController.abort()) never surfaces as an unhandled
+	// rejection.
+	return Promise.race([bodyPromise, clientAborted]).finally(removeListener);
+}

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -918,6 +918,37 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 			? body.n
 			: 1;
 
+	// Simulate an upstream that returns a non-OK status (500) plus a partial
+	// error body, then hangs without finishing it. The gateway's res.text() on
+	// the error path blocks waiting for the rest, letting a test abort the
+	// client mid-read to exercise the error-body cancellation path. Checked
+	// before the stream branch so streaming requests hit it too: a non-OK
+	// upstream response is a plain (non-SSE) body in both modes. The trigger
+	// deliberately avoids the "TRIGGER_ERROR" substring so the generic-error
+	// handler above doesn't short-circuit it.
+	if (hasUserMessageTrigger(chatMessages, "TRIGGER_5XX_BODY_HANG")) {
+		const encoder = new TextEncoder();
+		let sentPartialBody = false;
+		const hangingErrorBody = new ReadableStream({
+			pull(controller) {
+				if (!sentPartialBody) {
+					sentPartialBody = true;
+					// Flush a partial JSON body so headers are written first.
+					controller.enqueue(encoder.encode('{"error":{"message":"partial'));
+					notifyMockCheckpoint("TRIGGER_5XX_BODY_HANG");
+					return;
+				}
+				// Never enqueue more and never close: the body read hangs until the
+				// client disconnects.
+				return new Promise<void>(() => {});
+			},
+		});
+		return new Response(hangingErrorBody, {
+			status: 500,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
 	if (body.stream === true) {
 		return streamSSE(c, async (stream) => {
 			let eventId = 0;
@@ -1169,35 +1200,6 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		});
 		return new Response(hangingBody, {
 			status: 200,
-			headers: { "Content-Type": "application/json" },
-		});
-	}
-
-	// Simulate an upstream that returns a non-OK status (500) plus a partial
-	// error body, then hangs without finishing it. The gateway's res.text() on
-	// the error path blocks waiting for the rest, letting a test abort the
-	// client mid-read to exercise the non-streaming error-body cancellation
-	// path. The trigger deliberately avoids the "TRIGGER_ERROR" substring so the
-	// generic-error handler above doesn't short-circuit it.
-	if (hasUserMessageTrigger(chatMessages, "TRIGGER_5XX_BODY_HANG")) {
-		const encoder = new TextEncoder();
-		let sentPartialBody = false;
-		const hangingErrorBody = new ReadableStream({
-			pull(controller) {
-				if (!sentPartialBody) {
-					sentPartialBody = true;
-					// Flush a partial JSON body so headers are written first.
-					controller.enqueue(encoder.encode('{"error":{"message":"partial'));
-					notifyMockCheckpoint("TRIGGER_5XX_BODY_HANG");
-					return;
-				}
-				// Never enqueue more and never close: the body read hangs until the
-				// client disconnects.
-				return new Promise<void>(() => {});
-			},
-		});
-		return new Response(hangingErrorBody, {
-			status: 500,
 			headers: { "Content-Type": "application/json" },
 		});
 	}


### PR DESCRIPTION
## Summary

Fixes the flaky `cancellation.spec.ts` CI failure ("abort while reading a non-OK error body is logged as canceled" timing out after 60s waiting for the log) by making the gateway's non-streaming client-cancellation handling robust against abort-propagation races.

## Root cause

Turning a client disconnect during an upstream body read into a `canceled` log relied on a long, timing-sensitive chain: client socket close → `c.req.raw.signal` abort event → `onAbort()` → `AbortController.abort()` → undici propagating the abort into the in-flight `res.text()`/`res.json()` → rejection with an error named exactly `AbortError`.

If the last hop is missed or delayed (a late abort can fail to interrupt undici's body machinery, or surface as a generic `TypeError: terminated`), the read blocks until the ~80s non-streaming fetch timeout — past the test's 60s log wait, so no log row ever appears in time — and the request is then mislogged as `upstream_error` with `hasError: true` even though the client canceled.

## Changes

- **New `raceClientAbort()` helper** (`apps/gateway/src/lib/client-abort.ts`): races an upstream body read against the client-abort signal directly, so a disconnect settles the read immediately with an `AbortError` instead of depending on abort propagation through undici. On a disconnect it also aborts the upstream controller so the losing read doesn't hold the socket, and it keeps handlers attached to the losing promise so its eventual rejection never surfaces as an unhandled rejection. When the provider doesn't support cancellation, the read is passed through unchanged (the gateway deliberately finishes reading for logging/billing).
- **Applied to all four non-streaming body-read sites** in `chat.ts`: the non-OK error-body `res.text()`, the force-stream SSE collapse `res.text()`, the forced image-stream `res.text()`, and the plain `res.json()`.
- **Broadened cancellation classification** in both body-read catch blocks: a read failure is recorded as `canceled` not only for `AbortError`, but for any error when the client has already disconnected and the request is cancelable — covering aborts that surface as `TypeError: terminated` or as a `TimeoutError` after a missed abort.
- **Unit tests** for the helper (`client-abort.spec.ts`): resolution/rejection passthrough, abort-mid-read, already-aborted signal, cancellation-unsupported passthrough, late-rejection swallowing, and listener cleanup.

The existing abort-listener wiring in `chat.ts` is left in place as a second layer of defense; this change only adds guarantees on top of it.

## Testing

- `vitest run apps/gateway/src/lib/client-abort.spec.ts` — 7 passed
- `vitest run apps/gateway/src/cancellation.spec.ts` — 3 passed, 4 consecutive runs
- `vitest run` on `api.spec.ts` (117 passed), `fallback.spec.ts`, `chat-resilience.spec.ts`, `stealth-error-redaction.spec.ts` (71 passed) — the suites covering the touched body-read paths
- `turbo run build --filter=gateway` — clean
- `pnpm format` / lint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lrrho8DGdxQPgpTTHQiK5E

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lrrho8DGdxQPgpTTHQiK5E)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling when a client disconnects while responses are being read.
  * Prevented disconnected requests from being misclassified as upstream errors or timeouts.
  * Ensured in-progress upstream reads are stopped promptly when cancellation is supported.
* **Tests**
  * Added coverage for client cancellation, upstream failures, listener cleanup, and uncaught rejection prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-ups (second commit)

An extensive multi-agent review of the first commit confirmed the core change is sound (no correctness bugs; the closure captures, listener lifecycle, and unhandled-rejection handling all verified). The follow-up commit addresses the surviving findings:

- **Coverage gap**: the streaming path's non-OK error-body `res.text()` and the embeddings upstream body read had the same late-abort hang/mislog bug. Both are now wrapped with `raceClientAbort`; the streaming canceled-logging block is extracted into a shared `respondCanceledStreaming()` helper (mirroring the non-streaming `respondCanceled`), and embeddings classifies post-disconnect read failures as canceled.
- **Duplication**: the broadened cancellation predicate (verbatim in two catch blocks) is now a single `isClientAbortError()` closure used by both non-streaming catch blocks and the new streaming catch.
- **Docs**: `raceClientAbort`'s docstring notes the intentional (idempotent) overlap between its upstream teardown and the callers' `onAbort` listeners.
- **Tests**: the mock `TRIGGER_5XX_BODY_HANG` handler moved ahead of the stream branch so streaming requests reach it, plus a new streaming error-body cancellation test (4/4 passing).

Sibling endpoints (`responses.ts`, `anthropic.ts`, `images.ts`) were checked and deliberately left alone: they read in-memory Hono `app.request()` responses, not undici sockets, so the bug class does not apply.
