### PR TITLE
feat(api): master API for custom providers/models

### DIFF
--- a/apps/api/src/routes/custom-models.ts
+++ b/apps/api/src/routes/custom-models.ts
@@ -26,7 +26,7 @@ const priceField = z
 	)
 	.nullish();
 
-const customModelSchema = z.object({
+export const customModelSchema = z.object({
 	id: z.string(),
 	createdAt: z.date(),
 	updatedAt: z.date(),
@@ -86,12 +86,12 @@ const customModelFields = {
 	status: z.enum(["active", "inactive"]).optional(),
 };
 
-const createCustomModelSchema = z.object({
+export const createCustomModelSchema = z.object({
 	providerKeyId: z.string().min(1, "Provider key is required"),
 	...customModelFields,
 });
 
-const updateCustomModelSchema = z
+export const updateCustomModelSchema = z
 	.object({
 		...customModelFields,
 		modelName: customModelFields.modelName.optional(),
@@ -99,6 +99,132 @@ const updateCustomModelSchema = z
 	.refine((v) => Object.keys(v).length > 0, {
 		message: "No updatable fields provided",
 	});
+
+type CustomModelCreateFields = Omit<
+	z.infer<typeof createCustomModelSchema>,
+	"providerKeyId"
+>;
+type CustomModelUpdateFields = z.infer<typeof updateCustomModelSchema>;
+
+interface CustomModelOwner {
+	id: string;
+	organizationId: string;
+}
+
+interface ExistingCustomModel {
+	id: string;
+	organizationId: string;
+	providerKeyId: string;
+	modelName: string;
+}
+
+async function assertModelNameAvailable(
+	providerKeyId: string,
+	modelName: string,
+) {
+	const conflict = await db.query.customModel.findFirst({
+		where: {
+			providerKeyId: { eq: providerKeyId },
+			modelName: { eq: modelName },
+			status: { ne: "deleted" },
+		},
+	});
+
+	if (conflict) {
+		throw new HTTPException(400, {
+			message: `A custom model named '${modelName}' already exists for this provider key`,
+		});
+	}
+}
+
+/**
+ * Create/update/delete helpers shared by the dashboard routes below and the
+ * master-key API (`v1-master.ts`), so both surfaces apply the same uniqueness
+ * checks, cache busting and audit logging. Callers are responsible for
+ * authorizing the acting principal against the provider key first.
+ */
+export async function insertCustomModel(
+	providerKey: CustomModelOwner,
+	userId: string,
+	fields: CustomModelCreateFields,
+) {
+	await assertModelNameAvailable(providerKey.id, fields.modelName);
+
+	const [customModel] = await cdb
+		.insert(tables.customModel)
+		.values({
+			providerKeyId: providerKey.id,
+			organizationId: providerKey.organizationId,
+			...fields,
+		})
+		.returning();
+
+	await logAuditEvent({
+		organizationId: providerKey.organizationId,
+		userId,
+		action: "custom_model.create",
+		resourceType: "custom_model",
+		resourceId: customModel.id,
+		metadata: {
+			providerKeyId: providerKey.id,
+			modelName: fields.modelName,
+		},
+	});
+
+	return customModel;
+}
+
+export async function applyCustomModelUpdate(
+	existing: ExistingCustomModel,
+	userId: string,
+	fields: CustomModelUpdateFields,
+) {
+	if (fields.modelName && fields.modelName !== existing.modelName) {
+		await assertModelNameAvailable(existing.providerKeyId, fields.modelName);
+	}
+
+	const [customModel] = await cdb
+		.update(tables.customModel)
+		.set(fields)
+		.where(eq(tables.customModel.id, existing.id))
+		.returning();
+
+	await logAuditEvent({
+		organizationId: existing.organizationId,
+		userId,
+		action: "custom_model.update",
+		resourceType: "custom_model",
+		resourceId: existing.id,
+		metadata: {
+			providerKeyId: existing.providerKeyId,
+			modelName: customModel.modelName,
+		},
+	});
+
+	return customModel;
+}
+
+export async function softDeleteCustomModel(
+	existing: ExistingCustomModel,
+	userId: string,
+) {
+	await cdb
+		.update(tables.customModel)
+		.set({ status: "deleted" })
+		.where(eq(tables.customModel.id, existing.id));
+
+	await logAuditEvent({
+		organizationId: existing.organizationId,
+		userId,
+		action: "custom_model.delete",
+		resourceType: "custom_model",
+		resourceId: existing.id,
+		metadata: {
+			providerKeyId: existing.providerKeyId,
+			modelName: existing.modelName,
+		},
+	});
+}
 
 /**
  * Resolves a custom provider key the user can manage and asserts that the
@@ -228,40 +354,7 @@ customModels.openapi(create, async (c) => {
 
 	const providerKey = await getManageableProviderKey(user.id, providerKeyId);
 
-	const existing = await db.query.customModel.findFirst({
-		where: {
-			providerKeyId: { eq: providerKeyId },
-			modelName: { eq: fields.modelName },
-			status: { ne: "deleted" },
-		},
-	});
-
-	if (existing) {
-		throw new HTTPException(400, {
-			message: `A custom model named '${fields.modelName}' already exists for this provider key`,
-		});
-	}
-
-	const [customModel] = await cdb
-		.insert(tables.customModel)
-		.values({
-			providerKeyId,
-			organizationId: providerKey.organizationId,
-			...fields,
-		})
-		.returning();
-
-	await logAuditEvent({
-		organizationId: providerKey.organizationId,
-		userId: user.id,
-		action: "custom_model.create",
-		resourceType: "custom_model",
-		resourceId: customModel.id,
-		metadata: {
-			providerKeyId,
-			modelName: fields.modelName,
-		},
-	});
+	const customModel = await insertCustomModel(providerKey, user.id, fields);
 
 	return c.json({ customModel });
 });
@@ -327,38 +420,7 @@ customModels.openapi(update, async (c) => {
 	// Enforce enterprise plan + custom provider key ownership.
 	await getManageableProviderKey(user.id, existing.providerKeyId);
 
-	if (fields.modelName && fields.modelName !== existing.modelName) {
-		const conflict = await db.query.customModel.findFirst({
-			where: {
-				providerKeyId: { eq: existing.providerKeyId },
-				modelName: { eq: fields.modelName },
-				status: { ne: "deleted" },
-			},
-		});
-		if (conflict) {
-			throw new HTTPException(400, {
-				message: `A custom model named '${fields.modelName}' already exists for this provider key`,
-			});
-		}
-	}
-
-	const [customModel] = await cdb
-		.update(tables.customModel)
-		.set(fields)
-		.where(eq(tables.customModel.id, id))
-		.returning();
-
-	await logAuditEvent({
-		organizationId: existing.organizationId,
-		userId: user.id,
-		action: "custom_model.update",
-		resourceType: "custom_model",
-		resourceId: id,
-		metadata: {
-			providerKeyId: existing.providerKeyId,
-			modelName: customModel.modelName,
-		},
-	});
+	const customModel = await applyCustomModelUpdate(existing, user.id, fields);
 
 	return c.json({ customModel }, 200);
 });
@@ -413,22 +475,7 @@ customModels.openapi(deleteCustomModel, async (c) => {
 
 	await getManageableProviderKey(user.id, existing.providerKeyId);
 
-	await cdb
-		.update(tables.customModel)
-		.set({ status: "deleted" })
-		.where(eq(tables.customModel.id, id));
-
-	await logAuditEvent({
-		organizationId: existing.organizationId,
-		userId: user.id,
-		action: "custom_model.delete",
-		resourceType: "custom_model",
-		resourceId: id,
-		metadata: {
-			providerKeyId: existing.providerKeyId,
-			modelName: existing.modelName,
-		},
-	});
+	await softDeleteCustomModel(existing, user.id);
 
 	return c.json({ message: "Custom model deleted successfully" });
 });

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -20,7 +20,7 @@ export const keysProvider = new OpenAPIHono<ServerTypes>();
 
 // Self-attested compliance posture for a custom provider key. Client-supplied
 // fields only — attestedAt/attestedByUserId are stamped server-side.
-const complianceAttestationSchema = z.object({
+export const complianceAttestationSchema = z.object({
 	soc2: z
 		.union([z.literal(1), z.literal(2)])
 		.nullable()
@@ -41,7 +41,7 @@ const complianceAttestationSchema = z.object({
 
 // Create a schema for provider key responses
 // Using z.object directly instead of createSelectSchema due to compatibility issues
-const providerKeySchema = z.object({
+export const providerKeySchema = z.object({
 	id: z.string(),
 	createdAt: z.date(),
 	updatedAt: z.date(),
@@ -94,12 +94,90 @@ const providerKeySchema = z.object({
 	organizationId: z.string(),
 });
 
+// Provider keys are only ever returned with a masked token, never the plaintext.
+export const providerKeyResponseSchema = providerKeySchema
+	.omit({ token: true })
+	.extend({
+		maskedToken: z.string(),
+	});
+
+export function serializeProviderKey<T extends { token: string }>(
+	providerKey: T,
+) {
+	const { token, ...rest } = providerKey;
+	return { ...rest, maskedToken: maskToken(token) };
+}
+
+// The custom provider name is the routing segment used in `custom/<name>/<model>`
+// model strings, so it must stay URL-safe and unique within the organization.
+export const customProviderNameSchema = z
+	.string()
+	.regex(
+		/^[a-z]+(-[a-z]+)*$/,
+		"Name must contain only lowercase letters a-z and single hyphens between them",
+	);
+
+export async function assertCustomProviderNameAvailable(
+	organizationId: string,
+	name: string,
+) {
+	const existing = await db.query.providerKey.findFirst({
+		where: {
+			status: { ne: "deleted" },
+			provider: { eq: "custom" },
+			name: { eq: name },
+			organizationId: { eq: organizationId },
+		},
+	});
+
+	if (existing) {
+		throw new HTTPException(400, {
+			message: `A custom provider named '${name}' already exists for this organization`,
+		});
+	}
+}
+
+/**
+ * SSRF guard: reject base URLs that resolve to internal/reserved addresses
+ * before they are stored or used as an outbound fetch target. No-op unless the
+ * hosted provider URL guard is enabled.
+ */
+export async function assertProviderBaseUrlAllowed(baseUrl: string) {
+	try {
+		await assertSafeProviderUrl(baseUrl);
+	} catch (error) {
+		throw new HTTPException(400, {
+			message:
+				error instanceof Error
+					? error.message
+					: "Provider base URL is not allowed",
+		});
+	}
+}
+
+/**
+ * Provenance is stamped server-side only so the audit trail can't be forged by
+ * the request body.
+ */
+export function stampComplianceAttestation(
+	attestation: z.infer<typeof complianceAttestationSchema> | null,
+	userId: string,
+): ProviderKeyComplianceAttestation | null {
+	return attestation
+		? {
+				...attestation,
+				attestedAt: new Date().toISOString(),
+				attestedByUserId: userId,
+			}
+		: null;
+}
+
 // Schema for creating a new provider key
 // Regular API keys must be printable ASCII without whitespace, but
 // service-account keys (Vertex providers) are JSON blobs that may be
 // pretty-printed, so ASCII whitespace is allowed when the value parses as a
 // JSON object.
-function isValidProviderToken(value: string): boolean {
+export function isValidProviderToken(value: string): boolean {
 	if (/^[\x21-\x7E]+$/.test(value)) {
 		return true;
 	}
@@ -129,13 +207,7 @@ const createProviderKeySchema = z.object({
 		message:
 			"API key contains invalid characters. Make sure you copied the actual key, not a masked version.",
 	}),
-	name: z
-		.string()
-		.regex(
-			/^[a-z]+(-[a-z]+)*$/,
-			"Name must contain only lowercase letters a-z and single hyphens between them",
-		)
-		.optional(),
+	name: customProviderNameSchema.optional(),
 	baseUrl: z.string().url().optional(),
 	options: z
 		.object({
@@ -213,12 +285,7 @@ const create = createRoute({
 			content: {
 				"application/json": {
 					schema: z.object({
-						providerKey: providerKeySchema
-							.omit({ token: true })
-							.extend({
-								maskedToken: z.string(),
-							})
-							.openapi({}),
+						providerKey: providerKeyResponseSchema.openapi({}),
 					}),
 				},
 			},
@@ -298,45 +365,12 @@ keysProvider.openapi(create, async (c) => {
 		});
 	}
 
-	// SSRF guard: reject base URLs that resolve to internal/reserved addresses
-	// before they are stored or used as an outbound fetch target. No-op unless
-	// the hosted provider URL guard is enabled.
 	if (baseUrl) {
-		try {
-			await assertSafeProviderUrl(baseUrl);
-		} catch (error) {
-			throw new HTTPException(400, {
-				message:
-					error instanceof Error
-						? error.message
-						: "Provider base URL is not allowed",
-			});
-		}
+		await assertProviderBaseUrlAllowed(baseUrl);
 	}
 
 	if (provider === "custom" && name) {
-		const existingCustomProvider = await db.query.providerKey.findFirst({
-			where: {
-				status: {
-					ne: "deleted",
-				},
-				provider: {
-					eq: "custom",
-				},
-				name: {
-					eq: name,
-				},
-				organizationId: {
-					eq: organizationId,
-				},
-			},
-		});
-
-		if (existingCustomProvider) {
-			throw new HTTPException(400, {
-				message: `A custom provider named '${name}' already exists for this organization`,
-			});
-		}
+		await assertCustomProviderNameAvailable(organizationId, name);
 	}
 
 	let validationResult;
@@ -420,13 +454,7 @@ keysProvider.openapi(create, async (c) => {
 		},
 	});
 
-	return c.json({
-		providerKey: {
-			...providerKey,
-			maskedToken: maskToken(userToken),
-			token: undefined,
-		},
-	});
+	return c.json({ providerKey: serializeProviderKey(providerKey) });
 });
 
 // List all provider keys
@@ -439,14 +467,7 @@ const list = createRoute({
 			content: {
 				"application/json": {
 					schema: z.object({
-						providerKeys: z
-							.array(
-								providerKeySchema.omit({ token: true }).extend({
-									// Only return a masked version of the token
-									maskedToken: z.string(),
-								}),
-							)
-							.openapi({}),
+						providerKeys: z.array(providerKeyResponseSchema).openapi({}),
 					}),
 				},
 			},
@@ -479,13 +500,7 @@ keysProvider.openapi(list, async (c) => {
 		},
 	});
 
-	return c.json({
-		providerKeys: providerKeys.map((key) => ({
-			...key,
-			maskedToken: maskToken(key.token),
-			token: undefined,
-		})),
-	});
+	return c.json({ providerKeys: providerKeys.map(serializeProviderKey) });
 });
 
 // List provider keys with minimal fields (provider + status only)
@@ -665,12 +680,7 @@ const updateStatus = createRoute({
 				"application/json": {
 					schema: z.object({
 						message: z.string(),
-						providerKey: providerKeySchema
-							.omit({ token: true })
-							.extend({
-								maskedToken: z.string(),
-							})
-							.openapi({}),
+						providerKey: providerKeyResponseSchema.openapi({}),
 					}),
 				},
 			},
@@ -775,15 +785,10 @@ keysProvider.openapi(updateStatus, async (c) => {
 		updates.customModelsOnly = customModelsOnly;
 	}
 	if (complianceAttestation !== undefined) {
-		// Provenance is stamped server-side only so the audit trail can't be
-		// forged by the request body.
-		updates.complianceAttestation = complianceAttestation
-			? {
-					...complianceAttestation,
-					attestedAt: new Date().toISOString(),
-					attestedByUserId: user.id,
-				}
-			: null;
+		updates.complianceAttestation = stampComplianceAttestation(
+			complianceAttestation,
+			user.id,
+		);
 	}
 
 	// Update the provider key
@@ -829,11 +834,7 @@ keysProvider.openapi(updateStatus, async (c) => {
 
 	return c.json({
 		message: "Provider key updated",
-		providerKey: {
-			...updatedProviderKey,
-			maskedToken: maskToken(updatedProviderKey.token),
-			token: undefined,
-		},
+		providerKey: serializeProviderKey(updatedProviderKey),
 	});
 });
 

--- a/apps/api/src/routes/v1-master-custom-catalog.spec.ts
+++ b/apps/api/src/routes/v1-master-custom-catalog.spec.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
+
+describe("v1/master custom providers and models", () => {
+	let masterToken: string;
+
+	beforeEach(async () => {
+		// createTestUser runs deleteAll and seeds test-user-id.
+		await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: "test-org-id",
+				name: "Test Organization",
+				billingEmail: "test@example.com",
+				plan: "enterprise",
+			},
+			{
+				id: "other-org-id",
+				name: "Other Organization",
+				billingEmail: "other@example.com",
+				plan: "enterprise",
+			},
+		]);
+
+		await db.insert(tables.userOrganization).values({
+			id: "test-user-org-id",
+			userId: "test-user-id",
+			organizationId: "test-org-id",
+			role: "owner",
+		});
+
+		await db.insert(tables.project).values({
+			id: "test-project-id",
+			name: "Test Project",
+			organizationId: "test-org-id",
+		});
+
+		masterToken = `mk-${crypto.randomUUID()}`;
+		await db.insert(tables.masterKey).values({
+			id: "test-master-key-id",
+			tokenHash: getApiKeyFingerprint(masterToken),
+			maskedToken: "mk-****",
+			description: "Test Master Key",
+			status: "active",
+			organizationId: "test-org-id",
+			createdBy: "test-user-id",
+		});
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	function authHeaders(extra: Record<string, string> = {}) {
+		return {
+			Authorization: `Bearer ${masterToken}`,
+			...extra,
+		};
+	}
+
+	function request(path: string, init: RequestInit = {}) {
+		return app.request(`/v1/master${path}`, {
+			...init,
+			headers: authHeaders(
+				init.body ? { "Content-Type": "application/json" } : {},
+			),
+		});
+	}
+
+	async function createProvider(name = "acme") {
+		const res = await request("/custom-providers", {
+			method: "POST",
+			body: JSON.stringify({
+				name,
+				baseUrl: "https://llm.acme.example.com/v1",
+				token: "sk-acme-secret",
+			}),
+		});
+		expect(res.status).toBe(201);
+		const json = (await res.json()) as {
+			customProvider: { id: string; maskedToken: string; token?: string };
+		};
+		return json.customProvider;
+	}
+
+	test("creates a custom provider without echoing the plaintext token", async () => {
+		const provider = await createProvider();
+
+		expect(provider.token).toBeUndefined();
+		expect(provider.maskedToken).not.toContain("secret");
+
+		const stored = await db.query.providerKey.findFirst({
+			where: { id: { eq: provider.id } },
+		});
+		expect(stored?.provider).toBe("custom");
+		expect(stored?.organizationId).toBe("test-org-id");
+		expect(stored?.token).toBe("sk-acme-secret");
+	});
+
+	test("rejects a duplicate custom provider name in the same organization", async () => {
+		await createProvider("acme");
+
+		const res = await request("/custom-providers", {
+			method: "POST",
+			body: JSON.stringify({
+				name: "acme",
+				baseUrl: "https://other.example.com/v1",
+				token: "sk-other",
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	test("lists, reads and updates custom providers", async () => {
+		const provider = await createProvider();
+
+		const listRes = await request("/custom-providers");
+		expect(listRes.status).toBe(200);
+		const list = (await listRes.json()) as {
+			customProviders: { id: string }[];
+		};
+		expect(list.customProviders.map((p) => p.id)).toEqual([provider.id]);
+
+		const patchRes = await request(`/custom-providers/${provider.id}`, {
+			method: "PATCH",
+			body: JSON.stringify({
+				baseUrl: "https://llm2.acme.example.com/v1",
+				customModelsOnly: true,
+				status: "inactive",
+			}),
+		});
+		expect(patchRes.status).toBe(200);
+
+		const getRes = await request(`/custom-providers/${provider.id}`);
+		expect(getRes.status).toBe(200);
+		const fetched = (await getRes.json()) as {
+			customProvider: {
+				baseUrl: string;
+				customModelsOnly: boolean;
+				status: string;
+			};
+		};
+		expect(fetched.customProvider.baseUrl).toBe(
+			"https://llm2.acme.example.com/v1",
+		);
+		expect(fetched.customProvider.customModelsOnly).toBe(true);
+		expect(fetched.customProvider.status).toBe("inactive");
+	});
+
+	test("soft-deletes a custom provider and hides it afterwards", async () => {
+		const provider = await createProvider();
+
+		const deleteRes = await request(`/custom-providers/${provider.id}`, {
+			method: "DELETE",
+		});
+		expect(deleteRes.status).toBe(200);
+
+		const getRes = await request(`/custom-providers/${provider.id}`);
+		expect(getRes.status).toBe(404);
+
+		const stored = await db.query.providerKey.findFirst({
+			where: { id: { eq: provider.id } },
+		});
+		expect(stored?.status).toBe("deleted");
+	});
+
+	test("does not expose provider keys from other organizations", async () => {
+		const [foreign] = await db
+			.insert(tables.providerKey)
+			.values({
+				organizationId: "other-org-id",
+				provider: "custom",
+				name: "foreign",
+				baseUrl: "https://foreign.example.com/v1",
+				token: "sk-foreign",
+			})
+			.returning();
+
+		const getRes = await request(`/custom-providers/${foreign.id}`);
+		expect(getRes.status).toBe(404);
+
+		const listRes = await request("/custom-providers");
+		const list = (await listRes.json()) as {
+			customProviders: { id: string }[];
+		};
+		expect(list.customProviders).toHaveLength(0);
+	});
+
+	test("rejects a non-custom provider key by id", async () => {
+		const [byok] = await db
+			.insert(tables.providerKey)
+			.values({
+				organizationId: "test-org-id",
+				provider: "openai",
+				token: "sk-openai",
+			})
+			.returning();
+
+		const res = await request(`/custom-providers/${byok.id}`);
+		expect(res.status).toBe(404);
+	});
+
+	test("round-trips custom model pricing and context window", async () => {
+		const provider = await createProvider();
+
+		const createRes = await request("/custom-models", {
+			method: "POST",
+			body: JSON.stringify({
+				providerKeyId: provider.id,
+				modelName: "acme-large",
+				displayName: "Acme Large",
+				contextSize: 200000,
+				maxOutput: 32000,
+				inputPrice: "3.0e-6",
+				outputPrice: "15.0e-6",
+				cachedInputPrice: "0.3e-6",
+				streaming: "true",
+				vision: true,
+				tools: true,
+				supportedParameters: ["temperature", "top_p"],
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const created = (await createRes.json()) as {
+			customModel: { id: string; contextSize: number; inputPrice: string };
+		};
+		expect(created.customModel.contextSize).toBe(200000);
+		expect(created.customModel.inputPrice).toBe("3.0e-6");
+
+		const listRes = await request(
+			`/custom-models?providerKeyId=${provider.id}`,
+		);
+		expect(listRes.status).toBe(200);
+		const list = (await listRes.json()) as {
+			customModels: {
+				id: string;
+				modelName: string;
+				maxOutput: number;
+				outputPrice: string;
+				supportedParameters: string[];
+			}[];
+		};
+		expect(list.customModels).toHaveLength(1);
+		expect(list.customModels[0].modelName).toBe("acme-large");
+		expect(list.customModels[0].maxOutput).toBe(32000);
+		expect(list.customModels[0].outputPrice).toBe("15.0e-6");
+		expect(list.customModels[0].supportedParameters).toEqual([
+			"temperature",
+			"top_p",
+		]);
+
+		const patchRes = await request(`/custom-models/${created.customModel.id}`, {
+			method: "PATCH",
+			body: JSON.stringify({ contextSize: 400000, status: "inactive" }),
+		});
+		expect(patchRes.status).toBe(200);
+		const patched = (await patchRes.json()) as {
+			customModel: { contextSize: number; status: string };
+		};
+		expect(patched.customModel.contextSize).toBe(400000);
+		expect(patched.customModel.status).toBe("inactive");
+
+		const deleteRes = await request(
+			`/custom-models/${created.customModel.id}`,
+			{
+				method: "DELETE",
+			},
+		);
+		expect(deleteRes.status).toBe(200);
+
+		const afterRes = await request("/custom-models");
+		const after = (await afterRes.json()) as { customModels: unknown[] };
+		expect(after.customModels).toHaveLength(0);
+	});
+
+	test("rejects a duplicate model name on the same provider", async () => {
+		const provider = await createProvider();
+
+		const body = JSON.stringify({
+			providerKeyId: provider.id,
+			modelName: "acme-large",
+		});
+		expect(
+			(await request("/custom-models", { method: "POST", body })).status,
+		).toBe(201);
+		expect(
+			(await request("/custom-models", { method: "POST", body })).status,
+		).toBe(400);
+	});
+
+	test("rejects custom models for a provider in another organization", async () => {
+		const [foreign] = await db
+			.insert(tables.providerKey)
+			.values({
+				organizationId: "other-org-id",
+				provider: "custom",
+				name: "foreign",
+				baseUrl: "https://foreign.example.com/v1",
+				token: "sk-foreign",
+			})
+			.returning();
+
+		const res = await request("/custom-models", {
+			method: "POST",
+			body: JSON.stringify({
+				providerKeyId: foreign.id,
+				modelName: "foreign-model",
+			}),
+		});
+		expect(res.status).toBe(404);
+	});
+
+	test("requires a valid master key", async () => {
+		const res = await app.request("/v1/master/custom-models", {
+			headers: { Authorization: "Bearer not-a-real-master-key" },
+		});
+		expect(res.status).toBe(401);
+	});
+});

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -11,6 +11,14 @@ import {
 } from "@/lib/iam-rules.js";
 import { maskToken } from "@/lib/maskToken.js";
 import {
+	applyCustomModelUpdate,
+	createCustomModelSchema,
+	customModelSchema,
+	insertCustomModel,
+	softDeleteCustomModel,
+	updateCustomModelSchema,
+} from "@/routes/custom-models.js";
+import {
 	buildApiKeyLimitAuditChanges,
 	createApiKeyForProject,
 	hasPeriodConfigChanged,
@@ -20,6 +28,16 @@ import {
 	parseApiKeyPeriodConfig,
 	type PartialApiKeyLimitConfig,
 } from "@/routes/keys-api.js";
+import {
+	assertCustomProviderNameAvailable,
+	assertProviderBaseUrlAllowed,
+	complianceAttestationSchema,
+	customProviderNameSchema,
+	isValidProviderToken,
+	providerKeyResponseSchema,
+	serializeProviderKey,
+	stampComplianceAttestation,
+} from "@/routes/keys-provider.js";
 import { createProjectForOrg } from "@/routes/projects.js";
 import { memberIamRuleSchema } from "@/routes/team.js";
 
@@ -34,6 +52,7 @@ import {
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 
 import type { ServerTypes } from "@/vars.js";
+import type { ProviderKeyComplianceAttestation } from "@llmgateway/db";
 
 export const v1Master = new OpenAPIHono<ServerTypes>();
 
@@ -1423,6 +1442,585 @@ v1Master.openapi(deleteMemberIamRule, async (c) => {
 	});
 
 	return c.json({ message: "Member IAM rule deleted successfully" });
+});
+
+// Custom providers are BYOK provider keys with `provider: "custom"`, addressed
+// by the gateway as `custom/<name>/<model>`. Only custom keys are exposed here:
+// catalog providers require an upstream credential check that isn't meaningful
+// for unattended provisioning.
+async function loadCustomProviderKeyForOrg(id: string, organizationId: string) {
+	const providerKey = await db.query.providerKey.findFirst({
+		where: { id: { eq: id } },
+	});
+
+	if (
+		!providerKey ||
+		providerKey.status === "deleted" ||
+		providerKey.organizationId !== organizationId ||
+		providerKey.provider !== "custom"
+	) {
+		throw new HTTPException(404, {
+			message: "Custom provider not found in this organization",
+		});
+	}
+
+	return providerKey;
+}
+
+async function loadCustomModelForOrg(id: string, organizationId: string) {
+	const customModel = await db.query.customModel.findFirst({
+		where: {
+			id: { eq: id },
+			organizationId: { eq: organizationId },
+			status: { ne: "deleted" },
+		},
+	});
+
+	if (!customModel) {
+		throw new HTTPException(404, {
+			message: "Custom model not found in this organization",
+		});
+	}
+
+	return customModel;
+}
+
+const providerTokenField = z
+	.string()
+	.min(1, "API key is required")
+	.refine(isValidProviderToken, {
+		message:
+			"API key contains invalid characters. Make sure you copied the actual key, not a masked version.",
+	});
+
+const createCustomProviderBody = z.object({
+	name: customProviderNameSchema,
+	baseUrl: z.string().url(),
+	token: providerTokenField,
+	customModelsOnly: z.boolean().optional(),
+	complianceAttestation: complianceAttestationSchema.optional(),
+});
+
+const updateCustomProviderBody = z
+	.object({
+		baseUrl: z.string().url().optional(),
+		token: providerTokenField.optional(),
+		status: z.enum(["active", "inactive"]).optional(),
+		customModelsOnly: z.boolean().optional(),
+		complianceAttestation: complianceAttestationSchema.nullable().optional(),
+	})
+	.refine((v) => Object.keys(v).length > 0, {
+		message: "At least one field must be provided",
+	});
+
+const createCustomProvider = createRoute({
+	method: "post",
+	path: "/custom-providers",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: createCustomProviderBody,
+				},
+			},
+		},
+	},
+	responses: {
+		201: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						customProvider: providerKeyResponseSchema.openapi({}),
+					}),
+				},
+			},
+			description: "Custom provider created successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(createCustomProvider, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { name, baseUrl, token, customModelsOnly, complianceAttestation } =
+		c.req.valid("json");
+
+	await assertProviderBaseUrlAllowed(baseUrl);
+	await assertCustomProviderNameAvailable(masterKey.organizationId, name);
+
+	const [providerKey] = await cdb
+		.insert(tables.providerKey)
+		.values({
+			organizationId: masterKey.organizationId,
+			provider: "custom",
+			name,
+			baseUrl,
+			token,
+			customModelsOnly: customModelsOnly ?? false,
+			complianceAttestation: complianceAttestation
+				? stampComplianceAttestation(complianceAttestation, masterKey.createdBy)
+				: null,
+		})
+		.returning();
+
+	await logAuditEvent({
+		organizationId: masterKey.organizationId,
+		userId: masterKey.createdBy,
+		action: "provider_key.create",
+		resourceType: "provider_key",
+		resourceId: providerKey.id,
+		metadata: { provider: "custom", resourceName: name },
+	});
+
+	return c.json({ customProvider: serializeProviderKey(providerKey) }, 201);
+});
+
+const listCustomProviders = createRoute({
+	method: "get",
+	path: "/custom-providers",
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						customProviders: z.array(providerKeyResponseSchema).openapi({}),
+					}),
+				},
+			},
+			description:
+				"List the non-deleted custom providers in the master key's organization.",
+		},
+	},
+});
+
+v1Master.openapi(listCustomProviders, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const providerKeys = await db.query.providerKey.findMany({
+		where: {
+			organizationId: { eq: masterKey.organizationId },
+			provider: { eq: "custom" },
+			status: { ne: "deleted" },
+		},
+		orderBy: { createdAt: "asc" },
+	});
+
+	return c.json({ customProviders: providerKeys.map(serializeProviderKey) });
+});
+
+const getCustomProvider = createRoute({
+	method: "get",
+	path: "/custom-providers/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						customProvider: providerKeyResponseSchema.openapi({}),
+					}),
+				},
+			},
+			description: "Get a single custom provider via master key.",
+		},
+	},
+});
+
+v1Master.openapi(getCustomProvider, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+
+	const providerKey = await loadCustomProviderKeyForOrg(
+		id,
+		masterKey.organizationId,
+	);
+
+	return c.json({ customProvider: serializeProviderKey(providerKey) });
+});
+
+const updateCustomProvider = createRoute({
+	method: "patch",
+	path: "/custom-providers/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+		body: {
+			content: {
+				"application/json": {
+					schema: updateCustomProviderBody,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						customProvider: providerKeyResponseSchema.openapi({}),
+					}),
+				},
+			},
+			description: "Custom provider updated successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(updateCustomProvider, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+	const { baseUrl, token, status, customModelsOnly, complianceAttestation } =
+		c.req.valid("json");
+
+	const existing = await loadCustomProviderKeyForOrg(
+		id,
+		masterKey.organizationId,
+	);
+
+	if (baseUrl !== undefined) {
+		await assertProviderBaseUrlAllowed(baseUrl);
+	}
+
+	const updates: {
+		baseUrl?: string;
+		token?: string;
+		status?: "active" | "inactive";
+		customModelsOnly?: boolean;
+		complianceAttestation?: ProviderKeyComplianceAttestation | null;
+	} = {};
+	if (baseUrl !== undefined) {
+		updates.baseUrl = baseUrl;
+	}
+	if (token !== undefined) {
+		updates.token = token;
+	}
+	if (status !== undefined) {
+		updates.status = status;
+	}
+	if (customModelsOnly !== undefined) {
+		updates.customModelsOnly = customModelsOnly;
+	}
+	if (complianceAttestation !== undefined) {
+		updates.complianceAttestation = stampComplianceAttestation(
+			complianceAttestation,
+			masterKey.createdBy,
+		);
+	}
+
+	const [updated] = await cdb
+		.update(tables.providerKey)
+		.set(updates)
+		.where(eq(tables.providerKey.id, id))
+		.returning();
+
+	const changes: Record<string, { old: unknown; new: unknown }> = {};
+	if (baseUrl !== undefined && existing.baseUrl !== baseUrl) {
+		changes.baseUrl = { old: existing.baseUrl, new: baseUrl };
+	}
+	// The token itself is never written to the audit log, only the fact it rotated.
+	if (token !== undefined && existing.token !== token) {
+		changes.token = { old: "<redacted>", new: "<rotated>" };
+	}
+	if (status !== undefined && existing.status !== status) {
+		changes.status = { old: existing.status, new: status };
+	}
+	if (
+		customModelsOnly !== undefined &&
+		existing.customModelsOnly !== customModelsOnly
+	) {
+		changes.customModelsOnly = {
+			old: existing.customModelsOnly,
+			new: customModelsOnly,
+		};
+	}
+	if (complianceAttestation !== undefined) {
+		changes.complianceAttestation = {
+			old: existing.complianceAttestation ?? null,
+			new: updates.complianceAttestation ?? null,
+		};
+	}
+
+	if (Object.keys(changes).length > 0) {
+		await logAuditEvent({
+			organizationId: masterKey.organizationId,
+			userId: masterKey.createdBy,
+			action: "provider_key.update",
+			resourceType: "provider_key",
+			resourceId: id,
+			metadata: {
+				provider: "custom",
+				resourceName: existing.name ?? undefined,
+				changes,
+			},
+		});
+	}
+
+	return c.json({ customProvider: serializeProviderKey(updated) });
+});
+
+const deleteCustomProvider = createRoute({
+	method: "delete",
+	path: "/custom-providers/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description: "Custom provider deleted successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(deleteCustomProvider, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+
+	const existing = await loadCustomProviderKeyForOrg(
+		id,
+		masterKey.organizationId,
+	);
+
+	await cdb
+		.update(tables.providerKey)
+		.set({ status: "deleted" })
+		.where(eq(tables.providerKey.id, id));
+
+	await logAuditEvent({
+		organizationId: masterKey.organizationId,
+		userId: masterKey.createdBy,
+		action: "provider_key.delete",
+		resourceType: "provider_key",
+		resourceId: id,
+		metadata: { provider: "custom", resourceName: existing.name ?? undefined },
+	});
+
+	return c.json({ message: "Custom provider deleted successfully" });
+});
+
+const createCustomModel = createRoute({
+	method: "post",
+	path: "/custom-models",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: createCustomModelSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		201: {
+			content: {
+				"application/json": {
+					schema: z.object({ customModel: customModelSchema.openapi({}) }),
+				},
+			},
+			description: "Custom model created successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(createCustomModel, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { providerKeyId, ...fields } = c.req.valid("json");
+
+	const providerKey = await loadCustomProviderKeyForOrg(
+		providerKeyId,
+		masterKey.organizationId,
+	);
+
+	const customModel = await insertCustomModel(
+		providerKey,
+		masterKey.createdBy,
+		fields,
+	);
+
+	return c.json({ customModel }, 201);
+});
+
+const listCustomModels = createRoute({
+	method: "get",
+	path: "/custom-models",
+	request: {
+		query: z.object({
+			providerKeyId: z.string().min(1).optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						customModels: z.array(customModelSchema).openapi({}),
+					}),
+				},
+			},
+			description:
+				"List the custom models in the master key's organization, with their context window, limits and per-token pricing. Optionally filter by providerKeyId.",
+		},
+	},
+});
+
+v1Master.openapi(listCustomModels, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { providerKeyId } = c.req.valid("query");
+
+	if (providerKeyId) {
+		await loadCustomProviderKeyForOrg(providerKeyId, masterKey.organizationId);
+	}
+
+	const customModels = await db.query.customModel.findMany({
+		where: {
+			organizationId: { eq: masterKey.organizationId },
+			status: { ne: "deleted" },
+			...(providerKeyId ? { providerKeyId: { eq: providerKeyId } } : {}),
+		},
+		orderBy: { createdAt: "asc" },
+	});
+
+	return c.json({ customModels });
+});
+
+const getCustomModel = createRoute({
+	method: "get",
+	path: "/custom-models/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ customModel: customModelSchema.openapi({}) }),
+				},
+			},
+			description: "Get a single custom model via master key.",
+		},
+	},
+});
+
+v1Master.openapi(getCustomModel, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+
+	const customModel = await loadCustomModelForOrg(id, masterKey.organizationId);
+
+	return c.json({ customModel });
+});
+
+const updateCustomModel = createRoute({
+	method: "patch",
+	path: "/custom-models/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+		body: {
+			content: {
+				"application/json": {
+					schema: updateCustomModelSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ customModel: customModelSchema.openapi({}) }),
+				},
+			},
+			description: "Custom model updated successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(updateCustomModel, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+	const fields = c.req.valid("json");
+
+	const existing = await loadCustomModelForOrg(id, masterKey.organizationId);
+
+	const customModel = await applyCustomModelUpdate(
+		existing,
+		masterKey.createdBy,
+		fields,
+	);
+
+	return c.json({ customModel });
+});
+
+const deleteCustomModel = createRoute({
+	method: "delete",
+	path: "/custom-models/{id}",
+	request: {
+		params: z.object({ id: z.string() }),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description: "Custom model deleted successfully via master key.",
+		},
+	},
+});
+
+v1Master.openapi(deleteCustomModel, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { id } = c.req.param();
+
+	const existing = await loadCustomModelForOrg(id, masterKey.organizationId);
+
+	await softDeleteCustomModel(existing, masterKey.createdBy);
+
+	return c.json({ message: "Custom model deleted successfully" });
 });
 
 export default v1Master;

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Master Keys
-description: Provision projects and gateway API keys programmatically with org-scoped bearer tokens (Enterprise only)
+description: Provision projects, gateway API keys, and custom providers/models programmatically with org-scoped bearer tokens (Enterprise only)
 icon: KeyRound
 ---
 
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 # Master Keys
 
