### PR TITLE
feat: bulk block filtered organizations

### DIFF
--- a/apps/api/src/routes/admin-bulk-block.spec.ts
+++ b/apps/api/src/routes/admin-bulk-block.spec.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+interface PreviewResponse {
+	search: string;
+	matched: number;
+	blockable: number;
+	skipped: number;
+	maxBulkSize: number;
+	organizations: { id: string; name: string }[];
+}
+
+interface BulkBlockResponse {
+	message: string;
+	blockedCount: number;
+	failedCount: number;
+	blocked: { id: string; name: string }[];
+	failed: { id: string; name: string; error: string }[];
+}
+
+async function insertOrg(
+	id: string,
+	name: string,
+	overrides: Partial<typeof tables.organization.$inferInsert> = {},
+) {
+	await db.insert(tables.organization).values({
+		id,
+		name,
+		billingEmail: `${id}@fraudring.test`,
+		...overrides,
+	});
+}
+
+async function preview(search: string, token?: string): Promise<Response> {
+	return await app.request(
+		`/admin/organizations/bulk-block/preview?search=${encodeURIComponent(search)}`,
+		{
+			headers: token ? { Cookie: token } : {},
+		},
+	);
+}
+
+async function bulkBlock(body: unknown, token?: string): Promise<Response> {
+	return await app.request("/admin/organizations/bulk-block", {
+		method: "POST",
+		headers: {
+			...(token ? { Cookie: token } : {}),
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+async function getStatus(orgId: string) {
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId } },
+	});
+	return org?.status ?? null;
+}
+
+describe("admin bulk block organizations", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	it("rejects unauthenticated and non-admin requests", async () => {
+		expect((await preview("fraud")).status).toBe(401);
+		expect(
+			(await bulkBlock({ search: "fraud", expectedCount: 1 })).status,
+		).toBe(401);
+
+		process.env.ADMIN_EMAILS = "someone-else@example.com";
+		expect((await preview("fraud", cookie)).status).toBe(403);
+		expect(
+			(await bulkBlock({ search: "fraud", expectedCount: 1 }, cookie)).status,
+		).toBe(403);
+	});
+
+	it("rejects an empty or too short search filter", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+
+		for (const search of ["", " ", "fr", "  a  "]) {
+			expect((await preview(search, cookie)).status).toBe(400);
+			expect(
+				(await bulkBlock({ search, expectedCount: 1 }, cookie)).status,
+			).toBe(400);
+		}
+
+		expect(await getStatus("bulk-a")).toBe("active");
+	});
+
+	it("rejects a zero or negative expected count", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+
+		for (const expectedCount of [0, -1]) {
+			const res = await bulkBlock({ search: "fraud", expectedCount }, cookie);
+			expect(res.status).toBe(400);
+		}
+
+		expect(await getStatus("bulk-a")).toBe("active");
+	});
+
+	it("escapes LIKE wildcards so a wildcard search matches nothing", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-b", "Legit Corp");
+
+		const res = await preview("%%%", cookie);
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as PreviewResponse;
+		expect(json.matched).toBe(0);
+		expect(json.blockable).toBe(0);
+
+		const blockRes = await bulkBlock(
+			{ search: "%%%", expectedCount: 2 },
+			cookie,
+		);
+		expect(blockRes.status).toBe(409);
+		expect(await getStatus("bulk-a")).toBe("active");
+		expect(await getStatus("bulk-b")).toBe("active");
+	});
+
+	it("previews only the organizations the filter can block", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-b", "Fraud Ring Beta");
+		await insertOrg("bulk-deleted", "Fraud Ring Gone", { status: "deleted" });
+		await insertOrg("bulk-own", "Fraud Ring Own");
+		await insertOrg("bulk-other", "Legit Corp");
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: "bulk-own",
+			role: "owner",
+		});
+
+		const res = await preview("fraud ring", cookie);
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as PreviewResponse;
+
+		expect(json.matched).toBe(4);
+		expect(json.blockable).toBe(2);
+		expect(json.skipped).toBe(2);
+		expect(json.organizations.map((o) => o.id).sort()).toEqual([
+			"bulk-a",
+			"bulk-b",
+		]);
+	});
+
+	it("blocks exactly the filtered organizations and nothing else", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-b", "Fraud Ring Beta");
+		await insertOrg("bulk-other", "Legit Corp");
+
+		const res = await bulkBlock(
+			{ search: "fraud ring", expectedCount: 2 },
+			cookie,
+		);
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as BulkBlockResponse;
+		expect(json.blockedCount).toBe(2);
+		expect(json.failedCount).toBe(0);
+
+		expect(await getStatus("bulk-a")).toBe("deleted");
+		expect(await getStatus("bulk-b")).toBe("deleted");
+		expect(await getStatus("bulk-other")).toBe("active");
+	});
+
+	it("blocks nothing when the confirmed count does not match", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-b", "Fraud Ring Beta");
+
+		const res = await bulkBlock(
+			{ search: "fraud ring", expectedCount: 1 },
+			cookie,
+		);
+		expect(res.status).toBe(409);
+
+		expect(await getStatus("bulk-a")).toBe("active");
+		expect(await getStatus("bulk-b")).toBe("active");
+	});
+
+	it("never touches the acting admin's own organizations", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-own", "Fraud Ring Own");
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: "bulk-own",
+			role: "owner",
+		});
+
+		const res = await bulkBlock(
+			{ search: "fraud ring", expectedCount: 1 },
+			cookie,
+		);
+		expect(res.status).toBe(200);
+
+		expect(await getStatus("bulk-a")).toBe("deleted");
+		expect(await getStatus("bulk-own")).toBe("active");
+	});
+
+	it("deactivates members of blocked organizations", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await db.insert(tables.user).values({
+			id: "bulk-member",
+			name: "Bulk Member",
+			email: "member@fraudring.test",
+			emailVerified: true,
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "bulk-member",
+			organizationId: "bulk-a",
+			role: "owner",
+		});
+
+		const res = await bulkBlock({ search: "fraud", expectedCount: 1 }, cookie);
+		expect(res.status).toBe(200);
+
+		const member = await db.query.user.findFirst({
+			where: { id: { eq: "bulk-member" } },
+		});
+		expect(member?.status).toBe("deactivated");
+	});
+
+	it("refuses filters that match more than the bulk cap", async () => {
+		await db.insert(tables.organization).values(
+			Array.from({ length: 101 }, (_, index) => ({
+				id: `bulkcap-${index}`,
+				name: `Bulkcap Org ${index}`,
+				billingEmail: `bulkcap-${index}@fraudring.test`,
+			})),
+		);
+
+		const previewRes = await preview("bulkcap", cookie);
+		expect(previewRes.status).toBe(400);
+
+		const blockRes = await bulkBlock(
+			{ search: "bulkcap", expectedCount: 100 },
+			cookie,
+		);
+		expect(blockRes.status).toBe(400);
+
+		expect(await getStatus("bulkcap-0")).toBe("active");
+	});
+});

