### PR TITLE
feat(compliance): provider/model restrictions

### DIFF
--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -34,8 +34,11 @@ import {
 	tables,
 	projectHourlyStats,
 } from "@llmgateway/db";
-import { getProviderCountries } from "@llmgateway/models";
-import { CREDIT_TOP_UP_MAX_AMOUNT } from "@llmgateway/shared";
+import { getProviderCountries, models, providers } from "@llmgateway/models";
+import {
+	CREDIT_TOP_UP_MAX_AMOUNT,
+	CUSTOM_PROVIDER_NAME_REGEX,
+} from "@llmgateway/shared";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -46,6 +49,39 @@ export const organization = new OpenAPIHono<ServerTypes>();
 const providerCountryCodes = new Set(
 	getProviderCountries().map((country) => country.code),
 );
+
+// Closed sets for the compliance policy's fine-grained restriction lists.
+// Custom providers are addressed as `custom:<name>` and their models as
+// `<name>/<model>`; the names are only format-validated because provider keys
+// can be created/renamed independently of the stored policy.
+const catalogueProviderIds = new Set<string>(
+	providers.map((provider) => provider.id),
+);
+const catalogueModelIds = new Set<string>(models.map((model) => model.id));
+const customProviderRefRegex = new RegExp(
+	`^custom:${CUSTOM_PROVIDER_NAME_REGEX.source.slice(1, -1)}$`,
+);
+const customModelRefRegex = new RegExp(
+	`^${CUSTOM_PROVIDER_NAME_REGEX.source.slice(1, -1)}/.+$`,
+);
+
+const complianceProviderRefSchema = z
+	.string()
+	.max(256)
+	.refine(
+		(ref) => catalogueProviderIds.has(ref) || customProviderRefRegex.test(ref),
+		{ message: "Unknown provider" },
+	);
+
+const complianceModelRefSchema = z
+	.string()
+	.max(256)
+	.refine(
+		(ref) => catalogueModelIds.has(ref) || customModelRefRegex.test(ref),
+		{
+			message: "Unknown model",
+		},
+	);
 
 // Define schemas directly with Zod instead of using createSelectSchema
 const providerCompliancePolicySchema = z.object({
@@ -64,6 +100,10 @@ const providerCompliancePolicySchema = z.object({
 			}),
 		)
 		.optional(),
+	blockedProviders: z.array(complianceProviderRefSchema).max(500).optional(),
+	allowedProviders: z.array(complianceProviderRefSchema).max(500).optional(),
+	blockedModels: z.array(complianceModelRefSchema).max(500).optional(),
+	allowedModels: z.array(complianceModelRefSchema).max(500).optional(),
 });
 
 const organizationSchema = z.object({

--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -129,6 +129,8 @@ Control access to specific providers:
 - **Allow Providers**: Only allow access to specific providers
 - **Deny Providers**: Block access to specific providers
 
+Provider rules can also target your organization's own [custom providers](/features/custom-providers). The generic `custom` entry matches every custom provider, while a `custom:<name>` entry (offered in the selector for each of your custom providers) matches only the custom provider with that name. Model rules can likewise reference a custom-catalog model as `<name>/<model>`.
+
 #### Pricing Rules
 
 Control access based on model pricing:

--- a/apps/docs/content/features/compliance.mdx
+++ b/apps/docs/content/features/compliance.mdx
@@ -41,6 +41,19 @@ The selector only offers countries that are referenced by a provider in the cata
 
 The country filter composes with the certification and data-policy requirements above — a provider must satisfy all active requirements to be allowed.
 
+## Provider & model restrictions
+
+Beyond attribute-based requirements, the **Provider & Model Restrictions** card lets you block or allow individual providers and models:
+
+- **Blocked providers / blocked models** — deny lists. A listed provider or model is always blocked, even when it satisfies every requirement above.
+- **Allowed providers / allowed models** — fine-grained allow lists. When non-empty, only the listed providers (or models) may be used; everything else is blocked. An empty list applies no restriction.
+
+Deny lists always win over allow lists, and both compose with the requirements above — an allow-listed provider must still satisfy every active certification, data-policy, and country requirement.
+
+The selectors include your organization's own [custom providers](/features/custom-providers) (stored as `custom:<name>` refs) and their custom-catalog models (stored as `<name>/<model>` refs), so a specific custom deployment can be blocked or allow-listed individually just like a catalogue provider.
+
+These restrictions are **organization-wide** and take precedence over member-level and API-key-level [IAM rules](/features/api-keys): they are enforced after IAM evaluation, so no user-, team-, or key-level allow rule can grant access to a provider or model the compliance policy excludes.
+
 ## Enforcement
 
 When no available provider for a model meets the policy — or a pinned provider is non-compliant — the gateway returns a `403`:
@@ -48,7 +61,7 @@ When no available provider for a model meets the policy — or a pinned provider
 ```json
 {
 	"error": {
-		"message": "This request was blocked by your organization's provider compliance policy. No available provider for deepseek-v3.2 meets the required certifications. Contact your LLMGateway admin to adjust the policy."
+		"message": "This request was blocked by your organization's provider compliance policy. No available provider for deepseek-v3.2 meets the required certifications or provider/model restrictions. Contact your LLMGateway admin to adjust the policy."
 	}
 }
 ```

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1258,6 +1258,245 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 	});
 
