### PR TITLE
feat(responses): properly handle state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,15 @@ DATABASE_URL=postgres://postgres:change_this_secure_password@postgres:5432/llmga
 REDIS_PASSWORD=change_this_redis_password
 REDIS_PORT=6379
 
+# Storage Redis: dedicated instance for Responses API state (30-day retention)
+# and gateway response caching. With no STORAGE_REDIS_* var set, the main
+# REDIS_* connection is reused (single-Redis setups keep working). Once any
+# STORAGE_REDIS_* var is set, the others default to localhost/6379/no-password
+# rather than inheriting from REDIS_*.
+STORAGE_REDIS_PORT=6380
+# STORAGE_REDIS_HOST=localhost
+STORAGE_REDIS_PASSWORD=change_this_redis_password
+
 # =============================================================================
 # SERVICE PORTS
 # =============================================================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,11 +52,11 @@ Do not run test files or suites in parallel unless the repository instructions f
 - `pnpm test:unit` - Run unit tests (\*.spec.ts files)
 - `pnpm test:e2e` - Run end-to-end tests (\*.e2e.ts files)
 
-When running curl commands against the local API, you can use `test-token` as authentication.
+When running curl commands against the local API, you can use `test-token` as authentication. To exercise retention-off behavior, use `test-token-no-retention` instead — it belongs to a seeded sibling org with `retentionLevel: "none"` (the default `test-token` org retains all data for easier debugging).
 
 Every seeded account's password is its own email address (password == email). For example, log into the dashboard as `admin@example.com` with the password `admin@example.com`. This applies to all users created by `packages/db/src/seed.ts`, including:
 
-- `admin@example.com` — default test admin (owns "Test Organization" + a DevPass Pro workspace)
+- `admin@example.com` — default test admin (owns "Test Organization", "Test No Retention Organization" + a DevPass Pro workspace)
 - `enterprise@example.com` — owner of the enterprise org
 - `developer@example.com` — project-scoped developer in the enterprise org (RBAC testing)
 - the bulk demo users such as `alice.chen@techcorp.io`, `bob@startupinc.com`, etc.

--- a/apps/docs/content/features/data-retention.mdx
+++ b/apps/docs/content/features/data-retention.mdx
@@ -62,6 +62,14 @@ Data retention is configured at the organization level in your dashboard setting
 
 Data is retained for 30 days for all users. Enterprise plans can have custom retention periods. After the retention period expires, data is automatically deleted.
 
+<Callout type="info">
+	The Responses API does not require data retention. Stored responses (used for
+	`previous_response_id` chaining and `GET /v1/responses/:id`) are kept in
+	dedicated storage for 30 days — matching OpenAI's own retention — regardless
+	of your organization's data retention policy, and are not billed as data
+	storage.
+</Callout>
+
 ## Accessing Stored Data
 
 When data retention is enabled, you can access your stored requests through the dashboard:

--- a/apps/docs/content/guides/codex-cli.mdx
+++ b/apps/docs/content/guides/codex-cli.mdx
@@ -120,18 +120,13 @@ model = "gpt-5.3-codex"
 
 ### Data retention required
 
-If you see an error like:
+Older versions of LLM Gateway rejected Responses API requests with:
 
 ```
 The Responses API requires data retention to be enabled.
 ```
 
