### PR TITLE
fix: show highest model discount on model page

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -25,6 +25,7 @@ import { ModelRating } from "@/components/models/model-rating";
 import { ModelStatusBadgeAuto } from "@/components/models/model-status-badge-auto";
 import { ProviderTabs } from "@/components/models/provider-tabs";
 import { Badge } from "@/lib/components/badge";
+import { findEffectiveProviderDiscount } from "@/lib/discount";
 import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -85,66 +86,16 @@ export default async function ModelProviderPage({ params }: PageProps) {
 		}),
 	]);
 	const discounts = discountData?.discounts ?? [];
-	const globalDiscount = (() => {
-		const providerModel = discounts.find(
-			(d) => d.provider === decodedProvider && d.model === decodedName,
-		);
-		if (providerModel) {
-			return providerModel.discountPercent;
-		}
-		const providerOnly = discounts.find(
-			(d) => d.provider === decodedProvider && d.model === null,
-		);
-		if (providerOnly) {
-			return providerOnly.discountPercent;
-		}
-		const modelOnly = discounts.find(
-			(d) => d.provider === null && d.model === decodedName,
-		);
-		if (modelOnly) {
-			return modelOnly.discountPercent;
-		}
-		const fullyGlobal = discounts.find(
-			(d) => d.provider === null && d.model === null,
-		);
-		if (fullyGlobal) {
-			return fullyGlobal.discountPercent;
-		}
-		return undefined;
-	})();
+	const bannerDiscount = findEffectiveProviderDiscount(
+		discounts,
+		decodedProvider,
+		decodedName,
+	);
 
 	const providerMapping = {
 		...staticProviderMapping,
-		discount: globalDiscount,
+		discount: bannerDiscount?.discountPercent,
 	};
-
-	const bannerDiscount: DiscountData | null = (() => {
-		const providerModel = discounts.find(
-			(d) => d.provider === decodedProvider && d.model === decodedName,
-		);
-		if (providerModel) {
-			return providerModel;
-		}
-		const providerOnly = discounts.find(
-			(d) => d.provider === decodedProvider && d.model === null,
-		);
-		if (providerOnly) {
-			return providerOnly;
-		}
-		const modelOnly = discounts.find(
-			(d) => d.provider === null && d.model === decodedName,
-		);
-		if (modelOnly) {
-			return modelOnly;
-		}
-		const fullyGlobal = discounts.find(
-			(d) => d.provider === null && d.model === null,
-		);
-		if (fullyGlobal) {
-			return fullyGlobal;
-		}
-		return null;
-	})();
 
 	const getStabilityBadgeProps = (stability?: StabilityLevel) => {
 		switch (stability) {
@@ -415,7 +366,14 @@ export default async function ModelProviderPage({ params }: PageProps) {
 
 					{bannerDiscount && (
 						<div className="mb-6">
-							<GlobalDiscountBanner discount={bannerDiscount} />
+							<GlobalDiscountBanner
+								discount={bannerDiscount}
+								providerName={
+									bannerDiscount.provider
+										? (providerInfo?.name ?? bannerDiscount.provider)
+										: null
+								}
+							/>
 						</div>
 					)}
 
@@ -449,7 +407,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 								providerMappings.map((p) => ({
 									...p,
 									providerInfo,
-									discount: globalDiscount,
+									discount: bannerDiscount?.discountPercent,
 								})),
 							)}
 						/>

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -411,7 +411,11 @@ export default async function ModelProviderPage({ params }: PageProps) {
 								providerMappings.map((p) => ({
 									...p,
 									providerInfo,
-									discount: bannerDiscount?.discountPercent,
+									// Regions deactivate independently, and the cards can reveal a
+									// deactivated one — it must not show a discounted price.
+									discount: isMappingDeactivated(p)
+										? undefined
+										: bannerDiscount?.discountPercent,
 								})),
 							)}
 						/>

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -36,6 +36,7 @@ import {
 	type StabilityLevel,
 	type ModelDefinition,
 } from "@llmgateway/models";
+import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 import type { Metadata } from "next";
 
