### PR TITLE
fix(models): pin Novita DeepSeek V4 Flash to -0731

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -471,7 +471,7 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "novita",
-				externalId: "deepseek/deepseek-v4-flash",
+				externalId: "deepseek/deepseek-v4-flash-0731",
 				inputPrice: "0.14e-6",
 				cachedInputPrice: "0.028e-6",
 				outputPrice: "0.28e-6",
@@ -483,6 +483,10 @@ export const deepseekModels = [
 				reasoning: true,
 				vision: false,
 				tools: true,
+				// The -0731 deployment 400s on "required" and named-function
+				// tool_choice, and silently emits no tool call at all when "required"
+				// is streamed; only "auto"/"none" behave (verified 2026-08-02).
+				supportedToolChoices: ["auto", "none"],
 				jsonOutput: true,
 			},
 			{


### PR DESCRIPTION
## Problem

Novita serves the current DeepSeek V4 Flash snapshot under a dated model id, `deepseek/deepseek-v4-flash-0731`. The mapping still pointed at the undated `deepseek/deepseek-v4-flash` alias, which resolves to the older deployment. The other providers on this root model (DeepSeek, Runware, Alibaba, DeepInfra, ByteDance, Fireworks) already serve the new variant from their existing external IDs, so only the Novita mapping needed changing.

## Change

- Novita `externalId` → `deepseek/deepseek-v4-flash-0731`.
- Declare `supportedToolChoices: ["auto", "none"]` on the Novita mapping.

The second part is required by the first: the `-0731` deployment rejects forced tool choice where the old alias accepted it. Verified directly against Novita:

| request | old alias | `-0731` |
| --- | --- | --- |
| `tool_choice: "auto"` | tool call | tool call |
| `tool_choice: "none"` | text | text |
| `tool_choice: "required"` | tool call | `400 invalid_request_error` |
| `tool_choice: {type: "function", ...}` | tool call | `400 invalid_request_error` |
| `tool_choice: "required"`, streaming | tool call | `200`, **zero tool-call chunks** |

The streaming case is the nastier one — no error, just a silently tool-less response. `supportedToolChoices` makes `prepare-request-body` coerce both forced modes down to `auto`, which behaves correctly on this deployment. This is the declarative mechanism the repo already uses for the same quirk on Moonshot, Alibaba, and Meta mappings, rather than a per-provider downgrade in gateway code.

## Verification

`TEST_MODELS="novita/deepseek-v4-flash" FULL_MODE=true pnpm test:e2e`

- With only the external-ID change: 5 failures — `tool calls`, `streaming tool calls`, `tool calls res`, `responses tool calls`, `responses tool calls stateless`.
- With `supportedToolChoices` added: **29 files passed, 102 tests passed, 0 failures.**

`pnpm format` and a full `pnpm build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)