### PR TITLE
docs: fix /model picker guidance for non-Claude models

### DIFF
--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -41,10 +41,10 @@ claude
 ```
 
 <Callout type="info">
-	Environment variables are read once at startup. To switch models mid-session
-	with `/model`, restrict the picker with `availableModels`, or have Claude Code
-	populate its picker from our catalog automatically via gateway model
-	discovery, see the [Claude Code guide](/guides/claude-code).
+	Environment variables are read once at startup. The `/model` picker lists
+	Claude models only, so non-Claude models are selected with `ANTHROPIC_MODEL`
+	or `--model`. See the [Claude Code guide](/guides/claude-code) for the
+	settings-file options and gateway model discovery.
 </Callout>
 
 ### Choosing Models

--- a/apps/docs/content/guides/claude-code.mdx
+++ b/apps/docs/content/guides/claude-code.mdx
@@ -119,7 +119,7 @@ Environment variables are read once at startup, so changing `ANTHROPIC_MODEL` me
 
 `fallbackModel` names the models to try when the primary one is unavailable, capped at three.
 
-The same key also _adds_ models to the picker — including non-Claude ones. See [Adding Non-Claude Models to the Picker](#adding-non-claude-models-to-the-picker).
+`availableModels` only filters the rows Claude Code already has — it never creates new ones. To put a non-Claude model in the picker, see [Adding Non-Claude Models to the Picker](#adding-non-claude-models-to-the-picker).
 
 ## Fetching Models From LLM Gateway
 
@@ -134,49 +134,37 @@ export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 On startup Claude Code calls our [`/v1/models`](https://api.llmgateway.io/v1/models) endpoint and adds what it returns to the picker, labeled **From gateway**. Entries are cached in `~/.claude/cache/gateway-models.json` and refreshed on each launch, so a failed lookup falls back to the previous list rather than breaking your session. Requires Claude Code v2.1.129 or later.
 
 <Callout type="warn">
-	Claude Code discards discovered models whose ID does not start with `claude`
-	or `anthropic`, so discovery alone surfaces only the Claude models in our
-	catalog. Models like GPT-5 or Gemini are filtered out by the client, not by
-	the gateway. List them in `availableModels` to add them to the picker.
+	Claude Code drops discovered models whose ID does not start with `claude` or
+	`anthropic`, before they ever reach the picker — the cache it writes to
+	`~/.claude/cache/gateway-models.json` contains only the surviving entries.
+	Discovery therefore surfaces just the Claude models in our catalog. GPT-5,
+	Gemini, and custom models are filtered out by the client, not by the gateway.
 </Callout>
 
 ### Adding Non-Claude Models to the Picker
 
-`availableModels` is not limited to Claude model IDs. Any ID you list that has no built-in row gets its own row in the `/model` picker, which is how you put the rest of our catalog in front of the picker:
+The `/model` picker is a Claude-model list. Its own header says so: _"Switch between Claude models… For other/previous model names, specify with `--model`."_ Neither gateway discovery nor `availableModels` adds a non-Claude row — `availableModels` filters the rows Claude Code already has rather than creating new ones.
 
-```json title="~/.claude/settings.json"
-{
-	"availableModels": [
-		"claude-sonnet-5",
-		"claude-haiku-4-5",
-		"gpt-5",
-		"gpt-5-mini",
-		"gemini-3.1-pro-preview",
-		"kimi-k3"
-	]
-}
-```
-
-Requires Claude Code v2.1.199 or later; on earlier versions these IDs are still selectable, but only by typing `/model <id>` rather than picking a row.
-
-<Callout type="warn">
-	`availableModels` is an allowlist, so it replaces the built-in list rather
-	than extending it. Any model you leave out becomes unselectable — naming it
-	with `--model` or `ANTHROPIC_MODEL` silently starts the session on a different
-	model instead. Include every model you want to keep, Claude ones included.
-</Callout>
-
-### Adding a Single Model Without an Allowlist
-
-If you only need one extra model and don't want to enumerate an allowlist, `ANTHROPIC_CUSTOM_MODEL_OPTION` appends one entry to the picker:
+`ANTHROPIC_CUSTOM_MODEL_OPTION` is the one setting that adds a non-Claude row:
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION=gpt-5
-export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="GPT-5 via LLM Gateway"
+export ANTHROPIC_CUSTOM_MODEL_OPTION=gemini-3.5-flash
+export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="Gemini 3.5 Flash"
 export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Routed through LLM Gateway"
 ```
 
