### PR TITLE
chore(gateway): drop content filter images warning

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -3347,12 +3347,15 @@ describe("api", () => {
 				return await originalFetch(input as RequestInfo | URL, init);
 			});
 
+		const requestId = "image-generation-content-filter-request";
+
 		try {
 			const res = await app.request("/v1/images/generations", {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
 					Authorization: "Bearer real-token-image-generation-content-filter",
+					"x-request-id": requestId,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -3367,6 +3370,12 @@ describe("api", () => {
 		} finally {
 			fetchSpy.mockRestore();
 		}
+
+		// The empty-data response is only acceptable because the request is still
+		// classified as content filtered in the logs.
+		const log = await waitForLogByRequestId(requestId);
+		expect(log.finishReason).toBe("content_filter");
+		expect(log.unifiedFinishReason).toBe("content_filter");
 	});
 
 	test("/v1/images/edits returns empty data for content filter", async () => {
@@ -3386,6 +3395,7 @@ describe("api", () => {
 			baseUrl: mockServerUrl,
 		});
 
+		const requestId = "image-edits-content-filter-request";
 		const originalFetch = globalThis.fetch;
 		const fetchSpy = vi
 			.spyOn(globalThis, "fetch")
@@ -3438,6 +3448,7 @@ describe("api", () => {
 				headers: {
 					"Content-Type": "application/json",
 					Authorization: "Bearer real-token-image-edits-content-filter",
+					"x-request-id": requestId,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -3458,6 +3469,12 @@ describe("api", () => {
 		} finally {
 			fetchSpy.mockRestore();
 		}
+
+		// The empty-data response is only acceptable because the request is still
+		// classified as content filtered in the logs.
+		const log = await waitForLogByRequestId(requestId);
+		expect(log.finishReason).toBe("content_filter");
+		expect(log.unifiedFinishReason).toBe("content_filter");
 	});
 
 	test("/v1/chat/completions blocks with openai content filter mode", async () => {

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -313,10 +313,12 @@ async function extractImagesFromChatResponse(
 	}
 
 	if (imageObjects.length === 0) {
+		// A content-filtered generation is an expected, user-caused outcome, not an
+		// operational problem: the internal chat completions request already logged
+		// the request with a content_filter finish reason (the provider's raw reason
+		// is mapped to the OpenAI-canonical "content_filter" before it reaches here),
+		// so there is nothing to warn about.
 		if (chatResponse.choices?.[0]?.finish_reason === "content_filter") {
-			logger.warn("Images API - content filtered response", {
-				model,
-			});
 			return [];
 		}
 


### PR DESCRIPTION
## Problem

The images endpoints emit a WARNING-severity log line whenever a generation is content filtered:

```
Images API - content filtered response   (model: gpt-image-2)
```

A content-filtered generation is an expected, user-caused outcome — not an operational problem — so this is pure noise in production logs.

## Changes

- `apps/gateway/src/images/images.ts`: remove the `logger.warn` from the `content_filter` branch of `extractImagesFromChatResponse`. The early `return []` (and therefore the `200` + empty `data` response) is unchanged; only the log line goes away, with a comment recording why the branch is intentionally silent.
- `apps/gateway/src/api.spec.ts`: the two existing images content-filter tests (`/v1/images/generations` and `/v1/images/edits`) now send an `x-request-id` and assert the resulting log row carries `finishReason: "content_filter"` and `unifiedFinishReason: "content_filter"`.

## Why the classification still holds

Both images endpoints forward to the internal `/v1/chat/completions` handler, which does its own logging. That request is recorded with a content-filter finish reason, and the provider's raw reason is normalized to the OpenAI-canonical `content_filter` by `mapFinishReasonToOpenai` before the response reaches the images handler — which is also why the `finish_reason === "content_filter"` check here is sound for Google-style reasons such as `IMAGE_SAFETY` / `PROHIBITED_CONTENT`. `getUnifiedFinishReason` then maps that to `CONTENT_FILTER`, so the request keeps showing up as content filtered in logs and analytics without the warning. The new assertions pin that behavior down, since the log line is no longer the signal.

## Testing

- `vitest run apps/gateway/src/api.spec.ts --no-file-parallelism` — 122 passed, 2 skipped (includes both updated content-filter tests).
- `pnpm build:core` and `pnpm format` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AA2WeTQVXxWtCjtauovJWV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image requests blocked by content filtering.
  * Content-filtered image responses now complete without generating unnecessary warning logs.
  * Logs consistently record content-filter outcomes for image generation and editing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->