### PR TITLE
feat(security): gateway secret keyring groundwork

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,9 @@ SSO_ENABLED=false
 # Secret used to HMAC-hash logged upstream provider API keys, and to derive the
 # AES-256-GCM data key that encrypts BYOK provider tokens at rest.
 # Required in production. Generate with: openssl rand -base64 32
+# Accepts a comma-separated keyring (newest first) during secret rotation:
+# the first entry signs/encrypts everything new, older entries are only used
+# to decrypt provider-key ciphertexts written before the rotation.
 GATEWAY_API_KEY_HASH_SECRET=your-api-key-hash-secret-here
 
 # Custom/BYOK provider base URLs AND user-supplied content URLs (image/video

--- a/.env.unified.example
+++ b/.env.unified.example
@@ -11,7 +11,10 @@ POSTGRES_PASSWORD=your_secure_password_here
 # Authentication secret (must be at least 32 characters, generate with: openssl rand -base64 32)
 AUTH_SECRET=your-secret-key-here-must-be-32+
 
-# Secret used to HMAC-hash logged upstream provider API keys
+# Secret used to HMAC-hash logged upstream provider API keys and to encrypt
+# BYOK provider tokens at rest. Accepts a comma-separated keyring (newest
+# first) during secret rotation; older entries only decrypt existing
+# provider-key ciphertexts.
 GATEWAY_API_KEY_HASH_SECRET=your-api-key-hash-secret-here
 
 # =============================================================================

