### PR TITLE
chore(security): fix brace-expansion DoS (CVE-2026-14257)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
 			"valibot@<1.4.2": "^1.4.2",
 			"body-parser@<1.20.6": "^1.20.6",
 			"body-parser@>=2 <2.3.0": "^2.3.0",
-			"brace-expansion@>=1 <2.1.3": "2.1.3",
-			"brace-expansion@>=5 <5.0.8": "5.0.8",
+			"brace-expansion@<5.0.8": "5.0.8",
 			"mermaid@>=11 <11.15.0": "^11.15.0",
 			"js-yaml@<4.3.0": "^4.3.0",
 			"mdast-util-to-hast@>=13 <13.2.1": "^13.2.1",
@@ -130,7 +129,8 @@
 			}
 		},
 		"patchedDependencies": {
-			"gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch"
+			"gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch",
+			"brace-expansion@5.0.8": "patches/brace-expansion@5.0.8.patch"
 		}
 	},
 	"dependencies": {

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -1,5 +1,18 @@
+diff --git a/dist/commonjs/index.d.ts b/dist/commonjs/index.d.ts
+index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e59233f2208c 100644
+--- a/dist/commonjs/index.d.ts
++++ b/dist/commonjs/index.d.ts
+@@ -5,4 +5,7 @@ export type BraceExpansionOptions = {
+     maxLength?: number;
+ };
+ export declare function expand(str: string, options?: BraceExpansionOptions): string[];
++// The runtime patch exposes `expand` as the callable default export;
++// declare it so `import expand from "brace-expansion"` type-checks too.
++export default expand;
+ //# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
 diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
-index be9df86be09c7655787a65c55ae6da01858894c3..25b4bc28ab55aca5e14ec9e24d2e1540732fe4e6 100644
+index be9df86be09c7655787a65c55ae6da01858894c3..d2844a0189495dc94e16afc5bb629c522e0df130 100644
 --- a/dist/commonjs/index.js
 +++ b/dist/commonjs/index.js
 @@ -261,3 +261,15 @@ function expand_(str, max, maxLength, isTop) {
@@ -18,8 +31,22 @@ index be9df86be09c7655787a65c55ae6da01858894c3..25b4bc28ab55aca5e14ec9e24d2e1540
 +expand.EXPANSION_MAX_LENGTH = exports.EXPANSION_MAX_LENGTH;
 +Object.defineProperty(expand, "__esModule", { value: true });
 +module.exports = expand;
+\ No newline at end of file
+diff --git a/dist/esm/index.d.ts b/dist/esm/index.d.ts
+index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e59233f2208c 100644
+--- a/dist/esm/index.d.ts
++++ b/dist/esm/index.d.ts
+@@ -5,4 +5,7 @@ export type BraceExpansionOptions = {
+     maxLength?: number;
+ };
+ export declare function expand(str: string, options?: BraceExpansionOptions): string[];
++// The runtime patch exposes `expand` as the callable default export;
++// declare it so `import expand from "brace-expansion"` type-checks too.
++export default expand;
+ //# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
 diff --git a/dist/esm/index.js b/dist/esm/index.js
-index 6dc0392fc0feedb811e63d70a30be2736af17a3a..1a912d5e9778afe14cb678c7264dc057240a7185 100644
+index 6dc0392fc0feedb811e63d70a30be2736af17a3a..88b481d7fa0b246d7100781d4c4f61b472acd2cc 100644
 --- a/dist/esm/index.js
 +++ b/dist/esm/index.js
 @@ -257,3 +257,6 @@ function expand_(str, max, maxLength, isTop) {

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/commonjs/index.d.ts b/dist/commonjs/index.d.ts
-index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e59233f2208c 100644
+index f3e2de9..af4e6e3 100644
 --- a/dist/commonjs/index.d.ts
 +++ b/dist/commonjs/index.d.ts
 @@ -5,4 +5,7 @@ export type BraceExpansionOptions = {
@@ -12,13 +12,13 @@ index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e592
  //# sourceMappingURL=index.d.ts.map
 \ No newline at end of file
 diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
-index be9df86be09c7655787a65c55ae6da01858894c3..d2844a0189495dc94e16afc5bb629c522e0df130 100644
+index be9df86..0744f0b 100644
 --- a/dist/commonjs/index.js
 +++ b/dist/commonjs/index.js
-@@ -261,3 +261,15 @@ function expand_(str, max, maxLength, isTop) {
+@@ -260,4 +260,16 @@ function expand_(str, max, maxLength, isTop) {
+     }
      return acc;
  }
- //# sourceMappingURL=index.js.map
 +// Backward-compat: expose the callable `expand` as the CommonJS default export.
 +// brace-expansion <5 used `module.exports = expand`, and consumers such as
 +// minimatch@3.x do `const expand = require('brace-expansion')` then call it
@@ -31,9 +31,10 @@ index be9df86be09c7655787a65c55ae6da01858894c3..d2844a0189495dc94e16afc5bb629c52
 +expand.EXPANSION_MAX_LENGTH = exports.EXPANSION_MAX_LENGTH;
 +Object.defineProperty(expand, "__esModule", { value: true });
 +module.exports = expand;
+ //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/dist/esm/index.d.ts b/dist/esm/index.d.ts
-index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e59233f2208c 100644
+index f3e2de9..af4e6e3 100644
 --- a/dist/esm/index.d.ts
 +++ b/dist/esm/index.d.ts
 @@ -5,4 +5,7 @@ export type BraceExpansionOptions = {
@@ -46,13 +47,15 @@ index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e592
  //# sourceMappingURL=index.d.ts.map
 \ No newline at end of file
 diff --git a/dist/esm/index.js b/dist/esm/index.js
-index 6dc0392fc0feedb811e63d70a30be2736af17a3a..88b481d7fa0b246d7100781d4c4f61b472acd2cc 100644
+index 6dc0392..633d61a 100644
 --- a/dist/esm/index.js
 +++ b/dist/esm/index.js
-@@ -257,3 +257,6 @@ function expand_(str, max, maxLength, isTop) {
+@@ -256,4 +256,7 @@ function expand_(str, max, maxLength, isTop) {
+     }
      return acc;
  }
- //# sourceMappingURL=index.js.map
 +// Provide a default export mirroring the pre-5.x callable export so consumers
 +// doing `import expand from 'brace-expansion'` keep working.
 +export default expand;
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index be9df86be09c7655787a65c55ae6da01858894c3..25b4bc28ab55aca5e14ec9e24d2e1540732fe4e6 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -261,3 +261,15 @@ function expand_(str, max, maxLength, isTop) {
+     return acc;
+ }
+ //# sourceMappingURL=index.js.map
++// Backward-compat: expose the callable `expand` as the CommonJS default export.
++// brace-expansion <5 used `module.exports = expand`, and consumers such as
++// minimatch@3.x do `const expand = require('brace-expansion')` then call it
++// directly. 5.x switched to a named-only `exports.expand`, which breaks them
++// ("expand is not a function"). Re-attach the named members onto the function
++// and export it as the default while keeping `.expand` for modern callers.
++expand.expand = expand;
++expand.default = expand;
++expand.EXPANSION_MAX = exports.EXPANSION_MAX;
++expand.EXPANSION_MAX_LENGTH = exports.EXPANSION_MAX_LENGTH;
++Object.defineProperty(expand, "__esModule", { value: true });
++module.exports = expand;
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 6dc0392fc0feedb811e63d70a30be2736af17a3a..1a912d5e9778afe14cb678c7264dc057240a7185 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -257,3 +257,6 @@ function expand_(str, max, maxLength, isTop) {
+     return acc;
+ }
+ //# sourceMappingURL=index.js.map
++// Provide a default export mirroring the pre-5.x callable export so consumers
++// doing `import expand from 'brace-expansion'` keep working.
++export default expand;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
 patchedDependencies:
   brace-expansion@5.0.8:
-    hash: 7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979
+    hash: 3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98
     path: patches/brace-expansion@5.0.8.patch
   gray-matter@4.0.3:
     hash: 5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc
@@ -18507,7 +18507,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979):
+  brace-expansion@5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98):
     dependencies:
       balanced-match: 4.0.4
 
@@ -22337,19 +22337,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
+      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
+      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
+      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
+      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,7 @@ overrides:
   valibot@<1.4.2: ^1.4.2
   body-parser@<1.20.6: ^1.20.6
   body-parser@>=2 <2.3.0: ^2.3.0
-  brace-expansion@>=1 <2.1.3: 2.1.3
-  brace-expansion@>=5 <5.0.8: 5.0.8
+  brace-expansion@<5.0.8: 5.0.8
   mermaid@>=11 <11.15.0: ^11.15.0
   js-yaml@<4.3.0: ^4.3.0
   mdast-util-to-hast@>=13 <13.2.1: ^13.2.1
@@ -57,6 +56,9 @@ overrides:
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
 patchedDependencies:
+  brace-expansion@5.0.8:
+    hash: 1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7
+    path: patches/brace-expansion@5.0.8.patch
   gray-matter@4.0.3:
     hash: 5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc
     path: patches/gray-matter@4.0.3.patch
@@ -6620,9 +6622,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -6751,9 +6750,6 @@ packages:
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
-
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -18337,8 +18333,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-arraybuffer@1.0.2:
@@ -18513,11 +18507,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@2.1.3:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7):
     dependencies:
       balanced-match: 4.0.4
 
@@ -22347,19 +22337,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
 patchedDependencies:
   brace-expansion@5.0.8:
-    hash: 1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7
+    hash: 7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979
     path: patches/brace-expansion@5.0.8.patch
   gray-matter@4.0.3:
     hash: 5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc
@@ -18507,7 +18507,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7):
+  brace-expansion@5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979):
     dependencies:
       balanced-match: 4.0.4
 