@@ -86,11 +87,14 @@ export default async function ModelProviderPage({ params }: PageProps) {
 		}),
 	]);
 	const discounts = discountData?.discounts ?? [];
-	const bannerDiscount = findEffectiveProviderDiscount(
-		discounts,
-		decodedProvider,
-		decodedName,
+	// A provider whose mappings are all deactivated still renders this page, but
+	// nothing can be routed to it — so it must not advertise a discounted price.
+	const hasRoutableMapping = providerMappings.some(
+		(mapping) => !isMappingDeactivated(mapping),
 	);
+	const bannerDiscount = hasRoutableMapping
+		? findEffectiveProviderDiscount(discounts, decodedProvider, decodedName)
+		: null;
 
 	const providerMapping = {
 		...staticProviderMapping,

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -116,8 +116,6 @@ export default async function ModelPage({ params }: PageProps) {
 			discount: globalDiscount,
 		};
 	});
-	const currentModelDiscount = getBestDiscount(allDiscounts, decodedName);
-
 	// Aggregated metrics (pricing, context, capabilities) describe what can
 	// actually be routed today, so deactivated providers are excluded. Models
 	// whose providers are all deactivated fall back to showing everything.
@@ -126,6 +124,16 @@ export default async function ModelPage({ params }: PageProps) {
 	);
 	const visibleProviders =
 		activeProviders.length > 0 ? activeProviders : modelProviders;
+
+	const currentModelDiscount = getBestDiscount(
+		allDiscounts,
+		decodedName,
+		Array.from(new Set(activeProviders.map((p) => p.providerId))),
+	);
+	const currentModelDiscountProvider = currentModelDiscount?.provider
+		? (providerDefinitions.find((p) => p.id === currentModelDiscount.provider)
+				?.name ?? currentModelDiscount.provider)
+		: null;
 
 	const adaptedModel = adaptModel(modelDef, modelProviders);
 
