### PR TITLE
feat(models): add Tencent Hy3 model

### DIFF
--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -19,6 +19,7 @@ import { openbmbModels } from "./models/openbmb.js";
 import { perplexityModels } from "./models/perplexity.js";
 import { reveModels } from "./models/reve.js";
 import { sakanaModels } from "./models/sakana.js";
+import { tencentModels } from "./models/tencent.js";
 import { xaiModels } from "./models/xai.js";
 import { xiaomiModels } from "./models/xiaomi.js";
 import { zaiModels } from "./models/zai.js";
@@ -736,6 +737,7 @@ export const models = [
 	...nousresearchModels,
 	...reveModels,
 	...sakanaModels,
+	...tencentModels,
 	...nvidiaModels,
 	...openbmbModels,
 	...zaiModels,

--- a/packages/models/src/models/tencent.ts
+++ b/packages/models/src/models/tencent.ts
@@ -25,6 +25,7 @@ export const tencentModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				jsonOutputSchema: true,
 			},
 			{
 				providerId: "novita",
@@ -40,7 +41,7 @@ export const tencentModels = [
 				reasoningEfforts: ["none", "low", "high"],
 				vision: false,
 				tools: true,
-				jsonOutput: true,
+				jsonOutputSchema: true,
 			},
 		],
 	},

--- a/packages/models/src/models/tencent.ts
+++ b/packages/models/src/models/tencent.ts
@@ -1,0 +1,47 @@
+import type { ModelDefinition } from "@/models.js";
+
+export const tencentModels = [
+	{
+		id: "hy3",
+		name: "Hy3",
+		description:
+			"Tencent's 295B Mixture-of-Experts model with 21B active parameters, native 256K context support, and three reasoning modes for complex reasoning and agentic tasks.",
+		family: "tencent",
+		releasedAt: new Date("2026-07-06"),
+		providers: [
+			{
+				providerId: "deepinfra",
+				externalId: "tencent/Hy3",
+				inputPrice: "0.14e-6",
+				cachedInputPrice: "0.035e-6",
+				outputPrice: "0.58e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 131072,
+				quantization: "fp8",
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["none", "low", "high"],
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
+			{
+				providerId: "novita",
+				externalId: "tencent/hy3",
+				inputPrice: "0.14e-6",
+				cachedInputPrice: "0.035e-6",
+				outputPrice: "0.58e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 262144,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["none", "low", "high"],
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
+		],
+	},
+] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary
Adds Tencent's Hy3 model to the catalogue with provider mappings for DeepInfra and NovitaAI.

Hy3 is Tencent's 295B Mixture-of-Experts model (21B active params) with native 256K context and three reasoning modes, targeting complex reasoning and agentic tasks.

## Provider mappings

| Field | DeepInfra | NovitaAI |
|---|---|---|
| External ID | `tencent/Hy3` | `tencent/hy3` |
| Input price | $0.14/M | $0.14/M |
| Cached input price | $0.035/M | $0.035/M |
| Output price | $0.58/M | $0.58/M |
| Context size | 262144 | 262144 |
| Max output | 131072 | 262144 |
| Quantization | fp8 | — |
| Streaming | yes | yes |
| Reasoning | yes (`none`, `low`, `high`) | yes (`none`, `low`, `high`) |
| Vision | no | no |
| Tools | yes | yes |
| JSON output | yes | yes |

`reasoningEfforts: ["none", "low", "high"]` on both. DeepInfra's max output is 131072 (`max_output_tokens` from its model metadata; the page's `max_tokens: 262144` is the full context window, not the output cap). Novita's `max_output_tokens` is 262144.

## References
- https://deepinfra.com/tencent/Hy3
- https://novita.ai/models/model-detail/tencent-hy3
- https://openrouter.ai/tencent/hy3
- https://github.com/Tencent-Hunyuan/Hy3

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tencent’s HY3 model to the available model catalog.
  * Added support for streaming, reasoning, tool use, vision, and JSON output capabilities.
  * Included provider availability, context limits, quantization, and pricing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->