### PR TITLE
feat: notify Discord on account deletion

### DIFF
--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -7,6 +7,7 @@ import {
 	deleteResendContact,
 	updateResendContact,
 } from "@/auth/config.js";
+import { notifyUserAccountDeleted } from "@/utils/discord.js";
 import { computeProfileData, profileSchema } from "@/utils/profile.js";
 
 import { and, db, eq, tables } from "@llmgateway/db";
@@ -502,6 +503,8 @@ user.openapi(deleteUser, async (c) => {
 	}
 
 	await db.delete(tables.user).where(eq(tables.user.id, authUser.id));
+
+	await notifyUserAccountDeleted(userRecord.email, userRecord.name);
 
 	await deleteResendContact(userRecord.email);
 

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -547,3 +547,24 @@ export async function notifyChatPlanRenewed(
 		],
 	});
 }
+
+export async function notifyUserAccountDeleted(
+	email: string,
+	name: string | null | undefined,
+): Promise<void> {
+	const displayName = name ?? "Unknown";
+
+	await sendDiscordNotification({
+		embeds: [
+			{
+				title: "Account Deleted",
+				color: 0xef4444, // Red
+				fields: [
+					{ name: "Email", value: email, inline: true },
+					{ name: "Name", value: displayName, inline: true },
+				],
+				timestamp: new Date().toISOString(),
+			},
+		],
+	});
+}


### PR DESCRIPTION
## Summary

Sends a Discord notification with a red hint (`0xef4444`) whenever a user deletes their account via `DELETE /me`.

## Changes

- Added `notifyUserAccountDeleted(email, name)` to `apps/api/src/utils/discord.ts`, following the existing `notify*` embed pattern. Uses the red color (`0xef4444`) already used for cancellation events, with `Email` and `Name` fields.
- Wired the notification into the account-deletion handler in `apps/api/src/routes/user.ts`, firing after the user row is deleted (using the fetched `userRecord.email` / `userRecord.name`) and before the Resend contact cleanup.

The notification reuses the existing `DISCORD_NOTIFICATION_URL` webhook and silently no-ops if it is unset, consistent with the other notifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJsdav7AJNjUuXn8sGm57g

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsdav7AJNjUuXn8sGm57g)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account deletion now sends an administrative notification after the account is removed.
  * Notifications include the account email, optional name, and deletion timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->