### PR TITLE
fix: bill storage cost in all modes and show it

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -414,6 +414,7 @@ const orgMetricsSchema = z.object({
 	cachedCost: z.number(),
 	cacheWriteTokens: z.number(),
 	cacheWriteCost: z.number(),
+	dataStorageCost: z.number(),
 	mostUsedModel: z.string().nullable(),
 	mostUsedProvider: z.string().nullable(),
 	mostUsedModelCost: z.number(),
@@ -2602,6 +2603,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 	let cachedCost = 0;
 	let cacheWriteTokens = 0;
 	let cacheWriteCost = 0;
+	let dataStorageCost = 0;
 	let discountSavings = 0;
 	let mostUsedModel: string | null = null;
 	let mostUsedProvider: string | null = null;
@@ -2659,6 +2661,10 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 					sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
 						"cacheWriteInputCost",
 					),
+				dataStorageCost:
+					sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+						"dataStorageCost",
+					),
 			})
 			.from(projectHourlyStats)
 			.where(
@@ -2685,6 +2691,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 			cachedCost = Number(totals.cachedInputCost) || 0;
 			cacheWriteTokens = Number(totals.cacheWriteTokens) || 0;
 			cacheWriteCost = Number(totals.cacheWriteInputCost) || 0;
+			dataStorageCost = Number(totals.dataStorageCost) || 0;
 			discountSavings = Number(totals.discountSavings) || 0;
 		}
 
@@ -2758,6 +2765,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 		cachedCost,
 		cacheWriteTokens,
 		cacheWriteCost,
+		dataStorageCost,
 		mostUsedModel,
 		mostUsedProvider,
 		mostUsedModelCost,
@@ -3112,6 +3120,7 @@ const projectMetricsSchema = z.object({
 	cachedCost: z.number(),
 	cacheWriteTokens: z.number(),
 	cacheWriteCost: z.number(),
+	dataStorageCost: z.number(),
 	mostUsedModel: z.string().nullable(),
 	mostUsedProvider: z.string().nullable(),
 	mostUsedModelCost: z.number(),
@@ -3194,6 +3203,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 	let cachedCost = 0;
 	let cacheWriteTokens = 0;
 	let cacheWriteCost = 0;
+	let dataStorageCost = 0;
 	let discountSavings = 0;
 	let mostUsedModel: string | null = null;
 	let mostUsedProvider: string | null = null;
@@ -3249,6 +3259,10 @@ admin.openapi(getProjectMetrics, async (c) => {
 				sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
 					"cacheWriteInputCost",
 				),
+			dataStorageCost:
+				sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+					"dataStorageCost",
+				),
 		})
 		.from(projectHourlyStats)
 		.where(
@@ -3275,6 +3289,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 		cachedCost = Number(totals.cachedInputCost) || 0;
 		cacheWriteTokens = Number(totals.cacheWriteTokens) || 0;
 		cacheWriteCost = Number(totals.cacheWriteInputCost) || 0;
+		dataStorageCost = Number(totals.dataStorageCost) || 0;
 		discountSavings = Number(totals.discountSavings) || 0;
 	}
 
@@ -3337,6 +3352,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 		cachedCost,
 		cacheWriteTokens,
 		cacheWriteCost,
+		dataStorageCost,
 		mostUsedModel,
 		mostUsedProvider,
 		mostUsedModelCost,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -209,6 +209,7 @@ const orgMetricsSchema = z.object({
 	cachedCost: z.number(),
 	cacheWriteTokens: z.number(),
 	cacheWriteCost: z.number(),
+	dataStorageCost: z.number(),
 	mostUsedModel: z.string().nullable(),
 	mostUsedProvider: z.string().nullable(),
 	mostUsedModelCost: z.number(),
@@ -2269,6 +2270,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 	let cachedCost = 0;
 	let cacheWriteTokens = 0;
 	let cacheWriteCost = 0;
+	let dataStorageCost = 0;
 	let discountSavings = 0;
 	let mostUsedModel: string | null = null;
 	let mostUsedProvider: string | null = null;
@@ -2325,6 +2327,10 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 					sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
 						"cacheWriteInputCost",
 					),
+				dataStorageCost:
+					sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+						"dataStorageCost",
+					),
 			})
 			.from(projectHourlyStats)
 			.where(
@@ -2347,6 +2353,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 			cachedCost = Number(totals.cachedInputCost) || 0;
 			cacheWriteTokens = Number(totals.cacheWriteTokens) || 0;
 			cacheWriteCost = Number(totals.cacheWriteInputCost) || 0;
+			dataStorageCost = Number(totals.dataStorageCost) || 0;
 			discountSavings = Number(totals.discountSavings) || 0;
 		}
 
