### PR TITLE
fix: lounge UX fixes + STT pricing display

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -72,6 +72,7 @@ const modelProviderMappingSchema = z.object({
 	inputCharacterPrice: z.string().nullable(),
 	outputAudioPrice: z.string().nullable(),
 	requestPrice: z.string().nullable(),
+	inputAudioHourPrice: z.string().nullable(),
 	contextSize: z.number().nullable(),
 	maxOutput: z.number().nullable(),
 	streaming: z.boolean(),
@@ -259,6 +260,10 @@ internalModels.openapi(getModelsRoute, async (c) => {
 				outputAudioPrice:
 					sharedMapping?.outputAudioPrice !== undefined
 						? String(sharedMapping.outputAudioPrice)
+						: null,
+				inputAudioHourPrice:
+					sharedMapping?.inputAudioHourPrice !== undefined
+						? String(sharedMapping.inputAudioHourPrice)
 						: null,
 				supportedVideoSizes: sharedMapping?.supportedVideoSizes ?? null,
 				supportedVideoDurationsSeconds:

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -5,6 +5,7 @@ import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import ChatPageClient from "@/components/playground/chat-page-client";
 import OrgPageClient from "@/components/playground/org-page-client";
 import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
+import { CHAT_CONTEXT_COOKIE } from "@/lib/constants";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import {
 	CHAT_MODEL_COOKIE,
@@ -87,7 +88,9 @@ export async function renderPlaygroundShell({
 	// org land on that org instead; the Chat plan context stays the default only
 	// when no org has credits, so the plan upsell can take over. Runs before the
 	// chat-org fetch so redirected users never get a Chat org provisioned.
-	if (!orgId && !orgShareView) {
+	// Skipped when the user explicitly picked the Chat plan context in the org
+	// switcher (cookie) — this fallback must not override an explicit choice.
+	if (!orgId && !orgShareView && !cookieStore.get(CHAT_CONTEXT_COOKIE)) {
 		const chatPlanStatusData = await fetchServerData(
 			"GET",
 			"/chat-plans/status",

--- a/apps/playground/src/components/playground/organization-switcher.tsx
+++ b/apps/playground/src/components/playground/organization-switcher.tsx
@@ -13,6 +13,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useSidebar } from "@/components/ui/sidebar";
+import { CHAT_CONTEXT_COOKIE } from "@/lib/constants";
 
 import type { Organization } from "@/lib/types";
 
@@ -35,6 +36,13 @@ export function OrganizationSwitcher({
 	}, []);
 
 	const handleSelectOrganization = (org: Organization | null) => {
+		// Remember an explicit "Chat plan" choice so the playground shell's
+		// funded-org fallback doesn't bounce the user back to a dashboard org.
+		if (org) {
+			document.cookie = `${CHAT_CONTEXT_COOKIE}=; path=/; max-age=0; samesite=lax`;
+		} else {
+			document.cookie = `${CHAT_CONTEXT_COOKIE}=1; path=/; max-age=31536000; samesite=lax`;
+		}
 		if (isMobile) {
 			setOpenMobile(false);
 		}

--- a/apps/playground/src/components/ui/dialog.tsx
+++ b/apps/playground/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 					className,
 				)}
 				{...props}

--- a/apps/playground/src/lib/audio-gen.ts
+++ b/apps/playground/src/lib/audio-gen.ts
@@ -88,6 +88,17 @@ const GEMINI_TTS_VOICES = [
 	"Sulafat",
 ];
 
+// Qwen-Audio-TTS voice rosters are per-model and non-mixable: each tier only
+// accepts its own voices.
+const QWEN_AUDIO_TTS_PLUS_VOICES = ["longanlingxin", "longanlufeng"];
+
+const QWEN_AUDIO_TTS_FLASH_VOICES = [
+	"longanhuan_v3.6",
+	"longjielidou_v3.6",
+	"loongeva_v3.6",
+	"loongjohn",
+];
+
 const ELEVENLABS_VOICES = [
 	"Sarah",
 	"Aria",
@@ -150,6 +161,21 @@ export function getModelAudioConfig(model: string): AudioModelConfig {
 			supportsSpeed: false,
 			availableSpeeds: [],
 			supportsInstructions: true,
+		};
+	}
+
+	if (lower.includes("qwen")) {
+		const isPlus = lower.includes("tts-plus");
+		return {
+			voices: isPlus ? QWEN_AUDIO_TTS_PLUS_VOICES : QWEN_AUDIO_TTS_FLASH_VOICES,
+			defaultVoice: isPlus ? "longanlingxin" : "longanhuan_v3.6",
+			// DashScope's non-streaming TTS endpoint only returns WAV, and
+			// `speed`/`instructions` have no upstream equivalent on Qwen-Audio-TTS.
+			availableFormats: ["wav"],
+			defaultFormat: "wav",
+			supportsSpeed: false,
+			availableSpeeds: [],
+			supportsInstructions: false,
 		};
 	}
 

--- a/apps/playground/src/lib/constants.ts
+++ b/apps/playground/src/lib/constants.ts
@@ -3,3 +3,8 @@ export const PLAYGROUND_KEY_COOKIE_NAMES = [
 	PLAYGROUND_KEY_COOKIE_NAME,
 	`__Host-${PLAYGROUND_KEY_COOKIE_NAME}`,
 ] as const;
+
+// Set when the user explicitly picks the "Chat plan" context in the org
+// switcher; cleared when they pick a dashboard org. The playground shell's
+// funded-org fallback must not override an explicit choice.
+export const CHAT_CONTEXT_COOKIE = "llmgateway_chat_context";

--- a/apps/ui/src/components/models/adapt-model.ts
+++ b/apps/ui/src/components/models/adapt-model.ts
@@ -65,6 +65,7 @@ export function adaptProviderMapping(
 			imageOutputTokensByResolution: p.imageOutputTokensByResolution ?? null,
 			requestPrice: toStr(p.requestPrice),
 			ocrPagePrice: toStr(p.ocrPagePrice),
+			inputAudioHourPrice: toStr(p.inputAudioHourPrice),
 			contextSize: p.contextSize ?? null,
 			maxOutput: p.maxOutput ?? null,
 			quantization: p.quantization ?? null,

--- a/packages/shared/src/components/models-directory/api-types.ts
+++ b/packages/shared/src/components/models-directory/api-types.ts
@@ -40,6 +40,7 @@ export interface ApiModelProviderMapping {
 	outputAudioPrice: string | null;
 	requestPrice: string | null;
 	ocrPagePrice?: string | null;
+	inputAudioHourPrice?: string | null;
 	contextSize: number | null;
 	maxOutput: number | null;
 	quantization?: string | null;

--- a/packages/shared/src/components/models-directory/model-card.tsx
+++ b/packages/shared/src/components/models-directory/model-card.tsx
@@ -941,6 +941,47 @@ export function ProviderSection({
 							})()}
 						</div>
 					</div>
+				) : activeMapping.inputAudioHourPrice &&
+				  parseFloat(activeMapping.inputAudioHourPrice) > 0 &&
+				  !(parseFloat(activeMapping.inputPrice ?? "0") > 0) &&
+				  !(parseFloat(activeMapping.outputPrice ?? "0") > 0) ? (
+					(() => {
+						const discountNum = activeMapping.discount
+							? parseFloat(activeMapping.discount)
+							: 0;
+						const perHour =
+							parseFloat(activeMapping.inputAudioHourPrice!) *
+							serviceTierMultiplier;
+						const formatHour = (value: number) =>
+							`$${parseFloat(value.toFixed(4))}`;
+						return (
+							<div className="rounded-md bg-muted/40 border border-border/30 p-2.5">
+								<div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">
+									Audio Transcription Pricing
+								</div>
+								<div className="flex justify-between text-sm">
+									<span className="text-muted-foreground">Input audio</span>
+									<span className="font-semibold tabular-nums">
+										{discountNum > 0 ? (
+											<>
+												<span className="line-through text-muted-foreground mr-1 text-xs">
+													{formatHour(perHour)}
+												</span>
+												<span className="text-green-600">
+													{formatHour(perHour * (1 - discountNum))}
+												</span>
+											</>
+										) : (
+											formatHour(perHour)
+										)}
+										<span className="text-muted-foreground text-xs ml-0.5">
+											/hour
+										</span>
+									</span>
+								</div>
+							</div>
+						);
+					})()
 				) : (
 					<div className="space-y-2">
 						<div className="grid grid-cols-3 gap-px rounded-md bg-border/30 border border-border/30 overflow-hidden">


### PR DESCRIPTION
## Summary

Four fixes across the Lounge (playground) and model pages:

- **Mobile dialog overflow** — the playground's base `DialogContent` had no max-height/scroll, so tall dialogs (e.g. Top Up Credits) ran past the viewport on phones. It now clamps to `100dvh - 2rem` with internal scrolling, matching the dashboard's dialog component.
- **"Chat plan" switcher bounced to the default org** — selecting Chat plan navigated to `/` without an `orgId`, where the shell's funded-org fallback immediately redirected unsubscribed users back to their funded dashboard org, making the Chat plan context unreachable. The switcher now records the explicit choice in a cookie (`llmgateway_chat_context`) and the shell skips the fallback while it's set; picking an organization clears it, so the funded-org default still applies to users who never chose.
- **Qwen TTS rejected audio-studio requests** — Qwen-Audio-TTS models fell through to the OpenAI defaults (voice `alloy`, format `mp3`), which the gateway rejects. The studio now uses the per-model voice rosters (plus: `longanlingxin`/`longanlufeng`; flash: `longanhuan_v3.6` etc.) and wav-only output, mirroring `supportedVoices` in `packages/models`.
- **STT models showed $0/$0 token pricing** — duration-billed transcription models (`grok-stt-1-0`) now render an “Audio Transcription Pricing — $0.1 /hour” box instead of the empty per-token grid. `inputAudioHourPrice` is exposed through `/internal/models` and the static model adapter.

## Verification

- Playwright against the local stack: Top Up dialog fits and scrolls at 390×844 and 375×667; Chat plan selection sticks (cookie set, no redirect, persists across bare `/` loads) and reverts correctly after selecting an org; audio studio shows the correct Qwen voice roster per tier; `/models/grok-stt-1-0` shows the per-hour price.
- `pnpm build` (17/17) and `pnpm test:unit` (3032 passed) are green.

Note: `grok-stt-1-0` doesn't appear in the audio studio because the studio only lists TTS models (`output` includes `audio`); transcription models (`output: ["transcription"]`) have no playground surface yet — that would be a separate feature.

https://claude.ai/code/session_01UM6nAABCAu1MGeEUP3vsMx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio transcription pricing details to model cards, including hourly rates and discounts.
  * Added support for Qwen Audio-TTS models with tier-specific voices and WAV output.
  * Preserved explicit “Chat plan” selections when switching organizations or loading the playground.
* **Bug Fixes**
  * Improved dialog layouts on smaller screens with constrained sizing and internal scrolling.
  * Added audio pricing data to model information displayed across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->