-Master keys are org-scoped bearer tokens that let you create projects, gateway API keys, and IAM rules (both per key and per organization member) programmatically — without going through the dashboard. They are intended for server-to-server provisioning (e.g. multi-tenant onboarding from your own backend).
+Master keys are org-scoped bearer tokens that let you create projects, gateway API keys, IAM rules (both per key and per organization member), and your organization's custom providers and custom models programmatically — without going through the dashboard. They are intended for server-to-server provisioning (e.g. multi-tenant onboarding from your own backend).
 
 <Callout type="info">
 	Master keys are available on the **Enterprise** plan only. Contact us at
@@ -573,4 +573,259 @@ Response (200):
 
 ```json
 { "message": "Member IAM rule deleted successfully" }
+```
+
+## Custom providers
+
+Custom providers are your own OpenAI-compatible endpoints, registered as BYOK provider keys with `provider: "custom"`. The gateway routes to them with the model string `custom/<name>/<model>`. See [Custom Providers](/features/custom-providers) for the dashboard flow and routing semantics.
+
+Only custom providers are exposed through the master API — catalog providers (OpenAI, Anthropic, …) require an interactive upstream credential check and must be added from the dashboard.
+
+All endpoints scope by the master key's organization: a `404` is returned if the provider key is not a non-deleted custom provider in that organization.
+
+<Callout type="warning">
+	The provider token is stored but never returned. Responses only include a
+	`maskedToken` for identification.
+</Callout>
+
+### List custom providers
+
+`GET /v1/master/custom-providers`
+
+```bash
+curl https://internal.llmgateway.io/v1/master/custom-providers \
+  -H "Authorization: Bearer $MASTER_KEY"
+```
+
+Response (200):
+
+```json
+{
+	"customProviders": [
+		{
+			"id": "pk_...",
+			"provider": "custom",
+			"name": "acme",
+			"baseUrl": "https://llm.acme.example.com/v1",
+			"maskedToken": "sk-a...cret",
+			"status": "active",
+			"customModelsOnly": true,
+			"complianceAttestation": null,
+			"organizationId": "org_...",
+			"createdAt": "...",
+			"updatedAt": "..."
+		}
+	]
+}
+```
+
+### Get a custom provider
+
+`GET /v1/master/custom-providers/{id}`
+
+Returns a single custom provider in the master key's organization.
+
+### Create a custom provider
+
+`POST /v1/master/custom-providers`
+
+```bash
+curl -X POST https://internal.llmgateway.io/v1/master/custom-providers \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "acme",
+    "baseUrl": "https://llm.acme.example.com/v1",
+    "token": "sk-acme-...",
+    "customModelsOnly": true
+  }'
+```
+
+Body parameters:
+
+| Field                   | Type               | Description                                                                                  |
+| ----------------------- | ------------------ | -------------------------------------------------------------------------------------------- |
+| `name`                  | string             | Lowercase letters and single hyphens only. Unique per organization; used in the model string |
+| `baseUrl`               | string             | OpenAI-compatible base URL. Internal/reserved addresses are rejected                         |
+| `token`                 | string             | Upstream API key. Stored server-side, never returned                                         |
+| `customModelsOnly`      | boolean (optional) | Restrict the provider to models defined in your custom catalog. Default `false`              |
+| `complianceAttestation` | object (optional)  | Self-attested compliance posture. `attestedAt` / `attestedByUserId` are stamped server-side  |
+
+Response (201): the created custom provider.
+
+### Update a custom provider
+
+`PATCH /v1/master/custom-providers/{id}`
+
+All body fields are optional; provide only the ones you want to change.
+
+```bash
+curl -X PATCH https://internal.llmgateway.io/v1/master/custom-providers/pk_... \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "baseUrl": "https://llm2.acme.example.com/v1",
+    "token": "sk-acme-rotated-..."
+  }'
+```
+
+Body parameters (all optional, at least one required):
+
+| Field                   | Type                     | Description                                    |
+| ----------------------- | ------------------------ | ---------------------------------------------- |
+| `baseUrl`               | string                   | Repoint the provider at a new endpoint         |
+| `token`                 | string                   | Rotate the upstream API key                    |
+| `status`                | `"active" \| "inactive"` | Disable the provider without deleting it       |
+| `customModelsOnly`      | boolean                  | Toggle the custom-catalog restriction          |
+| `complianceAttestation` | object \| null           | Replace the attestation, or `null` to clear it |
+
+The provider `name` is immutable — it is the routing segment your model strings reference. Create a new provider instead of renaming.
+
+Response (200): the updated custom provider.
+
+### Delete a custom provider
+
+`DELETE /v1/master/custom-providers/{id}`
+
+Soft-deletes the provider (sets `status` to `"deleted"`). Its custom models stop resolving immediately.
+
+Response (200):
+
+```json
+{ "message": "Custom provider deleted successfully" }
+```
+
+## Custom models
+
+Custom models are your organization's catalogue entries for a custom provider: the context window, output limit, per-token pricing, and capability flags the gateway uses to route, validate, and bill requests to that model. When a provider has `customModelsOnly: true`, only models in this catalogue can be called through it.
+
+Query these endpoints to read the full catalogue you have registered — including `contextSize`, `maxOutput`, and every price field — for surfacing in your own dashboards or cost tooling.
+
+<Callout type="info">
+	Per-token prices are strings in USD per token. Use `e-6` notation so the
+	coefficient reads directly as USD per million tokens — `"3.0e-6"` is $3.00/M.
+</Callout>
+
+### List custom models
+
+`GET /v1/master/custom-models`
+
+Returns the non-deleted custom models in the master key's organization. Pass an optional `providerKeyId` query parameter to scope the list to a single custom provider.
+
+```bash
+curl "https://internal.llmgateway.io/v1/master/custom-models?providerKeyId=pk_..." \
+  -H "Authorization: Bearer $MASTER_KEY"
+```
+
+Response (200):
+
+```json
+{
+	"customModels": [
+		{
+			"id": "cm_...",
+			"providerKeyId": "pk_...",
+			"organizationId": "org_...",
+			"modelName": "acme-large",
+			"displayName": "Acme Large",
+			"contextSize": 200000,
+			"maxOutput": 32000,
+			"inputPrice": "3.0e-6",
+			"outputPrice": "15.0e-6",
+			"cachedInputPrice": "0.3e-6",
+			"streaming": "true",
+			"vision": true,
+			"tools": true,
+			"reasoning": null,
+			"jsonOutput": true,
+			"supportedParameters": ["temperature", "top_p"],
+			"status": "active",
+			"createdAt": "...",
+			"updatedAt": "..."
+		}
+	]
+}
+```
+
+### Get a custom model
+
+`GET /v1/master/custom-models/{id}`
+
+Returns a single custom model in the master key's organization.
+
+### Create a custom model
+
+`POST /v1/master/custom-models`
+
+```bash
+curl -X POST https://internal.llmgateway.io/v1/master/custom-models \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "providerKeyId": "pk_...",
+    "modelName": "acme-large",
+    "displayName": "Acme Large",
+    "contextSize": 200000,
+    "maxOutput": 32000,
+    "inputPrice": "3.0e-6",
+    "outputPrice": "15.0e-6",
+    "tools": true
+  }'
+```
+
+Body parameters:
+
+| Field                    | Type                                | Description                                                |
+| ------------------------ | ----------------------------------- | ---------------------------------------------------------- |
+| `providerKeyId`          | string                              | Must be a custom provider in the master key's organization |
+| `modelName`              | string                              | Model id sent upstream. Unique per provider                |
+| `displayName`            | string (optional)                   | Human-readable label                                       |
+| `contextSize`            | number (optional)                   | Context window in tokens                                   |
+| `maxOutput`              | number (optional)                   | Max output tokens                                          |
+| `inputPrice`             | string (optional)                   | USD per input token                                        |
+| `outputPrice`            | string (optional)                   | USD per output token                                       |
+| `cachedInputPrice`       | string (optional)                   | USD per cached input token                                 |
+| `cacheReadInputPrice`    | string (optional)                   | USD per cache-read token                                   |
+| `cacheWriteInputPrice`   | string (optional)                   | USD per cache-write token (5m TTL)                         |
+| `cacheWriteInputPrice1h` | string (optional)                   | USD per cache-write token (1h TTL)                         |
+| `requestPrice`           | string (optional)                   | Flat USD charged per request                               |
+| `webSearchPrice`         | string (optional)                   | USD per web search                                         |
+| `imageInputPrice`        | string (optional)                   | USD per image input token                                  |
+| `audioInputPrice`        | string (optional)                   | USD per audio input token                                  |
+| `streaming`              | `"true" \| "false" \| "only"`       | Streaming support (`"only"` = streaming-only model)        |
+| `vision`                 | boolean (optional)                  | Accepts image input                                        |
+| `tools`                  | boolean (optional)                  | Supports tool calling                                      |
+| `reasoning`              | boolean (optional)                  | Emits reasoning output                                     |
+| `jsonOutput`             | boolean (optional)                  | Supports JSON / structured output                          |
+| `audio`                  | boolean (optional)                  | Accepts audio input                                        |
+| `supportedParameters`    | string[] (optional)                 | Request parameters the upstream accepts                    |
+| `status`                 | `"active" \| "inactive"` (optional) | Defaults to `"active"`                                     |
+
+Response (201): the created custom model.
+
+### Update a custom model
+
+`PATCH /v1/master/custom-models/{id}`
+
+Accepts the same fields as create (except `providerKeyId`), all optional — provide only the ones you want to change. Renaming to a `modelName` already used by another model on the same provider returns a `400`.
+
+```bash
+curl -X PATCH https://internal.llmgateway.io/v1/master/custom-models/cm_... \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "contextSize": 400000, "outputPrice": "12.0e-6" }'
+```
+
+Response (200): the updated custom model.
+
+### Delete a custom model
+
+`DELETE /v1/master/custom-models/{id}`
+
+Soft-deletes the model (sets `status` to `"deleted"`).
+
+Response (200):
+
+```json
+{ "message": "Custom model deleted successfully" }
 ```


