### PR TITLE
fix(models): correct kimi-k3 reasoning efforts on moonshot

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -659,8 +659,8 @@ export const moonshotModels = [
 				reasoning: true,
 				// K3 always thinks; the effort level is set via the native
 				// top-level `reasoning_effort` field (no K2-era `thinking`
-				// toggle), which currently accepts only "max".
-				reasoningEfforts: ["max"],
+				// toggle), which accepts low, high, and max (default max).
+				reasoningEfforts: ["low", "high", "max"],
 				streaming: true,
 				vision: true,
 				tools: true,


### PR DESCRIPTION
## Summary

Corrects an existing wrong value: `moonshot/kimi-k3`'s `reasoningEfforts` was declared as `["max"]` only. Moonshot's own docs confirm three values are supported.

## Fix

`["max"]` → `["low", "high", "max"]` (default: max)

Sources (3 independent, all Moonshot-owned):
- [Kimi K3 quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart#reasoning-effort) — "supports low, high, and max (default max); K3 always has thinking mode enabled"
- [MoonshotAI/Kimi-K3 GitHub](https://github.com/MoonshotAI/Kimi-K3#6-model-usage) — same enum, same default
- [Moonshot reasoning_effort guide](https://platform.kimi.ai/docs/guide/use-reasoning-effort) — same enum, plus migration note that K2.x thinking config should be removed when moving to K3

Also updated a stale in-code comment that said the field "currently accepts only max."

## Note for reviewers

kimi-k3 mappings on other providers (Fireworks, Canopywave) declare different enums for the same underlying model — flagging for awareness, not touched in this PR since this fix is scoped to the native `moonshot` mapping only.

## Testing

- `pnpm format` — only `moonshot.ts` changed, 2 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moonshot’s Kimi K3 provider now supports `low`, `high`, and `max` reasoning effort levels.
  * Updated guidance reflects the provider’s native reasoning effort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->