### PR TITLE
fix(gateway): derive safety id from tenant ids

### DIFF
--- a/apps/gateway/src/realtime/preflight.ts
+++ b/apps/gateway/src/realtime/preflight.ts
@@ -67,6 +67,24 @@ export interface RealtimePreflightResult {
 	safetyIdentifier: string;
 }
 
+/**
+ * Derive the opaque `OpenAI-Safety-Identifier` for a session. It is keyed on the
+ * tenant (organization + project) rather than on the API key: keys are rotatable
+ * credentials, so deriving from one would reset the upstream abuse-tracking
+ * identity on every rotation, and no part of a credential should ever be fed
+ * into a fast digest. Organization and project ids are unguessable v4 UUIDs, and
+ * hashing them keeps internal ids from leaking to the provider.
+ */
+function deriveSafetyIdentifier(
+	organizationId: string,
+	projectId: string,
+): string {
+	return createHash("sha256")
+		.update(`realtime-safety-identifier:${organizationId}:${projectId}`)
+		.digest("hex")
+		.slice(0, 32);
+}
+
 export function getAvailableCredits(organization: Organization): number {
 	const regularCredits = parseFloat(organization.credits ?? "0");
 	const devPlanCreditsRemaining =
@@ -350,9 +368,6 @@ async function runRealtimePreflightInner(
 		usedMode: providerKey ? "api-keys" : "credits",
 		allowedTranscriptionModelIds,
 		clientIp: input.clientIp,
-		safetyIdentifier: createHash("sha256")
-			.update(`${organization.id}:${apiKey.id}`)
-			.digest("hex")
-			.slice(0, 32),
+		safetyIdentifier: deriveSafetyIdentifier(organization.id, project.id),
 	};
 }

--- a/apps/gateway/src/realtime/preflight.ts
+++ b/apps/gateway/src/realtime/preflight.ts
@@ -72,8 +72,9 @@ export interface RealtimePreflightResult {
  * tenant (organization + project) rather than on the API key: keys are rotatable
  * credentials, so deriving from one would reset the upstream abuse-tracking
  * identity on every rotation, and no part of a credential should ever be fed
- * into a fast digest. Organization and project ids are unguessable v4 UUIDs, and
- * hashing them keeps internal ids from leaking to the provider.
+ * into a fast digest. Both ids are 20-character CSPRNG nanoids (~119 bits each),
+ * so a plain digest needs no salt or pepper: there is no small input space to
+ * enumerate, and the hash exists only to keep internal ids off the wire.
  */
 function deriveSafetyIdentifier(
 	organizationId: string,


### PR DESCRIPTION
Fixes code scanning alert [#91](https://github.com/theopenco/llmgateway/security/code-scanning/91) — `js/insufficient-password-hash` (High), `apps/gateway/src/realtime/preflight.ts:354`.

## Problem

The realtime preflight built the upstream `OpenAI-Safety-Identifier` as:

```ts
safetyIdentifier: createHash("sha256")
	.update(`${organization.id}:${apiKey.id}`)
	.digest("hex")
	.slice(0, 32),
```

`apiKey` is the full row returned by `findApiKeyByToken`, which also carries the raw credential `token`. CodeQL tracks taint from an object to its property reads, so `apiKey.id` counts as credential-derived data flowing into a fast (non-KDF) digest, and the query reports both `findApiKeyByToken` and the `apiKey` access as sources.

Switching to a keyed HMAC would not have cleared it. The query's sink is any input to a cryptographic operation whose algorithm is not a `PasswordHashingAlgorithm` (bcrypt/scrypt/argon2/PBKDF2), and for node `crypto` that input is argument 0 of `.update()` — so the tainted value stays a sink no matter which digest wraps it. The flow itself had to go.

## Fix

Derive the identifier from the organization and project ids instead, via a documented `deriveSafetyIdentifier()` helper with a domain-separation prefix. Nothing credential-derived reaches the digest, so the alert's source is gone.

This is also the better identity for what the header is for. `safety_identifier` is meant to give the provider a *stable* handle for abuse tracking; API keys are rotatable, so keying on one reset the upstream identity on every rotation. The organization/project pair is stable across key rotation while still isolating a single tenant.

## On salting

Deliberately a plain unsalted digest. Both ids are 20-character nanoids over a 62-character alphabet from a CSPRNG (`packages/db/src/schema.ts:41-45`) — roughly 119 bits each, ~238 bits combined. Salts defend a small, enumerable input space; there is nothing to enumerate here. A per-record salt would also have to be stored and looked up to keep the identifier stable across sessions, which is state bought for no gain.

A pepper (HMAC under `getApiKeyHashSecret()`) was considered and skipped for the same reason: it would defend against someone who both observes the header and already knows candidate org/project ids, which is nobody in this path — the digest's only recipient is the provider, and they hold neither id. This is why `hashSessionCacheKey` peppering is not an inconsistency: its input is caller-supplied and may already be known to the provider, which is exactly the correlation risk a pepper addresses.

## Verification

- `turbo run build --filter=gateway` — passes
- `vitest run apps/gateway/src/realtime` — 69 tests passing
- `pnpm format` — clean

The value is opaque and only ever sent upstream in the `OpenAI-Safety-Identifier` header (`realtime/server.ts:170`); nothing persists or asserts on the previous derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny3jqUm59JC7eoCkMHKWpY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime connection safety identification by generating a consistent identifier from the organization and project context.
  * Updated safety identifiers to remain stable across API key changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->