### PR TITLE
feat(playground): resume calls and replay audio

### DIFF
--- a/apps/api/src/routes/playground-realtime-history.spec.ts
+++ b/apps/api/src/routes/playground-realtime-history.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { db } from "@llmgateway/db";
+import { db, tables } from "@llmgateway/db";
 
 const usage = {
 	responses: 2,
@@ -137,7 +137,32 @@ describe("playground realtime history", () => {
 	});
 
 	test("PATCH 404s on a call the user does not own", async () => {
-		const res = await patchCall(token, "does-not-exist", { title: "Nope" });
+		const missing = await patchCall(token, "does-not-exist", { title: "Nope" });
+		expect(missing.status).toBe(404);
+
+		// Another user's existing call must look identical to a missing one.
+		await db.insert(tables.user).values({
+			id: "other-user-id",
+			name: "Other User",
+			email: "other@example.com",
+			emailVerified: true,
+		});
+		const [theirs] = await db
+			.insert(tables.playgroundRealtimeHistory)
+			.values({
+				userId: "other-user-id",
+				title: "Their call",
+				model: "openai/gpt-realtime",
+				transcript: [turn("their message")],
+			})
+			.returning({ id: tables.playgroundRealtimeHistory.id });
+
+		const res = await patchCall(token, theirs.id, { title: "Nope" });
 		expect(res.status).toBe(404);
+
+		const row = await db.query.playgroundRealtimeHistory.findFirst({
+			where: { id: { eq: theirs.id } },
+		});
+		expect(row?.title).toBe("Their call");
 	});
 });

--- a/apps/api/src/routes/playground-realtime-history.spec.ts
+++ b/apps/api/src/routes/playground-realtime-history.spec.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db } from "@llmgateway/db";
+
+const usage = {
+	responses: 2,
+	inputTokens: 100,
+	outputTokens: 40,
+	totalTokens: 140,
+	audioInputTokens: 60,
+	audioOutputTokens: 30,
+};
+
+function turn(text: string, role: "user" | "assistant" = "user") {
+	return { role, text, status: "final" as const, timestamp: 1_700_000_000_000 };
+}
+
+async function createCall(token: string, body: Record<string, unknown> = {}) {
+	const res = await app.request("/playground/realtime-history", {
+		method: "POST",
+		headers: { "Content-Type": "application/json", Cookie: token },
+		body: JSON.stringify({
+			title: "Test call",
+			model: "openai/gpt-realtime",
+			durationSeconds: 30,
+			transcript: [turn("hello"), turn("hi there", "assistant")],
+			usage,
+			...body,
+		}),
+	});
+	expect(res.status).toBe(201);
+	const json = await res.json();
+	return json.item as { id: string; turnCount: number };
+}
+
+async function patchCall(
+	token: string,
+	id: string,
+	body: Record<string, unknown>,
+) {
+	return await app.request(`/playground/realtime-history/${id}`, {
+		method: "PATCH",
+		headers: { "Content-Type": "application/json", Cookie: token },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("playground realtime history", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("round-trips assistant audio on a transcript entry", async () => {
+		const audio = { base64: "UklGRgAAAABXQVZF", mediaType: "audio/wav" };
+		const item = await createCall(token, {
+			transcript: [turn("hello"), { ...turn("hi", "assistant"), audio }],
+		});
+
+		const res = await app.request(`/playground/realtime-history/${item.id}`, {
+			headers: { Cookie: token },
+		});
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.item.transcript[0].audio).toBeUndefined();
+		expect(json.item.transcript[1].audio).toEqual(audio);
+	});
+
+	test("PATCH renames without touching the transcript", async () => {
+		const item = await createCall(token);
+
+		const res = await patchCall(token, item.id, { title: "Renamed" });
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.item.title).toBe("Renamed");
+		expect(json.item.turnCount).toBe(2);
+		expect(json.item.durationSeconds).toBe(30);
+	});
+
+	test("PATCH appends turns and sums duration and usage", async () => {
+		const item = await createCall(token);
+
+		const res = await patchCall(token, item.id, {
+			appendTranscript: [turn("and again"), turn("sure", "assistant")],
+			addDurationSeconds: 12,
+			addUsage: usage,
+		});
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.item.turnCount).toBe(4);
+		expect(json.item.durationSeconds).toBe(42);
+
+		const row = await db.query.playgroundRealtimeHistory.findFirst({
+			where: { id: { eq: item.id } },
+		});
+		expect(row?.transcript.map((entry) => entry.text)).toEqual([
+			"hello",
+			"hi there",
+			"and again",
+			"sure",
+		]);
+		expect(row?.usage).toEqual({
+			responses: 4,
+			inputTokens: 200,
+			outputTokens: 80,
+			totalTokens: 280,
+			audioInputTokens: 120,
+			audioOutputTokens: 60,
+		});
+	});
+
+	test("PATCH sums usage onto a call that had none", async () => {
+		const item = await createCall(token, { usage: undefined });
+
+		const res = await patchCall(token, item.id, { addUsage: usage });
+		expect(res.status).toBe(200);
+
+		const row = await db.query.playgroundRealtimeHistory.findFirst({
+			where: { id: { eq: item.id } },
+		});
+		expect(row?.usage).toEqual(usage);
+	});
+
+	// A no-op body would otherwise reach Drizzle as an empty .set(), which throws.
+	test("PATCH rejects an empty body", async () => {
+		const item = await createCall(token);
+		const res = await patchCall(token, item.id, {});
+		expect(res.status).toBe(400);
+	});
+
+	test("PATCH 404s on a call the user does not own", async () => {
+		const res = await patchCall(token, "does-not-exist", { title: "Nope" });
+		expect(res.status).toBe(404);
+	});
+});

