### PR TITLE
feat: move auto top-up card under credits

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx
@@ -52,6 +52,8 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
 						</CardContent>
 					</Card>
 
+					<AutoTopUpSettings />
+
 					<Card>
 						<CardHeader>
 							<CardTitle>Plan Management</CardTitle>
@@ -87,8 +89,6 @@ export default async function BillingPage({ searchParams }: BillingPageProps) {
 							<OrganizationBillingEmailSettings />
 						</CardContent>
 					</Card>
-
-					<AutoTopUpSettings />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Moves the Auto Top-Up card on the organization billing page (`apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx`) from the bottom of the page to directly below the Credits card, making it the second card on the page.

New order: Credits → Auto Top-Up → Plan Management → Payment Methods → Billing Email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Caeurt6gfoz4aS8zM3AEtY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Caeurt6gfoz4aS8zM3AEtY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reordered billing settings so Auto Top-Up options appear immediately after the Credits section for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->