### PR TITLE
refactor: replace Math.random with crypto random

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { db, eq, tables } from "@llmgateway/db";
+import { randomInt } from "@llmgateway/shared/random";
 
 import { apiAuth, isClientJsonError, redisClient } from "./config.js";
 
@@ -186,7 +187,7 @@ describe("API auth hooks functionality", () => {
 				headers: {
 					"Content-Type": "application/json",
 					Origin: codeUrl,
-					"CF-Connecting-IP": `192.168.30.${Math.floor(Math.random() * 255)}`,
+					"CF-Connecting-IP": `192.168.30.${randomInt(0, 255)}`,
 				},
 				body: JSON.stringify({ email, password, name: "Dev User" }),
 			}),
@@ -244,7 +245,7 @@ describe("API auth hooks functionality", () => {
 				headers: {
 					"Content-Type": "application/json",
 					Origin: codeUrl,
-					"CF-Connecting-IP": `192.168.31.${Math.floor(Math.random() * 255)}`,
+					"CF-Connecting-IP": `192.168.31.${randomInt(0, 255)}`,
 				},
 				body: JSON.stringify({ email, password, name: "Dev User" }),
 			}),
@@ -325,7 +326,7 @@ describe("API auth hooks functionality", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"CF-Connecting-IP": `192.168.10.${Math.floor(Math.random() * 255)}`,
+					"CF-Connecting-IP": `192.168.10.${randomInt(0, 255)}`,
 				},
 				body: JSON.stringify({ email, password, name: "Test User" }),
 			}),
@@ -359,7 +360,7 @@ describe("API auth hooks functionality", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"CF-Connecting-IP": `192.168.20.${Math.floor(Math.random() * 255)}`,
+					"CF-Connecting-IP": `192.168.20.${randomInt(0, 255)}`,
 				},
 				body: JSON.stringify({ email, password }),
 			}),
@@ -384,7 +385,7 @@ describe("API auth hooks functionality", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"CF-Connecting-IP": `192.168.21.${Math.floor(Math.random() * 255)}`,
+					"CF-Connecting-IP": `192.168.21.${randomInt(0, 255)}`,
 				},
 				body: JSON.stringify({ email, password, name: "Alice Wonder" }),
 			}),

--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -12,10 +12,11 @@ import {
 	models,
 	providers,
 } from "@llmgateway/models";