-Codex CLI uses the OpenAI Responses API (`/v1/responses`), which requires data retention to be enabled. To fix this:
-
-1. Go to your [organization settings](https://llmgateway.io/dashboard) and navigate to **Settings > Policies**
-2. Select **Retain All Data** and click **Save Settings**
-
-If you prefer not to enable data retention, you can configure Codex CLI to use the Chat Completions API instead by setting the `OPENAI_CHAT_COMPLETIONS_PATH` environment variable, if supported by your Codex CLI version.
+This is no longer the case — the Responses API (which Codex CLI uses) works regardless of your organization's data retention policy. If you still see this error, the gateway you are talking to is running an outdated version; on a self-hosted deployment, update to the latest release.
 
 ### Authentication errors
 

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1000,10 +1000,10 @@ describe("api", () => {
 		expect((logRow?.content ?? "").length).toBeGreaterThan(0);
 	});
 
-	test("/v1/responses is rejected outright when retention is disabled", async () => {
-		// The Responses API stores conversation state, so it is gated to
-		// retaining orgs — a non-retaining org is rejected before any request or
-		// response payload can be processed or logged.
+	test("/v1/responses works when retention is disabled and keeps state out of the log", async () => {
+		// Responses API state lives in the dedicated responses storage (30d
+		// TTL), not the log table, so a non-retaining org can use the full
+		// stateful API while its log rows stay metadata-only.
 		await db
 			.update(tables.organization)
 			.set({ retentionLevel: "none" })
@@ -1015,6 +1015,14 @@ describe("api", () => {
 			projectId: "project-id",
 			description: "Test API Key",
 			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-responses-retention-none",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
 		});
 
 		const res = await app.request("/v1/responses", {
@@ -1029,9 +1037,29 @@ describe("api", () => {
 			}),
 		});
 
-		expect(res.status).toBe(400);
+		expect(res.status).toBe(200);
 		const json = await res.json();
-		expect(json.error.code).toBe("data_retention_required");
+		expect(json.id).toMatch(/^resp_/);
+		expect(json.output.length).toBeGreaterThan(0);
+
+		// The stored response is retrievable (state lives in responses storage).
+		const getRes = await app.request(`/v1/responses/${json.id}`, {
+			headers: {
+				Authorization: "Bearer real-token-responses-retention-none",
+			},
+		});
+		expect(getRes.status).toBe(200);
+		const stored = await getRes.json();
+		expect(stored.id).toBe(json.id);
+		expect(stored.output.length).toBeGreaterThan(0);
+
+		// The log row keeps metadata only — no payload, no responsesApiData.
+		const logs = await waitForLogs(1);
+		const logRow = logs.find((log) => log.id === json.id);
+		expect(logRow).toBeTruthy();
+		expect(logRow?.messages).toBeNull();
+		expect(logRow?.content).toBeNull();
+		expect(logRow?.responsesApiData).toBeNull();
 	});
 
 	test("/v1/chat/completions rejects Vertex service tiers outside the global endpoint", async () => {

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -13,7 +13,7 @@ import {
 	UnsupportedAudioFormatError,
 	UnsupportedDocumentFormatError,
 } from "@llmgateway/actions";
-import { redisClient } from "@llmgateway/cache";
+import { redisClient, storageRedisClient } from "@llmgateway/cache";
 import { db } from "@llmgateway/db";
 import {
 	createHonoRequestLogger,
@@ -326,7 +326,14 @@ app.openapi(root, async (c) => {
 	const TIMEOUT_MS = Number(process.env.HEALTH_CHECK_TIMEOUT_MS) || 15000;
 
 	const healthChecker = new HealthChecker({
-		redisClient,
+		// Ping both the main and the storage Redis; either failing marks the
+		// gateway unhealthy (they may be the same instance via env fallback).
+		redisClient: {
+			ping: async () => {
+				await Promise.all([redisClient.ping(), storageRedisClient.ping()]);
+				return "PONG";
+			},
+		},
 		db,
 		logger,
 	});

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1653,29 +1653,24 @@ chat.openapi(completions, async (c) => {
 	const responsesContext = responsesContextKey
 		? getResponsesContext(responsesContextKey)
 		: undefined;
-	const syncLogInsert = responsesContext?.syncInsert ?? false;
 	const logIdOverride = responsesContext?.logId;
 	const finalLogId = logIdOverride ?? shortid();
-	const responsesApiData: unknown = responsesContext?.responsesApiData ?? null;
 
-	// Wrapper that injects Responses API fields into every log entry.
-	// Only override the id for the final log entry (retried !== true) to avoid
-	// PK conflicts when the request retries across multiple providers.
+	// Wrapper that logs Responses API proxy requests under the resp_ id the
+	// client sees. Only override the id for the final log entry (retried !==
+	// true) to avoid PK conflicts when the request retries across multiple
+	// providers.
 	const insertLogEntry = (logData: LogInsertData) =>
-		insertLog(
-			{
-				// Service tiers default from the request-level requested tier and the
-				// served tier resolved so far, so every log path (guardrail/validation
-				// rejections, cache hits, streaming/upstream errors, fetch errors)
-				// records them. Explicit values in logData still win.
-				requestedServiceTier,
-				usedServiceTier: servedServiceTier,
-				...logData,
-				...(logIdOverride && !logData.retried ? { id: logIdOverride } : {}),
-				responsesApiData,
-			},
-			{ syncInsert: syncLogInsert },
-		);
+		insertLog({
+			// Service tiers default from the request-level requested tier and the
+			// served tier resolved so far, so every log path (guardrail/validation
+			// rejections, cache hits, streaming/upstream errors, fetch errors)
+			// records them. Explicit values in logData still win.
+			requestedServiceTier,
+			usedServiceTier: servedServiceTier,
+			...logData,
+			...(logIdOverride && !logData.retried ? { id: logIdOverride } : {}),
+		});
 
 	// Check for X-No-Fallback header to disable provider fallback on low uptime
 	const xNoFallbackHeaderSet =
@@ -2128,7 +2123,6 @@ chat.openapi(completions, async (c) => {
 							image_config,
 						),
 						...(logIdOverride ? { id: logIdOverride } : {}),
-						responsesApiData,
 						apiOrigin,
 						content: null,
 						responseSize: 0,
@@ -2170,7 +2164,7 @@ chat.openapi(completions, async (c) => {
 						usedServiceTier: null,
 						dataStorageCost: "0",
 					},
-					{ syncInsert: syncLogInsert, retentionLevel },
+					{ retentionLevel },
 				);
 			} catch (error) {
 				logger.error("Failed to log unsupported service tier rejection", {
@@ -2608,7 +2602,6 @@ chat.openapi(completions, async (c) => {
 							image_config,
 						),
 						...(logIdOverride ? { id: logIdOverride } : {}),
-						responsesApiData,
 						apiOrigin,
 						content: null,
 						responseSize: 0,
@@ -2646,7 +2639,7 @@ chat.openapi(completions, async (c) => {
 						usedServiceTier: null,
 						dataStorageCost: "0",
 					},
-					{ syncInsert: syncLogInsert, retentionLevel },
+					{ retentionLevel },
 				);
 			} catch (error) {
 				logger.error("Failed to log budget-thinking rejection", {

--- a/apps/gateway/src/lib/logs-retention.spec.ts
+++ b/apps/gateway/src/lib/logs-retention.spec.ts
@@ -108,28 +108,20 @@ describe("insertLog retention stripping", () => {
 		expect(published.content).toBeNull();
 	});
 
-	it("strips before a synchronous DB insert when retention is none", async () => {
-		await insertLog(baseLogData({}), {
-			syncInsert: true,
-			retentionLevel: "none",
-		});
+	it("strips all payload fields when retention is none", async () => {
+		await insertLog(baseLogData({}), { retentionLevel: "none" });
 
-		expect(dbInsertValues).toHaveBeenCalledTimes(1);
-		expect(publishToQueue).not.toHaveBeenCalled();
-		const inserted = dbInsertValues.mock.calls[0][0] as LogInsertData;
-		expect(inserted.messages).toBeNull();
-		expect(inserted.content).toBeNull();
-		expect(inserted.tools).toBeNull();
-		expect(inserted.responsesApiData).toBeNull();
+		const published = publishToQueue.mock.calls[0][1] as LogInsertData;
+		expect(published.messages).toBeNull();
+		expect(published.content).toBeNull();
+		expect(published.tools).toBeNull();
+		expect(published.responsesApiData).toBeNull();
 	});
 
-	it("keeps payload on a synchronous DB insert when retention is retain", async () => {
-		await insertLog(baseLogData({}), {
-			syncInsert: true,
-			retentionLevel: "retain",
-		});
+	it("keeps payload when retention is retain", async () => {
+		await insertLog(baseLogData({}), { retentionLevel: "retain" });
 
-		const inserted = dbInsertValues.mock.calls[0][0] as LogInsertData;
-		expect(inserted.content).toBe("secret completion");
+		const published = publishToQueue.mock.calls[0][1] as LogInsertData;
+		expect(published.content).toBe("secret completion");
 	});
 });

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -1,7 +1,5 @@
 import { publishToQueue, LOG_QUEUE } from "@llmgateway/cache";
 import {
-	db,
-	log,
 	stripRetentionSensitiveLogFields,
 	UnifiedFinishReason,
 	type LogInsertData,
@@ -14,7 +12,7 @@ import {
 	shouldRedactProviderError,
 } from "./stealth-provider-errors.js";
 
-import type { InferInsertModel } from "@llmgateway/db";
+import type { InferInsertModel, log } from "@llmgateway/db";
 
 /**
  * Check if a finish reason is expected to map to UNKNOWN
@@ -295,7 +293,7 @@ export type LogData = InferInsertModel<typeof log>;
 
 export async function insertLog(
 	logData: LogInsertData,
-	options?: { syncInsert?: boolean; retentionLevel?: "retain" | "none" | null },
+	options?: { retentionLevel?: "retain" | "none" | null },
 ): Promise<unknown> {
 	// Fail closed on retention: unless the organization is explicitly known to
 	// retain data, strip the request/response payload fields here — before the
@@ -369,11 +367,6 @@ export async function insertLog(
 			: undefined,
 		errorType,
 	});
-
-	if (options?.syncInsert) {
-		await db.insert(log).values(logData as LogData);
-		return 1;
-	}
 
 	await publishToQueue(LOG_QUEUE, logData);
 	return 1; // Return 1 to match test expectations

--- a/apps/gateway/src/lib/responses-context.ts
+++ b/apps/gateway/src/lib/responses-context.ts
@@ -1,7 +1,5 @@
 export interface ResponsesContext {
 	logId: string;
-	syncInsert: boolean;
-	responsesApiData: unknown;
 }
 
 const contextMap = new Map<string, ResponsesContext>();

--- a/apps/gateway/src/responses.e2e.ts
+++ b/apps/gateway/src/responses.e2e.ts
@@ -375,6 +375,116 @@ describe("e2e", getConcurrentTestOptions(), () => {
 					finalText.includes("72") ||
 					finalText.includes("weather"),
 			).toBe(true);
+
+			// The stored first response is retrievable by id (state lives in the
+			// dedicated responses storage, independent of data retention).
+			const getRes = await app.request(`/v1/responses/${firstJson.id}`, {
+				headers: { Authorization: `Bearer real-token` },
+			});
+			expect(getRes.status).toBe(200);
+			const storedJson = await getRes.json();
+			expect(storedJson.id).toBe(firstJson.id);
+			const storedFnCall = getFunctionCall(storedJson);
+			expect(storedFnCall?.name).toBe("get_weather");
+			expect(storedFnCall?.call_id).toBe(fnCall?.call_id);
+		},
+	);
+
+	// Stateless variant of the tool-call round trip: no previous_response_id —
+	// the client replays the full history itself (user message + the returned
+	// function_call item + the tool result), exactly how Codex-style clients
+	// drive the Responses API. Nothing is stored, so the replayed function_call
+	// item must convert back into an assistant tool_calls message ahead of the
+	// tool result or strict providers reject the orphaned tool message.
+	test.each(responsesToolCallModels)(
+		"responses tool calls stateless $model",
+		getTestOptions(),
+		async ({ model }) => {
+			const tools = [
+				{
+					type: "function",
+					name: "get_weather",
+					description: "Get the current weather for a given city",
+					parameters: {
+						type: "object",
+						properties: {
+							city: {
+								type: "string",
+								description: "The city name to get weather for",
+							},
+						},
+						required: ["city"],
+					},
+				},
+			];
+			const firstInput = [
+				{
+					role: "user",
+					content: "What's the weather like in San Francisco?",
+				},
+			];
+
+			const firstRequestId = generateTestRequestId();
+			const firstRes = await postResponses(
+				{
+					model,
+					store: false,
+					input: firstInput,
+					tools,
+					tool_choice: "required",
+				},
+				firstRequestId,
+			);
+			const firstJson = await firstRes.json();
+			if (logMode) {
+				console.log(
+					"responses tool calls stateless first:",
+					JSON.stringify(firstJson, null, 2),
+				);
+			}
+
+			expect(firstRes.status).toBe(200);
+			const fnCall = getFunctionCall(firstJson);
+			expect(fnCall).toBeDefined();
+			expect(fnCall?.name).toBe("get_weather");
+			expect(typeof fnCall?.call_id).toBe("string");
+			const parsedArgs = JSON.parse(fnCall?.arguments ?? "{}");
+			expect(parsedArgs.city.toLowerCase()).toContain("san francisco");
+
+			const secondRequestId = generateTestRequestId();
+			const secondRes = await postResponses(
+				{
+					model,
+					store: false,
+					input: [
+						...firstInput,
+						...firstJson.output,
+						{
+							type: "function_call_output",
+							call_id: fnCall?.call_id,
+							output: "72F and sunny",
+						},
+					],
+					tools,
+				},
+				secondRequestId,
+			);
+			const secondJson = await secondRes.json();
+			if (logMode) {
+				console.log(
+					"responses tool calls stateless second:",
+					JSON.stringify(secondJson, null, 2),
+				);
+			}
+
+			expect(secondRes.status).toBe(200);
+			const finalText = getOutputText(secondJson).toLowerCase();
+			expect(finalText.length).toBeGreaterThan(0);
+			expect(
+				finalText.includes("sunny") ||
+					finalText.includes("72") ||
+					finalText.includes("weather"),
+			).toBe(true);
 		},
 	);
 });

--- a/apps/gateway/src/responses/response-state.spec.ts
+++ b/apps/gateway/src/responses/response-state.spec.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+	storeResponse,
+	getStoredResponse,
+	resolveStoredItem,
+	RESPONSES_TTL_SECONDS,
+} from "./tools/response-state.js";
+import {
+	getResponsesStorage,
+	setResponsesStorageForTesting,
+	type ResponsesStorage,
+} from "./tools/response-storage.js";
+
+const dbSelectLimit = vi.fn().mockResolvedValue([]);
+vi.mock("@llmgateway/db", async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>();
+	return {
+		...actual,
+		db: {
+			select: vi.fn().mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: (...args: unknown[]) => dbSelectLimit(...args),
+						orderBy: vi.fn().mockReturnValue({
+							limit: (...args: unknown[]) => dbSelectLimit(...args),
+						}),
+					}),
+				}),
+			}),
+		},
+	};
+});
+
+vi.mock("@llmgateway/cache", () => ({
+	redisClient: {},
+	storageRedisClient: {},
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+class MemoryResponsesStorage implements ResponsesStorage {
+	public store = new Map<string, string>();
+	public writes = 0;
+
+	public async set(key: string, value: string): Promise<void> {
+		this.writes++;
+		this.store.set(key, value);
+	}
+
+	public async setMany(
+		entries: { key: string; value: string }[],
+	): Promise<void> {
+		for (const entry of entries) {
+			this.writes++;
+			this.store.set(entry.key, entry.value);
+		}
+	}
+
+	public async get(key: string): Promise<string | null> {
+		return this.store.get(key) ?? null;
+	}
+
+	public async getMany(keys: string[]): Promise<(string | null)[]> {
+		return keys.map((key) => this.store.get(key) ?? null);
+	}
+}
+
+let memory: MemoryResponsesStorage;
+
+beforeEach(() => {
+	memory = new MemoryResponsesStorage();
+	setResponsesStorageForTesting(memory);
+	dbSelectLimit.mockResolvedValue([]);
+});
+
+afterEach(() => {
+	setResponsesStorageForTesting(undefined);
+});
+
+const userMessage = { role: "user", content: "hello" };
+const outputMessage = {
+	type: "message",
+	id: "msg_1",
+	role: "assistant",
+	content: [{ type: "output_text", text: "hi there" }],
+};
+
+describe("storeResponse / getStoredResponse", () => {
+	it("round-trips a stored response through the storage backend", async () => {
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [userMessage],
+				output: [outputMessage],
+				instructions: "be nice",
+				model: "openai/gpt-5.5",
+				status: "completed",
+				usage: { total_tokens: 10 },
+				created_at: 1234,
+			},
+			"project_1",
+		);
+
+		const stored = await getStoredResponse("resp_1", "project_1");
+		expect(stored).not.toBeNull();
+		expect(stored!.input).toEqual([userMessage]);
+		expect(stored!.output).toEqual([outputMessage]);
+		expect(stored!.instructions).toBe("be nice");
+		expect(stored!.model).toBe("openai/gpt-5.5");
+		expect(stored!.status).toBe("completed");
+		expect(stored!.usage).toEqual({ total_tokens: 10 });
+		expect(stored!.created_at).toBe(1234);
+	});
+
+	it("is scoped by project", async () => {
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [userMessage],
+				output: [outputMessage],
+				model: "openai/gpt-5.5",
+				status: "completed",
+			},
+			"project_1",
+		);
+
+		expect(await getStoredResponse("resp_1", "project_2")).toBeNull();
+	});
+
+	it("stores each unique item once across chained turns", async () => {
+		const turn2User = { role: "user", content: "and then?" };
+		const turn2Output = {
+			type: "message",
+			id: "msg_2",
+			role: "assistant",
+			content: [{ type: "output_text", text: "the end" }],
+		};
+
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [userMessage],
+				output: [outputMessage],
+				model: "openai/gpt-5.5",
+				status: "completed",
+			},
+			"project_1",
+		);
+		const keysAfterTurn1 = memory.store.size;
+
+		// Chained turn: full reconstructed history + new items, as the POST
+		// handler builds it from a previous_response_id.
+		await storeResponse(
+			"resp_2",
+			{
+				id: "resp_2",
+				input: [userMessage, outputMessage, turn2User],
+				output: [turn2Output],
+				model: "openai/gpt-5.5",
+				status: "completed",
+			},
+			"project_1",
+		);
+
+		// Only the new record + the two new items appear; the shared history
+		// items dedup onto their existing keys instead of being stored again.
+		expect(memory.store.size).toBe(keysAfterTurn1 + 3);
+
+		const stored = await getStoredResponse("resp_2", "project_1");
+		expect(stored!.input).toEqual([userMessage, outputMessage, turn2User]);
+		expect(stored!.output).toEqual([turn2Output]);
+	});
+
+	it("dedups identical id-less items via content hashing", async () => {
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [userMessage, userMessage],
+				output: [],
+				model: "openai/gpt-5.5",
+				status: "completed",
+			},
+			"project_1",
+		);
+
+		// One record + one item key despite the item appearing twice; order and
+		// duplicates are still preserved on read via the record's ref list.
+		expect(memory.store.size).toBe(2);
+		const stored = await getStoredResponse("resp_1", "project_1");
+		expect(stored!.input).toEqual([userMessage, userMessage]);
+	});
+
+	it("never keys an item_reference by its id", async () => {
+		const reference = { type: "item_reference", id: "msg_1" };
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [outputMessage, reference],
+				output: [],
+				model: "openai/gpt-5.5",
+				status: "completed",
+			},
+			"project_1",
+		);
+
+		// The concrete msg_1 item must survive under its id; the reference gets
+		// a content-hash key instead of overwriting it.
+		expect(
+			JSON.parse(memory.store.get("responses:item:project_1:msg_1")!),
+		).toEqual(outputMessage);
+		const stored = await getStoredResponse("resp_1", "project_1");
+		expect(stored!.input).toEqual([outputMessage, reference]);
+	});
+
+	it("preserves incomplete_details and reasoning metadata", async () => {
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [userMessage],
+				output: [],
+				model: "openai/gpt-5.5",
+				status: "incomplete",
+				incomplete_details: { reason: "max_output_tokens" },
+				reasoning: { effort: "high", summary: null, context: "ctx" },
+			},
+			"project_1",
+		);
+
+		const stored = await getStoredResponse("resp_1", "project_1");
+		expect(stored!.status).toBe("incomplete");
+		expect(stored!.incomplete_details).toEqual({
+			reason: "max_output_tokens",
+		});
+		expect(stored!.reasoning).toEqual({
+			effort: "high",
+			summary: null,
+			context: "ctx",
+		});
+	});
+
+	it("falls back to legacy log.responsesApiData rows on a storage miss", async () => {
+		dbSelectLimit.mockResolvedValueOnce([
+			{
+				responsesApiData: {
+					input: [userMessage],
+					output: [outputMessage],
+					instructions: "legacy",
+					model: "openai/gpt-4o",
+					status: "completed",
+				},
+			},
+		]);
+
+		const stored = await getStoredResponse("resp_legacy", "project_1");
+		expect(stored).not.toBeNull();
+		expect(stored!.input).toEqual([userMessage]);
+		expect(stored!.output).toEqual([outputMessage]);
+		expect(stored!.instructions).toBe("legacy");
+	});
+
+	it("returns null when neither storage nor the legacy fallback has the response", async () => {
+		expect(await getStoredResponse("resp_missing", "project_1")).toBeNull();
+	});
+});
+
+describe("resolveStoredItem", () => {
+	it("resolves items directly from the item store", async () => {
+		await storeResponse(
+			"resp_1",
+			{
+				id: "resp_1",
+				input: [],
+				output: [outputMessage],
+				model: "openai/gpt-5.5",
+				status: "completed",
+			},
+			"project_1",
+		);
+
+		expect(await resolveStoredItem("msg_1", "project_1")).toEqual(
+			outputMessage,
+		);
+		expect(await resolveStoredItem("msg_1", "project_2")).toBeNull();
+	});
+});
+
+describe("getResponsesStorage", () => {
+	it("returns the Redis driver by default and throws on unknown drivers", () => {
+		setResponsesStorageForTesting(undefined);
+		expect(getResponsesStorage()).toBeDefined();
+
+		vi.stubEnv("RESPONSES_STORAGE_DRIVER", "gcs");
+		try {
+			expect(() => getResponsesStorage()).toThrow(
+				"Unknown RESPONSES_STORAGE_DRIVER: gcs",
+			);
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+});
+
+describe("RESPONSES_TTL_SECONDS", () => {
+	it("is 30 days", () => {
+		expect(RESPONSES_TTL_SECONDS).toBe(30 * 24 * 60 * 60);
+	});
+});

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -43,8 +43,17 @@ vi.mock("@llmgateway/db", async (importOriginal) => {
 const redisGet = vi.fn();
 vi.mock("@llmgateway/cache", () => ({
 	redisClient: {
+		get: vi.fn(),
+		set: vi.fn().mockResolvedValue("OK"),
+	},
+	storageRedisClient: {
 		get: (...args: unknown[]) => redisGet(...args),
 		set: vi.fn().mockResolvedValue("OK"),
+		mget: vi.fn().mockResolvedValue([]),
+		pipeline: vi.fn(() => ({
+			set: vi.fn(),
+			exec: vi.fn().mockResolvedValue([]),
+		})),
 	},
 }));
 

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -194,33 +194,11 @@ responses.post("/", async (c) => {
 		);
 	}
 
-	const { project, organization } = authResult;
+	const { project } = authResult;
 
 	const shouldStore = req.store !== false;
 	const includeEncryptedReasoning =
 		req.include?.includes("reasoning.encrypted_content") ?? false;
-
-	// Require retention to use the stateful Responses API features. Stateless
-	// requests (store:false without previous_response_id) persist nothing, so
-	// they work without retention — pair them with
-	// include:["reasoning.encrypted_content"] to preserve reasoning across
-	// calls without stored responses.
-	if (
-		organization.retentionLevel !== "retain" &&
-		(shouldStore || req.previous_response_id)
-	) {
-		return c.json(
-			{
-				error: {
-					message:
-						"The Responses API requires data retention to be enabled for stored responses. Enable 'Retain All Data' in your organization's policies, send store:false (optionally with include:[\"reasoning.encrypted_content\"]) for stateless use, or use /v1/chat/completions instead.",
-					type: "invalid_request_error",
-					code: "data_retention_required",
-				},
-			},
-			400,
-		);
-	}
 
 	const projectId = project.id;
 
@@ -375,15 +353,6 @@ responses.post("/", async (c) => {
 	const logId = `resp_${shortid(24)}`;
 	const state = createStreamingState(req.model, logId, req);
 
-	// Build Responses API data for storage in the log entry.
-	// Output starts empty and is updated after completion via storeResponse().
-	const responsesApiData = {
-		input: inputItems,
-		output: [] as unknown[],
-		instructions: req.instructions,
-		model: req.model,
-	};
-
 	// Make internal request to the existing chat completions endpoint
 	const internalHeaders: Record<string, string> = {
 		"Content-Type": "application/json",
@@ -397,17 +366,13 @@ responses.post("/", async (c) => {
 		...internalApiOriginHeaders("responses"),
 	};
 
-	// Pass Responses API context via in-memory Map (not headers) to avoid
-	// exposing internal control fields to external callers and header size limits.
+	// Pass Responses API context via in-memory Map (not headers) so the chat
+	// handler logs this request under the resp_ id the client sees. Response
+	// state itself is persisted to the dedicated responses storage via
+	// storeResponse(), not the log entry.
 	const contextKey = logId;
-	if (shouldStore) {
-		setResponsesContext(contextKey, {
-			logId,
-			syncInsert: true,
-			responsesApiData,
-		});
-		internalHeaders["x-responses-context-key"] = contextKey;
-	}
+	setResponsesContext(contextKey, { logId });
+	internalHeaders["x-responses-context-key"] = contextKey;
 
 	let response: Response;
 	try {
@@ -715,21 +680,7 @@ responses.post("/compact", async (c) => {
 		);
 	}
 
-	const { project, organization } = authResult;
-
-	if (organization.retentionLevel !== "retain") {
-		return c.json(
-			{
-				error: {
-					message:
-						"The Responses API requires data retention to be enabled. Enable 'Retain All Data' in your organization's policies, or use /v1/chat/completions instead.",
-					type: "invalid_request_error",
-					code: "data_retention_required",
-				},
-			},
-			400,
-		);
-	}
+	const { project } = authResult;
 
 	let inputItems: unknown[] = [];
 	if (typeof req.input === "string") {
@@ -824,16 +775,7 @@ responses.post("/compact", async (c) => {
 	};
 
 	const contextKey = compactionId;
-	setResponsesContext(contextKey, {
-		logId: compactionId,
-		syncInsert: true,
-		responsesApiData: {
-			input: inputItems,
-			output: [] as unknown[],
-			instructions: req.instructions,
-			model: req.model,
-		},
-	});
+	setResponsesContext(contextKey, { logId: compactionId });
 	internalHeaders["x-responses-context-key"] = contextKey;
 
 	let response: Response;

--- a/apps/gateway/src/responses/tools/response-state.ts
+++ b/apps/gateway/src/responses/tools/response-state.ts
@@ -262,8 +262,10 @@ export async function getStoredResponse(
 			const resolveRefs = (refList: string[]) =>
 				refList.flatMap((ref) => {
 					if (!itemsByRef.has(ref)) {
-						// Should not happen: items are written with (and re-refreshed
-						// alongside) every record that references them.
+						// Items are written with (and re-refreshed alongside) every
+						// record that references them, but the storage backend may
+						// evict least-recently-used keys under memory pressure —
+						// degrade by dropping the missing item rather than failing.
 						logger.warn("Stored response item missing from storage", {
 							responseId,
 							projectId,

--- a/apps/gateway/src/responses/tools/response-state.ts
+++ b/apps/gateway/src/responses/tools/response-state.ts
@@ -1,6 +1,9 @@
-import { redisClient } from "@llmgateway/cache";
+import crypto from "crypto";
+
 import { and, db, desc, eq, gte, log, sql } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
+
+import { getResponsesStorage } from "./response-storage.js";
 
 export interface StoredResponseData {
 	id: string;
@@ -19,85 +22,95 @@ export interface StoredResponseData {
 	created_at?: number;
 }
 
-// TTL for the per-item index used to resolve `item_reference` input items.
-// The Responses API requires full data retention, so a generous window is safe;
-// in practice references are resolved on the immediately following turn.
-const ITEM_INDEX_TTL_SECONDS = 30 * 24 * 60 * 60;
+// Stored responses (and the items they reference) are kept for 30 days,
+// matching OpenAI's own Responses API retention, independent of the
+// organization's data-retention policy.
+export const RESPONSES_TTL_SECONDS = 30 * 24 * 60 * 60;
 
-// Only the DB fallback for item resolution scans rows within this recent window
-// to keep the (un-indexed) JSONB containment query bounded.
-const ITEM_FALLBACK_LOOKBACK_MS = ITEM_INDEX_TTL_SECONDS * 1000;
+// Only the DB fallback (legacy responses stored in log.responsesApiData before
+// the move to dedicated storage) scans rows within this recent window to keep
+// the (un-indexed) JSONB containment query bounded.
+const ITEM_FALLBACK_LOOKBACK_MS = RESPONSES_TTL_SECONDS * 1000;
 
-function itemIndexKey(projectId: string, itemId: string): string {
-	return `responses:item:${projectId}:${itemId}`;
+/**
+ * A stored response is a small record of metadata plus ordered lists of item
+ * refs; each referenced item is stored once under its own key. Chained turns
+ * re-write the same item keys (idempotent, refreshes the TTL) instead of
+ * duplicating the conversation, so storage grows with unique items rather
+ * than O(N²) across an N-turn conversation.
+ */
+interface StoredResponseRecord {
+	model: string;
+	instructions?: string;
+	status: "completed" | "incomplete" | "failed";
+	incomplete_details?: { reason: string } | null;
+	reasoning?: {
+		effort: string | null;
+		summary: string | null;
+		context?: string;
+	} | null;
+	usage?: Record<string, unknown>;
+	created_at?: number;
+	inputRefs: string[];
+	outputRefs: string[];
+}
+
+function itemStorageKey(projectId: string, itemRef: string): string {
+	return `responses:item:${projectId}:${itemRef}`;
+}
+
+function responseStorageKey(projectId: string, responseId: string): string {
+	return `responses:resp:${projectId}:${responseId}`;
 }
 
 /**
- * Index individual response items (by their `id`) so they can later be resolved
- * from an `item_reference` input item. Stateful clients reference prior items
- * (e.g. a `function_call` the gateway emitted) by id instead of re-sending them.
+ * Ref an item by its own id when it has one (gateway-emitted output items and
+ * client items with ids), otherwise by a content hash so identical id-less
+ * items resent across turns dedup to the same key. item_reference pointers are
+ * never keyed by id — that would overwrite the concrete item they point at.
  */
-async function indexResponseItems(
-	projectId: string,
-	items: unknown[],
-): Promise<void> {
-	const writes: Promise<unknown>[] = [];
-	for (const item of items) {
-		if (!item || typeof item !== "object") {
-			continue;
-		}
+function itemRefFor(item: unknown): string {
+	if (item && typeof item === "object") {
 		const id = (item as { id?: unknown }).id;
 		const type = (item as { type?: unknown }).type;
-		// item_reference items are pointers, not concrete items — never index them.
-		if (typeof id !== "string" || typeof type !== "string") {
-			continue;
+		if (typeof id === "string" && id && type !== "item_reference") {
+			return id;
 		}
-		if (type === "item_reference") {
-			continue;
-		}
-		writes.push(
-			redisClient.set(
-				itemIndexKey(projectId, id),
-				JSON.stringify(item),
-				"EX",
-				ITEM_INDEX_TTL_SECONDS,
-			),
-		);
 	}
-	if (writes.length === 0) {
-		return;
-	}
-	try {
-		await Promise.all(writes);
-	} catch (error) {
-		logger.warn("Failed to index response items for item_reference", {
-			projectId,
-			error,
-		});
-	}
+	return `h_${crypto
+		.createHash("sha256")
+		.update(JSON.stringify(item))
+		.digest("hex")
+		.slice(0, 32)}`;
 }
 
 /**
  * Resolve an `item_reference` id to the concrete stored item it points at.
- * Tries the fast Redis index first, then falls back to a project-scoped lookup
- * over recently stored responses. Returns null when the item cannot be found.
+ * Tries the item store first, then falls back to a project-scoped lookup over
+ * legacy responses stored in log.responsesApiData. Returns null when the item
+ * cannot be found.
  */
 export async function resolveStoredItem(
 	itemId: string,
 	projectId: string,
 ): Promise<Record<string, unknown> | null> {
 	try {
-		const cached = await redisClient.get(itemIndexKey(projectId, itemId));
-		if (cached) {
-			return JSON.parse(cached) as Record<string, unknown>;
+		const stored = await getResponsesStorage().get(
+			itemStorageKey(projectId, itemId),
+		);
+		if (stored) {
+			return JSON.parse(stored) as Record<string, unknown>;
 		}
 	} catch (error) {
-		logger.warn("Failed to read item index from Redis", { itemId, error });
+		logger.warn("Failed to read item from responses storage", {
+			itemId,
+			error,
+		});
 	}
 
-	// Fallback: scan recently stored responses for an output/input item with this
-	// id. Bounded by project and a recent time window to keep the un-indexed
-	// JSONB containment query cheap.
+	// Fallback: scan recently stored legacy responses for an output/input item
+	// with this id. Bounded by project and a recent time window to keep the
+	// un-indexed JSONB containment query cheap.
 	try {
 		const cutoff = new Date(Date.now() - ITEM_FALLBACK_LOOKBACK_MS);
 		const match = sql`(${log.responsesApiData} -> 'output' @> ${JSON.stringify([{ id: itemId }])}::jsonb OR ${log.responsesApiData} -> 'input' @> ${JSON.stringify([{ id: itemId }])}::jsonb)`;
@@ -173,51 +186,122 @@ export async function resolveItemReferences(
 }
 
 /**
- * Update the log entry's responsesApiData with the complete response data (including output).
- * The log entry was inserted synchronously with partial data (output: []).
- * This update fills in the full output for conversation chaining via previous_response_id.
+ * Store a completed response for previous_response_id chaining and retrieval
+ * via GET /v1/responses/:id. Items are written before the record so a readable
+ * record always has its items, and re-writing shared items on chained turns
+ * refreshes their TTL alongside the new record.
  */
 export async function storeResponse(
-	logId: string,
+	responseId: string,
 	data: StoredResponseData,
-	projectId?: string,
+	projectId: string,
 ): Promise<void> {
-	try {
-		await db
-			.update(log)
-			.set({ responsesApiData: data })
-			.where(eq(log.id, logId));
-	} catch (error) {
-		logger.warn("Failed to update log with responsesApiData", {
-			logId,
-			error,
+	const entriesByKey = new Map<string, string>();
+	const refsFor = (items: unknown[]) =>
+		items.map((item) => {
+			const ref = itemRefFor(item);
+			entriesByKey.set(itemStorageKey(projectId, ref), JSON.stringify(item));
+			return ref;
 		});
-	}
+	const inputRefs = refsFor(data.input ?? []);
+	const outputRefs = refsFor(data.output ?? []);
 
-	// Index items so future item_reference inputs can resolve them. Index both
-	// input and output: input may carry items resolved on earlier turns, keeping
-	// long-running references fresh.
-	if (projectId) {
-		await indexResponseItems(projectId, [
-			...(data.output ?? []),
-			...(data.input ?? []),
-		]);
+	const record: StoredResponseRecord = {
+		model: data.model,
+		instructions: data.instructions,
+		status: data.status,
+		incomplete_details: data.incomplete_details ?? null,
+		reasoning: data.reasoning ?? null,
+		usage: data.usage,
+		created_at: data.created_at,
+		inputRefs,
+		outputRefs,
+	};
+
+	try {
+		const storage = getResponsesStorage();
+		await storage.setMany(
+			[...entriesByKey].map(([key, value]) => ({ key, value })),
+			RESPONSES_TTL_SECONDS,
+		);
+		await storage.set(
+			responseStorageKey(projectId, responseId),
+			JSON.stringify(record),
+			RESPONSES_TTL_SECONDS,
+		);
+	} catch (error) {
+		logger.warn("Failed to store response", { responseId, projectId, error });
 	}
 }
 
 /**
- * Retrieve stored response data by log entry ID (primary key lookup).
- * Uses projectId for security scoping.
+ * Retrieve stored response data by response ID, scoped to the project. Reads
+ * the dedicated storage first and falls back to legacy responses persisted in
+ * log.responsesApiData before the storage move.
  */
 export async function getStoredResponse(
-	logId: string,
+	responseId: string,
 	projectId: string,
 ): Promise<StoredResponseData | null> {
+	try {
+		const storage = getResponsesStorage();
+		const raw = await storage.get(responseStorageKey(projectId, responseId));
+		if (raw) {
+			const record = JSON.parse(raw) as StoredResponseRecord;
+			const refs = [...new Set([...record.inputRefs, ...record.outputRefs])];
+			const values = await storage.getMany(
+				refs.map((ref) => itemStorageKey(projectId, ref)),
+			);
+			const itemsByRef = new Map<string, unknown>();
+			refs.forEach((ref, i) => {
+				const value = values[i];
+				if (value !== null && value !== undefined) {
+					itemsByRef.set(ref, JSON.parse(value));
+				}
+			});
+			const resolveRefs = (refList: string[]) =>
+				refList.flatMap((ref) => {
+					if (!itemsByRef.has(ref)) {
+						// Should not happen: items are written with (and re-refreshed
+						// alongside) every record that references them.
+						logger.warn("Stored response item missing from storage", {
+							responseId,
+							projectId,
+							ref,
+						});
+						return [];
+					}
+					return [itemsByRef.get(ref)];
+				});
+
+			return {
+				id: responseId,
+				input: resolveRefs(record.inputRefs),
+				output: resolveRefs(record.outputRefs),
+				instructions: record.instructions,
+				model: record.model ?? "",
+				status: record.status ?? "completed",
+				incomplete_details: record.incomplete_details ?? null,
+				reasoning: record.reasoning ?? null,
+				usage: record.usage,
+				created_at: record.created_at,
+			};
+		}
+	} catch (error) {
+		logger.warn("Failed to read response from responses storage", {
+			responseId,
+			projectId,
+			error,
+		});
+	}
+
+	// Legacy fallback: responses stored in log.responsesApiData before the move
+	// to dedicated storage.
 	try {
 		const rows = await db
 			.select({ responsesApiData: log.responsesApiData })
 			.from(log)
-			.where(and(eq(log.id, logId), eq(log.projectId, projectId)))
+			.where(and(eq(log.id, responseId), eq(log.projectId, projectId)))
 			.limit(1);
 
 		const row = rows[0];
@@ -242,7 +326,7 @@ export async function getStoredResponse(
 		};
 
 		return {
-			id: logId,
+			id: responseId,
 			input: data.input,
 			output: data.output,
 			instructions: data.instructions,

--- a/apps/gateway/src/responses/tools/response-storage.ts
+++ b/apps/gateway/src/responses/tools/response-storage.ts
@@ -1,0 +1,78 @@
+import { storageRedisClient } from "@llmgateway/cache";
+
+/**
+ * Backend-neutral storage for Responses API state. Keys are flat strings,
+ * values are opaque JSON strings, and every write carries a TTL, so the
+ * interface can be implemented by Redis today and an object store (GCS/S3
+ * with a bucket lifecycle rule for the TTL) later without touching the
+ * response-state domain logic built on top.
+ */
+export interface ResponsesStorage {
+	set: (key: string, value: string, ttlSeconds: number) => Promise<void>;
+	setMany: (
+		entries: { key: string; value: string }[],
+		ttlSeconds: number,
+	) => Promise<void>;
+	get: (key: string) => Promise<string | null>;
+	getMany: (keys: string[]) => Promise<(string | null)[]>;
+}
+
+class RedisResponsesStorage implements ResponsesStorage {
+	public async set(
+		key: string,
+		value: string,
+		ttlSeconds: number,
+	): Promise<void> {
+		await storageRedisClient.set(key, value, "EX", ttlSeconds);
+	}
+
+	public async setMany(
+		entries: { key: string; value: string }[],
+		ttlSeconds: number,
+	): Promise<void> {
+		if (entries.length === 0) {
+			return;
+		}
+		const pipeline = storageRedisClient.pipeline();
+		for (const entry of entries) {
+			pipeline.set(entry.key, entry.value, "EX", ttlSeconds);
+		}
+		await pipeline.exec();
+	}
+
+	public async get(key: string): Promise<string | null> {
+		return await storageRedisClient.get(key);
+	}
+
+	public async getMany(keys: string[]): Promise<(string | null)[]> {
+		if (keys.length === 0) {
+			return [];
+		}
+		return await storageRedisClient.mget(...keys);
+	}
+}
+
+let redisStorage: RedisResponsesStorage | undefined;
+let storageOverride: ResponsesStorage | undefined;
+
+export function setResponsesStorageForTesting(
+	storage: ResponsesStorage | undefined,
+): void {
+	storageOverride = storage;
+}
+
+export function getResponsesStorage(): ResponsesStorage {
+	if (storageOverride) {
+		return storageOverride;
+	}
+	const driver = process.env.RESPONSES_STORAGE_DRIVER ?? "redis";
+	if (driver === "redis") {
+		redisStorage ??= new RedisResponsesStorage();
+		return redisStorage;
+	}
+	throw new Error(`Unknown RESPONSES_STORAGE_DRIVER: ${driver}`);
+}
+
+// Fail fast on a misconfigured driver at import time (gateway startup)
+// instead of on the first stateful Responses API request.
+getResponsesStorage();

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 
-import { redisClient } from "@llmgateway/cache";
+import { redisClient, storageRedisClient } from "@llmgateway/cache";
 import { closeDatabase, setQueryTags } from "@llmgateway/db";
 import {
 	initializeInstrumentation,
@@ -193,9 +193,9 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 		await closeDatabase();
 		logger.info("Database connection closed");
 
-		logger.info("Closing Redis connection");
-		await redisClient.quit();
-		logger.info("Redis connection closed");
+		logger.info("Closing Redis connections");
+		await Promise.all([redisClient.quit(), storageRedisClient.quit()]);
+		logger.info("Redis connections closed");
 
 		// Shutdown instrumentation last to ensure all spans are flushed
 		if (sdk) {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import {
 	closeRedisClient,
+	closeStorageRedisClient,
 	consumeFromQueue,
 	LOG_QUEUE,
 	publishToQueue,
@@ -2779,7 +2780,11 @@ export async function stopWorker(): Promise<boolean> {
 
 	// Close database and Redis connections
 	try {
-		await Promise.all([closeDatabase(), closeRedisClient()]);
+		await Promise.all([
+			closeDatabase(),
+			closeRedisClient(),
+			closeStorageRedisClient(),
+		]);
 		logger.info("All connections closed successfully");
 	} catch (error) {
 		logger.error(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,29 @@ services:
       - "6379:6379"
     environment:
       CI: ${CI}
+
+  # Storage Redis: Responses API state (30d retention) + gateway response
+  # cache. AOF persistence because it holds a source of truth, not just cache.
+  redis-storage:
+    container_name: redis-storage
+    image: redis:8
+    command:
+      [
+        "redis-server",
+        "--protected-mode",
+        "no",
+        "--bind",
+        "0.0.0.0",
+        "--appendonly",
+        "yes",
+      ]
+    restart: always
+    ports:
+      - "6380:6379"
+    environment:
+      CI: ${CI}
+    volumes:
+      - redis_storage_data:/data
+
+volumes:
+  redis_storage_data:

--- a/infra/bunnyshell.yaml
+++ b/infra/bunnyshell.yaml
@@ -153,6 +153,9 @@ components:
         REDIS_HOST: redis
         REDIS_PASSWORD: redis_dev_password
         REDIS_PORT: "6379"
+        STORAGE_REDIS_HOST: redis-storage
+        STORAGE_REDIS_PASSWORD: redis_dev_password
+        STORAGE_REDIS_PORT: "6379"
         TOGETHER_AI_API_KEY: ""
         VERTEX_API_KEY: ""
       healthcheck:
@@ -250,6 +253,45 @@ components:
       - name: redis-data
         mount: /data
         subPath: ""
+  - kind: Service
+    name: redis-storage
+    dockerCompose:
+      command:
+        - redis-server
+        - "--appendonly"
+        - "yes"
+        - "--requirepass"
+        - redis_dev_password
+      healthcheck:
+        test:
+          - CMD
+          - redis-cli
+          - "--raw"
+          - incr
+          - ping
+        timeout: 3s
+        interval: 10s
+        retries: 5
+      deploy:
+        resources:
+          limits:
+            cpus: "0.1"
+            memory: 128M
+          reservations:
+            cpus: "0.1"
+            memory: 128M
+      image: "redis:8-alpine"
+      ports:
+        - "6380:6379"
+      restart: unless-stopped
+    hosts:
+      - hostname: "redis-storage-{{ env.base_domain }}"
+        path: /
+        servicePort: 6379
+    volumes:
+      - name: redis-storage-data
+        mount: /data
+        subPath: ""
   - kind: Application
     name: ui
     gitRepo: "https://github.com/theopenco/llmgateway.git"
@@ -337,5 +379,8 @@ volumes:
     size: 1Gi
     type: disk
   - name: redis-data
+    size: 1Gi
+    type: disk
+  - name: redis-storage-data
     size: 1Gi
     type: disk

--- a/infra/docker-compose.split.local.yml
+++ b/infra/docker-compose.split.local.yml
@@ -16,6 +16,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      redis-storage:
+        condition: service_healthy
     healthcheck:
       test:
         [
@@ -38,6 +40,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
+      - STORAGE_REDIS_HOST=redis-storage
+      - STORAGE_REDIS_PORT=6379
+      - STORAGE_REDIS_PASSWORD=${STORAGE_REDIS_PASSWORD:-redis_dev_password}
       - GATEWAY_API_KEY_HASH_SECRET=${GATEWAY_API_KEY_HASH_SECRET}
       # LLM Provider API Keys
       - LLM_OPENAI_API_KEY=${LLM_OPENAI_API_KEY}
@@ -82,6 +87,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
+      - STORAGE_REDIS_HOST=redis-storage
+      - STORAGE_REDIS_PORT=6379
+      - STORAGE_REDIS_PASSWORD=${STORAGE_REDIS_PASSWORD:-redis_dev_password}
       - UI_URL=${UI_URL:-http://localhost:3002}
       - API_URL=${API_URL:-http://localhost:4002}
       - ORIGIN_URLS=${ORIGIN_URLS:-http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3006,http://localhost:4002}
@@ -318,10 +326,40 @@ services:
     networks:
       - llmgateway-network
 
+  # Storage Redis: Responses API state (30d retention) + gateway response cache
+  redis-storage:
+    image: redis:8-alpine
+    platform: linux/amd64
+    container_name: llmgateway-redis-storage
+    restart: unless-stopped
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--requirepass",
+        "${STORAGE_REDIS_PASSWORD:-redis_dev_password}",
+      ]
+    volumes:
+      - redis_storage_data:/data
+    ports:
+      - "${STORAGE_REDIS_PORT:-6380}:6379"
+    environment:
+      CI: ${CI}
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    networks:
+      - llmgateway-network
+
 volumes:
   postgres_data:
     driver: local
   redis_data:
+    driver: local
+  redis_storage_data:
     driver: local
 
 networks:

--- a/infra/docker-compose.split.yml
+++ b/infra/docker-compose.split.yml
@@ -13,6 +13,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      redis-storage:
+        condition: service_healthy
     healthcheck:
       test:
         [
@@ -35,6 +37,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-redis_dev_password}
+      - STORAGE_REDIS_HOST=redis-storage
+      - STORAGE_REDIS_PORT=6379
+      - STORAGE_REDIS_PASSWORD=${STORAGE_REDIS_PASSWORD:-redis_dev_password}
       - GATEWAY_API_KEY_HASH_SECRET=${GATEWAY_API_KEY_HASH_SECRET}
       # LLM Provider API Keys
       - LLM_OPENAI_API_KEY=${LLM_OPENAI_API_KEY}
@@ -292,10 +297,40 @@ services:
     networks:
       - llmgateway-network
 
+  # Storage Redis: Responses API state (30d retention) + gateway response cache
+  redis-storage:
+    image: redis:8-alpine
+    platform: linux/amd64
+    container_name: llmgateway-redis-storage
+    restart: unless-stopped
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--requirepass",
+        "${STORAGE_REDIS_PASSWORD:-redis_dev_password}",
+      ]
+    volumes:
+      - redis_storage_data:/data
+    ports:
+      - "${STORAGE_REDIS_PORT:-6380}:6379"
+    environment:
+      CI: ${CI}
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    networks:
+      - llmgateway-network
+
 volumes:
   postgres_data:
     driver: local
   redis_data:
+    driver: local
+  redis_storage_data:
     driver: local
 
 networks:

--- a/infra/helm/llmgateway/templates/_helpers.tpl
+++ b/infra/helm/llmgateway/templates/_helpers.tpl
@@ -177,6 +177,28 @@ Redis port
 {{- end }}
 
 {{/*
+Storage Redis host
+*/}}
+{{- define "llmgateway.storageRedis.host" -}}
+{{- if .Values.storageRedis.enabled }}
+{{- printf "%s-redis-storage" (include "llmgateway.fullname" .) }}
+{{- else }}
+{{- .Values.externalStorageRedis.host }}
+{{- end }}
+{{- end }}
+
+{{/*
+Storage Redis port
+*/}}
+{{- define "llmgateway.storageRedis.port" -}}
+{{- if .Values.storageRedis.enabled }}
+{{- .Values.storageRedis.port | default 6379 }}
+{{- else }}
+{{- .Values.externalStorageRedis.port | default 6379 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Internal service URL helper.
 Usage: {{ include "llmgateway.serviceUrl" (dict "context" . "name" "api") }}
 */}}

--- a/infra/helm/llmgateway/templates/api-deployment.yaml
+++ b/infra/helm/llmgateway/templates/api-deployment.yaml
@@ -40,6 +40,18 @@ spec:
                 echo "Waiting for Redis..."
                 sleep 2
               done
+        {{- if or .Values.storageRedis.enabled .Values.externalStorageRedis.host }}
+        - name: wait-for-storage-redis
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "llmgateway.storageRedis.host" . }} {{ include "llmgateway.storageRedis.port" . }}; do
+                echo "Waiting for Storage Redis..."
+                sleep 2
+              done
+        {{- end }}
       containers:
         - name: api
           image: {{ include "llmgateway.image" (dict "context" . "image" .Values.api.image) }}

--- a/infra/helm/llmgateway/templates/configmap.yaml
+++ b/infra/helm/llmgateway/templates/configmap.yaml
@@ -12,6 +12,10 @@ data:
   API_BACKEND_URL: {{ include "llmgateway.serviceUrl" (dict "context" . "name" "api") | quote }}
   REDIS_HOST: {{ include "llmgateway.redis.host" . | quote }}
   REDIS_PORT: {{ include "llmgateway.redis.port" . | quote }}
+  {{- if or .Values.storageRedis.enabled .Values.externalStorageRedis.host }}
+  STORAGE_REDIS_HOST: {{ include "llmgateway.storageRedis.host" . | quote }}
+  STORAGE_REDIS_PORT: {{ include "llmgateway.storageRedis.port" . | quote }}
+  {{- end }}
 
   # Public-facing URLs
   {{- if .Values.urls.ui }}

--- a/infra/helm/llmgateway/templates/gateway-deployment.yaml
+++ b/infra/helm/llmgateway/templates/gateway-deployment.yaml
@@ -43,6 +43,18 @@ spec:
                 echo "Waiting for Redis..."
                 sleep 2
               done
+        {{- if or .Values.storageRedis.enabled .Values.externalStorageRedis.host }}
+        - name: wait-for-storage-redis
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "llmgateway.storageRedis.host" . }} {{ include "llmgateway.storageRedis.port" . }}; do
+                echo "Waiting for Storage Redis..."
+                sleep 2
+              done
+        {{- end }}
       containers:
         - name: gateway
           image: {{ include "llmgateway.image" (dict "context" . "image" .Values.gateway.image) }}

--- a/infra/helm/llmgateway/templates/secret.yaml
+++ b/infra/helm/llmgateway/templates/secret.yaml
@@ -28,6 +28,15 @@ stringData:
   REDIS_PASSWORD: {{ .Values.externalRedis.password | quote }}
   {{- end }}
 
+  # Storage Redis
+  {{- if .Values.storageRedis.enabled }}
+  {{- if .Values.storageRedis.password }}
+  STORAGE_REDIS_PASSWORD: {{ .Values.storageRedis.password | quote }}
+  {{- end }}
+  {{- else if .Values.externalStorageRedis.password }}
+  STORAGE_REDIS_PASSWORD: {{ .Values.externalStorageRedis.password | quote }}
+  {{- end }}
+
   # Auth
   AUTH_SECRET: {{ .Values.auth.authSecret | quote }}
   GATEWAY_API_KEY_HASH_SECRET: {{ .Values.auth.gatewayApiKeyHashSecret | quote }}

--- a/infra/helm/llmgateway/templates/storage-redis-service.yaml
+++ b/infra/helm/llmgateway/templates/storage-redis-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.storageRedis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "llmgateway.fullname" . }}-redis-storage
+  labels:
+    {{- include "llmgateway.componentLabels" (dict "context" . "component" "redis-storage") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "llmgateway.componentSelectorLabels" (dict "context" . "component" "redis-storage") | nindent 4 }}
+{{- end }}

--- a/infra/helm/llmgateway/templates/storage-redis-statefulset.yaml
+++ b/infra/helm/llmgateway/templates/storage-redis-statefulset.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.storageRedis.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "llmgateway.fullname" . }}-redis-storage
+  labels:
+    {{- include "llmgateway.componentLabels" (dict "context" . "component" "redis-storage") | nindent 4 }}
+spec:
+  serviceName: {{ include "llmgateway.fullname" . }}-redis-storage
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "llmgateway.componentSelectorLabels" (dict "context" . "component" "redis-storage") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "llmgateway.componentSelectorLabels" (dict "context" . "component" "redis-storage") | nindent 8 }}
+    spec:
+      {{- include "llmgateway.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: redis-storage
+          image: {{ .Values.storageRedis.image.repository }}:{{ .Values.storageRedis.image.tag }}
+          imagePullPolicy: {{ .Values.storageRedis.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          # AOF persistence: this instance holds Responses API state (30-day
+          # retention), not just cache, so it must survive restarts.
+          command:
+            - redis-server
+            - --appendonly
+            - "yes"
+            {{- if .Values.storageRedis.password }}
+            - --requirepass
+            - $(STORAGE_REDIS_PASSWORD)
+            {{- end }}
+          {{- if .Values.storageRedis.password }}
+          env:
+            - name: STORAGE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "llmgateway.secretName" . }}
+                  key: STORAGE_REDIS_PASSWORD
+          {{- end }}
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                {{- if .Values.storageRedis.password }}
+                - -a
+                - $(STORAGE_REDIS_PASSWORD)
+                {{- end }}
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                {{- if .Values.storageRedis.password }}
+                - -a
+                - $(STORAGE_REDIS_PASSWORD)
+                {{- end }}
+                - ping
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.storageRedis.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.storageRedis.persistence.storageClass }}
+        storageClassName: {{ .Values.storageRedis.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.storageRedis.persistence.size | default "10Gi" }}
+{{- end }}

--- a/infra/helm/llmgateway/templates/worker-deployment.yaml
+++ b/infra/helm/llmgateway/templates/worker-deployment.yaml
@@ -40,6 +40,18 @@ spec:
                 echo "Waiting for Redis..."
                 sleep 2
               done
+        {{- if or .Values.storageRedis.enabled .Values.externalStorageRedis.host }}
+        - name: wait-for-storage-redis
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "llmgateway.storageRedis.host" . }} {{ include "llmgateway.storageRedis.port" . }}; do
+                echo "Waiting for Storage Redis..."
+                sleep 2
+              done
+        {{- end }}
       containers:
         - name: worker
           image: {{ include "llmgateway.image" (dict "context" . "image" .Values.worker.image) }}

--- a/infra/helm/llmgateway/values.yaml
+++ b/infra/helm/llmgateway/values.yaml
@@ -381,6 +381,40 @@ externalRedis:
   password: ""
 
 # =============================================================================
+# Built-in Storage Redis
+# Dedicated instance for Responses API state (30-day retention) and gateway
+# response caching. Runs with AOF persistence since it holds a source of
+# truth, not just cache. Set enabled: false to use an external instance
+# (configure externalStorageRedis); with neither configured, the apps fall
+# back to the main Redis connection.
+# =============================================================================
+storageRedis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "8-alpine"
+    pullPolicy: IfNotPresent
+  # -- Redis password (leave empty for no authentication)
+  password: ""
+  port: 6379
+  persistence:
+    size: 10Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi
+
+# -- External storage Redis (used when storageRedis.enabled is false)
+externalStorageRedis:
+  host: ""
+  port: 6379
+  password: ""
+
+# =============================================================================
 # Ingress
 # =============================================================================
 ingress:

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 
 import { logger } from "@llmgateway/logger";
 
-import { redisClient } from "./redis.js";
+import { storageRedisClient } from "./storage-redis.js";
 
 export function generateCacheKey(payload: Record<string, any>): string {
 	return crypto
@@ -22,7 +22,12 @@ export async function setCache(
 	}
 
 	try {
-		await redisClient.set(key, JSON.stringify(value), "EX", expirationSeconds);
+		await storageRedisClient.set(
+			key,
+			JSON.stringify(value),
+			"EX",
+			expirationSeconds,
+		);
 	} catch (error) {
 		logger.error("Error setting cache:", error as Error);
 	}
@@ -30,7 +35,7 @@ export async function setCache(
 
 export async function getCache(key: string): Promise<any | null> {
 	try {
-		const cachedValue = await redisClient.get(key);
+		const cachedValue = await storageRedisClient.get(key);
 		if (!cachedValue) {
 			return null;
 		}
@@ -78,7 +83,12 @@ export async function setStreamingCache(
 	}
 
 	try {
-		await redisClient.set(key, JSON.stringify(data), "EX", expirationSeconds);
+		await storageRedisClient.set(
+			key,
+			JSON.stringify(data),
+			"EX",
+			expirationSeconds,
+		);
 	} catch (error) {
 		logger.error("Error setting streaming cache:", error as Error);
 	}
@@ -88,7 +98,7 @@ export async function getStreamingCache(
 	key: string,
 ): Promise<StreamingCacheData | null> {
 	try {
-		const cachedValue = await redisClient.get(key);
+		const cachedValue = await storageRedisClient.get(key);
 		if (!cachedValue) {
 			return null;
 		}

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./cache.js";
 export * from "./redis.js";
+export * from "./storage-redis.js";
 export * from "./swr.js";

--- a/packages/cache/src/storage-redis.ts
+++ b/packages/cache/src/storage-redis.ts
@@ -28,6 +28,11 @@ export const storageRedisClient = new Redis({
 		? process.env.STORAGE_REDIS_PASSWORD
 		: process.env.REDIS_PASSWORD,
 	enableAutoPipelining: true,
+	// Connect on first command. Many consumers of @llmgateway/cache (seed
+	// script, one-off scripts, the API) never touch storage functions; an
+	// eager connection would keep their event loop alive on exit unless every
+	// such path remembered to quit this client too.
+	lazyConnect: true,
 });
 
 storageRedisClient.on("error", (err) =>

--- a/packages/cache/src/storage-redis.ts
+++ b/packages/cache/src/storage-redis.ts
@@ -1,0 +1,45 @@
+import { Redis } from "ioredis";
+
+import { logger } from "@llmgateway/logger";
+
+// Dedicated "storage" Redis instance for bulk data: Responses API state
+// (30-day retention) and gateway response caching. Kept separate from the
+// main Redis, which is reserved for critical infrastructure (log queue,
+// rate limiting, preferred-provider state, video jobs).
+//
+// The fallback to the main Redis settings is all-or-nothing: with no
+// STORAGE_REDIS_* var set, single-instance deployments keep working with
+// zero extra configuration; once any STORAGE_REDIS_* var is set, the
+// remaining fields are NOT inherited from REDIS_* (a dedicated passwordless
+// instance must not inherit the main instance's password).
+const hasStorageRedisConfig =
+	process.env.STORAGE_REDIS_HOST !== undefined ||
+	process.env.STORAGE_REDIS_PORT !== undefined ||
+	process.env.STORAGE_REDIS_PASSWORD !== undefined;
+
+export const storageRedisClient = new Redis({
+	host: hasStorageRedisConfig
+		? (process.env.STORAGE_REDIS_HOST ?? "localhost")
+		: (process.env.REDIS_HOST ?? "localhost"),
+	port: hasStorageRedisConfig
+		? Number(process.env.STORAGE_REDIS_PORT) || 6379
+		: Number(process.env.REDIS_PORT) || 6379,
+	password: hasStorageRedisConfig
+		? process.env.STORAGE_REDIS_PASSWORD
+		: process.env.REDIS_PASSWORD,
+	enableAutoPipelining: true,
+});
+
+storageRedisClient.on("error", (err) =>
+	logger.error("Storage Redis Client Error", err),
+);
+
+export async function closeStorageRedisClient(): Promise<void> {
+	try {
+		await storageRedisClient.disconnect();
+		logger.info("Storage Redis client disconnected");
+	} catch (error) {
+		logger.error("Error disconnecting storage Redis client", error);
+		throw error;
+	}
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1369,6 +1369,40 @@ async function seed() {
 		createdBy: "test-user-id",
 	});
 
+	// Sibling org for the test admin with data retention disabled, so
+	// retention-off behavior (e.g. the Responses API without stored log
+	// payloads) can be exercised locally while the default Test Organization
+	// stays on "retain" for easier debugging.
+	await upsert(tables.organization, {
+		id: "test-no-retention-org-id",
+		name: "Test No Retention Organization",
+		billingEmail: "admin@example.com",
+		credits: 5,
+		retentionLevel: "none",
+	});
+
+	await upsert(tables.userOrganization, {
+		id: "test-no-retention-user-org-id",
+		userId: "test-user-id",
+		organizationId: "test-no-retention-org-id",
+		role: "owner",
+	});
+
+	await upsert(tables.project, {
+		id: "test-no-retention-project-id",
+		name: "Test No Retention Project",
+		organizationId: "test-no-retention-org-id",
+		mode: "hybrid",
+	});
+
+	await upsert(tables.apiKey, {
+		id: "test-no-retention-api-key-id",
+		token: "test-token-no-retention",
+		projectId: "test-no-retention-project-id",
+		description: "Test API Key (no data retention)",
+		createdBy: "test-user-id",
+	});
+
 	// Embeddable Payments SDK POC: a project with the SDK enabled and a 50%
 	// end-user top-up bonus, plus a live platform secret key, so the end-user
 	// wallet + bonus flow can be exercised end-to-end locally (mint a session with

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -5,7 +5,7 @@ import {
 	scrypt,
 } from "crypto";
 
-import { redisClient } from "@llmgateway/cache";
+import { redisClient, storageRedisClient } from "@llmgateway/cache";
 import {
 	models as allModels,
 	providers as allProviders,
@@ -2568,7 +2568,7 @@ async function seed() {
 	});
 
 	await closeDatabase();
-	await redisClient.quit();
+	await Promise.all([redisClient.quit(), storageRedisClient.quit()]);
 }
 
 void seed();


### PR DESCRIPTION
## Summary

Moves Responses API state (`previous_response_id` chaining, `GET /v1/responses/:id`, `/compact`) out of the `log` table's `responsesApiData` JSONB column into a **dedicated storage Redis** with a **30-day TTL** (matching OpenAI's own response retention), and **removes the data-retention requirement** for the Responses API entirely.

Builds on #3042 (encrypted reasoning / stateless `store: false`), which already unblocked Codex CLI's stateless shape. This PR unblocks the *stateful* side for non-retaining orgs and fixes the storage duplication for everyone.

## Why

1. **Retention coupling**: because stored responses lived in log rows, orgs had to enable (paid) full data retention to use `store: true`, chaining, retrieval, or `/compact` — the 400 `data_retention_required` error Codex/agent users kept hitting.
2. **O(N²) duplication**: every chained turn re-stored the entire reconstructed conversation in a new log row. A 50-turn conversation stored ~3,200 item copies instead of ~125 unique items.

## How

- **New `storageRedisClient`** (`packages/cache/src/storage-redis.ts`), configured via `STORAGE_REDIS_HOST/PORT/PASSWORD`. Fallback to the main `REDIS_*` settings is **all-or-nothing**: no `STORAGE_REDIS_*` var set → reuse the main Redis (zero-config single-instance deployments keep working); any var set → standalone config (a dedicated passwordless instance never inherits the main password).
- **Gateway response caching moves to the storage Redis too** (`getCache`/`setCache`/streaming cache). The main Redis stays reserved for critical infrastructure: log queue, rate limiting, preferred-provider state, video jobs. The Drizzle/SWR DB-layer caches intentionally stay on the main Redis.
- **Pluggable `ResponsesStorage` adapter** (`apps/gateway/src/responses/tools/response-storage.ts`): four backend-neutral methods (`set`/`setMany`/`get`/`getMany`, flat string keys, opaque JSON values, TTL-aware). `RESPONSES_STORAGE_DRIVER=redis` is the only driver today; a GCS/S3 driver (bucket lifecycle rule for the TTL) can be swapped in later without touching domain logic. Misconfigured driver fails at gateway startup.
- **Item-level dedup**: a response record is metadata + ordered lists of item refs (`responses:resp:{projectId}:{id}`); each unique item is stored once (`responses:item:{projectId}:{ref}`, keyed by the item's id, or a content hash for id-less items). Chained turns re-SET the same keys (idempotent, refreshes TTL) → storage grows with unique items, not O(N²). The item store doubles as the `item_reference` index (same key shape as before).
- **Retention gates removed** in both `POST /v1/responses` and `/compact`. Non-retaining orgs' log rows stay metadata-only via the existing fail-closed stripping in `insertLog` (#3222); `store: false` requests still write nothing at all.
- **Log decoupling**: `responsesApiData` is no longer written to log rows (the `syncInsert` path is gone); log rows still use the `resp_` id for tracing. **Legacy responses** stored in `log.responsesApiData` before this change keep resolving via a DB fallback on storage miss.
- **Preserves #3042 semantics**: stored output keeps encrypted reasoning payloads (`buildFinalOutputItems`) while GET strips them unless `include` opts in; `incomplete_details`/`reasoning` round-trip through the record.

## Infra

- `redis-storage` service (AOF persistence — it holds a 30-day source of truth, not just cache): root `docker-compose.yml` (host port 6380), `infra/docker-compose.split*.yml`, `bunnyshell.yaml`.
- Helm: `storageRedis`/`externalStorageRedis` values, statefulset + service templates, configmap/secret env, wait-for init containers. Unified images need no changes (env fallback).
- Seed: sibling org "Test No Retention Organization" (`retentionLevel: none`) under admin@example.com with token `test-token-no-retention`; the default `test-token` org stays on retain for debugging.
- Docs: Codex CLI troubleshooting updated (retention no longer required); data-retention page notes the 30-day, non-billed response storage.

## Testing

- New `response-state.spec.ts` (in-memory adapter): round-trip, project scoping, cross-turn dedup assertions, content-hash dedup, `item_reference` keying safety, legacy DB fallback, driver factory.
- `api.spec.ts`: the old "rejected when retention disabled" test is now "works when retention is disabled and keeps state out of the log" (POST → GET round-trip + metadata-only log row).
- Manual e2e against a live gateway + dedicated Redis container: POST with `test-token-no-retention` (200, previously 400) → chained turn recalls context → GET returns stored response; Redis shows 2 records + 4 unique items for the 2-turn chain (shared items deduped), TTL ≈ 30d; zero `responses:*` keys on the main Redis; chat-completions cache key lands on the storage Redis; log rows have `responses_api_data IS NULL`.
- `pnpm build` green (17/17), `pnpm lint` clean, responses/logs specs 113/113, `api.spec.ts` 122 passed (against a private test DB — the shared `test` DB was being used concurrently by another worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Storage Redis” option for Responses API state and gateway response caching (30-day retention), with Docker Compose and Helm configuration.
* **Bug Fixes**
  * Health checks and graceful shutdown now validate/close both primary Redis and Storage Redis.
  * Responses API requests and compaction work correctly when data retention is disabled.
* **Documentation**
  * Updated data-retention and Codex CLI troubleshooting guidance to match current Responses API behavior.
* **Tests**
  * Expanded coverage for retention-disabled responses and tool-call state round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->