### PR TITLE
docs: document api key rotation and renaming

### DIFF
--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -14,18 +14,29 @@ API keys are the primary method for authenticating with the LLM Gateway. This gu
 
 LLM Gateway provides comprehensive API key management with the following features:
 
-- **Basic API Key Management**: Create, list, update, and delete API keys
+- **Basic API Key Management**: Create, list, rename, update, and delete API keys
 - **Usage Limits**: Set lifetime and recurring spending limits on individual API keys
 - **Expiration (TTL)**: Give a key a time-to-live so it disables itself automatically
+- **Rotation (Rolling)**: Replace a key's secret in place without losing its settings or history
 - **IAM Rules**: Fine-grained access control for models, providers, and pricing
 - **Usage Tracking**: Monitor API key usage and costs
 - **Status Management**: Enable/disable keys without deletion
 
+### Related key types
+
+This page covers gateway API keys (`llmgtwy_…`), the keys you send to the
+gateway as a bearer token. LLM Gateway also issues three other kinds of keys,
+each with its own page:
+
+| Key                                                   | What it is for                                                                         |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [Master keys](/features/master-keys)                  | Manage projects, gateway API keys, IAM rules, and custom models programmatically       |
+| [Provider keys](/learn/provider-keys)                 | Bring your own upstream provider credentials so requests bill to your provider account |
+| [Platform secret keys](/features/embeddable-payments) | Mint end-user sessions from your backend when using the Payments SDK (`sk_…`)          |
+
 ## Creating API Keys
 
 ### Via Dashboard
-
-At this time, API keys can only be created via the dashboard.
 
 1. Navigate to your project in the LLM Gateway dashboard
 2. Go to the **API Keys** section
@@ -41,6 +52,30 @@ At this time, API keys can only be created via the dashboard.
 	store them securely.
 </Callout>
 
