### PR TITLE
chore(security): patch @hono/node-server path traversal

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
 			"@opentelemetry/core@<2.8.0": "^2.8.0",
 			"@opentelemetry/propagator-jaeger@<2.9.0": "^2.9.0",
 			"sharp@<0.35.0": "^0.35.0",
-			"@babel/core@<=7.29.0": "^7.29.6"
+			"@babel/core@<=7.29.0": "^7.29.6",
+				"@hono/node-server@<2.0.5": "^2.0.5"
 		},
 		"packageExtensions": {
 			"@hookform/resolvers": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 			"@opentelemetry/propagator-jaeger@<2.9.0": "^2.9.0",
 			"sharp@<0.35.0": "^0.35.0",
 			"@babel/core@<=7.29.0": "^7.29.6",
-				"@hono/node-server@<2.0.5": "^2.0.5"
+			"@hono/node-server@<2.0.5": "^2.0.5"
 		},
 		"packageExtensions": {
 			"@hookform/resolvers": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,7 @@ overrides:
   '@opentelemetry/propagator-jaeger@<2.9.0': ^2.9.0
   sharp@<0.35.0: ^0.35.0
   '@babel/core@<=7.29.0': ^7.29.6
+  '@hono/node-server@<2.0.5': ^2.0.5
 
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
@@ -2573,12 +2574,6 @@ packages:
 
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@hono/node-server@2.0.10':
     resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
@@ -13921,10 +13916,6 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
-    dependencies:
-      hono: 4.12.27
-
   '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
@@ -14224,7 +14215,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.75)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -14246,7 +14237,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5


### PR DESCRIPTION
## Summary

Swept the repository's dependency vulnerabilities (the Dependabot alert surface) and drove the tree to zero known advisories.

- Ran a full scan with both `pnpm audit` and an OSV query over all 2,275 resolved packages. **No high or critical vulnerabilities remain** — the existing `pnpm.overrides` block already eliminates them.
- One **moderate** advisory was still present: `@hono/node-server` < 2.0.5 — [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9), path traversal in `serve-static` on Windows via an encoded backslash (`%5C`). It was pulled in transitively by `@modelcontextprotocol/sdk@1.29.0` as `1.19.14`, even though the direct app dependencies (`apps/api`, `apps/gateway`) already declare the patched `^2.0.10`.

## Change

- Added `"@hono/node-server@<2.0.5": "^2.0.5"` to `pnpm.overrides`, following the repo's established security-override convention. This forces the MCP SDK's transitive copy up to a patched release and dedupes the whole tree onto the already-used `2.0.10`, so the vulnerable `1.19.14` is gone entirely.

`@hono/node-server@2.0.x` still exports the `getRequestListener` primitive that `@modelcontextprotocol/sdk` imports, and the gateway/playground apps already run `2.0.10` in production, so this is a no-behavior-change dedup.

## Verification

- `pnpm audit`: 0 vulnerabilities (info / low / moderate / high / critical all 0)
- `pnpm format`: pass
- `pnpm build`: 17/17 tasks successful
- `pnpm test:unit`: 3449 passed, 3 skipped, 0 failed

Only `package.json` and `pnpm-lock.yaml` change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyZs7Zk49wQKdMxyCxpwFN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency resolution for enhanced stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->