### PR TITLE
fix: format CSV export costs as plain floats

### DIFF
--- a/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
+++ b/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
@@ -88,6 +88,15 @@ function escapeCsvValue(value: unknown): string {
 	return str;
 }
 
+// String(number) switches to exponent notation below 1e-6 (e.g. "3.5e-7"),
+// which spreadsheets don't reliably parse as a float.
+function formatCostForCsv(cost: number | null | undefined): string {
+	if (cost === null || cost === undefined) {
+		return "";
+	}
+	return cost.toFixed(15).replace(/\.?0+$/, "");
+}
+
 function buildLogsCsv(logs: ApiLog[]): string {
 	const rows = logs.map((log) =>
 		[
@@ -99,7 +108,7 @@ function buildLogsCsv(logs: ApiLog[]): string {
 			log.completionTokens,
 			log.totalTokens,
 			log.cachedTokens ?? "",
-			log.cost,
+			formatCostForCsv(log.cost),
 			log.hasError,
 			log.streamed,
 			log.duration,

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -142,6 +142,15 @@ function escapeCsvValue(value: unknown): string {
 	return str;
 }
 
+// String(number) switches to exponent notation below 1e-6 (e.g. "3.5e-7"),
+// which spreadsheets don't reliably parse as a float.
+function formatCostForCsv(cost: number | null | undefined): string {
+	if (cost === null || cost === undefined) {
+		return "";
+	}
+	return cost.toFixed(15).replace(/\.?0+$/, "");
+}
+
 function buildLogsCsv(logs: ApiLog[]): string {
 	const rows = logs.map((log) =>
 		[
@@ -153,7 +162,7 @@ function buildLogsCsv(logs: ApiLog[]): string {
 			log.completionTokens,
 			log.totalTokens,
 			log.cachedTokens ?? "",
-			log.cost,
+			formatCostForCsv(log.cost),
 			log.hasError,
 			log.streamed,
 			log.duration,


### PR DESCRIPTION
## Summary

CSV exports on the agents pages — the DevPass agent detail page (`apps/code`) and the LLM Gateway agents activity view (`apps/ui`) — wrote the `cost` column via `String(number)`. JavaScript switches to scientific notation for numbers below 1e-6 (e.g. `3.5e-7`) and keeps float-noise digits (e.g. `0.00012000000000000002`), so spreadsheets did not parse the cost column as a clean float.

## Fix

Add a `formatCostForCsv` helper to both CSV builders that formats costs with `toFixed(15)` and trims trailing zeros, producing plain decimal notation:

| before | after |
|---|---|
| `3.5e-7` | `0.00000035` |
| `0.00012000000000000002` | `0.00012` |
| `0.30000000000000004` | `0.3` |
| `null` | (empty) |

## Testing

- Verified formatter output for sub-1e-6 costs, float noise, zero, and null values
- `turbo run build --filter=ui --filter=code` passes

https://claude.ai/code/session_01TdLmCta9DyjeXjghDoZ3de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV exports for request and agent logs by formatting cost values in a spreadsheet-friendly format.
  * Prevented very small cost values from appearing in exponent notation.
  * Preserved blank cost fields when no value is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->