@@ -2411,6 +2418,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 		cachedCost,
 		cacheWriteTokens,
 		cacheWriteCost,
+		dataStorageCost,
 		mostUsedModel,
 		mostUsedProvider,
 		mostUsedModelCost,
@@ -2740,6 +2748,7 @@ const projectMetricsSchema = z.object({
 	cachedCost: z.number(),
 	cacheWriteTokens: z.number(),
 	cacheWriteCost: z.number(),
+	dataStorageCost: z.number(),
 	mostUsedModel: z.string().nullable(),
 	mostUsedProvider: z.string().nullable(),
 	mostUsedModelCost: z.number(),
@@ -2818,6 +2827,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 	let cachedCost = 0;
 	let cacheWriteTokens = 0;
 	let cacheWriteCost = 0;
+	let dataStorageCost = 0;
 	let discountSavings = 0;
 	let mostUsedModel: string | null = null;
 	let mostUsedProvider: string | null = null;
@@ -2872,6 +2882,10 @@ admin.openapi(getProjectMetrics, async (c) => {
 				sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
 					"cacheWriteInputCost",
 				),
+			dataStorageCost:
+				sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+					"dataStorageCost",
+				),
 		})
 		.from(projectHourlyStats)
 		.where(
@@ -2894,6 +2908,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 		cachedCost = Number(totals.cachedInputCost) || 0;
 		cacheWriteTokens = Number(totals.cacheWriteTokens) || 0;
 		cacheWriteCost = Number(totals.cacheWriteInputCost) || 0;
+		dataStorageCost = Number(totals.dataStorageCost) || 0;
 		discountSavings = Number(totals.discountSavings) || 0;
 	}
 
@@ -2952,6 +2967,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 		cachedCost,
 		cacheWriteTokens,
 		cacheWriteCost,
+		dataStorageCost,
 		mostUsedModel,
 		mostUsedProvider,
 		mostUsedModelCost,

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -358,7 +358,10 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		(sum, day) => sum + day.requestCount,
 		0,
 	);
-	const prevCost = prevActivityData.reduce((sum, day) => sum + day.cost, 0);
+	const prevCost = prevActivityData.reduce(
+		(sum, day) => sum + day.cost + day.dataStorageCost,
+		0,
+	);
 	const prevSavings = prevActivityData.reduce(
 		(sum, day) => sum + day.discountSavings,
 		0,
@@ -366,7 +369,10 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 
 	const cacheHitRate =
 		totalRequests > 0 ? (totalCached / totalRequests) * 100 : 0;
-	const avgCostPerRequest = totalRequests > 0 ? totalCost / totalRequests : 0;
+	// Data retention storage is billed on top of inference costs, so the
+	// headline spend includes it.
+	const totalSpend = totalCost + totalDataStorageCost;
+	const avgCostPerRequest = totalRequests > 0 ? totalSpend / totalRequests : 0;
 
 	// Day-by-day series for the KPI sparklines, with missing days filled as 0.
 	const { requestsTrend, costTrend } = (() => {
@@ -376,7 +382,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 			);
 			return {
 				requestsTrend: sorted.map((day) => day.requestCount),
-				costTrend: sorted.map((day) => day.cost),
+				costTrend: sorted.map((day) => day.cost + day.dataStorageCost),
 			};
 		}
 		const byDate = new Map(activityData.map((day) => [day.date, day]));
@@ -385,7 +391,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		for (let i = 0; i < rangeDays; i++) {
 			const day = byDate.get(format(addDays(from, i), "yyyy-MM-dd"));
 			requests.push(day?.requestCount ?? 0);
-			costs.push(day?.cost ?? 0);
+			costs.push(day ? day.cost + day.dataStorageCost : 0);
 		}
 		return { requestsTrend: requests, costTrend: costs };
 	})();
@@ -550,7 +556,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 										? "BYOK Usage"
 										: "Total Spend"
 							}
-							value={`$${totalCost.toFixed(2)}`}
+							value={`$${totalSpend.toFixed(2)}`}
 							subtitle={
 								usageMode === "total" &&
 								totalCreditsCost > 0 &&
@@ -572,7 +578,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 							}
 							icon={<CircleDollarSign className="h-4 w-4" />}
 							accent="blue"
