### PR TITLE
feat: add Eden AI provider

### DIFF
--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -108,6 +108,7 @@ const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<ProviderId, string>> = {
 	groq: "https://api.groq.com/openai",
 	cerebras: "https://api.cerebras.ai",
 	deepseek: "https://api.deepseek.com",
+	edenai: "https://api.edenai.run/v3",
 	perplexity: "https://api.perplexity.ai",
 	novita: "https://api.novita.ai/v3/openai",
 	moonshot: "https://api.moonshot.ai",
@@ -499,6 +500,8 @@ export function getProviderEndpoint(
 			const vaEndpoint = stream ? "streamRawPredict" : "rawPredict";
 			return `${url}/v1/projects/${vaProjectId}/locations/${vaRegion}/publishers/anthropic/models/${vaModel}:${vaEndpoint}`;
 		}
+		case "edenai":
+			return `${url}/chat/completions`;
 		case "perplexity":
 			return `${url}/chat/completions`;
 		case "novita":

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -657,6 +657,33 @@ export const providers: ProviderDefinition[] = [
 		priority: 1.2,
 	},
 	{
+		id: "edenai",
+		name: "Eden AI",
+		description:
+			"Eden AI's unified API routing to many providers via an OpenAI-compatible interface",
+		env: {
+			required: {
+				apiKey: "LLM_EDENAI_API_KEY",
+			},
+		},
+		streaming: true,
+		cancellation: true,
+		color: "#4318D1",
+		website: "https://www.edenai.co",
+		statusPageUrl: null,
+		announcement: null,
+		termsUrl: "https://www.edenai.co/terms",
+		privacyPolicyUrl: "https://www.edenai.co/privacy-policy",
+		headquarters: "FR",
+		dataPolicy: {
+			apiTraining: false,
+			consumerTraining: false,
+			promptLogging: false,
+			retentionPeriod: null,
+			gdpr: true,
+		},
+	},
+	{
 		id: "alibaba",
 		name: "Alibaba Cloud",
 		description:


### PR DESCRIPTION
## What

Adds [Eden AI](https://www.edenai.co/) as a provider.

Eden AI exposes an OpenAI-compatible Chat Completions endpoint (`https://api.edenai.run/v3/chat/completions`) that routes to many underlying providers behind a single key, so it wires in with the existing OpenAI-compatible request path — no new auth handling (default `Bearer`). Models are addressed as `<provider>/<model>` (e.g. `openai/gpt-5.5`, `mistral/mistral-large-latest`).

## Changes

- `packages/models/src/providers.ts`: new `edenai` provider definition (`LLM_EDENAI_API_KEY`, streaming + cancellation, HQ `FR`, GDPR data policy).
- `packages/actions/src/get-provider-endpoint.ts`: default base URL `https://api.edenai.run/v3` and an `edenai` endpoint case returning `${url}/chat/completions` (the base already carries the `/v3` path, like `perplexity`/`novita`).

No model mappings are added in this PR: Eden AI is an aggregator whose model catalogue spans many upstream families, so first-class canonical mappings are best done as a follow-up. This PR is the provider wiring; users select Eden AI models via the `provider/model` string.

## Testing

- `packages/models` and `packages/actions` typecheck with no errors.
- Verified live against `https://api.edenai.run/v3`: `GET /models` and chat completions return 200, and tool/function calling passes through for `openai/gpt-5.5` and `mistral/mistral-large-latest`.

AGPLv3 core only — `ee/` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Eden AI as a supported provider.
  * Enabled Eden AI chat completions, streaming, and request cancellation.
  * Added configuration guidance, including the required API key setting and provider information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->