### PR TITLE
fix(routing): skip providers rejecting prefill

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -228,6 +228,7 @@ import {
 } from "./tools/messages-contain-audio.js";
 import { messagesContainDocuments } from "./tools/messages-contain-documents.js";
 import { messagesContainImages } from "./tools/messages-contain-images.js";
+import { messagesEndWithAssistant } from "./tools/messages-end-with-assistant.js";
 import { mightBeCompleteJson } from "./tools/might-be-complete-json.js";
 import { normalizeClientErrorBody } from "./tools/normalize-client-error.js";
 import {
@@ -548,6 +549,7 @@ function filterEligibleModelProviders(
 		hasAudio: boolean;
 		audioFormats?: string[];
 		hasDocuments: boolean;
+		hasAssistantPrefill?: boolean;
 		maxTokens?: number;
 		reasoningEffort?: string;
 		n?: number;
@@ -1544,6 +1546,9 @@ chat.openapi(completions, async (c) => {
 		? getAudioFormatsFromMessages(messages as BaseMessage[])
 		: [];
 	const hasDocuments = messagesContainDocuments(messages as BaseMessage[]);
+	const hasAssistantPrefill = messagesEndWithAssistant(
+		messages as BaseMessage[],
+	);
 
 	// Extract web_search tool from tools array if present
 	// The web_search tool is a special tool that enables native web search for providers that support it
@@ -3039,6 +3044,7 @@ chat.openapi(completions, async (c) => {
 			hasAudio,
 			audioFormats,
 			hasDocuments,
+			hasAssistantPrefill,
 			// web_search is extracted from tools above and can leave an empty
 			// array; an empty tools list must not require function-tool support.
 			hasTools:
@@ -3477,6 +3483,7 @@ chat.openapi(completions, async (c) => {
 					hasAudio,
 					audioFormats,
 					hasDocuments,
+					hasAssistantPrefill,
 					maxTokens: max_tokens,
 					reasoningEffort: reasoning_effort,
 					n,
@@ -3864,6 +3871,7 @@ chat.openapi(completions, async (c) => {
 						hasAudio,
 						audioFormats,
 						hasDocuments,
+						hasAssistantPrefill,
 						maxTokens: max_tokens,
 						reasoningEffort: reasoning_effort,
 						n,
@@ -4076,6 +4084,7 @@ chat.openapi(completions, async (c) => {
 				hasAudio,
 				audioFormats,
 				hasDocuments,
+				hasAssistantPrefill,
 				maxTokens: max_tokens,
 				reasoningEffort: reasoning_effort,
 			};
@@ -4133,9 +4142,11 @@ chat.openapi(completions, async (c) => {
 						? `No provider with audio support is available for model ${usedInternalModel}. The request contains audio but none of the ${audience} providers support audio input.`
 						: hasImages
 							? `No provider with vision support is available for model ${usedInternalModel}. The request contains images but none of the ${audience} providers support vision.`
-							: project.mode === "api-keys"
-								? `No provider key set for any of the providers that support model ${usedInternalModel}. Please add the provider key in the settings or switch the project mode to credits or hybrid.`
-								: `No available provider could be found for model ${usedInternalModel}`,
+							: hasAssistantPrefill
+								? `No provider that accepts a trailing assistant message is available for model ${usedInternalModel}. The conversation ends on an assistant turn but none of the ${audience} providers support assistant prefill.`
+								: project.mode === "api-keys"
+									? `No provider key set for any of the providers that support model ${usedInternalModel}. Please add the provider key in the settings or switch the project mode to credits or hybrid.`
+									: `No available provider could be found for model ${usedInternalModel}`,
 				});
 			}
 
@@ -4415,6 +4426,7 @@ chat.openapi(completions, async (c) => {
 					hasAudio,
 					audioFormats,
 					hasDocuments,
+					hasAssistantPrefill,
 					maxTokens: max_tokens,
 					reasoningEffort: reasoning_effort,
 					n,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2552,6 +2552,7 @@ chat.openapi(completions, async (c) => {
 			webSearchTool,
 			hasImages,
 			hasDocuments,
+			hasAssistantPrefill,
 		});
 	} catch (capabilityError) {
 		// The /v1/messages layer flags requests that used Anthropic's explicit-budget

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4138,12 +4138,25 @@ chat.openapi(completions, async (c) => {
 						});
 					}
 				}
+				// A trailing assistant message is ordinary traffic, so its mere
+				// presence says nothing about why routing came up empty. Only blame
+				// assistant prefill when dropping that constraint would have left a
+				// candidate — otherwise the failure is about keys, regions or another
+				// capability and must keep its own message.
+				const excludedOnlyByAssistantPrefill =
+					hasAssistantPrefill &&
+					filterEligibleModelProviders(preparedModelProviders, {
+						...eligibilityOptions,
+						n,
+						stream,
+						hasAssistantPrefill: false,
+					}).length > 0;
 				throw new HTTPException(400, {
 					message: hasAudio
 						? `No provider with audio support is available for model ${usedInternalModel}. The request contains audio but none of the ${audience} providers support audio input.`
 						: hasImages
 							? `No provider with vision support is available for model ${usedInternalModel}. The request contains images but none of the ${audience} providers support vision.`
-							: hasAssistantPrefill
+							: excludedOnlyByAssistantPrefill
 								? `No provider that accepts a trailing assistant message is available for model ${usedInternalModel}. The conversation ends on an assistant turn but none of the ${audience} providers support assistant prefill.`
 								: project.mode === "api-keys"
 									? `No provider key set for any of the providers that support model ${usedInternalModel}. Please add the provider key in the settings or switch the project mode to credits or hybrid.`

--- a/apps/gateway/src/chat/tools/messages-end-with-assistant.spec.ts
+++ b/apps/gateway/src/chat/tools/messages-end-with-assistant.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { messagesEndWithAssistant } from "./messages-end-with-assistant.js";
+
+import type { BaseMessage } from "@llmgateway/models";
+
+function messages(...roles: BaseMessage["role"][]): BaseMessage[] {
+	return roles.map((role) => ({ role, content: "hi" }) as BaseMessage);
+}
+
+describe("messagesEndWithAssistant", () => {
+	it("detects a trailing assistant turn", () => {
+		expect(messagesEndWithAssistant(messages("user", "assistant"))).toBe(true);
+	});
+
+	it("ignores assistant turns that are not last", () => {
+		expect(
+			messagesEndWithAssistant(messages("user", "assistant", "user")),
+		).toBe(false);
+		expect(
+			messagesEndWithAssistant(messages("user", "assistant", "tool")),
+		).toBe(false);
+	});
+
+	it("handles an empty conversation", () => {
+		expect(messagesEndWithAssistant([])).toBe(false);
+	});
+});

--- a/apps/gateway/src/chat/tools/messages-end-with-assistant.ts
+++ b/apps/gateway/src/chat/tools/messages-end-with-assistant.ts
@@ -1,0 +1,10 @@
+import type { BaseMessage } from "@llmgateway/models";
+
+/**
+ * Checks whether the conversation ends on an assistant turn (assistant prefill /
+ * continuation). Used to filter provider mappings whose upstream rejects such
+ * requests with a 400 ("a conversation cannot end on an assistant turn").
+ */
+export function messagesEndWithAssistant(messages: BaseMessage[]): boolean {
+	return messages[messages.length - 1]?.role === "assistant";
+}

--- a/apps/gateway/src/chat/tools/provider-filter-reasons.spec.ts
+++ b/apps/gateway/src/chat/tools/provider-filter-reasons.spec.ts
@@ -125,6 +125,23 @@ describe("getProviderFilterReasons", () => {
 		);
 	});
 
+	it("flags mappings that reject a trailing assistant message", () => {
+		expect(
+			getProviderFilterReasons(mapping({ supportsAssistantPrefill: false }), {
+				hasAssistantPrefill: true,
+			}),
+		).toEqual(["assistant prefill not supported"]);
+		expect(
+			getProviderFilterReasons(mapping(), { hasAssistantPrefill: true }),
+		).toEqual([]);
+		expect(
+			getProviderFilterReasons(
+				mapping({ supportsAssistantPrefill: false }),
+				{},
+			),
+		).toEqual([]);
+	});
+
 	it("flags max_tokens above the provider's max output", () => {
 		expect(
 			getProviderFilterReasons(mapping({ maxOutput: 4096 }), {

--- a/apps/gateway/src/chat/tools/provider-filter-reasons.ts
+++ b/apps/gateway/src/chat/tools/provider-filter-reasons.ts
@@ -9,6 +9,7 @@ export interface ProviderFilterOptions {
 	hasAudio?: boolean;
 	audioFormats?: string[];
 	hasDocuments?: boolean;
+	hasAssistantPrefill?: boolean;
 	hasTools?: boolean;
 	reasoningEffort?: string;
 	reasoningMaxTokens?: number;
@@ -97,6 +98,12 @@ export function getProviderFilterReasons(
 	}
 	if (options.hasDocuments && provider.document !== true) {
 		reasons.push("documents not supported");
+	}
+	if (
+		options.hasAssistantPrefill &&
+		provider.supportsAssistantPrefill === false
+	) {
+		reasons.push("assistant prefill not supported");
 	}
 	if (
 		options.maxTokens !== undefined &&

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -61,6 +61,49 @@ const textImageModel = (() => {
 	return m;
 })();
 
+// gemma-4-31b-it has runware (supportsAssistantPrefill: false) alongside
+// providers that accept a trailing assistant message.
+const mixedPrefillModel = getModel("gemma-4-31b-it");
+
+describe("validateModelCapabilities - assistant prefill", () => {
+	it("rejects when the explicit provider rejects a trailing assistant message", () => {
+		expect(() =>
+			validateModelCapabilities(
+				mixedPrefillModel,
+				"gemma-4-31b-it",
+				"runware",
+				{ hasAssistantPrefill: true },
+			),
+		).toThrow(HTTPException);
+	});
+
+	it("allows when a sibling provider accepts a trailing assistant message", () => {
+		expect(() =>
+			validateModelCapabilities(
+				mixedPrefillModel,
+				"gemma-4-31b-it",
+				undefined,
+				{
+					hasAssistantPrefill: true,
+				},
+			),
+		).not.toThrow();
+	});
+
+	it("allows the same provider when the conversation does not end on an assistant turn", () => {
+		expect(() =>
+			validateModelCapabilities(
+				mixedPrefillModel,
+				"gemma-4-31b-it",
+				"runware",
+				{
+					hasAssistantPrefill: false,
+				},
+			),
+		).not.toThrow();
+	});
+});
+
 describe("validateModelCapabilities - vision", () => {
 	it("rejects when explicit provider does not support vision", () => {
 		expect(() =>

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.ts
@@ -23,6 +23,7 @@ export interface ValidateModelCapabilitiesOptions {
 	webSearchTool?: WebSearchTool;
 	hasImages?: boolean;
 	hasDocuments?: boolean;
+	hasAssistantPrefill?: boolean;
 }
 
 /**
@@ -49,6 +50,7 @@ export function validateModelCapabilities(
 		webSearchTool,
 		hasImages,
 		hasDocuments,
+		hasAssistantPrefill,
 	} = options;
 
 	// Custom providers have no catalog entry, so the gateway cannot know which
@@ -108,6 +110,36 @@ export function validateModelCapabilities(
 				message: requestedProvider
 					? `Provider ${requestedProvider} does not support document input for model ${requestedModel}. Remove the file content or use a document-capable model.`
 					: `Model ${requestedModel} does not support document input. Remove the file content or use a document-capable model.`,
+			});
+		}
+	}
+
+	// Validate assistant prefill when the conversation ends on an assistant turn.
+	// Routing already skips mappings that declare `supportsAssistantPrefill: false`,
+	// but that filter is bypassed when the provider is pinned explicitly or the
+	// model has a single mapping, so reject here instead of letting the upstream
+	// return its own 400.
+	if (
+		hasAssistantPrefill &&
+		requestedModel !== "auto" &&
+		requestedModel !== "custom"
+	) {
+		const providersToCheck = requestedProvider
+			? modelInfo.providers.filter(
+					(p) => (p as ProviderModelMapping).providerId === requestedProvider,
+				)
+			: modelInfo.providers;
+
+		const supportsAssistantPrefill = providersToCheck.some(
+			(provider) =>
+				(provider as ProviderModelMapping).supportsAssistantPrefill !== false,
+		);
+
+		if (!supportsAssistantPrefill) {
+			throw new HTTPException(400, {
+				message: requestedProvider
+					? `Provider ${requestedProvider} does not support a conversation ending on an assistant message for model ${requestedModel}. End the conversation with a user or tool message, or use another provider.`
+					: `Model ${requestedModel} does not support a conversation ending on an assistant message. End the conversation with a user or tool message.`,
 			});
 		}
 	}

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -506,6 +506,14 @@ export interface ProviderModelMapping {
 	 */
 	supportsDeveloperRole?: boolean;
 	/**
+	 * Whether this mapping's upstream accepts a conversation whose last message is
+	 * an assistant turn (assistant prefill / continuation). Defaults to `true`
+	 * (assumed supported). When set to `false`, routing skips this mapping for
+	 * requests that end on an assistant message, since the upstream rejects them
+	 * with a 400 ("a conversation cannot end on an assistant turn").
+	 */
+	supportsAssistantPrefill?: boolean;
+	/**
 	 * Test skip/only functionality
 	 */
 	test?: "skip" | "only";

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -301,6 +301,9 @@ export const deepseekModels = [
 				// parameter: 'jsonSchema'"); only schema-based output is supported.
 				jsonOutput: false,
 				jsonOutputSchema: true,
+				// Runware 400s ("a conversation cannot end on an assistant turn") when
+				// the last message is an assistant turn (verified 2026-07-28).
+				supportsAssistantPrefill: false,
 			},
 			{
 				providerId: "together-ai",
@@ -456,6 +459,9 @@ export const deepseekModels = [
 				// parameter: 'jsonSchema'"); only schema-based output is supported.
 				jsonOutput: false,
 				jsonOutputSchema: true,
+				// Runware 400s ("a conversation cannot end on an assistant turn") when
+				// the last message is an assistant turn (verified 2026-07-28).
+				supportsAssistantPrefill: false,
 			},
 			{
 				providerId: "novita",

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2272,6 +2272,9 @@ export const googleModels = [
 				// parameter: 'jsonSchema'") and its json_schema path hangs until the
 				// upstream inference timeout, so no structured-output mode is offered.
 				jsonOutput: false,
+				// Runware 400s ("a conversation cannot end on an assistant turn") when
+				// the last message is an assistant turn (verified 2026-07-28).
+				supportsAssistantPrefill: false,
 			},
 			{
 				providerId: "novita",


### PR DESCRIPTION
## Problem

The `runware` mapping for `gemma-4-31b-it` had a ~58% error rate, all with the same upstream 400:

```json
{"error":{"message":"Invalid value for 'messages'. The last message must have role \"user\" or \"tool\" (a conversation cannot end on an assistant turn).","type":"invalid_request_error","param":null,"code":"invalid_value"}}
```

## Investigation

Probed Runware directly with a conversation ending on an assistant turn (assistant prefill / continuation):

| Runware model | result |
| --- | --- |
| `google-gemma-4-31b` | 400 |
| `deepseek-v4-pro` | 400 |
| `deepseek-v4-flash` | 400 |
| `openai-gpt-oss-120b` | 200 |
| `zai-glm-5-2` | 200 |
| `moonshotai-kimi-k2-6` | 200 |

Same request against other providers of `gemma-4-31b-it`: DeepInfra 200, Together AI 200. A trailing `tool` message on Runware/gemma also works (200), so the restriction is exactly "last message must be `user` or `tool`".

So it is **Runware-specific, but not specific to this model** — it affects three of its six chat mappings. Those deployments sit behind a different backend than the ones that accept prefill (their responses carry `chatcmpl-`/`fp_` ids instead of Runware's own `rw-` ids).

## Fix

Trailing-assistant messages are valid OpenAI requests that most providers accept, and a generic 4xx does not trigger fallback, so users got a hard 400 even though another provider would have served the request. Anthropic-style prefill via `/v1/messages` funnels through the same path and hit this too.

- New per-mapping catalogue flag `supportsAssistantPrefill` (defaults to `true`), mirroring the existing `supportsDeveloperRole` pattern.
- Set `supportsAssistantPrefill: false` on the three affected Runware mappings.
- Routing filters out such mappings when the conversation ends on an assistant message (`messagesEndWithAssistant`), so the request goes to a provider that accepts it.
- `validateModelCapabilities` rejects up front when the provider is pinned explicitly or the model resolves to a single mapping — those two paths bypass the routing filter, so without this they'd still burn a round trip on a provider that will 400.
- The messages array is never mutated: nothing is truncated, dropped, or rewritten. Only provider selection changes.

## Behavior

| Request | Result |
| --- | --- |
| `gemma-4-31b-it` (or `auto`), ends on assistant | Runware filtered out; another provider serves it |
| `runware/gemma-4-31b-it` pinned, ends on assistant | `400 Provider runware does not support a conversation ending on an assistant message for model gemma-4-31b-it. End the conversation with a user or tool message, or use another provider.` |
| Same pin, ends on `user` or `tool` | Unaffected |

## Testing

Verified end-to-end against a local gateway with the real Runware key:

- unpinned + trailing assistant → routed to `novita/gemma-4-31b-it`, which continued the prefill
- pinned runware + trailing assistant → clean gateway 400, no upstream call
- pinned runware + user-final → 200 from Runware (control)
- pinned runware + tool-final → 200 from Runware (control)

Plus `pnpm test:unit` (3280 passed; 3 unrelated order-dependent flakes in `fallback.spec.ts`/`chat-resilience.spec.ts` that pass in isolation and never send an assistant message), `pnpm build`, `pnpm format`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for conversations ending with an assistant message, enabling compatible providers to continue the conversation.
  * Automatically filters out providers that do not support assistant prefill requests.
  * Added a clear error message when no eligible provider supports assistant prefill.
  * Marked affected model providers as incompatible with assistant-prefill requests.

* **Bug Fixes**
  * Prevented unsupported providers from receiving requests that would result in upstream errors.

* **Tests**
  * Added coverage for assistant-prefill detection, provider filtering, and capability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->