### PR TITLE
feat(gateway): restrict CORS to env allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,12 @@ API_BACKEND_URL=http://localhost:4002
 ORIGIN_URLS=http://localhost:3002
 DOCS_URL=http://localhost:3005
 
+# Browser origins allowed to call the gateway (apps/gateway) cross-origin.
+# Comma-separated list of full origins; a leading "*." label matches any
+# subdomain (e.g. https://www.example.com,https://*.example.com). The gateway is
+# a server-to-server API, so leaving this empty sends no CORS headers at all.
+# GATEWAY_CORS_ORIGINS=
+
 # GitHub OAuth (optional - for "Sign in with GitHub")
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/.env.unified.example
+++ b/.env.unified.example
@@ -27,6 +27,10 @@ API_URL=http://localhost:4002
 API_BACKEND_URL=http://localhost:4002
 ORIGIN_URLS=http://localhost:3002
 
+# Browser origins allowed to call the gateway cross-origin. Comma-separated full
+# origins; a leading "*." label matches any subdomain. Empty means no CORS.
+# GATEWAY_CORS_ORIGINS=
+
 # =============================================================================
 # AUTHENTICATION & SECURITY
 # =============================================================================

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -33,6 +33,7 @@ import {
 	buildOpenAIErrorBody,
 } from "./lib/error-response.js";
 import { mcpHandler, registerMcpOAuthRoutes } from "./mcp/mcp.js";
+import { corsMiddleware } from "./middleware/cors.js";
 import { tracingMiddleware } from "./middleware/tracing.js";
 import { models } from "./models/route.js";
 import { moderationsRoute } from "./moderations/route.js";
