### PR TITLE
feat(models): add canopywave kimi-k3 mapping

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -751,6 +751,38 @@ export const moonshotModels = [
 				tools: true,
 				jsonOutput: true,
 			},
+			{
+				providerId: "canopywave",
+				externalId: "moonshotai/kimi-k3",
+				// A named function choice is rejected with a 400 ("tool_choice
+				// 'specified' is incompatible with thinking enabled"); "required"
+				// works and reliably returns a tool call.
+				supportedToolChoices: ["auto", "none", "required"],
+				inputPrice: "3.0e-6",
+				cachedInputPrice: "0.3e-6",
+				outputPrice: "15.0e-6",
+				requestPrice: "0",
+				// A 300K-token prompt was served correctly; prompts beyond ~1M are
+				// rejected with a 429 because the upstream TPM quota is 1M.
+				contextSize: 1048576,
+				maxOutput: 1048576,
+				streaming: true,
+				reasoning: true,
+				// This deployment accepts every effort tier, including "none"
+				// (which returns zero reasoning tokens) and "minimal".
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary

Adds a `canopywave` provider mapping for `kimi-k3` (`moonshotai/kimi-k3`), priced at the rates CanopyWave publishes: $3.00/M input, $15.00/M output, $0.30/M cached input.

## Verification

Every capability flag was probed live against `https://inference.canopywave.io/v1/chat/completions` before being declared:

- **streaming** — chunked deltas plus a usage frame with `stream_options.include_usage` ✅
- **reasoning** — `reasoning_content` in both streaming and non-streaming responses ✅
- **reasoningEfforts** — all seven tiers accepted; `none` returns zero reasoning tokens and `minimal` works (unlike the Fireworks deployment) ✅
- **vision** — correctly described both a remote image URL and a data URL ✅
- **tools** — `auto` and `required` both return well-formed tool calls; a **named function choice is rejected** with `tool_choice 'specified' is incompatible with thinking enabled`, so `supportedToolChoices` omits `function` ✅
- **jsonOutput** — `response_format: {"type":"json_object"}` returns raw JSON in `content` ✅
- **context** — a 300K-token prompt was served correctly. Prompts past ~1M hit a `429` for the upstream 1M TPM quota rather than a context error, so `contextSize` follows the published 1M window and the quirk is noted in a comment.

E2E for the new mapping:

```
TEST_MODELS="canopywave/kimi-k3" FULL_MODE=true pnpm test:e2e
Test Files  28 passed | 2 skipped (30)
     Tests  106 passed | 86 skipped (192)
```

`pnpm format` and `pnpm build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi K3 model through the CanopyWave provider.
  * Enabled vision, tool use, structured JSON output, and reasoning effort options.
  * Added support for extended prompts up to approximately 1 million tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->