### PR TITLE
feat(api): notify Discord on plan resume

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -31,11 +31,13 @@ import { getStripe, type StripeMode } from "./routes/payments.js";
 import {
 	notifyChatPlanCancelled,
 	notifyChatPlanRenewed,
+	notifyChatPlanResumed,
 	notifyChatPlanSubscribed,
 	notifyCreditsPurchased,
 	notifyRefund,
 	notifyDevPlanCancelled,
 	notifyDevPlanRenewed,
+	notifyDevPlanResumed,
 	notifyDevPlanSubscribed,
 	notifyResetPassPurchased,
 } from "./utils/discord.js";
@@ -4787,6 +4789,20 @@ export async function handleSubscriptionUpdated(
 					source: "stripe_subscription_updated",
 				},
 			});
+			const resumeEmail =
+				(metadata?.userEmail as string | undefined) ??
+				organization.billingEmail;
+			if (resumeEmail) {
+				const resumeUser = await db.query.user.findFirst({
+					where: { email: { eq: resumeEmail } },
+				});
+				await notifyChatPlanResumed(
+					resumeEmail,
+					resumeUser?.name,
+					organization.chatPlan ?? "unknown",
+				);
+			}
+
 			logger.info(
 				`Reactivated chat plan subscription for organization ${organizationId}`,
 			);
@@ -4899,6 +4915,20 @@ export async function handleSubscriptionUpdated(
 					source: "stripe_subscription_updated",
 				},
 			});
+			const resumeEmail =
+				(metadata?.userEmail as string | undefined) ??
+				organization.billingEmail;
+			if (resumeEmail) {
+				const resumeUser = await db.query.user.findFirst({
+					where: { email: { eq: resumeEmail } },
+				});
+				await notifyDevPlanResumed(
+					resumeEmail,
+					resumeUser?.name,
+					organization.devPlan ?? "unknown",
+				);
+			}
+
 			logger.info(
 				`Reactivated dev plan subscription for organization ${organizationId}`,
 			);

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -279,6 +279,41 @@ export async function notifyDevPlanCancelled(
 	});
 }
 
+export async function notifyDevPlanResumed(
+	email: string,
+	name: string | null | undefined,
+	devPlan: string,
+): Promise<void> {
+	const displayName = name ?? "Unknown";
+
+	await sendDiscordNotification({
+		embeds: [
+			{
+				title: "DevPass Resumed",
+				color: 0x10b981, // Emerald
+				fields: [
+					{
+						name: "Email",
+						value: email,
+						inline: true,
+					},
+					{
+						name: "Name",
+						value: displayName,
+						inline: true,
+					},
+					{
+						name: "Plan",
+						value: devPlan.toUpperCase(),
+						inline: true,
+					},
+				],
+				timestamp: new Date().toISOString(),
+			},
+		],
+	});
+}
+
 export async function notifyChatSupportEscalation(args: {
 	name?: string;
 	email?: string;
@@ -514,6 +549,29 @@ export async function notifyChatPlanCancelled(
 			{
 				title: "Chat Plan Cancelled",
 				color: 0xef4444,
+				fields: [
+					{ name: "Email", value: email, inline: true },
+					{ name: "Name", value: displayName, inline: true },
+					{ name: "Plan", value: chatPlan.toUpperCase(), inline: true },
+				],
+				timestamp: new Date().toISOString(),
+			},
+		],
+	});
+}
+
+export async function notifyChatPlanResumed(
+	email: string,
+	name: string | null | undefined,
+	chatPlan: string,
+): Promise<void> {
+	const displayName = name ?? "Unknown";
+
+	await sendDiscordNotification({
+		embeds: [
+			{
+				title: "Chat Plan Resumed",
+				color: 0x10b981,
 				fields: [
 					{ name: "Email", value: email, inline: true },
 					{ name: "Name", value: displayName, inline: true },


### PR DESCRIPTION
## Problem

The Discord notifier posted a `DevPass Cancelled` embed followed five minutes later by a `DevPass Renewed` embed for the same org, which read as a contradiction (or a duplicate notification).

They weren't duplicates. The org's subscription history showed three events:

| Time | Transaction | Discord |
|---|---|---|
| 11:03 | `dev_plan_cancel` | **DevPass Cancelled** |
| 11:04 | `dev_plan_resume` | *(nothing)* |
| 11:08 | `dev_plan_renewal` | **DevPass Renewed** |

The user cancelled, undid it a minute later, and the renewal invoice was then collected. Both notifications were correct and correctly guarded — the cancel fires only on the `!isSubscriptionActive && !wasDevPlanCancelled` edge, and the renewal only after a paid renewal invoice.

The reactivation branch in `handleSubscriptionUpdated` wrote a `dev_plan_resume` transaction row and a PostHog `dev_plan_reactivated` event but sent no Discord notification, so the step that reconciles the two visible events was invisible in the channel. The Lounge/chat-plan branch had the same gap.

## Changes

- Add `notifyDevPlanResumed` and `notifyChatPlanResumed` to `apps/api/src/utils/discord.ts`, mirroring the existing cancelled/renewed embeds with an emerald color.
- Call them from the dev-plan and chat-plan reactivation branches in `apps/api/src/stripe.ts`, resolving the recipient with the same `metadata.userEmail ?? organization.billingEmail` fallback the cancellation notifications already use.

The sequence above now reads Cancelled → Resumed → Renewed.

## Testing

- `pnpm format`
- `turbo run build --filter=api`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED62SmxGDTn5uY6dzUtVC1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications when chat or developer subscriptions are reactivated.
  * Notifications include the subscriber’s email, name, plan type, and resumption timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->