### PR TITLE
feat(seo): implement Aug 2026 SEO audit fixes

### DIFF
--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -19,6 +19,7 @@ import { Marquee } from "@/components/ui/marquee";
 import { NumberTicker } from "@/components/ui/number-ticker";
 import { marqueeTools } from "@/lib/agent-tools";
 import { getConfig } from "@/lib/config-server";
+import { buildDevPassProductSchema } from "@/lib/product-schema";
 
 import {
 	DEV_PLAN_PRICES,
@@ -102,8 +103,19 @@ export default function LandingPage() {
 	};
 	const usageRatio = Math.round(credits.lite / DEV_PLAN_PRICES.lite);
 
+	const productSchemaJson = JSON.stringify(
+		buildDevPassProductSchema("https://devpass.llmgateway.io/#pricing"),
+	).replace(/</g, "\\u003c");
+
 	return (
 		<div className="min-h-screen bg-background">
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{
+					__html: productSchemaJson,
+				}}
+			/>
 			<LandingPageTracker />
 			<Header />
 
@@ -126,7 +138,7 @@ export default function LandingPage() {
 									$1 in → $3 of model usage, at provider rates
 								</div>
 								<h1 className="font-display mb-6 text-5xl font-bold tracking-tight text-balance sm:text-6xl lg:text-7xl">
-									One key.
+									One AI coding subscription.
 									<br />
 									Every model.
 									<br />

--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -15,6 +15,7 @@ import { CodeCTATracker } from "@/components/LandingTracker";
 import { PricingPlans } from "@/components/PricingPlans";
 import { Button } from "@/components/ui/button";
 import { getConfig } from "@/lib/config-server";
+import { buildDevPassProductSchema } from "@/lib/product-schema";
 import { formatUsageRatio } from "@/lib/utils";
 
 import {
@@ -56,83 +57,9 @@ const maxCredits = getDevPlanCreditsLimit("max");
 const premiumInputPerM = Math.round(HIGH_COST_INPUT_PRICE * 1_000_000);
 const premiumOutputPerM = Math.round(HIGH_COST_OUTPUT_PRICE * 1_000_000);
 
-const productSchema = {
-	"@context": "https://schema.org",
-	"@type": "Product",
-	name: "DevPass by LLM Gateway",
-	description:
-		"Flat-rate AI coding plans with access to 200+ models — Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GLM-4.7, and more. Works with Claude Code, OpenCode, Empryo, SoulForge, and any OpenAI-compatible tool.",
-	brand: {
-		"@type": "Brand",
-		name: "LLM Gateway",
-	},
-	offers: {
-		"@type": "AggregateOffer",
-		priceCurrency: "USD",
-		lowPrice: DEV_PLAN_PRICES.lite,
-		highPrice: DEV_PLAN_PRICES.max,
-		offerCount: 3,
-		offers: [
-			{
-				"@type": "Offer",
-				name: "DevPass Lite",
-				price: DEV_PLAN_PRICES.lite,
-				priceCurrency: "USD",
-				url: "https://devpass.llmgateway.io/pricing",
-				availability: "https://schema.org/InStock",
-				priceSpecification: {
-					"@type": "UnitPriceSpecification",
-					price: DEV_PLAN_PRICES.lite,
-					priceCurrency: "USD",
-					unitCode: "MON",
-					referenceQuantity: {
-						"@type": "QuantitativeValue",
-						value: 1,
-						unitCode: "MON",
-					},
-				},
-			},
-			{
-				"@type": "Offer",
-				name: "DevPass Pro",
-				price: DEV_PLAN_PRICES.pro,
-				priceCurrency: "USD",
-				url: "https://devpass.llmgateway.io/pricing",
-				availability: "https://schema.org/InStock",
-				priceSpecification: {
-					"@type": "UnitPriceSpecification",
-					price: DEV_PLAN_PRICES.pro,
-					priceCurrency: "USD",
-					unitCode: "MON",
-					referenceQuantity: {
-						"@type": "QuantitativeValue",
-						value: 1,
-						unitCode: "MON",
-					},
-				},
-			},
-			{
-				"@type": "Offer",
-				name: "DevPass Max",
-				price: DEV_PLAN_PRICES.max,
-				priceCurrency: "USD",
-				url: "https://devpass.llmgateway.io/pricing",
-				availability: "https://schema.org/InStock",
-				priceSpecification: {
-					"@type": "UnitPriceSpecification",
-					price: DEV_PLAN_PRICES.max,
-					priceCurrency: "USD",
-					unitCode: "MON",
-					referenceQuantity: {
-						"@type": "QuantitativeValue",
-						value: 1,
-						unitCode: "MON",
-					},
-				},
-			},
-		],
-	},
-};
+const productSchema = buildDevPassProductSchema(
+	"https://devpass.llmgateway.io/pricing",
+);
 
 const usageRows: UsageRow[] = [
 	{

--- a/apps/code/src/lib/product-schema.ts
+++ b/apps/code/src/lib/product-schema.ts
@@ -1,0 +1,86 @@
+import { DEV_PLAN_PRICES } from "@llmgateway/shared";
+
+/**
+ * Product + AggregateOffer JSON-LD for the three DevPass plans, shared by the
+ * landing and pricing pages so plan data stays in one place. `offerUrl` should
+ * point at the page (or anchor) where the plans are visible.
+ */
+export function buildDevPassProductSchema(offerUrl: string) {
+	return {
+		"@context": "https://schema.org",
+		"@type": "Product",
+		name: "DevPass by LLM Gateway",
+		description:
+			"Flat-rate AI coding plans with access to 200+ models — Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GLM-4.7, and more. Works with Claude Code, OpenCode, Empryo, SoulForge, and any OpenAI-compatible tool.",
+		brand: {
+			"@type": "Brand",
+			name: "LLM Gateway",
+		},
+		offers: {
+			"@type": "AggregateOffer",
+			priceCurrency: "USD",
+			lowPrice: DEV_PLAN_PRICES.lite,
+			highPrice: DEV_PLAN_PRICES.max,
+			offerCount: 3,
+			offers: [
+				{
+					"@type": "Offer",
+					name: "DevPass Lite",
+					price: DEV_PLAN_PRICES.lite,
+					priceCurrency: "USD",
+					url: offerUrl,
+					availability: "https://schema.org/InStock",
+					priceSpecification: {
+						"@type": "UnitPriceSpecification",
+						price: DEV_PLAN_PRICES.lite,
+						priceCurrency: "USD",
+						unitCode: "MON",
+						referenceQuantity: {
+							"@type": "QuantitativeValue",
+							value: 1,
+							unitCode: "MON",
+						},
+					},
+				},
+				{
+					"@type": "Offer",
+					name: "DevPass Pro",
+					price: DEV_PLAN_PRICES.pro,
+					priceCurrency: "USD",
+					url: offerUrl,
+					availability: "https://schema.org/InStock",
+					priceSpecification: {
+						"@type": "UnitPriceSpecification",
+						price: DEV_PLAN_PRICES.pro,
+						priceCurrency: "USD",
+						unitCode: "MON",
+						referenceQuantity: {
+							"@type": "QuantitativeValue",
+							value: 1,
+							unitCode: "MON",
+						},
+					},
+				},
+				{
+					"@type": "Offer",
+					name: "DevPass Max",
+					price: DEV_PLAN_PRICES.max,
+					priceCurrency: "USD",
+					url: offerUrl,
+					availability: "https://schema.org/InStock",
+					priceSpecification: {
+						"@type": "UnitPriceSpecification",
+						price: DEV_PLAN_PRICES.max,
+						priceCurrency: "USD",
+						unitCode: "MON",
+						referenceQuantity: {
+							"@type": "QuantitativeValue",
+							value: 1,
+							unitCode: "MON",
+						},
+					},
+				},
+			],
+		},
+	};
+}

--- a/apps/docs/app/(home)/[[...slug]]/page.tsx
+++ b/apps/docs/app/(home)/[[...slug]]/page.tsx
@@ -38,15 +38,23 @@ export async function generateMetadata({
 		marketingGuideCanonical(page.url) ?? `${docsBaseUrl}${path}`;
 	const image = ["/docs-og", ...slug, "image.png"].join("/");
 
+	// The root page's frontmatter title composes to a short 46-char <title> via
+	// the layout template, so it gets an absolute, keyword-carrying title
+	// instead. The visible page H1 (frontmatter title) is unchanged.
+	const isRoot = page.url === "/";
+	const metaTitle = isRoot
+		? "LLM Gateway Documentation — OpenAI-Compatible AI Gateway"
+		: page.data.title;
+
 	return {
 		metadataBase: new URL(docsBaseUrl),
-		title: page.data.title,
+		title: isRoot ? { absolute: metaTitle } : metaTitle,
 		description: page.data.description,
 		alternates: {
 			canonical: canonicalUrl,
 		},
 		openGraph: {
-			title: page.data.title,
+			title: metaTitle,
 			description: page.data.description,
 			url: canonicalUrl,
 			images: image,
@@ -55,7 +63,7 @@ export async function generateMetadata({
 		},
 		twitter: {
 			card: "summary_large_image",
-			title: page.data.title,
+			title: metaTitle,
 			description: page.data.description,
 			images: image,
 		},

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Providers } from "@/components/providers";
 import { BRAND } from "@/lib/brand";
 import { getConfig } from "@/lib/config-server";
 
+import { CHAT_PLAN_PRICES } from "@llmgateway/shared";
+
 import "./globals.css";
 
 import type { Metadata } from "next";
@@ -95,6 +97,14 @@ const softwareApplicationSchema = {
 	operatingSystem: "Web",
 	description:
 		"Chat with 200+ AI models including GPT, Claude, and Gemini, plus image and video generation — one membership, every frontier model.",
+	offers: {
+		"@type": "AggregateOffer",
+		priceCurrency: "USD",
+		lowPrice: CHAT_PLAN_PRICES.starter,
+		highPrice: CHAT_PLAN_PRICES.pro,
+		offerCount: 3,
+		url: `${BRAND.url}/pricing`,
+	},
 	publisher: {
 		"@type": "Organization",
 		name: BRAND.publisher,

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from "next/navigation";
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import ChatPageClient from "@/components/playground/chat-page-client";
 import OrgPageClient from "@/components/playground/org-page-client";
+import { LoungeLandingSections } from "@/components/seo/lounge-landing-sections";
 import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { CHAT_CONTEXT_COOKIE } from "@/lib/constants";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
@@ -234,6 +235,12 @@ export async function renderPlaygroundShell({
 		);
 	}
 
+	// The chat org is provisioned on demand for every signed-in user, so its
+	// absence is a cheap signed-out signal (no extra request). Signed-out
+	// visitors — which includes crawlers — get the visible landing sections
+	// below the app; members keep the clean full-viewport chat.
+	const isMember = chatOrg !== null;
+
 	return (
 		<>
 			{projectOrgId && selectedProject?.id ? (
@@ -242,7 +249,7 @@ export async function renderPlaygroundShell({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="chat" />
+			{isMember ? <PlaygroundSeoSection variant="chat" /> : null}
 			<ChatPageClient
 				models={models.filter(
 					(m) =>
@@ -256,6 +263,7 @@ export async function renderPlaygroundShell({
 				initialPrompt={q}
 				enableWebSearch={hints === "search"}
 			/>
+			{isMember ? null : <LoungeLandingSections />}
 		</>
 	);
 }

--- a/apps/playground/src/components/seo/lounge-landing-sections.tsx
+++ b/apps/playground/src/components/seo/lounge-landing-sections.tsx
@@ -1,0 +1,424 @@
+import Link from "next/link";
+
+import { BRAND } from "@/lib/brand";
+
+import {
+	CHAT_PLAN_PRICES,
+	getChatPlanCreditsLimit,
+	MARKETING_STATS,
+} from "@llmgateway/shared";
+
+const MODEL_FAMILIES = [
+	"GPT-5",
+	"Claude Opus",
+	"Claude Sonnet",
+	"Gemini Pro",
+	"Gemini Flash",
+	"Grok",
+	"DeepSeek",
+	"Llama",
+	"Mistral",
+];
+
+const STUDIOS = [
+	{
+		href: "/group",
+		name: "Group chat",
+		description:
+			"One prompt, several models answering side by side — compare quality, speed, and cost in real time.",
+	},
+	{
+		href: "/image",
+		name: "Image studio",
+		description:
+			"Generate images with DALL·E, Flux, and Stable Diffusion — up to four variants per prompt, side by side.",
+	},
+	{
+		href: "/video",
+		name: "Video studio",
+		description:
+			"Text-to-video with Google Veo, Alibaba Wan, and more, previewed right in the browser.",
+	},
+	{
+		href: "/audio",
+		name: "Audio studio",
+		description:
+			"Text to speech with ElevenLabs, OpenAI, and Gemini voices — pick a voice, compare, download.",
+	},
+	{
+		href: "/canvas",
+		name: "Canvas",
+		description:
+			"Generate and edit UI specs as JSON with live preview, then export to PDF or PNG.",
+	},
+	{
+		href: "/compare",
+		name: "Comparisons",
+		description:
+			"How Lounge stacks up against ChatGPT, Claude, Gemini, and the other chat subscriptions.",
+	},
+];
+
+const USE_CASES = [
+	{
+		name: "Writing and editing",
+		description:
+			"Draft, rewrite, and polish anything with the model that suits the job — then switch mid-conversation when another does it better.",
+	},
+	{
+		name: "Coding help",
+		description:
+			"Debug, review, and explain code with frontier coding models, with files and images attached for context.",
+	},
+	{
+		name: "Research with web search",
+		description:
+			"Turn on web search and get sourced answers on current events instead of a model's memory alone.",
+	},
+	{
+		name: "Choosing a model",
+		description:
+			"Run the same prompt through several models in a group chat and see which one earns a place in your workflow.",
+	},
+];
+
+function formatUsd(value: number): string {
+	return value % 1 === 0 ? `$${value}` : `$${value.toFixed(2)}`;
+}
+
+const PLANS = [
+	{
+		name: "Starter",
+		price: CHAT_PLAN_PRICES.starter,
+		allowance: getChatPlanCreditsLimit("starter"),
+		description:
+			"The fast models — Claude Sonnet and Haiku, Gemini Flash, and hundreds more.",
+	},
+	{
+		name: "Plus",
+		price: CHAT_PLAN_PRICES.plus,
+		allowance: getChatPlanCreditsLimit("plus"),
+		description:
+			"Every frontier flagship — Claude Opus, GPT-5, Gemini Pro, and Grok included.",
+		featured: true,
+	},
+	{
+		name: "Pro",
+		price: CHAT_PLAN_PRICES.pro,
+		allowance: getChatPlanCreditsLimit("pro"),
+		description:
+			"The same full catalogue with the largest allowance, for heavy daily use.",
+	},
+];
+
+const FAQ_ITEMS = [
+	{
+		question: "What is Lounge?",
+		answer: `Lounge is the members' AI chat by LLM Gateway. One membership covers chat with ${MARKETING_STATS.models} AI models — including GPT, Claude, Gemini, and Grok — plus image, video, and audio generation, side-by-side group chats, and a canvas studio, all from a single credit balance.`,
+	},
+	{
+		question: "Which AI models can I chat with?",
+		answer: `Lounge routes to ${MARKETING_STATS.models} models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers through LLM Gateway. New frontier models arrive as providers release them, and you can switch models mid-conversation without losing context.`,
+	},
+	{
+		question: "How much does a Lounge membership cost?",
+		answer: `Starter is $${CHAT_PLAN_PRICES.starter}/month for the fast models, Plus is $${CHAT_PLAN_PRICES.plus}/month and unlocks every frontier flagship, and Pro is $${CHAT_PLAN_PRICES.pro}/month for heavy daily use. Every tier includes a credit allowance worth more than the price you pay, refreshed each billing cycle.`,
+	},
+	{
+		question: "Do I still need ChatGPT Plus, Claude Pro, or Gemini Advanced?",
+		answer:
+			"No. One Lounge membership replaces separate ChatGPT Plus, Claude Pro, and Gemini Advanced subscriptions — every frontier flagship lives in the same lounge, and you can put them side by side in a group chat before trusting any one of them.",
+	},
+	{
+		question: "Can Lounge generate images, video, and audio?",
+		answer:
+			"Yes. Dedicated studios cover image generation with DALL·E, Flux, and Stable Diffusion, video generation with Veo and Wan, and text to speech with ElevenLabs, OpenAI, and Gemini voices — alongside chat and multi-model group chats.",
+	},
+	{
+		question: "Are my conversations private?",
+		answer:
+			"Conversations are private to your account, and a chat is only visible to others if you explicitly create a read-only share link. LLM Gateway does not use your conversations to train models. The LLM Gateway privacy policy covers the full details.",
+	},
+	{
+		question: "What happens to unused credits?",
+		answer:
+			"Your full credit allowance refills at the start of each billing cycle, and unspent credits don't roll over. If you've barely used a new membership, there's a 7-day money-back guarantee.",
+	},
+];
+
+const faqSchema = {
+	"@context": "https://schema.org",
+	"@type": "FAQPage",
+	mainEntity: FAQ_ITEMS.map((item) => ({
+		"@type": "Question",
+		name: item.question,
+		acceptedAnswer: {
+			"@type": "Answer",
+			text: item.answer,
+		},
+	})),
+};
+
+function Kicker({ children }: { children: string }) {
+	return (
+		<p className="mb-4 flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.28em] text-lounge-gold">
+			<span aria-hidden className="h-px w-8 bg-lounge-gold/50" />
+			{children}
+		</p>
+	);
+}
+
+/**
+ * Crawlable landing content rendered below the full-viewport chat app for
+ * signed-out visitors (and therefore crawlers). Members get the clean app
+ * without a marketing tail — see renderPlaygroundShell.
+ */
+export function LoungeLandingSections() {
+	return (
+		<div className="border-t bg-background">
+			<script
+				type="application/ld+json"
+				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+				dangerouslySetInnerHTML={{
+					__html: JSON.stringify(faqSchema).replace(/</g, "\\u003c"),
+				}}
+			/>
+
+			<div className="mx-auto max-w-6xl px-4 py-20 sm:py-28">
+				{/* Definition */}
+				<header className="max-w-3xl">
+					<Kicker>{`${BRAND.displayName} · Members' AI chat`}</Kicker>
+					<h1 className="font-display text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+						Lounge — AI chat with {MARKETING_STATS.models} models in one place
+					</h1>
+					<p className="mt-6 text-lg leading-relaxed text-muted-foreground">
+						Lounge is the members&apos; AI chat by{" "}
+						<a
+							href="https://llmgateway.io"
+							className="underline underline-offset-4 hover:text-foreground"
+						>
+							LLM Gateway
+						</a>
+						. One membership covers GPT, Claude, Gemini, Grok, and{" "}
+						{MARKETING_STATS.models} models in total — chat, side-by-side group
+						chats, and image, video, and audio studios, drawing on a single
+						credit balance instead of a stack of per-provider subscriptions.
+					</p>
+				</header>
+
+				{/* Models */}
+				<section className="mt-20 grid gap-10 lg:grid-cols-2 lg:gap-16">
+					<div>
+						<h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+							Every frontier model, one membership
+						</h2>
+						<p className="mt-4 leading-relaxed text-muted-foreground">
+							The house catalogue spans {MARKETING_STATS.models} models from{" "}
+							{MARKETING_STATS.providers} providers, routed through LLM Gateway.
+							When a new flagship ships, it appears in the model picker — no new
+							account, no new bill. Switch models mid-conversation and keep your
+							context.
+						</p>
+						<p className="mt-4 text-sm text-muted-foreground">
+							<a
+								href="https://llmgateway.io/models"
+								className="underline underline-offset-4 hover:text-foreground"
+							>
+								Browse the full model catalogue
+							</a>
+						</p>
+					</div>
+					<ul className="flex flex-wrap content-start items-start gap-2.5">
+						{MODEL_FAMILIES.map((family) => (
+							<li
+								key={family}
+								className="rounded-full border border-border/70 bg-muted/40 px-4 py-1.5 font-mono text-sm text-foreground"
+							>
+								{family}
+							</li>
+						))}
+						<li className="rounded-full border border-lounge-gold/40 bg-lounge-gold/10 px-4 py-1.5 font-mono text-sm text-lounge-gold">
+							and {MARKETING_STATS.models} more
+						</li>
+					</ul>
+				</section>
+
+				{/* Studios */}
+				<section className="mt-20">
+					<Kicker>Inside the Lounge</Kicker>
+					<h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+						Six studios, one seat
+					</h2>
+					<div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+						{STUDIOS.map((studio) => (
+							<Link
+								key={studio.href}
+								href={studio.href}
+								className="group rounded-2xl border bg-card p-6 shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-lounge-gold/50 hover:shadow-lg"
+							>
+								<h3 className="font-display text-lg font-semibold tracking-tight">
+									{studio.name}
+								</h3>
+								<p className="mt-2 text-sm leading-6 text-muted-foreground">
+									{studio.description}
+								</p>
+								<span className="mt-4 inline-block text-sm font-medium text-lounge-gold">
+									Step inside →
+								</span>
+							</Link>
+						))}
+					</div>
+				</section>
+
+				{/* Use cases */}
+				<section className="mt-20">
+					<h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+						What members use the Lounge for
+					</h2>
+					<dl className="mt-8 grid gap-x-12 gap-y-8 sm:grid-cols-2">
+						{USE_CASES.map((useCase) => (
+							<div key={useCase.name}>
+								<dt className="font-semibold text-foreground">
+									{useCase.name}
+								</dt>
+								<dd className="mt-2 text-sm leading-6 text-muted-foreground">
+									{useCase.description}
+								</dd>
+							</div>
+						))}
+					</dl>
+				</section>
+
+				{/* Membership pricing */}
+				<section className="mt-20">
+					<Kicker>Membership</Kicker>
+					<h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+						Membership pricing
+					</h2>
+					<p className="mt-4 max-w-2xl leading-relaxed text-muted-foreground">
+						{BRAND.tagline} Every tier includes a monthly credit allowance worth
+						more than the price you pay, refreshed each billing cycle.
+					</p>
+					<div className="mt-8 grid gap-5 md:grid-cols-3">
+						{PLANS.map((plan) => (
+							<div
+								key={plan.name}
+								className={`rounded-2xl border p-6 ${
+									plan.featured
+										? "border-lounge-gold/60 bg-lounge-gold/5"
+										: "bg-card"
+								}`}
+							>
+								<h3 className="font-display text-lg font-semibold tracking-tight">
+									{plan.name}
+								</h3>
+								<p className="mt-2 font-mono text-2xl font-semibold">
+									${plan.price}
+									<span className="text-sm font-normal text-muted-foreground">
+										/month
+									</span>
+								</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									{formatUsd(plan.allowance)} of model usage included
+								</p>
+								<p className="mt-4 text-sm leading-6 text-muted-foreground">
+									{plan.description}
+								</p>
+							</div>
+						))}
+					</div>
+					<p className="mt-6 text-sm text-muted-foreground">
+						Cancel anytime, with a 7-day money-back guarantee on new
+						memberships.{" "}
+						<Link
+							href="/pricing"
+							className="text-foreground underline underline-offset-4"
+						>
+							See full membership details
+						</Link>
+					</p>
+				</section>
+
+				{/* Privacy */}
+				<section className="mt-20 max-w-3xl">
+					<h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+						Private by default
+					</h2>
+					<ul className="mt-6 space-y-3 text-muted-foreground">
+						<li className="leading-relaxed">
+							<strong className="text-foreground">
+								Your conversations stay yours.
+							</strong>{" "}
+							Chats are private to your account, and you can delete them at any
+							time.
+						</li>
+						<li className="leading-relaxed">
+							<strong className="text-foreground">Sharing is explicit.</strong>{" "}
+							A conversation only becomes visible to others when you create a
+							read-only share link for it.
+						</li>
+						<li className="leading-relaxed">
+							<strong className="text-foreground">No training on you.</strong>{" "}
+							LLM Gateway does not use your conversations to train models. Read
+							the{" "}
+							<a
+								href="https://llmgateway.io/legal/privacy"
+								className="text-foreground underline underline-offset-4"
+							>
+								privacy policy
+							</a>{" "}
+							for the full picture.
+						</li>
+					</ul>
+				</section>
+
+				{/* FAQ */}
+				<section className="mt-20 max-w-3xl">
+					<Kicker>Common questions</Kicker>
+					<h2 className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+						Lounge, answered
+					</h2>
+					<div className="mt-8 divide-y divide-border/60 border-y border-border/60">
+						{FAQ_ITEMS.map((item) => (
+							<details key={item.question} className="group py-5">
+								<summary className="flex cursor-pointer list-none items-center justify-between gap-4 font-display text-lg font-medium text-foreground [&::-webkit-details-marker]:hidden">
+									{item.question}
+									<span
+										aria-hidden
+										className="shrink-0 text-lounge-gold transition-transform duration-200 group-open:rotate-45"
+									>
+										+
+									</span>
+								</summary>
+								<p className="mt-3 border-l-2 border-lounge-gold/30 pl-4 leading-relaxed text-muted-foreground">
+									{item.answer}
+								</p>
+							</details>
+						))}
+					</div>
+				</section>
+
+				{/* Closing CTA */}
+				<section className="mt-20 rounded-3xl border border-lounge-gold/30 bg-lounge-gold/5 px-8 py-12 text-center sm:px-12">
+					<p className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
+						{BRAND.tagline}
+					</p>
+					<div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+						<Link
+							href="/pricing"
+							className="rounded-full bg-foreground px-6 py-2.5 text-sm font-medium text-background transition-opacity hover:opacity-90"
+						>
+							Take a seat — see plans
+						</Link>
+						<Link
+							href="/compare"
+							className="rounded-full border px-6 py-2.5 text-sm font-medium text-foreground transition-colors hover:border-lounge-gold/60"
+						>
+							Compare Lounge
+						</Link>
+					</div>
+				</section>
+			</div>
+		</div>
+	);
+}

--- a/apps/playground/src/components/seo/playground-seo-section.tsx
+++ b/apps/playground/src/components/seo/playground-seo-section.tsx
@@ -12,9 +12,9 @@ interface VariantContent {
 
 const variants: Record<SeoVariant, VariantContent> = {
 	chat: {
-		h1: "AI chat playground — talk to 200+ models in one place",
+		h1: "Lounge — AI chat with 200+ models in one place",
 		intro:
-			"Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time. Pay-as-you-go from a single credit balance — no per-provider billing setup.",
+			"Lounge is the members' AI chat by LLM Gateway. Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time — one credit balance, no per-provider billing setup.",
 		bullets: [
 			"Supports 200+ models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers.",
 			"Stream responses, fork past conversations, and share read-only chat snapshots via public links.",
@@ -39,7 +39,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"All requests route through LLM Gateway for unified billing and usage tracking.",
 		],
 		related: [
-			{ href: "/", label: "AI chat playground" },
+			{ href: "/", label: "Lounge AI chat" },
 			{ href: "/video", label: "AI video generation" },
 			{ href: "/audio", label: "AI audio generation" },
 			{ href: "/group", label: "Compare models side by side" },
@@ -56,7 +56,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"Routes through LLM Gateway for cost tracking across providers.",
 		],
 		related: [
-			{ href: "/", label: "AI chat playground" },
+			{ href: "/", label: "Lounge AI chat" },
 			{ href: "/image", label: "AI image generation" },
 			{ href: "/audio", label: "AI audio generation" },
 			{ href: "/group", label: "Compare models side by side" },
@@ -73,7 +73,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"All requests route through LLM Gateway for unified billing and usage tracking.",
 		],
 		related: [
-			{ href: "/", label: "AI chat playground" },
+			{ href: "/", label: "Lounge AI chat" },
 			{ href: "/image", label: "AI image generation" },
 			{ href: "/video", label: "AI video generation" },
 			{ href: "/group", label: "Compare models side by side" },
@@ -89,7 +89,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"Compare latency, token counts, and cost per response in a single view.",
 		],
 		related: [
-			{ href: "/", label: "AI chat playground" },
+			{ href: "/", label: "Lounge AI chat" },
 			{ href: "/image", label: "AI image generation" },
 			{ href: "/video", label: "AI video generation" },
 			{ href: "/audio", label: "AI audio generation" },
@@ -106,7 +106,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"Export the canvas to PDF or PNG for sharing.",
 		],
 		related: [
-			{ href: "/", label: "AI chat playground" },
+			{ href: "/", label: "Lounge AI chat" },
 			{ href: "/image", label: "AI image generation" },
 			{ href: "/video", label: "AI video generation" },
 			{ href: "/audio", label: "AI audio generation" },

--- a/apps/ui/src/app/blog/page.tsx
+++ b/apps/ui/src/app/blog/page.tsx
@@ -21,22 +21,29 @@ export default async function BlogPage() {
 		.filter((entry: any) => !entry?.draft)
 		.map(({ ...entry }: any) => entry as BlogItem);
 
+	// Standalone top-level ItemList (referenced by the CollectionPage via @id)
+	// so parsers that only inspect top-level @type values still see the list.
+	const itemListSchema = {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		"@id": "https://llmgateway.io/blog#post-list",
+		name: "LLM Gateway Blog",
+		numberOfItems: sortedEntries.length,
+		itemListElement: sortedEntries.map((entry, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			url: `https://llmgateway.io/blog/${entry.slug}`,
+			name: entry.title,
+		})),
+	};
+
 	const collectionSchema = {
 		"@context": "https://schema.org",
 		"@type": "CollectionPage",
 		name: "LLM Gateway Blog",
 		description: "News, tutorials, and deep-dives from the LLM Gateway team.",
 		url: "https://llmgateway.io/blog",
-		mainEntity: {
-			"@type": "ItemList",
-			numberOfItems: sortedEntries.length,
-			itemListElement: sortedEntries.map((entry, index) => ({
-				"@type": "ListItem",
-				position: index + 1,
-				url: `https://llmgateway.io/blog/${entry.slug}`,
-				name: entry.title,
-			})),
-		},
+		mainEntity: { "@id": "https://llmgateway.io/blog#post-list" },
 	};
 
 	const breadcrumbSchema = {
@@ -60,7 +67,7 @@ export default async function BlogPage() {
 
 	return (
 		<div>
-			<JsonLd data={[collectionSchema, breadcrumbSchema]} />
+			<JsonLd data={[collectionSchema, itemListSchema, breadcrumbSchema]} />
 			<HeroRSC navbarOnly />
 			<BlogList
 				entries={sortedEntries}
@@ -75,12 +82,12 @@ export async function generateMetadata() {
 	return {
 		title: "Blog — News, Tutorials, and Deep-Dives",
 		description:
-			"News, tutorials, and deep-dives from the LLM Gateway team on AI gateways, routing, costs, and building with LLMs.",
+			"News, tutorials, and deep-dives from the LLM Gateway team on AI gateways, model routing, LLM costs, model comparisons, and shipping production AI apps.",
 		alternates: { canonical: "/blog" },
 		openGraph: {
 			title: "Blog — News, Tutorials, and Deep-Dives",
 			description:
-				"News, tutorials, and deep-dives from the LLM Gateway team on AI gateways, routing, costs, and building with LLMs.",
+				"News, tutorials, and deep-dives from the LLM Gateway team on AI gateways, model routing, LLM costs, model comparisons, and shipping production AI apps.",
 			type: "website",
 			url: "https://llmgateway.io/blog",
 		},

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
 		template: "%s | LLM Gateway",
 	},
 	description:
-		"Route, manage, and analyze LLM requests across OpenAI, Anthropic, Google, and 40+ providers through one unified API.",
+		"Route, manage, and analyze LLM requests across OpenAI, Anthropic, Google, and 40+ providers through one unified, OpenAI-compatible API. Free and open source.",
 	authors: [{ name: "LLM Gateway" }],
 	creator: "LLM Gateway",
 	publisher: "LLM Gateway",
@@ -66,7 +66,7 @@ export const metadata: Metadata = {
 	openGraph: {
 		title: "LLM Gateway - Unified API for Multiple LLM Providers",
 		description:
-			"Route, manage, and analyze LLM requests across OpenAI, Anthropic, Google, and 40+ providers through one unified API.",
+			"Route, manage, and analyze LLM requests across OpenAI, Anthropic, Google, and 40+ providers through one unified, OpenAI-compatible API. Free and open source.",
 		images: ["/opengraph.png?v=2"],
 		type: "website",
 		url: "https://llmgateway.io",

--- a/apps/ui/src/app/models/page.tsx
+++ b/apps/ui/src/app/models/page.tsx
@@ -34,11 +34,11 @@ export const metadata = {
 	},
 	title: "AI Models Directory — Compare 200+ LLM Models",
 	description:
-		"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and more. Filter by capabilities, pricing, and context size.",
+		"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and 40+ providers. Filter by capability, price, and context — call any model via one API.",
 	openGraph: {
 		title: "AI Models Directory — Compare 200+ LLM Models",
 		description:
-			"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and more. Filter by capabilities, pricing, and context size.",
+			"Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and 40+ providers. Filter by capability, price, and context — call any model via one API.",
 		type: "website",
 		url: "https://llmgateway.io/models",
 	},
@@ -56,6 +56,22 @@ export default async function ModelsPage() {
 		fetchProviders(),
 	]);
 
+	// Standalone top-level ItemList (referenced by the CollectionPage via @id)
+	// so parsers that only inspect top-level @type values still see the list.
+	const itemListSchema = {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		"@id": "https://llmgateway.io/models#model-list",
+		name: "AI Models Directory",
+		numberOfItems: models.length,
+		itemListElement: models.map((model, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			url: `https://llmgateway.io/models/${encodeURIComponent(model.id)}`,
+			name: model.name ?? model.id,
+		})),
+	};
+
 	const collectionSchema = {
 		"@context": "https://schema.org",
 		"@type": "CollectionPage",
@@ -63,16 +79,7 @@ export default async function ModelsPage() {
 		description:
 			"Browse and compare 200+ AI models from leading providers like OpenAI, Anthropic, and Google. Filter by capabilities, pricing, and context size.",
 		url: "https://llmgateway.io/models",
-		mainEntity: {
-			"@type": "ItemList",
-			numberOfItems: models.length,
-			itemListElement: models.map((model, index) => ({
-				"@type": "ListItem",
-				position: index + 1,
-				url: `https://llmgateway.io/models/${encodeURIComponent(model.id)}`,
-				name: model.name ?? model.id,
-			})),
-		},
+		mainEntity: { "@id": "https://llmgateway.io/models#model-list" },
 	};
 
 	const breadcrumbSchema = {
@@ -96,7 +103,7 @@ export default async function ModelsPage() {
 
 	return (
 		<>
-			<JsonLd data={[collectionSchema, breadcrumbSchema]} />
+			<JsonLd data={[collectionSchema, itemListSchema, breadcrumbSchema]} />
 			<Suspense>
 				<AllModels
 					models={models}
@@ -104,23 +111,82 @@ export default async function ModelsPage() {
 					title="AI Models Directory"
 					description="Browse and compare 200+ AI models from OpenAI, Anthropic, Google, and 40+ providers — filter by capabilities, pricing, and context size."
 					seoContent={
-						<section className="container mx-auto px-4 pb-16">
-							<h2 className="text-2xl font-bold mb-6">
-								Browse models by use case
-							</h2>
-							<ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-3 max-w-3xl">
-								{CATEGORY_LINKS.map((category) => (
-									<li key={category.href}>
-										<Link
-											href={category.href}
-											className="text-muted-foreground hover:text-foreground hover:underline underline-offset-4"
-										>
-											{category.label}
-										</Link>
-									</li>
-								))}
-							</ul>
-						</section>
+						<>
+							<section className="container mx-auto px-4 pb-16">
+								<h2 className="text-2xl font-bold mb-6">
+									Browse models by use case
+								</h2>
+								<ul className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-3 max-w-3xl">
+									{CATEGORY_LINKS.map((category) => (
+										<li key={category.href}>
+											<Link
+												href={category.href}
+												className="text-muted-foreground hover:text-foreground hover:underline underline-offset-4"
+											>
+												{category.label}
+											</Link>
+										</li>
+									))}
+								</ul>
+							</section>
+							<section className="container mx-auto px-4 pb-16">
+								<div className="grid gap-x-12 gap-y-10 md:grid-cols-3 max-w-6xl">
+									<div>
+										<h2 className="text-2xl font-bold mb-4">
+											How to choose an AI model
+										</h2>
+										<p className="text-muted-foreground leading-relaxed">
+											Start from the capability you need — reasoning, vision,
+											tool calling, or long context — then compare price per
+											million tokens and context window. The filters above
+											narrow the directory, and each model&apos;s page lists
+											provider availability, live pricing, and uptime.
+										</p>
+									</div>
+									<div>
+										<h2 className="text-2xl font-bold mb-4">
+											Compare AI model pricing
+										</h2>
+										<p className="text-muted-foreground leading-relaxed">
+											Prices are shown per million input and output tokens,
+											exactly as providers publish them. Sort by price to find
+											the{" "}
+											<Link
+												href="/models/cheapest"
+												className="text-foreground underline underline-offset-4"
+											>
+												cheapest models
+											</Link>
+											, or estimate a monthly bill for your traffic with the{" "}
+											<Link
+												href="/token-cost-calculator"
+												className="text-foreground underline underline-offset-4"
+											>
+												token cost calculator
+											</Link>
+											.
+										</p>
+									</div>
+									<div>
+										<h2 className="text-2xl font-bold mb-4">
+											Try a model before you integrate
+										</h2>
+										<p className="text-muted-foreground leading-relaxed">
+											Every model here is callable through one OpenAI-compatible
+											API — switch models by changing a single string. Chat with
+											any of them first in the{" "}
+											<a
+												href="https://chat.llmgateway.io"
+												className="text-foreground underline underline-offset-4"
+											>
+												Lounge
+											</a>{" "}
+											to compare quality, speed, and cost side by side.
+										</p>
+									</div>
+								</div>
+							</section>
+						</>
 					}
 				>
 					<HeroRSC navbarOnly sticky={false} />

--- a/apps/ui/src/app/pricing/page.tsx
+++ b/apps/ui/src/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
+import { PricingFaq } from "@/components/pricing/pricing-faq";
 import { PricingHero } from "@/components/pricing/pricing-hero";
 import { PricingTable } from "@/components/pricing/pricing-table";
 import { JsonLd } from "@/components/seo/json-ld";
@@ -91,6 +92,7 @@ export default function PricingPage() {
 			<main>
 				<PricingHero />
 				<PricingTable />
+				<PricingFaq />
 			</main>
 			<Footer />
 		</>

--- a/apps/ui/src/components/pricing/pricing-faq.tsx
+++ b/apps/ui/src/components/pricing/pricing-faq.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+
+import { JsonLd } from "@/components/seo/json-ld";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+interface PricingFaqItem {
+	question: string;
+	/** Plain text — rendered on the page and reused verbatim for FAQPage JSON-LD. */
+	answer: string;
+	links?: Array<{ href: string; label: string }>;
+}
+
+const FAQ_ITEMS: PricingFaqItem[] = [
+	{
+		question: "How much does LLM Gateway cost?",
+		answer: `You pay per-token at each provider's own rates. The only platform fee is a flat ${MARKETING_STATS.platformFee} when you buy credits — no seats, no minimums, no subscription. You can start free without a credit card.`,
+	},
+	{
+		question: "Is there a fee when I bring my own API keys?",
+		answer:
+			"No. With your own provider keys (BYOK), routing through LLM Gateway is free — you pay your providers directly and still get unified analytics, caching, and failover.",
+	},
+	{
+		question: "How much do tokens cost for each model?",
+		answer:
+			"Every model's input and output price per million tokens is listed in the models directory, alongside context size and capabilities. The token cost calculator turns those rates into a monthly estimate for your actual traffic.",
+		links: [
+			{ href: "/models", label: "Browse model pricing" },
+			{ href: "/token-cost-calculator", label: "Token cost calculator" },
+		],
+	},
+	{
+		question: "Do you offer volume discounts?",
+		answer:
+			"Yes. Enterprise plans include volume discounts on credits along with custom routing and negotiated terms — talk to us about your expected volume for a quote.",
+		links: [{ href: "/enterprise", label: "Learn about Enterprise" }],
+	},
+	{
+		question: "What does the Enterprise plan include?",
+		answer: `Enterprise adds volume discounts, custom routing, unlimited data retention, and a ${MARKETING_STATS.uptimeSla} uptime SLA on top of everything in the free plan.`,
+		links: [{ href: "/enterprise", label: "Explore Enterprise" }],
+	},
+	{
+		question: "Can I self-host LLM Gateway?",
+		answer:
+			"Yes. LLM Gateway is open source under AGPLv3, so you can self-host the gateway for free — or use the hosted platform and pay only the credit fee.",
+		links: [{ href: "/open-source", label: "See the open-source project" }],
+	},
+];
+
+const faqSchema = {
+	"@context": "https://schema.org",
+	"@type": "FAQPage",
+	mainEntity: FAQ_ITEMS.map((item) => ({
+		"@type": "Question",
+		name: item.question,
+		acceptedAnswer: {
+			"@type": "Answer",
+			text: item.answer,
+		},
+	})),
+};
+
+export function PricingFaq() {
+	return (
+		<section className="w-full py-16 md:py-24" id="faq">
+			<JsonLd data={faqSchema} />
+			<div className="container mx-auto px-4 md:px-6">
+				<p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-10 text-center">
+					LLM API pricing, answered
+				</p>
+				<div className="grid gap-x-12 gap-y-10 md:grid-cols-2 max-w-5xl mx-auto">
+					{FAQ_ITEMS.map((item) => (
+						<div key={item.question}>
+							<h2 className="font-display text-xl font-semibold tracking-tight text-foreground">
+								{item.question}
+							</h2>
+							<p className="mt-3 text-muted-foreground leading-relaxed">
+								{item.answer}
+							</p>
+							{item.links ? (
+								<p className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-sm">
+									{item.links.map((link) => (
+										<Link
+											key={link.href}
+											href={link.href}
+											className="text-foreground underline underline-offset-4 hover:text-primary"
+										>
+											{link.label}
+										</Link>
+									))}
+								</p>
+							) : null}
+						</div>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/ui/src/components/pricing/pricing-hero.tsx
+++ b/apps/ui/src/components/pricing/pricing-hero.tsx
@@ -12,7 +12,7 @@ export function PricingHero() {
 						Pricing
 					</Badge>
 					<h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl mb-4">
-						Simple, Transparent Pricing
+						Simple, Transparent LLM API Pricing
 					</h1>
 					<p className="text-xl text-muted-foreground">
 						Start free with no credit card. Pay only for what you use with


### PR DESCRIPTION
Implements the fixes from the August 2026 monthly SEO audit (87/100) and AI-SEO audit (88/100).

## Chat / Lounge landing (`chat.llmgateway.io`)

- **Thin content (🟠, ~169 words):** new `LoungeLandingSections` server component renders visible, crawlable sections below the full-viewport chat app — product definition, model catalogue, the six studios, use cases, membership pricing (driven off `CHAT_PLAN_PRICES`), privacy, a native-`<details>` FAQ (always in the DOM), and a closing CTA. Rendered only for signed-out visitors (crawlers included) via the existing chat-org signal, so members keep the clean app; the compact `sr-only` block remains for them.
- **Naming inconsistency (🟠):** H1 is now "Lounge — AI chat with 200+ models in one place", aligned with the title/description; "AI chat playground" labels across the studio variants renamed to "Lounge AI chat".
- **Schema:** FAQPage JSON-LD on the landing + `AggregateOffer` ($9–$49) added to the `SoftwareApplication` schema.

## DevPass landing (`devpass.llmgateway.io`)

- **Product schema (🟢):** Product + AggregateOffer JSON-LD for the three plans now renders on `/`, extracted into a shared `buildDevPassProductSchema()` also used by `/pricing`.
- **H1 keyword (🟢):** "One key." → "One AI coding subscription."

## Main site (`llmgateway.io`)

- **Meta descriptions (🟢):** home 116→157 chars, `/models` 126→155, `/blog` 113→151 (mirrored to OpenGraph).
- **Pricing (🟠/🟢):** H1 → "Simple, Transparent LLM API Pricing"; new `PricingFaq` server component with question-led H2 sections answering fees, BYOK, per-model token costs, volume discounts, Enterprise, and self-hosting — answers always visible (not collapsed) + FAQPage JSON-LD.
- **/models (🟠):** ItemList JSON-LD hoisted to a top-level entity (CollectionPage references it via `@id`) so parsers that only read top-level `@type` see it; three query-led H2 sections added (choosing a model, comparing pricing, trying before integrating).
- **/blog (🟢):** same top-level ItemList hoist (entries already carry name + canonical URL).

## Docs (`docs.llmgateway.io`)

- **Root title (🟢):** 46 → 56 chars: "LLM Gateway Documentation — OpenAI-Compatible AI Gateway" (absolute title for the root page only; visible H1 unchanged).

Build (`turbo run build` for playground/code/ui/docs) and `pnpm format` pass.

https://claude.ai/code/session_01CwMzYAG41sRF81SXL5aZvc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a crawlable Lounge landing experience with model, pricing, privacy, FAQ, and use-case information.
  - Added pricing FAQs and structured data to pricing pages.
  - Added richer product, blog, model, and pricing metadata for improved search presentation.
  - Added detailed plan and offer information to product and application pages.

- **Improvements**
  - Updated messaging to clarify AI coding subscriptions, LLM API pricing, Lounge features, unified credits, and billing.
  - Improved page titles and descriptions across documentation, model, blog, and application pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->