--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -99,7 +99,7 @@ describe("admin provider credentials", () => {
 		const [row] = await db.query.providerKey.findMany({
 			where: { managed: { eq: true } },
 		});
-		expect(row.tokenCiphertext).toMatch(/^llmgw:v1:/);
+		expect(row.tokenCiphertext).toMatch(/^llmgw:v2:/);
 		expect(
 			decryptProviderKey(row.tokenCiphertext!, row.id, "llmgateway:managed"),
 		).toBe("sk-encrypt-me");

--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -208,7 +208,7 @@ describe(
 				// and the ciphertext decrypts back to the submitted key.
 				// eslint-disable-next-line no-restricted-syntax
 				expect(providerKey?.token).toBeNull();
-				expect(providerKey?.tokenCiphertext).toMatch(/^llmgw:v1:/);
+				expect(providerKey?.tokenCiphertext).toMatch(/^llmgw:v2:/);
 				expect(readProviderKey(providerKey!)).toBe(envVarValue);
 			},
 		);

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -143,7 +143,7 @@ describe("provider keys route", () => {
 		// this test, so it is one of the few places allowed to read it directly.
 		// eslint-disable-next-line no-restricted-syntax
 		expect(providerKey?.token).toBeNull();
-		expect(providerKey?.tokenCiphertext).toMatch(/^llmgw:v1:/);
+		expect(providerKey?.tokenCiphertext).toMatch(/^llmgw:v2:/);
 		expect(providerKey?.tokenMasked).toBeTruthy();
 		expect(providerKey?.tokenMasked).not.toBe("inference-test-token");
 	});
@@ -166,7 +166,7 @@ describe("provider keys route", () => {
 		const row = await db.query.providerKey.findFirst({
 			where: { provider: { eq: "inference.net" } },
 		});
-		expect(row?.tokenCiphertext).toMatch(/^llmgw:v1:/);
+		expect(row?.tokenCiphertext).toMatch(/^llmgw:v2:/);
 
 		// Correct row id + org → decrypts.
 		expect(

--- a/apps/api/src/routes/v1-master-custom-catalog.spec.ts
+++ b/apps/api/src/routes/v1-master-custom-catalog.spec.ts
@@ -104,7 +104,7 @@ describe("v1/master custom providers and models", () => {
 		// Stored encrypted at rest: the legacy plaintext column stays NULL and
 		// the ciphertext decrypts back to the submitted token.
 		expect(stored?.token).toBeNull();
-		expect(stored?.tokenCiphertext).toMatch(/^llmgw:v1:/);
+		expect(stored?.tokenCiphertext).toMatch(/^llmgw:v2:/);
 		expect(readProviderKey(stored!)).toBe("sk-acme-secret");
 	});
 

--- a/docs/internal/2026-05-21-byok.md
+++ b/docs/internal/2026-05-21-byok.md
@@ -93,6 +93,12 @@ data_key   = HKDF-SHA256(master_key, salt=null, info="provider-key-token:v1", le
 
 No new env var: this reuses the existing `GATEWAY_API_KEY_HASH_SECRET`, which is already provisioned for gateway, API, and worker in every deployment. The HKDF `info` string domain-separates the encryption data key from the API-key fingerprint HMAC that uses the same secret. Like `getApiKeyHashSecret()`, the secret is only required in production; outside production a fixed dev secret is used so builds, CI, and local runs work with no configuration.
 
+### Secret rotation groundwork
+
+`GATEWAY_API_KEY_HASH_SECRET` accepts a comma-separated keyring, newest first (`getApiKeyHashSecrets()`). The first entry is the current secret: all fingerprint HMACs and all new encryptions use it. New ciphertexts are written as `llmgw:v2:<kid>:<iv>:<ct>:<tag>`, where `kid` is an HKDF-derived 8-hex-char id of the encrypting secret (`getSecretKeyId()`), so decryption picks the right keyring entry directly and reports precisely when a needed secret has been dropped. Legacy `llmgw:v1` ciphertexts (no key id) are trial-decrypted against every keyring entry.
+
+To rotate: prepend the new secret to the keyring on all services, re-encrypt existing `token_ciphertext` rows (backfill tooling not built yet — decrypt-with-old/encrypt-with-new), then drop the old entry. NOT yet rotation-safe: persisted HMAC lookups (`master_key.tokenHash`, `scim_token.tokenHash`) and historical `log.usedApiKeyHash` attribution are matched against the current secret only; multi-secret lookup / lazy re-stamping is deferred until a rotation is actually needed.
+
 ---
 
 ### Write path

--- a/packages/actions/src/provider-key/crypto.spec.ts
+++ b/packages/actions/src/provider-key/crypto.spec.ts
@@ -1,6 +1,8 @@
-import { randomBytes } from "node:crypto";
+import { createCipheriv, hkdfSync, randomBytes } from "node:crypto";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getSecretKeyId } from "@llmgateway/shared/api-key-hash";
 
 import {
 	decryptProviderKey,
@@ -23,6 +25,39 @@ const ORIGINAL_KEY = process.env[ENV_VAR];
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 const VALID_KEY_A = randomBytes(32).toString("base64");
 const VALID_KEY_B = randomBytes(32).toString("base64");
+
+/**
+ * Reimplements the retired llmgw:v1 write path (same HKDF/AES-GCM/AAD
+ * primitives, no key id) so tests can cover rows written before v2 shipped.
+ */
+function encryptV1(
+	secret: string,
+	plaintext: string,
+	rowId: string,
+	organizationId: string,
+): string {
+	const dataKey = Buffer.from(
+		hkdfSync(
+			"sha256",
+			Buffer.from(secret, "utf8"),
+			Buffer.alloc(0),
+			Buffer.from("provider-key-token:v1", "utf8"),
+			32,
+		),
+	);
+	const iv = randomBytes(12);
+	const cipher = createCipheriv("aes-256-gcm", dataKey, iv);
+	cipher.setAAD(Buffer.from(`provider_key|${rowId}|${organizationId}`, "utf8"));
+	const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+	const tag = cipher.getAuthTag();
+	const b64 = (buf: Buffer) =>
+		buf
+			.toString("base64")
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+	return ["llmgw:v1", b64(iv), b64(ct), b64(tag)].join(":");
+}
 
 afterEach(() => {
 	setMasterKey(ORIGINAL_KEY);
@@ -58,10 +93,12 @@ describe("master secret resolution", () => {
 });
 
 describe("encryptProviderKey / decryptProviderKey", () => {
-	it("round-trips a plaintext token", () => {
+	it("round-trips a plaintext token as llmgw:v2 stamped with the current key id", () => {
 		const plaintext = "sk-test-abc123def456";
 		const ct = encryptProviderKey(plaintext, "row-id-1", "org-1");
-		expect(ct.startsWith("llmgw:v1:")).toBe(true);
+		expect(ct.startsWith(`llmgw:v2:${getSecretKeyId(VALID_KEY_A)}:`)).toBe(
+			true,
+		);
 		expect(decryptProviderKey(ct, "row-id-1", "org-1")).toBe(plaintext);
 	});
 
@@ -87,9 +124,9 @@ describe("encryptProviderKey / decryptProviderKey", () => {
 	it("rejects a tampered ciphertext byte (GCM tag check)", () => {
 		const ct = encryptProviderKey("sk-test-tamper", "row-id-1", "org-1");
 		const parts = ct.split(":");
-		const flipped = Array.from(parts[3]);
+		const flipped = Array.from(parts[4]);
 		flipped[0] = flipped[0] === "A" ? "B" : "A";
-		parts[3] = flipped.join("");
+		parts[4] = flipped.join("");
 		const tampered = parts.join(":");
 		expect(() => decryptProviderKey(tampered, "row-id-1", "org-1")).toThrow();
 	});
@@ -97,29 +134,37 @@ describe("encryptProviderKey / decryptProviderKey", () => {
 	it("rejects a tampered auth tag", () => {
 		const ct = encryptProviderKey("sk-test-tag", "row-id-1", "org-1");
 		const parts = ct.split(":");
-		const flipped = Array.from(parts[4]);
+		const flipped = Array.from(parts[5]);
 		flipped[0] = flipped[0] === "A" ? "B" : "A";
-		parts[4] = flipped.join("");
+		parts[5] = flipped.join("");
 		expect(() =>
 			decryptProviderKey(parts.join(":"), "row-id-1", "org-1"),
 		).toThrow();
 	});
 
-	it("rejects ciphertext encrypted with a different master key", () => {
+	it("rejects ciphertext whose key id was dropped from the keyring", () => {
 		const ct = encryptProviderKey("sk-test-key-rotate", "row-id-1", "org-1");
 		setMasterKey(VALID_KEY_B);
-		expect(() => decryptProviderKey(ct, "row-id-1", "org-1")).toThrow();
+		expect(() => decryptProviderKey(ct, "row-id-1", "org-1")).toThrow(
+			/not in the GATEWAY_API_KEY_HASH_SECRET keyring/,
+		);
 	});
 
 	it("rejects an unknown version prefix", () => {
 		expect(() =>
-			decryptProviderKey("llmgw:v2:aaa:bbb:ccc", "row-id-1", "org-1"),
+			decryptProviderKey("llmgw:v3:aaa:bbb:ccc", "row-id-1", "org-1"),
 		).toThrow(/unknown ciphertext version/);
 	});
 
-	it("rejects malformed shape (wrong segment count)", () => {
+	it("rejects malformed v1 shape (wrong segment count)", () => {
 		expect(() =>
 			decryptProviderKey("llmgw:v1:onlytwo:parts", "row-id-1", "org-1"),
+		).toThrow(/malformed ciphertext/);
+	});
+
+	it("rejects malformed v2 shape (wrong segment count)", () => {
+		expect(() =>
+			decryptProviderKey("llmgw:v2:kid:iv:ct", "row-id-1", "org-1"),
 		).toThrow(/malformed ciphertext/);
 	});
 
@@ -133,10 +178,55 @@ describe("encryptProviderKey / decryptProviderKey", () => {
 		const ct = encryptProviderKey("sk-test", "row-id-1", "org-1");
 		const parts = ct.split(":");
 		// Substitute a too-short iv
-		parts[2] = Buffer.from("short").toString("base64url");
+		parts[3] = Buffer.from("short").toString("base64url");
 		expect(() =>
 			decryptProviderKey(parts.join(":"), "row-id-1", "org-1"),
 		).toThrow(/invalid iv length/);
+	});
+});
+
+describe("secret keyring rotation", () => {
+	it("decrypts a v2 ciphertext written under the previous secret after rotation", () => {
+		const ct = encryptProviderKey("sk-rotate-v2", "row-id-1", "org-1");
+		setMasterKey(`${VALID_KEY_B},${VALID_KEY_A}`);
+		expect(decryptProviderKey(ct, "row-id-1", "org-1")).toBe("sk-rotate-v2");
+	});
+
+	it("stamps new ciphertexts with the current (first) secret after rotation", () => {
+		setMasterKey(`${VALID_KEY_B},${VALID_KEY_A}`);
+		const ct = encryptProviderKey("sk-rotate-new", "row-id-1", "org-1");
+		expect(ct.startsWith(`llmgw:v2:${getSecretKeyId(VALID_KEY_B)}:`)).toBe(
+			true,
+		);
+		setMasterKey(VALID_KEY_B);
+		expect(decryptProviderKey(ct, "row-id-1", "org-1")).toBe("sk-rotate-new");
+	});
+
+	it("still enforces AAD scope for previous-secret ciphertexts", () => {
+		const ct = encryptProviderKey("sk-rotate-aad", "row-id-1", "org-1");
+		setMasterKey(`${VALID_KEY_B},${VALID_KEY_A}`);
+		expect(() => decryptProviderKey(ct, "row-id-1", "org-2")).toThrow(
+			/decryption failed for key id/,
+		);
+	});
+
+	it("decrypts a legacy v1 ciphertext with the current secret", () => {
+		const ct = encryptV1(VALID_KEY_A, "sk-legacy-v1", "row-id-1", "org-1");
+		expect(decryptProviderKey(ct, "row-id-1", "org-1")).toBe("sk-legacy-v1");
+	});
+
+	it("decrypts a legacy v1 ciphertext via a previous keyring secret", () => {
+		const ct = encryptV1(VALID_KEY_A, "sk-legacy-v1", "row-id-1", "org-1");
+		setMasterKey(`${VALID_KEY_B},${VALID_KEY_A}`);
+		expect(decryptProviderKey(ct, "row-id-1", "org-1")).toBe("sk-legacy-v1");
+	});
+
+	it("rejects a legacy v1 ciphertext once its secret leaves the keyring", () => {
+		const ct = encryptV1(VALID_KEY_A, "sk-legacy-v1", "row-id-1", "org-1");
+		setMasterKey(VALID_KEY_B);
+		expect(() => decryptProviderKey(ct, "row-id-1", "org-1")).toThrow(
+			/decryption failed with all 1 keyring secret/,
+		);
 	});
 });
 
@@ -146,10 +236,14 @@ describe("isProviderKeyCiphertext", () => {
 		expect(isProviderKeyCiphertext(ct)).toBe(true);
 	});
 
-	it("returns false for plain strings", () => {
+	it("returns true for legacy v1 ciphertexts", () => {
+		expect(isProviderKeyCiphertext("llmgw:v1:aaa:bbb:ccc")).toBe(true);
+	});
+
+	it("returns false for plain strings and unknown versions", () => {
 		expect(isProviderKeyCiphertext("sk-abc123")).toBe(false);
 		expect(isProviderKeyCiphertext("")).toBe(false);
-		expect(isProviderKeyCiphertext("llmgw:v2:something")).toBe(false);
+		expect(isProviderKeyCiphertext("llmgw:v3:something")).toBe(false);
 	});
 });
 

--- a/packages/actions/src/provider-key/crypto.ts
+++ b/packages/actions/src/provider-key/crypto.ts
@@ -5,14 +5,24 @@ import {
 	randomBytes,
 } from "node:crypto";
 
-import { getApiKeyHashSecret } from "@llmgateway/shared/api-key-hash";
+import {
+	getApiKeyHashSecret,
+	getApiKeyHashSecrets,
+	getSecretKeyId,
+} from "@llmgateway/shared/api-key-hash";
 
 const ALGORITHM = "aes-256-gcm";
 const IV_BYTES = 12;
 const TAG_BYTES = 16;
 const KEY_BYTES = 32;
 
-const FORMAT_PREFIX = "llmgw:v1:";
+// v1: llmgw:v1:<iv>:<ct>:<tag> — no key id; decryption trial-decrypts against
+// every keyring secret. Only rows written before v2 shipped carry this format.
+// v2: llmgw:v2:<kid>:<iv>:<ct>:<tag> — kid names the keyring secret that
+// encrypted the row (see getSecretKeyId), so a rotated deployment can pick the
+// right secret directly and report precisely when it has been dropped too early.
+const FORMAT_PREFIX_V1 = "llmgw:v1:";
+const FORMAT_PREFIX_V2 = "llmgw:v2:";
 const HKDF_INFO_PROVIDER_KEY_TOKEN = "provider-key-token:v1";
 
 function decodeBase64UrlNoPad(input: string): Buffer {
@@ -30,14 +40,15 @@ function encodeBase64UrlNoPad(buf: Buffer): string {
 }
 
 /**
- * Derives the provider-key data key from the gateway's shared secret
- * (GATEWAY_API_KEY_HASH_SECRET). The HKDF info string domain-separates it from
- * the API-key fingerprint HMAC, so the two uses never share key material.
+ * Derives the provider-key data key from a gateway secret (an entry of the
+ * GATEWAY_API_KEY_HASH_SECRET keyring). The HKDF info string domain-separates
+ * it from the API-key fingerprint HMAC, so the two uses never share key
+ * material.
  */
-function getDataKey(): Buffer {
+function getDataKey(secret: string): Buffer {
 	const derived = hkdfSync(
 		"sha256",
-		Buffer.from(getApiKeyHashSecret(), "utf8"),
+		Buffer.from(secret, "utf8"),
 		Buffer.alloc(0),
 		Buffer.from(HKDF_INFO_PROVIDER_KEY_TOKEN, "utf8"),
 		KEY_BYTES,
@@ -51,50 +62,44 @@ function buildAad(rowId: string, organizationId: string): Buffer {
 
 /**
  * Encrypts a provider key plaintext for storage in provider_key.token_ciphertext.
- * AAD binds the ciphertext to the row id and organization id; copying the
- * ciphertext to another row or another org will fail GCM verification on decrypt.
+ * Always encrypts with the current (first) keyring secret and stamps its key id
+ * into the llmgw:v2 format. AAD binds the ciphertext to the row id and
+ * organization id; copying the ciphertext to another row or another org will
+ * fail GCM verification on decrypt.
  */
 export function encryptProviderKey(
 	plaintext: string,
 	rowId: string,
 	organizationId: string,
 ): string {
+	const secret = getApiKeyHashSecret();
 	const iv = randomBytes(IV_BYTES);
 	const aad = buildAad(rowId, organizationId);
-	const cipher = createCipheriv(ALGORITHM, getDataKey(), iv);
+	const cipher = createCipheriv(ALGORITHM, getDataKey(secret), iv);
 	cipher.setAAD(aad);
 	const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
 	const tag = cipher.getAuthTag();
 	return [
-		FORMAT_PREFIX.slice(0, -1),
+		FORMAT_PREFIX_V2.slice(0, -1),
+		getSecretKeyId(secret),
 		encodeBase64UrlNoPad(iv),
 		encodeBase64UrlNoPad(ct),
 		encodeBase64UrlNoPad(tag),
 	].join(":");
 }
 
-/**
- * Decrypts a provider key ciphertext produced by encryptProviderKey.
- * Throws on any failure (unknown prefix, wrong shape, tag mismatch, wrong AAD).
- * Callers must not fall back to plaintext on failure.
- */
-export function decryptProviderKey(
-	ciphertext: string,
+interface CiphertextParts {
+	iv: Buffer;
+	ct: Buffer;
+	tag: Buffer;
+}
+
+function parseParts(
 	rowId: string,
-	organizationId: string,
-): string {
-	if (!ciphertext.startsWith(FORMAT_PREFIX)) {
-		throw new Error(
-			`provider_key ${rowId}: unknown ciphertext version (expected ${FORMAT_PREFIX} prefix)`,
-		);
-	}
-	const parts = ciphertext.split(":");
-	if (parts.length !== 5) {
-		throw new Error(
-			`provider_key ${rowId}: malformed ciphertext (expected 5 colon-separated parts, got ${parts.length})`,
-		);
-	}
-	const [, , ivB64, ctB64, tagB64] = parts;
+	ivB64: string,
+	ctB64: string,
+	tagB64: string,
+): CiphertextParts {
 	const iv = decodeBase64UrlNoPad(ivB64);
 	const ct = decodeBase64UrlNoPad(ctB64);
 	const tag = decodeBase64UrlNoPad(tagB64);
@@ -108,19 +113,109 @@ export function decryptProviderKey(
 			`provider_key ${rowId}: invalid tag length ${tag.length}, expected ${TAG_BYTES}`,
 		);
 	}
-	const aad = buildAad(rowId, organizationId);
-	const decipher = createDecipheriv(ALGORITHM, getDataKey(), iv);
+	return { iv, ct, tag };
+}
+
+function decryptWithSecret(
+	secret: string,
+	parts: CiphertextParts,
+	aad: Buffer,
+): string {
+	const decipher = createDecipheriv(ALGORITHM, getDataKey(secret), parts.iv);
 	decipher.setAAD(aad);
-	decipher.setAuthTag(tag);
-	const pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+	decipher.setAuthTag(parts.tag);
+	const pt = Buffer.concat([decipher.update(parts.ct), decipher.final()]);
 	return pt.toString("utf8");
 }
 
+function decryptWithCandidates(
+	rowId: string,
+	secrets: string[],
+	parts: CiphertextParts,
+	aad: Buffer,
+	exhaustedMessage: string,
+): string {
+	for (const secret of secrets) {
+		try {
+			return decryptWithSecret(secret, parts, aad);
+		} catch {
+			// GCM tag mismatch — wrong keyring entry, tampering, or wrong AAD
+			// scope; indistinguishable here, so try the next candidate.
+		}
+	}
+	throw new Error(`provider_key ${rowId}: ${exhaustedMessage}`);
+}
+
 /**
- * Returns true if the given string looks like a llmgw:v1: ciphertext.
+ * Decrypts a provider key ciphertext produced by encryptProviderKey.
+ * Throws on any failure (unknown prefix, wrong shape, unknown key id, tag
+ * mismatch, wrong AAD). Callers must not fall back to plaintext on failure.
+ *
+ * llmgw:v2 ciphertexts resolve their keyring secret by the embedded key id;
+ * legacy llmgw:v1 ciphertexts are trial-decrypted against every keyring entry.
+ */
+export function decryptProviderKey(
+	ciphertext: string,
+	rowId: string,
+	organizationId: string,
+): string {
+	const aad = buildAad(rowId, organizationId);
+	const secrets = getApiKeyHashSecrets();
+
+	if (ciphertext.startsWith(FORMAT_PREFIX_V2)) {
+		const parts = ciphertext.split(":");
+		if (parts.length !== 6) {
+			throw new Error(
+				`provider_key ${rowId}: malformed ciphertext (expected 6 colon-separated parts, got ${parts.length})`,
+			);
+		}
+		const [, , kid, ivB64, ctB64, tagB64] = parts;
+		const candidates = secrets.filter(
+			(secret) => getSecretKeyId(secret) === kid,
+		);
+		if (candidates.length === 0) {
+			throw new Error(
+				`provider_key ${rowId}: encrypted with key id ${kid}, which is not in the GATEWAY_API_KEY_HASH_SECRET keyring (was the old secret removed before re-encrypting?)`,
+			);
+		}
+		return decryptWithCandidates(
+			rowId,
+			candidates,
+			parseParts(rowId, ivB64, ctB64, tagB64),
+			aad,
+			`decryption failed for key id ${kid} (tampered ciphertext or wrong row/org scope)`,
+		);
+	}
+
+	if (ciphertext.startsWith(FORMAT_PREFIX_V1)) {
+		const parts = ciphertext.split(":");
+		if (parts.length !== 5) {
+			throw new Error(
+				`provider_key ${rowId}: malformed ciphertext (expected 5 colon-separated parts, got ${parts.length})`,
+			);
+		}
+		const [, , ivB64, ctB64, tagB64] = parts;
+		return decryptWithCandidates(
+			rowId,
+			secrets,
+			parseParts(rowId, ivB64, ctB64, tagB64),
+			aad,
+			`decryption failed with all ${secrets.length} keyring secret(s) (rotated-out secret, tampered ciphertext, or wrong row/org scope)`,
+		);
+	}
+
+	throw new Error(
+		`provider_key ${rowId}: unknown ciphertext version (expected ${FORMAT_PREFIX_V1} or ${FORMAT_PREFIX_V2} prefix)`,
+	);
+}
+
+/**
+ * Returns true if the given string looks like a llmgw:v1/v2 ciphertext.
  * This is a cheap shape check used at the API/UI boundary only;
  * the gateway's read path keys off column nullity, not this predicate.
  */
 export function isProviderKeyCiphertext(value: string): boolean {
-	return value.startsWith(FORMAT_PREFIX);
+	return (
+		value.startsWith(FORMAT_PREFIX_V1) || value.startsWith(FORMAT_PREFIX_V2)
+	);
 }

--- a/packages/actions/src/provider-key/read.spec.ts
+++ b/packages/actions/src/provider-key/read.spec.ts
@@ -73,7 +73,7 @@ describe("readProviderKey", () => {
 			id: ROW_ID,
 			organizationId: ORG_ID,
 			token: "fallback-not-allowed",
-			tokenCiphertext: "llmgw:v2:aaa:bbb:ccc",
+			tokenCiphertext: "llmgw:v3:aaa:bbb:ccc",
 		};
 		expect(() => readProviderKey(row)).toThrow(/unknown ciphertext version/);
 	});

--- a/packages/shared/src/api-key-hash.spec.ts
+++ b/packages/shared/src/api-key-hash.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	getApiKeyFingerprint,
+	getApiKeyHashSecret,
+	getApiKeyHashSecrets,
+	getSecretKeyId,
+} from "./api-key-hash.js";
+
+const ENV_VAR = "GATEWAY_API_KEY_HASH_SECRET";
+const ORIGINAL_SECRET = process.env[ENV_VAR];
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function setSecret(value: string | undefined) {
+	if (value === undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+		delete process.env[ENV_VAR];
+	} else {
+		process.env[ENV_VAR] = value;
+	}
+}
+
+afterEach(() => {
+	setSecret(ORIGINAL_SECRET);
+	process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+});
+
+describe("getApiKeyHashSecrets", () => {
+	it("returns a single-entry keyring for a plain secret", () => {
+		setSecret("secret-a");
+		expect(getApiKeyHashSecrets()).toEqual(["secret-a"]);
+	});
+
+	it("splits a comma-separated keyring, newest first", () => {
+		setSecret("secret-new,secret-old");
+		expect(getApiKeyHashSecrets()).toEqual(["secret-new", "secret-old"]);
+	});
+
+	it("trims whitespace and drops empty entries", () => {
+		setSecret(" secret-new , secret-old ,, ");
+		expect(getApiKeyHashSecrets()).toEqual(["secret-new", "secret-old"]);
+	});
+
+	it("falls back to the dev secret outside production", () => {
+		setSecret(undefined);
+		expect(getApiKeyHashSecrets()).toEqual([
+			"llmgateway-dev-api-key-hash-secret",
+		]);
+	});
+
+	it("throws in production when unset or effectively empty", () => {
+		process.env.NODE_ENV = "production";
+		setSecret(undefined);
+		expect(() => getApiKeyHashSecrets()).toThrow(/required in production/);
+		setSecret(" , ");
+		expect(() => getApiKeyHashSecrets()).toThrow(/required in production/);
+	});
+});
+
+describe("getApiKeyHashSecret / getApiKeyFingerprint", () => {
+	it("uses the first keyring entry as the current secret", () => {
+		setSecret("secret-new,secret-old");
+		expect(getApiKeyHashSecret()).toBe("secret-new");
+	});
+
+	it("computes fingerprints with the current secret only", () => {
+		setSecret("secret-new");
+		const current = getApiKeyFingerprint("llmgtwy_token");
+		setSecret("secret-new,secret-old");
+		expect(getApiKeyFingerprint("llmgtwy_token")).toBe(current);
+		setSecret("secret-old");
+		expect(getApiKeyFingerprint("llmgtwy_token")).not.toBe(current);
+	});
+});
+
+describe("getSecretKeyId", () => {
+	it("is stable for the same secret and 8 hex chars long", () => {
+		expect(getSecretKeyId("secret-a")).toBe(getSecretKeyId("secret-a"));
+		expect(getSecretKeyId("secret-a")).toMatch(/^[0-9a-f]{8}$/);
+	});
+
+	it("differs across secrets and never echoes the secret", () => {
+		expect(getSecretKeyId("secret-a")).not.toBe(getSecretKeyId("secret-b"));
+		expect(getSecretKeyId("secret-a")).not.toContain("secret-a");
+	});
+});

--- a/packages/shared/src/api-key-hash.ts
+++ b/packages/shared/src/api-key-hash.ts
@@ -1,7 +1,10 @@
-import { createHmac } from "node:crypto";
+import { createHmac, hkdfSync } from "node:crypto";
 
 const API_KEY_HASH_SECRET_ENV = "GATEWAY_API_KEY_HASH_SECRET";
 const DEV_API_KEY_HASH_SECRET = "llmgateway-dev-api-key-hash-secret";
+
+const SECRET_KEY_ID_HKDF_INFO = "gateway-secret-key-id:v1";
+const SECRET_KEY_ID_BYTES = 4;
 
 export const GATEWAY_API_KEY_PREFIX_PROD = "llmgtwy_";
 export const GATEWAY_API_KEY_PREFIX_DEV = "llmgdev_";
@@ -9,10 +12,28 @@ export const GATEWAY_API_KEY_PREFIX_DEV = "llmgdev_";
 export const MASTER_KEY_PREFIX_PROD = "llmgmk_";
 export const MASTER_KEY_PREFIX_DEV = "llmgmkdev_";
 
-export function getApiKeyHashSecret(): string {
-	const configuredSecret = process.env[API_KEY_HASH_SECRET_ENV]?.trim();
-	if (configuredSecret) {
-		return configuredSecret;
+/**
+ * Returns the gateway secret keyring, newest first.
+ *
+ * GATEWAY_API_KEY_HASH_SECRET holds one or more comma-separated secrets. The
+ * first entry is the CURRENT secret: every new HMAC fingerprint and every new
+ * provider-key encryption uses it. Older entries exist only so provider-key
+ * ciphertexts written under a previous secret stay decryptable during a
+ * rotation (rotate by prepending the new secret, keep the old one until all
+ * ciphertexts are re-encrypted, then drop it).
+ *
+ * Rotation is currently supported for provider-key ciphertexts only. Persisted
+ * HMAC lookups (master_key.tokenHash, scim_token.tokenHash, log.usedApiKeyHash)
+ * are computed and matched with the current secret alone — rotating the secret
+ * invalidates those hashes until multi-secret lookup / re-stamping ships.
+ */
+export function getApiKeyHashSecrets(): string[] {
+	const secrets = (process.env[API_KEY_HASH_SECRET_ENV] ?? "")
+		.split(",")
+		.map((secret) => secret.trim())
+		.filter(Boolean);
+	if (secrets.length > 0) {
+		return secrets;
 	}
 
 	if (process.env.NODE_ENV === "production") {
@@ -21,7 +42,30 @@ export function getApiKeyHashSecret(): string {
 		);
 	}
 
-	return DEV_API_KEY_HASH_SECRET;
+	return [DEV_API_KEY_HASH_SECRET];
+}
+
+/** The current (newest) gateway secret. See getApiKeyHashSecrets(). */
+export function getApiKeyHashSecret(): string {
+	return getApiKeyHashSecrets()[0];
+}
+
+/**
+ * Short stable identifier for a gateway secret, embedded in provider-key
+ * ciphertexts (llmgw:v2) so decryption can pick the right keyring entry
+ * without trial decryption. One-way (HKDF with its own info string), so the
+ * id stored in the database reveals nothing about the secret itself.
+ */
+export function getSecretKeyId(secret: string): string {
+	return Buffer.from(
+		hkdfSync(
+			"sha256",
+			Buffer.from(secret, "utf8"),
+			Buffer.alloc(0),
+			Buffer.from(SECRET_KEY_ID_HKDF_INFO, "utf8"),
+			SECRET_KEY_ID_BYTES,
+		),
+	).toString("hex");
 }
 
 export function getApiKeyFingerprint(token: string): string {


### PR DESCRIPTION
## Summary

Groundwork for rotating `GATEWAY_API_KEY_HASH_SECRET`, laid now while all provider-key ciphertexts are still a single generation. Full rotation machinery (ciphertext backfill, multi-secret HMAC lookup / lazy re-stamping) is deliberately deferred until a rotation is actually needed.

**Stacked on #3234** (targets its branch, not `main`), since the provider-key crypto module only exists there. It will retarget to `main` automatically when #3234 merges.

## What changed

- **Secret keyring** — `GATEWAY_API_KEY_HASH_SECRET` now accepts a comma-separated list, newest first (`getApiKeyHashSecrets()` in `packages/shared`). The first entry is the current secret: all fingerprint HMACs, prompt-cache-key hashing, and new encryptions use it exclusively, so existing single-secret deployments behave identically.
- **Versioned ciphertext format** — new provider-key encryptions are written as `llmgw:v2:<kid>:<iv>:<ct>:<tag>`, where `kid` is an HKDF-derived 8-hex-char id of the encrypting secret (`getSecretKeyId()`, one-way, reveals nothing about the secret). Decryption resolves the keyring entry by key id and reports precisely when a needed secret was dropped from the keyring, instead of a bare GCM failure.
- **Legacy v1 decrypt** — existing `llmgw:v1` ciphertexts (no key id) are trial-decrypted against every keyring entry, so even pre-v2 rows survive a rotation as long as the old secret stays in the keyring.
- **Docs** — keyring semantics in `.env.example` / `.env.unified.example`, and a rotation-groundwork section in `docs/internal/2026-05-21-byok.md` documenting the procedure and what is explicitly NOT yet rotation-safe (`master_key.tokenHash`, `scim_token.tokenHash`, historical `log.usedApiKeyHash`).

## Verification

- New keyring spec (`packages/shared/src/api-key-hash.spec.ts`) and expanded crypto spec: rotation round-trips for v2 and legacy v1, key-id stamping, dropped-secret errors, AAD scope enforcement under previous secrets — 72 tests green.
- Affected API route suites (keys-provider, admin credentials, master custom catalog — 91 tests) pass against the v2 write format.
- `pnpm format` clean, full `pnpm build` 17/17 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)