### PR TITLE
feat(ui): policy-aware provider picker + dev nav

### DIFF
--- a/apps/docs/content/features/compliance.mdx
+++ b/apps/docs/content/features/compliance.mdx
@@ -31,7 +31,7 @@ Enable a policy under **Settings → Compliance** in the dashboard and toggle th
 
 Every requirement is **fail-closed**: a provider passes only if its published data policy explicitly satisfies the requirement. If an attribute is unknown for a provider, that provider is treated as non-compliant.
 
-The settings page shows a live preview of which providers are allowed and which are blocked under the current policy, so you can see the impact before saving.
+The settings page shows a live **Provider Impact** preview of which providers are allowed (green) and which are blocked (red) under the current policy, so you can see the impact before saving. Hovering a blocked provider lists exactly which requirements it does not meet — a missing certification, its data policy, its headquarters country, or a provider-list restriction.
 
 ## Provider headquarters
 
@@ -50,7 +50,27 @@ Beyond attribute-based requirements, the **Provider & Model Restrictions** card 
 
 Deny lists always win over allow lists, and both compose with the requirements above — an allow-listed provider must still satisfy every active certification, data-policy, and country requirement.
 
+<Callout type="warn">
+	A non-empty allowed-providers list blocks **every** provider not on it,
+	regardless of certifications or data policy. If you allow-list only a custom
+	provider, all catalogue providers show as blocked with the reason "Not on the
+	allowed-providers list" — add any additional provider you want to use to the
+	allow list.
+</Callout>
+
 The selectors include your organization's own [custom providers](/features/custom-providers) (stored as `custom:<name>` refs) and their custom-catalog models (stored as `<name>/<model>` refs), so a specific custom deployment can be blocked or allow-listed individually just like a catalogue provider.
+
+### Choosing a compliant provider
+
+The provider dropdowns are policy-aware, so you can tell **before** adding a provider to a list whether it satisfies your policy:
+
+- A **green shield** marks a provider that meets every active certification, data-policy, and headquarters requirement.
+- A **red shield** marks a provider that does not; the requirements it misses (for example "May log prompts" or "Headquartered in China, which is not an allowed country") are listed under its name.
+- The **"Only providers that meet policy requirements"** toggle at the top of the dropdown hides incompatible providers entirely.
+
+These indicators evaluate the requirements only — deliberately ignoring the allowed/blocked lists themselves — so an active allow list never paints every other provider red while you're deciding what to add to it. Your own custom providers are evaluated against their [self-attested posture](#custom-providers); one without an attestation on file shows "No compliance attestation on file".
+
+Elsewhere in the dashboard (for example the API-key provider filter), the colored dot next to a provider is simply the provider's **brand color** and carries no compliance meaning.
 
 These restrictions are **organization-wide** and take precedence over member-level and API-key-level [IAM rules](/features/api-keys): they are enforced after IAM evaluation, so no user-, team-, or key-level allow rule can grant access to a provider or model the compliance policy excludes.
 
@@ -92,6 +112,8 @@ Attestations only apply to custom provider keys. They can never be used to clear
 ## Access Control
 
 Only organization **owners** and **admins** can view and change the compliance policy.
+
+Project-scoped **developer** members cannot see the policy itself, but they can browse the org's available providers and models — including custom providers and their model catalogs — read-only on the **Custom Models** page. This is the recommended way for developers to discover what they can call without being granted additional permissions.
 
 ## Related
 

--- a/apps/docs/content/features/custom-providers.mdx
+++ b/apps/docs/content/features/custom-providers.mdx
@@ -150,6 +150,15 @@ undefined models are rejected with `400`. This guarantees that every request has
 known cost attribution and enforced limits. When disabled, undefined models
 still work but remain unbilled, as before.
 
+## Visibility
+
+Every active organization member — including project-scoped **developer**
+members — can browse the org's custom providers and their model catalogs
+read-only on the **Custom Models** page, so developers can always discover
+which providers and models are available to them. Creating, editing, and
+deleting providers, models, and attestations stays restricted to organization
+owners and admins.
+
 ## Compliance attestation
 
 If your organization enforces a [provider compliance policy](/features/compliance),

--- a/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
@@ -33,6 +33,7 @@ import { cn } from "@/lib/utils";
 import {
 	customProviderRef,
 	getAttestationComplianceFailures,
+	getDataPolicyComplianceFailures,
 	getProviderComplianceFailures,
 	getProviderCountries,
 	getProviderRefPolicyListFailures,
@@ -47,6 +48,7 @@ import {
 	MultiModelSelector,
 	MultiProviderSelector,
 	providerLogoUrls,
+	type SelectableProviderOption,
 } from "@llmgateway/shared/components";
 
 import { ContactSalesCard } from "./contact-sales-card";
@@ -339,14 +341,53 @@ export function ComplianceClient() {
 			};
 		});
 	}, [providerKeysData, selectedOrganization?.id, policy]);
