### PR TITLE
fix: refresh page after account deletion

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/account/account-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/account/account-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { useDeleteAccount, useUpdateUser } from "@/hooks/useUser";
@@ -44,6 +45,7 @@ function formatProviderName(providerId: string): string {
 
 export function AccountClient() {
 	const { user } = useUser();
+	const router = useRouter();
 
 	const [name, setName] = useState(user?.name ?? "");
 	const [email, setEmail] = useState(user?.email ?? "");
@@ -97,6 +99,8 @@ export function AccountClient() {
 				title: "Account Deleted",
 				description: "Your account has been successfully deleted.",
 			});
+
+			router.refresh();
 		} catch (error) {
 			toast({
 				title: "Error",


### PR DESCRIPTION
## Summary

When a user successfully deletes their account from the account settings page, the page now refreshes so the UI reflects the now-invalid session (routing the user out of the authenticated dashboard) instead of leaving them on a stale page.

## Changes

- Added `router.refresh()` (via `next/navigation`'s `useRouter`) in the account deletion success handler in `apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/account/account-client.tsx`, called after the success toast.

## Testing

- `pnpm format` / prettier on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XRD4K9etNZKLtyddWs6Gw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refreshed the account settings view after account deletion so the interface immediately reflects the updated state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->