+import { uniqueId } from "@llmgateway/shared/random";
 
 // Helper function to generate unique IDs for tests
 function generateTestId(): string {
-	return `test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+	return uniqueId("test");
 }
 
 // Helper function to check if a provider has any active models

--- a/apps/api/src/routes/organization.spec.ts
+++ b/apps/api/src/routes/organization.spec.ts
@@ -4,6 +4,7 @@ import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
 import { db, tables } from "@llmgateway/db";
+import { randomInt } from "@llmgateway/shared/random";
 
 describe("organization route", () => {
 	let token: string;
@@ -81,7 +82,7 @@ describe("organization route", () => {
 			headers: {
 				"Content-Type": "application/json",
 				Origin: codeUrl,
-				"CF-Connecting-IP": `192.168.32.${Math.floor(Math.random() * 255)}`,
+				"CF-Connecting-IP": `192.168.32.${randomInt(0, 255)}`,
 			},
 			body: JSON.stringify({ email, password, name: "Dev User" }),
 		});

--- a/apps/api/src/routes/payments.e2e.ts
+++ b/apps/api/src/routes/payments.e2e.ts
@@ -7,6 +7,7 @@ import { deleteAll } from "@/testing.js";
 
 import { db, tables } from "@llmgateway/db";
 import { CREDIT_TOP_UP_MIN_AMOUNT } from "@llmgateway/shared";
+import { uniqueId } from "@llmgateway/shared/random";
 
 // Reproduces the production credits top-up flow against real Stripe test
 // mode, server-side: create-setup-intent -> confirm the SetupIntent with a
@@ -26,7 +27,7 @@ const stripeTestingEnabled =
 	Boolean(stripeKey?.startsWith("sk_test_"));
 
 function generateTestId(): string {
-	return `test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+	return uniqueId("test");
 }
 
 describe.skipIf(!stripeTestingEnabled)(

--- a/apps/api/src/routes/public-chat-support.spec.ts
+++ b/apps/api/src/routes/public-chat-support.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
 
+import { randomInt, uniqueId } from "@llmgateway/shared/random";
+
 const BURST_LIMIT_MAX = 5;
 const RATE_LIMIT_MAX = 20;
 const DAILY_LIMIT_MAX = 60;
@@ -12,12 +14,12 @@ const META_BURST_LIMIT_MAX = 30;
 // Unique identifiers per call so runs never collide with earlier state in
 // Redis (the rate-limit keys live for up to 24 hours).
 function uniqueIp(): string {
-	const octet = () => Math.floor(Math.random() * 256);
+	const octet = () => randomInt(0, 256);
 	return `10.${octet()}.${octet()}.${octet()}`;
 }
 
 function uniqueClientId(): string {
-	return `spec-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	return uniqueId("spec");
 }
 
 // Seeds a single limiter bucket to its threshold so the next request trips

--- a/apps/code/src/components/ui/flickering-grid.tsx
+++ b/apps/code/src/components/ui/flickering-grid.tsx
@@ -10,6 +10,8 @@ import React, {
 
 import { cn } from "@/lib/utils";
 
+import { randomFloat } from "@llmgateway/shared/random";
+
 interface FlickeringGridProps extends React.HTMLAttributes<HTMLDivElement> {
 	squareSize?: number;
 	gridGap?: number;
@@ -68,7 +70,7 @@ export const FlickeringGrid: React.FC<FlickeringGridProps> = ({
 
 			const squares = new Float32Array(cols * rows);
 			for (let i = 0; i < squares.length; i++) {
-				squares[i] = Math.random() * maxOpacity;
+				squares[i] = randomFloat() * maxOpacity;
 			}
 
 			return { cols, rows, squares, dpr };
@@ -79,8 +81,8 @@ export const FlickeringGrid: React.FC<FlickeringGridProps> = ({
 	const updateSquares = useCallback(
 		(squares: Float32Array, deltaTime: number) => {
 			for (let i = 0; i < squares.length; i++) {
-				if (Math.random() < flickerChance * deltaTime) {
-					squares[i] = Math.random() * maxOpacity;
+				if (randomFloat() < flickerChance * deltaTime) {
+					squares[i] = randomFloat() * maxOpacity;
 				}
 			}
 		},

--- a/apps/code/src/components/ui/flickering-grid.tsx
+++ b/apps/code/src/components/ui/flickering-grid.tsx
@@ -10,7 +10,7 @@ import React, {
 
 import { cn } from "@/lib/utils";
 
-import { randomFloat } from "@llmgateway/shared/random";
+import { fillRandomFloats } from "@llmgateway/shared/random";
 
 interface FlickeringGridProps extends React.HTMLAttributes<HTMLDivElement> {
 	squareSize?: number;
@@ -69,20 +69,28 @@ export const FlickeringGrid: React.FC<FlickeringGridProps> = ({
 			const rows = Math.ceil(height / (squareSize + gridGap));
 
 			const squares = new Float32Array(cols * rows);
+			fillRandomFloats(squares);
 			for (let i = 0; i < squares.length; i++) {
-				squares[i] = randomFloat() * maxOpacity;
+				squares[i] *= maxOpacity;
 			}
 
-			return { cols, rows, squares, dpr };
+			// Two values per square per frame — one to decide whether it
+			// flickers, one for its new opacity — refilled in a single batch so
+			// the animation loop never makes a crypto call per cell.
+			const noise = new Float32Array(squares.length * 2);
+
+			return { cols, rows, squares, noise, dpr };
 		},
 		[squareSize, gridGap, maxOpacity],
 	);
 
 	const updateSquares = useCallback(
-		(squares: Float32Array, deltaTime: number) => {
+		(squares: Float32Array, noise: Float32Array, deltaTime: number) => {
+			fillRandomFloats(noise);
+			const flickerThreshold = flickerChance * deltaTime;
 			for (let i = 0; i < squares.length; i++) {
-				if (randomFloat() < flickerChance * deltaTime) {
-					squares[i] = randomFloat() * maxOpacity;
+				if (noise[i] < flickerThreshold) {
+					squares[i] = noise[squares.length + i] * maxOpacity;
 				}
 			}
 		},
@@ -148,7 +156,7 @@ export const FlickeringGrid: React.FC<FlickeringGridProps> = ({
 				const deltaTime = (time - lastTime) / 1000;
 				lastTime = time;
 
-				updateSquares(gridParams.squares, deltaTime);
+				updateSquares(gridParams.squares, gridParams.noise, deltaTime);
 				drawGrid(
 					ctx,
 					canvas.width,

--- a/apps/gateway/src/cancellation.spec.ts
+++ b/apps/gateway/src/cancellation.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 
 import { db, tables } from "@llmgateway/db";
+import { randomToken } from "@llmgateway/shared/random";
 
 import { app } from "./app.js";
 import {
@@ -186,7 +187,7 @@ describe("client cancellation logging", () => {
 			// fixed sleep against slow CI runners.
 			const upstreamRequestReceived = waitForMockCheckpoint("TRIGGER_TIMEOUT");
 			const requestPromise = postChat(
-				`TRIGGER_TIMEOUT_5000 ${Math.random()}`,
+				`TRIGGER_TIMEOUT_5000 ${randomToken()}`,
 				controller.signal,
 				requestId,
 			);
@@ -213,7 +214,7 @@ describe("client cancellation logging", () => {
 			// abort fires.
 			const partialBodyFlushed = waitForMockCheckpoint("TRIGGER_BODY_HANG");
 			const requestPromise = postChat(
-				`TRIGGER_BODY_HANG ${Math.random()}`,
+				`TRIGGER_BODY_HANG ${randomToken()}`,
 				controller.signal,
 				requestId,
 			);
@@ -241,7 +242,7 @@ describe("client cancellation logging", () => {
 			// the abort fires.
 			const partialBodyFlushed = waitForMockCheckpoint("TRIGGER_5XX_BODY_HANG");
 			const requestPromise = postChat(
-				`TRIGGER_5XX_BODY_HANG ${Math.random()}`,
+				`TRIGGER_5XX_BODY_HANG ${randomToken()}`,
 				controller.signal,
 				requestId,
 			);
@@ -266,7 +267,7 @@ describe("client cancellation logging", () => {
 			// error-body res.text() instead of the non-streaming one.
 			const partialBodyFlushed = waitForMockCheckpoint("TRIGGER_5XX_BODY_HANG");
 			const requestPromise = postChat(
-				`TRIGGER_5XX_BODY_HANG ${Math.random()}`,
+				`TRIGGER_5XX_BODY_HANG ${randomToken()}`,
 				controller.signal,
 				requestId,
 				{ stream: true },

--- a/apps/gateway/src/chat-basic.e2e.ts
+++ b/apps/gateway/src/chat-basic.e2e.ts
@@ -13,11 +13,13 @@ import {
 	validateResponse,
 } from "@/chat-helpers.e2e.js";
 
+import { uniqueId } from "@llmgateway/shared/random";
+
 import { app } from "./app.js";
 
 // Helper function to generate unique request IDs for tests
 export function generateTestRequestId(): string {
-	return `test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+	return uniqueId("test");
 }
 
 describe("e2e", getConcurrentTestOptions(), () => {

--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -13,6 +13,7 @@ import {
 	getTestOptions,
 	expandAllProviderRegions,
 } from "@llmgateway/models";
+import { uniqueId } from "@llmgateway/shared/random";
 
 import {
 	clearCache,
@@ -23,7 +24,7 @@ export { getConcurrentTestOptions, getTestOptions };
 
 // Helper function to generate unique request IDs for tests
 export function generateTestRequestId(): string {
-	return `test-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+	return uniqueId("test");
 }
 
 export const fullMode = process.env.FULL_MODE;

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -2268,13 +2268,15 @@ describe("fallback and error status code handling", () => {
 		test("non-streaming: retries after random exploration selects a bad provider", async () => {
 			await setupMultiProviderKeys();
 
-			const randomSpy = vi
-				.spyOn(Math, "random")
-				.mockReturnValueOnce(0)
-				.mockReturnValue(0);
+			// An exploration rate of 1 always trips the epsilon-greedy branch, so the
+			// test does not depend on the value the secure RNG happens to produce.
+			// The mock fails the first upstream call regardless of which provider
+			// exploration lands on, so the retry assertions stay deterministic.
+			const originalExplorationRate = process.env.EXPLORATION_RATE;
 			const originalArgv = process.argv;
 			const originalNodeEnv = process.env.NODE_ENV;
 			const originalVitest = process.env.VITEST;
+			process.env.EXPLORATION_RATE = "1";
 			delete process.env.NODE_ENV;
 			delete process.env.VITEST;
 			process.argv = ["node", "/tmp/not-a-test-run.mjs"];
@@ -2330,7 +2332,11 @@ describe("fallback and error status code handling", () => {
 				);
 				expect(failedLog?.retried).toBe(true);
 			} finally {
-				randomSpy.mockRestore();
+				if (originalExplorationRate !== undefined) {
+					process.env.EXPLORATION_RATE = originalExplorationRate;
+				} else {
+					delete process.env.EXPLORATION_RATE;
+				}
 				process.argv = originalArgv;
 				if (originalNodeEnv !== undefined) {
 					process.env.NODE_ENV = originalNodeEnv;

--- a/apps/playground/src/components/ui/sidebar.tsx
+++ b/apps/playground/src/components/ui/sidebar.tsx
@@ -25,6 +25,8 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
+import { randomInt } from "@llmgateway/shared/random";
+
 import type { VariantProps } from "class-variance-authority";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
@@ -625,7 +627,7 @@ function SidebarMenuSkeleton({
 }) {
 	// Random width between 50 to 90%.
 	const width = React.useMemo(() => {
-		return `${Math.floor(Math.random() * 40) + 50}%`;
+		return `${randomInt(50, 90)}%`;
 	}, []);
 
 	return (

--- a/apps/playground/src/lib/hero-suggestions.ts
+++ b/apps/playground/src/lib/hero-suggestions.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "@llmgateway/shared/random";
+
 export const heroSuggestionGroups = {
 	Create: [
 		"Write a Python script to analyze CSV data and create visualizations",
@@ -297,7 +299,7 @@ export function sampleSuggestions(
 	const shuffled = [...items];
 
 	for (let i = shuffled.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1));
+		const j = randomInt(0, i + 1);
 		const current = shuffled[i]!;
 		shuffled[i] = shuffled[j]!;
 		shuffled[j] = current;

--- a/apps/ui/src/components/activity/activity-loading.tsx
+++ b/apps/ui/src/components/activity/activity-loading.tsx
@@ -1,5 +1,7 @@
 import { Skeleton } from "@/lib/components/skeleton";
 
+import { randomFloatBetween } from "@llmgateway/shared/random";
+
 export function ActivityLoading() {
 	return (
 		<div className="min-h-screen bg-background text-foreground p-6">
@@ -47,8 +49,7 @@ export function ActivityLoading() {
 								>
 									<div
 										className="w-full flex flex-col justify-end"
-										// eslint-disable-next-line no-mixed-operators
-										style={{ height: `${Math.random() * 80 + 20}%` }}
+										style={{ height: `${randomFloatBetween(20, 100)}%` }}
 									>
 										<Skeleton className="w-full h-full bg-gradient-to-t from-blue-600 to-blue-400 rounded-t" />
 									</div>

--- a/apps/ui/src/components/auth/auth-brand-panel.tsx
+++ b/apps/ui/src/components/auth/auth-brand-panel.tsx
@@ -2,6 +2,8 @@ import { Zap, Shield, Globe } from "lucide-react";
 
 import { TweetCard } from "@/lib/components/tweet-card";
 
+import { randomItem } from "@llmgateway/shared/random";
+
 const TWEET_IDS = [
 	"1970126770205757516",
 	"1967955025315106997",
@@ -13,16 +15,12 @@ const TWEET_IDS = [
 	"1958469139632464022",
 ];
 
-function pickRandom<T>(arr: T[]): T {
-	return arr[Math.floor(Math.random() * arr.length)]!;
-}
-
 export async function AuthBrandPanel({
 	variant,
 }: {
 	variant: "login" | "signup";
 }) {
-	const tweetId = pickRandom(TWEET_IDS);
+	const tweetId = randomItem(TWEET_IDS)!;
 
 	return (
 		<div className="relative hidden w-1/2 overflow-hidden bg-gradient-to-br from-zinc-100 via-zinc-50 to-zinc-100 dark:from-zinc-900 dark:via-zinc-800 dark:to-zinc-900 lg:flex lg:flex-col lg:justify-between">

--- a/apps/ui/src/components/dashboard/dashboard-loading.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-loading.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardHeader } from "@/lib/components/card";
 import { Skeleton } from "@/lib/components/skeleton";
 
+import { randomFloatBetween } from "@llmgateway/shared/random";
+
 export function DashboardLoading() {
 	return (
 		<div className="min-h-screen bg-background text-foreground p-6">
@@ -46,8 +48,7 @@ export function DashboardLoading() {
 								<div key={i} className="flex flex-col items-center gap-2">
 									<Skeleton
 										className="w-8"
-										// eslint-disable-next-line no-mixed-operators
-										style={{ height: `${Math.random() * 150 + 50}px` }}
+										style={{ height: `${randomFloatBetween(50, 200)}px` }}
 									/>
 									<Skeleton className="h-3 w-12" />
 								</div>

--- a/apps/ui/src/components/landing/animated-beam.tsx
+++ b/apps/ui/src/components/landing/animated-beam.tsx
@@ -5,6 +5,8 @@ import { useEffect, useId, useState } from "react";
 import { motion } from "@/components/motion-wrapper";
 import { cn } from "@/lib/utils";
 
+import { randomFloatBetween } from "@llmgateway/shared/random";
+
 import type { RefObject } from "react";
 
 export interface AnimatedBeamProps {
@@ -34,8 +36,7 @@ export const AnimatedBeam: React.FC<AnimatedBeamProps> = ({
 	toRef,
 	curvature = 0,
 	reverse = false, // Include the reverse prop
-	// eslint-disable-next-line no-mixed-operators
-	duration = Math.random() * 3 + 4,
+	duration = randomFloatBetween(4, 7),
 	delay = 0,
 	pathColor = "gray",
 	pathWidth = 2,

--- a/apps/ui/src/lib/components/sidebar.tsx
+++ b/apps/ui/src/lib/components/sidebar.tsx
@@ -34,6 +34,8 @@ import {
 } from "@/lib/components/tooltip";
 import { cn } from "@/lib/utils";
 
+import { randomInt } from "@llmgateway/shared/random";
+
 import type { VariantProps } from "class-variance-authority";
 
 const SIDEBAR_STORAGE_KEY = "sidebar_state";
@@ -628,7 +630,7 @@ function SidebarMenuSkeleton({
 }) {
 	// Random width between 50 to 90%.
 	const width = useMemo(() => {
-		return `${Math.floor(Math.random() * 40) + 50}%`;
+		return `${randomInt(50, 90)}%`;
 	}, []);
 
 	return (

--- a/apps/ui/src/lib/mock-feature-data.ts
+++ b/apps/ui/src/lib/mock-feature-data.ts
@@ -1,5 +1,7 @@
 import { subDays, format } from "date-fns";
 
+import { randomFloatBetween, randomInt } from "@llmgateway/shared/random";
+
 export const generateMockActivityData = () => {
 	const today = new Date();
 	const days = 7;
@@ -11,38 +13,33 @@ export const generateMockActivityData = () => {
 
 		activity.push({
 			date: dateStr,
-			requestCount: Math.floor(Math.random() * 500) + 100,
-			inputTokens: Math.floor(Math.random() * 50000) + 10000,
-			outputTokens: Math.floor(Math.random() * 30000) + 5000,
-			totalTokens: Math.floor(Math.random() * 80000) + 15000,
-			// eslint-disable-next-line no-mixed-operators
-			cost: Math.random() * 5 + 0.5,
-			errorCount: Math.floor(Math.random() * 10),
-			cacheCount: Math.floor(Math.random() * 50) + 10,
-			errorRate: Math.random() * 2,
-			// eslint-disable-next-line no-mixed-operators
-			cacheRate: Math.random() * 20 + 5,
+			requestCount: randomInt(100, 600),
+			inputTokens: randomInt(10000, 60000),
+			outputTokens: randomInt(5000, 35000),
+			totalTokens: randomInt(15000, 95000),
+			cost: randomFloatBetween(0.5, 5.5),
+			errorCount: randomInt(0, 10),
+			cacheCount: randomInt(10, 60),
+			errorRate: randomFloatBetween(0, 2),
+			cacheRate: randomFloatBetween(5, 25),
 			modelBreakdown: [
 				{
 					id: "anthropic/claude-3-5-sonnet-20241022",
-					requestCount: Math.floor(Math.random() * 200) + 50,
-					// eslint-disable-next-line no-mixed-operators
-					cost: Math.random() * 2 + 0.2,
-					totalTokens: Math.floor(Math.random() * 40000) + 8000,
+					requestCount: randomInt(50, 250),
+					cost: randomFloatBetween(0.2, 2.2),
+					totalTokens: randomInt(8000, 48000),
 				},
 				{
 					id: "openai/gpt-4o",
-					requestCount: Math.floor(Math.random() * 150) + 30,
-					// eslint-disable-next-line no-mixed-operators
-					cost: Math.random() * 1.5 + 0.1,
-					totalTokens: Math.floor(Math.random() * 30000) + 5000,
+					requestCount: randomInt(30, 180),
+					cost: randomFloatBetween(0.1, 1.6),
+					totalTokens: randomInt(5000, 35000),
 				},
 				{
 					id: "google-ai-studio/gemini-1.5-pro",
-					requestCount: Math.floor(Math.random() * 100) + 20,
-					// eslint-disable-next-line no-mixed-operators
-					cost: Number(Math.random()) * 1 + 0.05,
-					totalTokens: Math.floor(Math.random() * 20000) + 3000,
+					requestCount: randomInt(20, 120),
+					cost: randomFloatBetween(0.05, 1.05),
+					totalTokens: randomInt(3000, 23000),
 				},
 			],
 		});

--- a/ee/admin/src/components/ui/sidebar.tsx
+++ b/ee/admin/src/components/ui/sidebar.tsx
@@ -25,6 +25,8 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
+import { randomInt } from "@llmgateway/shared/random";
+
 import type { VariantProps } from "class-variance-authority";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
@@ -610,7 +612,7 @@ function SidebarMenuSkeleton({
 }) {
 	// Random width between 50 to 90%.
 	const width = React.useMemo(() => {
-		return `${Math.floor(Math.random() * 40) + 50}%`;
+		return `${randomInt(50, 90)}%`;
 	}, []);
 
 	return (

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,15 @@ export default [
 			"@eslint-react/naming-convention/use-state": "off",
 			"@eslint-react/prefer-use-state-lazy-initialization": "off",
 			"no-console": "error",
+			"no-restricted-properties": [
+				"error",
+				{
+					object: "Math",
+					property: "random",
+					message:
+						"Math.random() is not cryptographically secure. Use randomFloat/randomInt/randomItem/randomToken/uniqueId from @llmgateway/shared/random instead.",
+				},
+			],
 			"no-unused-vars": [
 				"error",
 				{

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -11,6 +11,7 @@ import {
 	type ModelWithPricing,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
+import { randomFloat, randomInt } from "@llmgateway/shared/random";
 import {
 	getDefaultRoutingConfig,
 	type ResolvedRoutingConfig,
@@ -561,10 +562,10 @@ export async function getCheapestFromAvailableProviders<
 	if (
 		!sessionSticky &&
 		!isTestProcess() &&
-		Math.random() < getExplorationRate(cfg)
+		randomFloat() < getExplorationRate(cfg)
 	) {
 		const randomProvider =
-			stableProviders[Math.floor(Math.random() * stableProviders.length)];
+			stableProviders[randomInt(0, stableProviders.length)];
 		return {
 			provider: randomProvider,
 			metadata: {

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { metricsKey } from "@llmgateway/db";
 import {
@@ -1020,10 +1020,13 @@ describe("getCheapestFromAvailableProviders", () => {
 			throw new Error("Missing Veo provider test fixtures");
 		}
 
-		const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+		// An exploration rate of 1 always trips the epsilon-greedy branch, so the
+		// test does not depend on the value the secure RNG happens to produce.
+		const originalExplorationRate = process.env.EXPLORATION_RATE;
 		const originalArgv = process.argv;
 		const originalNodeEnv = process.env.NODE_ENV;
 		const originalVitest = process.env.VITEST;
+		process.env.EXPLORATION_RATE = "1";
 		delete process.env.NODE_ENV;
 		delete process.env.VITEST;
 		process.argv = ["node", "/tmp/vitest.mjs"];
@@ -1072,7 +1075,11 @@ describe("getCheapestFromAvailableProviders", () => {
 			expect(result?.provider.providerId).toBe("google-vertex");
 			expect(result?.metadata.selectionReason).toBe("weighted-score");
 		} finally {
-			randomSpy.mockRestore();
+			if (originalExplorationRate !== undefined) {
+				process.env.EXPLORATION_RATE = originalExplorationRate;
+			} else {
+				delete process.env.EXPLORATION_RATE;
+			}
 			process.argv = originalArgv;
 			if (originalNodeEnv !== undefined) {
 				process.env.NODE_ENV = originalNodeEnv;
@@ -1107,13 +1114,13 @@ describe("getCheapestFromAvailableProviders", () => {
 			throw new Error("Missing Veo provider test fixtures");
 		}
 
-		const randomSpy = vi
-			.spyOn(Math, "random")
-			.mockReturnValueOnce(0)
-			.mockReturnValueOnce(0);
+		// An exploration rate of 1 always trips the epsilon-greedy branch, so the
+		// test does not depend on the value the secure RNG happens to produce.
+		const originalExplorationRate = process.env.EXPLORATION_RATE;
 		const originalArgv = process.argv;
 		const originalNodeEnv = process.env.NODE_ENV;
 		const originalVitest = process.env.VITEST;
+		process.env.EXPLORATION_RATE = "1";
 		delete process.env.NODE_ENV;
 		delete process.env.VITEST;
 		process.argv = ["node", "/tmp/not-a-test-run.mjs"];
@@ -1165,7 +1172,11 @@ describe("getCheapestFromAvailableProviders", () => {
 				expect.arrayContaining(["avalanche", "google-vertex"]),
 			);
 		} finally {
-			randomSpy.mockRestore();
+			if (originalExplorationRate !== undefined) {
+				process.env.EXPLORATION_RATE = originalExplorationRate;
+			} else {
+				delete process.env.EXPLORATION_RATE;
+			}
 			process.argv = originalArgv;
 			if (originalNodeEnv !== undefined) {
 				process.env.NODE_ENV = originalNodeEnv;

--- a/packages/db/src/seed-demo-analytics.ts
+++ b/packages/db/src/seed-demo-analytics.ts
@@ -7,6 +7,8 @@
  * enterprise "DataFlow AI" organization so every new page renders rich data.
  * Safe to re-run (idempotent via ON CONFLICT).
  */
+import { randomFloat, randomFloatBetween } from "@llmgateway/shared/random";
+
 import { closeDatabase, db, tables } from "./index.js";
 
 const ORG_ID = "org-dataflow";
@@ -128,10 +130,6 @@ function hourBucket(dayOffset: number, hour: number): Date {
 	return d;
 }
 
-function rand(min: number, max: number): number {
-	return min + (max - min) * Math.random(); // eslint-disable-line no-mixed-operators
-}
-
 async function main(): Promise<void> {
 	const keyStatsRows: (typeof tables.apiKeyHourlyStats.$inferInsert)[] = [];
 	const keyModelStatsRows: (typeof tables.apiKeyHourlyModelStats.$inferInsert)[] =
@@ -174,22 +172,30 @@ async function main(): Promise<void> {
 					let hourOutputCost = 0;
 
 					// Each key uses a rotating subset of models.
-					const modelCount = 3 + Math.floor(rand(0, 3));
+					const modelCount = 3 + Math.floor(randomFloatBetween(0, 3));
 					for (let m = 0; m < modelCount; m++) {
 						const model =
 							MODELS[(key.id.length + dayOffset + m) % MODELS.length];
 						const requestCount = Math.max(
 							1,
-							Math.round(owner.weight * activityFactor * rand(2, 10)),
+							Math.round(
+								owner.weight * activityFactor * randomFloatBetween(2, 10),
+							),
 						);
-						const inputTokens = Math.round(requestCount * rand(350, 900));
-						const outputTokens = Math.round(requestCount * rand(180, 520));
+						const inputTokens = Math.round(
+							requestCount * randomFloatBetween(350, 900),
+						);
+						const outputTokens = Math.round(
+							requestCount * randomFloatBetween(180, 520),
+						);
 						const totalTokens = inputTokens + outputTokens;
 						const inputCost = (inputTokens / 1000) * model.inPrice;
 						const outputCost = (outputTokens / 1000) * model.outPrice;
 						const cost = inputCost + outputCost;
-						const errorCount = Math.random() < 0.15 ? 1 : 0;
-						const cacheCount = Math.round(requestCount * rand(0, 0.25));
+						const errorCount = randomFloat() < 0.15 ? 1 : 0;
+						const cacheCount = Math.round(
+							requestCount * randomFloatBetween(0, 0.25),
+						);
 
 						hourRequests += requestCount;
 						hourErrors += errorCount;

--- a/packages/scripts/src/generate-test-logs.ts
+++ b/packages/scripts/src/generate-test-logs.ts
@@ -13,6 +13,11 @@
 import { customAlphabet } from "nanoid";
 
 import { db, tables } from "@llmgateway/db";
+import {
+	randomFloat,
+	randomFloatBetween,
+	randomInt,
+} from "@llmgateway/shared/random";
 
 const generate = customAlphabet(
 	"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -121,7 +126,7 @@ const FINISH_REASONS = [
 
 function weightedRandom<T extends { weight: number }>(items: T[]): T {
 	const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
-	let random = Math.random() * totalWeight;
+	let random = randomFloat() * totalWeight;
 
 	for (const item of items) {
 		random -= item.weight;
@@ -133,27 +138,19 @@ function weightedRandom<T extends { weight: number }>(items: T[]): T {
 	return items[items.length - 1];
 }
 
-function randomInt(min: number, max: number): number {
-	return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-function randomFloat(min: number, max: number): number {
-	// eslint-disable-next-line no-mixed-operators
-	return Math.random() * (max - min) + min;
-}
-
 // Log-normal distribution for more realistic heavy-tailed randomness
 // Most values cluster near the median, but occasional large outliers occur
 function logNormalRandom(median: number, sigma: number): number {
-	const u1 = Math.random();
-	const u2 = Math.random();
+	// 1 - randomFloat() keeps u1 in (0, 1] so Math.log never sees zero.
+	const u1 = 1 - randomFloat();
+	const u2 = randomFloat();
 	const z = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
 	return median * Math.exp(sigma * z);
 }
 
 function randomDate(daysBack: number): Date {
 	const now = new Date();
-	const msBack = randomInt(0, daysBack * 24 * 60 * 60 * 1000);
+	const msBack = randomInt(0, daysBack * 24 * 60 * 60 * 1000 + 1);
 	return new Date(now.getTime() - msBack);
 }
 
@@ -178,10 +175,10 @@ function generateLog(
 	);
 
 	// Determine if this request has cached input tokens
-	const hasCachedTokens = Math.random() < model.cacheChance;
+	const hasCachedTokens = randomFloat() < model.cacheChance;
 	// Cached tokens are a portion (20-80%) of the input tokens
 	const cachedTokens = hasCachedTokens
-		? Math.round(inputTokens * randomFloat(0.2, 0.8))
+		? Math.round(inputTokens * randomFloatBetween(0.2, 0.8))
 		: 0;
 
 	const totalTokens = inputTokens + outputTokens;
@@ -220,8 +217,8 @@ function generateLog(
 	);
 
 	// Random flags
-	const streamed = Math.random() > 0.3; // 70% are streamed
-	const cached = Math.random() > 0.9; // 10% are cached
+	const streamed = randomFloat() > 0.3; // 70% are streamed
+	const cached = randomFloat() > 0.9; // 10% are cached
 
 	// Time to first token (only for streamed, log-normal for variability)
 	const timeToFirstToken = streamed
@@ -247,7 +244,7 @@ function generateLog(
 		requestedProvider: model.provider,
 		usedModel: model.id,
 		usedProvider: model.provider,
-		responseSize: outputTokens * randomInt(3, 6), // Variable bytes-per-token estimate
+		responseSize: outputTokens * randomInt(3, 7), // Variable bytes-per-token estimate
 		promptTokens: String(inputTokens),
 		completionTokens: String(outputTokens),
 		totalTokens: String(totalTokens),
@@ -268,7 +265,7 @@ function generateLog(
 		messages: JSON.stringify([
 			{ role: "user", content: "Test message for visualization" },
 		]),
-		temperature: randomFloat(0, 1.5),
+		temperature: randomFloatBetween(0, 1.5),
 		maxTokens: Math.round(logNormalRandom(2000, 0.6)),
 	};
 }

--- a/packages/scripts/src/generate-test-logs.ts
+++ b/packages/scripts/src/generate-test-logs.ts
@@ -148,6 +148,10 @@ function logNormalRandom(median: number, sigma: number): number {
 	return median * Math.exp(sigma * z);
 }
 
+// Keeps the millisecond span randomDate draws from well inside the safe
+// integer range that randomInt requires.
+const MAX_DAYS_BACK = 36500;
+
 function randomDate(daysBack: number): Date {
 	const now = new Date();
 	const msBack = randomInt(0, daysBack * 24 * 60 * 60 * 1000 + 1);
@@ -300,6 +304,13 @@ async function main() {
 
 	if (isNaN(count) || count <= 0) {
 		console.error("Error: count must be a positive integer");
+		process.exit(1);
+	}
+
+	if (!Number.isInteger(daysBack) || daysBack < 0 || daysBack > MAX_DAYS_BACK) {
+		console.error(
+			`Error: daysBack must be an integer between 0 and ${MAX_DAYS_BACK}`,
+		);
 		process.exit(1);
 	}
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,6 +29,10 @@
 			"types": "./dist/api-key-hash.d.ts",
 			"import": "./dist/api-key-hash.js"
 		},
+		"./random": {
+			"types": "./dist/random.d.ts",
+			"import": "./dist/random.js"
+		},
 		"./routing-config": {
 			"types": "./dist/routing-config.d.ts",
 			"import": "./dist/routing-config.js"

--- a/packages/shared/src/components/ui/sidebar.tsx
+++ b/packages/shared/src/components/ui/sidebar.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { randomInt } from "@/random";
 
 import { Button } from "./button";
 import { Input } from "./input";
@@ -611,7 +612,7 @@ function SidebarMenuSkeleton({
 }) {
 	// Random width between 50 to 90%.
 	const width = React.useMemo(() => {
-		return `${Math.floor(Math.random() * 40) + 50}%`;
+		return `${randomInt(50, 90)}%`;
 	}, []);
 
 	return (

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -130,6 +130,7 @@ export {
 export { selectLoadBalancedItem } from "./load-balance.js";
 
 export {
+	fillRandomFloats,
 	randomFloat,
 	randomFloatBetween,
 	randomInt,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -129,6 +129,15 @@ export {
 
 export { selectLoadBalancedItem } from "./load-balance.js";
 
+export {
+	randomFloat,
+	randomFloatBetween,
+	randomInt,
+	randomItem,
+	randomToken,
+	uniqueId,
+} from "./random.js";
+
 export { MARKETING_STATS, RUNWARE_PROMO } from "./marketing.js";
 
 export { isContentFilterErrorText } from "./content-filter.js";

--- a/packages/shared/src/random.spec.ts
+++ b/packages/shared/src/random.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	fillRandomFloats,
 	randomFloat,
 	randomFloatBetween,
 	randomInt,
@@ -50,6 +51,61 @@ describe("randomInt", () => {
 		expect(() => randomInt(5, 5)).toThrow(RangeError);
 		expect(() => randomInt(10, 5)).toThrow(RangeError);
 	});
+
+	test("stays in bounds for a range wider than 2^32", () => {
+		// 100 days in milliseconds — the span generate-test-logs draws from.
+		const max = 100 * 24 * 60 * 60 * 1000;
+		expect(max).toBeGreaterThan(2 ** 32);
+
+		for (let i = 0; i < 1000; i++) {
+			const value = randomInt(0, max);
+			expect(Number.isSafeInteger(value)).toBe(true);
+			expect(value).toBeGreaterThanOrEqual(0);
+			expect(value).toBeLessThan(max);
+		}
+	});
+
+	test("spreads a wide range across its whole span", () => {
+		const max = 2 ** 40;
+		const buckets = new Set<number>();
+		for (let i = 0; i < 200; i++) {
+			buckets.add(Math.floor((randomInt(0, max) / max) * 4));
+		}
+		expect(buckets.size).toBe(4);
+	});
+
+	test("rejects bounds outside the safe integer range", () => {
+		expect(() => randomInt(0, 2 ** 53)).toThrow(RangeError);
+		expect(() => randomInt(-(2 ** 53), 0)).toThrow(RangeError);
+	});
+});
+
+describe("fillRandomFloats", () => {
+	test("fills every slot with a value in [0, 1)", () => {
+		const target = new Float32Array(1000);
+		fillRandomFloats(target);
+
+		for (const value of Array.from(target)) {
+			expect(value).toBeGreaterThanOrEqual(0);
+			expect(value).toBeLessThan(1);
+		}
+		expect(new Set(Array.from(target)).size).toBeGreaterThan(900);
+	});
+
+	test("fills buffers larger than one crypto chunk", () => {
+		// getRandomValues caps at 65536 bytes, so this spans several chunks.
+		const target = new Float32Array(40000);
+		fillRandomFloats(target);
+
+		expect(Array.from(target).every((v) => v >= 0 && v < 1)).toBe(true);
+		expect(
+			new Set(Array.from(target.subarray(16384, 33000))).size,
+		).toBeGreaterThan(15000);
+	});
+
+	test("handles an empty buffer", () => {
+		expect(() => fillRandomFloats(new Float32Array(0))).not.toThrow();
+	});
 });
 
 describe("randomFloatBetween", () => {
@@ -89,6 +145,18 @@ describe("randomToken", () => {
 	test("returns an empty string for a non-positive length", () => {
 		expect(randomToken(0)).toBe("");
 		expect(randomToken(-1)).toBe("");
+	});
+
+	test("rejects a fractional length instead of looping forever", () => {
+		// A fractional length truncates to a zero-byte request part way through,
+		// which would never let the loop reach its target length.
+		expect(() => randomToken(1.5)).toThrow(RangeError);
+		expect(() => randomToken(Number.NaN)).toThrow(RangeError);
+		expect(() => randomToken(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+	});
+
+	test("fills lengths beyond one crypto chunk", () => {
+		expect(randomToken(70000)).toMatch(/^[0-9a-z]{70000}$/);
 	});
 
 	test("does not repeat", () => {

--- a/packages/shared/src/random.spec.ts
+++ b/packages/shared/src/random.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	randomFloat,
+	randomFloatBetween,
+	randomInt,
+	randomItem,
+	randomToken,
+	uniqueId,
+} from "./random.js";
+
+describe("randomFloat", () => {
+	test("stays within [0, 1)", () => {
+		for (let i = 0; i < 1000; i++) {
+			const value = randomFloat();
+			expect(value).toBeGreaterThanOrEqual(0);
+			expect(value).toBeLessThan(1);
+		}
+	});
+
+	test("produces distinct values", () => {
+		const values = new Set(Array.from({ length: 100 }, () => randomFloat()));
+		expect(values.size).toBe(100);
+	});
+});
+
+describe("randomInt", () => {
+	test("stays within [min, max)", () => {
+		for (let i = 0; i < 1000; i++) {
+			const value = randomInt(5, 10);
+			expect(Number.isInteger(value)).toBe(true);
+			expect(value).toBeGreaterThanOrEqual(5);
+			expect(value).toBeLessThan(10);
+		}
+	});
+
+	test("covers every value in the range", () => {
+		const seen = new Set<number>();
+		for (let i = 0; i < 2000; i++) {
+			seen.add(randomInt(0, 5));
+		}
+		expect(Array.from(seen).sort()).toEqual([0, 1, 2, 3, 4]);
+	});
+
+	test("returns the only value of a single-element range", () => {
+		expect(randomInt(3, 4)).toBe(3);
+	});
+
+	test("rejects an empty or inverted range", () => {
+		expect(() => randomInt(5, 5)).toThrow(RangeError);
+		expect(() => randomInt(10, 5)).toThrow(RangeError);
+	});
+});
+
+describe("randomFloatBetween", () => {
+	test("stays within [min, max)", () => {
+		for (let i = 0; i < 1000; i++) {
+			const value = randomFloatBetween(2.5, 4);
+			expect(value).toBeGreaterThanOrEqual(2.5);
+			expect(value).toBeLessThan(4);
+		}
+	});
+});
+
+describe("randomItem", () => {
+	test("returns undefined for an empty list", () => {
+		expect(randomItem([])).toBeUndefined();
+	});
+
+	test("only returns members of the list", () => {
+		const items = ["a", "b", "c"] as const;
+		const seen = new Set<string>();
+		for (let i = 0; i < 500; i++) {
+			const item = randomItem(items)!;
+			expect(items).toContain(item);
+			seen.add(item);
+		}
+		expect(seen.size).toBe(items.length);
+	});
+});
+
+describe("randomToken", () => {
+	test("returns a lowercase alphanumeric token of the requested length", () => {
+		expect(randomToken(9)).toMatch(/^[0-9a-z]{9}$/);
+		expect(randomToken(64)).toMatch(/^[0-9a-z]{64}$/);
+		expect(randomToken()).toHaveLength(12);
+	});
+
+	test("returns an empty string for a non-positive length", () => {
+		expect(randomToken(0)).toBe("");
+		expect(randomToken(-1)).toBe("");
+	});
+
+	test("does not repeat", () => {
+		const tokens = new Set(Array.from({ length: 500 }, () => randomToken()));
+		expect(tokens.size).toBe(500);
+	});
+});
+
+describe("uniqueId", () => {
+	test("uses the given prefix and stays unique", () => {
+		const ids = Array.from({ length: 500 }, () => uniqueId("test"));
+		for (const id of ids) {
+			expect(id).toMatch(/^test-\d+-[0-9a-z]{9}$/);
+		}
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	test("defaults to the id prefix", () => {
+		expect(uniqueId()).toMatch(/^id-\d+-[0-9a-z]{9}$/);
+	});
+});

--- a/packages/shared/src/random.spec.ts
+++ b/packages/shared/src/random.spec.ts
@@ -106,6 +106,19 @@ describe("fillRandomFloats", () => {
 	test("handles an empty buffer", () => {
 		expect(() => fillRandomFloats(new Float32Array(0))).not.toThrow();
 	});
+
+	test("emits values on the exact float32 fraction grid", () => {
+		// Sampling alone only catches a value rounding up to 1 once in ~33m
+		// draws, so assert the invariant that rules it out: every value is a
+		// multiple of 2^-24, which float32 stores exactly and caps below 1.
+		const target = new Float32Array(5000);
+		fillRandomFloats(target);
+
+		for (const value of Array.from(target)) {
+			expect(Number.isInteger(value * 16777216)).toBe(true);
+			expect(value).toBeLessThanOrEqual((16777216 - 1) / 16777216);
+		}
+	});
 });
 
 describe("randomFloatBetween", () => {

--- a/packages/shared/src/random.ts
+++ b/packages/shared/src/random.ts
@@ -1,4 +1,7 @@
 const UINT32_RANGE = 0x1_0000_0000;
+const UINT53_RANGE = 9007199254740992;
+// crypto.getRandomValues rejects requests larger than 65536 bytes.
+const MAX_RANDOM_BYTES = 65536;
 
 function nextUint32(): number {
 	const buffer = new Uint32Array(1);
@@ -6,16 +9,19 @@ function nextUint32(): number {
 	return buffer[0]!;
 }
 
+function nextUint53(): number {
+	const buffer = new Uint32Array(2);
+	crypto.getRandomValues(buffer);
+	// 27 high bits + 26 low bits: the 53 a double represents exactly.
+	return (buffer[0]! >>> 5) * 67108864 + (buffer[1]! >>> 6); // eslint-disable-line no-mixed-operators
+}
+
 /**
  * Cryptographically secure drop-in replacement for `Math.random()`.
  * Returns a float in [0, 1) with the same 53 bits of precision.
  */
 export function randomFloat(): number {
-	const buffer = new Uint32Array(2);
-	crypto.getRandomValues(buffer);
-	const high = buffer[0]! >>> 5;
-	const low = buffer[1]! >>> 6;
-	return (high * 67108864 + low) / 9007199254740992; // eslint-disable-line no-mixed-operators
+	return nextUint53() / UINT53_RANGE;
 }
 
 /**
@@ -32,15 +38,22 @@ export function randomInt(minInclusive: number, maxExclusive: number): number {
 		);
 	}
 
-	if (range > UINT32_RANGE) {
-		return min + Math.floor(randomFloat() * range);
+	if (!Number.isSafeInteger(min) || !Number.isSafeInteger(min + range)) {
+		throw new RangeError(
+			`randomInt requires bounds within the safe integer range, got ${minInclusive} and ${maxExclusive}`,
+		);
 	}
 
-	// Discard values from the incomplete final bucket to avoid modulo bias.
-	const limit = UINT32_RANGE - (UINT32_RANGE % range);
-	let value = nextUint32();
+	// Sample from the smallest space that covers the range, then discard the
+	// incomplete final bucket so the modulo cannot favour the low end.
+	const wide = range > UINT32_RANGE;
+	const space = wide ? UINT53_RANGE : UINT32_RANGE;
+	const next = wide ? nextUint53 : nextUint32;
+	const limit = space - (space % range);
+
+	let value = next();
 	while (value >= limit) {
-		value = nextUint32();
+		value = next();
 	}
 
 	return min + (value % range);
@@ -64,6 +77,31 @@ export function randomItem<T>(items: readonly T[]): T | undefined {
 	return items[randomInt(0, items.length)];
 }
 
+/**
+ * Fills the target with floats in [0, 1), using one `getRandomValues` call per
+ * 16384 values. Prefer this over calling `randomFloat()` in a loop on a hot
+ * path such as an animation frame, where per-value crypto calls dominate.
+ */
+export function fillRandomFloats(target: Float32Array): void {
+	if (target.length === 0) {
+		return;
+	}
+
+	const chunkLength = Math.min(Math.floor(MAX_RANDOM_BYTES / 4), target.length);
+	const scratch = new Uint32Array(chunkLength);
+
+	for (let offset = 0; offset < target.length; offset += chunkLength) {
+		const count = Math.min(chunkLength, target.length - offset);
+		crypto.getRandomValues(
+			count === chunkLength ? scratch : scratch.subarray(0, count),
+		);
+
+		for (let i = 0; i < count; i++) {
+			target[offset + i] = scratch[i]! / UINT32_RANGE;
+		}
+	}
+}
+
 const TOKEN_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 /**
@@ -74,13 +112,23 @@ export function randomToken(length = 12): string {
 		return "";
 	}
 
+	// A fractional length would truncate to a zero-byte request part way
+	// through and spin forever, so reject it before allocating anything.
+	if (!Number.isSafeInteger(length)) {
+		throw new RangeError(
+			`randomToken requires a safe integer length, got ${length}`,
+		);
+	}
+
 	// Bytes at or above the last whole multiple of the alphabet size are
 	// rejected so every character is uniformly distributed.
 	const limit = 256 - (256 % TOKEN_ALPHABET.length);
 
 	let token = "";
 	while (token.length < length) {
-		const bytes = new Uint8Array(length - token.length);
+		const bytes = new Uint8Array(
+			Math.min(length - token.length, MAX_RANDOM_BYTES),
+		);
 		crypto.getRandomValues(bytes);
 
 		bytes.forEach((byte) => {

--- a/packages/shared/src/random.ts
+++ b/packages/shared/src/random.ts
@@ -1,0 +1,102 @@
+const UINT32_RANGE = 0x1_0000_0000;
+
+function nextUint32(): number {
+	const buffer = new Uint32Array(1);
+	crypto.getRandomValues(buffer);
+	return buffer[0]!;
+}
+
+/**
+ * Cryptographically secure drop-in replacement for `Math.random()`.
+ * Returns a float in [0, 1) with the same 53 bits of precision.
+ */
+export function randomFloat(): number {
+	const buffer = new Uint32Array(2);
+	crypto.getRandomValues(buffer);
+	const high = buffer[0]! >>> 5;
+	const low = buffer[1]! >>> 6;
+	return (high * 67108864 + low) / 9007199254740992; // eslint-disable-line no-mixed-operators
+}
+
+/**
+ * Cryptographically secure integer in [minInclusive, maxExclusive).
+ * Uses rejection sampling so every value in the range is equally likely.
+ */
+export function randomInt(minInclusive: number, maxExclusive: number): number {
+	const min = Math.ceil(minInclusive);
+	const range = Math.floor(maxExclusive) - min;
+
+	if (!Number.isFinite(range) || range <= 0) {
+		throw new RangeError(
+			`randomInt requires maxExclusive > minInclusive, got ${minInclusive} and ${maxExclusive}`,
+		);
+	}
+
+	if (range > UINT32_RANGE) {
+		return min + Math.floor(randomFloat() * range);
+	}
+
+	// Discard values from the incomplete final bucket to avoid modulo bias.
+	const limit = UINT32_RANGE - (UINT32_RANGE % range);
+	let value = nextUint32();
+	while (value >= limit) {
+		value = nextUint32();
+	}
+
+	return min + (value % range);
+}
+
+/**
+ * Cryptographically secure float in [min, max).
+ */
+export function randomFloatBetween(min: number, max: number): number {
+	return min + randomFloat() * (max - min); // eslint-disable-line no-mixed-operators
+}
+
+/**
+ * Picks one item uniformly at random. Returns `undefined` for an empty list.
+ */
+export function randomItem<T>(items: readonly T[]): T | undefined {
+	if (items.length === 0) {
+		return undefined;
+	}
+
+	return items[randomInt(0, items.length)];
+}
+
+const TOKEN_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Cryptographically secure lowercase alphanumeric token of the given length.
+ */
+export function randomToken(length = 12): string {
+	if (length <= 0) {
+		return "";
+	}
+
+	// Bytes at or above the last whole multiple of the alphabet size are
+	// rejected so every character is uniformly distributed.
+	const limit = 256 - (256 % TOKEN_ALPHABET.length);
+
+	let token = "";
+	while (token.length < length) {
+		const bytes = new Uint8Array(length - token.length);
+		crypto.getRandomValues(bytes);
+
+		bytes.forEach((byte) => {
+			if (byte < limit) {
+				token += TOKEN_ALPHABET[byte % TOKEN_ALPHABET.length];
+			}
+		});
+	}
+
+	return token;
+}
+
+/**
+ * Collision-resistant identifier, e.g. `test-1753699200000-k3f9zq1xs`.
+ * Intended for tests and seed data that need a unique-but-readable id.
+ */
+export function uniqueId(prefix = "id"): string {
+	return `${prefix}-${Date.now()}-${randomToken(9)}`;
+}

--- a/packages/shared/src/random.ts
+++ b/packages/shared/src/random.ts
@@ -1,5 +1,7 @@
 const UINT32_RANGE = 0x1_0000_0000;
 const UINT53_RANGE = 9007199254740992;
+// 2^24 — the largest power of two a float32 mantissa represents exactly.
+const FLOAT32_FRACTION_RANGE = 16777216;
 // crypto.getRandomValues rejects requests larger than 65536 bytes.
 const MAX_RANDOM_BYTES = 65536;
 
@@ -97,7 +99,10 @@ export function fillRandomFloats(target: Float32Array): void {
 		);
 
 		for (let i = 0; i < count; i++) {
-			target[offset + i] = scratch[i]! / UINT32_RANGE;
+			// 24-bit fractions land exactly on the float32 mantissa grid. A full
+			// uint32 divided by 2^32 would round up to 1 for the top 128 values,
+			// breaking the [0, 1) contract once stored in a Float32Array.
+			target[offset + i] = (scratch[i]! >>> 8) / FLOAT32_FRACTION_RANGE;
 		}
 	}
 }


### PR DESCRIPTION
## What

Replaces every `Math.random()` call in the repository with cryptographically secure equivalents, so static analysis / security scanners stop flagging insecure randomness anywhere in the codebase.

`git grep "Math\.random"` now returns only the ESLint rule message and one doc comment.

## New helper: `@llmgateway/shared/random`

A single `crypto.getRandomValues`-backed module (`packages/shared/src/random.ts`), exported both from the package root and as a `./random` subpath so client components can import it without pulling in the rest of `shared`:

| Helper | Purpose |
| --- | --- |
| `randomFloat()` | Drop-in for `Math.random()` — float in `[0, 1)` with the same 53 bits of precision |
| `randomInt(min, max)` | Integer in `[min, max)`, rejection-sampled from a 32- or 53-bit space depending on range width; rejects bounds outside the safe integer range |
| `randomFloatBetween(min, max)` | Float in `[min, max)` |
| `randomItem(items)` | Uniform pick, `undefined` on an empty list |
| `randomToken(length)` | Lowercase alphanumeric token, also rejection-sampled |
| `uniqueId(prefix)` | Collision-resistant readable id (`test-1753699200000-k3f9zq1xs`) |
| `fillRandomFloats(target)` | Batch-fills a `Float32Array` with one crypto call per 16384 values — for hot paths where per-value calls would dominate |

Covered by 22 unit tests in `packages/shared/src/random.spec.ts`: range bounds, full range coverage, bias-free character set, uniqueness, wide-range (> 2³²) behaviour, chunking past the 65536-byte `getRandomValues` quota, and the error cases.

## Call sites updated

- **Gateway routing** — the epsilon-greedy provider exploration in `packages/actions/src/get-cheapest-from-available-providers.ts`
- **UI** — sidebar skeleton widths (4 copies), activity/dashboard loading skeletons, the landing animated beam, auth panel tweet pick, playground hero-suggestion shuffle, flickering grid
- **Mock + seed data** — `apps/ui/src/lib/mock-feature-data.ts`, `packages/db/src/seed-demo-analytics.ts`, `packages/scripts/src/generate-test-logs.ts`
- **Tests** — `uniqueId()` now backs the `generateTestId` / `generateTestRequestId` / `uniqueClientId` helpers; `randomInt` backs the random IP octets used to keep rate-limit buckets isolated

Several `// eslint-disable-next-line no-mixed-operators` comments went away because the arithmetic moved into the helper.

## Performance note

The flickering grid is the one place where swapping in a CSPRNG mattered: `updateSquares` ran up to two `getRandomValues` calls per cell per frame. Measured at ~64ms per 20,000 per-cell calls against a 16.7ms frame budget. It now refills a single reusable noise buffer per frame via `fillRandomFloats()` — **0.17ms** for the same grid — with `flickerChance` and `maxOpacity` semantics unchanged.

## Test changes

Three tests forced the exploration branch by stubbing `Math.random`, which no longer intercepts anything. They now set `EXPLORATION_RATE=1` — `randomFloat() < 1` is always true, so the branch is entered deterministically without depending on the RNG implementation:

- `packages/actions/src/models.spec.ts` (2 tests)
- `apps/gateway/src/fallback.spec.ts` (1 test)

The gateway test no longer pins which provider exploration lands on, but its mock fails the first upstream call via a global counter regardless of provider, so the retry assertions stay deterministic. Both files were re-run 5× to confirm no flakiness.

## Regression guard

An ESLint `no-restricted-properties` rule now errors on `Math.random`, pointing at the helpers.

## Verification

- `pnpm build` — 17/17 packages
- `pnpm lint` — clean (2 remaining warnings are pre-existing, in untouched files)
- `pnpm test:unit` — 3292 passed / 0 failed
- `pnpm format` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared, cryptographically secure randomness utilities for generating IDs, tokens, and bulk random float data, and exposed them via a new shared `random` entrypoint.
* **Refactor**
  * Updated UI loading placeholders, sidebar skeleton widths, the flickering grid animation, and demo/mock-data generation to use the shared randomness helpers.
  * Switched provider exploration randomness to the shared utilities.
* **Tests**
  * Improved test/e2e determinism by replacing time-/Math-based values with shared unique ID/token helpers and controlled exploration settings.
* **Chores**
  * Added an ESLint rule to prevent direct `Math.random` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->