### PR TITLE
feat(gateway): add Fireworks priority service tier

### DIFF
--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Service Tiers
-description: Trade latency against cost on supported OpenAI and Google models with Flex and Priority processing tiers.
+description: Trade latency against cost on supported OpenAI, Google, and Fireworks models with Flex and Priority processing tiers.
 icon: Gauge
 ---
 
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 # Service Tiers
 
-Some OpenAI and Google models support selectable **processing tiers** that trade
+Some OpenAI, Google, and Fireworks models support selectable **processing tiers** that trade
 latency and availability against price. You pick one per request with the
 OpenAI-compatible `service_tier` parameter, and LLM Gateway forwards it only
 when the selected provider/model mapping supports that tier.
@@ -62,6 +62,13 @@ the exact tiers exposed by each provider card.
 - **Google AI Studio / Gemini API** (`google-ai-studio`) — sent as a
   `service_tier` field in the request body for configured models that opt in.
 
+- **Fireworks AI** (`fireworks`) — sent as a `service_tier` field in the request
+  body on its OpenAI-compatible chat completions endpoint. Only Priority is
+  offered (Fireworks publishes no Flex rate card), billed at a 1.25x multiplier.
+  Fireworks does not report the tier it served, but a Priority request is either
+  served at Priority or shed with a 503, so an accepted request is billed at the
+  tier it was sent at.
+
 <Callout type="info">
 	Tiers are supported on a **subset** of models, and the Flex and Priority
 	subsets differ by provider. For example, Google Flex PayGo lists Gemini 3
@@ -70,14 +77,14 @@ the exact tiers exposed by each provider card.
 </Callout>
 
 <Callout type="warn">
-	Flex and Priority are only honored when the request reaches Google directly,
-	so a `google-vertex` / `google-ai-studio` provider key with a **custom base
-	URL** (a proxy) is excluded from service-tier routing — a proxy may silently
-	drop the tier and serve standard. With multiple providers/keys, the gateway
-	routes around the ineligible key automatically; if a request pins a provider
-	whose only key uses a custom base URL, it returns a 400 instead of silently
-	downgrading. Keys with no custom base URL (the managed default) are always
-	eligible.
+	Flex and Priority are only honored when the request reaches the provider
+	directly, so a `google-vertex` / `google-ai-studio` / `fireworks` provider key
+	with a **custom base URL** (a proxy) is excluded from service-tier routing — a
+	proxy may silently drop the tier and serve standard. With multiple
+	providers/keys, the gateway routes around the ineligible key automatically; if
+	a request pins a provider whose only key uses a custom base URL, it returns a
+	400 instead of silently downgrading. Keys with no custom base URL (the managed
+	default) are always eligible.
 </Callout>
 
 ## Pricing uses multipliers
@@ -105,7 +112,9 @@ The served tier is read back from the provider response — Vertex reports it in
 `usageMetadata.trafficType` (`ON_DEMAND_PRIORITY` / `ON_DEMAND_FLEX` /
 `ON_DEMAND`), Google AI Studio reports it in the `x-gemini-service-tier`
 response header, and OpenAI can return `service_tier` in response payloads or
-stream events.
+stream events. Providers that report no tier at all (Fireworks) never downgrade
+silently — they reject the request instead — so an accepted request is billed at
+the tier it was sent at.
 
 <Callout type="warn">
 	LLM Gateway rejects unsupported tier requests before provider routing. For
