### PR TITLE
fix(gateway): disable CORS entirely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,8 @@ NOTE: these commands can only be run in the root directory of the repository, no
 
 - **Gateway** (`apps/gateway`) - LLM request routing and provider management (Hono + Zod + OpenAPI)
 - **API** (`apps/api`) - Backend API for user management, billing, analytics (Hono + Zod + OpenAPI)
+
+Production domain mapping (counterintuitive — do not mix these up): `api.llmgateway.io` serves `apps/gateway` (the LLM gateway, :4001 in dev), and `internal.llmgateway.io` serves `apps/api` (the backend API, :4002 in dev).
 - **UI** (`apps/ui`) - Frontend dashboard (Next.js App Router)
 - **Playground** (`apps/playground`) - Interactive LLM testing environment (Next.js App Router)
 - **Code** (`apps/code`) - Dev plans + coding tools landing & dashboard (Next.js App Router)

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -2,6 +2,8 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
 
+import { getGatewayUrl } from "@/utils/playground-key.js";
+
 import { logger } from "@llmgateway/logger";
 
 import type { ServerTypes } from "@/vars.js";
@@ -18,6 +20,8 @@ const chatCompletionSchema = z.object({
 	model: z.string(),
 	stream: z.boolean().optional().default(false),
 	apiKey: z.string().optional(), // Optional user API key
+	free_models_only: z.boolean().optional(),
+	onboarding: z.boolean().optional(),
 });
 
 const completionRoute = createRoute({
@@ -42,7 +46,8 @@ const completionRoute = createRoute({
 chat.openapi(completionRoute, async (c) => {
 	try {
 		const body = c.req.valid("json");
-		const { messages, model, stream, apiKey } = body;
+		const { messages, model, stream, apiKey, free_models_only, onboarding } =
+			body;
 
 		// Require user to provide their own API key
 		if (!apiKey) {
@@ -50,23 +55,20 @@ chat.openapi(completionRoute, async (c) => {
 		}
 		const authToken = apiKey;
 
-		const response = await fetch(
-			process.env.NODE_ENV === "production"
-				? "https://api.llmgateway.io/v1/chat/completions"
-				: "http://localhost:4001/v1/chat/completions",
-			{
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer ${authToken}`,
-				},
-				body: JSON.stringify({
-					model,
-					messages,
-					stream,
-				}),
+		const response = await fetch(`${getGatewayUrl()}/chat/completions`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${authToken}`,
 			},
-		);
+			body: JSON.stringify({
+				model,
+				messages,
+				stream,
+				...(free_models_only !== undefined && { free_models_only }),
+				...(onboarding !== undefined && { onboarding }),
+			}),
+		});
 
 		if (!response.ok) {
 			const errorText = await response.text();

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -3,7 +3,6 @@ import "dotenv/config";
 
 import { swaggerUI } from "@hono/swagger-ui";
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
-import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
@@ -90,23 +89,6 @@ const requestLifecycleMiddleware = createRequestLifecycleMiddleware({
 app.use("*", tracingMiddleware);
 app.use("*", requestLifecycleMiddleware);
 app.use("*", honoRequestLogger);
-
-app.use(
-	"*",
-	cors({
-		origin: "*",
-		allowHeaders: [
-			"Content-Type",
-			"Authorization",
-			"Cache-Control",
-			"x-api-key",
-			"mcp-session-id",
-		],
-		allowMethods: ["POST", "GET", "OPTIONS", "PUT", "PATCH", "DELETE"],
-		exposeHeaders: ["Content-Length", "mcp-session-id"],
-		maxAge: 600,
-	}),
-);
 
 // Middleware to check for application/json content type on POST requests
 // Excludes /mcp endpoint which handles its own content type validation

--- a/apps/gateway/src/mcp/mcp.ts
+++ b/apps/gateway/src/mcp/mcp.ts
@@ -1109,20 +1109,6 @@ export async function mcpHandler(c: Context): Promise<Response> {
 		},
 	});
 
-	// Handle OPTIONS for CORS
-	if (method === "OPTIONS") {
-		return new Response(null, {
-			status: 204,
-			headers: {
-				"Access-Control-Allow-Origin": "*",
-				"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-				"Access-Control-Allow-Headers":
-					"Content-Type, Authorization, x-api-key, mcp-session-id",
-				"Access-Control-Expose-Headers": "mcp-session-id",
-			},
-		});
-	}
-
 	// Extract API key for authentication
 	const apiKey = parseApiToken(c);
 	if (!apiKey) {
@@ -1257,9 +1243,6 @@ export async function mcpHandler(c: Context): Promise<Response> {
 				"Content-Type": "text/event-stream",
 				"Cache-Control": "no-cache",
 				Connection: "keep-alive",
-				"Access-Control-Allow-Origin": "*",
-				"Access-Control-Allow-Headers":
-					"Content-Type, Authorization, x-api-key, mcp-session-id",
 				"mcp-session-id": sessionId,
 			},
 		});

--- a/apps/ui/src/components/onboarding/onboarding-wizard.tsx
+++ b/apps/ui/src/components/onboarding/onboarding-wizard.tsx
@@ -120,11 +120,12 @@ export function OnboardingWizard() {
 		const timeout = setTimeout(() => controller.abort(), 30_000);
 
 		try {
-			const res = await fetch(`${config.gatewayUrl}/v1/chat/completions`, {
+			// The gateway does not allow cross-origin browser requests, so the
+			// test request goes through the API's server-side proxy.
+			const res = await fetch(`${config.apiUrl}/chat/completion`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: `Bearer ${apiKey}`,
 				},
 				body: JSON.stringify({
 					model: "auto",
@@ -136,6 +137,7 @@ export function OnboardingWizard() {
 						{ role: "user", content: prompt.trim() },
 					],
 					stream: true,
+					apiKey,
 					free_models_only: true,
 					onboarding: true,
 				}),
@@ -144,7 +146,9 @@ export function OnboardingWizard() {
 
 			if (!res.ok) {
 				const data = await res.json();
-				const errorMsg = data.error?.message ?? "Request failed";
+				const errorMsg =
+					(typeof data.error === "string" ? data.error : data.error?.message) ??
+					"Request failed";
 				setTryError(errorMsg);
 				posthog.capture("onboarding_try_error", { error: errorMsg });
 				return;


### PR DESCRIPTION
## Summary

The gateway (`api.llmgateway.io`) is not meant to be called from browsers directly — only server-to-server via API key. This PR removes all CORS handling from it:

- Remove the `origin: "*"` `hono/cors` middleware from `apps/gateway/src/app.ts`
- Remove the CORS preflight (OPTIONS) branch and `Access-Control-*` headers from the MCP handler (`apps/gateway/src/mcp/mcp.ts`)

The one in-repo browser consumer of the gateway was the onboarding wizard's "try it" request in the UI. It now goes through the existing server-side proxy `POST /chat/completion` in `apps/api` (same path the playground's API key test already uses), which was extended to forward the `free_models_only` and `onboarding` flags and now resolves the gateway URL via the shared `getGatewayUrl()` helper instead of a hardcoded URL.

Also documents the production domain mapping in AGENTS.md: `api.llmgateway.io` → `apps/gateway`, `internal.llmgateway.io` → `apps/api`.

## Test plan

- `turbo run build --filter=gateway --filter=api --filter=ui` passes
- No unit/e2e tests referenced the gateway's CORS headers
- Onboarding wizard streaming path is unchanged on the client (the API proxy forwards raw `data:` SSE lines, including `[DONE]` and the `model` field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat completion requests now support optional free-model filtering and onboarding-specific behavior.
  - The onboarding “Try It” experience now uses the application’s API connection and provides the API key securely within the request.

- **Bug Fixes**
  - Improved onboarding error handling so meaningful error messages are displayed across supported response formats.

- **Documentation**
  - Clarified how production domains map to the application’s services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->