### PR TITLE
feat(admin): gate org deletion on credit balance

### DIFF
--- a/apps/api/src/routes/admin-bulk-block.spec.ts
+++ b/apps/api/src/routes/admin-bulk-block.spec.ts
@@ -163,6 +163,43 @@ describe("admin bulk block organizations", () => {
 		]);
 	});
 
+	it("excludes organizations that still have credits", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-paying", "Fraud Ring Paying", { credits: "42.00" });
+		await insertOrg("bulk-negative", "Fraud Ring Negative", {
+			credits: "-3.00",
+		});
+
+		const res = await preview("fraud ring", cookie);
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as PreviewResponse;
+
+		expect(json.matched).toBe(3);
+		expect(json.blockable).toBe(2);
+		expect(json.skipped).toBe(1);
+		expect(json.organizations.map((o) => o.id).sort()).toEqual([
+			"bulk-a",
+			"bulk-negative",
+		]);
+	});
+
+	it("never blocks an organization that still has credits", async () => {
+		await insertOrg("bulk-a", "Fraud Ring Alpha");
+		await insertOrg("bulk-paying", "Fraud Ring Paying", { credits: "0.01" });
+
+		const res = await bulkBlock(
+			{ search: "fraud ring", expectedCount: 1 },
+			cookie,
+		);
+		expect(res.status).toBe(200);
+		const json = (await res.json()) as BulkBlockResponse;
+		expect(json.blockedCount).toBe(1);
+		expect(json.blocked.map((o) => o.id)).toEqual(["bulk-a"]);
+
+		expect(await getStatus("bulk-a")).toBe("deleted");
+		expect(await getStatus("bulk-paying")).toBe("active");
+	});
+
 	it("blocks exactly the filtered organizations and nothing else", async () => {
 		await insertOrg("bulk-a", "Fraud Ring Alpha");
 		await insertOrg("bulk-b", "Fraud Ring Beta");

--- a/apps/api/src/routes/admin-org-delete-credits.spec.ts
+++ b/apps/api/src/routes/admin-org-delete-credits.spec.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+async function insertOrg(id: string, credits: string) {
+	await db.insert(tables.organization).values({
+		id,
+		name: `Credit Org ${id}`,
+		billingEmail: `${id}@credits.test`,
+		credits,
+	});
+}
+
+async function block(orgId: string, token: string): Promise<Response> {
+	return await app.request(`/admin/organizations/${orgId}/block`, {
+		method: "POST",
+		headers: { Cookie: token },
+	});
+}
+
+async function setStatus(
+	orgId: string,
+	status: "active" | "deleted",
+	token: string,
+): Promise<Response> {
+	return await app.request(`/admin/organizations/${orgId}/status`, {
+		method: "PATCH",
+		headers: { Cookie: token, "Content-Type": "application/json" },
+		body: JSON.stringify({ status }),
+	});
+}
+
+async function getStatus(orgId: string) {
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId } },
+	});
+	return org?.status ?? null;
+}
+
+describe("admin organization deletion credit guard", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	it("refuses to block an organization with positive credits", async () => {
+		await insertOrg("credit-positive", "12.34");
+
+		const res = await block("credit-positive", cookie);
+		expect(res.status).toBe(409);
+		const json = (await res.json()) as { message: string };
+		expect(json.message).toContain("positive credit balance");
+
+		expect(await getStatus("credit-positive")).toBe("active");
+	});
+
+	it("refuses to disable an organization with positive credits", async () => {
+		await insertOrg("credit-positive", "0.01");
+
+		const res = await setStatus("credit-positive", "deleted", cookie);
+		expect(res.status).toBe(409);
+
+		expect(await getStatus("credit-positive")).toBe("active");
+	});
+
+	it.each([
+		["zero credits", "0"],
+		["negative credits", "-5.00"],
+	])("blocks an organization with %s", async (_label, credits) => {
+		await insertOrg("credit-empty", credits);
+
+		const res = await block("credit-empty", cookie);
+		expect(res.status).toBe(200);
+
+		expect(await getStatus("credit-empty")).toBe("deleted");
+	});
+
+	it.each([
+		["zero credits", "0"],
+		["negative credits", "-1.50"],
+	])("disables an organization with %s", async (_label, credits) => {
+		await insertOrg("credit-empty", credits);
+
+		const res = await setStatus("credit-empty", "deleted", cookie);
+		expect(res.status).toBe(200);
+
+		expect(await getStatus("credit-empty")).toBe("deleted");
+	});
+
+	it("still re-enables an organization that has credits", async () => {
+		await insertOrg("credit-restore", "0");
+		expect((await setStatus("credit-restore", "deleted", cookie)).status).toBe(
+			200,
+		);
+
+		// A gifted refund after the block must not trap the organization in the
+		// deleted state: only the destructive direction is credit-gated.
+		await db
+			.update(tables.organization)
+			.set({ credits: "25.00" })
+			.where(eq(tables.organization.id, "credit-restore"));
+
+		const res = await setStatus("credit-restore", "active", cookie);
+		expect(res.status).toBe(200);
+
+		expect(await getStatus("credit-restore")).toBe("active");
+	});
+
+	it("does not deactivate members when the block is refused", async () => {
+		await insertOrg("credit-positive", "10.00");
+		await db.insert(tables.user).values({
+			id: "credit-member",
+			name: "Credit Member",
+			email: "member@credits.test",
+			emailVerified: true,
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "credit-member",
+			organizationId: "credit-positive",
+			role: "owner",
+		});
+
+		expect((await block("credit-positive", cookie)).status).toBe(409);
+
+		const member = await db.query.user.findFirst({
+			where: { id: { eq: "credit-member" } },
+		});
+		expect(member?.status).toBe("active");
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -6096,6 +6096,33 @@ admin.openapi(manageOrganizationRoute, async (c) => {
 	});
 });
 
+// --- Deleting/blocking an organization requires a non-positive balance ---
+
+/**
+ * Admin deletion is a fallback for abuse handling, not an account-closure tool.
+ * An organization that still holds credits is a paying customer, so wiping it
+ * from the admin panel is never the right move — the balance has to be spent,
+ * refunded, or zeroed deliberately first, and the account then handled manually.
+ *
+ * Every path that marks an organization `deleted` (status toggle, single block,
+ * bulk block) funnels through this guard so no single entry point can bypass it.
+ */
+function assertOrganizationDeletable(org: {
+	name: string;
+	credits: string | null;
+}): void {
+	const credits = Number(org.credits ?? "0");
+
+	// Written as `!(credits <= 0)` rather than `credits > 0` so an unparseable
+	// balance (NaN) also refuses the delete: not deleting is always the safe
+	// direction here.
+	if (!(credits <= 0)) {
+		throw new HTTPException(409, {
+			message: `"${org.name}" still has a positive credit balance (${org.credits ?? "0"}). Deleting is only allowed for organizations with zero or negative credits — zero out or refund the balance first, then handle this account manually.`,
+		});
+	}
+}
+
 // --- Set Organization Status ---
 
 const orgStatusSchema = z.enum(["active", "deleted"]);
@@ -6139,6 +6166,16 @@ const setOrganizationStatusRoute = createRoute({
 			},
 			description: "Organization not found.",
 		},
+		409: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Organization still has a positive credit balance.",
+		},
 	},
 });
 
