### PR TITLE
fix(ui): gate TTFT display on streamed sample count

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -592,6 +592,9 @@ const uptimeProviderSchema = z.object({
 	upstreamErrorsCount: z.number(),
 	uptime: z.number().nullable(),
 	avgTtft: z.number().nullable(),
+	// Streamed-request count behind avgTtft, so callers can gate its display on
+	// its own sample size instead of logsCount.
+	ttftCount: z.number(),
 	avgDuration: z.number().nullable(),
 	tokensPerSecond: z.number().nullable(),
 	points: z.array(uptimePointSchema),
@@ -837,6 +840,7 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			uptime,
 			avgTtft:
 				totalTtftCount > 0 ? Math.round(totalTtft / totalTtftCount) : null,
+			ttftCount: totalTtftCount,
 			avgDuration: totalLogs > 0 ? Math.round(totalDuration / totalLogs) : null,
 			tokensPerSecond,
 			points,

--- a/apps/api/src/routes/public-providers-stats.spec.ts
+++ b/apps/api/src/routes/public-providers-stats.spec.ts
@@ -70,6 +70,9 @@ describe("public providers stats", () => {
 		const provider = await fetchProviderStats();
 		expect(provider.logsCount).toBe(10);
 		expect(provider.avgTimeToFirstToken).toBe(200);
+		// Exposed so the UI can gate the TTFT card on the sample size behind the
+		// average rather than on logsCount.
+		expect(provider.timeToFirstTokenCount).toBe(4);
 	});
 
 	test("reports no TTFT when nothing was streamed", async () => {
@@ -82,5 +85,6 @@ describe("public providers stats", () => {
 		const provider = await fetchProviderStats();
 		expect(provider.logsCount).toBe(25);
 		expect(provider.avgTimeToFirstToken).toBeNull();
+		expect(provider.timeToFirstTokenCount).toBe(0);
 	});
 });

--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -18,6 +18,11 @@ const providerStatRowSchema = z.object({
 	errorsCount: z.number(),
 	cachedCount: z.number(),
 	avgTimeToFirstToken: z.number().nullable(),
+	// How many requests actually contributed a TTFT sample (streamed ones only).
+	// Exposed so callers can gate the display of avgTimeToFirstToken on its own
+	// sample size rather than on logsCount, which counts non-streaming requests
+	// that never fed into the average.
+	timeToFirstTokenCount: z.number(),
 	throughput: z.number().nullable(),
 	uptime: z.number().nullable(),
 	updatedAt: z.string().nullable(),
@@ -143,6 +148,7 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 			errorsCount,
 			cachedCount,
 			avgTimeToFirstToken,
+			timeToFirstTokenCount,
 			throughput,
 			uptime,
 			updatedAt: r.updatedAt ? new Date(r.updatedAt).toISOString() : null,

--- a/apps/ui/src/components/models/model-uptime-charts.tsx
+++ b/apps/ui/src/components/models/model-uptime-charts.tsx
@@ -30,6 +30,7 @@ import {
 import { useApi } from "@/lib/fetch-client";
 import {
 	hasEnoughRequestsForStats,
+	hasEnoughTtftSamplesForStats,
 	MIN_REQUESTS_FOR_STATS,
 } from "@/lib/provider-stats";
 import { cn } from "@/lib/utils";
@@ -90,6 +91,9 @@ function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 	const dataKeys = Object.keys(config);
 
 	const hasEnoughData = hasEnoughRequestsForStats(provider.logsCount);
+	// TTFT only has samples from streamed requests, so it gates on its own count
+	// rather than on the request count that feeds uptime/duration/throughput.
+	const hasEnoughTtftData = hasEnoughTtftSamplesForStats(provider.ttftCount);
 
 	const errorRate =
 		provider.logsCount > 0
@@ -160,7 +164,7 @@ function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 						icon={Clock}
 						label="Avg TTFT"
 						value={
-							hasEnoughData && provider.avgTtft !== null
+							hasEnoughTtftData && provider.avgTtft !== null
 								? `${provider.avgTtft}ms`
 								: "—"
 						}

--- a/apps/ui/src/components/providers/providers-grid.tsx
+++ b/apps/ui/src/components/providers/providers-grid.tsx
@@ -221,6 +221,7 @@ export function ProvidersGrid({
 						logsCount: row.logsCount,
 						uptime: row.uptime,
 						avgTimeToFirstToken: row.avgTimeToFirstToken,
+						timeToFirstTokenCount: row.timeToFirstTokenCount,
 						throughput: row.throughput,
 					}),
 				);

--- a/apps/ui/src/lib/provider-stats.spec.ts
+++ b/apps/ui/src/lib/provider-stats.spec.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
 	gateProviderStats,
 	hasEnoughRequestsForStats,
+	hasEnoughTtftSamplesForStats,
 	MIN_REQUESTS_FOR_STATS,
+	MIN_TTFT_SAMPLES_FOR_STATS,
 } from "./provider-stats";
 
 describe("hasEnoughRequestsForStats", () => {
@@ -14,12 +16,25 @@ describe("hasEnoughRequestsForStats", () => {
 	});
 });
 
+describe("hasEnoughTtftSamplesForStats", () => {
+	it("requires strictly more samples than the threshold", () => {
+		expect(hasEnoughTtftSamplesForStats(0)).toBe(false);
+		expect(hasEnoughTtftSamplesForStats(MIN_TTFT_SAMPLES_FOR_STATS)).toBe(
+			false,
+		);
+		expect(hasEnoughTtftSamplesForStats(MIN_TTFT_SAMPLES_FOR_STATS + 1)).toBe(
+			true,
+		);
+	});
+});
+
 describe("gateProviderStats", () => {
 	it("nulls derived stats below the threshold so small samples are hidden", () => {
 		const gated = gateProviderStats({
 			logsCount: 8,
 			uptime: 100,
 			avgTimeToFirstToken: 63470,
+			timeToFirstTokenCount: 8,
 			throughput: 12,
 		});
 		expect(gated).toEqual({
@@ -30,13 +45,56 @@ describe("gateProviderStats", () => {
 		});
 	});
 
-	it("keeps derived stats once the sample is large enough", () => {
-		const stats = {
+	it("keeps derived stats once both samples are large enough", () => {
+		const gated = gateProviderStats({
+			logsCount: MIN_REQUESTS_FOR_STATS + 1,
+			uptime: 99.7,
+			avgTimeToFirstToken: 412,
+			timeToFirstTokenCount: MIN_TTFT_SAMPLES_FOR_STATS + 1,
+			throughput: 85,
+		});
+		expect(gated).toEqual({
 			logsCount: MIN_REQUESTS_FOR_STATS + 1,
 			uptime: 99.7,
 			avgTimeToFirstToken: 412,
 			throughput: 85,
-		};
-		expect(gateProviderStats(stats)).toEqual(stats);
+		});
+	});
+
+	// The case this gating exists for: plenty of traffic, but almost none of it
+	// streamed, so the TTFT average rests on a handful of samples even though the
+	// request count sails past MIN_REQUESTS_FOR_STATS.
+	it("hides TTFT when few requests were streamed but keeps request-based stats", () => {
+		const gated = gateProviderStats({
+			logsCount: 5000,
+			uptime: 99.9,
+			avgTimeToFirstToken: 63470,
+			timeToFirstTokenCount: 3,
+			throughput: 85,
+		});
+		expect(gated).toEqual({
+			logsCount: 5000,
+			uptime: 99.9,
+			avgTimeToFirstToken: null,
+			throughput: 85,
+		});
+	});
+
+	// Converse: a low-traffic provider whose every request was streamed still has
+	// no meaningful uptime, and not enough TTFT samples either.
+	it("hides both when traffic is low even if every request was streamed", () => {
+		const gated = gateProviderStats({
+			logsCount: 40,
+			uptime: 100,
+			avgTimeToFirstToken: 300,
+			timeToFirstTokenCount: 40,
+			throughput: 90,
+		});
+		expect(gated).toEqual({
+			logsCount: 40,
+			uptime: null,
+			avgTimeToFirstToken: null,
+			throughput: null,
+		});
 	});
 });

--- a/apps/ui/src/lib/provider-stats.ts
+++ b/apps/ui/src/lib/provider-stats.ts
@@ -4,8 +4,26 @@
 // instead of showing misleading small-sample averages.
 export const MIN_REQUESTS_FOR_STATS = 1000;
 
+// TTFT is averaged over streamed requests only — non-streaming requests never
+// record a first-token time — so it needs its own, separate sample gate. A
+// provider can serve 5k requests with only a handful streamed, which would sail
+// past MIN_REQUESTS_FOR_STATS while resting on a 3-sample average.
+//
+// The bar is lower than MIN_REQUESTS_FOR_STATS because it guards a different
+// kind of statistic: uptime needs many samples to tell 99.9% from 99%, whereas
+// the mean of a latency distribution stabilises after far fewer. Reusing 1000
+// here would hide well-sampled TTFT from any provider whose traffic is mostly
+// non-streaming.
+export const MIN_TTFT_SAMPLES_FOR_STATS = 100;
+
 export function hasEnoughRequestsForStats(logsCount: number): boolean {
 	return logsCount > MIN_REQUESTS_FOR_STATS;
+}
+
+export function hasEnoughTtftSamplesForStats(
+	timeToFirstTokenCount: number,
+): boolean {
+	return timeToFirstTokenCount > MIN_TTFT_SAMPLES_FOR_STATS;
 }
 
 export interface ProviderWindowStats {
@@ -16,15 +34,19 @@ export interface ProviderWindowStats {
 }
 
 export function gateProviderStats(
-	stats: ProviderWindowStats,
+	stats: ProviderWindowStats & { timeToFirstTokenCount: number },
 ): ProviderWindowStats {
-	if (hasEnoughRequestsForStats(stats.logsCount)) {
-		return stats;
-	}
+	const enoughRequests = hasEnoughRequestsForStats(stats.logsCount);
 	return {
 		logsCount: stats.logsCount,
-		uptime: null,
-		avgTimeToFirstToken: null,
-		throughput: null,
+		// Uptime and throughput are averaged over every request, so they gate on
+		// the request count; TTFT gates on its own sample count.
+		uptime: enoughRequests ? stats.uptime : null,
+		throughput: enoughRequests ? stats.throughput : null,
+		avgTimeToFirstToken: hasEnoughTtftSamplesForStats(
+			stats.timeToFirstTokenCount,
+		)
+			? stats.avgTimeToFirstToken
+			: null,
 	};
 }


### PR DESCRIPTION
Follow-up to #3271. Independent of #3272 — this only needs the `time_to_first_token_count` column, which is already on main.

## Problem

#3262 hides provider stats below `MIN_REQUESTS_FOR_STATS` (1000 requests), but that gate counts **total** requests while TTFT is averaged over **streamed** requests only. A provider with 5,000 requests of which 3 were streamed sails past the gate and displays a 3-sample TTFT.

#3271 made the average *correct* (it now divides by the sample count instead of the request count) but it did not make the *sample size* honest — and before #3271 the dilution bug happened to mask this, since diluting by 5,000 pulled the number down toward something plausible-looking. So the gap is newly visible rather than newly introduced.

## Fix

Gate each metric on the denominator that actually feeds it:

| Metric | Averaged over | Gated on |
| --- | --- | --- |
| `uptime` | all requests | `logsCount` (unchanged) |
| `throughput` | all requests | `logsCount` (unchanged) |
| `avgTimeToFirstToken` | streamed requests only | **`timeToFirstTokenCount`** |

`GET /public/providers/stats` now returns `timeToFirstTokenCount`, and the model-uptime endpoint returns `ttftCount`, so the UI can gate on the real sample size.

## On the threshold

`MIN_TTFT_SAMPLES_FOR_STATS = 100`, deliberately lower than `MIN_REQUESTS_FOR_STATS = 1000`. The two guard different kinds of statistic: uptime needs many samples to distinguish 99.9% from 99%, whereas the mean of a latency distribution stabilises after far fewer. Reusing 1000 would newly hide well-sampled TTFT from any provider whose traffic is mostly non-streaming — a regression in usefulness, not a fix. Easy to tune if you'd rather be stricter.

## Scope note

`model-benchmarks.tsx` declares `avgTimeToFirstToken` but never renders it, so there was no gap there and I did not add an unused field to that endpoint.

## Testing

- `provider-stats.spec.ts` covers the case this exists for (5,000 requests / 3 streamed → TTFT hidden, uptime and throughput kept) and the converse (40 requests, all streamed → everything hidden).
- `public-providers-stats.spec.ts` asserts the new field is returned.
- `pnpm build` passes; UI + API specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)