### PR TITLE
feat(models): add Claude Opus 5

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -1422,4 +1422,67 @@ export const anthropicModels = [
 			},
 		],
 	},
+	{
+		id: "claude-opus-5",
+		name: "Claude Opus 5",
+		description:
+			"Claude Opus 5 is Anthropic's model for complex agentic coding and enterprise work, with state-of-the-art reasoning and agentic capabilities.",
+		family: "anthropic",
+		releasedAt: new Date("2026-07-24"),
+		providers: [
+			{
+				providerId: "anthropic",
+				externalId: "claude-opus-5",
+				inputPrice: "5.0e-6",
+				outputPrice: "25.0e-6",
+				cachedInputPrice: "0.5e-6",
+				cacheWriteInputPrice: "6.25e-6",
+				cacheWriteInputPrice1h: "10.0e-6",
+				minCacheableTokens: 4096,
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 128000,
+				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+				reasoningMode: "adaptive",
+				reasoningOutput: "omit",
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutputSchema: true,
+				supportedParameters: ["max_tokens", "effort"],
+				webSearch: true,
+				webSearchPrice: "0.01",
+			},
+			{
+				providerId: "aws-bedrock",
+				externalId: "anthropic.claude-opus-5",
+				inputPrice: "5.0e-6",
+				outputPrice: "25.0e-6",
+				cachedInputPrice: "0.5e-6",
+				cacheWriteInputPrice: "6.25e-6",
+				cacheWriteInputPrice1h: "10.0e-6",
+				minCacheableTokens: 4096,
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 128000,
+				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+				reasoningMode: "adaptive",
+				reasoningOutput: "omit",
+				streaming: true,
+				vision: true,
+				tools: true,
+				// `temperature` and `top_p` are deprecated for Opus 5 on Bedrock
+				// and rejected with a 400, so they are excluded here to strip them
+				// from forwarded requests. `effort` drives adaptive thinking via the
+				// Bedrock Converse builder (output_config.effort).
+				supportedParameters: ["max_tokens", "effort"],
+				// Opus 5 is provisioned on Bedrock in global/us/eu at launch; the
+				// jp and au regions return 503 (not yet available) and are omitted
+				// until Bedrock rolls the model out there.
+				regions: [{ id: "global" }, { id: "us" }, { id: "eu" }],
+			},
+		],
+	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary

Adds **Claude Opus 5** (`claude-opus-5`, released 2026-07-24) to the model catalogue with `anthropic` and `aws-bedrock` provider mappings.

Specs mirror Opus 4.8 (confirmed against the [Anthropic models overview](https://platform.claude.com/docs/en/about-claude/models/overview) and the live Models API):

- **Pricing:** $5 / input MTok, $25 / output MTok (`5.0e-6` / `25.0e-6`), cache read `0.5e-6`, 5m write `6.25e-6`, 1h write `10.0e-6`
- **Context:** 1M tokens · **Max output:** 128k
- **Reasoning:** adaptive thinking, effort `low`..`max`, reasoning output omitted (matches Opus 4.7/4.8 API surface — no `budget_tokens`, no `temperature`/`top_p`)
- **Capabilities:** vision, tools, streaming, JSON schema output (anthropic), web search (anthropic)

### Bedrock region scoping

Opus 5 is provisioned on Bedrock in **global / us / eu** at launch. The `jp` and `au` regions currently return `503 "Bedrock is unable to process your request"` (model not yet available there), so they are omitted until AWS rolls it out — unlike Opus 4.8 which lists all five.

## Verification

- Live Anthropic Models API returns the model (HTTP 200) and a real completion serves successfully.
- `packages/models` unit tests: **78 passed** (compliance, providers, metadata).
- Scoped e2e (`basic` / `streaming` / `reasoning` / `tool-calls` / `json`):
  - `anthropic/claude-opus-5` — **17 passed**
  - `aws-bedrock/claude-opus-5` (global/us/eu) — **30 passed**
- `pnpm format` clean; `turbo build` (models + gateway) green.

The unrelated `apps/api/.../keys-provider.e2e.ts` failures seen in the full suite (Sakana AI / Reve / ElevenLabs) are pre-existing BYOK key-validation failures against those providers' live APIs with local test keys — not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Opus 5 AI model.
  * Enabled streaming, vision, tool use, JSON schema, adaptive reasoning, and web search capabilities.
  * Added availability through Anthropic and AWS Bedrock, including regional availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->