### PR TITLE
feat: raise provider listing fee to $2500

### DIFF
--- a/apps/api/src/routes/public-contact.ts
+++ b/apps/api/src/routes/public-contact.ts
@@ -703,7 +703,7 @@ publicContact.openapi(submitProviderContact, async (c) => {
 
 	const compliance = complianceSummary(validatedData);
 
-	// Create the Stripe checkout session for the $1000 listing fee up front so the
+	// Create the Stripe checkout session for the $2500 listing fee up front so the
 	// payment link is returned to the client even if the confirmation email can't
 	// be sent. The fee is refunded in full if we don't end up listing the provider.
 	let checkoutUrl: string | null = null;

--- a/apps/ui/src/components/add-provider/add-provider-form.tsx
+++ b/apps/ui/src/components/add-provider/add-provider-form.tsx
@@ -10,6 +10,7 @@ import {
 	Loader2,
 	LogIn,
 	MailWarning,
+	TrendingUp,
 } from "lucide-react";
 import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
@@ -210,15 +211,28 @@ export function AddProviderForm({
 					</div>
 
 					{initialPayment !== "success" && (
-						<div className="mb-8 flex items-start gap-3 rounded-xl border border-border bg-muted/30 p-4">
-							<Info className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
-							<p className="text-sm text-muted-foreground">
-								There is a{" "}
-								<span className="font-semibold text-foreground">$1000</span> fee
-								to list a provider, collected securely via Stripe right after
-								you submit. It is refunded in full if we don't end up listing
-								your provider.
-							</p>
+						<div className="mb-8 space-y-3">
+							<div className="flex items-start gap-3 rounded-xl border border-border bg-muted/30 p-4">
+								<Info className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+								<p className="text-sm text-muted-foreground">
+									There is a{" "}
+									<span className="font-semibold text-foreground">$2500</span>{" "}
+									fee to list a provider, collected securely via Stripe right
+									after you submit. It is refunded in full if we don't end up
+									listing your provider.
+								</p>
+							</div>
+							<div className="flex items-start gap-3 rounded-xl border border-border bg-muted/30 p-4">
+								<TrendingUp className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+								<p className="text-sm text-muted-foreground">
+									The fee buys a listing, not traffic — we can't guarantee any
+									volume. Requests are routed on the merits of the model
+									catalogue you offer: mostly price, but also latency,
+									throughput, and uptime. A provider whose models are
+									competitive on those gets picked; one that isn't may see
+									little to no traffic.
+								</p>
+							</div>
 						</div>
 					)}
 
@@ -226,7 +240,7 @@ export function AddProviderForm({
 						<div className="mb-8 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-400">
 							Payment was canceled, so your provider isn't queued for listing
 							yet. Your details were saved — submit the form again to retry the
-							$1000 listing fee whenever you're ready.
+							$2500 listing fee whenever you're ready.
 						</div>
 					)}
 
@@ -240,10 +254,12 @@ export function AddProviderForm({
 									Payment received!
 								</h3>
 								<p className="text-muted-foreground">
-									Thanks — we've received your $1000 listing fee and your
+									Thanks — we've received your $2500 listing fee and your
 									provider details. Our team will review your provider and
 									follow up. The fee is refunded in full if we don't end up
-									listing it.
+									listing it. It covers the listing only — traffic isn't
+									guaranteed and depends on how your model catalogue compares on
+									price, latency, throughput, and uptime.
 								</p>
 							</div>
 						) : isSuccess ? (


### PR DESCRIPTION
## Summary

Bumps the provider listing fee copy from $1000 to $2500 and adds copy setting expectations about traffic on the add-provider page.

## Changes

**`apps/ui/src/components/add-provider/add-provider-form.tsx`**

- Fee amount updated to `$2500` in all three places: the pre-submit info callout, the payment-canceled banner, and the payment-success message.
- New callout under the fee notice making explicit that the fee buys a listing, not traffic — routing depends on the merits of the model catalogue offered: mostly price, but also latency, throughput, and uptime. A provider that isn't competitive on those may see little to no traffic.
- The payment-success message carries a short version of the same caveat, so it's still visible to submitters who land there directly from Stripe.

**`apps/api/src/routes/public-contact.ts`**

- Updated the stale `$1000` reference in the checkout-session comment.

## Notes

The actual charged amount lives in Stripe behind `STRIPE_PROVIDER_LISTING_PRICE_ID` — no amount is hardcoded in the codebase, so **the Stripe price must be updated to $2500 separately** for the charge to match this copy.

## Testing

- `pnpm format`
- `pnpm exec turbo run build --filter=ui --filter=api` — both build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9NyvbmLdVZBCNGg4EggZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9NyvbmLdVZBCNGg4EggZk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the provider listing fee displayed throughout the submission and payment flow from $1,000 to $2,500.
  * Added clarification that provider traffic is evaluated using catalogue characteristics such as price, latency, throughput, and uptime.
  * Improved payment confirmation messaging with additional explanatory details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->