### PR TITLE
fix(payments): attach top-up card at setup confirm

### DIFF
--- a/apps/api/src/routes/payments.e2e.ts
+++ b/apps/api/src/routes/payments.e2e.ts
@@ -1,0 +1,183 @@
+import "dotenv/config";
+import Stripe from "stripe";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+import { CREDIT_TOP_UP_MIN_AMOUNT } from "@llmgateway/shared";
+
+// Reproduces the production credits top-up flow against real Stripe test
+// mode, server-side: create-setup-intent -> confirm the SetupIntent with a
+// test card (what the browser's confirmCardSetup does) -> immediately
+// create-payment-intent with the resulting payment method. No webhook is
+// delivered locally, which is exactly the losing side of the production race:
+// if the SetupIntent is created without a customer, the payment method comes
+// out of confirmation used-but-unattached and Stripe rejects the
+// PaymentIntent ("The provided PaymentMethod cannot be attached...").
+
+const stripeKey = process.env.STRIPE_SECRET_KEY;
+// Never run against a live key; skip entirely when no test key is configured.
+const hasTestStripeKey = Boolean(stripeKey?.startsWith("sk_test_"));
+
+function generateTestId(): string {
+	return `test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+describe.skipIf(!hasTestStripeKey)("e2e credits top-up payment flow", () => {
+	const stripeCustomerIds: string[] = [];
+
+	beforeAll(async () => {
+		await deleteAll();
+	});
+
+	afterAll(async () => {
+		// Remove the Stripe test-mode customers created by ensureStripeCustomer
+		// so repeated runs don't accumulate clutter.
+		const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
+		for (const customerId of stripeCustomerIds) {
+			try {
+				await stripe.customers.del(customerId);
+			} catch {
+				// best-effort cleanup only
+			}
+		}
+		await deleteAll();
+	});
+
+	async function setupTestData() {
+		const testId = generateTestId();
+		const userId = `user-${testId}`;
+		const orgId = `org-${testId}`;
+
+		await db.insert(tables.user).values({
+			id: userId,
+			name: "Test User",
+			email: `admin-${testId}@example.com`,
+			emailVerified: true,
+		});
+
+		await db.insert(tables.account).values({
+			id: `account-${testId}`,
+			providerId: "credential",
+			accountId: `account-${testId}`,
+			userId,
+			password:
+				"c11ef27a7f9264be08db228ebb650888:a4d985a9c6bd98608237fd507534424950aa7fc255930d972242b81cbe78594f8568feb0d067e95ddf7be242ad3e9d013f695f4414fce68bfff091079f1dc460",
+		});
+
+		const auth = await app.request("/auth/sign-in/email", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				email: `admin-${testId}@example.com`,
+				password: "admin@example.com1A",
+			}),
+		});
+
+		if (auth.status !== 200) {
+			throw new Error(`Failed to authenticate: ${auth.status}`);
+		}
+
+		const token = auth.headers.get("set-cookie")!;
+
+		await db.insert(tables.organization).values({
+			id: orgId,
+			name: "Test Organization",
+			billingEmail: `admin-${testId}@example.com`,
+			plan: "pro",
+		});
+
+		await db.insert(tables.userOrganization).values({
+			id: `user-org-${testId}`,
+			userId,
+			organizationId: orgId,
+		});
+
+		return { token, orgId };
+	}
+
+	test("new saved card is chargeable immediately after setup confirmation", async () => {
+		const { token, orgId } = await setupTestData();
+		const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
+
+		const setupRes = await app.request("/payments/create-setup-intent", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({ organizationId: orgId }),
+		});
+		expect(setupRes.status).toBe(200);
+		const { clientSecret } = (await setupRes.json()) as {
+			clientSecret: string;
+		};
+		expect(clientSecret).toContain("_secret");
+
+		const organization = await db.query.organization.findFirst({
+			where: { id: orgId },
+		});
+		expect(organization?.stripeCustomerId).toBeTruthy();
+		stripeCustomerIds.push(organization!.stripeCustomerId!);
+
+		// What stripe.confirmCardSetup(clientSecret, ...) does in the browser.
+		const setupIntentId = clientSecret.split("_secret")[0];
+		const confirmedSetup = await stripe.setupIntents.confirm(setupIntentId, {
+			payment_method: "pm_card_visa",
+			// Stripe.js supplies this implicitly in the browser; confirming
+			// server-side requires it because redirect-based payment methods are
+			// enabled on the account.
+			return_url: "https://llmgateway.io/",
+		});
+		expect(confirmedSetup.status).toBe("succeeded");
+
+		const paymentMethodId =
+			typeof confirmedSetup.payment_method === "string"
+				? confirmedSetup.payment_method
+				: confirmedSetup.payment_method!.id;
+
+		// Root-cause regression: confirmation must leave the payment method
+		// attached to the org's Stripe customer. A customer-less SetupIntent
+		// leaves it unattached here, and only the (async, absent in this test)
+		// setup_intent.succeeded webhook would attach it.
+		const paymentMethod = await stripe.paymentMethods.retrieve(paymentMethodId);
+		const attachedCustomerId =
+			typeof paymentMethod.customer === "string"
+				? paymentMethod.customer
+				: (paymentMethod.customer?.id ?? null);
+		expect(attachedCustomerId).toBe(organization!.stripeCustomerId);
+
+		// The client calls this immediately after confirmCardSetup — before any
+		// webhook can possibly have run. On unfixed code Stripe rejects this
+		// with 400 ("The provided PaymentMethod cannot be attached...") and the
+		// API 500s.
+		const intentRes = await app.request("/payments/create-payment-intent", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({
+				amount: CREDIT_TOP_UP_MIN_AMOUNT,
+				stripePaymentMethodId: paymentMethodId,
+				organizationId: orgId,
+			}),
+		});
+		expect(intentRes.status).toBe(200);
+		const intentJson = (await intentRes.json()) as { clientSecret: string };
+		expect(intentJson.clientSecret).toContain("_secret");
+
+		// The intent must be confirmable with the saved card, i.e. the payment
+		// method is genuinely reusable (attached), not a consumed one-off.
+		const paymentIntentId = intentJson.clientSecret.split("_secret")[0];
+		const confirmedIntent = await stripe.paymentIntents.confirm(
+			paymentIntentId,
+			{ payment_method: paymentMethodId, return_url: "https://llmgateway.io/" },
+		);
+		expect(confirmedIntent.status).toBe("succeeded");
+	});
+});

--- a/apps/api/src/routes/payments.e2e.ts
+++ b/apps/api/src/routes/payments.e2e.ts
@@ -18,166 +18,177 @@ import { CREDIT_TOP_UP_MIN_AMOUNT } from "@llmgateway/shared";
 // PaymentIntent ("The provided PaymentMethod cannot be attached...").
 
 const stripeKey = process.env.STRIPE_SECRET_KEY;
-// Never run against a live key; skip entirely when no test key is configured.
-const hasTestStripeKey = Boolean(stripeKey?.startsWith("sk_test_"));
+// Opt-in only (STRIPE_TESTING=true): hits the real Stripe test-mode API, so
+// it must not run as part of the default e2e suite. Never runs against a
+// live key.
+const stripeTestingEnabled =
+	process.env.STRIPE_TESTING === "true" &&
+	Boolean(stripeKey?.startsWith("sk_test_"));
 
 function generateTestId(): string {
 	return `test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 }
 