--- a/apps/api/src/routes/playground.ts
+++ b/apps/api/src/routes/playground.ts
@@ -1142,6 +1142,14 @@ const realtimeTranscriptEntrySchema = z.object({
 	text: z.string(),
 	status: z.enum(["partial", "final", "interrupted"]),
 	timestamp: z.number(),
+	// Assistant speech for the turn as a base64 WAV, so a saved call can be
+	// listened to and not just read.
+	audio: z
+		.object({
+			base64: z.string().max(48_000_000),
+			mediaType: z.literal("audio/wav"),
+		})
+		.optional(),
 });
 
 const realtimeUsageSchema = z.object({
@@ -1373,7 +1381,10 @@ playground.openapi(saveRealtimeHistory, async (c) => {
 
 // ── PATCH /realtime-history/:id ──────────────────────────────────────────────
 
-const renameRealtimeHistory = createRoute({
+// Renames a call, and/or grows it with the turns of a continued session: a
+// resumed call appends to the row it continued rather than starting a new one,
+// so one conversation stays one history entry.
+const updateRealtimeHistory = createRoute({
 	method: "patch",
 	path: "/realtime-history/{id}",
 	request: {
@@ -1381,7 +1392,21 @@ const renameRealtimeHistory = createRoute({
 		body: {
 			content: {
 				"application/json": {
-					schema: z.object({ title: z.string().trim().min(1).max(200) }),
+					schema: z
+						.object({
+							title: z.string().trim().min(1).max(200).optional(),
+							appendTranscript: z
+								.array(realtimeTranscriptEntrySchema)
+								.min(1)
+								.optional(),
+							addDurationSeconds: z.number().int().min(0).optional(),
+							addUsage: realtimeUsageSchema.optional(),
+						})
+						.refine(
+							(body) =>
+								Object.values(body).some((value) => value !== undefined),
+							{ message: "At least one field must be provided" },
+						),
 				},
 			},
 		},
@@ -1398,18 +1423,68 @@ const renameRealtimeHistory = createRoute({
 	},
 });
 
-playground.openapi(renameRealtimeHistory, async (c) => {
+playground.openapi(updateRealtimeHistory, async (c) => {
 	const user = c.get("user");
 	if (!user) {
 		throw new HTTPException(401, { message: "Unauthorized" });
 	}
 
 	const { id } = c.req.valid("param");
-	const { title } = c.req.valid("json");
+	const body = c.req.valid("json");
+
+	// Appending needs the current transcript/duration/usage, so this is a
+	// read-modify-write. Two continuations of the same call finishing at once
+	// could drop one side's turns, which needs two concurrent live calls on one
+	// saved conversation — not reachable from the single-call UI.
+	const [existing] = await db
+		.select()
+		.from(tables.playgroundRealtimeHistory)
+		.where(
+			and(
+				eq(tables.playgroundRealtimeHistory.id, id),
+				eq(tables.playgroundRealtimeHistory.userId, user.id),
+			),
+		);
+
+	if (!existing) {
+		throw new HTTPException(404, { message: "Not found" });
+	}
+
+	const addUsage = body.addUsage;
+	const previousUsage = existing.usage;
 
 	const [row] = await db
 		.update(tables.playgroundRealtimeHistory)
-		.set({ title })
+		.set({
+			...(body.title !== undefined ? { title: body.title } : {}),
+			...(body.appendTranscript
+				? { transcript: [...existing.transcript, ...body.appendTranscript] }
+				: {}),
+			...(body.addDurationSeconds !== undefined
+				? {
+						durationSeconds: existing.durationSeconds + body.addDurationSeconds,
+					}
+				: {}),
+			...(addUsage
+				? {
+						usage: {
+							responses: (previousUsage?.responses ?? 0) + addUsage.responses,
+							inputTokens:
+								(previousUsage?.inputTokens ?? 0) + addUsage.inputTokens,
+							outputTokens:
+								(previousUsage?.outputTokens ?? 0) + addUsage.outputTokens,
+							totalTokens:
+								(previousUsage?.totalTokens ?? 0) + addUsage.totalTokens,
+							audioInputTokens:
+								(previousUsage?.audioInputTokens ?? 0) +
+								addUsage.audioInputTokens,
+							audioOutputTokens:
+								(previousUsage?.audioOutputTokens ?? 0) +
+								addUsage.audioOutputTokens,
+						},
+					}
+				: {}),
+		})
 		.where(
 			and(
 				eq(tables.playgroundRealtimeHistory.id, id),

--- a/apps/api/src/routes/playground.ts
+++ b/apps/api/src/routes/playground.ts
@@ -1433,65 +1433,66 @@ playground.openapi(updateRealtimeHistory, async (c) => {
 	const body = c.req.valid("json");
 
 	// Appending needs the current transcript/duration/usage, so this is a
-	// read-modify-write. Two continuations of the same call finishing at once
-	// could drop one side's turns, which needs two concurrent live calls on one
-	// saved conversation — not reachable from the single-call UI.
-	const [existing] = await db
-		.select()
-		.from(tables.playgroundRealtimeHistory)
-		.where(
-			and(
-				eq(tables.playgroundRealtimeHistory.id, id),
-				eq(tables.playgroundRealtimeHistory.userId, user.id),
-			),
-		);
+	// read-modify-write. The row lock serializes two continuations of the same
+	// call finishing at once (e.g. from two tabs), so the later one appends to
+	// the earlier one's result instead of overwriting it from a stale read.
+	const row = await db.transaction(async (tx) => {
+		const [existing] = await tx
+			.select()
+			.from(tables.playgroundRealtimeHistory)
+			.where(
+				and(
+					eq(tables.playgroundRealtimeHistory.id, id),
+					eq(tables.playgroundRealtimeHistory.userId, user.id),
+				),
+			)
+			.for("update");
 
-	if (!existing) {
-		throw new HTTPException(404, { message: "Not found" });
-	}
+		if (!existing) {
+			throw new HTTPException(404, { message: "Not found" });
+		}
 
-	const addUsage = body.addUsage;
-	const previousUsage = existing.usage;
+		const addUsage = body.addUsage;
+		const previousUsage = existing.usage;
 
-	const [row] = await db
-		.update(tables.playgroundRealtimeHistory)
-		.set({
-			...(body.title !== undefined ? { title: body.title } : {}),
-			...(body.appendTranscript
-				? { transcript: [...existing.transcript, ...body.appendTranscript] }
-				: {}),
-			...(body.addDurationSeconds !== undefined
-				? {
-						durationSeconds: existing.durationSeconds + body.addDurationSeconds,
-					}
-				: {}),
-			...(addUsage
-				? {
-						usage: {
-							responses: (previousUsage?.responses ?? 0) + addUsage.responses,
-							inputTokens:
-								(previousUsage?.inputTokens ?? 0) + addUsage.inputTokens,
-							outputTokens:
-								(previousUsage?.outputTokens ?? 0) + addUsage.outputTokens,
-							totalTokens:
-								(previousUsage?.totalTokens ?? 0) + addUsage.totalTokens,
-							audioInputTokens:
-								(previousUsage?.audioInputTokens ?? 0) +
-								addUsage.audioInputTokens,
-							audioOutputTokens:
-								(previousUsage?.audioOutputTokens ?? 0) +
-								addUsage.audioOutputTokens,
-						},
-					}
-				: {}),
-		})
-		.where(
-			and(
-				eq(tables.playgroundRealtimeHistory.id, id),
-				eq(tables.playgroundRealtimeHistory.userId, user.id),
-			),
-		)
-		.returning();
+		const [updated] = await tx
+			.update(tables.playgroundRealtimeHistory)
+			.set({
+				...(body.title !== undefined ? { title: body.title } : {}),
+				...(body.appendTranscript
+					? { transcript: [...existing.transcript, ...body.appendTranscript] }
+					: {}),
+				...(body.addDurationSeconds !== undefined
+					? {
+							durationSeconds:
+								existing.durationSeconds + body.addDurationSeconds,
+						}
+					: {}),
+				...(addUsage
+					? {
+							usage: {
+								responses: (previousUsage?.responses ?? 0) + addUsage.responses,
+								inputTokens:
+									(previousUsage?.inputTokens ?? 0) + addUsage.inputTokens,
+								outputTokens:
+									(previousUsage?.outputTokens ?? 0) + addUsage.outputTokens,
+								totalTokens:
+									(previousUsage?.totalTokens ?? 0) + addUsage.totalTokens,
+								audioInputTokens:
+									(previousUsage?.audioInputTokens ?? 0) +
+									addUsage.audioInputTokens,
+								audioOutputTokens:
+									(previousUsage?.audioOutputTokens ?? 0) +
+									addUsage.audioOutputTokens,
+							},
+						}
+					: {}),
+			})
+			.where(eq(tables.playgroundRealtimeHistory.id, existing.id))
+			.returning();
+
+		return updated;
+	});
 
 	if (!row) {
 		throw new HTTPException(404, { message: "Not found" });

--- a/apps/playground/src/components/playground/call-history-list.tsx
+++ b/apps/playground/src/components/playground/call-history-list.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input";
 import { SidebarMenuAction, SidebarMenuButton } from "@/components/ui/sidebar";
 import {
 	useDeleteRealtimeHistory,
-	useRenameRealtimeHistory,
+	useUpdateRealtimeHistory,
 } from "@/hooks/usePlaygroundHistory";
 import { formatCallDuration } from "@/lib/call-history";
 
@@ -315,7 +315,7 @@ export function CallHistoryList({
 	onItemClick,
 	onItemDeleted,
 }: CallHistoryListProps) {
-	const renameItem = useRenameRealtimeHistory();
+	const renameItem = useUpdateRealtimeHistory();
 	const deleteItem = useDeleteRealtimeHistory();
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editTitle, setEditTitle] = useState("");

--- a/apps/playground/src/components/playground/realtime-page-client.tsx
+++ b/apps/playground/src/components/playground/realtime-page-client.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { Mic, MicOff, Phone, PhoneOff } from "lucide-react";
+import {
+	Mic,
+	MicOff,
+	Phone,
+	PhoneForwarded,
+	PhoneOff,
+	Play,
+	Square,
+} from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { Action, Actions } from "@/components/ai-elements/actions";
 import { ModelSelector } from "@/components/model-selector";
 import { AuthDialog } from "@/components/playground/auth-dialog";
 import { RealtimeSidebar } from "@/components/playground/realtime-sidebar";
@@ -22,12 +31,14 @@ import {
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import {
 	useRealtimeCall,
+	type RealtimeTranscriptEntry,
 	type RealtimeCallStatus,
 } from "@/hooks/use-realtime-call";
 import {
 	useRealtimeHistory,
 	useRealtimeHistoryItem,
 	useSaveRealtimeHistory,
+	useUpdateRealtimeHistory,
 } from "@/hooks/usePlaygroundHistory";
 import { useUser } from "@/hooks/useUser";
 import { deriveCallTitle, formatCallDuration } from "@/lib/call-history";
@@ -36,6 +47,7 @@ import {
 	REALTIME_MODEL_COOKIE,
 	setModelPreferenceCookie,
 } from "@/lib/model-preferences";
+import { base64ToBytes } from "@/lib/realtime-audio";
 import { cn } from "@/lib/utils";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
@@ -61,6 +73,18 @@ const STATUS_LABELS: Record<RealtimeCallStatus, string> = {
 	live: "Live",
 	ending: "Ending…",
 };
+
+/**
+ * Replayed turns are re-sent to the model as conversation items, so a long
+ * thread costs input tokens on the first response of the continued call.
+ * Past either threshold the user gets a heads-up rather than a surprise bill.
+ */
+const REPLAY_TURN_WARNING = 20;
+const REPLAY_CHAR_WARNING = 8000;
+/** Marks a turn that came from the continued call rather than this session. */
+const SEED_ID_PREFIX = "seed-";
+/** How close to the bottom still counts as "following" the live transcript. */
+const FOLLOW_TRANSCRIPT_THRESHOLD_PX = 64;
 
 /**
  * Restrict the catalogue to models that have at least one active realtime
@@ -182,6 +206,7 @@ export default function RealtimePageClient({
 		selectedOrganization?.id,
 	);
 	const { mutate: saveCallHistory } = useSaveRealtimeHistory();
+	const { mutate: updateCallHistory } = useUpdateRealtimeHistory();
 	const [viewedCallId, setViewedCallId] = useState<string | null>(null);
 	const { data: viewedCallData, isLoading: isViewedCallLoading } =
 		useRealtimeHistoryItem(inCall ? null : viewedCallId);
@@ -191,6 +216,9 @@ export default function RealtimePageClient({
 	// deliberately does not store conversation content.
 	const savedCallRef = useRef(false);
 	const previousStatusRef = useRef<RealtimeCallStatus>("idle");
+	// Set while this session continues a saved call: its turns are appended to
+	// that row instead of starting a second history entry.
+	const continuedCallIdRef = useRef<string | null>(null);
 	// Latest-ref so the unmount cleanup below saves current (not first-render)
 	// call state.
 	const persistCallRef = useRef<() => void>(() => {});
@@ -202,27 +230,68 @@ export default function RealtimePageClient({
 		if (spoken.length === 0 || !selectedModel) {
 			return;
 		}
-		savedCallRef.current = true;
-		saveCallHistory({
-			body: {
-				title: deriveCallTitle(spoken),
-				model: selectedModel,
-				durationSeconds: elapsedSeconds,
-				// Upstream item ids are dropped: they identify a session that no
-				// longer exists and are not needed to replay the conversation.
-				transcript: spoken.map((entry) => ({
-					role: entry.role,
-					text: entry.text,
-					status: entry.status,
-					timestamp: entry.timestamp,
-				})),
-				usage,
-				...(voice ? { voice } : {}),
-				...(selectedOrganization?.id
-					? { organizationId: selectedOrganization.id }
-					: {}),
-			},
+		const continuedCallId = continuedCallIdRef.current;
+		// Upstream item ids are dropped: they identify a session that no longer
+		// exists and are not needed to replay the conversation.
+		const toEntry = (entry: RealtimeTranscriptEntry) => ({
+			role: entry.role,
+			text: entry.text,
+			status: entry.status,
+			timestamp: entry.timestamp,
+			...(entry.audio ? { audio: entry.audio } : {}),
 		});
+
+		if (continuedCallId) {
+			// Replayed turns are already stored on the row being continued.
+			const newTurns = spoken.filter(
+				(entry) => !entry.id.startsWith(SEED_ID_PREFIX),
+			);
+			if (newTurns.length === 0) {
+				// Nothing new was said, so there is nothing to append — but the
+				// session still belongs to that call, and leaving it deselected would
+				// hide both its header and the button to continue it again.
+				setViewedCallId(continuedCallId);
+				return;
+			}
+			savedCallRef.current = true;
+			// Duration and usage are session-only counters; the server adds them
+			// to what the row already holds.
+			updateCallHistory(
+				{
+					params: { path: { id: continuedCallId } },
+					body: {
+						appendTranscript: newTurns.map(toEntry),
+						addDurationSeconds: elapsedSeconds,
+						addUsage: usage,
+					},
+				},
+				// Reopen the call so its summary header is there as soon as the call
+				// ends, instead of only after picking it out of the sidebar. Settled
+				// rather than success: a failed append still has to return the user
+				// to the call they were on. The hook seeds the detail cache before
+				// this runs, so the reopen reads from memory without a loading flash.
+				{ onSettled: () => setViewedCallId(continuedCallId) },
+			);
+			return;
+		}
+
+		savedCallRef.current = true;
+		saveCallHistory(
+			{
+				body: {
+					title: deriveCallTitle(spoken),
+					model: selectedModel,
+					durationSeconds: elapsedSeconds,
+					transcript: spoken.map(toEntry),
+					usage,
+					...(voice ? { voice } : {}),
+					...(selectedOrganization?.id
+						? { organizationId: selectedOrganization.id }
+						: {}),
+				},
+			},
+			{ onSuccess: (data) => setViewedCallId(data.item.id) },
+		);
 	};
 	useEffect(() => {
 		const previous = previousStatusRef.current;
@@ -261,6 +330,7 @@ export default function RealtimePageClient({
 				role: entry.role,
 				text: entry.text,
 				status: entry.status,
+				audio: entry.audio,
 			}));
 		}
 		return transcript.map((entry) => ({
@@ -268,8 +338,95 @@ export default function RealtimePageClient({
 			role: entry.role,
 			text: entry.text,
 			status: entry.status,
+			audio: entry.audio,
 		}));
 	}, [isViewingHistory, transcript, viewedCall]);
+
+	// One clip plays at a time, decoded into a blob URL on demand so the base64
+	// WAVs are not eagerly turned into objects for every turn on screen.
+	const [playingKey, setPlayingKey] = useState<string | null>(null);
+	const audioElementRef = useRef<HTMLAudioElement | null>(null);
+	const blobUrlRef = useRef<string | null>(null);
+
+	const stopPlayback = useCallback(() => {
+		const element = audioElementRef.current;
+		audioElementRef.current = null;
+		if (element) {
+			// Detached first so a late "ended" from the outgoing clip cannot clear
+			// the state of the one replacing it.
+			element.onended = null;
+			element.pause();
+		}
+		if (blobUrlRef.current) {
+			URL.revokeObjectURL(blobUrlRef.current);
+			blobUrlRef.current = null;
+		}
+		setPlayingKey(null);
+	}, []);
+
+	const playTurnAudio = useCallback(
+		(key: string, base64: string) => {
+			stopPlayback();
+			const url = URL.createObjectURL(
+				new Blob([base64ToBytes(base64)], { type: "audio/wav" }),
+			);
+			blobUrlRef.current = url;
+			const element = new Audio(url);
+			audioElementRef.current = element;
+			element.onended = stopPlayback;
+			setPlayingKey(key);
+			void element.play().catch(() => {
+				toast.error("Could not play this turn.");
+				stopPlayback();
+			});
+		},
+		[stopPlayback],
+	);
+
+	// Whatever is playing belongs to the turns on screen: opening another call,
+	// closing one, or starting a new call invalidates it — as does unmounting.
+	useEffect(() => {
+		return () => {
+			stopPlayback();
+		};
+	}, [inCall, stopPlayback, viewedCallId]);
+
+	// A turn's audio is attached at response.done, while the live scheduler is
+	// often still draining the tail of that same speech. Replaying it then would
+	// play the response over itself, so manual playback yields to the call.
+	useEffect(() => {
+		if (assistantSpeaking) {
+			stopPlayback();
+		}
+	}, [assistantSpeaking, stopPlayback]);
+
+	const transcriptScrollRef = useRef<HTMLDivElement | null>(null);
+	const followTranscriptRef = useRef(true);
+
+	const handleTranscriptScroll = useCallback(
+		(event: React.UIEvent<HTMLDivElement>) => {
+			const element = event.currentTarget;
+			followTranscriptRef.current =
+				element.scrollHeight - element.scrollTop - element.clientHeight <
+				FOLLOW_TRANSCRIPT_THRESHOLD_PX;
+		},
+		[],
+	);
+
+	// Each conversation opens pinned to its newest turn, regardless of where the
+	// previous one was left scrolled.
+	useEffect(() => {
+		followTranscriptRef.current = true;
+	}, [inCall, viewedCallId]);
+
+	// Follow the live transcript only while the user is already at the bottom, so
+	// scrolling back to re-read or replay an earlier turn is not yanked away.
+	useEffect(() => {
+		const element = transcriptScrollRef.current;
+		if (element && followTranscriptRef.current) {
+			element.scrollTop = element.scrollHeight;
+		}
+	}, [displayedTurns]);
 
 	const displayedUsage = isViewingHistory
 		? viewedCall?.usage
@@ -288,10 +445,17 @@ export default function RealtimePageClient({
 		[inCall],
 	);
 
+	// Also reachable from the sidebar mid-call, where clearing the continued-call
+	// link would silently strand the live session's turns in a new history row.
 	const handleNewCall = useCallback(() => {
+		if (inCall) {
+			toast.error("End the current call before starting a new one.");
+			return;
+		}
+		continuedCallIdRef.current = null;
 		setViewedCallId(null);
 		reset();
-	}, [reset]);
+	}, [inCall, reset]);
 
 	const handleCallDeleted = useCallback((itemId: string) => {
 		setViewedCallId((current) => (current === itemId ? null : current));
@@ -356,9 +520,57 @@ export default function RealtimePageClient({
 			voice,
 		});
 		savedCallRef.current = false;
+		continuedCallIdRef.current = null;
 		setViewedCallId(null);
 		start();
 	}, [posthog, selectedModel, start, voice]);
+
+	// Reopen a saved call as a live one: its turns are replayed to the model as
+	// conversation items and the new turns are appended back onto the same row.
+	const handleContinueCall = useCallback(() => {
+		if (!viewedCall || !selectedModel) {
+			return;
+		}
+		const seed: RealtimeTranscriptEntry[] = viewedCall.transcript
+			.filter(
+				(entry) => entry.status !== "partial" && entry.text.trim().length > 0,
+			)
+			.map((entry, index) => ({
+				id: `${SEED_ID_PREFIX}${index}`,
+				role: entry.role,
+				text: entry.text,
+				status: entry.status,
+				timestamp: entry.timestamp,
+				...(entry.audio ? { audio: entry.audio } : {}),
+			}));
+		if (seed.length === 0) {
+			toast.error("This call has no completed turns to continue from.");
+			return;
+		}
+		if (selectedModel !== viewedCall.model) {
+			toast.warning(
+				`Continuing with ${selectedModel} — this call was recorded on ${viewedCall.model}.`,
+			);
+		}
+		const totalChars = seed.reduce(
+			(total, entry) => total + entry.text.length,
+			0,
+		);
+		if (seed.length > REPLAY_TURN_WARNING || totalChars > REPLAY_CHAR_WARNING) {
+			toast.warning(
+				`Replaying ${seed.length} turns — the first response will bill the whole conversation as input tokens.`,
+			);
+		}
+		posthog.capture("playground_realtime_call_continued", {
+			model: selectedModel,
+			voice,
+			turns: seed.length,
+		});
+		savedCallRef.current = false;
+		continuedCallIdRef.current = viewedCall.id;
+		setViewedCallId(null);
+		start(seed);
+	}, [posthog, selectedModel, start, viewedCall, voice]);
 
 	const hasBillingContext = !!selectedOrganization && !!selectedProject;
 	const isIdleEmptyState =
@@ -441,7 +653,7 @@ export default function RealtimePageClient({
 
 					<div
 						className={cn(
-							"flex flex-1 flex-col overflow-y-auto",
+							"flex min-h-0 flex-1 flex-col",
 							isIdleEmptyState && "justify-center",
 						)}
 					>
@@ -472,77 +684,129 @@ export default function RealtimePageClient({
 							</div>
 						) : (
 							<>
+								{/* Only the transcript scrolls: the call controls below stay
+								    on screen no matter how long the conversation gets. */}
 								<div
+									ref={transcriptScrollRef}
+									onScroll={handleTranscriptScroll}
 									className={cn(
-										"mx-auto flex w-full max-w-3xl flex-col gap-3 p-4",
-										!isIdleEmptyState && "flex-1",
+										"flex flex-col",
+										!isIdleEmptyState && "min-h-0 flex-1 overflow-y-auto",
 									)}
 								>
-									{isViewingHistory && viewedCall && (
-										<div className="bg-muted/40 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-4 py-2.5 text-xs">
-											<span className="text-sm font-medium">
-												{viewedCall.title}
-											</span>
-											<span className="text-muted-foreground">
-												{new Date(viewedCall.createdAt).toLocaleString()}
-											</span>
-											<span className="text-muted-foreground tabular-nums">
-												{formatCallDuration(viewedCall.durationSeconds)}
-											</span>
-											<span className="text-muted-foreground">
-												{viewedCall.model}
-												{viewedCall.voice ? ` · ${viewedCall.voice}` : ""}
-											</span>
-											<Button
-												variant="ghost"
-												size="sm"
-												className="text-muted-foreground ml-auto h-7 text-xs"
-												onClick={handleNewCall}
-											>
-												Close
-											</Button>
-										</div>
-									)}
-									{displayedTurns.length === 0 ? (
-										<div
-											className={cn(
-												"flex flex-col items-center justify-center gap-3 text-center",
-												!isIdleEmptyState && "flex-1",
-											)}
-										>
-											<Phone className="text-muted-foreground/50 h-12 w-12" />
-											<p className="text-muted-foreground text-sm">
-												{isViewedCallLoading
-													? "Loading transcript…"
-													: inCall
-														? "Say something — the transcript appears here."
-														: "Start a call to have a live voice conversation."}
-											</p>
-										</div>
-									) : (
-										<div className="flex flex-col gap-3 pb-4">
-											{displayedTurns.map((turn) => (
-												<div
-													key={turn.key}
-													className={
-														turn.role === "user"
-															? "self-end max-w-[80%] rounded-2xl rounded-br-sm bg-primary px-4 py-2 text-sm text-primary-foreground"
-															: "self-start max-w-[80%] rounded-2xl rounded-bl-sm bg-muted px-4 py-2 text-sm"
-													}
+									<div
+										className={cn(
+											"mx-auto flex w-full max-w-3xl flex-col gap-3 p-4",
+											!isIdleEmptyState && "flex-1",
+										)}
+									>
+										{isViewingHistory && viewedCall && (
+											<div className="bg-muted/40 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-4 py-2.5 text-xs">
+												<span className="text-sm font-medium">
+													{viewedCall.title}
+												</span>
+												<span className="text-muted-foreground">
+													{new Date(viewedCall.createdAt).toLocaleString()}
+												</span>
+												<span className="text-muted-foreground tabular-nums">
+													{formatCallDuration(viewedCall.durationSeconds)}
+												</span>
+												<span className="text-muted-foreground">
+													{viewedCall.model}
+													{viewedCall.voice ? ` · ${viewedCall.voice}` : ""}
+												</span>
+												<Button
+													variant="ghost"
+													size="sm"
+													className="text-muted-foreground ml-auto h-7 text-xs"
+													onClick={handleNewCall}
 												>
-													{turn.text || "…"}
-													{turn.status === "interrupted" && (
-														<span className="text-muted-foreground ml-2 text-xs italic">
-															(interrupted)
-														</span>
-													)}
-												</div>
-											))}
-										</div>
-									)}
+													Close
+												</Button>
+											</div>
+										)}
+										{displayedTurns.length === 0 ? (
+											<div
+												className={cn(
+													"flex flex-col items-center justify-center gap-3 text-center",
+													!isIdleEmptyState && "flex-1",
+												)}
+											>
+												<Phone className="text-muted-foreground/50 h-12 w-12" />
+												<p className="text-muted-foreground text-sm">
+													{isViewedCallLoading
+														? "Loading transcript…"
+														: inCall
+															? "Say something — the transcript appears here."
+															: "Start a call to have a live voice conversation."}
+												</p>
+											</div>
+										) : (
+											<div className="flex flex-col gap-3 pb-4">
+												{displayedTurns.map((turn) => {
+													const audio = turn.audio;
+													const isPlaying = playingKey === turn.key;
+													return (
+														<div
+															key={turn.key}
+															className={cn(
+																"flex max-w-[80%] flex-col gap-0.5",
+																turn.role === "user"
+																	? "items-end self-end"
+																	: "items-start self-start",
+															)}
+														>
+															<div
+																className={
+																	turn.role === "user"
+																		? "rounded-2xl rounded-br-sm bg-primary px-4 py-2 text-sm text-primary-foreground"
+																		: "rounded-2xl rounded-bl-sm bg-muted px-4 py-2 text-sm"
+																}
+															>
+																{turn.text || "…"}
+																{turn.status === "interrupted" && (
+																	<span className="text-muted-foreground ml-2 text-xs italic">
+																		(interrupted)
+																	</span>
+																)}
+															</div>
+															{audio && (
+																<Actions>
+																	<Action
+																		disabled={assistantSpeaking}
+																		onClick={() =>
+																			isPlaying
+																				? stopPlayback()
+																				: playTurnAudio(turn.key, audio.base64)
+																		}
+																		label={isPlaying ? "Stop" : "Play"}
+																		tooltip={
+																			assistantSpeaking
+																				? "Wait for the assistant to finish"
+																				: isPlaying
+																					? "Stop playback"
+																					: "Play this response"
+																		}
+																	>
+																		{isPlaying ? (
+																			<Square className="size-3" />
+																		) : (
+																			<Play className="size-3" />
+																		)}
+																	</Action>
+																</Actions>
+															)}
+														</div>
+													);
+												})}
+											</div>
+										)}
+									</div>
 								</div>
 
-								<div className={cn(!isIdleEmptyState && "border-t")}>
+								<div
+									className={cn("shrink-0", !isIdleEmptyState && "border-t")}
+								>
 									{status === "live" && (
 										<div className="mx-auto flex w-full max-w-3xl items-center justify-center pt-5">
 											<VoiceActivityIndicator
@@ -557,19 +821,37 @@ export default function RealtimePageClient({
 									)}
 									<div className="mx-auto flex w-full max-w-3xl items-center justify-center gap-4 p-6">
 										{!inCall ? (
-											<Button
-												size="lg"
-												className="gap-2 rounded-full px-8"
-												disabled={
-													!selectedModel ||
-													!isAuthenticated ||
-													!hasBillingContext
-												}
-												onClick={handleStart}
-											>
-												<Phone className="h-4 w-4" />
-												Start call
-											</Button>
+											<>
+												<Button
+													size="lg"
+													className="gap-2 rounded-full px-8"
+													disabled={
+														!selectedModel ||
+														!isAuthenticated ||
+														!hasBillingContext
+													}
+													onClick={handleStart}
+												>
+													<Phone className="h-4 w-4" />
+													Start call
+												</Button>
+												{isViewingHistory && (
+													<Button
+														size="lg"
+														variant="outline"
+														className="gap-2 rounded-full px-8"
+														disabled={
+															!selectedModel ||
+															!isAuthenticated ||
+															!hasBillingContext
+														}
+														onClick={handleContinueCall}
+													>
+														<PhoneForwarded className="h-4 w-4" />
+														Continue call
+													</Button>
+												)}
+											</>
 										) : (
 											<>
 												<Button

--- a/apps/playground/src/hooks/use-realtime-call.ts
+++ b/apps/playground/src/hooks/use-realtime-call.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	computeRms,
 	floatToPcm16Base64,
+	pcm16ChunksToWavBase64,
 	RealtimePlayback,
 	resampleLinear,
 	rmsToLevel,
@@ -28,6 +29,8 @@ export interface RealtimeTranscriptEntry {
 	text: string;
 	status: "partial" | "final" | "interrupted";
 	timestamp: number;
+	/** Assistant speech for this turn, retained so it can be replayed. */
+	audio?: { base64: string; mediaType: "audio/wav" };
 }
 
 export interface RealtimeUsageTotals {
@@ -58,6 +61,13 @@ const METER_EPSILON = 0.02;
  * queued deltas would otherwise flicker the "speaking" state off and on.
  */
 const SPEAKING_HOLD_MS = 300;
+/**
+ * Ceiling on retained assistant PCM for one call (~8 minutes of speech at
+ * 24kHz mono PCM16). Past it, audio capture stops for the rest of the call so
+ * a long conversation cannot grow an unbounded in-memory buffer or an
+ * unsendable save payload; the transcript text is still recorded in full.
+ */
+const MAX_CALL_AUDIO_BYTES = 24 * 1024 * 1024;
 
 interface UseRealtimeCallOptions {
 	model: string | null;
@@ -105,6 +115,10 @@ export function useRealtimeCall({
 	const speakingUntilRef = useRef(0);
 	const responseActiveRef = useRef(false);
 	const transcriptionModelRef = useRef<string | null>(null);
+	/** Base64 PCM deltas per in-progress assistant item, pending WAV encoding. */
+	const audioChunksRef = useRef(new Map<string, string[]>());
+	const audioBytesRef = useRef(0);
+	const seedRef = useRef<RealtimeTranscriptEntry[] | null>(null);
 	const voiceRef = useRef<string | null>(voice);
 	voiceRef.current = voice;
 	const onCallErrorRef = useRef(onCallError);
@@ -204,6 +218,9 @@ export function useRealtimeCall({
 			void context.close().catch(() => {});
 		}
 		responseActiveRef.current = false;
+		audioChunksRef.current.clear();
+		audioBytesRef.current = 0;
+		seedRef.current = null;
 		updateStatus("idle");
 	}, [updateStatus]);
 
@@ -262,6 +279,41 @@ export function useRealtimeCall({
 		},
 		[],
 	);
+
+	/**
+	 * Encode every finished item's buffered PCM into a WAV and hang it off the
+	 * matching transcript entry. This runs at response.done rather than at the
+	 * transcript's own done event because audio deltas can still trail the
+	 * transcript. An interrupted turn keeps every delta that arrived — a little
+	 * more than the listener actually heard, but the entry already reads as
+	 * interrupted, and truncating to the played duration would cost a decode
+	 * pass for no real gain.
+	 */
+	const finalizeResponseAudio = useCallback(() => {
+		const pending = audioChunksRef.current;
+		if (pending.size === 0) {
+			return;
+		}
+		const encoded = new Map<string, string>();
+		pending.forEach((chunks, itemId) => {
+			if (chunks.length > 0) {
+				encoded.set(itemId, pcm16ChunksToWavBase64(chunks));
+			}
+		});
+		pending.clear();
+		if (encoded.size === 0) {
+			return;
+		}
+		setTranscript((prev) =>
+			prev.map((entry) => {
+				const base64 =
+					entry.role === "assistant" ? encoded.get(entry.id) : undefined;
+				return base64
+					? { ...entry, audio: { base64, mediaType: "audio/wav" as const } }
+					: entry;
+			}),
+		);
+	}, []);
 
 	const handleBargeIn = useCallback(() => {
 		const playback = playbackRef.current;
@@ -325,6 +377,35 @@ export function useRealtimeCall({
 				}
 				case "session.updated":
 					if (statusRef.current === "configuring") {
+						// Replay a continued call's prior turns before going live, so the
+						// model has the earlier conversation in context. Fire-and-forget
+						// is safe: microphone chunks are dropped until the status flips
+						// to "live" below, so nothing can race ahead of the seed.
+						// Only the text is replayed — the realtime API cannot accept
+						// assistant audio items — and the content type is the role's
+						// side of the GA enum: input_text for user, output_text for
+						// assistant.
+						const seed = seedRef.current;
+						seedRef.current = null;
+						for (const entry of seed ?? []) {
+							if (entry.status === "partial" || !entry.text.trim()) {
+								continue;
+							}
+							sendEvent({
+								type: "conversation.item.create",
+								item: {
+									type: "message",
+									role: entry.role,
+									content: [
+										{
+											type:
+												entry.role === "user" ? "input_text" : "output_text",
+											text: entry.text,
+										},
+									],
+								},
+							});
+						}
 						updateStatus("live");
 						setElapsedSeconds(0);
 						const startedAt = Date.now();
@@ -339,6 +420,7 @@ export function useRealtimeCall({
 					return;
 				case "response.done": {
 					responseActiveRef.current = false;
+					finalizeResponseAudio();
 					const response =
 						event.response && typeof event.response === "object"
 							? (event.response as Record<string, unknown>)
@@ -380,6 +462,20 @@ export function useRealtimeCall({
 						typeof event.content_index === "number" ? event.content_index : 0;
 					if (itemId && delta) {
 						playbackRef.current?.enqueue(itemId, contentIndex, delta);
+						if (audioBytesRef.current < MAX_CALL_AUDIO_BYTES) {
+							audioBytesRef.current += Math.ceil((delta.length * 3) / 4);
+							const chunks = audioChunksRef.current.get(itemId);
+							if (chunks) {
+								chunks.push(delta);
+							} else {
+								audioChunksRef.current.set(itemId, [delta]);
+							}
+							if (audioBytesRef.current >= MAX_CALL_AUDIO_BYTES) {
+								// Over budget: drop what is still buffered, including this
+								// half-captured item, rather than save a truncated clip.
+								audioChunksRef.current.clear();
+							}
+						}
 					}
 					return;
 				}
@@ -466,7 +562,14 @@ export function useRealtimeCall({
 				default:
 			}
 		},
-		[handleBargeIn, sendEvent, startMeterLoop, updateStatus, upsertTranscript],
+		[
+			finalizeResponseAudio,
+			handleBargeIn,
+			sendEvent,
+			startMeterLoop,
+			updateStatus,
+			upsertTranscript,
+		],
 	);
 
 	const runStart = useCallback(
@@ -644,22 +747,36 @@ export function useRealtimeCall({
 		setTranscript([]);
 		setUsage(EMPTY_USAGE);
 		setElapsedSeconds(0);
+		audioChunksRef.current.clear();
+		audioBytesRef.current = 0;
 	}, []);
 
-	const start = useCallback(() => {
-		if (statusRef.current !== "idle" || !model) {
-			return;
-		}
-		reset();
-		// The AudioContext must be created and resumed synchronously inside the
-		// click gesture (before any await) or Safari drops the user activation.
-		const context = new AudioContext();
-		void context.resume().catch(() => {});
-		audioContextRef.current = context;
-		updateStatus("preparing-audio");
-		const callId = callIdRef.current;
-		void runStart(context, callId);
-	}, [model, reset, runStart, updateStatus]);
+	/**
+	 * Begin a call. A seed continues an earlier conversation: its entries are
+	 * shown immediately (audio included, so they stay playable) and replayed to
+	 * the model once the session is configured.
+	 */
+	const start = useCallback(
+		(seed?: RealtimeTranscriptEntry[]) => {
+			if (statusRef.current !== "idle" || !model) {
+				return;
+			}
+			reset();
+			seedRef.current = seed?.length ? seed : null;
+			if (seed?.length) {
+				setTranscript(seed);
+			}
+			// The AudioContext must be created and resumed synchronously inside the
+			// click gesture (before any await) or Safari drops the user activation.
+			const context = new AudioContext();
+			void context.resume().catch(() => {});
+			audioContextRef.current = context;
+			updateStatus("preparing-audio");
+			const callId = callIdRef.current;
+			void runStart(context, callId);
+		},
+		[model, reset, runStart, updateStatus],
+	);
 
 	const end = useCallback(() => {
 		if (statusRef.current === "idle") {

--- a/apps/playground/src/hooks/use-realtime-call.ts
+++ b/apps/playground/src/hooks/use-realtime-call.ts
@@ -65,7 +65,10 @@ const SPEAKING_HOLD_MS = 300;
  * Ceiling on retained assistant PCM for one call (~8 minutes of speech at
  * 24kHz mono PCM16). Past it, audio capture stops for the rest of the call so
  * a long conversation cannot grow an unbounded in-memory buffer or an
- * unsendable save payload; the transcript text is still recorded in full.
+ * unsendable save payload; the transcript text is still recorded in full. A
+ * continued call starts with its seeded turns' audio already counted, so
+ * repeated continuations cannot grow one saved conversation past this budget
+ * either.
  */
 const MAX_CALL_AUDIO_BYTES = 24 * 1024 * 1024;
 
@@ -170,6 +173,41 @@ export function useRealtimeCall({
 	}, []);
 
 	/**
+	 * Encode every finished item's buffered PCM into a WAV and hang it off the
+	 * matching transcript entry. This runs at response.done rather than at the
+	 * transcript's own done event because audio deltas can still trail the
+	 * transcript. An interrupted turn keeps every delta that arrived — a little
+	 * more than the listener actually heard, but the entry already reads as
+	 * interrupted, and truncating to the played duration would cost a decode
+	 * pass for no real gain.
+	 */
+	const finalizeResponseAudio = useCallback(() => {
+		const pending = audioChunksRef.current;
+		if (pending.size === 0) {
+			return;
+		}
+		const encoded = new Map<string, string>();
+		pending.forEach((chunks, itemId) => {
+			if (chunks.length > 0) {
+				encoded.set(itemId, pcm16ChunksToWavBase64(chunks));
+			}
+		});
+		pending.clear();
+		if (encoded.size === 0) {
+			return;
+		}
+		setTranscript((prev) =>
+			prev.map((entry) => {
+				const base64 =
+					entry.role === "assistant" ? encoded.get(entry.id) : undefined;
+				return base64
+					? { ...entry, audio: { base64, mediaType: "audio/wav" as const } }
+					: entry;
+			}),
+		);
+	}, []);
+
+	/**
 	 * Tear down every media/audio/network resource. Safe to call from any
 	 * state and idempotent per call attempt.
 	 */
@@ -218,11 +256,15 @@ export function useRealtimeCall({
 			void context.close().catch(() => {});
 		}
 		responseActiveRef.current = false;
+		// Ending mid-response: encode whatever assistant audio is already
+		// buffered so the final turn keeps its replay clip instead of losing
+		// it with the buffers.
+		finalizeResponseAudio();
 		audioChunksRef.current.clear();
 		audioBytesRef.current = 0;
 		seedRef.current = null;
 		updateStatus("idle");
-	}, [updateStatus]);
+	}, [finalizeResponseAudio, updateStatus]);
 
 	const failCall = useCallback(
 		(message: string) => {
@@ -279,41 +321,6 @@ export function useRealtimeCall({
 		},
 		[],
 	);
-
-	/**
-	 * Encode every finished item's buffered PCM into a WAV and hang it off the
-	 * matching transcript entry. This runs at response.done rather than at the
-	 * transcript's own done event because audio deltas can still trail the
-	 * transcript. An interrupted turn keeps every delta that arrived — a little
-	 * more than the listener actually heard, but the entry already reads as
-	 * interrupted, and truncating to the played duration would cost a decode
-	 * pass for no real gain.
-	 */
-	const finalizeResponseAudio = useCallback(() => {
-		const pending = audioChunksRef.current;
-		if (pending.size === 0) {
-			return;
-		}
-		const encoded = new Map<string, string>();
-		pending.forEach((chunks, itemId) => {
-			if (chunks.length > 0) {
-				encoded.set(itemId, pcm16ChunksToWavBase64(chunks));
-			}
-		});
-		pending.clear();
-		if (encoded.size === 0) {
-			return;
-		}
-		setTranscript((prev) =>
-			prev.map((entry) => {
-				const base64 =
-					entry.role === "assistant" ? encoded.get(entry.id) : undefined;
-				return base64
-					? { ...entry, audio: { base64, mediaType: "audio/wav" as const } }
-					: entry;
-			}),
-		);
-	}, []);
 
 	const handleBargeIn = useCallback(() => {
 		const playback = playbackRef.current;
@@ -380,11 +387,14 @@ export function useRealtimeCall({
 						// Replay a continued call's prior turns before going live, so the
 						// model has the earlier conversation in context. Fire-and-forget
 						// is safe: microphone chunks are dropped until the status flips
-						// to "live" below, so nothing can race ahead of the seed.
-						// Only the text is replayed — the realtime API cannot accept
-						// assistant audio items — and the content type is the role's
-						// side of the GA enum: input_text for user, output_text for
-						// assistant.
+						// to "live" below, so nothing can race ahead of the seed, and a
+						// rejected item surfaces through the server's "error" event like
+						// any other session fault. Only the text is replayed — the
+						// realtime API cannot accept assistant audio items — and the
+						// content type is the role's side of the GA enum: input_text for
+						// user, output_text for assistant. Interrupted turns are replayed
+						// in full: the heard-text boundary is unknowable client-side, and
+						// the full text is what the transcript already shows the user.
 						const seed = seedRef.current;
 						seedRef.current = null;
 						for (const entry of seed ?? []) {
@@ -765,6 +775,15 @@ export function useRealtimeCall({
 			seedRef.current = seed?.length ? seed : null;
 			if (seed?.length) {
 				setTranscript(seed);
+				// Seeded audio counts toward the call's audio budget (see
+				// MAX_CALL_AUDIO_BYTES); base64 decodes to 3/4 of its length.
+				audioBytesRef.current = seed.reduce(
+					(total, entry) =>
+						entry.audio
+							? total + Math.ceil((entry.audio.base64.length * 3) / 4)
+							: total,
+					0,
+				);
 			}
 			// The AudioContext must be created and resumed synchronously inside the
 			// click gesture (before any await) or Safari drops the user activation.

--- a/apps/playground/src/hooks/usePlaygroundHistory.ts
+++ b/apps/playground/src/hooks/usePlaygroundHistory.ts
@@ -2,6 +2,11 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { useApi } from "@/lib/fetch-client";
 
+import type { paths } from "@/lib/api/v1";
+
+type RealtimeHistoryDetail =
+	paths["/playground/realtime-history/{id}"]["get"]["responses"][200]["content"]["application/json"];
+
 export function useImageHistory(enabled = true, organizationId?: string) {
 	const api = useApi();
 	return api.useQuery(
@@ -151,9 +156,9 @@ export function useRealtimeHistory(enabled = true, organizationId?: string) {
 	);
 }
 
-// Full call including its transcript, fetched only when a call is opened.
-// Calls are immutable apart from title renames (which invalidate this query),
-// so the data never goes stale.
+// Full call including its transcript, fetched only when a call is opened. The
+// only writes are title renames and continued-call appends, both of which
+// invalidate this query, so the data never goes stale.
 export function useRealtimeHistoryItem(id: string | null) {
 	const api = useApi();
 	return api.useQuery(
@@ -193,25 +198,44 @@ export function useSaveRealtimeHistory() {
 	});
 }
 
-export function useRenameRealtimeHistory() {
+// Renames a call and/or appends the turns of a continued session to it. Both
+// change the detail payload, so it is invalidated alongside the list.
+export function useUpdateRealtimeHistory() {
 	const queryClient = useQueryClient();
 	const api = useApi();
 	return api.useMutation("patch", "/playground/realtime-history/{id}", {
-		onSuccess: (_data, variables) => {
+		onSuccess: (data, variables) => {
 			void queryClient.invalidateQueries({
 				queryKey: api.queryOptions("get", "/playground/realtime-history")
 					.queryKey,
 			});
 			const id = variables.params?.path?.id;
-			if (id) {
-				void queryClient.invalidateQueries({
-					queryKey: api.queryOptions(
-						"get",
-						"/playground/realtime-history/{id}",
-						{ params: { path: { id } } },
-					).queryKey,
+			if (!id) {
+				return;
+			}
+			const detailKey = api.queryOptions(
+				"get",
+				"/playground/realtime-history/{id}",
+				{ params: { path: { id } } },
+			).queryKey;
+			const appended = variables.body?.appendTranscript;
+			// Fold the appended turns into the cached detail up front, so a call
+			// that just ended reads complete the instant it is opened rather than
+			// showing its pre-continuation transcript until the refetch lands.
+			// The cache key is tagged as `{}` by openapi-react-query, so the shape
+			// has to be reapplied on read.
+			const previous = queryClient.getQueryData(detailKey) as
+				RealtimeHistoryDetail | undefined;
+			if (appended?.length && previous) {
+				queryClient.setQueryData(detailKey, {
+					item: {
+						...previous.item,
+						...data.item,
+						transcript: [...previous.item.transcript, ...appended],
+					},
 				});
 			}
+			void queryClient.invalidateQueries({ queryKey: detailKey });
 		},
 	});
 }

--- a/apps/playground/src/lib/realtime-audio.spec.ts
+++ b/apps/playground/src/lib/realtime-audio.spec.ts
@@ -5,10 +5,14 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+	base64ToBytes,
+	bytesToBase64,
 	computeRms,
 	floatToPcm16Base64,
 	PCM_RECORDER_WORKLET_URL,
 	pcm16Base64ToFloat,
+	pcm16ChunksToWavBase64,
+	REALTIME_SAMPLE_RATE,
 	resampleLinear,
 	rmsToLevel,
 } from "./realtime-audio";
@@ -81,6 +85,87 @@ describe("PCM16 base64 round trip", () => {
 		const binary = atob(base64);
 		expect(binary.charCodeAt(0)).toBe(0x00);
 		expect(binary.charCodeAt(1)).toBe(0x40);
+	});
+});
+
+describe("pcm16ChunksToWavBase64", () => {
+	const readAscii = (bytes: Uint8Array, offset: number, length: number) =>
+		String.fromCharCode(...Array.from(bytes.subarray(offset, offset + length)));
+	const view = (bytes: Uint8Array) =>
+		new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+	it("writes a RIFF/WAVE header", () => {
+		const wav = base64ToBytes(
+			pcm16ChunksToWavBase64([bytesToBase64(new Uint8Array([1, 2, 3, 4]))]),
+		);
+		expect(readAscii(wav, 0, 4)).toBe("RIFF");
+		expect(readAscii(wav, 8, 4)).toBe("WAVE");
+		expect(readAscii(wav, 12, 4)).toBe("fmt ");
+		expect(readAscii(wav, 36, 4)).toBe("data");
+		expect(view(wav).getUint32(4, true)).toBe(36 + 4);
+		expect(view(wav).getUint32(40, true)).toBe(4);
+	});
+
+	it("describes mono 16-bit PCM at the given sample rate", () => {
+		const wav = base64ToBytes(pcm16ChunksToWavBase64([], 16000));
+		const header = view(wav);
+		expect(header.getUint32(16, true)).toBe(16);
+		expect(header.getUint16(20, true)).toBe(1);
+		expect(header.getUint16(22, true)).toBe(1);
+		expect(header.getUint32(24, true)).toBe(16000);
+		expect(header.getUint32(28, true)).toBe(16000 * 2);
+		expect(header.getUint16(32, true)).toBe(2);
+		expect(header.getUint16(34, true)).toBe(16);
+	});
+
+	it("defaults to the realtime wire sample rate", () => {
+		const wav = base64ToBytes(pcm16ChunksToWavBase64([]));
+		expect(view(wav).getUint32(24, true)).toBe(REALTIME_SAMPLE_RATE);
+	});
+
+	it("concatenates chunks in order without altering the payload", () => {
+		const first = new Uint8Array([0x00, 0x40, 0x01, 0x80]);
+		const second = new Uint8Array([0xff, 0x7f]);
+		const wav = base64ToBytes(
+			pcm16ChunksToWavBase64([bytesToBase64(first), bytesToBase64(second)]),
+		);
+		expect(Array.from(wav.subarray(44))).toEqual([
+			...Array.from(first),
+			...Array.from(second),
+		]);
+		expect(view(wav).getUint32(40, true)).toBe(6);
+	});
+
+	it("returns a header-only WAV for empty input", () => {
+		const wav = base64ToBytes(pcm16ChunksToWavBase64([]));
+		expect(wav.length).toBe(44);
+		expect(view(wav).getUint32(40, true)).toBe(0);
+		expect(view(wav).getUint32(4, true)).toBe(36);
+	});
+
+	it("survives payloads larger than the base64 chunk size", () => {
+		const chunk = new Uint8Array(0x8000 * 3).fill(0x7f);
+		const wav = base64ToBytes(pcm16ChunksToWavBase64([bytesToBase64(chunk)]));
+		expect(wav.length).toBe(44 + chunk.length);
+		expect(wav[44]).toBe(0x7f);
+		expect(wav[wav.length - 1]).toBe(0x7f);
+	});
+});
+
+describe("bytesToBase64 / base64ToBytes", () => {
+	it("round-trips arbitrary bytes", () => {
+		const bytes = new Uint8Array(256);
+		for (let i = 0; i < bytes.length; i++) {
+			bytes[i] = i;
+		}
+		expect(Array.from(base64ToBytes(bytesToBase64(bytes)))).toEqual(
+			Array.from(bytes),
+		);
+	});
+
+	it("round-trips an empty buffer", () => {
+		expect(bytesToBase64(new Uint8Array(0))).toBe("");
+		expect(base64ToBytes("").length).toBe(0);
 	});
 });
 

--- a/apps/playground/src/lib/realtime-audio.ts
+++ b/apps/playground/src/lib/realtime-audio.ts
@@ -36,6 +36,35 @@ export function resampleLinear(
 }
 
 /**
+ * Base64-encode raw bytes. Chunked because String.fromCharCode is applied as a
+ * variadic call and a whole call's worth of audio would blow the argument
+ * limit.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+	let binary = "";
+	const chunkSize = 0x8000;
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		binary += String.fromCharCode.apply(
+			null,
+			Array.from(bytes.subarray(i, i + chunkSize)),
+		);
+	}
+	return btoa(binary);
+}
+
+/**
+ * Decode base64 into raw bytes.
+ */
+export function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes;
+}
+
+/**
  * Encode Float32 samples ([-1, 1]) as little-endian PCM16 base64.
  */
 export function floatToPcm16Base64(samples: Float32Array): string {
@@ -45,16 +74,52 @@ export function floatToPcm16Base64(samples: Float32Array): string {
 		const clamped = Math.max(-1, Math.min(1, samples[i]));
 		view.setInt16(i * 2, Math.round(clamped * 0x7fff), true);
 	}
-	let binary = "";
-	const bytes = new Uint8Array(buffer);
-	const chunkSize = 0x8000;
-	for (let i = 0; i < bytes.length; i += chunkSize) {
-		binary += String.fromCharCode.apply(
-			null,
-			Array.from(bytes.subarray(i, i + chunkSize)),
-		);
+	return bytesToBase64(new Uint8Array(buffer));
+}
+
+const WAV_HEADER_BYTES = 44;
+
+/**
+ * Wrap base64 PCM16 chunks (as received on the wire) in a WAV container and
+ * return it base64-encoded, ready to store or hand to an <audio> element. The
+ * payload bytes are copied through verbatim — no float round-trip — so the
+ * stored audio is bit-identical to what was played.
+ */
+export function pcm16ChunksToWavBase64(
+	base64Chunks: string[],
+	sampleRate: number = REALTIME_SAMPLE_RATE,
+): string {
+	const chunks = base64Chunks.map(base64ToBytes);
+	const dataSize = chunks.reduce((total, chunk) => total + chunk.length, 0);
+	const output = new Uint8Array(WAV_HEADER_BYTES + dataSize);
+	const view = new DataView(output.buffer);
+	const writeAscii = (offset: number, text: string) => {
+		for (let i = 0; i < text.length; i++) {
+			view.setUint8(offset + i, text.charCodeAt(i));
+		}
+	};
+	const channels = 1;
+	const bitsPerSample = 16;
+	const blockAlign = (channels * bitsPerSample) / 8;
+	writeAscii(0, "RIFF");
+	view.setUint32(4, 36 + dataSize, true);
+	writeAscii(8, "WAVE");
+	writeAscii(12, "fmt ");
+	view.setUint32(16, 16, true);
+	view.setUint16(20, 1, true);
+	view.setUint16(22, channels, true);
+	view.setUint32(24, sampleRate, true);
+	view.setUint32(28, sampleRate * blockAlign, true);
+	view.setUint16(32, blockAlign, true);
+	view.setUint16(34, bitsPerSample, true);
+	writeAscii(36, "data");
+	view.setUint32(40, dataSize, true);
+	let offset = WAV_HEADER_BYTES;
+	for (const chunk of chunks) {
+		output.set(chunk, offset);
+		offset += chunk.length;
 	}
-	return btoa(binary);
+	return bytesToBase64(output);
 }
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4427,6 +4427,8 @@ export const playgroundRealtimeHistory = pgTable(
 				text: string;
 				status: "partial" | "final" | "interrupted";
 				timestamp: number;
+				// Assistant speech for the turn, retained so it can be replayed.
+				audio?: { base64: string; mediaType: "audio/wav" };
 			}[]
 		>(),
 		usage: jsonb().$type<{


### PR DESCRIPTION
Realtime voice calls were one-shot: a saved call could not be picked up again, and assistant speech was played once and discarded. This adds a **Continue call** action that replays a saved call's turns to the model as conversation items and appends the new turns back onto the same history row, plus per-turn WAV capture of the assistant's audio so every response gets a Play button both live and in history. `PATCH /realtime-history/{id}` is widened from rename-only to also append transcript turns and sum duration/usage server-side, covered by a new API spec; the schema change is type-only, so `pnpm migrations` generates no SQL. The call controls are now pinned while only the transcript scrolls, following the newest turn only when already scrolled to the bottom.

Note: this has not been exercised against a live provider call — `pnpm build`, `pnpm lint` and the unit/API tests all pass, but the seeded-replay item shape and audio playback are verified by tests and code review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Realtime call history can now store and play back assistant audio for individual transcript turns.
  * Continue existing calls by replaying prior turns and appending new conversation data.
  * Call history updates now support titles, transcript additions, duration, and usage totals.

* **Bug Fixes**
  * Prevented starting a new call while another call is active.
  * Improved transcript scrolling and playback state handling.

* **Tests**
  * Added coverage for audio conversion, call history updates (aggregation/validation), and authorization scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->