### PR TITLE
feat(admin): edit org name in Manage org dialog

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -5719,6 +5719,7 @@ const manageOrganizationRoute = createRoute({
 			content: {
 				"application/json": {
 					schema: z.object({
+						name: z.string().min(1).max(255),
 						plan: z.enum(["free", "pro", "enterprise"]),
 						// Null clears the override and reverts to the plan default.
 						seats: z.number().int().min(0).max(100000).nullable(),
@@ -5735,6 +5736,7 @@ const manageOrganizationRoute = createRoute({
 				"application/json": {
 					schema: z.object({
 						message: z.string(),
+						name: z.string(),
 						plan: z.string(),
 						seats: z.number().int().nullable(),
 						apiKeyLimit: z.number().int().nullable(),
@@ -5759,7 +5761,7 @@ const manageOrganizationRoute = createRoute({
 admin.openapi(manageOrganizationRoute, async (c) => {
 	const user = c.get("user");
 	const { orgId } = c.req.valid("param");
-	const { plan, seats, apiKeyLimit } = c.req.valid("json");
+	const { name, plan, seats, apiKeyLimit } = c.req.valid("json");
 
 	const org = await db.query.organization.findFirst({
 		where: {
@@ -5776,6 +5778,7 @@ admin.openapi(manageOrganizationRoute, async (c) => {
 	await db
 		.update(tables.organization)
 		.set({
+			name,
 			plan,
 			seats,
 			apiKeyLimit,
@@ -5789,6 +5792,8 @@ admin.openapi(manageOrganizationRoute, async (c) => {
 		resourceType: "organization",
 		resourceId: orgId,
 		metadata: {
+			previousName: org.name,
+			newName: name,
 			previousPlan: org.plan,
 			newPlan: plan,
 			previousSeats: org.seats,
@@ -5800,6 +5805,7 @@ admin.openapi(manageOrganizationRoute, async (c) => {
 
 	return c.json({
 		message: "Organization updated successfully",
+		name,
 		plan,
 		seats,
 		apiKeyLimit,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -5719,7 +5719,7 @@ const manageOrganizationRoute = createRoute({
 			content: {
 				"application/json": {
 					schema: z.object({
-						name: z.string().min(1).max(255),
+						name: z.string().trim().min(1).max(255),
 						plan: z.enum(["free", "pro", "enterprise"]),
 						// Null clears the override and reverts to the plan default.
 						seats: z.number().int().min(0).max(100000).nullable(),

--- a/ee/admin/src/app/organizations/[orgId]/manage-org-dialog.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/manage-org-dialog.tsx
@@ -32,6 +32,7 @@ interface ManageOrgDialogProps {
 	seats: number | null;
 	apiKeyLimit: number | null;
 	onSave: (data: {
+		name: string;
 		plan: Plan;
 		seats: number | null;
 		apiKeyLimit: number | null;
@@ -61,6 +62,7 @@ export function ManageOrgDialog({
 	const [open, setOpen] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [nameValue, setNameValue] = useState(orgName);
 	const [planValue, setPlanValue] = useState<Plan>(
 		plan === "pro" || plan === "enterprise" ? plan : "free",
 	);
@@ -72,6 +74,12 @@ export function ManageOrgDialog({
 	);
 
 	const handleSubmit = async () => {
+		const trimmedName = nameValue.trim();
+		if (trimmedName === "") {
+			setError("Organization name is required");
+			return;
+		}
+
 		let seatsToSave: number | null = null;
 		const trimmed = seatsValue.trim();
 		if (trimmed !== "") {
@@ -98,6 +106,7 @@ export function ManageOrgDialog({
 		setError(null);
 
 		const result = await onSave({
+			name: trimmedName,
 			plan: planValue,
 			seats: seatsToSave,
 			apiKeyLimit: apiKeyLimitToSave,
@@ -131,6 +140,17 @@ export function ManageOrgDialog({
 				</DialogHeader>
 
 				<div className="space-y-4 py-4">
+					<div className="space-y-2">
+						<Label htmlFor="manageName">Organization name</Label>
+						<Input
+							id="manageName"
+							value={nameValue}
+							onChange={(e) => setNameValue(e.target.value)}
+							placeholder="Organization name"
+							maxLength={255}
+						/>
+					</div>
+
 					<div className="space-y-2">
 						<Label htmlFor="managePlan">Plan tier</Label>
 						<Select

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -98,6 +98,7 @@ export async function updateReferralBonus(
 export async function manageOrganization(
 	orgId: string,
 	body: {
+		name: string;
 		plan: "free" | "pro" | "enterprise";
 		seats: number | null;
 		apiKeyLimit: number | null;


### PR DESCRIPTION
## Summary

Adds the ability to edit an organization's name from the **Manage org** dialog in the admin dashboard. Previously the dialog only allowed changing the plan tier and overriding the seat / API-key limits; the org name was read-only.

## Changes

- **API** (`apps/api/src/routes/admin.ts`): The `PATCH /admin/organizations/{orgId}/manage` endpoint now accepts a `name` field (`z.string().min(1).max(255)`, matching the validation used elsewhere for org names), persists it to the organization, records `previousName`/`newName` in the audit-log metadata, and returns the updated name in the response.
- **Admin dialog** (`ee/admin/src/app/organizations/[orgId]/manage-org-dialog.tsx`): Adds an "Organization name" input pre-filled with the current name, trims and requires a non-empty value on submit, and passes it through to the save action.
- **Admin action** (`ee/admin/src/lib/admin-organizations.ts`): Extends the `manageOrganization` server-action body type with `name`.

The generated OpenAPI spec / typed API client are gitignored and regenerated at build time.

## Testing

- `pnpm turbo run build --filter=api` (regenerates `openapi.json`; confirmed `name` present in request + response schemas)
- `pnpm --filter admin generate` (confirmed `name` present in generated `v1.d.ts` types)
- `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2vuNyRWiZvR87c58gM3Dw

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2vuNyRWiZvR87c58gM3Dw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can now edit an organization’s name alongside plan, seat, and API key limits.
  * Organization names are validated before saving (trimmed, non-empty, with length constraints).
  * Updated organization names are returned in management responses and included in audit history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->