### PR TITLE
fix(messages): web-search replay, msg_ id, cache marks

### DIFF
--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -155,3 +155,22 @@ Cache usage comes back in Anthropic's native fields: `usage.cache_creation_input
 	Control](/features/caching/provider-cache-control) for the per-model
 	thresholds and details.
 </Callout>
+
+### Web Search
+
+Anthropic's server-side web search tool works on this endpoint. Pass it as usual and the response carries `server_tool_use` and `web_search_tool_result` blocks before the text that cites them, so Anthropic SDK clients surface sources:
+
+```json
+{
+	"model": "claude-haiku-4-5",
+	"max_tokens": 400,
+	"messages": [{ "role": "user", "content": "What shipped in Node 24?" }],
+	"tools": [{ "type": "web_search_20250305", "name": "web_search" }]
+}
+```
+
+Replaying the assistant turn verbatim on the next request is supported: the `server_tool_use` and `web_search_tool_result` blocks are accepted and dropped, since the provider re-runs the search rather than reusing the previous results.
+
+### Gateway Response Cache
+
+If [gateway caching](/features/caching/gateway-caching) is enabled on the project, a byte-identical request is replayed from cache instead of being sent upstream. Because the replayed body is identical (same `id`, same `usage`), the `x-llmgateway-cache: HIT` response header is the marker to check. Send `x-no-cache: true` to bypass the cache for a single request.

--- a/apps/docs/content/features/caching/gateway-caching.mdx
+++ b/apps/docs/content/features/caching/gateway-caching.mdx
@@ -115,22 +115,44 @@ The default cache duration is 60 seconds. Adjust this based on your use case—l
 
 ## Identifying Cached Responses
 