@@ -550,7 +558,10 @@ export default async function ModelPage({ params }: PageProps) {
 
 					{currentModelDiscount && (
 						<div className="mb-6">
-							<GlobalDiscountBanner discount={currentModelDiscount} />
+							<GlobalDiscountBanner
+								discount={currentModelDiscount}
+								providerName={currentModelDiscountProvider}
+							/>
 						</div>
 					)}
 

--- a/apps/ui/src/components/models/global-discount-banner.tsx
+++ b/apps/ui/src/components/models/global-discount-banner.tsx
@@ -9,12 +9,19 @@ export type { DiscountData };
 
 interface GlobalDiscountBannerProps {
 	discount: DiscountData | null;
+	/** Display name of the provider the discount applies through, if scoped. */
+	providerName?: string | null;
 }
 
-export function GlobalDiscountBanner({ discount }: GlobalDiscountBannerProps) {
+export function GlobalDiscountBanner({
+	discount,
+	providerName,
+}: GlobalDiscountBannerProps) {
 	if (!discount) {
 		return null;
 	}
+
+	const provider = providerName ?? discount.provider;
 
 	const percent = (discountFraction(discount.discountPercent) * 100).toFixed(0);
 
@@ -28,8 +35,8 @@ export function GlobalDiscountBanner({ discount }: GlobalDiscountBannerProps) {
 					{percent}% off
 				</span>
 				<span className="text-sm text-muted-foreground">
-					{discount.model ? "this model" : "all models"}
-					{discount.provider ? ` via ${discount.provider}` : ""}
+					this model
+					{provider ? ` via ${provider}` : ""}
 				</span>
 				{discount.expiresAt && (
 					<>

--- a/apps/ui/src/lib/discount.spec.ts
+++ b/apps/ui/src/lib/discount.spec.ts
@@ -41,7 +41,45 @@ describe("model-detail discounts", () => {
 		expect(
 			getEffectiveProviderDiscount(discounts, "alibaba", "qwen3.7-max"),
 		).toBe("0.5");
-		expect(getBestDiscount(discounts, "qwen3.7-max")).toEqual(fiftyPercentOff);
+		expect(getBestDiscount(discounts, "qwen3.7-max", ["alibaba"])).toEqual(
+			fiftyPercentOff,
+		);
+	});
+
+	it("picks the highest effective discount across the model's providers", () => {
+		const providerWide: DiscountData = {
+			...fiftyPercentOff,
+			id: "provider-wide",
+			provider: "novita",
+			model: null,
+			discountPercent: "0.3",
+		};
+		const modelSpecific: DiscountData = {
+			...fiftyPercentOff,
+			id: "model-specific",
+			provider: "alibaba",
+			discountPercent: "0.2",
+		};
+
+		expect(
+			getBestDiscount([modelSpecific, providerWide], "qwen3.7-max", [
+				"alibaba",
+				"novita",
+			]),
+		).toEqual(providerWide);
+	});
+
+	it("ignores discounts that only apply to providers that were filtered out", () => {
+		const novitaOnly: DiscountData = {
+			...fiftyPercentOff,
+			provider: "novita",
+			model: null,
+		};
+
+		expect(
+			getBestDiscount([novitaOnly], "qwen3.7-max", ["alibaba"]),
+		).toBeNull();
+		expect(getBestDiscount([novitaOnly], "qwen3.7-max", [])).toBeNull();
 	});
 
 	it("applies the 50% discount to all per-million token prices", () => {
@@ -82,7 +120,9 @@ describe("model-detail discounts", () => {
 		expect(
 			getEffectiveProviderDiscount([byExternalId], "alibaba", "qwen3.7-max"),
 		).toBeUndefined();
-		expect(getBestDiscount([byExternalId], "qwen3.7-max")).toBeNull();
+		expect(
+			getBestDiscount([byExternalId], "qwen3.7-max", ["alibaba"]),
+		).toBeNull();
 	});
 
 	it("returns base prices when no discount is active", () => {
@@ -103,7 +143,7 @@ describe("model-detail discounts", () => {
 			expect(
 				getEffectiveProviderDiscount(discounts, "alibaba", "qwen3.7-max"),
 			).toBeUndefined();
-			expect(getBestDiscount(discounts, "qwen3.7-max")).toBeNull();
+			expect(getBestDiscount(discounts, "qwen3.7-max", ["alibaba"])).toBeNull();
 
 			expect(
 				applyDiscount(perMillion(alibaba.inputPrice)!, discountPercent),

--- a/apps/ui/src/lib/discount.ts
+++ b/apps/ui/src/lib/discount.ts
@@ -22,15 +22,32 @@ function isValidDiscount(discount?: string | null): boolean {
 // Discounts are always keyed by the root model id — the provider-specific
 // externalId is reserved for upstream requests and is never persisted as a
 // discount target.
-export function getBestDiscount(
+export function findEffectiveProviderDiscount(
 	discounts: DiscountData[],
+	providerId: string,
 	modelId: string,
 ): DiscountData | null {
 	const valid = discounts.filter((d) => isValidDiscount(d.discountPercent));
-	// Precedence: model-specific > fully global
-	const modelSpecific = valid.find((d) => d.model === modelId);
-	if (modelSpecific) {
-		return modelSpecific;
+	// Precedence: provider+model > provider > model > fully global
+	const providerModel = valid.find(
+		(d) => d.provider === providerId && d.model === modelId,
+	);
+	if (providerModel) {
+		return providerModel;
+	}
+
+	const providerOnly = valid.find(
+		(d) => d.provider === providerId && d.model === null,
+	);
+	if (providerOnly) {
+		return providerOnly;
+	}
+
+	const modelOnly = valid.find(
+		(d) => d.provider === null && d.model === modelId,
+	);
+	if (modelOnly) {
+		return modelOnly;
 	}
 
 	const fullyGlobal = valid.find(
@@ -43,42 +60,37 @@ export function getBestDiscount(
 	return null;
 }
 
+// The banner on a model page advertises the best deal a user can actually get
+// for that model right now, so it takes the highest effective discount across
+// the providers passed in. Callers pass only routable (non-deactivated)
+// providers, otherwise the banner would promise a price nobody can be served.
+export function getBestDiscount(
+	discounts: DiscountData[],
+	modelId: string,
+	providerIds: string[],
+): DiscountData | null {
+	let best: DiscountData | null = null;
+	for (const providerId of providerIds) {
+		const match = findEffectiveProviderDiscount(discounts, providerId, modelId);
+		if (
+			match &&
+			(!best || Number(match.discountPercent) > Number(best.discountPercent))
+		) {
+			best = match;
+		}
+	}
+	return best;
+}
+
 export function getEffectiveProviderDiscount(
 	discounts: DiscountData[],
 	providerId: string,
 	modelId: string,
 ): string | undefined {
-	const valid = discounts.filter((d) => isValidDiscount(d.discountPercent));
-	// Precedence: provider+model > provider > model > fully global
-	const providerModel = valid.find(
-		(d) => d.provider === providerId && d.model === modelId,
+	return (
+		findEffectiveProviderDiscount(discounts, providerId, modelId)
+			?.discountPercent ?? undefined
 	);
-	if (providerModel) {
-		return providerModel.discountPercent;
-	}
-
-	const providerOnly = valid.find(
-		(d) => d.provider === providerId && d.model === null,
-	);
-	if (providerOnly) {
-		return providerOnly.discountPercent;
-	}
-
-	const modelOnly = valid.find(
-		(d) => d.provider === null && d.model === modelId,
-	);
-	if (modelOnly) {
-		return modelOnly.discountPercent;
-	}
-
-	const fullyGlobal = valid.find(
-		(d) => d.provider === null && d.model === null,
-	);
-	if (fullyGlobal) {
-		return fullyGlobal.discountPercent;
-	}
-
-	return undefined;
 }
 
 export function discountFraction(discount?: string | null): number {


### PR DESCRIPTION
## Problem

The discount banner on `/models/[name]` resolved discounts in a completely different way than the provider cards rendered right below it, so the two could disagree. On a GLM-5.2 page the banner advertised **"20% off this model via granite"** while the Runware card underneath showed **30% off** — and 30% was the price actually applied.

`getBestDiscount` had three issues:

- It returned the **first** discount matching `d.model === modelId` — array order, not the largest.
- It never considered **provider-scoped** discounts (`provider: "runware", model: null`), so a provider-wide promo was invisible to the banner even though it applied to the model's price.
- It had no notion of deactivated mappings, so it could advertise a discount on a provider nothing can be routed to.

## Changes

- Extracted `findEffectiveProviderDiscount()` in `apps/ui/src/lib/discount.ts` — the existing `provider+model > provider > model > global` precedence, returning the full record rather than just the percent. `getEffectiveProviderDiscount()` now delegates to it, so the banner and the provider cards resolve discounts through one code path.
- `getBestDiscount(discounts, modelId, providerIds)` resolves the effective discount per provider and returns the **highest**. The model page passes only providers already filtered by `isMappingDeactivated`, so a deactivated mapping can never win the banner, and a model whose providers are all deactivated shows no banner.
- The banner renders the provider **display name** ("via Runware", not "via granite"), and reads "this model" instead of "all models" — the discount is now resolved as what is effective for the model being viewed, whatever its stored scope.
- Removed the two hand-inlined copies of the precedence chain on `/models/[name]/[provider]`, which now use the shared helper.

## Notes

A fully-deactivated model shows no discount banner at all. The page's aggregate pricing has a fallback that shows every provider in that case; I deliberately did not extend it to the banner, since advertising an unroutable discount is the bug being fixed here.

## Testing

- `pnpm test:unit` on `apps/ui/src/lib/discount.spec.ts` — 12 passing, including three new cases: highest-across-providers wins, provider-only discounts for a filtered-out provider are ignored, and an empty provider list yields no banner.
- `pnpm build` and `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGaPP8zedV7krWmYRraqNX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGaPP8zedV7krWmYRraqNX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discount banners can now display the associated provider label (“via …”) when available (including the global discount banner).
* **Bug Fixes**
  * Discount selection now prioritizes active eligible providers (provider+model first, then provider-only, then model-only, then global).
  * Provider/model banner discounts are suppressed when all provider mappings are deactivated.
  * Invalid discount values are ignored and discounts are restricted to applicable providers.
* **Tests**
  * Updated and expanded discount-selection tests to cover filtered “allowed provider” behavior and best-discount selection across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->