### PR TITLE
feat(models): add deprecation notices for legacy Qwen and Gemini models

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -443,6 +443,7 @@ export const alibabaModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				deactivatedAt: new Date("2026-10-10"),
 			},
 		],
 	},
@@ -1335,6 +1336,7 @@ export const alibabaModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+				deactivatedAt: new Date("2026-10-10"),
 			},
 			{
 				providerId: "novita",
@@ -1352,6 +1354,7 @@ export const alibabaModels = [
 				// novita rejects tool_choice "required" and named function choices
 				// with invalid_request_error; "auto" and "none" work
 				supportedToolChoices: ["auto", "none"],
+				deactivatedAt: new Date("2026-10-10"),
 			},
 		],
 	},
@@ -2427,6 +2430,7 @@ export const alibabaModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+				deactivatedAt: new Date("2026-10-10"),
 			},
 		],
 	},
@@ -2763,6 +2767,7 @@ export const alibabaModels = [
 					"tools",
 					"reasoning_effort",
 				],
+				deactivatedAt: new Date("2026-10-10"),
 			},
 		],
 	},

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -86,6 +86,7 @@ export const googleModels = [
 				supportsN: true,
 				supportsNStreaming: false,
 				maxN: 8,
+				deactivatedAt: new Date("2026-10-16"),
 			},
 			{
 				providerId: "google-vertex",
@@ -127,6 +128,7 @@ export const googleModels = [
 				supportsN: true,
 				supportsNStreaming: false,
 				maxN: 8,
+				deactivatedAt: new Date("2026-10-16"),
 			},
 		],
 	},
@@ -456,6 +458,7 @@ export const googleModels = [
 				supportsN: true,
 				supportsNStreaming: false,
 				maxN: 8,
+				deactivatedAt: new Date("2026-10-16"),
 			},
 			{
 				providerId: "google-vertex",
@@ -483,6 +486,7 @@ export const googleModels = [
 				supportsN: true,
 				supportsNStreaming: false,
 				maxN: 8,
+				deactivatedAt: new Date("2026-10-16"),
 			},
 		],
 	},
@@ -516,6 +520,7 @@ export const googleModels = [
 				supportsN: true,
 				supportsNStreaming: false,
 				maxN: 8,
+				deactivatedAt: new Date("2026-10-16"),
 			},
 			{
 				providerId: "google-vertex",
@@ -539,6 +544,7 @@ export const googleModels = [
 				supportsN: true,
 				supportsNStreaming: false,
 				maxN: 8,
+				deactivatedAt: new Date("2026-10-16"),
 			},
 		],
 	},


### PR DESCRIPTION
## Summary

Adds deactivatedAt notices for models scheduled for retirement.

### Qwen Models (Alibaba Cloud)
Scheduled for retirement **October 10, 2026**.

| Model | Successor |
|-------|-----------|
| qwen3-vl-flash | — |
| qwen3-coder-plus | qwen3.7-plus |
| qwen3-max (Alibaba) | qwen3.7-max |
| qwen3-max (Novita) | qwen3.7-max |
| qwen3.6-max-preview | qwen3.7-max |

**Reference:** [Alibaba Cloud Service Notice](https://www.alibabacloud.com/en/notice/detail?_p_lc=1&id=1950)

### Gemini Models (Google AI)
Scheduled for retirement **October 16, 2026**.

| Model |
|-------|
| gemini-2.5-pro |
| gemini-2.5-flash |
| gemini-2.5-flash-lite |

**Reference:** [Gemini API Deprecation Schedule](https://ai.google.dev/gemini-api/docs/deprecations)

### Commits
1. `feat(models): add deprecation notices for legacy Qwen models`
2. `feat(models): add deprecation notices for Gemini 2.5 models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Model Availability**
  * Added scheduled deactivation dates for select Alibaba Qwen models, effective October 10, 2026.
  * Added scheduled deactivation dates for Gemini 2.5 Pro, Gemini 2.5 Flash, and Gemini 2.5 Flash Lite models across supported Google providers, effective October 16, 2026.
  * These models will remain available until their listed deactivation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->