### PR TITLE
fix(playground): unify voice calls sidebar

### DIFF
--- a/apps/playground/src/components/playground/realtime-page-client.tsx
+++ b/apps/playground/src/components/playground/realtime-page-client.tsx
@@ -36,6 +36,7 @@ import {
 	REALTIME_MODEL_COOKIE,
 	setModelPreferenceCookie,
 } from "@/lib/model-preferences";
+import { cn } from "@/lib/utils";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
 import type { Organization, Project } from "@/lib/types";
@@ -360,6 +361,8 @@ export default function RealtimePageClient({
 	}, [posthog, selectedModel, start, voice]);
 
 	const hasBillingContext = !!selectedOrganization && !!selectedProject;
+	const isIdleEmptyState =
+		!inCall && !isViewingHistory && displayedTurns.length === 0;
 
 	return (
 		<SidebarProvider>
@@ -436,7 +439,12 @@ export default function RealtimePageClient({
 						</div>
 					</header>
 
-					<div className="flex flex-1 flex-col overflow-y-auto">
+					<div
+						className={cn(
+							"flex flex-1 flex-col overflow-y-auto",
+							isIdleEmptyState && "justify-center",
+						)}
+					>
 						{!hasBillingContext && isAuthenticated ? (
 							<div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
 								<Phone className="text-muted-foreground/50 h-12 w-12" />
@@ -464,7 +472,12 @@ export default function RealtimePageClient({
 							</div>
 						) : (
 							<>
-								<div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-3 p-4">
+								<div
+									className={cn(
+										"mx-auto flex w-full max-w-3xl flex-col gap-3 p-4",
+										!isIdleEmptyState && "flex-1",
+									)}
+								>
 									{isViewingHistory && viewedCall && (
 										<div className="bg-muted/40 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-4 py-2.5 text-xs">
 											<span className="text-sm font-medium">
@@ -491,7 +504,12 @@ export default function RealtimePageClient({
 										</div>
 									)}
 									{displayedTurns.length === 0 ? (
-										<div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+										<div
+											className={cn(
+												"flex flex-col items-center justify-center gap-3 text-center",
+												!isIdleEmptyState && "flex-1",
+											)}
+										>
 											<Phone className="text-muted-foreground/50 h-12 w-12" />
 											<p className="text-muted-foreground text-sm">
 												{isViewedCallLoading
@@ -524,7 +542,7 @@ export default function RealtimePageClient({
 									)}
 								</div>
 
-								<div className="border-t">
+								<div className={cn(!isIdleEmptyState && "border-t")}>
 									{status === "live" && (
 										<div className="mx-auto flex w-full max-w-3xl items-center justify-center pt-5">
 											<VoiceActivityIndicator

--- a/apps/playground/src/components/playground/realtime-sidebar.tsx
+++ b/apps/playground/src/components/playground/realtime-sidebar.tsx
@@ -1,23 +1,13 @@
 "use client";
 
-import {
-	AudioLines,
-	ChevronUp,
-	ExternalLink,
-	Film,
-	ImageIcon,
-	LogOut,
-	MessageSquare,
-	PenTool,
-	Phone,
-	Users,
-} from "lucide-react";
+import { ChevronUp, ExternalLink, LogOut } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 
 import { CreditsDisplay } from "@/components/credits/credits-display";
 import { ThemeToggle } from "@/components/landing/theme-toggle";
+import { SidebarLoungePoints } from "@/components/lounge/sidebar-points";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,10 +32,12 @@ import { useOrganization } from "@/hooks/useOrganization";
 import { useUser } from "@/hooks/useUser";
 import { clearLastUsedProjectCookiesAction } from "@/lib/actions/project";
 import { useAuth } from "@/lib/auth-client";
+import { withOrgParam } from "@/lib/utils";
 
 import { CallHistoryList } from "./call-history-list";
 import { OrganizationSwitcher } from "./organization-switcher";
-import { SidebarNewAction } from "./sidebar-actions";
+import { SidebarChatSearch, SidebarNewAction } from "./sidebar-actions";
+import { StudioNav } from "./studio-nav";
 
 import type { CallHistoryItem } from "./call-history-list";
 import type { Organization } from "@/lib/types";
@@ -82,13 +74,11 @@ export function RealtimeSidebar({
 		switcherOrganizations.find((org) => org.id === selectedOrganization?.id) ??
 		null;
 	const router = useRouter();
-	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	// Preserve the selected organization across playground navigation so users
 	// don't have to re-pick their org on every page.
 	const orgIdParam = searchParams.get("orgId");
-	const withOrg = (path: string) =>
-		orgIdParam ? `${path}?orgId=${orgIdParam}` : path;
+	const withOrg = (path: string) => withOrgParam(path, orgIdParam);
 	const posthog = usePostHog();
 	const { state: sidebarState, isMobile } = useSidebar();
 	const { user, isLoading: isUserLoading } = useUser();
@@ -129,6 +119,7 @@ export function RealtimeSidebar({
 							<Badge>Voice</Badge>
 						</Link>
 					</div>
+					<StudioNav />
 				</SidebarHeader>
 			</Sidebar>
 		);
@@ -162,6 +153,7 @@ export function RealtimeSidebar({
 							</div>
 						</div>
 					</div>
+					<StudioNav />
 				</SidebarHeader>
 			</Sidebar>
 		);
@@ -181,92 +173,10 @@ export function RealtimeSidebar({
 							</Link>
 						</SidebarMenuButton>
 					</SidebarMenuItem>
+					<SidebarChatSearch disabled />
 					<SidebarNewAction label="New Call" onAction={onNewCall} />
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Chat"
-							isActive={pathname === "/"}
-						>
-							<Link href={withOrg("/")} prefetch={true}>
-								<MessageSquare className="h-4 w-4" />
-								<span>Chat</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Group Chat"
-							isActive={pathname === "/group"}
-						>
-							<Link href={withOrg("/group")} prefetch={true}>
-								<Users className="h-4 w-4" />
-								<span>Group Chat</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Image Studio"
-							isActive={pathname === "/image"}
-						>
-							<Link href={withOrg("/image")} prefetch={true}>
-								<ImageIcon className="h-4 w-4" />
-								<span>Image Studio</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Video Studio"
-							isActive={pathname === "/video"}
-						>
-							<Link href={withOrg("/video")} prefetch={true}>
-								<Film className="h-4 w-4" />
-								<span>Video Studio</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Audio Studio"
-							isActive={pathname === "/audio"}
-						>
-							<Link href={withOrg("/audio")} prefetch={true}>
-								<AudioLines className="h-4 w-4" />
-								<span>Audio Studio</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Voice Calls"
-							isActive={pathname === "/realtime"}
-						>
-							<Link href={withOrg("/realtime")} prefetch={true}>
-								<Phone className="h-4 w-4" />
-								<span>Voice Calls</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
-					<SidebarMenuItem>
-						<SidebarMenuButton
-							asChild
-							tooltip="Canvas"
-							isActive={pathname === "/canvas"}
-						>
-							<Link href={withOrg("/canvas")} prefetch={true}>
-								<PenTool className="h-4 w-4" />
-								<span>Canvas</span>
-							</Link>
-						</SidebarMenuButton>
-					</SidebarMenuItem>
 				</SidebarMenu>
+				<StudioNav />
 			</SidebarHeader>
 
 			<SidebarContent className="overflow-hidden pb-2">
@@ -299,6 +209,7 @@ export function RealtimeSidebar({
 			</SidebarContent>
 
 			<SidebarFooter>
+				<SidebarLoungePoints />
 				<div className="group-data-[collapsible=icon]:hidden">
 					<CreditsDisplay
 						organization={switcherSelectedOrganization ?? organization}


### PR DESCRIPTION
## Problem

Voice Calls was the only playground mode that hand-rolled its own sidebar nav instead of using the shared `StudioNav` tile grid, so it rendered a visibly different sidebar from Chat, Image Studio, Video Studio, Audio Studio and Canvas — seven full-width menu rows instead of the compact tile switcher.

Nothing was excluding `/realtime` from the shared nav; `realtime-sidebar.tsx` simply never imported it. `STUDIO_NAV_ITEMS` already contained a `/realtime` entry, so every *other* sidebar linked to Voice Calls correctly — only the Voice Calls page itself looked different.

## Changes

`apps/playground/src/components/playground/realtime-sidebar.tsx`

- Replace the seven hand-rolled `SidebarMenuItem` rows with `<StudioNav />`. This also restores the two destinations realtime was silently missing: **Projects** and **Skills**.
- Render `<StudioNav />` in the loading and signed-out states, which previously returned bare shells with no nav at all.
- Add `<SidebarChatSearch disabled />` to the header and `<SidebarLoungePoints />` to the footer, both present in every other sidebar.
- Reorder the header to the canonical shape: wordmark → search → new action inside `SidebarMenu`, then `<StudioNav />`. `SidebarNewAction` had been sitting above the nav.
- Use the shared `withOrgParam` from `@/lib/utils` instead of an inlined copy that unconditionally appended `?orgId=`, producing a malformed URL on any path that already carried a query string.

`apps/playground/src/components/playground/realtime-page-client.tsx`

- Centre the idle empty state. Before the first call there is no transcript to scroll, but the transcript pane still stretched to full height, leaving a large blank gap between "Start a call to have a live voice conversation." and the Start call button. When idle and empty, the pane drops `flex-1`, the scroll container centres its content, and the divider above the controls is suppressed so the two read as one block.

Call history (`CallHistoryList`) and the `Voice` badge are left as-is — those are realtime's own content, not sidebar chrome.

## Screenshots
### Before
<img width="1910" height="713" alt="image" src="https://github.com/user-attachments/assets/ca4370c0-b6cc-4713-ba18-6a1967bfc32f" />

### After
<img width="1912" height="727" alt="image" src="https://github.com/user-attachments/assets/101a52a0-23e8-451a-a8ca-206bf86e26fd" />


## Testing

- `pnpm format` clean
- `turbo run build --filter=playground` passes
- `turbo run lint --filter=playground` clean (the single remaining warning is pre-existing, in `realtime-audio.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamlined sidebar navigation with studio links, chat search, and a new-action entry point.
  * Added lounge points visibility in the sidebar.
* **Improvements**
  * Improved the real-time page layout so empty states are centered and content expands appropriately.
  * Added clearer visual separation between the main content and footer when applicable.
  * Simplified navigation presentation across loading and signed-out states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->