### PR TITLE
fix(models): pin DeepInfra V4 Flash to 0731

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -513,7 +513,7 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "deepinfra",
-				externalId: "deepseek-ai/DeepSeek-V4-Flash",
+				externalId: "deepseek-ai/DeepSeek-V4-Flash-0731",
 				inputPrice: "0.14e-6",
 				cachedInputPrice: "0.028e-6",
 				outputPrice: "0.28e-6",


### PR DESCRIPTION
## Problem

The `deepseek-v4-flash` root model is served by seven providers. All of them except DeepInfra roll their undated model alias forward to the current `0731` snapshot automatically. DeepInfra keeps the undated `deepseek-ai/DeepSeek-V4-Flash` id pinned to the launch deployment and exposes the new variant only under a dated id, so requests routed to DeepInfra were silently landing on the older snapshot.

## Change

Point the DeepInfra provider mapping's `externalId` at `deepseek-ai/DeepSeek-V4-Flash-0731`. No other mapping needs touching — the remaining providers already resolve to the new variant through their existing ids, and Alibaba/ByteDance/Fireworks were already pinned to their own dated ids.

Pricing, context size, quantization and capability flags are unchanged; this is purely a deployment-id correction.

## Verification

- `pnpm format`, full `pnpm build`, `packages/models` unit specs — all pass.
- Full e2e suite scoped to the changed mapping: `TEST_MODELS="deepinfra/deepseek-v4-flash" FULL_MODE=true pnpm test:e2e` → 29 files passed, 102 tests passed.
- Confirmed with a verbose run that the mapping actually executed live requests against DeepInfra under the new id rather than being filtered out — basic, streaming, tool calls, streaming tool calls, reasoning, and JSON output (streaming and non-streaming) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the DeepSeek V4 Flash provider configuration to use the current external model identifier, ensuring requests are routed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->