### PR TITLE
fix(ui): hide provider TTFT below request threshold

### DIFF
--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -20,7 +20,7 @@ const providerStatRowSchema = z.object({
 	avgTimeToFirstToken: z.number().nullable(),
 	// How many requests actually contributed a TTFT sample (streamed ones only).
 	// Exposed so callers can gate the display of avgTimeToFirstToken on its own
-	// sample size rather than on logsCount, which counts non-streaming requests
+	// sample size in addition to logsCount, which counts non-streaming requests
 	// that never fed into the average.
 	timeToFirstTokenCount: z.number(),
 	throughput: z.number().nullable(),

--- a/apps/ui/src/components/models/model-uptime-charts.tsx
+++ b/apps/ui/src/components/models/model-uptime-charts.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/components/chart";
 import { useApi } from "@/lib/fetch-client";
 import {
+	formatCompact,
 	hasEnoughRequestsForStats,
 	hasEnoughTtftSamplesForStats,
 	MIN_REQUESTS_FOR_STATS,
@@ -71,19 +72,6 @@ const metricTabs: { key: ActiveMetric; label: string }[] = [
 	{ key: "tokens", label: "Tokens" },
 ];
 
-function formatCompact(n: number): string {
-	if (n >= 1_000_000_000) {
-		return `${(n / 1_000_000_000).toFixed(1)}B`;
-	}
-	if (n >= 1_000_000) {
-		return `${(n / 1_000_000).toFixed(1)}M`;
-	}
-	if (n >= 1_000) {
-		return `${(n / 1_000).toFixed(1)}k`;
-	}
-	return n.toLocaleString();
-}
-
 function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("requests");
 	const ProviderIcon = getProviderIcon(provider.providerId);
@@ -91,9 +79,10 @@ function ProviderUptimeCard({ provider }: { provider: UptimeProvider }) {
 	const dataKeys = Object.keys(config);
 
 	const hasEnoughData = hasEnoughRequestsForStats(provider.logsCount);
-	// TTFT only has samples from streamed requests, so it gates on its own count
-	// rather than on the request count that feeds uptime/duration/throughput.
-	const hasEnoughTtftData = hasEnoughTtftSamplesForStats(provider.ttftCount);
+	// TTFT only has samples from streamed requests, so on top of the request
+	// threshold it also gates on its own streamed-sample count.
+	const hasEnoughTtftData =
+		hasEnoughData && hasEnoughTtftSamplesForStats(provider.ttftCount);
 
 	const errorRate =
 		provider.logsCount > 0

--- a/apps/ui/src/components/providers/providers-grid.tsx
+++ b/apps/ui/src/components/providers/providers-grid.tsx
@@ -32,7 +32,10 @@ import {
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
 import {
+	formatCompact,
 	gateProviderStats,
+	hasEnoughRequestsForStats,
+	MIN_REQUESTS_FOR_STATS,
 	type ProviderWindowStats,
 } from "@/lib/provider-stats";
 
@@ -473,6 +476,14 @@ export function ProvidersGrid({
 											{provider.description}
 										</CardDescription>
 									</div>
+
+									{provider.stats &&
+										!hasEnoughRequestsForStats(provider.stats.logsCount) && (
+											<div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-3 text-xs text-muted-foreground">
+												Stats hidden until{" "}
+												{formatCompact(MIN_REQUESTS_FOR_STATS)} requests
+											</div>
+										)}
 
 									{provider.stats &&
 										(provider.stats.avgTimeToFirstToken !== null ||

--- a/apps/ui/src/lib/provider-stats.spec.ts
+++ b/apps/ui/src/lib/provider-stats.spec.ts
@@ -97,4 +97,23 @@ describe("gateProviderStats", () => {
 			throughput: null,
 		});
 	});
+
+	// A provider can clear the streamed-sample bar while still being low-traffic
+	// overall; every stat stays hidden so surfaces show one consistent
+	// "stats hidden until N requests" state instead of a lone TTFT.
+	it("hides TTFT below the request threshold despite enough samples", () => {
+		const gated = gateProviderStats({
+			logsCount: MIN_TTFT_SAMPLES_FOR_STATS + 50,
+			uptime: 100,
+			avgTimeToFirstToken: 114820,
+			timeToFirstTokenCount: MIN_TTFT_SAMPLES_FOR_STATS + 50,
+			throughput: 12,
+		});
+		expect(gated).toEqual({
+			logsCount: MIN_TTFT_SAMPLES_FOR_STATS + 50,
+			uptime: null,
+			avgTimeToFirstToken: null,
+			throughput: null,
+		});
+	});
 });

--- a/apps/ui/src/lib/provider-stats.ts
+++ b/apps/ui/src/lib/provider-stats.ts
@@ -5,7 +5,7 @@
 export const MIN_REQUESTS_FOR_STATS = 1000;
 
 // TTFT is averaged over streamed requests only — non-streaming requests never
-// record a first-token time — so it needs its own, separate sample gate. A
+// record a first-token time — so it needs its own, additional sample gate. A
 // provider can serve 5k requests with only a handful streamed, which would sail
 // past MIN_REQUESTS_FOR_STATS while resting on a 3-sample average.
 //
@@ -15,6 +15,19 @@ export const MIN_REQUESTS_FOR_STATS = 1000;
 // here would hide well-sampled TTFT from any provider whose traffic is mostly
 // non-streaming.
 export const MIN_TTFT_SAMPLES_FOR_STATS = 100;
+
+export function formatCompact(n: number): string {
+	if (n >= 1_000_000_000) {
+		return `${(n / 1_000_000_000).toFixed(1)}B`;
+	}
+	if (n >= 1_000_000) {
+		return `${(n / 1_000_000).toFixed(1)}M`;
+	}
+	if (n >= 1_000) {
+		return `${(n / 1_000).toFixed(1)}k`;
+	}
+	return n.toLocaleString();
+}
 
 export function hasEnoughRequestsForStats(logsCount: number): boolean {
 	return logsCount > MIN_REQUESTS_FOR_STATS;
@@ -39,14 +52,15 @@ export function gateProviderStats(
 	const enoughRequests = hasEnoughRequestsForStats(stats.logsCount);
 	return {
 		logsCount: stats.logsCount,
-		// Uptime and throughput are averaged over every request, so they gate on
-		// the request count; TTFT gates on its own sample count.
+		// Every stat hides below the request threshold, so surfaces can show one
+		// consistent "stats hidden until N requests" state; TTFT additionally
+		// gates on its own streamed-sample count.
 		uptime: enoughRequests ? stats.uptime : null,
 		throughput: enoughRequests ? stats.throughput : null,
-		avgTimeToFirstToken: hasEnoughTtftSamplesForStats(
-			stats.timeToFirstTokenCount,
-		)
-			? stats.avgTimeToFirstToken
-			: null,
+		avgTimeToFirstToken:
+			enoughRequests &&
+			hasEnoughTtftSamplesForStats(stats.timeToFirstTokenCount)
+				? stats.avgTimeToFirstToken
+				: null,
 	};
 }


### PR DESCRIPTION
Gate avgTimeToFirstToken on the 1k-request minimum in addition to its
streamed-sample gate, so low-traffic providers no longer show a lone
TTFT (and speed badge) while uptime is hidden. Provider cards now show
the same "stats hidden until 1.0k requests" note as the model uptime
page, and the model page's TTFT tile gates identically.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014fLMFjH4Jxx1ojuRUWozzp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider statistics now remain hidden until enough requests have been recorded, with a clear threshold message shown.
  * Large request counts are displayed in a more compact, readable format.

* **Bug Fixes**
  * Time-to-first-token metrics now appear only when both overall request and streamed-sample thresholds are met.
  * Updated provider uptime charts to apply the correct data-availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->