### PR TITLE
ci: restrict GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   autofix:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   quality:
     if: github.event_name == 'pull_request' && github.head_ref != 'main'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,9 @@ on:
       - "**/*.e2e.ts"
       - ".github/workflows/e2e.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,6 +22,8 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       image_tag: ${{ steps.set-tag.outputs.IMAGE_TAG }}
       short_sha: ${{ steps.set-tag.outputs.SHORT_SHA }}
@@ -453,6 +455,8 @@ jobs:
       - setup
       - merge-split
     if: github.event_name == 'push' && needs.merge-split.result == 'success'
+    permissions:
+      contents: read
     steps:
       - name: Trigger infra image update
         env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the ten open CodeQL `actions/missing-workflow-permissions` alerts (#89, #81, #37, #35, #10, #7, #6, #5, #4, #3) by giving every flagged workflow job an explicit least-privilege `permissions` block, so `GITHUB_TOKEN` no longer falls back to the repository default (read-write for repos created before Feb 2023).

## Changes

| Workflow | Alerts | Change |
| --- | --- | --- |
| `run.yml` | #89 | workflow-level `contents: read` |
| `ci.yml` | #37, #6, #5, #4, #3 | workflow-level `contents: read` (covers `quality` plus the four `run.yml` caller jobs) |
| `e2e.yml` | #81, #2 | workflow-level `contents: read` |
| `autofix.yml` | #35 | workflow-level `contents: read` |
| `images.yml` | #10, #7 | job-level `contents: read` on `setup` and `trigger-infra-update` — the file's other jobs already scope their own permissions, so this matches the existing style |

## Why `contents: read` is sufficient everywhere

Every flagged job only reads the repository; the writes in these workflows are already done with dedicated PATs rather than the workflow token:

- `autofix.yml` passes `token: ${{ secrets.GH_TOKEN }}` to the autofix action, which is what pushes the fixup commit.
- `images.yml` → `trigger-infra-update` dispatches into a different repository with `GH_TOKEN: ${{ secrets.GH_INFRA_TOKEN }}`.
- `images.yml` → `setup` just checks out and computes an image tag.
- `e2e.yml`'s `upload-artifact`/`download-artifact` steps operate on same-run artifacts, which use the runtime artifact API and need no token scope.
- `run.yml` sets `GITHUB_TOKEN` on the command step, but nothing in the build/lint/setup scripts reads it — it only serves to raise API rate limits during dependency resolution.

`run.yml` is a reusable workflow, so its `contents: read` is a subset of what `ci.yml` now grants and does not conflict.

## Verification

- Parsed all 11 workflow files and audited the effective permissions of every job: all are now covered at either the workflow or job level, with none missing.
- `prettier` reports all five touched files unchanged (already correctly formatted).

---
_Generated by [Claude Code](https://claude.ai/code/session_01368Ax2WpJaKG32ySXDKKX7)_