### PR DESCRIPTION
## Summary

Answers "do you have an API to query the custom providers and custom models we've built, with context window, price per token, etc.?" — yes, now, and it's full CRUD, wired into the same place as the master keys API / IAM programmatic endpoints.

Previously custom providers and custom models were **session + org-admin + enterprise only** (dashboard `/keys/provider` and `/custom-models`). There was no programmatic surface: `/v1/models` on the gateway is anonymous and only serves the static catalogue, so an org's custom catalogue was invisible to machines.

## New endpoints (master-key auth, `/v1/master/*`)

Custom providers — BYOK provider keys with `provider: "custom"`, routed as `custom/<name>/<model>`:

| Method | Path |
| --- | --- |
| `POST` | `/v1/master/custom-providers` |
| `GET` | `/v1/master/custom-providers` |
| `GET` | `/v1/master/custom-providers/{id}` |
| `PATCH` | `/v1/master/custom-providers/{id}` |
| `DELETE` | `/v1/master/custom-providers/{id}` |

Custom models — the org's catalogue entries:

| Method | Path |
| --- | --- |
| `POST` | `/v1/master/custom-models` |
| `GET` | `/v1/master/custom-models?providerKeyId=` |
| `GET` | `/v1/master/custom-models/{id}` |
| `PATCH` | `/v1/master/custom-models/{id}` |
| `DELETE` | `/v1/master/custom-models/{id}` |

