### PR TITLE
fix(ui): make provider select scrollable in dialog

### DIFF
--- a/apps/ui/src/components/provider-keys/provider-select.tsx
+++ b/apps/ui/src/components/provider-keys/provider-select.tsx
@@ -55,7 +55,7 @@ export function ProviderSelect({
 		: undefined;
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover open={open} onOpenChange={setOpen} modal={true}>
 			<PopoverTrigger asChild>
 				<Button
 					type="button"


### PR DESCRIPTION
## Summary

The provider combobox in the **Add Provider Key** dialog could not be scrolled, so providers below the fold were unreachable (screenshot in report showed the list cut off with no scroll).

**Cause:** `ProviderSelect` renders a non-modal Radix Popover whose content portals outside the `DialogContent`. The open Dialog's scroll lock therefore swallows wheel/touch events on the portaled list, and the `CommandList`'s `max-h-60 overflow-y-auto` never gets a chance to scroll.

**Fix:** set `modal={true}` on the Popover so it installs its own scroll layer while open, restoring wheel/touch scrolling inside the list. This is the standard fix for the Popover+Command-inside-Dialog combobox pattern.

Checked the other provider pickers: `MultiProviderSelector` uses `DropdownMenu`, which is modal by default, so it is unaffected.

## Test plan

- `turbo run build --filter=ui` passes
- Manually: open Settings → Provider Keys → Add Provider Key → open the provider dropdown → the list scrolls with the wheel/trackpad

https://claude.ai/code/session_01GcjWbxi9pc7tbshh1AndFt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider selection popover behavior by ensuring it opens as a modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->