### PR TITLE
docs: sync docs with gateway and api behavior

### DIFF
--- a/apps/docs/content/developers/ai-sdk.mdx
+++ b/apps/docs/content/developers/ai-sdk.mdx
@@ -40,7 +40,7 @@ Switching models is a one-line change — the same provider serves every model:
 
 ```typescript
 const { text } = await generateText({
-	model: llmgateway("anthropic/claude-3-5-sonnet-20241022"),
+	model: llmgateway("anthropic/claude-sonnet-4-6"),
 	prompt: "Hello!",
 });
 ```
@@ -65,7 +65,7 @@ const llmgateway = createLLMGateway({
 });
 
 const { textStream } = await streamText({
-	model: llmgateway("anthropic/claude-3-5-sonnet-20241022"),
+	model: llmgateway("anthropic/claude-sonnet-4-6"),
 	prompt: "Write a poem about coding",
 });
 

--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -62,7 +62,7 @@ export ANTHROPIC_MODEL=gpt-5-mini
 export ANTHROPIC_MODEL=gemini-3.1-pro-preview
 
 # Use Anthropic's actual Claude models
-export ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
+export ANTHROPIC_MODEL=claude-sonnet-4-6
 ```
 
 ## Environment Variables
@@ -162,6 +162,23 @@ Cache usage comes back in Anthropic's native fields: `usage.cache_creation_input
 	Control](/features/caching/provider-cache-control) for the per-model
 	thresholds and details.
 </Callout>
+
+### Extended Thinking / Reasoning
+
+Anthropic's reasoning controls are supported and mapped onto the gateway's unified reasoning parameters, so the requested effort reaches whichever provider serves the request:
+
+- `thinking: { "type": "enabled", "budget_tokens": <n> }` forwards the exact token budget (`reasoning.max_tokens` internally). Without a `budget_tokens`, reasoning runs at `high` effort — Anthropic's default depth.
+- `thinking: { "type": "disabled" }` turns reasoning off.
+- `output_config.effort` (adaptive thinking on newer Claude models) accepts the full effort range `none | minimal | low | medium | high | xhigh | max` — the same enum as the chat completions `reasoning_effort` parameter.
+
+```json
+{
+	"model": "claude-sonnet-4-6",
+	"max_tokens": 1024,
+	"thinking": { "type": "enabled", "budget_tokens": 4096 },
+	"messages": [{ "role": "user", "content": "Solve this step by step..." }]
+}
+```
 
 ### Web Search
 

--- a/apps/docs/content/features/audit-logs.mdx
+++ b/apps/docs/content/features/audit-logs.mdx
@@ -30,58 +30,25 @@ Every significant action is logged with detailed metadata:
 
 ## Tracked Actions
 
-### Organization Management
+Actions are logged as `resource.action` pairs (e.g. `api_key.create`, `project.update`). Coverage spans every management surface of the platform, including:
 
-- `organization.update` — Organization settings changed
-- `organization.delete` — Organization deleted
+- **Organization & projects** — settings changes, creation, deletion
+- **Team** — members, roles, invitations, per-member budgets, and member-level IAM rules
+- **API keys** — creation, rotation, status/limit/description changes, deletion, and per-key IAM rules
+- **Master keys** — creation, status changes, deletion
+- **Provider keys and custom models** — creation, updates, deletion
+- **Billing** — subscriptions, credit top-ups, payment methods, auto top-up settings, refunds
+- **Plans** — DevPass and chat plan lifecycle events
+- **SSO & SCIM** — identity provider configuration, sign-ins, and directory sync events
 
-### Project Management
-
-- `project.create` — New project created
-- `project.update` — Project settings changed
-- `project.delete` — Project deleted
-
-### Team Management
-
-- `team_member.add` — New member invited
-- `team_member.update` — Member role changed
-- `team_member.remove` — Member removed
-
-### API Key Management
-
-- `api_key.create` — New API key created
-- `api_key.update_status` — API key enabled/disabled
-- `api_key.update_limit` — Usage limit changed
-- `api_key.delete` — API key deleted
-- `api_key.iam_rule.create` — IAM rule added
-- `api_key.iam_rule.update` — IAM rule modified
-- `api_key.iam_rule.delete` — IAM rule removed
-
-### Provider Key Management
-
-- `provider_key.create` — Provider key added
-- `provider_key.update` — Provider key status changed
-- `provider_key.delete` — Provider key removed
-
-### Billing Events
-
-- `subscription.create` — Subscription started
-- `subscription.cancel` — Subscription cancelled
-- `subscription.resume` — Subscription resumed
-- `payment.credit_topup` — Credits purchased
+The **Action** filter on the audit logs page always lists the complete, current set of tracked actions.
 
 ## Filtering and Search
 
-Filter logs by:
+Filter logs in the dashboard by:
 
 - **Action** — Specific action type
 - **Resource Type** — Category of resource
-- **User** — Who performed the action
-- **Date Range** — Time period
-
-## Data Retention
-
-Audit logs are retained for **90 days** on the Enterprise plan.
 
 ## Access Control
 

--- a/apps/docs/content/features/caching/gateway-caching.mdx
+++ b/apps/docs/content/features/caching/gateway-caching.mdx
@@ -61,24 +61,38 @@ To use caching:
 2. Configure the cache duration (TTL) as needed
 3. Make requests as normal—caching is automatic
 
+<Callout type="info">
+	Gateway caching is only available on regular (pay-as-you-go and Enterprise)
+	organizations. Organizations on a DevPass coding plan never get gateway-level
+	response caching, regardless of the project setting.
+</Callout>
+
 ## Cache Key Generation
 
 The cache key is generated from these request parameters:
 
-- Model identifier
-- Messages array (roles and content)
+- The resolved provider and model
+- Messages array (roles and content, including the system prompt)
 - Temperature
 - Max tokens
 - Top P
-- Tools/functions
-- Tool choice
+- Frequency penalty and presence penalty
 - Response format
-- System prompt
-- Other model-specific parameters
+- Reasoning parameters (`reasoning_effort`, `reasoning_max_tokens`)
+- Prompt-caching parameters (`prompt_cache_key`, `prompt_cache_retention`, `prompt_cache_options`)
+- `n` (number of choices)
+- Service tier
 
 <Callout type="info">
-	Requests with different parameter values, even slight variations, will not
-	share cache entries.
+	Requests with different values for any of these parameters, even slight
+	variations, will not share cache entries.
+</Callout>
+
+<Callout type="warn">
+	Tool definitions (`tools`, `tool_choice`) are **not** part of the cache key.
+	Two requests with identical messages but different tools can share a cache
+	entry, so avoid enabling gateway caching for workloads where the same messages
+	are sent with varying tool definitions.
 </Callout>
 
 ## Cache Behavior
@@ -228,8 +242,8 @@ Caching may not be suitable for:
 ## Pricing
 
 Caching is **completely free**. Cached responses are held in a short-lived
