### PR TITLE
feat: motion polish across ui, playground, code

### DIFF
--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -12,6 +12,7 @@ import {
 	Stamp,
 	UserRound,
 } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -102,8 +103,8 @@ const setupActivationCopy: Record<
 			"DevPass will activate as soon as Stripe confirms the payment.",
 	},
 	success: {
-		title: "DevPass activated",
-		description: "Refreshing your dashboard.",
+		title: "Welcome aboard",
+		description: "Loading your dashboard.",
 	},
 	error: {
 		title: "Activation failed",
@@ -217,6 +218,7 @@ export default function DashboardShell({
 	);
 	const [setupActivationStatus, setSetupActivationStatus] =
 		useState<SetupActivationStatus | null>(null);
+	const reduceMotion = useReducedMotion();
 	const activeSetupSession = useRef<string | null>(null);
 	const finalizeDevPlanRef = useRef(finalizeMutation.mutateAsync);
 	const purchaseTrackedSession = useRef<string | null>(null);
@@ -308,13 +310,12 @@ export default function DashboardShell({
 		};
 
 		finalizeDevPlan()
-			.then((result) => {
+			.then(async (result) => {
 				if (signal.aborted) {
 					return;
 				}
 				if (result?.status === "ok" || result?.status === "already_processed") {
 					setSetupActivationStatus("success");
-					toast.success("DevPass activated");
 					if (purchaseTrackedSession.current !== sessionId) {
 						purchaseTrackedSession.current = sessionId;
 						const tier = devPlanStatusRef.current?.devPlan;
@@ -336,6 +337,9 @@ export default function DashboardShell({
 							return Array.isArray(key) && key[1] === "/dev-plans/status";
 						},
 					});
+					// Hold the success screen long enough for the stamp to land and
+					// be read before the setup param is cleared and the card unmounts.
+					await wait(1600, signal);
 				} else if (result?.status === "payment_pending") {
 					shouldClearSetupParam = false;
 					setSetupActivationStatus("processing");
@@ -512,14 +516,41 @@ export default function DashboardShell({
 			{activeSetupActivationCopy ? (
 				<main className="container mx-auto flex min-h-[calc(100vh-120px)] max-w-3xl items-center justify-center px-4 py-12">
 					<div className="w-full rounded-xl border bg-background p-8 text-center shadow-sm sm:p-12">
-						<div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
-							<Loader2
-								className={cn(
-									"h-10 w-10 text-foreground",
-									activeSetupActivationStatus !== "error" && "animate-spin",
-								)}
-							/>
-						</div>
+						{activeSetupActivationStatus === "success" ? (
+							<motion.div
+								initial={
+									reduceMotion
+										? { opacity: 0 }
+										: { opacity: 0, scale: 2.4, rotate: -18 }
+								}
+								animate={
+									reduceMotion
+										? { opacity: 1 }
+										: { opacity: 1, scale: 1, rotate: -8 }
+								}
+								transition={{ type: "spring", duration: 0.4 }}
+								className="mx-auto mb-6 flex justify-center"
+							>
+								<div className="rounded-md border-4 border-double border-emerald-700/80 px-6 py-3 text-center font-mono uppercase text-emerald-800 mix-blend-multiply dark:border-emerald-400/80 dark:text-emerald-300 dark:mix-blend-screen">
+									<div className="flex items-center justify-center gap-2 text-base font-bold tracking-[0.3em]">
+										<Stamp className="h-4 w-4" />
+										DevPass activated
+									</div>
+									<div className="mt-0.5 text-[9px] tracking-[0.2em]">
+										Visa granted · welcome aboard
+									</div>
+								</div>
+							</motion.div>
+						) : (
+							<div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
+								<Loader2
+									className={cn(
+										"h-10 w-10 text-foreground",
+										activeSetupActivationStatus !== "error" && "animate-spin",
+									)}
+								/>
+							</div>
+						)}
 						<h1 className="text-2xl font-semibold sm:text-3xl">
 							{activeSetupActivationCopy.title}
 						</h1>

--- a/apps/code/src/app/dashboard/components/QuickStart.tsx
+++ b/apps/code/src/app/dashboard/components/QuickStart.tsx
@@ -144,12 +144,21 @@ export default function QuickStart({ apiKey }: { apiKey: string }) {
 					onClick={handleCopy}
 					className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
 				>
-					{copied ? (
-						<Check className="h-3 w-3" />
-					) : (
-						<Copy className="h-3 w-3" />
-					)}
-					{copied ? "Copied" : "Copy"}
+					<span className="relative flex h-3 w-3 items-center justify-center">
+						<Copy
+							className={`h-3 w-3 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-[opacity] ${
+								copied ? "scale-[0.45] opacity-0" : "scale-100 opacity-100"
+							}`}
+						/>
+						<Check
+							className={`absolute h-3 w-3 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-[opacity] ${
+								copied ? "scale-100 opacity-100" : "scale-[0.45] opacity-0"
+							}`}
+						/>
+					</span>
+					<span className="min-w-[6ch] text-left">
+						{copied ? "Copied" : "Copy"}
+					</span>
 				</button>
 			</div>
 

--- a/apps/code/src/app/dashboard/components/ResetPassCard.tsx
+++ b/apps/code/src/app/dashboard/components/ResetPassCard.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { ArrowUpRight, Loader2, Plane, Stamp } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
@@ -114,7 +114,10 @@ export default function ResetPassCard({
 	const queryClient = useQueryClient();
 	const { uiUrl, posthogKey } = useAppConfig();
 	const posthog = usePostHog();
-	const [justStamped, setJustStamped] = useState(false);
+	const [stampOverlay, setStampOverlay] = useState<
+		{ kind: "redeemed" } | { kind: "purchased"; amount: number } | null
+	>(null);
+	const reduceMotion = useReducedMotion();
 
 	const available = includedRemaining + purchased;
 	const nothingToReset = premiumCreditsUsed <= 0;
@@ -158,8 +161,8 @@ export default function ResetPassCard({
 		"/dev-plans/reset-pass/redeem",
 		{
 			onSuccess: async () => {
-				setJustStamped(true);
-				setTimeout(() => setJustStamped(false), 2200);
+				setStampOverlay({ kind: "redeemed" });
+				setTimeout(() => setStampOverlay(null), 2200);
 				await invalidateStatus();
 			},
 			onError: () => {
@@ -173,9 +176,8 @@ export default function ResetPassCard({
 		"/dev-plans/reset-pass/purchase",
 		{
 			onSuccess: async (data) => {
-				toast.success("Reset Pass stamped into your passport", {
-					description: `$${data.amount} was charged to your saved payment method.`,
-				});
+				setStampOverlay({ kind: "purchased", amount: data.amount });
+				setTimeout(() => setStampOverlay(null), 2200);
 				await invalidateStatus();
 			},
 			onError: (error) => {
@@ -203,24 +205,50 @@ export default function ResetPassCard({
 
 	return (
 		<div className="relative mt-4 overflow-hidden rounded-lg border border-dashed border-stone-400/70 bg-stone-50/70 dark:border-stone-600/70 dark:bg-stone-900/30">
-			{/* Full-card stamp slammed on a successful redeem */}
+			{/* Full-card stamp slammed on a successful redeem or purchase */}
 			<AnimatePresence>
-				{justStamped && (
+				{stampOverlay && (
 					<motion.div
-						initial={{ opacity: 0, scale: 2.2, rotate: -18 }}
-						animate={{ opacity: 1, scale: 1, rotate: -8 }}
+						key={stampOverlay.kind}
+						initial={
+							reduceMotion
+								? { opacity: 0 }
+								: stampOverlay.kind === "redeemed"
+									? { opacity: 0, scale: 2.2, rotate: -18 }
+									: { opacity: 0, scale: 2.2, rotate: 16 }
+						}
+						animate={
+							reduceMotion
+								? { opacity: 1 }
+								: {
+										opacity: 1,
+										scale: 1,
+										rotate: stampOverlay.kind === "redeemed" ? -8 : 6,
+									}
+						}
 						exit={{ opacity: 0 }}
 						transition={{ type: "spring", duration: 0.4 }}
 						className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center"
 					>
-						<div className="rounded-md border-4 border-double border-emerald-700/80 px-6 py-2 text-center font-mono uppercase text-emerald-800 mix-blend-multiply dark:border-emerald-400/80 dark:text-emerald-300 dark:mix-blend-screen">
-							<div className="text-sm font-bold tracking-[0.3em]">
-								Allowance restored
+						{stampOverlay.kind === "redeemed" ? (
+							<div className="rounded-md border-4 border-double border-emerald-700/80 px-6 py-2 text-center font-mono uppercase text-emerald-800 mix-blend-multiply dark:border-emerald-400/80 dark:text-emerald-300 dark:mix-blend-screen">
+								<div className="text-sm font-bold tracking-[0.3em]">
+									Allowance restored
+								</div>
+								<div className="mt-0.5 text-[9px] tracking-[0.2em]">
+									Fresh week · full premium limit
+								</div>
 							</div>
-							<div className="mt-0.5 text-[9px] tracking-[0.2em]">
-								Fresh week · full premium limit
+						) : (
+							<div className="rounded-md border-4 border-double border-indigo-700/80 px-6 py-2 text-center font-mono uppercase text-indigo-800 mix-blend-multiply dark:border-indigo-400/80 dark:text-indigo-300 dark:mix-blend-screen">
+								<div className="text-sm font-bold tracking-[0.3em]">
+									Pass acquired
+								</div>
+								<div className="mt-0.5 text-[9px] tracking-[0.2em]">
+									${stampOverlay.amount} charged · redeem anytime
+								</div>
 							</div>
-						</div>
+						)}
 					</motion.div>
 				)}
 			</AnimatePresence>

--- a/apps/code/src/app/data/[year]/page.tsx
+++ b/apps/code/src/app/data/[year]/page.tsx
@@ -88,8 +88,20 @@ function ScoreMeter({ label, value }: { label: string; value: number }) {
 
 function ModelRow({ model, rank }: { model: ModelSurveyModel; rank: number }) {
 	const topUseCase = model.useCases[0];
+	// Only the rows near the fold stagger in; deep rows render instantly so a
+	// long registry never feels like it's loading.
+	const staggered = rank <= 10;
+	const staggerStep = (rank - 1) * 70;
+	const delayMs = 140 + staggerStep;
 	return (
-		<div className="border-b border-dashed border-stone-300/80 px-4 py-5 last:border-b-0 dark:border-stone-700/80 sm:flex sm:flex-wrap sm:items-center sm:gap-x-6 sm:gap-y-4 sm:px-6">
+		<div
+			className={`border-b border-dashed border-stone-300/80 px-4 py-5 last:border-b-0 dark:border-stone-700/80 sm:flex sm:flex-wrap sm:items-center sm:gap-x-6 sm:gap-y-4 sm:px-6 ${
+				staggered
+					? "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both"
+					: ""
+			}`}
+			style={staggered ? { animationDelay: `${delayMs}ms` } : undefined}
+		>
 			<div className="flex min-w-0 items-center gap-4 sm:flex-1">
 				<div
 					className={
@@ -186,7 +198,7 @@ export default async function CensusPage({
 				{/* Hero */}
 				<section className="relative overflow-hidden border-b">
 					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_55%_55%_at_50%_-5%,_var(--tw-gradient-stops))] from-emerald-500/10 via-transparent to-transparent" />
-					<div className="container relative mx-auto max-w-3xl px-4 pt-16 pb-12 text-center sm:pt-20">
+					<div className="container relative mx-auto max-w-3xl px-4 pt-16 pb-12 text-center motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both sm:pt-20">
 						<div className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-1.5 font-mono text-xs font-medium uppercase tracking-[0.15em] text-emerald-600 dark:text-emerald-400">
 							<ClipboardCheck className="h-3.5 w-3.5" />
 							{isCurrentYear
@@ -232,8 +244,12 @@ export default async function CensusPage({
 									label: "Models on the registry",
 									value: results.totalModelsRated,
 								},
-							].map((stat) => (
-								<div key={stat.label}>
+							].map((stat, index) => (
+								<div
+									key={stat.label}
+									className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both"
+									style={{ animationDelay: `${index * 70}ms` }}
+								>
 									<div className="font-mono text-2xl font-bold tabular-nums sm:text-3xl">
 										{stat.value.toLocaleString()}
 									</div>

--- a/apps/code/src/components/CodingModelsShowcase.tsx
+++ b/apps/code/src/components/CodingModelsShowcase.tsx
@@ -282,14 +282,25 @@ export function CodingModelsShowcase({
 								<button
 									type="button"
 									onClick={() => copyToClipboard(model.id)}
-									className="shrink-0 p-1 rounded hover:bg-muted transition-colors"
+									className="shrink-0 p-1 rounded hover:bg-muted transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.98]"
 									title="Copy model ID"
 								>
-									{copiedModel === model.id ? (
-										<Check className="h-3 w-3 text-green-600" />
-									) : (
-										<Copy className="h-3 w-3 text-muted-foreground" />
-									)}
+									<span className="relative flex h-3 w-3 items-center justify-center">
+										<Copy
+											className={`h-3 w-3 text-muted-foreground transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-[opacity] ${
+												copiedModel === model.id
+													? "scale-[0.45] opacity-0"
+													: "scale-100 opacity-100"
+											}`}
+										/>
+										<Check
+											className={`absolute h-3 w-3 text-green-600 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-[opacity] ${
+												copiedModel === model.id
+													? "scale-100 opacity-100"
+													: "scale-[0.45] opacity-0"
+											}`}
+										/>
+									</span>
 								</button>
 							</div>
 

--- a/apps/code/src/components/ui/button.tsx
+++ b/apps/code/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive active:scale-[0.98]",
 	{
 		variants: {
 			variant: {

--- a/apps/playground/src/components/ai-elements/code-block.tsx
+++ b/apps/playground/src/components/ai-elements/code-block.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CheckIcon, CopyIcon } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
 	createContext,
 	memo,
@@ -461,6 +462,7 @@ export const CodeBlockCopyButton = ({
 	const [isCopied, setIsCopied] = useState(false);
 	const timeoutRef = useRef<number>(0);
 	const { code } = use(CodeBlockContext);
+	const reduceMotion = useReducedMotion();
 
 	const copyToClipboard = useCallback(async () => {
 		if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -490,8 +492,6 @@ export const CodeBlockCopyButton = ({
 		[],
 	);
 
-	const Icon = isCopied ? CheckIcon : CopyIcon;
-
 	return (
 		<Button
 			className={cn("shrink-0", className)}
@@ -500,7 +500,34 @@ export const CodeBlockCopyButton = ({
 			variant="ghost"
 			{...props}
 		>
-			{children ?? <Icon size={14} />}
+			{children ?? (
+				<span className="relative flex size-4 items-center justify-center">
+					<AnimatePresence initial={false}>
+						<motion.span
+							key={isCopied ? "check" : "copy"}
+							initial={
+								reduceMotion
+									? { opacity: 0 }
+									: { opacity: 0, transform: "scale(0.45) rotate(-18deg)" }
+							}
+							animate={
+								reduceMotion
+									? { opacity: 1 }
+									: { opacity: 1, transform: "scale(1) rotate(0deg)" }
+							}
+							exit={
+								reduceMotion
+									? { opacity: 0 }
+									: { opacity: 0, transform: "scale(0.45) rotate(18deg)" }
+							}
+							transition={{ duration: 0.16, ease: "easeOut" }}
+							className="absolute inset-0 flex items-center justify-center"
+						>
+							{isCopied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+						</motion.span>
+					</AnimatePresence>
+				</span>
+			)}
 		</Button>
 	);
 };

--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -6,6 +6,7 @@ import {
 } from "@stripe/react-stripe-js";
 import { useQueryClient } from "@tanstack/react-query";
 import { CreditCard, ExternalLink, Plus } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -403,6 +404,7 @@ function AmountStep({
 }
 
 function SuccessStep({ onClose }: { onClose: () => void }) {
+	const reduceMotion = useReducedMotion();
 	return (
 		<>
 			<DialogHeader>
@@ -414,12 +416,25 @@ function SuccessStep({ onClose }: { onClose: () => void }) {
 				</DialogDescription>
 			</DialogHeader>
 			<div className="flex flex-col items-center gap-4 py-4">
-				<span
+				<motion.span
 					aria-hidden
-					className="-rotate-6 rounded border-2 border-lounge-gold/60 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.3em] text-lounge-gold"
+					initial={
+						reduceMotion
+							? { opacity: 0 }
+							: { opacity: 0, scale: 2, rotate: -16 }
+					}
+					animate={
+						reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, rotate: -6 }
+					}
+					transition={
+						reduceMotion
+							? { duration: 0.2, ease: "easeOut" }
+							: { type: "spring", duration: 0.4 }
+					}
+					className="rounded border-2 border-lounge-gold/60 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.3em] text-lounge-gold"
 				>
 					Credits added
-				</span>
+				</motion.span>
 				<p className="text-center">
 					Thank you for your purchase. Your credits are now available for use.
 				</p>

--- a/apps/playground/src/components/lounge/sidebar-points.tsx
+++ b/apps/playground/src/components/lounge/sidebar-points.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Flame, Trophy } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 
 import { useLoungePoints } from "@/hooks/useLoungePoints";
@@ -10,6 +11,7 @@ import { useUser } from "@/hooks/useUser";
 export function SidebarLoungePoints() {
 	const { user } = useUser();
 	const { data } = useLoungePoints();
+	const reduceMotion = useReducedMotion();
 
 	if (!user || !data) {
 		return null;
@@ -26,16 +28,47 @@ export function SidebarLoungePoints() {
 			className="mx-2 mb-1 flex items-center gap-2 rounded-md bg-sidebar-accent/60 px-3 py-2 text-xs text-sidebar-foreground transition-colors hover:bg-sidebar-accent group-data-[collapsible=icon]:hidden"
 		>
 			<Trophy className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-			<span className="font-semibold tabular-nums">
-				{stats.totalPoints.toLocaleString()}
+			{/* Points earned after a message roll in like an odometer so the
+			    reward is visible without pulsing or floating badges. */}
+			<span className="relative inline-flex overflow-hidden font-semibold tabular-nums">
+				<AnimatePresence mode="popLayout" initial={false}>
+					<motion.span
+						key={stats.totalPoints}
+						initial={
+							reduceMotion
+								? { opacity: 0 }
+								: { opacity: 0, transform: "translateY(100%)" }
+						}
+						animate={{ opacity: 1, transform: "translateY(0%)" }}
+						exit={
+							reduceMotion
+								? { opacity: 0 }
+								: { opacity: 0, transform: "translateY(-100%)" }
+						}
+						transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+					>
+						{stats.totalPoints.toLocaleString()}
+					</motion.span>
+				</AnimatePresence>
 			</span>
 			<span className="text-muted-foreground">points · Lv {stats.level}</span>
-			{stats.currentStreak > 1 ? (
-				<span className="ml-auto inline-flex items-center gap-0.5 text-muted-foreground">
-					<Flame className="h-3.5 w-3.5 text-orange-500" />
-					{stats.currentStreak}
-				</span>
-			) : null}
+			<AnimatePresence initial={false}>
+				{stats.currentStreak > 1 ? (
+					<motion.span
+						key="streak"
+						initial={
+							reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.45 }
+						}
+						animate={{ opacity: 1, scale: 1 }}
+						exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.45 }}
+						transition={{ duration: 0.16, ease: "easeOut" }}
+						className="ml-auto inline-flex items-center gap-0.5 text-muted-foreground"
+					>
+						<Flame className="h-3.5 w-3.5 text-orange-500" />
+						{stats.currentStreak}
+					</motion.span>
+				) : null}
+			</AnimatePresence>
 		</Link>
 	);
 }

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -530,6 +530,12 @@ export const ChatSidebar = function ChatSidebar({
 				.split("; ")
 				.includes(`${HISTORY_COLLAPSED_STORAGE_KEY}=1`),
 	);
+	// Transitions stay off until after hydration so a cookie-collapsed list
+	// doesn't animate shut on every page load.
+	const [historyTransitionReady, setHistoryTransitionReady] = useState(false);
+	useEffect(() => {
+		setHistoryTransitionReady(true);
+	}, []);
 
 	const toggleHistoryCollapsed = useCallback(() => {
 		setIsHistoryCollapsed((prev) => {
@@ -865,59 +871,79 @@ export const ChatSidebar = function ChatSidebar({
 							}`}
 						/>
 					</button>
-					{isHistoryCollapsed ? null : chats.length === 0 ? (
-						<div className="flex flex-col items-center justify-center py-8 text-center">
-							<MessageSquare className="h-12 w-12 text-muted-foreground/50 mb-4" />
-							<p className="text-sm text-muted-foreground mb-2">
-								No chat history
-							</p>
-							<p className="text-xs text-muted-foreground">
-								Start a new conversation to see it here
-							</p>
-						</div>
-					) : (
-						<>
-							{pinnedChats.length > 0 && (
-								<div className="shrink-0 max-h-[45%] overflow-y-auto border-b border-sidebar-border/60 pb-1">
-									<div className="px-5 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider group-data-[collapsible=icon]:hidden">
-										Pinned
-									</div>
-									{pinnedChats.map((chat) => (
-										<div key={chat.id} style={{ height: ROW_HEIGHT_CHAT }}>
-											<ChatHistoryItem
-												chat={chat}
-												currentChatId={currentChatId}
-												editingId={editingId}
-												editTitle={editTitle}
-												pendingFocusChatId={pendingFocusChatId}
-												isPageLoading={isPageLoading}
-												isMobile={isMobile}
-												onChatSelect={handleChatSelect}
-												onEditTitleChange={setEditTitle}
-												onSaveTitle={saveTitle}
-												onCancelEdit={cancelEditTitle}
-												onDeleteChat={handleDeleteChat}
-												onTogglePin={handleTogglePin}
-												onStartEdit={handleEditTitle}
-												onEditFocused={onEditFocused}
-											/>
-										</div>
-									))}
+					{/* Collapse animates height so the rotating chevron's promise is
+					    kept; grid-rows keeps the transition interruptible. */}
+					<div
+						className={`grid min-h-0 flex-1 ${
+							historyTransitionReady
+								? "transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-[opacity]"
+								: ""
+						} ${
+							isHistoryCollapsed
+								? "grid-rows-[0fr] opacity-0"
+								: "grid-rows-[1fr] opacity-100"
+						}`}
+					>
+						<div
+							className="flex min-h-0 flex-col overflow-hidden"
+							aria-hidden={isHistoryCollapsed}
+							{...(isHistoryCollapsed ? { inert: true } : {})}
+						>
+							{chats.length === 0 ? (
+								<div className="flex flex-col items-center justify-center py-8 text-center">
+									<MessageSquare className="h-12 w-12 text-muted-foreground/50 mb-4" />
+									<p className="text-sm text-muted-foreground mb-2">
+										No chat history
+									</p>
+									<p className="text-xs text-muted-foreground">
+										Start a new conversation to see it here
+									</p>
 								</div>
+							) : (
+								<>
+									{pinnedChats.length > 0 && (
+										<div className="shrink-0 max-h-[45%] overflow-y-auto border-b border-sidebar-border/60 pb-1">
+											<div className="px-5 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider group-data-[collapsible=icon]:hidden">
+												Pinned
+											</div>
+											{pinnedChats.map((chat) => (
+												<div key={chat.id} style={{ height: ROW_HEIGHT_CHAT }}>
+													<ChatHistoryItem
+														chat={chat}
+														currentChatId={currentChatId}
+														editingId={editingId}
+														editTitle={editTitle}
+														pendingFocusChatId={pendingFocusChatId}
+														isPageLoading={isPageLoading}
+														isMobile={isMobile}
+														onChatSelect={handleChatSelect}
+														onEditTitleChange={setEditTitle}
+														onSaveTitle={saveTitle}
+														onCancelEdit={cancelEditTitle}
+														onDeleteChat={handleDeleteChat}
+														onTogglePin={handleTogglePin}
+														onStartEdit={handleEditTitle}
+														onEditFocused={onEditFocused}
+													/>
+												</div>
+											))}
+										</div>
+									)}
+									{historyRows.length > 0 && (
+										<List
+											className="min-h-0 w-full flex-1"
+											style={{ width: "100%" }}
+											rowComponent={ChatHistoryRowComponent}
+											rowCount={historyRows.length}
+											rowHeight={getChatHistoryRowHeight}
+											rowProps={rowProps}
+											overscanCount={8}
+										/>
+									)}
+								</>
 							)}
-							{historyRows.length > 0 && (
-								<List
-									className="min-h-0 w-full flex-1"
-									style={{ width: "100%" }}
-									rowComponent={ChatHistoryRowComponent}
-									rowCount={historyRows.length}
-									rowHeight={getChatHistoryRowHeight}
-									rowProps={rowProps}
-									overscanCount={8}
-								/>
-							)}
-						</>
-					)}
+						</div>
+					</div>
 				</div>
 			</SidebarContent>
 

--- a/apps/playground/src/components/ui/button.tsx
+++ b/apps/playground/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive active:scale-[0.98]",
 	{
 		variants: {
 			variant: {

--- a/apps/playground/src/components/ui/popover.tsx
+++ b/apps/playground/src/components/ui/popover.tsx
@@ -26,7 +26,7 @@ const PopoverContent = ({
 			align={align}
 			sideOffset={sideOffset}
 			className={cn(
-				"z-50 w-72 rounded-md border bg-popover p-2 text-popover-foreground shadow-md outline-none",
+				"z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-2 text-popover-foreground shadow-md outline-none",
 				"data-[state=open]:animate-in data-[state=closed]:animate-out",
 				"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
 				"data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",

--- a/apps/ui/src/lib/components/button.tsx
+++ b/apps/ui/src/lib/components/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer active:scale-[0.98]",
 	{
 		variants: {
 			variant: {

--- a/apps/ui/src/lib/components/toast.tsx
+++ b/apps/ui/src/lib/components/toast.tsx
@@ -28,7 +28,7 @@ const ToastViewport = ({
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-	"group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+	"group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:not-data-[swipe=end]:slide-out-to-top-full data-[state=closed]:not-data-[swipe=end]:sm:slide-out-to-bottom-full data-[swipe=end]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
 	{
 		variants: {
 			variant: {

--- a/apps/ui/src/lib/utils/markdown-code-block.tsx
+++ b/apps/ui/src/lib/utils/markdown-code-block.tsx
@@ -188,14 +188,25 @@ function CopyButton({ code }: { code: string }) {
 		<button
 			type="button"
 			onClick={handleCopy}
-			className="absolute top-3 right-3 p-2 rounded-md bg-muted/50 hover:bg-muted transition-colors z-10"
+			className="absolute top-3 right-3 p-2 rounded-md bg-muted/50 hover:bg-muted transition-[background-color,color,transform] duration-150 ease-out z-10 active:scale-[0.98]"
 			aria-label="Copy code"
 		>
-			{copied ? (
-				<CheckIcon className="h-4 w-4 text-green-500" />
-			) : (
-				<CopyIcon className="h-4 w-4 text-muted-foreground" />
-			)}
+			<span className="relative flex h-4 w-4 items-center justify-center">
+				<CopyIcon
+					className={`h-4 w-4 text-muted-foreground transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-[opacity] ${
+						copied
+							? "scale-[0.45] opacity-0 -rotate-[18deg]"
+							: "scale-100 opacity-100 rotate-0"
+					}`}
+				/>
+				<CheckIcon
+					className={`absolute h-4 w-4 text-green-500 transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-[opacity] ${
+						copied
+							? "scale-100 opacity-100 rotate-0"
+							: "scale-[0.45] opacity-0 rotate-[18deg]"
+					}`}
+				/>
+			</span>
 		</button>
 	);
 }

--- a/packages/shared/src/components/ui/button.tsx
+++ b/packages/shared/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive active:scale-[0.98]",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## Summary

Implements the 10 highest-leverage opportunities from a full animation audit of `apps/ui`, `apps/playground`, and `apps/code`, gated on Emil Kowalski's frequency/purpose/speed/function framework. Every candidate that failed the gate (keyboard-driven surfaces, data being read, nav pills, modal origins) was deliberately left alone.

### What changed

| Surface | Change |
| --- | --- |
| All four shared `Button`s (ui, playground, code, shared) | `active:scale-[0.98]` press feedback — nothing in any app responded to press before |
| playground `PopoverContent` | added the missing `origin-(--radix-popover-content-transform-origin)` — the 720px model picker now grows from its trigger like every sibling primitive |
| ui Radix toast | exits the same edge it enters (bottom on desktop, top on mobile); swipe-dismiss keeps its rightward exit via a `not-data-[swipe=end]` variant |
| DevPass activation (`DashboardShell`) | spinner+toast replaced with a "DEVPASS ACTIVATED" visa stamp (house spring, `{ type: "spring", duration: 0.4 }`), success screen held 1.6s (abort-safe) before the dashboard swap |
| Reset Pass purchase (`ResetPassCard`) | purchase now slams the full-card stamp the copy always promised (indigo "PASS ACQUIRED" with the charge amount folded in); duplicate success toast removed |
| Lounge points pill | odometer-style digit roll on value change (250ms, `[0.16,1,0.3,1]`), streak flame crossfade — the core gamification loop is finally visible |
| Copy buttons (ui markdown code blocks, playground code blocks, code QuickStart + models showcase) | 150–160ms icon crossfade instead of instant swaps; QuickStart label width jump fixed |
| playground Chats section | grid-rows height transition matching the chevron that always rotated; transition suppressed on hydration so cookie-collapsed users don't watch it close on load |
| playground credits dialog | the stamp-shaped "CREDITS ADDED" badge now stamps in |
| Census `/data/[year]` | `motion-safe:` staggered entrance (70ms steps) for hero, stats, and the first 10 registry rows — deep rows render instantly |

All new movement has `prefers-reduced-motion` fallbacks (fade-only, never zero feedback). Only `transform`/`opacity` are animated except the Chats collapse, which is an interruptible accordion-style transition confined to the sidebar subtree.

### Review

Ran an adversarial review against the repo's review-animations bar; its findings (diagonal toast swipe exit, untransitioned press scales on raw buttons, reduced-motion gaps, split stamp physics, stamp+toast double-fire, collapse replay on hydration) are all fixed in this diff. Two conscious accepts: the pre-existing `transition-all` on the shared Button cva is left as-is (stock shadcn; scoping it repo-wide is a separate change), and the points pill snaps ~2ch wider at digit-count boundaries (rare; the fixes are all worse).

### Test plan

- `turbo run build --filter=ui --filter=playground --filter=code` ✓ (15/15)
- `pnpm test:unit` ✓ (3053 passed)
- `pnpm format` / lint-staged ✓
- Recorded an end-to-end demo video of every animation against the live local stack, including the real Stripe test checkout for the activation and purchase stamps (shared in the session)

https://claude.ai/code/session_01DobvVEwfVg89UUMzUBsxRF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer activation success screens for DevPass purchases and redemptions, including animated confirmation overlays and transaction details.
  * Copy buttons now smoothly transition between copy and copied states.
  * Chat history collapse transitions now preserve accessibility and avoid unwanted animation during initial loading.

* **Improvements**
  * Added polished entry animations across dashboard, census, credits, and points displays.
  * Animations now respect reduced-motion preferences.
  * Buttons provide subtle pressed-state feedback, and toast dismissal behavior is more consistent.
  * Improved popover animation positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->