-							delta={pctChange(totalCost, prevCost)}
+							delta={pctChange(totalSpend, prevCost)}
 							trend={costTrend}
 							isLoading={isLoading}
 						/>

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -337,7 +337,10 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		(sum, day) => sum + day.requestCount,
 		0,
 	);
-	const prevCost = prevActivityData.reduce((sum, day) => sum + day.cost, 0);
+	const prevCost = prevActivityData.reduce(
+		(sum, day) => sum + day.cost + day.dataStorageCost,
+		0,
+	);
 	const prevSavings = prevActivityData.reduce(
 		(sum, day) => sum + day.discountSavings,
 		0,
@@ -345,7 +348,10 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 
 	const cacheHitRate =
 		totalRequests > 0 ? (totalCached / totalRequests) * 100 : 0;
-	const avgCostPerRequest = totalRequests > 0 ? totalCost / totalRequests : 0;
+	// Data retention storage is billed on top of inference costs, so the
+	// headline spend includes it.
+	const totalSpend = totalCost + totalDataStorageCost;
+	const avgCostPerRequest = totalRequests > 0 ? totalSpend / totalRequests : 0;
 
 	// Day-by-day series for the KPI sparklines, with missing days filled as 0.
 	const { requestsTrend, costTrend } = (() => {
@@ -355,7 +361,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 			);
 			return {
 				requestsTrend: sorted.map((day) => day.requestCount),
-				costTrend: sorted.map((day) => day.cost),
+				costTrend: sorted.map((day) => day.cost + day.dataStorageCost),
 			};
 		}
 		const byDate = new Map(activityData.map((day) => [day.date, day]));
@@ -364,7 +370,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		for (let i = 0; i < rangeDays; i++) {
 			const day = byDate.get(format(addDays(from, i), "yyyy-MM-dd"));
 			requests.push(day?.requestCount ?? 0);
-			costs.push(day?.cost ?? 0);
+			costs.push(day ? day.cost + day.dataStorageCost : 0);
 		}
 		return { requestsTrend: requests, costTrend: costs };
 	})();
@@ -522,7 +528,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 						/>
 						<MetricCard
 							label="Total Spend"