-in-memory cache (bounded by your configured TTL) and do not incur storage
-charges. Storage costs only apply if you separately enable [Data
+TTL-bound cache (bounded by your configured cache duration) and do not incur
+storage charges. Storage costs only apply if you separately enable [Data
 Retention](/features/data-retention) for full request/response payloads.
 
 <Callout type="success">

--- a/apps/docs/content/features/custom-providers.mdx
+++ b/apps/docs/content/features/custom-providers.mdx
@@ -61,9 +61,12 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 ### Base URL
 
-- Must be a valid URL pointing to your provider's base endpoint
-- Use an `https://` URL for hosted providers; an `http://` URL is allowed when
-  self-hosting (for example a service on your own network)
+- Must be a valid `https://` URL pointing to your provider's base endpoint
+- On the hosted platform, `http://` URLs and private, internal, or reserved
+  addresses are rejected with a `400` at registration time. Self-hosted
+  deployments can opt out of this guard with
+  `ALLOW_INSECURE_PROVIDER_URLS=true` to point at an internal or http-only
+  model server (for example a local Ollama)
 - LLMGateway will append `/v1/chat/completions` automatically
 - **Example**: `https://api.example.com` → `https://api.example.com/v1/chat/completions`
 

--- a/apps/docs/content/features/data-retention.mdx
+++ b/apps/docs/content/features/data-retention.mdx
@@ -26,10 +26,9 @@ LLM Gateway supports two retention levels that can be configured per organizatio
 
 ## Storage Pricing
 
-When full data retention is enabled, storage is billed at **$0.01 per 1 million tokens**. This rate applies to:
+When full data retention is enabled, storage is billed at **$0.01 per 1 million tokens**. This rate applies to the sum of:
 
 - Input tokens (prompt)
-- Cached input tokens
 - Output tokens (completion)
 - Reasoning tokens
 
@@ -60,7 +59,7 @@ Data retention is configured at the organization level in your dashboard setting
 
 ## Retention Periods
 
-Data is retained for 30 days for all users. Enterprise plans can have custom retention periods. After the retention period expires, data is automatically deleted.
+Stored payloads are retained for **30 days** for all organizations. After the retention period expires, the payload data (messages, responses, tool calls, raw request/response bodies) is automatically removed from each request record — the request's metadata (timestamps, model, tokens, costs) is kept for analytics.
 
 <Callout type="info">
 	The Responses API does not require data retention. Stored responses (used for
@@ -120,6 +119,8 @@ In **credits mode**:
 
 - Both inference and storage costs are deducted from credits
 
+In **hybrid mode** (the default for new projects), each request follows the rules of the mode that served it: requests served by your own provider keys only incur storage costs, while requests served by credits incur both.
+
 ### Monitoring Storage Costs
 
 Storage costs appear in:
@@ -136,7 +137,7 @@ Storage costs appear in:
 
 Self-hosted deployments have full control over data retention:
 
-- Configure retention periods in environment variables
+- The retention cleanup job is opt-in — enable it with `ENABLE_DATA_RETENTION_CLEANUP=true` on the worker service (with it disabled, payloads are kept indefinitely)
 - Data is stored in your own PostgreSQL database
 - No additional storage costs (you manage your own infrastructure)
 
@@ -144,5 +145,5 @@ Self-hosted deployments have full control over data retention:
 
 - All stored data is encrypted at rest
 - Access is restricted to organization members with appropriate permissions
-- Data is automatically deleted after the retention period
+- Stored payloads are automatically removed after the retention period
 - You can request immediate deletion of specific records through support

--- a/apps/docs/content/features/embeddings.mdx
+++ b/apps/docs/content/features/embeddings.mdx
@@ -12,13 +12,33 @@ LLMGateway exposes an OpenAI-compatible `/v1/embeddings` endpoint for generating
 
 Browse available embedding models on the [models page](https://llmgateway.io/models?filters=1&embedding=true).
 
-## Supported providers
+<Callout type="info">
+	Embeddings are not available on DevPass coding plans — coding plans only
+	include text-based inference, so requests from a coding-plan organization
+	return a `403`.
+</Callout>
 
-- **OpenAI** — `text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`
-- **Google AI Studio** — `gemini-embedding-2` (recommended), `gemini-embedding-001` (legacy)
-- **Google Vertex AI** — `gemini-embedding-001`, `text-embedding-005`
+## Supported models
+
+Any model marked as an embedding model in the catalogue works on this endpoint — see the full list on the [models page](https://llmgateway.io/models?filters=1&embedding=true).
 
 The gateway translates between provider-native request/response shapes (e.g. Google's `:embedContent` / `:batchEmbedContents`) and the OpenAI-compatible payload, so you can swap models without changing your client code.
+
+## Request parameters
+
+| Parameter         | Type              | Required | Description                                                                                                                           |
+| ----------------- | ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`           | string            | yes      | ID of the embedding model to use                                                                                                      |
+| `input`           | string or array   | yes      | Text to embed: a single string, an array of strings, an array of token IDs, or an array of token-ID arrays                            |
+| `encoding_format` | `float`, `base64` | no       | Format of the returned embeddings. `float` returns plain arrays, `base64` returns a packed base64 string                              |
+| `dimensions`      | integer           | no       | Number of output dimensions — only supported by models that allow shortening output (e.g. `text-embedding-3-*`, `gemini-embedding-*`) |
+| `user`            | string            | no       | Stable end-user identifier forwarded to OpenAI for abuse monitoring                                                                   |
+
+<Callout type="info">
+	Token-ID inputs are not supported on Google providers — requests with token-ID
+	input to a Google-served model are rejected with a `400`
+	(`unsupported_input`). Pass a string or array of strings instead.
+</Callout>
 
 ## cURL
 

--- a/apps/docs/content/features/guardrails.mdx
+++ b/apps/docs/content/features/guardrails.mdx
@@ -17,11 +17,13 @@ Guardrails protect your organization by automatically detecting and blocking har
 
 ## Overview
 
-Guardrails run on every API request, scanning message content for:
+Guardrails run on chat completion requests, scanning message content for:
 
 - Security threats (prompt injection, jailbreak attempts)
 - Sensitive data (PII, secrets, credentials)
 - Policy violations (blocked terms, restricted topics)
+
+Guardrails cover `/v1/chat/completions` and the endpoints that route through it internally — the [Anthropic-compatible `/v1/messages` endpoint](/features/anthropic-endpoint), the Responses API, and image generation via chat models. Non-chat endpoints (embeddings, moderations, OCR, rerank, audio, video) are not scanned.
 
 When a violation is detected, you control what happens: block the request, redact the content, or log a warning.
 

--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -35,6 +35,7 @@ The `/v1/images/generations` endpoint provides a drop-in replacement for OpenAI'
 | `quality`         | string  | —            | Image quality. Supported values depend on the model/provider — see [Image Configuration](#image-configuration)   |
 | `response_format` | string  | `"b64_json"` | Only `b64_json` is supported                                                                                     |
 | `style`           | string  | —            | Image style: `vivid` or `natural`                                                                                |
+| `aspect_ratio`    | string  | —            | Aspect ratio (e.g. `1:1`, `16:9`, `4:3`, `5:4`). Takes precedence over `size` if both are provided               |
 
 ### curl
 
@@ -134,8 +135,15 @@ The `/v1/images/edits` endpoint is OpenAI-compatible and supports a focused subs
 | `size`               | string                   | no       | Output size. Examples: `1024x1024`, `1536x1024`, `1K`, `2K`, `4K`  |
 | `aspect_ratio`       | string                   | no       | Aspect ratio override. Examples: `1:1`, `16:9`, `4:3`, `5:4`       |
 
+### Multipart requests (OpenAI SDK compatibility)
+
+Besides the JSON body above, `/v1/images/edits` also accepts `multipart/form-data` — the format the OpenAI SDK's `images.edit()` sends. Multipart requests support the `prompt`, `image` (also accepted as `image[]` or `file`), `mask`, `model`, `n`, `size`, and `quality` fields; uploaded files are converted to data URLs internally.
+
 <Callout type="warning">
-	`mask` is not supported yet on `/v1/images/edits`.
+	A `mask` file is accepted on multipart requests, but it is forwarded to the
+	model as an **additional input image** rather than applied as a strict alpha
+	mask — how the model uses it depends on the model. JSON requests have no
+	`mask` field; include the mask as another entry in `images` instead.
 </Callout>
 
 ### curl (HTTPS image URL)

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -404,7 +404,7 @@ Response (200):
 			"apiKeyId": "ak_...",
 			"ruleType": "allow_models",
 			"ruleValue": {
-				"models": ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]
+				"models": ["openai/gpt-4o", "anthropic/claude-sonnet-4-6"]
 			},
 			"status": "active",
 			"createdAt": "...",
@@ -425,7 +425,7 @@ curl -X POST https://internal.llmgateway.io/v1/master/keys/ak_.../iam \
   -d '{
     "ruleType": "allow_models",
     "ruleValue": {
-      "models": ["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]
+      "models": ["openai/gpt-4o", "anthropic/claude-sonnet-4-6"]
     }
   }'
 ```

--- a/apps/docs/content/features/ocr.mdx
+++ b/apps/docs/content/features/ocr.mdx
@@ -19,6 +19,10 @@ Use it when you want to:
 For the full request and response schema, see the
 [API reference](/v1_ocr).
 
+OCR is not available on DevPass coding plans — coding plans only include
+text-based inference, so requests from a coding-plan organization return a
+`403`.
+
 ## Endpoint
 
 `POST https://api.llmgateway.io/v1/ocr`

--- a/apps/docs/content/features/rerank.mdx
+++ b/apps/docs/content/features/rerank.mdx
@@ -24,6 +24,12 @@ Browse available rerank models on the
 For the full request and response schema, see the
 [API reference](/v1_rerank).
 
+<Callout type="info">
+	Rerank is not available on DevPass coding plans — coding plans only include
+	text-based inference, so requests from a coding-plan organization return a
+	`403`.
+</Callout>
+
 ## Endpoint
 
 `POST https://api.llmgateway.io/v1/rerank`

--- a/apps/docs/content/features/response-healing.mdx
+++ b/apps/docs/content/features/response-healing.mdx
@@ -42,6 +42,14 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 	or `json_schema`. For regular text responses, the plugin has no effect.
 </Callout>
 
+<Callout type="info">
+	The gateway also applies JSON healing **automatically** — without the plugin —
+	to JSON-mode responses on a few providers and models whose deployments are
+	known to emit malformed JSON-mode output (for example a stray closing brace or
+	JSON wrapped in explanatory text). The plugin makes healing explicit and
+	applies it regardless of provider.
+</Callout>
+
 ## How It Works
 
 When Response Healing is enabled, LLM Gateway applies a series of repair strategies to malformed JSON responses:
@@ -189,8 +197,11 @@ When a response is healed, the healing method is logged for debugging. The follo
 ## Limitations
 
 <Callout type="warning">
-	Response Healing is only available for non-streaming requests. Streaming
-	responses are returned as-is without healing.
+	On streaming requests, healing buffers the streamed content and replays the
+	healed result as a single chunk at the end of the stream — you lose
+	incremental token delivery for that response. Streaming healing is skipped
+	when `n` is greater than 1 (multiple choices), since each choice streams its
+	own content.
 </Callout>
 
 Response Healing works best for:

--- a/apps/docs/content/features/responses.mdx
+++ b/apps/docs/content/features/responses.mdx
@@ -1,0 +1,69 @@
+---
+title: Responses API
+description: Use the OpenAI-compatible Responses API with stored responses, stateless reasoning replay, and conversation compaction.
+icon: Layers
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+# Responses API
+
+LLMGateway exposes an OpenAI-compatible **Responses API** at `/v1/responses`. Requests are converted internally to chat completions and proxied through the same pipeline as `/v1/chat/completions`, so smart routing, caching, guardrails, and cost tracking all apply — with any model in the catalogue, not just OpenAI's.
+
+Authenticate with `Authorization: Bearer <key>` or the `x-api-key` header.
+
+## Creating a response
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/responses" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5",
+    "input": "Tell me a three sentence bedtime story about a unicorn."
+  }'
+```
+
+### Request parameters
+
+| Parameter                                                            | Type               | Description                                                                                                                      |
+| -------------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                                                              | string             | Any catalogue model, with the same [routing syntax](/features/routing) as chat completions                                       |
+| `input`                                                              | string or array    | A plain string, or an array of items: `message`, `reasoning`, `function_call`, `function_call_output`, and `item_reference`      |
+| `instructions`                                                       | string             | System-level instructions                                                                                                        |
+| `previous_response_id`                                               | string             | Chain onto a stored response — its conversation is loaded and prepended                                                          |
+| `stream`                                                             | boolean            | Stream the response as server-sent events                                                                                        |
+| `tools`                                                              | array              | `function` and `web_search` tools; unknown tool types are accepted and passed through                                            |
+| `tool_choice`                                                        | string or object   | `auto`, `none`, `required`, or a specific function                                                                               |
+| `reasoning`                                                          | object             | `effort` (`none` … `max`), `summary`, and `context`                                                                              |
+| `temperature`, `top_p`, `max_output_tokens`                          | number             | Standard sampling and length controls                                                                                            |
+| `text`                                                               | object             | Output format configuration (e.g. `json_schema`)                                                                                 |
+| `service_tier`                                                       | enum               | `auto`, `default`, `flex`, or `priority` — see [Service Tiers](/features/service-tiers)                                          |
+| `routing`                                                            | enum               | Per-request [routing strategy](/features/routing#routing-strategy) (`auto`, `price`, `throughput`, `latency`)                    |
+| `store`                                                              | boolean            | Whether to store the response for retrieval and chaining. Defaults to `true`                                                     |
+| `include`                                                            | array              | `"reasoning.encrypted_content"` returns encrypted reasoning payloads for stateless replay; other values are accepted and ignored |
+| `prompt_cache_key`, `prompt_cache_retention`, `prompt_cache_options` | string/enum/object | Provider prompt-cache controls, same as on chat completions                                                                      |
+| `metadata`                                                           | object             | String key/value metadata                                                                                                        |
+| `truncation`                                                         | enum               | `auto` or `disabled` (default)                                                                                                   |
+
+<Callout type="info">
+	Request bodies may be sent zstd-compressed (`Content-Encoding: zstd`).
+</Callout>
+
+## Stored responses and chaining
+
+Unless you set `store: false`, each response is stored and can be:
+
+- **Retrieved** with `GET /v1/responses/{response_id}`
+- **Continued** by passing its id as `previous_response_id` on the next request
+- **Referenced item-by-item**: stateful clients can send `{ "type": "item_reference", "id": "..." }` input items pointing at stored output items instead of re-sending them
+
+Stored responses are kept for **30 days** — matching OpenAI's own Responses API retention — independent of your organization's [data retention](/features/data-retention) policy, and are not billed as data storage.
+
+## Conversation compaction
+
+`POST /v1/responses/compact` is an LLMGateway extension that summarizes a conversation: it runs a single non-streaming pass with a summarization prompt and returns the summary as a `compaction` output item appended to the echoed input. It accepts `model`, `input`, `previous_response_id`, `instructions`, and `prompt_cache_key`. Use it to shrink a long conversation into a compact context you can continue from.
+
+## Errors
+
+Errors use the standard OpenAI error envelope — see [Error Handling](/resources/error-handling).

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -151,7 +151,7 @@ This transparency allows you to understand and debug routing decisions.
 
 ### Routing Strategy
 
-By default, model-ID routing uses the full weighted score described above (`routing: "auto"`). When you care about a single dimension, set the `routing` field — named after the factor it optimizes — to bias provider selection toward it:
+By default, model-ID routing uses the full weighted score described above (`routing: "auto"`). When you care about a single dimension, set the `routing` field — named after the factor it optimizes — to bias provider selection toward it. A **default routing strategy** can also be configured per project in the project settings; an explicit `routing` field on the request always takes precedence over the project default:
 
 | Strategy           | Behavior                                                                             |
 | ------------------ | ------------------------------------------------------------------------------------ |
@@ -208,8 +208,10 @@ Sticky session routing solves this: attach a session identifier and LLMGateway p
 For chat completions, the session key is resolved in priority order:
 
 1. The `x-session-id` header
-2. The `prompt_cache_key` body field (OpenAI-compatible)
-3. The `user` body field (OpenAI-compatible)
+2. The `x-session-affinity` header (sent by coding agents such as opencode)
+3. The `session_id` or `session-id` header
+4. The `prompt_cache_key` body field (OpenAI-compatible)
+5. The `user` body field (OpenAI-compatible)
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
@@ -234,11 +236,12 @@ Because the pinned provider is replayed directly, sticky requests **skip the eps
 
 An established pin yields only when its provider can no longer serve the session well. A session is re-scored and re-pinned to the current weighted-best provider when its provider:
 
-- Drops below the session uptime threshold (default 85%),
-- Is filtered out by health checks (e.g. excluded for low uptime), or
-- Fails the request and is dropped by the [automatic retry & fallback](#automatic-retry--fallback) loop.
+- Drops below the session uptime threshold (default 85%), or
+- Leaves the set of available providers for the request (e.g. filtered out by health checks).
 
 Re-pinning runs the same weighted algorithm again, so the replacement is the best currently available provider — not an arbitrary one.
+
+Session-sticky requests do **not** use cross-provider fallback: switching providers mid-session would break the pin and lose the warm prompt cache. When a sticky request fails with a retryable error, it is retried against the **pinned provider** instead — first on an alternate key for that provider when one is configured, otherwise on the same key with a short exponential backoff. Repeated failures lower the provider's uptime score until the session uptime threshold triggers a re-pin.
 
 The selection reason in routing metadata shows `session-sticky` when a request was pinned via a session id.
 
@@ -367,7 +370,7 @@ When using model ID routing (without a provider prefix), LLMGateway automaticall
 ### How Retry Works
 
 1. Your request is routed to the best available provider using the smart routing algorithm
-2. If that provider returns a server error (5xx), times out, or has a connection failure, the gateway marks the provider as failed
+2. If that provider fails with a retryable error (see below), the gateway marks the provider as failed
 3. The next best available provider is selected and the request is retried
 4. Up to **2 retries** are attempted before returning an error to the client
 
@@ -379,15 +382,19 @@ Both streaming and non-streaming requests support automatic retry.
 
 ### What Triggers a Retry
 
-Retries are triggered by **server-side failures** only:
+Retries are triggered by failures on the **provider or gateway side** — errors where the same request can legitimately succeed on another provider or key:
 
 - **5xx errors** (500 Internal Server Error, 502 Bad Gateway, 503 Service Unavailable, etc.)
+- **429 rate limits** from the upstream provider
+- **404 errors** from the upstream provider (model or endpoint not found on that deployment)
+- **401/403 authentication errors** from the provider (a bad provider-side credential — the gateway also rotates to another configured key for the same provider)
+- **402 / provider-account funding errors** (the provider account behind the key is out of funds)
 - **Timeouts** (upstream provider took too long to respond)
 - **Connection failures** (network errors, DNS failures, etc.)
 
 Retries are **not** triggered by:
 
-- **4xx client errors** (400 Bad Request, 401 Unauthorized, 403 Forbidden, 422 Unprocessable Entity)
+- **Other 4xx client errors** — a request that is actually invalid (e.g. 400 validation errors, 422 Unprocessable Entity) fails the same way everywhere and is returned to you directly
 - **Content filter responses** (Azure ResponsibleAI, etc.)
 
 ### When Retry Is Disabled
@@ -396,6 +403,7 @@ Automatic retry to a different provider is disabled when:
 
 - The `X-No-Fallback: true` header is set
 - A specific provider is requested (e.g., `openai/gpt-4o`)
+- The request carries a session id ([sticky session routing](#sticky-session-routing)) — failures are retried against the pinned provider instead
 - No alternative providers are available for the requested model
 - The maximum retry count (2) has been exhausted
 
@@ -414,7 +422,7 @@ Every provider attempt — both failed and successful — is recorded in the `ro
 				"provider": "openai",
 				"model": "gpt-4o",
 				"status_code": 500,
-				"error_type": "server_error",
+				"error_type": "upstream_error",
 				"succeeded": false
 			},
 			{
@@ -461,15 +469,15 @@ Overrides are merged on top of the defaults, so you only set the values you want
 
 The following groups can be customized per project:
 
-| Group                   | What it controls                                                                                                                                                                     | Defaults                                                                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **Weights**             | Relative importance of each scoring factor                                                                                                                                           | `price 0.6`, `imagePrice 1.0`, `uptime 0.5`, `throughput 0.05`, `latency 0.025`, `cache 0.2`                                             |
-| **Thresholds**          | Cache prompt-size threshold, uptime-penalty threshold, exploration rate, and the assumed defaults used when no metrics exist                                                         | `cachePromptTokens 5000`, `uptimePenalty 95`, `defaultUptime 100`, `defaultLatency 1000`, `defaultThroughput 50`, `explorationRate 0.01` |
-| **Retry**               | Max cross-provider fallback attempts and the low-uptime reroute threshold                                                                                                            | `maxRetries 2`, `lowUptimeFallbackThreshold 90`                                                                                          |
-| **Timeouts**            | Per-request time limits (end-to-end, streaming, non-streaming) — see [Request Timeouts](/features/timeouts). Capped at the infrastructure defaults — an override can only lower them | `gatewayMs 1,500,000`, `streamingMs 1,200,000`, `plainMs 600,000`                                                                        |
-| **History**             | The metrics window and the time-decay tier boundaries and weights                                                                                                                    | `windowMinutes 60` (max 120), `tier1Minutes 1`, `tier2Minutes 5`, `tier1Weight 10`, `tier2Weight 3`, `tier3Weight 1`                     |
-| **Sticky**              | Stable-provider preference: on/off, TTL, hard-switch uptime floor, soft-switch score margin                                                                                          | `enabled true`, `ttlSeconds 3600`, `uptimeThreshold 85`, `scoreMargin 0.15`                                                              |
-| **Provider priorities** | Per-provider priority multipliers; set a provider to `0` to disable it for that project                                                                                              | `1` for every provider                                                                                                                   |
+| Group                   | What it controls                                                                                                                                                         | Defaults                                                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Weights**             | Relative importance of each scoring factor                                                                                                                               | `price 0.6`, `imagePrice 1.0`, `uptime 0.5`, `throughput 0.05`, `latency 0.025`, `cache 0.2`                                             |
+| **Thresholds**          | Cache prompt-size threshold, uptime-penalty threshold, exploration rate, and the assumed defaults used when no metrics exist                                             | `cachePromptTokens 5000`, `uptimePenalty 95`, `defaultUptime 100`, `defaultLatency 1000`, `defaultThroughput 50`, `explorationRate 0.01` |
+| **Retry**               | Max cross-provider fallback attempts and the low-uptime reroute threshold                                                                                                | `maxRetries 2`, `lowUptimeFallbackThreshold 90`                                                                                          |
+| **Timeouts**            | Per-request time limits (streaming, non-streaming) — see [Request Timeouts](/features/timeouts). Capped at the infrastructure defaults — an override can only lower them | `gatewayMs 1,500,000`, `streamingMs 1,200,000`, `plainMs 600,000`                                                                        |
+| **History**             | The metrics window and the time-decay tier boundaries and weights                                                                                                        | `windowMinutes 60` (max 120), `tier1Minutes 1`, `tier2Minutes 5`, `tier1Weight 10`, `tier2Weight 3`, `tier3Weight 1`                     |
+| **Sticky**              | Stable-provider preference: on/off, TTL, hard-switch uptime floor, soft-switch score margin                                                                              | `enabled true`, `ttlSeconds 3600`, `uptimeThreshold 85`, `scoreMargin 0.15`                                                              |
+| **Provider priorities** | Per-provider priority multipliers; set a provider to `0` to disable it for that project                                                                                  | `1` for every provider                                                                                                                   |
 
 <Callout type="info">
 	Per-project routing configuration requires the Enterprise plan. If you'd like

--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -43,6 +43,11 @@ The parameter works the same on the OpenAI-compatible **Responses API**
 (`/v1/responses`): the tier is forwarded to the provider and the response's
 `service_tier` field echoes the tier that was actually served.
 
+DevPass organizations can additionally configure a **default service tier** of
+`flex` in their DevPass settings: requests that omit `service_tier` are then
+automatically sent at Flex whenever the resolved model/provider supports it
+(and served at standard otherwise).
+
 ## Supported providers
 
 Service tiers are explicit per provider/model mapping. Check the model page for

--- a/apps/docs/content/features/sessions.mdx
+++ b/apps/docs/content/features/sessions.mdx
@@ -18,8 +18,9 @@ For chat completions, the session key is resolved in priority order — the firs
 
 1. The `x-session-id` header
 2. The `x-session-affinity` header (sent automatically by coding agents such as opencode)
-3. The `prompt_cache_key` body field (OpenAI-compatible)
-4. The `user` body field (OpenAI-compatible)
+3. The `session_id` or `session-id` header (sent by coding agents such as pi)
+4. The `prompt_cache_key` body field (OpenAI-compatible)
+5. The `user` body field (OpenAI-compatible)
 
 ```bash
 curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
@@ -42,7 +43,7 @@ For the [Anthropic Messages endpoint](/features/anthropic-endpoint) (`/v1/messag
 
 When a model is served by multiple providers, requests are normally scored independently, so a multi-turn conversation can bounce between providers. That defeats provider-side **prompt caching**, which only pays off when consecutive requests with a shared prefix reach the **same** provider.
 
-With a session id set, LLMGateway scores the session's first request with the normal weighted smart-routing algorithm (price, priority, uptime, throughput) and then **pins that provider for the session**, reusing it on every subsequent request to keep the prompt cache warm. The session stays on that provider — skipping the epsilon-greedy exploration — and only moves when its provider drops below the session uptime threshold or leaves the available pool (health filtering or a failed request dropped by retry/fallback), at which point the session is re-scored and re-pinned to the current best provider.
+With a session id set, LLMGateway scores the session's first request with the normal weighted smart-routing algorithm (price, priority, uptime, throughput) and then **pins that provider for the session**, reusing it on every subsequent request to keep the prompt cache warm. The session stays on that provider — skipping the epsilon-greedy exploration — and only moves when its provider drops below the session uptime threshold or leaves the available pool (e.g. health filtering), at which point the session is re-scored and re-pinned to the current best provider. Cross-provider fallback is disabled for sticky requests: a retryable failure is retried against the pinned provider (on an alternate key when one is configured, otherwise on the same key), never bounced to a different provider mid-session.
 
 See [Routing → Sticky Session Routing](/features/routing) for the full algorithm, fallback behavior, and the `session-sticky` routing-metadata reason.
 
@@ -58,7 +59,7 @@ Session stickiness is **on by default**. Enterprise projects can turn it off per
 
 Some providers use an OpenAI-style `prompt_cache_key` to route requests to the cache shard that already holds your prompt prefix — without it, repeat requests can land on different backends and miss the cache entirely (Meta requires it for cache hits in practice; OpenAI and Azure use it to improve hit rates under load).
 
-When a request has a session id and you didn't send a `prompt_cache_key` yourself, LLMGateway forwards a **keyed hash** (HMAC-SHA256 with a gateway-side secret) of the session id as the `prompt_cache_key` to providers that support it (currently OpenAI, Azure, and Meta). Hashing means your raw session ids are never exposed to providers; the hash is stable per session, which is all cache routing needs. A `prompt_cache_key` you set explicitly takes precedence and is forwarded as-is on those same surfaces.
+When a request has a session id and you didn't send a `prompt_cache_key` yourself, LLMGateway forwards a **keyed hash** (HMAC-SHA256 with a gateway-side secret) of the session id as the `prompt_cache_key` to providers that support it (currently OpenAI, Azure, Amazon Bedrock Mantle, and Meta). Hashing means your raw session ids are never exposed to providers; the hash is stable per session, which is all cache routing needs. A `prompt_cache_key` you set explicitly takes precedence on those same surfaces and is hashed the same way before being forwarded — the raw value you send is never exposed to providers, and the hashed key stays stable so cache routing still works.
 
 On provider surfaces that don't support the field, no key is sent at all — whether derived or explicit. This currently applies to Sakana (the field is not part of its API) and to Azure chat-completions requests, which can be served by legacy deployment-based API versions that reject unknown body fields; Azure requests on the Responses API always carry the key. Providers not listed above use different caching mechanisms (for example Anthropic `cache_control` breakpoints or Google implicit caching), so the `prompt_cache_key` doesn't apply to them either.
 

--- a/apps/docs/content/features/source.mdx
+++ b/apps/docs/content/features/source.mdx
@@ -43,10 +43,8 @@ All variations will be stripped down to the base domain (`example.com`) for aggr
 
 Data from the `X-Source` header is used to generate public statistics about LLM Gateway usage, including:
 
-- **Popular Domains**: Which websites and applications are using LLM Gateway most frequently
-- **Model Usage**: What models are being used by different domains
-- **Geographic Distribution**: Where requests are coming from across different sources
-- **Growth Trends**: How usage is growing over time for different domains
+- **Popular Domains**: Which websites and applications are using LLM Gateway most frequently, ranked by aggregated token and request counts
+- **Growth Trends**: How usage is growing over time for different domains (aggregated per day)
 
 These statistics help demonstrate the adoption and impact of LLM Gateway across the ecosystem.
 
@@ -55,8 +53,7 @@ These statistics help demonstrate the adoption and impact of LLM Gateway across 
 ### What's Public
 
 - Domain names (stripped of protocol and www prefixes)
-- Aggregated request counts and model usage
-- General geographic regions (country-level data)
+- Aggregated request and token counts
 
 ### What's Private
 

--- a/apps/docs/content/features/speech-generation.mdx
+++ b/apps/docs/content/features/speech-generation.mdx
@@ -19,6 +19,12 @@ and Alibaba Qwen speech models.
 	controls.
 </Callout>
 
+<Callout type="info">
+	Speech generation is not available on DevPass coding plans — coding plans only
+	include text-based inference, so requests from a coding-plan organization
+	return a `403`.
+</Callout>
+
 ## Available Models
 
 Browse all speech generation models, with up-to-date pricing, on the

--- a/apps/docs/content/features/timeouts.mdx
+++ b/apps/docs/content/features/timeouts.mdx
@@ -13,11 +13,10 @@ platform from stuck upstream connections, but they matter to you directly if
 you run long generations or agentic pipelines: a single completion that runs
 longer than the limit is terminated.
 
-| Limit             | Default    | Applies to                                               |
-| ----------------- | ---------- | -------------------------------------------------------- |
-| **Streaming**     | 20 minutes | Streaming completions (`stream: true`)                   |
-| **Non-streaming** | 10 minutes | Non-streaming completions                                |
-| **End-to-end**    | 25 minutes | Overall ceiling for the whole request, including retries |
+| Limit             | Default    | Applies to                             |
+| ----------------- | ---------- | -------------------------------------- |
+| **Streaming**     | 20 minutes | Streaming completions (`stream: true`) |
+| **Non-streaming** | 10 minutes | Non-streaming completions              |
 
 ## How the limits behave
 
@@ -25,6 +24,9 @@ longer than the limit is terminated.
   the gateway opens the upstream provider request and keeps running for the
   entire response — a stream is cut at the limit even while it is actively
   producing tokens.
+- **They apply per provider attempt.** When the gateway [retries a failed
+  request](/features/routing#automatic-retry--fallback) on another provider or
+  key, the retried attempt gets a fresh window.
 - **They apply per request, not per session or conversation.** Every
   completion call gets a fresh window. A long-running agent that makes many
   calls over hours is unaffected; only a _single_ call exceeding the limit
@@ -64,11 +66,11 @@ project.
 **Self-hosted deployments** control the limits with environment variables on
 the gateway service:
 
-| Variable                  | Default   | Controls                  |
-| ------------------------- | --------- | ------------------------- |
-| `AI_STREAMING_TIMEOUT_MS` | `1200000` | Streaming completions     |
-| `AI_TIMEOUT_MS`           | `600000`  | Non-streaming completions |
-| `GATEWAY_TIMEOUT_MS`      | `1500000` | End-to-end ceiling        |
+| Variable                  | Default   | Controls                                                                                                               |
+| ------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `AI_STREAMING_TIMEOUT_MS` | `1200000` | Streaming completions                                                                                                  |
+| `AI_TIMEOUT_MS`           | `600000`  | Non-streaming completions                                                                                              |
+| `GATEWAY_TIMEOUT_MS`      | `1500000` | Caps the default streaming timeout (when `AI_STREAMING_TIMEOUT_MS` is unset, streaming uses at most 80% of this value) |
 
 <Callout type="warn">
 	When raising the limits on a self-hosted deployment, raise the surrounding

--- a/apps/docs/content/features/transcription.mdx
+++ b/apps/docs/content/features/transcription.mdx
@@ -20,6 +20,10 @@ Use it when you want to:
 For the full request and response schema, see the
 [API reference](/v1_audio_transcriptions).
 
+Transcription is not available on DevPass coding plans — coding plans only
+include text-based inference, so requests from a coding-plan organization
+return a `403`.
+
 ## Endpoint
 
 `POST https://api.llmgateway.io/v1/audio/transcriptions`

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -19,6 +19,12 @@ Currently available models:
 
 You can find the current list of video-capable models on our [models page with the video filter enabled](https://llmgateway.io/models?filters=1&videoGeneration=true) or programmatically through the [/v1/models endpoint](/v1_models).
 
+<Callout type="info">
+	Video generation is not available on DevPass coding plans — coding plans only
+	include text-based inference, so requests from a coding-plan organization
+	return a `403`.
+</Callout>
+
 ## What Works Today
 
 - `POST /v1/videos`
@@ -41,7 +47,7 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | `audio`            | boolean | no       | Whether to include audio in the output (default `true`). Only honored when the model supports both audio and silent output |
 | `image`            | object  | no       | Optional first frame for image-to-video generation (see first/last frame inputs below)                                     |
 | `last_frame`       | object  | no       | Optional ending frame when `image` is provided (see first/last frame inputs below)                                         |
-| `reference_images` | array   | no       | One to three provider-specific image inputs                                                                                |
+| `reference_images` | array   | no       | Provider-specific image inputs — up to 9 on Seedance 2.0, up to 3 elsewhere                                                |
 | `input_reference`  | object  | no       | Alias for one or more `reference_images`                                                                                   |
 | `reference_videos` | array   | no       | One to three reference video HTTPS URLs (Seedance 2.0 only, see below)                                                     |
 | `reference_audios` | array   | no       | One to three reference audio HTTPS URLs (Seedance 2.0 only, see below)                                                     |
@@ -116,11 +122,11 @@ curl -X POST "https://api.llmgateway.io/v1/videos" \
 
 Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`, `seedance-2-0-mini`) can generate a video that is guided by reference **images**, **videos**, and **audio** — sometimes called omni-reference. You attach references as top-level fields in the same `POST /v1/videos` payload; the gateway forwards each one to the provider tagged with the correct role, so you don't set roles yourself.
 
-| Reference type | Payload field                                | Count | Accepted input                   | Available on                                         |
-| -------------- | -------------------------------------------- | ----- | -------------------------------- | ---------------------------------------------------- |
-| Image          | `reference_images` (`input_reference` alias) | 1–3   | HTTPS URL **or** base64 data URL | Seedance 2.0, Veo 3.1 (`google-vertex`, `avalanche`) |
-| Video          | `reference_videos`                           | 1–3   | HTTPS URL only                   | Seedance 2.0                                         |
-| Audio          | `reference_audios`                           | 1–3   | HTTPS URL only                   | Seedance 2.0                                         |
+| Reference type | Payload field                                | Count                            | Accepted input                   | Available on                                         |
+| -------------- | -------------------------------------------- | -------------------------------- | -------------------------------- | ---------------------------------------------------- |
+| Image          | `reference_images` (`input_reference` alias) | 1–9 (Seedance 2.0), 1–3 (others) | HTTPS URL **or** base64 data URL | Seedance 2.0, Veo 3.1 (`google-vertex`, `avalanche`) |
+| Video          | `reference_videos`                           | 1–3                              | HTTPS URL only                   | Seedance 2.0                                         |
+| Audio          | `reference_audios`                           | 1–3                              | HTTPS URL only                   | Seedance 2.0                                         |
 
 Each list item accepts either a bare URL string or an object form:
 

--- a/apps/docs/content/guides/claude-code.mdx
+++ b/apps/docs/content/guides/claude-code.mdx
@@ -87,7 +87,7 @@ export ANTHROPIC_MODEL=gemini-3.1-pro-preview
 ### Use Anthropic's Claude Models
 
 ```bash
-export ANTHROPIC_MODEL=anthropic/claude-3-5-sonnet-20241022
+export ANTHROPIC_MODEL=anthropic/claude-sonnet-4-6
 ```
 
 ## Predefining Models in a Settings File

--- a/apps/docs/content/integrations/aws-bedrock.mdx
+++ b/apps/docs/content/integrations/aws-bedrock.mdx
@@ -82,7 +82,7 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
   -H "Authorization: Bearer YOUR_LLMGATEWAY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "aws-bedrock/claude-3-5-sonnet",
+    "model": "aws-bedrock/claude-sonnet-4-6",
     "messages": [
       {
         "role": "user",
@@ -99,14 +99,9 @@ Replace `YOUR_LLMGATEWAY_API_KEY` with your LLM Gateway API key.
 
 ## Available Models
 
-Once configured, you can access all AWS Bedrock models through LLM Gateway:
+Once configured, you can access the Bedrock-backed models in the catalogue through LLM Gateway by prefixing the model id with `aws-bedrock/` (for example `aws-bedrock/claude-sonnet-4-6`).
 
-- **Anthropic Claude**: `aws-bedrock/claude-3-5-sonnet`, `aws-bedrock/claude-3-5-haiku`
-- **Meta Llama**: `aws-bedrock/llama-3-2-90b`, `aws-bedrock/llama-3-2-11b`
-- **Amazon Titan**: `aws-bedrock/amazon.titan-text-express-v1`
-- **And more...**
-
-Browse all available models at [llmgateway.io/models](https://llmgateway.io/models?provider=aws-bedrock)
+Browse the current list of Bedrock-backed models at [llmgateway.io/models](https://llmgateway.io/models?provider=aws-bedrock)
 
 ## Troubleshooting
 

--- a/apps/docs/content/integrations/azure.mdx
+++ b/apps/docs/content/integrations/azure.mdx
@@ -121,7 +121,7 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
   -H "Authorization: Bearer YOUR_LLMGATEWAY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "azure/gpt-4o-mini",
+    "model": "azure/gpt-4o",
     "messages": [
       {
         "role": "user",
@@ -138,11 +138,7 @@ Replace `YOUR_LLMGATEWAY_API_KEY` with your LLM Gateway API key.
 
 ## Available Models
 
-Once configured, you can access your Azure deployments through LLM Gateway:
-
-- **GPT-4o**: `azure/gpt-4o`
-- **GPT-4o Mini**: `azure/gpt-4o-mini`
-- **GPT-3.5 Turbo**: `azure/gpt-3.5-turbo` (note: use gpt-3.5-turbo as llmgateway model name instead of gpt-35-turbo)
+Once configured, you can access your Azure deployments through LLM Gateway by prefixing the model id with `azure/` (for example `azure/gpt-4o` or `azure/gpt-5.1`). Where Azure's deployment name differs from the catalogue id, use the LLM Gateway id — e.g. `azure/gpt-3.5-turbo` maps to Azure's `gpt-35-turbo` deployment automatically.
 
 **Note**: Only models you have deployed in Azure Studio will be available. Ensure your deployment names match the expected model identifiers.
 

--- a/apps/docs/content/integrations/vertex-anthropic.mdx
+++ b/apps/docs/content/integrations/vertex-anthropic.mdx
@@ -34,7 +34,7 @@ Available models:
 - `claude-sonnet-4-6`
 - `claude-sonnet-4-5`
 - `claude-haiku-4-5`
-- `claude-opus-4-5`
+- `claude-opus-4-5-20251101`
 - `claude-opus-4-6`
 - `claude-opus-4-7`
 

--- a/apps/docs/content/learn/audit-logs.mdx
+++ b/apps/docs/content/learn/audit-logs.mdx
@@ -23,7 +23,7 @@ Narrow down the log entries:
 - **Action** — Filter by action type (create, delete, update, etc.)
 - **Resource type** — Filter by resource (API, IAM, API Keys, etc.)
 
-Both filters are populated dynamically based on the actions recorded in your organization.
+Both filters list the complete set of trackable action and resource types.
 
 ## Audit Log Entries
 

--- a/apps/docs/content/learn/billing.mdx
+++ b/apps/docs/content/learn/billing.mdx
@@ -23,13 +23,13 @@ Top-ups are charged the credit amount plus the following fees:
 
 The full breakdown (credits, platform fee, and — when applicable — the international card fee) is shown in the top-up dialog before you confirm payment, so the total charge is always transparent.
 
-## Plan Management
+## Plan & Billing
 
-View and manage your subscription:
+The **Plan & Billing** card shows your current plan badge: **Free** for standard pay-as-you-go organizations (all features included, billing via credits), or **Pro (Legacy)** for organizations still on the legacy Pro subscription — those see their renewal or expiry date and can cancel or resume the subscription from here.
 
-- See your current plan (Free or Enterprise)
-- Billing cycle information
-- Click **Manage Subscription** to upgrade, downgrade, or cancel
+## Billing Email
+
+Manage the email address that receives your organization's billing communication.
 
 ## Payment Methods
 

--- a/apps/docs/content/learn/model-usage.mdx
+++ b/apps/docs/content/learn/model-usage.mdx
@@ -12,16 +12,17 @@ The Model Usage page shows how your API requests are distributed across differen
 
 ## Filters
 
-Two filters let you narrow down the data:
+Three controls let you shape the data:
 
-- **API Key** — Select a specific API key or view usage across all keys
+- **Group by** — Switch between **Breakdown by model** and **Breakdown by API key**
+- **API Key** — Select a specific API key or view usage across all keys (when grouping by model)
 - **Date range** — Choose a time period to analyze
 
 ## Usage Chart
 
-The main chart displays a time-series breakdown of requests per model. Each model is represented by a different color, making it easy to see:
+The main chart displays a time-series breakdown of requests per model (or per API key, when grouped by API key). Each series is represented by a different color, making it easy to see:
 
-- Which models are used most frequently
+- Which models (or API keys) are used most frequently
 - How usage patterns change over time
 - Whether usage is concentrated on a single model or spread across many
 

--- a/apps/docs/content/learn/team.mdx
+++ b/apps/docs/content/learn/team.mdx
@@ -16,18 +16,23 @@ Click **Add Member** to invite someone by email. You'll need to:
 
 1. Enter their email address
 2. Select a role (Developer, Admin, or Owner)
+3. For the **Developer** role, select the project(s) the developer may access — developer access is project-scoped and requires at least one project
 
-Your plan includes up to **5 team seats**. The current count is displayed, and the Add button is disabled when all seats are used. Contact sales for additional seats.
+Plans include up to **5 team seats** by default (**100** on Enterprise; higher limits can be arranged). The current count — which includes pending invitations — is displayed, and the Add button is disabled when all seats are used. Contact sales for additional seats.
+
+Invitations that have not been accepted yet appear in a **Pending Invitations** table below the member list, where they can be revoked.
 
 ## Team Members List
 
 Each member shows:
 
-| Field     | Description                                      |
-| --------- | ------------------------------------------------ |
-| **Name**  | The member's display name                        |
-| **Email** | Their email address                              |
-| **Role**  | Their current role (can be changed via dropdown) |
+| Field        | Description                                                                           |
+| ------------ | ------------------------------------------------------------------------------------- |
+| **Name**     | The member's display name                                                             |
+| **Email**    | Their email address                                                                   |
+| **Role**     | Their current role                                                                    |
+| **Projects** | The projects a developer has access to (all projects for other roles)                 |
+| **Limits**   | The member's spending limits, alongside their cost, token, request, and API-key usage |
 
 ## Actions
 
@@ -51,10 +56,12 @@ For the full rule semantics, see [Member-Level IAM Rules](/features/api-keys#mem
 
 ## Role Permissions
 
-| Role          | Permissions                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------- |
-| **Owner**     | Full access to all settings, billing, team management, and all projects                               |
-| **Admin**     | Can manage team members, projects, and API keys, but cannot access billing or delete the organization |
-| **Developer** | View and use resources only. Cannot modify settings or manage team                                    |
+| Role          | Permissions                                                                                                                               |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Owner**     | Full access to all settings, billing, team management, and all projects                                                                   |
+| **Admin**     | Can manage team members, projects, and API keys. Cannot manage subscriptions or change billing and policy settings — those are owner-only |
+| **Developer** | Access restricted to their granted project(s). Cannot modify settings or manage the team                                                  |
 
-Developers can also be given **restricted access** at the API key level, limiting which keys they can view and use.
+The **Developer** role is project-scoped and requires the **Enterprise plan** — assigning it on other plans returns an error. A developer must always be granted at least one project.
+
+Owners and admins can also set organization-wide **default developer limits** from the Team page — spending and API-key caps applied to every developer in the organization, which a developer's own limits (set via "Manage budget") override.

--- a/apps/docs/content/migrations/openrouter.mdx
+++ b/apps/docs/content/migrations/openrouter.mdx
@@ -101,7 +101,7 @@ const client = new OpenAI({
 
 // Usage remains the same
 const completion = await client.chat.completions.create({
-	model: "anthropic/claude-3-5-sonnet-20241022",
+	model: "anthropic/claude-sonnet-4-6",
 	messages: [{ role: "user", content: "Hello!" }],
 });
 ```
@@ -167,7 +167,7 @@ LLM Gateway supports streaming responses identically to OpenRouter:
 
 ```typescript
 const stream = await client.chat.completions.create({
-	model: "anthropic/claude-3-5-sonnet-20241022",
+	model: "anthropic/claude-sonnet-4-6",
 	messages: [{ role: "user", content: "Write a story" }],
 	stream: true,
 });

--- a/apps/docs/content/migrations/vercel-ai-gateway.mdx
+++ b/apps/docs/content/migrations/vercel-ai-gateway.mdx
@@ -76,7 +76,7 @@ const { text: openaiText } = await generateText({
 });
 
 const { text: claudeText } = await generateText({
-	model: anthropic("claude-3-5-sonnet-20241022"),
+	model: anthropic("claude-sonnet-4-6"),
 	prompt: "Hello!",
 });
 
@@ -94,7 +94,7 @@ const { text: openaiText } = await generateText({
 });
 
 const { text: claudeText } = await generateText({
-	model: llmgateway("anthropic/claude-3-5-sonnet-20241022"),
+	model: llmgateway("anthropic/claude-sonnet-4-6"),
 	prompt: "Hello!",
 });
 ```
@@ -110,7 +110,7 @@ const llmgateway = createLLMGateway({
 });
 
 const { textStream } = await streamText({
-	model: llmgateway("anthropic/claude-3-5-sonnet-20241022"),
+	model: llmgateway("anthropic/claude-sonnet-4-6"),
 	prompt: "Write a poem about coding",
 });
 
@@ -190,27 +190,27 @@ LLM Gateway supports two model ID formats:
 
 ```
 gpt-4o
-claude-3-5-sonnet-20241022
-gemini-1.5-pro
+claude-sonnet-4-6
+gemini-3.5-flash
 ```
 
 **Provider-Prefixed Model IDs** - Routes to a specific provider with automatic failover if uptime drops below 90%:
 
 ```
 openai/gpt-4o
-anthropic/claude-3-5-sonnet-20241022
-google-ai-studio/gemini-1.5-pro
+anthropic/claude-sonnet-4-6
+google-ai-studio/gemini-3.5-flash
 ```
 
 For more details on routing behavior, see the [routing documentation](/features/routing).
 
 ### Model Mapping Examples
 
-| Vercel AI SDK                             | LLM Gateway                                                                                        |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `openai("gpt-4o")`                        | `llmgateway("gpt-4o")` or `llmgateway("openai/gpt-4o")`                                            |
-| `anthropic("claude-3-5-sonnet-20241022")` | `llmgateway("claude-3-5-sonnet-20241022")` or `llmgateway("anthropic/claude-3-5-sonnet-20241022")` |
-| `google("gemini-1.5-pro")`                | `llmgateway("gemini-1.5-pro")` or `llmgateway("google-ai-studio/gemini-1.5-pro")`                  |
+| Vercel AI SDK                    | LLM Gateway                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| `openai("gpt-4o")`               | `llmgateway("gpt-4o")` or `llmgateway("openai/gpt-4o")`                               |
+| `anthropic("claude-sonnet-4-6")` | `llmgateway("claude-sonnet-4-6")` or `llmgateway("anthropic/claude-sonnet-4-6")`      |
+| `google("gemini-3.5-flash")`     | `llmgateway("gemini-3.5-flash")` or `llmgateway("google-ai-studio/gemini-3.5-flash")` |
 
 Check the [models page](https://llmgateway.io/models) for the full list of available models.
 

--- a/apps/docs/content/resources/error-handling.mdx
+++ b/apps/docs/content/resources/error-handling.mdx
@@ -34,6 +34,10 @@ Errors on the OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/embeddin
 
 The HTTP status code on the response always matches the error and is the authoritative signal — read it from the response status line rather than the body.
 
+## Request IDs
+
+Every chat completion response — success or error — carries an `x-request-id` response header identifying the request. You can also supply your own id by sending an `x-request-id` request header, and the gateway will echo it back. Include this id when reporting issues so the request can be correlated with gateway logs.
+
 ## Status Codes
 
 The gateway maps HTTP status codes to OpenAI error types and codes as follows:

--- a/apps/docs/content/resources/rate-limits.mdx
+++ b/apps/docs/content/resources/rate-limits.mdx
@@ -38,21 +38,28 @@ For organizations that have **purchased at least some credits**:
 
 ## Paid Models
 
-**Paid AI models are not currently rate limited.** You can make as many requests as needed to paid models, subject only to your account's credit balance and any provider-specific limits.
+**Paid AI models have no fixed platform-wide rate limits.** You can make as many requests as needed to paid models, subject to your account's credit balance.
+
+However, individual provider/model combinations can carry configurable **requests-per-minute (RPM)** and **requests-per-day (RPD)** caps, applied per organization or shared platform-wide. When such a cap is reached, smart routing automatically avoids the capped provider and serves your request from another one. Only when you pin the capped provider explicitly with the `X-No-Fallback: true` header does the request fail with a `429 Too Many Requests` response.
 
 ## Rate Limit Headers
 
-All API responses include rate limit information in the headers:
+Requests to **free models** include rate limit information in the response headers:
 
 ```http
 X-RateLimit-Limit: 20
 X-RateLimit-Remaining: 19
-X-RateLimit-Reset: 1640995200
 ```
 
 - `X-RateLimit-Limit`: Maximum number of requests allowed in the current window
 - `X-RateLimit-Remaining`: Number of requests remaining in the current window
+
+When a request is rejected with `429`, the response additionally includes:
+
+- `Retry-After`: Seconds to wait before retrying
 - `X-RateLimit-Reset`: Unix timestamp when the rate limit window resets
+
+Requests served by a provider/model combination with a configured RPM or RPD cap include the cap state in separate headers: `X-RateLimit-Limit-Provider` / `X-RateLimit-Remaining-Provider` for the primary window, plus per-window variants suffixed with `-RPM` and `-RPD` (e.g. `X-RateLimit-Remaining-Provider-RPM`).
 
 ## Rate Limit Exceeded
 


### PR DESCRIPTION
## Summary

Monthly documentation audit: compared the documentation site against the actual implementation in `apps/gateway` and `apps/api`, and fixed every major mismatch found. Every changed line was verified directly against the current source (file/line refs below cite the authoritative code).

## Major discrepancies fixed

### Gateway — core chat path

- **Retry/fallback triggers** (`features/routing.mdx`): docs claimed retries fire on "5xx only, never 4xx". The classifier (`apps/gateway/src/chat/tools/get-finish-reason-from-error.ts`) also retries 429, 404, 402, 405, and 401/403 (with same-provider key rotation via `shouldRetryAlternateKey`). Rewrote the trigger list.
- **Session-sticky fallback** (`features/routing.mdx`, `features/sessions.mdx`): docs said a failed sticky request is "dropped by the retry/fallback loop" and re-pinned. `shouldRetryRequest` returns `false` for sticky requests (`retry-with-fallback.ts:201-203`) — they retry against the pinned provider only, and re-pin happens solely on uptime drop or the provider leaving the candidate set (`packages/actions/src/get-cheapest-from-available-providers.ts` `applySessionSticky`). Also documented the full 6-source session-id resolution order (`x-session-id` → `x-session-affinity` → `session_id`/`session-id` → `prompt_cache_key` → `user`, `chat.ts:1439-1446`).
- **Timeouts** (`features/timeouts.mdx`): removed the documented 25-minute "end-to-end ceiling including retries" — no request-level timer exists; timeout signals are created per provider attempt inside the retry loop, and `GATEWAY_TIMEOUT_MS` only caps the derived streaming default (`lib/timeout-config.ts`).
- **Gateway caching** (`features/caching/gateway-caching.mdx`): the documented cache-key list included tools/tool-choice, but the hashed payload (`chat.ts:5460-5477`) excludes them — documented the real field list plus a warning about tool-variant collisions. Also documented that DevPass orgs never get response caching (`chat.ts:5453-5454`) and corrected "in-memory" to the TTL-bound (Redis) cache.
- **Rate limits** (`resources/rate-limits.mdx`): "all API responses include X-RateLimit-\*" and "paid models are not rate limited" were both wrong. Documented the actual free-model headers (`validate-free-model-usage.ts`), the 429-only `Retry-After`/`X-RateLimit-Reset`, and the configurable per-provider/model RPM/RPD caps with their `X-RateLimit-*-Provider*` headers (`lib/provider-rate-limit.ts`, `chat.ts:5043-5110`).
- **Response healing** (`features/response-healing.mdx`): docs said streaming is unsupported — streaming responses ARE healed via buffer-and-replay (`chat.ts:8526-8550`, skipped when `n > 1`). Also documented automatic healing without the plugin for known-bad JSON-mode deployments (`chat.ts:12913-12924`).
- **Sessions** (`features/sessions.mdx`): an explicit `prompt_cache_key` is HMAC-hashed before forwarding, not "forwarded as-is", and Bedrock Mantle is among the supporting providers (`packages/actions/src/prepare-request-body.ts:59-71, 2002-2021`).
- **Routing metadata example**: `error_type: "server_error"` doesn't exist — attempts record `getErrorType()` values; fixed to `upstream_error`.
- Documented the project-level **default routing strategy** (`chat.ts:2265`) and echoed/accepted **`x-request-id`** (`chat.ts:1355`, `:1665`) in `resources/error-handling.mdx`.

### Gateway — other endpoints

- **New page for `/v1/responses`** (`features/responses.mdx`): the Responses API (POST `/`, GET `/{id}`, and the `/compact` compaction extension, `responses/responses.ts`) had no documentation at all. Documented the request schema (`responses/schemas.ts`), `store` defaulting to true, item references, 30-day storage TTL, and zstd request bodies.
- **Image edits** (`features/image-generation.mdx`): docs claimed `mask` is unsupported — the multipart handler accepts `mask` and forwards it as an additional input image (`images/images.ts:991-996`); multipart/form-data support (what the OpenAI SDK sends) and the `aspect_ratio` generations param were undocumented.
- **Guardrails** (`features/guardrails.mdx`): "run on every API request" → they run on the chat lane only (`checkGuardrails` is called solely in `chat.ts:2324-2332`), covering `/v1/messages`, `/v1/responses`, and chat-based image generation via internal re-entry; non-chat endpoints are not scanned.
- **Anthropic endpoint** (`features/anthropic-endpoint.mdx`): documented the implemented-but-undocumented `thinking` and `output_config.effort` reasoning controls (`anthropic/thinking-to-reasoning.ts`).
- **DevPass 403s**: embeddings, speech, transcription, video, OCR, and rerank all reject coding-plan orgs with an undocumented 403 — added a note to each page (identical gates in all six handlers).
- **Video** (`features/video-generation.mdx`): Seedance 2.0 accepts up to 9 reference images, not 3 (`videos/videos.ts:235-241, 1083-1085`).
- **Embeddings** (`features/embeddings.mdx`): replaced the stale hardcoded provider list with a models-page link (per repo docs policy) and documented the implemented `encoding_format`/`dimensions`/`user` params and the Google token-ID input rejection.

### Backend API / platform

- **Data retention** (`features/data-retention.mdx`): retention is a hardcoded 30 days for all orgs (`apps/worker/src/worker.ts:664-665`) — removed the "Enterprise custom periods" and "configure periods via env vars" claims (only `ENABLE_DATA_RETENTION_CLEANUP` exists); cleanup nulls payload columns rather than deleting rows; storage cost sums prompt+completion+reasoning tokens (no separate cached-token line, `lib/logs.ts:276-283`); documented hybrid mode (the default) in billing considerations.
- **Audit logs** (`features/audit-logs.mdx`, `learn/audit-logs.mdx`): the hardcoded action list covered ~19 of ~85 actions in the enum (`packages/db/src/schema.ts:3165-3268`) — replaced with a category overview pointing at the always-current dashboard filter; removed the unimplemented "90-day retention" claim (no cleanup job touches `audit_log`); dashboard filters are Action + Resource type and list the full static enums.
- **Team** (`learn/team.mdx`): the Developer role is Enterprise-only and project-scoped with a required project grant (`team.ts:691-699`, `:1076-1084`), not "restricted at the API key level"; admins CAN access billing/purchase credits (no role check in `payments.ts`) while subscriptions and billing/policy settings are owner-only (`subscriptions.ts`, `organization.ts:632-635`); seats default 5 (100 on Enterprise, `lib/seat-limit.ts`); documented the Projects/Limits columns, Pending Invitations table, and org-wide default developer limits.
- **Billing** (`learn/billing.mdx`): the "Manage Subscription to upgrade/downgrade" UI no longer exists — matched the doc to the current Plan & Billing card (Free / Pro (Legacy) with cancel/resume only) and added the Billing Email card.
- **Custom providers** (`features/custom-providers.mdx`): `http://` base URLs are rejected by default (https-only + private-address blocking in `packages/shared/src/url-safety.ts`); documented the `ALLOW_INSECURE_PROVIDER_URLS` self-host opt-out.
- **Source stats** (`features/source.mdx`): removed the "geographic distribution / country-level data" and per-domain model-usage claims — `globalSourceStats` stores no geo or model data.
- **Model usage** (`learn/model-usage.mdx`): documented the Group by (model / API key) selector (`activity.ts:162`).

### Dead example models

Replaced fully deactivated catalogue entries that made copy-paste examples fail with 400/410: `claude-3-5-sonnet-20241022` → `claude-sonnet-4-6` (ai-sdk, openrouter/vercel migrations, claude-code guide, anthropic endpoint), `gemini-1.5-pro` → `gemini-3.5-flash`, `azure/gpt-4o-mini` → `azure/gpt-4o` (the old example silently fell back to OpenAI, defeating the "test your Azure key" purpose), `aws-bedrock/claude-3-5-sonnet` → `aws-bedrock/claude-sonnet-4-6`, and `claude-opus-4-5` → `claude-opus-4-5-20251101` in the Vertex list. De-hardcoded the Bedrock/Azure "Available Models" lists (which included nonexistent IDs like `aws-bedrock/llama-3-2-90b` and `amazon.titan-text-express-v1`) into links to the live models page, per the repo's docs policy against catalogue-derived lists.

## Verification

- `pnpm format` — clean
- `turbo run build --filter=docs` — build succeeds (11/11 tasks)
- All replacement model IDs verified active (no `deactivatedAt` in the past) against `packages/models/src/models/*`

## Observations for maintainers (not doc issues, flagged during the audit)

- `DELETE /organizations/{id}` (`apps/api/src/routes/organization.ts:948`) appears to have **no role check** — any member of an org can soft-delete it. The team docs previously claimed admins can't delete the org; enforcement looks UI-only.
- `GET /v1/videos/logs/{log_id}/content` (`apps/gateway/src/videos/videos.ts:572-578`) is registered without a `security` block and is bearer-token-unauthenticated (optional `?token=` only) — worth a security review if it's not intentionally a signed proxy URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU992beifRcCkhCwLKqUSS)_