### PR TITLE
fix(ui): hide small-sample provider card stats

### DIFF
--- a/apps/ui/src/components/models/model-uptime-charts.tsx
+++ b/apps/ui/src/components/models/model-uptime-charts.tsx
@@ -28,6 +28,10 @@ import {
 	type ChartConfig,
 } from "@/lib/components/chart";
 import { useApi } from "@/lib/fetch-client";
+import {
+	hasEnoughRequestsForStats,
+	MIN_REQUESTS_FOR_STATS,
+} from "@/lib/provider-stats";
 import { cn } from "@/lib/utils";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
@@ -35,12 +39,6 @@ import { getProviderIcon } from "@llmgateway/shared/components";
 import type { paths } from "@/lib/api/v1";
 
 type ActiveMetric = "requests" | "errors" | "latency" | "tokens";
-
-// Derived metrics (uptime %, error rate, latency averages, throughput) are only
-// statistically meaningful once a provider has served a reasonable number of
-// requests. Below this threshold we show "—" instead so the numbers don't look
-// misleading.
-const MIN_REQUESTS_FOR_STATS = 1000;
 
 type UptimeResponse =
 	paths["/internal/models/{modelId}/uptime"]["get"]["responses"]["200"]["content"]["application/json"];
@@ -91,7 +89,7 @@ function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 	const config = chartConfigs[activeMetric];
 	const dataKeys = Object.keys(config);
 
-	const hasEnoughData = provider.logsCount > MIN_REQUESTS_FOR_STATS;
+	const hasEnoughData = hasEnoughRequestsForStats(provider.logsCount);
 
 	const errorRate =
 		provider.logsCount > 0

