### PR TITLE
feat(models): add Poolside Laguna S 2.1 and XS 2.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,9 @@ LLM_AZURE_API_KEY=your_azure_key_here
 # DeepInfra
 LLM_DEEPINFRA_API_KEY=your_deepinfra_key_here
 
+# Poolside
+LLM_POOLSIDE_API_KEY=your_poolside_key_here
+
 # Azure AI Foundry (third-party models like Grok, Llama, Mistral)
 LLM_AZURE_AI_FOUNDRY_API_KEY=your_azure_ai_foundry_key_here
 LLM_AZURE_AI_FOUNDRY_RESOURCE=your_azure_ai_foundry_resource_here

--- a/apps/ui/src/components/provider-keys/provider-logo.ts
+++ b/apps/ui/src/components/provider-keys/provider-logo.ts
@@ -40,6 +40,7 @@ export const providerLogoUrls: Partial<
 	xiaomi: ProviderIcons.xiaomi,
 	embercloud: ProviderIcons.embercloud,
 	deepinfra: ProviderIcons.deepinfra,
+	poolside: ProviderIcons.poolside,
 	reve: ProviderIcons.reve,
 	sakana: ProviderIcons.sakana,
 	"scx-ai": ProviderIcons["scx-ai"],

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -129,6 +129,7 @@ const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<ProviderId, string>> = {
 	canopywave: "https://inference.canopywave.io",
 	embercloud: "https://api.embercloud.ai",
 	deepinfra: "https://api.deepinfra.com/v1/openai",
+	poolside: "https://inference.poolside.ai",
 	gonka24: "https://api.gonka24.com",
 	fireworks: "https://api.fireworks.ai/inference",
 };