+	test("/v1/chat/completions blocks a provider on the policy's blockedProviders list", async () => {
+		// OpenAI meets every attribute requirement here (none are set); the deny
+		// list alone blocks it.
+		await db
+			.update(tables.organization)
+			.set({
+				plan: "enterprise",
+				providerCompliancePolicy: {
+					enabled: true,
+					blockedProviders: ["openai"],
+				},
+			})
+			.where(eq(tables.organization.id, "org-id"));
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-blocked-provider",
+			token: "real-token-blocked-provider",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-blocked-provider",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-blocked-provider",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o",
+				messages: [{ role: "user", content: "Hello blocked provider!" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(json.error.message).toContain("provider compliance policy");
+
+		const violations = await db.query.guardrailViolation.findMany({
+			where: { organizationId: { eq: "org-id" } },
+		});
+		expect(violations.some((v) => v.category === "provider_compliance")).toBe(
+			true,
+		);
+	});
+
+	test("/v1/chat/completions blocks providers absent from allowedProviders", async () => {
+		// A non-empty allow list without OpenAI blocks the pinned request.
+		await db
+			.update(tables.organization)
+			.set({
+				plan: "enterprise",
+				providerCompliancePolicy: {
+					enabled: true,
+					allowedProviders: ["anthropic"],
+				},
+			})
+			.where(eq(tables.organization.id, "org-id"));
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-allowed-provider-block",
+			token: "real-token-allowed-provider-block",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-allowed-provider-block",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-allowed-provider-block",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o",
+				messages: [{ role: "user", content: "Hello allow list block!" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		expect((await res.json()).error.message).toContain(
+			"provider compliance policy",
+		);
+	});
+
+	test("/v1/chat/completions allows providers on allowedProviders", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				plan: "enterprise",
+				providerCompliancePolicy: {
+					enabled: true,
+					allowedProviders: ["anthropic", "openai"],
+				},
+			})
+			.where(eq(tables.organization.id, "org-id"));
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-allowed-provider-pass",
+			token: "real-token-allowed-provider-pass",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-allowed-provider-pass",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-allowed-provider-pass",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o",
+				messages: [{ role: "user", content: "Hello allow list pass!" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+	});
+
+	test("/v1/chat/completions blocks a model on the policy's blockedModels list", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				plan: "enterprise",
+				providerCompliancePolicy: {
+					enabled: true,
+					blockedModels: ["gpt-4o"],
+				},
+			})
+			.where(eq(tables.organization.id, "org-id"));
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-blocked-model",
+			token: "real-token-blocked-model",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-blocked-model",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const request = (model: string, content: string) =>
+			app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-blocked-model",
+					"x-no-fallback": "true",
+				},
+				body: JSON.stringify({
+					model,
+					messages: [{ role: "user", content }],
+				}),
+			});
+
+		const blocked = await request("openai/gpt-4o", "Hello blocked model!");
+		expect(blocked.status).toBe(403);
+		expect((await blocked.json()).error.message).toContain(
+			"provider compliance policy",
+		);
+
+		// A sibling model on the same provider is unaffected.
+		const allowed = await request("openai/gpt-4o-mini", "Hello allowed model!");
+		expect(allowed.status).toBe(200);
+	});
+
+	test("/v1/chat/completions blocks an individually restricted custom provider", async () => {
+		// The attestation satisfies the policy, but the custom provider is on the
+		// deny list via its custom:<name> ref.
+		await seedCustomProviderCompliance({
+			policy: {
+				enabled: true,
+				requireSoc2: true,
+				blockedProviders: ["custom:mycustom"],
+			},
+			attestation: { soc2: 2 },
+		});
+
+		const res = await requestCustomProvider();
+
+		expect(res.status).toBe(403);
+		expect((await res.json()).error.message).toContain(
+			"provider compliance policy",
+		);
+	});
+
+	test("/v1/chat/completions blocks a custom model via its <provider>/<model> ref", async () => {
+		await seedCustomProviderCompliance({
+			policy: {
+				enabled: true,
+				blockedModels: ["mycustom/gpt-4o-mini"],
+			},
+			attestation: { soc2: 2 },
+		});
+
+		const blocked = await requestCustomProvider("mycustom/gpt-4o-mini");
+		expect(blocked.status).toBe(403);
+		expect((await blocked.json()).error.message).toContain(
+			"provider compliance policy",
+		);
+
+		const allowed = await requestCustomProvider("mycustom/gpt-4o");
+		expect(allowed.status).toBe(200);
+	});
+
 	test("/v1/chat/completions rejects unsupported service tiers", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-unsupported-service-tier",

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1313,6 +1313,63 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/chat/completions org policy overrides API-key IAM allow rules", async () => {
+		// The org policy always takes precedence: an explicit allow_providers
+		// rule on the API key cannot grant access to a policy-blocked provider.
+		await db
+			.update(tables.organization)
+			.set({
+				plan: "enterprise",
+				providerCompliancePolicy: {
+					enabled: true,
+					blockedProviders: ["openai"],
+				},
+			})
+			.where(eq(tables.organization.id, "org-id"));
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-policy-over-iam",
+			token: "real-token-policy-over-iam",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.apiKeyIamRule).values({
+			id: "iam-allow-openai-policy-over-iam",
+			apiKeyId: "token-id-policy-over-iam",
+			ruleType: "allow_providers",
+			ruleValue: { providers: ["openai"] },
+			status: "active",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-policy-over-iam",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-policy-over-iam",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o",
+				messages: [{ role: "user", content: "Hello policy precedence!" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		expect((await res.json()).error.message).toContain(
+			"provider compliance policy",
+		);
+	});
+
 	test("/v1/chat/completions blocks providers absent from allowedProviders", async () => {
 		// A non-empty allow list without OpenAI blocks the pinned request.
 		await db

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -40,6 +40,7 @@ import {
 	complianceBlockMessage,
 	filterCompliantProviders,
 	getActiveCompliancePolicy,
+	isModelIdCompliant,
 	isProviderIdCompliant,
 	logComplianceBlock,
 	type ComplianceCheckContext,
@@ -2699,6 +2700,7 @@ chat.openapi(completions, async (c) => {
 		organizationId: project.organizationId,
 		requestedModel: modelInfo.id,
 		requestedProvider,
+		customProviderName,
 		activeModelInfo: modelInfo,
 		clientIp,
 	});
@@ -2742,6 +2744,7 @@ chat.openapi(completions, async (c) => {
 	}
 	const complianceContext: ComplianceCheckContext = {
 		customAttestation: customProviderKey?.complianceAttestation ?? null,
+		customProviderName,
 	};
 
 	// Enterprise provider compliance guardrails: drop providers that do not meet
@@ -2774,7 +2777,19 @@ chat.openapi(completions, async (c) => {
 			usedProvider !== "llmgateway" &&
 			usedProvider !== "custom" &&
 			!isProviderIdCompliant(usedProvider, compliancePolicy, complianceContext);
-		if (iamFilteredModelProviders.length === 0 || pinnedBlocked) {
+		// The policy's model lists block the model outright, regardless of which
+		// provider would serve it (custom-provider requests also answer to their
+		// `<customProvider>/<model>` ref).
+		const modelBlocked = !isModelIdCompliant(
+			modelInfo.id,
+			compliancePolicy,
+			complianceContext,
+		);
+		if (
+			iamFilteredModelProviders.length === 0 ||
+			pinnedBlocked ||
+			modelBlocked
+		) {
 			await logComplianceBlock(project.organizationId, {
 				apiKeyId: apiKey.id,
 				model: requestedModel,
@@ -3166,10 +3181,12 @@ chat.openapi(completions, async (c) => {
 				: availableModelProviders;
 
 			// Drop providers that don't meet the org's compliance policy so auto
-			// routing picks a compliant provider instead of being blocked later.
-			const complianceFilteredProviders = applyCompliancePolicy(
-				cachedFilteredProviders,
-			);
+			// routing picks a compliant provider instead of being blocked later. A
+			// model excluded by the policy's model lists loses all its providers.
+			const complianceFilteredProviders =
+				compliancePolicy && !isModelIdCompliant(modelDef.id, compliancePolicy)
+					? []
+					: applyCompliancePolicy(cachedFilteredProviders);
 			if (cachedFilteredProviders.length > 0) {
 				anyPreComplianceCandidate = true;
 				if (complianceFilteredProviders.length > 0) {

--- a/apps/gateway/src/lib/compliance.spec.ts
+++ b/apps/gateway/src/lib/compliance.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	filterCompliantProviders,
+	isModelIdCompliant,
 	isProviderIdCompliant,
 } from "./compliance.js";
 
@@ -88,5 +89,126 @@ describe("filterCompliantProviders passes context through", () => {
 				customAttestation: { soc2: 1 },
 			}).map((p) => p.providerId),
 		).toEqual(["openai", "custom"]);
+	});
+});
+
+describe("provider restriction lists", () => {
+	it("blocks a catalogue provider on the deny list even when certified", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedProviders: ["openai"],
+		};
+		expect(isProviderIdCompliant("openai", policy)).toBe(false);
+		expect(isProviderIdCompliant("anthropic", policy)).toBe(true);
+	});
+
+	it("a non-empty allow list blocks unlisted providers", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			allowedProviders: ["anthropic"],
+		};
+		expect(isProviderIdCompliant("anthropic", policy)).toBe(true);
+		expect(isProviderIdCompliant("openai", policy)).toBe(false);
+	});
+
+	it("addresses custom providers as custom:<name>", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedProviders: ["custom:acme"],
+		};
+		expect(
+			isProviderIdCompliant("custom", policy, {
+				customAttestation: { soc2: 2 },
+				customProviderName: "acme",
+			}),
+		).toBe(false);
+		expect(
+			isProviderIdCompliant("custom", policy, {
+				customAttestation: { soc2: 2 },
+				customProviderName: "other",
+			}),
+		).toBe(true);
+	});
+
+	it("an allow list without the custom ref blocks custom traffic", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			allowedProviders: ["custom:acme"],
+		};
+		expect(
+			isProviderIdCompliant("custom", policy, {
+				customAttestation: { soc2: 2 },
+				customProviderName: "acme",
+			}),
+		).toBe(true);
+		expect(
+			isProviderIdCompliant("custom", policy, {
+				customAttestation: { soc2: 2 },
+				customProviderName: "other",
+			}),
+		).toBe(false);
+	});
+
+	it("a listed custom provider still needs a compliant attestation", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			requireSoc2: true,
+			allowedProviders: ["custom:acme"],
+		};
+		expect(
+			isProviderIdCompliant("custom", policy, {
+				customAttestation: null,
+				customProviderName: "acme",
+			}),
+		).toBe(false);
+	});
+});
+
+describe("isModelIdCompliant", () => {
+	it("applies no restriction without model lists", () => {
+		expect(isModelIdCompliant("gpt-5.2", { enabled: true })).toBe(true);
+	});
+
+	it("blocks models on the deny list", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedModels: ["gpt-5.2"],
+		};
+		expect(isModelIdCompliant("gpt-5.2", policy)).toBe(false);
+		expect(isModelIdCompliant("claude-sonnet-4-6", policy)).toBe(true);
+	});
+
+	it("a non-empty allow list blocks unlisted models", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			allowedModels: ["claude-sonnet-4-6"],
+		};
+		expect(isModelIdCompliant("claude-sonnet-4-6", policy)).toBe(true);
+		expect(isModelIdCompliant("gpt-5.2", policy)).toBe(false);
+	});
+
+	it("custom-provider models answer to their <provider>/<model> ref", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedModels: ["acme/my-model"],
+		};
+		expect(
+			isModelIdCompliant("my-model", policy, { customProviderName: "acme" }),
+		).toBe(false);
+		expect(
+			isModelIdCompliant("my-model", policy, { customProviderName: "other" }),
+		).toBe(true);
+		// Without a custom provider the scoped ref never matches.
+		expect(isModelIdCompliant("my-model", policy)).toBe(true);
+	});
+
+	it("custom-provider models also answer to their bare name", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedModels: ["my-model"],
+		};
+		expect(
+			isModelIdCompliant("my-model", policy, { customProviderName: "acme" }),
+		).toBe(false);
 	});
 });

