### PR TITLE
fix(gateway): clamp temperature to provider ceiling

### DIFF
--- a/apps/gateway/src/chat-params.e2e.ts
+++ b/apps/gateway/src/chat-params.e2e.ts
@@ -33,6 +33,9 @@ const parameterTests: Array<{
 	{ name: "frequency_penalty", params: { frequency_penalty: 0.5 } },
 	{ name: "presence_penalty", params: { presence_penalty: 0.5 } },
 	{ name: "temperature + top_p", params: { temperature: 0.7, top_p: 0.9 } },
+	// providers with a lower ceiling (zai, anthropic) must get this clamped
+	// instead of a 400
+	{ name: "temperature above ceiling", params: { temperature: 1.9 } },
 ];
 
 // Generate test cases: combine each parameter config with each model

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -189,6 +189,7 @@ import {
 	shouldApplyContentFilterToModel,
 } from "./tools/check-content-filter.js";
 import { chunkMayCompleteSseEvent } from "./tools/chunk-may-complete-sse-event.js";
+import { clampTemperature } from "./tools/clamp-temperature.js";
 import { collapseImageGenSse } from "./tools/collapse-image-gen-sse.js";
 import { convertImagesToBase64 } from "./tools/convert-images-to-base64.js";
 import { countInputImages } from "./tools/count-input-images.js";
@@ -6083,6 +6084,8 @@ chat.openapi(completions, async (c) => {
 			top_p = undefined;
 		}
 	}
+
+	temperature = clampTemperature(temperature, usedProvider);
 
 	// Check if the request can be canceled
 	let requestCanBeCanceled =

--- a/apps/gateway/src/chat/tools/clamp-temperature.spec.ts
+++ b/apps/gateway/src/chat/tools/clamp-temperature.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { clampTemperature } from "./clamp-temperature.js";
+
+describe("clampTemperature", () => {
+	it("returns undefined when no temperature is set", () => {
+		expect(clampTemperature(undefined, "zai")).toBeUndefined();
+	});
+
+	it("leaves the temperature untouched for providers without a ceiling", () => {
+		expect(clampTemperature(1.8, "openai")).toBe(1.8);
+	});
+
+	it("clamps values above the provider ceiling", () => {
+		expect(clampTemperature(1.5, "zai")).toBe(1);
+		expect(clampTemperature(2, "zai")).toBe(1);
+	});
+
+	it("keeps values within the provider ceiling", () => {
+		expect(clampTemperature(1, "zai")).toBe(1);
+		expect(clampTemperature(0.7, "zai")).toBe(0.7);
+		expect(clampTemperature(0, "zai")).toBe(0);
+	});
+});

--- a/apps/gateway/src/chat/tools/clamp-temperature.ts
+++ b/apps/gateway/src/chat/tools/clamp-temperature.ts
@@ -1,0 +1,22 @@
+import { providers } from "@llmgateway/models";
+
+/**
+ * Clamp the requested temperature to the ceiling the selected provider accepts.
+ * The OpenAI schema allows temperature up to 2, but providers such as zai reject
+ * anything above 1 with a 400, so lower the value instead of failing the request.
+ */
+export function clampTemperature(
+	temperature: number | undefined,
+	providerId: string,
+): number | undefined {
+	if (temperature === undefined) {
+		return undefined;
+	}
+	const maxTemperature = providers.find(
+		(p) => p.id === providerId,
+	)?.maxTemperature;
+	if (maxTemperature === undefined || temperature <= maxTemperature) {
+		return temperature;
+	}
+	return maxTemperature;
+}

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -41,6 +41,7 @@ import {
 	isPremiumModel,
 } from "@llmgateway/shared";
 
+import { clampTemperature } from "./clamp-temperature.js";
 import {
 	getProviderEnv,
 	getServiceTierIneligibleEnvIndices,
@@ -614,6 +615,8 @@ export async function resolveProviderContext(
 			top_p = undefined;
 		}
 	}
