### PR TITLE
feat(admin): project chart breakdown by source

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7459,6 +7459,10 @@ admin.openapi(getOrgCostByModel, async (c) => {
 
 const costByModelTimeseriesModelViewSchema = z.enum(["mapping", "canonical"]);
 
+const costTimeseriesGroupBySchema = z.enum(["model", "source"]);
+
+const TOP_TIMESERIES_SERIES = 10;
+
 const costByModelTimeseriesBucketSchema = z.object({
 	model: z.string(),
 	cost: z.number(),
@@ -7475,6 +7479,7 @@ const costByModelTimeseriesResponseSchema = z.object({
 	window: tokenWindowSchema,
 	bucket: z.enum(["hour", "day"]),
 	modelView: costByModelTimeseriesModelViewSchema,
+	groupBy: costTimeseriesGroupBySchema,
 	models: z.array(z.string()),
 	data: z.array(costByModelTimeseriesPointSchema),
 });
@@ -7577,6 +7582,7 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 			window,
 			bucket: bucketUnit,
 			modelView,
+			groupBy: "model" as const,
 			models: [],
 			data: [],
 		});
@@ -7596,6 +7602,7 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 		window,
 		bucket: bucketUnit,
 		modelView,
+		groupBy: "model" as const,
 		models: result.models,
 		data: result.data,
 	});
@@ -7611,6 +7618,7 @@ const getProjectCostByModelTimeseries = createRoute({
 			modelView: costByModelTimeseriesModelViewSchema
 				.default("mapping")
 				.optional(),
+			groupBy: costTimeseriesGroupBySchema.default("model").optional(),
 		}),
 	},
 	responses: {
@@ -7620,7 +7628,7 @@ const getProjectCostByModelTimeseries = createRoute({
 					schema: costByModelTimeseriesResponseSchema.openapi({}),
 				},
 			},
-			description: "Project cost breakdown by model over time.",
+			description: "Project cost breakdown by model or source over time.",
 		},
 		404: {
 			description: "Project not found.",
@@ -7633,6 +7641,7 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 	const query = c.req.valid("query");
 	const window = query.window ?? "7d";
 	const modelView = query.modelView ?? "mapping";
+	const groupBy = query.groupBy ?? "model";
 	const startDate = getTokenWindowStartDate(window);
 	const bucketUnit = getBucketUnitForWindow(window);
 
@@ -7647,20 +7656,31 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 		throw new HTTPException(404, { message: "Project not found" });
 	}
 
-	const result = await buildCostByModelTimeseries({
-		modelView,
-		bucketUnit,
-		startDate,
-		baseFilter: and(
-			eq(projectHourlyModelStats.projectId, projectId),
-			gte(projectHourlyModelStats.hourTimestamp, startDate),
-		),
-	});
+	const result =
+		groupBy === "source"
+			? await buildCostBySourceTimeseries({
+					bucketUnit,
+					startDate,
+					baseFilter: and(
+						eq(projectHourlySourceStats.projectId, projectId),
+						gte(projectHourlySourceStats.hourTimestamp, startDate),
+					),
+				})
+			: await buildCostByModelTimeseries({
+					modelView,
+					bucketUnit,
+					startDate,
+					baseFilter: and(
+						eq(projectHourlyModelStats.projectId, projectId),
+						gte(projectHourlyModelStats.hourTimestamp, startDate),
+					),
+				});
 
 	return c.json({
 		window,
 		bucket: bucketUnit,
 		modelView,
+		groupBy,
 		models: result.models,
 		data: result.data,
 	});