+### Programmatically
+
+Gateway API keys can also be created, listed, updated, and deleted without the
+dashboard using a [master key](/features/master-keys) — useful when you provision
+a key per customer or per environment from your own backend:
+
+```bash
+curl -X POST https://internal.llmgateway.io/v1/master/keys \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectId": "proj_...",
+    "description": "Customer ACME — production key",
+    "periodUsageLimit": "10.00",
+    "periodUsageDurationValue": 1,
+    "periodUsageDurationUnit": "day"
+  }'
+```
+
+Usage limits and IAM rules can be configured through the master key API as well.
+Expiration (TTL) and rotation are currently dashboard-only. See the [master key
+API reference](/features/master-keys#create-a-gateway-api-key) for the full
+endpoint list.
+
 ## Using API Keys
 
 Once you have an API key, use it in the `Authorization` header of your requests:
@@ -55,9 +90,40 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
   }'
 ```
 
+## Renaming API Keys
+
+A key's name is only a label, so you can change it at any time from the dashboard
+without affecting the secret, its usage history, limits, or IAM rules.
+
 ## Disabling/Enabling API Keys
 
 You can disable an API key to stop it from being used, but the key is not deleted and can be re-enabled later.
+
+## Rotating (Rolling) API Keys
+
+Rolling a key generates a **new secret for the same key** and invalidates the old
+one immediately. Everything else about the key is preserved: its name, usage
+history and statistics, all-time and recurring limits (including the active
+period window), IAM rules, and expiration.
+
+Use this when a secret may have been exposed — in a commit, a log, a CI
+artifact, or a shared environment — and you want to cut off the leaked value
+without losing the key's spend tracking or access rules.
+
+1. Open the **API Keys** page and pick the key's actions menu
+2. Choose **Roll Key** and confirm
+3. Copy the new secret and update every client that used the old one
+
+<Callout type="warning">
+	The old secret stops working the moment the key is rolled, and the new secret
+	is shown only once. Roll during a window where you can update your clients
+	promptly.
+</Callout>
+
+Requests made with the old secret are rejected with a `401 Unauthorized`.
+Rolling is limited to regular gateway API keys — the auto-generated playground
+key cannot be rolled, and Payments SDK [platform secret
+keys](/features/embeddable-payments) have their own lifecycle.
 
 ## Expiration (TTL)
 
@@ -195,6 +261,7 @@ Common error scenarios:
 - Pricing limits exceeded
 - API key disabled or deleted
 - API key expired (TTL passed)
+- API key rolled, so the old secret is no longer valid
 - Usage limit reached
 
 ## Migration from Legacy Keys

--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -92,8 +92,10 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 ## Renaming API Keys
 
-A key's name is only a label, so you can change it at any time from the dashboard
-without affecting the secret, its usage history, limits, or IAM rules.
+A key's name is only a label, so you can change it at any time — from the
+dashboard, or with the `description` field on [`PATCH
+/v1/master/keys/{id}`](/features/master-keys#update-a-gateway-api-key) — without
+affecting the secret, its usage history, limits, or IAM rules.
 
 ## Disabling/Enabling API Keys
 

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -315,6 +315,14 @@ Body parameters (all optional, at least one required):
 
 Response (200): the updated API key, including its configured limits, consumed `usage` / `currentPeriodUsage`, and the `currentPeriodResetAt` window-reset time (same fields as the [list endpoint](#list-gateway-api-keys)). The plain token is **not** included — it is only returned at creation.
 
+<Callout type="info">
+	Two dashboard-only key features have no master API equivalent yet: [expiration
+	(TTL)](/features/api-keys#expiration-ttl) and [rolling a key's
+	secret](/features/api-keys#rotating-rolling-api-keys). To replace a key
+	programmatically, create a new one and delete the old one once your clients
+	have switched over.
+</Callout>
+
 ### Delete a gateway API key
 
 `DELETE /v1/master/keys/{id}`

--- a/apps/docs/content/learn/api-keys.mdx
+++ b/apps/docs/content/learn/api-keys.mdx
@@ -18,7 +18,8 @@ Use this page to:
 - Set all-time and recurring spend limits per key
 - Set an expiration (TTL) so a key disables itself automatically
 - Track usage for each key, including the active recurring window
-- Enable or disable keys without deleting them
+- Rename keys and enable or disable them without deleting them
+- Roll a key's secret in place if it may have leaked
 - Configure IAM rules for model, provider, and pricing access
 
 <Callout type="warning">
@@ -111,14 +112,42 @@ Each key in the list shows:
 
 ## Actions
 
-For each API key you can:
+The actions menu on each key offers:
 
-- **Update limits**: Change all-time or recurring limits
-- **Disable or enable**: Pause usage without deleting the key (reactivating an
-  expired key prompts for a new expiration)
-- **Configure IAM rules**: Restrict which models, providers, or pricing tiers the key can use
 - **View Statistics**: Open a dedicated analytics page for that key (see below)
+- **Manage IAM Rules**: Restrict which models, providers, or pricing tiers the key can use
+- **Rename Key**: Change the key's label without touching its secret or history
+- **Activate / Deactivate Key**: Pause usage without deleting the key (reactivating
+  an expired key prompts for a new expiration)
+- **Roll Key**: Generate a new secret for the key and invalidate the old one (see below)
+- **Update limits**: Change all-time or recurring limits
 - **Delete**: Permanently remove the key
+
+<Callout type="info">
+	The auto-generated playground key is managed for you: it cannot be renamed,
+	rolled, deactivated, or deleted. Members with the developer role can only
+	modify keys they created themselves.
+</Callout>
+
+## Rolling a Key
+
+**Roll Key** replaces a key's secret while keeping the key itself. The name,
+usage history and statistics, all-time and recurring limits (including the
+current period window), IAM rules, and expiration all stay exactly as they were —
+only the secret changes.
+
+This is the fastest fix when a secret leaks into a commit, a log, or a shared
+environment: you cut off the exposed value without recreating the key or losing
+its spend tracking.
+
+1. Open the key's actions menu and choose **Roll Key**
+2. Confirm in the dialog
+3. Copy the new secret and update every client using the old one
+
+<Callout type="warning">
+	The previous secret stops working immediately, and the new one is shown only
+	once. Requests still using the old secret fail with `401 Unauthorized`.
+</Callout>
 
 ## Per-Key Statistics
 
@@ -150,6 +179,7 @@ Supported rule types include:
 - **Allow/Deny models**
 - **Allow/Deny providers**
 - **Allow/Deny pricing**
+- **Allow/Deny IP ranges (CIDR)** — Enterprise plan only
 
 Use IAM rules when you want a key to be valid, but only for a specific subset of
 models or providers. For a deeper explanation, see the [API Keys & IAM Rules
@@ -163,11 +193,16 @@ shows a notice when organization-level restrictions apply to your keys.
 
 ## Plan Limits
 
-The page also shows how many API keys your current project is using relative to
-your plan allowance.
+The page also shows how many API keys you are using relative to your plan
+allowance. The cap counts **active** keys across every project in the
+organization, so deactivated and deleted keys do not count against it.
 
 - **Free**: Standard API key count limit
+- **Pro**: A larger allowance
 - **Enterprise**: Custom limits
 
-If you reach the project key limit, the **Create API Key** button is disabled
-until you delete unused keys or upgrade.
+Owners and admins can also set a per-member key cap on the [Team
+page](/learn/team), which applies on top of the organization-wide allowance.
+
+If you reach the limit, the **Create API Key** button is disabled until you
+delete or deactivate unused keys, or upgrade.


### PR DESCRIPTION
Refreshes the API key documentation to cover functionality that shipped but was never documented, and removes a stale claim.

## What was missing

- **Rolling a key** (`POST /keys/api/{id}/roll` + `roll-api-key-dialog.tsx`) was entirely undocumented.
- **Renaming a key** (`description` on `PATCH /keys/api/{id}`) was undocumented and absent from the Learn actions list.
- `features/api-keys.mdx` claimed "At this time, API keys can only be created via the dashboard" — contradicted by `POST /v1/master/keys`, which the master keys page already documents.

## Changes

**`features/api-keys.mdx`**
- New **Rotating (Rolling) API Keys** section: what is preserved (name, usage history, limits and the active period window, IAM rules, TTL), what is invalidated, and when to use it.
- New **Renaming API Keys** section.
- Replaced the dashboard-only claim with a **Programmatically** subsection showing master-key creation and linking to the reference.
- Added a **Related key types** table distinguishing gateway keys from master keys, provider keys, and Payments SDK platform secret keys.
- Added rolled keys to the common error scenarios.

**`learn/api-keys.mdx`**
- Actions list now matches the dashboard menu (View Statistics, Manage IAM Rules, Rename Key, Activate/Deactivate, Roll Key, update limits, Delete), with a note that the playground key is exempt and that developers can only modify their own keys.
- New **Rolling a Key** walkthrough.
- IAM rule types now include Enterprise-only IP CIDR rules.
- Plan Limits corrected: the cap counts active keys org-wide (not per project), mentions Pro, and notes the per-member cap on the Team page.

**`features/master-keys.mdx`**
- Callout noting TTL and rolling have no master API equivalent, with the create-then-delete workaround.

## Verification

`pnpm format`, `pnpm lint`, and `turbo run build --filter=docs` all pass. Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k1guU5v2FtAQhKq9PfxLn

---
_Generated by [Claude Code](https://claude.ai/code/session_012k1guU5v2FtAQhKq9PfxLn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded API key documentation with renaming, activation/deactivation, usage tracking, expiration, and secret rotation guidance.
  * Added programmatic API key management guidance (create/list/update/delete) with a cURL example.
  * Clarified rolling key behavior: the previous secret is invalidated immediately (returns `401 Unauthorized`) while preserving key identity and settings.
  * Documented master API limitations vs dashboard-only capabilities for expiration/TTL and rolling.
  * Enhanced IAM rules with CIDR support (Enterprise) and updated plan limits, organization allowance, per-member caps, and playground key restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->