### PR TITLE
fix: return 400 for non-HTTPS image URLs

### DIFF
--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -2,6 +2,7 @@ import { logger } from "@llmgateway/logger";
 import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import { parseDataUrl } from "./parse-data-url.js";
+import { RequestError } from "./request-error.js";
 
 /**
  * Generates a user-friendly error message for image size limits
@@ -89,7 +90,7 @@ export async function processImageUrl(
 		logger.warn("Non-HTTPS URL provided for image fetch in production", {
 			url: url.substring(0, 20) + "...",
 		});
-		throw new Error("Image URLs must use HTTPS protocol in production");
+		throw new RequestError("Image URLs must use HTTPS protocol in production");
 	}
 
 	// SSRF: a tenant-supplied content URL must not resolve to an internal host.

--- a/packages/actions/src/transform-google-messages.spec.ts
+++ b/packages/actions/src/transform-google-messages.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { RequestError } from "./request-error.js";
 import {
 	googleProviderSupportsAudioFormat,
 	parseGoogleUpstreamDocumentError,
@@ -120,6 +121,33 @@ describe("transformGoogleMessages — audio MIME resolution", () => {
 			const e = err as UnsupportedAudioFormatError;
 			expect(e.format).toBe("aiff");
 			expect(e.providerTarget).toBe("Vertex AI");
+		}
+	});
+});
+
+describe("transformGoogleMessages — image URL processing errors", () => {
+	it("throws RequestError (400) for a non-HTTPS image URL in production", async () => {
+		const messages: BaseMessage[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "image_url",
+						image_url: { url: "http://example.com/image.png" },
+					},
+				],
+			},
+		];
+		try {
+			await transformGoogleMessages(messages, true);
+			throw new Error("expected throw");
+		} catch (err) {
+			expect(err).toBeInstanceOf(RequestError);
+			const e = err as RequestError;
+			expect(e.statusCode).toBe(400);
+			expect(e.message).toBe(
+				"Failed to process image: Image URLs must use HTTPS protocol in production",
+			);
 		}
 	});
 });

--- a/packages/actions/src/transform-google-messages.ts
+++ b/packages/actions/src/transform-google-messages.ts
@@ -9,6 +9,7 @@ import {
 
 import { parseDataUrl } from "./parse-data-url.js";
 import { processImageUrl } from "./process-image-url.js";
+import { RequestError } from "./request-error.js";
 
 type GoogleAudioFormat =
 	| "wav"
@@ -378,6 +379,15 @@ export async function transformGoogleMessages(
 						// Don't expose the URL in the error message for security
 						const errorMsg =
 							error instanceof Error ? error.message : "Unknown error";
+						// Preserve the RequestError type (and its status code) so the
+						// gateway returns a 4xx and logs a client_error row instead of
+						// treating a client-caused image failure as an unhandled 500.
+						if (error instanceof RequestError) {
+							throw new RequestError(
+								`Failed to process image: ${errorMsg}`,
+								error.statusCode,
+							);
+						}
 						throw new Error(`Failed to process image: ${errorMsg}`);
 					}
 				} else if (isInputAudioContent(content)) {


### PR DESCRIPTION
## Problem

A production request with an `http://` image URL to a Google-family model surfaced as an **unhandled 500** ("Internal Server Error") and produced no request log row:

```
Error: Failed to process image: Image URLs must use HTTPS protocol in production
    at transformGoogleMessages (.../transform-google-messages.ts:381)
```

This is a client mistake (non-HTTPS image URL), not a gateway failure, so it should be a 4xx — and it should show up in the user's activity feed.

## Changes

- `packages/actions/src/process-image-url.ts`: the HTTPS-in-production validation now throws the existing typed `RequestError` (status 400) instead of a plain `Error`.
- `packages/actions/src/transform-google-messages.ts`: the image-processing catch block now preserves the `RequestError` type (and its status code) when adding the sanitized `Failed to process image:` prefix, instead of collapsing everything into a plain `Error`.

With `RequestError` reaching the gateway, the existing handling kicks in with no gateway changes needed:

- `apps/gateway/src/chat/chat.ts` (catch around `prepareRequestBody`) writes a `client_error` log row via `insertLogEntry` with the 400 status and message, so the rejected request appears in the user's request history.
- `apps/gateway/src/app.ts` (`app.onError`) maps `RequestError` to its carried status code (400) with the provider-compatible error envelope, logged at `warn` instead of `error`.

## Testing

- Added a unit test asserting that a non-HTTPS image URL with `isProd=true` throws `RequestError` with `statusCode: 400` and the exact wrapped message (`transform-google-messages.spec.ts` — 25/25 pass).
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XScRgsYzrrtzoorJBC6KYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XScRgsYzrrtzoorJBC6KYG)_