+
+	temperature = clampTemperature(temperature, usedProvider);
 
 	// --- max_tokens validation ---
 	if (max_tokens !== undefined && providerMappingForSelected) {

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -1209,14 +1209,12 @@ export const zaiModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
-				// zai rejects temperature outside [0,1] with a 400 ("The temperature
-				// parameter is illegal"). Exclude it so out-of-range values are stripped
-				// instead of failing the request.
 				supportedParameters: [
 					"messages",
 					"model",
 					"stream",
 					"stream_options",
+					"temperature",
 					"top_p",
 					"max_tokens",
 					"max_completion_tokens",

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -146,6 +146,12 @@ export interface ProviderDefinition {
 	// Whether requests that match the gateway content filter should avoid this provider
 	// when an alternative provider is available.
 	contentFilter?: boolean;
+	/**
+	 * Highest `temperature` this provider accepts. The OpenAI schema allows up
+	 * to 2, but some providers reject anything above their own ceiling with a
+	 * 400, so the gateway clamps the requested value instead of failing.
+	 */
+	maxTemperature?: number;
 	/** Region routing config - when set, provider supports multiple geographic endpoints */
 	regionConfig?: ProviderRegionConfig;
 	/**
@@ -254,6 +260,8 @@ export const providers: ProviderDefinition[] = [
 		},
 		streaming: true,
 		cancellation: true,
+		// the Messages API rejects temperature above 1 ("temperature: range: 0..1")
+		maxTemperature: 1,
 		color: "#8b5cf6",
 		website: "https://anthropic.com",
 		statusPageUrl: "https://status.claude.com",
@@ -499,6 +507,8 @@ export const providers: ProviderDefinition[] = [
 		},
 		streaming: true,
 		cancellation: true,
+		// same Messages API ceiling as anthropic
+		maxTemperature: 1,
 		color: "#4285f4",
 		website: "https://cloud.google.com/vertex-ai",
 		statusPageUrl: "https://status.cloud.google.com",
@@ -1019,6 +1029,9 @@ export const providers: ProviderDefinition[] = [
 		},
 		streaming: true,
 		cancellation: true,
+		// every GLM model rejects temperature above 1 with a 400
+		// ("The temperature parameter is illegal", range [0,1])
+		maxTemperature: 1,
 		color: "#22c55e",
 		website: "https://z.ai",
 		statusPageUrl: null,


### PR DESCRIPTION
## Problem

`zai/glm-5.2` was returning a recurring 400 in production:

```
{"error":{"code":"1210","message":"The temperature parameter is illegal.：限制数值范围[0,1]"}}
```

The OpenAI schema we accept allows `temperature` up to 2, but zai only accepts `[0, 1]` and rejects anything above it. Verified live against the zai API — `1.01`, `1.5` and `2` all 400, `0`/`0.5`/`1` succeed, and the ceiling applies to every GLM model (`glm-5.2`, `glm-4.6`, `glm-4.5-air`, `glm-4.6v`), not just `glm-5.2`.

Anthropic's Messages API has the same ceiling (`temperature: range: 0..1`, verified live), so `temperature > 1` on a Claude model via `/v1/chat/completions` failed the same way.

## Change

- New provider-level `maxTemperature` in `packages/models`, declared for `zai`, `anthropic` and `vertex-anthropic`.
- `clampTemperature()` lowers the requested value to that ceiling instead of forwarding a value the upstream rejects. Applied on both the initial routing path (`chat.ts`) and the retry/fallback path (`resolve-provider-context.ts`), so a fallback into zai/anthropic is clamped too.
- Dropped the older `glm-4.6v-flash` workaround that excluded `temperature` from `supportedParameters` entirely — clamping supersedes it, so in-range values are now forwarded instead of silently dropped.

Values within range are untouched; only out-of-range values are lowered (no rejection).

## Verification

- `apps/gateway/src/chat/tools/clamp-temperature.spec.ts` — unit coverage for the clamp.
- New `temperature above ceiling` case (`temperature: 1.9`) in `chat-params.e2e.ts`, run live with `x-no-fallback`:
  - `TEST_MODELS="zai/glm-5.2"` → 9 passed
  - `TEST_MODELS="anthropic/claude-haiku-4-5-20251001"` → 9 passed
- Negative control: rebuilt `@llmgateway/models` with zai's ceiling removed and the same e2e case fails with `expected 400 to be 200`, confirming the test actually exercises the fix.
- `pnpm format` and full `pnpm build` pass.