@@ -7704,7 +7724,7 @@ async function buildCostByModelTimeseries({
 
 	const topKeys = [...totalByKey.entries()]
 		.sort((a, b) => b[1] - a[1])
-		.slice(0, 10)
+		.slice(0, TOP_TIMESERIES_SERIES)
 		.map(([k]) => k);
 
 	if (topKeys.length === 0) {
@@ -7746,28 +7766,126 @@ async function buildCostByModelTimeseries({
 		.groupBy(bucketExpr, projectHourlyModelStats.usedModel)
 		.orderBy(asc(bucketExpr));
 
+	return {
+		models: topKeys,
+		data: assembleCostTimeseriesPoints({
+			allBuckets,
+			rows: rows.map((row) => ({
+				bucket: row.bucket,
+				key: keyOf(row.usedModel),
+				cost: Number(row.cost),
+				requestCount: Number(row.requestCount),
+				totalTokens: Number(row.totalTokens),
+			})),
+		}),
+	};
+}
+
+async function buildCostBySourceTimeseries({
+	bucketUnit,
+	startDate,
+	baseFilter,
+}: {
+	bucketUnit: "hour" | "day";
+	startDate: Date;
+	baseFilter: ReturnType<typeof and>;
+}): Promise<{
+	models: string[];
+	data: z.infer<typeof costByModelTimeseriesPointSchema>[];
+}> {
+	const sourceTotals = await db
+		.select({
+			source: projectHourlySourceStats.source,
+			cost: sql<number>`SUM(${projectHourlySourceStats.cost})`.as("cost"),
+		})
+		.from(projectHourlySourceStats)
+		.where(baseFilter)
+		.groupBy(projectHourlySourceStats.source);
+
+	const topKeys = [...sourceTotals]
+		.sort((a, b) => Number(b.cost) - Number(a.cost))
+		.slice(0, TOP_TIMESERIES_SERIES)
+		.map((row) => row.source);
+
+	if (topKeys.length === 0) {
+		return { models: [], data: [] };
+	}
+
+	const allBuckets = generateBucketTimestamps(
+		startDate,
+		new Date(),
+		bucketUnit,
+	);
+
+	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${projectHourlySourceStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
+
+	const rows = await db
+		.select({
+			bucket: bucketExpr.as("bucket"),
+			source: projectHourlySourceStats.source,
+			cost: sql<number>`SUM(${projectHourlySourceStats.cost})`.as("cost"),
+			requestCount:
+				sql<number>`SUM(${projectHourlySourceStats.requestCount})`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`SUM(CAST(${projectHourlySourceStats.totalTokens} AS NUMERIC))`.as(
+					"total_tokens",
+				),
+		})
+		.from(projectHourlySourceStats)
+		.where(and(baseFilter, inArray(projectHourlySourceStats.source, topKeys)))
+		.groupBy(bucketExpr, projectHourlySourceStats.source)
+		.orderBy(asc(bucketExpr));
+
+	return {
+		models: topKeys,
+		data: assembleCostTimeseriesPoints({
+			allBuckets,
+			rows: rows.map((row) => ({
+				bucket: row.bucket,
+				key: row.source,
+				cost: Number(row.cost),
+				requestCount: Number(row.requestCount),
+				totalTokens: Number(row.totalTokens),
+			})),
+		}),
+	};
+}
+
+function assembleCostTimeseriesPoints({
+	allBuckets,
+	rows,
+}: {
+	allBuckets: string[];
+	rows: {
+		bucket: string;
+		key: string;
+		cost: number;
+		requestCount: number;
+		totalTokens: number;
+	}[];
+}): z.infer<typeof costByModelTimeseriesPointSchema>[] {
 	const bucketMap = new Map<
 		string,
 		Map<string, { cost: number; requestCount: number; totalTokens: number }>
 	>();
 
 	for (const row of rows) {
-		const ts = row.bucket;
-		const key = keyOf(row.usedModel);
-		const entry = bucketMap.get(ts) ?? new Map();
-		const existing = entry.get(key) ?? {
+		const entry = bucketMap.get(row.bucket) ?? new Map();
+		const existing = entry.get(row.key) ?? {
 			cost: 0,
 			requestCount: 0,
 			totalTokens: 0,
 		};
-		existing.cost += Number(row.cost);
-		existing.requestCount += Number(row.requestCount);
-		existing.totalTokens += Number(row.totalTokens);
-		entry.set(key, existing);
-		bucketMap.set(ts, entry);
+		existing.cost += row.cost;
+		existing.requestCount += row.requestCount;
+		existing.totalTokens += row.totalTokens;
+		entry.set(row.key, existing);
+		bucketMap.set(row.bucket, entry);
 	}
 
-	const data = allBuckets.map((timestamp) => ({
+	return allBuckets.map((timestamp) => ({
 		timestamp,
 		entries: Array.from(bucketMap.get(timestamp)?.entries() ?? []).map(
 			([model, v]) => ({
@@ -7778,8 +7896,6 @@ async function buildCostByModelTimeseries({
 			}),
 		),
 	}));
-
-	return { models: topKeys, data };
 }
 
 // --- Project Model-Provider Stats ---

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
 import { CostByModelTimeseriesChart } from "@/components/cost-by-model-timeseries-chart";
 import { getProjectCostByModelTimeseries } from "@/lib/admin-history";
 
-import type { ModelView, TokenWindow } from "@/lib/types";
+import type {
+	CostTimeseriesGroupBy,
+	ModelView,
+	TokenWindow,
+} from "@/lib/types";
 
 const validWindows = new Set<TokenWindow>([
 	"1h",
@@ -26,6 +30,10 @@ function parseWindow(value: string | null): TokenWindow {
 	return "1d";
 }
 
+function parseGroupBy(value: string | null): CostTimeseriesGroupBy {
+	return value === "source" ? "source" : "model";
+}
+
 export function ProjectCostByModelTimeseries({
 	orgId,
 	projectId,
@@ -34,26 +42,55 @@ export function ProjectCostByModelTimeseries({
 	projectId: string;
 }) {
 	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
+
 	const window = parseWindow(searchParams.get("window"));
+	const groupBy = parseGroupBy(searchParams.get("breakdown"));
 
 	const fetchData = useCallback(
-		async (w: TokenWindow, modelView: ModelView) => {
+		async (w: TokenWindow, modelView: ModelView, g: CostTimeseriesGroupBy) => {
 			return await getProjectCostByModelTimeseries(
 				orgId,
 				projectId,
 				w,
 				modelView,
+				g,
 			);
 		},
 		[orgId, projectId],
 	);
 
+	const handleGroupByChange = useCallback(
+		(next: CostTimeseriesGroupBy) => {
+			const params = new URLSearchParams(searchParams.toString());
+			if (next === "model") {
+				params.delete("breakdown");
+			} else {
+				params.set("breakdown", next);
+			}
+			const query = params.toString();
+			router.push(query ? `${pathname}?${query}` : pathname);
+		},
+		[searchParams, router, pathname],
+	);
+
 	return (
 		<CostByModelTimeseriesChart
-			title="Cost by Model Over Time"
-			description="Stacked breakdown of top 10 models for this project"
+			title={
+				groupBy === "source"
+					? "Cost by Source Over Time"
+					: "Cost by Model Over Time"
+			}
+			description={
+				groupBy === "source"
+					? "Stacked breakdown of top 10 sources for this project"
+					: "Stacked breakdown of top 10 models for this project"
+			}
 			fetchData={fetchData}
 			externalWindow={window}
+			groupBy={groupBy}
+			onGroupByChange={handleGroupByChange}
 		/>
 	);
 }

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import type { ChartConfig } from "@/components/ui/chart";
 import type {
 	CostByModelTimeseriesResponse,
+	CostTimeseriesGroupBy,
 	ModelView,
 	TokenWindow,
 } from "@/lib/types";
@@ -36,6 +37,11 @@ const metricTabs: { key: ActiveMetric; label: string }[] = [
 const modelViewTabs: { key: ModelView; label: string }[] = [
 	{ key: "mapping", label: "Mappings" },
 	{ key: "canonical", label: "Canonical" },
+];
+
+const groupByTabs: { key: CostTimeseriesGroupBy; label: string }[] = [
+	{ key: "model", label: "By model" },
+	{ key: "source", label: "By source" },
 ];
 
 const seriesColors = [
@@ -66,26 +72,32 @@ export function CostByModelTimeseriesChart({
 	description,
 	fetchData,
 	externalWindow,
+	groupBy,
+	onGroupByChange,
 }: {
 	title: string;
 	description?: string;
 	fetchData: (
 		window: TokenWindow,
 		modelView: ModelView,
+		groupBy: CostTimeseriesGroupBy,
 	) => Promise<CostByModelTimeseriesResponse | null>;
 	externalWindow: TokenWindow;
+	groupBy?: CostTimeseriesGroupBy;
+	onGroupByChange?: (groupBy: CostTimeseriesGroupBy) => void;
 }) {
 	const [data, setData] = useState<CostByModelTimeseriesResponse | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("cost");
 	const [modelView, setModelView] = useState<ModelView>("mapping");
 	const latestRequestRef = useRef(0);
+	const activeGroupBy = groupBy ?? "model";
 
 	const loadData = useCallback(async () => {
 		const requestId = ++latestRequestRef.current;
 		setLoading(true);
 		try {
-			const result = await fetchData(externalWindow, modelView);
+			const result = await fetchData(externalWindow, modelView, activeGroupBy);
 			if (requestId !== latestRequestRef.current) {
 				return;
 			}
@@ -101,7 +113,7 @@ export function CostByModelTimeseriesChart({
 				setLoading(false);
 			}
 		}
-	}, [fetchData, externalWindow, modelView]);
+	}, [fetchData, externalWindow, modelView, activeGroupBy]);
 
 	useEffect(() => {
 		void loadData();
@@ -180,21 +192,43 @@ export function CostByModelTimeseriesChart({
 							</button>
 						))}
 					</div>
-					<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
-						{modelViewTabs.map((tab) => (
-							<button
-								key={tab.key}
-								className={cn(
-									"rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
-									modelView === tab.key
-										? "bg-primary text-primary-foreground"
-										: "text-muted-foreground hover:text-foreground",
-								)}
-								onClick={() => setModelView(tab.key)}
-							>
-								{tab.label}
-							</button>
-						))}
+					<div className="flex flex-wrap items-center gap-2">
+						{onGroupByChange && (
+							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
+								{groupByTabs.map((tab) => (
+									<button
+										key={tab.key}
+										className={cn(
+											"rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
+											activeGroupBy === tab.key
+												? "bg-primary text-primary-foreground"
+												: "text-muted-foreground hover:text-foreground",
+										)}
+										onClick={() => onGroupByChange(tab.key)}
+									>
+										{tab.label}
+									</button>
+								))}
+							</div>
+						)}
+						{activeGroupBy === "model" && (
+							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
+								{modelViewTabs.map((tab) => (
+									<button
+										key={tab.key}
+										className={cn(
+											"rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
+											modelView === tab.key
+												? "bg-primary text-primary-foreground"
+												: "text-muted-foreground hover:text-foreground",
+										)}
+										onClick={() => setModelView(tab.key)}
+									>
+										{tab.label}
+									</button>
+								))}
+							</div>
+						)}
 					</div>
 				</div>
 			</CardHeader>

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -2,7 +2,12 @@
 
 import { createServerApiClient } from "./server-api";
 
-import type { GlobalStatsModelView, ModelView, TokenWindow } from "./types";
+import type {
+	CostTimeseriesGroupBy,
+	GlobalStatsModelView,
+	ModelView,
+	TokenWindow,
+} from "./types";
 import type { HistoryWindow } from "@/components/history-chart";
 
 export async function getProviderHistory(
@@ -186,12 +191,16 @@ export async function getProjectCostByModelTimeseries(
 	projectId: string,
 	window: TokenWindow,
 	modelView: ModelView = "mapping",
+	groupBy: CostTimeseriesGroupBy = "model",
 ) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET(
 		"/admin/organizations/{orgId}/projects/{projectId}/cost-by-model-timeseries",
 		{
-			params: { path: { orgId, projectId }, query: { window, modelView } },
+			params: {
+				path: { orgId, projectId },
+				query: { window, modelView, groupBy },
+			},
 		},
 	);
 	return data ?? null;

--- a/ee/admin/src/lib/types.ts
+++ b/ee/admin/src/lib/types.ts
@@ -103,6 +103,7 @@ export type CostByModelResponse =
 export type CostByModelTimeseriesResponse =
 	GetJsonResponse<"/admin/organizations/{orgId}/cost-by-model-timeseries">;
 export type ModelView = CostByModelTimeseriesResponse["modelView"];
+export type CostTimeseriesGroupBy = CostByModelTimeseriesResponse["groupBy"];
 
 // Global stats
 export type GlobalStatsResponse = GetJsonResponse<"/admin/global-stats">;


### PR DESCRIPTION
## Summary

The admin project detail chart (`/organizations/:orgId/projects/:projectId`) was hardcoded to a per-model breakdown. We already aggregate per-project usage by `source` (`project_hourly_source_stats`), so this adds a **By model / By source** switch above the chart, persisted in the URL (`?breakdown=source`).

## Changes

- **API** (`apps/api/src/routes/admin.ts`): the project `cost-by-model-timeseries` endpoint takes a new `groupBy=model|source` query param. `source` reads from `project_hourly_source_stats` (top 10 sources by cost, same bucketing/back-fill as the model path). The bucket-assembly logic is shared between both builders; the response now echoes `groupBy`.
- **Admin UI**: `CostByModelTimeseriesChart` accepts optional `groupBy`/`onGroupByChange` props — the mapping/canonical model-view tabs only render for the model breakdown. The project page drives the toggle from the `breakdown` search param (default `model`, param omitted) and swaps the card title/description accordingly. The org-level chart is unchanged.

## Test plan

- `pnpm build` and `pnpm format` pass.
- Manual: on a project page, toggling to **By source** updates the URL to `?breakdown=source` and reloads the stacked chart with source series; toggling back removes the param. Existing `window` param and metric tabs (Cost/Requests/Tokens) keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to view project cost trends grouped by either model or source.
  * Added a chart control for switching between model and source breakdowns.
  * Preserved model-specific view options when viewing model-grouped data.
  * Added source-grouped cost data to the project cost timeseries API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->