### PR TITLE
feat: raise minimum password length to 12

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -678,6 +678,9 @@ export const apiAuth: ReturnType<typeof instrumentBetterAuth> =
 			],
 			emailAndPassword: {
 				enabled: true,
+				// Enforced on sign-up/reset/change/set-password only, never on
+				// sign-in, so existing accounts with shorter passwords keep working.
+				minPasswordLength: 12,
 				sendResetPassword: async ({
 					user,
 					url,

--- a/apps/code/src/app/reset-password/page.tsx
+++ b/apps/code/src/app/reset-password/page.tsx
@@ -26,7 +26,7 @@ const formSchema = z
 	.object({
 		password: z
 			.string()
-			.min(8, { message: "Password must be at least 8 characters" }),
+			.min(12, { message: "Password must be at least 12 characters" }),
 		confirmPassword: z.string(),
 	})
 	.refine((data) => data.password === data.confirmPassword, {
@@ -189,7 +189,7 @@ function ResetPasswordForm() {
 									Set a new password
 								</h1>
 								<p className="text-sm text-muted-foreground">
-									Choose a strong password — at least 8 characters.
+									Choose a strong password — at least 12 characters.
 								</p>
 							</div>
 

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -33,7 +33,7 @@ const formSchema = z.object({
 	email: z.string().email({ message: "Please enter a valid email address" }),
 	password: z
 		.string()
-		.min(8, { message: "Password must be at least 8 characters" }),
+		.min(12, { message: "Password must be at least 12 characters" }),
 });
 
 function getSafeRedirectUrl(url: string | null): string {

--- a/apps/playground/src/app/signup/page.tsx
+++ b/apps/playground/src/app/signup/page.tsx
@@ -36,7 +36,7 @@ const formSchema = z.object({
 	email: z.string().email({ message: "Please enter a valid email address" }),
 	password: z
 		.string()
-		.min(8, { message: "Password must be at least 8 characters" }),
+		.min(12, { message: "Password must be at least 12 characters" }),
 });
 
 function getSafeRedirectUrl(url: string | null): string {

--- a/apps/ui/src/app/reset-password/page.tsx
+++ b/apps/ui/src/app/reset-password/page.tsx
@@ -24,8 +24,8 @@ import { toast } from "@/lib/components/use-toast";
 
 const formSchema = z
 	.object({
-		password: z.string().min(8, {
-			message: "Password must be at least 8 characters",
+		password: z.string().min(12, {
+			message: "Password must be at least 12 characters",
 		}),
 		confirmPassword: z.string(),
 	})
@@ -121,7 +121,7 @@ function ResetPasswordForm() {
 							Set a new password
 						</h1>
 						<p className="text-sm text-muted-foreground">
-							Choose a strong password — at least 8 characters.
+							Choose a strong password — at least 12 characters.
 						</p>
 					</div>
 

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -45,8 +45,8 @@ const createFormSchema = (isHosted: boolean) =>
 			: z.string().email({
 					message: "Please enter a valid email address",
 				}),
-		password: z.string().min(8, {
-			message: "Password must be at least 8 characters",
+		password: z.string().min(12, {
+			message: "Password must be at least 12 characters",
 		}),
 		newsletter: z.boolean(),
 	});
@@ -251,7 +251,7 @@ export default function Signup() {
 										</div>
 									</FormControl>
 									<p className="text-xs text-muted-foreground">
-										Minimum 8 characters
+										Minimum 12 characters
 									</p>
 									<FormMessage />
 								</FormItem>


### PR DESCRIPTION
## Summary

Remediates the **Weak Password Policy (Low, CVSS 3.7)** finding from the April 2026 pentest (Comp AI): the app only enforced Better Auth's default 8-character minimum, and the tester was able to set an account password to `password`.

- Set `minPasswordLength: 12` on the Better Auth `emailAndPassword` config (`apps/api/src/auth/config.ts`) — server-side enforcement on sign-up, reset-password, change-password, and set-password.
- Align client-side Zod validation and helper text on the sign-up and reset-password forms in `apps/ui`, `apps/code`, and `apps/playground` (8 → 12).

## Existing users are not affected

Better Auth applies `minPasswordLength` only when a password is **created or replaced** — never on sign-in (verified against the sign-in route implementation). Login forms intentionally keep their 8-char minimum so existing accounts with shorter passwords can still log in; those users will only be required to meet the new minimum the next time they change or reset their password.

Existing test fixtures (`Password123!`, 12 chars) already satisfy the new minimum.

## Testing

- `turbo run build --filter=api --filter=ui --filter=code --filter=playground` passes
- `pnpm format` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Strengthened password requirements for new accounts, resets, and password changes: passwords must now contain at least 12 characters.
  - Updated password guidance and validation messages across signup and reset-password forms.
  - Existing shorter passwords remain valid when signing in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->