### PR TITLE
fix: format B/T tokens for heavy DevPass users

### DIFF
--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -13,6 +13,7 @@ import {
 	YAxis,
 } from "recharts";
 
+import { formatTokens } from "@/app/dashboard/components/coding-agents-shared";
 import {
 	Select,
 	SelectContent,
@@ -62,16 +63,6 @@ const MODEL_COLORS = [
 
 function isHourlyRange(range: AgentChartTimeRange): boolean {
 	return range === "4h" || range === "24h";
-}
-
-function formatTokens(n: number): string {
-	if (n >= 1_000_000) {
-		return `${(n / 1_000_000).toFixed(1)}M`;
-	}
-	if (n >= 1_000) {
-		return `${(n / 1_000).toFixed(1)}K`;
-	}
-	return n.toLocaleString();
 }
 
 interface AgentModelUsageChartProps {

--- a/apps/code/src/app/dashboard/components/coding-agents-shared.ts
+++ b/apps/code/src/app/dashboard/components/coding-agents-shared.ts
@@ -134,6 +134,12 @@ export interface AgentStats {
 }
 
 export function formatTokens(count: number): string {
+	if (count >= 1_000_000_000_000) {
+		return `${(count / 1_000_000_000_000).toFixed(1)}T`;
+	}
+	if (count >= 1_000_000_000) {
+		return `${(count / 1_000_000_000).toFixed(1)}B`;
+	}
 	if (count >= 1_000_000) {
 		return `${(count / 1_000_000).toFixed(1)}M`;
 	}


### PR DESCRIPTION
## Problem

The shared `formatTokens` helper in the DevPass `code` app capped its largest unit at millions. Heavy users who route a billion or more tokens rendered as `1000.0M` (or worse, `12345.6M`) on the **leaderboard** and **profile** instead of a readable `1.0B`.

## Fix

- Add billion (`B`) and trillion (`T`) tiers to `formatTokens` in `apps/code/src/app/dashboard/components/coding-agents-shared.ts`. This helper backs the leaderboard, profile stats, profile agent breakdown, wrapped card, share text, and OpenGraph image, so all of them now render large totals correctly.
- Consolidate the duplicate local `formatTokens` in `AgentModelUsageChart.tsx` to import the shared helper (DRY), which also fixes the same capping bug on the dashboard chart tooltip and axis.

Examples after the change:

| tokens | before | after |
| --- | --- | --- |
| 1,000,000,000 | `1000.0M` | `1.0B` |
| 2,500,000,000,000 | `2500000.0M` | `2.5T` |

## Testing

- `pnpm format`
- `turbo run build --filter=code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wco2k4BWPv6X2HHxDU9q34

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wco2k4BWPv6X2HHxDU9q34)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage charts now display very large values using concise **B** (billions) and **T** (trillions) units.

* **Bug Fixes**
  * Standardized token formatting across chart tooltips and axis labels for clearer, more consistent usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->