### PR TITLE
fix(stats): prefer reasoning TTFT with fallback

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -32,8 +32,10 @@ import {
 	aliasedTable,
 	and,
 	asc,
+	avgEffectiveTtftSql,
 	db,
 	desc,
+	effectiveTtftTotals,
 	eq,
 	gte,
 	inArray,
@@ -4435,11 +4437,9 @@ admin.openapi(getProviderStats, async (c) => {
 				),
 				// Only streamed requests record a time-to-first-token, so the
 				// average divides by the sample count, not the request count.
-				avgTimeToFirstToken: sql<
-					number | null
-				>`CASE WHEN SUM(${mph.timeToFirstTokenCount}) > 0 THEN SUM(${mph.totalTimeToFirstToken})::float / SUM(${mph.timeToFirstTokenCount}) ELSE NULL END`.as(
-					"avgTimeToFirstToken",
-				),
+				// Reasoning-token samples take precedence so thinking mappings
+				// aren't measured on their (much later) first content token.
+				avgTimeToFirstToken: avgEffectiveTtftSql(mph).as("avgTimeToFirstToken"),
 			})
 			.from(mph)
 			.where(and(gte(mphTs, startDate), lt(mphTs, endDateExclusive)))
@@ -4454,7 +4454,7 @@ admin.openapi(getProviderStats, async (c) => {
 			errorsCount: sql`COALESCE(${providerStatsSub.errorsCount}, 0)`,
 			cachedCount: sql`COALESCE(${providerStatsSub.cachedCount}, 0)`,
 			totalCost: sql`COALESCE(${providerStatsSub.totalCost}, 0)`,
-			avgTimeToFirstToken: sql`COALESCE(${providerStatsSub.avgTimeToFirstToken}, ${tables.provider.avgTimeToFirstToken})`,
+			avgTimeToFirstToken: sql`COALESCE(${providerStatsSub.avgTimeToFirstToken}, ${tables.provider.avgTimeToFirstReasoningToken}, ${tables.provider.avgTimeToFirstToken})`,
 			modelCount: sql`COALESCE(${modelCountSub.count}, 0)`,
 			updatedAt: tables.provider.updatedAt,
 		} as const;
@@ -4497,7 +4497,7 @@ admin.openapi(getProviderStats, async (c) => {
 						),
 					avgTimeToFirstToken: sql<
 						number | null
-					>`COALESCE(${providerStatsSub.avgTimeToFirstToken}, ${tables.provider.avgTimeToFirstToken})`.as(
+					>`COALESCE(${providerStatsSub.avgTimeToFirstToken}, ${tables.provider.avgTimeToFirstReasoningToken}, ${tables.provider.avgTimeToFirstToken})`.as(
 						"avgTimeToFirstToken",
 					),
 					modelCount: sql<number>`COALESCE(${modelCountSub.count}, 0)`.as(
@@ -4557,7 +4557,7 @@ admin.openapi(getProviderStats, async (c) => {
 		errorsCount: tables.provider.errorsCount,
 		cachedCount: tables.provider.cachedCount,
 		totalCost: sql`0`,
-		avgTimeToFirstToken: tables.provider.avgTimeToFirstToken,
+		avgTimeToFirstToken: sql`COALESCE(${tables.provider.avgTimeToFirstReasoningToken}, ${tables.provider.avgTimeToFirstToken})`,
 		modelCount: sql`COALESCE(${modelCountSub.count}, 0)`,
 		updatedAt: tables.provider.updatedAt,
 	} as const;
@@ -4573,7 +4573,11 @@ admin.openapi(getProviderStats, async (c) => {
 			logsCount: tables.provider.logsCount,
 			errorsCount: tables.provider.errorsCount,
 			cachedCount: tables.provider.cachedCount,
-			avgTimeToFirstToken: tables.provider.avgTimeToFirstToken,
+			avgTimeToFirstToken: sql<
+				number | null
+			>`COALESCE(${tables.provider.avgTimeToFirstReasoningToken}, ${tables.provider.avgTimeToFirstToken})`.as(
+				"avgTimeToFirstToken",
+			),
 			modelCount: sql<number>`COALESCE(${modelCountSub.count}, 0)`.as(
 				"modelCount",
 			),
@@ -4804,7 +4808,7 @@ admin.openapi(getModelStats, async (c) => {
 			gatewayErrorsCount: sql`COALESCE(${modelAggSub.gatewayErrorsCount}, 0)`,
 			upstreamErrorsCount: sql`COALESCE(${modelAggSub.upstreamErrorsCount}, 0)`,
 			cachedCount: sql`COALESCE(${modelAggSub.cachedCount}, 0)`,
-			avgTimeToFirstToken: tables.model.avgTimeToFirstToken,
+			avgTimeToFirstToken: sql`COALESCE(${tables.model.avgTimeToFirstReasoningToken}, ${tables.model.avgTimeToFirstToken})`,
 			providerCount: sql`COALESCE(${providerCountSub.count}, 0)`,
 			updatedAt: tables.model.updatedAt,
 		} as const;
@@ -4860,7 +4864,11 @@ admin.openapi(getModelStats, async (c) => {
 				cachedCount: sql<number>`COALESCE(${modelAggSub.cachedCount}, 0)`.as(
 					"cachedCount",
 				),
-				avgTimeToFirstToken: tables.model.avgTimeToFirstToken,
+				avgTimeToFirstToken: sql<
+					number | null
+				>`COALESCE(${tables.model.avgTimeToFirstReasoningToken}, ${tables.model.avgTimeToFirstToken})`.as(
+					"avgTimeToFirstToken",
+				),
 				providerCount: sql<number>`COALESCE(${providerCountSub.count}, 0)`.as(
 					"providerCount",
 				),
@@ -4983,7 +4991,7 @@ admin.openapi(getModelStats, async (c) => {
 		gatewayErrorsCount: tables.model.gatewayErrorsCount,
 		upstreamErrorsCount: tables.model.upstreamErrorsCount,
 		cachedCount: tables.model.cachedCount,
-		avgTimeToFirstToken: tables.model.avgTimeToFirstToken,
+		avgTimeToFirstToken: sql`COALESCE(${tables.model.avgTimeToFirstReasoningToken}, ${tables.model.avgTimeToFirstToken})`,
 		providerCount: sql`COALESCE(${providerCountSub.count}, 0)`,
 		updatedAt: tables.model.updatedAt,
 	} as const;
@@ -5004,7 +5012,11 @@ admin.openapi(getModelStats, async (c) => {
 			gatewayErrorsCount: tables.model.gatewayErrorsCount,
 			upstreamErrorsCount: tables.model.upstreamErrorsCount,
 			cachedCount: tables.model.cachedCount,
-			avgTimeToFirstToken: tables.model.avgTimeToFirstToken,
+			avgTimeToFirstToken: sql<
+				number | null
+			>`COALESCE(${tables.model.avgTimeToFirstReasoningToken}, ${tables.model.avgTimeToFirstToken})`.as(
+				"avgTimeToFirstToken",
+			),
 			providerCount: sql<number>`COALESCE(${providerCountSub.count}, 0)`.as(
 				"providerCount",
 			),
@@ -5336,7 +5348,11 @@ admin.openapi(getModelDetail, async (c) => {
 		db
 			.select({
 				providerId: tables.modelProviderMapping.providerId,
-				avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+				avgTimeToFirstToken: sql<
+					number | null
+				>`COALESCE(${tables.modelProviderMapping.avgTimeToFirstReasoningToken}, ${tables.modelProviderMapping.avgTimeToFirstToken})`.as(
+					"avgTimeToFirstToken",
+				),
 				updatedAt: tables.modelProviderMapping.updatedAt,
 			})
 			.from(tables.modelProviderMapping)
@@ -5394,6 +5410,14 @@ admin.openapi(getModelDetail, async (c) => {
 					sql<number>`COALESCE(SUM(${mph.timeToFirstTokenCount}), 0)`.as(
 						"ttft_count",
 					),
+				totalTtfrt:
+					sql<number>`COALESCE(SUM(${mph.totalTimeToFirstReasoningToken}), 0)`.as(
+						"total_ttfrt",
+					),
+				ttfrtCount:
+					sql<number>`COALESCE(SUM(${mph.timeToFirstReasoningTokenCount}), 0)`.as(
+						"ttfrt_count",
+					),
 			})
 			.from(mph)
 			.where(and(eq(mph.modelId, modelId), gte(mphTs, startDate)))
@@ -5413,10 +5437,16 @@ admin.openapi(getModelDetail, async (c) => {
 		statsRows.map((r) => {
 			const logsCount = Number(r.logsCount ?? 0);
 			const cachedCount = Number(r.cachedCount ?? 0);
-			const totalTtft = Number(r.totalTtft ?? 0);
 			// Only streamed requests record a time-to-first-token, so the average
-			// divides by the sample count, not the request count.
-			const ttftCount = Number(r.ttftCount ?? 0);
+			// divides by the sample count, not the request count. Reasoning-token
+			// samples take precedence so thinking mappings aren't measured on
+			// their (much later) first content token.
+			const { total: totalTtft, count: ttftCount } = effectiveTtftTotals({
+				totalTimeToFirstToken: Number(r.totalTtft ?? 0),
+				timeToFirstTokenCount: Number(r.ttftCount ?? 0),
+				totalTimeToFirstReasoningToken: Number(r.totalTtfrt ?? 0),
+				timeToFirstReasoningTokenCount: Number(r.ttfrtCount ?? 0),
+			});
 			return [
 				r.providerId,
 				{
@@ -5458,6 +5488,8 @@ admin.openapi(getModelDetail, async (c) => {
 			acc.cachedCount += Number(r.cachedCount ?? 0);
 			acc.totalTtft += Number(r.totalTtft ?? 0);
 			acc.ttftCount += Number(r.ttftCount ?? 0);
+			acc.totalTtfrt += Number(r.totalTtfrt ?? 0);
+			acc.ttfrtCount += Number(r.ttfrtCount ?? 0);
 			return acc;
 		},
 		{
@@ -5475,10 +5507,20 @@ admin.openapi(getModelDetail, async (c) => {
 			cachedCount: 0,
 			totalTtft: 0,
 			ttftCount: 0,
+			totalTtfrt: 0,
+			ttfrtCount: 0,
 		},
 	);
 	const hasWindowData = agg.logsCount > 0;
-	const aggAvgTtft = agg.ttftCount > 0 ? agg.totalTtft / agg.ttftCount : null;
+	const { total: aggEffectiveTtft, count: aggEffectiveTtftCount } =
+		effectiveTtftTotals({
+			totalTimeToFirstToken: agg.totalTtft,
+			timeToFirstTokenCount: agg.ttftCount,
+			totalTimeToFirstReasoningToken: agg.totalTtfrt,
+			timeToFirstReasoningTokenCount: agg.ttfrtCount,
+		});
+	const aggAvgTtft =
+		aggEffectiveTtftCount > 0 ? aggEffectiveTtft / aggEffectiveTtftCount : null;
 
 	return c.json({
 		model: {
@@ -5507,8 +5549,10 @@ admin.openapi(getModelDetail, async (c) => {
 			unknownFinishCount: agg.unknownFinishCount,
 			cachedCount: hasWindowData ? agg.cachedCount : model.cachedCount,
 			avgTimeToFirstToken: hasWindowData
-				? (aggAvgTtft ?? model.avgTimeToFirstToken)
-				: model.avgTimeToFirstToken,
+				? (aggAvgTtft ??
+					model.avgTimeToFirstReasoningToken ??
+					model.avgTimeToFirstToken)
+				: (model.avgTimeToFirstReasoningToken ?? model.avgTimeToFirstToken),
 			providerCount: providerStats.length,
 			updatedAt: model.updatedAt.toISOString(),
 		},
@@ -6188,6 +6232,8 @@ function mapHistoryRows(
 		totalDuration: number;
 		totalTimeToFirstToken: number;
 		timeToFirstTokenCount: number;
+		totalTimeToFirstReasoningToken: number;
+		timeToFirstReasoningTokenCount: number;
 		totalTokens: number;
 		totalCost?: number;
 	}[],
@@ -6204,10 +6250,21 @@ function mapHistoryRows(
 		const errorsCount = Number(r.errorsCount);
 		const cachedCount = Number(r.cachedCount);
 		const totalDuration = Number(r.totalDuration);
-		const totalTimeToFirstToken = Number(r.totalTimeToFirstToken);
 		// Only streamed requests record a time-to-first-token, so the average
-		// divides by the sample count, not the request count.
-		const timeToFirstTokenCount = Number(r.timeToFirstTokenCount);
+		// divides by the sample count, not the request count. Reasoning-token
+		// samples take precedence so thinking mappings aren't measured on their
+		// (much later) first content token.
+		const { total: totalTimeToFirstToken, count: timeToFirstTokenCount } =
+			effectiveTtftTotals({
+				totalTimeToFirstToken: Number(r.totalTimeToFirstToken),
+				timeToFirstTokenCount: Number(r.timeToFirstTokenCount),
+				totalTimeToFirstReasoningToken: Number(
+					r.totalTimeToFirstReasoningToken,
+				),
+				timeToFirstReasoningTokenCount: Number(
+					r.timeToFirstReasoningTokenCount,
+				),
+			});
 		const totalTokens = Number(r.totalTokens);
 
 		let totalCost: number;
@@ -6308,6 +6365,14 @@ admin.openapi(getProviderHistory, async (c) => {
 					sql<number>`SUM(${modelProviderMappingHistoryHourly.timeToFirstTokenCount})`.as(
 						"ttft_count",
 					),
+				totalTimeToFirstReasoningToken:
+					sql<number>`SUM(${modelProviderMappingHistoryHourly.totalTimeToFirstReasoningToken})`.as(
+						"total_ttfrt",
+					),
+				timeToFirstReasoningTokenCount:
+					sql<number>`SUM(${modelProviderMappingHistoryHourly.timeToFirstReasoningTokenCount})`.as(
+						"ttfrt_count",
+					),
 				totalTokens:
 					sql<number>`SUM(${modelProviderMappingHistoryHourly.totalTokens})`.as(
 						"total_tokens",
@@ -6369,6 +6434,14 @@ admin.openapi(getProviderHistory, async (c) => {
 				timeToFirstTokenCount:
 					sql<number>`SUM(${modelProviderMappingHistory.timeToFirstTokenCount})`.as(
 						"ttft_count",
+					),
+				totalTimeToFirstReasoningToken:
+					sql<number>`SUM(${modelProviderMappingHistory.totalTimeToFirstReasoningToken})`.as(
+						"total_ttfrt",
+					),
+				timeToFirstReasoningTokenCount:
+					sql<number>`SUM(${modelProviderMappingHistory.timeToFirstReasoningTokenCount})`.as(
+						"ttfrt_count",
 					),
 				totalTokens:
 					sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
@@ -6525,6 +6598,14 @@ admin.openapi(getModelHistory, async (c) => {
 					sql<number>`SUM(${modelHistoryHourly.timeToFirstTokenCount})`.as(
 						"ttft_count",
 					),
+				totalTimeToFirstReasoningToken:
+					sql<number>`SUM(${modelHistoryHourly.totalTimeToFirstReasoningToken})`.as(
+						"total_ttfrt",
+					),
+				timeToFirstReasoningTokenCount:
+					sql<number>`SUM(${modelHistoryHourly.timeToFirstReasoningTokenCount})`.as(
+						"ttfrt_count",
+					),
 				totalTokens: sql<number>`SUM(${modelHistoryHourly.totalTokens})`.as(
 					"total_tokens",
 				),
@@ -6576,6 +6657,14 @@ admin.openapi(getModelHistory, async (c) => {
 			timeToFirstTokenCount:
 				sql<number>`SUM(${modelHistory.timeToFirstTokenCount})`.as(
 					"ttft_count",
+				),
+			totalTimeToFirstReasoningToken:
+				sql<number>`SUM(${modelHistory.totalTimeToFirstReasoningToken})`.as(
+					"total_ttfrt",
+				),
+			timeToFirstReasoningTokenCount:
+				sql<number>`SUM(${modelHistory.timeToFirstReasoningTokenCount})`.as(
+					"ttfrt_count",
 				),
 			totalTokens: sql<number>`SUM(${modelHistory.totalTokens})`.as(
 				"total_tokens",
@@ -6757,6 +6846,14 @@ admin.openapi(getMappingHistory, async (c) => {
 					sql<number>`SUM(${modelProviderMappingHistoryHourly.timeToFirstTokenCount})`.as(
 						"ttft_count",
 					),
+				totalTimeToFirstReasoningToken:
+					sql<number>`SUM(${modelProviderMappingHistoryHourly.totalTimeToFirstReasoningToken})`.as(
+						"total_ttfrt",
+					),
+				timeToFirstReasoningTokenCount:
+					sql<number>`SUM(${modelProviderMappingHistoryHourly.timeToFirstReasoningTokenCount})`.as(
+						"ttfrt_count",
+					),
 				totalTokens:
 					sql<number>`SUM(${modelProviderMappingHistoryHourly.totalTokens})`.as(
 						"total_tokens",
@@ -6819,6 +6916,14 @@ admin.openapi(getMappingHistory, async (c) => {
 			timeToFirstTokenCount:
 				sql<number>`SUM(${modelProviderMappingHistory.timeToFirstTokenCount})`.as(
 					"ttft_count",
+				),
+			totalTimeToFirstReasoningToken:
+				sql<number>`SUM(${modelProviderMappingHistory.totalTimeToFirstReasoningToken})`.as(
+					"total_ttfrt",
+				),
+			timeToFirstReasoningTokenCount:
+				sql<number>`SUM(${modelProviderMappingHistory.timeToFirstReasoningTokenCount})`.as(
+					"ttfrt_count",
 				),
 			totalTokens:
 				sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
@@ -6928,7 +7033,11 @@ admin.openapi(getProviderDetail, async (c) => {
 				externalId: tables.modelProviderMapping.externalId,
 				region: tables.modelProviderMapping.region,
 				status: tables.modelProviderMapping.status,
-				avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+				avgTimeToFirstToken: sql<
+					number | null
+				>`COALESCE(${tables.modelProviderMapping.avgTimeToFirstReasoningToken}, ${tables.modelProviderMapping.avgTimeToFirstToken})`.as(
+					"avgTimeToFirstToken",
+				),
 				updatedAt: tables.modelProviderMapping.updatedAt,
 			})
 			.from(tables.modelProviderMapping)
@@ -6965,6 +7074,14 @@ admin.openapi(getProviderDetail, async (c) => {
 					sql<number>`COALESCE(SUM(${mph.timeToFirstTokenCount}), 0)`.as(
 						"ttft_count",
 					),
+				totalTtfrt:
+					sql<number>`COALESCE(SUM(${mph.totalTimeToFirstReasoningToken}), 0)`.as(
+						"total_ttfrt",
+					),
+				ttfrtCount:
+					sql<number>`COALESCE(SUM(${mph.timeToFirstReasoningTokenCount}), 0)`.as(
+						"ttfrt_count",
+					),
 				totalCost: sql<number>`COALESCE(SUM(${mph.totalCost}), 0)`.as(
 					"total_cost",
 				),
@@ -6980,10 +7097,16 @@ admin.openapi(getProviderDetail, async (c) => {
 		const s = statsByModel.get(m.modelId);
 		const logsCount = Number(s?.logsCount ?? 0);
 		const cachedCount = Number(s?.cachedCount ?? 0);
-		const totalTtft = Number(s?.totalTtft ?? 0);
 		// Only streamed requests record a time-to-first-token, so the average
-		// divides by the sample count, not the request count.
-		const ttftCount = Number(s?.ttftCount ?? 0);
+		// divides by the sample count, not the request count. Reasoning-token
+		// samples take precedence so thinking mappings aren't measured on their
+		// (much later) first content token.
+		const { total: totalTtft, count: ttftCount } = effectiveTtftTotals({
+			totalTimeToFirstToken: Number(s?.totalTtft ?? 0),
+			timeToFirstTokenCount: Number(s?.ttftCount ?? 0),
+			totalTimeToFirstReasoningToken: Number(s?.totalTtfrt ?? 0),
+			timeToFirstReasoningTokenCount: Number(s?.ttfrtCount ?? 0),
+		});
 		const avgTtft = ttftCount > 0 ? totalTtft / ttftCount : null;
 		return {
 			modelId: m.modelId,
@@ -7013,6 +7136,8 @@ admin.openapi(getProviderDetail, async (c) => {
 			acc.cachedCount += Number(r.cachedCount ?? 0);
 			acc.totalTtft += Number(r.totalTtft ?? 0);
 			acc.ttftCount += Number(r.ttftCount ?? 0);
+			acc.totalTtfrt += Number(r.totalTtfrt ?? 0);
+			acc.ttfrtCount += Number(r.ttfrtCount ?? 0);
 			return acc;
 		},
 		{
@@ -7024,10 +7149,20 @@ admin.openapi(getProviderDetail, async (c) => {
 			cachedCount: 0,
 			totalTtft: 0,
 			ttftCount: 0,
+			totalTtfrt: 0,
+			ttfrtCount: 0,
 		},
 	);
 	const hasWindowData = agg.logsCount > 0;
-	const aggAvgTtft = agg.ttftCount > 0 ? agg.totalTtft / agg.ttftCount : null;
+	const { total: aggEffectiveTtft, count: aggEffectiveTtftCount } =
+		effectiveTtftTotals({
+			totalTimeToFirstToken: agg.totalTtft,
+			timeToFirstTokenCount: agg.ttftCount,
+			totalTimeToFirstReasoningToken: agg.totalTtfrt,
+			timeToFirstReasoningTokenCount: agg.ttfrtCount,
+		});
+	const aggAvgTtft =
+		aggEffectiveTtftCount > 0 ? aggEffectiveTtft / aggEffectiveTtftCount : null;
 
 	return c.json({
 		provider: {
@@ -7050,8 +7185,11 @@ admin.openapi(getProviderDetail, async (c) => {
 				: providerRow.upstreamErrorsCount,
 			cachedCount: hasWindowData ? agg.cachedCount : providerRow.cachedCount,
 			avgTimeToFirstToken: hasWindowData
-				? (aggAvgTtft ?? providerRow.avgTimeToFirstToken)
-				: providerRow.avgTimeToFirstToken,
+				? (aggAvgTtft ??
+					providerRow.avgTimeToFirstReasoningToken ??
+					providerRow.avgTimeToFirstToken)
+				: (providerRow.avgTimeToFirstReasoningToken ??
+					providerRow.avgTimeToFirstToken),
 			modelCount: mappings.length,
 			updatedAt: providerRow.updatedAt.toISOString(),
 		},
@@ -7152,7 +7290,11 @@ admin.openapi(getMappingDetail, async (c) => {
 			gatewayErrorsCount: tables.modelProviderMapping.gatewayErrorsCount,
 			upstreamErrorsCount: tables.modelProviderMapping.upstreamErrorsCount,
 			cachedCount: tables.modelProviderMapping.cachedCount,
-			avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+			avgTimeToFirstToken: sql<
+				number | null
+			>`COALESCE(${tables.modelProviderMapping.avgTimeToFirstReasoningToken}, ${tables.modelProviderMapping.avgTimeToFirstToken})`.as(
+				"avgTimeToFirstToken",
+			),
 			updatedAt: tables.modelProviderMapping.updatedAt,
 		})
 		.from(tables.modelProviderMapping)
@@ -7227,12 +7369,10 @@ admin.openapi(getMappingDetail, async (c) => {
 				"cached_count",
 			),
 			// Only streamed requests record a time-to-first-token, so the average
-			// divides by the sample count, not the request count.
-			avgTtft: sql<
-				number | null
-			>`CASE WHEN SUM(${mph.timeToFirstTokenCount}) > 0 THEN SUM(${mph.totalTimeToFirstToken})::float / SUM(${mph.timeToFirstTokenCount}) ELSE NULL END`.as(
-				"avg_ttft",
-			),
+			// divides by the sample count, not the request count. Reasoning-token
+			// samples take precedence so thinking mappings aren't measured on
+			// their (much later) first content token.
+			avgTtft: avgEffectiveTtftSql(mph).as("avg_ttft"),
 		})
 		.from(mph)
 		.where(and(eq(mph.modelProviderMappingId, m.id), gte(mphTs, startDate)));
@@ -8375,7 +8515,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 		gatewayErrorsCount: sql`COALESCE(${statsJoin.gatewayErrorsCount}, 0)`,
 		upstreamErrorsCount: sql`COALESCE(${statsJoin.upstreamErrorsCount}, 0)`,
 		cost: sql`COALESCE(${statsJoin.cost}, 0)`,
-		avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+		avgTimeToFirstToken: sql`COALESCE(${tables.modelProviderMapping.avgTimeToFirstReasoningToken}, ${tables.modelProviderMapping.avgTimeToFirstToken})`,
 		updatedAt: tables.modelProviderMapping.updatedAt,
 	} as const;
 
@@ -8418,7 +8558,11 @@ admin.openapi(getModelProviderMappings, async (c) => {
 					"cachedCount",
 				),
 				cost: sql<number>`COALESCE(${statsJoin.cost}, 0)`.as("cost"),
-				avgTimeToFirstToken: tables.modelProviderMapping.avgTimeToFirstToken,
+				avgTimeToFirstToken: sql<
+					number | null
+				>`COALESCE(${tables.modelProviderMapping.avgTimeToFirstReasoningToken}, ${tables.modelProviderMapping.avgTimeToFirstToken})`.as(
+					"avgTimeToFirstToken",
+				),
 				inputPrice: tables.modelProviderMapping.inputPrice,
 				outputPrice: tables.modelProviderMapping.outputPrice,
 				contextSize: tables.modelProviderMapping.contextSize,

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -6,7 +6,9 @@ import { findArenaMatch, getArenaBenchmarks } from "@/lib/arena-benchmarks.js";
 import {
 	and,
 	asc,
+	avgEffectiveTtftSql,
 	db,
+	effectiveTtftTotals,
 	eq,
 	gte,
 	isNull,
@@ -477,9 +479,9 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 			// Only streamed requests record a time-to-first-token, so the average
 			// divides by the sample count rather than by the non-cached request
 			// count — otherwise non-streaming traffic drags it towards zero.
-			avgTimeToFirstToken: sql<
-				number | null
-			>`CASE WHEN SUM(${modelProviderMappingHistory.timeToFirstTokenCount}) > 0 THEN SUM(${modelProviderMappingHistory.totalTimeToFirstToken})::float / SUM(${modelProviderMappingHistory.timeToFirstTokenCount}) ELSE NULL END`.as(
+			// Reasoning-token samples are preferred so thinking mappings aren't
+			// measured on their (much later) first content token.
+			avgTimeToFirstToken: avgEffectiveTtftSql(modelProviderMappingHistory).as(
 				"avgTimeToFirstToken",
 			),
 			totalDuration:
@@ -697,6 +699,14 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.timeToFirstTokenCount}), 0)`.as(
 						"ttft_count",
 					),
+				totalTimeToFirstReasoningToken:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTimeToFirstReasoningToken}), 0)`.as(
+						"total_ttfrt",
+					),
+				timeToFirstReasoningTokenCount:
+					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.timeToFirstReasoningTokenCount}), 0)`.as(
+						"ttfrt_count",
+					),
 				totalTokens:
 					sql<number>`COALESCE(SUM(${modelProviderMappingHistory.totalTokens}), 0)`.as(
 						"total_tokens",
@@ -741,6 +751,8 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 				totalDuration: number;
 				totalTimeToFirstToken: number;
 				timeToFirstTokenCount: number;
+				totalTimeToFirstReasoningToken: number;
+				timeToFirstReasoningTokenCount: number;
 				totalTokens: number;
 				totalOutputTokens: number;
 			}>;
@@ -776,6 +788,8 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			totalDuration: Number(r.totalDuration),
 			totalTimeToFirstToken: Number(r.totalTimeToFirstToken),
 			timeToFirstTokenCount: Number(r.timeToFirstTokenCount),
+			totalTimeToFirstReasoningToken: Number(r.totalTimeToFirstReasoningToken),
+			timeToFirstReasoningTokenCount: Number(r.timeToFirstReasoningTokenCount),
 			totalTokens: Number(r.totalTokens),
 			totalOutputTokens: Number(r.totalOutputTokens),
 		});
@@ -789,6 +803,8 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 		let totalDuration = 0;
 		let totalTtft = 0;
 		let totalTtftCount = 0;
+		let totalTtfrt = 0;
+		let totalTtfrtCount = 0;
 		let totalOutputTokens = 0;
 
 		const points = p.points.map((pt) => {
@@ -798,7 +814,15 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			totalDuration += pt.totalDuration;
 			totalTtft += pt.totalTimeToFirstToken;
 			totalTtftCount += pt.timeToFirstTokenCount;
+			totalTtfrt += pt.totalTimeToFirstReasoningToken;
+			totalTtfrtCount += pt.timeToFirstReasoningTokenCount;
 			totalOutputTokens += pt.totalOutputTokens;
+			// Only streamed requests contribute a TTFT sample, so divide by the
+			// sample count instead of the request count. Reasoning-token samples
+			// take precedence so thinking mappings aren't measured on their
+			// (much later) first content token.
+			const { total: pointTtft, count: pointTtftCount } =
+				effectiveTtftTotals(pt);
 			return {
 				timestamp: pt.timestamp,
 				logsCount: pt.logsCount,
@@ -807,12 +831,8 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 				gatewayErrorsCount: pt.gatewayErrorsCount,
 				upstreamErrorsCount: pt.upstreamErrorsCount,
 				cachedCount: pt.cachedCount,
-				// Only streamed requests contribute a TTFT sample, so divide by the
-				// sample count instead of the request count.
 				avgTtft:
-					pt.timeToFirstTokenCount > 0
-						? Math.round(pt.totalTimeToFirstToken / pt.timeToFirstTokenCount)
-						: null,
+					pointTtftCount > 0 ? Math.round(pointTtft / pointTtftCount) : null,
 				avgDuration:
 					pt.logsCount > 0 ? Math.round(pt.totalDuration / pt.logsCount) : null,
 				totalTokens: pt.totalTokens,
@@ -830,6 +850,13 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			totalDuration > 0
 				? Math.round(totalOutputTokens / (totalDuration / 1000))
 				: null;
+		const { total: providerTtft, count: providerTtftCount } =
+			effectiveTtftTotals({
+				totalTimeToFirstToken: totalTtft,
+				timeToFirstTokenCount: totalTtftCount,
+				totalTimeToFirstReasoningToken: totalTtfrt,
+				timeToFirstReasoningTokenCount: totalTtfrtCount,
+			});
 
 		return {
 			providerId: p.providerId,
@@ -839,8 +866,10 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 			upstreamErrorsCount: totalUpstreamErrors,
 			uptime,
 			avgTtft:
-				totalTtftCount > 0 ? Math.round(totalTtft / totalTtftCount) : null,
-			ttftCount: totalTtftCount,
+				providerTtftCount > 0
+					? Math.round(providerTtft / providerTtftCount)
+					: null,
+			ttftCount: providerTtftCount,
 			avgDuration: totalLogs > 0 ? Math.round(totalDuration / totalLogs) : null,
 			tokensPerSecond,
 			points,

--- a/apps/api/src/routes/public-providers-stats.spec.ts
+++ b/apps/api/src/routes/public-providers-stats.spec.ts
@@ -20,6 +20,8 @@ async function seedMinute(
 		logsCount: number;
 		totalTimeToFirstToken: number;
 		timeToFirstTokenCount: number;
+		totalTimeToFirstReasoningToken?: number;
+		timeToFirstReasoningTokenCount?: number;
 	},
 ) {
 	const minuteMs = 60_000;
@@ -73,6 +75,23 @@ describe("public providers stats", () => {
 		// Exposed so the UI can gate the TTFT card on the sample size behind the
 		// average rather than on logsCount.
 		expect(provider.timeToFirstTokenCount).toBe(4);
+	});
+
+	test("prefers reasoning-token samples over content-token samples", async () => {
+		// Thinking mappings stream reasoning long before the first content
+		// token, so the content-token average (500ms) would misrepresent them;
+		// the reasoning-token average (100ms) is the real first-token latency.
+		await seedMinute(1, {
+			logsCount: 10,
+			totalTimeToFirstToken: 2000,
+			timeToFirstTokenCount: 4,
+			totalTimeToFirstReasoningToken: 300,
+			timeToFirstReasoningTokenCount: 3,
+		});
+
+		const provider = await fetchProviderStats();
+		expect(provider.avgTimeToFirstToken).toBe(100);
+		expect(provider.timeToFirstTokenCount).toBe(3);
 	});
 
 	test("reports no TTFT when nothing was streamed", async () => {

--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -6,7 +6,7 @@ import {
 	pickMappingHistoryTable,
 } from "@/utils/history-window.js";
 
-import { and, cdb, gte, sql } from "@llmgateway/db";
+import { and, cdb, effectiveTtftTotals, gte, sql } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -17,6 +17,9 @@ const providerStatRowSchema = z.object({
 	logsCount: z.number(),
 	errorsCount: z.number(),
 	cachedCount: z.number(),
+	// Effective TTFT: averaged over first-reasoning-token times when the
+	// provider streams reasoning, falling back to first-content-token times
+	// otherwise, so mappings that stream thinking aren't penalized.
 	avgTimeToFirstToken: z.number().nullable(),
 	// How many requests actually contributed a TTFT sample (streamed ones only).
 	// Exposed so callers can gate the display of avgTimeToFirstToken on its own
@@ -98,6 +101,8 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 			cachedCount: sql<string>`COALESCE(SUM(${mph.cachedCount}), 0)`,
 			totalTimeToFirstToken: sql<string>`COALESCE(SUM(${mph.totalTimeToFirstToken}), 0)`,
 			timeToFirstTokenCount: sql<string>`COALESCE(SUM(${mph.timeToFirstTokenCount}), 0)`,
+			totalTimeToFirstReasoningToken: sql<string>`COALESCE(SUM(${mph.totalTimeToFirstReasoningToken}), 0)`,
+			timeToFirstReasoningTokenCount: sql<string>`COALESCE(SUM(${mph.timeToFirstReasoningTokenCount}), 0)`,
 			totalOutputTokens: sql<string>`COALESCE(SUM(${mph.totalOutputTokens}), 0)`,
 			totalDuration: sql<string>`COALESCE(SUM(${mph.totalDuration}), 0)`,
 			updatedAt: sql<Date | null>`MAX(${mphTs})`,
@@ -114,7 +119,7 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 		.$withCache({
 			// The version prefix is bumped whenever the selected columns change so
 			// a rolling deploy doesn't serve rows cached in the previous shape.
-			tag: `publicProviderStats:v2:${window}`,
+			tag: `publicProviderStats:v3:${window}`,
 			autoInvalidate: false,
 			config: { ex: STATS_CACHE_TTL_SECONDS },
 		});
@@ -123,14 +128,24 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 		const logsCount = Number(r.logsCount) || 0;
 		const errorsCount = Number(r.errorsCount) || 0;
 		const cachedCount = Number(r.cachedCount) || 0;
-		const totalTimeToFirstToken = Number(r.totalTimeToFirstToken) || 0;
-		const timeToFirstTokenCount = Number(r.timeToFirstTokenCount) || 0;
 		const totalOutputTokens = Number(r.totalOutputTokens) || 0;
 		const totalDuration = Number(r.totalDuration) || 0;
 
 		// Only streamed requests record a time-to-first-token, so the average
 		// divides by the number of samples rather than by the request count —
 		// otherwise non-streaming traffic drags the reported TTFT towards zero.
+		// Reasoning-token samples take precedence over content-token samples so
+		// mappings that stream thinking aren't measured on their (much later)
+		// first content token.
+		const { total: totalTimeToFirstToken, count: timeToFirstTokenCount } =
+			effectiveTtftTotals({
+				totalTimeToFirstToken: Number(r.totalTimeToFirstToken) || 0,
+				timeToFirstTokenCount: Number(r.timeToFirstTokenCount) || 0,
+				totalTimeToFirstReasoningToken:
+					Number(r.totalTimeToFirstReasoningToken) || 0,
+				timeToFirstReasoningTokenCount:
+					Number(r.timeToFirstReasoningTokenCount) || 0,
+			});
 		const avgTimeToFirstToken =
 			timeToFirstTokenCount > 0
 				? totalTimeToFirstToken / timeToFirstTokenCount

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -354,7 +354,12 @@ export async function insertLog(
 		finishReason: logData.finishReason ?? null,
 		streaming: logData.streamed ?? false,
 		durationMs: logData.duration || 0,
-		ttftMs: logData.timeToFirstToken ?? undefined,
+		// Reasoning models stream thinking before any content, so the first
+		// reasoning token is the real first-token latency when present.
+		ttftMs:
+			logData.timeToFirstReasoningToken ??
+			logData.timeToFirstToken ??
+			undefined,
 		inputTokens: logData.promptTokens
 			? Number(logData.promptTokens)
 			: undefined,

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -490,6 +490,11 @@ export function LogDetailClient({
 			? (Number(log.completionTokens) / (log.duration / 1000)).toFixed(1)
 			: null;
 
+	// Reasoning models stream thinking before any content, so the first
+	// reasoning token is the real first-token latency when present.
+	const timeToFirstToken =
+		log.timeToFirstReasoningToken ?? log.timeToFirstToken;
+
 	return (
 		<div className="flex flex-col">
 			<div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
@@ -559,14 +564,14 @@ export function LogDetailClient({
 							{throughput ? `${throughput} t/s` : "-"}
 						</p>
 					</div>
-					{log.timeToFirstToken && (
+					{timeToFirstToken && (
 						<div className="rounded-lg border bg-card p-3">
 							<div className="flex items-center gap-2 text-muted-foreground mb-1">
 								<Clock className="h-3.5 w-3.5" />
 								<span className="text-xs">TTFT</span>
 							</div>
 							<p className="text-lg font-semibold tabular-nums">
-								{formatDuration(log.timeToFirstToken)}
+								{formatDuration(timeToFirstToken)}
 							</p>
 						</div>
 					)}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,7 @@ export * from "./relations.js";
 export * from "./provider-metrics.js";
 export * from "./provider-metrics-history.js";
 export * from "./query-tags.js";
+export * from "./ttft.js";
 export * from "./webhook-helpers.js";
 
 export * from "drizzle-orm";

--- a/packages/db/src/provider-metrics-history.ts
+++ b/packages/db/src/provider-metrics-history.ts
@@ -9,6 +9,7 @@ import {
 import { cdb } from "./cdb.js";
 import { metricsKey, type ProviderMetrics } from "./provider-metrics.js";
 import { modelProviderMappingHistory } from "./schema.js";
+import { effectiveTtftTotals } from "./ttft.js";
 
 const historyTableName = getTableName(modelProviderMappingHistory);
 
@@ -48,11 +49,13 @@ function rowToMetrics(row: HistoryRow): ProviderMetrics | undefined {
 	// Only streamed requests record a first-token latency, so each average
 	// divides by its own sample count. Dividing by the request count instead
 	// would make providers look faster the more non-streaming traffic they see.
-	const useReasoning = weightedTTFRT > 0 && weightedTTFRTCount > 0;
-	const effectiveTTFT = useReasoning ? weightedTTFRT : weightedTTFT;
-	const effectiveTTFTCount = useReasoning
-		? weightedTTFRTCount
-		: weightedTTFTCount;
+	const { total: effectiveTTFT, count: effectiveTTFTCount } =
+		effectiveTtftTotals({
+			totalTimeToFirstToken: weightedTTFT,
+			timeToFirstTokenCount: weightedTTFTCount,
+			totalTimeToFirstReasoningToken: weightedTTFRT,
+			timeToFirstReasoningTokenCount: weightedTTFRTCount,
+		});
 	const averageLatency =
 		effectiveTTFT > 0 && effectiveTTFTCount > 0
 			? effectiveTTFT / effectiveTTFTCount

--- a/packages/db/src/ttft.ts
+++ b/packages/db/src/ttft.ts
@@ -1,0 +1,65 @@
+import { sql } from "drizzle-orm";
+
+import type { AnyColumn, SQL } from "drizzle-orm";
+
+// Reasoning models stream thinking before any content, so their first content
+// token only arrives after thinking finishes. Measuring TTFT on content alone
+// would penalize mappings that stream reasoning. Wherever a
+// first-reasoning-token time was recorded it is the real first-token latency;
+// the content-token TTFT is the fallback for mappings that never stream
+// reasoning (which correctly penalizes providers that think without
+// streaming it).
+
+interface TtftAggregateColumns {
+	totalTimeToFirstToken: AnyColumn;
+	timeToFirstTokenCount: AnyColumn;
+	totalTimeToFirstReasoningToken: AnyColumn;
+	timeToFirstReasoningTokenCount: AnyColumn;
+}
+
+/**
+ * Average effective TTFT over aggregated history rows: prefers
+ * reasoning-token samples when any exist in the aggregate, otherwise falls
+ * back to content-token samples. Only streamed requests record either
+ * metric, so each branch divides by its own sample count.
+ */
+export function avgEffectiveTtftSql(
+	table: TtftAggregateColumns,
+): SQL<number | null> {
+	return sql<
+		number | null
+	>`CASE WHEN SUM(${table.timeToFirstReasoningTokenCount}) > 0 THEN SUM(${table.totalTimeToFirstReasoningToken})::float / SUM(${table.timeToFirstReasoningTokenCount}) WHEN SUM(${table.timeToFirstTokenCount}) > 0 THEN SUM(${table.totalTimeToFirstToken})::float / SUM(${table.timeToFirstTokenCount}) ELSE NULL END`;
+}
+
+export interface TtftTotals {
+	totalTimeToFirstToken: number;
+	timeToFirstTokenCount: number;
+	totalTimeToFirstReasoningToken: number;
+	timeToFirstReasoningTokenCount: number;
+}
+
+/**
+ * Same preference applied to already-summed totals: returns the
+ * reasoning-token sum/count pair when it has samples, else the content-token
+ * pair.
+ */
+export function effectiveTtftTotals(totals: TtftTotals): {
+	total: number;
+	count: number;
+} {
+	if (totals.timeToFirstReasoningTokenCount > 0) {
+		return {
+			total: totals.totalTimeToFirstReasoningToken,
+			count: totals.timeToFirstReasoningTokenCount,
+		};
+	}
+	return {
+		total: totals.totalTimeToFirstToken,
+		count: totals.timeToFirstTokenCount,
+	};
+}
+
+export function avgEffectiveTtft(totals: TtftTotals): number | null {
+	const { total, count } = effectiveTtftTotals(totals);
+	return count > 0 ? total / count : null;
+}


### PR DESCRIPTION
## Summary

TTFT/TTFB calculations throughout the project now use the **time to first reasoning token** when it was recorded, and only fall back to the time to first (content) token when it wasn't.

Reasoning models stream thinking before any content, so their first content token only arrives after thinking finishes. Measuring TTFT on content alone penalized mappings that stream reasoning — their real first-token latency was recorded as `timeToFirstReasoningToken`, but most surfaces averaged only `timeToFirstToken`. Providers that think without streaming it are still measured on their first content token, which correctly penalizes hidden thinking time.

## Changes

- **`packages/db/src/ttft.ts` (new)**: shared helpers — `avgEffectiveTtftSql()` (SQL aggregate that prefers reasoning-token sums/counts, else content-token sums/counts) and `effectiveTtftTotals()` / `avgEffectiveTtft()` for already-summed totals.
- **Routing metrics** (`provider-metrics-history.ts`): already applied this preference; refactored to reuse the shared helper so there is one definition.
- **Public provider stats** (`/public/providers/stats`): effective average and effective sample count (used by the providers-grid TTFT gating); cache tag bumped to `v3` since the selected columns changed. Added a spec covering the preference.
- **Internal models API**: per-provider benchmarks and the uptime timeseries (per-point and per-provider aggregates).
- **Admin API**: provider/model/mapping lists, detail endpoints, and all history timeseries (`mapHistoryRows` + its six minute/hourly queries). Stored per-entity averages now fall back as `COALESCE(avgTimeToFirstReasoningToken, avgTimeToFirstToken)`.
- **Gateway**: the Prometheus `chat_completion_ttft_ms` histogram now records the effective per-request value.
- **Dashboard**: the log detail TTFT card shows the effective per-log value (the expanded log card keeps showing both raw metrics separately).

Raw storage is unchanged — logs and the history rollups keep recording both metrics separately; only the derived calculations changed. The e2e benchmark script already treated the first reasoning chunk as the first token, so no change there.

## Testing

- `pnpm build` — all 17 tasks pass
- `pnpm test:unit` — 3281 passed, including a new spec asserting reasoning-token samples take precedence in the public provider stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SptbG5SFkmt5mC4aJh4a2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SptbG5SFkmt5mC4aJh4a2Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Time-to-first-token metrics now prioritize the first reasoning token when available, with fallback to the first content token.
  * Updated provider, model, mapping, benchmark, uptime, and public statistics to reflect the improved calculation.
  * Log ingestion and log details now display reasoning-aware TTFT values.

* **Tests**
  * Added coverage verifying reasoning-token samples take precedence in provider statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->