### PR TITLE
fix(gateway): forward reasoning_effort to Together AI

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -4802,6 +4802,110 @@ describe("prepareRequestBody - max_tokens forwarding", () => {
 
 			expect(requestBody.max_tokens).toBeUndefined();
 		});
+
+		// Together AI takes graded tiers through `reasoning_effort` everywhere,
+		// but disabling thinking differs per serving stack: the gpt-oss and Gemma
+		// deployments take `reasoning_effort: "none"`, while the DeepSeek/MiniMax/
+		// Kimi deployments only honour `thinking: { type: "disabled" }` and mark
+		// themselves with `requiresDisableThinkingParam`. Verified live.
+		const togetherReasoning = (
+			model: string,
+			externalId: string,
+			reasoning_effort:
+				| "none"
+				| "minimal"
+				| "low"
+				| "medium"
+				| "high"
+				| "xhigh"
+				| "max"
+				| undefined,
+		) =>
+			prepareRequestBody(
+				"together-ai",
+				model,
+				null,
+				externalId,
+				[{ role: "user", content: "Hello!" }],
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				reasoning_effort,
+				true,
+				false,
+			) as Promise<any>;
+
+		test("forwards reasoning_effort on validating routes", async () => {
+			const requestBody = await togetherReasoning(
+				"gpt-oss-120b",
+				"openai/gpt-oss-120b",
+				"high",
+			);
+
+			expect(requestBody.reasoning_effort).toBe("high");
+			expect(requestBody.thinking).toBeUndefined();
+		});
+
+		test("forwards none as an effort on validating routes", async () => {
+			const requestBody = await togetherReasoning(
+				"gemma-4-31b-it",
+				"google/gemma-4-31b-it",
+				"none",
+			);
+
+			expect(requestBody.reasoning_effort).toBe("none");
+			expect(requestBody.thinking).toBeUndefined();
+		});
+
+		test("drops none on routes that do not declare it", async () => {
+			const requestBody = await togetherReasoning(
+				"gpt-oss-120b",
+				"openai/gpt-oss-120b",
+				"none",
+			);
+
+			expect(requestBody.reasoning_effort).toBeUndefined();
+			expect(requestBody.thinking).toBeUndefined();
+		});
+
+		test("maps none onto the thinking switch when the mapping needs it", async () => {
+			const requestBody = await togetherReasoning(
+				"deepseek-v4-pro",
+				"deepseek-ai/DeepSeek-V4-Pro",
+				"none",
+			);
+
+			expect(requestBody.thinking).toEqual({ type: "disabled" });
+			expect(requestBody.reasoning_effort).toBeUndefined();
+		});
+
+		test("forwards graded tiers verbatim on thinking-switch routes", async () => {
+			const requestBody = await togetherReasoning(
+				"kimi-k3",
+				"moonshotai/Kimi-K3",
+				"high",
+			);
+
+			expect(requestBody.reasoning_effort).toBe("high");
+			expect(requestBody.thinking).toBeUndefined();
+		});
+
+		test("sends no reasoning parameters when the caller omits effort", async () => {
+			const requestBody = await togetherReasoning(
+				"minimax-m3",
+				"MiniMaxAI/MiniMax-M3",
+				undefined,
+			);
+
+			expect(requestBody.reasoning_effort).toBeUndefined();
+			expect(requestBody.thinking).toBeUndefined();
+		});
 	});
 
 	describe("inference.net", () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1167,10 +1167,10 @@ export async function prepareRequestBody(
 	// `none` reasoning effort is handled natively by a few providers:
 	// OpenAI/Azure forward it (their newer models accept it to turn reasoning
 	// off), and Google, Moonshot, Alibaba, MiniMax, Xiaomi, DeepSeek, Fireworks,
-	// and Z.ai reason by default so they must explicitly disable thinking when
-	// asked. Every other provider treats the absence of reasoning_effort as
-	// "off" already, so normalize `none` away for them to avoid forwarding an
-	// unsupported enum value.
+	// Together AI, and Z.ai reason by default so they must explicitly disable
+	// thinking when asked. Every other provider treats the absence of
+	// reasoning_effort as "off" already, so normalize `none` away for them to
+	// avoid forwarding an unsupported enum value.
 	const handlesNoneNatively =
 		usedProvider === "openai" ||
 		usedProvider === "azure" ||
@@ -1186,6 +1186,7 @@ export async function prepareRequestBody(
 		usedProvider === "xiaomi" ||
 		usedProvider === "deepseek" ||
 		usedProvider === "fireworks" ||
+		usedProvider === "together-ai" ||
 		usedProvider === "zai" ||
 		providerMappingForOptions?.apiFormat === "openai-chat-completions";
 	if (reasoning_effort === "none" && !handlesNoneNatively) {
@@ -3718,6 +3719,33 @@ export async function prepareRequestBody(
 			}
 			if (presence_penalty !== undefined) {
 				requestBody.presence_penalty = presence_penalty;
+			}
+
+			// Together AI is OpenAI-compatible on `reasoning_effort`, so graded
+			// tiers are forwarded verbatim (unsupported ones surface the provider's
+			// 4xx per the no-downgrade rule). Turning thinking *off* is not uniform:
+			// Together runs reasoning models on two serving stacks, each with its
+			// own switch (verified live against the API). The gpt-oss and Gemma
+			// deployments validate `reasoning_effort` — they name their accepted
+			// literals in the 400 — and take `none` there, while `thinking` is
+			// ignored. The DeepSeek V4 Pro, MiniMax M3 and Kimi deployments do the
+			// reverse: they accept any `reasoning_effort` string without complaint
+			// and keep thinking on, and only `thinking: { type: "disabled" }`
+			// (which they validate) actually turns it off. Mappings on the second
+			// stack set `requiresDisableThinkingParam`; either way only mappings
+			// that declare `none` in `reasoningEfforts` can disable at all.
+			if (supportsReasoning && reasoning_effort !== undefined) {
+				if (reasoning_effort !== "none") {
+					requestBody.reasoning_effort = reasoning_effort;
+				} else if (
+					providerMappingForOptions?.reasoningEfforts?.includes("none")
+				) {
+					if (providerMappingForOptions.requiresDisableThinkingParam) {
+						requestBody.thinking = { type: "disabled" };
+					} else {
+						requestBody.reasoning_effort = "none";
+					}
+				}
 			}
 			break;
 		}

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -372,6 +372,17 @@ export interface ProviderModelMapping {
 	 */
 	requiresEnableThinking?: boolean;
 	/**
+	 * Whether this provider mapping turns thinking off through a separate binary
+	 * `thinking: { type: "disabled" }` parameter instead of
+	 * `reasoning_effort: "none"`. Together AI serves reasoning models on two
+	 * stacks: its gpt-oss/Gemma deployments validate `reasoning_effort` and take
+	 * `none` there (sending `thinking` has no effect), while its
+	 * DeepSeek/MiniMax/Kimi deployments ignore `reasoning_effort: "none"` and
+	 * only honour the `thinking` switch. Only meaningful on mappings that
+	 * declare `none` in `reasoningEfforts`.
+	 */
+	requiresDisableThinkingParam?: boolean;
+	/**
 	 * Whether this model supports the OpenAI responses API (defaults to true if reasoning is true)
 	 */
 	supportsResponsesApi?: boolean;

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -316,7 +316,13 @@ export const deepseekModels = [
 				maxOutput: 163840,
 				streaming: true,
 				reasoning: true,
-				reasoningEfforts: ["high", "max"],
+				// Together's deployment accepts any reasoning_effort string without
+				// validating it, and only the top tiers measurably change behaviour:
+				// xhigh and max roughly double the reasoning tokens, while
+				// low/medium/high land on the provider default. `none` is honoured
+				// through the `thinking` switch, not through reasoning_effort.
+				reasoningEfforts: ["none", "xhigh", "max"],
+				requiresDisableThinkingParam: true,
 				reasoningOutput: "omit",
 				vision: false,
 				tools: true,

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2307,6 +2307,10 @@ export const googleModels = [
 				maxOutput: 32768,
 				streaming: true,
 				reasoning: true,
+				// Together validates reasoning_effort on this route and names the
+				// accepted literals in its 400 ("Input should be 'none', 'low',
+				// 'medium' or 'high'"); `none` zeroes out the reasoning output.
+				reasoningEfforts: ["none", "low", "medium", "high"],
 				vision: false,
 				tools: true,
 				jsonOutput: true,

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -48,6 +48,12 @@ export const minimaxModels = [
 				quantization: "fp4",
 				streaming: true,
 				reasoning: true,
+				// Together's deployment accepts any reasoning_effort string without
+				// validating it, and no tier measurably changes the reasoning length,
+				// so `none` — honoured through the `thinking` switch rather than
+				// reasoning_effort — is the only effort this mapping really applies.
+				reasoningEfforts: ["none"],
+				requiresDisableThinkingParam: true,
 				vision: false,
 				tools: false,
 				jsonOutput: true,

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -465,6 +465,12 @@ export const moonshotModels = [
 				maxOutput: 32768,
 				streaming: true,
 				reasoning: true,
+				// Together's deployment accepts any reasoning_effort string without
+				// validating it, and no tier measurably changes the reasoning length,
+				// so `none` — honoured through the `thinking` switch rather than
+				// reasoning_effort — is the only effort this mapping really applies.
+				reasoningEfforts: ["none"],
+				requiresDisableThinkingParam: true,
 				vision: true,
 				tools: false,
 				jsonOutput: false,
@@ -694,6 +700,12 @@ export const moonshotModels = [
 				quantization: "fp4",
 				streaming: true,
 				reasoning: true,
+				// Together's deployment accepts any reasoning_effort string without
+				// validating it, and no tier measurably changes the reasoning length,
+				// so `none` — honoured through the `thinking` switch rather than
+				// reasoning_effort — is the only effort this mapping really applies.
+				reasoningEfforts: ["none"],
+				requiresDisableThinkingParam: true,
 				vision: true,
 				tools: true,
 				jsonOutput: true,

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -776,6 +776,9 @@ export const openaiModels = [
 				vision: false,
 				tools: true,
 				reasoning: true,
+				// Together validates reasoning_effort on the gpt-oss route and 400s
+				// ("Input validation error") on anything outside low/medium/high.
+				reasoningEfforts: ["low", "medium", "high"],
 				jsonOutput: false,
 			},
 			{
@@ -878,6 +881,9 @@ export const openaiModels = [
 				vision: false,
 				tools: true,
 				reasoning: true,
+				// Together validates reasoning_effort on the gpt-oss route and 400s
+				// ("Input validation error") on anything outside low/medium/high.
+				reasoningEfforts: ["low", "medium", "high"],
 				jsonOutput: false,
 			},
 		],


### PR DESCRIPTION
Fixes #3361.

## The bug

`case "inference.net": case "together-ai":` in `packages/actions/src/prepare-request-body.ts` forwarded `response_format`, `temperature`, `max_tokens`, `top_p` and the penalties, then `break`ed before the `default` case's generic `reasoning_effort` forwarder. `reasoning_effort` was therefore **never** sent to Together AI for any model — including the gateway's own auto-routing default and `deepseek-v4-pro`'s declared `reasoningEfforts: ["high", "max"]`, which was dead on arrival.

## What the upstream API actually does

Probed live against `api.together.ai` (not from docs). Together is OpenAI-compatible on `reasoning_effort`, but **disabling** thinking is not uniform — reasoning models run on two serving stacks with different switches:

| Mapping | `reasoning_effort` | Disable switch |
|---|---|---|
| `openai/gpt-oss-120b`, `openai/gpt-oss-20b` | validated, 400s outside `low`/`medium`/`high` | n/a (`none` is rejected) |
| `google/gemma-4-31b-it` | validated; the 400 names the literals (`'none'`, `'low'`, `'medium'`, `'high'`) | `reasoning_effort: "none"` → 0 reasoning tokens |
| `deepseek-ai/DeepSeek-V4-Pro` | accepted unvalidated; `xhigh`/`max` roughly double reasoning tokens, `low`/`medium`/`high` land on the default | `thinking: { type: "disabled" }` |
| `MiniMaxAI/MiniMax-M3`, `moonshotai/Kimi-K2.6`, `moonshotai/Kimi-K3` | accepted unvalidated; no tier measurably changes reasoning length | `thinking: { type: "disabled" }` |

The two switches are **not** interchangeable: Gemma ignores `thinking` (5 runs, reasoning continued at ~1.5k tokens), and DeepSeek V4 Pro / Kimi K2.6 ignore `reasoning_effort: "none"` (still reasoned). `thinking.type` is validated by the second stack — a bad value 400s with `unknown variant ... expected one of enabled, disabled, adaptive`.

## The fix

- Forward `reasoning_effort` verbatim from the `together-ai` case, per the repo's no-downgrade rule.
- Add `together-ai` to `handlesNoneNatively` so `none` survives to the switch.
- Translate `none` per serving stack, driven by a new per-mapping `requiresDisableThinkingParam` flag (sibling to the existing `requiresEnableThinking`), so the DeepSeek/MiniMax/Kimi mappings emit `thinking: { type: "disabled" }` and Gemma emits `reasoning_effort: "none"`.
- Set each mapping's `reasoningEfforts` from measured behaviour rather than assumption, replacing `deepseek-v4-pro`'s unverified `["high", "max"]`.

## Testing

- 6 new unit tests in `prepare-request-body.spec.ts` covering both stacks, the `none` translation, and the drop when a mapping does not declare `none`. `pnpm test:unit` for `packages/actions` + `packages/models`: 546 passed.
- `pnpm build` and `pnpm format` clean.
- E2E against the real Together API (`TEST_MODELS=... FULL_MODE=true pnpm test:e2e`), which expands one case per declared effort tier. All pass: gpt-oss-120b/20b `low`/`medium`/`high`, gemma `none`/`low`/`medium`/`high`, deepseek-v4-pro `none`/`xhigh`/`max`, and `none` for minimax-m3, kimi-k2.6, kimi-k3.

### Pre-existing failures (not from this change)

`together-ai/gemma-4-31b-it` times out at 60s intermittently across unrelated suites (JSON output, streaming, tool calls) and on the plain no-parameter baseline when probed directly — its effort tiers each pass in one run and time out in another, in a different combination each time. `together-ai/gpt-oss-120b` fails tool-calling and Responses tool-calling. Neither of those suites sends `reasoning_effort` at all.

## Out of scope

`moonshotai/Kimi-K2.5` and `zai-org/GLM-4.7` on Together return `Unable to access non-serverless model` for every request — those mappings need a dedicated endpoint and appear unusable as configured. Left untouched here; worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-specific reasoning effort support for Together AI models, including supported `none`, `low`, `medium`, `high`, `xhigh`, and `max` tiers where applicable.
  * Added support for disabling reasoning on compatible models.
  * Added Together AI configurations for additional Kimi models.
* **Bug Fixes**
  * Improved request handling so reasoning settings are correctly forwarded, translated, or omitted based on model capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->