### PR TITLE
fix(gateway): heal JSON with braces inside strings

### DIFF
--- a/apps/gateway/src/chat/tools/heal-json-response.spec.ts
+++ b/apps/gateway/src/chat/tools/heal-json-response.spec.ts
@@ -216,6 +216,15 @@ describe("healJsonResponse", () => {
 			// The healed content should be valid JSON
 			expect(() => JSON.parse(result.content)).not.toThrow();
 		});
+
+		it("should complete when a string value contains a brace", () => {
+			const input = '{"note": "a}b"';
+			const result = healJsonResponse(input);
+
+			expect(result.healed).toBe(true);
+			expect(result.healingMethod).toBe("truncation_completion");
+			expect(JSON.parse(result.content)).toEqual({ note: "a}b" });
+		});
 	});
 
 	describe("combined strategies", () => {

--- a/apps/gateway/src/chat/tools/heal-json-response.ts
+++ b/apps/gateway/src/chat/tools/heal-json-response.ts
@@ -172,19 +172,9 @@ function fixJsonSyntax(content: string): string {
 function completeTruncatedJson(content: string): string | null {
 	let completed = content.trim();
 
-	// Count opening and closing brackets
-	const openBraces = (completed.match(/{/g) ?? []).length;
-	const closeBraces = (completed.match(/}/g) ?? []).length;
-	const openBrackets = (completed.match(/\[/g) ?? []).length;
-	const closeBrackets = (completed.match(/]/g) ?? []).length;
-
-	// If already balanced, return as-is
-	if (openBraces === closeBraces && openBrackets === closeBrackets) {
-		return completed;
-	}
-
-	// Add missing closing brackets/braces
-	// We need to track the order of opening brackets to close them correctly
+	// Track unclosed structures with a string-aware scan. A naive bracket count
+	// would mistake braces inside string values (e.g. `{"note": "a}b"`) for
+	// balance and skip completion, leaving the JSON truncated.
 	const stack: string[] = [];
 	let inString = false;
 	let escapeNext = false;


### PR DESCRIPTION
`completeTruncatedJson` decides whether anything needs closing by counting `{`/`}`/`[`/`]` with four regexes and bailing out early when the counts are balanced. That count includes braces sitting inside string values, so a truncated response like `{"note": "a}b"` looks balanced (one `{`, one `}`) and gets returned untouched — the closing brace is never added and `JSON.parse` still fails, so healing gives up on JSON it could have completed.

The rest of the function already walks the string with a proper string-aware scanner that skips brackets inside quotes. I dropped the naive regex pre-count and let that scan be the single source of truth: if it ends with an empty stack and not mid-string, nothing is appended and the input comes back unchanged, same as before; otherwise the missing closers get added. One pass instead of four regexes plus a scan.

Added a test for the in-string-brace case, and the existing truncation/streaming heal tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of truncated JSON responses containing braces or brackets inside text values.
  * JSON completion now correctly preserves valid string content and produces parseable results in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->