### PR TITLE
feat(gateway): surface region in routing metadata

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -70,6 +70,7 @@ import {
 	getIncludedResetPassesRemaining,
 	MAX_BULK_BLOCK_ORGANIZATIONS,
 	MIN_BULK_BLOCK_SEARCH_LENGTH,
+	parseUsedModel,
 } from "@llmgateway/shared";
 import {
 	getResendClient,
@@ -9449,28 +9450,6 @@ async function listIgnoredErrorMatchers() {
 			createdAt: "desc",
 		},
 	});
-}
-
-// Gateway logs store `used_model` as the display value `provider/model[:region]`
-// (for example `openai/gpt-5-nano` or `alibaba/glm-4.6:cn-beijing`), but the
-// mapping detail page and the `model_provider_mapping` table key off the bare
-// `model_id` plus `region`. Split the provider prefix and region suffix so the
-// table can link to the exact regional mapping rather than a root/other region.
-function parseUsedModel(
-	usedModel: string,
-	usedProvider: string,
-): { modelId: string; region: string | null } {
-	let rest = usedModel;
-	const prefix = `${usedProvider}/`;
-	if (rest.startsWith(prefix)) {
-		rest = rest.slice(prefix.length);
-	} else if (rest.includes("/")) {
-		rest = rest.slice(rest.indexOf("/") + 1);
-	}
-	const regionIdx = rest.lastIndexOf(":");
-	return regionIdx === -1
-		? { modelId: rest, region: null }
-		: { modelId: rest.slice(0, regionIdx), region: rest.slice(regionIdx + 1) };
 }
 
 const unstableMappingEntrySchema = z.object({

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -5562,6 +5562,115 @@ describe("api", () => {
 		}
 	});
 
+	describe("regional routing metadata", () => {
+		async function seedRegionalProviderKey() {
+			await harness.setProjectMode("hybrid");
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-db-key",
+				provider: "alibaba",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+		}
+
+		test("non-streaming response reports the served region", async () => {
+			await seedRegionalProviderKey();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "alibaba/qwen-plus:us-virginia",
+					messages: [
+						{ role: "user", content: "region metadata, non-streaming" },
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.metadata.used_provider).toBe("alibaba");
+			expect(json.metadata.used_region).toBe("us-virginia");
+			expect(json.metadata.routing?.[0]?.region).toBe("us-virginia");
+		});
+
+		test("streaming final chunk reports the served region", async () => {
+			await seedRegionalProviderKey();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "alibaba/qwen-plus:us-virginia",
+					stream: true,
+					messages: [{ role: "user", content: "region metadata, streaming" }],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const body = await res.text();
+			const metadataChunks = body
+				.split("\n")
+				.filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+				.map((line) => JSON.parse(line.slice("data: ".length)))
+				.filter((chunk) => chunk.metadata);
+
+			expect(metadataChunks.length).toBeGreaterThan(0);
+			const finalMetadata = metadataChunks[metadataChunks.length - 1]!.metadata;
+			expect(finalMetadata.used_provider).toBe("alibaba");
+			expect(finalMetadata.used_region).toBe("us-virginia");
+			expect(finalMetadata.routing?.[0]?.region).toBe("us-virginia");
+		});
+
+		test("region-less providers omit used_region", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-db-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "openai/gpt-4o-mini",
+					messages: [{ role: "user", content: "no region for openai" }],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.metadata.used_provider).toBe("openai");
+			expect(json.metadata.used_region).toBeUndefined();
+		});
+	});
+
 	test("/v1/chat/completions hybrid prefers keyed provider over credits-backed provider for gemini-2.5-flash-lite", async () => {
 		await harness.setProjectMode("hybrid");
 		await harness.setRoutingMetrics(

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1939,6 +1939,19 @@ chat.openapi(completions, async (c) => {
 		}
 	};
 
+	// Which provider/model/region actually served the request. The non-streaming
+	// path gets this from `transformResponseToOpenai`; streaming has to build it
+	// itself so both surfaces report the same routing identity.
+	const buildRoutingIdentityMetadata = () => ({
+		requested_model: initialRequestedModel,
+		requested_provider: requestedProvider ?? null,
+		used_model: usedInternalModel,
+		used_provider: usedProvider,
+		// Omitted for providers without regional deployments (OpenAI, Anthropic, …).
+		...(usedRegion ? { used_region: usedRegion } : {}),
+		underlying_used_model: usedInternalModel,
+	});
+
 	const buildFinalResponseMetadata = (discount?: number | null) =>
 		toResponseMetadataExtras({
 			logId: finalLogId,
@@ -7015,6 +7028,18 @@ chat.openapi(completions, async (c) => {
 
 				// --- Retry loop for provider fallback ---
 				const routingAttempts: RoutingAttempt[] = [];
+
+				// Routing metadata used to ride on a separate chunk emitted after the
+				// stream drained, but that chunk is skipped whenever the upstream SSE
+				// carries its own `[DONE]` (the common case) — so streaming clients
+				// never saw `used_provider`/`used_region`/`routing` at all. Attach it
+				// to the final usage chunk instead, which is always written before
+				// `[DONE]`.
+				const buildStreamingFinalMetadata = (discount?: number | null) => ({
+					...buildRoutingIdentityMetadata(),
+					...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
+					...buildFinalResponseMetadata(discount),
+				});
 				const failedProviderIds = new Set<string>();
 				let sameKeyRetryCount = 0;
 				let res: Response | undefined;
@@ -9064,7 +9089,7 @@ chat.openapi(completions, async (c) => {
 											},
 										],
 										usage: finalStreamUsage,
-										metadata: buildFinalResponseMetadata(
+										metadata: buildStreamingFinalMetadata(
 											streamingCosts.discount ?? null,
 										),
 									};
@@ -10593,7 +10618,7 @@ chat.openapi(completions, async (c) => {
 									});
 									return earlyUsage;
 								})(),
-								metadata: buildFinalResponseMetadata(
+								metadata: buildStreamingFinalMetadata(
 									streamingCostsEarly.discount ?? null,
 								),
 							};
@@ -10706,18 +10731,9 @@ chat.openapi(completions, async (c) => {
 											finish_reason: null,
 										},
 									],
-									metadata: {
-										requested_model: initialRequestedModel,
-										requested_provider: requestedProvider ?? null,
-										used_model: usedInternalModel,
-										used_provider: usedProvider,
-										...(usedRegion && { used_region: usedRegion }),
-										underlying_used_model: usedInternalModel,
-										routing: routingAttempts,
-										...buildFinalResponseMetadata(
-											streamingCostsEarly.discount ?? null,
-										),
-									},
+									metadata: buildStreamingFinalMetadata(
+										streamingCostsEarly.discount ?? null,
+									),
 								};
 								await writeSSEAndCache({
 									data: JSON.stringify(routingChunk),

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -40,6 +40,7 @@ import {
 	formatServiceTierMultiplier,
 	getServiceTier,
 } from "@llmgateway/models";
+import { regionFromUsedModel } from "@llmgateway/shared";
 import { API_ORIGIN_LABELS } from "@llmgateway/shared/components";
 
 import type { LogDetailData } from "@/types/activity";
@@ -465,6 +466,10 @@ export function LogDetailClient({
 
 	const inputImages = extractMessageImages(log.messages);
 
+	// Regional mappings encode the served region as a `:region` suffix on
+	// `usedModel`; providers without regional deployments have none.
+	const usedRegion = regionFromUsedModel(log.usedModel, log.usedProvider);
+
 	const retentionEnabled =
 		log.dataStorageCost !== null &&
 		log.dataStorageCost !== undefined &&
@@ -624,6 +629,7 @@ export function LogDetailClient({
 									/>
 								)}
 								<Field label="Provider" value={log.usedProvider} />
+								{usedRegion && <Field label="Region" value={usedRegion} mono />}
 								{log.requestedProvider && (
 									<Field
 										label="Requested Provider"

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -43,6 +43,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { regionFromUsedModel } from "@/used-model.js";
 
 import {
 	formatServiceTierMultiplier,
@@ -375,6 +376,9 @@ export function LogCard({
 	fetchInputImages,
 }: LogCardProps) {
 	const routingMetadata = log.routingMetadata as RoutingMetadata | undefined;
+	// Regional mappings encode the served region as a `:region` suffix on
+	// `usedModel`; providers without regional deployments have none.
+	const usedRegion = regionFromUsedModel(log.usedModel, log.usedProvider);
 	const errorDetails = log.errorDetails as ErrorDetails | undefined;
 	const pluginResults = log.pluginResults as PluginResults | undefined;
 	const toolResults = log.toolResults as ToolCall[] | undefined;
@@ -643,6 +647,14 @@ export function LogCard({
 								)}
 								<div className="text-muted-foreground">Provider</div>
 								<div>{log.usedProvider}</div>
+								{usedRegion && (
+									<>
+										<div className="text-muted-foreground">Region</div>
+										<div className="font-mono text-xs break-all">
+											{usedRegion}
+										</div>
+									</>
+								)}
 							</div>
 							{routingMetadata && (
 								<div className="mt-3">

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -201,4 +201,6 @@ export {
 	isProviderUrlGuardEnabled,
 } from "./url-safety.js";
 
+export { parseUsedModel, regionFromUsedModel } from "./used-model.js";
+
 export * from "./components/ui/index.js";

--- a/packages/shared/src/used-model.spec.ts
+++ b/packages/shared/src/used-model.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { parseUsedModel, regionFromUsedModel } from "./used-model.js";
+
+describe("parseUsedModel", () => {
+	it("splits the provider prefix and region suffix", () => {
+		expect(parseUsedModel("alibaba/glm-4.6:cn-beijing", "alibaba")).toEqual({
+			modelId: "glm-4.6",
+			region: "cn-beijing",
+		});
+	});
+
+	it("returns a null region for providers without regional deployments", () => {
+		expect(parseUsedModel("openai/gpt-5-nano", "openai")).toEqual({
+			modelId: "gpt-5-nano",
+			region: null,
+		});
+	});
+
+	it("strips a mismatched provider prefix", () => {
+		expect(parseUsedModel("alibaba/qwen-plus:us-virginia", "openai")).toEqual({
+			modelId: "qwen-plus",
+			region: "us-virginia",
+		});
+	});
+
+	it("works without a provider hint", () => {
+		expect(parseUsedModel("aws-bedrock/claude-sonnet-5:global")).toEqual({
+			modelId: "claude-sonnet-5",
+			region: "global",
+		});
+	});
+
+	it("keeps a bare model id intact", () => {
+		expect(parseUsedModel("gpt-5-nano", "openai")).toEqual({
+			modelId: "gpt-5-nano",
+			region: null,
+		});
+	});
+
+	it("splits on the last colon so versioned ids survive", () => {
+		expect(
+			parseUsedModel("google-vertex/gemini-3:preview:us-central1"),
+		).toEqual({
+			modelId: "gemini-3:preview",
+			region: "us-central1",
+		});
+	});
+});
+
+describe("regionFromUsedModel", () => {
+	it("returns the region", () => {
+		expect(
+			regionFromUsedModel("alibaba/qwen-plus:us-virginia", "alibaba"),
+		).toBe("us-virginia");
+	});
+
+	it("returns null for empty or missing values", () => {
+		expect(regionFromUsedModel("")).toBeNull();
+		expect(regionFromUsedModel(null)).toBeNull();
+		expect(regionFromUsedModel(undefined)).toBeNull();
+	});
+});

--- a/packages/shared/src/used-model.ts
+++ b/packages/shared/src/used-model.ts
@@ -1,0 +1,37 @@
+/**
+ * Log rows store `used_model` as the fully qualified routing target
+ * (`provider/model`, plus a `:region` suffix for regional mappings, e.g.
+ * `alibaba/qwen-plus:us-virginia`). Consumers that need the bare catalogue id
+ * or the served region have to split it back apart, because neither is stored
+ * in its own column.
+ */
+export function parseUsedModel(
+	usedModel: string,
+	usedProvider?: string | null,
+): { modelId: string; region: string | null } {
+	let rest = usedModel;
+	const prefix = usedProvider ? `${usedProvider}/` : null;
+	if (prefix && rest.startsWith(prefix)) {
+		rest = rest.slice(prefix.length);
+	} else if (rest.includes("/")) {
+		rest = rest.slice(rest.indexOf("/") + 1);
+	}
+	const regionIdx = rest.lastIndexOf(":");
+	return regionIdx === -1
+		? { modelId: rest, region: null }
+		: { modelId: rest.slice(0, regionIdx), region: rest.slice(regionIdx + 1) };
+}
+
+/**
+ * The region a log row was served from, or null for providers without regional
+ * deployments (OpenAI, Anthropic, …), which never carry a `:region` suffix.
+ */
+export function regionFromUsedModel(
+	usedModel: string | null | undefined,
+	usedProvider?: string | null,
+): string | null {
+	if (!usedModel) {
+		return null;
+	}
+	return parseUsedModel(usedModel, usedProvider).region;
+}


### PR DESCRIPTION
## Problem

`used_region` and `routing[].region` were missing from streaming responses, and the region was never shown in the dashboard.

Two separate gaps, one that turned out not to be a gap at all:

1. **Non-streaming was already correct.** `metadata.used_region` and `routing[].region` are emitted whenever the mapping resolves a region. They are legitimately absent for providers without regional deployments (OpenAI, Anthropic, …), which is what a DevPass request against those providers looks like.
2. **Streaming never emitted them at all** — not even `used_provider`. The routing metadata rode on a separate SSE chunk written after the stream drained, guarded by `!doneSent`. But when the upstream SSE carries its own `[DONE]` (the common case), the gateway forwards it and sets `doneSent` well before that point, so the chunk was silently skipped. Streaming clients only ever received `log_id`/`organization_id`/`project_id`/`discount`.
3. **The dashboard never showed the region.** It is only stored as the `:region` suffix on `log.usedModel`, so the log card and the activity detail page showed `Provider: alibaba` with no indication of which region served it.

## Approach

- Extract the routing identity (`requested_model`, `requested_provider`, `used_model`, `used_provider`, `used_region`, `underlying_used_model`) into `buildRoutingIdentityMetadata()` and merge it, plus `routing`, into the streaming **final usage chunk** — which is always written immediately before `[DONE]`. The old post-drain routing chunk now reuses the same builder, so the two streaming exits can't drift.
- Add `parseUsedModel` / `regionFromUsedModel` to `@llmgateway/shared`, replacing the private copy that lived in the admin route, and use it to render a `Region` row on the shared log card and a `Region` field on the activity log detail page. Both are hidden when there is no region rather than showing a placeholder.

`used_region` stays omitted (not `null`) for region-less providers, matching the existing non-streaming behaviour and the OpenAPI schema, which already declared the field as optional.

## Verification

- New gateway specs pin `alibaba/qwen-plus:us-virginia` and assert `used_region` + `routing[0].region` on both the JSON and streaming paths, plus a negative case for `openai/gpt-4o-mini`. The streaming assertion fails on `main`.
- Unit tests for the shared parser (provider-prefix mismatch, no prefix, no region, last-colon split so versioned ids survive).
- `pnpm format`, `pnpm build`, and the full `pnpm test:unit` (3662 tests) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added regional routing details to chat response metadata, including served provider, model, and region.
  - Regional information now appears in request logs and expanded activity details when available.

- **Bug Fixes**
  - Improved handling of model identifiers with provider and regional information.

- **Tests**
  - Added coverage for streaming and non-streaming regional routing responses, including region-less requests and varied model formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->