@@ -22337,19 +22337,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
+      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
+      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
+      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=1959badb16c8fd0611448925b64c89be369d943272a1d47081a123fb5052dee7)
+      brace-expansion: 5.0.8(patch_hash=7629e26d6eb30e64c89238ea359dc60bc2e6dfc38e471997181f81e581109979)
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

Resolves the open **high**-severity Dependabot alert for `brace-expansion` — **GHSA-mh99-v99m-4gvg / CVE-2026-14257** (DoS via unbounded expansion length causing an out-of-memory process crash).

## What was wrong

The existing overrides pinned the 1.x/2.x line of `brace-expansion` to `2.1.3`:

```jsonc
"brace-expansion@>=1 <2.1.3": "2.1.3",
"brace-expansion@>=5 <5.0.8": "5.0.8",
```

The advisory's affected range is a flat `<5.0.8`, so `2.1.3` is still flagged even though it contains a backported fix. Only `5.0.8` is unambiguously outside the advisory range, so the alert stays open until every resolved copy is `>=5.0.8`.

## Fix

- **Consolidate the override** to force all `brace-expansion` below `5.0.8` up to the patched `5.0.8`:

  ```jsonc
  "brace-expansion@<5.0.8": "5.0.8",
  ```

  After this, the lockfile resolves `brace-expansion` to a single `5.0.8` and `pnpm audit` reports no high/critical vulnerabilities.

