### PR TITLE
fix(runware): drop empty tool schema properties

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1351,6 +1351,93 @@ describe("prepareRequestBody - DeepSeek thinking", () => {
 	});
 });
 
+describe("prepareRequestBody - Runware tool schemas", () => {
+	async function prepare(
+		provider: Parameters<typeof prepareRequestBody>[0],
+		tools: Parameters<typeof prepareRequestBody>[12],
+	) {
+		return (await prepareRequestBody(
+			provider,
+			"deepseek-v4-flash",
+			null,
+			"deepseek-v4-flash",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			tools,
+		)) as unknown as Record<string, any>;
+	}
+
+	function tool(parameters: unknown) {
+		return [
+			{
+				type: "function" as const,
+				function: {
+					name: "get_time",
+					description: "Get the current time",
+					parameters: parameters as any,
+				},
+			},
+		];
+	}
+
+	test("drops empty properties so parameter-less tools are accepted", async () => {
+		const requestBody = await prepare(
+			"runware",
+			tool({ type: "object", properties: {}, required: [] }),
+		);
+
+		expect(requestBody.tools[0].function.parameters).toEqual({
+			type: "object",
+			required: [],
+		});
+	});
+
+	test("drops properties that is not an object", async () => {
+		const requestBody = await prepare(
+			"runware",
+			tool({ type: "object", properties: [] }),
+		);
+
+		expect(requestBody.tools[0].function.parameters).toEqual({
+			type: "object",
+		});
+	});
+
+	test("keeps populated properties untouched", async () => {
+		const parameters = {
+			type: "object",
+			properties: { tz: { type: "string" } },
+			required: ["tz"],
+		};
+		const requestBody = await prepare("runware", tool(parameters));
+
+		expect(requestBody.tools[0].function.parameters).toEqual(parameters);
+	});
+
+	test("leaves nested empty properties alone", async () => {
+		const parameters = {
+			type: "object",
+			properties: { opts: { type: "object", properties: {} } },
+		};
+		const requestBody = await prepare("runware", tool(parameters));
+
+		expect(requestBody.tools[0].function.parameters).toEqual(parameters);
+	});
+
+	test("does not touch other providers", async () => {
+		const parameters = { type: "object", properties: {}, required: [] };
+		const requestBody = await prepare("deepseek", tool(parameters));
+
+		expect(requestBody.tools[0].function.parameters).toEqual(parameters);
+	});
+});
+
 describe("prepareRequestBody - Z.ai thinking", () => {
 	async function prepare(options: {
 		model: string;

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -142,6 +142,31 @@ function stripSchemaDefaults(
 	return schema;
 }
 
+/**
+ * Drops a function schema's `properties` key when it holds no properties.
+ * `{"type":"object","properties":{}}` — what every SDK emits for a
+ * parameter-less tool — and `{"type":"object"}` describe the same
+ * unconstrained object, but Runware's self-hosted vLLM path rejects the former
+ * with "Function schema properties must be a non-empty object".
+ */
+function dropEmptySchemaProperties(parameters: unknown): unknown {
+	if (
+		!parameters ||
+		typeof parameters !== "object" ||
+		Array.isArray(parameters) ||
+		!("properties" in parameters)
+	) {
+		return parameters;
+	}
+	const { properties, ...rest } = parameters as Record<string, unknown>;
+	const hasProperties =
+		!!properties &&
+		typeof properties === "object" &&
+		!Array.isArray(properties) &&
+		Object.keys(properties).length > 0;
+	return hasProperties ? parameters : rest;
+}
+
 function getProviderMapping(
 	modelDef: ModelDefinition | undefined,
 	usedProvider: ProviderId,
@@ -1756,6 +1781,26 @@ export async function prepareRequestBody(
 		if (functionTools.length > 0) {
 			requestBody.tools = functionTools;
 		}
+	}
+
+	// Runware routes its DeepSeek models through a self-hosted vLLM whose request
+	// validator 400s on parameter-less tools ("Function schema properties must be
+	// a non-empty object", verified live 2026-07-28). DeepSeek upstream and
+	// Runware's partner-API models accept them, so this is Runware-specific.
+	// Runware has no dedicated case in the switch below, so apply it here.
+	if (usedProvider === "runware" && Array.isArray(requestBody.tools)) {
+		requestBody.tools = requestBody.tools.map(
+			(tool: { function?: { parameters?: unknown } }) =>
+				tool?.function?.parameters
+					? {
+							...tool,
+							function: {
+								...tool.function,
+								parameters: dropEmptySchemaProperties(tool.function.parameters),
+							},
+						}
+					: tool,
+		);
 	}
 
 	// Resolve tool_choice against what the mapping declares it accepts. Fall


### PR DESCRIPTION
## Problem

`runware/deepseek-v4-flash` had a 19.7% error rate, and the top error by a wide margin was:

```
Invalid value for 'tools[3].schema.properties'.
Function schema properties must be a non-empty object.
```

203 of 338 sampled non-streaming errors and 14 of 18 streaming errors. Any request carrying a parameter-less tool — `{"type":"object","properties":{}}`, which is what every SDK emits — 400s outright.

## Root cause

Runware routes its DeepSeek models through a **self-hosted vLLM** (`vllm04/06.runware.xyz`), unlike its other models (moonshot/zai/gpt-oss) which go to partner APIs. Only that self-hosted path has a validator rejecting empty `properties`.

Verified live against both APIs:

| Request | DeepSeek upstream | Runware DeepSeek | Runware moonshot/zai/gpt-oss |
|---|---|---|---|
| `properties: {}` | 200 | **400** | 200 |
| `properties: []` | 200 | **400** | 200 |
| no `properties` key | 200 | 200 | 200 |

## Fix

For `runware` only, drop `properties` when it holds nothing. `{"type":"object"}` and `{"type":"object","properties":{}}` describe the same unconstrained object, and the former is accepted. Nested schemas are untouched — Runware only validates the top level.

Applied before the provider `switch` since Runware has no dedicated case; mirrors the existing zai `stripSchemaDefaults` prior art.

Verified end-to-end by feeding the real `prepareRequestBody` output to the live Runware API: the exact request that previously 400'd now returns 200 with a correct `list_files` tool call.

## Known remaining Runware-side bug (not fixed here)

The other 4 streaming errors:

```
'list' object has no attribute 'items'  (500)
```

Isolated to: **a replayed assistant `tool_call` whose `arguments` decode to an empty object.** `arguments: "{}"` → 500. `arguments: "{\"a\":\"x\"}"` → 200. Independent of the tool schema, and `arguments` omitted or `null` 500s too. Looks like PHP `json_encode` turning an empty associative array into `[]` before it reaches vLLM, whose Jinja chat template then calls `.items()` on it.

DeepSeek upstream accepts `"{}"` fine, and Runware's partner-API models do too — again self-hosted-vLLM-only.

There is no lossless gateway workaround (every empty-arguments encoding 500s; the only alternative is fabricating arguments the model never produced), so this one needs a fix on Runware's side. In the meantime a 500 classifies as `upstream_error` and falls back to another provider. Note this fix makes the case reachable more often — parameter-less tool calls now succeed, and their `arguments: "{}"` is what gets replayed on the next turn — but it is still a strict improvement over the current unconditional 400.

## Test plan

- 5 new unit tests in `prepare-request-body.spec.ts` (empty object, non-object, populated, nested, other-provider passthrough)
- `pnpm vitest run packages/actions/src/` — 408 passed
- `pnpm build` — 17/17 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Runware tool handling for parameter-less functions.
  * Prevented invalid or empty parameter schema fields from causing request validation failures.
  * Preserved valid schemas and nested object definitions.
  * Applied these adjustments only to Runware requests, leaving other providers unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->