### PR TITLE
fix(ui): warn refunds cancel the subscription

### DIFF
--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -204,12 +204,14 @@ function RefundButton({ invoice }: { invoice: Invoice }) {
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>
-						{isResetPass ? "Refund this Reset Pass?" : "Refund this payment?"}
+						{isResetPass
+							? "Refund this Reset Pass?"
+							: "Refund and cancel your DevPass?"}
 					</AlertDialogTitle>
 					<AlertDialogDescription>
 						{isResetPass
 							? `${formatAmount(invoice.amount, invoice.currency)} will be refunded to your payment method and the unused pass removed from your passport. Your DevPass plan is not affected. This cannot be undone.`
-							: `${formatAmount(invoice.amount, invoice.currency)} will be refunded to your payment method and your DevPass will be cancelled immediately. This cannot be undone.`}
+							: `Refunding cancels your subscription completely: ${formatAmount(invoice.amount, invoice.currency)} goes back to your payment method and your DevPass ends right away — not at the end of the billing period — so the rest of this cycle's credits are lost. To use DevPass again you would have to subscribe from scratch. This cannot be undone.`}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>

--- a/apps/playground/src/components/pricing/chat-billing-history.tsx
+++ b/apps/playground/src/components/pricing/chat-billing-history.tsx
@@ -245,18 +245,21 @@ function RefundButton({
 			</AlertDialogTrigger>
 			<AlertDialogContent>
 				<AlertDialogHeader>
-					<AlertDialogTitle>Refund this payment?</AlertDialogTitle>
-					<AlertDialogDescription>
-						{formatAmount(transaction.amount, transaction.currency)} will be
-						refunded to your payment method.{" "}
+					<AlertDialogTitle>
 						{isPlanPayment(transaction.type)
-							? "Your chat plan will be cancelled immediately. "
-							: "The purchased credits will be removed from your balance. "}
-						This cannot be undone.
+							? "Refund and cancel your membership?"
+							: "Refund this payment?"}
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						{isPlanPayment(transaction.type)
+							? `Refunding cancels your Lounge membership completely: ${formatAmount(transaction.amount, transaction.currency)} goes back to your payment method and your access ends right away — not at the end of the billing period — so the rest of this cycle's credits are lost. To keep using the Lounge you would have to subscribe again. This cannot be undone.`
+							: `${formatAmount(transaction.amount, transaction.currency)} will be refunded to your payment method. The purchased credits will be removed from your balance. This cannot be undone.`}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
-					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogCancel>
+						{isPlanPayment(transaction.type) ? "Keep my membership" : "Cancel"}
+					</AlertDialogCancel>
 					<AlertDialogAction
 						onClick={() =>
 							refundMutation.mutate({
@@ -266,7 +269,9 @@ function RefundButton({
 							})
 						}
 					>
-						Request refund
+						{isPlanPayment(transaction.type)
+							? "Refund and cancel"
+							: "Request refund"}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/apps/ui/src/components/billing/transactions-client.tsx
+++ b/apps/ui/src/components/billing/transactions-client.tsx
@@ -59,7 +59,12 @@ interface Transaction {
 		| "credit_gift"
 		| "subscription_start"
 		| "subscription_cancel"
-		| "subscription_end";
+		| "subscription_end"
+		| "dev_plan_start"
+		| "dev_plan_renewal"
+		| "dev_plan_reset_pass"
+		| "chat_plan_start"
+		| "chat_plan_renewal";
 	creditAmount: string | null;
 	amount: string | null;
 	status: "pending" | "completed" | "failed";
@@ -82,6 +87,17 @@ const REFUND_INELIGIBILITY_COPY: Record<
 	usage_exceeded: "More than 10% of these credits have been used",
 	pass_already_used: "This Reset Pass has already been redeemed",
 };
+
+// Refunding a plan payment does not just return the money: the webhook cancels
+// the Stripe subscription outright, so the dialog has to say so.
+function isPlanPayment(type: Transaction["type"]): boolean {
+	return (
+		type === "dev_plan_start" ||
+		type === "dev_plan_renewal" ||
+		type === "chat_plan_start" ||
+		type === "chat_plan_renewal"
+	);
+}
 
 function RefundButton({
 	orgId,
@@ -114,8 +130,9 @@ function RefundButton({
 			}
 			toast({
 				title: "Refund processing",
-				description:
-					"Your refund has been submitted and will appear in your transaction history shortly.",
+				description: isPlanPayment(transaction.type)
+					? "Your subscription has been cancelled and the refund will appear in your transaction history shortly."
+					: "Your refund has been submitted and will appear in your transaction history shortly.",
 			});
 			router.refresh();
 		} catch {
@@ -164,18 +181,37 @@ function RefundButton({
 			</AlertDialogTrigger>
 			<AlertDialogContent>
 				<AlertDialogHeader>
-					<AlertDialogTitle>Refund this purchase?</AlertDialogTitle>
+					<AlertDialogTitle>
+						{isPlanPayment(transaction.type)
+							? "Refund and cancel your subscription?"
+							: "Refund this purchase?"}
+					</AlertDialogTitle>
 					<AlertDialogDescription>
-						${Number(transaction.amount ?? 0).toFixed(2)} will be refunded to
-						your original payment method and{" "}
-						{Number(transaction.creditAmount ?? 0).toFixed(2)} credits will be
-						removed from your balance. This cannot be undone.
+						{isPlanPayment(transaction.type)
+							? `Refunding cancels your subscription completely: $${Number(
+									transaction.amount ?? 0,
+								).toFixed(
+									2,
+								)} goes back to your original payment method and the plan ends right away — not at the end of the billing period — so the rest of this cycle's credits are lost. To use it again you would have to subscribe from scratch. This cannot be undone.`
+							: transaction.type === "dev_plan_reset_pass"
+								? `$${Number(transaction.amount ?? 0).toFixed(2)} will be refunded to your original payment method and the unused Reset Pass removed from your account. Your plan is not affected. This cannot be undone.`
+								: `$${Number(transaction.amount ?? 0).toFixed(2)} will be refunded to your original payment method and ${Number(
+										transaction.creditAmount ?? 0,
+									).toFixed(
+										2,
+									)} credits will be removed from your balance. This cannot be undone.`}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
-					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogCancel>
+						{isPlanPayment(transaction.type)
+							? "Keep my subscription"
+							: "Cancel"}
+					</AlertDialogCancel>
 					<AlertDialogAction onClick={handleRefund}>
-						Request refund
+						{isPlanPayment(transaction.type)
+							? "Refund and cancel"
+							: "Request refund"}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>


### PR DESCRIPTION
## Summary

Refunding a plan payment cancels the Stripe subscription outright — `handleChargeRefunded` calls `subscriptions.cancel(...)` on any full refund of a dev/chat plan payment, which ends the plan immediately and wipes the rest of the cycle's credits. The self-refund dialogs either buried that ("your DevPass will be cancelled immediately", as a trailing clause) or never mentioned it at all. This makes the consequence the first thing users read.

## Changes

- **DevPass invoices** (`apps/code/.../DevPassInvoices.tsx`) — plan payments now lead with "Refunding cancels your subscription completely", state that the plan ends right away rather than at the end of the billing period, that the cycle's remaining credits are lost, and that resubscribing means starting from scratch. Title changed to "Refund and cancel your DevPass?". Reset Pass copy is unchanged (it does not touch the subscription).
- **Lounge billing history** (`apps/playground/.../chat-billing-history.tsx`) — same warning for chat plan payments, plus a "Keep my membership" cancel action and a "Refund and cancel" confirm action so the destructive path is explicit. Credit top-up copy is unchanged.
- **Org billing transactions** (`apps/ui/.../billing/transactions-client.tsx`) — this dialog rendered credit top-up copy ("N credits will be removed from your balance") for every refundable transaction, including plan payments and Reset Passes, which the endpoint does return here. The copy now branches by transaction type: subscription-cancellation warning for plan payments, pass-specific copy for Reset Passes, existing copy for top-ups. The success toast mentions the cancellation for plan payments too.

Copy-only change; no behavior, API, or eligibility logic touched.

## Testing

- `pnpm format`
- `turbo run build --filter=ui --filter=playground --filter=code` — all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01QT99FzP9yQUdM8ii1Y45M7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer refund confirmations for DevPass and chat plan payments.
  * Plan refunds now explain that the subscription ends immediately, remaining credits are lost, and a new subscription is required to use the plan again.
  * Updated action labels to distinguish keeping a membership from requesting a refund.

* **Bug Fixes**
  * Improved refund processing messages based on the type of transaction.
  * Preserved the existing messaging for Reset Pass refunds and one-time purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->