--- a/apps/gateway/src/lib/compliance.ts
+++ b/apps/gateway/src/lib/compliance.ts
@@ -3,9 +3,12 @@ import { HTTPException } from "hono/http-exception";
 import { logViolation } from "@llmgateway/guardrails";
 import { logger, toError } from "@llmgateway/logger";
 import {
+	customProviderRef,
 	getProviderDefinition,
 	isAttestationCompliant,
+	isModelAllowedByPolicy,
 	isProviderCompliant,
+	isProviderRefAllowedByPolicy,
 	type ProviderComplianceAttestation,
 	type ProviderCompliancePolicy,
 } from "@llmgateway/models";
@@ -32,6 +35,8 @@ export function getActiveCompliancePolicy(
 /** Request-scoped facts the policy needs beyond the catalogue. */
 export interface ComplianceCheckContext {
 	customAttestation?: ProviderComplianceAttestation | null;
+	/** Routing-prefix name of the custom provider handling this request. */
+	customProviderName?: string;
 }
 
 /** Whether a provider id satisfies the policy (unknown providers fail closed). */
@@ -41,12 +46,35 @@ export function isProviderIdCompliant(
 	context?: ComplianceCheckContext,
 ): boolean {
 	// "custom" has a catalogue entry with a null dataPolicy, so it must be
-	// short-circuited before the lookup below or it always fails closed.
+	// short-circuited before the lookup below or it always fails closed. The
+	// policy's provider lists address custom providers as `custom:<name>`.
 	if (providerId === "custom") {
-		return isAttestationCompliant(context?.customAttestation, policy);
+		const providerRef = context?.customProviderName
+			? customProviderRef(context.customProviderName)
+			: providerId;
+		return (
+			isProviderRefAllowedByPolicy(providerRef, policy) &&
+			isAttestationCompliant(context?.customAttestation, policy)
+		);
 	}
 	const definition = getProviderDefinition(providerId);
 	return definition ? isProviderCompliant(definition, policy) : false;
+}
+
+/**
+ * Whether the requested model passes the policy's fine-grained model lists. A
+ * model served through a custom provider answers to both its bare model name
+ * and the `<customProvider>/<model>` ref the dashboard stores.
+ */
+export function isModelIdCompliant(
+	modelId: string,
+	policy: ProviderCompliancePolicy,
+	context?: ComplianceCheckContext,
+): boolean {
+	const modelRefs = context?.customProviderName
+		? [modelId, `${context.customProviderName}/${modelId}`]
+		: [modelId];
+	return isModelAllowedByPolicy(modelRefs, policy);
 }
 
 /** Drop provider mappings that don't satisfy the policy. */
@@ -61,7 +89,7 @@ export function filterCompliantProviders<T extends { providerId: string }>(
 }
 
 export function complianceBlockMessage(modelId: string): string {
-	return `This request was blocked by your organization's provider compliance policy. No available provider for ${modelId} meets the required certifications. Contact your LLMGateway admin to adjust the policy.`;
+	return `This request was blocked by your organization's provider compliance policy. No available provider for ${modelId} meets the required certifications or provider/model restrictions. Contact your LLMGateway admin to adjust the policy.`;
 }
 
 /**
@@ -96,7 +124,8 @@ export async function logComplianceBlock(
 /**
  * Enforce the org's compliance policy for a single resolved provider (used by
  * endpoints that pick one provider rather than routing across many). Throws a
- * 403 and records a security event when the provider is non-compliant.
+ * 403 and records a security event when the provider is non-compliant or the
+ * model is excluded by the policy's fine-grained model lists.
  */
 export async function assertProviderCompliant(
 	organization: OrganizationLike,
@@ -109,7 +138,11 @@ export async function assertProviderCompliant(
 	},
 ): Promise<void> {
 	const policy = getActiveCompliancePolicy(organization);
-	if (!policy || isProviderIdCompliant(providerId, policy)) {
+	if (
+		!policy ||
+		(isProviderIdCompliant(providerId, policy) &&
+			isModelIdCompliant(context.modelId, policy))
+	) {
 		return;
 	}
 	await logComplianceBlock(context.organizationId, {

--- a/apps/gateway/src/lib/compliance.ts
+++ b/apps/gateway/src/lib/compliance.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { logViolation } from "@llmgateway/guardrails";
 import { logger, toError } from "@llmgateway/logger";
 import {
+	customModelRef,
 	customProviderRef,
 	getProviderDefinition,
 	isAttestationCompliant,
@@ -72,7 +73,7 @@ export function isModelIdCompliant(
 	context?: ComplianceCheckContext,
 ): boolean {
 	const modelRefs = context?.customProviderName
-		? [modelId, `${context.customProviderName}/${modelId}`]
+		? [modelId, customModelRef(context.customProviderName, modelId)]
 		: [modelId];
 	return isModelAllowedByPolicy(modelRefs, policy);
 }

--- a/apps/gateway/src/lib/iam.spec.ts
+++ b/apps/gateway/src/lib/iam.spec.ts
@@ -1356,6 +1356,191 @@ describe("validateRequestModelAccess — member + key composition", () => {
 });
 
 // ===========================
+// Custom provider matching (custom:<name> refs, <name>/<model> refs)
+// ===========================
+
+/** The synthetic model definition chat.ts builds for custom-provider requests. */
+const customProviderModel: ModelDefinition = {
+	id: "my-model",
+	family: "custom",
+	providers: [
+		{
+			providerId: "custom",
+			externalId: "my-model",
+			streaming: true,
+			inputPrice: "0",
+			outputPrice: "0",
+		},
+	],
+};
+
+describe("validateRequestModelAccess — custom provider refs", () => {
+	beforeEach(() => {
+		vi.mocked(mockCachedQueries.findActiveUserIamRules).mockResolvedValue([]);
+	});
+
+	it("deny_providers with custom:<name> blocks only that custom provider", async () => {
+		vi.mocked(mockCachedQueries.findActiveIamRules).mockResolvedValue([
+			makeRule({
+				ruleType: "deny_providers",
+				ruleValue: { providers: ["custom:acme"] },
+			}),
+		]);
+
+		const denied = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "acme",
+			activeModelInfo: customProviderModel,
+		});
+		expect(denied.allowed).toBe(false);
+		expect(denied.reason).toContain("denied providers list");
+
+		const allowed = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "other",
+			activeModelInfo: customProviderModel,
+		});
+		expect(allowed.allowed).toBe(true);
+	});
+
+	it("allow_providers with custom:<name> admits only that custom provider", async () => {
+		vi.mocked(mockCachedQueries.findActiveIamRules).mockResolvedValue([
+			makeRule({
+				ruleType: "allow_providers",
+				ruleValue: { providers: ["custom:acme"] },
+			}),
+		]);
+
+		const allowed = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "acme",
+			activeModelInfo: customProviderModel,
+		});
+		expect(allowed.allowed).toBe(true);
+		expect(allowed.allowedProviders).toEqual(["custom"]);
+
+		const denied = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "other",
+			activeModelInfo: customProviderModel,
+		});
+		expect(denied.allowed).toBe(false);
+	});
+
+	it("the plain custom entry still matches every custom provider", async () => {
+		vi.mocked(mockCachedQueries.findActiveIamRules).mockResolvedValue([
+			makeRule({
+				ruleType: "allow_providers",
+				ruleValue: { providers: ["custom"] },
+			}),
+		]);
+
+		const result = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "acme",
+			activeModelInfo: customProviderModel,
+		});
+		expect(result.allowed).toBe(true);
+	});
+
+	it("model rules match the <name>/<model> ref for custom providers", async () => {
+		vi.mocked(mockCachedQueries.findActiveIamRules).mockResolvedValue([
+			makeRule({
+				ruleType: "deny_models",
+				ruleValue: { models: ["acme/my-model"] },
+			}),
+		]);
+
+		const denied = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "acme",
+			activeModelInfo: customProviderModel,
+		});
+		expect(denied.allowed).toBe(false);
+
+		const allowed = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "other",
+			activeModelInfo: customProviderModel,
+		});
+		expect(allowed.allowed).toBe(true);
+	});
+
+	it("allow_models with a <name>/<model> ref admits that custom model", async () => {
+		vi.mocked(mockCachedQueries.findActiveIamRules).mockResolvedValue([
+			makeRule({
+				ruleType: "allow_models",
+				ruleValue: { models: ["acme/my-model"] },
+			}),
+		]);
+
+		const allowed = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "acme",
+			activeModelInfo: customProviderModel,
+		});
+		expect(allowed.allowed).toBe(true);
+
+		const denied = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "other",
+			activeModelInfo: customProviderModel,
+		});
+		expect(denied.allowed).toBe(false);
+	});
+
+	it("member-level custom:<name> ceilings bind API keys", async () => {
+		vi.mocked(mockCachedQueries.findActiveUserIamRules).mockResolvedValue([
+			makeMemberRule({
+				ruleType: "deny_providers",
+				ruleValue: { providers: ["custom:acme"] },
+			}),
+		]);
+		vi.mocked(mockCachedQueries.findActiveIamRules).mockResolvedValue([]);
+
+		const result = await validateRequestModelAccess({
+			apiKey: makeApiKey(),
+			organizationId: "org-1",
+			requestedModel: customProviderModel.id,
+			requestedProvider: "custom",
+			customProviderName: "acme",
+			activeModelInfo: customProviderModel,
+		});
+		expect(result.allowed).toBe(false);
+		expect(result.reason).toContain(
+			"organization member IAM rule set by your org admin",
+		);
+	});
+});
+
+// ===========================
 // throwIamException
 // ===========================
 

