### PR TITLE
fix: delete Resend contact on account deletion

### DIFF
--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -2,7 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { apiAuth as auth, updateResendContact } from "@/auth/config.js";
+import {
+	apiAuth as auth,
+	deleteResendContact,
+	updateResendContact,
+} from "@/auth/config.js";
 import { computeProfileData, profileSchema } from "@/utils/profile.js";
 
 import { and, db, eq, tables } from "@llmgateway/db";
@@ -498,6 +502,8 @@ user.openapi(deleteUser, async (c) => {
 	}
 
 	await db.delete(tables.user).where(eq(tables.user.id, authUser.id));
+
+	await deleteResendContact(userRecord.email);
 
 	await auth.api.signOut({
 		headers: c.req.raw.headers,


### PR DESCRIPTION
## Problem

When a user deletes their own account via `DELETE /me`, the handler in `apps/api/src/routes/user.ts` removed the user row from the database but never removed the corresponding contact from the Resend audience. The contact is created on email verification (`createResendContact`) and kept in sync on profile updates (`updateResendContact`), but was orphaned on deletion — so a deleted user could keep receiving marketing/transactional email and lingers in the audience.

The admin org-deletion paths (`apps/api/src/routes/admin.ts`) already clean up Resend contacts via `deleteResendContact` for every affected member, so the self-service deletion path was the only gap.

## Change

- Import and call `deleteResendContact(userRecord.email)` in the `DELETE /me` handler, right after the DB delete, mirroring the admin flow.

`deleteResendContact` is already resilient: it no-ops when `RESEND_API_KEY` is unset and swallows/logs API errors, so it never breaks the deletion flow.

## Testing

- `pnpm format` — clean
- `turbo run build --filter=api` — 12/12 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4R1ZL7ZRuyZhXY6DFvoLy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an account now also removes the associated email contact, helping ensure account data is fully removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->