### PR TITLE
feat: blue DevPass subscribed notif with amount

### DIFF
--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -1181,6 +1181,8 @@ export async function finalizeDevPlanSetupSession(
 			subscribedUser?.name,
 			devPlanTier,
 			devPlanCycle,
+			parseFloat(invoiceAmount),
+			invoiceCurrency,
 		);
 	}
 
@@ -1561,6 +1563,8 @@ async function handleCheckoutSessionCompleted(
 					subscribedUser?.name,
 					devPlanTier,
 					devPlanCycle,
+					(session.amount_total ?? 0) / 100,
+					(session.currency ?? "USD").toUpperCase(),
 				);
 			}
 		} else {
@@ -3831,6 +3835,8 @@ export async function handleInvoicePaymentSucceeded(event: {
 				subscribedUser?.name,
 				initialDevPlanTier,
 				initialDevPlanCycle,
+				invoice.amount_paid / 100,
+				invoice.currency.toUpperCase(),
 			);
 		}
 

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -55,6 +55,13 @@ async function sendDiscordNotification(
 	}
 }
 
+function formatAmount(amount: number, currency: string): string {
+	const normalized = currency.toUpperCase();
+	return normalized === "USD"
+		? `$${amount.toFixed(2)}`
+		: `${amount.toFixed(2)} ${normalized}`;
+}
+
 export async function notifyUserSignup(
 	email: string,
 	name: string | null | undefined,
@@ -172,6 +179,8 @@ export async function notifyDevPlanSubscribed(
 	name: string | null | undefined,
 	devPlan: string,
 	cycle: string,
+	amount: number,
+	currency: string,
 ): Promise<void> {
 	const displayName = name ?? "Unknown";
 
@@ -179,7 +188,7 @@ export async function notifyDevPlanSubscribed(
 		embeds: [
 			{
 				title: "DevPass Subscribed",
-				color: 0x22c55e, // Green
+				color: 0x3b82f6, // Blue
 				fields: [
 					{
 						name: "Email",
@@ -194,6 +203,11 @@ export async function notifyDevPlanSubscribed(
 					{
 						name: "Plan",
 						value: `${devPlan.toUpperCase()} (${cycle})`,
+						inline: true,
+					},
+					{
+						name: "Amount",
+						value: formatAmount(amount, currency),
 						inline: true,
 					},
 				],


### PR DESCRIPTION
## Summary

The Discord "DevPass Subscribed" notification was green and didn't say how much the customer paid. This makes it blue and adds an Amount field.

## Changes

- `apps/api/src/utils/discord.ts`
  - `notifyDevPlanSubscribed` embed color changed from `0x22c55e` (green) to `0x3b82f6` (blue), matching the "Credits Purchased" blue.
  - Added `amount` / `currency` params and a new inline **Amount** field.
  - Added a small `formatAmount` helper: `$12.34` for USD, `12.34 EUR` otherwise.
- `apps/api/src/stripe.ts` — passed the charged amount at all three DevPass activation paths:
  - setup-mode checkout finalize → `parseFloat(invoiceAmount)` / `invoiceCurrency`
  - legacy subscription-mode checkout → `session.amount_total / 100` / `session.currency`
  - initial invoice webhook → `invoice.amount_paid / 100` / `invoice.currency`

Each call site already computed these values for the transaction record and invoice email, so no new Stripe lookups were introduced.

## Testing

- `pnpm format`
- `turbo run build --filter=api` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9DwxMt8XAPQMb7aJMCdXc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription notifications now include the billed amount and currency.
  * Monetary values are formatted for clearer readability, including dollar formatting for USD.

* **Style**
  * Updated the subscription notification color from green to blue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->