### PR TITLE
feat(ui): hide deactivated models by default

### DIFF
--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -43,6 +43,7 @@ import {
 	type StabilityLevel,
 	type ModelDefinition,
 } from "@llmgateway/models";
+import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 import type { Metadata } from "next";
 
@@ -117,6 +118,15 @@ export default async function ModelPage({ params }: PageProps) {
 	});
 	const currentModelDiscount = getBestDiscount(allDiscounts, decodedName);
 
+	// Aggregated metrics (pricing, context, capabilities) describe what can
+	// actually be routed today, so deactivated providers are excluded. Models
+	// whose providers are all deactivated fall back to showing everything.
+	const activeProviders = modelProviders.filter(
+		(p) => !isMappingDeactivated(p),
+	);
+	const visibleProviders =
+		activeProviders.length > 0 ? activeProviders : modelProviders;
+
 	const adaptedModel = adaptModel(modelDef, modelProviders);
 
 	const breadcrumbSchema = {
@@ -144,7 +154,7 @@ export default async function ModelPage({ params }: PageProps) {
 		],
 	};
 
-	const providerPrices = modelProviders
+	const providerPrices = visibleProviders
 		.filter((p) => p.inputPrice)
 		.map((p) => applyDiscount(perMillion(p.inputPrice)!, p.discount));
 	const lowestInputPrice = Math.min(...providerPrices);
@@ -168,7 +178,7 @@ export default async function ModelPage({ params }: PageProps) {
 			priceCurrency: "USD",
 			lowPrice: isFinite(lowestInputPrice) ? lowestInputPrice : 0,
 			highPrice: isFinite(highestInputPrice) ? highestInputPrice : 0,
-			offerCount: modelProviders.length,
+			offerCount: visibleProviders.length,
 			availability: "https://schema.org/InStock",
 			url: `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`,
 		},
