### PR TITLE
fix(gateway): keep session pin on service tier change

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4089,6 +4089,17 @@ chat.openapi(completions, async (c) => {
 			usedInternalModel = modelInfo.id;
 			usedExternalId = iamFilteredModelProviders[0].externalId;
 			usedRegion = iamFilteredModelProviders[0].region;
+			// This shortcut bypasses provider selection (and with it the sticky
+			// pinning inside getCheapestFromAvailableProviders), but the session is
+			// now genuinely served by this provider — e.g. a service_tier request
+			// narrowed the candidates to the one tier-capable provider. Persist the
+			// pin so later requests in the same session with a wider candidate list
+			// (e.g. after the tier is dropped again) stay on this provider and keep
+			// its prompt cache warm instead of re-scoring to a different provider.
+			const singleProviderSessionStore = createSessionStore(modelInfo.id);
+			if (singleProviderSessionStore) {
+				await singleProviderSessionStore.set(usedProvider, usedRegion);
+			}
 		} else {
 			const providerIds = iamFilteredModelProviders.map((p) => p.providerId);
 			const providerKeys = await findProviderKeysByProviders(

--- a/apps/gateway/src/session-sticky.spec.ts
+++ b/apps/gateway/src/session-sticky.spec.ts
@@ -1,0 +1,242 @@
+import { beforeAll, describe, expect, test } from "vitest";
+
+import { redisClient } from "@llmgateway/cache";
+import { db, tables } from "@llmgateway/db";
+
+import { app } from "./app.js";
+import { createGatewayApiTestHarness } from "./test-utils/gateway-api-test-harness.js";
+
+// Regression tests for https://github.com/theopenco/llmgateway/issues/3347:
+// switching service tiers mid-session must not break session stickiness.
+//
+// gpt-5.5 is served by openai (the only mapping with serviceTiers) and azure.
+// Azure has provider priority 2, so with equal prices it is always the natural
+// routing winner — any request that lands on openai instead can only be
+// explained by the session pin. A `service_tier: "priority"` request narrows
+// the candidate list to just openai, which routes through the single-provider
+// shortcut in chat.ts; that shortcut must keep the session pin in sync so a
+// later request without the tier stays on openai instead of re-scoring to
+// azure and cold-starting a different provider's prompt cache.
+describe("session stickiness across service tier changes", () => {
+	const harness = createGatewayApiTestHarness();
+	let mockServerUrl = "";
+
+	beforeAll(() => {
+		mockServerUrl = harness.mockServerUrl;
+	});
+
+	const MODEL = "gpt-5.5";
+
+	function sessionPinKey(sessionId: string): string {
+		return `session_provider:org-id:${MODEL}:${sessionId}`;
+	}
+
+	async function readSessionPin(
+		sessionId: string,
+	): Promise<{ providerId: string; region?: string } | null> {
+		const raw = await redisClient.get(sessionPinKey(sessionId));
+		return raw ? JSON.parse(raw) : null;
+	}
+
+	async function seedApiAndProviderKeys(suffix: string) {
+		await db.insert(tables.apiKey).values({
+			id: `token-id-session-sticky-${suffix}`,
+			token: `real-token-session-sticky-${suffix}`,
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values([
+			{
+				id: `provider-key-session-sticky-openai-${suffix}`,
+				token: "sk-openai-test-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+			{
+				id: `provider-key-session-sticky-azure-${suffix}`,
+				token: "sk-azure-test-key",
+				provider: "azure",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+				// Pin the deployment type so a developer's LLM_AZURE_DEPLOYMENT_TYPE
+				// env value can't reroute the request off the mock server's
+				// /openai/v1/* aliases.
+				options: { azure_deployment_type: "ai-foundry" },
+			},
+		]);
+
+		return `real-token-session-sticky-${suffix}`;
+	}
+
+	async function chatCompletion(
+		token: string,
+		body: Record<string, unknown>,
+		headers: Record<string, string> = {},
+	) {
+		return await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+				...headers,
+			},
+			body: JSON.stringify(body),
+		});
+	}
+
+	test("azure is the natural routing winner for the model without a session", async () => {
+		// Control for the tests below: with equal prices, azure's provider
+		// priority (2) makes it the deterministic first choice. If this ever
+		// stops holding (catalog/priority change), the sticky assertions below
+		// would become vacuous — this test flags that setup drift.
+		const token = await seedApiAndProviderKeys("control");
+
+		const res = await chatCompletion(token, {
+			model: MODEL,
+			messages: [{ role: "user", content: "control request" }],
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		const routing = json.metadata?.routing ?? [];
+		expect(routing.length).toBeGreaterThan(0);
+		// Azure must be attempted first; the mock upstream serves no azure
+		// endpoint, so the request then falls back to openai — which is fine,
+		// the control only cares about the first pick.
+		expect(routing[0].provider).toBe("azure");
+	});
+
+	test("session started on priority tier stays on the tier provider after the tier is disabled", async () => {
+		const token = await seedApiAndProviderKeys("tier-off");
+		const sessionId = "session-priority-then-default";
+
+		// 1. Priority request: the tier filter narrows candidates to openai
+		// (the only tier-capable mapping), taking the single-provider shortcut.
+		const priorityRes = await chatCompletion(
+			token,
+			{
+				model: MODEL,
+				service_tier: "priority",
+				messages: [{ role: "user", content: "start of session" }],
+			},
+			{ "x-session-id": sessionId },
+		);
+
+		expect(priorityRes.status).toBe(200);
+		const priorityJson = await priorityRes.json();
+		expect(priorityJson.metadata?.used_provider).toBe("openai");
+		expect(priorityJson.metadata?.used_service_tier).toBe("priority");
+
+		// The shortcut must have pinned the session to openai.
+		expect(await readSessionPin(sessionId)).toMatchObject({
+			providerId: "openai",
+		});
+		const ttl = await redisClient.ttl(sessionPinKey(sessionId));
+		expect(ttl).toBeGreaterThan(0);
+		expect(ttl).toBeLessThanOrEqual(3600);
+
+		// 2. Same session without the tier: azure is back in the candidate list
+		// (and is the natural winner per the control test), but the session pin
+		// must keep the request on openai so its prompt cache stays warm.
+		const defaultRes = await chatCompletion(
+			token,
+			{
+				model: MODEL,
+				messages: [{ role: "user", content: "continuing the session" }],
+			},
+			{ "x-session-id": sessionId },
+		);
+
+		expect(defaultRes.status).toBe(200);
+		const defaultJson = await defaultRes.json();
+		expect(defaultJson.metadata?.used_provider).toBe("openai");
+		// No attempt may have gone to azure — a fallback from a failed azure
+		// attempt would also end on openai, which is exactly the bug.
+		const attempts = defaultJson.metadata?.routing ?? [];
+		for (const attempt of attempts) {
+			expect(attempt.provider).toBe("openai");
+		}
+
+		// The pin survives (TTL refreshed by the sticky reuse).
+		expect(await readSessionPin(sessionId)).toMatchObject({
+			providerId: "openai",
+		});
+	});
+
+	test("enabling the priority tier mid-session re-pins the session to the tier provider", async () => {
+		const token = await seedApiAndProviderKeys("tier-on");
+		const sessionId = "session-default-then-priority";
+
+		// Session previously ran on azure (e.g. before the user enabled
+		// priority). The tier request is forced onto openai, so the pin must
+		// move with it — the session's cache is building on openai now.
+		await redisClient.set(
+			sessionPinKey(sessionId),
+			JSON.stringify({ providerId: "azure" }),
+			"EX",
+			3600,
+		);
+
+		const priorityRes = await chatCompletion(
+			token,
+			{
+				model: MODEL,
+				service_tier: "priority",
+				messages: [{ role: "user", content: "switching to priority" }],
+			},
+			{ "x-session-id": sessionId },
+		);
+
+		expect(priorityRes.status).toBe(200);
+		const priorityJson = await priorityRes.json();
+		expect(priorityJson.metadata?.used_provider).toBe("openai");
+		expect(await readSessionPin(sessionId)).toMatchObject({
+			providerId: "openai",
+		});
+
+		// Dropping the tier keeps the session on openai instead of bouncing
+		// back to the stale azure pin.
+		const defaultRes = await chatCompletion(
+			token,
+			{
+				model: MODEL,
+				messages: [{ role: "user", content: "back to default tier" }],
+			},
+			{ "x-session-id": sessionId },
+		);
+
+		expect(defaultRes.status).toBe(200);
+		const defaultJson = await defaultRes.json();
+		expect(defaultJson.metadata?.used_provider).toBe("openai");
+		const attempts = defaultJson.metadata?.routing ?? [];
+		for (const attempt of attempts) {
+			expect(attempt.provider).toBe("openai");
+		}
+	});
+
+	test("the single-provider shortcut writes no pin without a session id", async () => {
+		const token = await seedApiAndProviderKeys("no-session");
+
+		const res = await chatCompletion(token, {
+			model: MODEL,
+			service_tier: "priority",
+			messages: [{ role: "user", content: "no session header" }],
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.metadata?.used_provider).toBe("openai");
+
+		const [, keys] = await redisClient.scan(
+			"0",
+			"MATCH",
+			"session_provider:*",
+			"COUNT",
+			1000,
+		);
+		expect(keys).toEqual([]);
+	});
+});

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -605,6 +605,17 @@ function delay(ms: number): Promise<void> {
 	});
 }
 
+// Azure AI Foundry serves the OpenAI-compatible endpoints under an /openai
+// prefix. Rewrite those paths to the plain handlers below so azure provider
+// keys pointing at the mock server can complete requests.
+function stripAzureOpenaiPrefix(c: Context): Response | Promise<Response> {
+	const url = new URL(c.req.url);
+	url.pathname = url.pathname.replace(/^\/openai/, "");
+	return mockOpenAIServer.fetch(new Request(url, c.req.raw));
+}
+mockOpenAIServer.post("/openai/v1/responses", stripAzureOpenaiPrefix);
+mockOpenAIServer.post("/openai/v1/chat/completions", stripAzureOpenaiPrefix);
+
 // Handle OpenAI Responses API endpoint (for gpt-5 and other models with supportsResponsesApi)
 mockOpenAIServer.post("/v1/responses", async (c) => {
 	const body = await c.req.json();


### PR DESCRIPTION
## Summary

Fixes #3347 — autorouting invalidated session stickiness when switching priority tiers.

### Root cause

When a request carries `service_tier: "flex" | "priority"`, the gateway filters the model's provider mappings down to the tier-capable ones. For models where only one provider sells the tier (e.g. `kimi-k3`, where only Fireworks has `serviceTiers: ["priority"]`), routing then hits the **single-provider shortcut** in `chat.ts`, which assigns the provider directly and bypasses `getCheapestFromAvailableProviders` — and with it the sticky-session pinning (`applySessionSticky`).

So a session running on priority never got its `session_provider:{org}:{model}:{session}` pin written (or updated). When the user later disabled priority, the full candidate list came back, the session had no (or a stale) pin, and the weighted scorer picked a different provider — invalidating the warm prompt cache and increasing cost and latency, exactly as reported.

### Fix

The single-provider shortcut now persists the forced choice to the session store (when a session id is present and session stickiness is enabled). This covers both directions:

- **priority → default**: the tier phase pins the tier provider, so dropping the tier keeps the session on it.
- **default → priority**: a pre-existing pin on a non-tier provider is overwritten by the forced tier provider, so the session doesn't bounce back to the stale pin after the tier is dropped.

`/v1/responses` and `/v1/messages` proxy through the chat completions handler, so they are covered by the same fix.

### Tests

New integration spec `apps/gateway/src/session-sticky.spec.ts` (uses gpt-5.5: openai is the only tier-capable mapping, azure — provider priority 2 — is the deterministic natural routing winner):

- control: azure is the natural winner without a session (guards against the sticky assertions going vacuous through catalog drift)
- session started on priority stays on the tier provider after the tier is disabled (pin content + TTL + no azure attempt) — **fails without the fix**
- enabling priority mid-session re-pins the session away from a pre-existing pin — **fails without the fix**
- the shortcut writes no pin when the request has no session id

Test infra: the mock OpenAI server now also serves Azure AI Foundry's `/openai/v1/responses` and `/openai/v1/chat/completions` path aliases so azure provider keys can complete requests against it.

Full gateway unit suite (101 files, 1981 tests) and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session stickiness when routing selects a single eligible provider, ensuring subsequent requests consistently reuse the same provider and region.
  * Fixed provider pinning when switching service tiers for GPT-5.5.
  * Requests without a session ID no longer create unnecessary session-affinity records.

* **Tests**
  * Added coverage for provider selection, tier changes, session persistence, and Azure-compatible API routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->