### PR TITLE
fix(gateway): extract vertex-anthropic streaming token usage

### DIFF
--- a/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
@@ -361,6 +361,50 @@ describe("extractTokenUsage", () => {
 		});
 	});
 
+	describe("vertex-anthropic", () => {
+		// Vertex Anthropic streams the same Anthropic Messages wire format, so it
+		// must extract usage identically to the direct anthropic provider rather
+		// than falling through to the OpenAI-shaped default branch.
+		it("extracts cache and reasoning tokens from a streaming message_start", () => {
+			const data = {
+				type: "message_start",
+				message: {
+					usage: {
+						input_tokens: 100,
+						cache_creation_input_tokens: 50,
+						cache_read_input_tokens: 800,
+						output_tokens: 2928,
+						output_tokens_details: { thinking_tokens: 1502 },
+					},
+				},
+			};
+
+			const result = extractTokenUsage(data, "vertex-anthropic");
+
+			expect(result.promptTokens).toBe(950); // 100 + 50 + 800
+			expect(result.cachedTokens).toBe(800);
+			expect(result.cacheCreationTokens).toBe(50);
+			expect(result.completionTokens).toBe(2928);
+			expect(result.reasoningTokens).toBe(1502);
+			expect(result.totalTokens).toBe(3878); // 950 + 2928, reasoning not double-counted
+		});
+
+		it("matches the direct anthropic provider for the same chunk", () => {
+			const data = {
+				usage: {
+					input_tokens: 51,
+					cache_read_input_tokens: 20,
+					output_tokens: 136,
+					reasoning_output_tokens: 31,
+				},
+			};
+
+			expect(extractTokenUsage(data, "vertex-anthropic")).toEqual(
+				extractTokenUsage(data, "anthropic"),
+			);
+		});
+	});
+
 	describe("alibaba", () => {
 		it("extracts prompt_tokens_details.cache_creation_input_tokens into 5m cache write fields", () => {
 			const data = {

--- a/apps/gateway/src/chat/tools/extract-token-usage.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.ts
@@ -167,6 +167,7 @@ export function extractTokenUsage(
 			}
 			break;
 		case "anthropic":
+		case "vertex-anthropic":
 			{
 				const usage = data.message?.usage ?? data.usage;
 				if (!usage) {


### PR DESCRIPTION
Streaming usage for `vertex-anthropic` was silently coming back empty. `extractTokenUsage` switches on the provider, and the Anthropic block is `case "anthropic":` only — so `vertex-anthropic` fell through to the OpenAI-shaped default, which reads `data.usage.prompt_tokens`/`completion_tokens`. Vertex Anthropic streams the Anthropic Messages wire format (`message.usage.input_tokens`, `output_tokens`, cache and thinking fields), so the default branch found nothing and returned all-null usage.

The effect is real cost drift: with usage null the streaming path falls back to `estimateTokens`, and `cachedTokens`, `cacheCreationTokens` and reasoning/thinking tokens are dropped entirely, so the cache-read discount never applies. The direct `anthropic` provider bills the same chunk correctly; `vertex-anthropic` did not.

Every sibling handler already groups the two the same way — `map-finish-reason-to-openai`, `extract-tool-calls`, `extract-reasoning`, the finish-reason switch in `chat.ts`, and the non-streaming `parse-provider-response` — so this was just a missing case label on the streaming usage extractor. Added it, and added a spec that asserts `vertex-anthropic` extracts the streaming `message_start` shape and matches `anthropic` for an identical chunk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage reporting for Vertex Anthropic conversations.
  * Prompt, cached, completion, reasoning, and total token counts are now extracted consistently without double-counting reasoning tokens.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->