### PR TITLE
fix(gateway): stop logging google usage-only chunks

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -2,8 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { transformStreamingToOpenai } from "./transform-streaming-to-openai.js";
 
-const { warn } = vi.hoisted(() => ({
+const { warn, error } = vi.hoisted(() => ({
 	warn: vi.fn(),
+	error: vi.fn(),
 }));
 
 vi.mock("@llmgateway/cache", () => ({
@@ -16,7 +17,7 @@ vi.mock("@llmgateway/cache", () => ({
 vi.mock("@llmgateway/logger", () => ({
 	logger: {
 		warn,
-		error: vi.fn(),
+		error,
 		debug: vi.fn(),
 		info: vi.fn(),
 	},
@@ -445,5 +446,66 @@ describe("transformStreamingToOpenai", () => {
 			reasoning_tokens: 9,
 		});
 		expect(result?.choices?.[0]?.finish_reason).toBe("stop");
+	});
+
+	it("maps Google usage-only trailing chunk without logging", () => {
+		warn.mockClear();
+		error.mockClear();
+
+		const result = transformStreamingToOpenai(
+			"google-vertex",
+			"gemini-2.5-pro",
+			{
+				usageMetadata: {
+					promptTokenCount: 12,
+					candidatesTokenCount: 34,
+					totalTokenCount: 46,
+				},
+				modelVersion: "gemini-2.5-pro",
+				createTime: "2026-07-22T04:37:29.687Z",
+				responseId: "resp_abc",
+			},
+			[],
+		);
+
+		expect(result).toMatchObject({
+			id: "resp_abc",
+			object: "chat.completion.chunk",
+			model: "gemini-2.5-pro",
+			choices: [
+				{
+					index: 0,
+					delta: { role: "assistant" },
+					finish_reason: null,
+				},
+			],
+			usage: {
+				prompt_tokens: 12,
+				completion_tokens: 34,
+				total_tokens: 46,
+			},
+		});
+		expect(warn).not.toHaveBeenCalled();
+		expect(error).not.toHaveBeenCalled();
+	});
+
+	it("logs error for Google chunk with no candidates and no usage", () => {
+		warn.mockClear();
+		error.mockClear();
+
+		transformStreamingToOpenai(
+			"google-ai-studio",
+			"gemini-2.5-pro",
+			{
+				modelVersion: "gemini-2.5-pro",
+				responseId: "resp_def",
+			},
+			[],
+		);
+
+		expect(error).toHaveBeenCalledWith(
+			"[transform-streaming-to-openai] Google streaming chunk missing candidates",
+			expect.objectContaining({ hasCandidates: false }),
+		);
 	});
 });

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -466,9 +466,16 @@ export function transformStreamingToOpenai(
 				? data.candidates[0]
 				: undefined;
 
+			// Google streams may end with a usage-only chunk (usageMetadata +
+			// modelVersion/responseId, no candidates) — that's expected, not an error.
+			const isUsageOnlyChunk =
+				(!data.candidates || data.candidates.length === 0) &&
+				!!data.usageMetadata;
+
 			if (
 				(!data.candidates || data.candidates.length === 0) &&
-				!data.promptFeedback?.blockReason
+				!data.promptFeedback?.blockReason &&
+				!isUsageOnlyChunk
 			) {
 				logger.error(
 					"[transform-streaming-to-openai] Google streaming chunk missing candidates",
@@ -704,17 +711,21 @@ export function transformStreamingToOpenai(
 					usage: buildUsage(data.usageMetadata, messages),
 				};
 			} else {
-				logger.warn("[streaming] Google chunk with no content", {
-					provider: usedProvider,
-					model: usedModel,
-					hasCandidates: hasCandidatesArray,
-					candidatesCount: candidates.length,
-					firstCandidateKeys: firstCandidate ? Object.keys(firstCandidate) : [],
-					hasContentParts: !!(firstCandidate?.content?.parts?.length > 0),
-					partsCount: firstCandidate?.content?.parts?.length ?? 0,
-					hasUsageMetadata: !!data.usageMetadata,
-					dataKeys: Object.keys(data),
-				});
+				if (!isUsageOnlyChunk) {
+					logger.warn("[streaming] Google chunk with no content", {
+						provider: usedProvider,
+						model: usedModel,
+						hasCandidates: hasCandidatesArray,
+						candidatesCount: candidates.length,
+						firstCandidateKeys: firstCandidate
+							? Object.keys(firstCandidate)
+							: [],
+						hasContentParts: !!(firstCandidate?.content?.parts?.length > 0),
+						partsCount: firstCandidate?.content?.parts?.length ?? 0,
+						hasUsageMetadata: !!data.usageMetadata,
+						dataKeys: Object.keys(data),
+					});
+				}
 				transformedData = {
 					id: data.responseId ?? `chatcmpl-${Date.now()}`,
 					object: "chat.completion.chunk",


### PR DESCRIPTION
## Summary

Production logs are flooded with ERROR-level entries like:

`[transform-streaming-to-openai] Google streaming chunk missing candidates` with `dataKeys: [usageMetadata, modelVersion, createTime, responseId]`

Google/Vertex streams legitimately end with a trailing usage-only chunk (`usageMetadata` + `modelVersion`/`responseId`, no `candidates`). The transform already handles it correctly — it falls through to the fallback branch and emits an empty-delta chunk carrying the usage — but it logged an ERROR (added for content-filter debugging in #1117) plus a `Google chunk with no content` WARN on every streaming request.

## Changes

- Recognize candidate-less chunks that carry `usageMetadata` as expected usage-only chunks and skip both the ERROR and the WARN for them.
- The ERROR still fires for genuinely anomalous chunks (no candidates, no block reason, no usage).
- Added unit tests: the usage-only trailing chunk maps to an OpenAI chunk with correct usage and no log calls, and a chunk with neither candidates nor usage still logs the error.

## Testing

- `pnpm vitest run apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts` — 21 tests pass
- `pnpm build` — full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)