@@ -816,6 +817,7 @@ export function getProviderEndpoint(
 		case "embercloud":
 		case "tundra":
 		case "scx-ai":
+		case "poolside":
 		case "custom":
 		default:
 			return `${url}/v1/chat/completions`;

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -17,6 +17,7 @@ import { nvidiaModels } from "./models/nvidia.js";
 import { openaiModels } from "./models/openai.js";
 import { openbmbModels } from "./models/openbmb.js";
 import { perplexityModels } from "./models/perplexity.js";
+import { poolsideModels } from "./models/poolside.js";
 import { reveModels } from "./models/reve.js";
 import { sakanaModels } from "./models/sakana.js";
 import { tencentModels } from "./models/tencent.js";
@@ -735,6 +736,7 @@ export const models = [
 	...baaiModels,
 	...bytedanceModels,
 	...nousresearchModels,
+	...poolsideModels,
 	...reveModels,
 	...sakanaModels,
 	...tencentModels,

--- a/packages/models/src/models/poolside.ts
+++ b/packages/models/src/models/poolside.ts
@@ -1,0 +1,63 @@
+import type { ModelDefinition } from "@/models.js";
+
+export const poolsideModels = [
+	{
+		id: "laguna-s-2.1",
+		name: "Laguna S 2.1",
+		description:
+			"Poolside's 118B Mixture-of-Experts model with 8B active parameters, 1M token context, and native reasoning with thinking on or off per request for long-horizon agentic coding.",
+		family: "poolside",
+		releasedAt: new Date("2026-07-21"),
+		providers: [
+			{
+				providerId: "poolside",
+				externalId: "poolside/laguna-s-2.1",
+				inputPrice: "0.09e-6",
+				cachedInputPrice: "0.009e-6",
+				outputPrice: "0.18e-6",
+				requestPrice: "0",
+				contextSize: 1048576,
+				maxOutput: 131072,
+				quantization: "fp4",
+				streaming: true,
+				reasoning: true,
+				// Thinking on the Poolside Platform defaults to max and this release
+				// supports only off/max (low/medium/high are not available).
+				reasoningEfforts: ["none", "max"],
+				splitTaggedReasoning: true,
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
+		],
+	},
+	{
+		id: "laguna-xs-2.1",
+		name: "Laguna XS 2.1",
+		description:
+			"Poolside's fast 33B Mixture-of-Experts model with 3B active parameters, 256K token context, and per-request thinking for rapid agentic coding.",
+		family: "poolside",
+		releasedAt: new Date("2026-07-02"),
+		providers: [
+			{
+				providerId: "poolside",
+				externalId: "poolside/laguna-xs-2.1",
+				inputPrice: "0.06e-6",
+				cachedInputPrice: "0.03e-6",
+				outputPrice: "0.12e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 32768,
+				quantization: "fp8",
+				streaming: true,
+				reasoning: true,
+				// XS 2.1 ships the same two thinking settings as S 2.1 in this release.
+				reasoningEfforts: ["none", "max"],
+				splitTaggedReasoning: true,
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
+		],
+	},
+] as const satisfies ModelDefinition[];

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1630,6 +1630,35 @@ export const providers: ProviderDefinition[] = [
 		},
 	},
 	{
+		id: "poolside",
+		name: "Poolside",
+		description:
+			"Poolside's Laguna models with native reasoning and 1M token context for agentic coding.",
+		env: {
+			required: {
+				apiKey: "LLM_POOLSIDE_API_KEY",
+			},
+			optional: {
+				baseUrl: "LLM_POOLSIDE_BASE_URL",
+			},
+		},
+		streaming: true,
+		cancellation: true,
+		color: "#000000",
+		website: "https://poolside.ai",
+		statusPageUrl: "https://status.poolside.ai",
+		announcement: null,
+		termsUrl: "https://poolside.ai/legal/terms-of-service",
+		privacyPolicyUrl: "https://poolside.ai/legal/privacy-policy",
+		headquarters: "US",
+		dataPolicy: {
+			apiTraining: false,
+			consumerTraining: false,
+			promptLogging: false,
+			retentionPeriod: "0 days",
+		},
+	},
+	{
 		id: "runware",
 		name: "Runware",
 		description:

--- a/packages/shared/src/components/provider-icons.tsx
+++ b/packages/shared/src/components/provider-icons.tsx
@@ -1330,6 +1330,19 @@ export const FireworksIconStatic: React.FC<React.SVGProps<SVGSVGElement>> = (
 	</svg>
 );
 
+export const PoolsideIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
+	props,
+) => (
+	<svg
+		{...props}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		fill="currentColor"
+	>
+		<path d="M4 2h9.5A5.5 5.5 0 0 1 19 7.5 5.5 5.5 0 0 1 13.5 13H9v9H4V2zm5 5v4h4.5a2 2 0 0 0 0-4H9z" />
+	</svg>
+);
+
 export const DeepInfraIcon: React.FC<React.SVGProps<SVGSVGElement>> = (
 	props,
 ) => (
@@ -1579,6 +1592,7 @@ export const ProviderIcons = {
 	xiaomi: XiaomiIcon,
 	embercloud: EmberCloudIcon,
 	deepinfra: DeepInfraIcon,
+	poolside: PoolsideIcon,
 	reve: ReveIcon,
 	sakana: SakanaIcon,
 	"scx-ai": ScxIcon,
@@ -1629,6 +1643,7 @@ export const providerLogoUrls: Partial<
 	xiaomi: ProviderIcons.xiaomi,
 	embercloud: ProviderIcons.embercloud,
 	deepinfra: ProviderIcons.deepinfra,
+	poolside: ProviderIcons.poolside,
 	reve: ProviderIcons.reve,
 	sakana: ProviderIcons.sakana,
 	"scx-ai": ProviderIcons["scx-ai"],


### PR DESCRIPTION
## Summary

Adds **Poolside** as a new provider with its **Laguna 2.1 tier** models — **Laguna S 2.1** and **Laguna XS 2.1** — served through the official Poolside Platform API (`https://inference.poolside.ai`).

## Model catalogue

| | Laguna S 2.1 | Laguna XS 2.1 |
|---|---|---|
| externalId | `poolside/laguna-s-2.1` | `poolside/laguna-xs-2.1` |
| Parameters | 118B total / 8B active | 33B total / 3B active |
| Context / max output | 1,048,576 / 131,072 | 262,144 / 32,768 |
| Input / cached / output (per 1M) | $0.09 / $0.009 / $0.18 | $0.06 / $0.03 / $0.12 |
| Quantization | fp4 | fp8 |
| Capabilities | streaming, tools, reasoning | streaming, tools, reasoning |
| Vision | ❌ | ❌ |

Note: the per-model serving quant is Poolside's own — the flagship S 2.1 is served at NVFP4 (fp4) to fit its 1M context, while the smaller XS 2.1 runs fp8 (both confirmed via OpenRouter's Poolside endpoint metadata; both models publish BF16 weights with FP8/NVFP4/INT4 variants).

**Supported parameters** (shared by both): `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`, `response_format`, `tools`, `tool_choice`, `reasoning` (+ `reasoning_effort`: `none`/`max` via the unified reasoning interface)

Reasoning: this release ships only `off`/`max` thinking (max on by default), so `reasoningEfforts: ["none", "max"]`; `splitTaggedReasoning` handles the tagged reasoning content.

## Files changed

- `packages/models/src/providers.ts` — new `poolside` provider (`LLM_POOLSIDE_API_KEY`)
- `packages/models/src/models/poolside.ts` + `models.ts` — new mappings, registered
- `packages/actions/src/get-provider-endpoint.ts` — default base URL + `/v1/chat/completions`
- `packages/shared/.../provider-icons.tsx` + `apps/ui/.../provider-logo.ts` — icon
- `.env.example` — `LLM_POOLSIDE_API_KEY`

## Verification

Lint + prettier pass, builds pass (models, shared, actions, ui, gateway), unit tests pass (88 models + 405 actions). Pricing from OpenRouter endpoint metadata (Poolside's pricing page is access-gated); live verification against `inference.poolside.ai` with a real key recommended before marking ready.

## References

- Poolside docs — supported models: https://docs.poolside.ai/get-started/supported-models
- Poolside docs — OpenAI API examples (model IDs, base URLs, `chat_template_kwargs.enable_thinking`): https://docs.poolside.ai/api/openai-api-examples
- Poolside docs — release notes / models (thinking settings: off/max only, default on): https://docs.poolside.ai/release-notes/models
- Poolside docs — API overview: https://docs.poolside.ai/api/overview
- OpenRouter — Laguna S 2.1 page: https://openrouter.ai/poolside/laguna-s-2.1
- OpenRouter — Laguna XS 2.1 page: https://openrouter.ai/poolside/laguna-xs-2.1
- OpenRouter API — Laguna S 2.1 endpoint metadata (pricing, context, max tokens, quantization): https://openrouter.ai/api/v1/models/poolside/laguna-s-2.1/endpoints
- OpenRouter API — Laguna XS 2.1 endpoint metadata: https://openrouter.ai/api/v1/models/poolside/laguna-xs-2.1/endpoints
- Hugging Face — Laguna S 2.1 weights: https://huggingface.co/poolside/Laguna-S-2.1
- Hugging Face — Laguna XS 2.1 weights: https://huggingface.co/poolside/Laguna-XS-2.1
- Poolside website: https://poolside.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Poolside as an available AI provider.
  * Added support for Poolside’s Laguna S 2.1 and Laguna XS 2.1 models.
  * Added Poolside branding and provider logo across the interface.
  * Added support for streaming, tool use, JSON output, and reasoning capabilities.
  * Added Poolside API configuration through an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->