@@ -123,3 +132,4 @@ each tier.
 - [OpenAI API pricing](https://openai.com/api/pricing/)
 - [Google Flex PayGo](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo)
 - [Google Priority PayGo](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/priority-paygo)
+- [Fireworks Serverless Priority and Fast](https://docs.fireworks.ai/serverless/priority-and-fast)

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1600,6 +1600,76 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/chat/completions rejects flex on Fireworks, which only sells priority", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-fireworks-flex",
+			token: "real-token-fireworks-flex",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-fireworks-flex",
+			},
+			body: JSON.stringify({
+				model: "fireworks/kimi-k3",
+				service_tier: "flex",
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error).toMatchObject({
+			param: "service_tier",
+			code: "unsupported_service_tier",
+		});
+	});
+
+	test("/v1/chat/completions rejects a Fireworks tier request on a proxied key", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-fireworks-proxy-tier",
+			token: "real-token-fireworks-proxy-tier",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// Fireworks never reports the tier it served, so a priority request is
+		// billed at the tier it was sent at. A proxy base URL may silently drop
+		// the field, which would overbill — the request must be rejected instead.
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-fireworks-proxy-tier",
+			token: "sk-test-key",
+			provider: "fireworks",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-fireworks-proxy-tier",
+			},
+			body: JSON.stringify({
+				model: "fireworks/kimi-k3",
+				service_tier: "priority",
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.error.message).toContain(
+			"requires a provider key that targets the original upstream endpoint",
+		);
+	});
+
 	test("/v1/chat/completions strips log payload when retention is disabled", async () => {
 		await db
 			.update(tables.organization)

--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -6,6 +6,7 @@ import {
 	type ModelDefinition,
 	getProviderDefinition,
 	getProviderEnvVar,
+	getSupportedServiceTiers,
 	models,
 	type ProviderModelMapping,
 	providers,
@@ -913,6 +914,30 @@ export const reasoningEffortModels = fullMode
 
 export const verbosityModels = testModels.filter((m) =>
 	m.providers.some((p: ProviderModelMapping) => p.verbosity === true),
+);
+
+/**
+ * One case per (provider mapping, service tier) the catalogue declares, so a
+ * mapping that opts into Flex/Priority is exercised against the real upstream.
+ * Only provider-pinned entries are used — the tier is a per-mapping property,
+ * and the tests pin the provider with x-no-fallback so an upstream that rejects
+ * the tier surfaces instead of falling back.
+ */
+export const serviceTierModels = testModels.flatMap((m) =>
+	m.originalModel
+		? m.providers.flatMap((p: ProviderModelMapping) =>
+				getSupportedServiceTiers(
+					m.originalModel as string,
+					p.providerId,
+					p.region ?? null,
+				).map((tier) => ({
+					model: m.model,
+					serviceTier: tier.id,
+					multiplier: tier.multiplier,
+					mapping: p,
+				})),
+			)
+		: [],
 );
 
 export const streamingReasoningModels = reasoningModels.filter((m) =>

--- a/apps/gateway/src/chat-service-tier.e2e.ts
+++ b/apps/gateway/src/chat-service-tier.e2e.ts
@@ -1,0 +1,154 @@
+import "dotenv/config";
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import {
+	beforeAllHook,
+	beforeEachHook,
+	generateTestRequestId,
+	getConcurrentTestOptions,
+	getTestOptions,
+	logMode,
+	serviceTierModels,
+	validateLogByRequestId,
+	validateResponse,
+} from "@/chat-helpers.e2e.js";
+import { readAll } from "@/test-utils/test-helpers.js";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+/**
+ * Token costs are scaled by the tier multiplier, so recompute the expected
+ * uncached input cost from the tokens the upstream actually reported (cached
+ * prompt tokens are billed separately as cachedInputCost).
+ */
+function expectedInputCost(
+	mapping: ProviderModelMapping,
+	multiplier: number,
+	promptTokens: number,
+	cachedTokens: number,
+) {
+	return (
+		(promptTokens - cachedTokens) * Number(mapping.inputPrice ?? 0) * multiplier
+	);
+}
+
+describe("e2e service tiers", getConcurrentTestOptions(), () => {
+	beforeAll(beforeAllHook);
+
+	beforeEach(beforeEachHook);
+
+	test("empty", () => {
+		expect(true).toBe(true);
+	});
+
+	test.each(serviceTierModels)(
+		"service_tier $serviceTier $model",
+		getTestOptions(),
+		async ({ model, serviceTier, multiplier, mapping }) => {
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model,
+					service_tier: serviceTier,
+					messages: [
+						{
+							role: "user",
+							content: `Say 'OK' (${serviceTier} tier test)`,
+						},
+					],
+				}),
+			});
+
+			const json = await res.json();
+			if (logMode) {
+				console.log(
+					`service_tier ${serviceTier} response for ${model}:`,
+					JSON.stringify(json, null, 2),
+				);
+			}
+
+			expect(res.status).toBe(200);
+			validateResponse(json);
+			expect(json.metadata?.requested_service_tier).toBe(serviceTier);
+
+			const log = await validateLogByRequestId(requestId);
+			expect(log.requestedServiceTier).toBe(serviceTier);
+			// Providers may downgrade to standard under load, in which case the
+			// request is billed (and logged) at the standard rate instead.
+			expect([serviceTier, null]).toContain(log.usedServiceTier);
+			expect(log.usedServiceTier).toBe(
+				json.metadata?.used_service_tier ?? null,
+			);
+
+			const billedMultiplier =
+				log.usedServiceTier === serviceTier ? multiplier : 1;
+			expect(Number(log.inputCost)).toBeCloseTo(
+				expectedInputCost(
+					mapping,
+					billedMultiplier,
+					Number(log.promptTokens ?? 0),
+					Number(log.cachedTokens ?? 0),
+				),
+				8,
+			);
+		},
+	);
+
+	test.each(serviceTierModels)(
+		"streaming service_tier $serviceTier $model",
+		getTestOptions(),
+		async ({ model, serviceTier }) => {
+			const requestId = generateTestRequestId();
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-request-id": requestId,
+					"x-no-fallback": "true",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model,
+					service_tier: serviceTier,
+					stream: true,
+					messages: [
+						{
+							role: "user",
+							content: `Say 'OK' (streaming ${serviceTier} tier test)`,
+						},
+					],
+				}),
+			});
+
+			if (res.status !== 200) {
+				console.log("response:", await res.text());
+				throw new Error(`Request failed with status ${res.status}`);
+			}
+
+			const streamResult = await readAll(res.body);
+			if (logMode) {
+				console.log("streamResult", JSON.stringify(streamResult, null, 2));
+			}
+
+			expect(streamResult.hasValidSSE).toBe(true);
+			expect(streamResult.hasContent).toBe(true);
+
+			const metadataChunk = streamResult.chunks.find(
+				(chunk) => chunk.metadata?.requested_service_tier,
+			);
+			expect(metadataChunk?.metadata?.requested_service_tier).toBe(serviceTier);
+
+			const log = await validateLogByRequestId(requestId);
+			expect(log.requestedServiceTier).toBe(serviceTier);
+			expect([serviceTier, null]).toContain(log.usedServiceTier);
+		},
+	);
+});

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -104,6 +104,7 @@ import { validateModelOutput } from "@/lib/validate-model-output.js";
 
 import {
 	applyGoogleServiceTier,
+	assumeServedServiceTier,
 	getCheapestFromAvailableProviders,
 	getDiscountedProviderSelectionPrice,
 	getGcpServiceAccountAccessToken,
@@ -763,7 +764,8 @@ function isVertexCompatibleProvider(provider: string): boolean {
  * Dev-only verification log confirming a requested processing tier reached the
  * provider. AI Studio reports the served tier in the `x-gemini-service-tier`
  * response header; Vertex reports it in `usageMetadata.trafficType` (logged
- * separately once the response body is parsed).
+ * separately once the response body is parsed); Fireworks reports nothing, so
+ * an accepted request is attributed to the tier it was sent at.
  */
 function logServiceTierRequest(
 	provider: string,
@@ -773,7 +775,7 @@ function logServiceTierRequest(
 	if (
 		process.env.NODE_ENV === "production" ||
 		(serviceTier !== "flex" && serviceTier !== "priority") ||
-		!isGoogleCompatibleProvider(provider)
+		!(isGoogleCompatibleProvider(provider) || provider === "fireworks")
 	) {
 		return;
 	}
@@ -783,7 +785,13 @@ function logServiceTierRequest(
 		transport: isVertexCompatibleProvider(provider)
 			? "X-Vertex-AI-LLM-Shared-Request-Type header"
 			: "service_tier body field",
-		servedServiceTier: res?.headers.get("x-gemini-service-tier") ?? null,
+		servedServiceTier:
+			res?.headers.get("x-gemini-service-tier") ??
+			assumeServedServiceTier(
+				provider as Provider,
+				serviceTier,
+				res?.ok ?? false,
+			),
 		status: res?.status,
 	});
 }
@@ -7145,9 +7153,17 @@ chat.openapi(completions, async (c) => {
 						logServiceTierRequest(usedProvider, forwardedServiceTier, res);
 						// AI Studio reports the served tier in a response header; Vertex
 						// reports it later in usageMetadata.trafficType (set below).
-						servedServiceTier = resolveServedServiceTier({
-							serviceTierHeader: res?.headers.get("x-gemini-service-tier"),
-						});
+						// Providers that report no tier at all (Fireworks) fall back to
+						// the tier the accepted request was sent at.
+						servedServiceTier =
+							resolveServedServiceTier({
+								serviceTierHeader: res?.headers.get("x-gemini-service-tier"),
+							}) ??
+							assumeServedServiceTier(
+								usedProvider,
+								forwardedServiceTier,
+								res?.ok ?? false,
+							);
 					} catch (error) {
 						// Clean up the event listeners
 						c.req.raw.signal.removeEventListener("abort", onAbort);
@@ -11398,10 +11414,18 @@ chat.openapi(completions, async (c) => {
 
 			logServiceTierRequest(usedProvider, forwardedServiceTier, res);
 			// AI Studio reports the served tier in a response header; Vertex reports
-			// it later in usageMetadata.trafficType (set below).
-			servedServiceTier = resolveServedServiceTier({
-				serviceTierHeader: res?.headers.get("x-gemini-service-tier"),
-			});
+			// it later in usageMetadata.trafficType (set below). Providers that
+			// report no tier at all (Fireworks) fall back to the tier the accepted
+			// request was sent at.
+			servedServiceTier =
+				resolveServedServiceTier({
+					serviceTierHeader: res?.headers.get("x-gemini-service-tier"),
+				}) ??
+				assumeServedServiceTier(
+					usedProvider,
+					forwardedServiceTier,
+					res?.ok ?? false,
+				);
 		} catch (error) {
 			// Check for timeout error first (AbortSignal.timeout throws TimeoutError)
 			if (isTimeoutError(error)) {
@@ -13032,6 +13056,15 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// OpenAI echoes the served tier in its response payload; providers that
+	// report no tier of their own (Fireworks) echo the tier the gateway
+	// resolved so clients still see what the request actually ran at.
+	const echoedServiceTier =
+		usedProvider === "openai"
+			? readServiceTierValue(json)
+			: (assumeServedServiceTier(usedProvider, servedServiceTier, true) ??
+				undefined);
+
 	// Transform response to OpenAI format for non-OpenAI providers
 	// Include costs in response for all users
 	const shouldIncludeCosts = true;
@@ -13081,7 +13114,7 @@ chat.openapi(completions, async (c) => {
 		cacheCreation5mTokens,
 		cacheCreation1hTokens,
 		audioInputTokens,
-		usedProvider === "openai" ? readServiceTierValue(json) : undefined,
+		echoedServiceTier,
 	);
 	// Attach opaque reasoning payloads (e.g. OpenAI encrypted reasoning) to the
 	// assistant message so clients can replay them on later turns to preserve

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -877,6 +877,33 @@ describe("calculateCosts", () => {
 			expect(result.totalCost).toBeCloseTo(standardCost * 2, 8);
 		});
 
+		it("applies the Fireworks Priority multiplier (1.25x) to token costs", async () => {
+			const result = await calculateCosts(
+				"kimi-k3",
+				"fireworks",
+				null,
+				1000,
+				700,
+				200,
+				undefined,
+				null,
+				0,
+				undefined,
+				0,
+				null,
+				null,
+				undefined,
+				null,
+				null,
+				{ servedServiceTier: "priority" },
+			);
+			// Fireworks publishes Kimi K3 Priority at $3.75 / $0.375 / $18.75 per
+			// million, i.e. exactly 1.25x the standard $3.00 / $0.30 / $15.00.
+			expect(result.inputCost).toBeCloseTo(800 * 3.75e-6, 8);
+			expect(result.cachedInputCost).toBeCloseTo(200 * 0.375e-6, 8);
+			expect(result.outputCost).toBeCloseTo(700 * 18.75e-6, 8);
+		});
+
 		it("bills a downgraded request (servedServiceTier null) at standard rates", async () => {
 			const result = await calculateCosts(
 				"gemini-2.5-pro",

--- a/packages/actions/src/apply-google-service-tier.spec.ts
+++ b/packages/actions/src/apply-google-service-tier.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	applyGoogleServiceTier,
+	assumeServedServiceTier,
 	isPremiumServiceTier,
 	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
@@ -189,5 +190,43 @@ describe("providerKeyBaseUrlSupportsServiceTier", () => {
 				"https://glacier.internal/v1beta",
 			),
 		).toBe(true);
+	});
+
+	it("rejects a proxy base URL on fireworks but allows its upstream", () => {
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"fireworks",
+				"https://my-proxy.example.com/v1",
+			),
+		).toBe(false);
+		expect(
+			providerKeyBaseUrlSupportsServiceTier(
+				"fireworks",
+				"https://api.fireworks.ai/inference",
+			),
+		).toBe(true);
+		expect(providerKeyBaseUrlSupportsServiceTier("fireworks", null)).toBe(true);
+	});
+});
+
+describe("assumeServedServiceTier", () => {
+	it("attributes an accepted Fireworks request to the forwarded tier", () => {
+		expect(assumeServedServiceTier("fireworks", "priority", true)).toBe(
+			"priority",
+		);
+	});
+
+	it("returns null when the upstream rejected the request", () => {
+		expect(assumeServedServiceTier("fireworks", "priority", false)).toBeNull();
+	});
+
+	it("returns null for standard requests", () => {
+		expect(assumeServedServiceTier("fireworks", undefined, true)).toBeNull();
+		expect(assumeServedServiceTier("fireworks", "default", true)).toBeNull();
+	});
+
+	it("returns null for providers that report their served tier", () => {
+		expect(assumeServedServiceTier("openai", "priority", true)).toBeNull();
+		expect(assumeServedServiceTier("google-vertex", "flex", true)).toBeNull();
 	});
 });

--- a/packages/actions/src/apply-google-service-tier.ts
+++ b/packages/actions/src/apply-google-service-tier.ts
@@ -34,18 +34,16 @@ export function applyGoogleServiceTier(
 }
 
 /**
- * The Google providers the gateway forwards premium tiers to via Google's
- * transports: the `service_tier` body field (BODY_TIER_PROVIDERS) or the
- * Vertex request headers. A premium tier is only guaranteed to apply when the
- * request reaches Google's real upstream — a key pointing at a proxy / custom
- * base URL may silently drop the tier and the request is served (and billed)
- * as standard, never at the tier the caller asked for. Service-tier routing
- * is therefore restricted to keys targeting the provider's default base URL.
+ * Providers whose premium tiers only apply when the request reaches their real
+ * upstream: the Google providers (the `service_tier` body field for
+ * BODY_TIER_PROVIDERS, the Vertex request headers for google-vertex) and
+ * Fireworks. A key pointing at a proxy / custom base URL may silently drop the
+ * tier, so the request is served (and billed) as standard, never at the tier
+ * the caller asked for. Service-tier routing is therefore restricted to keys
+ * targeting the provider's default base URL.
  */
-const GOOGLE_TIER_PROVIDERS: ReadonlySet<ProviderId> = new Set<ProviderId>([
-	...BODY_TIER_PROVIDERS,
-	"google-vertex",
-]);
+const UPSTREAM_ONLY_TIER_PROVIDERS: ReadonlySet<ProviderId> =
+	new Set<ProviderId>([...BODY_TIER_PROVIDERS, "google-vertex", "fireworks"]);
 
 /**
  * The OpenAI-compatible processing tiers that select premium (Flex / Priority)
@@ -71,18 +69,19 @@ function normalizeServiceTierBaseUrl(baseUrl: string): string {
 
 /**
  * Whether a provider key's base URL is eligible to carry a Flex/Priority
- * service-tier request. Eligible when the provider is not one of the Google
- * tier providers, when the key uses the managed default (no custom base URL),
- * or when the custom base URL exactly matches the provider's default base URL
- * (its real upstream). A custom base URL on google-ai-studio / google-vertex
- * is the only case this rejects — glacier has no static default base URL
- * (env-defined deployment), so there is no canonical upstream to enforce.
+ * service-tier request. Eligible when the provider is not one of the
+ * upstream-only tier providers, when the key uses the managed default (no
+ * custom base URL), or when the custom base URL exactly matches the provider's
+ * default base URL (its real upstream). A custom base URL on google-ai-studio /
+ * google-vertex / fireworks is the only case this rejects — glacier has no
+ * static default base URL (env-defined deployment), so there is no canonical
+ * upstream to enforce.
  */
 export function providerKeyBaseUrlSupportsServiceTier(
 	provider: ProviderId,
 	baseUrl: string | null | undefined,
 ): boolean {
-	if (!GOOGLE_TIER_PROVIDERS.has(provider) || !baseUrl) {
+	if (!UPSTREAM_ONLY_TIER_PROVIDERS.has(provider) || !baseUrl) {
 		return true;
 	}
 	const upstream = getProviderDefaultBaseUrl(provider);
@@ -134,4 +133,31 @@ export function resolveServedServiceTier(signals: {
 		return "flex";
 	}
 	return null;
+}
+
+/**
+ * Providers that honor `service_tier` but report nothing back about the tier
+ * they served — no field in the response body, no response header. Fireworks
+ * is one: a Priority request is either served at Priority or shed with a 503
+ * ("server overloaded"), so there is no silent downgrade to standard and a
+ * successful response can be attributed to the tier that was forwarded.
+ */
+const UNREPORTED_TIER_PROVIDERS: ReadonlySet<ProviderId> = new Set<ProviderId>([
+	"fireworks",
+]);
+
+/**
+ * The tier to bill for providers that never report a served tier. Returns the
+ * forwarded tier when the upstream accepted the request, and null otherwise so
+ * a rejected request is never logged as having run at a premium tier.
+ */
+export function assumeServedServiceTier(
+	provider: ProviderId,
+	forwardedServiceTier: string | null | undefined,
+	responseOk: boolean,
+): "flex" | "priority" | null {
+	if (!responseOk || !isPremiumServiceTier(forwardedServiceTier)) {
+		return null;
+	}
+	return UNREPORTED_TIER_PROVIDERS.has(provider) ? forwardedServiceTier : null;
 }

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -770,6 +770,76 @@ describe("prepareRequestBody - OpenAI service tiers", () => {
 	});
 });
 
+describe("prepareRequestBody - Fireworks service tiers", () => {
+	async function prepareFireworksRequest(options: {
+		provider?: "fireworks" | "novita";
+		serviceTier?: "flex" | "priority";
+	}) {
+		return (await prepareRequestBody(
+			options.provider ?? "fireworks",
+			"kimi-k3",
+			null,
+			"accounts/fireworks/models/kimi-k3",
+			[{ role: "user", content: "Hello!" }] as any,
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+			20,
+			null,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			undefined,
+			undefined,
+			true,
+			undefined,
+			options.serviceTier,
+		)) as { service_tier?: string };
+	}
+
+	test("forwards priority to Fireworks chat completions", async () => {
+		const requestBody = await prepareFireworksRequest({
+			serviceTier: "priority",
+		});
+
+		expect(requestBody.service_tier).toBe("priority");
+	});
+
+	test("does not forward flex, which Fireworks has no rate card for", async () => {
+		const requestBody = await prepareFireworksRequest({ serviceTier: "flex" });
+
+		expect(requestBody.service_tier).toBeUndefined();
+	});
+
+	test("does not forward a tier to another provider serving the same model", async () => {
+		const requestBody = await prepareFireworksRequest({
+			provider: "novita",
+			serviceTier: "priority",
+		});
+
+		expect(requestBody.service_tier).toBeUndefined();
+	});
+
+	test("omits service_tier for standard requests", async () => {
+		const requestBody = await prepareFireworksRequest({});
+
+		expect(requestBody.service_tier).toBeUndefined();
+	});
+});
+
 describe("prepareRequestBody - verbosity", () => {
 	test("forwards verbosity to gpt-5.6 chat completions", async () => {
 		const requestBody = (await prepareOpenAITextRequest({

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -3940,6 +3940,14 @@ export async function prepareRequestBody(
 				requestBody.response_format = response_format;
 			}
 
+			// Fireworks selects the processing tier with the OpenAI-compatible
+			// `service_tier` body field on its chat completions endpoint. Its
+			// schema only accepts auto/default/flex/priority, and supportedServiceTier
+			// already narrows to the tiers the catalog declares for this mapping.
+			if (usedProvider === "fireworks" && supportedServiceTier) {
+				requestBody.service_tier = supportedServiceTier;
+			}
+
 			// Vertex's OpenAI-compatible chat completions endpoint requires the
 			// model field to be partner-prefixed, e.g. "xai/grok-4.20-reasoning".
 			// Derive the prefix from the model family so we don't have to encode

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -740,6 +740,10 @@ export const moonshotModels = [
 				cachedInputPrice: "0.3e-6",
 				outputPrice: "15.0e-6",
 				requestPrice: "0",
+				// Fireworks publishes a Priority rate card for Kimi K3 at exactly
+				// 1.25x the standard rates ($3.75 / $0.375 / $18.75 per million),
+				// which is the provider-level multiplier — no override needed.
+				serviceTiers: ["priority"],
 				contextSize: 1040384,
 				maxOutput: 1040384,
 				streaming: true,

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -154,6 +154,22 @@ describe("model service tier support", () => {
 		).toEqual(["flex"]);
 	});
 
+	it("returns the Fireworks Priority tier for Kimi K3 only", () => {
+		expect(
+			getSupportedServiceTiers("kimi-k3", "fireworks").map((tier) => tier.id),
+		).toEqual(["priority"]);
+		expect(
+			getSupportedServiceTiers("kimi-k3", "fireworks").find(
+				(tier) => tier.id === "priority",
+			)?.multiplier,
+		).toBe(1.25);
+		// Fireworks' schema accepts "flex", but it has no published flex rate
+		// card, so the gateway must not route flex traffic there.
+		expect(supportsServiceTier("kimi-k3", "fireworks", "flex")).toBe(false);
+		// Other providers serving the same model expose no tiers.
+		expect(getSupportedServiceTiers("kimi-k3", "novita")).toEqual([]);
+	});
+
 	it("returns explicit Google AI Studio tiers for supported models", () => {
 		expect(
 			getSupportedServiceTiers("gemini-2.5-pro", "google-ai-studio").map(

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1698,6 +1698,15 @@ export const providers: ProviderDefinition[] = [
 		website: "https://fireworks.ai",
 		statusPageUrl: "https://status.fireworks.ai",
 		announcement: null,
+		serviceTiers: [
+			{
+				id: "priority",
+				name: "Priority",
+				multiplier: 1.25,
+				description:
+					"Queue precedence over standard traffic and protection from load shedding during congestion, at a 25% premium.",
+			},
+		],
 		termsUrl: "https://fireworks.ai/terms-of-service",
 		privacyPolicyUrl: "https://fireworks.ai/privacy-policy",
 		headquarters: "US",


### PR DESCRIPTION
## Summary

Adds support for [Fireworks' Priority serverless tier](https://docs.fireworks.ai/serverless/priority-and-fast) on `fireworks/kimi-k3`, wired through the existing `service_tier` catalogue plumbing.

Priority buys queue precedence over standard traffic and protection from load shedding (503 "server overloaded") during congestion, priced at **exactly 1.25x** the standard rate card — Kimi K3 Priority is $3.75 / $0.375 / $18.75 per million vs $3.00 / $0.30 / $15.00 standard.

## Changes

- **Catalogue** — declare a `priority` tier (1.25x) on the `fireworks` provider and opt the Kimi K3 mapping into it. Only Priority is declared: Fireworks' schema also accepts `flex`, but it publishes no flex rate card, so a flex request is rejected with `400 unsupported_service_tier` rather than routed there and billed at an unknown rate.
- **Forwarding** — send `service_tier` in the upstream chat-completions body for Fireworks, gated on `supportsServiceTier` so it is only ever sent for mappings the catalogue declares.
- **Served tier** — Fireworks reports nothing about the tier it served (no response field, no header; verified against the live API). Since a Priority request is either served at Priority or shed with a 503, a new `assumeServedServiceTier` helper attributes an *accepted* request to the tier it was sent at. A rejected request logs no tier, so a failure is never billed at the premium.
- **Billing safety** — Fireworks joins the upstream-only tier providers (renamed from `GOOGLE_TIER_PROVIDERS`), so a provider key with a proxy base URL that could silently drop the field is excluded from tier routing instead of being billed +25% for standard service.
- **Response echo** — the resolved tier is echoed back as `service_tier` alongside the existing `requested_service_tier` / `used_service_tier` metadata.

Cost multipliers, the 400 rejection path, DB logging (`requested_service_tier` / `used_service_tier`), the log UI and the model-card tier selector are all provider-agnostic and pick this up from the catalogue with no further changes.

## Tests

- `packages/models/src/providers.spec.ts` — Kimi K3 exposes Priority at 1.25x on Fireworks only, flex is not supported.
- `packages/actions/src/prepare-request-body.spec.ts` — priority is forwarded, flex and other providers are not.
- `packages/actions/src/apply-google-service-tier.spec.ts` — `assumeServedServiceTier` and the fireworks base-URL guard.
- `apps/gateway/src/lib/costs.spec.ts` — the 1.25x multiplier applied to input/cached/output costs.
- `apps/gateway/src/api.spec.ts` — flex rejected with `unsupported_service_tier`; a proxied Fireworks key is rejected instead of silently downgrading.
- `apps/gateway/src/chat-service-tier.e2e.ts` (new) — catalogue-driven e2e over every mapping that declares a tier, streaming and non-streaming, asserting the requested/used tier on the log and that the input cost matches the tier-scaled rate.

## Verification

`TEST_MODELS="fireworks/kimi-k3" FULL_MODE=true pnpm test:e2e` — 110 passed, including the new service-tier file. Confirmed against the real upstream:

```
"requestedServiceTier": "priority",
"usedServiceTier": "priority",
"promptTokens": "98",  "inputCost": 0.0003675    // 98 x 3.75e-6
"completionTokens": "129", "outputCost": 0.00241875  // 129 x 18.75e-6
```

`pnpm test:unit` (3459 passed), `pnpm format` and `pnpm build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Fireworks AI Priority service-tier support for Kimi K3.
  - Priority requests now receive the applicable 1.25× pricing multiplier.
  - Responses include the served service tier when available or inferred.
  - Added validation for supported tiers and eligible Fireworks base URLs.
- **Documentation**
  - Updated service-tier documentation with Fireworks support, pricing, billing, failure behavior, and eligibility details.
- **Bug Fixes**
  - Improved billing and tier attribution when providers do not report the served tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->