### PR TITLE
feat(playground): link pricing in account menu

### DIFF
--- a/apps/playground/src/components/playground/audio-sidebar.tsx
+++ b/apps/playground/src/components/playground/audio-sidebar.tsx
@@ -3,6 +3,7 @@
 import {
 	AudioLines,
 	ChevronUp,
+	CreditCard,
 	Edit2,
 	ExternalLink,
 	LogOut,
@@ -671,6 +672,13 @@ export function AudioSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/canvas-sidebar.tsx
+++ b/apps/playground/src/components/playground/canvas-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronUp, ExternalLink, LogOut } from "lucide-react";
+import { ChevronUp, CreditCard, ExternalLink, LogOut } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
@@ -225,6 +225,13 @@ export function CanvasSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -11,6 +11,7 @@ import {
 	PinOff,
 	ChevronDown,
 	ChevronUp,
+	CreditCard,
 	LogOut,
 	ExternalLink,
 	Sparkles,
@@ -1006,6 +1007,12 @@ export const ChatSidebar = function ChatSidebar({
 									<Link href="/leaderboard" prefetch={true}>
 										<Trophy className="mr-2 h-4 w-4" />
 										Leaderboard
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
 									</Link>
 								</DropdownMenuItem>
 								<DropdownMenuSeparator />

--- a/apps/playground/src/components/playground/image-sidebar.tsx
+++ b/apps/playground/src/components/playground/image-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
 	ChevronUp,
+	CreditCard,
 	Edit2,
 	ExternalLink,
 	ImageIcon,
@@ -673,6 +674,13 @@ export function ImageSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/org-sidebar.tsx
+++ b/apps/playground/src/components/playground/org-sidebar.tsx
@@ -5,6 +5,7 @@ import { format } from "date-fns";
 import {
 	MessageSquare,
 	ChevronUp,
+	CreditCard,
 	LogOut,
 	ExternalLink,
 	Search,
@@ -506,6 +507,13 @@ export function OrgSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/projects-sidebar.tsx
+++ b/apps/playground/src/components/playground/projects-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import {
 	ChevronUp,
+	CreditCard,
 	ExternalLink,
 	FolderIcon,
 	LogOut,
@@ -252,6 +253,13 @@ export function ProjectsSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/realtime-sidebar.tsx
+++ b/apps/playground/src/components/playground/realtime-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronUp, ExternalLink, LogOut } from "lucide-react";
+import { ChevronUp, CreditCard, ExternalLink, LogOut } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
@@ -251,6 +251,13 @@ export function RealtimeSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/skills-sidebar.tsx
+++ b/apps/playground/src/components/playground/skills-sidebar.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
 	ChevronDown,
 	ChevronUp,
+	CreditCard,
 	ExternalLink,
 	LogOut,
 	Plus,
@@ -277,6 +278,13 @@ export function SkillsSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={

--- a/apps/playground/src/components/playground/video-sidebar.tsx
+++ b/apps/playground/src/components/playground/video-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
 	ChevronUp,
+	CreditCard,
 	Edit2,
 	ExternalLink,
 	Film,
@@ -683,6 +684,13 @@ export function VideoSidebar({
 								align="end"
 								sideOffset={4}
 							>
+								<DropdownMenuItem asChild>
+									<Link href="/pricing" prefetch={true}>
+										<CreditCard className="mr-2 h-4 w-4" />
+										Membership &amp; Billing
+									</Link>
+								</DropdownMenuItem>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem asChild>
 									<a
 										href={


### PR DESCRIPTION
## Summary

Users had no obvious way to find where to upgrade, cancel, or subscribe in the Lounge — the `/pricing` page (plans, upgrade/cancel/resume, billing history) existed but wasn't linked from the account dropdown.

This adds a **Membership & Billing** item (CreditCard icon) linking to `/pricing` in the account dropdown of every studio sidebar:

- **chat** — grouped with the Lounge items (Profile & Points, Leaderboard, Membership & Billing)
- **realtime, image, org, projects, video, canvas, audio, skills** — placed above the Dashboard item with a separator

No new routes or endpoints; purely a discoverability fix for the existing pricing page.

https://claude.ai/code/session_015hvPGket9DmuWs4Gk2rhRm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Membership & Billing” option to account menus across playground sidebars.
  * Added a credit card icon for easier recognition.
  * Selecting the option opens the pricing and billing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->