### PR TITLE
fix: map anthropic context window exceeded stop reason

### DIFF
--- a/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
+++ b/apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts
@@ -29,6 +29,14 @@ export function mapFinishReasonToOpenai(
 		return "content_filter";
 	}
 
+	// Anthropic models stop with `model_context_window_exceeded` when generation
+	// hits the model's context window before `max_tokens`. Like `refusal`, it
+	// surfaces across the direct API, Vertex, and Bedrock, so map it uniformly
+	// to the OpenAI-canonical length limit.
+	if (finishReason === "model_context_window_exceeded") {
+		return "length";
+	}
+
 	switch (finishReason) {
 		case "stop":
 		case "length":

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -136,7 +136,10 @@ export function parseProviderResponse(
 			const stopReason = json.stopReason;
 			if (stopReason === "end_turn") {
 				finishReason = "stop";
-			} else if (stopReason === "max_tokens") {
+			} else if (
+				stopReason === "max_tokens" ||
+				stopReason === "model_context_window_exceeded"
+			) {
 				finishReason = "length";
 			} else if (stopReason === "tool_use") {
 				finishReason = "tool_calls";

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1271,7 +1271,10 @@ export function transformStreamingToOpenai(
 			} else if (eventType === "messageStop") {
 				const stopReason = data.stopReason;
 				let finishReason = "stop";
-				if (stopReason === "max_tokens") {
+				if (
+					stopReason === "max_tokens" ||
+					stopReason === "model_context_window_exceeded"
+				) {
 					finishReason = "length";
 				} else if (stopReason === "tool_use") {
 					finishReason = "tool_calls";

--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -45,6 +45,9 @@ describe("getUnifiedFinishReason", () => {
 		expect(getUnifiedFinishReason("refusal", "anthropic")).toBe(
 			UnifiedFinishReason.CONTENT_FILTER,
 		);
+		expect(
+			getUnifiedFinishReason("model_context_window_exceeded", "anthropic"),
+		).toBe(UnifiedFinishReason.LENGTH_LIMIT);
 	});
 
 	it("maps Vertex Anthropic finish reasons correctly", () => {
@@ -63,12 +66,24 @@ describe("getUnifiedFinishReason", () => {
 		expect(getUnifiedFinishReason("refusal", "vertex-anthropic")).toBe(
 			UnifiedFinishReason.CONTENT_FILTER,
 		);
+		expect(
+			getUnifiedFinishReason(
+				"model_context_window_exceeded",
+				"vertex-anthropic",
+			),
+		).toBe(UnifiedFinishReason.LENGTH_LIMIT);
 	});
 
 	it("maps aws-bedrock refusal to content filter", () => {
 		expect(getUnifiedFinishReason("refusal", "aws-bedrock")).toBe(
 			UnifiedFinishReason.CONTENT_FILTER,
 		);
+	});
+
+	it("maps aws-bedrock model_context_window_exceeded to length limit", () => {
+		expect(
+			getUnifiedFinishReason("model_context_window_exceeded", "aws-bedrock"),
+		).toBe(UnifiedFinishReason.LENGTH_LIMIT);
 	});
 
 	it("maps Google AI Studio finish reasons correctly (original Google format)", () => {
@@ -334,6 +349,12 @@ describe("isLengthLimitFinishReason", () => {
 
 	it("returns true for Anthropic max_tokens finish reason", () => {
 		expect(isLengthLimitFinishReason("max_tokens", "anthropic")).toBe(true);
+	});
+
+	it("returns true for Anthropic model_context_window_exceeded finish reason", () => {
+		expect(
+			isLengthLimitFinishReason("model_context_window_exceeded", "anthropic"),
+		).toBe(true);
 	});
 
 	it("returns false for normal stop finish reasons", () => {

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -86,6 +86,13 @@ export function getUnifiedFinishReason(
 	if (finishReason === "refusal") {
 		return UnifiedFinishReason.CONTENT_FILTER;
 	}
+	// Anthropic models stop with `model_context_window_exceeded` when generation
+	// hits the model's context window before `max_tokens`. Like `refusal`, it
+	// surfaces across the direct API, Vertex, and Bedrock, so map it uniformly
+	// here as a length limit.
+	if (finishReason === "model_context_window_exceeded") {
+		return UnifiedFinishReason.LENGTH_LIMIT;
+	}
 
 	switch (provider) {
 		case "anthropic":


### PR DESCRIPTION
## Problem

Production gateway pods log spurious errors like:

```
{"finishReason":"model_context_window_exceeded","msg":"Unknown finish reason encountered","provider":"anthropic","model":"anthropic/claude-sonnet-4-5",...}
```

Anthropic models emit the stop reason `model_context_window_exceeded` when generation hits the model's context window before reaching `max_tokens`. The gateway didn't recognize it, so:

- `getUnifiedFinishReason` classified it as `UNKNOWN` and logged an `ERROR`-level "Unknown finish reason encountered" alert on every occurrence.
- `mapFinishReasonToOpenai` silently converted it to `"stop"`, so OpenAI-compatible clients saw a normal completion instead of `"length"`.
- `isLengthLimitFinishReason` didn't treat these responses as length-limited.

## Fix

Map `model_context_window_exceeded` as a length limit uniformly. Like the existing cross-provider `refusal` handling, this stop reason surfaces across the Anthropic direct API, Vertex, and Bedrock, so it's handled at the top level of both mappers:

- `apps/gateway/src/lib/logs.ts` — `getUnifiedFinishReason` returns `LENGTH_LIMIT` (also fixes `isLengthLimitFinishReason`, which derives from it), eliminating the spurious error log.
- `apps/gateway/src/chat/tools/map-finish-reason-to-openai.ts` — clients now receive the OpenAI-canonical `"length"` finish reason (streaming and non-streaming).
- `apps/gateway/src/chat/tools/parse-provider-response.ts` and `transform-streaming-to-openai.ts` — the Bedrock Converse branches map the raw stop reason to `"length"` alongside `max_tokens`.

## Testing

- Added unit tests covering the new mapping for `anthropic`, `vertex-anthropic`, and `aws-bedrock` in `logs.spec.ts` (65 tests passing in affected files).
- `turbo run build --filter=gateway` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxoFcM6Btfm7x2MR56wDXs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxoFcM6Btfm7x2MR56wDXs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model context-window limits across supported providers.
  * Context-limit responses are now consistently reported as length-limit completions.
  * Streaming and non-streaming responses now use the correct OpenAI-compatible finish reason.
* **Tests**
  * Added coverage for context-window limit handling across Anthropic, Vertex, and AWS Bedrock responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->