### PR TITLE
feat(agents): show all requests, auto-load, CSV export

### DIFF
--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -1745,4 +1745,146 @@ describe("activity endpoint", () => {
 		expect(twoDaysAgoData.totalTokens).toBe(50);
 		expect(twoDaysAgoData.cost).toBeCloseTo(0.1, 2);
 	});
+
+	describe("GET /activity/sources", () => {
+		beforeEach(async () => {
+			const hoursAgo = (hours: number) => {
+				const ms = hours * 60 * 60 * 1000;
+				return new Date(Date.now() - ms);
+			};
+
+			// One opencode row per time bucket so each wider range picks up
+			// exactly one more row: 1h -> 1, 4h -> 2, 24h -> 3, 7d -> 4, 30d -> 5.
+			await db.insert(tables.projectHourlySourceStats).values([
+				...[0, 2, 12, 72, 360].map((hours) => ({
+					projectId: "test-project-id",
+					hourTimestamp: hoursAgo(hours),
+					source: "opencode",
+					requestCount: 1,
+					inputTokens: "10",
+					outputTokens: "20",
+					totalTokens: "30",
+					cost: 0.5,
+				})),
+				{
+					projectId: "test-project-id",
+					hourTimestamp: hoursAgo(0),
+					source: "cursor",
+					requestCount: 2,
+					inputTokens: "100",
+					outputTokens: "200",
+					totalTokens: "300",
+					cost: 5,
+				},
+			]);
+		});
+
+		test.each([
+			["1h", 1],
+			["4h", 2],
+			["24h", 3],
+			["7d", 4],
+			["30d", 5],
+		])(
+			"timeRange=%s aggregates the matching hour buckets",
+			async (timeRange, expectedRequests) => {
+				const res = await app.request(
+					`/activity/sources?projectId=test-project-id&timeRange=${timeRange}`,
+					{
+						headers: {
+							Cookie: token,
+						},
+					},
+				);
+
+				expect(res.status).toBe(200);
+				const data = await res.json();
+				const opencode = data.sources.find(
+					(s: { source: string }) => s.source === "opencode",
+				);
+				expect(opencode).toBeDefined();
+				expect(opencode.requestCount).toBe(expectedRequests);
+				expect(opencode.totalTokens).toBe(expectedRequests * 30);
+				expect(opencode.cost).toBeCloseTo(expectedRequests * 0.5, 5);
+			},
+		);
+
+		test("should default to 7d when no timeRange is provided", async () => {
+			const res = await app.request(
+				"/activity/sources?projectId=test-project-id",
+				{
+					headers: {
+						Cookie: token,
+					},
+				},
+			);
+
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			const opencode = data.sources.find(
+				(s: { source: string }) => s.source === "opencode",
+			);
+			expect(opencode.requestCount).toBe(4);
+		});
+
+		test("should group by source and order by cost descending", async () => {
+			const res = await app.request(
+				"/activity/sources?projectId=test-project-id&timeRange=1h",
+				{
+					headers: {
+						Cookie: token,
+					},
+				},
+			);
+
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data.sources.map((s: { source: string }) => s.source)).toEqual([
+				"cursor",
+				"opencode",
+			]);
+
+			const cursor = data.sources[0];
+			expect(cursor.requestCount).toBe(2);
+			expect(cursor.inputTokens).toBe(100);
+			expect(cursor.outputTokens).toBe(200);
+			expect(cursor.totalTokens).toBe(300);
+			expect(cursor.cost).toBeCloseTo(5, 5);
+			expect(typeof cursor.lastUsedAt).toBe("string");
+		});
+
+		test("should reject an invalid timeRange", async () => {
+			const res = await app.request(
+				"/activity/sources?projectId=test-project-id&timeRange=365d",
+				{
+					headers: {
+						Cookie: token,
+					},
+				},
+			);
+
+			expect(res.status).toBe(400);
+		});
+
+		test("should require authentication", async () => {
+			const res = await app.request(
+				"/activity/sources?projectId=test-project-id",
+			);
+
+			expect(res.status).toBe(401);
+		});
+
+		test("should reject projects the user cannot access", async () => {
+			const res = await app.request(
+				"/activity/sources?projectId=some-other-project-id",
+				{
+					headers: {
+						Cookie: token,
+					},
+				},
+			);
+
+			expect(res.status).toBe(403);
+		});
+	});
 });

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -887,7 +887,7 @@ const getSourceActivity = createRoute({
 	request: {
 		query: z.object({
 			projectId: z.string(),
-			timeRange: z.enum(["7d", "30d"]).optional(),
+			timeRange: z.enum(["1h", "4h", "24h", "7d", "30d"]).optional(),
 			from: z.string().optional(),
 			to: z.string().optional(),
 		}),
@@ -926,7 +926,17 @@ activity.openapi(getSourceActivity, async (c) => {
 	} else {
 		endDate = new Date();
 		startDate = new Date();
-		startDate.setDate(startDate.getDate() - (timeRange === "30d" ? 30 : 7));
+		const hours =
+			timeRange === "1h"
+				? 1
+				: timeRange === "4h"
+					? 4
+					: timeRange === "24h"
+						? 24
+						: timeRange === "30d"
+							? 30 * 24
+							: 7 * 24;
+		startDate.setTime(startDate.getTime() - hours * 60 * 60 * 1000);
 	}
 
 	if (!(await userHasProjectAccess(user.id, projectId))) {

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -880,7 +880,16 @@ const sourceUsageSchema = z.object({
 });
 
 // Aggregated source usage for a single project, read from the per-project
-// hourly source rollup. Powers the agents dashboard. Limited to 7d/30d ranges.
+// hourly source rollup. Powers the agents dashboard. Supports 1h/4h/24h/7d/30d
+// ranges.
+const sourceActivityRangeHours = {
+	"1h": 1,
+	"4h": 4,
+	"24h": 24,
+	"7d": 7 * 24,
+	"30d": 30 * 24,
+} as const;
+
 const getSourceActivity = createRoute({
 	method: "get",
 	path: "/sources",
@@ -925,18 +934,9 @@ activity.openapi(getSourceActivity, async (c) => {
 		endDate = new Date(to + "T23:59:59.999");
 	} else {
 		endDate = new Date();
-		startDate = new Date();
-		const hours =
-			timeRange === "1h"
-				? 1
-				: timeRange === "4h"
-					? 4
-					: timeRange === "24h"
-						? 24
-						: timeRange === "30d"
-							? 30 * 24
-							: 7 * 24;
-		startDate.setTime(startDate.getTime() - hours * 60 * 60 * 1000);
+		const windowMs =
+			sourceActivityRangeHours[timeRange ?? "7d"] * 60 * 60 * 1000;
+		startDate = new Date(endDate.getTime() - windowMs);
 	}
 
 	if (!(await userHasProjectAccess(user.id, projectId))) {

--- a/apps/api/src/testing.ts
+++ b/apps/api/src/testing.ts
@@ -4,6 +4,7 @@ import {
 	sql,
 	projectHourlyStats,
 	projectHourlyModelStats,
+	projectHourlySourceStats,
 	apiKeyHourlyStats,
 	apiKeyHourlyModelStats,
 	eq,
@@ -42,6 +43,7 @@ export async function deleteAll() {
 			await db.delete(tables.auditLog);
 			await db.delete(projectHourlyStats);
 			await db.delete(projectHourlyModelStats);
+			await db.delete(projectHourlySourceStats);
 			await db.delete(apiKeyHourlyStats);
 			await db.delete(apiKeyHourlyModelStats);
 			await db.delete(tables.apiKey);

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
@@ -17,7 +17,11 @@ export default async function AgentsPage({
 	const { orgId, projectId } = await params;
 	const searchParamsData = await searchParams;
 
-	const timeRange = searchParamsData?.timeRange === "30d" ? "30d" : "7d";
+	const validTimeRanges = ["1h", "4h", "24h", "7d", "30d"];
+	const rawTimeRange = searchParamsData?.timeRange;
+	const timeRange = validTimeRanges.includes(rawTimeRange ?? "")
+		? (rawTimeRange as "1h" | "4h" | "24h" | "7d" | "30d")
+		: "7d";
 
 	const initialData = await fetchServerData<SourceActivityData>(
 		"GET",

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 
 import { AgentsView } from "@/components/activity/agents-view";
 import { DevPassCard } from "@/components/dashboard/devpass-card";
+import { parseAgentTimeRange } from "@/lib/agent-time-ranges";
 import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -17,11 +18,7 @@ export default async function AgentsPage({
 	const { orgId, projectId } = await params;
 	const searchParamsData = await searchParams;
 
-	const validTimeRanges = ["1h", "4h", "24h", "7d", "30d"];
-	const rawTimeRange = searchParamsData?.timeRange;
-	const timeRange = validTimeRanges.includes(rawTimeRange ?? "")
-		? (rawTimeRange as "1h" | "4h" | "24h" | "7d" | "30d")
-		: "7d";
+	const timeRange = parseAgentTimeRange(searchParamsData?.timeRange);
 
 	const initialData = await fetchServerData<SourceActivityData>(
 		"GET",

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { subDays } from "date-fns";
 import {
 	ArrowLeft,
 	ChevronDown,
@@ -8,11 +7,12 @@ import {
 	Clock,
 	Coins,
 	Cpu,
+	Download,
 	Terminal,
 	Zap,
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { LogCard } from "@/components/dashboard/log-card";
 import {
@@ -20,7 +20,7 @@ import {
 	type TimeRangeValue,
 } from "@/components/time-range-picker";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
-import { useApi } from "@/lib/fetch-client";
+import { useApi, useFetchClient } from "@/lib/fetch-client";
 
 import { CODING_AGENTS } from "@llmgateway/shared";
 import {
@@ -76,7 +76,13 @@ const AGENTS: AgentDefinition[] = CODING_AGENTS.map((agent) => ({
 	sources: agent.xSourceValues,
 }));
 
-const AGENTS_TIME_RANGES = ["7d", "30d"] as const;
+const AGENT_TIME_RANGES: readonly TimeRangeValue[] = [
+	"1h",
+	"4h",
+	"24h",
+	"7d",
+	"30d",
+];
 
 interface AgentStats {
 	agent: AgentDefinition;
@@ -100,8 +106,24 @@ interface Session {
 
 const SESSION_GAP_MS = 30 * 60 * 1000;
 
-function timeRangeToDays(timeRange: TimeRangeValue): number {
-	return timeRange === "30d" ? 30 : 7;
+function getTimeRangeWindow(timeRange: TimeRangeValue): {
+	from: Date;
+	to: Date;
+} {
+	const to = new Date();
+	const from = new Date(to);
+	const hours =
+		timeRange === "1h"
+			? 1
+			: timeRange === "4h"
+				? 4
+				: timeRange === "24h"
+					? 24
+					: timeRange === "30d"
+						? 30 * 24
+						: 7 * 24;
+	from.setTime(to.getTime() - hours * 60 * 60 * 1000);
+	return { from, to };
 }
 
 function toUiLog(log: ApiLog): Partial<Log> {
@@ -392,8 +414,7 @@ function AgentDetail({
 	const api = useApi();
 
 	const range = useMemo(() => {
-		const to = new Date();
-		const from = subDays(to, timeRangeToDays(timeRange));
+		const { from, to } = getTimeRangeWindow(timeRange);
 		return { from: from.toISOString(), to: to.toISOString() };
 	}, [timeRange]);
 
@@ -441,6 +462,144 @@ function AgentDetail({
 
 	const sessions = useMemo(() => groupLogsIntoSessions(logs), [logs]);
 
+	const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+	// Auto-load next page when the sentinel scrolls into view.
+	useEffect(() => {
+		const node = sentinelRef.current;
+		if (!node || !hasNextPage || isFetchingNextPage) {
+			return;
+		}
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					fetchNextPage();
+				}
+			},
+			{ rootMargin: "400px" },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+	const fetchClient = useFetchClient();
+	const [isExporting, setIsExporting] = useState(false);
+
+	const handleExportCsv = useCallback(async () => {
+		setIsExporting(true);
+		try {
+			const collected: ApiLog[] = [];
+			// Pages already loaded via the infinite query are reused to avoid
+			// re-fetching them; remaining pages are fetched directly.
+			const pages = data?.pages ?? [];
+			for (const page of pages) {
+				for (const log of page?.logs ?? []) {
+					collected.push(log);
+				}
+			}
+			const lastPage = pages[pages.length - 1];
+			let cursor = lastPage?.pagination
+				?.nextCursor as string | undefined;
+			let hasMore = !!lastPage?.pagination?.hasMore;
+			if (hasMore && cursor) {
+				while (cursor) {
+					const res = await fetchClient.GET("/logs", {
+						params: {
+							query: {
+								orderBy: "createdAt_desc",
+								projectId,
+								limit: "100",
+								source: stats.agent.sources.join(","),
+								startDate: range.from,
+								endDate: range.to,
+								cursor,
+							},
+						},
+					});
+					const body = res.data;
+					if (!body) {
+						break;
+					}
+					for (const log of body.logs) {
+						collected.push(log);
+					}
+					if (!body.pagination.hasMore || !body.pagination.nextCursor) {
+						break;
+					}
+					cursor = body.pagination.nextCursor;
+				}
+			}
+			const exportLogs = collected.filter((log) => !log.retriedByLogId);
+			const headers = [
+				"createdAt",
+				"usedProvider",
+				"usedModel",
+				"finishReason",
+				"promptTokens",
+				"completionTokens",
+				"totalTokens",
+				"cachedTokens",
+				"cost",
+				"hasError",
+				"streamed",
+				"duration",
+				"requestId",
+				"id",
+			];
+			const escape = (value: unknown) => {
+				if (value === null || value === undefined) {
+					return "";
+				}
+				const str = String(value);
+				if (/[",\n]/.test(str)) {
+					return `"${str.replace(/"/g, '""')}"`;
+				}
+				return str;
+			};
+			const rows = exportLogs.map((log) =>
+				[
+					log.createdAt,
+					log.usedProvider,
+					log.usedModel,
+					log.unifiedFinishReason ?? log.finishReason ?? "",
+					log.promptTokens,
+					log.completionTokens,
+					log.totalTokens,
+					log.cachedTokens ?? "",
+					log.cost,
+					log.hasError,
+					log.streamed,
+					log.duration,
+					log.requestId,
+					log.id,
+				]
+					.map(escape)
+					.join(","),
+			);
+			const csv = [headers.join(","), ...rows].join("\n");
+			const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${stats.agent.id}-requests-${timeRange}.csv`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			URL.revokeObjectURL(url);
+		} finally {
+			setIsExporting(false);
+		}
+	}, [
+		data,
+		fetchClient,
+		projectId,
+		stats.agent.id,
+		stats.agent.sources,
+		range.from,
+		range.to,
+		timeRange,
+	]);
+
 	return (
 		<div className="space-y-4">
 			<button
@@ -452,7 +611,8 @@ function AgentDetail({
 				Back to agents
 			</button>
 
-			<div className="flex items-center gap-4 pb-2">
+		<div className="flex items-center justify-between gap-4 pb-2">
+			<div className="flex items-center gap-4">
 				<div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted">
 					<Icon className="h-6 w-6" />
 				</div>
@@ -462,6 +622,7 @@ function AgentDetail({
 					</h3>
 					<div className="flex items-center gap-3 text-sm text-muted-foreground">
 						<span>
+							{logs.length.toLocaleString()} of{" "}
 							{stats.requestCount.toLocaleString()} request
 							{stats.requestCount !== 1 ? "s" : ""}
 						</span>
@@ -472,6 +633,17 @@ function AgentDetail({
 					</div>
 				</div>
 			</div>
+			<button
+				type="button"
+				onClick={handleExportCsv}
+				disabled={isExporting || logs.length === 0}
+				className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+				title="Export all requests in this period to CSV"
+			>
+				<Download className="h-4 w-4" />
+				{isExporting ? "Exporting..." : "Export CSV"}
+			</button>
+		</div>
 
 			<div className="space-y-3">
 				{isLoading ? (
@@ -496,21 +668,23 @@ function AgentDetail({
 							projectId={projectId}
 						/>
 					))
-				)}
+			)}
 
-				{hasNextPage && (
-					<div className="flex justify-center pt-2">
-						<button
-							type="button"
-							onClick={() => fetchNextPage()}
-							disabled={isFetchingNextPage}
-							className="rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
-						>
-							{isFetchingNextPage ? "Loading more..." : "Load more sessions"}
-						</button>
-					</div>
-				)}
-			</div>
+			{/* Auto-load sentinel: fetches the next page when scrolled into view. */}
+			<div ref={sentinelRef} className="h-1" />
+			{hasNextPage && (
+				<div className="flex justify-center pt-2">
+					<button
+						type="button"
+						onClick={() => fetchNextPage()}
+						disabled={isFetchingNextPage}
+						className="rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+					>
+						{isFetchingNextPage ? "Loading more..." : "Load more sessions"}
+					</button>
+				</div>
+			)}
+		</div>
 		</div>
 	);
 }
@@ -563,8 +737,12 @@ export function AgentsView({
 	const { buildUrl } = useDashboardNavigation();
 	const api = useApi();
 
-	const timeRange: TimeRangeValue =
-		searchParams.get("timeRange") === "30d" ? "30d" : "7d";
+	const timeRangeParam = searchParams.get("timeRange");
+	const timeRange: TimeRangeValue = AGENT_TIME_RANGES.includes(
+		timeRangeParam as TimeRangeValue,
+	)
+		? (timeRangeParam as TimeRangeValue)
+		: "7d";
 
 	const updateTimeRange = (newTimeRange: TimeRangeValue) => {
 		const params = new URLSearchParams(searchParams);
@@ -609,7 +787,7 @@ export function AgentsView({
 				<TimeRangePicker
 					value={timeRange}
 					onChange={updateTimeRange}
-					allowedValues={AGENTS_TIME_RANGES}
+					allowedValues={AGENT_TIME_RANGES}
 				/>
 				{!selectedStats && agentStats.length > 0 && (
 					<div className="flex items-center gap-3 text-sm text-muted-foreground">

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -20,6 +20,12 @@ import {
 	type TimeRangeValue,
 } from "@/components/time-range-picker";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import {
+	AGENT_TIME_RANGE_HOURS,
+	AGENT_TIME_RANGES,
+	parseAgentTimeRange,
+} from "@/lib/agent-time-ranges";
+import { useToast } from "@/lib/components/use-toast";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
 import { CODING_AGENTS } from "@llmgateway/shared";
@@ -76,14 +82,6 @@ const AGENTS: AgentDefinition[] = CODING_AGENTS.map((agent) => ({
 	sources: agent.xSourceValues,
 }));
 
-const AGENT_TIME_RANGES: readonly TimeRangeValue[] = [
-	"1h",
-	"4h",
-	"24h",
-	"7d",
-	"30d",
-];
-
 interface AgentStats {
 	agent: AgentDefinition;
 	requestCount: number;
@@ -111,19 +109,61 @@ function getTimeRangeWindow(timeRange: TimeRangeValue): {
 	to: Date;
 } {
 	const to = new Date();
-	const from = new Date(to);
-	const hours =
-		timeRange === "1h"
-			? 1
-			: timeRange === "4h"
-				? 4
-				: timeRange === "24h"
-					? 24
-					: timeRange === "30d"
-						? 30 * 24
-						: 7 * 24;
-	from.setTime(to.getTime() - hours * 60 * 60 * 1000);
+	const windowMs = AGENT_TIME_RANGE_HOURS[timeRange] * 60 * 60 * 1000;
+	const from = new Date(to.getTime() - windowMs);
 	return { from, to };
+}
+
+const CSV_HEADERS = [
+	"createdAt",
+	"usedProvider",
+	"usedModel",
+	"finishReason",
+	"promptTokens",
+	"completionTokens",
+	"totalTokens",
+	"cachedTokens",
+	"cost",
+	"hasError",
+	"streamed",
+	"duration",
+	"requestId",
+	"id",
+];
+
+function escapeCsvValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const str = String(value);
+	if (/[",\n]/.test(str)) {
+		return `"${str.replace(/"/g, '""')}"`;
+	}
+	return str;
+}
+
+function buildLogsCsv(logs: ApiLog[]): string {
+	const rows = logs.map((log) =>
+		[
+			log.createdAt,
+			log.usedProvider,
+			log.usedModel,
+			log.unifiedFinishReason ?? log.finishReason ?? "",
+			log.promptTokens,
+			log.completionTokens,
+			log.totalTokens,
+			log.cachedTokens ?? "",
+			log.cost,
+			log.hasError,
+			log.streamed,
+			log.duration,
+			log.requestId,
+			log.id,
+		]
+			.map(escapeCsvValue)
+			.join(","),
+	);
+	return [CSV_HEADERS.join(","), ...rows].join("\n");
 }
 
 function toUiLog(log: ApiLog): Partial<Log> {
@@ -418,6 +458,18 @@ function AgentDetail({
 		return { from: from.toISOString(), to: to.toISOString() };
 	}, [timeRange]);
 
+	const logsQuery = useMemo(
+		() => ({
+			orderBy: "createdAt_desc" as const,
+			projectId,
+			limit: "100",
+			source: stats.agent.sources.join(","),
+			startDate: range.from,
+			endDate: range.to,
+		}),
+		[projectId, stats.agent.sources, range.from, range.to],
+	);
+
 	const {
 		data,
 		isLoading,
@@ -430,14 +482,7 @@ function AgentDetail({
 		"/logs",
 		{
 			params: {
-				query: {
-					orderBy: "createdAt_desc",
-					projectId,
-					limit: "100",
-					source: stats.agent.sources.join(","),
-					startDate: range.from,
-					endDate: range.to,
-				},
+				query: logsQuery,
 			},
 		},
 		{
@@ -473,7 +518,7 @@ function AgentDetail({
 		const observer = new IntersectionObserver(
 			(entries) => {
 				if (entries[0]?.isIntersecting) {
-					fetchNextPage();
+					void fetchNextPage();
 				}
 			},
 			{ rootMargin: "400px" },
@@ -483,100 +528,37 @@ function AgentDetail({
 	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
 	const fetchClient = useFetchClient();
+	const { toast } = useToast();
 	const [isExporting, setIsExporting] = useState(false);
 
 	const handleExportCsv = useCallback(async () => {
 		setIsExporting(true);
 		try {
-			const collected: ApiLog[] = [];
 			// Pages already loaded via the infinite query are reused to avoid
-			// re-fetching them; remaining pages are fetched directly.
+			// re-fetching them; remaining pages are fetched directly. Any failed
+			// page fetch aborts the export so a partial CSV is never downloaded.
 			const pages = data?.pages ?? [];
-			for (const page of pages) {
-				for (const log of page?.logs ?? []) {
-					collected.push(log);
-				}
-			}
+			const collected: ApiLog[] = pages.flatMap((page) => page?.logs ?? []);
 			const lastPage = pages[pages.length - 1];
-			let cursor = lastPage?.pagination
-				?.nextCursor as string | undefined;
-			let hasMore = !!lastPage?.pagination?.hasMore;
-			if (hasMore && cursor) {
-				while (cursor) {
-					const res = await fetchClient.GET("/logs", {
-						params: {
-							query: {
-								orderBy: "createdAt_desc",
-								projectId,
-								limit: "100",
-								source: stats.agent.sources.join(","),
-								startDate: range.from,
-								endDate: range.to,
-								cursor,
-							},
-						},
-					});
-					const body = res.data;
-					if (!body) {
-						break;
-					}
-					for (const log of body.logs) {
-						collected.push(log);
-					}
-					if (!body.pagination.hasMore || !body.pagination.nextCursor) {
-						break;
-					}
-					cursor = body.pagination.nextCursor;
+			let cursor = lastPage?.pagination?.hasMore
+				? (lastPage.pagination.nextCursor ?? undefined)
+				: undefined;
+			while (cursor) {
+				const res = await fetchClient.GET("/logs", {
+					params: {
+						query: { ...logsQuery, cursor },
+					},
+				});
+				const body = res.data;
+				if (!body) {
+					throw new Error("Failed to fetch logs for export");
 				}
+				collected.push(...body.logs);
+				cursor = body.pagination.hasMore
+					? (body.pagination.nextCursor ?? undefined)
+					: undefined;
 			}
-			const exportLogs = collected.filter((log) => !log.retriedByLogId);
-			const headers = [
-				"createdAt",
-				"usedProvider",
-				"usedModel",
-				"finishReason",
-				"promptTokens",
-				"completionTokens",
-				"totalTokens",
-				"cachedTokens",
-				"cost",
-				"hasError",
-				"streamed",
-				"duration",
-				"requestId",
-				"id",
-			];
-			const escape = (value: unknown) => {
-				if (value === null || value === undefined) {
-					return "";
-				}
-				const str = String(value);
-				if (/[",\n]/.test(str)) {
-					return `"${str.replace(/"/g, '""')}"`;
-				}
-				return str;
-			};
-			const rows = exportLogs.map((log) =>
-				[
-					log.createdAt,
-					log.usedProvider,
-					log.usedModel,
-					log.unifiedFinishReason ?? log.finishReason ?? "",
-					log.promptTokens,
-					log.completionTokens,
-					log.totalTokens,
-					log.cachedTokens ?? "",
-					log.cost,
-					log.hasError,
-					log.streamed,
-					log.duration,
-					log.requestId,
-					log.id,
-				]
-					.map(escape)
-					.join(","),
-			);
-			const csv = [headers.join(","), ...rows].join("\n");
+			const csv = buildLogsCsv(collected.filter((log) => !log.retriedByLogId));
 			const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement("a");
@@ -586,19 +568,17 @@ function AgentDetail({
 			a.click();
 			document.body.removeChild(a);
 			URL.revokeObjectURL(url);
+		} catch {
+			toast({
+				title: "Export failed",
+				description:
+					"Could not fetch all requests for this period. Please try again.",
+				variant: "destructive",
+			});
 		} finally {
 			setIsExporting(false);
 		}
-	}, [
-		data,
-		fetchClient,
-		projectId,
-		stats.agent.id,
-		stats.agent.sources,
-		range.from,
-		range.to,
-		timeRange,
-	]);
+	}, [data, fetchClient, logsQuery, stats.agent.id, timeRange, toast]);
 
 	return (
 		<div className="space-y-4">
@@ -611,39 +591,39 @@ function AgentDetail({
 				Back to agents
 			</button>
 
-		<div className="flex items-center justify-between gap-4 pb-2">
-			<div className="flex items-center gap-4">
-				<div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted">
-					<Icon className="h-6 w-6" />
-				</div>
-				<div>
-					<h3 className="text-lg font-semibold tracking-tight">
-						{stats.agent.label}
-					</h3>
-					<div className="flex items-center gap-3 text-sm text-muted-foreground">
-						<span>
-							{logs.length.toLocaleString()} of{" "}
-							{stats.requestCount.toLocaleString()} request
-							{stats.requestCount !== 1 ? "s" : ""}
-						</span>
-						<span className="text-border">&middot;</span>
-						<span>${stats.totalCost.toFixed(2)}</span>
-						<span className="text-border">&middot;</span>
-						<span>{formatTokens(stats.totalTokens)} tokens</span>
+			<div className="flex items-center justify-between gap-4 pb-2">
+				<div className="flex items-center gap-4">
+					<div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted">
+						<Icon className="h-6 w-6" />
+					</div>
+					<div>
+						<h3 className="text-lg font-semibold tracking-tight">
+							{stats.agent.label}
+						</h3>
+						<div className="flex items-center gap-3 text-sm text-muted-foreground">
+							<span>
+								{logs.length.toLocaleString()} of{" "}
+								{stats.requestCount.toLocaleString()} request
+								{stats.requestCount !== 1 ? "s" : ""}
+							</span>
+							<span className="text-border">&middot;</span>
+							<span>${stats.totalCost.toFixed(2)}</span>
+							<span className="text-border">&middot;</span>
+							<span>{formatTokens(stats.totalTokens)} tokens</span>
+						</div>
 					</div>
 				</div>
+				<button
+					type="button"
+					onClick={handleExportCsv}
+					disabled={isExporting || logs.length === 0}
+					className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+					title="Export all requests in this period to CSV"
+				>
+					<Download className="h-4 w-4" />
+					{isExporting ? "Exporting..." : "Export CSV"}
+				</button>
 			</div>
-			<button
-				type="button"
-				onClick={handleExportCsv}
-				disabled={isExporting || logs.length === 0}
-				className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
-				title="Export all requests in this period to CSV"
-			>
-				<Download className="h-4 w-4" />
-				{isExporting ? "Exporting..." : "Export CSV"}
-			</button>
-		</div>
 
 			<div className="space-y-3">
 				{isLoading ? (
@@ -668,23 +648,23 @@ function AgentDetail({
 							projectId={projectId}
 						/>
 					))
-			)}
+				)}
 
-			{/* Auto-load sentinel: fetches the next page when scrolled into view. */}
-			<div ref={sentinelRef} className="h-1" />
-			{hasNextPage && (
-				<div className="flex justify-center pt-2">
-					<button
-						type="button"
-						onClick={() => fetchNextPage()}
-						disabled={isFetchingNextPage}
-						className="rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
-					>
-						{isFetchingNextPage ? "Loading more..." : "Load more sessions"}
-					</button>
-				</div>
-			)}
-		</div>
+				{/* Auto-load sentinel: fetches the next page when scrolled into view. */}
+				<div ref={sentinelRef} className="h-1" />
+				{hasNextPage && (
+					<div className="flex justify-center pt-2">
+						<button
+							type="button"
+							onClick={() => fetchNextPage()}
+							disabled={isFetchingNextPage}
+							className="rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+						>
+							{isFetchingNextPage ? "Loading more..." : "Load more sessions"}
+						</button>
+					</div>
+				)}
+			</div>
 		</div>
 	);
 }
@@ -737,12 +717,7 @@ export function AgentsView({
 	const { buildUrl } = useDashboardNavigation();
 	const api = useApi();
 
-	const timeRangeParam = searchParams.get("timeRange");
-	const timeRange: TimeRangeValue = AGENT_TIME_RANGES.includes(
-		timeRangeParam as TimeRangeValue,
-	)
-		? (timeRangeParam as TimeRangeValue)
-		: "7d";
+	const timeRange = parseAgentTimeRange(searchParams.get("timeRange"));
 
 	const updateTimeRange = (newTimeRange: TimeRangeValue) => {
 		const params = new URLSearchParams(searchParams);

--- a/apps/ui/src/lib/agent-time-ranges.ts
+++ b/apps/ui/src/lib/agent-time-ranges.ts
@@ -1,0 +1,27 @@
+import type { TimeRangeValue } from "@/components/time-range-picker";
+
+// Single source of truth for the ranges offered on the agents dashboard,
+// shared between the server page (URL parsing) and the client view.
+export const AGENT_TIME_RANGES = [
+	"1h",
+	"4h",
+	"24h",
+	"7d",
+	"30d",
+] as const satisfies readonly TimeRangeValue[];
+
+export const AGENT_TIME_RANGE_HOURS: Record<TimeRangeValue, number> = {
+	"1h": 1,
+	"4h": 4,
+	"24h": 24,
+	"7d": 7 * 24,
+	"30d": 30 * 24,
+};
+
+export function parseAgentTimeRange(
+	value: string | null | undefined,
+): TimeRangeValue {
+	return (AGENT_TIME_RANGES as readonly string[]).includes(value ?? "")
+		? (value as TimeRangeValue)
+		: "7d";
+}


### PR DESCRIPTION
## Problem

On the agents dashboard, clicking an agent (e.g. opencode) only showed the most recent ~20 requests for that agent, with yesterday's requests disappearing day by day and no working pagination. Root cause (confirmed via the \`/logs\` request captured in DevTools): the deployed DevPass UI was running a pre-\`6e2e2781\` build of the agents view that hardcoded \`source: ALL_SOURCES.join(\",\")\` — so every agent card fetched the latest 100 logs *across all agents*, not just the clicked agent. The 100 slots were shared, so only ~20 happened to be opencode, and as other agents were used they pushed opencode (and yesterday's opencode) out of the top-100. The 100 full logs (29 MB payload) also made the \`Load more\` pager effectively unusable.

\`6e2e2781\` already fixed the per-agent source filter in the repo, but the deployed build hadn't been updated. This PR adds the remaining UX improvements so the next deploy is unambiguously correct.

## Changes

- **Full time-range picker** (\`apps/ui/...\agents-view.tsx\`, \`apps/ui/...\agents/page.tsx\`): expand from 7d/30d to the same 1h/4h/24h/7d/30d set offered by the Model Usage Overview chart, so the agents page can be filtered to the same window.
- **Auto-load on scroll**: an \`IntersectionObserver\` sentinel at the bottom of the session list fetches the next 100-log page as you scroll, so all requests in the selected window become reachable without repeatedly clicking \`Load more\`. The manual button is kept as a fallback.
- **CSV export**: an \`Export CSV\` button in the agent detail header that pages through every matching \`/logs\` page (reusing already-loaded pages, then fetching remaining ones directly) and downloads all non-retried requests in the window as CSV.
- **Visible count**: the header now reads \`N of M requests\` (loaded vs aggregated total) instead of just \`M\`, so it's clear when more pages remain.
- **API**: \`GET /activity/sources\` now accepts \`timeRange\` of \`1h\`/\`4h\`/\`24h\`/\`7d\`/\`30d\` (was 7d/30d only) and computes the window in hours, mirroring \`GET /activity\`.

## Notes

- The per-agent \`source\` filter (the actual fix for the "only 20 shown / yesterday's gone" bug) is already in the repo from \`6e2e2781\`; this PR builds on it. Deploying the current \`main\` already resolves the reported issue; this PR makes the experience usable for heavy usage (hundreds–thousands of requests per window).
- The 29 MB-per-100-logs payload (full \`messages\`/\`tools\` per log) is a separate, follow-on concern; a lighter list endpoint would help the pager/export for very heavy users. Not addressed here to keep the PR focused.

I could not run \`pnpm build\` locally in this worktree (the supply-chain \`minimumReleaseAge\` policy blocks the lockfile and a fresh 19-workspace install times out); CI should verify the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded agent activity time-range options to include the past 1 hour, 4 hours, and 24 hours (in addition to 7 days and 30 days).
  - Added CSV export for agent activity logs across all loaded and remaining pages.
  - Agent sessions now load automatically as users scroll.
- **Bug Fixes**
  - Improved time-range handling to consistently default to the past 7 days when missing or invalid.
  - Updated API validation and source aggregation for the expanded time ranges.
- **Tests**
  - Added endpoint coverage for `/activity/sources` across all supported time ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->