@@ -6153,6 +6190,11 @@ admin.openapi(setOrganizationStatusRoute, async (c) => {
 
 	if (!org) {
 		throw new HTTPException(404, { message: "Organization not found" });
+	}
+
+	// Re-enabling is always allowed; only the destructive direction is gated.
+	if (status === "deleted") {
+		assertOrganizationDeletable(org);
 	}
 
 	const memberLinks = await db.query.userOrganization.findMany({
@@ -6280,6 +6322,16 @@ const blockOrganizationRoute = createRoute({
 			},
 			description: "Organization not found.",
 		},
+		409: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Organization still has a positive credit balance.",
+		},
 	},
 });
 
@@ -6306,6 +6358,10 @@ async function blockOrganizationById(
 	if (!org) {
 		throw new HTTPException(404, { message: "Organization not found" });
 	}
+
+	// Checked before any Stripe call so a paying organization is refused without
+	// its subscriptions being cancelled first.
+	assertOrganizationDeletable(org);
 
 	const subscriptionIds = [
 		org.stripeSubscriptionId,
@@ -6484,6 +6540,8 @@ interface BulkBlockCandidates {
  * - an empty or too-short search throws, so there is no unfiltered code path;
  * - the LIKE filter escapes wildcards, so "%" cannot match every row;
  * - organizations that are already blocked are excluded;
+ * - organizations that still hold credits are excluded, so a bulk block can
+ *   never sweep up a paying customer (see assertOrganizationDeletable);
  * - organizations the acting admin belongs to are excluded, so an admin can
  *   never lock themselves (or their own org's members) out;
  * - a filter resolving to more than MAX_BULK_BLOCK_ORGANIZATIONS throws rather
@@ -6526,6 +6584,7 @@ async function resolveBulkBlockCandidates(
 			isNull(tables.organization.status),
 			ne(tables.organization.status, "deleted"),
 		),
+		lte(tables.organization.credits, "0"),
 		adminOrgIds.length > 0
 			? notInArray(tables.organization.id, adminOrgIds)
 			: undefined,

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -30,6 +30,7 @@ import {
 	manageOrganization,
 	updateReferralBonus,
 } from "@/lib/admin-organizations";
+import { getOrgDeletionBlockedReason } from "@/lib/org-deletion";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 
@@ -301,7 +302,13 @@ export default async function OrganizationPage({
 						orgId={orgId}
 						orgName={org.name}
 						variant="full"
-						disabled={org.status === "deleted"}
+						disabled={
+							org.status === "deleted" ||
+							getOrgDeletionBlockedReason(org.credits) !== null
+						}
+						disabledReason={
+							getOrgDeletionBlockedReason(org.credits) ?? undefined
+						}
 						onBlock={async (id) => {
 							"use server";
 							return await blockOrganization(id);

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -28,6 +28,7 @@ import {
 	previewBulkBlockOrganizations,
 	setOrganizationStatus,
 } from "@/lib/admin-organizations";
+import { getOrgDeletionBlockedReason } from "@/lib/org-deletion";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
@@ -430,12 +431,21 @@ export default async function OrganizationsPage({
 												orgId={org.id}
 												orgName={org.name}
 												currentStatus={org.status}
+												disableBlockedReason={getOrgDeletionBlockedReason(
+													org.credits,
+												)}
 												onToggle={handleToggleOrgStatus}
 											/>
 											<BlockOrgButton
 												orgId={org.id}
 												orgName={org.name}
-												disabled={org.status === "deleted"}
+												disabled={
+													org.status === "deleted" ||
+													getOrgDeletionBlockedReason(org.credits) !== null
+												}
+												disabledReason={
+													getOrgDeletionBlockedReason(org.credits) ?? undefined
+												}
 												onBlock={handleBlockOrganization}
 											/>
 										</div>

--- a/ee/admin/src/components/block-org-button.tsx
+++ b/ee/admin/src/components/block-org-button.tsx
@@ -19,6 +19,12 @@ interface BlockOrgButtonProps {
 	orgId: string;
 	orgName: string;
 	disabled?: boolean;
+	/**
+	 * Why the button is disabled, surfaced as its tooltip. Set when an
+	 * organization still has credits so the admin sees that blocking is refused
+	 * on purpose rather than broken.
+	 */
+	disabledReason?: string;
 	variant?: "icon" | "full";
 	onBlock: (orgId: string) => Promise<{
 		success: boolean;
@@ -31,6 +37,7 @@ export function BlockOrgButton({
 	orgId,
 	orgName,
 	disabled,
+	disabledReason,
 	variant = "icon",
 	onBlock,
 }: BlockOrgButtonProps) {
@@ -74,7 +81,12 @@ export function BlockOrgButton({
 		>
 			<DialogTrigger asChild>
 				{variant === "full" ? (
-					<Button variant="destructive" size="sm" disabled={disabled}>
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={disabled}
+						title={disabled ? disabledReason : "Block account"}
+					>
 						<ShieldBan className="mr-1.5 h-4 w-4" />
 						Block account
 					</Button>
@@ -84,7 +96,7 @@ export function BlockOrgButton({
 						size="icon-sm"
 						className="text-destructive hover:text-destructive"
 						disabled={disabled}
-						title="Block account"
+						title={disabled ? disabledReason : "Block account"}
 					>
 						<ShieldBan className="h-4 w-4" />
 					</Button>

--- a/ee/admin/src/components/bulk-block-orgs-button.tsx
+++ b/ee/admin/src/components/bulk-block-orgs-button.tsx
@@ -175,7 +175,8 @@ export function BulkBlockOrgsButton({
 						<DialogDescription>
 							Blocking cancels every active Stripe subscription, marks each
 							organization as deleted, and deactivates members that have no
-							other active organization.
+							other active organization. Organizations with a positive credit
+							balance are never included — handle those manually.
 						</DialogDescription>
 					</DialogHeader>
 
@@ -201,8 +202,8 @@ export function BulkBlockOrgsButton({
 									{preview.skipped > 0 && (
 										<>
 											{" "}
-											{preview.skipped} skipped (already blocked, or your own
-											organizations).
+											{preview.skipped} skipped (already blocked, still holding
+											credits, or your own organizations).
 										</>
 									)}
 								</p>

--- a/ee/admin/src/components/org-status-toggle-button.tsx
+++ b/ee/admin/src/components/org-status-toggle-button.tsx
@@ -10,6 +10,12 @@ interface OrgStatusToggleButtonProps {
 	orgId: string;
 	orgName: string;
 	currentStatus: "active" | "deleted" | string | null | undefined;
+	/**
+	 * Why disabling is refused, surfaced as the tooltip. Set when the
+	 * organization still has credits. Only gates the disable direction —
+	 * re-enabling an already-disabled organization is always allowed.
+	 */
+	disableBlockedReason?: string | null;
 	onToggle: (
 		orgId: string,
 		status: "active" | "deleted",
@@ -20,6 +26,7 @@ export function OrgStatusToggleButton({
 	orgId,
 	orgName,
 	currentStatus,
+	disableBlockedReason,
 	onToggle,
 }: OrgStatusToggleButtonProps) {
 	const router = useRouter();
@@ -27,6 +34,7 @@ export function OrgStatusToggleButton({
 
 	const isDisabled = currentStatus === "deleted";
 	const nextStatus: "active" | "deleted" = isDisabled ? "active" : "deleted";
+	const blockedReason = isDisabled ? null : (disableBlockedReason ?? null);
 
 	const handleClick = async () => {
 		const verb = isDisabled ? "re-enable" : "disable";
@@ -58,13 +66,16 @@ export function OrgStatusToggleButton({
 			variant="ghost"
 			size="icon-sm"
 			onClick={handleClick}
-			disabled={loading}
+			disabled={loading || blockedReason !== null}
 			className={
 				isDisabled
 					? "text-emerald-600 hover:text-emerald-600"
 					: "text-amber-600 hover:text-amber-600"
 			}
-			title={isDisabled ? "Re-enable organization" : "Disable organization"}
+			title={
+				blockedReason ??
+				(isDisabled ? "Re-enable organization" : "Disable organization")
+			}
 		>
 			{loading ? (
 				<Loader2 className="h-4 w-4 animate-spin" />

--- a/ee/admin/src/lib/org-deletion.ts
+++ b/ee/admin/src/lib/org-deletion.ts
@@ -1,0 +1,35 @@
+const creditsFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+});
+
+/**
+ * Mirrors the server-side `assertOrganizationDeletable` guard in
+ * `apps/api/src/routes/admin.ts`: an organization that still holds credits is a
+ * paying customer and has to be handled manually instead of being deleted from
+ * the admin panel.
+ *
+ * This is a UI convenience only — the API re-checks the balance and rejects the
+ * disable/block/bulk-block endpoints with HTTP 409 regardless of what the
+ * dashboard renders.
+ *
+ * Returns the reason deletion is blocked, or null when the organization may be
+ * deleted.
+ */
+export function getOrgDeletionBlockedReason(
+	credits: string | null | undefined,
+): string | null {
+	const parsed = Number(credits ?? "0");
+
+	// `!(parsed <= 0)` rather than `parsed > 0` so an unparseable balance (NaN)
+	// also blocks: refusing to delete is the safe direction.
+	if (!(parsed <= 0)) {
+		return `Organization still has a positive credit balance (${
+			Number.isFinite(parsed)
+				? creditsFormatter.format(parsed)
+				: (credits ?? "unknown")
+		}). Zero out or refund it first, then handle this account manually.`;
+	}
+
+	return null;
+}


### PR DESCRIPTION
Deleting an organization from the admin panel is a fallback for abuse handling, not an account-closure tool. An organization that still holds credits is a paying customer, so it must never be swept up by an admin delete — the balance has to be spent, refunded, or zeroed deliberately first, and the account then handled manually.

## What changed

Every path that marks an organization `deleted` now funnels through a single `assertOrganizationDeletable` guard in `apps/api/src/routes/admin.ts` and rejects with **HTTP 409** when the organization's credit balance is positive. Zero or negative balances are unaffected.

| Path | Behavior |
| --- | --- |
| Single block — `POST /admin/organizations/{orgId}/block` | Refused with 409. Checked **before** any Stripe call, so a refusal never leaves subscriptions cancelled on an org that stays active. |
| Status toggle — `PATCH /admin/organizations/{orgId}/status` | Refused with 409 in the `deleted` direction only. Re-enabling (`active`) stays unconditional, so an org that is gifted credits after being disabled can still be restored. |
| Bulk block — `POST /admin/organizations/bulk-block` | Organizations with credits are excluded from `resolveBulkBlockCandidates`, so they count as *skipped* in the preview and the confirm-count check agrees with the mutation. The per-org guard still runs during the block loop, so a top-up landing between preview and confirm fails that one org into `failed` rather than deleting it. |

The balance check is written as `!(credits <= 0)` rather than `credits > 0` so an unparseable balance also refuses the delete — not deleting is the safe direction.

### Scope note

The status toggle wasn't named in the request, but it sets the same `status: "deleted"` (and logs `organization.delete`), so leaving it open would have made the guard bypassable with the button right next to it. Happy to drop that part if you'd rather keep the toggle unrestricted.

### Admin dashboard

The dashboard mirrors the rule as a UX convenience — enforcement is server-side regardless of what the UI renders:

- New `ee/admin/src/lib/org-deletion.ts` helper returns the reason deletion is blocked, or null.
- Block and status-toggle buttons on the organizations list and the org detail page are disabled for organizations with credits, with the reason as their tooltip.
- The bulk-block dialog states that organizations with a positive balance are never included, and the skipped-count copy now lists "still holding credits" alongside the existing reasons.

## Testing

- New `apps/api/src/routes/admin-org-delete-credits.spec.ts` — 8 tests covering refusal on positive credits for both single block and status toggle, success at zero and negative balances, that re-enabling still works after a post-block credit gift, and that a refused block leaves members active.
- `apps/api/src/routes/admin-bulk-block.spec.ts` — 2 new tests: credit-holding orgs are excluded from the preview and are never blocked by a bulk run.
- `pnpm exec vitest run --no-file-parallelism apps/api/src/routes` → 377 passed, 1 skipped.
- `pnpm build` and `pnpm lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcFa59wVqaes2t8bXZEjNN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations with positive or invalid credit balances can no longer be blocked or deleted.
  * Bulk-block actions automatically exclude organizations that still hold credits.
  * Admin controls explain why an organization cannot be blocked or deleted.
  * Organizations with zero or negative balances remain eligible for deletion.
  * Reactivation remains available after credits are added.

* **Bug Fixes**
  * Prevented destructive actions and subscription cancellation when organizations retain credits.
  * Improved handling of deletion attempts that are not allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->