### PR TITLE
fix: address bulk block review comments

### DIFF
--- a/apps/api/src/routes/admin-bulk-block.spec.ts
+++ b/apps/api/src/routes/admin-bulk-block.spec.ts
@@ -4,11 +4,9 @@ import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
 import { db, tables } from "@llmgateway/db";
+import { MAX_BULK_BLOCK_ORGANIZATIONS } from "@llmgateway/shared";
 
 const originalAdminEmails = process.env.ADMIN_EMAILS;
-
-// Mirrors MAX_BULK_BLOCK_ORGANIZATIONS in apps/api/src/routes/admin.ts.
-const MAX_BULK_BLOCK_ORGANIZATIONS = 500;
 
 interface PreviewResponse {
 	search: string;

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -66,6 +66,8 @@ import {
 	type DevPlanTier,
 	getDevPlanPremiumWeeklyLimit,
 	getIncludedResetPassesRemaining,
+	MAX_BULK_BLOCK_ORGANIZATIONS,
+	MIN_BULK_BLOCK_SEARCH_LENGTH,
 } from "@llmgateway/shared";
 import {
 	getResendClient,
@@ -6247,14 +6249,6 @@ admin.openapi(blockOrganizationRoute, async (c) => {
 });
 
 // --- Bulk block organizations (filtered list) ---
-
-// Hard ceiling on a single bulk block. A filter matching more than this is
-// treated as too broad to be an intentional selection and is rejected outright
-// rather than partially applied.
-const MAX_BULK_BLOCK_ORGANIZATIONS = 500;
-// A one or two character filter matches far too much to be a deliberate
-// selection, so require something specific enough to identify a set of orgs.
-const MIN_BULK_BLOCK_SEARCH_LENGTH = 3;
 
 const bulkBlockOrganizationSchema = z.object({
 	id: z.string(),

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -32,6 +32,8 @@ import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
 
+import { MIN_BULK_BLOCK_SEARCH_LENGTH } from "@llmgateway/shared";
+
 type SortBy =
 	| "name"
 	| "billingEmail"
@@ -43,11 +45,6 @@ type SortBy =
 	| "totalCreditsAllTime"
 	| "totalSpent";
 type SortOrder = "asc" | "desc";
-
-// Mirrors MIN_BULK_BLOCK_SEARCH_LENGTH in apps/api/src/routes/admin.ts. The
-// server rejects anything shorter; this only hides the entry point so the
-// action never looks available for an empty or near-empty filter.
-const BULK_BLOCK_MIN_SEARCH_LENGTH = 3;
 
 function SortableHeader({
 	label,
@@ -252,7 +249,7 @@ export default async function OrganizationsPage({
 				</form>
 			</header>
 
-			{search.trim().length >= BULK_BLOCK_MIN_SEARCH_LENGTH && (
+			{search.trim().length >= MIN_BULK_BLOCK_SEARCH_LENGTH && (
 				<div className="flex flex-col items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
 					<p className="text-sm text-muted-foreground">
 						Bulk actions apply to every organization matching the current
@@ -260,7 +257,7 @@ export default async function OrganizationsPage({
 					</p>
 					<BulkBlockOrgsButton
 						search={search}
-						minSearchLength={BULK_BLOCK_MIN_SEARCH_LENGTH}
+						minSearchLength={MIN_BULK_BLOCK_SEARCH_LENGTH}
 						onPreview={handlePreviewBulkBlock}
 						onBulkBlock={handleBulkBlock}
 					/>

--- a/ee/admin/src/components/bulk-block-orgs-button.tsx
+++ b/ee/admin/src/components/bulk-block-orgs-button.tsx
@@ -53,7 +53,10 @@ export function BulkBlockOrgsButton({
 	const [preview, setPreview] = useState<BulkBlockPreview | null>(null);
 	const [confirmation, setConfirmation] = useState("");
 	const [blocking, setBlocking] = useState(false);
-	const [error, setError] = useState<string | null>(null);
+	// Preview and block failures are tracked separately: a failed block re-resolves
+	// the preview, and that reload must not clear the block error it accompanies.
+	const [previewError, setPreviewError] = useState<string | null>(null);
+	const [blockError, setBlockError] = useState<string | null>(null);
 	const [result, setResult] = useState<BulkBlockResult | null>(null);
 
 	const trimmedSearch = search.trim();
@@ -62,7 +65,8 @@ export function BulkBlockOrgsButton({
 	const resetState = () => {
 		setPreview(null);
 		setConfirmation("");
-		setError(null);
+		setPreviewError(null);
+		setBlockError(null);
 		setResult(null);
 		setPreviewLoading(false);
 	};
@@ -70,16 +74,17 @@ export function BulkBlockOrgsButton({
 	const loadPreview = async () => {
 		setPreview(null);
 		setConfirmation("");
+		setPreviewError(null);
 		setPreviewLoading(true);
 		try {
 			const response = await onPreview(trimmedSearch);
 			if (response.success && response.preview) {
 				setPreview(response.preview);
 			} else {
-				setError(response.error ?? "Failed to preview bulk block");
+				setPreviewError(response.error ?? "Failed to preview bulk block");
 			}
 		} catch (err) {
-			setError(
+			setPreviewError(
 				err instanceof Error ? err.message : "Failed to preview bulk block",
 			);
 		} finally {
@@ -98,7 +103,7 @@ export function BulkBlockOrgsButton({
 			return;
 		}
 		setBlocking(true);
-		setError(null);
+		setBlockError(null);
 		try {
 			const response = await onBulkBlock(preview.search, preview.blockable);
 			if (response.success) {
@@ -106,14 +111,9 @@ export function BulkBlockOrgsButton({
 				router.refresh();
 				return;
 			}
-			// A failure keeps the dialog on the confirmation step instead of showing
-			// a summary. The most likely cause is the server rejecting a count that
-			// no longer matches, so re-resolve the set: the admin then confirms
-			// against current numbers rather than resubmitting the stale one.
-			setError(response.error ?? "Failed to bulk block organizations");
-			await loadPreview();
+			setBlockError(response.error ?? "Failed to bulk block organizations");
 		} catch (err) {
-			setError(
+			setBlockError(
 				err instanceof Error
 					? err.message
 					: "Failed to bulk block organizations",
@@ -121,6 +121,12 @@ export function BulkBlockOrgsButton({
 		} finally {
 			setBlocking(false);
 		}
+		// Only reached when the block failed — the success path returns above. The
+		// dialog stays on the confirmation step instead of showing a summary, and
+		// re-resolving the set makes the admin confirm against current numbers
+		// rather than resubmitting a stale one. This also covers a thrown request:
+		// it may still have been applied server-side before the connection failed.
+		await loadPreview();
 	};
 
 	// The admin has to retype the exact number of organizations the server
@@ -269,10 +275,15 @@ export function BulkBlockOrgsButton({
 						</div>
 					)}
 
-					{error && (
-						<p className="text-sm text-destructive" role="alert">
-							{error}
-						</p>
+					{(blockError || previewError) && (
+						<div className="space-y-1" role="alert">
+							{blockError && (
+								<p className="text-sm text-destructive">{blockError}</p>
+							)}
+							{previewError && (
+								<p className="text-sm text-destructive">{previewError}</p>
+							)}
+						</div>
 					)}
 
 					<DialogFooter>

--- a/ee/admin/src/components/bulk-block-orgs-button.tsx
+++ b/ee/admin/src/components/bulk-block-orgs-button.tsx
@@ -67,17 +67,30 @@ export function BulkBlockOrgsButton({
 		setPreviewLoading(false);
 	};
 
+	const loadPreview = async () => {
+		setPreview(null);
+		setConfirmation("");
+		setPreviewLoading(true);
+		try {
+			const response = await onPreview(trimmedSearch);
+			if (response.success && response.preview) {
+				setPreview(response.preview);
+			} else {
+				setError(response.error ?? "Failed to preview bulk block");
+			}
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : "Failed to preview bulk block",
+			);
+		} finally {
+			setPreviewLoading(false);
+		}
+	};
+
 	const handleOpen = async () => {
 		resetState();
 		setOpen(true);
-		setPreviewLoading(true);
-		const response = await onPreview(trimmedSearch);
-		setPreviewLoading(false);
-		if (response.success && response.preview) {
-			setPreview(response.preview);
-		} else {
-			setError(response.error ?? "Failed to preview bulk block");
-		}
+		await loadPreview();
 	};
 
 	const handleConfirm = async () => {
@@ -88,12 +101,17 @@ export function BulkBlockOrgsButton({
 		setError(null);
 		try {
 			const response = await onBulkBlock(preview.search, preview.blockable);
-			setResult(response);
 			if (response.success) {
+				setResult(response);
 				router.refresh();
-			} else {
-				setError(response.error ?? "Failed to bulk block organizations");
+				return;
 			}
+			// A failure keeps the dialog on the confirmation step instead of showing
+			// a summary. The most likely cause is the server rejecting a count that
+			// no longer matches, so re-resolve the set: the admin then confirms
+			// against current numbers rather than resubmitting the stale one.
+			setError(response.error ?? "Failed to bulk block organizations");
+			await loadPreview();
 		} catch (err) {
 			setError(
 				err instanceof Error

--- a/packages/shared/src/bulk-block.ts
+++ b/packages/shared/src/bulk-block.ts
@@ -1,0 +1,13 @@
+// Limits for the admin "bulk block organizations" action. Shared so the admin
+// dashboard gates on the same numbers the API enforces — the API is the only
+// thing that actually protects the data, and a UI copy that drifts from it
+// would show or hide the action for filters the server disagrees about.
+
+// A one or two character filter matches far too much to be a deliberate
+// selection, so require something specific enough to identify a set of orgs.
+export const MIN_BULK_BLOCK_SEARCH_LENGTH = 3;
+
+// Hard ceiling on a single bulk block. A filter matching more than this is
+// treated as too broad to be an intentional selection and is rejected outright
+// rather than partially applied.
+export const MAX_BULK_BLOCK_ORGANIZATIONS = 500;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -144,6 +144,11 @@ export { MARKETING_STATS, RUNWARE_PROMO } from "./marketing.js";
 export { isContentFilterErrorText } from "./content-filter.js";
 
 export {
+	MAX_BULK_BLOCK_ORGANIZATIONS,
+	MIN_BULK_BLOCK_SEARCH_LENGTH,
+} from "./bulk-block.js";
+
+export {
 	CUSTOM_PROVIDER_NAME_MESSAGE,
 	CUSTOM_PROVIDER_NAME_REGEX,
 } from "./custom-providers.js";


### PR DESCRIPTION
Follow-up to #3358, which merged before these review-comment fixes could be pushed. Three small robustness fixes; no change to the bulk-block safety guards themselves.

## Changes

**Share the bulk block limits instead of duplicating them** (`packages/shared/src/bulk-block.ts`)

`MIN_BULK_BLOCK_SEARCH_LENGTH` and `MAX_BULK_BLOCK_ORGANIZATIONS` now live in `@llmgateway/shared`, imported by both the API and the admin dashboard. Previously the UI hard-coded `3` with a comment asking future readers to keep it in sync — if the server value changed, the UI would silently show or hide the bulk action for filters the server disagrees about. The spec imports the shared constant too, so the over-cap test can no longer drift from the real limit.

**Don't strand the preview dialog in a loading state** (`bulk-block-orgs-button.tsx`)

`handleOpen` awaited the preview server action without a `try`/`finally`. A rejection (network error, server crash) left `previewLoading` stuck at `true` with no error surfaced. Now wrapped, so the loading flag always clears and the error is shown.

**Keep the confirmation form usable after a failed block** (`bulk-block-orgs-button.tsx`)

`handleConfirm` set `result` unconditionally, which hid the preview and the count input while still rendering an enabled destructive button with a stale `confirmationMatches`. A second click resubmitted the same stale count. Now `result` is set only on success; on failure the dialog stays on the confirmation step and re-resolves the preview, so the admin retypes against current numbers. The most likely failure is exactly the `409` the server returns when the set no longer matches the confirmed count, so re-previewing is what makes a retry meaningful.

## Testing

`apps/api/src/routes/admin-bulk-block.spec.ts` — 10/10 passing against merged `main`. `turbo run build --filter=api --filter=admin` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVus1fjS6z6xppaEai34Uj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for bulk organization blocking.
  * Preview loading now recovers correctly from failures and consistently resets its loading state.
  * Failed bulk-block actions no longer leave stale results and refresh the preview before retrying.

* **Improvements**
  * Bulk organization actions now consistently enforce minimum search-length and maximum selection limits.
  * Separate preview and blocking errors provide clearer feedback during bulk actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->