### PR TITLE
feat: provider visibility for devs + block reasons

### DIFF
--- a/apps/api/src/routes/custom-models.ts
+++ b/apps/api/src/routes/custom-models.ts
@@ -2,7 +2,10 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
-import { getAdminOrganizationIds } from "@/utils/authorization.js";
+import {
+	getActiveUserOrganizationIds,
+	getAdminOrganizationIds,
+} from "@/utils/authorization.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import { cdb, db, eq, tables } from "@llmgateway/db";
@@ -298,7 +301,10 @@ customModels.openapi(list, async (c) => {
 
 	const { providerKeyId } = c.req.valid("query");
 
-	const organizationIds = await getAdminOrganizationIds(user.id);
+	// Reads are member-level so every org member (including project-scoped
+	// developers) can browse the custom-model catalog; create/update/delete
+	// stay owner/admin-gated via getManageableProviderKey.
+	const organizationIds = await getActiveUserOrganizationIds(user.id);
 	if (!organizationIds.length) {
 		return c.json({ customModels: [] });
 	}

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -3,7 +3,10 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { maskToken } from "@/lib/maskToken.js";
-import { getAdminOrganizationIds } from "@/utils/authorization.js";
+import {
+	getActiveUserOrganizationIds,
+	getAdminOrganizationIds,
+} from "@/utils/authorization.js";
 
 import { validateProviderKey } from "@llmgateway/actions";
 import { logAuditEvent } from "@llmgateway/audit";
@@ -489,8 +492,10 @@ keysProvider.openapi(list, async (c) => {
 		});
 	}
 
-	// Get all active organization IDs the user has access to
-	const organizationIds = await getAdminOrganizationIds(user.id);
+	// Reads are member-level so every org member (including project-scoped
+	// developers) can see which providers/custom models are available; tokens
+	// are masked and all mutations stay owner/admin-gated.
+	const organizationIds = await getActiveUserOrganizationIds(user.id);
 
 	if (!organizationIds.length) {
 		return c.json({ providerKeys: [] });
@@ -542,7 +547,8 @@ keysProvider.openapi(listActive, async (c) => {
 		});
 	}
 
-	const organizationIds = await getAdminOrganizationIds(user.id);
+	// Member-level read: exposes only provider ids and status.
+	const organizationIds = await getActiveUserOrganizationIds(user.id);
 
 	if (!organizationIds.length) {
 		return c.json({ providerKeys: [] });

--- a/apps/docs/content/features/compliance.mdx
+++ b/apps/docs/content/features/compliance.mdx
@@ -31,7 +31,7 @@ Enable a policy under **Settings → Compliance** in the dashboard and toggle th
 
 Every requirement is **fail-closed**: a provider passes only if its published data policy explicitly satisfies the requirement. If an attribute is unknown for a provider, that provider is treated as non-compliant.
 
-The settings page shows a live preview of which providers are allowed and which are blocked under the current policy, so you can see the impact before saving.
+The settings page shows a live **Provider Impact** preview of which providers are allowed (green) and which are blocked (red) under the current policy, so you can see the impact before saving. Hovering a blocked provider lists exactly which requirements it does not meet — a missing certification, its data policy, its headquarters country, or a provider-list restriction.
 
 ## Provider headquarters
 
@@ -50,7 +50,27 @@ Beyond attribute-based requirements, the **Provider & Model Restrictions** card 
 
 Deny lists always win over allow lists, and both compose with the requirements above — an allow-listed provider must still satisfy every active certification, data-policy, and country requirement.
 
+<Callout type="warn">
+	A non-empty allowed-providers list blocks **every** provider not on it,
+	regardless of certifications or data policy. If you allow-list only a custom
+	provider, all catalogue providers show as blocked with the reason "Not on the
+	allowed-providers list" — add any additional provider you want to use to the
+	allow list.
+</Callout>
+
 The selectors include your organization's own [custom providers](/features/custom-providers) (stored as `custom:<name>` refs) and their custom-catalog models (stored as `<name>/<model>` refs), so a specific custom deployment can be blocked or allow-listed individually just like a catalogue provider.
+
+### Choosing a compliant provider
+
+The provider dropdowns are policy-aware, so you can tell **before** adding a provider to a list whether it satisfies your policy:
+
+- A **green shield** marks a provider that meets every active certification, data-policy, and headquarters requirement.
+- A **red shield** marks a provider that does not; the requirements it misses (for example "May log prompts" or "Headquartered in China, which is not an allowed country") are listed under its name.
+- The **"Only providers that meet policy requirements"** toggle at the top of the dropdown hides incompatible providers entirely.
+
+These indicators evaluate the requirements only — deliberately ignoring the allowed/blocked lists themselves — so an active allow list never paints every other provider red while you're deciding what to add to it. Your own custom providers are evaluated against their [self-attested posture](#custom-providers); one without an attestation on file shows "No compliance attestation on file".
+
+Elsewhere in the dashboard (for example the API-key provider filter), the colored dot next to a provider is simply the provider's **brand color** and carries no compliance meaning.
 
 These restrictions are **organization-wide** and take precedence over member-level and API-key-level [IAM rules](/features/api-keys): they are enforced after IAM evaluation, so no user-, team-, or key-level allow rule can grant access to a provider or model the compliance policy excludes.
 
@@ -92,6 +112,8 @@ Attestations only apply to custom provider keys. They can never be used to clear
 ## Access Control
 
 Only organization **owners** and **admins** can view and change the compliance policy.
+
+Project-scoped **developer** members cannot see the policy itself, but they can browse the org's available providers and models — including custom providers and their model catalogs — read-only on the **Custom Models** page. This is the recommended way for developers to discover what they can call without being granted additional permissions.
 
 ## Related
 

--- a/apps/docs/content/features/custom-providers.mdx
+++ b/apps/docs/content/features/custom-providers.mdx
@@ -150,6 +150,15 @@ undefined models are rejected with `400`. This guarantees that every request has
 known cost attribution and enforced limits. When disabled, undefined models
 still work but remain unbilled, as before.
 
+## Visibility
+
+Every active organization member — including project-scoped **developer**
+members — can browse the org's custom providers and their model catalogs
+read-only on the **Custom Models** page, so developers can always discover
+which providers and models are available to them. Creating, editing, and
+deleting providers, models, and attestations stays restricted to organization
+owners and admins.
+
 ## Compliance attestation
 
 If your organization enforces a [provider compliance policy](/features/compliance),

--- a/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
@@ -20,18 +20,25 @@ import {
 } from "@/lib/components/card";
 import { Label } from "@/lib/components/label";
 import { Switch } from "@/lib/components/switch";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/lib/components/tooltip";
 import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
 import {
 	customProviderRef,
+	getAttestationComplianceFailures,
+	getProviderComplianceFailures,
 	getProviderCountries,
-	isAttestationCompliant,
-	isProviderCompliant,
-	isProviderRefAllowedByPolicy,
+	getProviderRefPolicyListFailures,
 	models,
 	providers,
+	type ComplianceFailureReason,
 	type ProviderCompliancePolicy,
 	type ProviderDefinition,
 	type ProviderId,
@@ -44,34 +51,96 @@ import {
 
 import { ContactSalesCard } from "./contact-sales-card";
 
+import type { ReactElement } from "react";
+
 // Internal/virtual providers that should never appear in the impact preview.
 const HIDDEN_PROVIDER_IDS = new Set(["llmgateway", "custom"]);
+
+// Human-readable explanation for each way a provider can fail the policy,
+// shown on the blocked chips in the impact preview.
+const FAILURE_LABELS: Record<ComplianceFailureReason, string> = {
+	requireSoc2: "No SOC 2 report",
+	requireSoc2Type2: "No SOC 2 Type 2 report",
+	requireIso27001: "No ISO 27001 certification",
+	requireSoc2OrIso27001: "Neither SOC 2 Type 2 nor ISO 27001",
+	requireGdpr: "Not GDPR compliant",
+	blockApiTraining: "May train on API prompts",
+	blockPromptLogging: "May log prompts",
+	allowedCountries: "Headquarters not in an allowed country",
+	blockedProviders: "On the blocked-providers list",
+	allowedProviders: "Not on the allowed-providers list",
+	noAttestation: "No compliance attestation on file",
+};
+
+function failureLabel(
+	reason: ComplianceFailureReason,
+	headquarters: string | null | undefined,
+): string {
+	if (reason === "allowedCountries" && headquarters) {
+		const country = PROVIDER_COUNTRIES.find((c) => c.code === headquarters);
+		return `Headquartered in ${country?.name ?? headquarters}, which is not an allowed country`;
+	}
+	return FAILURE_LABELS[reason];
+}
+
+// Wraps a chip in a tooltip listing why the provider is blocked.
+function BlockedReasonsTooltip({
+	reasons,
+	children,
+}: {
+	reasons: string[];
+	children: ReactElement;
+}) {
+	if (reasons.length === 0) {
+		return children;
+	}
+	return (
+		<TooltipProvider delayDuration={200}>
+			<Tooltip>
+				<TooltipTrigger asChild>{children}</TooltipTrigger>
+				<TooltipContent className="max-w-xs">
+					<ul
+						className={cn(reasons.length > 1 && "list-disc pl-4 space-y-0.5")}
+					>
+						{reasons.map((reason) => (
+							<li key={reason}>{reason}</li>
+						))}
+					</ul>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
 
 function ProviderChip({
 	provider,
 	tone,
+	reasons = [],
 }: {
 	provider: ProviderDefinition;
 	tone: "allowed" | "blocked";
+	reasons?: string[];
 }) {
 	const Logo = providerLogoUrls[provider.id as ProviderId];
 	return (
-		<div
-			className={cn(
-				"inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium",
-				tone === "allowed"
-					? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
-					: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
-			)}
-		>
-			{Logo ? <Logo className="h-4 w-4 shrink-0" /> : null}
-			<span>{provider.name}</span>
-			{tone === "allowed" ? (
-				<Check className="h-3.5 w-3.5 shrink-0" />
-			) : (
-				<Ban className="h-3.5 w-3.5 shrink-0" />
-			)}
-		</div>
+		<BlockedReasonsTooltip reasons={reasons}>
+			<div
+				className={cn(
+					"inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium",
+					tone === "allowed"
+						? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+						: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
+				)}
+			>
+				{Logo ? <Logo className="h-4 w-4 shrink-0" /> : null}
+				<span>{provider.name}</span>
+				{tone === "allowed" ? (
+					<Check className="h-3.5 w-3.5 shrink-0" />
+				) : (
+					<Ban className="h-3.5 w-3.5 shrink-0" />
+				)}
+			</div>
+		</BlockedReasonsTooltip>
 	);
 }
 
@@ -80,26 +149,30 @@ function ProviderChip({
 function CustomProviderChip({
 	name,
 	tone,
+	reasons = [],
 }: {
 	name: string;
 	tone: "allowed" | "blocked";
+	reasons?: string[];
 }) {
 	return (
-		<div
-			className={cn(
-				"inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium",
-				tone === "allowed"
-					? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
-					: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
-			)}
-		>
-			<span className="font-mono">{name}</span>
-			{tone === "allowed" ? (
-				<Check className="h-3.5 w-3.5 shrink-0" />
-			) : (
-				<Ban className="h-3.5 w-3.5 shrink-0" />
-			)}
-		</div>
+		<BlockedReasonsTooltip reasons={reasons}>
+			<div
+				className={cn(
+					"inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium",
+					tone === "allowed"
+						? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+						: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
+				)}
+			>
+				<span className="font-mono">{name}</span>
+				{tone === "allowed" ? (
+					<Check className="h-3.5 w-3.5 shrink-0" />
+				) : (
+					<Ban className="h-3.5 w-3.5 shrink-0" />
+				)}
+			</div>
+		</BlockedReasonsTooltip>
 	);
 }
 
@@ -214,15 +287,22 @@ export function ComplianceClient() {
 
 	const { allowed, blocked } = useMemo(() => {
 		const allowedList: ProviderDefinition[] = [];
-		const blockedList: ProviderDefinition[] = [];
+		const blockedList: { provider: ProviderDefinition; reasons: string[] }[] =
+			[];
 		for (const provider of providers) {
 			if (HIDDEN_PROVIDER_IDS.has(provider.id)) {
 				continue;
 			}
-			if (isProviderCompliant(provider, policy)) {
+			const failures = getProviderComplianceFailures(provider, policy);
+			if (failures.length === 0) {
 				allowedList.push(provider);
 			} else {
-				blockedList.push(provider);
+				blockedList.push({
+					provider,
+					reasons: failures.map((reason) =>
+						failureLabel(reason, provider.headquarters),
+					),
+				});
 			}
 		}
 		return { allowed: allowedList, blocked: blockedList };
@@ -240,16 +320,24 @@ export function ComplianceClient() {
 				key.status !== "deleted" &&
 				key.organizationId === selectedOrganization?.id,
 		);
-		return keys.map((key) => ({
-			id: key.id,
-			name: key.name ?? key.id,
-			compliant:
-				isProviderRefAllowedByPolicy(
+		return keys.map((key) => {
+			const failures = [
+				...getProviderRefPolicyListFailures(
 					customProviderRef(key.name ?? key.id),
 					policy,
-				) && isAttestationCompliant(key.complianceAttestation, policy),
-			attested: Boolean(key.complianceAttestation),
-		}));
+				),
+				...getAttestationComplianceFailures(key.complianceAttestation, policy),
+			];
+			return {
+				id: key.id,
+				name: key.name ?? key.id,
+				compliant: failures.length === 0,
+				attested: Boolean(key.complianceAttestation),
+				reasons: failures.map((reason) =>
+					failureLabel(reason, key.complianceAttestation?.headquarters),
+				),
+			};
+		});
 	}, [providerKeysData, selectedOrganization?.id, policy]);
 
 	// Custom providers/models as selector entries for the restriction lists.
@@ -548,6 +636,18 @@ export function ComplianceClient() {
 					</CardHeader>
 					{policy.enabled && (
 						<CardContent className="space-y-6">
+							{(policy.allowedProviders?.length ?? 0) > 0 && (
+								<div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-300">
+									An allowed-providers list is active: only the{" "}
+									{policy.allowedProviders!.length === 1
+										? "provider"
+										: `${policy.allowedProviders!.length} providers`}{" "}
+									on it can be used, and every other provider is blocked
+									regardless of certifications or data policy. Add providers to
+									the &quot;Allowed providers&quot; list above to make them
+									available.
+								</div>
+							)}
 							<div className="space-y-3">
 								<Label className="text-emerald-700 dark:text-emerald-400">
 									Allowed ({allowed.length})
@@ -573,15 +673,22 @@ export function ComplianceClient() {
 									Blocked ({blocked.length})
 								</Label>
 								{blocked.length > 0 ? (
-									<div className="flex flex-wrap gap-2">
-										{blocked.map((provider) => (
-											<ProviderChip
-												key={provider.id}
-												provider={provider}
-												tone="blocked"
-											/>
-										))}
-									</div>
+									<>
+										<p className="text-sm text-muted-foreground">
+											Hover over a provider to see which requirements it does
+											not meet.
+										</p>
+										<div className="flex flex-wrap gap-2">
+											{blocked.map(({ provider, reasons }) => (
+												<ProviderChip
+													key={provider.id}
+													provider={provider}
+													tone="blocked"
+													reasons={reasons}
+												/>
+											))}
+										</div>
+									</>
 								) : (
 									<p className="text-sm text-muted-foreground">
 										No providers are blocked by this policy.
@@ -608,6 +715,7 @@ export function ComplianceClient() {
 												key={provider.id}
 												name={provider.name}
 												tone={provider.compliant ? "allowed" : "blocked"}
+												reasons={provider.compliant ? [] : provider.reasons}
 											/>
 										))}
 									</div>

--- a/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
@@ -33,6 +33,7 @@ import { cn } from "@/lib/utils";
 import {
 	customProviderRef,
 	getAttestationComplianceFailures,
+	getDataPolicyComplianceFailures,
 	getProviderComplianceFailures,
 	getProviderCountries,
 	getProviderRefPolicyListFailures,
@@ -47,6 +48,7 @@ import {
 	MultiModelSelector,
 	MultiProviderSelector,
 	providerLogoUrls,
+	type SelectableProviderOption,
 } from "@llmgateway/shared/components";
 
 import { ContactSalesCard } from "./contact-sales-card";
@@ -339,14 +341,53 @@ export function ComplianceClient() {
 			};
 		});
 	}, [providerKeysData, selectedOrganization?.id, policy]);
+	const compliantCustomCount = customProviders.filter(
+		(provider) => provider.compliant,
+	).length;
 
 	// Custom providers/models as selector entries for the restriction lists.
+	// Each entry carries its requirement-level compatibility (certifications,
+	// data policy, headquarters — deliberately NOT the allowed/blocked lists,
+	// which the pickers themselves edit), so the dropdowns can show which
+	// providers would satisfy the policy if selected.
 	const { customProviderOptions, customModelOptions } =
 		useCustomProviderSelection();
-	const selectableProviders = useMemo(
-		() => [...SELECTABLE_PROVIDERS, ...customProviderOptions],
-		[customProviderOptions],
-	);
+	const selectableProviders = useMemo<SelectableProviderOption[]>(() => {
+		const catalogueOptions = SELECTABLE_PROVIDERS.map((provider) => {
+			const failures = getDataPolicyComplianceFailures(
+				provider.dataPolicy,
+				provider.headquarters,
+				policy,
+			);
+			return {
+				id: provider.id,
+				name: provider.name,
+				color: provider.color,
+				meetsPolicy: failures.length === 0,
+				policyNotes: failures.map((reason) =>
+					failureLabel(reason, provider.headquarters),
+				),
+			};
+		});
+		const attestationByKeyId = new Map(
+			(providerKeysData?.providerKeys ?? []).map((key) => [
+				key.id,
+				key.complianceAttestation,
+			]),
+		);
+		const customOptions = customProviderOptions.map((option) => {
+			const attestation = attestationByKeyId.get(option.providerKeyId);
+			const failures = getAttestationComplianceFailures(attestation, policy);
+			return {
+				...option,
+				meetsPolicy: failures.length === 0,
+				policyNotes: failures.map((reason) =>
+					failureLabel(reason, attestation?.headquarters),
+				),
+			};
+		});
+		return [...catalogueOptions, ...customOptions];
+	}, [customProviderOptions, providerKeysData, policy]);
 	const selectableModels = useMemo(
 		() => [...models, ...customModelOptions],
 		[customModelOptions],
@@ -548,7 +589,10 @@ export function ComplianceClient() {
 							Block or allow individual providers and models — including your
 							own custom providers. These organization-wide lists are enforced
 							on top of the requirements above and take precedence over any
-							member or API key IAM rule.
+							member or API key IAM rule. In the provider dropdowns, a green
+							shield marks providers that meet the certification, data-policy,
+							and headquarters requirements above; a red shield lists the
+							requirements they miss.
 						</CardDescription>
 					</CardHeader>
 					<CardContent
@@ -630,7 +674,15 @@ export function ComplianceClient() {
 						<CardTitle>Provider Impact</CardTitle>
 						<CardDescription>
 							{policy.enabled
-								? `${allowed.length} of ${totalProviders} providers meet this policy.`
+								? `${allowed.length} of ${totalProviders} catalogue providers meet this policy.${
+										customProviders.length > 0
+											? ` ${compliantCustomCount} of ${customProviders.length} custom ${
+													customProviders.length === 1
+														? "provider complies"
+														: "providers comply"
+												}.`
+											: ""
+									}`
 								: "Enable the policy to restrict which providers can be used."}
 						</CardDescription>
 					</CardHeader>
@@ -664,7 +716,10 @@ export function ComplianceClient() {
 									</div>
 								) : (
 									<p className="text-sm text-muted-foreground">
-										No providers meet this policy. Requests will be blocked.
+										No catalogue providers meet this policy.{" "}
+										{compliantCustomCount > 0
+											? "Only the compliant custom providers below can serve requests."
+											: "Requests will be blocked."}
 									</p>
 								)}
 							</div>

--- a/apps/ui/src/components/custom-models/compliance-attestation-card.tsx
+++ b/apps/ui/src/components/custom-models/compliance-attestation-card.tsx
@@ -111,11 +111,11 @@ function buildInitialState(
 export function ComplianceAttestationCard({
 	providerKey,
 	organizationId,
-	isEnterprise,
+	canManage,
 }: {
 	providerKey: ProviderKeyItem;
 	organizationId: string;
-	isEnterprise: boolean;
+	canManage: boolean;
 }) {
 	const api = useApi();
 	const queryClient = useQueryClient();
@@ -239,7 +239,7 @@ export function ComplianceAttestationCard({
 						<Select
 							value={form.soc2}
 							onValueChange={(v) => set("soc2", v)}
-							disabled={!isEnterprise}
+							disabled={!canManage}
 						>
 							<SelectTrigger id="attest-soc2">
 								<SelectValue />
@@ -257,7 +257,7 @@ export function ComplianceAttestationCard({
 							<Select
 								value={form[key]}
 								onValueChange={(v) => set(key, v)}
-								disabled={!isEnterprise}
+								disabled={!canManage}
 							>
 								<SelectTrigger id={`attest-${key}`}>
 									<SelectValue />
@@ -277,7 +277,7 @@ export function ComplianceAttestationCard({
 							placeholder='e.g. "0 days" or "30 days"'
 							value={form.retentionPeriod}
 							onChange={(e) => set("retentionPeriod", e.target.value)}
-							disabled={!isEnterprise}
+							disabled={!canManage}
 						/>
 					</div>
 					<div className="space-y-2">
@@ -293,7 +293,7 @@ export function ComplianceAttestationCard({
 							onChange={(e) =>
 								set("headquarters", e.target.value.toUpperCase())
 							}
-							disabled={!isEnterprise}
+							disabled={!canManage}
 						/>
 						<datalist id="attest-headquarters-countries">
 							{PROVIDER_COUNTRIES.map((country) => (
@@ -345,7 +345,7 @@ export function ComplianceAttestationCard({
 								<AlertDialogTrigger asChild>
 									<Button
 										variant="outline"
-										disabled={!isEnterprise || mutation.isPending}
+										disabled={!canManage || mutation.isPending}
 										className="text-destructive"
 									>
 										Clear
@@ -375,7 +375,7 @@ export function ComplianceAttestationCard({
 						)}
 						<Button
 							onClick={handleSave}
-							disabled={!isEnterprise || mutation.isPending}
+							disabled={!canManage || mutation.isPending}
 						>
 							{mutation.isPending ? "Saving..." : "Save attestation"}
 						</Button>

--- a/apps/ui/src/components/custom-models/custom-models-client.tsx
+++ b/apps/ui/src/components/custom-models/custom-models-client.tsx
@@ -3,12 +3,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { Pencil, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 import { ComplianceAttestationCard } from "@/components/custom-models/compliance-attestation-card";
 import { CustomModelDialog } from "@/components/custom-models/custom-model-dialog";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { useTeamMembers } from "@/hooks/useTeam";
+import { useUser } from "@/hooks/useUser";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -56,12 +58,24 @@ type ListResponse =
 export type CustomModel = ListResponse["customModels"][number];
 
 export function CustomModelsClient() {
+	const params = useParams();
+	const organizationId = params.orgId as string;
 	const { selectedOrganization, buildOrgUrl } = useDashboardNavigation();
 	const api = useApi();
 	const queryClient = useQueryClient();
 	const searchParams = useSearchParams();
 
 	const isEnterprise = selectedOrganization?.plan === "enterprise";
+
+	// Project-scoped developers can browse the catalog but not manage it —
+	// mutations are owner/admin-only (enforced server-side as well).
+	const { user } = useUser();
+	const { data: teamData } = useTeamMembers(organizationId);
+	const currentUserRole = teamData?.members.find(
+		(member) => member.userId === user?.id,
+	)?.role;
+	const isOrgAdmin = currentUserRole === "owner" || currentUserRole === "admin";
+	const canManage = isEnterprise && isOrgAdmin;
 
 	const providerKeysQueryKey = api.queryOptions(
 		"get",
@@ -163,6 +177,9 @@ export function CustomModelsClient() {
 						<h2 className="flex items-center gap-2 text-3xl font-bold tracking-tight">
 							Custom Models
 							{!isEnterprise && <Badge variant="outline">Enterprise</Badge>}
+							{isEnterprise && currentUserRole === "developer" && (
+								<Badge variant="outline">Read-only</Badge>
+							)}
 						</h2>
 						<p className="text-muted-foreground">
 							Define pricing and limits for models served through your custom
@@ -178,7 +195,7 @@ export function CustomModelsClient() {
 					</div>
 					{selectedKey && (
 						<CustomModelDialog providerKeyId={selectedKey.id}>
-							<Button disabled={!isEnterprise}>
+							<Button disabled={!canManage}>
 								<Plus className="mr-2 h-4 w-4" />
 								Add custom model
 							</Button>
@@ -253,7 +270,7 @@ export function CustomModelsClient() {
 										<Switch
 											id="custom-models-only"
 											checked={Boolean(selectedKey.customModelsOnly)}
-											disabled={!isEnterprise || toggleMutation.isPending}
+											disabled={!canManage || toggleMutation.isPending}
 											onCheckedChange={handleToggle}
 										/>
 										<div className="space-y-1">
@@ -276,7 +293,7 @@ export function CustomModelsClient() {
 								key={selectedKey.id}
 								providerKey={selectedKey}
 								organizationId={selectedOrganization.id}
-								isEnterprise={isEnterprise}
+								canManage={canManage}
 							/>
 						)}
 
@@ -324,7 +341,7 @@ export function CustomModelsClient() {
 																<Button
 																	variant="ghost"
 																	size="sm"
-																	disabled={!isEnterprise}
+																	disabled={!canManage}
 																>
 																	<Pencil className="h-4 w-4" />
 																	<span className="sr-only">Edit</span>
@@ -335,7 +352,7 @@ export function CustomModelsClient() {
 																	<Button
 																		variant="ghost"
 																		size="sm"
-																		disabled={!isEnterprise}
+																		disabled={!canManage}
 																		className="text-destructive focus:text-destructive"
 																	>
 																		<Trash2 className="h-4 w-4" />

--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -602,6 +602,44 @@ function OrganizationSection({
 	);
 }
 
+// Org-level entries visible to project-scoped "developer" members: the custom
+// models catalog is readable by every active member, so developers get a
+// read-only view of the providers and models their org makes available.
+function DeveloperOrgSection({
+	isActive,
+	isMobile,
+	toggleSidebar,
+	isEnterprise,
+}: {
+	isActive: (path: string) => boolean;
+	isMobile: boolean;
+	toggleSidebar: () => void;
+	isEnterprise: boolean;
+}) {
+	const { buildOrgUrl } = useDashboardNavigation();
+
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel className="text-muted-foreground px-2 text-xs font-medium">
+				Organization
+			</SidebarGroupLabel>
+			<SidebarGroupContent className="mt-2">
+				<SidebarMenu>
+					<OrgNavItem
+						href={buildOrgUrl("org/custom-models")}
+						label="Custom Models"
+						icon={AnimatedBotMessageSquare}
+						isActive={isActive("org/custom-models")}
+						isMobile={isMobile}
+						toggleSidebar={toggleSidebar}
+						showEnterpriseBadge={!isEnterprise}
+					/>
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
 function ToolsResourceItem({
 	item,
 	isActive,
@@ -1100,24 +1138,33 @@ export function DashboardSidebar({
 			<SidebarContent>
 				{selectedOrganization?.role === "developer" ? (
 					// Project-scoped "developer" members get a minimal, personal nav:
-					// their own usage dashboard and their own API keys — nothing else.
-					<SidebarGroup>
-						<SidebarGroupLabel className="text-muted-foreground px-2 text-xs font-medium">
-							User
-						</SidebarGroupLabel>
-						<SidebarGroupContent className="mt-2">
-							<SidebarMenu>
-								{USER_NAVIGATION.map((item) => (
-									<NavigationItem
-										key={item.href}
-										item={item}
-										isActive={isActive}
-										onClick={handleNavClick}
-									/>
-								))}
-							</SidebarMenu>
-						</SidebarGroupContent>
-					</SidebarGroup>
+					// their own usage dashboard, their own API keys, and a read-only
+					// view of the org's custom-models catalog.
+					<>
+						<SidebarGroup>
+							<SidebarGroupLabel className="text-muted-foreground px-2 text-xs font-medium">
+								User
+							</SidebarGroupLabel>
+							<SidebarGroupContent className="mt-2">
+								<SidebarMenu>
+									{USER_NAVIGATION.map((item) => (
+										<NavigationItem
+											key={item.href}
+											item={item}
+											isActive={isActive}
+											onClick={handleNavClick}
+										/>
+									))}
+								</SidebarMenu>
+							</SidebarGroupContent>
+						</SidebarGroup>
+						<DeveloperOrgSection
+							isActive={isActive}
+							isMobile={isMobile}
+							toggleSidebar={toggleSidebar}
+							isEnterprise={selectedOrganization?.plan === "enterprise"}
+						/>
+					</>
 				) : (
 					<>
 						<SidebarGroup>

--- a/packages/models/src/compliance.spec.ts
+++ b/packages/models/src/compliance.spec.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
 	countryCodeToFlag,
 	customProviderRef,
+	getAttestationComplianceFailures,
+	getProviderComplianceFailures,
 	getProviderCountries,
 	getProviderDefinition,
+	getProviderRefPolicyListFailures,
 	isAttestationCompliant,
 	isModelAllowedByPolicy,
 	isProviderCompliant,
@@ -675,5 +678,121 @@ describe("provider headquarters country mappings are complete", () => {
 			orphans,
 			`PROVIDER_COUNTRY_NAMES has entries for codes no provider uses: ${orphans.join(", ")}`,
 		).toEqual([]);
+	});
+});
+
+describe("compliance failure reasons", () => {
+	it("reports every unmet requirement for a provider", () => {
+		const provider = makeProvider(
+			{
+				apiTraining: true,
+				consumerTraining: true,
+				promptLogging: true,
+				soc2: 1,
+			},
+			"CN",
+		);
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			requireSoc2Type2: true,
+			blockApiTraining: true,
+			blockPromptLogging: true,
+			allowedCountries: ["US"],
+		};
+		expect(getProviderComplianceFailures(provider, policy)).toEqual([
+			"requireSoc2Type2",
+			"blockApiTraining",
+			"blockPromptLogging",
+			"allowedCountries",
+		]);
+	});
+
+	it("is empty for compliant providers and disabled policies", () => {
+		const provider = makeProvider(
+			{
+				apiTraining: false,
+				consumerTraining: false,
+				promptLogging: false,
+				soc2: 2,
+			},
+			"US",
+		);
+		expect(
+			getProviderComplianceFailures(provider, {
+				enabled: true,
+				requireSoc2Type2: true,
+				blockApiTraining: true,
+				allowedCountries: ["US"],
+			}),
+		).toEqual([]);
+		expect(
+			getProviderComplianceFailures(makeProvider(null), {
+				enabled: false,
+				requireSoc2: true,
+			}),
+		).toEqual([]);
+	});
+
+	it("reports allow-list exclusion when only a custom provider is allowed", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			allowedProviders: [customProviderRef("bedrock")],
+		};
+		expect(getProviderRefPolicyListFailures("openai", policy)).toEqual([
+			"allowedProviders",
+		]);
+		expect(
+			getProviderRefPolicyListFailures(customProviderRef("bedrock"), policy),
+		).toEqual([]);
+	});
+
+	it("reports deny-list hits", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockedProviders: ["openai"],
+		};
+		expect(getProviderRefPolicyListFailures("openai", policy)).toEqual([
+			"blockedProviders",
+		]);
+	});
+
+	it("fails closed with noAttestation when no attestation is on file", () => {
+		expect(getAttestationComplianceFailures(null, { enabled: true })).toEqual([
+			"noAttestation",
+		]);
+		expect(getAttestationComplianceFailures(null, { enabled: false })).toEqual(
+			[],
+		);
+	});
+
+	it("reports unmet requirements from an attestation", () => {
+		const attestation: ProviderComplianceAttestation = {
+			soc2: 2,
+			promptLogging: null,
+			headquarters: "US",
+		};
+		expect(
+			getAttestationComplianceFailures(attestation, {
+				enabled: true,
+				requireSoc2Type2: true,
+				blockPromptLogging: true,
+				requireGdpr: true,
+			}),
+		).toEqual(["requireGdpr", "blockPromptLogging"]);
+	});
+
+	it("stays consistent with the boolean predicates for the whole catalogue", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			requireSoc2OrIso27001: true,
+			blockApiTraining: true,
+			allowedCountries: ["US", "FR"],
+			blockedProviders: ["openai"],
+		};
+		for (const provider of providers) {
+			expect(getProviderComplianceFailures(provider, policy).length === 0).toBe(
+				isProviderCompliant(provider, policy),
+			);
+		}
 	});
 });

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1747,6 +1747,73 @@ export interface ProviderComplianceAttestation {
 }
 
 /**
+ * Machine-readable reason a provider (or attestation) fails a compliance
+ * policy. Requirement keys mirror {@link ProviderCompliancePolicy}; the list
+ * keys report a hit on the fine-grained provider lists, and `noAttestation`
+ * marks a custom provider with no self-attested posture on file.
+ */
+export type ComplianceFailureReason =
+	| "requireSoc2"
+	| "requireSoc2Type2"
+	| "requireIso27001"
+	| "requireSoc2OrIso27001"
+	| "requireGdpr"
+	| "blockApiTraining"
+	| "blockPromptLogging"
+	| "allowedCountries"
+	| "blockedProviders"
+	| "allowedProviders"
+	| "noAttestation";
+
+/**
+ * Every active requirement of the policy that the data policy does not
+ * explicitly satisfy (fail-closed, so a missing data policy fails all active
+ * requirements). Empty when compliant; always empty for a disabled policy.
+ */
+export function getDataPolicyComplianceFailures(
+	dataPolicy: ProviderDataPolicy | null | undefined,
+	headquarters: string | null | undefined,
+	policy: ProviderCompliancePolicy,
+): ComplianceFailureReason[] {
+	if (!policy.enabled) {
+		return [];
+	}
+	const failures: ComplianceFailureReason[] = [];
+	if (policy.requireSoc2 && !dataPolicy?.soc2) {
+		failures.push("requireSoc2");
+	}
+	if (policy.requireSoc2Type2 && dataPolicy?.soc2 !== 2) {
+		failures.push("requireSoc2Type2");
+	}
+	if (policy.requireIso27001 && dataPolicy?.iso27001 !== true) {
+		failures.push("requireIso27001");
+	}
+	if (
+		policy.requireSoc2OrIso27001 &&
+		!(dataPolicy?.soc2 === 2 || dataPolicy?.iso27001 === true)
+	) {
+		failures.push("requireSoc2OrIso27001");
+	}
+	if (policy.requireGdpr && dataPolicy?.gdpr !== true) {
+		failures.push("requireGdpr");
+	}
+	if (policy.blockApiTraining && dataPolicy?.apiTraining !== false) {
+		failures.push("blockApiTraining");
+	}
+	if (policy.blockPromptLogging && dataPolicy?.promptLogging !== false) {
+		failures.push("blockPromptLogging");
+	}
+	if (
+		policy.allowedCountries &&
+		policy.allowedCountries.length > 0 &&
+		(!headquarters || !policy.allowedCountries.includes(headquarters))
+	) {
+		failures.push("allowedCountries");
+	}
+	return failures;
+}
+
+/**
  * Core fail-closed compliance predicate shared by catalogue providers and
  * self-attested custom deployments: any active requirement that the data
  * policy does not explicitly satisfy (including a missing policy) fails.
@@ -1757,41 +1824,10 @@ export function isDataPolicyCompliant(
 	headquarters: string | null | undefined,
 	policy: ProviderCompliancePolicy,
 ): boolean {
-	if (!policy.enabled) {
-		return true;
-	}
-	if (policy.requireSoc2 && !dataPolicy?.soc2) {
-		return false;
-	}
-	if (policy.requireSoc2Type2 && dataPolicy?.soc2 !== 2) {
-		return false;
-	}
-	if (policy.requireIso27001 && dataPolicy?.iso27001 !== true) {
-		return false;
-	}
-	if (
-		policy.requireSoc2OrIso27001 &&
-		!(dataPolicy?.soc2 === 2 || dataPolicy?.iso27001 === true)
-	) {
-		return false;
-	}
-	if (policy.requireGdpr && dataPolicy?.gdpr !== true) {
-		return false;
-	}
-	if (policy.blockApiTraining && dataPolicy?.apiTraining !== false) {
-		return false;
-	}
-	if (policy.blockPromptLogging && dataPolicy?.promptLogging !== false) {
-		return false;
-	}
-	if (
-		policy.allowedCountries &&
-		policy.allowedCountries.length > 0 &&
-		(!headquarters || !policy.allowedCountries.includes(headquarters))
-	) {
-		return false;
-	}
-	return true;
+	return (
+		getDataPolicyComplianceFailures(dataPolicy, headquarters, policy).length ===
+		0
+	);
 }
 
 /**
@@ -1826,20 +1862,33 @@ export function isProviderRefAllowedByPolicy(
 	providerRef: string,
 	policy: ProviderCompliancePolicy,
 ): boolean {
+	return getProviderRefPolicyListFailures(providerRef, policy).length === 0;
+}
+
+/**
+ * The fine-grained provider-list checks a provider ref fails: an entry on the
+ * deny list, or absence from a non-empty allow list. Empty when the ref passes
+ * both lists; always empty for a disabled policy.
+ */
+export function getProviderRefPolicyListFailures(
+	providerRef: string,
+	policy: ProviderCompliancePolicy,
+): ComplianceFailureReason[] {
 	if (!policy.enabled) {
-		return true;
+		return [];
 	}
+	const failures: ComplianceFailureReason[] = [];
 	if (policy.blockedProviders?.includes(providerRef)) {
-		return false;
+		failures.push("blockedProviders");
 	}
 	if (
 		policy.allowedProviders &&
 		policy.allowedProviders.length > 0 &&
 		!policy.allowedProviders.includes(providerRef)
 	) {
-		return false;
+		failures.push("allowedProviders");
 	}
-	return true;
+	return failures;
 }
 
 /**
@@ -1880,10 +1929,26 @@ export function isProviderCompliant(
 	provider: ProviderDefinition,
 	policy: ProviderCompliancePolicy,
 ): boolean {
-	return (
-		isProviderRefAllowedByPolicy(provider.id, policy) &&
-		isDataPolicyCompliant(provider.dataPolicy, provider.headquarters, policy)
-	);
+	return getProviderComplianceFailures(provider, policy).length === 0;
+}
+
+/**
+ * Every reason a catalogue provider fails an organization's compliance policy:
+ * fine-grained provider-list hits plus unmet certification/data-policy
+ * requirements. Empty when the provider is compliant.
+ */
+export function getProviderComplianceFailures(
+	provider: ProviderDefinition,
+	policy: ProviderCompliancePolicy,
+): ComplianceFailureReason[] {
+	return [
+		...getProviderRefPolicyListFailures(provider.id, policy),
+		...getDataPolicyComplianceFailures(
+			provider.dataPolicy,
+			provider.headquarters,
+			policy,
+		),
+	];
 }
 
 /**
@@ -1895,13 +1960,25 @@ export function isAttestationCompliant(
 	attestation: ProviderComplianceAttestation | null | undefined,
 	policy: ProviderCompliancePolicy,
 ): boolean {
+	return getAttestationComplianceFailures(attestation, policy).length === 0;
+}
+
+/**
+ * Every reason a self-attested compliance posture fails an organization's
+ * compliance policy. A missing attestation fails closed as `noAttestation`
+ * (even when no individual requirement is active). Empty when compliant.
+ */
+export function getAttestationComplianceFailures(
+	attestation: ProviderComplianceAttestation | null | undefined,
+	policy: ProviderCompliancePolicy,
+): ComplianceFailureReason[] {
 	if (!policy.enabled) {
-		return true;
+		return [];
 	}
 	if (!attestation) {
-		return false;
+		return ["noAttestation"];
 	}
-	return isDataPolicyCompliant(
+	return getDataPolicyComplianceFailures(
 		{
 			apiTraining: attestation.apiTraining ?? null,
 			consumerTraining: attestation.consumerTraining ?? null,

--- a/packages/shared/src/components/multi-provider-selector.tsx
+++ b/packages/shared/src/components/multi-provider-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, ChevronDown, X } from "lucide-react";
+import { Check, ChevronDown, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import { useState, useCallback } from "react";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
@@ -15,6 +15,7 @@ import {
 	CommandList,
 } from "./ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Switch } from "./ui/switch";
 
 /**
  * Minimal structural shape a selectable provider entry must have. Catalogue
@@ -25,6 +26,15 @@ export interface SelectableProviderOption {
 	id: string;
 	name: string | null;
 	color?: string | null;
+	/**
+	 * Whether the provider currently meets the caller's policy requirements.
+	 * When set (on any option), the dropdown becomes policy-aware: options show
+	 * a green/red shield instead of the brand color dot, failing options list
+	 * their `policyNotes`, and a "compatible only" filter toggle is offered.
+	 */
+	meetsPolicy?: boolean;
+	/** Human-readable requirements behind `meetsPolicy === false`. */
+	policyNotes?: string[];
 }
 
 interface MultiProviderSelectorProps {
@@ -41,6 +51,20 @@ export function MultiProviderSelector({
 	placeholder = "Select providers...",
 }: MultiProviderSelectorProps) {
 	const [open, setOpen] = useState(false);
+	const [compatibleOnly, setCompatibleOnly] = useState(false);
+
+	const isPolicyAware = providers.some(
+		(provider) => provider.meetsPolicy !== undefined,
+	);
+	// Selected options stay visible under the filter so they can be unselected.
+	const visibleProviders =
+		isPolicyAware && compatibleOnly
+			? providers.filter(
+					(provider) =>
+						provider.meetsPolicy !== false ||
+						selectedProviders.includes(provider.id),
+				)
+			: providers;
 
 	const handleProviderToggle = useCallback(
 		(providerId: string) => {
@@ -76,6 +100,20 @@ export function MultiProviderSelector({
 							>
 								{ProviderIcon && <ProviderIcon className="h-3 w-3" />}
 								{provider?.name ?? providerId}
+								{provider?.meetsPolicy === false && (
+									<span
+										title={
+											provider.policyNotes?.length
+												? provider.policyNotes.join("; ")
+												: "Does not meet policy requirements"
+										}
+									>
+										<ShieldAlert
+											className="h-3 w-3 text-red-500"
+											aria-label="Does not meet policy requirements"
+										/>
+									</span>
+								)}
 								<Button
 									variant="ghost"
 									size="sm"
@@ -109,10 +147,26 @@ export function MultiProviderSelector({
 				<PopoverContent className="w-80 p-0 max-h-[400px]" align="start">
 					<Command className="flex flex-col">
 						<CommandInput placeholder="Search providers..." />
+						{isPolicyAware && (
+							<div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+								<span className="text-xs text-muted-foreground">
+									Only providers that meet policy requirements
+								</span>
+								<Switch
+									checked={compatibleOnly}
+									onCheckedChange={setCompatibleOnly}
+									aria-label="Only show providers that meet policy requirements"
+								/>
+							</div>
+						)}
 						<div className="max-h-[300px] overflow-y-auto">
 							<CommandList>
-								<CommandEmpty>No providers found.</CommandEmpty>
-								{providers.map((provider) => {
+								<CommandEmpty>
+									{isPolicyAware && compatibleOnly
+										? "No providers meet the policy requirements."
+										: "No providers found."}
+								</CommandEmpty>
+								{visibleProviders.map((provider) => {
 									const isSelected = selectedProviders.includes(provider.id);
 									const ProviderIcon = getProviderIcon(provider.id);
 
@@ -123,17 +177,45 @@ export function MultiProviderSelector({
 											onSelect={() => handleProviderToggle(provider.id)}
 											className="flex items-center justify-between py-3 cursor-pointer"
 										>
-											<div className="flex items-center gap-2">
-												{ProviderIcon && <ProviderIcon className="h-4 w-4" />}
-												<span className="font-medium">{provider.name}</span>
+											<div className="flex min-w-0 items-center gap-2">
+												{ProviderIcon && (
+													<ProviderIcon className="h-4 w-4 shrink-0" />
+												)}
+												<div className="min-w-0">
+													<span className="font-medium">{provider.name}</span>
+													{provider.meetsPolicy === false &&
+														provider.policyNotes &&
+														provider.policyNotes.length > 0 && (
+															<p
+																className="truncate text-xs text-red-600 dark:text-red-400"
+																title={provider.policyNotes.join("; ")}
+															>
+																{provider.policyNotes.join(" · ")}
+															</p>
+														)}
+												</div>
 											</div>
 
-											<div className="flex items-center gap-2">
-												{provider.color && (
-													<div
-														className="w-3 h-3 rounded-full"
-														style={{ backgroundColor: provider.color }}
-													/>
+											<div className="flex shrink-0 items-center gap-2">
+												{provider.meetsPolicy !== undefined ? (
+													provider.meetsPolicy ? (
+														<ShieldCheck
+															className="h-4 w-4 text-emerald-600"
+															aria-label="Meets policy requirements"
+														/>
+													) : (
+														<ShieldAlert
+															className="h-4 w-4 text-red-500"
+															aria-label="Does not meet policy requirements"
+														/>
+													)
+												) : (
+													provider.color && (
+														<div
+															className="w-3 h-3 rounded-full"
+															style={{ backgroundColor: provider.color }}
+														/>
+													)
 												)}
 												{isSelected && (
 													<Check className="h-4 w-4 text-green-600" />
@@ -144,6 +226,18 @@ export function MultiProviderSelector({
 								})}
 							</CommandList>
 						</div>
+						{isPolicyAware && (
+							<div className="flex items-center gap-3 border-t px-3 py-2 text-xs text-muted-foreground">
+								<span className="flex items-center gap-1">
+									<ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
+									Meets policy requirements
+								</span>
+								<span className="flex items-center gap-1">
+									<ShieldAlert className="h-3.5 w-3.5 text-red-500" />
+									Does not meet
+								</span>
+							</div>
+						)}
 					</Command>
 				</PopoverContent>
 			</Popover>


### PR DESCRIPTION
## Summary

Addresses two issues reported by an enterprise customer:

**1. Developer-role members saw an empty Custom Models page** and had no way to see which providers/models their org makes available. The `GET /keys/provider`, `GET /keys/provider/active`, and `GET /custom-models` read endpoints scoped orgs through `getAdminOrganizationIds()`, so `developer` memberships silently got `200 []`.

- These three **read** endpoints now scope to all active org memberships (`getActiveUserOrganizationIds`), so project-scoped developers can browse the org's providers and custom-model catalog. Provider-key tokens remain masked, and every mutation stays owner/admin-gated server-side (`POST /keys/provider` role check, `getManageableProviderKey`, admin-scoped PATCH/DELETE).
- The Custom Models page disables its management controls (add/edit/delete, catalog-only toggle, attestation form) for developers and shows a "Read-only" badge, using the same `useTeamMembers` role lookup as the compliance page.

**2. The compliance page showed every provider as blocked with no explanation.** Selecting only a custom provider in `allowedProviders` blocks all catalogue providers by allow-list semantics, and the Provider Impact card only rendered a boolean Ban icon.

- `@llmgateway/models` compliance predicates are now backed by reason-returning variants — `getProviderComplianceFailures`, `getDataPolicyComplianceFailures`, `getProviderRefPolicyListFailures`, `getAttestationComplianceFailures` (+ `ComplianceFailureReason` type). The boolean predicates are reimplemented on top of them, so gateway enforcement behavior is unchanged.
- Every blocked chip (catalogue and custom providers) now has a tooltip listing exactly which requirements it fails, e.g. "Not on the allowed-providers list", "No SOC 2 Type 2 report", "Headquartered in China, which is not an allowed country", "No compliance attestation on file".
- When an allowed-providers list is active, the Provider Impact card shows a banner explaining that every provider not on the list is blocked regardless of certifications — the exact situation the customer hit.

## Testing

- Added unit tests for the new failure-reason functions, including a whole-catalogue consistency check against the boolean predicates (`packages/models/src/compliance.spec.ts`).
- `pnpm test:unit` — 208 files, 3457 tests pass.
- `pnpm build` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active organization members can browse custom-model catalogs and provider keys.
  * Compliance indicators explain blocked providers with detailed reasons, including policy, attestation, country, and allow-list issues.
  * Provider selectors show policy status, notes, compatible-only filtering, and helpful empty states.
  * Compliance previews provide guidance for resolving provider restrictions.

* **Access Control**
  * Custom-model management remains limited to organization owners and administrators.
  * Developers receive read-only catalog access where applicable.

* **Bug Fixes**
  * Improved consistency between compliance indicators and policy checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->