### PR TITLE
fix(gateway): bill cancelled requests by default

### DIFF
--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
 	calculateCosts,
 	isRefusalFinishReason,
+	shouldBillCancelledRequests,
 	zeroInferenceCosts,
 } from "./costs.js";
 
@@ -1782,5 +1783,40 @@ describe("zeroInferenceCosts", () => {
 		expect(costs.totalCost).toBe(0);
 		// Storage retention is billed separately from inference.
 		expect(costs.dataStorageCost).toBe(0.01);
+	});
+});
+
+describe("shouldBillCancelledRequests", () => {
+	const original = process.env.BILL_CANCELLED_REQUESTS;
+
+	afterEach(() => {
+		if (original === undefined) {
+			delete process.env.BILL_CANCELLED_REQUESTS;
+		} else {
+			process.env.BILL_CANCELLED_REQUESTS = original;
+		}
+	});
+
+	// Regression for GHSA-724j-f2pf-phf7: an unset value must bill cancelled
+	// requests so a client cannot abort a stream after receiving content to
+	// dodge usage/cost accounting.
+	it("defaults to true when unset", () => {
+		delete process.env.BILL_CANCELLED_REQUESTS;
+		expect(shouldBillCancelledRequests()).toBe(true);
+	});
+
+	it("defaults to true for an empty string (Helm's empty ConfigMap value)", () => {
+		process.env.BILL_CANCELLED_REQUESTS = "";
+		expect(shouldBillCancelledRequests()).toBe(true);
+	});
+
+	it("stays enabled when explicitly set to true", () => {
+		process.env.BILL_CANCELLED_REQUESTS = "true";
+		expect(shouldBillCancelledRequests()).toBe(true);
+	});
+
+	it("only disables billing when explicitly set to false", () => {
+		process.env.BILL_CANCELLED_REQUESTS = "false";
+		expect(shouldBillCancelledRequests()).toBe(false);
 	});
 });

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -111,12 +111,16 @@ export function zeroInferenceCosts(costs: MutableInferenceCosts): void {
 
 /**
  * Check if billing for cancelled requests is enabled via environment variable.
- * Defaults to false if not set.
+ * Defaults to true if not set: a cancelled streaming request has already
+ * consumed upstream inference (prompt tokens, plus any completion tokens
+ * emitted before the client disconnected), so it must be billed by default to
+ * prevent a streaming-abort billing bypass (GHSA-724j-f2pf-phf7). Only an
+ * explicit "false" disables it.
  */
 export function shouldBillCancelledRequests(): boolean {
 	const envValue = process.env.BILL_CANCELLED_REQUESTS;
-	// Default to false if not set, only enable if explicitly set to "true"
-	return envValue === "true";
+	// Default to true unless explicitly disabled with "false".
+	return envValue !== "false";
 }
 
 /**

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -1149,8 +1149,9 @@ export class RealtimeProxySession {
 		// Recorded for auditability only: realtime deliberately does NOT honour
 		// BILL_CANCELLED_REQUESTS. A cancelled response still reports the audio
 		// it already generated, and the upstream provider bills us for it, so
-		// every terminal response is charged regardless of status. This differs
-		// from the HTTP path, where cancelled requests are free by default.
+		// every terminal response is charged regardless of status. The HTTP path
+		// bills cancelled requests by default too (BILL_CANCELLED_REQUESTS), but
+		// can be opted out of; realtime cannot.
 		const responseStatus =
 			response && typeof response.status === "string"
 				? response.status

--- a/infra/helm/llmgateway/values.yaml
+++ b/infra/helm/llmgateway/values.yaml
@@ -483,6 +483,8 @@ stripe:
   devPlanMaxPriceId: ""
 
 billing:
+  # Bill cancelled/aborted streaming requests for the inference already consumed.
+  # Defaults to enabled in code; set to "false" only to opt out (see GHSA-724j-f2pf-phf7).
   billCancelledRequests: ""
   platformFeePercentage: ""
 


### PR DESCRIPTION
## Summary

Fixes the streaming-abort billing bypass reported in [GHSA-724j-f2pf-phf7](https://github.com/theopenco/llmgateway/security/advisories/GHSA-724j-f2pf-phf7).

An authenticated user could `POST /v1/chat/completions` with `stream: true`, read the useful assistant output, then close the connection before the final usage chunk. The gateway logged the request as `canceled` with **null** `promptTokens`/`completionTokens`/`cost`, and the worker's project-stats aggregator sums those nulls as zero — so the request was billed as **0 tokens / \$0** while upstream inference (and upstream cost to us) had already been consumed.

## Verification of the report

The report is **valid** and its dependency on `BILL_CANCELLED_REQUESTS` is confirmed:

- `shouldBillCancelledRequests()` returned `true` only when `BILL_CANCELLED_REQUESTS === "true"`, defaulting to `false`.
- When `canceled && !shouldBillCancelledRequests()`, both the streaming cost object and the final log entry force token/cost fields to `null` (`apps/gateway/src/chat/chat.ts`).
- The production Helm default is empty (`infra/helm/llmgateway/values.yaml` → `billCancelledRequests: ""`), so the unbilled path was live in production — matching the reporter's observed behavior.
- The gateway already estimates prompt tokens (from messages) and completion tokens (from streamed content) at cancel time, so once billing is enabled these requests are charged for the work actually performed.

## Fix

Flip the default: `shouldBillCancelledRequests()` now bills unless `BILL_CANCELLED_REQUESTS` is explicitly `"false"`. This is exactly the mitigation the advisory recommends ("Bill canceled streaming requests by default") and aligns the code with the already-documented `.env.example` default (`# ... default: true`). The empty Helm value now resolves to billing enabled.

## Changes

- `apps/gateway/src/lib/costs.ts` — default `shouldBillCancelledRequests()` to `true` (opt out with `"false"`).
- `apps/gateway/src/lib/costs.spec.ts` — regression tests covering unset / empty / `"true"` / `"false"`.
- `infra/helm/llmgateway/values.yaml` — comment documenting the enabled-by-default behavior.
- `apps/gateway/src/realtime/session.ts` — update a now-stale comment that claimed the HTTP path leaves cancelled requests free by default.

The realtime path already bills every terminal response regardless of status, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Billing**
  * Cancelled requests are now billed by default.
  * Billing can be disabled through the available configuration setting.
* **Documentation**
  * Updated configuration guidance to explain the default behavior and opt-out option.
  * Clarified billing behavior for realtime and HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->