### PR TITLE
fix: disclose data storage cost in BYOK copy

### DIFF
--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -87,7 +87,7 @@ const faqData: FaqItem[] = [
 	},
 	{
 		question: "Do I need a subscription, or is there pay-as-you-go?",
-		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free (optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}).`,
+		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free. In both modes, optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}.`,
 	},
 	{
 		question: "Can my team or company use DevPass?",

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -87,7 +87,7 @@ const faqData: FaqItem[] = [
 	},
 	{
 		question: "Do I need a subscription, or is there pay-as-you-go?",
-		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free.`,
+		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free (optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}).`,
 	},
 	{
 		question: "Can my team or company use DevPass?",

--- a/apps/docs/content/learn/provider-keys.mdx
+++ b/apps/docs/content/learn/provider-keys.mdx
@@ -42,6 +42,8 @@ For each provider key:
 
 <Callout type="info">
 	When you use your own provider keys, requests are routed directly to the
-	provider. You are only charged the provider's standard rates with no
-	additional gateway markup.
+	provider. You pay the provider's standard rates with no additional gateway
+	markup — the only LLM Gateway charge is the optional [data
+	storage](/features/data-retention#storage-pricing) cost when full data
+	retention is enabled.
 </Callout>

--- a/apps/docs/content/learn/provider-keys.mdx
+++ b/apps/docs/content/learn/provider-keys.mdx
@@ -7,7 +7,7 @@ icon: KeyRound
 import { Callout } from "fumadocs-ui/components/callout";
 import { ThemedImage } from "@/components/themed-image";
 
-The Provider Keys page lets you add your own API keys from LLM providers (OpenAI, Anthropic, Google, etc.) to route requests directly through your accounts without additional gateway fees.
+The Provider Keys page lets you add your own API keys from LLM providers (OpenAI, Anthropic, Google, etc.) to route requests directly through your accounts without additional gateway fees. The only optional charge is [data storage](/features/data-retention#storage-pricing): if your organization enables full data retention, stored requests are billed at $0.01 per 1M tokens from your credits.
 
 <ThemedImage alt="Provider Keys" basePath="/learn/provider-keys" />
 

--- a/apps/ui/src/app/compare/aws-bedrock/page.tsx
+++ b/apps/ui/src/app/compare/aws-bedrock/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonBedrock } from "@/components/landing/comparison-bedrock";
 import Footer from "@/components/landing/footer";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const bedrockFaqs: CompareFaqItem[] = [
@@ -23,8 +25,7 @@ const bedrockFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "How does pricing compare to AWS Bedrock?",
-		answer:
-			"Bedrock bills model-provider rates through your AWS account. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including AWS credentials. Optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the open-source gateway is free.",
+		answer: `Bedrock bills model-provider rates through your AWS account. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including AWS credentials. Optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}. Self-hosting the open-source gateway is free.`,
 	},
 	{
 		question: "How hard is it to migrate from Bedrock to LLM Gateway?",

--- a/apps/ui/src/app/compare/aws-bedrock/page.tsx
+++ b/apps/ui/src/app/compare/aws-bedrock/page.tsx
@@ -24,7 +24,7 @@ const bedrockFaqs: CompareFaqItem[] = [
 	{
 		question: "How does pricing compare to AWS Bedrock?",
 		answer:
-			"Bedrock bills model-provider rates through your AWS account. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including AWS credentials. Self-hosting the open-source gateway is free.",
+			"Bedrock bills model-provider rates through your AWS account. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including AWS credentials. Optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the open-source gateway is free.",
 	},
 	{
 		question: "How hard is it to migrate from Bedrock to LLM Gateway?",

--- a/apps/ui/src/app/compare/azure-ai-foundry/page.tsx
+++ b/apps/ui/src/app/compare/azure-ai-foundry/page.tsx
@@ -24,7 +24,7 @@ const foundryFaqs: CompareFaqItem[] = [
 	{
 		question: "How does pricing compare to Azure AI Foundry?",
 		answer:
-			"Foundry bills model rates through your Azure subscription, with provisioned-throughput (PTU) reservations for guaranteed capacity. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including Azure credentials. Self-hosting the open-source gateway is free.",
+			"Foundry bills model rates through your Azure subscription, with provisioned-throughput (PTU) reservations for guaranteed capacity. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including Azure credentials. Optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the open-source gateway is free.",
 	},
 	{
 		question: "How hard is it to migrate from Azure AI Foundry to LLM Gateway?",

--- a/apps/ui/src/app/compare/azure-ai-foundry/page.tsx
+++ b/apps/ui/src/app/compare/azure-ai-foundry/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonAzureFoundry } from "@/components/landing/comparison-azure-foundry";
 import Footer from "@/components/landing/footer";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const foundryFaqs: CompareFaqItem[] = [
@@ -23,8 +25,7 @@ const foundryFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "How does pricing compare to Azure AI Foundry?",
-		answer:
-			"Foundry bills model rates through your Azure subscription, with provisioned-throughput (PTU) reservations for guaranteed capacity. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including Azure credentials. Optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the open-source gateway is free.",
+		answer: `Foundry bills model rates through your Azure subscription, with provisioned-throughput (PTU) reservations for guaranteed capacity. LLM Gateway charges the same provider rates with a flat 5% platform fee on credits — or 0% when you bring your own provider keys, including Azure credentials. Optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}. Self-hosting the open-source gateway is free.`,
 	},
 	{
 		question: "How hard is it to migrate from Azure AI Foundry to LLM Gateway?",

--- a/apps/ui/src/app/compare/litellm/page.tsx
+++ b/apps/ui/src/app/compare/litellm/page.tsx
@@ -24,7 +24,7 @@ const liteLlmFaqs: CompareFaqItem[] = [
 	{
 		question: "How does pricing work compared to LiteLLM?",
 		answer:
-			"Managed usage is pay-as-you-go with a flat 5% platform fee on credits, or free when you bring your own provider keys. Self-hosting the AGPLv3 build is free.",
+			"Managed usage is pay-as-you-go with a flat 5% platform fee on credits, or free when you bring your own provider keys; optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the AGPLv3 build is free.",
 	},
 	{
 		question: "Does it provide analytics and routing out of the box?",

--- a/apps/ui/src/app/compare/litellm/page.tsx
+++ b/apps/ui/src/app/compare/litellm/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonLiteLLM } from "@/components/landing/comparison-litellm";
 import Footer from "@/components/landing/footer";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const liteLlmFaqs: CompareFaqItem[] = [
@@ -23,8 +25,7 @@ const liteLlmFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "How does pricing work compared to LiteLLM?",
-		answer:
-			"Managed usage is pay-as-you-go with a flat 5% platform fee on credits, or free when you bring your own provider keys; optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the AGPLv3 build is free.",
+		answer: `Managed usage is pay-as-you-go with a flat 5% platform fee on credits, or free when you bring your own provider keys; optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}. Self-hosting the AGPLv3 build is free.`,
 	},
 	{
 		question: "Does it provide analytics and routing out of the box?",

--- a/apps/ui/src/app/compare/open-router/page.tsx
+++ b/apps/ui/src/app/compare/open-router/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { Comparison } from "@/components/landing/comparison";
 import Footer from "@/components/landing/footer";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const openRouterFaqs: CompareFaqItem[] = [
@@ -18,8 +20,7 @@ const openRouterFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "How does pricing compare to OpenRouter?",
-		answer:
-			"Use pay-as-you-go credits with a flat 5% platform fee, or bring your own provider keys and pay providers directly for free. Token pricing matches provider rates with no markup, and optional full data retention is billed at $0.01 per 1M tokens.",
+		answer: `Use pay-as-you-go credits with a flat 5% platform fee, or bring your own provider keys and pay providers directly for free. Token pricing matches provider rates with no markup, and optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}.`,
 	},
 	{
 		question: "Which models and providers are supported?",

--- a/apps/ui/src/app/compare/open-router/page.tsx
+++ b/apps/ui/src/app/compare/open-router/page.tsx
@@ -19,7 +19,7 @@ const openRouterFaqs: CompareFaqItem[] = [
 	{
 		question: "How does pricing compare to OpenRouter?",
 		answer:
-			"Use pay-as-you-go credits with a flat 5% platform fee, or bring your own provider keys and pay providers directly for free. Token pricing matches provider rates with no markup.",
+			"Use pay-as-you-go credits with a flat 5% platform fee, or bring your own provider keys and pay providers directly for free. Token pricing matches provider rates with no markup, and optional full data retention is billed at $0.01 per 1M tokens.",
 	},
 	{
 		question: "Which models and providers are supported?",

--- a/apps/ui/src/app/compare/portkey/page.tsx
+++ b/apps/ui/src/app/compare/portkey/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonPortkey } from "@/components/landing/comparison-portkey";
 import Footer from "@/components/landing/footer";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const portkeyFaqs: CompareFaqItem[] = [
@@ -18,8 +20,7 @@ const portkeyFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "How does pricing compare to Portkey?",
-		answer:
-			"Pay per token at provider rates with a flat 5% platform fee on credits, or bring your own provider keys and pay providers directly for free. There are no per-seat or request-volume tiers, and optional full data retention is billed at $0.01 per 1M tokens.",
+		answer: `Pay per token at provider rates with a flat 5% platform fee on credits, or bring your own provider keys and pay providers directly for free. There are no per-seat or request-volume tiers, and optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}.`,
 	},
 	{
 		question: "Can I migrate from Portkey without changing my code?",

--- a/apps/ui/src/app/compare/portkey/page.tsx
+++ b/apps/ui/src/app/compare/portkey/page.tsx
@@ -19,7 +19,7 @@ const portkeyFaqs: CompareFaqItem[] = [
 	{
 		question: "How does pricing compare to Portkey?",
 		answer:
-			"Pay per token at provider rates with a flat 5% platform fee on credits, or bring your own provider keys and pay providers directly for free. There are no per-seat or request-volume tiers.",
+			"Pay per token at provider rates with a flat 5% platform fee on credits, or bring your own provider keys and pay providers directly for free. There are no per-seat or request-volume tiers, and optional full data retention is billed at $0.01 per 1M tokens.",
 	},
 	{
 		question: "Can I migrate from Portkey without changing my code?",

--- a/apps/ui/src/app/compare/vercel-ai-gateway/page.tsx
+++ b/apps/ui/src/app/compare/vercel-ai-gateway/page.tsx
@@ -24,7 +24,7 @@ const vercelFaqs: CompareFaqItem[] = [
 	{
 		question: "How does pricing compare to Vercel AI Gateway?",
 		answer:
-			"Both charge no markup on tokens. On the managed tier LLM Gateway adds a flat 5% platform fee on credits, or 0% when you bring your own provider keys. Self-hosting the AGPLv3 build is free, and there are no team-seat or governance add-ons gated behind a higher plan.",
+			"Both charge no markup on tokens. On the managed tier LLM Gateway adds a flat 5% platform fee on credits, or 0% when you bring your own provider keys; optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the AGPLv3 build is free, and there are no team-seat or governance add-ons gated behind a higher plan.",
 	},
 	{
 		question: "What can LLM Gateway do that Vercel AI Gateway doesn't?",

--- a/apps/ui/src/app/compare/vercel-ai-gateway/page.tsx
+++ b/apps/ui/src/app/compare/vercel-ai-gateway/page.tsx
@@ -3,6 +3,8 @@ import { HeroCompare } from "@/components/compare/hero-compare";
 import { ComparisonVercel } from "@/components/landing/comparison-vercel";
 import Footer from "@/components/landing/footer";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const vercelFaqs: CompareFaqItem[] = [
@@ -23,8 +25,7 @@ const vercelFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "How does pricing compare to Vercel AI Gateway?",
-		answer:
-			"Both charge no markup on tokens. On the managed tier LLM Gateway adds a flat 5% platform fee on credits, or 0% when you bring your own provider keys; optional full data retention is billed at $0.01 per 1M tokens. Self-hosting the AGPLv3 build is free, and there are no team-seat or governance add-ons gated behind a higher plan.",
+		answer: `Both charge no markup on tokens. On the managed tier LLM Gateway adds a flat 5% platform fee on credits, or 0% when you bring your own provider keys; optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}. Self-hosting the AGPLv3 build is free, and there are no team-seat or governance add-ons gated behind a higher plan.`,
 	},
 	{
 		question: "What can LLM Gateway do that Vercel AI Gateway doesn't?",

--- a/apps/ui/src/app/open-source/page.tsx
+++ b/apps/ui/src/app/open-source/page.tsx
@@ -57,7 +57,7 @@ const openSourceFaqs: CompareFaqItem[] = [
 	{
 		question: "Is there a managed option too?",
 		answer:
-			"Yes. If you would rather not run infrastructure, the hosted LLM API gateway is pay-as-you-go with a flat 5% platform fee on credits, or 0% when you bring your own provider keys.",
+			"Yes. If you would rather not run infrastructure, the hosted LLM API gateway is pay-as-you-go with a flat 5% platform fee on credits, or 0% when you bring your own provider keys. Optional full data retention is billed at $0.01 per 1M tokens.",
 	},
 	{
 		question: "Which models does the open-source gateway support?",

--- a/apps/ui/src/app/open-source/page.tsx
+++ b/apps/ui/src/app/open-source/page.tsx
@@ -9,6 +9,8 @@ import { AuthLink } from "@/components/shared/auth-link";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 import type { CompareFaqItem } from "@/components/compare/compare-faq";
 
 const reasons = [
@@ -56,8 +58,7 @@ const openSourceFaqs: CompareFaqItem[] = [
 	},
 	{
 		question: "Is there a managed option too?",
-		answer:
-			"Yes. If you would rather not run infrastructure, the hosted LLM API gateway is pay-as-you-go with a flat 5% platform fee on credits, or 0% when you bring your own provider keys. Optional full data retention is billed at $0.01 per 1M tokens.",
+		answer: `Yes. If you would rather not run infrastructure, the hosted LLM API gateway is pay-as-you-go with a flat 5% platform fee on credits, or 0% when you bring your own provider keys. Optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}.`,
 	},
 	{
 		question: "Which models does the open-source gateway support?",

--- a/apps/ui/src/components/landing/faq.tsx
+++ b/apps/ui/src/components/landing/faq.tsx
@@ -28,7 +28,7 @@ const faqData = [
 	},
 	{
 		question: "How much does it cost?",
-		answer: `Credits: Pay-as-you-go with a flat 5% platform fee. BYOK: Use your own provider API keys for free — optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}. Enterprise: Custom SLA, dedicated infrastructure, and volume discounts. Self-host: Deploy free forever under AGPLv3 license.`,
+		answer: `Credits: Pay-as-you-go with a flat 5% platform fee. BYOK: Use your own provider API keys for free. Enterprise: Custom SLA, dedicated infrastructure, and volume discounts. Self-host: Deploy free forever under AGPLv3 license. Optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice} in both credits and BYOK modes.`,
 	},
 ];
 
@@ -197,14 +197,7 @@ export function Faq() {
 												<strong>Bring Your Own Keys – free:</strong> Use your
 												own LLM provider API keys (OpenAI, Anthropic, Google,
 												etc.) and pay providers directly. Usage tracking and
-												analytics included at no extra cost; optional{" "}
-												<a
-													href="https://docs.llmgateway.io/features/data-retention#storage-pricing"
-													className="underline"
-												>
-													full data retention
-												</a>{" "}
-												is billed at {MARKETING_STATS.dataStoragePrice}.
+												analytics included at no extra cost.
 											</li>
 											<li>
 												<strong>Enterprise:</strong> Custom SLA, dedicated
@@ -216,6 +209,17 @@ export function Faq() {
 												gateway on your own infrastructure—free forever.
 											</li>
 										</ul>
+										<p className="mt-2">
+											Optional{" "}
+											<a
+												href="https://docs.llmgateway.io/features/data-retention#storage-pricing"
+												className="underline"
+											>
+												full data retention
+											</a>{" "}
+											is billed at {MARKETING_STATS.dataStoragePrice} in both
+											credits and BYOK modes.
+										</p>
 									</div>
 								</AccordionContent>
 							</AccordionItem>

--- a/apps/ui/src/components/landing/faq.tsx
+++ b/apps/ui/src/components/landing/faq.tsx
@@ -28,8 +28,7 @@ const faqData = [
 	},
 	{
 		question: "How much does it cost?",
-		answer:
-			"Credits: Pay-as-you-go with a flat 5% platform fee. BYOK: Use your own provider API keys for free. Enterprise: Custom SLA, dedicated infrastructure, and volume discounts. Self-host: Deploy free forever under AGPLv3 license.",
+		answer: `Credits: Pay-as-you-go with a flat 5% platform fee. BYOK: Use your own provider API keys for free — optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}. Enterprise: Custom SLA, dedicated infrastructure, and volume discounts. Self-host: Deploy free forever under AGPLv3 license.`,
 	},
 ];
 
@@ -198,7 +197,14 @@ export function Faq() {
 												<strong>Bring Your Own Keys – free:</strong> Use your
 												own LLM provider API keys (OpenAI, Anthropic, Google,
 												etc.) and pay providers directly. Usage tracking and
-												analytics included at no extra cost.
+												analytics included at no extra cost; optional{" "}
+												<a
+													href="https://docs.llmgateway.io/features/data-retention#storage-pricing"
+													className="underline"
+												>
+													full data retention
+												</a>{" "}
+												is billed at {MARKETING_STATS.dataStoragePrice}.
 											</li>
 											<li>
 												<strong>Enterprise:</strong> Custom SLA, dedicated

--- a/apps/ui/src/components/pricing/pricing-faq.tsx
+++ b/apps/ui/src/components/pricing/pricing-faq.tsx
@@ -18,8 +18,13 @@ const FAQ_ITEMS: PricingFaqItem[] = [
 	},
 	{
 		question: "Is there a fee when I bring my own API keys?",
-		answer:
-			"No. With your own provider keys (BYOK), routing through LLM Gateway is free — you pay your providers directly and still get unified analytics, caching, and failover.",
+		answer: `No platform fee. With your own provider keys (BYOK), routing through LLM Gateway is free — you pay your providers directly and still get unified analytics, caching, and failover. The only optional charge is storage: if you enable full data retention, stored requests are billed at ${MARKETING_STATS.dataStoragePrice}.`,
+		links: [
+			{
+				href: "https://docs.llmgateway.io/features/data-retention#storage-pricing",
+				label: "See storage pricing",
+			},
+		],
 	},
 	{
 		question: "How much do tokens cost for each model?",

--- a/apps/ui/src/components/pricing/pricing-table.tsx
+++ b/apps/ui/src/components/pricing/pricing-table.tsx
@@ -66,6 +66,10 @@ const pricingFeatures: PricingFeature[] = [
 	},
 	{
 		name: "Data Retention",
+		description: "Metadata is free; full payloads are $0.01/1M tokens",
+		learnMoreLink:
+			"https://docs.llmgateway.io/features/data-retention#storage-pricing",
+		learnMoreText: "See storage pricing →",
 		free: "30 days",
 		enterprise: "Unlimited",
 	},

--- a/apps/ui/src/components/pricing/pricing-table.tsx
+++ b/apps/ui/src/components/pricing/pricing-table.tsx
@@ -7,6 +7,8 @@ import { AuthLink } from "@/components/shared/auth-link";
 import { Button } from "@/lib/components/button";
 import { cn } from "@/lib/utils";
 
+import { MARKETING_STATS } from "@llmgateway/shared";
+
 type FeatureValue = boolean | string;
 
 interface PricingFeature {
@@ -66,7 +68,7 @@ const pricingFeatures: PricingFeature[] = [
 	},
 	{
 		name: "Data Retention",
-		description: "Metadata is free; full payloads are $0.01/1M tokens",
+		description: `Metadata is free; full payloads are ${MARKETING_STATS.dataStoragePrice}`,
 		learnMoreLink:
 			"https://docs.llmgateway.io/features/data-retention#storage-pricing",
 		learnMoreText: "See storage pricing →",

--- a/packages/shared/src/marketing.ts
+++ b/packages/shared/src/marketing.ts
@@ -10,6 +10,7 @@ export const MARKETING_STATS = {
 	uptimeSla: "99.9%",
 	effectiveUptime: "99.9999%",
 	platformFee: "5%",
+	dataStoragePrice: "$0.01 per 1M tokens",
 	githubStars: "20K+",
 } as const;
 


### PR DESCRIPTION
## Summary

Marketing and docs copy claimed BYOK (bring-your-own-keys) usage is entirely free. That's still true for routing — 0% platform fee — but when an organization enables **full data retention**, storage is billed at **$0.01 per 1M tokens** from LLM Gateway credits in *all* modes, including BYOK (see #3247, which made that billing consistent). This PR adds the caveat everywhere the free-BYOK claim appears and links the [storage pricing docs](https://docs.llmgateway.io/features/data-retention#storage-pricing).

## Changes

- **`packages/shared`**: add `MARKETING_STATS.dataStoragePrice` ("$0.01 per 1M tokens") next to `platformFee` as the single source of truth for surfaces that already consume `MARKETING_STATS`.
- **Pricing page** (`apps/ui`):
  - `pricing-faq.tsx` — the "Is there a fee when I bring my own API keys?" answer now explains the optional storage charge and links "See storage pricing" to the docs section (answer is reused verbatim for FAQPage JSON-LD).
  - `pricing-table.tsx` — the Data Retention row gets a description ("Metadata is free; full payloads are $0.01/1M tokens") and a "See storage pricing →" link.
- **Landing FAQ** (`landing/faq.tsx`) — the "How much does it cost?" BYOK bullet (both the JSON-LD string and the rendered accordion, kept in sync) now mentions the charge, with the rendered version linking the docs section.
- **Comparison pages** — pricing FAQ answers on `/compare/open-router`, `/compare/portkey`, `/compare/litellm`, `/compare/vercel-ai-gateway`, `/compare/aws-bedrock`, `/compare/azure-ai-foundry`, and the `/open-source` FAQ.
- **DevPass** (`apps/code/Faq.tsx`) — the pay-as-you-go answer gets the same parenthetical.
- **Docs** (`learn/provider-keys.mdx`) — the "without additional gateway fees" intro now notes the optional storage charge and links `/features/data-retention#storage-pricing`.

## Deliberately unchanged

- Headline one-liners, meta descriptions, hero badges, and referral copy saying BYOK has "0% / zero platform fees" — that claim remains accurate (storage is a separate, opt-in charge); the nuance lives in FAQ/detail copy where users check fees.
- Comparison-table platform-fee rows ("5% or 0% (BYOK)") for the same reason.
- Dated blog posts.

## Testing

- `pnpm build` — 17/17 tasks pass.
- `pnpm format` — clean.

https://claude.ai/code/session_0196L4fULdokeKNu7stvbLWm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pricing FAQs and provider-key guidance to clarify that optional full data retention costs **$0.01 per 1M tokens**.
  * Added storage-pricing links and clearer explanations of retention charges.

* **Pricing**
  * Displayed the data-storage price consistently across pricing, comparison, and retention sections.
  * Clarified that charges may apply to BYOK and managed usage when full data retention is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->