### PR TITLE
docs: add crush integration guide

### DIFF
--- a/apps/docs/content/guides/crush.mdx
+++ b/apps/docs/content/guides/crush.mdx
@@ -1,13 +1,13 @@
 ---
 title: Crush Integration
-description: Use GPT-5, Claude, Gemini, or any model with Charm's Crush coding agent. One provider entry, 200+ models, full cost tracking.
+description: Connect Charm's Crush coding agent to 200+ models through LLM Gateway's built-in provider. No config files needed — just select, authenticate, and code.
 icon: Crush
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. Connecting it to LLM Gateway gives you access to 200+ models from 40+ providers through a single API key, with every request tracked in your dashboard.
+[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. LLM Gateway is a built-in provider in Crush, so setup takes under a minute — export your API key, pick LLM Gateway from the provider list, and you have access to 200+ models from 40+ providers, all tracked in one dashboard.
 
 ## Prerequisites
 
@@ -44,20 +44,35 @@ Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
 <Step>
 ### Select LLM Gateway
 
-Launch Crush and pick LLM Gateway from the provider list — it's a built-in provider in Crush's provider catalog:
+Launch Crush:
 
 ```bash
 crush
 ```
 
-If LLM Gateway doesn't appear in your provider list yet (the catalog rolls out gradually), add it manually with the config in the next step.
+LLM Gateway is listed as a built-in provider. Select "LLM Gateway" from the provider list — with `LLMGATEWAY_API_KEY` set, Crush picks up your credentials automatically.
 
 </Step>
 
 <Step>
-### Or Configure It Manually
+### Start Coding
 
-Create a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
+Select a model and start building. You can switch models at any time from within Crush.
+
+</Step>
+</Steps>
+
+## Why Use LLM Gateway with Crush
+
+- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
+- **One API key** — Stop juggling credentials for every provider
+- **Cost tracking** — See what each coding session costs in your dashboard
+- **Automatic fallback** — Requests route to a healthy provider if one is down
+- **Volume discounts** — The more you use, the more you save
+
+## Manual Configuration
+
+The built-in provider needs no config files. If you want to customize the setup — for example to pin request headers or maintain an explicit model list — you can define the provider yourself in a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
 
 ```json
 {
@@ -75,27 +90,9 @@ Create a `crush.json` in your project directory (or `~/.config/crush/crush.json`
 
 Crush auto-discovers all available models from LLM Gateway's `/v1/models` endpoint, so there is no model list to maintain.
 
-</Step>
-
-<Step>
-### Start Coding
-
-Restart Crush, select a model, and start building. You can switch models at any time from within Crush.
-
-</Step>
-</Steps>
-
-## Why Use LLM Gateway with Crush
-
-- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
-- **One API key** — Stop juggling credentials for every provider
-- **Cost tracking** — See what each coding session costs in your dashboard
-- **Automatic fallback** — Requests route to a healthy provider if one is down
-- **Volume discounts** — The more you use, the more you save
-
 ## Locking to a Specific Provider
 
-By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — pass the `X-No-Fallback` header and pin the provider in the model name:
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — use a manual provider config and pass the `X-No-Fallback` header:
 
 ```json
 {

--- a/apps/docs/content/guides/crush.mdx
+++ b/apps/docs/content/guides/crush.mdx
@@ -1,0 +1,147 @@
+---
+title: Crush Integration
+description: Use GPT-5, Claude, Gemini, or any model with Charm's Crush coding agent. One provider entry, 200+ models, full cost tracking.
+icon: Crush
+---
+
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Callout } from "fumadocs-ui/components/callout";
+
+[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. Connecting it to LLM Gateway gives you access to 200+ models from 40+ providers through a single API key, with every request tracked in your dashboard.
+
+## Prerequisites
+
+- Crush installed:
+
+  ```bash
+  # Homebrew
+  brew install charmbracelet/tap/crush
+
+  # NPM
+  npm install -g @charmland/crush
+  ```
+
+  See the [Crush README](https://github.com/charmbracelet/crush#installation) for Windows, Arch, Nix, and FreeBSD instructions.
+
+- An LLM Gateway API key — [sign up](https://llmgateway.io/signup) and create one from your dashboard
+
+## Setup
+
+<Steps>
+<Step>
+### Set Your API Key
+
+Export your LLM Gateway API key in your shell:
+
+```bash
+export LLMGATEWAY_API_KEY=your-api-key-here
+```
+
+Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
+
+</Step>
+
+<Step>
+### Select LLM Gateway
+
+Launch Crush and pick LLM Gateway from the provider list — it's a built-in provider in Crush's provider catalog:
+
+```bash
+crush
+```
+
+If LLM Gateway doesn't appear in your provider list yet (the catalog rolls out gradually), add it manually with the config in the next step.
+
+</Step>
+
+<Step>
+### Or Configure It Manually
+
+Create a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
+
+```json
+{
+	"$schema": "https://charm.land/crush.json",
+	"providers": {
+		"llmgateway": {
+			"name": "LLM Gateway",
+			"type": "openai-compat",
+			"base_url": "https://api.llmgateway.io/v1",
+			"api_key": "$LLMGATEWAY_API_KEY"
+		}
+	}
+}
+```
+
+Crush auto-discovers all available models from LLM Gateway's `/v1/models` endpoint, so there is no model list to maintain.
+
+</Step>
+
+<Step>
+### Start Coding
+
+Restart Crush, select a model, and start building. You can switch models at any time from within Crush.
+
+</Step>
+</Steps>
+
+## Why Use LLM Gateway with Crush
+
+- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
+- **One API key** — Stop juggling credentials for every provider
+- **Cost tracking** — See what each coding session costs in your dashboard
+- **Automatic fallback** — Requests route to a healthy provider if one is down
+- **Volume discounts** — The more you use, the more you save
+
+## Locking to a Specific Provider
+
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — pass the `X-No-Fallback` header and pin the provider in the model name:
+
+```json
+{
+	"$schema": "https://charm.land/crush.json",
+	"providers": {
+		"llmgateway": {
+			"name": "LLM Gateway",
+			"type": "openai-compat",
+			"base_url": "https://api.llmgateway.io/v1",
+			"api_key": "$LLMGATEWAY_API_KEY",
+			"extra_headers": {
+				"X-No-Fallback": "true"
+			}
+		}
+	}
+}
+```
+
+<Callout type="warn">
+	Disabling fallback means requests will fail if the chosen provider is down.
+	See the [routing docs](/features/routing) for details.
+</Callout>
+
+## Switching Models
+
+Use Crush's model picker to switch between any of the discovered models.
+
+<Callout type="info">
+	View all available models on the [models page](https://llmgateway.io/models).
+</Callout>
+
+## Troubleshooting
+
+### 401 Unauthorized
+
+Verify `LLMGATEWAY_API_KEY` is exported in the shell where you launch Crush and that the key is active in your [dashboard](https://llmgateway.io/dashboard).
+
+### 404 Not Found with manual config
+
+Verify your `base_url` is set to `https://api.llmgateway.io/v1` (note the `/v1` at the end).
+
+### Models not showing up
+
+Model discovery runs when Crush starts — restart Crush after adding or changing the provider config.
+
+<Callout type="info">
+	Need help? Join our [Discord community](https://llmgateway.io/discord) for
+	support and troubleshooting assistance.
+</Callout>

--- a/apps/docs/content/guides/crush.mdx
+++ b/apps/docs/content/guides/crush.mdx
@@ -1,13 +1,13 @@
 ---
 title: Crush Integration
-description: Connect Charm's Crush coding agent to 200+ models through LLM Gateway's built-in provider. No config files needed — just select, authenticate, and code.
+description: Use GPT-5, Claude, Gemini, or any model with Charm's Crush coding agent. One provider entry, 200+ models, full cost tracking.
 icon: Crush
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. LLM Gateway is a built-in provider in Crush, so setup takes under a minute — export your API key, pick LLM Gateway from the provider list, and you have access to 200+ models from 40+ providers, all tracked in one dashboard.
+[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. Connecting it to LLM Gateway takes a single provider entry in Crush's config — and gives you access to 200+ models from 40+ providers through one API key, with every request tracked in your dashboard.
 
 ## Prerequisites
 
@@ -42,37 +42,9 @@ Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
 </Step>
 
 <Step>
-### Select LLM Gateway
+### Add LLM Gateway as a Provider
 
-Launch Crush:
-
-```bash
-crush
-```
-
-LLM Gateway is listed as a built-in provider. Select "LLM Gateway" from the provider list — with `LLMGATEWAY_API_KEY` set, Crush picks up your credentials automatically.
-
-</Step>
-
-<Step>
-### Start Coding
-
-Select a model and start building. You can switch models at any time from within Crush.
-
-</Step>
-</Steps>
-
-## Why Use LLM Gateway with Crush
-
-- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
-- **One API key** — Stop juggling credentials for every provider
-- **Cost tracking** — See what each coding session costs in your dashboard
-- **Automatic fallback** — Requests route to a healthy provider if one is down
-- **Volume discounts** — The more you use, the more you save
-
-## Manual Configuration
-
-The built-in provider needs no config files. If you want to customize the setup — for example to pin request headers or maintain an explicit model list — you can define the provider yourself in a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
+Create a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
 
 ```json
 {
@@ -90,9 +62,33 @@ The built-in provider needs no config files. If you want to customize the setup 
 
 Crush auto-discovers all available models from LLM Gateway's `/v1/models` endpoint, so there is no model list to maintain.
 
+</Step>
+
+<Step>
+### Start Coding
+
+Launch Crush:
+
+```bash
+crush
+```
+
+Select "LLM Gateway" from the provider list, pick a model, and start building. You can switch models at any time from within Crush.
+
+</Step>
+</Steps>
+
+## Why Use LLM Gateway with Crush
+
+- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
+- **One API key** — Stop juggling credentials for every provider
+- **Cost tracking** — See what each coding session costs in your dashboard
+- **Automatic fallback** — Requests route to a healthy provider if one is down
+- **Volume discounts** — The more you use, the more you save
+
 ## Locking to a Specific Provider
 
-By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — use a manual provider config and pass the `X-No-Fallback` header:
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — add the `X-No-Fallback` header to your provider entry:
 
 ```json
 {
@@ -130,7 +126,7 @@ Use Crush's model picker to switch between any of the discovered models.
 
 Verify `LLMGATEWAY_API_KEY` is exported in the shell where you launch Crush and that the key is active in your [dashboard](https://llmgateway.io/dashboard).
 
-### 404 Not Found with manual config
+### 404 Not Found
 
 Verify your `base_url` is set to `https://api.llmgateway.io/v1` (note the `/v1` at the end).
 

--- a/apps/docs/lib/custom-icons.tsx
+++ b/apps/docs/lib/custom-icons.tsx
@@ -80,6 +80,17 @@ export const customIcons: Record<string, IconComponent> = {
 			/>
 		</svg>
 	),
+	Crush: (props) => (
+		<svg
+			style={{ flex: "none", lineHeight: "1" }}
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			{...props}
+		>
+			<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+		</svg>
+	),
 	ClaudeCode: (props) => (
 		<svg
 			style={{ flex: "none", lineHeight: "1" }}

--- a/apps/ui/src/components/integrations/integration-cards.tsx
+++ b/apps/ui/src/components/integrations/integration-cards.tsx
@@ -10,6 +10,7 @@ import {
 	AutohandIcon,
 	CodexIcon,
 	ContinueIcon,
+	CrushIcon,
 	OpenClawIcon,
 	ClineIcon,
 	CursorIcon,
@@ -94,6 +95,14 @@ const integrations: Integration[] = [
 			"Use LLM Gateway with Continue's open-source AI code assistant CLI.",
 		href: "/guides/continue",
 		icon: ContinueIcon,
+		comingSoon: false,
+	},
+	{
+		name: "Crush",
+		description:
+			"Use LLM Gateway with Charm's Crush coding agent for AI-powered terminal coding.",
+		href: "/guides/crush",
+		icon: CrushIcon,
 		comingSoon: false,
 	},
 	{

--- a/apps/ui/src/content/guides/crush.md
+++ b/apps/ui/src/content/guides/crush.md
@@ -2,11 +2,11 @@
 id: crush
 slug: crush
 title: Crush Integration
-description: Use GPT-5, Claude, Gemini, or any model with Charm's Crush coding agent. One provider entry, 200+ models, full cost tracking.
+description: Connect Charm's Crush coding agent to 200+ models through LLM Gateway's built-in provider. No config files needed — just select, authenticate, and code.
 date: 2026-07-22
 ---
 
-[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. Connecting it to LLM Gateway gives you access to 200+ models from 40+ providers through a single API key, with every request tracked in your dashboard.
+[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. LLM Gateway is a built-in provider in Crush, so setup takes under a minute — export your API key, pick LLM Gateway from the provider list, and you have access to 200+ models from 40+ providers, all tracked in one dashboard.
 
 ## Prerequisites
 
@@ -38,17 +38,29 @@ Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
 
 ### Step 2: Select LLM Gateway
 
-Launch Crush and pick LLM Gateway from the provider list — it's a built-in provider in Crush's provider catalog:
+Launch Crush:
 
 ```bash
 crush
 ```
 
-If LLM Gateway doesn't appear in your provider list yet (the catalog rolls out gradually), add it manually with the config in the next step.
+LLM Gateway is listed as a built-in provider. Select "LLM Gateway" from the provider list — with `LLMGATEWAY_API_KEY` set, Crush picks up your credentials automatically.
 
-### Step 3: Or Configure It Manually
+### Step 3: Start Coding
 
-Create a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
+Select a model and start building. You can switch models at any time from within Crush.
+
+## Why Use LLM Gateway with Crush?
+
+- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
+- **One API key** — Stop juggling credentials for every provider
+- **Cost tracking** — See what each coding session costs in your dashboard
+- **Automatic fallback** — Requests route to a healthy provider if one is down
+- **Volume discounts** — The more you use, the more you save
+
+## Manual Configuration
+
+The built-in provider needs no config files. If you want to customize the setup — for example to pin request headers or maintain an explicit model list — you can define the provider yourself in a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
 
 ```json
 {
@@ -66,21 +78,9 @@ Create a `crush.json` in your project directory (or `~/.config/crush/crush.json`
 
 Crush auto-discovers all available models from LLM Gateway's `/v1/models` endpoint, so there is no model list to maintain.
 
-### Step 4: Start Coding
-
-Restart Crush, select a model, and start building. You can switch models at any time from within Crush.
-
-## Why Use LLM Gateway with Crush?
-
-- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
-- **One API key** — Stop juggling credentials for every provider
-- **Cost tracking** — See what each coding session costs in your dashboard
-- **Automatic fallback** — Requests route to a healthy provider if one is down
-- **Volume discounts** — The more you use, the more you save
-
 ## Locking to a Specific Provider
 
-By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping, pass the `X-No-Fallback` header:
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping, use a manual provider config and pass the `X-No-Fallback` header:
 
 ```json
 {

--- a/apps/ui/src/content/guides/crush.md
+++ b/apps/ui/src/content/guides/crush.md
@@ -1,0 +1,124 @@
+---
+id: crush
+slug: crush
+title: Crush Integration
+description: Use GPT-5, Claude, Gemini, or any model with Charm's Crush coding agent. One provider entry, 200+ models, full cost tracking.
+date: 2026-07-22
+---
+
+[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. Connecting it to LLM Gateway gives you access to 200+ models from 40+ providers through a single API key, with every request tracked in your dashboard.
+
+## Prerequisites
+
+Install Crush with your package manager of choice:
+
+```bash
+# Homebrew
+brew install charmbracelet/tap/crush
+
+# NPM
+npm install -g @charmland/crush
+```
+
+See the [Crush README](https://github.com/charmbracelet/crush#installation) for Windows, Arch, Nix, and FreeBSD instructions.
+
+You also need an LLM Gateway API key — [sign up](/signup) and create one from your dashboard.
+
+## Setup
+
+### Step 1: Set Your API Key
+
+Export your LLM Gateway API key in your shell:
+
+```bash
+export LLMGATEWAY_API_KEY=your-api-key-here
+```
+
+Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
+
+### Step 2: Select LLM Gateway
+
+Launch Crush and pick LLM Gateway from the provider list — it's a built-in provider in Crush's provider catalog:
+
+```bash
+crush
+```
+
+If LLM Gateway doesn't appear in your provider list yet (the catalog rolls out gradually), add it manually with the config in the next step.
+
+### Step 3: Or Configure It Manually
+
+Create a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "providers": {
+    "llmgateway": {
+      "name": "LLM Gateway",
+      "type": "openai-compat",
+      "base_url": "https://api.llmgateway.io/v1",
+      "api_key": "$LLMGATEWAY_API_KEY"
+    }
+  }
+}
+```
+
+Crush auto-discovers all available models from LLM Gateway's `/v1/models` endpoint, so there is no model list to maintain.
+
+### Step 4: Start Coding
+
+Restart Crush, select a model, and start building. You can switch models at any time from within Crush.
+
+## Why Use LLM Gateway with Crush?
+
+- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
+- **One API key** — Stop juggling credentials for every provider
+- **Cost tracking** — See what each coding session costs in your dashboard
+- **Automatic fallback** — Requests route to a healthy provider if one is down
+- **Volume discounts** — The more you use, the more you save
+
+## Locking to a Specific Provider
+
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping, pass the `X-No-Fallback` header:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "providers": {
+    "llmgateway": {
+      "name": "LLM Gateway",
+      "type": "openai-compat",
+      "base_url": "https://api.llmgateway.io/v1",
+      "api_key": "$LLMGATEWAY_API_KEY",
+      "extra_headers": {
+        "X-No-Fallback": "true"
+      }
+    }
+  }
+}
+```
+
+Note that disabling fallback means requests will fail if the chosen provider is down.
+
+## Switching Models
+
+Use Crush's model picker to switch between any of the discovered models. View all available models on the [models page](/models).
+
+## Troubleshooting
+
+### 401 Unauthorized
+
+Verify `LLMGATEWAY_API_KEY` is exported in the shell where you launch Crush and that the key is active in your [dashboard](/dashboard).
+
+### 404 Not Found with manual config
+
+Verify your `base_url` is set to `https://api.llmgateway.io/v1` (note the `/v1` at the end).
+
+### Models not showing up
+
+Model discovery runs when Crush starts — restart Crush after adding or changing the provider config.
+
+## Get Started
+
+Ready to use Crush with any model? [Sign up for LLM Gateway](/signup) and get your API key today.

--- a/apps/ui/src/content/guides/crush.md
+++ b/apps/ui/src/content/guides/crush.md
@@ -2,11 +2,11 @@
 id: crush
 slug: crush
 title: Crush Integration
-description: Connect Charm's Crush coding agent to 200+ models through LLM Gateway's built-in provider. No config files needed — just select, authenticate, and code.
+description: Use GPT-5, Claude, Gemini, or any model with Charm's Crush coding agent. One provider entry, 200+ models, full cost tracking.
 date: 2026-07-22
 ---
 
-[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. LLM Gateway is a built-in provider in Crush, so setup takes under a minute — export your API key, pick LLM Gateway from the provider list, and you have access to 200+ models from 40+ providers, all tracked in one dashboard.
+[Crush](https://github.com/charmbracelet/crush) is Charm's glamorous open-source AI coding agent for your terminal. Connecting it to LLM Gateway takes a single provider entry in Crush's config — and gives you access to 200+ models from 40+ providers through one API key, with every request tracked in your dashboard.
 
 ## Prerequisites
 
@@ -36,31 +36,9 @@ export LLMGATEWAY_API_KEY=your-api-key-here
 
 Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to make it permanent.
 
-### Step 2: Select LLM Gateway
+### Step 2: Add LLM Gateway as a Provider
 
-Launch Crush:
-
-```bash
-crush
-```
-
-LLM Gateway is listed as a built-in provider. Select "LLM Gateway" from the provider list — with `LLMGATEWAY_API_KEY` set, Crush picks up your credentials automatically.
-
-### Step 3: Start Coding
-
-Select a model and start building. You can switch models at any time from within Crush.
-
-## Why Use LLM Gateway with Crush?
-
-- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
-- **One API key** — Stop juggling credentials for every provider
-- **Cost tracking** — See what each coding session costs in your dashboard
-- **Automatic fallback** — Requests route to a healthy provider if one is down
-- **Volume discounts** — The more you use, the more you save
-
-## Manual Configuration
-
-The built-in provider needs no config files. If you want to customize the setup — for example to pin request headers or maintain an explicit model list — you can define the provider yourself in a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
+Create a `crush.json` in your project directory (or `~/.config/crush/crush.json` for a global setup):
 
 ```json
 {
@@ -78,9 +56,27 @@ The built-in provider needs no config files. If you want to customize the setup 
 
 Crush auto-discovers all available models from LLM Gateway's `/v1/models` endpoint, so there is no model list to maintain.
 
+### Step 3: Start Coding
+
+Launch Crush:
+
+```bash
+crush
+```
+
+Select "LLM Gateway" from the provider list, pick a model, and start building. You can switch models at any time from within Crush.
+
+## Why Use LLM Gateway with Crush?
+
+- **200+ models** — GPT-5, Claude, Gemini, Kimi, GLM, and more from 40+ providers
+- **One API key** — Stop juggling credentials for every provider
+- **Cost tracking** — See what each coding session costs in your dashboard
+- **Automatic fallback** — Requests route to a healthy provider if one is down
+- **Volume discounts** — The more you use, the more you save
+
 ## Locking to a Specific Provider
 
-By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping, use a manual provider config and pass the `X-No-Fallback` header:
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping, add the `X-No-Fallback` header to your provider entry:
 
 ```json
 {
@@ -111,7 +107,7 @@ Use Crush's model picker to switch between any of the discovered models. View al
 
 Verify `LLMGATEWAY_API_KEY` is exported in the shell where you launch Crush and that the key is active in your [dashboard](/dashboard).
 
-### 404 Not Found with manual config
+### 404 Not Found
 
 Verify your `base_url` is set to `https://api.llmgateway.io/v1` (note the `/v1` at the end).
 

--- a/packages/shared/src/components/integration-guides-grid.tsx
+++ b/packages/shared/src/components/integration-guides-grid.tsx
@@ -8,6 +8,7 @@ import {
 	ClineIcon,
 	CodexIcon,
 	ContinueIcon,
+	CrushIcon,
 	CursorIcon,
 	DevPassCodeIcon,
 	GitHubCopilotIcon,
@@ -91,6 +92,14 @@ export const DEFAULT_INTEGRATION_GUIDES: IntegrationGuide[] = [
 			"Use LLM Gateway with Continue's open-source AI code assistant CLI.",
 		href: "/guides/continue",
 		icon: ContinueIcon,
+		comingSoon: false,
+	},
+	{
+		name: "Crush",
+		description:
+			"Use LLM Gateway with Charm's Crush coding agent for AI-powered terminal coding.",
+		href: "/guides/crush",
+		icon: CrushIcon,
 		comingSoon: false,
 	},
 	{

--- a/packages/shared/src/components/integration-icons.tsx
+++ b/packages/shared/src/components/integration-icons.tsx
@@ -399,3 +399,15 @@ export const DevPassCodeIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 		/>
 	</svg>
 );
+
+// Crush Icon (heart mark)
+export const CrushIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="currentColor"
+		{...props}
+	>
+		<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+	</svg>
+);


### PR DESCRIPTION
## Summary

Adds a [Crush](https://github.com/charmbracelet/crush) (Charm's terminal coding agent) integration guide, documenting the manual `crush.json` provider setup that works today.

- `apps/docs/content/guides/crush.mdx` — docs guide: export `LLMGATEWAY_API_KEY`, add an `openai-compat` provider entry (models auto-discovered from `/v1/models`, no model list to maintain), `X-No-Fallback` provider pinning, troubleshooting
- `apps/ui/src/content/guides/crush.md` — UI guide mirror (content-collections picks it up on `/guides`)
- Crush cards added to both integration grids (`integration-cards.tsx`, `integration-guides-grid.tsx`) with a new `CrushIcon` / docs `Crush` custom icon

An upstream PR to make LLM Gateway a built-in Crush provider is open at [charmbracelet/catwalk#458](https://github.com/charmbracelet/catwalk/pull/458); this guide intentionally does not reference the built-in flow — if that PR ever lands, the guide can be updated to lead with it.

## Verification

- `pnpm format` and full `pnpm build` pass (17/17 tasks)
- `crush.json` config field names verified against crush's `ProviderConfig` schema (`base_url`, `type: openai-compat`, `api_key`, `extra_headers`; model auto-discovery via `/v1/models` is on by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Crush to the supported LLM Gateway integrations, including a new Crush icon and direct link to its guide.
* **Documentation**
  * Updated the Crush + LLM Gateway guide with revised setup steps using a single `crush.json` provider entry (including `openai-compat` `base_url` and `LLMGATEWAY_API_KEY`), clarified model discovery from `/v1/models`, and updated “Start Coding” to include the `crush` launch command.
  * Refined provider locking instructions to use the `X-No-Fallback` header and renamed the troubleshooting section for “404 Not Found.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->