-Only one custom entry is supported at a time. If you also set `availableModels`, include this ID in that list or it will be filtered back out.
+The entry appears at the bottom of the picker under your chosen name. Only one is supported at a time, so it suits a single alternate model rather than a menu. If you also set `availableModels`, include this ID there or it will be filtered back out.
+
+### Selecting Any Other Model
+
+For everything else — including [custom models](/features/custom-providers) — name the model directly. These paths accept any ID our gateway routes, with no picker row involved:
+
+```bash
+export ANTHROPIC_MODEL=gemini-3.5-flash   # session default
+claude --model gemini-3.5-flash           # single session
+```
+
+To rotate between several non-Claude models, keep a per-project `.claude/settings.json` with the `model` you want for that repo.
 
 ## Environment Variables
 

--- a/apps/ui/src/content/guides/claude-code.md
+++ b/apps/ui/src/content/guides/claude-code.md
@@ -96,6 +96,8 @@ Environment variables are read once at startup, so changing `ANTHROPIC_MODEL` me
 
 `fallbackModel` names the models to try when the primary one is unavailable, capped at three.
 
+`availableModels` only filters the rows Claude Code already has — it never creates new ones. To put a non-Claude model in the picker, see [Adding Non-Claude Models to the Picker](#adding-non-claude-models-to-the-picker) below.
+
 ## Fetching Models From LLM Gateway
 
 Claude Code can populate its `/model` picker directly from our catalog instead of you hardcoding IDs. Set the discovery flag alongside the base URL:
@@ -108,40 +110,32 @@ export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 
 On startup Claude Code calls our `/v1/models` endpoint and adds what it returns to the picker, labeled **From gateway**. Entries are cached in `~/.claude/cache/gateway-models.json` and refreshed on each launch, so a failed lookup falls back to the previous list rather than breaking your session. Requires Claude Code v2.1.129 or later.
 
-> **Heads up:** Claude Code discards discovered models whose ID does not start with `claude` or `anthropic`, so discovery alone surfaces only the Claude models in our catalog. Models like GPT-5 or Gemini are filtered out by the client, not by the gateway. List them in `availableModels` to add them to the picker.
+> **Heads up:** Claude Code drops discovered models whose ID does not start with `claude` or `anthropic`, before they ever reach the picker — the cache it writes to `~/.claude/cache/gateway-models.json` contains only the surviving entries. Discovery therefore surfaces just the Claude models in our catalog. GPT-5, Gemini, and custom models are filtered out by the client, not by the gateway.
 
 ### Adding Non-Claude Models to the Picker
 
-`availableModels` is not limited to Claude model IDs. Any ID you list that has no built-in row gets its own row in the `/model` picker, which is how you put the rest of our catalog in front of the picker:
+The `/model` picker is a Claude-model list. Its own header says so: _"Switch between Claude models… For other/previous model names, specify with `--model`."_ Neither gateway discovery nor `availableModels` adds a non-Claude row — `availableModels` filters the rows Claude Code already has rather than creating new ones.
 
-```json
-{
-  "availableModels": [
-    "claude-sonnet-5",
-    "claude-haiku-4-5",
-    "gpt-5",
-    "gpt-5-mini",
-    "gemini-3.1-pro-preview",
-    "kimi-k3"
-  ]
-}
-```
-
-Requires Claude Code v2.1.199 or later; on earlier versions these IDs are still selectable, but only by typing `/model <id>` rather than picking a row.
-
-> **Note:** `availableModels` is an allowlist, so it replaces the built-in list rather than extending it. Any model you leave out becomes unselectable — naming it with `--model` or `ANTHROPIC_MODEL` silently starts the session on a different model instead. Include every model you want to keep, Claude ones included.
-
-### Adding a Single Model Without an Allowlist
-
-If you only need one extra model and don't want to enumerate an allowlist, `ANTHROPIC_CUSTOM_MODEL_OPTION` appends one entry to the picker:
+`ANTHROPIC_CUSTOM_MODEL_OPTION` is the one setting that adds a non-Claude row:
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION=gpt-5
-export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="GPT-5 via LLM Gateway"
+export ANTHROPIC_CUSTOM_MODEL_OPTION=gemini-3.5-flash
+export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="Gemini 3.5 Flash"
 export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Routed through LLM Gateway"
 ```
 
-Only one custom entry is supported at a time. If you also set `availableModels`, include this ID in that list or it will be filtered back out.
+The entry appears at the bottom of the picker under your chosen name. Only one is supported at a time, so it suits a single alternate model rather than a menu. If you also set `availableModels`, include this ID there or it will be filtered back out.
+
+### Selecting Any Other Model
+
+For everything else — including custom models — name the model directly. These paths accept any ID our gateway routes, with no picker row involved:
+
+```bash
+export ANTHROPIC_MODEL=gemini-3.5-flash   # session default
+claude --model gemini-3.5-flash           # single session
+```
+
+To rotate between several non-Claude models, keep a per-project `.claude/settings.json` with the `model` you want for that repo.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Corrects guidance shipped in #3310. That PR claimed `availableModels` adds non-Claude models to the `/model` picker. **It does not.** `availableModels` filters the rows Claude Code already has; it never creates new ones.

This came from a user report: custom gateway model IDs added to `availableModels` never appeared in `/model` on Claude Code 2.1.220. They were right.

## What I got wrong

In #3310 I tested that `availableModels` makes an arbitrary ID *selectable* (a listed `gpt-5` was forwarded verbatim; an unlisted one was silently swapped for the default) and inferred from the docs that it would therefore render a picker row. I flagged the row rendering as the one thing I couldn't verify, because the picker is an interactive TUI. That inference was wrong.

## Verification

Drove the real TUI through a pty against a local gateway serving three models — `claude-sonnet-5`, `gemini-3.5-flash`, `gpt-5`.

Claude Code called `GET /v1/models?limit=1000`, then wrote this cache:

```json
{"baseUrl":"http://127.0.0.1:8124","models":[{"id":"claude-sonnet-5","display_name":"Claude Sonnet 5"}]}
```

Only the Claude model survived — the other two were dropped at ingest, before the picker. Adding them to `availableModels` produced no rows either. The picker header states the rule outright:

> "Switch between Claude models… For other/previous model names, specify with `--model`."

`ANTHROPIC_CUSTOM_MODEL_OPTION=gemini-3.5-flash` **did** render, as row 7 — so it's now documented as the single-row mechanism.

| Mechanism | Non-Claude row in `/model`? |
|---|---|
| Gateway discovery | No — filtered at ingest |
| `availableModels` | No — filters existing rows only |
| `ANTHROPIC_CUSTOM_MODEL_OPTION` | Yes, exactly one |
| `ANTHROPIC_MODEL` / `--model` | Selects it, no row |

## Changes

- `guides/claude-code.mdx` + `ui/content/guides/claude-code.md` — replaced the `availableModels` section with the verified mechanisms; added a "Selecting Any Other Model" section for `ANTHROPIC_MODEL` / `--model`.
- `features/anthropic-endpoint.mdx` — the cross-link callout repeated the same wrong claim.

The gateway `display_name` change from #3310 is unaffected and still correct: it's what labels discovered Claude models.

`pnpm format` and `pnpm build` (17/17) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Claude Code’s model picker handles Claude and non-Claude models.
  * Explained that `availableModels` filters existing Claude model entries and does not add new models.
  * Documented how to add a custom picker option or select other models directly using environment variables or command-line options.
  * Updated gateway discovery guidance to reflect Claude-only model filtering and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->