@@ -281,15 +291,15 @@ export default async function ModelPage({ params }: PageProps) {
 						<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 text-sm text-muted-foreground mb-4">
 							<div>
 								{Math.max(
-									...modelProviders.map((p) => p.contextSize ?? 0),
+									...visibleProviders.map((p) => p.contextSize ?? 0),
 								).toLocaleString()}{" "}
 								context
 							</div>
-							{modelProviders.some((p) => p.inputPrice) && (
+							{visibleProviders.some((p) => p.inputPrice) && (
 								<div>
 									Starting at{" "}
 									{(() => {
-										const inputPrices = modelProviders
+										const inputPrices = visibleProviders
 											.filter((p) => p.inputPrice)
 											.map((p) => ({
 												price: applyDiscount(
@@ -310,18 +320,18 @@ export default async function ModelPage({ params }: PageProps) {
 											: `$${minPrice.toFixed(2)}/M`;
 									})()}{" "}
 									input tokens
-									{modelProviders.some(
+									{visibleProviders.some(
 										(p) => (p.pricingTiers?.length ?? 0) > 1,
 									) && (
 										<span className="text-muted-foreground/70"> (tiered)</span>
 									)}
 								</div>
 							)}
-							{modelProviders.some((p) => p.outputPrice) && (
+							{visibleProviders.some((p) => p.outputPrice) && (
 								<div>
 									Starting at{" "}
 									{(() => {
-										const outputPrices = modelProviders
+										const outputPrices = visibleProviders
 											.filter((p) => p.outputPrice)
 											.map((p) => ({
 												price: applyDiscount(
@@ -342,18 +352,20 @@ export default async function ModelPage({ params }: PageProps) {
 											: `$${minPrice.toFixed(2)}/M`;
 									})()}{" "}
 									output tokens
-									{modelProviders.some(
+									{visibleProviders.some(
 										(p) => (p.pricingTiers?.length ?? 0) > 1,
 									) && (
 										<span className="text-muted-foreground/70"> (tiered)</span>
 									)}
 								</div>
 							)}
-							{modelProviders.some((p) => p.imageOutputPrice !== undefined) && (
+							{visibleProviders.some(
+								(p) => p.imageOutputPrice !== undefined,
+							) && (
 								<div>
 									Starting at{" "}
 									{(() => {
-										const imageOutputPrices = modelProviders
+										const imageOutputPrices = visibleProviders
 											.filter((p) => p.imageOutputPrice !== undefined)
 											.map((p) => ({
 												price: applyDiscount(
@@ -381,7 +393,7 @@ export default async function ModelPage({ params }: PageProps) {
 									image output tokens
 								</div>
 							)}
-							{modelProviders.some(
+							{visibleProviders.some(
 								(p) =>
 									p.perSecondPrice && Object.keys(p.perSecondPrice).length > 0,
 							) && (
@@ -389,7 +401,7 @@ export default async function ModelPage({ params }: PageProps) {
 									Starting at{" "}
 									{(() => {
 										let minPrice: number | undefined;
-										for (const p of modelProviders) {
+										for (const p of visibleProviders) {
 											if (!p.perSecondPrice) {
 												continue;
 											}
@@ -411,11 +423,11 @@ export default async function ModelPage({ params }: PageProps) {
 									video generation
 								</div>
 							)}
-							{modelProviders.some((p) => p.ocrPagePrice !== undefined) && (
+							{visibleProviders.some((p) => p.ocrPagePrice !== undefined) && (
 								<div>
 									Starting at{" "}
 									{(() => {
-										const pagePrices = modelProviders
+										const pagePrices = visibleProviders
 											.filter((p) => p.ocrPagePrice !== undefined)
 											.map((p) => Number(p.ocrPagePrice))
 											.filter((n) => Number.isFinite(n));
@@ -439,11 +451,13 @@ export default async function ModelPage({ params }: PageProps) {
 									label: string;
 									color: string;
 								}> = [];
-								const hasStreaming = modelProviders.some((p) => p.streaming);
-								const hasVision = modelProviders.some((p) => p.vision);
-								const hasTools = modelProviders.some((p) => p.tools);
-								const hasReasoning = modelProviders.some((p) => p.reasoning);
-								const hasJsonOutput = modelProviders.some((p) => p.jsonOutput);
+								const hasStreaming = visibleProviders.some((p) => p.streaming);
+								const hasVision = visibleProviders.some((p) => p.vision);
+								const hasTools = visibleProviders.some((p) => p.tools);
+								const hasReasoning = visibleProviders.some((p) => p.reasoning);
+								const hasJsonOutput = visibleProviders.some(
+									(p) => p.jsonOutput,
+								);
 								const hasImageGen = Array.isArray(modelDef.output)
 									? modelDef.output.includes("image")
 									: false;
@@ -546,7 +560,7 @@ export default async function ModelPage({ params }: PageProps) {
 						</h2>
 						<ProviderTabs
 							modelId={decodedName}
-							providerIds={modelProviders.map((p) => p.providerId)}
+							providerIds={visibleProviders.map((p) => p.providerId)}
 							activeProviderId=""
 						/>
 					</div>

--- a/apps/ui/src/app/providers/[id]/page.tsx
+++ b/apps/ui/src/app/providers/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 	type ProviderModelMapping,
 } from "@llmgateway/models";
 import { isPremiumModel } from "@llmgateway/shared";
+import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 import type {
 	ApiModel,
@@ -176,6 +177,14 @@ export default async function ProviderPage({ params }: ProviderPageProps) {
 			return bDate - aDate; // Descending (newest first)
 		});
 
+	// Deactivated models are still reachable behind the grid's toggle, but they
+	// are not part of what this provider currently offers.
+	const activeProviderModels = providerModels.filter((model) =>
+		model.providerDetails.some(
+			({ provider: mapping }) => !isMappingDeactivated(mapping),
+		),
+	);
+
 	const providerUrl = `https://llmgateway.io/providers/${provider.id}`;
 
 	const organizationSchema = {
@@ -194,8 +203,8 @@ export default async function ProviderPage({ params }: ProviderPageProps) {
 		"@context": "https://schema.org",
 		"@type": "ItemList",
 		name: `${provider.name} models on LLM Gateway`,
-		numberOfItems: providerModels.length,
-		itemListElement: providerModels.map((model, index) => ({
+		numberOfItems: activeProviderModels.length,
+		itemListElement: activeProviderModels.map((model, index) => ({
 			"@type": "ListItem",
 			position: index + 1,
 			url: `https://llmgateway.io/models/${encodeURIComponent(model.id)}`,
@@ -266,8 +275,11 @@ export async function generateMetadata({
 		return {};
 	}
 
-	const modelCount = modelDefinitions.filter((model) =>
-		model.providers.some((p) => p.providerId === provider.id),
+	const modelCount = (modelDefinitions as readonly ModelDefinition[]).filter(
+		(model) =>
+			model.providers.some(
+				(p) => p.providerId === provider.id && !isMappingDeactivated(p),
+			),
 	).length;
 	const description = `Access ${modelCount} ${provider.name} models through LLM Gateway's OpenAI-compatible API with per-token pricing, automatic fallback, caching, and cost analytics.`;
 

--- a/apps/ui/src/app/sitemap.ts
+++ b/apps/ui/src/app/sitemap.ts
@@ -6,7 +6,9 @@ import {
 	getProviderCountries,
 	models as modelDefinitions,
 	providers as providerDefinitions,
+	type ModelDefinition,
 } from "@llmgateway/models";
+import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 import type { MetadataRoute } from "next";
 
@@ -409,7 +411,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
 	// Model pages
 	const modelPages: MetadataRoute.Sitemap = [];
-	for (const model of modelDefinitions) {
+	for (const model of modelDefinitions as readonly ModelDefinition[]) {
+		// Fully deactivated models are hidden from the public directory, so they
+		// are not advertised for crawling either (the pages still resolve).
+		if (
+			model.providers.length > 0 &&
+			model.providers.every((p) => isMappingDeactivated(p))
+		) {
+			continue;
+		}
+
 		// Main model page
 		modelPages.push({
 			url: `${baseUrl}/models/${encodeURIComponent(model.id)}`,

--- a/apps/ui/src/components/models/detail-provider-cards.tsx
+++ b/apps/ui/src/components/models/detail-provider-cards.tsx
@@ -1,11 +1,16 @@
 "use client";
 
+import { AlertCircle } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { ModelCtaButton } from "@/components/models/model-cta-button";
+import { Button } from "@/lib/components/button";
 import { TooltipProvider } from "@/lib/components/tooltip";
 
-import { getProviderIcon } from "@llmgateway/shared/components";
+import {
+	getProviderIcon,
+	isMappingDeactivated,
+} from "@llmgateway/shared/components";
 
 import { ProviderSection } from "./model-card";
 
@@ -24,6 +29,7 @@ interface ModelWithProviders extends ApiModel {
 
 export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 	const [copiedModel, setCopiedModel] = useState<string | null>(null);
+	const [showDeactivated, setShowDeactivated] = useState(false);
 	const isImageGen = Array.isArray(model.output)
 		? model.output.includes("image")
 		: false;
@@ -81,6 +87,26 @@ export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 		);
 	};
 
+	const deactivatedCount = useMemo(
+		() =>
+			model.providerDetails.filter(({ provider }) =>
+				isMappingDeactivated(provider),
+			).length,
+		[model.providerDetails],
+	);
+
+	// Deactivated providers cannot serve requests, so they are hidden unless the
+	// visitor asks for them. A model whose providers are all deactivated still
+	// shows them, otherwise the page would render an empty grid.
+	const visibleProviderDetails = useMemo(() => {
+		if (showDeactivated || deactivatedCount === model.providerDetails.length) {
+			return model.providerDetails;
+		}
+		return model.providerDetails.filter(
+			({ provider }) => !isMappingDeactivated(provider),
+		);
+	}, [model.providerDetails, showDeactivated, deactivatedCount]);
+
 	// Group by provider ID so regions show as tabs within one card
 	const groupedByProvider = useMemo(() => {
 		const map = new Map<
@@ -91,7 +117,7 @@ export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 				mappings: ApiModelProviderMapping[];
 			}
 		>();
-		for (const { provider, providerInfo } of model.providerDetails) {
+		for (const { provider, providerInfo } of visibleProviderDetails) {
 			const key = provider.providerId;
 			if (!map.has(key)) {
 				map.set(key, {
@@ -108,10 +134,27 @@ export function DetailProviderCards({ model }: { model: ModelWithProviders }) {
 				Number(Boolean(b.providerInfo?.modelCardBadge)) -
 				Number(Boolean(a.providerInfo?.modelCardBadge)),
 		);
-	}, [model.providerDetails]);
+	}, [visibleProviderDetails]);
+
+	const canToggleDeactivated =
+		deactivatedCount > 0 && deactivatedCount < model.providerDetails.length;
 
 	return (
 		<TooltipProvider>
+			{canToggleDeactivated && (
+				<div className="mb-4 flex justify-end">
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setShowDeactivated((prev) => !prev)}
+					>
+						<AlertCircle className="h-3.5 w-3.5 mr-1.5 text-red-500" />
+						{showDeactivated
+							? "Hide deactivated providers"
+							: `Show ${deactivatedCount} deactivated provider${deactivatedCount === 1 ? "" : "s"}`}
+					</Button>
+				</div>
+			)}
 			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 				{groupedByProvider.map(({ providerInfo, providerId, mappings }) => {
 					const ProviderIcon = getProviderIcon(providerId);

--- a/apps/ui/src/components/providers/provider-models-grid.tsx
+++ b/apps/ui/src/components/providers/provider-models-grid.tsx
@@ -9,10 +9,15 @@ import {
 	FileJson2,
 	ImagePlus,
 	Gift,
+	AlertCircle,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
 
 import { ModelCard } from "@/components/models/model-card";
+import { Button } from "@/lib/components/button";
+
+import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 import type {
 	ApiModel,
@@ -35,6 +40,30 @@ interface ProviderModelsGridProps {
 
 export function ProviderModelsGrid({ models }: ProviderModelsGridProps) {
 	const router = useRouter();
+	const [showDeactivated, setShowDeactivated] = useState(false);
+
+	// One card per provider mapping here, so a model is deactivated for this
+	// provider exactly when its mapping is.
+	const deactivatedCount = useMemo(
+		() =>
+			models.filter((model) =>
+				model.providerDetails.every(({ provider }) =>
+					isMappingDeactivated(provider),
+				),
+			).length,
+		[models],
+	);
+
+	const visibleModels = useMemo(() => {
+		if (showDeactivated) {
+			return models;
+		}
+		return models.filter((model) =>
+			model.providerDetails.some(
+				({ provider }) => !isMappingDeactivated(provider),
+			),
+		);
+	}, [models, showDeactivated]);
 
 	const getCapabilityIcons = (
 		providerMapping: ApiModelProviderMapping,
@@ -150,19 +179,35 @@ export function ProviderModelsGrid({ models }: ProviderModelsGridProps) {
 	};
 
 	return (
-		<div className="grid gap-6 md:grid-cols-3">
-			{models.map((model, index) => (
-				<ModelCard
-					key={`${model.providerDetails[0].provider.providerId}-${model.id}-${index}`}
-					model={model}
-					shouldShowStabilityWarning={shouldShowStabilityWarning}
-					getCapabilityIcons={getCapabilityIcons}
-					goToModel={() =>
-						router.push(`/models/${encodeURIComponent(model.id)}`)
-					}
-					formatPrice={formatPrice}
-				/>
-			))}
-		</div>
+		<>
+			{deactivatedCount > 0 && (
+				<div className="mb-6 flex justify-end">
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setShowDeactivated((prev) => !prev)}
+					>
+						<AlertCircle className="h-3.5 w-3.5 mr-1.5 text-red-500" />
+						{showDeactivated
+							? "Hide deactivated models"
+							: `Show ${deactivatedCount} deactivated model${deactivatedCount === 1 ? "" : "s"}`}
+					</Button>
+				</div>
+			)}
+			<div className="grid gap-6 md:grid-cols-3">
+				{visibleModels.map((model, index) => (
+					<ModelCard
+						key={`${model.providerDetails[0].provider.providerId}-${model.id}-${index}`}
+						model={model}
+						shouldShowStabilityWarning={shouldShowStabilityWarning}
+						getCapabilityIcons={getCapabilityIcons}
+						goToModel={() =>
+							router.push(`/models/${encodeURIComponent(model.id)}`)
+						}
+						formatPrice={formatPrice}
+					/>
+				))}
+			</div>
+		</>
 	);
 }

--- a/apps/ui/src/components/providers/providers-grid.tsx
+++ b/apps/ui/src/components/providers/providers-grid.tsx
@@ -42,10 +42,14 @@ import {
 	isProviderCompliant,
 	models as modelDefinitions,
 	providers as providerDefinitions,
+	type ModelDefinition,
 	type ProviderCompliancePolicy,
 	type ProviderId,
 } from "@llmgateway/models";
-import { providerLogoUrls } from "@llmgateway/shared/components";
+import {
+	isMappingDeactivated,
+	providerLogoUrls,
+} from "@llmgateway/shared/components";
 
 type SortKey = "fastest" | "slowest" | "popular" | "name" | "uptime";
 
@@ -63,8 +67,11 @@ const getProviderLogo = (providerId: ProviderId) => {
 
 const getModelsCountByProvider = (): Record<string, number> => {
 	const counts: Record<string, number> = {};
-	for (const model of modelDefinitions) {
+	for (const model of modelDefinitions as readonly ModelDefinition[]) {
 		for (const providerMapping of model.providers) {
+			if (isMappingDeactivated(providerMapping)) {
+				continue;
+			}
 			const providerId = providerMapping.providerId;
 			counts[providerId] = (counts[providerId] || 0) + 1;
 		}

--- a/packages/shared/src/components/index.tsx
+++ b/packages/shared/src/components/index.tsx
@@ -4,6 +4,7 @@ export * from "./log-card";
 export * from "./model-selector";
 export * from "./models-directory/all-models";
 export * from "./models-directory/api-types";
+export * from "./models-directory/deactivation";
 export * from "./models-directory/model-card";
 export * from "./models-directory/model-category-filters";
 export * from "./models-directory/model-code-example-dialog";

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
+import { isMappingDeactivated } from "./deactivation";
 import { formatDeprecationDate } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
@@ -672,6 +673,7 @@ export function AllModels({
 			discounted: searchParams.get("discounted") === "true",
 		},
 		selectedProvider: searchParams.get("provider") ?? "all",
+		showDeactivated: searchParams.get("deactivated") === "true",
 		inputPrice: {
 			min: searchParams.get("inputPriceMin") ?? "",
 			max: searchParams.get("inputPriceMax") ?? "",
@@ -701,46 +703,52 @@ export function AllModels({
 		[router, searchParams],
 	);
 
-	// Calculate total counts (excluding deprecated models)
+	// Calculate total counts (excluding deprecated and deactivated models)
 	const { totalModelCount, totalProviderCount } = useMemo(() => {
 		const now = new Date();
 
-		// Count models that have at least one non-deprecated mapping
-		const nonDeprecatedModelCount = models.filter((model) =>
-			model.mappings.some(
-				(mapping) =>
-					!mapping.deprecatedAt || new Date(mapping.deprecatedAt) > now,
-			),
+		// Count models that have at least one visible mapping
+		const visibleModelCount = models.filter((model) =>
+			model.mappings.some((mapping) => {
+				if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= now) {
+					return false;
+				}
+				return filters.showDeactivated || !isMappingDeactivated(mapping, now);
+			}),
 		).length;
 
 		return {
-			totalModelCount: nonDeprecatedModelCount,
+			totalModelCount: visibleModelCount,
 			totalProviderCount: providers.length,
 		};
-	}, [models, providers]);
+	}, [models, providers, filters.showDeactivated]);
 
 	const modelsWithProviders: ModelWithProviders[] = useMemo(() => {
 		const now = new Date();
 
 		const baseModels = models
 			.map((model) => {
-				// Filter out deprecated provider mappings
-				const nonDeprecatedMappings = model.mappings.filter((mapping) => {
-					if (!mapping.deprecatedAt) {
-						return true;
+				// Filter out deprecated provider mappings, plus deactivated ones
+				// unless the visitor opted into seeing them
+				const visibleMappings = model.mappings.filter((mapping) => {
+					if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= now) {
+						return false;
 					}
-					return new Date(mapping.deprecatedAt) > now;
+					if (!filters.showDeactivated && isMappingDeactivated(mapping, now)) {
+						return false;
+					}
+					return true;
 				});
 
 				return {
 					...model,
-					providerDetails: nonDeprecatedMappings.map((mapping) => ({
+					providerDetails: visibleMappings.map((mapping) => ({
 						provider: mapping,
 						providerInfo: providers.find((p) => p.id === mapping.providerId)!,
 					})),
 				};
 			})
-			// Filter out models with no non-deprecated provider mappings
+			// Filter out models with no visible provider mappings
 			.filter((model) => model.providerDetails.length > 0);
 
 		// Apply category pre-filter if provided
@@ -1308,6 +1316,7 @@ export function AllModels({
 		(filters.tier && filters.tier !== "all") ||
 		Object.values(filters.capabilities).some(Boolean) ||
 		(filters.selectedProvider && filters.selectedProvider !== "all") ||
+		filters.showDeactivated ||
 		filters.inputPrice.min ||
 		filters.inputPrice.max ||
 		filters.outputPrice.min ||
@@ -1484,6 +1493,7 @@ export function AllModels({
 				discounted: false,
 			},
 			selectedProvider: "all",
+			showDeactivated: false,
 			inputPrice: { min: "", max: "" },
 			outputPrice: { min: "", max: "" },
 			contextSize: { min: "", max: "" },
@@ -1510,6 +1520,7 @@ export function AllModels({
 			free: undefined,
 			discounted: undefined,
 			provider: undefined,
+			deactivated: undefined,
 			inputPriceMin: undefined,
 			inputPriceMax: undefined,
 			outputPriceMin: undefined,
@@ -1792,6 +1803,24 @@ export function AllModels({
 								})}
 							</SelectContent>
 						</Select>
+
+						<div className="font-medium text-sm">Status</div>
+						<Toggle
+							variant="outline"
+							size="sm"
+							pressed={filters.showDeactivated}
+							onPressedChange={(pressed) => {
+								setFilters((prev) => ({ ...prev, showDeactivated: pressed }));
+								updateUrlWithFilters({
+									deactivated: pressed ? "true" : undefined,
+									page: undefined,
+								});
+							}}
+							className="gap-1.5"
+						>
+							<AlertCircle className="h-3.5 w-3.5 text-red-500" />
+							<span className="text-xs">Show deactivated</span>
+						</Toggle>
 					</div>
 
 					<div className="space-y-3">
@@ -2111,6 +2140,7 @@ export function AllModels({
 														: 0,
 													Object.values(filters.capabilities).filter(Boolean)
 														.length,
+													filters.showDeactivated ? 1 : 0,
 													[
 														filters.inputPrice.min,
 														filters.inputPrice.max,

--- a/packages/shared/src/components/models-directory/deactivation.spec.ts
+++ b/packages/shared/src/components/models-directory/deactivation.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import { isMappingDeactivated } from "./deactivation";
+
+const now = new Date("2026-07-27T00:00:00.000Z");
+
+describe("isMappingDeactivated", () => {
+	test("is false without a deactivation date", () => {
+		expect(isMappingDeactivated({}, now)).toBe(false);
+		expect(isMappingDeactivated({ deactivatedAt: null }, now)).toBe(false);
+	});
+
+	test("is true once the date has passed", () => {
+		expect(
+			isMappingDeactivated({ deactivatedAt: new Date("2026-07-26") }, now),
+		).toBe(true);
+		expect(isMappingDeactivated({ deactivatedAt: "2026-01-01" }, now)).toBe(
+			true,
+		);
+	});
+
+	test("is false for a scheduled future deactivation", () => {
+		expect(
+			isMappingDeactivated({ deactivatedAt: new Date("2026-07-28") }, now),
+		).toBe(false);
+		expect(isMappingDeactivated({ deactivatedAt: "2026-12-31" }, now)).toBe(
+			false,
+		);
+	});
+});

--- a/packages/shared/src/components/models-directory/deactivation.ts
+++ b/packages/shared/src/components/models-directory/deactivation.ts
@@ -1,0 +1,13 @@
+/**
+ * A provider mapping only counts as deactivated once its deactivation date has
+ * passed — a future date is a scheduled deactivation and the mapping is still
+ * routable, so it stays visible in public model lists.
+ */
+export function isMappingDeactivated(
+	mapping: { deactivatedAt?: Date | string | null },
+	now: Date = new Date(),
+): boolean {
+	return Boolean(
+		mapping.deactivatedAt && new Date(mapping.deactivatedAt) <= now,
+	);
+}


### PR DESCRIPTION
## Problem

Public model listings still rendered provider mappings that had already been deactivated, so visitors saw models, providers and pricing that cannot actually be routed. The gateway's `/v1/models` endpoint already hides them behind an `includeDeactivated` flag — the web surfaces did not.

## What changed

A mapping counts as deactivated only once its `deactivatedAt` date has passed; scheduled future deactivations stay visible as before. New shared helper `isMappingDeactivated()` (`packages/shared/src/components/models-directory/deactivation.ts`) is the single source of that rule.

Deactivated mappings are now hidden by default, with an opt-in way to bring them back on every surface that lists them:

- **Models directory** (`/models`, category pages, DevPass directory — shared `AllModels`): new **Show deactivated** toggle in the Filters panel, persisted in the URL as `deactivated=true`, counted in the active-filter badge and reset by *Clear*. The model/provider stat cards follow the filtered set.
- **Provider pages** (`/providers/[id]`): **Show N deactivated models** toggle above the grid.
- **Model detail pages** (`/models/[name]`): **Show N deactivated providers** toggle above the provider cards. Aggregated metrics (context size, starting prices, capabilities) and the provider tabs now reflect only routable providers.

Counts that have no toggle follow the same rule: provider model counts on `/providers`, the provider page's JSON-LD item list and meta description, and the sitemap skip fully deactivated models (the detail pages themselves still resolve).

Models whose providers are *all* deactivated fall back to rendering from the deactivated data rather than showing an empty page.

## Testing

- `pnpm build` — all 17 packages build
- `pnpm lint` — clean (only pre-existing warnings)
- Unit tests for the touched packages pass (`packages/shared`, `apps/ui`), including a new spec for `isMappingDeactivated`. The full `pnpm test:unit` run has 19 DB-backed suites failing locally on `column "api_origin" of relation "log" does not exist` — local Postgres schema drift, unrelated to this diff, which touches no DB code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoVTpu9Wb1JaxTCD7pc5Tw)_