### PR TITLE
chore: set opus 4.1 bedrock deprecation dates

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -897,6 +897,8 @@ export const anthropicModels = [
 				test: "skip",
 				providerId: "aws-bedrock",
 				externalId: "anthropic.claude-opus-4-1-20250805-v1:0",
+				deprecatedAt: new Date("2026-07-08"),
+				deactivatedAt: new Date("2027-01-08"),
 				inputPrice: "15.0e-6",
 				outputPrice: "75.0e-6",
 				cachedInputPrice: "1.5e-6",


### PR DESCRIPTION
AWS published the Bedrock deprecation timeline for `anthropic.claude-opus-4-1-20250805-v1:0`:

- **July 8, 2026** — Legacy state begins (no further quota increases)
- **October 8, 2026** — Extended access begins
- **January 8, 2027** — end of life, requests to this model ID will fail

This sets the corresponding fields on the `aws-bedrock` provider mapping for `claude-opus-4-1-20250805` in `packages/models`:

- `deprecatedAt: 2026-07-08` — Legacy start, so the mapping is filtered out of selection algorithms while remaining usable when pinned
- `deactivatedAt: 2027-01-08` — EOL, after which the mapping returns an error

The Anthropic first-party mapping for the same model is untouched — the notice only covers Bedrock.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGQs2iM9fVc8wsVhh8yUqe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the status information for the Claude Opus 4.1 model available through AWS Bedrock.
  * The model now reflects its deprecation and deactivation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->