### PR TITLE
docs(census): reward is per quarter, not per year

### DIFF
--- a/apps/api/src/routes/model-survey.spec.ts
+++ b/apps/api/src/routes/model-survey.spec.ts
@@ -208,7 +208,7 @@ describe("model survey submit", () => {
 		).toBe(400);
 	});
 
-	it("records the response and grants one reset pass per org per year", async () => {
+	it("records the response and grants one reset pass per org per quarter", async () => {
 		await insertOrg();
 		await seedModelStats("survey-coder-large", "openai", 80);
 		await seedModelStats("survey-coder-small", "anthropic", 120);
@@ -323,6 +323,30 @@ describe("model survey submit", () => {
 		expect(json.response.quarter).toBe(QUARTER);
 		expect(json.rewardGranted).toBe(true);
 		expect((await getOrg()).devPlanResetPassesPro).toBe(1);
+	});
+
+	it("stacks the reward on top of already-held purchased passes", async () => {
+		await insertOrg({ devPlanResetPassesPro: 2, devPlanResetPassesLite: 1 });
+		await seedModelStats("survey-coder-large", "openai", 80);
+		await seedModelStats("survey-coder-small", "anthropic", 120);
+
+		const res = await submitRequest(validBody, token);
+		expect(res.status).toBe(200);
+		expect((await res.json()).rewardGranted).toBe(true);
+
+		const org = await getOrg();
+		expect(org.devPlanResetPassesPro).toBe(3);
+		expect(org.devPlanResetPassesLite).toBe(1);
+
+		// The second entry of the same wave records but never stacks a second
+		// reward on top, no matter how many passes the org already holds.
+		const second = await submitRequest(
+			{ ...validBody, modelId: "survey-coder-small" },
+			token,
+		);
+		expect(second.status).toBe(200);
+		expect((await second.json()).rewardGranted).toBe(false);
+		expect((await getOrg()).devPlanResetPassesPro).toBe(3);
 	});
 
 	it("grants the pass on the org's current tier", async () => {

--- a/apps/api/src/routes/model-survey.ts
+++ b/apps/api/src/routes/model-survey.ts
@@ -287,7 +287,7 @@ const submitSurvey = createRoute({
 				},
 			},
 			description:
-				"Survey response recorded. The org's first response of the year grants a free Reset Pass.",
+				"Survey response recorded. The org's first response of the quarterly wave grants a free Reset Pass; later responses in the same wave record without a second pass.",
 		},
 	},
 });

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -670,7 +670,8 @@ export const modelSurveyResponse = pgTable(
 		requestCount: integer().notNull(),
 		devPlanTier: text({ enum: MODEL_SURVEY_TIERS }).notNull(),
 		// Tier of the free Reset Pass granted for this response. Null when no
-		// pass was granted (only the org's first response each year rewards).
+		// pass was granted (only the org's first response of each quarterly
+		// wave rewards; the pass stacks on any passes already held).
 		rewardTier: text({ enum: MODEL_SURVEY_TIERS }),
 	},
 	(table) => [


### PR DESCRIPTION
## Context

A DevPass user reported: *"I did the census 2 times while I still possessed my original paid premium reset pass. I thought it would stack on top of my preexisting reset pass, but instead I found out that the census did not give me the census reset pass at all."*

I traced the grant path to validate it. **The claim does not hold — the reward is capped at one per quarterly wave, and it does stack on pre-existing paid passes.**

- `apps/api/src/routes/model-survey.ts` grants the pass with an unconditional `devPlanResetPassesX = devPlanResetPassesX + 1`. There is no cap, clamp, or "already holds a pass" guard anywhere in the reset-pass code — the only counter that ever resets is `devPlanIncludedResetPassesUsed`.
- The single real limit is one reward per org per `(year, quarter)`, enforced twice: `findRewardedResponse` under a `FOR UPDATE` row lock, and the partial unique index `model_survey_response_org_period_reward_unique`.

So two entries in the same wave yield exactly one pass, which is almost certainly what the reporter saw and misread as "no pass at all".

## What this changes

The behaviour is correct, so this is a docs + coverage fix for the thing that likely fed the confusion.

**Stale wording.** The implementation, the DB index, and all user-facing copy in `apps/code` say *quarterly wave*. Two places still said *year*:
- the OpenAPI response description on `POST /model-survey` (public API docs)
- the `rewardTier` schema comment

Both now describe the per-quarter rule and the stacking behaviour explicitly.

**Missing coverage.** Every existing test started from a zero pass balance, so the reporter's exact scenario — an org that already holds purchased passes — was never exercised. Added a regression test: an org holding 2 Pro + 1 Lite pass gets the Pro column stacked to 3, the Lite column untouched, and a second entry in the same wave stacks nothing further.

## Notes

Two adjacent things I looked at and deliberately did not change:

- **Purchased inventory is tier-bound.** The reward lands in the column for `org.devPlan` at submission time, and `getPurchasedResetPasses` only reads the current tier's column — so a tier change between taking the census and checking the dashboard silently orphans the pass. This matches the documented intent for paid passes ("a cheap Lite pass can't reset the larger Pro/Max allowance") and is the one remaining code path that could genuinely produce a missing pass. Worth a separate decision rather than a drive-by change.
- `apps/ui/src/components/billing/transactions-client.tsx` has a hand-written `Transaction["type"]` union that omits `dev_plan_reset_pass_reward` (and `_gift`). Cosmetic, out of scope here.

## Test plan

- `pnpm vitest run apps/api/src/routes/model-survey.spec.ts` — 17/17 pass, including the new stacking case
- `pnpm format`
- `pnpm build` — 17/17 tasks pass

Comment-only change to `schema.ts`; no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that the free Reset Pass is awarded for an organization’s first survey response in each quarterly wave.
  * Confirmed that earned Reset Passes stack with purchased passes.
  * Prevented additional free passes from being awarded for subsequent submissions within the same quarterly wave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->