### PR TITLE
ci: run e2e only on /e2e comment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,26 +1,65 @@
 name: e2e
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "apps/gateway/**"
-      - "packages/actions/**"
-      - "packages/models/**"
-      - "packages/shared/**"
-      - "**/*.e2e.ts"
-      - ".github/workflows/e2e.yml"
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/e2e') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      ref: ${{ steps.target.outputs.ref }}
+    steps:
+      - name: Resolve target commit
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ref=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          head_repo=$(echo "$pr" | jq -r '.head.repo.full_name')
+          head_sha=$(echo "$pr" | jq -r '.head.sha')
+          if [ "$head_repo" != "$REPO" ]; then
+            echo "Refusing to run e2e for a pull request from a fork ($head_repo)." >&2
+            exit 1
+          fi
+          echo "ref=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api --method POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=rocket
+
   e2e-shards:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: resolve
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:
+          ref: ${{ needs.resolve.outputs.ref }}
           persist-credentials: false
 
       - name: Collect versions
@@ -110,12 +150,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: e2e-shards
-    if: always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: [resolve, e2e-shards]
+    if: always() && needs.resolve.result == 'success'
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:
+          ref: ${{ needs.resolve.outputs.ref }}
           persist-credentials: false
 
       - name: Collect versions

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: read
     outputs:
       ref: ${{ steps.target.outputs.ref }}
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - NEVER run the full E2E suite across all models. Instead, scope `pnpm test:e2e` to the model(s) you changed with `TEST_MODELS`, e.g. `TEST_MODELS="granite/glm-5.2" FULL_MODE=true pnpm test:e2e`. This runs every e2e file (streaming, reasoning, tool calls, json, etc.) but only for the pinned mapping, so do NOT invoke the individual `*.e2e.ts` files one by one — let `TEST_MODELS` filter the whole suite in a single run.
 - Run `pnpm build` to ensure production builds work
 - Run `pnpm format` after code changes
+- The CI e2e workflow (`.github/workflows/e2e.yml`) does NOT run automatically on pull requests, because e2e runs spend real money on provider API calls. Trigger it on demand by commenting `/e2e` on the pull request (only for maintainers/collaborators, and only for branches in this repository, not forks), or via `workflow_dispatch`.
 
 ### Service URLs (Development)
 


### PR DESCRIPTION
E2E runs spend real money on provider API calls, so they should not fire automatically on every pull request.

## Changes

- `.github/workflows/e2e.yml`: replaced the `pull_request` trigger with `issue_comment` (`created`). The workflow now runs on `workflow_dispatch`, or when someone comments `/e2e` on a pull request.
- New `resolve` job gates and resolves the target commit:
  - only runs when the comment is on a pull request, starts with `/e2e`, and the commenter's `author_association` is `OWNER`/`MEMBER`/`COLLABORATOR`
  - looks up the PR head SHA via the GitHub API and refuses to run for pull requests from forks (same protection the old `head.repo.full_name == github.repository` check provided, since secrets are exposed to the run)
  - adds a 🚀 reaction to the triggering comment so it's visible that the run started
- Both `e2e-shards` and the merge job now check out the resolved head SHA instead of the default branch (an `issue_comment` event checks out the default branch by default).
- `concurrency` group is now keyed by PR number so repeated `/e2e` comments on the same PR cancel the previous run.
- `AGENTS.md`: documented the new trigger.

## Notes

- Because `issue_comment` workflows always run the version of the workflow file on the default branch, this takes effect only once merged to `main`.
- Runs triggered by a comment are not linked to the PR's check list (that is inherent to `issue_comment` events); the run is reachable from the Actions tab, and the 🚀 reaction acknowledges the trigger. Posting a commit status could be added later if PR-level visibility is wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1Apjv2473yXVHpAW44b3B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for starting end-to-end tests through `/e2e` comments or manual workflow dispatch.
  * Added commit resolution so test shards run against the intended revision.

* **Bug Fixes**
  * Prevented end-to-end tests from running for pull requests originating from forks.
  * Improved test coordination and result merging across parallel runs.

* **Documentation**
  * Clarified how and when the end-to-end workflow can be triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->