### PR TITLE
fix(models): set scx-ai prices natively in USD

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -719,10 +719,8 @@ export const alibabaModels = [
 			{
 				providerId: "scx-ai",
 				externalId: "Qwen3-32B",
-				// 1.105 AUD / 2.635 AUD per 1M tokens at 0.692662 AUD/USD
-				inputPrice: "0.7654e-6",
-				cachedInputPrice: "0.11481e-6",
-				outputPrice: "1.8252e-6",
+				inputPrice: "0.36e-6",
+				outputPrice: "0.87e-6",
 				requestPrice: "0",
 				contextSize: 32768,
 				maxOutput: 8192,

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2284,10 +2284,8 @@ export const googleModels = [
 			{
 				providerId: "scx-ai",
 				externalId: "gemma-4-31B-it",
-				// 0.54 AUD / 1.63 AUD per 1M tokens at 0.692662 AUD/USD
-				inputPrice: "0.374e-6",
-				cachedInputPrice: "0.0561e-6",
-				outputPrice: "1.129e-6",
+				inputPrice: "0.30e-6",
+				outputPrice: "0.91e-6",
 				requestPrice: "0",
 				contextSize: 131072,
 				maxOutput: 8192,

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -463,10 +463,8 @@ export const metaModels = [
 			{
 				providerId: "scx-ai",
 				externalId: "Llama-4-Maverick-17B-128E-Instruct",
-				// 1.615 AUD / 4.93 AUD per 1M tokens at 0.692662 AUD/USD
-				inputPrice: "1.1186e-6",
-				cachedInputPrice: "0.16779e-6",
-				outputPrice: "3.4148e-6",
+				inputPrice: "0.53e-6",
+				outputPrice: "1.62e-6",
 				requestPrice: "0",
 				contextSize: 131072,
 				maxOutput: 8192,

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -151,10 +151,9 @@ export const minimaxModels = [
 			{
 				providerId: "scx-ai",
 				externalId: "MiniMax-M2.7",
-				// 0.68 AUD / 3.20 AUD per 1M tokens at 0.692662 AUD/USD
-				inputPrice: "0.471e-6",
-				cachedInputPrice: "0.07065e-6",
-				outputPrice: "2.2165e-6",
+				inputPrice: "0.48e-6",
+				cachedInputPrice: "0.05e-6",
+				outputPrice: "1.79e-6",
 				requestPrice: "0",
 				contextSize: 196608,
 				maxOutput: 196608,

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -782,10 +782,8 @@ export const openaiModels = [
 			{
 				providerId: "scx-ai",
 				externalId: "gpt-oss-120b",
-				// 0.51 AUD / 1.666 AUD per 1M tokens at 0.692662 AUD/USD
-				inputPrice: "0.3533e-6",
-				cachedInputPrice: "0.052995e-6",
-				outputPrice: "1.154e-6",
+				inputPrice: "0.17e-6",
+				outputPrice: "0.55e-6",
 				requestPrice: "0",
 				contextSize: 131072,
 				maxOutput: 32768,


### PR DESCRIPTION
## Summary

SCX AI now sets its USD prices natively rather than converting from AUD, so the `scx-ai` provider mappings are updated to the published USD rates. The previous values were AUD figures converted at 0.692662 USD/AUD, with cached reads derived as a flat 15% of input.

| Model | Input / 1M | Cached / 1M | Output / 1M |
| --- | --- | --- | --- |
| `MiniMax-M2.7` | $0.48 | $0.05 | $1.79 |
| `Llama-4-Maverick-17B-128E-Instruct` | $0.53 | — | $1.62 |
| `Qwen3-32B` | $0.36 | — | $0.87 |
| `gemma-4-31B-it` | $0.30 | — | $0.91 |
| `gpt-oss-120b` | $0.17 | — | $0.55 |

## Cached-read pricing

Only `MiniMax-M2.7` has a separately published cached-read rate. The other four mappings drop `cachedInputPrice` entirely, so cached prompt tokens bill at the full input rate via the existing fallback in `calculateCosts` (`pricing.cachedInputPrice ?? pricing.inputPrice`, `apps/gateway/src/lib/costs.ts`). This intentionally supersedes the flat 15%-of-input rate previously set for all five models, which was a derived placeholder rather than a published rate — note that MiniMax's real $0.05 works out to ~10.4% of input, not 15%.

The AUD conversion comments are removed along with the conversions, since the prices are no longer derived from anything.

## Test plan

- [x] `pnpm build` — all tasks pass
- [x] `packages/models` unit tests — 64 pass
- [x] Pricing/cost suites pass: `costs.spec.ts`, `alibaba-pricing.spec.ts`, `anthropic-pricing.spec.ts`, `openai-gpt56-pricing.spec.ts`, `apps/gateway/src/models/models.spec.ts`, `packages/actions`
- [x] `pnpm format`

No migration is needed — `apps/worker/src/services/sync-models.ts` upserts the catalogue into `model_provider_mapping` on its next run. Billing is forward-only: existing `log` rows store their computed cost, so historical usage is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated pricing information for several AI models, including Qwen3, Gemma, Llama, MiniMax, and GPT-OSS.
  * Refined cached-input pricing availability for affected models.
  * Ensured displayed model costs reflect the latest provider rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->