### PR TITLE
feat(compliance): add no-stealth-providers option

### DIFF
--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -93,6 +93,7 @@ const providerCompliancePolicySchema = z.object({
 	requireGdpr: z.boolean().optional(),
 	blockApiTraining: z.boolean().optional(),
 	blockPromptLogging: z.boolean().optional(),
+	blockStealthProviders: z.boolean().optional(),
 	allowedCountries: z
 		.array(
 			z.string().refine((code) => providerCountryCodes.has(code), {

--- a/apps/docs/content/features/compliance.mdx
+++ b/apps/docs/content/features/compliance.mdx
@@ -28,8 +28,11 @@ Enable a policy under **Settings → Compliance** in the dashboard and toggle th
 | **GDPR compliant**            | it is GDPR compliant                               |
 | **No training on prompts**    | it does not train on API prompts                   |
 | **No prompt logging**         | it does not log prompts                            |
+| **No stealth providers**      | it is not a stealth provider                       |
 
 Every requirement is **fail-closed**: a provider passes only if its published data policy explicitly satisfies the requirement. If an attribute is unknown for a provider, that provider is treated as non-compliant.
+
+Stealth providers are undisclosed platforms that LLM Gateway routes to without naming the operator, so their data policy and headquarters are unknown. That already makes them fail every certification and data-policy requirement above, but **No stealth providers** excludes them explicitly — useful when you want them gone without turning on any other requirement.
 
 The settings page shows a live **Provider Impact** preview of which providers are allowed (green) and which are blocked (red) under the current policy, so you can see the impact before saving. Hovering a blocked provider lists exactly which requirements it does not meet — a missing certification, its data policy, its headquarters country, or a provider-list restriction.
 

--- a/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/compliance/compliance-client.tsx
@@ -33,10 +33,10 @@ import { cn } from "@/lib/utils";
 import {
 	customProviderRef,
 	getAttestationComplianceFailures,
-	getDataPolicyComplianceFailures,
 	getProviderComplianceFailures,
 	getProviderCountries,
 	getProviderRefPolicyListFailures,
+	getProviderRequirementFailures,
 	models,
 	providers,
 	type ComplianceFailureReason,
@@ -68,6 +68,7 @@ const FAILURE_LABELS: Record<ComplianceFailureReason, string> = {
 	requireGdpr: "Not GDPR compliant",
 	blockApiTraining: "May train on API prompts",
 	blockPromptLogging: "May log prompts",
+	blockStealthProviders: "Stealth provider",
 	allowedCountries: "Headquarters not in an allowed country",
 	blockedProviders: "On the blocked-providers list",
 	allowedProviders: "Not on the allowed-providers list",
@@ -185,7 +186,8 @@ type RequirementKey =
 	| "requireSoc2OrIso27001"
 	| "requireGdpr"
 	| "blockApiTraining"
-	| "blockPromptLogging";
+	| "blockPromptLogging"
+	| "blockStealthProviders";
 
 const REQUIREMENTS: {
 	key: RequirementKey;
@@ -229,6 +231,12 @@ const REQUIREMENTS: {
 		key: "blockPromptLogging",
 		name: "No prompt logging",
 		description: "Block providers that log prompts.",
+	},
+	{
+		key: "blockStealthProviders",
+		name: "No stealth providers",
+		description:
+			"Block stealth providers — undisclosed platforms whose data policy and headquarters are unknown.",
 	},
 ];
 
@@ -354,11 +362,7 @@ export function ComplianceClient() {
 		useCustomProviderSelection();
 	const selectableProviders = useMemo<SelectableProviderOption[]>(() => {
 		const catalogueOptions = SELECTABLE_PROVIDERS.map((provider) => {
-			const failures = getDataPolicyComplianceFailures(
-				provider.dataPolicy,
-				provider.headquarters,
-				policy,
-			);
+			const failures = getProviderRequirementFailures(provider, policy);
 			return {
 				id: provider.id,
 				name: provider.name,

--- a/packages/models/src/compliance.spec.ts
+++ b/packages/models/src/compliance.spec.ts
@@ -12,6 +12,7 @@ import {
 	isModelAllowedByPolicy,
 	isProviderCompliant,
 	isProviderRefAllowedByPolicy,
+	isStealthProvider,
 	PROVIDER_COUNTRY_NAMES,
 	providers,
 	type ProviderComplianceAttestation,
@@ -794,5 +795,84 @@ describe("compliance failure reasons", () => {
 				isProviderCompliant(provider, policy),
 			);
 		}
+	});
+});
+
+describe("blockStealthProviders", () => {
+	const stealth: ProviderDefinition = {
+		id: "stealthy",
+		name: "Stealthy",
+		description: "",
+		env: { required: { apiKey: "TEST", baseUrl: "TEST_BASE_URL" } },
+		dataPolicy: {
+			apiTraining: false,
+			consumerTraining: false,
+			promptLogging: false,
+			soc2: 2,
+			iso27001: true,
+			gdpr: true,
+		},
+		headquarters: "US",
+	};
+
+	it("blocks stealth providers that satisfy every other requirement", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockStealthProviders: true,
+		};
+		expect(getProviderComplianceFailures(stealth, policy)).toEqual([
+			"blockStealthProviders",
+		]);
+		expect(isProviderCompliant(stealth, policy)).toBe(false);
+	});
+
+	it("leaves stealth providers alone when the toggle is off or the policy is disabled", () => {
+		expect(getProviderComplianceFailures(stealth, { enabled: true })).toEqual(
+			[],
+		);
+		expect(
+			getProviderComplianceFailures(stealth, {
+				enabled: false,
+				blockStealthProviders: true,
+			}),
+		).toEqual([]);
+	});
+
+	it("does not affect non-stealth providers", () => {
+		expect(
+			getProviderComplianceFailures(makeProvider(stealth.dataPolicy, "US"), {
+				enabled: true,
+				blockStealthProviders: true,
+			}),
+		).toEqual([]);
+	});
+
+	it("blocks every catalogue stealth provider", () => {
+		const policy: ProviderCompliancePolicy = {
+			enabled: true,
+			blockStealthProviders: true,
+		};
+		const stealthProviders = providers.filter(isStealthProvider);
+		expect(stealthProviders.length).toBeGreaterThan(0);
+		for (const provider of stealthProviders) {
+			expect(getProviderComplianceFailures(provider, policy)).toContain(
+				"blockStealthProviders",
+			);
+		}
+	});
+
+	it("does not apply to custom-provider attestations", () => {
+		const attestation: ProviderComplianceAttestation = {
+			soc2: 2,
+			apiTraining: false,
+			promptLogging: false,
+			headquarters: "US",
+		};
+		expect(
+			getAttestationComplianceFailures(attestation, {
+				enabled: true,
+				blockStealthProviders: true,
+			}),
+		).toEqual([]);
 	});
 });

--- a/packages/models/src/helpers.ts
+++ b/packages/models/src/helpers.ts
@@ -1,10 +1,5 @@
 import { models, type ProviderModelMapping } from "./models.js";
-import {
-	providers,
-	type ProviderDefinition,
-	type ProviderId,
-	type ServiceTier,
-} from "./providers.js";
+import { providers, type ServiceTier } from "./providers.js";
 import { expandAllProviderRegions } from "./region-helpers.js";
 
 /**
@@ -198,21 +193,4 @@ const OPENAI_EXPLICIT_PROMPT_CACHE_MODELS = new Set<string>([
 
 export function supportsOpenAIExplicitPromptCache(modelName: string): boolean {
 	return OPENAI_EXPLICIT_PROMPT_CACHE_MODELS.has(modelName);
-}
-
-/**
- * Whether a provider is a "stealth" provider — one that has no default base URL
- * and instead requires the base URL to be supplied via a `baseUrl` env var
- * (`env.required.baseUrl`). Because the platform behind such a provider is
- * undisclosed, users cannot self-configure a provider key for it (they can't
- * know the endpoint), so these are hidden from the UI provider selector.
- */
-export function isStealthProvider(
-	provider: ProviderId | ProviderDefinition,
-): boolean {
-	const def =
-		typeof provider === "string"
-			? providers.find((p) => p.id === provider)
-			: provider;
-	return Boolean(def?.env.required.baseUrl);
 }

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	getSupportedServiceTiers,
-	isStealthProvider,
-	supportsServiceTier,
-} from "./helpers.js";
+import { getSupportedServiceTiers, supportsServiceTier } from "./helpers.js";
 import { anthropicModels } from "./models/anthropic.js";
 import { models } from "./models.js";
 import {
 	formatServiceTierMultiplier,
 	getServiceTier,
+	isStealthProvider,
 	providers,
 } from "./providers.js";
 import {

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -107,6 +107,14 @@ export interface ProviderCompliancePolicy {
 	/** Require the provider to NOT log prompts (promptLogging === false). */
 	blockPromptLogging?: boolean;
 	/**
+	 * Block stealth providers (see {@link isStealthProvider}) — undisclosed
+	 * platforms whose data policy and headquarters are unknown. They already
+	 * fail every certification/data-policy requirement (fail-closed on a null
+	 * `dataPolicy`), so this exists to exclude them even when no other
+	 * requirement is active.
+	 */
+	blockStealthProviders?: boolean;
+	/**
 	 * Restrict routing to providers headquartered in one of these ISO 3166-1
 	 * alpha-2 country codes. Empty/omitted means no country restriction. Only
 	 * codes present in the catalogue (see {@link getProviderCountries}) are
@@ -1756,6 +1764,23 @@ export interface ProviderComplianceAttestation {
 }
 
 /**
+ * Whether a provider is a "stealth" provider — one that has no default base URL
+ * and instead requires the base URL to be supplied via a `baseUrl` env var
+ * (`env.required.baseUrl`). Because the platform behind such a provider is
+ * undisclosed, users cannot self-configure a provider key for it (they can't
+ * know the endpoint), so these are hidden from the UI provider selector.
+ */
+export function isStealthProvider(
+	provider: ProviderId | ProviderDefinition,
+): boolean {
+	const def =
+		typeof provider === "string"
+			? providers.find((p) => p.id === provider)
+			: provider;
+	return Boolean(def?.env.required.baseUrl);
+}
+
+/**
  * Machine-readable reason a provider (or attestation) fails a compliance
  * policy. Requirement keys mirror {@link ProviderCompliancePolicy}; the list
  * keys report a hit on the fine-grained provider lists, and `noAttestation`
@@ -1769,6 +1794,7 @@ export type ComplianceFailureReason =
 	| "requireGdpr"
 	| "blockApiTraining"
 	| "blockPromptLogging"
+	| "blockStealthProviders"
 	| "allowedCountries"
 	| "blockedProviders"
 	| "allowedProviders"
@@ -1942,6 +1968,31 @@ export function isProviderCompliant(
 }
 
 /**
+ * Every requirement a catalogue provider fails: the certification/data-policy
+ * checks plus the provider-level stealth check. Deliberately excludes the
+ * fine-grained provider lists, so callers editing those lists (the dashboard
+ * pickers) can show whether a provider would otherwise satisfy the policy.
+ */
+export function getProviderRequirementFailures(
+	provider: ProviderDefinition,
+	policy: ProviderCompliancePolicy,
+): ComplianceFailureReason[] {
+	const failures = getDataPolicyComplianceFailures(
+		provider.dataPolicy,
+		provider.headquarters,
+		policy,
+	);
+	if (
+		policy.enabled &&
+		policy.blockStealthProviders &&
+		isStealthProvider(provider)
+	) {
+		failures.push("blockStealthProviders");
+	}
+	return failures;
+}
+
+/**
  * Every reason a catalogue provider fails an organization's compliance policy:
  * fine-grained provider-list hits plus unmet certification/data-policy
  * requirements. Empty when the provider is compliant.
@@ -1952,11 +2003,7 @@ export function getProviderComplianceFailures(
 ): ComplianceFailureReason[] {
 	return [
 		...getProviderRefPolicyListFailures(provider.id, policy),
-		...getDataPolicyComplianceFailures(
-			provider.dataPolicy,
-			provider.headquarters,
-			policy,
-		),
+		...getProviderRequirementFailures(provider, policy),
 	];
 }
 


### PR DESCRIPTION
Adds a **No stealth providers** toggle to the enterprise provider compliance policy (Settings → Compliance), so stealth providers can be excluded explicitly instead of only incidentally.

Stealth providers (Glacier, Iceberg, Granite, …) have a `null` `dataPolicy` and `headquarters`, so they already fail every existing requirement fail-closed. But that only holds if at least one other requirement is on — an org that wants a policy consisting solely of "no undisclosed platforms" previously had no way to express it. This makes the exclusion intentional and self-documenting in the impact preview.

## Changes

- `packages/models`: `blockStealthProviders` on `ProviderCompliancePolicy`, plus the matching `ComplianceFailureReason`. Because the check is provider-level (not data-policy-level), it lives in a new `getProviderRequirementFailures(provider, policy)` that `getProviderComplianceFailures` composes — the dashboard pickers need requirement-level failures without the fine-grained provider lists, and now pick up the stealth reason too.
- `isStealthProvider` moves from `helpers.ts` to `providers.ts` (helpers imports providers, so the compliance predicates couldn't call it without a circular import). Same export surface via the package index; only the internal import paths in specs changed.
- `apps/api`: accept the new field in `providerCompliancePolicySchema`. The policy is a JSON column, so no migration.
- `apps/ui`: new requirement switch + `"Stealth provider"` blocked-chip reason.
- `apps/docs`: requirement table row and a paragraph on why the option exists.

Gateway enforcement needed no change — it routes through `isProviderCompliant`, which takes the full `ProviderDefinition`. Custom-provider attestations are unaffected: a self-attested deployment is never stealth.

## Testing

- New `blockStealthProviders` suite in `packages/models/src/compliance.spec.ts` covering the enabled/disabled/toggle-off matrix, non-stealth providers, every catalogue stealth provider, and attestation non-applicability.
- `pnpm test:unit` — 3475 passed, 2 skipped.
- `pnpm build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compliance option to block stealth providers.
  * Added clear compliance failure messaging when a stealth provider is blocked.
  * Provider compliance evaluation now consistently applies all configured requirements.

* **Documentation**
  * Documented the new “No stealth providers” compliance requirement.

* **Tests**
  * Added coverage for stealth-provider blocking, disabled policies, supported providers, and custom-provider attestations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->