### PR TITLE
docs: correct DevPass data retention copy

### DIFF
--- a/apps/code/src/app/legal/privacy/page.tsx
+++ b/apps/code/src/app/legal/privacy/page.tsx
@@ -14,7 +14,7 @@ export default function PrivacyPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> June 26, 2026
+				<strong>Last Updated:</strong> August 2, 2026
 			</p>
 			<p>
 				This Supplemental Privacy Policy describes how{" "}
@@ -74,21 +74,14 @@ export default function PrivacyPage() {
 				<li>IP address, user agent, and approximate region</li>
 			</ul>
 			<p>
-				Whether full request and response <strong>payloads</strong> (your
-				prompts and the model output) are stored depends on your DevPass
-				retention settings:
+				Full request and response <strong>payloads</strong> (your prompts and
+				the model output) are <strong>never stored</strong> on DevPass. DevPass
+				is metadata only: the counts, costs, and routing information listed
+				above are kept, and prompts and responses are discarded once the request
+				completes. There is no setting to turn payload storage on, on any
+				DevPass plan. The configurable data retention available on pay-as-you-go
+				LLM Gateway organizations does not apply to DevPass.
 			</p>
-			<ul>
-				<li>
-					<strong>Retain all data</strong> — payloads and metadata are stored
-					and visible in the dashboard
-				</li>
-				<li>
-					<strong>Metadata only</strong> — only counts, costs, and routing info
-					are kept; prompts and responses are discarded after the request
-					completes
-				</li>
-			</ul>
 			<h3>c. Cookies and Local Storage</h3>
 			<p>
 				We use first-party cookies and local storage to keep you signed in,
@@ -167,12 +160,11 @@ export default function PrivacyPage() {
 				</li>
 				<li>
 					<strong>Request metadata</strong> — kept for the life of your active
-					DevPass subscription according to your retention setting (default:
-					retained on Lite, Pro, and Max)
+					DevPass subscription on every plan (Lite, Pro, and Max)
 				</li>
 				<li>
-					<strong>Request payloads</strong> — only stored if you opt in; you can
-					purge them at any time from settings
+					<strong>Request payloads</strong> — never stored; prompts and
+					responses are discarded once the request completes
 				</li>
 				<li>
 					<strong>Logs and audit trails</strong> — kept for security and

--- a/apps/code/src/app/legal/privacy/page.tsx
+++ b/apps/code/src/app/legal/privacy/page.tsx
@@ -74,13 +74,27 @@ export default function PrivacyPage() {
 				<li>IP address, user agent, and approximate region</li>
 			</ul>
 			<p>
-				Full request and response <strong>payloads</strong> (your prompts and
-				the model output) are <strong>never stored</strong> on DevPass. DevPass
-				is metadata only: the counts, costs, and routing information listed
-				above are kept, and prompts and responses are discarded once the request
-				completes. There is no setting to turn payload storage on, on any
-				DevPass plan. The configurable data retention available on pay-as-you-go
-				LLM Gateway organizations does not apply to DevPass.
+				DevPass is <strong>metadata only</strong>: we keep the counts, costs,
+				and routing information listed above, and full request and response{" "}
+				<strong>payloads</strong> (your prompts and the model output) are not
+				retained in your DevPass logs or dashboard. There is no setting to turn
+				payload storage on, on any DevPass plan — the configurable data
+				retention available on pay-as-you-go LLM Gateway organizations does not
+				apply to DevPass.
+			</p>
+			<p>
+				<strong>Exception — the Responses API.</strong> Requests to{" "}
+				<code>/v1/responses</code> (used by tools such as Codex CLI) are
+				stateful by design: so that <code>previous_response_id</code> chaining
+				and <code>GET /v1/responses/&#123;id&#125;</code> work, the input and
+				output items of those requests are held in dedicated storage for up to{" "}
+				<strong>30 days</strong>, after which they are automatically deleted.
+				This applies regardless of retention settings and matches OpenAI&rsquo;s
+				own Responses API retention. Send <code>store: false</code> with the
+				request to opt out; other endpoints, such as{" "}
+				<code>/v1/chat/completions</code> and <code>/v1/messages</code>, are
+				unaffected. Payloads may also be held transiently in memory or cache
+				while a request is being processed.
 			</p>
 			<h3>c. Cookies and Local Storage</h3>
 			<p>
@@ -163,8 +177,10 @@ export default function PrivacyPage() {
 					DevPass subscription on every plan (Lite, Pro, and Max)
 				</li>
 				<li>
-					<strong>Request payloads</strong> — never stored; prompts and
-					responses are discarded once the request completes
+					<strong>Request payloads</strong> — not retained; prompts and
+					responses are discarded once the request completes. The one exception
+					is the Responses API described in Section&nbsp;1b, whose stored
+					responses are kept for up to 30 days and then deleted
 				</li>
 				<li>
 					<strong>Logs and audit trails</strong> — kept for security and

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -16,7 +16,7 @@ export default function TermsPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> July 22, 2026
+				<strong>Last Updated:</strong> August 2, 2026
 			</p>
 			<p>
 				<strong>DevPass</strong> is a service operated by{" "}
@@ -261,9 +261,10 @@ export default function TermsPage() {
 				<Link href="/legal/privacy">DevPass Privacy Policy</Link>, which builds
 				on the main{" "}
 				<a href="https://llmgateway.io/privacy">LLM Gateway Privacy Policy</a>.
-				Request payloads, responses, and per-agent metadata are stored to power
-				your dashboard, usage reporting, and per-tool insights, subject to the
-				retention options available in your account settings.
+				Per-agent metadata — token counts, costs, models, and routing
+				information — is stored to power your dashboard, usage reporting, and
+				per-tool insights. Request payloads and responses are never stored on
+				DevPass.
 			</p>
 			<hr />
 			<h2>6. Contact</h2>

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -263,8 +263,9 @@ export default function TermsPage() {
 				<a href="https://llmgateway.io/privacy">LLM Gateway Privacy Policy</a>.
 				Per-agent metadata — token counts, costs, models, and routing
 				information — is stored to power your dashboard, usage reporting, and
-				per-tool insights. Request payloads and responses are never stored on
-				DevPass.
+				per-tool insights. Request payloads and responses are not retained on
+				DevPass, except for stateful Responses API requests, which are stored
+				for up to 30 days so response chaining works.
 			</p>
 			<hr />
 			<h2>6. Contact</h2>

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -87,7 +87,7 @@ const faqData: FaqItem[] = [
 	},
 	{
 		question: "Do I need a subscription, or is there pay-as-you-go?",
-		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free. In both modes, optional full data retention is billed at ${MARKETING_STATS.dataStoragePrice}.`,
+		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free. Pay-as-you-go organizations can optionally enable full data retention, billed at ${MARKETING_STATS.dataStoragePrice}; DevPass never stores request payloads.`,
 	},
 	{
 		question: "Can my team or company use DevPass?",

--- a/apps/code/src/components/Faq.tsx
+++ b/apps/code/src/components/Faq.tsx
@@ -87,7 +87,7 @@ const faqData: FaqItem[] = [
 	},
 	{
 		question: "Do I need a subscription, or is there pay-as-you-go?",
-		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free. Pay-as-you-go organizations can optionally enable full data retention, billed at ${MARKETING_STATS.dataStoragePrice}; DevPass never stores request payloads.`,
+		answer: `Both work. DevPass plans turn every dollar into $3 of model usage. If you'd rather not subscribe, LLM Gateway offers pay-as-you-go: top up credits and pay per token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee, or bring your own provider keys for free. Pay-as-you-go organizations can optionally enable full data retention, billed at ${MARKETING_STATS.dataStoragePrice}; DevPass is metadata only and has no retention option.`,
 	},
 	{
 		question: "Can my team or company use DevPass?",

--- a/apps/docs/content/features/data-retention.mdx
+++ b/apps/docs/content/features/data-retention.mdx
@@ -26,9 +26,9 @@ LLM Gateway supports two retention levels that can be configured per organizatio
 
 <Callout type="warning">
 	Retention levels are configurable on standard (pay-as-you-go) organizations
-	only. DevPass and chat subscriptions are always metadata only — request and
-	response payloads are never stored for them, and there is no setting to turn
-	payload storage on.
+	only. DevPass and chat subscriptions are always metadata only — their request
+	and response payloads are not retained, and there is no setting to turn
+	payload storage on. The Responses API exception below still applies to them.
 </Callout>
 
 ## Storage Pricing
@@ -74,7 +74,10 @@ Data is retained for 30 days for all users. Enterprise plans can have custom ret
 	`previous_response_id` chaining and `GET /v1/responses/:id`) are kept in
 	dedicated storage for 30 days — matching OpenAI's own retention — regardless
 	of your organization's data retention policy, and are not billed as data
-	storage.
+	storage. Because this is independent of the retention level, it applies to
+	metadata-only organizations, including DevPass and chat, whose Responses API
+	input and output items are therefore held for up to 30 days. Send `store:
+	false` with the request to opt out.
 </Callout>
 
 ## Accessing Stored Data

--- a/apps/docs/content/features/data-retention.mdx
+++ b/apps/docs/content/features/data-retention.mdx
@@ -24,6 +24,13 @@ LLM Gateway supports two retention levels that can be configured per organizatio
 	without additional storage costs.
 </Callout>
 
+<Callout type="warning">
+	Retention levels are configurable on standard (pay-as-you-go) organizations
+	only. DevPass and chat subscriptions are always metadata only — request and
+	response payloads are never stored for them, and there is no setting to turn
+	payload storage on.
+</Callout>
+
 ## Storage Pricing
 
 When full data retention is enabled, storage is billed at **$0.01 per 1 million tokens**. This rate applies to:
@@ -47,7 +54,7 @@ Storage cost = 1,500 / 1,000,000 × $0.01 = **$0.000015**
 
 ## Configuring Retention
 
-Data retention is configured at the organization level in your dashboard settings:
+Data retention is configured at the organization level in your dashboard settings. The setting is only available on standard pay-as-you-go organizations:
 
 1. Navigate to **Organization Settings** → **Policies**
 2. Select your preferred **Data Retention Level**

--- a/apps/docs/content/learn/policies.mdx
+++ b/apps/docs/content/learn/policies.mdx
@@ -21,4 +21,6 @@ Control how long your request logs and activity data are stored. The retention p
 
 After the retention period expires, request logs and associated data are automatically deleted.
 
+The retention level itself is configurable on standard pay-as-you-go organizations only. DevPass and chat subscriptions are always metadata only — their request and response payloads are never stored.
+
 Learn more about data retention in the [Data Retention feature docs](/features/data-retention).

--- a/apps/docs/content/learn/policies.mdx
+++ b/apps/docs/content/learn/policies.mdx
@@ -21,6 +21,6 @@ Control how long your request logs and activity data are stored. The retention p
 
 After the retention period expires, request logs and associated data are automatically deleted.
 
-The retention level itself is configurable on standard pay-as-you-go organizations only. DevPass and chat subscriptions are always metadata only — their request and response payloads are never stored.
+The retention level itself is configurable on standard pay-as-you-go organizations only. DevPass and chat subscriptions are always metadata only — their request and response payloads are not retained, aside from Responses API stored responses, which are kept for 30 days independently of the retention level.
 
 Learn more about data retention in the [Data Retention feature docs](/features/data-retention).


### PR DESCRIPTION
## Problem

A support-chat conversation had the assistant confidently tell a DevPass user that "Data Retention settings apply to DevPass too", complete with a Metadata Only / Retain All Data table, "default on Lite, Pro, Max", and "you can purge stored payloads at any time from settings".

None of that is true since #3296 (Jul 29, 2026), which removed the DevPass retention toggle entirely: `PATCH /organizations/{id}` now rejects `retentionLevel` for any org whose `kind` is not `default`, `getOrCreatePersonalOrg`/`getOrCreateChatOrg` create orgs as `retentionLevel: "none"`, and a migration forced existing devpass/chat orgs to `none`.

The assistant wasn't hallucinating from nothing — it was reading stale public copy. Its knowledge set is built from the live sitemaps of llmgateway.io, devpass.llmgateway.io, docs.llmgateway.io and chat.llmgateway.io (`apps/api/src/utils/chat-support-knowledge.ts`), and `devpass.llmgateway.io/legal/privacy` still described exactly that retention setting, phrase for phrase. Nothing in the docs stated the carve-out either, so the generic `/features/data-retention` page ("configured per organization") read as applying everywhere.

## The Responses API caveat

"Metadata only" is not the same as "nothing is ever stored", and the copy has to say so. `/v1/responses` is stateful by design: `storeResponse()` writes the input and output items to dedicated storage with a 30-day TTL whenever `store !== false` (`apps/gateway/src/responses/tools/response-state.ts`), independently of the org's retention level and org kind. DevPass users reach this through Codex CLI, which we document as a DevPass guide — so their payloads *are* held for up to 30 days on that endpoint. The pages now state this exception, and that `store: false` opts out.

## Changes

Fixed the sources rather than patching the bot's prompt:

- **DevPass privacy policy** (`apps/code/.../legal/privacy`) — §1b now says DevPass is metadata only with no setting to enable payload storage, followed by an explicit Responses API exception (30-day dedicated storage, `store: false` to opt out, transient in-flight caching). §5 drops the removed retain/metadata choice and the "purge from settings" flow that doesn't exist.
- **DevPass terms** (`apps/code/.../legal/terms`) — §5 no longer claims payloads are stored "subject to the retention options available in your account settings"; notes the Responses API exception.
- **DevPass FAQ** — the PAYG answer attached the retention add-on to "both modes"; retention is now scoped to pay-as-you-go, with DevPass called out as metadata only with no retention option.
- **Docs** — `features/data-retention` gains a callout that the levels are configurable on standard pay-as-you-go orgs only, and its existing Responses API callout now spells out that the 30-day storage applies to metadata-only orgs including DevPass and chat; `learn/policies` gets the same note. This gives the assistant a positive source for both facts, not just the absence of a claim.

Both DevPass legal pages got their "Last Updated" dates bumped since the substance changed.

## Verification

`pnpm format` and a full `pnpm build` pass. No behavior change — the enforcement already exists in the API; this is public copy catching up to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that DevPass and chat subscriptions retain metadata only; request payloads and responses are not stored.
  * Documented that configurable data-retention settings are available only for standard pay-as-you-go plans.
  * Noted that Responses API items may be retained for up to 30 days, with an opt-out option.
  * Updated privacy policy and terms last-updated dates to August 2, 2026.
  * Updated FAQ and data-retention guidance to reflect these policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->