### PR TITLE
fix(models): remove license from BGE-M3 and Qwen3-Embedding-8B descriptions

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2881,7 +2881,7 @@ export const alibabaModels = [
 		id: "qwen3-embedding-8b",
 		name: "Qwen3 Embedding 8B",
 		description:
-			"Qwen3 embedding model with 32K context and configurable output dimensions (32–4096) via Matryoshka representation learning. No. 1 on the MTEB multilingual leaderboard as of June 2025 (score 70.58), supporting 100+ languages. Apache 2.0 license.",
+			"Qwen3 embedding model with 32K context and configurable output dimensions (32–4096) via Matryoshka representation learning. No. 1 on the MTEB multilingual leaderboard as of June 2025 (score 70.58), supporting 100+ languages.",
 		family: "alibaba",
 		output: ["embedding"],
 		releasedAt: new Date("2025-06-05"),

--- a/packages/models/src/models/baai.ts
+++ b/packages/models/src/models/baai.ts
@@ -5,7 +5,7 @@ export const baaiModels = [
 		id: "bge-m3",
 		name: "BGE-M3",
 		description:
-			"BAAI's multilingual embedding model supporting dense, sparse, and multi-vector retrieval across 100+ languages. 8K context, 1024-dim output. MIT license.",
+			"BAAI's multilingual embedding model supporting dense, sparse, and multi-vector retrieval across 100+ languages. 8K context, 1024-dim output.",
 		family: "baai",
 		output: ["embedding"],
 		releasedAt: new Date("2024-01-29"),


### PR DESCRIPTION
Model descriptions on the website should describe the model's capabilities, not its license. The license info is available on the provider's site and doesn't belong in the description text.

## Changes
- Removed "MIT license." from BGE-M3 description
- Removed "Apache 2.0 license." from Qwen3-Embedding-8B description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model descriptions to remove license wording while preserving all other information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->