-Cached responses show zero or minimal token usage since no inference occurred:
+A cache hit replays the stored response body, so it is byte-identical to the original — same `id`, same content. Two markers tell you it was a replay:
+
+- the `x-llmgateway-cache: HIT` response header (set on every lane, including `/v1/messages`, which has no metadata envelope)
+- `metadata.cached: true` on the response body (and on the final metadata chunk of a streamed replay)
+
+All cost fields are zeroed on a replay, because no upstream call was made:
 
 ```json
 {
 	"usage": {
-		"prompt_tokens": 0,
-		"completion_tokens": 0,
-		"total_tokens": 0,
+		"prompt_tokens": 12,
+		"completion_tokens": 48,
+		"total_tokens": 60,
 		"cost": 0,
 		"cost_details": {
 			"total_cost": 0,
 			"input_cost": 0,
 			"output_cost": 0
 		}
+	},
+	"metadata": {
+		"cached": true
 	}
 }
+```
+
+Token counts are **not** zeroed — they still describe the completion you are receiving, and are what the dashboard records for analytics. Note that any prompt-caching fields (`prompt_tokens_details.cached_tokens`, `cache_write_tokens`) describe the _original_ upstream call, not the replay.
+
+## Bypassing the Cache for a Single Request
+
+Send `x-no-cache: true` to skip the cache for one request — the call goes upstream and its response is not stored. Useful when a client retries an identical request and expects a fresh sample (for example an agent loop) without disabling caching for the whole project.
+
+```bash
+curl https://api.llmgateway.io/v1/chat/completions \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "x-no-cache: true" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
 ## Use Cases

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -76,6 +76,27 @@ const anthropicMessageSchema = z.object({
 					type: z.literal("redacted_thinking"),
 					data: z.string(),
 				}),
+				// Anthropic server-tool blocks (web search) echoed back in
+				// conversation history. The gateway emits them on responses, so
+				// native SDK clients replay them on the next turn; they carry no
+				// representation in the internal OpenAI-format request (the
+				// `encrypted_content` Anthropic requires is not reconstructible from
+				// url_citation annotations), so they're accepted here and stripped
+				// during transformation.
+				z.object({
+					type: z.literal("server_tool_use"),
+					id: z.string(),
+					name: z.string(),
+					input: z.record(z.unknown()).optional(),
+				}),
+				z.object({
+					type: z.literal("web_search_tool_result"),
+					tool_use_id: z.string(),
+					// Either an array of web_search_result entries or an error object.
+					content: z
+						.union([z.array(z.unknown()), z.record(z.unknown())])
+						.optional(),
+				}),
 			]),
 		),
 	]),
@@ -297,8 +318,32 @@ interface AnthropicWebSearchResult {
 	page_age: string | null;
 }
 
+// Response-only Anthropic content blocks. Clients replay the assistant turn
+// verbatim on the next request, so these arrive back here; none of them has an
+// OpenAI-format equivalent, so they're dropped on the request direction.
+const NON_FORWARDABLE_CONTENT_BLOCK_TYPES = new Set([
+	"thinking",
+	"redacted_thinking",
+	"server_tool_use",
+	"web_search_tool_result",
+]);
+
 function generateServerToolUseId(): string {
 	return `srvtoolu_${randomUUID()}`;
+}
+
+// Anthropic message ids are `msg_`-prefixed and SDK clients key on that prefix.
+// The inner /v1/chat/completions response carries an OpenAI-style
+// `chatcmpl-` id, so normalize it here — reusing the inner id keeps the
+// response correlatable with the gateway log instead of inventing a new one.
+function toAnthropicMessageId(id: unknown): string {
+	if (typeof id !== "string" || id.length === 0) {
+		return `msg_${randomUUID()}`;
+	}
+	if (id.startsWith("msg_")) {
+		return id;
+	}
+	return `msg_${id.replace(/^chatcmpl[-_]/, "")}`;
 }
 
 // Map the inner chat completions response's url_citation annotations onto
@@ -617,18 +662,33 @@ anthropic.openapi(messages, async (c) => {
 
 		// Handle regular messages and multi-modal content
 		if (Array.isArray(message.content)) {
+			// Blocks that exist only in the Anthropic response format (extended
+			// thinking, server-side web search) are dropped: the internal
+			// OpenAI-format request has no equivalent, and forwarding them verbatim
+			// would reach the provider as an unknown content type.
+			const forwardableBlocks = message.content.filter(
+				(block) => !NON_FORWARDABLE_CONTENT_BLOCK_TYPES.has(block.type),
+			);
+
+			// A turn made up entirely of dropped blocks (e.g. a `pause_turn` reply
+			// carrying only server_tool_use) would otherwise become an empty
+			// message, which providers reject.
+			if (forwardableBlocks.length === 0) {
+				continue;
+			}
+
 			// Check if this is complex multi-modal content that should be flattened
-			const hasOnlyText = message.content.every(
+			const hasOnlyText = forwardableBlocks.every(
 				(block) => block.type === "text",
 			);
-			const hasAnyCacheControl = message.content.some(
+			const hasAnyCacheControl = forwardableBlocks.some(
 				(block) => block.type === "text" && block.cache_control,
 			);
 
 			if (hasOnlyText && !hasAnyCacheControl) {
 				// For text-only content with no cache markers, flatten to a simple
 				// string to avoid content type issues.
-				const textContent = message.content
+				const textContent = forwardableBlocks
 					.filter((block) => block.type === "text")
 					.map((block) => block.text)
 					.join("");
@@ -641,31 +701,26 @@ anthropic.openapi(messages, async (c) => {
 				// For multi-modal content, or text content with cache_control markers,
 				// transform blocks while preserving cache_control so the inner
 				// completions path can forward it to Anthropic.
-				const content = message.content
-					.filter(
-						(block) =>
-							block.type !== "thinking" && block.type !== "redacted_thinking",
-					)
-					.map((block) => {
-						if (block.type === "text" && block.text) {
-							return {
-								type: "text",
-								text: block.text,
-								...(block.cache_control && {
-									cache_control: block.cache_control,
-								}),
-							};
-						}
-						if (block.type === "image" && block.source) {
-							return {
-								type: "image_url",
-								image_url: {
-									url: `data:${block.source.media_type};base64,${block.source.data}`,
-								},
-							};
-						}
-						return block;
-					});
+				const content = forwardableBlocks.map((block) => {
+					if (block.type === "text" && block.text) {
+						return {
+							type: "text",
+							text: block.text,
+							...(block.cache_control && {
+								cache_control: block.cache_control,
+							}),
+						};
+					}
+					if (block.type === "image" && block.source) {
+						return {
+							type: "image_url",
+							image_url: {
+								url: `data:${block.source.media_type};base64,${block.source.data}`,
+							},
+						};
+					}
+					return block;
+				});
 
 				openaiMessages.push({
 					role: message.role,
@@ -788,6 +843,11 @@ anthropic.openapi(messages, async (c) => {
 			...(c.req.header("x-no-fallback") !== undefined
 				? { "x-no-fallback": c.req.header("x-no-fallback")! }
 				: {}),
+			// Forward the gateway response-cache opt-out so a native Anthropic
+			// caller can request a fresh sample for a byte-identical body.
+			...(c.req.header("x-no-cache") !== undefined
+				? { "x-no-cache": c.req.header("x-no-cache")! }
+				: {}),
 			// Signal to the inner /v1/chat/completions handler that the caller used
 			// Anthropic's explicit-budget thinking API (`thinking.type: "enabled"`).
 			// On adaptive-only models the budget maps to an unsupported
@@ -858,6 +918,16 @@ anthropic.openapi(messages, async (c) => {
 			}),
 			response.status as 400 | 401 | 402 | 403 | 404 | 429 | 500,
 		);
+	}
+
+	// Surface gateway response-cache replays to native Anthropic clients. The
+	// Anthropic response body has no metadata envelope to carry the marker the
+	// inner /v1/chat/completions puts on `metadata.cached`, so forward the
+	// header instead — without it a replayed body (same id, same usage) is
+	// indistinguishable from a fresh sample.
+	const innerCacheStatus = response.headers.get("x-llmgateway-cache");
+	if (innerCacheStatus) {
+		c.header("x-llmgateway-cache", innerCacheStatus);
 	}
 
 	// Handle streaming response
@@ -1079,7 +1149,7 @@ anthropic.openapi(messages, async (c) => {
 								}
 
 								if (!messageId && chunk.id) {
-									messageId = chunk.id;
+									messageId = toAnthropicMessageId(chunk.id);
 									model = chunk.model ?? anthropicRequest.model;
 
 									// Send message_start event
@@ -1551,7 +1621,7 @@ anthropic.openapi(messages, async (c) => {
 		| undefined;
 
 	const anthropicResponse = {
-		id: openaiResponse.id,
+		id: toAnthropicMessageId(openaiResponse.id),
 		type: "message" as const,
 		role: "assistant" as const,
 		model: openaiResponse.model,

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
 import { db, eq, tables } from "@llmgateway/db";
@@ -535,6 +537,216 @@ describe("api", () => {
 			(block: any) => block.type === "thinking",
 		);
 		expect(thinkingIndex).toBeLessThan(textIndex);
+	});
+
+	// The gateway emits server_tool_use + web_search_tool_result blocks for
+	// native web search, so SDK clients replay them on the following turn. They
+	// have no OpenAI-format equivalent and must be dropped, not rejected and not
+	// forwarded verbatim.
+	test("/v1/messages accepts web-search blocks in conversation history", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		let capturedBody: any;
+		const originalFetch = globalThis.fetch;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url.includes(`${mockServerUrl}/v1/chat/completions`)) {
+					capturedBody = JSON.parse(init?.body as string);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		try {
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					max_tokens: 1024,
+					messages: [
+						{ role: "user", content: "What is the latest ai release?" },
+						{
+							role: "assistant",
+							content: [
+								{
+									type: "server_tool_use",
+									id: "srvtoolu_1",
+									name: "web_search",
+									input: { query: "latest ai release" },
+								},
+								{
+									type: "web_search_tool_result",
+									tool_use_id: "srvtoolu_1",
+									content: [
+										{
+											type: "web_search_result",
+											url: "https://example.com",
+											title: "Example",
+										},
+									],
+								},
+								{ type: "text", text: "The latest release is 7.0.37." },
+							],
+						},
+						{ role: "user", content: "Thanks!" },
+					],
+				}),
+			});
+
+			// Before the fix this returned 400 with a Zod invalid_union error.
+			expect(res.status).toBe(200);
+
+			// The response-only blocks must not reach the provider.
+			const forwarded = JSON.stringify(capturedBody?.messages ?? []);
+			expect(forwarded).not.toContain("server_tool_use");
+			expect(forwarded).not.toContain("web_search_tool_result");
+			expect(forwarded).toContain("The latest release is 7.0.37.");
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	// The Anthropic response body has no metadata envelope, so the header is the
+	// only way a native client can tell a response-cache replay (identical id,
+	// identical usage) from a fresh sample.
+	test("/v1/messages marks gateway response-cache replays", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db
+			.update(tables.project)
+			.set({ cachingEnabled: true })
+			.where(eq(tables.project.id, "project-id"));
+
+		const body = JSON.stringify({
+			model: "llmgateway/custom",
+			max_tokens: 1024,
+			messages: [{ role: "user", content: `Cache me! ${randomUUID()}` }],
+		});
+
+		const makeRequest = (headers: Record<string, string> = {}) =>
+			app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+					...headers,
+				},
+				body,
+			});
+
+		// setCache is a no-op under NODE_ENV=test, so briefly flip it to prime the
+		// cache the way production would.
+		const originalNodeEnv = process.env.NODE_ENV;
+		try {
+			process.env.NODE_ENV = "development";
+			const firstRes = await makeRequest();
+			expect(firstRes.status).toBe(200);
+			expect(firstRes.headers.get("x-llmgateway-cache")).toBeNull();
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+		}
+
+		const secondRes = await makeRequest();
+		expect(secondRes.status).toBe(200);
+		expect(secondRes.headers.get("x-llmgateway-cache")).toBe("HIT");
+
+		// ...and the opt-out reaches the inner completions endpoint.
+		const bypassRes = await makeRequest({ "x-no-cache": "true" });
+		expect(bypassRes.status).toBe(200);
+		expect(bypassRes.headers.get("x-llmgateway-cache")).toBeNull();
+	});
+
+	// Anthropic SDK clients key on the `msg_` id prefix; the inner
+	// /v1/chat/completions response carries an OpenAI-style `chatcmpl-` id.
+	test("/v1/messages returns an Anthropic msg_ id", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const makeRequest = (stream: boolean) =>
+			app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					max_tokens: 1024,
+					stream,
+					messages: [{ role: "user", content: "Hello!" }],
+				}),
+			});
+
+		const res = await makeRequest(false);
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.id).toMatch(/^msg_/);
+
+		const streamRes = await makeRequest(true);
+		expect(streamRes.status).toBe(200);
+		const events = (await streamRes.text())
+			.split("\n")
+			.filter((line) => line.startsWith("data: "))
+			.map((line) => line.slice(6).trim())
+			.filter((data) => data && data !== "[DONE]")
+			.map((data) => JSON.parse(data));
+
+		const messageStart = events.find((e) => e.type === "message_start");
+		expect(messageStart).toBeTruthy();
+		expect(messageStart.message.id).toMatch(/^msg_/);
 	});
 
 	test("/v1/messages surfaces reasoning as thinking_delta events (streaming)", async () => {
@@ -4528,17 +4740,20 @@ describe("api", () => {
 			.set({ cachingEnabled: true })
 			.where(eq(tables.project.id, "project-id"));
 
+		// The primed entry outlives the test (cacheDurationSeconds defaults to
+		// 60), so vary the prompt per run or a re-run starts on a hit.
 		const body = JSON.stringify({
 			model: "openai/gpt-4o-mini",
-			messages: [{ role: "user", content: "Cache me!" }],
+			messages: [{ role: "user", content: `Cache me! ${randomUUID()}` }],
 		});
 
-		const makeRequest = () =>
+		const makeRequest = (headers: Record<string, string> = {}) =>
 			app.request("/v1/chat/completions", {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
 					Authorization: "Bearer real-token-cache",
+					...headers,
 				},
 				body,
 			});
@@ -4555,6 +4770,10 @@ describe("api", () => {
 			process.env.NODE_ENV = originalNodeEnv;
 		}
 		expect(firstRes.status).toBe(200);
+		const firstJson = await firstRes.json();
+		expect(firstRes.headers.get("x-llmgateway-cache")).toBeNull();
+		expect(firstJson.metadata.cached).toBeUndefined();
+		expect(firstJson.usage.cost).toBeGreaterThan(0);
 
 		const afterFirst = await waitForLogs(1);
 		expect(afterFirst.length).toBe(1);
@@ -4565,6 +4784,20 @@ describe("api", () => {
 		// Second identical request: served entirely from the gateway cache.
 		const secondRes = await makeRequest();
 		expect(secondRes.status).toBe(200);
+
+		// A replay must be distinguishable from a fresh sample: same body, same
+		// id, so the marker is the only signal a caller has.
+		expect(secondRes.headers.get("x-llmgateway-cache")).toBe("HIT");
+		const secondJson = await secondRes.json();
+		expect(secondJson.metadata.cached).toBe(true);
+		// ...and it must not report the original call's cost, which the caller
+		// was not charged for.
+		expect(secondJson.usage.cost).toBe(0);
+		expect(secondJson.usage.cost_details.total_cost).toBe(0);
+		expect(secondJson.usage.cost_details.input_cost).toBe(0);
+		expect(secondJson.usage.cost_details.output_cost).toBe(0);
+		// Token counts still describe the returned completion.
+		expect(secondJson.usage.prompt_tokens).toBeGreaterThan(0);
 
 		const afterSecond = await waitForLogs(2);
 		expect(afterSecond.length).toBe(2);
@@ -4581,6 +4814,95 @@ describe("api", () => {
 
 		// Token counts are still recorded for analytics.
 		expect(Number(cachedLog?.promptTokens)).toBeGreaterThan(0);
+
+		// x-no-cache bypasses the replay and goes upstream for a fresh sample.
+		const bypassRes = await makeRequest({ "x-no-cache": "true" });
+		expect(bypassRes.status).toBe(200);
+		expect(bypassRes.headers.get("x-llmgateway-cache")).toBeNull();
+		const bypassJson = await bypassRes.json();
+		expect(bypassJson.metadata.cached).toBeUndefined();
+		expect(bypassJson.usage.cost).toBeGreaterThan(0);
+
+		const afterBypass = await waitForLogs(3);
+		expect(afterBypass.filter((log) => log.cached).length).toBe(1);
+	});
+
+	test("/v1/chat/completions streaming cache hits are marked and free", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-cache-stream",
+			token: "real-token-cache-stream",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-cache-stream",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db
+			.update(tables.project)
+			.set({ cachingEnabled: true })
+			.where(eq(tables.project.id, "project-id"));
+
+		const body = JSON.stringify({
+			model: "openai/gpt-4o-mini",
+			stream: true,
+			messages: [{ role: "user", content: `Stream cache me! ${randomUUID()}` }],
+		});
+
+		const makeRequest = () =>
+			app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-cache-stream",
+				},
+				body,
+			});
+
+		// setStreamingCache is a no-op under NODE_ENV=test, so briefly flip it to
+		// prime the cache the way production would.
+		const findCostChunk = (chunks: any[]) =>
+			chunks.find((chunk) => chunk?.usage?.cost !== undefined);
+
+		const originalNodeEnv = process.env.NODE_ENV;
+		try {
+			process.env.NODE_ENV = "development";
+			const firstRes = await makeRequest();
+			expect(firstRes.status).toBe(200);
+			const first = await readAll(firstRes.body);
+			expect(firstRes.headers.get("x-llmgateway-cache")).toBeNull();
+			expect(findCostChunk(first.chunks).usage.cost).toBeGreaterThan(0);
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+		}
+		await waitForLogs(1);
+
+		const secondRes = await makeRequest();
+		expect(secondRes.status).toBe(200);
+		expect(secondRes.headers.get("x-llmgateway-cache")).toBe("HIT");
+
+		const replay = await readAll(secondRes.body);
+		const metadataChunk = replay.chunks.find(
+			(chunk: any) => chunk?.metadata !== undefined,
+		);
+		expect(metadataChunk.metadata.cached).toBe(true);
+
+		// The stored chunks carry the original call's cost; the replay must not.
+		const replayCostChunk = findCostChunk(replay.chunks);
+		expect(replayCostChunk.usage.cost).toBe(0);
+		expect(replayCostChunk.usage.cost_details.total_cost).toBe(0);
+		expect(replayCostChunk.usage.prompt_tokens).toBeGreaterThan(0);
+
+		const logs = await waitForLogs(2);
+		const cachedLog = logs.find((log) => log.cached);
+		expect(cachedLog).toBeTruthy();
+		expect(Number(cachedLog?.cost)).toBe(0);
 	});
 
 	test("/v1/chat/completions hybrid prefers provider key over regional env token", async () => {
@@ -4998,9 +5320,16 @@ describe("api", () => {
 				return await originalFetch(input as RequestInfo | URL, init);
 			});
 
+		// The primed entry outlives the test (cacheDurationSeconds defaults to
+		// 60), so vary the prompt per run or a re-run starts on a hit.
 		const body = JSON.stringify({
 			model: "anthropic/claude-opus-4-8",
-			messages: [{ role: "user", content: "Cache this anthropic response!" }],
+			messages: [
+				{
+					role: "user",
+					content: `Cache this anthropic response! ${randomUUID()}`,
+				},
+			],
 		});
 
 		const makeRequest = () =>

--- a/apps/gateway/src/chat-websearch.e2e.ts
+++ b/apps/gateway/src/chat-websearch.e2e.ts
@@ -499,4 +499,85 @@ describeWebSearch("e2e web search", getConcurrentTestOptions(), () => {
 			expect(messageDelta!.usage!.output_tokens).toBeGreaterThan(0);
 		},
 	);
+
+	// Native SDK clients append the assistant turn verbatim, so the
+	// server_tool_use / web_search_tool_result blocks the previous test asserts
+	// come straight back on the next request. They must be accepted (and
+	// dropped) rather than rejected as an unknown content block.
+	test(
+		"native /v1/messages accepts its own web-search blocks on the next turn",
+		{ timeout: 300000 },
+		async () => {
+			const search = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": generateTestRequestId(),
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "anthropic/claude-haiku-4-5",
+					max_tokens: 400,
+					tools: [{ type: "web_search_20250305", name: "web_search" }],
+					messages: [
+						{
+							role: "user",
+							content:
+								"What is the latest published version of the ai npm package?",
+						},
+					],
+				}),
+			});
+
+			expect(search.status).toBe(200);
+			const searchJson = await search.json();
+			const blockTypes: string[] = searchJson.content.map(
+				(block: { type: string }) => block.type,
+			);
+			expect(blockTypes).toContain("web_search_tool_result");
+
+			const requestId = generateTestRequestId();
+			const followUp = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "anthropic/claude-haiku-4-5",
+					max_tokens: 400,
+					tools: [{ type: "web_search_20250305", name: "web_search" }],
+					messages: [
+						{
+							role: "user",
+							content:
+								"What is the latest published version of the ai npm package?",
+						},
+						// Replayed verbatim, exactly as an Anthropic SDK client would.
+						{ role: "assistant", content: searchJson.content },
+						{ role: "user", content: "Thanks! Say OK." },
+					],
+				}),
+			});
+
+			const followUpJson = await followUp.json();
+			if (logMode) {
+				console.log(
+					"native messages web search follow-up:",
+					JSON.stringify(followUpJson, null, 2),
+				);
+			}
+
+			expect(followUp.status).toBe(200);
+			expect(
+				followUpJson.content.some(
+					(block: { type: string }) => block.type === "text",
+				),
+			).toBe(true);
+			await validateLogByRequestId(requestId);
+		},
+	);
 });

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -275,6 +275,7 @@ import {
 	toResponseMetadataExtras,
 	transformResponseToOpenai,
 	withCurrentRequestMetadataOnOpenAiResponse,
+	zeroCostsOnCachedResponseUsage,
 } from "./tools/transform-response-to-openai.js";
 import { transformStreamingToOpenai } from "./tools/transform-streaming-to-openai.js";
 import { validateFreeModelUsage } from "./tools/validate-free-model-usage.js";
@@ -1286,6 +1287,10 @@ const completions = createRoute({
 							organization_id: z.string().optional(),
 							project_id: z.string().optional(),
 							discount: z.number().nullable().optional(),
+							cached: z.boolean().optional().openapi({
+								description:
+									"True when the response was replayed from the gateway response cache instead of being generated upstream. Omitted otherwise.",
+							}),
 							routing: z
 								.array(
 									z.object({
@@ -5362,8 +5367,13 @@ chat.openapi(completions, async (c) => {
 		duration: cacheDuration,
 		providerCacheControlEnabled,
 	} = await isCachingEnabled(project.id);
+	// Per-request opt-out, mirroring X-No-Fallback. Agent workloads that retry a
+	// byte-identical request expect a fresh sample rather than a replay, so let
+	// a caller bypass the response cache (both read and write) without turning
+	// the project setting off.
+	const noCache = c.req.header("x-no-cache") === "true";
 	const cachingEnabled =
-		organization.devPlan !== "none" ? false : projectCachingEnabled;
+		organization.devPlan !== "none" || noCache ? false : projectCachingEnabled;
 
 	let cacheKey: string | null = null;
 	let streamingCacheKey: string | null = null;
@@ -5618,9 +5628,11 @@ chat.openapi(completions, async (c) => {
 							?.toolResults ?? null,
 				});
 
-				const cachedResponseMetadata = buildFinalResponseMetadata(
-					costs.discount ?? null,
-				);
+				const cachedResponseMetadata = {
+					...buildFinalResponseMetadata(costs.discount ?? null),
+					cached: true,
+				};
+				c.header("x-llmgateway-cache", "HIT");
 				let hasMetadataChunk = false;
 				for (
 					let chunkIndex = cachedStreamingResponse.chunks.length - 1;
@@ -5696,6 +5708,15 @@ chat.openapi(completions, async (c) => {
 											: {};
 									data = JSON.stringify({
 										...parsed,
+										// The replay is free; the stored chunk still carries the
+										// original call's cost.
+										...(parsed.usage
+											? {
+													usage: zeroCostsOnCachedResponseUsage(
+														parsed.usage as Record<string, unknown>,
+													),
+												}
+											: {}),
 										metadata: {
 											...metadata,
 											...cachedResponseMetadata,
@@ -5773,17 +5794,27 @@ chat.openapi(completions, async (c) => {
 					},
 				);
 
+				// A replay is served from Redis with no upstream call, so it is free
+				// and must not report the original call's cost. Mark it explicitly
+				// too — byte-identical bodies are otherwise indistinguishable from a
+				// fresh sample, and the replayed usage (e.g. a prompt-cache write)
+				// describes the original request, not this one.
 				const responseForCurrentRequest =
 					withCurrentRequestMetadataOnOpenAiResponse(
-						cachedResponse,
+						{
+							...cachedResponse,
+							usage: zeroCostsOnCachedResponseUsage(cachedResponse.usage),
+						},
 						requestId,
 						{
 							logId: finalLogId,
 							organizationId: project.organizationId,
 							projectId: apiKey.projectId,
 							discount: cachedCosts.discount ?? null,
+							cached: true,
 						},
 					);
+				c.header("x-llmgateway-cache", "HIT");
 
 				// Extract plugin IDs for logging (cached non-streaming)
 				const cachedPluginIds = plugins?.map((p) => p.id) ?? [];

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -39,6 +39,11 @@ export interface ResponseMetadataExtras {
 	 * an org-level default (e.g. the DevPass flex setting) stays visible.
 	 */
 	usedServiceTier?: "flex" | "priority" | null;
+	/**
+	 * True when the body is a gateway response-cache replay rather than a fresh
+	 * upstream call. Only emitted on hits, so a missing key means "not cached".
+	 */
+	cached?: boolean;
 }
 
 export function toResponseMetadataExtras(
@@ -61,7 +66,39 @@ export function toResponseMetadataExtras(
 		...(extras.requestedServiceTier || extras.usedServiceTier
 			? { used_service_tier: extras.usedServiceTier ?? null }
 			: {}),
+		...(extras.cached ? { cached: true } : {}),
 	};
+}
+
+/**
+ * Zero the cost fields of a gateway response-cache replay.
+ *
+ * A cache hit never reaches a provider, so it is free — but the stored body
+ * still carries the cost of the original (uncached) call, which made replays
+ * report a full charge to the caller. Token counts are left untouched: they
+ * still describe the completion being returned and are what the log row keeps
+ * for analytics.
+ */
+export function zeroCostsOnCachedResponseUsage(
+	usage: Record<string, unknown> | undefined | null,
+): Record<string, unknown> | undefined | null {
+	if (!usage || typeof usage !== "object") {
+		return usage;
+	}
+
+	const next: Record<string, unknown> = { ...usage };
+	if (typeof next.cost === "number") {
+		next.cost = 0;
+	}
+	const costDetails = next.cost_details;
+	if (costDetails && typeof costDetails === "object") {
+		next.cost_details = Object.fromEntries(
+			Object.entries(costDetails as Record<string, unknown>).map(
+				([key, value]) => [key, typeof value === "number" ? 0 : value],
+			),
+		);
+	}
+	return next;
 }
 
 export function applyExtendedUsageFields(


### PR DESCRIPTION
Follow-up to a user report retesting `/v1/messages` against production, side by side with Anthropic first-party.

## 1. Multi-turn web search 400s (regression from #3256)

#3256 made `/v1/messages` emit `server_tool_use` + `web_search_tool_result` blocks. Native SDK clients append the assistant turn verbatim, so those blocks come straight back on the next request — and the request schema rejected them with `400 Invalid request format`. Every multi-turn web-search conversation broke on turn 2.

Both block types are now accepted and dropped on the request direction, alongside `thinking`/`redacted_thinking`. Dropping (rather than forwarding) is deliberate: the `encrypted_content` Anthropic requires to reuse prior results is not reconstructible from the `url_citation` annotations we get back from the inner endpoint, so the provider re-runs the search. A turn left with no forwardable blocks (e.g. a `pause_turn` reply carrying only `server_tool_use`) is skipped instead of being sent as an empty message.

## 2. `chatcmpl-` id on non-streaming `/v1/messages`

Non-streaming responses returned the inner `/v1/chat/completions` id verbatim, so Anthropic clients keying on the `msg_` prefix mis-handled it — and it disagreed with the streaming path, which returns a `msg_` id. Both paths now normalize, reusing the inner id so responses stay correlatable with the gateway log.

## 3. Response-cache replays reported the original call's cost

With gateway caching enabled, a byte-identical request replays the stored body verbatim — same `id`, same `usage`. Two problems:

- the replay is free (the log row already records `cost: 0`), but the body still carried the original call's `usage.cost` / `cost_details`, so a caller's cost dashboard attributed a full charge to a request that cost nothing;
- nothing distinguished a replay from a fresh sample, which is what made the reporter's prompt-cache numbers look inconsistent — a replayed `cache_creation_input_tokens` describes the *original* request, so a repeated probe could never observe a cache read.

Cache hits now zero the cost fields (token counts are kept — they still describe the completion being returned), set `metadata.cached: true`, and carry an `x-llmgateway-cache: HIT` response header. The header is the marker that works on the Anthropic lane, which has no metadata envelope; `/v1/messages` forwards it from the inner call.

`x-no-cache: true` bypasses the cache (read and write) for a single request, mirroring `x-no-fallback`, for agent loops that retry an identical request and want a fresh sample.

## Tests

- `api.spec.ts`: web-search blocks in conversation history are accepted and stripped from the forwarded body (400 before the fix); `/v1/messages` returns a `msg_` id streaming and non-streaming; `/v1/messages` marks replays and honors `x-no-cache`; non-streaming and streaming cache hits are marked, zero-cost, and bypassable.
- `chat-websearch.e2e.ts`: a real Anthropic web-search response is replayed verbatim on the next turn and accepted (verified green against production Anthropic).
- Fixed latent flakiness in two existing cache tests that primed Redis with a fixed prompt, so a re-run within the 60s TTL started on a hit.

Docs updated for the cache marker, the corrected "identifying cached responses" section (it claimed zero token usage, which was never true), the opt-out header, and `/v1/messages` web search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic web-search content blocks, including follow-up turns using returned search results.
  * Added cache status metadata and headers for cached chat and Anthropic responses.
  * Added `x-no-cache: true` to bypass the response cache for individual requests.
  * Cached responses now report zero inference costs while preserving token usage for analytics.

* **Documentation**
  * Expanded guidance for Anthropic web search and gateway response caching.
  * Documented cache detection, replay behavior, and single-request cache bypassing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->