### PR TITLE
fix(models): restore vertex flex on gemini-3.6-flash

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -1185,9 +1185,7 @@ export const googleModels = [
 			{
 				providerId: "google-vertex",
 				externalId: "gemini-3.6-flash",
-				// Vertex rejects Flex for this model ("Flex API is not supported
-				// for model: gemini-3.6-flash"); Flex is served via AI Studio only.
-				serviceTiers: ["priority"],
+				serviceTiers: ["flex", "priority"],
 				serviceTierRegions: ["global"],
 				inputPrice: "1.5e-6",
 				outputPrice: "7.5e-6",


### PR DESCRIPTION
## Summary

Reverts the service-tier change from #3170: `google-vertex/gemini-3.6-flash` supports Flex PayGo again (`serviceTiers: ["flex", "priority"]`).

Google's Flex PayGo documentation lists `gemini-3.6-flash` as supported on the global Vertex endpoint, and live probes confirm it. The "Flex API is not supported for model: gemini-3.6-flash" rejection that motivated #3170 no longer reproduces — most likely a day-one rollout gap, since the model launched the same day the tier was dropped.

## Verification

- **Direct Vertex probe** (global endpoint, `X-Vertex-AI-LLM-Request-Type: shared` + `X-Vertex-AI-LLM-Shared-Request-Type: flex`): HTTP 200 with `usageMetadata.trafficType: ON_DEMAND_FLEX`. Priority still returns `ON_DEMAND_PRIORITY`.
- **Through the gateway** (local build, `service_tier: "flex"`, pinned with `x-no-fallback`): non-streaming and streaming both return `metadata.requested_service_tier: "flex"` and `used_service_tier: "flex"`, billed at the 0.5× Flex multiplier (e.g. input 12 tokens → $9e-06 = 12 × 1.5e-6 × 0.5).
- **E2E**: `TEST_MODELS="google-vertex/gemini-3.6-flash" pnpm test:e2e` — 26 files passed, 91 tests passed, 0 failures.
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flex service tier support for the Gemini 3.6 Flash Google Vertex provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->