### PR TITLE
test(gateway): isolate shared e2e test state

### DIFF
--- a/apps/gateway/src/chat-cache-no-db.e2e.ts
+++ b/apps/gateway/src/chat-cache-no-db.e2e.ts
@@ -12,7 +12,10 @@ import {
 } from "vitest";
 
 import { app } from "@/app.js";
-import { clearCache } from "@/test-utils/test-helpers.js";
+import {
+	cleanupTestOrganization,
+	clearCache,
+} from "@/test-utils/test-helpers.js";
 
 import { db, pool, tables } from "@llmgateway/db";
 
@@ -116,16 +119,7 @@ describe("Chat completions caching: repeated requests do not re-read Postgres", 
 	beforeEach(async () => {
 		await clearCache();
 
-		await Promise.all([
-			db.delete(tables.log),
-			db.delete(tables.apiKey),
-			db.delete(tables.providerKey),
-		]);
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-		await Promise.all([db.delete(tables.organization), db.delete(tables.user)]);
+		await cleanupTestOrganization("cache-org", ["cache-user"]);
 
 		await db.insert(tables.user).values({
 			id: "cache-user",
@@ -168,37 +162,45 @@ describe("Chat completions caching: repeated requests do not re-read Postgres", 
 		});
 	});
 
-	test("a warm chat request issues zero Postgres reads on cached metadata tables", async () => {
-		// Warm the cache: api key, project, org, provider key, rate limits,
-		// discounts and routing metrics are all looked up and cached here.
-		expect((await sendChat("warm up one")).status).toBe(200);
-		expect((await sendChat("warm up two")).status).toBe(200);
+	// Retried because the cache this measures is global: a test file running in
+	// parallel resets Redis between its own tests, which can evict the entries
+	// warmed below in the window before the measured request. A regression in
+	// the cached lookups themselves fails every attempt.
+	test(
+		"a warm chat request issues zero Postgres reads on cached metadata tables",
+		{ retry: 3 },
+		async () => {
+			// Warm the cache: api key, project, org, provider key, rate limits,
+			// discounts and routing metrics are all looked up and cached here.
+			expect((await sendChat("warm up one")).status).toBe(200);
+			expect((await sendChat("warm up two")).status).toBe(200);
 
-		// Record every statement the shared pool executes during a fresh request.
-		// Both the cached (cdb) and uncached (db) clients use this same pool, so
-		// this captures any query that actually reaches Postgres.
-		const statements: string[] = [];
-		const original = pool.query.bind(pool);
-		const spy = vi.spyOn(pool, "query").mockImplementation(((
-			...args: Parameters<typeof original>
-		) => {
-			statements.push(statementText(args));
-			return original(...args);
-		}) as typeof pool.query);
+			// Record every statement the shared pool executes during a fresh request.
+			// Both the cached (cdb) and uncached (db) clients use this same pool, so
+			// this captures any query that actually reaches Postgres.
+			const statements: string[] = [];
+			const original = pool.query.bind(pool);
+			const spy = vi.spyOn(pool, "query").mockImplementation(((
+				...args: Parameters<typeof original>
+			) => {
+				statements.push(statementText(args));
+				return original(...args);
+			}) as typeof pool.query);
 
-		try {
-			// A unique prompt guarantees the response cache cannot short-circuit
-			// the request, so the full auth/routing/pricing path runs.
-			const res = await sendChat("measured request with a unique prompt");
-			expect(res.status).toBe(200);
-		} finally {
-			spy.mockRestore();
-		}
+			try {
+				// A unique prompt guarantees the response cache cannot short-circuit
+				// the request, so the full auth/routing/pricing path runs.
+				const res = await sendChat("measured request with a unique prompt");
+				expect(res.status).toBe(200);
+			} finally {
+				spy.mockRestore();
+			}
 
-		const leaked = cachedTableReads(statements);
-		expect(
-			leaked,
-			`Expected zero cached-table SELECTs on a warm request, but these hit Postgres:\n${leaked.join("\n")}`,
-		).toEqual([]);
-	});
+			const leaked = cachedTableReads(statements);
+			expect(
+				leaked,
+				`Expected zero cached-table SELECTs on a warm request, but these hit Postgres:\n${leaked.join("\n")}`,
+			).toEqual([]);
+		},
+	);
 });

