### PR TITLE
feat(auth): block web.id root domain at signup

### DIFF
--- a/apps/api/src/utils/email-validation.spec.ts
+++ b/apps/api/src/utils/email-validation.spec.ts
@@ -49,10 +49,22 @@ describe("validateEmail", () => {
 			expect(result.reason).toBe("blacklisted_domain");
 		});
 
-		it("should reject emails from 1nawaks.web.id", () => {
-			const result = validateEmail("user@1nawaks.web.id");
+		it("should reject emails from web.id", () => {
+			const result = validateEmail("user@web.id");
 			expect(result.valid).toBe(false);
 			expect(result.reason).toBe("blacklisted_domain");
+		});
+
+		it("should reject emails from any web.id subdomain", () => {
+			for (const email of [
+				"user@1nawaks.web.id",
+				"user@2nawaks.web.id",
+				"user@a.b.web.id",
+			]) {
+				const result = validateEmail(email);
+				expect(result.valid).toBe(false);
+				expect(result.reason).toBe("blacklisted_domain");
+			}
 		});
 
 		it("should reject emails from web-library.net", () => {

--- a/apps/api/src/utils/email-validation.ts
+++ b/apps/api/src/utils/email-validation.ts
@@ -15,7 +15,7 @@ const BLACKLISTED_DOMAINS = [
 	"addy.io",
 	"xigege.me",
 	"duckmail.sbs",
-	"1nawaks.web.id",
+	"web.id",
 	"web-library.net",
 	"hitbtcpool.cloud",
 	"tempmail.edu.ge",


### PR DESCRIPTION
## Summary

Follow-up to #3356. That PR added subdomain matching to the signup blacklist and blocked `1nawaks.web.id` specifically — but only that one subdomain, so a sibling like `2nawaks.web.id` still gets through. This blocks the `web.id` root domain instead, which the existing subdomain matching then extends to everything under it.

Rebased onto #3356, so no duplication: the matching logic and the other domains added there are untouched.

## Changes

- `apps/api/src/utils/email-validation.ts`: replace the `1nawaks.web.id` blacklist entry with `web.id`. The entry it replaces is strictly covered by the root, so nothing is unblocked.
- Tests: swap the `1nawaks.web.id` case for a root `web.id` case, plus a subdomain case asserting `1nawaks.web.id`, `2nawaks.web.id`, and a multi-level `a.b.web.id` are all rejected.

## Testing

- `pnpm vitest run apps/api/src/utils/email-validation.spec.ts` — 21 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation to reject addresses using the broader `web.id` blacklisted domain and any nested subdomains.
  * Added coverage for exact-domain and nested-subdomain cases, including case-insensitive matching.
  * Confirmed that similarly named domains and suffix mismatches remain accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->