- **Patch `brace-expansion@5.0.8` for backward compatibility** (`patches/brace-expansion@5.0.8.patch`). Version 5 dropped the CommonJS default export (`module.exports = expand`) in favour of a named-only `exports.expand`, which breaks default-import consumers such as `minimatch@3.x` (used transitively by ESLint) with `TypeError: expand is not a function`. The patch re-exposes the callable function as the default export while keeping the named `expand` export and the module's constants — purely additive, matching the pre-5.x behaviour. This follows the repo's existing `patchedDependencies` convention.

## Verification

- `pnpm audit --audit-level high` → no high/critical findings (1 unrelated moderate remains, out of scope)
- Full OSV scan of all 1435 lockfile entries → no remaining high/critical
- GitHub Actions pins scanned against OSV → clean
- `pnpm format` ✓ (0 errors)
- `pnpm build` ✓ (17/17 packages)
- `pnpm test:unit` ✓ (3424 passed, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uc9wmKUo4RsEtoj7zyFwr

---
_Generated by [Claude Code](https://claude.ai/code/session_015uc9wmKUo4RsEtoj7zyFwr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compatibility for `brace-expansion` default-import and callable-export usage while preserving existing member exports.
  * Updated TypeScript declarations to ensure default imports type-check correctly.
* **Maintenance**
  * Adjusted dependency version override rules to apply a single targeted range override for `brace-expansion`.
  * Added an additional patch for `brace-expansion@5.0.8` to support the restored export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->