### PR TITLE
docs: provider pinning in OpenCode guide

### DIFF
--- a/apps/docs/content/guides/opencode.mdx
+++ b/apps/docs/content/guides/opencode.mdx
@@ -140,14 +140,6 @@ You can also pin one as your default model, or per-agent:
 
 For providers with multiple regions, append a region suffix to pin both provider and region, e.g. `aws-bedrock/claude-sonnet-5:us`. See the [routing docs](/features/routing#provider-specific-routing) for the full syntax, and each model's available providers on the [models page](https://llmgateway.io/models).
 
-<Callout type="info">
-	Prefer to keep OpenCode config untouched? You can instead pin at the API key
-	level: add an `allow_providers` [IAM rule](/features/api-keys#iam-rules) to
-	the key you use in OpenCode, and all requests through that key — including
-	root model IDs picked from the built-in list — will only ever route to the
-	providers you allow.
-</Callout>
-
 ### Disabling Fallback
 
 By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime — even for provider-pinned model IDs. To make the pin strict, pass the `X-No-Fallback` header. Requests will then be sent only to the provider you specified, with no automatic fallback.

--- a/apps/docs/content/guides/opencode.mdx
+++ b/apps/docs/content/guides/opencode.mdx
@@ -93,17 +93,9 @@ The built-in provider gives you access to all standard LLM Gateway models. If yo
 {
 	"provider": {
 		"llmgateway": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "LLM Gateway",
-			"options": {
-				"baseURL": "https://api.llmgateway.io/v1"
-			},
 			"models": {
-				"deepseek/deepseek-chat": {
-					"name": "DeepSeek Chat"
-				},
-				"meta/llama-3.3-70b": {
-					"name": "Llama 3.3 70B"
+				"deepseek-v3": {
+					"name": "DeepSeek V3"
 				}
 			}
 		}
@@ -111,20 +103,60 @@ The built-in provider gives you access to all standard LLM Gateway models. If yo
 }
 ```
 
+Since LLM Gateway is a built-in provider, you only need to specify what you're adding — OpenCode merges your config with the built-in provider definition, so `npm`, `name`, and `baseURL` don't need to be repeated.
+
 After updating `config.json`, restart OpenCode to see the new models.
 
-## Locking to a Specific Provider
+## Pinning a Model to a Specific Provider
 
-By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime. If you want to lock into a specific provider/model mapping — for example to guarantee a fixed price or to always use a single provider — pass the `X-No-Fallback` header. Requests will then be sent only to the provider you specified, with no automatic fallback.
+OpenCode's built-in model list only shows root model IDs (e.g. `claude-sonnet-5`), which LLM Gateway routes to the best available provider automatically. If you want a model to always run on one specific provider — for example to guarantee a fixed price, a compliance boundary, or consistent behavior — use LLM Gateway's [`provider/model` syntax](/features/routing#provider-specific-routing) as the model ID.
+
+Add the pinned variants you want as custom models, and they show up in OpenCode's model picker alongside the built-in list:
 
 ```json
 {
 	"provider": {
 		"llmgateway": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "LLM Gateway",
+			"models": {
+				"anthropic/claude-sonnet-5": {
+					"name": "Claude Sonnet 5 (Anthropic direct)"
+				},
+				"aws-bedrock/claude-sonnet-5": {
+					"name": "Claude Sonnet 5 (AWS Bedrock)"
+				}
+			}
+		}
+	}
+}
+```
+
+You can also pin one as your default model, or per-agent:
+
+```json
+{
+	"model": "llmgateway/anthropic/claude-sonnet-5"
+}
+```
+
+For providers with multiple regions, append a region suffix to pin both provider and region, e.g. `aws-bedrock/claude-sonnet-5:us`. See the [routing docs](/features/routing#provider-specific-routing) for the full syntax, and each model's available providers on the [models page](https://llmgateway.io/models).
+
+<Callout type="info">
+	Prefer to keep OpenCode config untouched? You can instead pin at the API key
+	level: add an `allow_providers` [IAM rule](/features/api-keys#iam-rules) to
+	the key you use in OpenCode, and all requests through that key — including
+	root model IDs picked from the built-in list — will only ever route to the
+	providers you allow.
+</Callout>
+
+### Disabling Fallback
+
+By default, LLM Gateway automatically fails over to alternative providers if your chosen provider is experiencing downtime — even for provider-pinned model IDs. To make the pin strict, pass the `X-No-Fallback` header. Requests will then be sent only to the provider you specified, with no automatic fallback.
+
+```json
+{
+	"provider": {
+		"llmgateway": {
 			"options": {
-				"baseURL": "https://api.llmgateway.io/v1",
 				"headers": {
 					"X-No-Fallback": "true"
 				}
@@ -136,7 +168,9 @@ By default, LLM Gateway automatically fails over to alternative providers if you
 
 <Callout type="warn">
 	Disabling fallback means requests will fail if the chosen provider is down.
-	See the [routing docs](/features/routing) for details.
+	See the [routing
+	docs](/features/routing#disabling-fallback-with-x-no-fallback-header) for
+	details.
 </Callout>
 
 ## Switching Models


### PR DESCRIPTION
## Problem

OpenCode has a built-in LLM Gateway provider, but its model picker only shows root model IDs (sourced from models.dev), which the gateway auto-routes. There was no documented way to pin a model to a specific upstream provider from OpenCode, even though the gateway fully supports it.

## Changes

Reworked the OpenCode integration guide (`apps/docs/content/guides/opencode.mdx`):

- New **Pinning a Model to a Specific Provider** section: add `provider/model` entries (e.g. `anthropic/claude-sonnet-5`, `aws-bedrock/claude-sonnet-5`) as custom models under `provider.llmgateway.models` in OpenCode config — they appear in the model picker and pin the provider; `:region` suffix for region pinning; setting a pinned variant as the default model.
- Folded the existing `X-No-Fallback` section in as **Disabling Fallback** (strict pinning) and linked the exact routing-docs anchors.
- Slimmed the custom-models example: OpenCode merges user config with the built-in provider definition, so `npm`/`name`/`baseURL` don't need to be repeated; swapped the example to a root model ID so it no longer conflates aliasing with pinning.

## End-to-end verification

Tested with **opencode 1.14.19** (headless `opencode run`, isolated `XDG_CONFIG_HOME`) against a locally built gateway + worker, using exactly the config from the guide (only `baseURL` pointed at the local gateway). Verified via the gateway's `log` table:

| OpenCode model | `used_model` | `used_provider` | `noFallback` |
|---|---|---|---|
| `llmgateway/anthropic/claude-sonnet-5` | `anthropic/claude-sonnet-5` | `anthropic` | — |
| `llmgateway/aws-bedrock/claude-sonnet-5` | `aws-bedrock/claude-sonnet-5:global` | `aws-bedrock` | — |
| `llmgateway/aws-bedrock/claude-sonnet-5:us` | `aws-bedrock/claude-sonnet-5:us` | `aws-bedrock` | `true` |
| `claude-haiku-4-5` (root ID, OpenCode title-gen) | `aws-bedrock/claude-haiku-4-5:global` | gateway's choice | — |

Also confirmed: pinned entries show up in `opencode models` alongside the built-in list; omitting `npm`/`name` in the provider config works (OpenCode merges with the built-in definition); `options.headers` with `X-No-Fallback: true` reaches the gateway (`routing_metadata.noFallback = true`).

`pnpm format` and `turbo run build --filter=docs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenCode configuration guidance for disabling LLM Gateway fallback.
  * Added an explicit header configuration example to prevent fallback routing.
  * Refined the routing documentation link in the warning callout.
  * Simplified provider-pinning guidance while retaining pinned model examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->