### PR TITLE
fix(actions): preserve none reasoning effort for ByteDance

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -970,6 +970,14 @@ describe("prepareRequestBody - reasoning_effort none", () => {
 		expect(requestBody.reasoning.effort).toBe("none");
 	});
 
+	test("forwards none to ByteDance GLM-5.2", async () => {
+		const requestBody = await prepare({
+			provider: "bytedance",
+			model: "glm-5.2",
+		});
+		expect(requestBody.reasoning_effort).toBe("none");
+	});
+
 	test("disables thinking for Google on none", async () => {
 		const requestBody = await prepare({
 			provider: "google-ai-studio",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1167,7 +1167,7 @@ export async function prepareRequestBody(
 	// `none` reasoning effort is handled natively by a few providers:
 	// OpenAI/Azure forward it (their newer models accept it to turn reasoning
 	// off), and Google, Moonshot, Alibaba, MiniMax, Xiaomi, DeepSeek, Fireworks,
-	// Together AI, and Z.ai reason by default so they must explicitly disable
+	// Together AI, ByteDance, and Z.ai reason by default so they must explicitly disable
 	// thinking when asked. Every other provider treats the absence of
 	// reasoning_effort as "off" already, so normalize `none` away for them to
 	// avoid forwarding an unsupported enum value.

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1187,6 +1187,7 @@ export async function prepareRequestBody(
 		usedProvider === "deepseek" ||
 		usedProvider === "fireworks" ||
 		usedProvider === "together-ai" ||
+		usedProvider === "bytedance" ||
 		usedProvider === "zai" ||
 		providerMappingForOptions?.apiFormat === "openai-chat-completions";
 	if (reasoning_effort === "none" && !handlesNoneNatively) {


### PR DESCRIPTION
## Summary`n`nFixes #3365. ByteDance GLM-5.2 supports reasoning_effort none, but request-body normalization stripped it because ByteDance was missing from the native-none provider allowlist.`n`n- Preserve reasoning_effort none for ByteDance.`n- Add a focused regression test.`n`n## Validation`n`n- prepare-request-body.spec.ts: 216 passed`n- prepare-request-body.spec.ts + models.spec.ts: 267 passed`n- Targeted Prettier and ESLint checks: passed`n- turbo build for @llmgateway/actions: passed, 6 tasks`n`nNo provider API key or external service was required. Package-wide lint is blocked by pre-existing formatting failures in 30 unrelated files; the changed files pass targeted checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ByteDance GLM-5.2 requests now preserve the `reasoning_effort: "none"` setting, ensuring it is correctly forwarded during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->