### PR TITLE
feat(gateway): support Claude Code model discovery

### DIFF
--- a/apps/code/src/app/claude-code-alternative/page.tsx
+++ b/apps/code/src/app/claude-code-alternative/page.tsx
@@ -116,7 +116,7 @@ const faqs = [
 	{
 		question: "Can I keep using the Claude Code CLI with DevPass?",
 		answer:
-			"Yes. Claude Code accepts a custom endpoint, so switching is two environment variables: set ANTHROPIC_BASE_URL to the DevPass endpoint and ANTHROPIC_AUTH_TOKEN to your DevPass key, then run claude as usual. No reinstall, no SDK changes — and you can switch models mid-session with /model, or set ANTHROPIC_MODEL to run non-Anthropic models through the same CLI.",
+			"Yes. Claude Code accepts a custom endpoint, so switching is two environment variables: set ANTHROPIC_BASE_URL to the DevPass endpoint and ANTHROPIC_AUTH_TOKEN to your DevPass key, then run claude as usual. No reinstall, no SDK changes. The /model picker lists the Claude models, and ANTHROPIC_MODEL points the same CLI at any of the other 200+.",
 	},
 	{
 		question: "How much cheaper is DevPass than Claude Max?",

--- a/apps/code/src/app/claude-code-alternative/page.tsx
+++ b/apps/code/src/app/claude-code-alternative/page.tsx
@@ -116,7 +116,7 @@ const faqs = [
 	{
 		question: "Can I keep using the Claude Code CLI with DevPass?",
 		answer:
-			"Yes. Claude Code accepts a custom endpoint, so switching is two environment variables: set ANTHROPIC_BASE_URL to the DevPass endpoint and ANTHROPIC_AUTH_TOKEN to your DevPass key, then run claude as usual. No reinstall, no SDK changes — and you can flip ANTHROPIC_MODEL to run non-Anthropic models through the same CLI.",
+			"Yes. Claude Code accepts a custom endpoint, so switching is two environment variables: set ANTHROPIC_BASE_URL to the DevPass endpoint and ANTHROPIC_AUTH_TOKEN to your DevPass key, then run claude as usual. No reinstall, no SDK changes — and you can switch models mid-session with /model, or set ANTHROPIC_MODEL to run non-Anthropic models through the same CLI.",
 	},
 	{
 		question: "How much cheaper is DevPass than Claude Max?",

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -46,7 +46,7 @@ const featuredTools = [
 		name: "Claude Code",
 		icon: AnthropicIcon,
 		description:
-			"Two env vars and Claude Code routes through LLM Gateway. Use any model — Claude, GPT-5, Gemini, GLM — with a single ANTHROPIC_MODEL flip.",
+			"Two env vars and Claude Code routes through LLM Gateway. Use any model — Claude, GPT-5, Gemini, GLM — and switch mid-session with /model.",
 		setup: "ANTHROPIC_BASE_URL + AUTH_TOKEN",
 	},
 	{

--- a/apps/code/src/components/SwitchIn60.tsx
+++ b/apps/code/src/components/SwitchIn60.tsx
@@ -50,7 +50,7 @@ const TOOLS: ToolGuide[] = [
 				code: `export ANTHROPIC_BASE_URL=${API_BASE}\nexport ANTHROPIC_AUTH_TOKEN=<your-devpass-key>`,
 			},
 			{
-				label: "Run it — switch models with one ANTHROPIC_MODEL flip",
+				label: "Run it — switch models any time with /model",
 				code: "claude",
 			},
 		],

--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -40,6 +40,13 @@ export ANTHROPIC_MODEL=gpt-5  # or any model from our catalog
 claude
 ```
 
+<Callout type="info">
+	Environment variables are read once at startup. To switch models mid-session
+	with `/model`, restrict the picker with `availableModels`, or have Claude Code
+	populate its picker from our catalog automatically via gateway model
+	discovery, see the [Claude Code guide](/guides/claude-code).
+</Callout>
+
 ### Choosing Models
 
 You can use any model from the [models page](https://llmgateway.io/models). Popular options for Claude Code include:

--- a/apps/docs/content/guides/claude-code.mdx
+++ b/apps/docs/content/guides/claude-code.mdx
@@ -119,6 +119,8 @@ Environment variables are read once at startup, so changing `ANTHROPIC_MODEL` me
 
 `fallbackModel` names the models to try when the primary one is unavailable, capped at three.
 
+The same key also _adds_ models to the picker — including non-Claude ones. See [Adding Non-Claude Models to the Picker](#adding-non-claude-models-to-the-picker).
+
 ## Fetching Models From LLM Gateway
 
 Claude Code can populate its `/model` picker directly from our catalog instead of you hardcoding IDs. Set the discovery flag alongside the base URL:
@@ -133,15 +135,40 @@ On startup Claude Code calls our [`/v1/models`](https://api.llmgateway.io/v1/mod
 
 <Callout type="warn">
 	Claude Code discards discovered models whose ID does not start with `claude`
-	or `anthropic`. Discovery therefore surfaces only the Claude models in our
-	catalog — models like GPT-5 or Gemini are filtered out by the client, not by
-	the gateway. To make one of those selectable, add it explicitly with
-	`ANTHROPIC_CUSTOM_MODEL_OPTION` as shown below.
+	or `anthropic`, so discovery alone surfaces only the Claude models in our
+	catalog. Models like GPT-5 or Gemini are filtered out by the client, not by
+	the gateway. List them in `availableModels` to add them to the picker.
 </Callout>
 
-### Adding a Non-Claude Model to the Picker
+### Adding Non-Claude Models to the Picker
 
-`ANTHROPIC_CUSTOM_MODEL_OPTION` adds a single custom entry to the `/model` picker, which is how you expose a model that the discovery filter drops:
+`availableModels` is not limited to Claude model IDs. Any ID you list that has no built-in row gets its own row in the `/model` picker, which is how you put the rest of our catalog in front of the picker:
+
+```json title="~/.claude/settings.json"
+{
+	"availableModels": [
+		"claude-sonnet-5",
+		"claude-haiku-4-5",
+		"gpt-5",
+		"gpt-5-mini",
+		"gemini-2.5-pro",
+		"kimi-k3"
+	]
+}
+```
+
+Requires Claude Code v2.1.199 or later; on earlier versions these IDs are still selectable, but only by typing `/model <id>` rather than picking a row.
+
+<Callout type="warn">
+	`availableModels` is an allowlist, so it replaces the built-in list rather
+	than extending it. Any model you leave out becomes unselectable — naming it
+	with `--model` or `ANTHROPIC_MODEL` silently starts the session on a different
+	model instead. Include every model you want to keep, Claude ones included.
+</Callout>
+
+### Adding a Single Model Without an Allowlist
+
+If you only need one extra model and don't want to enumerate an allowlist, `ANTHROPIC_CUSTOM_MODEL_OPTION` appends one entry to the picker:
 
 ```bash
 export ANTHROPIC_CUSTOM_MODEL_OPTION=gpt-5
@@ -149,7 +176,7 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="GPT-5 via LLM Gateway"
 export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Routed through LLM Gateway"
 ```
 
-Only one custom entry is supported at a time. If you also set `availableModels`, include the custom ID in that list or it will be filtered back out. For switching between several non-Claude models, keep using `ANTHROPIC_MODEL` per session, or define a per-project `.claude/settings.json` for each.
+Only one custom entry is supported at a time. If you also set `availableModels`, include this ID in that list or it will be filtered back out.
 
 ## Environment Variables
 

--- a/apps/docs/content/guides/claude-code.mdx
+++ b/apps/docs/content/guides/claude-code.mdx
@@ -90,6 +90,67 @@ export ANTHROPIC_MODEL=gemini-2.5-pro
 export ANTHROPIC_MODEL=anthropic/claude-3-5-sonnet-20241022
 ```
 
+## Predefining Models in a Settings File
+
+Environment variables are read once at startup, so changing `ANTHROPIC_MODEL` means restarting Claude Code. To switch models mid-session instead, put the configuration in `~/.claude/settings.json` (user-wide) or `.claude/settings.json` (per project) and use `/model` to switch on the fly:
+
+```json title="~/.claude/settings.json"
+{
+	"env": {
+		"ANTHROPIC_BASE_URL": "https://api.llmgateway.io",
+		"ANTHROPIC_AUTH_TOKEN": "llmgtwy_your_api_key_here"
+	},
+	"model": "claude-sonnet-5"
+}
+```
+
+`model` sets the model a new session starts on. `/model` overrides it for the running session and saves your choice as the new default.
+
+### Restricting the Model List
+
+`availableModels` limits which models the `/model` picker offers — useful for keeping a team on an approved, budget-appropriate set:
+
+```json title="~/.claude/settings.json"
+{
+	"availableModels": ["claude-sonnet-5", "claude-haiku-4-5"],
+	"fallbackModel": ["claude-haiku-4-5"]
+}
+```
+
+`fallbackModel` names the models to try when the primary one is unavailable, capped at three.
+
+## Fetching Models From LLM Gateway
+
+Claude Code can populate its `/model` picker directly from our catalog instead of you hardcoding IDs. Set the discovery flag alongside the base URL:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.llmgateway.io
+export ANTHROPIC_AUTH_TOKEN=llmgtwy_your_api_key_here
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+```
+
+On startup Claude Code calls our [`/v1/models`](https://api.llmgateway.io/v1/models) endpoint and adds what it returns to the picker, labeled **From gateway**. Entries are cached in `~/.claude/cache/gateway-models.json` and refreshed on each launch, so a failed lookup falls back to the previous list rather than breaking your session. Requires Claude Code v2.1.129 or later.
+
+<Callout type="warn">
+	Claude Code discards discovered models whose ID does not start with `claude`
+	or `anthropic`. Discovery therefore surfaces only the Claude models in our
+	catalog — models like GPT-5 or Gemini are filtered out by the client, not by
+	the gateway. To make one of those selectable, add it explicitly with
+	`ANTHROPIC_CUSTOM_MODEL_OPTION` as shown below.
+</Callout>
+
+### Adding a Non-Claude Model to the Picker
+
+`ANTHROPIC_CUSTOM_MODEL_OPTION` adds a single custom entry to the `/model` picker, which is how you expose a model that the discovery filter drops:
+
+```bash
+export ANTHROPIC_CUSTOM_MODEL_OPTION=gpt-5
+export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="GPT-5 via LLM Gateway"
+export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Routed through LLM Gateway"
+```
+
+Only one custom entry is supported at a time. If you also set `availableModels`, include the custom ID in that list or it will be filtered back out. For switching between several non-Claude models, keep using `ANTHROPIC_MODEL` per session, or define a per-project `.claude/settings.json` for each.
+
 ## Environment Variables
 
 ### ANTHROPIC_MODEL

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -49,6 +49,35 @@ describe("Models API", () => {
 		expect(firstModel).toHaveProperty("structured_outputs");
 	});
 
+	// Claude Code populates its /model picker from GET /v1/models?limit=1000 when
+	// CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1. It reads `id` and the optional
+	// `display_name` off each `data` entry and drops ids that don't start with
+	// "claude"/"anthropic", so our Claude models must keep carrying a label.
+	test("GET /v1/models serves the Claude Code gateway discovery contract", async () => {
+		const res = await app.request("/v1/models?limit=1000");
+		expect(res.status).toBe(200);
+
+		const json = await res.json();
+		expect(Array.isArray(json.data)).toBe(true);
+
+		for (const model of json.data) {
+			expect(typeof model.id).toBe("string");
+			expect(typeof model.display_name).toBe("string");
+			expect(model.display_name.length).toBeGreaterThan(0);
+		}
+
+		const discoverable = json.data.filter(
+			(m: { id: string }) =>
+				m.id.startsWith("claude") || m.id.startsWith("anthropic"),
+		);
+		expect(discoverable.length).toBeGreaterThan(0);
+
+		const sonnet = discoverable.find(
+			(m: { id: string }) => m.id === "claude-sonnet-5",
+		);
+		expect(sonnet?.display_name).toBe("Claude Sonnet 5");
+	});
+
 	test("GET /v1/models exposes min_cacheable_tokens on provider mappings that define it", async () => {
 		const res = await app.request("/v1/models");
 		expect(res.status).toBe(200);

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -16,6 +16,10 @@ export const modelsApi = new OpenAPIHono<ServerTypes>();
 const modelSchema = z.object({
 	id: z.string(),
 	name: z.string(),
+	display_name: z.string().openapi({
+		description:
+			"Human-readable model label, mirroring `name`. Anthropic-format clients such as Claude Code read this field when populating their model picker from gateway model discovery.",
+	}),
 	aliases: z.array(z.string()).optional(),
 	created: z.number().optional(),
 	description: z.string().optional(),
@@ -264,6 +268,7 @@ modelsApi.openapi(listModels, async (c) => {
 			return {
 				id: model.id,
 				name: model.name ?? model.id,
+				display_name: model.name ?? model.id,
 				aliases: model.aliases,
 				created: model.releasedAt
 					? Math.floor(model.releasedAt.getTime() / 1000)

--- a/apps/ui/src/content/guides/claude-code.md
+++ b/apps/ui/src/content/guides/claude-code.md
@@ -108,11 +108,32 @@ export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 
 On startup Claude Code calls our `/v1/models` endpoint and adds what it returns to the picker, labeled **From gateway**. Entries are cached in `~/.claude/cache/gateway-models.json` and refreshed on each launch, so a failed lookup falls back to the previous list rather than breaking your session. Requires Claude Code v2.1.129 or later.
 
-> **Heads up:** Claude Code discards discovered models whose ID does not start with `claude` or `anthropic`. Discovery therefore surfaces only the Claude models in our catalog — models like GPT-5 or Gemini are filtered out by the client, not by the gateway. To make one of those selectable, add it explicitly with `ANTHROPIC_CUSTOM_MODEL_OPTION` as shown below.
+> **Heads up:** Claude Code discards discovered models whose ID does not start with `claude` or `anthropic`, so discovery alone surfaces only the Claude models in our catalog. Models like GPT-5 or Gemini are filtered out by the client, not by the gateway. List them in `availableModels` to add them to the picker.
 
-### Adding a Non-Claude Model to the Picker
+### Adding Non-Claude Models to the Picker
 
-`ANTHROPIC_CUSTOM_MODEL_OPTION` adds a single custom entry to the `/model` picker, which is how you expose a model that the discovery filter drops:
+`availableModels` is not limited to Claude model IDs. Any ID you list that has no built-in row gets its own row in the `/model` picker, which is how you put the rest of our catalog in front of the picker:
+
+```json
+{
+  "availableModels": [
+    "claude-sonnet-5",
+    "claude-haiku-4-5",
+    "gpt-5",
+    "gpt-5-mini",
+    "gemini-2.5-pro",
+    "kimi-k3"
+  ]
+}
+```
+
+Requires Claude Code v2.1.199 or later; on earlier versions these IDs are still selectable, but only by typing `/model <id>` rather than picking a row.
+
+> **Note:** `availableModels` is an allowlist, so it replaces the built-in list rather than extending it. Any model you leave out becomes unselectable — naming it with `--model` or `ANTHROPIC_MODEL` silently starts the session on a different model instead. Include every model you want to keep, Claude ones included.
+
+### Adding a Single Model Without an Allowlist
+
+If you only need one extra model and don't want to enumerate an allowlist, `ANTHROPIC_CUSTOM_MODEL_OPTION` appends one entry to the picker:
 
 ```bash
 export ANTHROPIC_CUSTOM_MODEL_OPTION=gpt-5
@@ -120,7 +141,7 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="GPT-5 via LLM Gateway"
 export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Routed through LLM Gateway"
 ```
 
-Only one custom entry is supported at a time. If you also set `availableModels`, include the custom ID in that list or it will be filtered back out. For switching between several non-Claude models, keep using `ANTHROPIC_MODEL` per session, or define a per-project `.claude/settings.json` for each.
+Only one custom entry is supported at a time. If you also set `availableModels`, include this ID in that list or it will be filtered back out.
 
 ## Environment Variables
 

--- a/apps/ui/src/content/guides/claude-code.md
+++ b/apps/ui/src/content/guides/claude-code.md
@@ -67,6 +67,61 @@ export ANTHROPIC_MODEL=gemini-2.5-pro
 export ANTHROPIC_MODEL=anthropic/claude-3-5-sonnet-20241022
 ```
 
+## Predefining Models in a Settings File
+
+Environment variables are read once at startup, so changing `ANTHROPIC_MODEL` means restarting Claude Code. To switch models mid-session instead, put the configuration in `~/.claude/settings.json` (user-wide) or `.claude/settings.json` (per project) and use `/model` to switch on the fly:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.llmgateway.io",
+    "ANTHROPIC_AUTH_TOKEN": "llmgtwy_your_api_key_here"
+  },
+  "model": "claude-sonnet-5"
+}
+```
+
+`model` sets the model a new session starts on. `/model` overrides it for the running session and saves your choice as the new default.
+
+### Restricting the Model List
+
+`availableModels` limits which models the `/model` picker offers — useful for keeping a team on an approved, budget-appropriate set:
+
+```json
+{
+  "availableModels": ["claude-sonnet-5", "claude-haiku-4-5"],
+  "fallbackModel": ["claude-haiku-4-5"]
+}
+```
+
+`fallbackModel` names the models to try when the primary one is unavailable, capped at three.
+
+## Fetching Models From LLM Gateway
+
+Claude Code can populate its `/model` picker directly from our catalog instead of you hardcoding IDs. Set the discovery flag alongside the base URL:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.llmgateway.io
+export ANTHROPIC_AUTH_TOKEN=llmgtwy_your_api_key_here
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+```
+
+On startup Claude Code calls our `/v1/models` endpoint and adds what it returns to the picker, labeled **From gateway**. Entries are cached in `~/.claude/cache/gateway-models.json` and refreshed on each launch, so a failed lookup falls back to the previous list rather than breaking your session. Requires Claude Code v2.1.129 or later.
+
+> **Heads up:** Claude Code discards discovered models whose ID does not start with `claude` or `anthropic`. Discovery therefore surfaces only the Claude models in our catalog — models like GPT-5 or Gemini are filtered out by the client, not by the gateway. To make one of those selectable, add it explicitly with `ANTHROPIC_CUSTOM_MODEL_OPTION` as shown below.
+
+### Adding a Non-Claude Model to the Picker
+
+`ANTHROPIC_CUSTOM_MODEL_OPTION` adds a single custom entry to the `/model` picker, which is how you expose a model that the discovery filter drops:
+
+```bash
+export ANTHROPIC_CUSTOM_MODEL_OPTION=gpt-5
+export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="GPT-5 via LLM Gateway"
+export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Routed through LLM Gateway"
+```
+
+Only one custom entry is supported at a time. If you also set `availableModels`, include the custom ID in that list or it will be filtered back out. For switching between several non-Claude models, keep using `ANTHROPIC_MODEL` per session, or define a per-project `.claude/settings.json` for each.
+
 ## Environment Variables
 
 When configuring Claude Code, you can use these environment variables:
@@ -142,7 +197,7 @@ The endpoint returns responses in Anthropic's message format:
 
 1. [Sign up free](https://llmgateway.io/signup) — no credit card required
 2. Copy your API key from the dashboard
-3. Set the three environment variables above
-4. Run `claude` and start coding
+3. Set the environment variables above, or drop them into `~/.claude/settings.json`
+4. Run `claude` and start coding — switch models any time with `/model`
 
 Questions? Check [our docs](https://docs.llmgateway.io) or [join Discord](https://llmgateway.io/discord).


### PR DESCRIPTION
## Summary

Investigated whether Claude Code can be preconfigured with a set of models rather than pinning one via `ANTHROPIC_MODEL` and relaunching on every change. It can, in two ways — one needed a gateway change, and the docs needed a sweep.

**Claude Code supports gateway model discovery.** With `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` (v2.1.129+), it calls `GET /v1/models?limit=1000` on the configured `ANTHROPIC_BASE_URL` at startup and adds the results to the `/model` picker, labeled "From gateway". It reads `id` and the optional `display_name` off each `data` entry.

We already served the correct envelope, but had no `display_name`, so every discovered model rendered as a raw id (`claude-sonnet-4-5`). This adds it.

## Changes

**Gateway**
- Emit `display_name` on `/v1/models` entries, mirroring `name`. This is also the field name the [Anthropic Models API](https://platform.claude.com/docs/en/api/models-list) uses, so it aligns our Anthropic-format surface rather than inventing a field.
- Test locking in the discovery contract: every entry carries a non-empty `display_name`, and `claude-sonnet-5` resolves to "Claude Sonnet 5".

**Docs sweep** — the model-config story lived in several places that still presented env vars as the only mechanism, implying a relaunch to switch models:
- `apps/docs/.../guides/claude-code.mdx` — new sections for `~/.claude/settings.json` (`model`, `availableModels`, `fallbackModel`, `env`), gateway discovery, and `ANTHROPIC_CUSTOM_MODEL_OPTION`.
- `apps/ui/.../guides/claude-code.md` — the marketing mirror had drifted; ported the same two sections.
- `apps/docs/.../features/anthropic-endpoint.mdx` — cross-links the guide instead of growing a third copy of the same instructions.
- `apps/code` marketing (`page.tsx`, `SwitchIn60.tsx`, `claude-code-alternative`) — replaced the "flip `ANTHROPIC_MODEL`" framing, which implied killing and relaunching the session, with `/model` mid-session switching.

Deliberately left alone: dated changelog and blog entries are published records, so they weren't retroactively rewritten. If we want this announced, the right move is a new changelog entry. Also unchanged: `coding-agents`, `devpass-code`, `mimocode`, `agent-skills`, and the Copilot migration page — none of them configure Claude Code models.

## Verification

Measured against the real catalog through the Hono app:

```
BYTES=354926 (346.6 KB)  MS=11  TOTAL=248  DISCOVERABLE=15
claude-sonnet-5 => Claude Sonnet 5 | claude-haiku-4-5 => Claude Haiku 4.5 | ...
```

347 KB served in 11 ms, comfortably inside discovery's hard 3-second timeout.

## Known limitation (client-side, not fixable here)

Claude Code **discards discovered models whose id does not start with `claude` or `anthropic`**. So discovery surfaces 15 of our 248 models; GPT-5, Gemini, and the rest are filtered out by the client, not by the gateway. Renaming them to dodge the filter would misrepresent what a model is, so the docs call this out plainly and point at `ANTHROPIC_CUSTOM_MODEL_OPTION` (one custom picker entry) as the escape hatch.

The settings-file half still solves the original complaint for every model: `model` in `settings.json` plus `/model` switches mid-session without relaunching.

- `pnpm format`, `pnpm build` (17/17), and `apps/gateway/src/models/models.spec.ts` (22/22) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Model management” documentation, including mid-session model switching via `/model`.
  * Documented reading model settings from `~/.claude/settings.json` and per-project `.claude/settings.json`.
  * Added guidance for gateway-based model discovery, including local caching and refresh/fallback behavior on lookup failures.
  * Explained how model pickers can be restricted with `availableModels`/`fallbackModel`, plus discovery filtering and custom model exposure rules.
* **Enhancements**
  * Gateway model listings now include user-friendly `display_name` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->