### PR TITLE
fix(gateway): handle array JSON schema types for Google

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1445,6 +1445,54 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		]);
 	});
 
+	test("converts json_schema with array type (nullable) to Google schema", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.5-flash",
+			null,
+			"gemini-2.5-flash",
+			[{ role: "user", content: "Extract the user info" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{
+				type: "json_schema",
+				json_schema: {
+					name: "user_info",
+					schema: {
+						type: "object",
+						properties: {
+							name: { type: "string" },
+							nickname: { type: ["string", "null"] },
+							tags: { type: ["array", "null"], items: { type: "string" } },
+						},
+						required: ["name", "nickname"],
+					},
+				},
+			},
+		)) as any;
+
+		expect(requestBody.generationConfig.responseMimeType).toBe(
+			"application/json",
+		);
+		expect(requestBody.generationConfig.responseSchema).toEqual({
+			type: "OBJECT",
+			properties: {
+				name: { type: "STRING" },
+				nickname: { type: "STRING", nullable: true },
+				tags: {
+					type: "ARRAY",
+					nullable: true,
+					items: { type: "STRING" },
+				},
+			},
+			required: ["name", "nickname"],
+		});
+	});
+
 	test("should map gateway 0.5K image size to Google 512 for Vertex", async () => {
 		const requestBody = (await prepareRequestBody(
 			"google-vertex",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -324,9 +324,21 @@ function convertOpenAISchemaToGoogle(schema: any): any {
 
 	const converted: any = {};
 
-	// Convert type to uppercase
+	// Convert type to uppercase. JSON Schema allows `type` to be an array
+	// (e.g. ["string", "null"] for nullable fields); Google expects a single
+	// uppercase type plus a `nullable` flag instead.
 	if (schema.type) {
-		converted.type = schema.type.toUpperCase();
+		if (Array.isArray(schema.type)) {
+			const nonNullTypes = schema.type.filter((t: unknown) => t !== "null");
+			if (nonNullTypes.length !== schema.type.length) {
+				converted.nullable = true;
+			}
+			if (typeof nonNullTypes[0] === "string") {
+				converted.type = nonNullTypes[0].toUpperCase();
+			}
+		} else if (typeof schema.type === "string") {
+			converted.type = schema.type.toUpperCase();
+		}
 	}
 
 	// Copy description if present


### PR DESCRIPTION
## Summary

Fixes a production crash in the gateway (error group `CJ-s6PrZnfnfLA`):

```
TypeError: schema.type.toUpperCase is not a function
    at convertOpenAISchemaToGoogle (packages/actions/src/prepare-request-body.ts:329)
```

JSON Schema allows `type` to be an array — most commonly `["string", "null"]` to express a nullable field — but `convertOpenAISchemaToGoogle` assumed it was always a string, so any `response_format: json_schema` request with a nullable field routed to a Google provider threw an unhandled error.

## Fix

When `type` is an array, convert it to Google's schema format: take the first non-`"null"` entry as the single uppercase `type` and set `nullable: true` if `"null"` was present. Non-string types are now ignored instead of crashing.

## Testing

- Added a regression test covering `type: ["string", "null"]` and `type: ["array", "null"]` fields in a `json_schema` response format on google-ai-studio.
- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts` — 184 passed.
- `pnpm build` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)