### PR TITLE
fix(models): pin alibaba deepseek-v4-flash snapshot

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -481,7 +481,7 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "alibaba",
-				externalId: "deepseek-v4-flash",
+				externalId: "deepseek-v4-flash-0731",
 				inputPrice: "0.2e-6",
 				cachedInputPrice: "0.04e-6",
 				outputPrice: "0.4e-6",


### PR DESCRIPTION
Points the Alibaba provider mapping for `deepseek-v4-flash` at the dated `deepseek-v4-flash-0731` deployment instead of the undated alias.

## Testing

Scoped e2e run against the changed mapping (`TEST_MODELS="alibaba/deepseek-v4-flash:singapore" FULL_MODE=true pnpm test:e2e`) — 29 files passed, 102 tests. Verified with the verbose reporter that the mapping really executed live requests rather than being skipped:

- `basic 'alibaba/deepseek-v4-flash:singapore'` ✓
- `streaming ...` ✓
- `basic reasoning ...` ✓
- `tool calls ...` / `streaming tool calls ...` ✓

Only the `:singapore` region was exercised — the local BYOK Alibaba key is singapore-only, so the `:us-virginia` / `:cn-beijing` variants 401 locally regardless of this change.

`pnpm format` and a full `pnpm build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Alibaba DeepSeek V4 Flash model identifier to ensure requests target the correct model version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->