### PR TITLE
fix(gateway): toolu_ ids on Anthropic /v1/messages

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -346,6 +346,33 @@ function toAnthropicMessageId(id: unknown): string {
 	return `msg_${id.replace(/^chatcmpl[-_]/, "")}`;
 }
 
+// Anthropic tool_use ids are `toolu_`-prefixed, and Anthropic SDK clients key
+// on that prefix the same way they do on `msg_`. The inner
+// /v1/chat/completions response carries OpenAI-style tool-call ids — e.g.
+// Runware (a deepseek-v4-flash router) emits `chatcmpl-tool-…`, DeepSeek
+// native emits `call_…` — so re-prefix them here instead of leaking the raw
+// OpenAI schema. The full upstream id is kept (prefix included) so the mapping
+// is injective — `call_123` and `fc_123` must not collapse onto the same
+// `toolu_` id, or a response with both would emit duplicate tool_use blocks
+// the client could not pair back to distinct tool_results.
+//
+// The minted id is safe to reuse on both sides of the round trip: the client
+// echoes the assistant's `tool_use` id back in `tool_result.tool_use_id`, and
+// the request path forwards that verbatim as the OpenAI `tool_call_id` (see
+// the `tool_result` conversion below), while the replayed assistant message
+// carries the same minted id. OpenAI-compatible endpoints pair tool calls to
+// results by exact string equality and treat the id as opaque, so the pair
+// stays consistent without a remap table.
+function toAnthropicToolUseId(upstreamId: string | undefined): string {
+	if (!upstreamId) {
+		return `toolu_${randomUUID()}`;
+	}
+	if (upstreamId.startsWith("toolu_")) {
+		return upstreamId;
+	}
+	return `toolu_${upstreamId}`;
+}
+
 // Map the inner chat completions response's url_citation annotations onto
 // Anthropic web_search_result entries. The OpenAI-format annotations only
 // carry url/title, so the Anthropic-only fields (encrypted_content, page_age)
@@ -1072,6 +1099,24 @@ anthropic.openapi(messages, async (c) => {
 					});
 				};
 
