### PR TITLE
fix(playground): ship pcm-recorder worklet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,7 @@
 
 packages/**/*.js
 apps/**/*.js
+# Browser-loaded static assets that happen to be .js must survive the blanket
+# exclusion above, or the image ships without them and the fetch 404s at runtime.
+# Mirrors the same negation in .gitignore.
+!apps/playground/public/worklets/*.js

--- a/apps/playground/src/lib/realtime-audio.spec.ts
+++ b/apps/playground/src/lib/realtime-audio.spec.ts
@@ -1,12 +1,23 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
 	computeRms,
 	floatToPcm16Base64,
+	PCM_RECORDER_WORKLET_URL,
 	pcm16Base64ToFloat,
 	resampleLinear,
 	rmsToLevel,
 } from "./realtime-audio";
+
+const playgroundRoot = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+const repoRoot = resolve(playgroundRoot, "../..");
 
 describe("resampleLinear", () => {
 	it("passes through when rates match", () => {
@@ -119,4 +130,29 @@ describe("rmsToLevel", () => {
 			previous = level;
 		}
 	});
+});
+
+// The worklet is a .js file under apps/, so the blanket `apps/**/*.js`
+// exclusions in .gitignore and .dockerignore both swallow it unless negated.
+// When the deployed image lacks it, addModule() 404s, the hook tears the call
+// down, and the browser only reports "WebSocket is closed before the connection
+// is established" — so guard the asset here rather than in production.
+describe("pcm-recorder worklet asset", () => {
+	it("is present in the playground public directory", () => {
+		const worklet = join(playgroundRoot, "public", PCM_RECORDER_WORKLET_URL);
+		expect(existsSync(worklet)).toBe(true);
+	});
+
+	it.each([".gitignore", ".dockerignore"])(
+		"survives the blanket apps/**/*.js exclusion in %s",
+		(ignoreFile) => {
+			const lines = readFileSync(join(repoRoot, ignoreFile), "utf8")
+				.split("\n")
+				.map((line) => line.trim());
+			if (!lines.includes("apps/**/*.js")) {
+				return;
+			}
+			expect(lines).toContain("!apps/playground/public/worklets/*.js");
+		},
+	);
 });

--- a/apps/playground/src/lib/realtime-audio.ts
+++ b/apps/playground/src/lib/realtime-audio.ts
@@ -234,6 +234,14 @@ export interface MicrophoneCaptureHandles {
 }
 
 /**
+ * Served from apps/playground/public. Because it is a .js file under apps/,
+ * both .gitignore and .dockerignore blanket-exclude it and need an explicit
+ * negation — without one the deployed image 404s here and the failure surfaces
+ * as an opaque WebSocket close.
+ */
+export const PCM_RECORDER_WORKLET_URL = "/worklets/pcm-recorder.js";
+
+/**
  * Wire a microphone stream through the pcm-recorder AudioWorklet. The
  * worklet output goes through a zero-gain node so microphone audio is
  * processed without being played back locally. onChunk receives raw Float32
@@ -244,7 +252,7 @@ export async function startMicrophoneCapture(
 	stream: MediaStream,
 	onChunk: (samples: Float32Array) => void,
 ): Promise<MicrophoneCaptureHandles> {
-	await context.audioWorklet.addModule("/worklets/pcm-recorder.js");
+	await context.audioWorklet.addModule(PCM_RECORDER_WORKLET_URL);
 	const source = context.createMediaStreamSource(stream);
 	const worklet = new AudioWorkletNode(context, "pcm-recorder", {
 		numberOfInputs: 1,


### PR DESCRIPTION
## Problem

Starting a realtime voice call in the deployed playground failed with:

```
use-realtime-call.ts:157 WebSocket connection to
'wss://api.llmgateway.io/v1/realtime?model=gpt-realtime-2.1-mini' failed:
WebSocket is closed before the connection is established.
```

The WebSocket was never the problem. GCP load balancer logs for the failing attempts:

```
18:30:54  101  GET /v1/realtime  0.448s  client_disconnected_after_partial_response
18:30:28  101  GET /v1/realtime  0.697s  client_disconnected_after_partial_response
```

`101 Switching Protocols` means the handshake completed, and the gateway logged
`Realtime session opened` with an upstream OpenAI session attached. The **browser**
then hung up ~0.5s later.

## Cause

`https://chat.llmgateway.io/worklets/pcm-recorder.js` returned **404**, while every
other `public/` asset (`/llms.txt`, `/opengraph.png`, `/manifest.webmanifest`) served
fine.

`.dockerignore` blanket-excludes `apps/**/*.js`. `.gitignore` negates the worklet on
line 7; `.dockerignore` never did — so the file is git-tracked but stripped from the
Docker build context and absent from the image.

In production that chain is:

`addModule()` rejects on the 404 → `startMicrophoneCapture` throws →
the hook's `catch` calls `failCall` → `cleanup()` → `ws.close(1000)` on a
still-`CONNECTING` socket → Chrome reports exactly the message above.

It works locally because `next dev` serves `public/` off the filesystem.

## Fix

- Add `!apps/playground/public/worklets/*.js` to `.dockerignore`. Verified with a real
  `docker build`: the worklet is now included and other `apps/**/*.js` stay excluded.
- Extract `PCM_RECORDER_WORKLET_URL` so the asset path has one source of truth.
- Add a spec guarding the asset against both ignore files. Confirmed it **fails**
  without the `.dockerignore` change and passes with it.

This is the only `.js` file under any `public/` directory in the repo, so the single
negation is the complete fix.

## Out of scope

Two things surfaced while debugging that are **not** addressed here:

1. One attempt returned `502 upstream_connect_failed` — OpenAI answered the upstream
   handshake with HTTP 500. Probing `api.openai.com` with the gateway's exact header
   set 9x returned `101` every time, so it is transient upstream flakiness.
   `connectUpstream` (`apps/gateway/src/realtime/server.ts:158`) does not retry a
   transient upstream 5xx, so one hiccup kills the call.
2. A client-side audio failure currently tears down an already-established upstream
   session, after the billing row and concurrency lease are taken. Starting mic capture
   before minting would fail fast instead.

## Testing

- `pnpm test:unit` — 195 files, 3252 passed, 2 skipped
- `pnpm build` — 17/17 successful
- `pnpm format`
- `docker build` with the real ignore patterns, asserting the worklet lands in the context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed microphone capture in the playground when running from a deployed image.
  * Ensured the required audio processing asset is included and loads correctly, preventing runtime errors or missing-file failures.
* **Reliability**
  * Added validation to help ensure audio recording assets remain available in future builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->