### PR TITLE
fix(gateway): set cacheSupported on excluded scores

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -114,6 +114,7 @@ import {
 	InvalidFileContentError,
 	parseGoogleUpstreamDocumentError,
 	prepareRequestBody,
+	providerSupportsCaching,
 	selectProviderMapping,
 	RequestError,
 	UnsupportedAudioFormatError,
@@ -691,6 +692,7 @@ async function addContentFilterRoutingMetadata(
 								throughput: metrics?.throughput ?? 0,
 								price: price.toNumber(),
 								discount: discount.toNumber(),
+								cacheSupported: providerSupportsCaching(provider),
 								contentFilterProvider: true,
 								excludedByContentFilter: true,
 							};
@@ -1920,6 +1922,7 @@ chat.openapi(completions, async (c) => {
 				score: maxScore + 1000 + offset,
 				price: price.toNumber(),
 				discount: discount.toNumber(),
+				cacheSupported: providerSupportsCaching(candidate),
 				hybrid_demoted: true,
 			});
 			offset++;
@@ -3745,6 +3748,7 @@ chat.openapi(completions, async (c) => {
 							score: -1,
 							price: originalProviderPrice.toNumber(),
 							discount: originalProviderDiscount.toNumber(),
+							cacheSupported: providerSupportsCaching(originalProviderInfo),
 							rate_limited: true as const,
 						};
 
@@ -3985,6 +3989,7 @@ chat.openapi(completions, async (c) => {
 								uptime: currentUptime,
 								latency: metrics.averageLatency,
 								throughput: metrics.throughput,
+								cacheSupported: providerSupportsCaching(originalProviderInfo),
 							};
 
 							if (cheapestResult) {
@@ -4316,6 +4321,7 @@ chat.openapi(completions, async (c) => {
 									score: -1,
 									price: price.toNumber(),
 									discount: discount.toNumber(),
+									cacheSupported: providerSupportsCaching(providerInfo),
 									rate_limited: true,
 								});
 							}

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -201,7 +201,7 @@ function findProviderMapping<P extends ModelWithPricing["providers"][number]>(
 	);
 }
 
-function providerSupportsCaching(
+export function providerSupportsCaching(
 	providerInfo:
 		| {
 				cachedInputPrice?: string;

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -17,6 +17,7 @@ import {
 import {
 	getCheapestFromAvailableProviders,
 	getProviderSelectionPrice,
+	providerSupportsCaching,
 	type SessionProviderEntry,
 	type SessionProviderStore,
 } from "./get-cheapest-from-available-providers.js";
@@ -1430,6 +1431,45 @@ describe("getCheapestFromAvailableProviders", () => {
 			);
 
 			expect(result?.provider.providerId).toBe("deepseek");
+		});
+
+		describe("providerSupportsCaching", () => {
+			it("detects a cached price on the mapping, a tier, or a region", () => {
+				expect(providerSupportsCaching(undefined)).toBe(false);
+				expect(providerSupportsCaching({})).toBe(false);
+				expect(providerSupportsCaching({ cachedInputPrice: "0.014e-6" })).toBe(
+					true,
+				);
+				expect(
+					providerSupportsCaching({
+						pricingTiers: [
+							{
+								name: "200K",
+								upToTokens: 200000,
+								inputPrice: "0.14e-6",
+								outputPrice: "0.28e-6",
+								cachedInputPrice: "0.014e-6",
+							},
+						],
+					}),
+				).toBe(true);
+				expect(
+					providerSupportsCaching({
+						regions: [{ id: "singapore", cachedInputPrice: "0.028e-6" }],
+					}),
+				).toBe(true);
+			});
+
+			it("reports cache support for a runware mapping with a cached price", () => {
+				const runwareMapping = models
+					.find((model) => model.id === "deepseek-v4-flash")
+					?.providers.find(
+						(provider) => provider.providerId === "runware",
+					) as ProviderModelMapping;
+
+				expect(runwareMapping.cachedInputPrice).toBeDefined();
+				expect(providerSupportsCaching(runwareMapping)).toBe(true);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Problem

In the log detail view's **Provider Scores** list, a provider that was excluded from scoring (e.g. `runware` showing `rpm capped`) never rendered the `cache` badge — even though its mapping in `packages/models` has a `cachedInputPrice`.

## Cause

Scored providers get `cacheSupported` from `providerSupportsCaching()` inside `getCheapestFromAvailableProviders`. But excluded providers are appended to `routingMetadata.providerScores` as hand-built objects in `apps/gateway/src/chat/chat.ts`, and those sites omitted `cacheSupported`:

- rate-limited providers (the `rpm capped` entries)
- the original provider on the rate-limit fallback path
- the original provider on the low-uptime fallback path
- content-filter excluded providers
- hybrid-demoted candidates

Since `cacheSupported` was `undefined`, the UI's `{score.cacheSupported && ...}` badge never rendered.

## Fix

Export `providerSupportsCaching` from `@llmgateway/actions` and call it at each synthetic score-entry site, so cache support is reported from the catalogue mapping regardless of whether the provider was actually scored.

## Tests

Added unit coverage for `providerSupportsCaching` (mapping-level, pricing-tier, and region-level cached prices) plus a regression assertion that the runware `deepseek-v4-flash` mapping reports cache support.

- `pnpm exec vitest run packages/actions/src/models.spec.ts` — 51 passed
- `pnpm build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routing metadata now indicates whether each provider supports prompt caching.
  * Improved visibility into cache availability during provider selection and fallback routing.

* **Tests**
  * Added coverage verifying cache support detection across provider, pricing-tier, regional, and specific provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->