+				// If the upstream stream ends without ever sending a finish_reason
+				// while a tool_use block is still in flight (a dropped/truncated
+				// mid-tool-call stream), the client would otherwise be left with a
+				// dangling tool call and no terminal events. Synthesize a truncation
+				// stop_reason so it's treated as truncated (retryable) instead.
+				const synthesizeTruncatedStopReasonIfNeeded = () => {
+					if (
+						stopReason === null &&
+						contentBlocks.some((block) => block.type === "tool_use")
+					) {
+						logger.warn(
+							"Anthropic stream ended without finish_reason while tool call arguments were still streaming; emitting truncated stop_reason",
+							{ path: c.req.path },
+						);
+						stopReason = "max_tokens";
+					}
+				};
+
 				try {
 					while (true) {
 						const { done, value } = await reader.read();
@@ -1101,6 +1146,7 @@ anthropic.openapi(messages, async (c) => {
 							if (line.startsWith("data: ")) {
 								const data = line.slice(6).trim();
 								if (data === "[DONE]") {
+									synthesizeTruncatedStopReasonIfNeeded();
 									await sendContentBlockStops();
 									await sendMessageDelta();
 									// Send final Anthropic streaming event
@@ -1388,7 +1434,9 @@ anthropic.openapi(messages, async (c) => {
 										if (blockIndex === undefined) {
 											blockIndex = contentBlocks.length;
 											toolCallBlockIndex.set(toolCall.index, blockIndex);
-											const id = toolCall.id ?? `tool_${toolCall.index}`;
+											const id = toAnthropicToolUseId(
+												toolCall.id ?? `tool_${toolCall.index}`,
+											);
 											const name = toolCall.function?.name ?? "";
 											contentBlocks.push({
 												type: "tool_use",
@@ -1450,6 +1498,7 @@ anthropic.openapi(messages, async (c) => {
 					// Stream ended without an explicit [DONE]. Emit any deferred
 					// terminator events so downstream clients see a well-formed
 					// Anthropic stream.
+					synthesizeTruncatedStopReasonIfNeeded();
 					await sendContentBlockStops();
 					await sendMessageDelta();
 					if (stopReason !== null) {
@@ -1587,17 +1636,24 @@ anthropic.openapi(messages, async (c) => {
 			try {
 				input = JSON.parse(toolCall.function.arguments ?? "{}");
 			} catch (err) {
-				logger.error("Failed to parse anthropic tool call arguments", {
-					err: err instanceof Error ? err : new Error(String(err)),
-					arguments: toolCall.function.arguments,
-				});
-				throw new HTTPException(500, {
-					message: "Failed to parse tool call arguments",
-				});
+				// Truncated/malformed argument JSON is an upstream model fault,
+				// not a request fault. Degrade to an empty input so the turn
+				// stays alive for the remaining tool calls instead of killing
+				// the whole response with a 500 (the client can't fix it, and
+				// its tool_result for this call would be lost entirely).
+				logger.warn(
+					"Failed to parse tool call arguments; replacing with empty input",
+					{
+						err: err instanceof Error ? err : new Error(String(err)),
+						argumentsLength: toolCall.function.arguments?.length ?? 0,
+						toolName: toolCall.function.name,
+					},
+				);
+				input = {};
 			}
 			content.push({
 				type: "tool_use",
-				id: toolCall.id,
+				id: toAnthropicToolUseId(toolCall.id),
 				name: toolCall.function.name,
 				input,
 			});

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -752,6 +752,462 @@ describe("api", () => {
 		expect(messageStart.message.id).toMatch(/^msg_/);
 	});
 
+	interface ToolUseBlock {
+		type: "tool_use";
+		id: string;
+		name: string;
+		input: Record<string, unknown>;
+	}
+
+	interface UpstreamToolCall {
+		id: string;
+		type: "function";
+		function: { name: string; arguments: string };
+	}
+
+	interface UpstreamMessage {
+		role: string;
+		tool_calls?: UpstreamToolCall[];
+		tool_call_id?: string;
+		content?: unknown;
+	}
+
+	// The inner /v1/chat/completions response carries OpenAI-style tool-call ids
+	// (`chatcmpl-tool-…`). Anthropic SDK clients key on the `toolu_` prefix, so
+	// the gateway must re-prefix them rather than leaking the OpenAI schema.
+	test("/v1/messages returns Anthropic-style tool_use ids (non-streaming)", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "TRIGGER_TOOL_CALLS" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		const toolUse = json.content?.find(
+			(b: ToolUseBlock) => b.type === "tool_use",
+		);
+		expect(toolUse).toBeTruthy();
+		expect(toolUse.id).toMatch(/^toolu_/);
+		expect(toolUse.id).toBe("toolu_chatcmpl-tool-9c2b95219658aa6f");
+		expect(toolUse.name).toBe("Bash");
+		expect(toolUse.input).toEqual({ command: "echo hello_mangled_test" });
+		expect(json.stop_reason).toBe("tool_use");
+	});
+
+	test("/v1/messages returns Anthropic-style tool_use ids (streaming)", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				stream: true,
+				messages: [{ role: "user", content: "TRIGGER_TOOL_CALLS" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const events = (await res.text())
+			.split("\n")
+			.filter((line) => line.startsWith("data: "))
+			.map((line) => line.slice(6).trim())
+			.filter((data) => data && data !== "[DONE]")
+			.map((data) => JSON.parse(data));
+
+		const toolStart = events.find(
+			(e) =>
+				e.type === "content_block_start" &&
+				e.content_block?.type === "tool_use",
+		);
+		expect(toolStart).toBeTruthy();
+		expect(toolStart.content_block.id).toMatch(/^toolu_/);
+		expect(toolStart.content_block.id).toBe(
+			"toolu_chatcmpl-tool-9c2b95219658aa6f",
+		);
+		expect(toolStart.content_block.name).toBe("Bash");
+
+		const inputDelta = events.find(
+			(e) =>
+				e.type === "content_block_delta" &&
+				e.delta?.type === "input_json_delta",
+		);
+		expect(inputDelta).toBeTruthy();
+		expect(inputDelta.delta.partial_json).toContain("echo hello_mangled_test");
+
+		const messageDelta = events.find((e) => e.type === "message_delta");
+		expect(messageDelta).toBeTruthy();
+		expect(messageDelta.delta.stop_reason).toBe("tool_use");
+	});
+
+	// DeepSeek native emits OpenAI-style `call_…` tool-call ids (vs Runware's
+	// `chatcmpl-tool-…`); the gateway must normalize both to `toolu_` so the
+	// Anthropic-facing id is stable regardless of which router answered.
+	test("/v1/messages normalizes native DeepSeek `call_` tool-call ids", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "TRIGGER_TOOL_CALLS_CALL_PREFIX" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		const toolUse = json.content?.find(
+			(b: ToolUseBlock) => b.type === "tool_use",
+		);
+		expect(toolUse).toBeTruthy();
+		expect(toolUse.id).toBe("toolu_call_00_9c2b95219658aa6f");
+		expect(toolUse.id).toMatch(/^toolu_/);
+	});
+
+	// Two tool calls in one response must each get a distinct stable `toolu_`
+	// id that stays consistent across the stream, so the client can pair each
+	// tool_result with its own call (a shared/duplicated id would merge them).
+	test("/v1/messages mints distinct toolu_ ids per multi-tool-call stream", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				stream: true,
+				messages: [{ role: "user", content: "TRIGGER_TOOL_CALLS_MULTI" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const events = (await res.text())
+			.split("\n")
+			.filter((line) => line.startsWith("data: "))
+			.map((line) => line.slice(6).trim())
+			.filter((data) => data && data !== "[DONE]")
+			.map((data) => JSON.parse(data));
+
+		const toolStarts = events.filter(
+			(e) =>
+				e.type === "content_block_start" &&
+				e.content_block?.type === "tool_use",
+		);
+		expect(toolStarts).toHaveLength(2);
+
+		const ids = toolStarts.map((e) => e.content_block.id);
+		expect(new Set(ids).size).toBe(2);
+		expect(ids.every((id: string) => /^toolu_/.test(id))).toBe(true);
+		const inputDeltas = events.filter(
+			(e) =>
+				e.type === "content_block_delta" &&
+				e.delta?.type === "input_json_delta",
+		);
+		expect(inputDeltas).toHaveLength(2);
+		const deltaIndexes = inputDeltas.map((e) => e.index);
+		expect(deltaIndexes).toEqual([0, 1]);
+		// Each delta index must correspond to a content_block_start at the same index.
+		const startIndexes = toolStarts.map((e) => e.index);
+		expect(startIndexes).toEqual([0, 1]);
+
+		const messageDelta = events.find((e) => e.type === "message_delta");
+		expect(messageDelta).toBeTruthy();
+		expect(messageDelta.delta.stop_reason).toBe("tool_use");
+	});
+
+	// A truncated/malformed argument payload is an upstream model fault; the
+	// gateway must degrade to an empty input (HTTP 200) instead of killing the
+	// whole response with a 500 the client can't fix.
+	test("/v1/messages degrades malformed tool args to empty input instead of 500", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				messages: [
+					{ role: "user", content: "TRIGGER_TOOL_CALLS_MALFORMED_ARGS" },
+				],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		const toolUse = json.content?.find(
+			(b: ToolUseBlock) => b.type === "tool_use",
+		);
+		expect(toolUse).toBeTruthy();
+		expect(toolUse.input).toEqual({});
+		expect(toolUse.id).toMatch(/^toolu_/);
+		expect(json.stop_reason).toBe("tool_use");
+	});
+
+	// A stream that cuts off mid-tool-call (no finish_reason, no [DONE]) must
+	// still terminate the Anthropic stream with a synthesized stop_reason so
+	// the client treats the dangling tool call as truncated (retryable) rather
+	// than waiting on a stream that never ends.
+	test("/v1/messages terminates a mid-tool-call stream drop with a truncated stop_reason", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 1024,
+				stream: true,
+				messages: [{ role: "user", content: "TRIGGER_TOOL_CALLS_TRUNCATED" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const events = (await res.text())
+			.split("\n")
+			.filter((line) => line.startsWith("data: "))
+			.map((line) => line.slice(6).trim())
+			.filter((data) => data && data !== "[DONE]")
+			.map((data) => JSON.parse(data));
+
+		const messageDelta = events.find((e) => e.type === "message_delta");
+		expect(messageDelta).toBeTruthy();
+		expect(messageDelta.delta.stop_reason).toBe("max_tokens");
+		expect(events.some((e) => e.type === "message_stop")).toBe(true);
+	});
+
+	// The client echoes the assistant tool_use id back in its tool_result; the
+	// gateway must forward that id (not remap it) so the upstream sees a
+	// consistent tool_call / tool_call_id pair on the next turn.
+	test("/v1/messages round-trips tool_use ids into tool_result tool_call_ids", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const originalFetch = globalThis.fetch;
+		let upstreamBody: { messages: UpstreamMessage[] } | null = null;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url === `${mockServerUrl}/v1/chat/completions`) {
+					const body =
+						input instanceof Request ? await input.text() : String(init?.body);
+					upstreamBody = JSON.parse(body);
+
+					return new Response(
+						JSON.stringify({
+							id: "chatcmpl-1",
+							object: "chat.completion",
+							created: 1774549411,
+							model: "llmgateway/custom",
+							choices: [
+								{
+									index: 0,
+									message: { role: "assistant", content: "Done." },
+									finish_reason: "stop",
+								},
+							],
+							usage: {
+								prompt_tokens: 5,
+								completion_tokens: 3,
+								total_tokens: 8,
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		try {
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					max_tokens: 1024,
+					messages: [
+						{ role: "user", content: "Run the command." },
+						{
+							role: "assistant",
+							content: [
+								{
+									type: "tool_use",
+									id: "toolu_9c2b95219658aa6f",
+									name: "Bash",
+									input: { command: "echo hello" },
+								},
+							],
+						},
+						{
+							role: "user",
+							content: [
+								{
+									type: "tool_result",
+									tool_use_id: "toolu_9c2b95219658aa6f",
+									content: "hello",
+								},
+							],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(upstreamBody).toBeTruthy();
+
+			const assistantMsg = upstreamBody!.messages.find(
+				(m: UpstreamMessage) => m.role === "assistant" && m.tool_calls,
+			);
+			expect(assistantMsg).toBeTruthy();
+			expect(assistantMsg!.tool_calls![0].id).toBe("toolu_9c2b95219658aa6f");
+
+			const toolMsg = upstreamBody!.messages.find(
+				(m: UpstreamMessage) => m.role === "tool",
+			);
+			expect(toolMsg).toBeTruthy();
+			expect(toolMsg!.tool_call_id).toBe("toolu_9c2b95219658aa6f");
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
 	test("/v1/messages surfaces reasoning as thinking_delta events (streaming)", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -895,6 +895,38 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		chatMessages,
 		"TRIGGER_REASONING",
 	);
+	const shouldReturnToolCalls = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_TOOL_CALLS",
+	);
+	// Tool-call response variants that share the `shouldReturnToolCalls` shape
+	// but swap the id prefix, add a second call, or emit malformed arguments.
+	const shouldReturnCallPrefixToolId = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_TOOL_CALLS_CALL_PREFIX",
+	);
+	const shouldReturnMultiToolCalls = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_TOOL_CALLS_MULTI",
+	);
+	const shouldReturnMalformedToolArgs = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_TOOL_CALLS_MALFORMED_ARGS",
+	);
+	// A stream that cuts off mid-tool-call: tool-call start + partial args,
+	// then [DONE] with no finish_reason. The inner OpenAI layer treats [DONE]
+	// as a clean end, so the Anthropic translator must synthesize a terminal
+	// stop_reason instead of leaving a dangling tool_use block.
+	const shouldReturnTruncatedToolCall = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_TOOL_CALLS_TRUNCATED",
+	);
+	const toolCallId = shouldReturnCallPrefixToolId
+		? "call_00_9c2b95219658aa6f"
+		: "chatcmpl-tool-9c2b95219658aa6f";
+	const toolCallArguments = shouldReturnMalformedToolArgs
+		? "{command: broken"
+		: '{"command":"echo hello_mangled_test"}';
 	const reasoningContent = "Let me think about this step by step.";
 	const shouldTruncateStream = hasUserMessageTrigger(
 		chatMessages,
@@ -1078,6 +1110,129 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 				}
 			}
 
+			if (shouldReturnToolCalls) {
+				// Tool-call chunks: the first delta carries id + name, the second
+				// the arguments (mirrors real OpenAI streaming tool calls). The id
+				// is intentionally an OpenAI-style id (`chatcmpl-tool-…` or, for
+				// the `call_00_…` variant, a native DeepSeek `call_` id) so the
+				// regression tests can assert the gateway re-prefixes it `toolu_`.
+				const toolCalls = shouldReturnMultiToolCalls
+					? [
+							{
+								index: 0,
+								id: "chatcmpl-tool-9c2b95219658aa6f",
+								name: "Bash",
+								arguments: '{"command":"echo hello_first_tool"}',
+							},
+							{
+								index: 1,
+								id: "call_00_7d3f19a48b20c5e1",
+								name: "Read",
+								arguments: '{"file_path":"/tmp/second_tool.txt"}',
+							},
+						]
+					: [
+							{
+								index: 0,
+								id: toolCallId,
+								name: "Bash",
+								arguments: toolCallArguments,
+							},
+						];
+
+				for (const toolCall of toolCalls) {
+					await stream.writeSSE({
+						data: JSON.stringify({
+							id: "chatcmpl-123",
+							object: "chat.completion.chunk",
+							created: Math.floor(Date.now() / 1000),
+							model: body.model ?? "gpt-4o-mini",
+							choices: [
+								{
+									index: 0,
+									delta: {
+										tool_calls: [
+											{
+												index: toolCall.index,
+												id: toolCall.id,
+												type: "function",
+												function: {
+													name: toolCall.name,
+													arguments: "",
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						}),
+						id: String(eventId++),
+					});
+					await stream.writeSSE({
+						data: JSON.stringify({
+							id: "chatcmpl-123",
+							object: "chat.completion.chunk",
+							created: Math.floor(Date.now() / 1000),
+							model: body.model ?? "gpt-4o-mini",
+							choices: [
+								{
+									index: 0,
+									delta: {
+										tool_calls: [
+											{
+												index: toolCall.index,
+												function: {
+													arguments: toolCall.arguments,
+												},
+											},
+										],
+									},
+									finish_reason: null,
+								},
+							],
+						}),
+						id: String(eventId++),
+					});
+				}
+
+				if (shouldReturnTruncatedToolCall) {
+					// Terminate the stream mid-tool-call: [DONE] but no
+					// finish_reason. The inner OpenAI layer treats [DONE] as a
+					// clean end, so the Anthropic translator must synthesize a
+					// terminal stop_reason instead of ending the message with a
+					// dangling tool_use block and no stop_reason.
+					await stream.writeSSE({
+						event: "done",
+						data: "[DONE]",
+						id: String(eventId++),
+					});
+					return;
+				}
+
+				await stream.writeSSE({
+					data: JSON.stringify({
+						id: "chatcmpl-123",
+						object: "chat.completion.chunk",
+						created: Math.floor(Date.now() / 1000),
+						model: body.model ?? "gpt-4o-mini",
+						choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+						usage: {
+							prompt_tokens: 10,
+							completion_tokens: 20,
+							total_tokens: 30,
+						},
+					}),
+					id: String(eventId++),
+				});
+				await stream.writeSSE({
+					event: "done",
+					data: "[DONE]",
+					id: String(eventId++),
+				});
+				return;
+			}
+
 			// Content chunks: one per choice index. For n > 1 each variant tags
 			// the content so the test can assert that no two choice streams
 			// were merged into one buffer.
@@ -1216,17 +1371,55 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 	}
 
 	const baseChoice = sampleChatCompletionResponse.choices[0];
+	// OpenAI-style tool-call id; the regression test asserts the gateway
+	// re-prefixes it `toolu_` on the Anthropic-facing side.
+	const toolCalls = shouldReturnToolCalls
+		? shouldReturnMultiToolCalls
+			? [
+					{
+						id: "chatcmpl-tool-9c2b95219658aa6f",
+						type: "function",
+						function: {
+							name: "Bash",
+							arguments: '{"command":"echo hello_first_tool"}',
+						},
+					},
+					{
+						id: "call_00_7d3f19a48b20c5e1",
+						type: "function",
+						function: {
+							name: "Read",
+							arguments: '{"file_path":"/tmp/second_tool.txt"}',
+						},
+					},
+				]
+			: [
+					{
+						id: toolCallId,
+						type: "function",
+						function: {
+							name: "Bash",
+							arguments: toolCallArguments,
+						},
+					},
+				]
+		: undefined;
 	const choices = Array.from({ length: requestedN }, (_, index) => ({
 		...baseChoice,
 		index,
 		message: {
 			role: "assistant",
-			content:
-				requestedN > 1
+			content: shouldReturnToolCalls
+				? null
+				: requestedN > 1
 					? `${assistantContent} (variant ${index + 1})`
 					: assistantContent,
 			...(shouldReturnReasoning && { reasoning: reasoningContent }),
+			...(shouldReturnToolCalls && { tool_calls: toolCalls }),
 		},
+		finish_reason: shouldReturnToolCalls
+			? "tool_calls"
+			: baseChoice.finish_reason,
 	}));
 
 	const baseUsage = sampleChatCompletionResponse.usage;

--- a/apps/ui/src/content/blog/2025-09-08-how-configure-claude-code-with-llmgateway.md
+++ b/apps/ui/src/content/blog/2025-09-08-how-configure-claude-code-with-llmgateway.md
@@ -52,6 +52,17 @@ Browse [models with tool calling support](https://llmgateway.io/models?filters=1
 | `gpt-4o-mini`                        | Routine tasks, cost-conscious usage         | $    |
 | `glm-4.5v`                           | Similar quality, 50-70% cheaper than Claude | $    |
 
+> **Caveat:** tool-call ids are normalized to Anthropic's `toolu_` prefix by the
+> gateway, so they look right to Claude Code no matter which upstream answered
+> (see [this fix](https://github.com/theopenco/llmgateway/pull/3389)). However,
+> `deepseek-v4-flash` can still occasionally drop a command argument or invent
+> an extra field on tool-heavy turns — that argument flakiness is upstream model
+> behavior, not a gateway rewrite. If Claude Code executes a mangled command,
+> check what actually ran before retrying — a malformed command may already have
+> created, deleted, or modified files. Retry only if the tool call was rejected
+> outright or the command is known to be idempotent (e.g. a read-only `ls` or
+> `cat`). For tool-heavy work, prefer a higher-effort model.
+
 ## Advanced Configuration
 
 ### Model Switching


### PR DESCRIPTION
## Summary

The **Anthropic-compatible** `POST /v1/messages` endpoint leaked OpenAI-style tool-call ids (`chatcmpl-tool-…`, `call_…`) straight through from the inner `/v1/chat/completions` response — in both the streaming and non-streaming paths. Anthropic SDK clients key on the `toolu_` prefix, so the leaked ids were spec-incompliant on the Claude-facing side.

This mints `toolu_` ids on the Anthropic side by keeping the full upstream id (`toolu_<upstream-id>`), which keeps the response correlatable with the gateway log and keeps the mapping **injective** — `call_123` and `fc_123` must not collapse onto a shared `toolu_` id, or a response carrying both would emit duplicate `tool_use` blocks the client couldn't pair back. The client echoes the emitted id back in `tool_result.tool_use_id`, which the gateway already forwards verbatim — so the round-trip stays consistent with no remap table.

## Context: who's the culprit (measured, not guessed)

Identical tool-requiring prompts (streaming + non-streaming) were run through **DeepSeek native** (`api.deepseek.com`) and **LLM Gateway** (`api.llmgateway.io`, which routes `deepseek-v4-flash` to **Runware**), 8 runs each:

| Path | Tool call present | Args intact | tool_call id |
|---|---|---|---|
| DeepSeek native | 8/8 ✅ | 8/8 ✅ | `call_00_...` |
| Gateway → Runware | 8/8 ✅ | 8/8 ✅ | `chatcmpl-tool-...` |

- **Gateway is the tool-ID mangler** — confirmed in source: `anthropic.ts` reused `toolCall.id` verbatim in the Anthropic `tool_use` block (streaming + non-streaming). Fixed here.
- **The model is NOT the argument-mangler** — DeepSeek native returns structurally valid args 8/8. The earlier "dropped `echo`, invented `description`" case was an intermittent Flash-model flake on a specific one-shot run, not reproducible on the OpenAI wire path. It is upstream model behavior, not a gateway rewrite.

## Changes

- `apps/gateway/src/anthropic/anthropic.ts`:
  - Add `toAnthropicToolUseId()`; use it in both the streaming and non-streaming `tool_use` construction of the Anthropic-compatible endpoint (re-prefixes `chatcmpl-tool-…` / `call_…` / `fc_…` as `toolu_…`, keeping the full upstream id so the mapping is injective).
  - **Non-streaming malformed args:** unparseable `tool_call.arguments` previously returned an HTTP 500 and killed the whole response. Now degrades to an empty `input` so the turn survives for the remaining tool calls (an upstream model fault the client can't fix). Missing `arguments` is also guarded (no `.length` throw), and the log carries only arg length + tool name — never the raw payload, which can contain user data/secrets.
  - **Streaming mid-tool-call drop:** a stream ending with `[DONE]` but no `finish_reason` while a `tool_use` block is in flight emitted no terminal `stop_reason`, leaving the client with a dangling tool call. Now synthesizes `max_tokens` so it reads as truncated (retryable).
- `apps/gateway/src/test-utils/mock-openai-server.ts` — `TRIGGER_TOOL_CALLS` marker plus variants: `TRIGGER_TOOL_CALLS_CALL_PREFIX` (native DeepSeek `call_` id), `TRIGGER_TOOL_CALLS_MULTI` (two tool calls in one response), `TRIGGER_TOOL_CALLS_MALFORMED_ARGS` (unparseable JSON), `TRIGGER_TOOL_CALLS_TRUNCATED` (`[DONE]` without `finish_reason`).
- `apps/gateway/src/api.spec.ts` — regression tests for: non-streaming + streaming `toolu_` ids, `call_` prefix normalization, distinct ids per multi-tool-call stream, malformed-args degrade (HTTP 200 + `input: {}`), truncated-stream termination, and the `tool_result.tool_use_id` round-trip.
- `apps/ui/src/content/blog/2025-09-08-how-configure-claude-code-with-llmgateway.md` — caveat narrowed: tool-call id prefix is normalized by the gateway (now fixed); retry guidance now tells users to inspect what actually ran before retrying (a malformed command may already have side effects) and to prefer a higher-effort model for tool-heavy work.

## Multi-turn id round-trip (review question)

The minted `toolu_<upstream-id>` id is used consistently on **both** sides of the OpenAI wire: the assistant message's `tool_calls` carries it, and the client-echoed `tool_result.tool_use_id` is forwarded verbatim as the `tool` message's `tool_call_id`. OpenAI-compatible endpoints pair tool calls to results by exact string equality, and both Runware and DeepSeek native treat `tool_call_id` as an opaque string — neither validates a prefix format. So no bidirectional remap table is needed. If a provider is ever found to reject the `toolu_` prefix on a follow-up turn, that would be a follow-up issue, out of scope here.

## Testing

- `npx tsc --noEmit -p apps/gateway` — passed.
- `npx vitest run apps/gateway/src/api.spec.ts` — passed (153 passed / 2 skipped).
- `npx vitest run apps/gateway/src/anthropic/ apps/gateway/src/chat/tools/` — passed (567 tests).
- eslint + prettier clean.