--- a/apps/gateway/src/lib/iam.ts
+++ b/apps/gateway/src/lib/iam.ts
@@ -8,6 +8,8 @@ import { anyCidrMatches } from "@/lib/client-ip.js";
 import { validateEndUserSessionModelAccess } from "@/lib/end-user-session.js";
 
 import {
+	customModelRef,
+	customProviderRef,
 	models,
 	type ModelDefinition,
 	type ProviderId,
@@ -69,7 +71,7 @@ function providerEntryMatches(
 	return (
 		providerId === "custom" &&
 		customProviderName !== undefined &&
-		entry === `custom:${customProviderName}`
+		entry === customProviderRef(customProviderName)
 	);
 }
 
@@ -81,7 +83,7 @@ function modelRuleRefs(
 	customProviderName: string | undefined,
 ): string[] {
 	return customProviderName
-		? [modelDef.id, `${customProviderName}/${modelDef.id}`]
+		? [modelDef.id, customModelRef(customProviderName, modelDef.id)]
 		: [modelDef.id];
 }
 

--- a/apps/gateway/src/lib/iam.ts
+++ b/apps/gateway/src/lib/iam.ts
@@ -54,6 +54,37 @@ const scopeDenialSuffix = {
 
 type IamRuleScope = keyof typeof scopeDenialSuffix;
 
+// Whether a rule's provider entry matches a provider id. Custom providers all
+// share the provider id "custom", so rules can address one of them
+// individually with a `custom:<name>` entry; the plain "custom" entry keeps
+// matching every custom provider.
+function providerEntryMatches(
+	entry: string,
+	providerId: string,
+	customProviderName: string | undefined,
+): boolean {
+	if (entry === providerId) {
+		return true;
+	}
+	return (
+		providerId === "custom" &&
+		customProviderName !== undefined &&
+		entry === `custom:${customProviderName}`
+	);
+}
+
+// Every ref a model answers to in model rules. Custom-provider models are not
+// in the catalogue, so rules address them as `<customProvider>/<model>`; the
+// bare upstream model name also matches for symmetry with catalogue models.
+function modelRuleRefs(
+	modelDef: ModelDefinition,
+	customProviderName: string | undefined,
+): string[] {
+	return customProviderName
+		? [modelDef.id, `${customProviderName}/${modelDef.id}`]
+		: [modelDef.id];
+}
+
 // Evaluate one scope's rule set (member-level or key-level). Allow rules of
 // the same type are unioned within the scope; deny rules always apply. The
 // caller chains scopes by seeding `initialAllowedProviders` with the previous
@@ -67,6 +98,7 @@ async function evaluateIamRuleSet(
 	initialAllowedProviders: Set<ProviderId>,
 	clientIp: string | undefined,
 	scope: IamRuleScope,
+	customProviderName?: string,
 ): Promise<IamValidationResult> {
 	if (iamRules.length === 0) {
 		return {
@@ -109,6 +141,7 @@ async function evaluateIamRuleSet(
 				requestedProvider,
 				allowedProviders,
 				clientIp,
+				customProviderName,
 			);
 			if (result.allowed) {
 				groupAllowed = true;
@@ -143,6 +176,7 @@ async function evaluateIamRuleSet(
 			requestedProvider,
 			allowedProviders,
 			clientIp,
+			customProviderName,
 		);
 		if (!result.allowed) {
 			return {
@@ -202,6 +236,10 @@ export async function validateRequestModelAccess(params: {
 	organizationId: string;
 	requestedModel: string;
 	requestedProvider?: string;
+	// Routing-prefix name of the custom provider handling the request, when
+	// requestedProvider is "custom". Lets rules match `custom:<name>` provider
+	// entries and `<name>/<model>` model entries for that one custom provider.
+	customProviderName?: string;
 	activeModelInfo?: ModelDefinition;
 	clientIp?: string;
 	autoRouting?: boolean;
@@ -216,6 +254,7 @@ export async function validateRequestModelAccess(params: {
 		organizationId,
 		requestedModel,
 		requestedProvider,
+		customProviderName,
 		activeModelInfo,
 		clientIp,
 		autoRouting,
@@ -271,6 +310,7 @@ export async function validateRequestModelAccess(params: {
 		new Set(modelDef.providers.map((p) => p.providerId)),
 		clientIp,
 		"member",
+		customProviderName,
 	);
 	if (!memberResult.allowed) {
 		return memberResult;
@@ -284,6 +324,7 @@ export async function validateRequestModelAccess(params: {
 		new Set(memberResult.allowedProviders),
 		clientIp,
 		"key",
+		customProviderName,
 	);
 }
 
@@ -321,12 +362,18 @@ async function evaluateRule(
 	requestedProvider: string | undefined,
 	currentAllowedProviders: Set<ProviderId>,
 	clientIp: string | undefined,
+	customProviderName: string | undefined,
 ): Promise<RuleEvaluationResult> {
 	const { ruleType, ruleValue } = rule;
 
 	switch (ruleType) {
 		case "allow_models":
-			if (ruleValue.models && !ruleValue.models.includes(modelDef.id)) {
+			if (
+				ruleValue.models &&
+				!modelRuleRefs(modelDef, customProviderName).some((ref) =>
+					ruleValue.models!.includes(ref),
+				)
+			) {
 				return {
 					allowed: false,
 					reason: `Model ${modelDef.id} is not in the allowed models list`,
@@ -335,7 +382,12 @@ async function evaluateRule(
 			break;
 
 		case "deny_models":
-			if (ruleValue.models && ruleValue.models.includes(modelDef.id)) {
+			if (
+				ruleValue.models &&
+				modelRuleRefs(modelDef, customProviderName).some((ref) =>
+					ruleValue.models!.includes(ref),
+				)
+			) {
 				return {
 					allowed: false,
 					reason: `Model ${modelDef.id} is in the denied models list`,
@@ -345,16 +397,29 @@ async function evaluateRule(
 
 		case "allow_providers":
 			if (ruleValue.providers) {
+				const allowEntries = ruleValue.providers;
 				const newAllowedProviders = new Set<ProviderId>();
 				for (const provider of currentAllowedProviders) {
-					if (ruleValue.providers.includes(provider)) {
+					if (
+						allowEntries.some((entry) =>
+							providerEntryMatches(entry, provider, customProviderName),
+						)
+					) {
 						newAllowedProviders.add(provider);
 					}
 				}
 
 				if (requestedProvider) {
 					// Specific provider requested - check if it's allowed
-					if (!ruleValue.providers.includes(requestedProvider)) {
+					if (
+						!allowEntries.some((entry) =>
+							providerEntryMatches(
+								entry,
+								requestedProvider,
+								customProviderName,
+							),
+						)
+					) {
 						return {
 							allowed: false,
 							reason: `Provider ${requestedProvider} is not in the allowed providers list`,
@@ -375,16 +440,29 @@ async function evaluateRule(
 
 		case "deny_providers":
 			if (ruleValue.providers) {
+				const denyEntries = ruleValue.providers;
 				const newAllowedProviders = new Set<ProviderId>();
 				for (const provider of currentAllowedProviders) {
-					if (!ruleValue.providers.includes(provider)) {
+					if (
+						!denyEntries.some((entry) =>
+							providerEntryMatches(entry, provider, customProviderName),
+						)
+					) {
 						newAllowedProviders.add(provider);
 					}
 				}
 
 				if (requestedProvider) {
 					// Specific provider requested - check if it's denied
-					if (ruleValue.providers.includes(requestedProvider)) {
+					if (
+						denyEntries.some((entry) =>
+							providerEntryMatches(
+								entry,
+								requestedProvider,
+								customProviderName,
+							),
+						)
+					) {
 						return {
 							allowed: false,
 							reason: `Provider ${requestedProvider} is in the denied providers list`,

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -26,6 +26,7 @@ import {
 	complianceBlockMessage,
 	filterCompliantProviders,
 	getActiveCompliancePolicy,
+	isModelIdCompliant,
 	isProviderIdCompliant,
 	logComplianceBlock,
 } from "@/lib/compliance.js";
@@ -4448,11 +4449,16 @@ videos.openapi(createVideo, async (c) => {
 		const pinnedBlocked =
 			requestedProvider !== undefined &&
 			!isProviderIdCompliant(requestedProvider, videoCompliancePolicy);
+		// The policy's model lists block the model outright.
+		const modelBlocked = !isModelIdCompliant(
+			modelInfo.id,
+			videoCompliancePolicy,
+		);
 		const compliantProviders = filterCompliantProviders(
 			modelInfo.providers as ProviderModelMapping[],
 			videoCompliancePolicy,
 		);
-		if (pinnedBlocked || compliantProviders.length === 0) {
+		if (pinnedBlocked || modelBlocked || compliantProviders.length === 0) {
 			await logComplianceBlock(project.organizationId, {
 				apiKeyId: apiKey.id,
 				model: normalizedModel,

--- a/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useCustomProviderSelection } from "@/hooks/useCustomProviders";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { useTeamMembers } from "@/hooks/useTeam";
 import { useUser } from "@/hooks/useUser";
@@ -24,15 +25,22 @@ import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
 import {
+	customProviderRef,
 	getProviderCountries,
 	isAttestationCompliant,
 	isProviderCompliant,
+	isProviderRefAllowedByPolicy,
+	models,
 	providers,
 	type ProviderCompliancePolicy,
 	type ProviderDefinition,
 	type ProviderId,
 } from "@llmgateway/models";
-import { providerLogoUrls } from "@llmgateway/shared/components";
+import {
+	MultiModelSelector,
+	MultiProviderSelector,
+	providerLogoUrls,
+} from "@llmgateway/shared/components";
 
 import { ContactSalesCard } from "./contact-sales-card";
 
@@ -153,6 +161,15 @@ const DEFAULT_POLICY: ProviderCompliancePolicy = { enabled: false };
 
 const PROVIDER_COUNTRIES = getProviderCountries();
 
+// Catalogue providers offered by the restriction selectors (custom providers
+// are appended per-org at render time as `custom:<name>` refs).
+const SELECTABLE_PROVIDERS = providers.filter(
+	(provider) => !HIDDEN_PROVIDER_IDS.has(provider.id),
+);
+
+type RestrictionListKey =
+	"blockedProviders" | "allowedProviders" | "blockedModels" | "allowedModels";
+
 export function ComplianceClient() {
 	const params = useParams();
 	const organizationId = params.orgId as string;
@@ -213,7 +230,8 @@ export function ComplianceClient() {
 	const totalProviders = allowed.length + blocked.length;
 
 	// The org's own custom providers, evaluated against their self-attested
-	// compliance posture (fail-closed: no attestation on file → blocked).
+	// compliance posture (fail-closed: no attestation on file → blocked) and
+	// the policy's fine-grained provider lists (`custom:<name>` refs).
 	const { data: providerKeysData } = api.useQuery("get", "/keys/provider", {});
 	const customProviders = useMemo(() => {
 		const keys = (providerKeysData?.providerKeys ?? []).filter(
@@ -225,10 +243,33 @@ export function ComplianceClient() {
 		return keys.map((key) => ({
 			id: key.id,
 			name: key.name ?? key.id,
-			compliant: isAttestationCompliant(key.complianceAttestation, policy),
+			compliant:
+				isProviderRefAllowedByPolicy(
+					customProviderRef(key.name ?? key.id),
+					policy,
+				) && isAttestationCompliant(key.complianceAttestation, policy),
 			attested: Boolean(key.complianceAttestation),
 		}));
 	}, [providerKeysData, selectedOrganization?.id, policy]);
+
+	// Custom providers/models as selector entries for the restriction lists.
+	const { customProviderOptions, customModelOptions } =
+		useCustomProviderSelection();
+	const selectableProviders = useMemo(
+		() => [...SELECTABLE_PROVIDERS, ...customProviderOptions],
+		[customProviderOptions],
+	);
+	const selectableModels = useMemo(
+		() => [...models, ...customModelOptions],
+		[customModelOptions],
+	);
+
+	const setRestrictionList = (key: RestrictionListKey, values: string[]) => {
+		setPolicy((p) => ({
+			...p,
+			[key]: values.length > 0 ? values : undefined,
+		}));
+	};
 
 	const canManage =
 		selectedOrganization?.plan === "enterprise" &&
@@ -408,6 +449,90 @@ export function ComplianceClient() {
 									</button>
 								);
 							})}
+						</div>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Provider &amp; Model Restrictions</CardTitle>
+						<CardDescription>
+							Block or allow individual providers and models — including your
+							own custom providers. These organization-wide lists are enforced
+							on top of the requirements above and take precedence over any
+							member or API key IAM rule.
+						</CardDescription>
+					</CardHeader>
+					<CardContent
+						className={
+							policy.enabled
+								? undefined
+								: "opacity-60 pointer-events-none select-none"
+						}
+					>
+						<div className="grid gap-6 md:grid-cols-2">
+							<div className="space-y-2">
+								<Label>Blocked providers</Label>
+								<p className="text-sm text-muted-foreground">
+									Requests to these providers are always blocked, even when they
+									meet every requirement above.
+								</p>
+								<MultiProviderSelector
+									providers={selectableProviders}
+									selectedProviders={policy.blockedProviders ?? []}
+									onProvidersChange={(values) =>
+										setRestrictionList("blockedProviders", values)
+									}
+									placeholder="Select providers to block..."
+								/>
+							</div>
+							<div className="space-y-2">
+								<Label>Allowed providers</Label>
+								<p className="text-sm text-muted-foreground">
+									When set, only these providers may be used. Leave empty to
+									allow every provider that meets the requirements above.
+								</p>
+								<MultiProviderSelector
+									providers={selectableProviders}
+									selectedProviders={policy.allowedProviders ?? []}
+									onProvidersChange={(values) =>
+										setRestrictionList("allowedProviders", values)
+									}
+									placeholder="Select allowed providers..."
+								/>
+							</div>
+							<div className="space-y-2">
+								<Label>Blocked models</Label>
+								<p className="text-sm text-muted-foreground">
+									Requests for these models are always blocked, on every
+									provider.
+								</p>
+								<MultiModelSelector
+									models={selectableModels}
+									providers={providers}
+									selectedModels={policy.blockedModels ?? []}
+									onModelsChange={(values) =>
+										setRestrictionList("blockedModels", values)
+									}
+									placeholder="Select models to block..."
+								/>
+							</div>
+							<div className="space-y-2">
+								<Label>Allowed models</Label>
+								<p className="text-sm text-muted-foreground">
+									When set, only these models may be requested. Leave empty to
+									allow all models.
+								</p>
+								<MultiModelSelector
+									models={selectableModels}
+									providers={providers}
+									selectedModels={policy.allowedModels ?? []}
+									onModelsChange={(values) =>
+										setRestrictionList("allowedModels", values)
+									}
+									placeholder="Select allowed models..."
+								/>
+							</div>
 						</div>
 					</CardContent>
 				</Card>

--- a/apps/ui/src/components/iam/iam-rules-editor.tsx
+++ b/apps/ui/src/components/iam/iam-rules-editor.tsx
@@ -10,8 +10,9 @@ import {
 	Trash2,
 	Zap,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { useCustomProviderSelection } from "@/hooks/useCustomProviders";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 import {
@@ -170,6 +171,20 @@ export function IamRulesEditor({
 		maxOutputPrice: "",
 		ipCidrs: "",
 	});
+
+	// The org's custom providers/models are selectable alongside the catalogue:
+	// providers as `custom:<name>` refs, models as `<name>/<model>` refs — the
+	// formats the gateway's IAM evaluation matches for custom-provider traffic.
+	const { customProviderOptions, customModelOptions } =
+		useCustomProviderSelection();
+	const selectableProviders = useMemo(
+		() => [...providers, ...customProviderOptions],
+		[customProviderOptions],
+	);
+	const selectableModels = useMemo(
+		() => [...models, ...customModelOptions],
+		[customModelOptions],
+	);
 
 	const handleCreateRule = () => {
 		const ruleValue: IamRule["ruleValue"] = {};
@@ -332,7 +347,7 @@ export function IamRulesEditor({
 										Models
 									</Label>
 									<MultiModelSelector
-										models={models}
+										models={selectableModels}
 										providers={providers}
 										selectedModels={newRule.models}
 										onModelsChange={(selectedModels: string[]) =>
@@ -353,7 +368,7 @@ export function IamRulesEditor({
 										Providers
 									</Label>
 									<MultiProviderSelector
-										providers={providers}
+										providers={selectableProviders}
 										selectedProviders={newRule.providers}
 										onProvidersChange={(selectedProviders: string[]) =>
 											setNewRule((prev) => ({

--- a/apps/ui/src/hooks/useCustomProviders.ts
+++ b/apps/ui/src/hooks/useCustomProviders.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { useApi } from "@/lib/fetch-client";
+
+import { customProviderRef, type ModelDefinition } from "@llmgateway/models";
+
+export interface CustomProviderOption {
+	/** Restriction-list ref for this custom provider (`custom:<name>`). */
+	id: string;
+	name: string;
+	providerKeyId: string;
+	color: null;
+}
+
+/**
+ * The selected org's custom providers and custom-catalog models shaped as
+ * selector entries: providers as `custom:<name>` refs, models as synthetic
+ * `<name>/<model>` model definitions. These are the ref formats the
+ * compliance policy and IAM rules match at the gateway. Non-admin members
+ * cannot list provider keys, so both lists are empty for them.
+ */
+export function useCustomProviderSelection() {
+	const { selectedOrganization } = useDashboardNavigation();
+	const api = useApi();
+	const { data: providerKeysData } = api.useQuery("get", "/keys/provider", {});
+	const { data: customModelsData } = api.useQuery("get", "/custom-models", {});
+
+	return useMemo(() => {
+		const keys = (providerKeysData?.providerKeys ?? []).filter(
+			(key) =>
+				key.provider === "custom" &&
+				key.status !== "deleted" &&
+				key.organizationId === selectedOrganization?.id &&
+				key.name,
+		);
+		const customProviderOptions: CustomProviderOption[] = keys.map((key) => ({
+			id: customProviderRef(key.name!),
+			name: `${key.name} (custom)`,
+			providerKeyId: key.id,
+			color: null,
+		}));
+		const keyNameById = new Map(keys.map((key) => [key.id, key.name!]));
+		const customModelOptions: ModelDefinition[] = (
+			customModelsData?.customModels ?? []
+		)
+			.filter(
+				(model) =>
+					model.status === "active" && keyNameById.has(model.providerKeyId),
+			)
+			.map((model) => {
+				const providerName = keyNameById.get(model.providerKeyId)!;
+				const ref = `${providerName}/${model.modelName}`;
+				return {
+					id: ref,
+					name: model.displayName ? `${model.displayName} (${ref})` : ref,
+					family: "custom",
+					providers: [
+						{ providerId: "custom" as const, externalId: model.modelName },
+					],
+				};
+			});
+		return { customProviderOptions, customModelOptions };
+	}, [providerKeysData, customModelsData, selectedOrganization?.id]);
+}

--- a/apps/ui/src/hooks/useCustomProviders.ts
+++ b/apps/ui/src/hooks/useCustomProviders.ts
@@ -5,7 +5,11 @@ import { useMemo } from "react";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { useApi } from "@/lib/fetch-client";
 
-import { customProviderRef, type ModelDefinition } from "@llmgateway/models";
+import {
+	customModelRef,
+	customProviderRef,
+	type ModelDefinition,
+} from "@llmgateway/models";
 
 export interface CustomProviderOption {
 	/** Restriction-list ref for this custom provider (`custom:<name>`). */
@@ -52,13 +56,17 @@ export function useCustomProviderSelection() {
 			)
 			.map((model) => {
 				const providerName = keyNameById.get(model.providerKeyId)!;
-				const ref = `${providerName}/${model.modelName}`;
+				const ref = customModelRef(providerName, model.modelName);
 				return {
 					id: ref,
 					name: model.displayName ? `${model.displayName} (${ref})` : ref,
 					family: "custom",
 					providers: [
-						{ providerId: "custom" as const, externalId: model.modelName },
+						{
+							providerId: "custom" as const,
+							externalId: model.modelName,
+							streaming: true,
+						},
 					],
 				};
 			});

--- a/packages/models/src/compliance.spec.ts
+++ b/packages/models/src/compliance.spec.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
 	countryCodeToFlag,
+	customProviderRef,
 	getProviderCountries,
 	getProviderDefinition,
 	isAttestationCompliant,
+	isModelAllowedByPolicy,
 	isProviderCompliant,
+	isProviderRefAllowedByPolicy,
 	PROVIDER_COUNTRY_NAMES,
 	providers,
 	type ProviderComplianceAttestation,
@@ -289,6 +292,163 @@ describe("isProviderCompliant", () => {
 		);
 		expect(isProviderCompliant(compliant, policy)).toBe(true);
 		expect(isProviderCompliant(wrongCountry, policy)).toBe(false);
+	});
+});
+
+describe("isProviderRefAllowedByPolicy", () => {
+	it("applies no restriction when the policy is disabled or has no lists", () => {
+		expect(
+			isProviderRefAllowedByPolicy("openai", {
+				enabled: false,
+				blockedProviders: ["openai"],
+			}),
+		).toBe(true);
+		expect(isProviderRefAllowedByPolicy("openai", { enabled: true })).toBe(
+			true,
+		);
+	});
+
+	it("blocks providers on the deny list", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedProviders: ["openai", customProviderRef("acme")],
+		};
+		expect(isProviderRefAllowedByPolicy("openai", policy)).toBe(false);
+		expect(isProviderRefAllowedByPolicy("custom:acme", policy)).toBe(false);
+		expect(isProviderRefAllowedByPolicy("anthropic", policy)).toBe(true);
+		expect(isProviderRefAllowedByPolicy("custom:other", policy)).toBe(true);
+	});
+
+	it("a non-empty allow list blocks everything not on it", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			allowedProviders: ["anthropic", customProviderRef("acme")],
+		};
+		expect(isProviderRefAllowedByPolicy("anthropic", policy)).toBe(true);
+		expect(isProviderRefAllowedByPolicy("custom:acme", policy)).toBe(true);
+		expect(isProviderRefAllowedByPolicy("openai", policy)).toBe(false);
+		expect(isProviderRefAllowedByPolicy("custom:other", policy)).toBe(false);
+	});
+
+	it("an empty allow list applies no restriction", () => {
+		expect(
+			isProviderRefAllowedByPolicy("openai", {
+				enabled: true,
+				allowedProviders: [],
+			}),
+		).toBe(true);
+	});
+
+	it("the deny list wins over the allow list", () => {
+		expect(
+			isProviderRefAllowedByPolicy("openai", {
+				enabled: true,
+				allowedProviders: ["openai"],
+				blockedProviders: ["openai"],
+			}),
+		).toBe(false);
+	});
+});
+
+describe("isModelAllowedByPolicy", () => {
+	it("applies no restriction when the policy is disabled or has no lists", () => {
+		expect(
+			isModelAllowedByPolicy(["gpt-5.2"], {
+				enabled: false,
+				blockedModels: ["gpt-5.2"],
+			}),
+		).toBe(true);
+		expect(isModelAllowedByPolicy(["gpt-5.2"], { enabled: true })).toBe(true);
+	});
+
+	it("blocks a model when any of its refs is on the deny list", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedModels: ["acme/my-model"],
+		};
+		expect(isModelAllowedByPolicy(["my-model", "acme/my-model"], policy)).toBe(
+			false,
+		);
+		expect(isModelAllowedByPolicy(["my-model", "other/my-model"], policy)).toBe(
+			true,
+		);
+	});
+
+	it("a non-empty allow list requires one matching ref", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			allowedModels: ["claude-sonnet-4-6", "acme/my-model"],
+		};
+		expect(isModelAllowedByPolicy(["claude-sonnet-4-6"], policy)).toBe(true);
+		expect(isModelAllowedByPolicy(["my-model", "acme/my-model"], policy)).toBe(
+			true,
+		);
+		expect(isModelAllowedByPolicy(["gpt-5.2"], policy)).toBe(false);
+	});
+
+	it("an empty allow list applies no restriction", () => {
+		expect(
+			isModelAllowedByPolicy(["gpt-5.2"], { enabled: true, allowedModels: [] }),
+		).toBe(true);
+	});
+
+	it("the deny list wins over the allow list", () => {
+		expect(
+			isModelAllowedByPolicy(["gpt-5.2"], {
+				enabled: true,
+				allowedModels: ["gpt-5.2"],
+				blockedModels: ["gpt-5.2"],
+			}),
+		).toBe(false);
+	});
+});
+
+describe("isProviderCompliant with provider lists", () => {
+	const compliantDataPolicy = {
+		apiTraining: false,
+		consumerTraining: false,
+		promptLogging: false,
+		soc2: 2 as const,
+	};
+
+	it("blocks a listed provider even when it meets every requirement", () => {
+		const provider = makeProvider(compliantDataPolicy, "US");
+		expect(
+			isProviderCompliant(provider, {
+				enabled: true,
+				requireSoc2: true,
+				blockedProviders: ["test"],
+			}),
+		).toBe(false);
+	});
+
+	it("still requires certifications for allow-listed providers", () => {
+		const uncertified = makeProvider(null, "US");
+		expect(
+			isProviderCompliant(uncertified, {
+				enabled: true,
+				requireSoc2: true,
+				allowedProviders: ["test"],
+			}),
+		).toBe(false);
+		const certified = makeProvider(compliantDataPolicy, "US");
+		expect(
+			isProviderCompliant(certified, {
+				enabled: true,
+				requireSoc2: true,
+				allowedProviders: ["test"],
+			}),
+		).toBe(true);
+	});
+
+	it("blocks providers absent from a non-empty allow list", () => {
+		const provider = makeProvider(compliantDataPolicy, "US");
+		expect(
+			isProviderCompliant(provider, {
+				enabled: true,
+				allowedProviders: ["anthropic"],
+			}),
+		).toBe(false);
 	});
 });
 

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1805,6 +1805,18 @@ export function customProviderRef(customProviderName: string): string {
 }
 
 /**
+ * Policy-list ref for a model served by one of the org's custom providers,
+ * addressed as `<name>/<model>` (the custom provider's routing-prefix name
+ * plus the custom-catalog model name).
+ */
+export function customModelRef(
+	customProviderName: string,
+	modelName: string,
+): string {
+	return `${customProviderName}/${modelName}`;
+}
+
+/**
  * Whether a provider ref passes the policy's fine-grained provider lists.
  * The deny list always wins; a non-empty allow list blocks every provider
  * not on it. This is only the list check — certification/data-policy

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -114,6 +114,33 @@ export interface ProviderCompliancePolicy {
 	 * whenever this list is non-empty (fail-closed).
 	 */
 	allowedCountries?: string[];
+	/**
+	 * Deny list of individual providers. Entries are catalogue provider ids
+	 * (e.g. "openai") or `custom:<name>` refs (see {@link customProviderRef})
+	 * for the org's own custom providers. A listed provider is always blocked,
+	 * even when it satisfies every other requirement, and regardless of any
+	 * user-, member-, or API-key-level rule that would allow it.
+	 */
+	blockedProviders?: string[];
+	/**
+	 * Fine-grained provider allow list. When non-empty, only listed providers
+	 * (same ref format as {@link ProviderCompliancePolicy.blockedProviders})
+	 * may be routed to — and they must still satisfy every other requirement.
+	 * Empty/omitted applies no allow-list restriction.
+	 */
+	allowedProviders?: string[];
+	/**
+	 * Deny list of individual models. Entries are catalogue model ids (e.g.
+	 * "gpt-5.2") or `<customProvider>/<model>` refs for models served through
+	 * an org custom provider. A listed model is always blocked.
+	 */
+	blockedModels?: string[];
+	/**
+	 * Fine-grained model allow list. When non-empty, only listed models (same
+	 * ref format as {@link ProviderCompliancePolicy.blockedModels}) may be
+	 * requested. Empty/omitted applies no allow-list restriction.
+	 */
+	allowedModels?: string[];
 }
 
 export interface ProviderDefinition {
@@ -1768,19 +1795,82 @@ export function isDataPolicyCompliant(
 }
 
 /**
+ * Policy-list ref for one of the org's own custom providers. Custom providers
+ * share the single catalogue id "custom", so restriction lists address them as
+ * `custom:<name>` (the provider key's routing-prefix name) to stay
+ * unambiguous next to catalogue provider ids.
+ */
+export function customProviderRef(customProviderName: string): string {
+	return `custom:${customProviderName}`;
+}
+
+/**
+ * Whether a provider ref passes the policy's fine-grained provider lists.
+ * The deny list always wins; a non-empty allow list blocks every provider
+ * not on it. This is only the list check — certification/data-policy
+ * requirements are evaluated separately.
+ */
+export function isProviderRefAllowedByPolicy(
+	providerRef: string,
+	policy: ProviderCompliancePolicy,
+): boolean {
+	if (!policy.enabled) {
+		return true;
+	}
+	if (policy.blockedProviders?.includes(providerRef)) {
+		return false;
+	}
+	if (
+		policy.allowedProviders &&
+		policy.allowedProviders.length > 0 &&
+		!policy.allowedProviders.includes(providerRef)
+	) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Whether a model passes the policy's fine-grained model lists. `modelRefs`
+ * holds every ref the requested model answers to (the catalogue model id, and
+ * for custom providers additionally `<customProvider>/<model>`): the model is
+ * blocked when any ref is on the deny list, and a non-empty allow list must
+ * contain at least one of the refs.
+ */
+export function isModelAllowedByPolicy(
+	modelRefs: readonly string[],
+	policy: ProviderCompliancePolicy,
+): boolean {
+	if (!policy.enabled) {
+		return true;
+	}
+	if (policy.blockedModels?.some((ref) => modelRefs.includes(ref))) {
+		return false;
+	}
+	if (
+		policy.allowedModels &&
+		policy.allowedModels.length > 0 &&
+		!policy.allowedModels.some((ref) => modelRefs.includes(ref))
+	) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Whether a provider satisfies an organization's compliance policy. Fail-closed:
  * any active requirement that the provider's {@link ProviderDataPolicy} does not
  * explicitly satisfy (including a missing `dataPolicy`) makes the provider
- * non-compliant. A disabled policy treats every provider as compliant.
+ * non-compliant, as does an entry on the policy's fine-grained provider lists.
+ * A disabled policy treats every provider as compliant.
  */
 export function isProviderCompliant(
 	provider: ProviderDefinition,
 	policy: ProviderCompliancePolicy,
 ): boolean {
-	return isDataPolicyCompliant(
-		provider.dataPolicy,
-		provider.headquarters,
-		policy,
+	return (
+		isProviderRefAllowedByPolicy(provider.id, policy) &&
+		isDataPolicyCompliant(provider.dataPolicy, provider.headquarters, policy)
 	);
 }
 

--- a/packages/shared/src/components/multi-provider-selector.tsx
+++ b/packages/shared/src/components/multi-provider-selector.tsx
@@ -16,23 +16,19 @@ import {
 } from "./ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 
-import type { ProviderDefinition } from "@llmgateway/models";
-
-interface ApiProvider {
+/**
+ * Minimal structural shape a selectable provider entry must have. Catalogue
+ * `ProviderDefinition`s, DB-backed API provider rows, and synthetic entries
+ * (e.g. an org's custom providers as `custom:<name>` refs) all satisfy it.
+ */
+export interface SelectableProviderOption {
 	id: string;
-	createdAt: string;
 	name: string | null;
-	description: string | null;
-	streaming: boolean | null;
-	cancellation: boolean | null;
-	color: string | null;
-	website: string | null;
-	announcement: string | null;
-	status: "active" | "inactive";
+	color?: string | null;
 }
 
 interface MultiProviderSelectorProps {
-	providers: readonly ProviderDefinition[] | ApiProvider[];
+	providers: readonly SelectableProviderOption[];
 	selectedProviders: string[];
 	onProvidersChange: (providers: string[]) => void;
 	placeholder?: string;


### PR DESCRIPTION
## Summary

Extends the org-wide compliance page so that, in addition to attribute-based compliance requirements (SOC 2, ISO 27001, GDPR, …), admins can restrict specific providers and models individually via fine-grained allow/deny lists — and makes custom providers first-class citizens in both the compliance settings and the user/team/API-key IAM access settings.

### Policy model (`packages/models`)

- `ProviderCompliancePolicy` gains `blockedProviders`, `allowedProviders`, `blockedModels`, `allowedModels`.
- Deny lists always win; a non-empty allow list blocks everything not on it; empty/omitted lists apply no restriction. Allow-listed providers must still satisfy every active certification/data-policy/country requirement.
- Custom providers are addressed as `custom:<name>` refs (they all share the catalogue id `custom`); custom-catalog models as `<name>/<model>` refs. New helpers: `customProviderRef`, `isProviderRefAllowedByPolicy`, `isModelAllowedByPolicy`; `isProviderCompliant` now composes the list check.

### Gateway enforcement (`apps/gateway`)

- Compliance layer (`lib/compliance.ts`) enforces the lists everywhere the policy already applied: chat (pinned + auto-routing candidate filtering + post-resolution re-check), videos, and all single-provider endpoints via `assertProviderCompliant` (embeddings, speech, transcriptions, rerank, OCR, moderations, realtime), including model-level blocking.
- Applied **after** IAM evaluation, so the org policy takes precedence over member- and API-key-level rules — no user/team/key allow rule can grant access to a provider or model the policy excludes.
- IAM rules (`lib/iam.ts`) now match individual custom providers: `custom:<name>` entries in `allow_providers`/`deny_providers` target one custom provider (the plain `custom` entry still matches all), and `allow_models`/`deny_models` match `<name>/<model>` refs for custom-provider traffic. `validateRequestModelAccess` accepts `customProviderName`, threaded from the chat path.

### API (`apps/api`)

- `PATCH /orgs/{id}` validates the new list fields: catalogue provider/model ids as closed sets, custom refs format-validated against the custom provider name grammar; arrays capped at 500 entries.

### UI (`apps/ui`)

- Compliance page gets a **Provider & Model Restrictions** card reusing the existing shared `MultiProviderSelector` / `MultiModelSelector` components, with the org's custom providers and custom-catalog models included as selectable entries.
- The Provider Impact preview (including custom provider chips) reflects the restriction lists.
- The IAM rules editor (per-API-key and per-member pages) now also offers custom providers and custom models in its selectors, via a new shared `useCustomProviderSelection` hook.
- `MultiProviderSelector`'s props were loosened to a minimal structural `SelectableProviderOption` shape so catalogue and synthetic entries can be mixed (backward compatible).

### Docs

- `features/compliance.mdx`: new "Provider & model restrictions" section (precedence over IAM, custom refs).
- `features/api-keys.mdx`: note on `custom`/`custom:<name>`/`<name>/<model>` matching in provider/model rules.

## Notes

- No DB migration needed — the policy is stored in the existing `organization.provider_compliance_policy` JSON column.
- Custom providers only appear in the selectors for org owners/admins (listing provider keys requires admin); rules referencing custom refs are enforced regardless.

## Testing

- Unit: new predicate tests in `packages/models/src/compliance.spec.ts`, gateway list/custom-ref tests in `apps/gateway/src/lib/compliance.spec.ts`, custom `custom:<name>` / `<name>/<model>` IAM matching tests in `apps/gateway/src/lib/iam.spec.ts` — all passing.
- Integration (`apps/gateway/src/api.spec.ts`): blocked/allowed provider lists on pinned requests, blocked models (sibling models unaffected), individually blocked custom provider despite a compliant attestation, custom model blocked via its `<name>/<model>` ref — all passing.
- `pnpm build` (all apps) and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHxcb6bpzU9VYmXkmrXifS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHxcb6bpzU9VYmXkmrXifS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider/model restriction allowlists and blocklists to compliance policies (including custom providers and custom-provider models).
  * IAM rule evaluation and request routing now respect these restrictions for chat and video requests.
  * Compliance UI now includes controls for configuring provider & model restrictions.
* **Documentation**
  * Updated provider access and compliance docs to describe restriction formats and enforcement behavior.
* **Tests**
  * Added coverage for custom provider/model restriction scenarios and enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->