### PR TITLE
fix(admin): align default fonts with main UI

### DIFF
--- a/ee/admin/src/app/globals.css
+++ b/ee/admin/src/app/globals.css
@@ -8,8 +8,9 @@
 @theme inline {
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
-	--font-sans: var(--font-geist-sans);
+	--font-sans: var(--font-inter);
 	--font-mono: var(--font-geist-mono);
+	--font-family-display: var(--font-display);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -125,6 +126,10 @@
 	code {
 		@apply font-mono;
 	}
+}
+
+@utility font-display {
+	font-family: var(--font-display), var(--font-sans), system-ui, sans-serif;
 }
 
 @utility bg-dotgrid {

--- a/ee/admin/src/app/layout.tsx
+++ b/ee/admin/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Geist_Mono, Plus_Jakarta_Sans } from "next/font/google";
 
 import { AdminShell } from "@/components/admin-shell";
 import { getConfig } from "@/lib/config-server";
@@ -9,15 +9,26 @@ import "./globals.css";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-const geistSans = Geist({
-	variable: "--font-geist-sans",
+const inter = Inter({
+	variable: "--font-inter",
 	subsets: ["latin"],
 	display: "swap",
 });
 
 const geistMono = Geist_Mono({
+	// globals.css maps the Tailwind token: --font-mono: var(--font-geist-mono).
+	// Registering the font under --font-mono directly would leave that theme
+	// mapping dangling and every `font-mono` element falls back to sans.
 	variable: "--font-geist-mono",
 	subsets: ["latin"],
+	display: "swap",
+});
+
+const plusJakarta = Plus_Jakarta_Sans({
+	variable: "--font-display",
+	subsets: ["latin"],
+	weight: ["500", "600", "700", "800"],
+	display: "swap",
 });
 
 export const dynamic = "force-dynamic";
@@ -39,10 +50,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	const config = getConfig();
 
 	return (
-		<html lang="en" suppressHydrationWarning>
-			<body
-				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-			>
+		<html
+			lang="en"
+			className={`${inter.variable} ${geistMono.variable} ${plusJakarta.variable}`}
+			suppressHydrationWarning
+		>
+			<body className="antialiased">
 				<Providers config={config}>
 					<AdminShell>{children}</AdminShell>
 				</Providers>


### PR DESCRIPTION
## Problem

The admin dashboard registered **Geist** as its sans font (`--font-sans: var(--font-geist-sans)`), while `apps/ui` uses **Inter**. Body copy therefore rendered in a different typeface across the two surfaces. Admin also had no display font, so the `font-display` token that `apps/ui` defines did not exist there at all.

## Changes

`ee/admin/src/app/layout.tsx`:
- Replaced `Geist` with `Inter` under `--font-inter`, matching `apps/ui`.
- Added `Plus_Jakarta_Sans` under `--font-display` with the same weights as `apps/ui` (`500`–`800`).
- Added `display: "swap"` to `Geist_Mono`, which was missing it (`apps/ui` sets it), and carried over the comment explaining why the mono font registers as `--font-geist-mono` rather than `--font-mono`.
- Moved the font variable classes from `<body>` to `<html>` so the setup mirrors `apps/ui`.

`ee/admin/src/app/globals.css`:
- `--font-sans` now maps to `var(--font-inter)`.
- Added `--font-family-display: var(--font-display)` and the `@utility font-display` rule, both copied from `apps/ui`, so the token resolves for any shared component that uses it.

Net result: admin and `apps/ui` now share the same sans / mono / display font set.

## Verification

- `pnpm format` and `turbo run build --filter=admin` both pass.
- Ran the built admin app and inspected the served CSS and markup:
  - `--default-font-family: var(--font-inter)` — Tailwind's preflight `html` rule resolves to Inter.
  - All three faces are emitted: `Inter`, `Geist Mono`, `Plus Jakarta Sans` (each with its Next.js fallback metric face).
  - `<html>` carries all three next/font variable classes.
- No remaining references to `Geist(` or `--font-geist-sans` anywhere under `ee/admin`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8bcTJ92nnk2mWkC2BFgPp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application’s primary typography to use Inter.
  * Added Plus Jakarta Sans for display headings and prominent text.
  * Refined font styling for a more consistent visual appearance across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->