The custom-model responses carry the full entry: `contextSize`, `maxOutput`, every per-token price (`inputPrice`, `outputPrice`, `cachedInputPrice`, cache read/write incl. 1h TTL, `requestPrice`, `webSearchPrice`, `imageInputPrice`, `audioInputPrice`) and the capability flags (`streaming`, `vision`, `tools`, `reasoning`, `jsonOutput`, `audio`, `supportedParameters`).

`PATCH /custom-providers/{id}` additionally supports repointing `baseUrl` and rotating `token` — needed to adapt a custom provider without the dashboard. The provider `name` stays immutable since it is the routing segment.

## Notes

- Auth reuses the existing master-key middleware, which already enforces active key + non-deleted org + enterprise plan — exactly the gate custom models require.
- Only custom provider keys are addressable here. Catalog providers (OpenAI, Anthropic, …) need an interactive upstream credential check that isn't meaningful for unattended provisioning, so they stay dashboard-only.
- Create/update/delete logic was factored out of `custom-models.ts` and `keys-provider.ts` so the session routes and the master routes share the same uniqueness checks, `cdb` cache busting (gateway SWR mirrors) and audit logging. The SSRF base-URL guard and server-side compliance-attestation stamping are shared too.
- Rotated tokens are never written to the audit log — only the fact that a rotation happened.
- Everything is org-scoped: cross-org ids return `404`.

## Test plan

- New `apps/api/src/routes/v1-master-custom-catalog.spec.ts` (10 tests): create/list/get/patch/delete for both resources, pricing + context-window round-trip, duplicate name rejection (provider and model), cross-org isolation, non-custom provider key rejection, plaintext token never echoed, invalid master key → 401.
- `keys-provider.spec.ts`, `keys-api.spec.ts`, `v1-master.spec.ts` all still pass (69 tests total).
- `pnpm build`, `pnpm lint`, `pnpm format` clean.
- Docs: `apps/docs/content/features/master-keys.mdx` extended with both endpoint groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added master-key API support for creating, listing, updating, and soft-deleting custom providers and models.
  - Added provider token masking so plaintext credentials are never returned in API responses.
  - Added validation for provider URLs, names, tokens, organization access, and duplicate models.
  - Added support for compliance attestations and provider/model audit tracking.

- **Documentation**
  - Documented custom provider and model management, authentication, request formats, scoping, and soft-delete behavior.

- **Tests**
  - Added integration coverage for custom provider and model lifecycles, validation, isolation, and authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->