### PR TITLE
docs: note DevPass has no provider pinning

### DIFF
--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -123,6 +123,39 @@ const faqData: FaqItem[] = [
 			"Yes. Every plan includes the full catalog — Claude, GPT-5, Gemini, Llama, Qwen, and the rest. Plans differ in the size of your monthly usage allowance and the weekly fair-use allowance on premium frontier models.",
 	},
 	{
+		question: "Can I pin a specific provider, like on pay-as-you-go?",
+		answer:
+			"No — DevPass always smart-routes. You request a model by its plain id (e.g. claude-sonnet-5) and the gateway picks the best provider in real time based on uptime, speed, price, and prompt caching — that routing is part of how DevPass stretches every dollar into $3 of usage. Provider-prefixed model ids like openai/gpt-4o aren't available on DevPass; your coding sessions still stick to one provider automatically to keep prompt caches warm. If you need to pin an exact provider or region, use LLM Gateway's pay-as-you-go API on llmgateway.io, which fully supports provider pinning.",
+		content: (
+			<>
+				<p>
+					No — DevPass always smart-routes. You request a model by its plain id
+					(e.g. <code className="font-mono text-sm">claude-sonnet-5</code>) and
+					the gateway picks the best provider in real time based on uptime,
+					speed, price, and prompt caching — that routing is part of how DevPass
+					stretches every dollar into $3 of usage. Provider-prefixed model ids
+					like <code className="font-mono text-sm">openai/gpt-4o</code>{" "}
+					aren&apos;t available on DevPass, and your coding sessions still stick
+					to one provider automatically to keep prompt caches warm.
+				</p>
+				<p className="mt-3">
+					If you need to pin an exact provider or region, use{" "}
+					<Link href="https://llmgateway.io" className="underline">
+						LLM Gateway&apos;s pay-as-you-go API
+					</Link>{" "}
+					instead — it fully supports{" "}
+					<Link
+						href="https://docs.llmgateway.io/features/routing#provider-specific-routing"
+						className="underline"
+					>
+						provider-specific routing
+					</Link>
+					.
+				</p>
+			</>
+		),
+	},
+	{
 		question: "Are there limits on premium models?",
 		answer: `Premium models — any model priced at $${premiumInputPerM}+ per million input tokens or $${premiumOutputPerM}+ per million output tokens — are subject to a weekly fair-use allowance in addition to your monthly allowance: 12% of your monthly credits on Lite, 15% on Pro, and 18% on Max. Every other model draws on your full monthly allowance. The exact numbers are published on the plan cards — no hidden throttling.`,
 		content: (

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -275,6 +275,15 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
   }'
 ```
 
+<Callout type="info">
+	Provider-specific routing is not available on **DevPass coding plans** —
+	provider-prefixed model ids (and custom provider routing) return a `403`
+	there. DevPass always uses the prompt-cache–aware smart routing above with
+	plain model ids. Provider pinning requires the pay-as-you-go API. See
+	[Provider routing on
+	DevPass](/learn/model-categories#provider-routing-on-devpass).
+</Callout>
+
 #### Regions
 
 Some providers expose the same model in multiple regions. In that case, LLMGateway supports two routing modes:

--- a/apps/docs/content/learn/model-categories.mdx
+++ b/apps/docs/content/learn/model-categories.mdx
@@ -51,3 +51,17 @@ Once a DevPass plan reaches its weekly premium cap, premium requests are paused 
 ## Reset Passes
 
 You don't have to wait out the window: redeeming a [**Reset Pass**](/learn/reset-passes) instantly restores the full weekly premium allowance and starts a fresh 7-day window. A pass removes the weekly limit only — it grants no extra credits, so premium usage after a reset still draws from the plan's monthly allowance. Pro includes 1 pass per billing cycle and Max includes 2; extra passes are a one-time purchase from the DevPass dashboard. See the [Reset Passes page](/learn/reset-passes) for how redemption, included passes, and billing work.
+
+## Provider routing on DevPass
+
+DevPass plans always use the gateway's [smart routing](/features/routing): request a model by its plain id (e.g. `claude-sonnet-5`) and the gateway picks the best provider in real time based on uptime, throughput, price, and prompt-cache support. [Sticky session routing](/features/routing#sticky-session-routing) still keeps each coding session on one provider automatically, so upstream prompt caches stay warm across a conversation.
+
+<Callout type="warn">
+	**Provider pinning is not available on DevPass.** Provider-prefixed model ids
+	such as `openai/gpt-4o` — which pin a request to one specific provider on
+	pay-as-you-go — are rejected with a `403` on DevPass coding plans, as is
+	custom provider routing. If you need to target an exact provider or region,
+	use [pay-as-you-go credits](https://llmgateway.io) with the LLM Gateway API,
+	where [provider-specific routing](/features/routing#provider-specific-routing)
+	is fully supported.
+</Callout>


### PR DESCRIPTION
Documents that provider pinning (`provider/model` model strings) is not available on DevPass coding plans, unlike pay-as-you-go via llmgateway.io — the gateway rejects provider-prefixed ids with a `403` on dev plans (`apps/gateway/src/chat/chat.ts`).

## Changes

- **DevPass landing page** (`apps/code/src/components/Faq.tsx`): new FAQ entry "Can I pin a specific provider, like on pay-as-you-go?" — frames smart routing as part of how DevPass stretches $1 into $3, notes sticky sessions keep prompt caches warm, and points users who need pinning to the pay-as-you-go API. Also included in the page's FAQPage JSON-LD schema.
- **Knowledge base** (`apps/docs/content/learn/model-categories.mdx`): new "Provider routing on DevPass" section with a warn callout stating provider-prefixed model ids and custom provider routing return a `403` on DevPass, cross-linked to smart routing, sticky sessions, and provider-specific routing.
- **Routing feature docs** (`apps/docs/content/features/routing.mdx`): callout in the Provider-Specific Routing section noting the DevPass restriction, linking to the new KB section.

No behavior changes — docs and marketing copy only. `pnpm format` run; `code` and `docs` builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGE4KyW32zJZFGn3Mbvozc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGE4KyW32zJZFGn3Mbvozc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance explaining DevPass provider routing and smart provider selection.
  * Clarified that provider-specific routing and region targeting are unavailable on DevPass coding plans and return a `403` response.
  * Documented that exact provider or region selection is available through the pay-as-you-go LLM Gateway API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->