-							value={`$${totalCost.toFixed(2)}`}
+							value={`$${totalSpend.toFixed(2)}`}
 							subtitle={
 								totalRequests > 0
 									? `avg $${avgCostPerRequest.toFixed(4)} per request${
@@ -538,7 +544,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 							}
 							icon={<CircleDollarSign className="h-4 w-4" />}
 							accent="blue"
-							delta={pctChange(totalCost, prevCost)}
+							delta={pctChange(totalSpend, prevCost)}
 							trend={costTrend}
 							isLoading={isLoading}
 						/>

--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -354,6 +354,98 @@ describe("Log Processing", () => {
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits);
 		});
 
+		test("should deduct storage cost on top of inference cost for credits mode logs", async () => {
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-credits-storage",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.01,
+				dataStorageCost: "0.002",
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.012);
+		});
+
+		test("should deduct only storage cost for api-keys mode logs", async () => {
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-api-keys-storage",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.01,
+				dataStorageCost: "0.002",
+				cached: false,
+				usedMode: "api-keys",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "api-keys",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.002);
+		});
+
+		test("should deduct storage cost even when inference cost is zero", async () => {
+			const initialCredits = Number(testOrg.credits);
+
+			// Unbilled refusals zero the inference cost but keep the storage cost
+			// (retention is billed separately from inference).
+			await db.insert(log).values({
+				requestId: "test-request-zero-cost-storage",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0,
+				dataStorageCost: "0.003",
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.003);
+		});
+
 		test("should update API key usage for all non-cached logs with cost", async () => {
 			const initialUsage = Number(testApiKey.usage);
 

--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -263,6 +263,98 @@ describe("Log Processing", () => {
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits);
 		});
 
+		test("should deduct storage cost on top of inference cost for credits mode logs", async () => {
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-credits-storage",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.01,
+				dataStorageCost: "0.002",
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.012);
+		});
+
+		test("should deduct only storage cost for api-keys mode logs", async () => {
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-api-keys-storage",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.01,
+				dataStorageCost: "0.002",
+				cached: false,
+				usedMode: "api-keys",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "api-keys",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.002);
+		});
+
+		test("should deduct storage cost even when inference cost is zero", async () => {
+			const initialCredits = Number(testOrg.credits);
+
+			// Unbilled refusals zero the inference cost but keep the storage cost
+			// (retention is billed separately from inference).
+			await db.insert(log).values({
+				requestId: "test-request-zero-cost-storage",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0,
+				dataStorageCost: "0.003",
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.003);
+		});
+
 		test("should update API key usage for all non-cached logs with cost", async () => {
 			const initialUsage = Number(testApiKey.usage);
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1147,6 +1147,36 @@ export async function batchProcessLogs(): Promise<number> {
 					);
 				}
 
+				const sourceBucket = isChatSource(row.source) ? "chat" : "other";
+
+				const addToBucket = (amount: Decimal, premium: boolean) => {
+					const existing = orgCosts.get(row.organization_id) ?? {
+						chat: new Decimal(0),
+						other: new Decimal(0),
+						chatPremium: new Decimal(0),
+						otherPremium: new Decimal(0),
+					};
+					existing[sourceBucket] = existing[sourceBucket].plus(amount);
+					if (premium) {
+						const premiumBucket =
+							sourceBucket === "chat" ? "chatPremium" : "otherPremium";
+						existing[premiumBucket] = existing[premiumBucket].plus(amount);
+					}
+					orgCosts.set(row.organization_id, existing);
+				};
+
+				// Data retention storage is billed separately from inference (log.cost
+				// never includes it), so it is deducted from org credits for every
+				// mode: credits, api-keys (BYOK) and wallet-backed end-user traffic
+				// alike — and also when inference itself was free or zeroed (e.g.
+				// unbilled refusals keep their storage cost).
+				if (row.data_storage_cost) {
+					const storageCost = new Decimal(row.data_storage_cost);
+					if (storageCost.greaterThan(0)) {
+						addToBucket(storageCost, false);
+					}
+				}
+
 				// Prefer the exact decimal billingCost (realtime and other
 				// decimal-billed rows) over the legacy float cost column.
 				const effectiveCost =
@@ -1189,39 +1219,14 @@ export async function batchProcessLogs(): Promise<number> {
 						continue;
 					}
 
-					const sourceBucket = isChatSource(row.source) ? "chat" : "other";
-
-					const addToBucket = (amount: Decimal, premium: boolean) => {
-						const existing = orgCosts.get(row.organization_id) ?? {
-							chat: new Decimal(0),
-							other: new Decimal(0),
-							chatPremium: new Decimal(0),
-							otherPremium: new Decimal(0),
-						};
-						existing[sourceBucket] = existing[sourceBucket].plus(amount);
-						if (premium) {
-							const premiumBucket =
-								sourceBucket === "chat" ? "chatPremium" : "otherPremium";
-							existing[premiumBucket] = existing[premiumBucket].plus(amount);
-						}
-						orgCosts.set(row.organization_id, existing);
-					};
-
-					// Deduct organization credits based on mode:
-					// - Credits mode: deduct full cost (includes request cost + storage cost)
-					// - API keys mode: only deduct storage cost (data retention billing)
+					// Inference cost: credits mode deducts the full cost from org
+					// credits; api-keys mode pays the provider directly (BYOK), so
+					// only the storage cost above is billed.
 					if (row.used_mode === "credits") {
 						addToBucket(
 							apiKeyCost,
 							Boolean(row.used_model && isPremiumUsedModel(row.used_model)),
 						);
-					} else if (row.used_mode === "api-keys") {
-						if (row.data_storage_cost) {
-							const storageCost = new Decimal(row.data_storage_cost);
-							if (storageCost.greaterThan(0)) {
-								addToBucket(storageCost, false);
-							}
-						}
 					}
 				}
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1027,6 +1027,36 @@ export async function batchProcessLogs(): Promise<number> {
 					unifiedFinishReason: row.unified_finish_reason,
 				});
 
+				const sourceBucket = isChatSource(row.source) ? "chat" : "other";
+
+				const addToBucket = (amount: Decimal, premium: boolean) => {
+					const existing = orgCosts.get(row.organization_id) ?? {
+						chat: new Decimal(0),
+						other: new Decimal(0),
+						chatPremium: new Decimal(0),
+						otherPremium: new Decimal(0),
+					};
+					existing[sourceBucket] = existing[sourceBucket].plus(amount);
+					if (premium) {
+						const premiumBucket =
+							sourceBucket === "chat" ? "chatPremium" : "otherPremium";
+						existing[premiumBucket] = existing[premiumBucket].plus(amount);
+					}
+					orgCosts.set(row.organization_id, existing);
+				};
+
+				// Data retention storage is billed separately from inference (log.cost
+				// never includes it), so it is deducted from org credits for every
+				// mode: credits, api-keys (BYOK) and wallet-backed end-user traffic
+				// alike — and also when inference itself was free or zeroed (e.g.
+				// unbilled refusals keep their storage cost).
+				if (row.data_storage_cost) {
+					const storageCost = new Decimal(row.data_storage_cost);
+					if (storageCost.greaterThan(0)) {
+						addToBucket(storageCost, false);
+					}
+				}
+
 				// Prefer the exact decimal billingCost (realtime and other
 				// decimal-billed rows) over the legacy float cost column.
 				const effectiveCost =
@@ -1069,39 +1099,14 @@ export async function batchProcessLogs(): Promise<number> {
 						continue;
 					}
 
-					const sourceBucket = isChatSource(row.source) ? "chat" : "other";
-
-					const addToBucket = (amount: Decimal, premium: boolean) => {
-						const existing = orgCosts.get(row.organization_id) ?? {
-							chat: new Decimal(0),
-							other: new Decimal(0),
-							chatPremium: new Decimal(0),
-							otherPremium: new Decimal(0),
-						};
-						existing[sourceBucket] = existing[sourceBucket].plus(amount);
-						if (premium) {
-							const premiumBucket =
-								sourceBucket === "chat" ? "chatPremium" : "otherPremium";
-							existing[premiumBucket] = existing[premiumBucket].plus(amount);
-						}
-						orgCosts.set(row.organization_id, existing);
-					};
-
-					// Deduct organization credits based on mode:
-					// - Credits mode: deduct full cost (includes request cost + storage cost)
-					// - API keys mode: only deduct storage cost (data retention billing)
+					// Inference cost: credits mode deducts the full cost from org
+					// credits; api-keys mode pays the provider directly (BYOK), so
+					// only the storage cost above is billed.
 					if (row.used_mode === "credits") {
 						addToBucket(
 							apiKeyCost,
 							Boolean(row.used_model && isPremiumUsedModel(row.used_model)),
 						);
-					} else if (row.used_mode === "api-keys") {
-						if (row.data_storage_cost) {
-							const storageCost = new Decimal(row.data_storage_cost);
-							if (storageCost.greaterThan(0)) {
-								addToBucket(storageCost, false);
-							}
-						}
 					}
 				}
 

--- a/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
@@ -3,6 +3,7 @@
 import {
 	Activity,
 	CircleDollarSign,
+	Database,
 	Hash,
 	Loader2,
 	Server,
@@ -316,6 +317,13 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 								: "Billed against the organization's credits"
 					}
 					icon={<CircleDollarSign className="h-4 w-4" />}
+					accent="purple"
+				/>
+				<MetricCard
+					label="Storage Cost"
+					value={currencyFormatter.format(safeNumber(metrics.dataStorageCost))}
+					subtitle="Data retention billing, charged on top of usage costs"
+					icon={<Database className="h-4 w-4" />}
 					accent="purple"
 				/>
 				<MetricCard

--- a/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
@@ -3,6 +3,7 @@
 import {
 	Activity,
 	CircleDollarSign,
+	Database,
 	Hash,
 	Loader2,
 	Server,
@@ -266,8 +267,15 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 				<MetricCard
 					label="Total Cost"
 					value={currencyFormatter.format(safeNumber(metrics.totalCost))}
-					subtitle="Sum of metered usage costs (USD)"
+					subtitle="Sum of metered usage costs (USD, excludes storage)"
 					icon={<CircleDollarSign className="h-4 w-4" />}
+					accent="purple"
+				/>
+				<MetricCard
+					label="Storage Cost"
+					value={currencyFormatter.format(safeNumber(metrics.dataStorageCost))}
+					subtitle="Data retention billing, charged on top of usage costs"
+					icon={<Database className="h-4 w-4" />}
 					accent="purple"
 				/>
 				<MetricCard

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
@@ -3,6 +3,7 @@
 import {
 	Activity,
 	CircleDollarSign,
+	Database,
 	Hash,
 	Loader2,
 	Server,
@@ -282,6 +283,13 @@ export function ProjectMetricsSection({
 								: "Billed against the organization's credits"
 					}
 					icon={<CircleDollarSign className="h-4 w-4" />}
+					accent="purple"
+				/>
+				<MetricCard
+					label="Storage Cost"
+					value={currencyFormatter.format(safeNumber(metrics.dataStorageCost))}
+					subtitle="Data retention billing, charged on top of usage costs"
+					icon={<Database className="h-4 w-4" />}
 					accent="purple"
 				/>
 				<MetricCard

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
@@ -3,6 +3,7 @@
 import {
 	Activity,
 	CircleDollarSign,
+	Database,
 	Hash,
 	Loader2,
 	Server,
@@ -232,8 +233,15 @@ export function ProjectMetricsSection({
 				<MetricCard
 					label="Total Cost"
 					value={currencyFormatter.format(safeNumber(metrics.totalCost))}
-					subtitle="Sum of metered usage costs (USD)"
+					subtitle="Sum of metered usage costs (USD, excludes storage)"
 					icon={<CircleDollarSign className="h-4 w-4" />}
+					accent="purple"
+				/>
+				<MetricCard
+					label="Storage Cost"
+					value={currencyFormatter.format(safeNumber(metrics.dataStorageCost))}
+					subtitle="Data retention billing, charged on top of usage costs"
+					icon={<Database className="h-4 w-4" />}
 					accent="purple"
 				/>
 				<MetricCard


### PR DESCRIPTION
## Problem

Data retention storage cost (`log.dataStorageCost`, \$0.01/M total tokens when retention is on) was recorded on every log and aggregated into hourly stats, but was almost never actually billed or shown:

- **Billing**: the worker's credit deduction only deducted storage for `api-keys` mode logs — despite a comment claiming credits mode includes it, `log.cost` (= `totalCost` in `costs.ts`) never contains storage. Credits-mode orgs (including DevPass/chat plan pools), wallet-backed end-user traffic, and logs with zero inference cost (e.g. unbilled refusals, whose storage cost is intentionally preserved by `zeroInferenceCosts`) never paid storage at all. Example from admin: a DevPass org with retention on ran ~519M tokens/day ≈ \$5.19/day of storage that was never deducted.
- **Admin dashboard**: the org/project usage metrics endpoints didn't select `dataStorageCost` from the hourly stats, so the tiles summed exactly to inference cost with storage invisible.
- **User dashboard**: "Total Spend" excluded storage (it only appeared in a subtitle fragment and in the usage cost-breakdown chart).

## Changes

- **`apps/worker/src/worker.ts`**: deduct storage cost from org credits for every log that has one, independent of `usedMode` and of whether inference cost is nonzero. Inference cost handling is unchanged (credits mode deducts full cost; api-keys/BYOK pays the provider directly). Storage is never counted as premium usage.
- **`apps/api/src/routes/admin.ts`**: org and project metrics endpoints now aggregate and return `dataStorageCost`.
- **`ee/admin`**: new "Storage Cost" tile on org and project usage metrics; "Total Cost" subtitle clarifies it excludes storage.
- **`apps/ui`**: dashboard "Total Spend" (value, delta, sparkline, avg/request) now includes storage; the storage breakdown subtitle is unchanged.
- **Tests**: 3 new worker specs covering credits-mode storage on top of inference, api-keys storage-only, and zero-inference-cost storage billing.

## Notes

- Wallet-backed (LLM SDK end-user) traffic now bills storage to the developer's org (which owns the retention setting); the wallet debit itself is unchanged (inference only).
- `pnpm vitest run apps/worker/src/log-processing.spec.ts`: 15/15 pass. Failures in `sync-models.spec.ts`/`stats-calculator.spec.ts` are pre-existing shared-test-DB flakes unrelated to this diff.
- `pnpm build` and `pnpm format` pass.

## Screenshots

**UI dashboard** — Total Spend now includes storage, with the storage amount broken out in the subtitle:

<img width="1500" alt="UI dashboard with storage cost included in Total Spend" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d770fe33bbc3b7721bfcb89f3235a9d9912ed38/ui-dashboard.png" />

**Admin dashboard** — new Storage Cost tile on the org usage metrics:

<img width="1500" alt="Admin org metrics with Storage Cost tile" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d770fe33bbc3b7721bfcb89f3235a9d9912ed38/admin-org-metrics.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added storage cost metrics to organization and project usage dashboards.
  - Added dedicated “Storage Cost” cards showing data retention charges in USD.
  - Updated total spend trends, averages, and KPIs to include storage costs.

- **Bug Fixes**
  - Corrected billing so data storage costs are charged consistently across usage modes, including usage with no inference cost.
  - Improved storage cost reporting for more accurate usage totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
