### PR TITLE
perf(gateway): cut upstream TTFT overhead

### DIFF
--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -3,7 +3,12 @@ import { expect, test, beforeEach, describe, afterEach } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
+import {
+	redisClient,
+	SWR_PREFIX,
+	swrWrap,
+	waitForSwrMirrorWrites,
+} from "@llmgateway/cache";
 import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
 
 const ONE_MINUTE_MS = 60 * 1000;
@@ -363,6 +368,7 @@ describe("keys route", () => {
 		await swrWrap(swrCacheKey, [apiKeyTableName], async () => ({
 			token: "test-token",
 		}));
+		await waitForSwrMirrorWrites();
 		expect(await redisClient.get(SWR_PREFIX + swrCacheKey)).not.toBeNull();
 
 		const res = await app.request("/keys/api/test-api-key-id/roll", {
@@ -394,8 +400,8 @@ describe("keys route", () => {
 			description: "IAM Cache Test Key",
 			createdBy: "test-user-id",
 		});
-		const readActiveIamRules = () =>
-			swrWrap(
+		const readActiveIamRules = async () => {
+			const rules = await swrWrap(
 				`iamRules:${apiKeyId}`,
 				[getTableName(tables.apiKeyIamRule)],
 				async () =>
@@ -409,6 +415,9 @@ describe("keys route", () => {
 							),
 						),
 			);
+			await waitForSwrMirrorWrites();
+			return rules;
+		};
 
 		// Prime both cache layers with the "no rules" result.
 		expect(await readActiveIamRules()).toHaveLength(0);

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -3,7 +3,12 @@ import { expect, test, beforeEach, describe, afterEach } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
+import {
+	redisClient,
+	SWR_PREFIX,
+	swrWrap,
+	waitForSwrMirrorWrites,
+} from "@llmgateway/cache";
 import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
 
 describe("provider keys route", () => {
@@ -326,8 +331,8 @@ describe("provider keys route", () => {
 		return orgId;
 	}
 
-	function readActiveProviderKeys(orgId: string, provider: string) {
-		return swrWrap(
+	async function readActiveProviderKeys(orgId: string, provider: string) {
+		const keys = await swrWrap(
 			`providerKey:${orgId}:${provider}`,
 			[getTableName(tables.providerKey)],
 			async () =>
@@ -342,6 +347,8 @@ describe("provider keys route", () => {
 						),
 					),
 		);
+		await waitForSwrMirrorWrites();
+		return keys;
 	}
 
 	test("POST /keys/provider makes the new key visible to cached lookups", async () => {

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { redisClient, SWR_PREFIX, swrWrap } from "@llmgateway/cache";
+import {
+	redisClient,
+	SWR_PREFIX,
+	swrWrap,
+	waitForSwrMirrorWrites,
+} from "@llmgateway/cache";
 import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 
@@ -18,6 +23,7 @@ import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 // Seed an SWR mirror entry the way the gateway would and confirm it landed.
 async function primeSwrEntry<T>(key: string, table: string, value: T) {
 	await swrWrap(key, [table], async () => value);
+	await waitForSwrMirrorWrites();
 	expect(await redisClient.get(SWR_PREFIX + key)).not.toBeNull();
 }
 
@@ -25,8 +31,8 @@ async function assertSwrCleared(key: string) {
 	expect(await redisClient.get(SWR_PREFIX + key)).toBeNull();
 }
 
-function readActiveIamRules(apiKeyId: string) {
-	return swrWrap(
+async function readActiveIamRules(apiKeyId: string) {
+	const rules = await swrWrap(
 		`iamRules:${apiKeyId}`,
 		[getTableName(tables.apiKeyIamRule)],
 		async () =>
@@ -40,6 +46,8 @@ function readActiveIamRules(apiKeyId: string) {
 					),
 				),
 	);
+	await waitForSwrMirrorWrites();
+	return rules;
 }
 
 describe("v1/master cache invalidation", () => {

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -45,6 +45,7 @@
 		"ioredis": "5.7.0",
 		"ipaddr.js": "2.2.0",
 		"redis": "5.9.0",
+		"undici": "8.9.0",
 		"worker": "workspace:*",
 		"zod": "3.25.75",
 		"zod-openapi": "^5.4.3"

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1165,9 +1165,6 @@ export async function inspectImmediateStreamingProviderError(
 	};
 }
 
-// Reusable TextDecoder to avoid per-chunk allocation in the streaming hot path
-const sharedTextDecoder = new TextDecoder();
-
 export const chat = new OpenAPIHono<ServerTypes>();
 
 const completions = createRoute({
@@ -1817,7 +1814,12 @@ chat.openapi(completions, async (c) => {
 	// balance) so the existing credit-gating logic bills the wallet, while the
 	// log's endCustomerWalletId redirects the worker's debit to that wallet.
 	// (Shared with embeddings/moderations via apps/gateway/src/lib/end-user-session.ts.)
-	const endUserWallet = (await loadEndUserWallet(apiKey)) ?? undefined;
+	// Both lookups depend only on the api key, so they run concurrently.
+	const [endUserWalletOrNull, initialProject] = await Promise.all([
+		loadEndUserWallet(apiKey),
+		findProjectById(apiKey.projectId),
+	]);
+	const endUserWallet = endUserWalletOrNull ?? undefined;
 
 	// Test-mode end-user wallets are funded by Stripe-sandbox top-ups, so they may
 	// only spend on free models — force free-models-only auto routing for them, and
@@ -1826,7 +1828,7 @@ chat.openapi(completions, async (c) => {
 		free_models_only || endUserWallet?.mode === "test";
 
 	// Get the project to determine mode for routing decisions
-	let project = await findProjectById(apiKey.projectId);
+	let project = initialProject;
 
 	if (!project) {
 		throw new HTTPException(500, {
@@ -8355,6 +8357,10 @@ chat.openapi(completions, async (c) => {
 				let handledTerminalProviderEvent = false;
 				let buffer = ""; // Buffer for accumulating partial data across chunks (string for SSE)
 				let binaryBuffer = new Uint8Array(0); // Buffer for binary event streams (AWS Bedrock)
+				// Per-request decoder: decoding with { stream: true } keeps partial
+				// multibyte state between calls, so it must never be shared across
+				// concurrent streams
+				const streamTextDecoder = new TextDecoder();
 				let rawUpstreamData = ""; // Raw data received from upstream provider
 				// Raw upstream chunk that carried a finish_reason signalling an upstream
 				// failure (e.g. "error"), preserved so the log shows the actual provider
@@ -8439,7 +8445,7 @@ chat.openapi(completions, async (c) => {
 							}
 						} else {
 							// Convert the Uint8Array to a string for SSE
-							chunk = sharedTextDecoder.decode(value, { stream: true });
+							chunk = streamTextDecoder.decode(value, { stream: true });
 						}
 
 						// Log error on large chunks (1MB+) - should almost never happen

--- a/apps/gateway/src/lib/cached-queries-swr.spec.ts
+++ b/apps/gateway/src/lib/cached-queries-swr.spec.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { redisClient, SWR_PREFIX } from "@llmgateway/cache";
+import {
+	redisClient,
+	SWR_PREFIX,
+	waitForSwrMirrorWrites,
+} from "@llmgateway/cache";
 import {
 	cdb,
 	db,
@@ -61,6 +65,7 @@ async function flushSwrOnly(): Promise<void> {
 describe("cached-queries SWR integration", () => {
 	beforeEach(async () => {
 		vi.restoreAllMocks();
+		await waitForSwrMirrorWrites();
 
 		// Clean relevant tables
 		await db.delete(apiKeyIamRule);
@@ -160,6 +165,7 @@ describe("cached-queries SWR integration", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		await waitForSwrMirrorWrites();
 		await db.delete(apiKeyIamRule);
 		await db.delete(apiKey);
 		await db.delete(providerKey);
@@ -175,6 +181,7 @@ describe("cached-queries SWR integration", () => {
 		it("findApiKeyByToken primes mirror at hashed-token key", async () => {
 			const result = await findApiKeyByToken(testApiKeyToken);
 			expect(result?.id).toBe(testApiKeyId);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}apiKey:token:${getApiKeyFingerprint(testApiKeyToken)}`,
@@ -189,6 +196,7 @@ describe("cached-queries SWR integration", () => {
 		it("findProjectById primes mirror at project:{id}", async () => {
 			const result = await findProjectById(testProjectId);
 			expect(result?.id).toBe(testProjectId);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}project:${testProjectId}`,
@@ -199,6 +207,7 @@ describe("cached-queries SWR integration", () => {
 		it("findOrganizationById primes mirror at org:{id}", async () => {
 			const result = await findOrganizationById(testOrgId);
 			expect(result?.id).toBe(testOrgId);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(`${SWR_PREFIX}org:${testOrgId}`);
 			expect(mirror).not.toBeNull();
@@ -207,6 +216,7 @@ describe("cached-queries SWR integration", () => {
 		it("findActiveIamRules primes mirror at iamRules:{apiKeyId}", async () => {
 			const result = await findActiveIamRules(testApiKeyId);
 			expect(result).toHaveLength(1);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}iamRules:${testApiKeyId}`,
@@ -217,6 +227,7 @@ describe("cached-queries SWR integration", () => {
 		it("findProviderKey primes mirror at providerKey:{org}:{provider}", async () => {
 			const result = await findProviderKey(testOrgId, "openai");
 			expect(result).toBeDefined();
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}providerKey:${testOrgId}:openai`,
@@ -227,6 +238,7 @@ describe("cached-queries SWR integration", () => {
 		it("findActiveProviderKeys primes mirror at providerKey:active:{org}", async () => {
 			const result = await findActiveProviderKeys(testOrgId);
 			expect(result.length).toBeGreaterThan(0);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}providerKey:active:${testOrgId}`,
@@ -240,6 +252,7 @@ describe("cached-queries SWR integration", () => {
 				"anthropic",
 			]);
 			expect(result).toHaveLength(2);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}providerKey:byProviders:${testOrgId}:anthropic,openai`,
@@ -250,6 +263,7 @@ describe("cached-queries SWR integration", () => {
 		it("findUserFromOrganization primes mirror at userFromOrg:{org}", async () => {
 			const result = await findUserFromOrganization(testOrgId);
 			expect(result?.user.id).toBe(testUserId);
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}userFromOrg:${testOrgId}`,
@@ -261,6 +275,7 @@ describe("cached-queries SWR integration", () => {
 			const result = await findEffectiveDiscount(testOrgId, "openai", "gpt-4");
 			expect(result.discount).toBe("0.25");
 			expect(result.source).toBe("org_provider_model");
+			await waitForSwrMirrorWrites();
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}discount:${testOrgId}:openai:gpt-4`,
@@ -272,6 +287,7 @@ describe("cached-queries SWR integration", () => {
 			// First call populates the Drizzle cache.
 			const first = await findEffectiveDiscount(testOrgId, "openai", "gpt-4");
 			expect(first.discount).toBe("0.25");
+			await waitForSwrMirrorWrites();
 
 			// Drop the SWR mirror so the next call can't fall back to it — it must
 			// resolve through the Drizzle cache and apply the JS expiry filter to the
@@ -287,6 +303,7 @@ describe("cached-queries SWR integration", () => {
 	describe("fallback when DB fails", () => {
 		it("returns SWR mirror when Drizzle cache is flushed and DB errors", async () => {
 			await findApiKeyByToken(testApiKeyToken);
+			await waitForSwrMirrorWrites();
 
 			// Expire Drizzle cache keys only, keeping SWR mirror.
 			await flushDrizzleCache();
@@ -303,6 +320,7 @@ describe("cached-queries SWR integration", () => {
 
 		it("throws when SWR mirror is gone and DB errors", async () => {
 			await findApiKeyByToken(testApiKeyToken);
+			await waitForSwrMirrorWrites();
 			await flushDrizzleCache();
 			await flushSwrOnly();
 
@@ -320,6 +338,7 @@ describe("cached-queries SWR integration", () => {
 		it("zero-credit org still resolves via SWR when DB is down", async () => {
 			const primed = await findOrganizationById(testZeroOrgId);
 			expect(primed?.id).toBe(testZeroOrgId);
+			await waitForSwrMirrorWrites();
 
 			await flushDrizzleCache();
 
@@ -341,6 +360,7 @@ describe("cached-queries SWR integration", () => {
 
 		it("returns effective discount SWR mirror when DB errors", async () => {
 			await findEffectiveDiscount(testOrgId, "openai", "gpt-4");
+			await waitForSwrMirrorWrites();
 			await flushDrizzleCache();
 
 			const selectSpy = vi.spyOn(cdb, "select").mockImplementation(() => {
@@ -358,6 +378,7 @@ describe("cached-queries SWR integration", () => {
 	describe("mutation invalidates SWR mirror", () => {
 		it("updating a row via cdb clears SWR mirrors for that table", async () => {
 			await findProjectById(testProjectId);
+			await waitForSwrMirrorWrites();
 			expect(
 				await redisClient.get(`${SWR_PREFIX}project:${testProjectId}`),
 			).not.toBeNull();

--- a/apps/gateway/src/lib/upstream-dispatcher.spec.ts
+++ b/apps/gateway/src/lib/upstream-dispatcher.spec.ts
@@ -1,0 +1,90 @@
+import { createServer } from "node:http";
+
+import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+	closeUpstreamDispatcher,
+	installUpstreamDispatcher,
+} from "./upstream-dispatcher.js";
+
+import type { Server } from "node:http";
+import type { Dispatcher } from "undici";
+
+describe("upstream dispatcher", () => {
+	let originalDispatcher: Dispatcher;
+	let server: Server;
+	let baseUrl: string;
+	const clientPorts: number[] = [];
+
+	beforeAll(async () => {
+		originalDispatcher = getGlobalDispatcher();
+		server = createServer((req, res) => {
+			clientPorts.push(req.socket.remotePort!);
+			if (req.url === "/sse") {
+				res.writeHead(200, { "content-type": "text/event-stream" });
+				res.write("data: first\n\n");
+				// keep the stream open; a later write + end completes it
+				setTimeout(() => {
+					res.write("data: second\n\n");
+					res.end();
+				}, 200);
+			} else {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.end("{}");
+			}
+		});
+		await new Promise<void>((resolve) => {
+			server.listen(0, "127.0.0.1", resolve);
+		});
+		const address = server.address();
+		if (typeof address === "string" || !address) {
+			throw new Error("expected a TCP address");
+		}
+		baseUrl = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterEach(async () => {
+		await closeUpstreamDispatcher();
+		setGlobalDispatcher(originalDispatcher);
+		delete process.env.UPSTREAM_KEEPALIVE_TIMEOUT_MS;
+		clientPorts.length = 0;
+	});
+
+	afterAll(async () => {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	});
+
+	it("reuses one keep-alive socket across sequential fetches", async () => {
+		installUpstreamDispatcher();
+		for (let i = 0; i < 3; i++) {
+			const res = await fetch(`${baseUrl}/json`);
+			await res.text();
+			// give the pool a tick to release the socket back
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		expect(clientPorts).toHaveLength(3);
+		expect(new Set(clientPorts).size).toBe(1);
+	});
+
+	it("streams response bodies incrementally through the dispatcher", async () => {
+		installUpstreamDispatcher();
+		const res = await fetch(`${baseUrl}/sse`);
+		const reader = res.body!.getReader();
+		const start = Date.now();
+		const first = await reader.read();
+		const firstChunkMs = Date.now() - start;
+		expect(new TextDecoder().decode(first.value)).toContain("data: first");
+		// the first chunk must arrive well before the 200ms second write —
+		// i.e. the dispatcher must not buffer the stream until completion
+		expect(firstChunkMs).toBeLessThan(150);
+		await reader.cancel();
+	});
+
+	it("falls back to defaults on invalid env values", () => {
+		process.env.UPSTREAM_KEEPALIVE_TIMEOUT_MS = "not-a-number";
+		expect(() => installUpstreamDispatcher()).not.toThrow();
+	});
+});

--- a/apps/gateway/src/lib/upstream-dispatcher.ts
+++ b/apps/gateway/src/lib/upstream-dispatcher.ts
@@ -1,0 +1,102 @@
+import { Agent, interceptors, setGlobalDispatcher } from "undici";
+
+import { logger } from "@llmgateway/logger";
+
+import type { Dispatcher } from "undici";
+
+function envInt(name: string, fallback: number): number {
+	const value = Number(process.env[name]);
+	return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+let agent: Agent | null = null;
+let prewarmTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Installs a tuned undici Agent as the global dispatcher used by `fetch` for
+ * all upstream provider requests.
+ *
+ * Node's default dispatcher closes idle keep-alive sockets after 4 seconds
+ * and resolves DNS on every new connection. Streaming responses hold their
+ * socket for the whole generation, so under concurrent traffic most requests
+ * find no free socket and pay a fresh DNS + TCP + TLS setup to the provider
+ * before the first token can arrive — and in Kubernetes an uncached lookup
+ * goes through search-domain expansion (ndots:5), where a single dropped UDP
+ * packet stalls the request for multiple seconds. A long idle keep-alive plus
+ * an in-process DNS cache removes both from the time-to-first-token path.
+ */
+export function installUpstreamDispatcher(): Dispatcher {
+	const keepAliveTimeoutMs = envInt("UPSTREAM_KEEPALIVE_TIMEOUT_MS", 60_000);
+	const connectTimeoutMs = envInt("UPSTREAM_CONNECT_TIMEOUT_MS", 10_000);
+	const dnsCacheTtlMs = envInt("UPSTREAM_DNS_CACHE_TTL_MS", 30_000);
+
+	agent = new Agent({
+		keepAliveTimeout: keepAliveTimeoutMs,
+		connect: { timeout: connectTimeoutMs },
+	});
+
+	const dispatcher =
+		dnsCacheTtlMs > 0
+			? agent.compose(
+					interceptors.dns({ maxTTL: dnsCacheTtlMs, maxItems: 512 }),
+				)
+			: agent;
+
+	setGlobalDispatcher(dispatcher);
+	logger.info("Upstream dispatcher installed", {
+		keepAliveTimeoutMs,
+		connectTimeoutMs,
+		dnsCacheTtlMs,
+	});
+	return dispatcher;
+}
+
+/**
+ * Optionally keeps connections to configured provider origins warm so that
+ * even after idle periods the next real request finds an established socket,
+ * a cached DNS answer, and a resumable TLS session instead of paying full
+ * connection setup. Enabled by setting UPSTREAM_PREWARM_ORIGINS to a
+ * comma-separated list of origins (e.g. "https://api.anthropic.com").
+ */
+export function startUpstreamPrewarm(): void {
+	const origins = (process.env.UPSTREAM_PREWARM_ORIGINS ?? "")
+		.split(",")
+		.map((origin) => origin.trim())
+		.filter(Boolean);
+	if (origins.length === 0) {
+		return;
+	}
+
+	const intervalMs = envInt("UPSTREAM_PREWARM_INTERVAL_S", 30) * 1000;
+	if (intervalMs === 0) {
+		return;
+	}
+
+	const prewarm = () => {
+		for (const origin of origins) {
+			fetch(origin, {
+				method: "HEAD",
+				signal: AbortSignal.timeout(5_000),
+			}).then(
+				(res) => res.body?.cancel(),
+				() => {},
+			);
+		}
+	};
+
+	prewarm();
+	prewarmTimer = setInterval(prewarm, intervalMs);
+	prewarmTimer.unref();
+	logger.info("Upstream prewarm started", { origins, intervalMs });
+}
+
+export async function closeUpstreamDispatcher(): Promise<void> {
+	if (prewarmTimer) {
+		clearInterval(prewarmTimer);
+		prewarmTimer = null;
+	}
+	if (agent) {
+		await agent.close();
+		agent = null;
+	}
+}

--- a/apps/gateway/src/lib/upstream-dispatcher.ts
+++ b/apps/gateway/src/lib/upstream-dispatcher.ts
@@ -10,7 +10,6 @@ function envInt(name: string, fallback: number): number {
 }
 
 let agent: Agent | null = null;
-let prewarmTimer: NodeJS.Timeout | null = null;
 
 /**
  * Installs a tuned undici Agent as the global dispatcher used by `fetch` for
@@ -51,50 +50,7 @@ export function installUpstreamDispatcher(): Dispatcher {
 	return dispatcher;
 }
 
-/**
- * Optionally keeps connections to configured provider origins warm so that
- * even after idle periods the next real request finds an established socket,
- * a cached DNS answer, and a resumable TLS session instead of paying full
- * connection setup. Enabled by setting UPSTREAM_PREWARM_ORIGINS to a
- * comma-separated list of origins (e.g. "https://api.anthropic.com").
- */
-export function startUpstreamPrewarm(): void {
-	const origins = (process.env.UPSTREAM_PREWARM_ORIGINS ?? "")
-		.split(",")
-		.map((origin) => origin.trim())
-		.filter(Boolean);
-	if (origins.length === 0) {
-		return;
-	}
-
-	const intervalMs = envInt("UPSTREAM_PREWARM_INTERVAL_S", 30) * 1000;
-	if (intervalMs === 0) {
-		return;
-	}
-
-	const prewarm = () => {
-		for (const origin of origins) {
-			fetch(origin, {
-				method: "HEAD",
-				signal: AbortSignal.timeout(5_000),
-			}).then(
-				(res) => res.body?.cancel(),
-				() => {},
-			);
-		}
-	};
-
-	prewarm();
-	prewarmTimer = setInterval(prewarm, intervalMs);
-	prewarmTimer.unref();
-	logger.info("Upstream prewarm started", { origins, intervalMs });
-}
-
 export async function closeUpstreamDispatcher(): Promise<void> {
-	if (prewarmTimer) {
-		clearInterval(prewarmTimer);
-		prewarmTimer = null;
-	}
 	if (agent) {
 		await agent.close();
 		agent = null;

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -9,6 +9,11 @@ import {
 import { logger, toError } from "@llmgateway/logger";
 
 import { app } from "./app.js";
+import {
+	closeUpstreamDispatcher,
+	installUpstreamDispatcher,
+	startUpstreamPrewarm,
+} from "./lib/upstream-dispatcher.js";
 import { metricsApp } from "./metrics-app.js";
 
 import type { ServerType } from "@hono/node-server";
@@ -33,6 +38,9 @@ let metricsServer: ServerType | null = null;
 async function startServer() {
 	// Tag every DB query with the originating service for Cloud SQL Query Insights
 	setQueryTags({ application: "gateway" });
+
+	installUpstreamDispatcher();
+	startUpstreamPrewarm();
 
 	// Initialize tracing for gateway service
 	try {
@@ -124,6 +132,9 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 			await closeServer(metricsServer);
 			logger.info("Metrics server closed");
 		}
+
+		logger.info("Closing upstream dispatcher");
+		await closeUpstreamDispatcher();
 
 		logger.info("Closing database connection");
 		await closeDatabase();

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -12,7 +12,6 @@ import { app } from "./app.js";
 import {
 	closeUpstreamDispatcher,
 	installUpstreamDispatcher,
-	startUpstreamPrewarm,
 } from "./lib/upstream-dispatcher.js";
 import { metricsApp } from "./metrics-app.js";
 
@@ -40,7 +39,6 @@ async function startServer() {
 	setQueryTags({ application: "gateway" });
 
 	installUpstreamDispatcher();
-	startUpstreamPrewarm();
 
 	// Initialize tracing for gateway service
 	try {

--- a/packages/cache/src/redis.ts
+++ b/packages/cache/src/redis.ts
@@ -6,6 +6,12 @@ export const redisClient = new Redis({
 	host: process.env.REDIS_HOST ?? "localhost",
 	port: Number(process.env.REDIS_PORT) || 6379,
 	password: process.env.REDIS_PASSWORD,
+	// Batch commands issued in the same event-loop tick into one round trip.
+	// The gateway hot path issues dozens of independent commands per request
+	// (rate-limit peeks, discount lookups, cached queries) on this single
+	// connection; without pipelining they serialize RTT-by-RTT. No consumer
+	// of this client uses blocking commands or subscriptions.
+	enableAutoPipelining: true,
 });
 
 redisClient.on("error", (err) => logger.error("Redis Client Error", err));

--- a/packages/cache/src/swr.spec.ts
+++ b/packages/cache/src/swr.spec.ts
@@ -8,7 +8,20 @@ import {
 	getSwrStaleTtlSeconds,
 	invalidateSwrByTables,
 	swrWrap,
+	waitForSwrMirrorWrites,
 } from "./swr.js";
+
+// Mirror bookkeeping is detached from the request path; tests must flush it
+// before asserting Redis state.
+async function swrWrapFlushed<T>(
+	key: string,
+	tables: string[],
+	fetcher: () => Promise<T>,
+): Promise<T> {
+	const value = await swrWrap(key, tables, fetcher);
+	await waitForSwrMirrorWrites();
+	return value;
+}
 
 describe("swrWrap", () => {
 	beforeEach(async () => {
@@ -22,8 +35,10 @@ describe("swrWrap", () => {
 	});
 
 	it("returns fetcher value and writes to SWR mirror with configured TTL + table index", async () => {
-		const value = await swrWrap("test:key:1", ["table_a", "table_b"], () =>
-			Promise.resolve({ hello: "world" }),
+		const value = await swrWrapFlushed(
+			"test:key:1",
+			["table_a", "table_b"],
+			() => Promise.resolve({ hello: "world" }),
 		);
 		expect(value).toEqual({ hello: "world" });
 
@@ -46,7 +61,7 @@ describe("swrWrap", () => {
 	});
 
 	it("returns stale value when fetcher throws and mirror exists", async () => {
-		await swrWrap("test:key:stale", ["table_a"], () =>
+		await swrWrapFlushed("test:key:stale", ["table_a"], () =>
 			Promise.resolve({ cached: true }),
 		);
 
@@ -67,7 +82,7 @@ describe("swrWrap", () => {
 	});
 
 	it("encodes undefined via sentinel so missing row is distinguishable from missing mirror", async () => {
-		const primed = await swrWrap<{ id: string } | undefined>(
+		const primed = await swrWrapFlushed<{ id: string } | undefined>(
 			"test:key:undef",
 			["table_a"],
 			() => Promise.resolve(undefined),
@@ -87,13 +102,13 @@ describe("swrWrap", () => {
 	});
 
 	it("invalidateSwrByTables wipes mirrors and cleans index", async () => {
-		await swrWrap("test:key:inv1", ["table_a"], () =>
+		await swrWrapFlushed("test:key:inv1", ["table_a"], () =>
 			Promise.resolve({ v: 1 }),
 		);
-		await swrWrap("test:key:inv2", ["table_a"], () =>
+		await swrWrapFlushed("test:key:inv2", ["table_a"], () =>
 			Promise.resolve({ v: 2 }),
 		);
-		await swrWrap("test:key:inv3", ["table_b"], () =>
+		await swrWrapFlushed("test:key:inv3", ["table_b"], () =>
 			Promise.resolve({ v: 3 }),
 		);
 
@@ -109,7 +124,7 @@ describe("swrWrap", () => {
 	});
 
 	it("throttles mirror rewrites for the same key within the window", async () => {
-		await swrWrap("test:key:throttle", ["table_a"], () =>
+		await swrWrapFlushed("test:key:throttle", ["table_a"], () =>
 			Promise.resolve({ v: 1 }),
 		);
 		expect(
@@ -119,7 +134,7 @@ describe("swrWrap", () => {
 		// Drop the mirror, then call again within the throttle window. The fresh
 		// fetcher value is still returned, but the mirror is NOT rewritten.
 		await redisClient.del(`${SWR_PREFIX}test:key:throttle`);
-		const value = await swrWrap("test:key:throttle", ["table_a"], () =>
+		const value = await swrWrapFlushed("test:key:throttle", ["table_a"], () =>
 			Promise.resolve({ v: 2 }),
 		);
 		expect(value).toEqual({ v: 2 });
@@ -127,18 +142,44 @@ describe("swrWrap", () => {
 	});
 
 	it("releases the throttle slot so the next call retries when the mirror write fails", async () => {
+		// Poison only the mirror-write pipeline (identified by its SET of an
+		// swr: key). A blanket pipeline() mock would also intercept ioredis'
+		// internal auto-pipelining flushes, whose queued command callbacks
+		// would then never fire and hang the whole client.
 		const realPipeline = redisClient.pipeline.bind(redisClient);
+		let poisoned = false;
 		const pipelineSpy = vi
 			.spyOn(redisClient, "pipeline")
-			.mockImplementationOnce(() => {
-				const pipeline = realPipeline();
-				vi.spyOn(pipeline, "exec").mockRejectedValueOnce(
-					new Error("redis write failed"),
-				);
+			.mockImplementation((...args: unknown[]) => {
+				const pipeline = realPipeline(...(args as never[]));
+				let hasMirrorSet = false;
+				const realSet = pipeline.set.bind(pipeline);
+				pipeline.set = ((...setArgs: unknown[]) => {
+					const setKey = String(setArgs[0]);
+					if (
+						setKey.startsWith(SWR_PREFIX) &&
+						!setKey.startsWith(SWR_THROTTLE_PREFIX)
+					) {
+						hasMirrorSet = true;
+					}
+					return realSet(...(setArgs as Parameters<typeof realSet>));
+				}) as typeof pipeline.set;
+				const realExec = pipeline.exec.bind(pipeline);
+				pipeline.exec = ((...execArgs: unknown[]) => {
+					// The mirror write awaits exec() promise-style; ioredis'
+					// auto-pipelining always passes a callback. Only the former
+					// may be poisoned — swallowing an internal flush's callback
+					// would hang every command batched into it.
+					if (hasMirrorSet && execArgs.length === 0 && !poisoned) {
+						poisoned = true;
+						return Promise.reject(new Error("redis write failed"));
+					}
+					return realExec(...(execArgs as Parameters<typeof realExec>));
+				}) as typeof pipeline.exec;
 				return pipeline;
 			});
 
-		await swrWrap("test:key:relfail", ["table_a"], () =>
+		await swrWrapFlushed("test:key:relfail", ["table_a"], () =>
 			Promise.resolve({ v: 1 }),
 		);
 
@@ -153,7 +194,7 @@ describe("swrWrap", () => {
 
 		// The next call (still within the window) now succeeds in writing the
 		// mirror instead of being suppressed by a stuck throttle marker.
-		await swrWrap("test:key:relfail", ["table_a"], () =>
+		await swrWrapFlushed("test:key:relfail", ["table_a"], () =>
 			Promise.resolve({ v: 2 }),
 		);
 		expect(
@@ -162,13 +203,13 @@ describe("swrWrap", () => {
 	});
 
 	it("repopulates mirror on next fetch after invalidation despite throttle", async () => {
-		await swrWrap("test:key:reinv", ["table_a"], () =>
+		await swrWrapFlushed("test:key:reinv", ["table_a"], () =>
 			Promise.resolve({ v: 1 }),
 		);
 		await invalidateSwrByTables(["table_a"]);
 		expect(await redisClient.get(`${SWR_PREFIX}test:key:reinv`)).toBeNull();
 
-		await swrWrap("test:key:reinv", ["table_a"], () =>
+		await swrWrapFlushed("test:key:reinv", ["table_a"], () =>
 			Promise.resolve({ v: 2 }),
 		);
 		expect(await redisClient.get(`${SWR_PREFIX}test:key:reinv`)).not.toBeNull();
@@ -178,7 +219,9 @@ describe("swrWrap", () => {
 		process.env.SWR_STALE_TTL_SECONDS = "120";
 		expect(getSwrStaleTtlSeconds()).toBe(120);
 
-		await swrWrap("test:key:ttl", ["table_a"], () => Promise.resolve({ v: 1 }));
+		await swrWrapFlushed("test:key:ttl", ["table_a"], () =>
+			Promise.resolve({ v: 1 }),
+		);
 		const ttl = await redisClient.ttl(`${SWR_PREFIX}test:key:ttl`);
 		expect(ttl).toBeGreaterThan(0);
 		expect(ttl).toBeLessThanOrEqual(120);

--- a/packages/cache/src/swr.ts
+++ b/packages/cache/src/swr.ts
@@ -143,7 +143,31 @@ async function readMirror<T>(
 	return { hit: true, value: parsed as T };
 }
 
+// Coalesce concurrent fetches for the same key: identical lookups issued while
+// one is already in flight (parallel routing candidates, simultaneous requests
+// on the same org/project) share its result instead of each paying their own
+// query round trips.
+const inFlightFetches = new Map<string, Promise<unknown>>();
+
 export async function swrWrap<T>(
+	key: string,
+	tables: string[],
+	fetcher: () => Promise<T>,
+): Promise<T> {
+	const existing = inFlightFetches.get(key);
+	if (existing) {
+		return await (existing as Promise<T>);
+	}
+	const fetchPromise = swrFetch(key, tables, fetcher);
+	inFlightFetches.set(key, fetchPromise);
+	try {
+		return await fetchPromise;
+	} finally {
+		inFlightFetches.delete(key);
+	}
+}
+
+async function swrFetch<T>(
 	key: string,
 	tables: string[],
 	fetcher: () => Promise<T>,
@@ -170,13 +194,31 @@ export async function swrWrap<T>(
 		throw error;
 	}
 
-	if (await claimMirrorWrite(key)) {
-		const wrote = await writeMirror(key, tables, value);
-		if (!wrote) {
-			await releaseMirrorThrottle(key);
+	// Mirror bookkeeping is pure disaster-fallback maintenance — the caller's
+	// result never depends on it, so it must not add Redis round trips to the
+	// request's critical path. Every step below catches its own errors, so
+	// this floating chain cannot produce an unhandled rejection.
+	const bookkeeping = (async () => {
+		if (await claimMirrorWrite(key)) {
+			const wrote = await writeMirror(key, tables, value);
+			if (!wrote) {
+				await releaseMirrorThrottle(key);
+			}
 		}
-	}
+	})();
+	pendingMirrorWrites.add(bookkeeping);
+	void bookkeeping.finally(() => pendingMirrorWrites.delete(bookkeeping));
 	return value;
+}
+
+const pendingMirrorWrites = new Set<Promise<void>>();
+
+// Await all in-flight mirror bookkeeping. Mirror writes are detached from the
+// request path, so tests (and graceful shutdown) need a way to wait for them.
+export async function waitForSwrMirrorWrites(): Promise<void> {
+	while (pendingMirrorWrites.size > 0) {
+		await Promise.allSettled(Array.from(pendingMirrorWrites));
+	}
 }
 
 export async function invalidateSwrByTables(tables: string[]): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       redis:
         specifier: 5.9.0
         version: 5.9.0
+      undici:
+        specifier: 8.9.0
+        version: 8.9.0
       worker:
         specifier: workspace:*
         version: link:../worker
@@ -12134,6 +12137,10 @@ packages:
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -24684,6 +24691,8 @@ snapshots:
   undici-types@8.3.0: {}
 
   undici@6.27.0: {}
+
+  undici@8.9.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
## Why

On the [computesdk AI-gateway benchmark](https://www.computesdk.com/benchmarks/ai-gateway/) (Jul 24 run) LLM Gateway ranks last at 88.5 despite having the 2nd-best cold E2E median (718ms), 2nd-best warm TTFT median (602ms), and the **best warm TTFT p95 in the field (928ms — better than Anthropic direct)**. The entire gap is one axis: cold E2E p95 of 2810ms driven by a single 4145ms outlier. Their composite weights p95s at 15% each and they take only 10 cold samples, so p95 ≈ max — one slow request per run decides the ranking.

Root cause: provider requests use bare global `fetch` with undici defaults — idle upstream sockets close after **4s**, and DNS is resolved on every new connection. Requests arriving after a short idle period (the benchmark's round-robin spacing, but also any real traffic lull, and any concurrent burst since streaming holds sockets for the whole generation) pay a fresh DNS + TCP + TLS handshake to the provider before the first token. Under Kubernetes' default `ndots:5`, one dropped UDP packet during the search-domain walk stalls the request 2.5–5s — the exact profile of the observed tail.

## What

- **`upstream-dispatcher.ts`**: install a tuned undici `Agent` as the global fetch dispatcher at gateway boot — 60s idle keep-alive (`UPSTREAM_KEEPALIVE_TIMEOUT_MS`), in-process DNS cache via `interceptors.dns` (`UPSTREAM_DNS_CACHE_TTL_MS`, 30s default, 0 disables), 10s connect timeout (`UPSTREAM_CONNECT_TIMEOUT_MS`), closed on graceful shutdown.
- **ioredis auto-pipelining** on the shared client: the pre-dispatch hot path issues dozens of Redis commands per request on one connection; concurrent ones now batch into single round trips. No consumer uses blocking commands or subscriptions.
- **SWR cache layer**: mirror bookkeeping (throttle claim + mirror write) is disaster-fallback maintenance the request result never depends on — now detached from the critical path, with a `waitForSwrMirrorWrites()` hook for tests/shutdown. Concurrent identical lookups coalesce in flight.
- **chat.ts**: end-user-wallet + project lookups run concurrently (both depend only on the api key); the stream relay now uses a **per-request `TextDecoder`** — the previous module-level decoder was shared across concurrent streams with `{stream: true}`, whose partial-multibyte state could corrupt characters between requests (correctness fix, not just perf).

## Validation

- Benchmark-style A/B against a local mock provider edge (no Keep-Alive hint, like real edges): 8 requests spaced 6s apart opened **8 upstream connections on main vs 1 on this branch**.
- New spec covers socket reuse and incremental streaming through the installed dispatcher (guards the npm-undici ↔ built-in-fetch interop).
- Existing SWR specs updated for the detached mirror writes; full unit suite green (182 files / 3035 tests), full build passes.

## Deploy notes

- No env changes required.
- Infra follow-up (not in repo): `dnsConfig` `ndots:2` on gateway pods or NodeLocal DNSCache, as belt-and-braces alongside the in-process DNS cache.

https://claude.ai/code/session_01G2Q5BWHpcEymLf7ood92JZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved upstream request efficiency with connection reuse, optional DNS caching, and configurable timeouts.
  * Enabled Redis auto-pipelining to reduce round-trip overhead.
  * Reduced latency during early API-key validation.
* **Reliability**
  * Improved consistency of background cache updates by coordinating mirror-write completion.
  * Prevented duplicate concurrent cached fetches for the same key.
  * Improved stability for concurrent streaming responses.
* **Tests**
  * Updated and expanded cache synchronization and upstream dispatcher test coverage for more deterministic assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
