### PR TITLE
fix(devpass): census registry mobile layout

### DIFF
--- a/apps/code/src/app/data/[year]/page.tsx
+++ b/apps/code/src/app/data/[year]/page.tsx
@@ -73,13 +73,13 @@ function ScoreMeter({ label, value }: { label: string; value: number }) {
 			<span className="w-14 shrink-0 font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
 				{label}
 			</span>
-			<div className="h-1.5 w-24 overflow-hidden rounded-full bg-stone-200 dark:bg-stone-800">
+			<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-stone-200 dark:bg-stone-800 sm:w-24 sm:flex-none">
 				<div
 					className="h-full rounded-full bg-emerald-600 dark:bg-emerald-400"
 					style={{ width: `${(value / 5) * 100}%` }}
 				/>
 			</div>
-			<span className="w-8 text-right font-mono text-xs tabular-nums">
+			<span className="w-8 shrink-0 text-right font-mono text-xs tabular-nums">
 				{value.toFixed(1)}
 			</span>
 		</div>
@@ -89,8 +89,8 @@ function ScoreMeter({ label, value }: { label: string; value: number }) {
 function ModelRow({ model, rank }: { model: ModelSurveyModel; rank: number }) {
 	const topUseCase = model.useCases[0];
 	return (
-		<div className="flex flex-wrap items-center gap-x-6 gap-y-4 border-b border-dashed border-stone-300/80 px-4 py-5 last:border-b-0 dark:border-stone-700/80 sm:px-6">
-			<div className="flex min-w-0 flex-1 items-center gap-4">
+		<div className="border-b border-dashed border-stone-300/80 px-4 py-5 last:border-b-0 dark:border-stone-700/80 sm:flex sm:flex-wrap sm:items-center sm:gap-x-6 sm:gap-y-4 sm:px-6">
+			<div className="flex min-w-0 items-center gap-4 sm:flex-1">
 				<div
 					className={
 						rank === 1
@@ -100,7 +100,7 @@ function ModelRow({ model, rank }: { model: ModelSurveyModel; rank: number }) {
 				>
 					{rank}
 				</div>
-				<div className="min-w-0">
+				<div className="min-w-0 flex-1">
 					<div className="truncate font-mono text-sm font-semibold">
 						{model.modelId}
 					</div>
@@ -111,13 +111,21 @@ function ModelRow({ model, rank }: { model: ModelSurveyModel; rank: number }) {
 							: ""}
 					</div>
 				</div>
+				<div className="shrink-0 text-right sm:hidden">
+					<div className="font-mono text-xl font-bold tabular-nums">
+						{model.recommendPercent}%
+					</div>
+					<div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+						recommend
+					</div>
+				</div>
 			</div>
-			<div className="space-y-1.5">
+			<div className="mt-4 space-y-1.5 sm:mt-0">
 				<ScoreMeter label="Value" value={model.avgValueScore} />
 				<ScoreMeter label="Quality" value={model.avgQualityScore} />
 				<ScoreMeter label="Speed" value={model.avgSpeedScore} />
 			</div>
-			<div className="w-24 text-right">
+			<div className="hidden w-24 text-right sm:block">
 				<div className="font-mono text-xl font-bold tabular-nums">
 					{model.recommendPercent}%
 				</div>
@@ -226,10 +234,10 @@ export default async function CensusPage({
 								},
 							].map((stat) => (
 								<div key={stat.label}>
-									<div className="font-mono text-3xl font-bold tabular-nums">
+									<div className="font-mono text-2xl font-bold tabular-nums sm:text-3xl">
 										{stat.value.toLocaleString()}
 									</div>
-									<div className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+									<div className="mt-1 font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground sm:tracking-[0.2em]">
 										{stat.label}
 									</div>
 								</div>
@@ -241,11 +249,11 @@ export default async function CensusPage({
 				{/* Registry */}
 				<section className="px-4 py-12">
 					<div className="container mx-auto max-w-3xl">
-						<div className="mb-4 flex items-baseline justify-between">
-							<h2 className="font-mono text-[10px] uppercase tracking-[0.35em] text-stone-500 dark:text-stone-400">
+						<div className="mb-4 flex items-baseline justify-between gap-4">
+							<h2 className="font-mono text-[10px] uppercase tracking-[0.25em] text-stone-500 sm:tracking-[0.35em] dark:text-stone-400">
 								The registry · ranked by value score
 							</h2>
-							<span className="font-mono text-[9px] tracking-[0.25em] text-stone-400 dark:text-stone-500">
+							<span className="shrink-0 font-mono text-[9px] tracking-[0.25em] whitespace-nowrap text-stone-400 dark:text-stone-500">
 								Doc. CS-{year}
 							</span>
 						</div>


### PR DESCRIPTION
## Problem

On phones, the `/data/[year]` census registry rows collapsed (screenshot from a real device): the fixed-width score meters shared the first flex line with the `flex-1` identity column, squeezing the model name down to ~3 characters ("gem…"), wrapping the "N verified ratings · mostly X" meta line one word per line, and dropping the recommend block into leftover space.

## Changes

All in `apps/code/src/app/data/[year]/page.tsx`, keeping the census/registry document styling intact:

- **Stacked filing-card layout below `sm`**: rank stamp + full model name/meta with the "N% recommend" verdict docked top-right, and the three score meters full-width beneath (bars `flex-1` on mobile, back to fixed `w-24` from `sm` up). From `sm` up the existing horizontal ledger row is unchanged.
- **Registry header**: "Doc. CS-{year}" is `shrink-0 whitespace-nowrap` so it stays on one line, with slightly tighter heading tracking on mobile so the title no longer wraps mid-token.
- **Stats strip**: numbers `text-2xl` and label tracking `0.15em` on mobile (up to the original `text-3xl`/`0.2em` from `sm`) so the three columns fit without crowding.

## Verification

Verified with Playwright against the locally seeded census: 390px and 320px in dark + light, a long model id (`gemini-3.5-flash-preview-06-2026-experimental`) for graceful truncation, and 1280px to confirm the desktop layout is pixel-identical. `pnpm format` and a full `pnpm build` pass.

https://claude.ai/code/session_01Pxhem1afhLvsxVRhG8XYxF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout and sizing for census data score meters and model rows.
  * Enhanced mobile and desktop presentation of recommendation percentages.
  * Increased Stats typography for improved readability on larger screens.
  * Refined Registry header spacing and ensured documentation codes remain on one line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->