### PR TITLE
docs(devpass): individual use only, no teams

### DIFF
--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "Terms of Use — DevPass",
 	description:
-		"Supplemental DevPass Terms of Use. These build on the LLM Gateway Terms of Use and cover the DevPass flat-rate subscription: fair-use limits, one account per developer, approved coding tools, and AI provider policies.",
+		"Supplemental DevPass Terms of Use. These build on the LLM Gateway Terms of Use and cover the DevPass flat-rate subscription: fair-use limits, one account per developer, personal (non-team) use, approved coding tools, and AI provider policies.",
 	alternates: { canonical: "/legal/terms" },
 };
 
@@ -16,7 +16,7 @@ export default function TermsPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> July 19, 2026
+				<strong>Last Updated:</strong> July 22, 2026
 			</p>
 			<p>
 				<strong>DevPass</strong> is a service operated by{" "}
@@ -133,10 +133,11 @@ export default function TermsPage() {
 				refund is issued when you schedule the downgrade.
 			</p>
 			<p>
-				DevPass is intended for individual developer use. We may rate-limit,
-				suspend, or downgrade accounts that show signs of automated abuse, key
-				sharing, resale, or sustained traffic patterns inconsistent with
-				interactive coding workflows.
+				DevPass is intended for private, personal use by an individual developer
+				— not for teams, companies, or other organizations (see Section&nbsp;3).
+				We may rate-limit, suspend, or downgrade accounts that show signs of
+				automated abuse, key sharing, resale, or sustained traffic patterns
+				inconsistent with interactive coding workflows.
 			</p>
 			<hr />
 			<h2>3. One Account Per Developer</h2>
@@ -199,11 +200,14 @@ export default function TermsPage() {
 				</li>
 			</ul>
 			<p>
-				If you genuinely need DevPass for multiple developers (for example, a
-				team or company), contact{" "}
-				<a href="mailto:contact@llmgateway.io">contact@llmgateway.io</a> before
-				signing up. We offer team plans that let multiple developers share
-				DevPass legitimately.
+				<strong>No team or company use.</strong> DevPass is intended for
+				private, personal, individual use only. It may not be purchased, shared,
+				expensed, or otherwise used by or on behalf of a team, company, or other
+				organization, and we do not offer team or multi-seat DevPass plans. If
+				you need AI model access for multiple developers, use our pay-as-you-go
+				LLM Gateway product under the Base Terms instead — contact{" "}
+				<a href="mailto:contact@llmgateway.io">contact@llmgateway.io</a> for
+				custom solutions and volume discounts for teams.
 			</p>
 			<hr />
 			<h2>4. DevPass Acceptable Use</h2>

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -170,8 +170,8 @@ function SignupForm() {
 							with AI.
 						</h1>
 						<p className="mt-4 max-w-md text-lg text-zinc-400">
-							Dev plans, coding tools, and AI-powered workflows for modern
-							development teams.
+							Dev plans, coding tools, and AI-powered workflows for individual
+							developers.
 						</p>
 					</motion.div>
 

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -90,6 +90,29 @@ const faqData: FaqItem[] = [
 		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free.`,
 	},
 	{
+		question: "Can my team or company use DevPass?",
+		answer:
+			"No. DevPass is intended for private, personal use by individual developers — one developer, one account. It can't be purchased or shared as a team or company, and there are no team plans. For teams and companies, use LLM Gateway's pay-as-you-go product instead, and reach out to contact@llmgateway.io for custom solutions and volume discounts.",
+		content: (
+			<>
+				<p>
+					No. DevPass is intended for{" "}
+					<strong>private, personal use by individual developers</strong> — one
+					developer, one account. It can&apos;t be purchased or shared as a team
+					or company, and there are no team plans.
+				</p>
+				<p className="mt-3">
+					For teams and companies, use LLM Gateway&apos;s pay-as-you-go product
+					instead — and reach out to{" "}
+					<Link href="mailto:contact@llmgateway.io" className="underline">
+						contact@llmgateway.io
+					</Link>{" "}
+					for custom solutions and volume discounts.
+				</p>
+			</>
+		),
+	},
+	{
 		question: "Which tools and SDKs work with DevPass?",
 		answer:
 			"Anything that speaks the OpenAI or Anthropic API — Claude Code, Empryo, SoulForge, Cursor, Cline, Continue, Aider, the OpenAI and Anthropic SDKs, and more. Set two environment variables and you're in.",


### PR DESCRIPTION
## Summary

DevPass is intended for private, personal, individual use — it cannot be used by teams or companies, and we do not offer team/multi-seat DevPass plans. Teams should use the pay-as-you-go LLM Gateway product instead and can reach out for custom solutions and volume discounts. This PR makes that explicit in the DevPass terms and FAQ.

## Changes

- **DevPass Supplemental Terms** (`apps/code/src/app/legal/terms/page.tsx`)
  - Section 3: replaced the old "we offer team plans that let multiple developers share DevPass" paragraph with an explicit **No team or company use** clause — DevPass may not be purchased, shared, expensed, or used on behalf of a team/company/organization; multi-developer needs are directed to the PAYG product and contact@llmgateway.io for custom solutions and volume discounts
  - Section 2: strengthened the individual-use sentence ("private, personal use by an individual developer — not for teams, companies, or other organizations")
  - Bumped Last Updated to July 22, 2026 and updated the page metadata description
- **FAQ** (`apps/code/src/components/Faq.tsx`): added "Can my team or company use DevPass?" answering no (one developer, one account, no team plans) and pointing teams to PAYG + contact for volume discounts; included in the FAQPage JSON-LD schema
- **Signup page** (`apps/code/src/app/signup/page.tsx`): tagline no longer says "for modern development teams" — now "for individual developers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Terms of Use with a new revision date and clearer language limiting DevPass to individual, personal use.
  * Added guidance for teams and organizations interested in the LLM Gateway product.

* **Content Updates**
  * Revised signup messaging to emphasize individual developers.
  * Added a FAQ explaining team and company usage restrictions, including a contact option for product inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->