+	const compliantCustomCount = customProviders.filter(
+		(provider) => provider.compliant,
+	).length;
 
 	// Custom providers/models as selector entries for the restriction lists.
+	// Each entry carries its requirement-level compatibility (certifications,
+	// data policy, headquarters — deliberately NOT the allowed/blocked lists,
+	// which the pickers themselves edit), so the dropdowns can show which
+	// providers would satisfy the policy if selected.
 	const { customProviderOptions, customModelOptions } =
 		useCustomProviderSelection();
-	const selectableProviders = useMemo(
-		() => [...SELECTABLE_PROVIDERS, ...customProviderOptions],
-		[customProviderOptions],
-	);
+	const selectableProviders = useMemo<SelectableProviderOption[]>(() => {
+		const catalogueOptions = SELECTABLE_PROVIDERS.map((provider) => {
+			const failures = getDataPolicyComplianceFailures(
+				provider.dataPolicy,
+				provider.headquarters,
+				policy,
+			);
+			return {
+				id: provider.id,
+				name: provider.name,
+				color: provider.color,
+				meetsPolicy: failures.length === 0,
+				policyNotes: failures.map((reason) =>
+					failureLabel(reason, provider.headquarters),
+				),
+			};
+		});
+		const attestationByKeyId = new Map(
+			(providerKeysData?.providerKeys ?? []).map((key) => [
+				key.id,
+				key.complianceAttestation,
+			]),
+		);
+		const customOptions = customProviderOptions.map((option) => {
+			const attestation = attestationByKeyId.get(option.providerKeyId);
+			const failures = getAttestationComplianceFailures(attestation, policy);
+			return {
+				...option,
+				meetsPolicy: failures.length === 0,
+				policyNotes: failures.map((reason) =>
+					failureLabel(reason, attestation?.headquarters),
+				),
+			};
+		});
+		return [...catalogueOptions, ...customOptions];
+	}, [customProviderOptions, providerKeysData, policy]);
 	const selectableModels = useMemo(
 		() => [...models, ...customModelOptions],
 		[customModelOptions],
@@ -548,7 +589,10 @@ export function ComplianceClient() {
 							Block or allow individual providers and models — including your
 							own custom providers. These organization-wide lists are enforced
 							on top of the requirements above and take precedence over any
-							member or API key IAM rule.
+							member or API key IAM rule. In the provider dropdowns, a green
+							shield marks providers that meet the certification, data-policy,
+							and headquarters requirements above; a red shield lists the
+							requirements they miss.
 						</CardDescription>
 					</CardHeader>
 					<CardContent
@@ -630,7 +674,15 @@ export function ComplianceClient() {
 						<CardTitle>Provider Impact</CardTitle>
 						<CardDescription>
 							{policy.enabled
-								? `${allowed.length} of ${totalProviders} providers meet this policy.`
+								? `${allowed.length} of ${totalProviders} catalogue providers meet this policy.${
+										customProviders.length > 0
+											? ` ${compliantCustomCount} of ${customProviders.length} custom ${
+													customProviders.length === 1
+														? "provider complies"
+														: "providers comply"
+												}.`
+											: ""
+									}`
 								: "Enable the policy to restrict which providers can be used."}
 						</CardDescription>
 					</CardHeader>
@@ -664,7 +716,10 @@ export function ComplianceClient() {
 									</div>
 								) : (
 									<p className="text-sm text-muted-foreground">
-										No providers meet this policy. Requests will be blocked.
+										No catalogue providers meet this policy.{" "}
+										{compliantCustomCount > 0
+											? "Only the compliant custom providers below can serve requests."
+											: "Requests will be blocked."}
 									</p>
 								)}
 							</div>

--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -602,6 +602,44 @@ function OrganizationSection({
 	);
 }
 
+// Org-level entries visible to project-scoped "developer" members: the custom
+// models catalog is readable by every active member, so developers get a
+// read-only view of the providers and models their org makes available.
+function DeveloperOrgSection({
+	isActive,
+	isMobile,
+	toggleSidebar,
+	isEnterprise,
+}: {
+	isActive: (path: string) => boolean;
+	isMobile: boolean;
+	toggleSidebar: () => void;
+	isEnterprise: boolean;
+}) {
+	const { buildOrgUrl } = useDashboardNavigation();
+
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel className="text-muted-foreground px-2 text-xs font-medium">
+				Organization
+			</SidebarGroupLabel>
+			<SidebarGroupContent className="mt-2">
+				<SidebarMenu>
+					<OrgNavItem
+						href={buildOrgUrl("org/custom-models")}
+						label="Custom Models"
+						icon={AnimatedBotMessageSquare}
+						isActive={isActive("org/custom-models")}
+						isMobile={isMobile}
+						toggleSidebar={toggleSidebar}
+						showEnterpriseBadge={!isEnterprise}
+					/>
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
 function ToolsResourceItem({
 	item,
 	isActive,
@@ -1100,24 +1138,33 @@ export function DashboardSidebar({
 			<SidebarContent>
 				{selectedOrganization?.role === "developer" ? (
 					// Project-scoped "developer" members get a minimal, personal nav:
-					// their own usage dashboard and their own API keys — nothing else.
-					<SidebarGroup>
-						<SidebarGroupLabel className="text-muted-foreground px-2 text-xs font-medium">
-							User
-						</SidebarGroupLabel>
-						<SidebarGroupContent className="mt-2">
-							<SidebarMenu>
-								{USER_NAVIGATION.map((item) => (
-									<NavigationItem
-										key={item.href}
-										item={item}
-										isActive={isActive}
-										onClick={handleNavClick}
-									/>
-								))}
-							</SidebarMenu>
-						</SidebarGroupContent>
-					</SidebarGroup>
+					// their own usage dashboard, their own API keys, and a read-only
+					// view of the org's custom-models catalog.
+					<>
+						<SidebarGroup>
+							<SidebarGroupLabel className="text-muted-foreground px-2 text-xs font-medium">
+								User
+							</SidebarGroupLabel>
+							<SidebarGroupContent className="mt-2">
+								<SidebarMenu>
+									{USER_NAVIGATION.map((item) => (
+										<NavigationItem
+											key={item.href}
+											item={item}
+											isActive={isActive}
+											onClick={handleNavClick}
+										/>
+									))}
+								</SidebarMenu>
+							</SidebarGroupContent>
+						</SidebarGroup>
+						<DeveloperOrgSection
+							isActive={isActive}
+							isMobile={isMobile}
+							toggleSidebar={toggleSidebar}
+							isEnterprise={selectedOrganization?.plan === "enterprise"}
+						/>
+					</>
 				) : (
 					<>
 						<SidebarGroup>

--- a/packages/shared/src/components/multi-provider-selector.tsx
+++ b/packages/shared/src/components/multi-provider-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, ChevronDown, X } from "lucide-react";
+import { Check, ChevronDown, ShieldAlert, ShieldCheck, X } from "lucide-react";
 import { useState, useCallback } from "react";
 
 import { getProviderIcon } from "@llmgateway/shared/components";
@@ -15,6 +15,7 @@ import {
 	CommandList,
 } from "./ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Switch } from "./ui/switch";
 
 /**
  * Minimal structural shape a selectable provider entry must have. Catalogue
@@ -25,6 +26,15 @@ export interface SelectableProviderOption {
 	id: string;
 	name: string | null;
 	color?: string | null;
+	/**
+	 * Whether the provider currently meets the caller's policy requirements.
+	 * When set (on any option), the dropdown becomes policy-aware: options show
+	 * a green/red shield instead of the brand color dot, failing options list
+	 * their `policyNotes`, and a "compatible only" filter toggle is offered.
+	 */
+	meetsPolicy?: boolean;
+	/** Human-readable requirements behind `meetsPolicy === false`. */
+	policyNotes?: string[];
 }
 
 interface MultiProviderSelectorProps {
@@ -41,6 +51,20 @@ export function MultiProviderSelector({
 	placeholder = "Select providers...",
 }: MultiProviderSelectorProps) {
 	const [open, setOpen] = useState(false);
+	const [compatibleOnly, setCompatibleOnly] = useState(false);
+
+	const isPolicyAware = providers.some(
+		(provider) => provider.meetsPolicy !== undefined,
+	);
+	// Selected options stay visible under the filter so they can be unselected.
+	const visibleProviders =
+		isPolicyAware && compatibleOnly
+			? providers.filter(
+					(provider) =>
+						provider.meetsPolicy !== false ||
+						selectedProviders.includes(provider.id),
+				)
+			: providers;
 
 	const handleProviderToggle = useCallback(
 		(providerId: string) => {
@@ -76,6 +100,18 @@ export function MultiProviderSelector({
 							>
 								{ProviderIcon && <ProviderIcon className="h-3 w-3" />}
 								{provider?.name ?? providerId}
+								{provider?.meetsPolicy === false && (
+									<ShieldAlert
+										className="h-3 w-3 text-red-500"
+										aria-label="Does not meet policy requirements"
+									>
+										<title>
+											{provider.policyNotes?.length
+												? provider.policyNotes.join("; ")
+												: "Does not meet policy requirements"}
+										</title>
+									</ShieldAlert>
+								)}
 								<Button
 									variant="ghost"
 									size="sm"
@@ -109,10 +145,22 @@ export function MultiProviderSelector({
 				<PopoverContent className="w-80 p-0 max-h-[400px]" align="start">
 					<Command className="flex flex-col">
 						<CommandInput placeholder="Search providers..." />
+						{isPolicyAware && (
+							<div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+								<span className="text-xs text-muted-foreground">
+									Only providers that meet policy requirements
+								</span>
+								<Switch
+									checked={compatibleOnly}
+									onCheckedChange={setCompatibleOnly}
+									aria-label="Only show providers that meet policy requirements"
+								/>
+							</div>
+						)}
 						<div className="max-h-[300px] overflow-y-auto">
 							<CommandList>
 								<CommandEmpty>No providers found.</CommandEmpty>
-								{providers.map((provider) => {
+								{visibleProviders.map((provider) => {
 									const isSelected = selectedProviders.includes(provider.id);
 									const ProviderIcon = getProviderIcon(provider.id);
 
@@ -123,17 +171,44 @@ export function MultiProviderSelector({
 											onSelect={() => handleProviderToggle(provider.id)}
 											className="flex items-center justify-between py-3 cursor-pointer"
 										>
-											<div className="flex items-center gap-2">
-												{ProviderIcon && <ProviderIcon className="h-4 w-4" />}
-												<span className="font-medium">{provider.name}</span>
+											<div className="flex min-w-0 items-center gap-2">
+												{ProviderIcon && (
+													<ProviderIcon className="h-4 w-4 shrink-0" />
+												)}
+												<div className="min-w-0">
+													<span className="font-medium">{provider.name}</span>
+													{provider.meetsPolicy === false &&
+														(provider.policyNotes?.length ?? 0) > 0 && (
+															<p
+																className="truncate text-xs text-red-600 dark:text-red-400"
+																title={provider.policyNotes!.join("; ")}
+															>
+																{provider.policyNotes!.join(" · ")}
+															</p>
+														)}
+												</div>
 											</div>
 
-											<div className="flex items-center gap-2">
-												{provider.color && (
-													<div
-														className="w-3 h-3 rounded-full"
-														style={{ backgroundColor: provider.color }}
-													/>
+											<div className="flex shrink-0 items-center gap-2">
+												{provider.meetsPolicy !== undefined ? (
+													provider.meetsPolicy ? (
+														<ShieldCheck
+															className="h-4 w-4 text-emerald-600"
+															aria-label="Meets policy requirements"
+														/>
+													) : (
+														<ShieldAlert
+															className="h-4 w-4 text-red-500"
+															aria-label="Does not meet policy requirements"
+														/>
+													)
+												) : (
+													provider.color && (
+														<div
+															className="w-3 h-3 rounded-full"
+															style={{ backgroundColor: provider.color }}
+														/>
+													)
 												)}
 												{isSelected && (
 													<Check className="h-4 w-4 text-green-600" />
@@ -144,6 +219,18 @@ export function MultiProviderSelector({
 								})}
 							</CommandList>
 						</div>
+						{isPolicyAware && (
+							<div className="flex items-center gap-3 border-t px-3 py-2 text-xs text-muted-foreground">
+								<span className="flex items-center gap-1">
+									<ShieldCheck className="h-3.5 w-3.5 text-emerald-600" />
+									Meets policy requirements
+								</span>
+								<span className="flex items-center gap-1">
+									<ShieldAlert className="h-3.5 w-3.5 text-red-500" />
+									Does not meet
+								</span>
+							</div>
+						)}
 					</Command>
 				</PopoverContent>
 			</Popover>

--- a/packages/shared/src/components/multi-provider-selector.tsx
+++ b/packages/shared/src/components/multi-provider-selector.tsx
@@ -101,16 +101,18 @@ export function MultiProviderSelector({
 								{ProviderIcon && <ProviderIcon className="h-3 w-3" />}
 								{provider?.name ?? providerId}
 								{provider?.meetsPolicy === false && (
-									<ShieldAlert
-										className="h-3 w-3 text-red-500"
-										aria-label="Does not meet policy requirements"
-									>
-										<title>
-											{provider.policyNotes?.length
+									<span
+										title={
+											provider.policyNotes?.length
 												? provider.policyNotes.join("; ")
-												: "Does not meet policy requirements"}
-										</title>
-									</ShieldAlert>
+												: "Does not meet policy requirements"
+										}
+									>
+										<ShieldAlert
+											className="h-3 w-3 text-red-500"
+											aria-label="Does not meet policy requirements"
+										/>
+									</span>
 								)}
 								<Button
 									variant="ghost"
@@ -159,7 +161,11 @@ export function MultiProviderSelector({
 						)}
 						<div className="max-h-[300px] overflow-y-auto">
 							<CommandList>
-								<CommandEmpty>No providers found.</CommandEmpty>
+								<CommandEmpty>
+									{isPolicyAware && compatibleOnly
+										? "No providers meet the policy requirements."
+										: "No providers found."}
+								</CommandEmpty>
 								{visibleProviders.map((provider) => {
 									const isSelected = selectedProviders.includes(provider.id);
 									const ProviderIcon = getProviderIcon(provider.id);
@@ -178,12 +184,13 @@ export function MultiProviderSelector({
 												<div className="min-w-0">
 													<span className="font-medium">{provider.name}</span>
 													{provider.meetsPolicy === false &&
-														(provider.policyNotes?.length ?? 0) > 0 && (
+														provider.policyNotes &&
+														provider.policyNotes.length > 0 && (
 															<p
 																className="truncate text-xs text-red-600 dark:text-red-400"
-																title={provider.policyNotes!.join("; ")}
+																title={provider.policyNotes.join("; ")}
 															>
-																{provider.policyNotes!.join(" · ")}
+																{provider.policyNotes.join(" · ")}
 															</p>
 														)}
 												</div>


### PR DESCRIPTION
## Summary

Stacked on #3335 (base branch is `developer-models-compliance-visibility`; GitHub will retarget to `main` when that PR merges — only the last two commits are new here).

Completes the remaining asks from the enterprise customer report that #3335 addressed:

**1. "How can I tell which providers meet my compliance requirements when adding an allowed provider?"**

The provider dropdowns on the compliance page are now policy-aware:
- A **green shield** marks providers that meet every active certification, data-policy, and headquarters requirement; a **red shield** marks providers that don't, with the exact failing requirements listed under the name (e.g. "May log prompts · Headquartered in China, which is not an allowed country").
- A **"Only providers that meet policy requirements"** toggle at the top of the dropdown hides incompatible providers — the customer's "show only compatible providers" request.
- The indicators deliberately evaluate the requirements only and **ignore the allowed/blocked lists themselves**, so an active allow list (the customer's exact situation: only their custom provider allow-listed) no longer makes every candidate look blocked while choosing what to add.
- The org's custom providers are evaluated against their self-attested posture; ones without an attestation show "No compliance attestation on file".
- Selected chips that fail the policy get a small warning shield.

**2. "What do the different colors represent?"**

The unexplained dot in the picker was the provider's *brand color* and carried no compliance meaning. In the compliance context it is replaced by the meaningful shield indicators with an in-dropdown legend, and the docs now spell out what every indicator/color means (impact chips, shields, brand dots elsewhere).

**3. Developer-role discoverability (follow-up to #3335's read access)**

#3335 made the custom-models catalog readable for developers, but their sidebar had no path to it. Developers now get an **Organization → Custom Models** entry pointing at the read-only catalog, and the docs recommend this as the way for developers to see available providers/models without extra permissions.

Also fixes the Provider Impact counter to include custom providers ("0 of 45 providers meet this policy… Requests will be blocked" previously showed even when the org's allow-listed custom provider was fully compliant; it now reads "0 of 45 catalogue providers meet this policy. 1 of 2 custom providers comply." and the empty state says only compliant custom providers can serve requests).

The `MultiProviderSelector` changes are backward-compatible: options without `meetsPolicy` render exactly as before (brand-color dot, no toggle/legend), so the API-keys and IAM usages are unaffected.

## Testing

- `pnpm test:unit` — 208 files, 3457 tests pass.
- `pnpm build` — all 17 tasks pass.
- `pnpm format` clean.
- Verified end-to-end against a seeded enterprise org reproducing the customer scenario (policy with no-training/no-logging + FR/GB/US countries + only a custom provider allow-listed): recorded a demo video showing the owner flow (blocked reasons, picker shields, compatible-only filter, allow-listing a compliant provider) and the developer flow (new sidebar entry → read-only catalog).

https://claude.ai/code/session_01Vd3toRu4u6fU9quL7XjbC3