### PR TITLE
chore: move storage redis to port 6479

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ REDIS_PORT=6379
 # REDIS_* connection is reused (single-Redis setups keep working). Once any
 # STORAGE_REDIS_* var is set, the others default to localhost/6379/no-password
 # rather than inheriting from REDIS_*.
-STORAGE_REDIS_PORT=6380
+STORAGE_REDIS_PORT=6479
 # STORAGE_REDIS_HOST=localhost
 STORAGE_REDIS_PASSWORD=change_this_redis_password
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - Admin: http://localhost:3006
 - PostgreSQL: localhost:5432
 - Redis: localhost:6379
+- Storage Redis: localhost:6479 (only used when a `STORAGE_REDIS_*` var is set; otherwise the main Redis connection is reused)
 
 ## Folder Structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       ]
     restart: always
     ports:
-      - "6380:6379"
+      - "6479:6379"
     environment:
       CI: ${CI}
     volumes:

--- a/infra/bunnyshell.yaml
+++ b/infra/bunnyshell.yaml
@@ -282,7 +282,7 @@ components:
             memory: 128M
       image: "redis:8-alpine"
       ports:
-        - "6380:6379"
+        - "6479:6379"
       restart: unless-stopped
     hosts:
       - hostname: "redis-storage-{{ env.base_domain }}"

--- a/infra/docker-compose.split.local.yml
+++ b/infra/docker-compose.split.local.yml
@@ -343,7 +343,7 @@ services:
     volumes:
       - redis_storage_data:/data
     ports:
-      - "${STORAGE_REDIS_PORT:-6380}:6379"
+      - "${STORAGE_REDIS_PORT:-6479}:6379"
     environment:
       CI: ${CI}
     healthcheck:

--- a/infra/docker-compose.split.yml
+++ b/infra/docker-compose.split.yml
@@ -314,7 +314,7 @@ services:
     volumes:
       - redis_storage_data:/data
     ports:
-      - "${STORAGE_REDIS_PORT:-6380}:6379"
+      - "${STORAGE_REDIS_PORT:-6479}:6379"
     environment:
       CI: ${CI}
     healthcheck:


### PR DESCRIPTION
## Summary

The storage Redis added for Responses API state + gateway response caching publishes on host port `6380`. That's a commonly used alternate Redis port, and it already collides in-repo with the persistent `openllm-redis` container documented in `.claude/skills/verify/SKILL.md` (which binds `6380` for the *main* Redis). When both are around, `docker compose up -d` fails with `Bind for 0.0.0.0:6380 failed: port is already allocated`.

This moves the published port to `6479` — `6379 + 100`, matching the `+100` offset convention already used for running apps on alternate ports.

## Changes

- `docker-compose.yml` — `redis-storage` publishes `6479:6379`
- `.env.example` — `STORAGE_REDIS_PORT=6479`
- `infra/docker-compose.split.yml`, `infra/docker-compose.split.local.yml` — default `${STORAGE_REDIS_PORT:-6479}`
- `infra/bunnyshell.yaml` — `6479:6379`
- `AGENTS.md` — list the storage Redis under Service URLs (Development)

Container-internal ports are untouched: services still connect to the storage Redis on `6379` (`STORAGE_REDIS_PORT=6379` inside the compose networks, `servicePort: 6379` in bunnyshell), so only the host-side mapping changes.

## Why no app-layer default changed

`packages/cache/src/storage-redis.ts` is deliberately left alone. Its two defaults are both still correct:

- **No `STORAGE_REDIS_*` set** → reuse the main Redis connection. Hardcoding `6479` here would break every single-Redis deployment (self-hosters, CI), which has nothing listening on that port.
- **Some `STORAGE_REDIS_*` set, port omitted** → `6379`. That is the port a dedicated storage Redis listens on *inside* the container network. `6479` is a host-side publish port only and never applies in-container.

So the port a local dev needs is supplied by `.env.example`, which this PR updates.

## Migration

Anyone with an existing local stack should re-run `docker compose up -d` (or `pnpm run setup`) to recreate the container on the new port. If you have `STORAGE_REDIS_PORT=6380` in your local `.env`, bump it to `6479`.

## Test plan

- `docker compose up -d` recreates `redis-storage` on `0.0.0.0:6479->6379/tcp`; `redis-cli ping` → `PONG`
- End-to-end app-layer check: with `STORAGE_REDIS_HOST=localhost STORAGE_REDIS_PORT=6479`, a write through `storageRedisClient` from `@llmgateway/cache` lands in the `redis-storage` container and **not** in the main `redis` container
- `pnpm run setup` completes (schema push to `db` + `test`, seed)
- `pnpm format`, `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the dedicated Storage Redis service to use host port **6479** instead of **6380** across local and deployment configurations.
  * Updated the example environment settings to reflect the new port.
* **Documentation**
  * Documented the Storage Redis development URL as `localhost:6479`.
  * Clarified that the dedicated connection is used only when Storage Redis settings are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->