### PR TITLE
fix(devpass): 7d agent window + locale-safe CSV

### DIFF
--- a/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
+++ b/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
@@ -29,6 +29,8 @@ import {
 import { useUser } from "@/hooks/useUser";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
+import { buildCsv, detectCsvFormat, formatCsvNumber } from "@llmgateway/shared";
+
 type ModelSortColumn =
 	| "id"
 	| "provider"
@@ -53,7 +55,7 @@ const AGENT_TIME_RANGE_HOURS: Record<AgentTimeRange, number> = {
 function parseAgentTimeRange(value: string | null | undefined): AgentTimeRange {
 	return (AGENT_TIME_RANGES as readonly string[]).includes(value ?? "")
 		? (value as AgentTimeRange)
-		: "30d";
+		: "7d";
 }
 
 const CSV_HEADERS = [
@@ -73,52 +75,25 @@ const CSV_HEADERS = [
 	"id",
 ];
 
-function escapeCsvValue(value: unknown): string {
-	if (value === null || value === undefined) {
-		return "";
-	}
-	let str = String(value);
-	// Guard against spreadsheet formula injection for string values.
-	if (typeof value === "string" && /^[=+\-@\t\r]/.test(str)) {
-		str = `'${str}`;
-	}
-	if (/[",\n]/.test(str)) {
-		return `"${str.replace(/"/g, '""')}"`;
-	}
-	return str;
-}
-
-// String(number) switches to exponent notation below 1e-6 (e.g. "3.5e-7"),
-// which spreadsheets don't reliably parse as a float.
-function formatCostForCsv(cost: number | null | undefined): string {
-	if (cost === null || cost === undefined) {
-		return "";
-	}
-	return cost.toFixed(15).replace(/\.?0+$/, "");
-}
-
 function buildLogsCsv(logs: ApiLog[]): string {
-	const rows = logs.map((log) =>
-		[
-			log.createdAt,
-			log.usedProvider,
-			log.usedModel,
-			log.unifiedFinishReason ?? log.finishReason ?? "",
-			log.promptTokens,
-			log.completionTokens,
-			log.totalTokens,
-			log.cachedTokens ?? "",
-			formatCostForCsv(log.cost),
-			log.hasError,
-			log.streamed,
-			log.duration,
-			log.requestId,
-			log.id,
-		]
-			.map(escapeCsvValue)
-			.join(","),
-	);
-	return [CSV_HEADERS.join(","), ...rows].join("\n");
+	const format = detectCsvFormat();
+	const rows = logs.map((log) => [
+		log.createdAt,
+		log.usedProvider,
+		log.usedModel,
+		log.unifiedFinishReason ?? log.finishReason ?? "",
+		log.promptTokens,
+		log.completionTokens,
+		log.totalTokens,
+		log.cachedTokens ?? "",
+		formatCsvNumber(log.cost, format),
+		log.hasError,
+		log.streamed,
+		log.duration,
+		log.requestId,
+		log.id,
+	]);
+	return buildCsv(CSV_HEADERS, rows, format);
 }
 
 function TimeRangePicker({

--- a/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
+++ b/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
@@ -29,7 +29,7 @@ import {
 import { useUser } from "@/hooks/useUser";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
-import { buildCsv, detectCsvFormat, formatCsvNumber } from "@llmgateway/shared";
+import { buildAgentLogsCsv } from "@llmgateway/shared";
 
 type ModelSortColumn =
 	| "id"
@@ -56,44 +56,6 @@ function parseAgentTimeRange(value: string | null | undefined): AgentTimeRange {
 	return (AGENT_TIME_RANGES as readonly string[]).includes(value ?? "")
 		? (value as AgentTimeRange)
 		: "7d";
-}
-
-const CSV_HEADERS = [
-	"createdAt",
-	"usedProvider",
-	"usedModel",
-	"finishReason",
-	"promptTokens",
-	"completionTokens",
-	"totalTokens",
-	"cachedTokens",
-	"cost",
-	"hasError",
-	"streamed",
-	"duration",
-	"requestId",
-	"id",
-];
-
-function buildLogsCsv(logs: ApiLog[]): string {
-	const format = detectCsvFormat();
-	const rows = logs.map((log) => [
-		log.createdAt,
-		log.usedProvider,
-		log.usedModel,
-		log.unifiedFinishReason ?? log.finishReason ?? "",
-		log.promptTokens,
-		log.completionTokens,
-		log.totalTokens,
-		log.cachedTokens ?? "",
-		formatCsvNumber(log.cost, format),
-		log.hasError,
-		log.streamed,
-		log.duration,
-		log.requestId,
-		log.id,
-	]);
-	return buildCsv(CSV_HEADERS, rows, format);
 }
 
 function TimeRangePicker({
@@ -506,7 +468,9 @@ function AgentDetailBody({
 					? (body.pagination.nextCursor ?? undefined)
 					: undefined;
 			}
-			const csv = buildLogsCsv(collected.filter((log) => !log.retriedByLogId));
+			const csv = buildAgentLogsCsv(
+				collected.filter((log) => !log.retriedByLogId),
+			);
 			const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement("a");

--- a/apps/code/src/app/dashboard/components/CodingAgents.tsx
+++ b/apps/code/src/app/dashboard/components/CodingAgents.tsx
@@ -121,7 +121,7 @@ export default function CodingAgents({
 
 	const since = useMemo(() => {
 		const d = new Date();
-		d.setDate(d.getDate() - 30);
+		d.setDate(d.getDate() - 7);
 		return d.toISOString();
 	}, []);
 	const until = useMemo(() => new Date().toISOString(), []);
@@ -161,7 +161,8 @@ export default function CodingAgents({
 				<div>
 					<h2 className="font-semibold">Coding Agents</h2>
 					<p className="mt-0.5 text-sm text-muted-foreground">
-						Per-tool usage, costs, and recent activity from the last 30 days.
+						Per-tool usage, costs, and recent activity from the last 7 days.
+						Open an agent to expand the time window.
 					</p>
 				</div>
 				{agentStats.length > 0 && (

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -28,7 +28,12 @@ import {
 import { useToast } from "@/lib/components/use-toast";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
-import { CODING_AGENTS } from "@llmgateway/shared";
+import {
+	buildCsv,
+	CODING_AGENTS,
+	detectCsvFormat,
+	formatCsvNumber,
+} from "@llmgateway/shared";
 import {
 	AnthropicIcon,
 	AutohandIcon,
@@ -131,48 +136,25 @@ const CSV_HEADERS = [
 	"id",
 ];
 
-function escapeCsvValue(value: unknown): string {
-	if (value === null || value === undefined) {
-		return "";
-	}
-	const str = String(value);
-	if (/[",\n]/.test(str)) {
-		return `"${str.replace(/"/g, '""')}"`;
-	}
-	return str;
-}
-
-// String(number) switches to exponent notation below 1e-6 (e.g. "3.5e-7"),
-// which spreadsheets don't reliably parse as a float.
-function formatCostForCsv(cost: number | null | undefined): string {
-	if (cost === null || cost === undefined) {
-		return "";
-	}
-	return cost.toFixed(15).replace(/\.?0+$/, "");
-}
-
 function buildLogsCsv(logs: ApiLog[]): string {
-	const rows = logs.map((log) =>
-		[
-			log.createdAt,
-			log.usedProvider,
-			log.usedModel,
-			log.unifiedFinishReason ?? log.finishReason ?? "",
-			log.promptTokens,
-			log.completionTokens,
-			log.totalTokens,
-			log.cachedTokens ?? "",
-			formatCostForCsv(log.cost),
-			log.hasError,
-			log.streamed,
-			log.duration,
-			log.requestId,
-			log.id,
-		]
-			.map(escapeCsvValue)
-			.join(","),
-	);
-	return [CSV_HEADERS.join(","), ...rows].join("\n");
+	const format = detectCsvFormat();
+	const rows = logs.map((log) => [
+		log.createdAt,
+		log.usedProvider,
+		log.usedModel,
+		log.unifiedFinishReason ?? log.finishReason ?? "",
+		log.promptTokens,
+		log.completionTokens,
+		log.totalTokens,
+		log.cachedTokens ?? "",
+		formatCsvNumber(log.cost, format),
+		log.hasError,
+		log.streamed,
+		log.duration,
+		log.requestId,
+		log.id,
+	]);
+	return buildCsv(CSV_HEADERS, rows, format);
 }
 
 function toUiLog(log: ApiLog): Partial<Log> {

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -28,12 +28,7 @@ import {
 import { useToast } from "@/lib/components/use-toast";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
-import {
-	buildCsv,
-	CODING_AGENTS,
-	detectCsvFormat,
-	formatCsvNumber,
-} from "@llmgateway/shared";
+import { buildAgentLogsCsv, CODING_AGENTS } from "@llmgateway/shared";
 import {
 	AnthropicIcon,
 	AutohandIcon,
@@ -117,44 +112,6 @@ function getTimeRangeWindow(timeRange: TimeRangeValue): {
 	const windowMs = AGENT_TIME_RANGE_HOURS[timeRange] * 60 * 60 * 1000;
 	const from = new Date(to.getTime() - windowMs);
 	return { from, to };
-}
-
-const CSV_HEADERS = [
-	"createdAt",
-	"usedProvider",
-	"usedModel",
-	"finishReason",
-	"promptTokens",
-	"completionTokens",
-	"totalTokens",
-	"cachedTokens",
-	"cost",
-	"hasError",
-	"streamed",
-	"duration",
-	"requestId",
-	"id",
-];
-
-function buildLogsCsv(logs: ApiLog[]): string {
-	const format = detectCsvFormat();
-	const rows = logs.map((log) => [
-		log.createdAt,
-		log.usedProvider,
-		log.usedModel,
-		log.unifiedFinishReason ?? log.finishReason ?? "",
-		log.promptTokens,
-		log.completionTokens,
-		log.totalTokens,
-		log.cachedTokens ?? "",
-		formatCsvNumber(log.cost, format),
-		log.hasError,
-		log.streamed,
-		log.duration,
-		log.requestId,
-		log.id,
-	]);
-	return buildCsv(CSV_HEADERS, rows, format);
 }
 
 function toUiLog(log: ApiLog): Partial<Log> {
@@ -549,7 +506,9 @@ function AgentDetail({
 					? (body.pagination.nextCursor ?? undefined)
 					: undefined;
 			}
-			const csv = buildLogsCsv(collected.filter((log) => !log.retriedByLogId));
+			const csv = buildAgentLogsCsv(
+				collected.filter((log) => !log.retriedByLogId),
+			);
 			const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement("a");

--- a/packages/shared/src/csv.spec.ts
+++ b/packages/shared/src/csv.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	type AgentCsvLog,
+	buildAgentLogsCsv,
 	buildCsv,
 	DEFAULT_CSV_FORMAT,
 	detectCsvFormat,
@@ -72,13 +74,18 @@ describe("escapeCsvValue", () => {
 		expect(escapeCsvValue("line1\nline2")).toBe('"line1\nline2"');
 	});
 
-	it("guards string values against formula injection", () => {
+	it("guards non-numeric string values against formula injection", () => {
 		expect(escapeCsvValue("=SUM(A1)")).toBe("'=SUM(A1)");
-		expect(escapeCsvValue("+123")).toBe("'+123");
+		expect(escapeCsvValue("+1+1")).toBe("'+1+1");
+		expect(escapeCsvValue("-1-1")).toBe("'-1-1");
+		expect(escapeCsvValue("@cmd")).toBe("'@cmd");
 	});
 
-	it("does not treat negative numbers as formulas", () => {
+	it("does not treat numeric values or numeric strings as formulas", () => {
 		expect(escapeCsvValue(-1.5)).toBe("-1.5");
+		expect(escapeCsvValue("-1.5")).toBe("-1.5");
+		expect(escapeCsvValue("-1,5", COMMA_DECIMAL_FORMAT)).toBe("-1,5");
+		expect(escapeCsvValue("+123")).toBe("+123");
 	});
 });
 
@@ -101,5 +108,57 @@ describe("buildCsv", () => {
 			COMMA_DECIMAL_FORMAT,
 		);
 		expect(csv).toBe("cost;model\n0,334082;gpt-5.6-sol");
+	});
+
+	it("exports negative numbers unmodified", () => {
+		expect(buildCsv(["cost"], [[formatCsvNumber(-1.5)]])).toBe("cost\n-1.5");
+		expect(
+			buildCsv(
+				["cost"],
+				[[formatCsvNumber(-1.5, COMMA_DECIMAL_FORMAT)]],
+				COMMA_DECIMAL_FORMAT,
+			),
+		).toBe("cost\n-1,5");
+	});
+});
+
+describe("buildAgentLogsCsv", () => {
+	const log: AgentCsvLog = {
+		id: "log_1",
+		requestId: "req_1",
+		createdAt: "2026-07-02T16:41:00.000Z",
+		duration: 1200,
+		usedModel: "openai/gpt-5.6-sol",
+		usedProvider: "openai",
+		unifiedFinishReason: "completed",
+		finishReason: "stop",
+		promptTokens: "214668",
+		completionTokens: "7503",
+		totalTokens: "222171",
+		cachedTokens: "214379",
+		cost: -0.334082,
+		hasError: false,
+		streamed: true,
+	};
+
+	it("builds header and row with the given format", () => {
+		const csv = buildAgentLogsCsv([log], DEFAULT_CSV_FORMAT);
+		const [header, row] = csv.split("\n");
+		expect(header).toBe(
+			"createdAt,usedProvider,usedModel,finishReason,promptTokens,completionTokens,totalTokens,cachedTokens,cost,hasError,streamed,duration,requestId,id",
+		);
+		expect(row).toBe(
+			"2026-07-02T16:41:00.000Z,openai,openai/gpt-5.6-sol,completed,214668,7503,222171,214379,-0.334082,false,true,1200,req_1,log_1",
+		);
+	});
+
+	it("uses comma decimals and semicolon delimiters for comma-decimal locales", () => {
+		const csv = buildAgentLogsCsv(
+			[{ ...log, cachedTokens: null }],
+			COMMA_DECIMAL_FORMAT,
+		);
+		expect(csv.split("\n")[1]).toBe(
+			"2026-07-02T16:41:00.000Z;openai;openai/gpt-5.6-sol;completed;214668;7503;222171;;-0,334082;false;true;1200;req_1;log_1",
+		);
 	});
 });

--- a/packages/shared/src/csv.spec.ts
+++ b/packages/shared/src/csv.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildCsv,
+	DEFAULT_CSV_FORMAT,
+	detectCsvFormat,
+	escapeCsvValue,
+	formatCsvNumber,
+	type CsvFormat,
+} from "./csv.js";
+
+const COMMA_DECIMAL_FORMAT: CsvFormat = {
+	delimiter: ";",
+	decimalSeparator: ",",
+};
+
+describe("detectCsvFormat", () => {
+	it("returns dot decimals and comma delimiter for dot-decimal locales", () => {
+		expect(detectCsvFormat("en-US")).toEqual(DEFAULT_CSV_FORMAT);
+	});
+
+	it("returns comma decimals and semicolon delimiter for comma-decimal locales", () => {
+		expect(detectCsvFormat("fr-FR")).toEqual(COMMA_DECIMAL_FORMAT);
+		expect(detectCsvFormat("de-DE")).toEqual(COMMA_DECIMAL_FORMAT);
+	});
+
+	it("falls back to the default format for invalid locales", () => {
+		expect(detectCsvFormat("not a locale")).toEqual(DEFAULT_CSV_FORMAT);
+	});
+});
+
+describe("formatCsvNumber", () => {
+	it("formats sub-1e-6 values as plain decimals", () => {
+		expect(formatCsvNumber(3.5e-7)).toBe("0.00000035");
+	});
+
+	it("trims float noise", () => {
+		expect(formatCsvNumber(0.00012000000000000002)).toBe("0.00012");
+		expect(formatCsvNumber(0.30000000000000004)).toBe("0.3");
+	});
+
+	it("keeps integers intact", () => {
+		expect(formatCsvNumber(10)).toBe("10");
+		expect(formatCsvNumber(0)).toBe("0");
+	});
+
+	it("returns an empty string for nullish values", () => {
+		expect(formatCsvNumber(null)).toBe("");
+		expect(formatCsvNumber(undefined)).toBe("");
+	});
+
+	it("uses the locale decimal separator", () => {
+		expect(formatCsvNumber(0.334082, COMMA_DECIMAL_FORMAT)).toBe("0,334082");
+		expect(formatCsvNumber(3.5e-7, COMMA_DECIMAL_FORMAT)).toBe("0,00000035");
+	});
+});
+
+describe("escapeCsvValue", () => {
+	it("returns an empty string for nullish values", () => {
+		expect(escapeCsvValue(null)).toBe("");
+		expect(escapeCsvValue(undefined)).toBe("");
+	});
+
+	it("quotes values containing the active delimiter", () => {
+		expect(escapeCsvValue("a,b")).toBe('"a,b"');
+		expect(escapeCsvValue("a,b", COMMA_DECIMAL_FORMAT)).toBe("a,b");
+		expect(escapeCsvValue("a;b", COMMA_DECIMAL_FORMAT)).toBe('"a;b"');
+	});
+
+	it("quotes values containing quotes or newlines", () => {
+		expect(escapeCsvValue('say "hi"')).toBe('"say ""hi"""');
+		expect(escapeCsvValue("line1\nline2")).toBe('"line1\nline2"');
+	});
+
+	it("guards string values against formula injection", () => {
+		expect(escapeCsvValue("=SUM(A1)")).toBe("'=SUM(A1)");
+		expect(escapeCsvValue("+123")).toBe("'+123");
+	});
+
+	it("does not treat negative numbers as formulas", () => {
+		expect(escapeCsvValue(-1.5)).toBe("-1.5");
+	});
+});
+
+describe("buildCsv", () => {
+	it("joins headers and rows with the active delimiter", () => {
+		const csv = buildCsv(
+			["a", "b"],
+			[
+				[1, "x"],
+				[2, "y,z"],
+			],
+		);
+		expect(csv).toBe('a,b\n1,x\n2,"y,z"');
+	});
+
+	it("builds semicolon-delimited output for comma-decimal locales", () => {
+		const csv = buildCsv(
+			["cost", "model"],
+			[[formatCsvNumber(0.334082, COMMA_DECIMAL_FORMAT), "gpt-5.6-sol"]],
+			COMMA_DECIMAL_FORMAT,
+		);
+		expect(csv).toBe("cost;model\n0,334082;gpt-5.6-sol");
+	});
+});

--- a/packages/shared/src/csv.ts
+++ b/packages/shared/src/csv.ts
@@ -1,0 +1,74 @@
+export interface CsvFormat {
+	delimiter: "," | ";";
+	decimalSeparator: "." | ",";
+}
+
+export const DEFAULT_CSV_FORMAT: CsvFormat = {
+	delimiter: ",",
+	decimalSeparator: ".",
+};
+
+// Spreadsheets parse CSV numbers with the viewer's locale: in comma-decimal
+// locales a dot reads as a thousands separator, so "0.334082" silently becomes
+// 334082. Detect the locale's decimal separator and, for comma-decimal
+// locales, emit comma decimals with ";" as the field delimiter — the CSV
+// convention spreadsheets expect there.
+export function detectCsvFormat(locale?: string): CsvFormat {
+	let decimal: string | undefined;
+	try {
+		decimal = new Intl.NumberFormat(locale)
+			.formatToParts(1.1)
+			.find((part) => part.type === "decimal")?.value;
+	} catch {
+		decimal = undefined;
+	}
+	return decimal === ","
+		? { delimiter: ";", decimalSeparator: "," }
+		: DEFAULT_CSV_FORMAT;
+}
+
+export function escapeCsvValue(
+	value: unknown,
+	format: CsvFormat = DEFAULT_CSV_FORMAT,
+): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	let str = String(value);
+	// Guard against spreadsheet formula injection for string values.
+	if (typeof value === "string" && /^[=+\-@\t\r]/.test(str)) {
+		str = `'${str}`;
+	}
+	if (str.includes(format.delimiter) || /["\n\r]/.test(str)) {
+		return `"${str.replace(/"/g, '""')}"`;
+	}
+	return str;
+}
+
+// String(number) switches to exponent notation below 1e-6 (e.g. "3.5e-7"),
+// which spreadsheets don't reliably parse as a float, and keeps float-noise
+// digits (e.g. "0.00012000000000000002").
+export function formatCsvNumber(
+	value: number | null | undefined,
+	format: CsvFormat = DEFAULT_CSV_FORMAT,
+): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const plain = value.toFixed(15).replace(/\.?0+$/, "");
+	return format.decimalSeparator === "."
+		? plain
+		: plain.replace(".", format.decimalSeparator);
+}
+
+export function buildCsv(
+	headers: readonly string[],
+	rows: readonly (readonly unknown[])[],
+	format: CsvFormat = DEFAULT_CSV_FORMAT,
+): string {
+	return [headers, ...rows]
+		.map((row) =>
+			row.map((value) => escapeCsvValue(value, format)).join(format.delimiter),
+		)
+		.join("\n");
+}

--- a/packages/shared/src/csv.ts
+++ b/packages/shared/src/csv.ts
@@ -35,8 +35,13 @@ export function escapeCsvValue(
 		return "";
 	}
 	let str = String(value);
-	// Guard against spreadsheet formula injection for string values.
-	if (typeof value === "string" && /^[=+\-@\t\r]/.test(str)) {
+	// Guard against spreadsheet formula injection for string values, but leave
+	// plain numeric strings (e.g. negative costs from formatCsvNumber) intact.
+	if (
+		typeof value === "string" &&
+		/^[=+\-@\t\r]/.test(str) &&
+		!/^[+-]?\d+(?:[.,]\d+)?$/.test(str)
+	) {
 		str = `'${str}`;
 	}
 	if (str.includes(format.delimiter) || /["\n\r]/.test(str)) {
@@ -71,4 +76,62 @@ export function buildCsv(
 			row.map((value) => escapeCsvValue(value, format)).join(format.delimiter),
 		)
 		.join("\n");
+}
+
+export const AGENT_LOG_CSV_HEADERS = [
+	"createdAt",
+	"usedProvider",
+	"usedModel",
+	"finishReason",
+	"promptTokens",
+	"completionTokens",
+	"totalTokens",
+	"cachedTokens",
+	"cost",
+	"hasError",
+	"streamed",
+	"duration",
+	"requestId",
+	"id",
+] as const;
+
+export interface AgentCsvLog {
+	id: string;
+	requestId: string;
+	createdAt: string;
+	duration: number;
+	usedModel: string;
+	usedProvider: string;
+	unifiedFinishReason: string | null;
+	finishReason: string | null;
+	promptTokens: string | null;
+	completionTokens: string | null;
+	totalTokens: string | null;
+	cachedTokens?: string | null;
+	cost: number | null;
+	hasError: boolean | null;
+	streamed: boolean | null;
+}
+
+export function buildAgentLogsCsv(
+	logs: readonly AgentCsvLog[],
+	format: CsvFormat = detectCsvFormat(),
+): string {
+	const rows = logs.map((log) => [
+		log.createdAt,
+		log.usedProvider,
+		log.usedModel,
+		log.unifiedFinishReason ?? log.finishReason ?? "",
+		log.promptTokens,
+		log.completionTokens,
+		log.totalTokens,
+		log.cachedTokens ?? "",
+		formatCsvNumber(log.cost, format),
+		log.hasError,
+		log.streamed,
+		log.duration,
+		log.requestId,
+		log.id,
+	]);
+	return buildCsv(AGENT_LOG_CSV_HEADERS, rows, format);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,15 @@ export {
 } from "./coding-agents.js";
 
 export {
+	buildCsv,
+	type CsvFormat,
+	DEFAULT_CSV_FORMAT,
+	detectCsvFormat,
+	escapeCsvValue,
+	formatCsvNumber,
+} from "./csv.js";
+
+export {
 	AUTO_TOP_UP_DEFAULT_AMOUNT,
 	AUTO_TOP_UP_DEFAULT_THRESHOLD,
 	calculateFees,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,9 @@ export {
 } from "./coding-agents.js";
 
 export {
+	AGENT_LOG_CSV_HEADERS,
+	type AgentCsvLog,
+	buildAgentLogsCsv,
 	buildCsv,
 	type CsvFormat,
 	DEFAULT_CSV_FORMAT,


### PR DESCRIPTION
## Summary

Two fixes for the DevPass agent usage surfaces:

### Shorter default time window (perf)

Loading 30 days of agent summaries is slow and resource-heavy, and a shorter period is enough at a glance:

- **Dashboard "Coding Agents" summaries** (`apps/code`) now load the last **7 days** instead of 30, with the subtitle pointing users to open an agent to expand the window.
- **Agent detail page** now defaults to **7d** as well — the existing time-range picker still allows expanding up to 30d when needed.

### Locale-safe CSV export costs

Follow-up to #3218 — the cost column was still corrupted for users whose spreadsheet locale uses comma decimals. Those locales treat `.` as a thousands separator, so `0.334082` was parsed as the integer `334082`.

Fix: new shared CSV helpers in `@llmgateway/shared` (`detectCsvFormat`, `formatCsvNumber`, `escapeCsvValue`, `buildCsv`) that detect the browser locale's decimal separator via `Intl.NumberFormat`. For comma-decimal locales the export now writes `0,334082`-style decimals with `;` as the field delimiter — the CSV convention Excel/Numbers/Sheets expect there. Dot-decimal locales keep the exact same output as before.

Both CSV builders (DevPass agent detail in `apps/code`, agents activity view in `apps/ui`) now use the shared helpers, deduplicating the previously copy-pasted code. The `apps/ui` copy also gains the formula-injection guard that only `apps/code` had.

## Testing

- Added `packages/shared/src/csv.spec.ts` (15 tests: locale detection, decimal formatting, exponent/float-noise trimming, delimiter-aware quoting, formula-injection guard) — all pass
- `pnpm build` passes (17/17 tasks)
- `pnpm format` clean

https://claude.ai/code/session_01UuCoBJWWrACMPyW7BeYacA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agent activity CSV exports now use a shared, locale-aware CSV builder for consistent headers, escaping, and numeric formatting across the dashboard.
- **Bug Fixes**
  - Agent detail views now default to the last **7 days** when no valid time range is selected.
  - “Coding Agents” statistics now reflect the last **7 days** and prompt opening an agent to expand the time window.
- **Tests**
  - Added unit coverage for CSV formatting, escaping, delimiter/decimal detection, and agent-log CSV generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->