@@ -89,6 +90,7 @@ const requestLifecycleMiddleware = createRequestLifecycleMiddleware({
 app.use("*", tracingMiddleware);
 app.use("*", requestLifecycleMiddleware);
 app.use("*", honoRequestLogger);
+app.use("*", corsMiddleware);
 
 // Middleware to check for application/json content type on POST requests
 // Excludes /mcp endpoint which handles its own content type validation

--- a/apps/gateway/src/middleware/cors.spec.ts
+++ b/apps/gateway/src/middleware/cors.spec.ts
@@ -1,0 +1,141 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	corsMiddleware,
+	isAllowedOrigin,
+	parseAllowedOrigins,
+} from "./cors.js";
+
+describe("parseAllowedOrigins", () => {
+	it("returns an empty list when unset or blank", () => {
+		expect(parseAllowedOrigins(undefined)).toEqual([]);
+		expect(parseAllowedOrigins("")).toEqual([]);
+		expect(parseAllowedOrigins(" , ")).toEqual([]);
+	});
+
+	it("splits and trims a comma-separated list", () => {
+		expect(
+			parseAllowedOrigins("https://a.example.com, https://b.example.com"),
+		).toEqual(["https://a.example.com", "https://b.example.com"]);
+	});
+});
+
+describe("isAllowedOrigin", () => {
+	it("matches exact origins only", () => {
+		const allowed = ["https://www.typingmind.com"];
+		expect(isAllowedOrigin(allowed, "https://www.typingmind.com")).toBe(true);
+		expect(isAllowedOrigin(allowed, "http://www.typingmind.com")).toBe(false);
+		expect(isAllowedOrigin(allowed, "https://typingmind.com")).toBe(false);
+		expect(isAllowedOrigin(allowed, "https://www.typingmind.com:8080")).toBe(
+			false,
+		);
+	});
+
+	it("matches subdomains for wildcard patterns", () => {
+		const allowed = ["https://*.typingmind.com"];
+		expect(isAllowedOrigin(allowed, "https://www.typingmind.com")).toBe(true);
+		expect(isAllowedOrigin(allowed, "https://cloud.typingmind.com")).toBe(true);
+		expect(isAllowedOrigin(allowed, "https://a.b.typingmind.com")).toBe(true);
+	});
+
+	it("does not let a wildcard pattern match lookalike domains", () => {
+		const allowed = ["https://*.typingmind.com"];
+		expect(isAllowedOrigin(allowed, "https://typingmind.com")).toBe(false);
+		expect(isAllowedOrigin(allowed, "https://eviltypingmind.com")).toBe(false);
+		expect(isAllowedOrigin(allowed, "https://.typingmind.com")).toBe(false);
+		expect(isAllowedOrigin(allowed, "http://www.typingmind.com")).toBe(false);
+		expect(isAllowedOrigin(allowed, "https://www.typingmind.com.evil.io")).toBe(
+			false,
+		);
+	});
+
+	it("rejects everything when the allowlist is empty", () => {
+		expect(isAllowedOrigin([], "https://www.typingmind.com")).toBe(false);
+	});
+});
+
+describe("corsMiddleware", () => {
+	const app = new Hono();
+	app.use("*", corsMiddleware);
+	app.get("/v1/models", (c) => c.json({ ok: true }));
+
+	const originalOrigins = process.env.GATEWAY_CORS_ORIGINS;
+
+	beforeEach(() => {
+		delete process.env.GATEWAY_CORS_ORIGINS;
+	});
+
+	afterEach(() => {
+		if (originalOrigins === undefined) {
+			delete process.env.GATEWAY_CORS_ORIGINS;
+		} else {
+			process.env.GATEWAY_CORS_ORIGINS = originalOrigins;
+		}
+	});
+
+	it("sends no CORS headers when unconfigured", async () => {
+		const res = await app.request("/v1/models", {
+			headers: { Origin: "https://www.typingmind.com" },
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+	});
+
+	it("does not answer preflights when unconfigured", async () => {
+		const res = await app.request("/v1/models", {
+			method: "OPTIONS",
+			headers: { Origin: "https://www.typingmind.com" },
+		});
+
+		expect(res.status).toBe(404);
+	});
+
+	it("reflects an allowed origin", async () => {
+		process.env.GATEWAY_CORS_ORIGINS =
+			"https://www.typingmind.com,https://*.typingmind.com";
+
+		const res = await app.request("/v1/models", {
+			headers: { Origin: "https://cloud.typingmind.com" },
+		});
+
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+			"https://cloud.typingmind.com",
+		);
+		expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+	});
+
+	it("omits the header for an origin outside the allowlist", async () => {
+		process.env.GATEWAY_CORS_ORIGINS = "https://www.typingmind.com";
+
+		const res = await app.request("/v1/models", {
+			headers: { Origin: "https://evil.example.com" },
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+	});
+
+	it("answers preflights for an allowed origin", async () => {
+		process.env.GATEWAY_CORS_ORIGINS = "https://www.typingmind.com";
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "OPTIONS",
+			headers: {
+				Origin: "https://www.typingmind.com",
+				"Access-Control-Request-Method": "POST",
+				"Access-Control-Request-Headers": "authorization,content-type",
+			},
+		});
+
+		expect(res.status).toBe(204);
+		expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+			"https://www.typingmind.com",
+		);
+		expect(res.headers.get("Access-Control-Allow-Headers")).toContain(
+			"Authorization",
+		);
+		expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+	});
+});

--- a/apps/gateway/src/middleware/cors.ts
+++ b/apps/gateway/src/middleware/cors.ts
@@ -1,0 +1,71 @@
+import { cors } from "hono/cors";
+
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Parses the comma-separated `GATEWAY_CORS_ORIGINS` allowlist. Entries are full
+ * origins (`https://www.typingmind.com`) and may use a leading wildcard label
+ * (`https://*.typingmind.com`) to match any subdomain of that host.
+ */
+export function parseAllowedOrigins(value: string | undefined): string[] {
+	return (value ?? "")
+		.split(",")
+		.map((origin) => origin.trim())
+		.filter(Boolean);
+}
+
+export function isAllowedOrigin(
+	allowedOrigins: string[],
+	origin: string,
+): boolean {
+	return allowedOrigins.some((pattern) => {
+		if (pattern === origin) {
+			return true;
+		}
+
+		const wildcardIndex = pattern.indexOf("://*.");
+		if (wildcardIndex === -1) {
+			return false;
+		}
+
+		const scheme = pattern.slice(0, wildcardIndex + "://".length);
+		const suffix = pattern.slice(wildcardIndex + "://*".length);
+		return (
+			origin.startsWith(scheme) &&
+			origin.endsWith(suffix) &&
+			origin.length > scheme.length + suffix.length
+		);
+	});
+}
+
+/**
+ * The gateway is a server-to-server API authenticated with a bearer API key, so
+ * it sends no CORS headers by default. Browser-based clients that need direct
+ * access are opted in per deployment through `GATEWAY_CORS_ORIGINS`; when that
+ * variable is unset or empty the middleware is a no-op and every cross-origin
+ * browser request stays blocked.
+ *
+ * Credentials are deliberately not allowed: requests carry the API key in the
+ * `Authorization` header, never in cookies.
+ */
+export const corsMiddleware: MiddlewareHandler = async (c, next) => {
+	const allowedOrigins = parseAllowedOrigins(process.env.GATEWAY_CORS_ORIGINS);
+	if (allowedOrigins.length === 0) {
+		return await next();
+	}
+
+	return await cors({
+		origin: (origin) =>
+			isAllowedOrigin(allowedOrigins, origin) ? origin : null,
+		allowHeaders: [
+			"Content-Type",
+			"Authorization",
+			"Cache-Control",
+			"x-api-key",
+			"mcp-session-id",
+		],
+		allowMethods: ["POST", "GET", "OPTIONS", "PUT", "PATCH", "DELETE"],
+		exposeHeaders: ["Content-Length", "mcp-session-id"],
+		maxAge: 600,
+	})(c, next);
+};


### PR DESCRIPTION
## Summary

#3183 removed CORS from the gateway entirely. This restores it, but instead of the old `origin: "*"` it now serves CORS headers only for an explicit allowlist that is defined **entirely by an environment variable** — no domain is hardcoded in this repo.

- New `apps/gateway/src/middleware/cors.ts`, registered on `*` in `apps/gateway/src/app.ts`
- Allowlist comes from `GATEWAY_CORS_ORIGINS` (comma-separated full origins)
- An entry may use a leading `*.` label to match any subdomain, e.g. `https://www.example.com,https://*.example.com`
- **Unset/empty ⇒ complete no-op**: the middleware calls `next()` without touching headers, so self-hosters and any deployment that doesn't set the variable keep today's deny-everything behaviour (not even preflights are answered)
- `credentials` is deliberately *not* enabled — the gateway authenticates with a bearer API key in the `Authorization` header, never cookies
- `mcp-session-id` is back in the allowed/exposed headers, so the shared middleware covers `/mcp` preflights that #3183 dropped

The production allowlist is set in the infra repo: theopenco/llmgateway-infra#1297.

## Test plan

- New `apps/gateway/src/middleware/cors.spec.ts` (11 tests) covers parsing, exact vs. wildcard matching, lookalike-domain rejection (`https://eviltypingmind.com`, `https://www.typingmind.com.evil.io`, `https://.typingmind.com`, scheme mismatches), the unconfigured no-op path including OPTIONS still 404ing, origin reflection, non-allowlisted origins getting no header, and a full preflight response
- `pnpm build` passes
- `pnpm vitest run apps/gateway/src/middleware apps/gateway/src/api.spec.ts` — 145 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)