### PR TITLE
fix(gateway): classify low credit balance as gateway error

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -36,6 +36,21 @@ describe("getFinishReasonFromError", () => {
 		).toBe("gateway_error");
 	});
 
+	it("returns gateway_error for Anthropic low credit balance on 400", () => {
+		expect(
+			getFinishReasonFromError(
+				400,
+				'{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011CdVCeQNHP8ur9sMhB9gu3"}',
+			),
+		).toBe("gateway_error");
+	});
+
+	it("returns gateway_error for insufficient balance on non-402 status", () => {
+		expect(getFinishReasonFromError(400, "Insufficient Balance")).toBe(
+			"gateway_error",
+		);
+	});
+
 	it("returns gateway_error for 405 method not allowed", () => {
 		expect(getFinishReasonFromError(405)).toBe("gateway_error");
 		expect(getFinishReasonFromError(405, "Method Not Allowed")).toBe(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -74,6 +74,19 @@ export function getFinishReasonFromError(
 		return "gateway_error";
 	}
 
+	// Some providers report an exhausted gateway-side provider account with a 4xx
+	// other than 402 (e.g. Anthropic returns a 400 `invalid_request_error` with
+	// "Your credit balance is too low to access the Anthropic API."). Like the 402
+	// case above this is a funding problem on our provider account, not a client
+	// fault, so classify as gateway_error to allow fallback to another key or
+	// provider.
+	if (
+		errorText &&
+		/credit balance is too low|insufficient balance/i.test(errorText)
+	) {
+		return "gateway_error";
+	}
+
 	// Upstream reports the model id as unknown (e.g. Mistral / Together / Fireworks
 	// returning `Unknown model: <name>` on a 400). This is a gateway-side mapping
 	// gap rather than a client problem, so classify as gateway_error so the


### PR DESCRIPTION
## Problem

Anthropic returns a **400** `invalid_request_error` when the provider account behind the key runs out of funds:

```json
{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_..."}
```

Because it is a generic 4xx, `getFinishReasonFromError` fell through to `client_error` — blaming the user for a gateway-side funding problem and skipping fallback to another key/provider.

## Change

Match the funding wording (`credit balance is too low` / `insufficient balance`) and classify it as `gateway_error`, matching the existing 402 "Insufficient Balance" rule (DeepSeek). The `insufficient balance` half also covers providers that send that body on a non-402 status.

The patterns are provider-account funding messages that a client request can never trigger, so this does not fall under the "no broad 4xx reclassification" caveat in AGENTS.md.

## Testing

- Added unit tests for the Anthropic 400 payload and for `Insufficient Balance` on a non-402 status
- `pnpm vitest run apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts` — 26 passed
- `pnpm format`, `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for insufficient-balance and low-credit provider responses.
  * These errors are now consistently classified as gateway errors, including cases returned with unexpected status codes.
  * Added coverage for provider-specific billing messages and generic insufficient-balance messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->