### PR TITLE
feat(models): add DeepSeek V4 Flash on Fireworks

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -561,6 +561,7 @@ export const deepseekModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
+				jsonOutputSchema: true,
 			},
 		],
 	},

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -538,6 +538,30 @@ export const deepseekModels = [
 				tools: true,
 				jsonOutput: false,
 			},
+			{
+				providerId: "fireworks",
+				// The undated `deepseek-v4-flash` alias still resolves to the launch
+				// snapshot; `-0731` is the current deployment.
+				externalId: "accounts/fireworks/models/deepseek-v4-flash-0731",
+				inputPrice: "0.14e-6",
+				cachedInputPrice: "0.028e-6",
+				outputPrice: "0.28e-6",
+				requestPrice: "0",
+				// Fireworks prices DeepSeek's Priority tier at 1.5x standard rather
+				// than the 1.25x that applies to the rest of its catalogue.
+				serviceTiers: ["priority"],
+				serviceTierMultipliers: { priority: 1.5 },
+				contextSize: 1048576,
+				maxOutput: 393216,
+				streaming: true,
+				reasoning: true,
+				// Fireworks rejects "minimal" for this model; the rest of the enum
+				// (plus "none" for non-thinking mode) is accepted.
+				reasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
## Summary

There was no Fireworks provider mapping for `deepseek-v4-flash` at all — the model was only served by deepseek, runware, novita, alibaba, deepinfra and bytedance. This adds one, pinned to the dated snapshot.

Fireworks exposes **both** ids:

- `accounts/fireworks/models/deepseek-v4-flash` — the undated alias, still resolving to the launch snapshot
- `accounts/fireworks/models/deepseek-v4-flash-0731` — the current deployment

The mapping uses `-0731`. Verified live against the Fireworks API: the two ids return different prompt-template token counts for the same request, confirming they are distinct deployments.

## Mapping details (all verified live)

- **Pricing** matches Fireworks' published serverless rate card: `$0.14` input / `$0.028` cached / `$0.28` output per million.
- **Priority tier** is supported, but Fireworks prices DeepSeek's Priority tier at **1.5x** standard — not the 1.25x that applies to the rest of its catalogue — so the mapping carries a `serviceTierMultipliers` override to avoid under-billing.
- **Reasoning efforts**: `none`, `low`, `medium`, `high`, `xhigh`, `max`. `minimal` is rejected with a 400 (`Input should be 'low', 'medium', 'high', 'xhigh', 'max', 'none' or 'adaptive'`), so it is excluded.
- **Reasoning output** is returned separately in `reasoning_content`.
- **Tools**, **`json_object`** and **`json_schema`** all work.
- **Vision** is `false` (Fireworks' model list reports `supports_image_input: false`).
- Context `1048576` per Fireworks' model list; `maxOutput` `393216` matching the other V4 Flash mappings.

## Testing

`TEST_MODELS="fireworks/deepseek-v4-flash" pnpm test:e2e` — 29 files passed, 2 skipped. Confirmed with the verbose reporter that the new mapping actually ran:

- `basic`, `/v1/chat/completions streaming`
- `basic reasoning`
- `tool calls`, `streaming tool calls`
- `JSON output`, `JSON output streaming`
- `service_tier 'priority'`, `streaming service_tier 'priority'`

Also `pnpm test:unit` (3577 passed), `pnpm format`, `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fireworks support for the DeepSeek V4 Flash model.
  * Supports streaming, reasoning, tool use, JSON output, and configurable reasoning effort.
  * Supports up to 1,048,576 input tokens and 393,216 output tokens.
  * Added standard and priority service-tier pricing.
  * Enables structured output through schema-based responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->