--- a/apps/api/src/routes/admin-bulk-block.spec.ts
+++ b/apps/api/src/routes/admin-bulk-block.spec.ts
@@ -7,6 +7,9 @@ import { db, tables } from "@llmgateway/db";
 
 const originalAdminEmails = process.env.ADMIN_EMAILS;
 
+// Mirrors MAX_BULK_BLOCK_ORGANIZATIONS in apps/api/src/routes/admin.ts.
+const MAX_BULK_BLOCK_ORGANIZATIONS = 500;
+
 interface PreviewResponse {
 	search: string;
 	matched: number;
@@ -239,7 +242,7 @@ describe("admin bulk block organizations", () => {
 
 	it("refuses filters that match more than the bulk cap", async () => {
 		await db.insert(tables.organization).values(
-			Array.from({ length: 101 }, (_, index) => ({
+			Array.from({ length: MAX_BULK_BLOCK_ORGANIZATIONS + 1 }, (_, index) => ({
 				id: `bulkcap-${index}`,
 				name: `Bulkcap Org ${index}`,
 				billingEmail: `bulkcap-${index}@fraudring.test`,
@@ -250,7 +253,7 @@ describe("admin bulk block organizations", () => {
 		expect(previewRes.status).toBe(400);
 
 		const blockRes = await bulkBlock(
-			{ search: "bulkcap", expectedCount: 100 },
+			{ search: "bulkcap", expectedCount: MAX_BULK_BLOCK_ORGANIZATIONS },
 			cookie,
 		);
 		expect(blockRes.status).toBe(400);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -86,6 +86,38 @@ function escapeHtml(text: string): string {
 	return text.replace(/[&<>"']/g, (char) => htmlEscapeMap[char] || char);
 }
 
+// Search terms and stored matchers are plain substrings, so LIKE
+// metacharacters must be escaped before wrapping them in wildcards. For the
+// organization search this is a safety guard, not just correctness: an
+// unescaped "%" would silently become a match-everything filter, and the bulk
+// block endpoint reuses that filter to decide which organizations get banned.
+function escapeLikePattern(value: string): string {
+	return value.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
+/**
+ * Builds the organization search filter shared by the listing and the bulk
+ * block endpoints. Returns `undefined` for an empty search so callers must
+ * decide explicitly what "no filter" means — the listing shows everything, the
+ * bulk block endpoints reject the request.
+ */
+function buildOrganizationSearchFilter(search: string | undefined) {
+	const trimmed = search?.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+
+	const textPattern = `%${escapeLikePattern(trimmed.toLowerCase())}%`;
+	const idPattern = `%${escapeLikePattern(trimmed)}%`;
+
+	return or(
+		sql`LOWER(${tables.organization.name}) LIKE ${textPattern} ESCAPE '\\'`,
+		sql`LOWER(${tables.organization.billingEmail}) LIKE ${textPattern} ESCAPE '\\'`,
+		sql`${tables.organization.id} LIKE ${idPattern} ESCAPE '\\'`,
+		sql`EXISTS (SELECT 1 FROM ${tables.userOrganization} uo JOIN ${tables.user} u ON uo.user_id = u.id WHERE uo.organization_id = ${tables.organization.id} AND LOWER(u.email) LIKE ${textPattern} ESCAPE '\\')`,
+	);
+}
+
 export const admin = new OpenAPIHono<ServerTypes>();
 
 admin.use("/*", adminMiddleware);
@@ -2074,15 +2106,7 @@ admin.openapi(getOrganizations, async (c) => {
 	const sortBy = query.sortBy ?? "createdAt";
 	const sortOrder = query.sortOrder ?? "desc";
 
-	const searchLower = search?.toLowerCase();
-	const whereClause = searchLower
-		? or(
-				sql`LOWER(${tables.organization.name}) LIKE ${`%${searchLower}%`}`,
-				sql`LOWER(${tables.organization.billingEmail}) LIKE ${`%${searchLower}%`}`,
-				sql`${tables.organization.id} LIKE ${`%${search}%`}`,
-				sql`EXISTS (SELECT 1 FROM ${tables.userOrganization} uo JOIN ${tables.user} u ON uo.user_id = u.id WHERE uo.organization_id = ${tables.organization.id} AND LOWER(u.email) LIKE ${`%${searchLower}%`})`,
-			)
-		: undefined;
+	const whereClause = buildOrganizationSearchFilter(search);
 
 	const [countResult] = await db
 		.select({
@@ -6054,10 +6078,22 @@ const blockOrganizationRoute = createRoute({
 	},
 });
 
-admin.openapi(blockOrganizationRoute, async (c) => {
-	const user = c.get("user");
-	const { orgId } = c.req.valid("param");
+interface BlockOrganizationOutcome {
+	cancelledSubscriptionIds: string[];
+	memberCount: number;
+	deactivatedUserCount: number;
+}
 
+/**
+ * Blocks a single organization: cancels its Stripe subscriptions, marks it
+ * deleted, deactivates members that have no other active organization, and
+ * writes the audit entry. Shared by the single-org and bulk block endpoints so
+ * both paths always apply the exact same effects.
+ */
+async function blockOrganizationById(
+	orgId: string,
+	adminUserId: string,
+): Promise<BlockOrganizationOutcome> {
 	const org = await db.query.organization.findFirst({
 		where: { id: { eq: orgId } },
 	});
@@ -6174,7 +6210,7 @@ admin.openapi(blockOrganizationRoute, async (c) => {
 
 	await logAuditEvent({
 		organizationId: orgId,
-		userId: user!.id,
+		userId: adminUserId,
 		action: "organization.block",
 		resourceType: "organization",
 		resourceId: orgId,
@@ -6188,10 +6224,347 @@ admin.openapi(blockOrganizationRoute, async (c) => {
 		},
 	});
 
+	return {
+		cancelledSubscriptionIds,
+		memberCount: memberUserIds.length,
+		deactivatedUserCount: userIdsToDeactivate.length,
+	};
+}
+
+admin.openapi(blockOrganizationRoute, async (c) => {
+	const user = c.get("user");
+	const { orgId } = c.req.valid("param");
+
+	const { cancelledSubscriptionIds } = await blockOrganizationById(
+		orgId,
+		user!.id,
+	);
+
 	return c.json({
 		message: "Organization blocked and subscriptions cancelled.",
 		cancelledSubscriptionIds,
 	});
+});
+
+// --- Bulk block organizations (filtered list) ---
+
+// Hard ceiling on a single bulk block. A filter matching more than this is
+// treated as too broad to be an intentional selection and is rejected outright
+// rather than partially applied.
+const MAX_BULK_BLOCK_ORGANIZATIONS = 100;
+// A one or two character filter matches far too much to be a deliberate
+// selection, so require something specific enough to identify a set of orgs.
+const MIN_BULK_BLOCK_SEARCH_LENGTH = 3;
+
+const bulkBlockOrganizationSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	billingEmail: z.string(),
+	plan: z.string(),
+	status: z.string().nullable(),
+	createdAt: z.string(),
+});
+
+interface BulkBlockCandidates {
+	search: string;
+	matched: number;
+	candidates: {
+		id: string;
+		name: string;
+		billingEmail: string;
+		plan: string;
+		status: string | null;
+		createdAt: Date;
+	}[];
+}
+
+/**
+ * Resolves the exact set of organizations a bulk block would affect.
+ *
+ * Every guard that prevents a bulk block from degenerating into "ban
+ * everything" lives here, so the preview and the mutation can never disagree
+ * about the target set:
+ * - an empty or too-short search throws, so there is no unfiltered code path;
+ * - the LIKE filter escapes wildcards, so "%" cannot match every row;
+ * - organizations that are already blocked are excluded;
+ * - organizations the acting admin belongs to are excluded, so an admin can
+ *   never lock themselves (or their own org's members) out;
+ * - a filter resolving to more than MAX_BULK_BLOCK_ORGANIZATIONS throws rather
+ *   than silently truncating to the first N.
+ *
+ * Callers mutate strictly by the returned ids, never by re-running the filter
+ * as the WHERE clause of an UPDATE.
+ */
+async function resolveBulkBlockCandidates(
+	search: string,
+	adminUserId: string,
+): Promise<BulkBlockCandidates> {
+	const trimmed = search.trim();
+
+	if (trimmed.length < MIN_BULK_BLOCK_SEARCH_LENGTH) {
+		throw new HTTPException(400, {
+			message: `Bulk blocking requires a search filter of at least ${MIN_BULK_BLOCK_SEARCH_LENGTH} characters.`,
+		});
+	}
+
+	const searchFilter = buildOrganizationSearchFilter(trimmed);
+
+	if (!searchFilter) {
+		throw new HTTPException(400, {
+			message: "Bulk blocking requires a search filter.",
+		});
+	}
+
+	const adminOrgLinks = await db.query.userOrganization.findMany({
+		where: { userId: { eq: adminUserId } },
+		columns: { organizationId: true },
+	});
+	const adminOrgIds = [
+		...new Set(adminOrgLinks.map((link) => link.organizationId)),
+	];
+
+	const candidateFilter = and(
+		searchFilter,
+		or(
+			isNull(tables.organization.status),
+			ne(tables.organization.status, "deleted"),
+		),
+		adminOrgIds.length > 0
+			? notInArray(tables.organization.id, adminOrgIds)
+			: undefined,
+	);
+
+	const [matchedRow] = await db
+		.select({ count: sql<number>`COUNT(*)`.as("count") })
+		.from(tables.organization)
+		.where(searchFilter);
+
+	const candidates = await db
+		.select({
+			id: tables.organization.id,
+			name: tables.organization.name,
+			billingEmail: tables.organization.billingEmail,
+			plan: tables.organization.plan,
+			status: tables.organization.status,
+			createdAt: tables.organization.createdAt,
+		})
+		.from(tables.organization)
+		.where(candidateFilter)
+		.orderBy(asc(tables.organization.createdAt))
+		.limit(MAX_BULK_BLOCK_ORGANIZATIONS + 1);
+
+	if (candidates.length > MAX_BULK_BLOCK_ORGANIZATIONS) {
+		throw new HTTPException(400, {
+			message: `This filter matches more than ${MAX_BULK_BLOCK_ORGANIZATIONS} organizations. Narrow the search before bulk blocking.`,
+		});
+	}
+
+	return {
+		search: trimmed,
+		matched: Number(matchedRow?.count ?? 0),
+		candidates,
+	};
+}
+
+const bulkBlockPreviewRoute = createRoute({
+	method: "get",
+	path: "/organizations/bulk-block/preview",
+	request: {
+		query: z.object({
+			search: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						search: z.string(),
+						matched: z.number(),
+						blockable: z.number(),
+						skipped: z.number(),
+						maxBulkSize: z.number(),
+						organizations: z.array(bulkBlockOrganizationSchema),
+					}),
+				},
+			},
+			description: "Organizations a bulk block would affect.",
+		},
+		400: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description: "Search filter missing, too short, or too broad.",
+		},
+	},
+});
+
+admin.openapi(bulkBlockPreviewRoute, async (c) => {
+	const user = c.get("user");
+	const { search } = c.req.valid("query");
+
+	const {
+		matched,
+		candidates,
+		search: normalizedSearch,
+	} = await resolveBulkBlockCandidates(search, user!.id);
+
+	return c.json(
+		{
+			search: normalizedSearch,
+			matched,
+			blockable: candidates.length,
+			skipped: Math.max(0, matched - candidates.length),
+			maxBulkSize: MAX_BULK_BLOCK_ORGANIZATIONS,
+			organizations: candidates.map((org) => ({
+				id: org.id,
+				name: org.name,
+				billingEmail: org.billingEmail,
+				plan: org.plan,
+				status: org.status,
+				createdAt: org.createdAt.toISOString(),
+			})),
+		},
+		200,
+	);
+});
+
+const bulkBlockOrganizationsRoute = createRoute({
+	method: "post",
+	path: "/organizations/bulk-block",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						search: z.string(),
+						// The number of organizations the admin confirmed in the UI. The
+						// server re-resolves the set and refuses to act unless it matches
+						// exactly, so a filter that widened between preview and confirm
+						// blocks nothing instead of blocking extra organizations.
+						expectedCount: z
+							.number()
+							.int()
+							.min(1)
+							.max(MAX_BULK_BLOCK_ORGANIZATIONS),
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+						blockedCount: z.number(),
+						failedCount: z.number(),
+						blocked: z.array(
+							z.object({
+								id: z.string(),
+								name: z.string(),
+								cancelledSubscriptionIds: z.array(z.string()),
+							}),
+						),
+						failed: z.array(
+							z.object({
+								id: z.string(),
+								name: z.string(),
+								error: z.string(),
+							}),
+						),
+					}),
+				},
+			},
+			description: "Bulk block result.",
+		},
+		400: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description: "Search filter missing, too short, or too broad.",
+		},
+		409: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description:
+				"The confirmed count no longer matches the filtered organizations.",
+		},
+	},
+});
+
+admin.openapi(bulkBlockOrganizationsRoute, async (c) => {
+	const user = c.get("user");
+	const { search, expectedCount } = c.req.valid("json");
+
+	const { candidates } = await resolveBulkBlockCandidates(search, user!.id);
+
+	if (candidates.length !== expectedCount) {
+		throw new HTTPException(409, {
+			message: `The filter now matches ${candidates.length} blockable organization(s) but ${expectedCount} were confirmed. Nothing was blocked — re-run the search and confirm again.`,
+		});
+	}
+
+	// Defensive: `expectedCount` is already validated as >= 1, so this can only
+	// trip if the guards above ever change. Blocking nothing is the safe outcome.
+	if (candidates.length === 0) {
+		throw new HTTPException(400, {
+			message: "No organizations matched the filter.",
+		});
+	}
+
+	const blocked: {
+		id: string;
+		name: string;
+		cancelledSubscriptionIds: string[];
+	}[] = [];
+	const failed: { id: string; name: string; error: string }[] = [];
+
+	// Sequential on purpose: each iteration talks to Stripe, and one failure must
+	// not abort the organizations that follow it.
+	for (const candidate of candidates) {
+		try {
+			const outcome = await blockOrganizationById(candidate.id, user!.id);
+			blocked.push({
+				id: candidate.id,
+				name: candidate.name,
+				cancelledSubscriptionIds: outcome.cancelledSubscriptionIds,
+			});
+		} catch (error) {
+			const message =
+				error instanceof HTTPException
+					? error.message
+					: error instanceof Error
+						? error.message
+						: "Unknown error";
+			logger.error(
+				`Bulk block failed for organization ${candidate.id}: ${message}`,
+			);
+			failed.push({ id: candidate.id, name: candidate.name, error: message });
+		}
+	}
+
+	return c.json(
+		{
+			message:
+				failed.length === 0
+					? `Blocked ${blocked.length} organization(s).`
+					: `Blocked ${blocked.length} organization(s), ${failed.length} failed.`,
+			blockedCount: blocked.length,
+			failedCount: failed.length,
+			blocked,
+			failed,
+		},
+		200,
+	);
 });
 
 // --- History endpoints ---
@@ -8661,12 +9034,6 @@ function resolveUnstableMappingsWindow(
 // `retried` is nullable; legacy rows predate the column and are NULL. Treat
 // those as non-retried so they are not silently dropped from the rankings.
 const unstableMappingsNotRetriedClause = sql`AND ${tables.log.retried} IS DISTINCT FROM true`;
-
-// Matchers are plain substrings, so LIKE metacharacters in the stored pattern
-// must be escaped before wrapping in wildcards.
-function escapeLikePattern(pattern: string): string {
-	return pattern.replace(/[\\%_]/g, (char) => `\\${char}`);
-}
 
 interface IgnoredErrorMatcherTarget {
 	pattern: string | null;

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6251,7 +6251,7 @@ admin.openapi(blockOrganizationRoute, async (c) => {
 // Hard ceiling on a single bulk block. A filter matching more than this is
 // treated as too broad to be an intentional selection and is rejected outright
 // rather than partially applied.
-const MAX_BULK_BLOCK_ORGANIZATIONS = 100;
+const MAX_BULK_BLOCK_ORGANIZATIONS = 500;
 // A one or two character filter matches far too much to be a deliberate
 // selection, so require something specific enough to identify a set of orgs.
 const MIN_BULK_BLOCK_SEARCH_LENGTH = 3;

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { BlockOrgButton } from "@/components/block-org-button";
+import { BulkBlockOrgsButton } from "@/components/bulk-block-orgs-button";
 import { OrgStatusToggleButton } from "@/components/org-status-toggle-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,8 @@ import {
 } from "@/components/ui/table";
 import {
 	blockOrganization,
+	bulkBlockOrganizations,
+	previewBulkBlockOrganizations,
 	setOrganizationStatus,
 } from "@/lib/admin-organizations";
 import { requireSession } from "@/lib/require-session";
@@ -40,6 +43,11 @@ type SortBy =
 	| "totalCreditsAllTime"
 	| "totalSpent";
 type SortOrder = "asc" | "desc";
+
+// Mirrors MIN_BULK_BLOCK_SEARCH_LENGTH in apps/api/src/routes/admin.ts. The
+// server rejects anything shorter; this only hides the entry point so the
+// action never looks available for an empty or near-empty filter.
+const BULK_BLOCK_MIN_SEARCH_LENGTH = 3;
 
 function SortableHeader({
 	label,
@@ -198,6 +206,18 @@ export default async function OrganizationsPage({
 		return await blockOrganization(orgId);
 	}
 
+	async function handlePreviewBulkBlock(searchValue: string) {
+		"use server";
+
+		return await previewBulkBlockOrganizations(searchValue);
+	}
+
+	async function handleBulkBlock(searchValue: string, expectedCount: number) {
+		"use server";
+
+		return await bulkBlockOrganizations(searchValue, expectedCount);
+	}
+
 	return (
 		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
 			<header className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
@@ -231,6 +251,21 @@ export default async function OrganizationsPage({
 					</Button>
 				</form>
 			</header>
+
+			{search.trim().length >= BULK_BLOCK_MIN_SEARCH_LENGTH && (
+				<div className="flex flex-col items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+					<p className="text-sm text-muted-foreground">
+						Bulk actions apply to every organization matching the current
+						filter, not just this page.
+					</p>
+					<BulkBlockOrgsButton
+						search={search}
+						minSearchLength={BULK_BLOCK_MIN_SEARCH_LENGTH}
+						onPreview={handlePreviewBulkBlock}
+						onBulkBlock={handleBulkBlock}
+					/>
+				</div>
+			)}
 
 			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
 				<Table>

--- a/ee/admin/src/components/bulk-block-orgs-button.tsx
+++ b/ee/admin/src/components/bulk-block-orgs-button.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { AlertTriangle, Loader2, ShieldBan } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { BulkBlockPreview } from "@/lib/admin-organizations";
+
+interface BulkBlockResult {
+	success: boolean;
+	error?: string;
+	blockedCount?: number;
+	failedCount?: number;
+	failed?: { id: string; name: string; error: string }[];
+}
+
+interface BulkBlockOrgsButtonProps {
+	search: string;
+	minSearchLength: number;
+	onPreview: (search: string) => Promise<{
+		success: boolean;
+		error?: string;
+		preview?: BulkBlockPreview;
+	}>;
+	onBulkBlock: (
+		search: string,
+		expectedCount: number,
+	) => Promise<BulkBlockResult>;
+}
+
+export function BulkBlockOrgsButton({
+	search,
+	minSearchLength,
+	onPreview,
+	onBulkBlock,
+}: BulkBlockOrgsButtonProps) {
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [previewLoading, setPreviewLoading] = useState(false);
+	const [preview, setPreview] = useState<BulkBlockPreview | null>(null);
+	const [confirmation, setConfirmation] = useState("");
+	const [blocking, setBlocking] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [result, setResult] = useState<BulkBlockResult | null>(null);
+
+	const trimmedSearch = search.trim();
+	const searchTooShort = trimmedSearch.length < minSearchLength;
+
+	const resetState = () => {
+		setPreview(null);
+		setConfirmation("");
+		setError(null);
+		setResult(null);
+		setPreviewLoading(false);
+	};
+
+	const handleOpen = async () => {
+		resetState();
+		setOpen(true);
+		setPreviewLoading(true);
+		const response = await onPreview(trimmedSearch);
+		setPreviewLoading(false);
+		if (response.success && response.preview) {
+			setPreview(response.preview);
+		} else {
+			setError(response.error ?? "Failed to preview bulk block");
+		}
+	};
+
+	const handleConfirm = async () => {
+		if (!preview) {
+			return;
+		}
+		setBlocking(true);
+		setError(null);
+		try {
+			const response = await onBulkBlock(preview.search, preview.blockable);
+			setResult(response);
+			if (response.success) {
+				router.refresh();
+			} else {
+				setError(response.error ?? "Failed to bulk block organizations");
+			}
+		} catch (err) {
+			setError(
+				err instanceof Error
+					? err.message
+					: "Failed to bulk block organizations",
+			);
+		} finally {
+			setBlocking(false);
+		}
+	};
+
+	// The admin has to retype the exact number of organizations the server
+	// resolved. A stale or mistyped number leaves the confirm button disabled,
+	// and the server independently re-checks the same number before blocking.
+	const confirmationMatches =
+		preview !== null &&
+		preview.blockable > 0 &&
+		confirmation.trim() === String(preview.blockable);
+
+	return (
+		<>
+			<Button
+				variant="destructive"
+				size="sm"
+				disabled={searchTooShort}
+				onClick={handleOpen}
+				title={
+					searchTooShort
+						? `Search for at least ${minSearchLength} characters to bulk block the filtered organizations`
+						: "Block every organization matching the current filter"
+				}
+			>
+				<ShieldBan className="mr-1.5 h-4 w-4" />
+				Bulk block filtered
+			</Button>
+
+			<Dialog
+				open={open}
+				onOpenChange={(next) => {
+					if (blocking) {
+						return;
+					}
+					setOpen(next);
+					if (!next) {
+						resetState();
+					}
+				}}
+			>
+				<DialogContent className="max-w-2xl">
+					<DialogHeader>
+						<DialogTitle className="flex items-center gap-2">
+							<AlertTriangle className="h-5 w-5 text-destructive" />
+							Bulk block filtered organizations
+						</DialogTitle>
+						<DialogDescription>
+							Blocking cancels every active Stripe subscription, marks each
+							organization as deleted, and deactivates members that have no
+							other active organization.
+						</DialogDescription>
+					</DialogHeader>
+
+					{previewLoading && (
+						<div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+							<Loader2 className="h-4 w-4 animate-spin" />
+							Resolving the organizations this would affect…
+						</div>
+					)}
+
+					{!previewLoading && preview && !result && (
+						<div className="space-y-4">
+							<div className="rounded-md border border-border/60 bg-muted/40 p-3 text-sm">
+								<p>
+									Filter <code className="font-mono">{preview.search}</code>{" "}
+									matches <strong>{preview.matched}</strong> organization(s).
+								</p>
+								<p className="mt-1">
+									<strong className="text-destructive">
+										{preview.blockable}
+									</strong>{" "}
+									will be blocked.
+									{preview.skipped > 0 && (
+										<>
+											{" "}
+											{preview.skipped} skipped (already blocked, or your own
+											organizations).
+										</>
+									)}
+								</p>
+							</div>
+
+							{preview.blockable === 0 ? (
+								<p className="text-sm text-muted-foreground">
+									Nothing to block for this filter.
+								</p>
+							) : (
+								<>
+									<div className="max-h-64 overflow-y-auto rounded-md border border-border/60">
+										<ul className="divide-y divide-border/60 text-sm">
+											{preview.organizations.map((org) => (
+												<li
+													key={org.id}
+													className="flex items-center justify-between gap-3 px-3 py-2"
+												>
+													<div className="min-w-0">
+														<p className="truncate font-medium">{org.name}</p>
+														<p className="truncate text-xs text-muted-foreground">
+															{org.billingEmail} • {org.id}
+														</p>
+													</div>
+													<Badge variant="outline">{org.plan}</Badge>
+												</li>
+											))}
+										</ul>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="bulk-block-confirmation">
+											Type <strong>{preview.blockable}</strong> to confirm the
+											number of organizations to block
+										</Label>
+										<Input
+											id="bulk-block-confirmation"
+											inputMode="numeric"
+											autoComplete="off"
+											value={confirmation}
+											onChange={(event) => setConfirmation(event.target.value)}
+											placeholder={String(preview.blockable)}
+											disabled={blocking}
+										/>
+									</div>
+								</>
+							)}
+						</div>
+					)}
+
+					{result?.success && (
+						<div className="space-y-2 text-sm">
+							<p>
+								Blocked <strong>{result.blockedCount}</strong> organization(s).
+							</p>
+							{result.failedCount ? (
+								<div className="rounded-md border border-destructive/40 p-3">
+									<p className="font-medium text-destructive">
+										{result.failedCount} failed:
+									</p>
+									<ul className="mt-1 list-disc space-y-1 pl-5 text-muted-foreground">
+										{result.failed?.map((failure) => (
+											<li key={failure.id}>
+												{failure.name}: {failure.error}
+											</li>
+										))}
+									</ul>
+								</div>
+							) : null}
+						</div>
+					)}
+
+					{error && (
+						<p className="text-sm text-destructive" role="alert">
+							{error}
+						</p>
+					)}
+
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setOpen(false)}
+							disabled={blocking}
+						>
+							{result?.success ? "Close" : "Cancel"}
+						</Button>
+						{!result?.success && (
+							<Button
+								variant="destructive"
+								onClick={handleConfirm}
+								disabled={blocking || !confirmationMatches}
+							>
+								{blocking && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+								{preview
+									? `Block ${preview.blockable} organization(s)`
+									: "Block organizations"}
+							</Button>
+						)}
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -172,6 +172,75 @@ export async function blockOrganization(orgId: string): Promise<{
 	};
 }
 
+export interface BulkBlockPreview {
+	search: string;
+	matched: number;
+	blockable: number;
+	skipped: number;
+	maxBulkSize: number;
+	organizations: {
+		id: string;
+		name: string;
+		billingEmail: string;
+		plan: string;
+		status: string | null;
+		createdAt: string;
+	}[];
+}
+
+export async function previewBulkBlockOrganizations(search: string): Promise<{
+	success: boolean;
+	error?: string;
+	preview?: BulkBlockPreview;
+}> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.GET(
+		"/admin/organizations/bulk-block/preview",
+		{
+			params: { query: { search } },
+		},
+	);
+
+	if (error || !data) {
+		const message =
+			(error as { message?: string } | undefined)?.message ??
+			"Failed to preview bulk block";
+		return { success: false, error: message };
+	}
+
+	return { success: true, preview: data };
+}
+
+export async function bulkBlockOrganizations(
+	search: string,
+	expectedCount: number,
+): Promise<{
+	success: boolean;
+	error?: string;
+	blockedCount?: number;
+	failedCount?: number;
+	failed?: { id: string; name: string; error: string }[];
+}> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.POST("/admin/organizations/bulk-block", {
+		body: { search, expectedCount },
+	});
+
+	if (error || !data) {
+		const message =
+			(error as { message?: string } | undefined)?.message ??
+			"Failed to bulk block organizations";
+		return { success: false, error: message };
+	}
+
+	return {
+		success: true,
+		blockedCount: data.blockedCount,
+		failedCount: data.failedCount,
+		failed: data.failed,
+	};
+}
+
 export async function getLogContent(logId: string): Promise<string | null> {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/logs/{id}", {


### PR DESCRIPTION
## Summary

Adds a bulk action to the admin organizations page that blocks every organization matching the current search filter (not just the visible page). Each organization gets the exact same treatment as the existing single-org block: Stripe subscriptions cancelled, org marked `deleted`, and members with no other active organization deactivated and signed out.

## Safety design

Blocking organizations is destructive, so the target set is resolved once, in one place (`resolveBulkBlockCandidates`), and every guard lives there — the preview and the mutation can never disagree about what will be affected.

- **No unfiltered code path.** An empty or shorter-than-3-character search throws `400` before anything else runs. There is no "block everything" branch to reach by accident.
- **Wildcards are escaped.** `%`, `_` and `\` in the search are escaped with `ESCAPE '\'` before being wrapped in LIKE wildcards, so a search of `%` matches nothing instead of matching every row. This escaping was added to the shared filter, so the read-only listing gets it too (searching `a_b` no longer matches `axb`).
- **Mutations run over explicit ids.** The filter is used for a `SELECT` that resolves concrete organizations; the block then runs per resolved id. The filter is never reused as the `WHERE` clause of an `UPDATE`/`DELETE`.
- **Hard cap.** A filter resolving to more than 500 blockable organizations is rejected outright rather than truncated.
- **Exclusions.** Already-blocked organizations are skipped, and organizations the acting admin belongs to are excluded, so an admin cannot bulk-block themselves out.
- **Count confirmation, checked twice.** The dialog previews the exact list and requires the admin to retype the affected count. The server independently re-resolves the set and returns `409` — blocking nothing — unless it still matches the confirmed number.
- **Partial failures are isolated.** Organizations are blocked sequentially so a Stripe error on one does not abort the rest; the response reports which succeeded and which failed.

Each organization blocked in a bulk run writes its own `organization.block` audit entry, identical to a single block.

## Changes

- `apps/api/src/routes/admin.ts`
  - extracted `buildOrganizationSearchFilter` (shared by the listing and bulk endpoints) with LIKE escaping
  - extracted `blockOrganizationById` from the single-org block handler so both paths apply identical effects
  - new `GET /admin/organizations/bulk-block/preview` and `POST /admin/organizations/bulk-block`
- `ee/admin/src/components/bulk-block-orgs-button.tsx` — confirmation dialog with preview list and typed count confirmation
- `ee/admin/src/lib/admin-organizations.ts` — server actions for preview/bulk block
- `ee/admin/src/app/organizations/page.tsx` — bulk action bar, shown only when a filter is active

## Testing

New `apps/api/src/routes/admin-bulk-block.spec.ts` (10 tests, all passing) covers: auth/admin gating, empty and too-short filters, zero/negative confirmed counts, wildcard escaping, preview partitioning (matched vs. blockable vs. skipped), blocking exactly the filtered set, count mismatch blocking nothing, admin's own orgs untouched, member deactivation, and the over-cap rejection.

Also ran the existing admin/organization specs and a full `pnpm build`.