### PR TITLE
feat(devpass): 3DS flow for SCA-required upgrades

### DIFF
--- a/apps/api/src/routes/chat-plans.ts
+++ b/apps/api/src/routes/chat-plans.ts
@@ -554,6 +554,18 @@ chatPlans.openapi(changeTier, async (c) => {
 					"Upgrade payment could not be collected. Update your payment method and try again.",
 			});
 		}
+		// `error_if_incomplete` throws this when the bank demands 3DS/SCA
+		// authentication, which can't be completed server-side; the subscription
+		// is left unchanged. Also an expected user-facing outcome, so 402 + warn.
+		if (errCode === "subscription_payment_intent_requires_action") {
+			logger.warn("Chat plan tier change requires payment authentication", {
+				code: errCode,
+			});
+			throw new HTTPException(402, {
+				message:
+					"Your bank requires additional verification to complete this payment. Update or re-add your payment method and try again.",
+			});
+		}
 		logger.error(
 			"Stripe chat plan tier change error",
 			error instanceof Error ? error : new Error(String(error)),

--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -266,6 +266,96 @@ describe("dev plan tier changes", () => {
 		expect(transaction?.stripePaymentIntentId).toBe("pi_upgrade");
 	});
 
+	it("returns requires_action with a client secret when the bank demands 3DS", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.prices.retrieve.mockResolvedValue({ unit_amount: 7900 });
+		// The atomic `error_if_incomplete` attempt fails because the card needs
+		// customer authentication; the retry as a pending update returns an open
+		// invoice whose payment intent carries the confirmable client secret.
+		stripeMock.subscriptions.update
+			.mockRejectedValueOnce({
+				code: "subscription_payment_intent_requires_action",
+				message:
+					"This payment requires additional user action before it can be completed successfully.",
+			})
+			.mockResolvedValueOnce({
+				id: SUBSCRIPTION_ID,
+				customer: "cus_dev_plan",
+				status: "active",
+				metadata: { devPlan: "pro" },
+				latest_invoice: {
+					id: "in_pending_update",
+					status: "open",
+					payment_intent: {
+						object: "payment_intent",
+						id: "pi_3ds",
+						status: "requires_action",
+						client_secret: "pi_3ds_secret_123",
+					},
+				},
+				items: {
+					data: [
+						{
+							id: "si_dev_plan",
+							current_period_end: nowSeconds + THIRTY_DAYS,
+						},
+					],
+				},
+			});
+
+		const res = await app.request("/dev-plans/change-tier", {
+			method: "POST",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				newTier: "pro",
+				expectedAmountDueCents: 7900,
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			status: "requires_action",
+			clientSecret: "pi_3ds_secret_123",
+		});
+
+		expect(stripeMock.subscriptions.update).toHaveBeenNthCalledWith(
+			1,
+			SUBSCRIPTION_ID,
+			expect.objectContaining({ payment_behavior: "error_if_incomplete" }),
+		);
+		expect(stripeMock.subscriptions.update).toHaveBeenNthCalledWith(
+			2,
+			SUBSCRIPTION_ID,
+			expect.objectContaining({
+				items: [{ id: "si_dev_plan", price: "price_pro" }],
+				proration_behavior: "none",
+				billing_cycle_anchor: "now",
+				payment_behavior: "pending_if_incomplete",
+			}),
+		);
+
+		// Nothing is applied locally until the invoice.payment_succeeded webhook
+		// confirms the 3DS payment: tier and credits untouched, no transaction
+		// row, and the lease released so a retry isn't locked out.
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(org?.devPlan).toBe("lite");
+		expect(org?.devPlanCreditsUsed).toBe("12.5");
+		expect(org?.devPlanCreditsLimit).toBe("87");
+		expect(org?.devPlanTierChangeClaimedAt).toBeNull();
+
+		const transaction = await db.query.transaction.findFirst({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(transaction).toBeUndefined();
+	});
+
 	it("voids a pending cycle-renewal invoice before re-anchoring the cycle", async () => {
 		// The old cycle just ended: Stripe drafted its renewal invoice but has
 		// not charged it yet (that happens ~1h after drafting). The upgrade must

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -89,6 +89,15 @@ async function releaseTierChangeLease(organizationId: string) {
 		});
 }
 
+// Stripe errors carry a machine-readable `code` (e.g. `card_declined`,
+// `subscription_payment_intent_requires_action`) but the SDK types them as
+// `unknown` at the catch site, so narrow to the string code (or undefined).
+function getStripeErrorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String((error as { code?: unknown }).code)
+		: undefined;
+}
+
 // Helper to get or create API key for personal org
 async function getOrCreatePersonalOrgApiKey(
 	orgId: string,
@@ -1236,12 +1245,7 @@ devPlans.openapi(changeTier, async (c) => {
 					},
 				});
 			} catch (updateError) {
-				const updateErrCode =
-					typeof updateError === "object" &&
-					updateError !== null &&
-					"code" in updateError
-						? String((updateError as { code?: unknown }).code)
-						: undefined;
+				const updateErrCode = getStripeErrorCode(updateError);
 				if (updateErrCode !== "subscription_payment_intent_requires_action") {
 					throw updateError;
 				}
@@ -1286,6 +1290,13 @@ devPlans.openapi(changeTier, async (c) => {
 				});
 				// Release the lease: the charge is no longer in flight server-side, and
 				// the webhook completes (or Stripe discards) the change out-of-band.
+				// Releasing here — rather than holding until the webhook resolves — keeps
+				// the common "abandon the 3DS challenge, then retry" path unblocked (the
+				// completion webhook lives in the Stripe handler and never touches the
+				// lease, so a held lease would only clear on the 15-minute staleness
+				// window). A concurrent retry during the challenge cannot double-charge:
+				// a subscription holds at most one pending update, so re-issuing simply
+				// voids the prior invoice and replaces it — last write wins.
 				if (claimedLeaseThisCall) {
 					await releaseTierChangeLease(personalOrg.id);
 				}
@@ -1494,10 +1505,7 @@ devPlans.openapi(changeTier, async (c) => {
 		// so the UI can prompt the user to update billing. This is an expected
 		// user-facing outcome, not a server fault, so log it at warn — never
 		// error — to avoid noisy alerts for declined cards.
-		const errCode =
-			typeof error === "object" && error !== null && "code" in error
-				? String((error as { code?: unknown }).code)
-				: undefined;
+		const errCode = getStripeErrorCode(error);
 		if (errCode === "card_declined" || errCode === "invoice_payment_required") {
 			logger.warn("Dev plan tier change payment declined", {
 				code: errCode,

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1435,6 +1435,18 @@ devPlans.openapi(changeTier, async (c) => {
 					"Upgrade payment could not be collected. Update your payment method and try again.",
 			});
 		}
+		// `error_if_incomplete` throws this when the bank demands 3DS/SCA
+		// authentication, which can't be completed server-side; the subscription
+		// is left unchanged. Also an expected user-facing outcome, so 402 + warn.
+		if (errCode === "subscription_payment_intent_requires_action") {
+			logger.warn("Dev plan tier change requires payment authentication", {
+				code: errCode,
+			});
+			throw new HTTPException(402, {
+				message:
+					"Your bank requires additional verification to complete this payment. Update or re-add your payment method and try again.",
+			});
+		}
 		logger.error(
 			"Stripe dev plan tier change error",
 			error instanceof Error ? error : new Error(String(error)),

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -13,6 +13,7 @@ import {
 	ensureStripeCustomer,
 	finalizeDevPlanSetupSession,
 	fulfillResetPassPurchase,
+	getSubscriptionPaymentConfirmation,
 	isDevPlanCardDedupeEnforced,
 } from "@/stripe.js";
 import { findDefaultOrganization } from "@/utils/default-org.js";
@@ -987,12 +988,19 @@ const changeTier = createRoute({
 		200: {
 			content: {
 				"application/json": {
-					schema: z.object({
-						success: z.boolean(),
-					}),
+					schema: z.union([
+						z.object({
+							success: z.boolean(),
+						}),
+						z.object({
+							status: z.literal("requires_action"),
+							clientSecret: z.string(),
+						}),
+					]),
 				},
 			},
-			description: "Dev plan tier changed successfully",
+			description:
+				"Dev plan tier changed successfully, or the upgrade payment requires customer authentication (3DS) — confirm the returned client secret with Stripe.js to complete it",
 		},
 	},
 });
@@ -1208,23 +1216,87 @@ devPlans.openapi(changeTier, async (c) => {
 			// `error_if_incomplete` makes the update atomic: if the charge can't be
 			// collected Stripe throws and leaves the subscription on the old tier, so
 			// there's no half-applied upgrade to roll back.
-			const updated = await getStripe().subscriptions.update(subscriptionId, {
-				items: [
-					{
-						id: subscriptionItemId,
-						price: newPriceId,
+			let updated: Stripe.Subscription;
+			try {
+				updated = await getStripe().subscriptions.update(subscriptionId, {
+					items: [
+						{
+							id: subscriptionItemId,
+							price: newPriceId,
+						},
+					],
+					proration_behavior: "none",
+					billing_cycle_anchor: "now",
+					payment_behavior: "error_if_incomplete",
+					expand: ["latest_invoice.payment_intent"],
+					metadata: {
+						...subscription.metadata,
+						devPlan: newTier,
+						devPlanCycle: existingCycle,
 					},
-				],
-				proration_behavior: "none",
-				billing_cycle_anchor: "now",
-				payment_behavior: "error_if_incomplete",
-				expand: ["latest_invoice.payment_intent"],
-				metadata: {
-					...subscription.metadata,
-					devPlan: newTier,
-					devPlanCycle: existingCycle,
-				},
-			});
+				});
+			} catch (updateError) {
+				const updateErrCode =
+					typeof updateError === "object" &&
+					updateError !== null &&
+					"code" in updateError
+						? String((updateError as { code?: unknown }).code)
+						: undefined;
+				if (updateErrCode !== "subscription_payment_intent_requires_action") {
+					throw updateError;
+				}
+				// The bank demands 3DS/SCA authentication, which only the customer can
+				// complete in the browser. Re-issue the update as a Stripe pending
+				// update (`pending_if_incomplete`): nothing — price, cycle anchor, or
+				// metadata — is applied until the invoice is paid, and if the customer
+				// abandons the challenge Stripe voids the invoice and discards the
+				// update after at most 23 hours, leaving the subscription untouched.
+				// The client confirms the returned payment intent secret with
+				// Stripe.js; on success the `invoice.payment_succeeded` webhook's
+				// `subscription_update` fallback applies the tier change, credit
+				// rollover, transaction row and invoice email idempotently.
+				const pending = await getStripe().subscriptions.update(subscriptionId, {
+					items: [
+						{
+							id: subscriptionItemId,
+							price: newPriceId,
+						},
+					],
+					proration_behavior: "none",
+					billing_cycle_anchor: "now",
+					payment_behavior: "pending_if_incomplete",
+					expand: ["latest_invoice.payment_intent"],
+					metadata: {
+						...subscription.metadata,
+						devPlan: newTier,
+						devPlanCycle: existingCycle,
+					},
+				});
+				const { clientSecret } =
+					await getSubscriptionPaymentConfirmation(pending);
+				if (!clientSecret) {
+					// No confirmable payment intent to hand to the client; surface the
+					// original failure through the shared catch below.
+					throw updateError;
+				}
+				logger.info("Dev plan tier change pending customer authentication", {
+					organizationId: personalOrg.id,
+					subscriptionId,
+					newTier,
+				});
+				// Release the lease: the charge is no longer in flight server-side, and
+				// the webhook completes (or Stripe discards) the change out-of-band.
+				if (claimedLeaseThisCall) {
+					await releaseTierChangeLease(personalOrg.id);
+				}
+				return c.json(
+					{
+						status: "requires_action" as const,
+						clientSecret,
+					},
+					200,
+				);
+			}
 
 			if (updated.status !== "active" && updated.status !== "trialing") {
 				throw new HTTPException(402, {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -627,7 +627,7 @@ async function getSubscriptionInvoice(
 	});
 }
 
-async function getSubscriptionPaymentConfirmation(
+export async function getSubscriptionPaymentConfirmation(
 	subscription: Stripe.Subscription,
 ): Promise<{
 	paymentIntent: Stripe.PaymentIntent | null;

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -25,6 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
+import { useStripe } from "@/lib/stripe";
 import { cn } from "@/lib/utils";
 
 import type { TierChangeTiming } from "@/app/dashboard/components/ActivePlanChangeTier";
@@ -65,6 +66,7 @@ export default function BillingClient({
 	const posthog = usePostHog();
 	const api = useApi();
 	const queryClient = useQueryClient();
+	const { stripe } = useStripe();
 
 	const { data: devPlanStatus } = useDevPlanStatus(initialDevPlanStatus);
 
@@ -97,6 +99,26 @@ export default function BillingClient({
 	const [isResuming, setIsResuming] = useState(false);
 	const [isCancellingDowngrade, setIsCancellingDowngrade] = useState(false);
 
+	// After a 3DS-confirmed upgrade the tier is applied by the
+	// invoice.payment_succeeded webhook, not the change-tier response — poll
+	// status until the new tier lands so the dashboard reflects it promptly.
+	const waitForTierChange = async (newTier: PlanTier): Promise<boolean> => {
+		for (let attempt = 0; attempt < 15; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 2000));
+			try {
+				const status = await queryClient.fetchQuery(
+					api.queryOptions("get", "/dev-plans/status"),
+				);
+				if (status?.devPlan === newTier) {
+					return true;
+				}
+			} catch {
+				// Transient fetch failure — keep polling until the attempts run out.
+			}
+		}
+		return false;
+	};
+
 	const handleChangeTier = async (
 		newTier: PlanTier,
 		expectedAmountDueCents?: number,
@@ -107,9 +129,39 @@ export default function BillingClient({
 		// and looks up the matching annual or monthly Stripe price ID.
 		setSubscribingTier(newTier);
 		try {
-			await changeTierMutation.mutateAsync({
+			const result = await changeTierMutation.mutateAsync({
 				body: { newTier, expectedAmountDueCents, timing },
 			});
+			if ("status" in result && result.status === "requires_action") {
+				// The bank requires 3DS authentication for the upgrade charge. The
+				// server left the change as a Stripe pending update; confirming the
+				// payment intent here completes it (the webhook then applies the
+				// tier), while abandoning the challenge leaves the plan unchanged.
+				if (!stripe) {
+					throw new Error("Stripe is not ready. Please refresh and try again.");
+				}
+				const confirmation = await stripe.confirmCardPayment(
+					result.clientSecret,
+				);
+				if (confirmation.error) {
+					throw new Error(
+						confirmation.error.message ?? "Payment authentication failed",
+					);
+				}
+				const applied = await waitForTierChange(newTier);
+				await Promise.all([invalidateInvoices(), invalidateStatus()]);
+				if (posthogKey) {
+					posthog.capture("dev_plan_tier_changed", { newTier, timing });
+				}
+				if (applied) {
+					toast.success("Plan updated");
+				} else {
+					toast.success("Payment confirmed", {
+						description: "Your plan will update in a moment.",
+					});
+				}
+				return;
+			}
 			// An immediate upgrade records a new dev_plan_upgrade invoice
 			// server-side; refetch so the Invoices section reflects the just-paid
 			// charge immediately, and refresh status so the current tier /

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -119,6 +119,18 @@ export default function BillingClient({
 		return false;
 	};
 
+	// Shared post-change refresh: pull the just-recorded upgrade invoice and the
+	// new current tier / pending-change state, and record the analytics event.
+	const refreshAfterTierChange = async (
+		newTier: PlanTier,
+		timing?: TierChangeTiming,
+	): Promise<void> => {
+		await Promise.all([invalidateInvoices(), invalidateStatus()]);
+		if (posthogKey) {
+			posthog.capture("dev_plan_tier_changed", { newTier, timing });
+		}
+	};
+
 	const handleChangeTier = async (
 		newTier: PlanTier,
 		expectedAmountDueCents?: number,
@@ -149,10 +161,7 @@ export default function BillingClient({
 					);
 				}
 				const applied = await waitForTierChange(newTier);
-				await Promise.all([invalidateInvoices(), invalidateStatus()]);
-				if (posthogKey) {
-					posthog.capture("dev_plan_tier_changed", { newTier, timing });
-				}
+				await refreshAfterTierChange(newTier, timing);
 				if (applied) {
 					toast.success("Plan updated");
 				} else {
@@ -166,10 +175,7 @@ export default function BillingClient({
 			// server-side; refetch so the Invoices section reflects the just-paid
 			// charge immediately, and refresh status so the current tier /
 			// pending-change state updates.
-			await Promise.all([invalidateInvoices(), invalidateStatus()]);
-			if (posthogKey) {
-				posthog.capture("dev_plan_tier_changed", { newTier, timing });
-			}
+			await refreshAfterTierChange(newTier, timing);
 			toast.success(
 				timing === "next_cycle"
 					? "Plan change scheduled for your next renewal"


### PR DESCRIPTION
## Problem

Production alert (7/14, `llmgateway-api`): a dev plan tier upgrade failed with a `500 Failed to change dev plan tier` logged at ERROR severity. The underlying Stripe error was `subscription_payment_intent_requires_action` — the cardholder's bank required 3DS/SCA authentication to approve the upgrade charge.

The upgrade path uses `payment_behavior: "error_if_incomplete"`, so Stripe throws and leaves the subscription (and our DB) untouched — nothing was corrupted. But:

- the tier-change catch blocks only recognized `card_declined` and `invoice_payment_required`, so the SCA error fell through to a generic 500 + `logger.error`, paging on-call for a user-billing outcome, and
- there was **no way for the user to actually complete the 3DS challenge** for an upgrade — the `requires_action`/`clientSecret` flow existed only for initial subscription checkout, so banks that challenge every off-session charge left users unable to upgrade at all.

## Fix

**1. Error classification (dev plans + chat plans)**
`subscription_payment_intent_requires_action` is handled like the other expected payment failures: warn-level log and a 402 with an actionable message. This remains the terminal behavior for chat plans and for any dev-plan case where no confirmable payment intent can be produced.

**2. In-place 3DS flow for dev plan tier upgrades**
- **API** (`dev-plans.ts`): when the atomic `error_if_incomplete` update throws the SCA error, the change is re-issued as a Stripe **pending update** (`payment_behavior: "pending_if_incomplete"`). Nothing — price, cycle anchor, or metadata — applies until the invoice is paid, and if the customer abandons the challenge Stripe voids the invoice and discards the update after at most 23h, leaving the subscription untouched. The endpoint returns `{ status: "requires_action", clientSecret }` (new union member on the 200 response) and releases the upgrade lease.
- **Dashboard** (`BillingClient.tsx`): on `requires_action`, confirms the payment intent with `stripe.confirmCardPayment()` (same pattern as the finalize flow), then polls `/dev-plans/status` until the tier lands.
- **Completion**: on successful payment, the existing `invoice.payment_succeeded` webhook fallback for `subscription_update` invoices applies the tier change, credit rollover, transaction row, and invoice email idempotently — no webhook changes needed.
- **Safety checks verified**: the `invoice.payment_failed` freeze handler re-fetches the live subscription and only freezes on `past_due`/`unpaid`/`incomplete` statuses; a pending update keeps the subscription `active`, so failed/abandoned 3DS attempts cannot freeze the user's current paid cycle.

## Testing

- New spec: SCA-required upgrade returns `requires_action` + client secret, re-issues the update as `pending_if_incomplete`, applies nothing locally, records no transaction, and releases the lease.
- Full unit suite: 2970 passed. Full `pnpm build` passes (typed clients regenerated from the updated OpenAPI spec).

## Follow-up

Chat plan tier upgrades keep the 402-only behavior for SCA cards; extending the in-place 3DS flow there needs the equivalent UI work in the playground billing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6gxRwHbBXgbJdHGnw2yHM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan upgrades that require additional payment verification now support 3D Secure/SCA customer authentication.
  * Billing flows can complete the verification, then wait for the updated plan status before finalizing the upgrade.
  * Added tailored progress/success messaging for verified upgrades.

* **Bug Fixes**
  * When additional verification is required, upgrades now return an actionable 402 response guiding customers to re-add/update their payment method.
  * Prevented local tier/credit/lease state changes from being applied until payment confirmation/webhook completion.

* **Tests**
  * Added coverage for the 3DS/SCA “requires_action” upgrade flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->