--- a/apps/gateway/src/chat-custom-provider.e2e.ts
+++ b/apps/gateway/src/chat-custom-provider.e2e.ts
@@ -11,13 +11,19 @@ import {
 } from "vitest";
 
 import { app } from "@/app.js";
-import { clearCache } from "@/test-utils/test-helpers.js";
+import {
+	cleanupTestOrganization,
+	clearCache,
+} from "@/test-utils/test-helpers.js";
 
 import { db, tables } from "@llmgateway/db";
 
 const mockServer = new Hono();
 let server: ReturnType<typeof serve> | null = null;
-const MOCK_PORT = 3099;
+// Test files run in parallel, so every suite needs its own mock upstream port
+// and its own fixture organization.
+const MOCK_PORT = 3097;
+const TEST_TOKEN = "custom-provider-token";
 
 mockServer.post("/v1/chat/completions", async (c) => {
 	return c.json({
@@ -71,16 +77,7 @@ mockServer.post("/ssrf-internal/v1/chat/completions", async (c) => {
 });
 
 async function cleanupDb() {
-	await db.delete(tables.log);
-	await db.delete(tables.apiKey);
-	await db.delete(tables.providerKey);
-	await db.delete(tables.userOrganization);
-	await db.delete(tables.project);
-	await db.delete(tables.organization);
-	await db.delete(tables.user);
-	await db.delete(tables.account);
-	await db.delete(tables.session);
-	await db.delete(tables.verification);
+	await cleanupTestOrganization("custom-org", ["custom-user"]);
 }
 
 async function setupTestData(opts: {
@@ -89,39 +86,39 @@ async function setupTestData(opts: {
 	includeProviderKey?: boolean;
 }) {
 	await db.insert(tables.user).values({
-		id: "user-id",
+		id: "custom-user",
 		name: "user",
-		email: "user@test.com",
+		email: "custom-provider@test.com",
 	});
 
 	await db.insert(tables.organization).values({
-		id: "org-id",
+		id: "custom-org",
 		name: "Test Organization",
-		billingEmail: "user@test.com",
+		billingEmail: "custom-provider@test.com",
 		plan: "pro",
 		retentionLevel: "retain",
 		credits: opts.credits ?? "100.00",
 	});
 
 	await db.insert(tables.userOrganization).values({
-		id: "user-org-id",
-		userId: "user-id",
-		organizationId: "org-id",
+		id: "custom-user-org",
+		userId: "custom-user",
+		organizationId: "custom-org",
 	});
 
 	await db.insert(tables.project).values({
-		id: "project-id",
+		id: "custom-project",
 		name: "Test Project",
-		organizationId: "org-id",
+		organizationId: "custom-org",
 		mode: opts.mode,
 	});
 
 	await db.insert(tables.apiKey).values({
-		id: "token-id",
-		token: "real-token",
-		projectId: "project-id",
+		id: "custom-token",
+		token: TEST_TOKEN,
+		projectId: "custom-project",
 		description: "Test API Key",
-		createdBy: "user-id",
+		createdBy: "custom-user",
 	});
 
 	if (opts.includeProviderKey) {
@@ -130,7 +127,7 @@ async function setupTestData(opts: {
 			token: "sk-test-key",
 			provider: "custom",
 			name: "my-custom",
-			organizationId: "org-id",
+			organizationId: "custom-org",
 			baseUrl: `http://localhost:${MOCK_PORT}`,
 		});
 	}
@@ -163,7 +160,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "custom",
@@ -185,7 +182,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "custom",
@@ -209,7 +206,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "my-custom/gpt-4o-mini",
@@ -231,7 +228,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "my-custom/qwen3.6-plus",
@@ -254,7 +251,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "my-custom/qwen3.6-plus",
@@ -281,7 +278,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "my-custom/gpt-4o-mini",
@@ -307,7 +304,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "my-custom/gpt-4o-mini",
@@ -331,7 +328,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "nonexistent-provider/gpt-4o-mini",
@@ -353,7 +350,7 @@ describe("Custom Provider E2E", () => {
 				token: "sk-test-key",
 				provider: "custom",
 				name: "rdr",
-				organizationId: "org-id",
+				organizationId: "custom-org",
 				baseUrl: `http://localhost:${MOCK_PORT}/ssrf-redirect`,
 			});
 
@@ -361,7 +358,7 @@ describe("Custom Provider E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "rdr/gpt-4o-mini",

--- a/apps/gateway/src/chat-response-healing.e2e.ts
+++ b/apps/gateway/src/chat-response-healing.e2e.ts
@@ -12,14 +12,21 @@ import {
 } from "vitest";
 
 import { app } from "@/app.js";
-import { clearCache, readAll } from "@/test-utils/test-helpers.js";
+import {
+	cleanupTestOrganization,
+	clearCache,
+	readAll,
+} from "@/test-utils/test-helpers.js";
 
 import { db, tables } from "@llmgateway/db";
 
 // Create a mock server that returns configurable JSON responses
 const mockServer = new Hono();
 let server: ReturnType<typeof serve> | null = null;
+// Test files run in parallel, so every suite needs its own mock upstream port
+// and its own fixture organization.
 const MOCK_PORT = 3098;
+const TEST_TOKEN = "response-healing-token";
 
 // Configure different response types for testing
 let mockResponseContent = '{"message": "Hello World"}';
@@ -182,69 +189,51 @@ describe("Response Healing E2E", () => {
 	beforeEach(async () => {
 		await clearCache();
 
-		// Clean up database
-		await Promise.all([
-			db.delete(tables.log),
-			db.delete(tables.apiKey),
-			db.delete(tables.providerKey),
-		]);
-
-		await Promise.all([
-			db.delete(tables.userOrganization),
-			db.delete(tables.project),
-		]);
-
-		await Promise.all([
-			db.delete(tables.organization),
-			db.delete(tables.user),
-			db.delete(tables.account),
-			db.delete(tables.session),
-			db.delete(tables.verification),
-		]);
+		await cleanupTestOrganization("healing-org", ["healing-user"]);
 
 		// Setup test data
 		await db.insert(tables.user).values({
-			id: "user-id",
+			id: "healing-user",
 			name: "user",
-			email: "user@test.com",
+			email: "response-healing@test.com",
 		});
 
 		await db.insert(tables.organization).values({
-			id: "org-id",
+			id: "healing-org",
 			name: "Test Organization",
-			billingEmail: "user@test.com",
+			billingEmail: "response-healing@test.com",
 			plan: "pro",
 			retentionLevel: "retain",
 			credits: "100.00",
 		});
 
 		await db.insert(tables.userOrganization).values({
-			id: "user-org-id",
-			userId: "user-id",
-			organizationId: "org-id",
+			id: "healing-user-org",
+			userId: "healing-user",
+			organizationId: "healing-org",
 		});
 
 		await db.insert(tables.project).values({
-			id: "project-id",
+			id: "healing-project",
 			name: "Test Project",
-			organizationId: "org-id",
+			organizationId: "healing-org",
 			mode: "api-keys",
 		});
 
 		await db.insert(tables.apiKey).values({
-			id: "token-id",
-			token: "real-token",
-			projectId: "project-id",
+			id: "healing-token-id",
+			token: TEST_TOKEN,
+			projectId: "healing-project",
 			description: "Test API Key",
-			createdBy: "user-id",
+			createdBy: "healing-user",
 		});
 
 		// Create provider key with mock server URL as baseUrl
 		await db.insert(tables.providerKey).values({
-			id: "provider-key-id",
+			id: "healing-provider-key",
 			token: "sk-test-key",
 			provider: "llmgateway",
-			organizationId: "org-id",
+			organizationId: "healing-org",
 			baseUrl: `http://localhost:${MOCK_PORT}`,
 		});
 
@@ -258,7 +247,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -277,7 +266,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -299,7 +288,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -325,7 +314,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -351,7 +340,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -377,7 +366,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -405,7 +394,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -432,7 +421,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -459,7 +448,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -487,7 +476,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -533,7 +522,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -559,7 +548,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -587,7 +576,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -619,7 +608,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -649,7 +638,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -678,7 +667,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -705,7 +694,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -732,7 +721,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -759,7 +748,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -786,7 +775,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -825,7 +814,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",
@@ -853,7 +842,7 @@ describe("Response Healing E2E", () => {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
+					Authorization: `Bearer ${TEST_TOKEN}`,
 				},
 				body: JSON.stringify({
 					model: "llmgateway/custom",

--- a/apps/gateway/src/responses/tools/response-state.ts
+++ b/apps/gateway/src/responses/tools/response-state.ts
@@ -55,12 +55,16 @@ interface StoredResponseRecord {
 	outputRefs: string[];
 }
 
+// Shared prefix of every key written to the responses storage. Tests use it to
+// keep this state out of blanket Redis resets (see clearCache in test-utils).
+export const RESPONSES_STORAGE_KEY_PREFIX = "responses:";
+
 function itemStorageKey(projectId: string, itemRef: string): string {
-	return `responses:item:${projectId}:${itemRef}`;
+	return `${RESPONSES_STORAGE_KEY_PREFIX}item:${projectId}:${itemRef}`;
 }
 
 function responseStorageKey(projectId: string, responseId: string): string {
-	return `responses:resp:${projectId}:${responseId}`;
+	return `${RESPONSES_STORAGE_KEY_PREFIX}resp:${projectId}:${responseId}`;
 }
 
 /**

--- a/apps/gateway/src/test-utils/test-helpers.spec.ts
+++ b/apps/gateway/src/test-utils/test-helpers.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { RESPONSES_STORAGE_KEY_PREFIX } from "@/responses/tools/response-state.js";
+
+import { redisClient } from "@llmgateway/cache";
+
+import { clearCache } from "./test-helpers.js";
+
+describe("clearCache", () => {
+	it("drops cached state but keeps stored responses", async () => {
+		const responseKey = `${RESPONSES_STORAGE_KEY_PREFIX}resp:clear-cache-spec:resp_1`;
+		await redisClient.set(responseKey, "stored");
+		await redisClient.set("clear-cache-spec:cached", "cached");
+
+		await clearCache();
+
+		expect(await redisClient.get(responseKey)).toBe("stored");
+		expect(await redisClient.get("clear-cache-spec:cached")).toBeNull();
+
+		await redisClient.del(responseKey);
+	});
+});

--- a/apps/gateway/src/test-utils/test-helpers.ts
+++ b/apps/gateway/src/test-utils/test-helpers.ts
@@ -1,10 +1,77 @@
 import { processLogQueue } from "worker";
 
-import { redisClient } from "@llmgateway/cache";
-import { db, tables, eq } from "@llmgateway/db";
+import { RESPONSES_STORAGE_KEY_PREFIX } from "@/responses/tools/response-state.js";
 
+import { redisClient } from "@llmgateway/cache";
+import { db, inArray, tables, eq } from "@llmgateway/db";
+
+/**
+ * Reset Redis state between tests, except the Responses API state store.
+ *
+ * Test files run in parallel and the e2e suites run their tests concurrently,
+ * all against a single Redis (the storage Redis falls back to the main
+ * instance unless a STORAGE_REDIS_* var is set). A blanket `flushdb` therefore
+ * fires while sibling tests are mid-conversation and deletes the responses
+ * they stored, which surfaces as a follow-up `previous_response_id` turn
+ * losing its history or `GET /v1/responses/:id` returning 404. Those keys
+ * carry their own TTL and are namespaced per response id, so leaving them
+ * behind cannot leak into another test.
+ */
 export async function clearCache() {
-	await redisClient.flushdb();
+	let cursor = "0";
+	do {
+		const [nextCursor, keys] = await redisClient.scan(cursor, "COUNT", 1000);
+		cursor = nextCursor;
+		const deletable = keys.filter(
+			(key) => !key.startsWith(RESPONSES_STORAGE_KEY_PREFIX),
+		);
+		if (deletable.length > 0) {
+			await redisClient.unlink(...deletable);
+		}
+	} while (cursor !== "0");
+}
+
+/**
+ * Delete every row owned by a single test organization.
+ *
+ * Test files run in parallel against one database, so a suite that truncates
+ * whole tables deletes the API keys, projects and logs another suite is using
+ * mid-request. Suites that need a clean slate own a dedicated organization and
+ * clean up only that.
+ */
+export async function cleanupTestOrganization(
+	organizationId: string,
+	userIds: string[] = [],
+) {
+	const projects = await db.query.project.findMany({
+		where: { organizationId: { eq: organizationId } },
+		columns: { id: true },
+	});
+	const projectIds = projects.map((project) => project.id);
+
+	await db
+		.delete(tables.log)
+		.where(eq(tables.log.organizationId, organizationId));
+	if (projectIds.length > 0) {
+		await db
+			.delete(tables.apiKey)
+			.where(inArray(tables.apiKey.projectId, projectIds));
+	}
+	await db
+		.delete(tables.providerKey)
+		.where(eq(tables.providerKey.organizationId, organizationId));
+	await db
+		.delete(tables.userOrganization)
+		.where(eq(tables.userOrganization.organizationId, organizationId));
+	await db
+		.delete(tables.project)
+		.where(eq(tables.project.organizationId, organizationId));
+	await db
+		.delete(tables.organization)
+		.where(eq(tables.organization.id, organizationId));
+	if (userIds.length > 0) {
+		await db.delete(tables.user).where(inArray(tables.user.id, userIds));
+	}
 }
 
 /**


### PR DESCRIPTION
## Problem

The gateway e2e suites run their tests concurrently (`getConcurrentTestOptions()`), and test files run in parallel whenever they are invoked without `--no-file-parallelism`. All of them share one Redis and one Postgres, so every "reset" hook fires while sibling tests are mid-request.

Two concrete failure modes:

1. **`clearCache()` did `redisClient.flushdb()`**, which wipes the Responses API state store (`responses:*`). Those keys live on the storage Redis, which falls back to the main instance unless a `STORAGE_REDIS_*` var is set. A sibling test's follow-up `previous_response_id` turn then lost its history, and `GET /v1/responses/:id` returned 404 — reported as a flaky `responses tool calls` / `responses multi-turn` failure that moved between runs and reproduced on models unrelated to the change under test.
2. **Three suites truncated shared tables** (`log`, `api_key`, `project`, `organization`, `user`, ...) in their `beforeEach`, deleting the fixtures every other e2e file depends on, and `chat-cache-no-db` / `chat-custom-provider` both bound mock upstream port `3099`.

## Changes

- `clearCache()` now scans the keyspace and drops everything **except** `responses:*` (prefix exported as `RESPONSES_STORAGE_KEY_PREFIX` from `response-state.ts`, so the key layout stays single-sourced). Those keys carry their own TTL and are namespaced per response id, so leaving them behind cannot leak between tests.
- New `cleanupTestOrganization(organizationId, userIds)` helper deletes only the rows owned by one fixture organization.
- `chat-cache-no-db`, `chat-custom-provider` and `chat-response-healing` now own a dedicated organization id, API token, email and mock port, and clean up via the helper instead of truncating tables.
- The `chat-cache-no-db` measurement test gets `retry: 3`: it asserts on a *global* cache, which a parallel file's reset can legitimately evict between warm-up and measurement. A real regression in the cached lookups still fails every attempt.
- Added `test-helpers.spec.ts` locking in the "clearCache keeps stored responses" invariant.

## Verification

- `TEST_MODELS="deepinfra/deepseek-v4-flash,novita/gemma-4-31b-it" pnpm test:e2e` → 28 files / 111 tests passed, 0 failures. This is the configuration where the responses tests previously failed intermittently (two models in flight inside one concurrent file).
- The three refactored files run together in parallel: 32/32 passed on 3 consecutive runs. On `main` the same command gives 12 failed / 20 passed.
- `pnpm test:unit` → 207 files / 3432 tests passed.
- `pnpm build`, `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache clearing to preserve stored response data while removing temporary cached state.
  * Standardized response storage key handling for more consistent data access.

* **Tests**
  * Improved automated test isolation, cleanup, and retry handling.
  * Added coverage confirming cache cleanup does not remove persistent response data.

* **Refactor**
  * Consolidated test data cleanup and shared authentication fixtures to improve reliability across test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->