--- a/apps/ui/src/components/providers/providers-grid.tsx
+++ b/apps/ui/src/components/providers/providers-grid.tsx
@@ -31,6 +31,10 @@ import {
 	SelectValue,
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
+import {
+	gateProviderStats,
+	type ProviderWindowStats,
+} from "@/lib/provider-stats";
 
 import {
 	countryCodeToFlag,
@@ -201,23 +205,18 @@ export function ProvidersGrid({
 	);
 
 	const statsByProvider = useMemo(() => {
-		const map = new Map<
-			string,
-			{
-				uptime: number | null;
-				avgTimeToFirstToken: number | null;
-				throughput: number | null;
-				logsCount: number;
-			}
-		>();
+		const map = new Map<string, ProviderWindowStats>();
 		if (statsData?.providers) {
 			for (const row of statsData.providers) {
-				map.set(row.providerId, {
-					uptime: row.uptime,
-					avgTimeToFirstToken: row.avgTimeToFirstToken,
-					throughput: row.throughput,
-					logsCount: row.logsCount,
-				});
+				map.set(
+					row.providerId,
+					gateProviderStats({
+						logsCount: row.logsCount,
+						uptime: row.uptime,
+						avgTimeToFirstToken: row.avgTimeToFirstToken,
+						throughput: row.throughput,
+					}),
+				);
 			}
 		}
 		return map;

--- a/apps/ui/src/lib/provider-stats.spec.ts
+++ b/apps/ui/src/lib/provider-stats.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	gateProviderStats,
+	hasEnoughRequestsForStats,
+	MIN_REQUESTS_FOR_STATS,
+} from "./provider-stats";
+
+describe("hasEnoughRequestsForStats", () => {
+	it("requires strictly more requests than the threshold", () => {
+		expect(hasEnoughRequestsForStats(0)).toBe(false);
+		expect(hasEnoughRequestsForStats(MIN_REQUESTS_FOR_STATS)).toBe(false);
+		expect(hasEnoughRequestsForStats(MIN_REQUESTS_FOR_STATS + 1)).toBe(true);
+	});
+});
+
+describe("gateProviderStats", () => {
+	it("nulls derived stats below the threshold so small samples are hidden", () => {
+		const gated = gateProviderStats({
+			logsCount: 8,
+			uptime: 100,
+			avgTimeToFirstToken: 63470,
+			throughput: 12,
+		});
+		expect(gated).toEqual({
+			logsCount: 8,
+			uptime: null,
+			avgTimeToFirstToken: null,
+			throughput: null,
+		});
+	});
+
+	it("keeps derived stats once the sample is large enough", () => {
+		const stats = {
+			logsCount: MIN_REQUESTS_FOR_STATS + 1,
+			uptime: 99.7,
+			avgTimeToFirstToken: 412,
+			throughput: 85,
+		};
+		expect(gateProviderStats(stats)).toEqual(stats);
+	});
+});

--- a/apps/ui/src/lib/provider-stats.ts
+++ b/apps/ui/src/lib/provider-stats.ts
@@ -1,0 +1,30 @@
+// Derived provider metrics (uptime %, latency averages, throughput) are only
+// statistically meaningful once a provider has served a reasonable number of
+// requests in the window. Below this threshold surfaces hide the numbers
+// instead of showing misleading small-sample averages.
+export const MIN_REQUESTS_FOR_STATS = 1000;
+
+export function hasEnoughRequestsForStats(logsCount: number): boolean {
+	return logsCount > MIN_REQUESTS_FOR_STATS;
+}
+
+export interface ProviderWindowStats {
+	logsCount: number;
+	uptime: number | null;
+	avgTimeToFirstToken: number | null;
+	throughput: number | null;
+}
+
+export function gateProviderStats(
+	stats: ProviderWindowStats,
+): ProviderWindowStats {
+	if (hasEnoughRequestsForStats(stats.logsCount)) {
+		return stats;
+	}
+	return {
+		logsCount: stats.logsCount,
+		uptime: null,
+		avgTimeToFirstToken: null,
+		throughput: null,
+	};
+}


### PR DESCRIPTION
## Root cause

The public `/providers` page showed **"TTFT 63.47s"** for Gonka24 — a provider with only ~8 requests in recent hours.

Two surfaces compute average TTFT from the same rollup (`model_provider_mapping_history[_hourly]`) with the same formula, `SUM(total_time_to_first_token) / (SUM(logs_count) - SUM(cached_count))`, in milliseconds:

- **Provider grid** (`apps/ui/src/components/providers/providers-grid.tsx` → `GET /public/providers/stats` in `apps/api/src/routes/public-providers-stats.ts`)
- **Model uptime page** (`apps/ui/src/components/models/model-uptime-charts.tsx` → `GET /internal/models/{modelId}/uptime` in `apps/api/src/routes/internal-models.ts`)

The units, weighting, and request-type semantics already match (`timeToFirstToken` is only recorded for streaming chat completions — non-streaming, cached, image/video/speech and error logs all store `null`, so they add nothing to the numerator). The difference was the sample gate: the uptime page hides all derived stats until a provider exceeds `MIN_REQUESTS_FOR_STATS = 1000` requests in the window, while the provider grid rendered whatever the endpoint returned — no minimum sample. For a tiny open-weights provider, a handful of genuinely slow streaming responses (~60s cold-start TTFT) fully determine the average, so the card displayed a statistically meaningless 63.47s.

## Fix

- New `apps/ui/src/lib/provider-stats.ts` extracts the shared threshold (`MIN_REQUESTS_FOR_STATS`, `hasEnoughRequestsForStats`) plus `gateProviderStats`, which nulls `avgTimeToFirstToken`/`uptime`/`throughput` when the window's `logsCount` is at or below the threshold.
- `providers-grid.tsx` gates each provider's stats through it: below 1k requests the card renders no stats block and no speed badge (its existing missing-stats design), and the fastest/slowest/uptime sorts rank the provider last instead of letting a tiny sample win.
- `model-uptime-charts.tsx` now imports the shared constant/helper instead of its local copy, so both surfaces can't drift.

No API/response-shape changes, so no OpenAPI client regeneration was needed.

## Verification

- Added `apps/ui/src/lib/provider-stats.spec.ts` covering the gate at/below/above the threshold — 3 tests pass.
- `pnpm exec turbo run build --filter=ui --filter=api` passes.
- `pnpm format` clean.

https://claude.ai/code/session_01GHes4dnhGdhjDm1gMbCicV