### PR TITLE
fix: show quantization on all model cards

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -79,6 +79,9 @@ const modelProviderMappingSchema = z.object({
 	inputAudioHourPrice: z.string().nullable(),
 	contextSize: z.number().nullable(),
 	maxOutput: z.number().nullable(),
+	quantization: z
+		.enum(["int4", "int8", "fp4", "fp6", "fp8", "fp16", "bf16", "fp32"])
+		.nullable(),
 	streaming: z.boolean(),
 	vision: z.boolean().nullable(),
 	audio: z.boolean().nullable(),
@@ -248,6 +251,7 @@ internalModels.openapi(getModelsRoute, async (c) => {
 			return {
 				...mapping,
 				discount: getGlobalDiscount(mapping.providerId, model.id),
+				quantization: sharedMapping?.quantization ?? null,
 				reasoningEfforts: sharedMapping?.reasoningEfforts ?? null,
 				audio: sharedMapping?.audio ?? null,
 				document: sharedMapping?.document ?? null,

--- a/apps/ui/src/app/providers/[id]/page.tsx
+++ b/apps/ui/src/app/providers/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import Footer from "@/components/landing/footer";
 import { Navbar } from "@/components/landing/navbar";
+import { adaptProviderMapping } from "@/components/models/adapt-model";
 import { Hero } from "@/components/providers/hero";
 import { ProviderModelsGrid } from "@/components/providers/provider-models-grid";
 import { JsonLd } from "@/components/seo/json-ld";
@@ -62,115 +63,46 @@ export default async function ProviderPage({ params }: ProviderPageProps) {
 		def: ModelDefinition,
 		map: ProviderModelMapping,
 		providerInfo: (typeof providerDefinitions)[number],
-	): ModelWithProviders => ({
-		id: def.id,
-		premium: isPremiumModel(def.id),
-		createdAt: new Date().toISOString(),
-		releasedAt: def.releasedAt?.toISOString() ?? null,
-		name: def.name ?? null,
-		aliases: def.aliases ?? null,
-		description: def.description ?? null,
-		family: def.family,
-		free: def.free ?? null,
-		output: def.output ?? null,
-		stability: def.stability ?? null,
-		status: "active",
-		mappings: [],
-		providerDetails: [
+	): ModelWithProviders => {
+		const adapted = adaptProviderMapping(
 			{
-				provider: {
-					id: `${map.providerId}-${def.id}`,
-					createdAt: new Date().toISOString(),
-					modelId: def.id,
-					providerId: map.providerId,
-					externalId: map.externalId,
-					inputPrice: map.inputPrice?.toString() ?? null,
-					outputPrice: map.outputPrice?.toString() ?? null,
-					cachedInputPrice: map.cachedInputPrice?.toString() ?? null,
-					cacheWriteInputPrice: map.cacheWriteInputPrice?.toString() ?? null,
-					cacheWriteInputPrice1h:
-						map.cacheWriteInputPrice1h?.toString() ?? null,
-					imageInputPrice: map.imageInputPrice?.toString() ?? null,
-					imageOutputPrice: map.imageOutputPrice?.toString() ?? null,
-					inputCharacterPrice: map.inputCharacterPrice?.toString() ?? null,
-					outputAudioPrice: map.outputAudioPrice?.toString() ?? null,
-					imageInputTokensByResolution:
-						map.imageInputTokensByResolution ?? null,
-					imageOutputTokensByResolution:
-						map.imageOutputTokensByResolution ?? null,
-					requestPrice: map.requestPrice?.toString() ?? null,
-					contextSize: map.contextSize ?? null,
-					maxOutput: map.maxOutput ?? null,
-					streaming: map.streaming === "only" ? true : (map.streaming ?? true),
-					vision: map.vision ?? null,
-					reasoning: map.reasoning ?? null,
-					reasoningOutput: map.reasoningOutput ?? null,
-					reasoningMaxTokens: map.reasoningMaxTokens ?? null,
-					tools: map.tools ?? null,
-					jsonOutput: map.jsonOutput ?? null,
-					jsonOutputSchema: map.jsonOutputSchema ?? null,
-					webSearch: map.webSearch ?? null,
-					webSearchPrice: map.webSearchPrice?.toString() ?? null,
-					supportedVideoSizes: map.supportedVideoSizes ?? null,
-					supportedVideoDurationsSeconds:
-						map.supportedVideoDurationsSeconds ?? null,
-					supportsVideoAudio: map.supportsVideoAudio ?? null,
-					supportsVideoWithoutAudio: map.supportsVideoWithoutAudio ?? null,
-					perSecondPrice: map.perSecondPrice
-						? Object.fromEntries(
-								Object.entries(map.perSecondPrice).map(([k, v]) => [
-									k,
-									v.toString(),
-								]),
-							)
-						: null,
-					pricingTiers: map.pricingTiers
-						? map.pricingTiers.map((t) => ({
-								name: t.name,
-								upToTokens: isFinite(t.upToTokens) ? t.upToTokens : null,
-								inputPrice: String(t.inputPrice),
-								outputPrice: String(t.outputPrice),
-								cachedInputPrice:
-									t.cachedInputPrice !== undefined
-										? String(t.cachedInputPrice)
-										: null,
-								cacheReadInputPrice:
-									t.cacheReadInputPrice !== undefined
-										? String(t.cacheReadInputPrice)
-										: null,
-								cacheWriteInputPrice:
-									t.cacheWriteInputPrice !== undefined
-										? String(t.cacheWriteInputPrice)
-										: null,
-								cacheWriteInputPrice1h:
-									t.cacheWriteInputPrice1h !== undefined
-										? String(t.cacheWriteInputPrice1h)
-										: null,
-							}))
-						: null,
-					discount: discountByModelId.get(def.id) ?? null,
-					stability: map.stability ?? null,
-					supportedParameters: map.supportedParameters ?? null,
-					deprecatedAt: map.deprecatedAt?.toISOString() ?? null,
-					deactivatedAt: map.deactivatedAt?.toISOString() ?? null,
-					status: "active",
-				},
-				providerInfo: {
-					id: providerInfo.id,
-					createdAt: new Date().toISOString(),
-					name: providerInfo.name ?? null,
-					description: providerInfo.description ?? null,
-					streaming: providerInfo.streaming ?? null,
-					cancellation: providerInfo.cancellation ?? null,
-					color: providerInfo.color ?? null,
-					website: providerInfo.website ?? null,
-					announcement: providerInfo.announcement ?? null,
-					modelCardBadge: providerInfo.modelCardBadge ?? null,
-					status: "active",
-				},
+				...map,
+				discount: discountByModelId.get(def.id) ?? null,
+				providerInfo,
 			},
-		],
-	});
+			def.id,
+		);
+
+		return {
+			id: def.id,
+			premium: isPremiumModel(def.id),
+			createdAt: new Date().toISOString(),
+			releasedAt: def.releasedAt?.toISOString() ?? null,
+			name: def.name ?? null,
+			aliases: def.aliases ?? null,
+			description: def.description ?? null,
+			family: def.family,
+			free: def.free ?? null,
+			output: def.output ?? null,
+			stability: def.stability ?? null,
+			status: "active",
+			mappings: [],
+			providerDetails: [
+				{
+					provider: {
+						...adapted.provider,
+						createdAt: new Date().toISOString(),
+					},
+					providerInfo: {
+						...adapted.providerInfo,
+						createdAt: new Date().toISOString(),
+						cancellation: providerInfo.cancellation ?? null,
+						announcement: providerInfo.announcement ?? null,
+					},
+				},
+			],
+		};
+	};
 
 	const providerModels: ModelWithProviders[] = modelDefinitions
 		.filter((model) =>


### PR DESCRIPTION
## Problem

The **Quant:** chip in the shared model card (`packages/shared/src/components/models-directory/model-card.tsx`) only ever rendered on `/models/[name]`. It was missing on both other surfaces that use the same card, for two independent reasons:

1. **`/providers/[id]`** built its own `ApiModelProviderMapping` object literal inline in `convertToApiModel` instead of reusing `adaptProviderMapping` (the adapter the model detail pages use). That literal never set `quantization` — nor `region`, `serviceTiers`, `reasoningEfforts`, `ocrPagePrice`, `inputAudioHourPrice`.
2. **`/models`** reads mappings from `GET /internal/models`. There is no `quantization` column in `packages/db`, and the route's transform only backfills a fixed list of catalogue-only fields from `sharedMapping` — `quantization` was not one of them.

## Changes

- `apps/ui/src/app/providers/[id]/page.tsx` — delegate mapping construction to `adaptProviderMapping`, so the provider page carries the same fields as the model detail pages. The page keeps its own `cancellation`/`announcement` from the provider definition, which the adapter does not populate. Net −68 lines of duplicated field mapping.
- `apps/api/src/routes/internal-models.ts` — backfill `quantization` from the shared catalogue mapping alongside the existing `reasoningEfforts`/`audio`/`serviceTiers` fields, and add it to the response schema (typed as the `Quantization` union). No migration needed — it stays catalogue-derived like its neighbours.

## Verification

- `turbo run build --filter=api --filter=ui` passes; `pnpm format` clean.
- Ran the stack locally (API :4102 / UI :3102) against the seeded DB:
  - `GET /internal/models` now returns `quantization` for 76 mappings.
  - `/models?view=grid` renders `Context: 262.1k   Quant: FP8` on the Hy3 / DeepInfra card.
  - `/providers/novita` renders `Context: 1.1M   Quant: FP8` on the DeepSeek V4 Flash card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider model conversion for more consistent provider details and pricing information.
  * Preserved model-specific settings during provider data processing.
* **New Features**
  * Added quantization details to model-provider mappings, including supported formats when available.
  * Displays a null value when quantization information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->