-describe.skipIf(!hasTestStripeKey)("e2e credits top-up payment flow", () => {
-	const stripeCustomerIds: string[] = [];
+describe.skipIf(!stripeTestingEnabled)(
+	"e2e credits top-up payment flow",
+	() => {
+		const stripeCustomerIds: string[] = [];
 
-	beforeAll(async () => {
-		await deleteAll();
-	});
+		beforeAll(async () => {
+			await deleteAll();
+		});
 
-	afterAll(async () => {
-		// Remove the Stripe test-mode customers created by ensureStripeCustomer
-		// so repeated runs don't accumulate clutter.
-		const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
-		for (const customerId of stripeCustomerIds) {
-			try {
-				await stripe.customers.del(customerId);
-			} catch {
-				// best-effort cleanup only
+		afterAll(async () => {
+			// Remove the Stripe test-mode customers created by ensureStripeCustomer
+			// so repeated runs don't accumulate clutter.
+			const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
+			for (const customerId of stripeCustomerIds) {
+				try {
+					await stripe.customers.del(customerId);
+				} catch {
+					// best-effort cleanup only
+				}
 			}
-		}
-		await deleteAll();
-	});
-
-	async function setupTestData() {
-		const testId = generateTestId();
-		const userId = `user-${testId}`;
-		const orgId = `org-${testId}`;
-
-		await db.insert(tables.user).values({
-			id: userId,
-			name: "Test User",
-			email: `admin-${testId}@example.com`,
-			emailVerified: true,
+			await deleteAll();
 		});
 
-		await db.insert(tables.account).values({
-			id: `account-${testId}`,
-			providerId: "credential",
-			accountId: `account-${testId}`,
-			userId,
-			password:
-				"c11ef27a7f9264be08db228ebb650888:a4d985a9c6bd98608237fd507534424950aa7fc255930d972242b81cbe78594f8568feb0d067e95ddf7be242ad3e9d013f695f4414fce68bfff091079f1dc460",
-		});
+		async function setupTestData() {
+			const testId = generateTestId();
+			const userId = `user-${testId}`;
+			const orgId = `org-${testId}`;
 
-		const auth = await app.request("/auth/sign-in/email", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
+			await db.insert(tables.user).values({
+				id: userId,
+				name: "Test User",
 				email: `admin-${testId}@example.com`,
-				password: "admin@example.com1A",
-			}),
-		});
+				emailVerified: true,
+			});
 
-		if (auth.status !== 200) {
-			throw new Error(`Failed to authenticate: ${auth.status}`);
+			await db.insert(tables.account).values({
+				id: `account-${testId}`,
+				providerId: "credential",
+				accountId: `account-${testId}`,
+				userId,
+				password:
+					"c11ef27a7f9264be08db228ebb650888:a4d985a9c6bd98608237fd507534424950aa7fc255930d972242b81cbe78594f8568feb0d067e95ddf7be242ad3e9d013f695f4414fce68bfff091079f1dc460",
+			});
+
+			const auth = await app.request("/auth/sign-in/email", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					email: `admin-${testId}@example.com`,
+					password: "admin@example.com1A",
+				}),
+			});
+
+			if (auth.status !== 200) {
+				throw new Error(`Failed to authenticate: ${auth.status}`);
+			}
+
+			const token = auth.headers.get("set-cookie")!;
+
+			await db.insert(tables.organization).values({
+				id: orgId,
+				name: "Test Organization",
+				billingEmail: `admin-${testId}@example.com`,
+				plan: "pro",
+			});
+
+			await db.insert(tables.userOrganization).values({
+				id: `user-org-${testId}`,
+				userId,
+				organizationId: orgId,
+			});
+
+			return { token, orgId };
 		}
 
-		const token = auth.headers.get("set-cookie")!;
+		test("new saved card is chargeable immediately after setup confirmation", async () => {
+			const { token, orgId } = await setupTestData();
+			const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
 
-		await db.insert(tables.organization).values({
-			id: orgId,
-			name: "Test Organization",
-			billingEmail: `admin-${testId}@example.com`,
-			plan: "pro",
+			const setupRes = await app.request("/payments/create-setup-intent", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Cookie: token,
+				},
+				body: JSON.stringify({ organizationId: orgId }),
+			});
+			expect(setupRes.status).toBe(200);
+			const { clientSecret } = (await setupRes.json()) as {
+				clientSecret: string;
+			};
+			expect(clientSecret).toContain("_secret");
+
+			const organization = await db.query.organization.findFirst({
+				where: { id: orgId },
+			});
+			expect(organization?.stripeCustomerId).toBeTruthy();
+			stripeCustomerIds.push(organization!.stripeCustomerId!);
+
+			// What stripe.confirmCardSetup(clientSecret, ...) does in the browser.
+			const setupIntentId = clientSecret.split("_secret")[0];
+			const confirmedSetup = await stripe.setupIntents.confirm(setupIntentId, {
+				payment_method: "pm_card_visa",
+				// Stripe.js supplies this implicitly in the browser; confirming
+				// server-side requires it because redirect-based payment methods are
+				// enabled on the account.
+				return_url: "https://llmgateway.io/",
+			});
+			expect(confirmedSetup.status).toBe("succeeded");
+
+			const paymentMethodId =
+				typeof confirmedSetup.payment_method === "string"
+					? confirmedSetup.payment_method
+					: confirmedSetup.payment_method!.id;
+
+			// Root-cause regression: confirmation must leave the payment method
+			// attached to the org's Stripe customer. A customer-less SetupIntent
+			// leaves it unattached here, and only the (async, absent in this test)
+			// setup_intent.succeeded webhook would attach it.
+			const paymentMethod =
+				await stripe.paymentMethods.retrieve(paymentMethodId);
+			const attachedCustomerId =
+				typeof paymentMethod.customer === "string"
+					? paymentMethod.customer
+					: (paymentMethod.customer?.id ?? null);
+			expect(attachedCustomerId).toBe(organization!.stripeCustomerId);
+
+			// The client calls this immediately after confirmCardSetup — before any
+			// webhook can possibly have run. On unfixed code Stripe rejects this
+			// with 400 ("The provided PaymentMethod cannot be attached...") and the
+			// API 500s.
+			const intentRes = await app.request("/payments/create-payment-intent", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Cookie: token,
+				},
+				body: JSON.stringify({
+					amount: CREDIT_TOP_UP_MIN_AMOUNT,
+					stripePaymentMethodId: paymentMethodId,
+					organizationId: orgId,
+				}),
+			});
+			expect(intentRes.status).toBe(200);
+			const intentJson = (await intentRes.json()) as { clientSecret: string };
+			expect(intentJson.clientSecret).toContain("_secret");
+
+			// The intent must be confirmable with the saved card, i.e. the payment
+			// method is genuinely reusable (attached), not a consumed one-off.
+			const paymentIntentId = intentJson.clientSecret.split("_secret")[0];
+			const confirmedIntent = await stripe.paymentIntents.confirm(
+				paymentIntentId,
+				{
+					payment_method: paymentMethodId,
+					return_url: "https://llmgateway.io/",
+				},
+			);
+			expect(confirmedIntent.status).toBe("succeeded");
 		});
-
-		await db.insert(tables.userOrganization).values({
-			id: `user-org-${testId}`,
-			userId,
-			organizationId: orgId,
-		});
-
-		return { token, orgId };
-	}
-
-	test("new saved card is chargeable immediately after setup confirmation", async () => {
-		const { token, orgId } = await setupTestData();
-		const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
-
-		const setupRes = await app.request("/payments/create-setup-intent", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Cookie: token,
-			},
-			body: JSON.stringify({ organizationId: orgId }),
-		});
-		expect(setupRes.status).toBe(200);
-		const { clientSecret } = (await setupRes.json()) as {
-			clientSecret: string;
-		};
-		expect(clientSecret).toContain("_secret");
-
-		const organization = await db.query.organization.findFirst({
-			where: { id: orgId },
-		});
-		expect(organization?.stripeCustomerId).toBeTruthy();
-		stripeCustomerIds.push(organization!.stripeCustomerId!);
-
-		// What stripe.confirmCardSetup(clientSecret, ...) does in the browser.
-		const setupIntentId = clientSecret.split("_secret")[0];
-		const confirmedSetup = await stripe.setupIntents.confirm(setupIntentId, {
-			payment_method: "pm_card_visa",
-			// Stripe.js supplies this implicitly in the browser; confirming
-			// server-side requires it because redirect-based payment methods are
-			// enabled on the account.
-			return_url: "https://llmgateway.io/",
-		});
-		expect(confirmedSetup.status).toBe("succeeded");
-
-		const paymentMethodId =
-			typeof confirmedSetup.payment_method === "string"
-				? confirmedSetup.payment_method
-				: confirmedSetup.payment_method!.id;
-
-		// Root-cause regression: confirmation must leave the payment method
-		// attached to the org's Stripe customer. A customer-less SetupIntent
-		// leaves it unattached here, and only the (async, absent in this test)
-		// setup_intent.succeeded webhook would attach it.
-		const paymentMethod = await stripe.paymentMethods.retrieve(paymentMethodId);
-		const attachedCustomerId =
-			typeof paymentMethod.customer === "string"
-				? paymentMethod.customer
-				: (paymentMethod.customer?.id ?? null);
-		expect(attachedCustomerId).toBe(organization!.stripeCustomerId);
-
-		// The client calls this immediately after confirmCardSetup — before any
-		// webhook can possibly have run. On unfixed code Stripe rejects this
-		// with 400 ("The provided PaymentMethod cannot be attached...") and the
-		// API 500s.
-		const intentRes = await app.request("/payments/create-payment-intent", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Cookie: token,
-			},
-			body: JSON.stringify({
-				amount: CREDIT_TOP_UP_MIN_AMOUNT,
-				stripePaymentMethodId: paymentMethodId,
-				organizationId: orgId,
-			}),
-		});
-		expect(intentRes.status).toBe(200);
-		const intentJson = (await intentRes.json()) as { clientSecret: string };
-		expect(intentJson.clientSecret).toContain("_secret");
-
-		// The intent must be confirmable with the saved card, i.e. the payment
-		// method is genuinely reusable (attached), not a consumed one-off.
-		const paymentIntentId = intentJson.clientSecret.split("_secret")[0];
-		const confirmedIntent = await stripe.paymentIntents.confirm(
-			paymentIntentId,
-			{ payment_method: paymentMethodId, return_url: "https://llmgateway.io/" },
-		);
-		expect(confirmedIntent.status).toBe("succeeded");
-	});
-});
+	},
+);

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -323,7 +323,15 @@ payments.openapi(createSetupIntent, async (c) => {
 
 	const organizationId = userOrganization.organization.id;
 
+	const stripeCustomerId = await ensureStripeCustomer(organizationId);
+
+	// The customer must be set here so Stripe attaches the payment method
+	// atomically when the client confirms the setup. Without it the PM comes
+	// out of confirmCardSetup "used but unattached", and create-payment-intent
+	// races the setup_intent.succeeded webhook's attach — losing the race
+	// makes Stripe reject the PaymentIntent outright.
 	const setupIntent = await getStripe().setupIntents.create({
+		customer: stripeCustomerId,
 		usage: "off_session",
 		metadata: {
 			organizationId,

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -189,71 +189,22 @@ payments.openapi(createPaymentIntent, async (c) => {
 		isInternational,
 	});
 
-	let paymentIntent: Stripe.PaymentIntent;
-	try {
-		paymentIntent = await getStripe().paymentIntents.create({
-			amount: Math.round(feeBreakdown.totalAmount * 100),
-			currency: "usd",
-			description: `Credit purchase for ${amount} USD (including fees)`,
-			customer: stripeCustomerId,
-			...(stripePaymentMethodId
-				? { payment_method: stripePaymentMethodId }
-				: {}),
-			metadata: {
-				organizationId,
-				baseAmount: amount.toString(),
-				platformFee: feeBreakdown.platformFee.toString(),
-				internationalFee: feeBreakdown.internationalFee.toString(),
-				isInternational: isInternational.toString(),
-				userEmail: user.email,
-				userId: user.id,
-			},
-		});
-	} catch (err) {
-		// A single-use PaymentMethod can be dead by the time it reaches us: the
-		// client double-submitted with an already-consumed PM, or the
-		// setup_intent.succeeded webhook's duplicate-card check detached it
-		// mid-flow. Stripe rejects with "The provided PaymentMethod cannot be
-		// attached..." — a user-recoverable state, not a server fault.
-		if (
-			err instanceof Stripe.errors.StripeInvalidRequestError &&
-			err.param === "payment_method"
-		) {
-			logger.warn("Stripe rejected payment method on top-up intent", {
-				organizationId,
-				userId: user.id,
-				stripeCode: err.code,
-				stripeMessage: err.message,
-				stripeRequestId: err.requestId,
-			});
-			throw new HTTPException(400, {
-				message:
-					"This card can no longer be used for this payment. Please re-enter your card details and try again.",
-			});
-		}
-
-		if (err instanceof Stripe.errors.StripeError) {
-			logger.error("Stripe error on payment intent creation", err, {
-				organizationId,
-				userId: user.id,
-				stripeType: err.type,
-				stripeCode: err.code,
-				stripeStatusCode: err.statusCode,
-				stripeRequestId: err.requestId,
-			});
-
-			throw new HTTPException(
-				(err.statusCode ?? 400) as
-					| ClientErrorStatusCode
-					| ServerErrorStatusCode,
-				{
-					message: err.message,
-				},
-			);
-		}
-
-		throw err;
-	}
+	const paymentIntent = await getStripe().paymentIntents.create({
+		amount: Math.round(feeBreakdown.totalAmount * 100),
+		currency: "usd",
+		description: `Credit purchase for ${amount} USD (including fees)`,
+		customer: stripeCustomerId,
+		...(stripePaymentMethodId ? { payment_method: stripePaymentMethodId } : {}),
+		metadata: {
+			organizationId,
+			baseAmount: amount.toString(),
+			platformFee: feeBreakdown.platformFee.toString(),
+			internationalFee: feeBreakdown.internationalFee.toString(),
+			isInternational: isInternational.toString(),
+			userEmail: user.email,
+			userId: user.id,
+		},
+	});
 
 	return c.json({
 		clientSecret: paymentIntent.client_secret ?? "",

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -189,22 +189,71 @@ payments.openapi(createPaymentIntent, async (c) => {
 		isInternational,
 	});
 
-	const paymentIntent = await getStripe().paymentIntents.create({
-		amount: Math.round(feeBreakdown.totalAmount * 100),
-		currency: "usd",
-		description: `Credit purchase for ${amount} USD (including fees)`,
-		customer: stripeCustomerId,
-		...(stripePaymentMethodId ? { payment_method: stripePaymentMethodId } : {}),
-		metadata: {
-			organizationId,
-			baseAmount: amount.toString(),
-			platformFee: feeBreakdown.platformFee.toString(),
-			internationalFee: feeBreakdown.internationalFee.toString(),
-			isInternational: isInternational.toString(),
-			userEmail: user.email,
-			userId: user.id,
-		},
-	});
+	let paymentIntent: Stripe.PaymentIntent;
+	try {
+		paymentIntent = await getStripe().paymentIntents.create({
+			amount: Math.round(feeBreakdown.totalAmount * 100),
+			currency: "usd",
+			description: `Credit purchase for ${amount} USD (including fees)`,
+			customer: stripeCustomerId,
+			...(stripePaymentMethodId
+				? { payment_method: stripePaymentMethodId }
+				: {}),
+			metadata: {
+				organizationId,
+				baseAmount: amount.toString(),
+				platformFee: feeBreakdown.platformFee.toString(),
+				internationalFee: feeBreakdown.internationalFee.toString(),
+				isInternational: isInternational.toString(),
+				userEmail: user.email,
+				userId: user.id,
+			},
+		});
+	} catch (err) {
+		// A single-use PaymentMethod can be dead by the time it reaches us: the
+		// client double-submitted with an already-consumed PM, or the
+		// setup_intent.succeeded webhook's duplicate-card check detached it
+		// mid-flow. Stripe rejects with "The provided PaymentMethod cannot be
+		// attached..." — a user-recoverable state, not a server fault.
+		if (
+			err instanceof Stripe.errors.StripeInvalidRequestError &&
+			err.param === "payment_method"
+		) {
+			logger.warn("Stripe rejected payment method on top-up intent", {
+				organizationId,
+				userId: user.id,
+				stripeCode: err.code,
+				stripeMessage: err.message,
+				stripeRequestId: err.requestId,
+			});
+			throw new HTTPException(400, {
+				message:
+					"This card can no longer be used for this payment. Please re-enter your card details and try again.",
+			});
+		}
+
+		if (err instanceof Stripe.errors.StripeError) {
+			logger.error("Stripe error on payment intent creation", err, {
+				organizationId,
+				userId: user.id,
+				stripeType: err.type,
+				stripeCode: err.code,
+				stripeStatusCode: err.statusCode,
+				stripeRequestId: err.requestId,
+			});
+
+			throw new HTTPException(
+				(err.statusCode ?? 400) as
+					| ClientErrorStatusCode
+					| ServerErrorStatusCode,
+				{
+					message: err.message,
+				},
+			);
+		}
+
+		throw err;
+	}
 
 	return c.json({
 		clientSecret: paymentIntent.client_secret ?? "",

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3509,9 +3509,24 @@ async function handleSetupIntentSucceeded(
 		return;
 	}
 
-	await getStripe().paymentMethods.attach(paymentMethodId, {
-		customer: stripeCustomerId,
-	});
+	try {
+		await getStripe().paymentMethods.attach(paymentMethodId, {
+			customer: stripeCustomerId,
+		});
+	} catch (error) {
+		// A PM consumed by a payment (or detached) before this webhook ran can
+		// never be attached — failing the webhook would only make Stripe retry
+		// a permanently invalid request for days.
+		if (error instanceof Stripe.errors.StripeInvalidRequestError) {
+			logger.warn("Skipping unattachable payment method from setup intent", {
+				paymentMethodId,
+				organizationId,
+				stripeMessage: error.message,
+			});
+			return;
+		}
+		throw error;
+	}
 
 	const paymentMethod =
 		await getStripe().paymentMethods.retrieve(paymentMethodId);

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -3509,27 +3509,45 @@ async function handleSetupIntentSucceeded(
 		return;
 	}
 
-	try {
-		await getStripe().paymentMethods.attach(paymentMethodId, {
-			customer: stripeCustomerId,
-		});
-	} catch (error) {
-		// A PM consumed by a payment (or detached) before this webhook ran can
-		// never be attached — failing the webhook would only make Stripe retry
-		// a permanently invalid request for days.
-		if (error instanceof Stripe.errors.StripeInvalidRequestError) {
-			logger.warn("Skipping unattachable payment method from setup intent", {
-				paymentMethodId,
-				organizationId,
-				stripeMessage: error.message,
-			});
-			return;
-		}
-		throw error;
-	}
-
 	const paymentMethod =
 		await getStripe().paymentMethods.retrieve(paymentMethodId);
+
+	// Setup intents created with a customer come out of confirmation already
+	// attached; only PMs from legacy customer-less setup intents still need the
+	// manual attach here.
+	const attachedCustomerId =
+		typeof paymentMethod.customer === "string"
+			? paymentMethod.customer
+			: (paymentMethod.customer?.id ?? null);
+
+	if (!attachedCustomerId) {
+		try {
+			await getStripe().paymentMethods.attach(paymentMethodId, {
+				customer: stripeCustomerId,
+			});
+		} catch (error) {
+			// A PM consumed by a payment (or detached) before this webhook ran can
+			// never be attached — failing the webhook would only make Stripe retry
+			// a permanently invalid request for days.
+			if (error instanceof Stripe.errors.StripeInvalidRequestError) {
+				logger.warn("Skipping unattachable payment method from setup intent", {
+					paymentMethodId,
+					organizationId,
+					stripeMessage: error.message,
+				});
+				return;
+			}
+			throw error;
+		}
+	} else if (attachedCustomerId !== stripeCustomerId) {
+		logger.warn("Setup intent payment method is attached to another customer", {
+			paymentMethodId,
+			organizationId,
+			attachedCustomerId,
+			expectedCustomerId: stripeCustomerId,
+		});
+		return;
+	}
 
 	// Check for duplicate card by fingerprint
 	if (paymentMethod.type === "card" && paymentMethod.card?.fingerprint) {


### PR DESCRIPTION
## Summary

Fixes the production `Unhandled error` (500) on `POST /payments/create-payment-intent`:

```
StripeInvalidRequestError: The provided PaymentMethod cannot be attached.
To reuse a PaymentMethod, you must attach it to a Customer first.
```

(trace `1dc2db44e793137c81916d77dd2e3797`, error group `CPTJ2fj3s5D8zwE`)

## Root cause (confirmed from production logs)

`/payments/create-setup-intent` created the SetupIntent **without a `customer`**. A PM confirmed through a customer-less SetupIntent is *used but unattached* — Stripe only lets it be used in a PaymentIntent after it is attached. The code relied on the `setup_intent.succeeded` webhook to do that attach, so every save-card top-up raced the webhook against the client's immediate `create-payment-intent` call.

Log timeline of the incident (one user, three attempts):

| time | event |
|---|---|
| 02:12:00.15 | attempt 1: setup_intent.succeeded |
| 02:12:00.83 | webhook attaches PM (+0.68s) |
| 02:12:01.56 | create-payment-intent OK (+1.41s) — webhook won the race |
| 02:13:28.27 | attempt 2: setup_intent.succeeded |
| **02:13:28.65** | **500** — create-payment-intent reached Stripe +0.38s later, before the attach |
| 02:13:29.12 | webhook attach lands too late (+0.85s) |
| 02:13:35.77→36.21 | attempt 3: same race, same 500 |

## Changes

- `create-setup-intent` now passes `customer` (matching the DevPass flow in `dev-plans.ts`), so Stripe attaches the PM **atomically during `confirmCardSetup`**, before the client can call `create-payment-intent`. This removes the race entirely.
- `handleSetupIntentSucceeded` retrieves the PM first and only attaches when still unattached (legacy customer-less setup intents); a permanently unattachable/foreign PM is logged and skipped instead of failing the webhook (which made Stripe retry an invalid attach for days).
- New e2e test `apps/api/src/routes/payments.e2e.ts`: reproduces the production sequence against **real Stripe test mode** — `create-setup-intent` → confirm the SetupIntent with `pm_card_visa` (what the browser's `confirmCardSetup` does) → `create-payment-intent` immediately. No webhook is delivered in the test, which is exactly the losing side of the production race, so it fails deterministically on unfixed code (verified: removing the `customer` line makes it fail at the attach assertion). Also confirms the resulting PaymentIntent end-to-end with the saved card. Opt-in via `STRIPE_TESTING=true` (and requires an `sk_test_` key), so it never runs in the default e2e suite nor against live Stripe.

## Testing

- `STRIPE_TESTING=true E2E_TEST=true vitest run -c vitest/vitest.e2e.config.mts apps/api/src/routes/payments.e2e.ts` — passes with the fix, fails without it (red/green verified)
- `turbo run build --filter=api` passes
- `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment method setup to ensure cards are linked to the correct billing customer.
  * Prevented duplicate or conflicting payment method attachments during payment processing.
  * Added safer handling for payment provider attachment errors.

* **Tests**
  * Added an end-to-end test covering card setup, attachment, and credit top-up payments using Stripe test mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->