### PR TITLE
perf: eliminate server-side request waterfalls

### DIFF
--- a/apps/code/src/app/dashboard/feedback/dev-plan-cancellation/page.tsx
+++ b/apps/code/src/app/dashboard/feedback/dev-plan-cancellation/page.tsx
@@ -17,19 +17,22 @@ interface EligibilityResponse {
 }
 
 export default async function DevPlanCancellationFeedbackPage() {
-	const userData = await fetchServerData<{ user: { id: string } } | null>(
+	const userDataPromise = fetchServerData<{ user: { id: string } } | null>(
 		"GET",
 		"/user/me",
 	);
+	const eligibilityPromise = fetchServerData<EligibilityResponse>(
+		"GET",
+		"/dev-plan-cancellation-feedback/eligibility",
+	);
+
+	const userData = await userDataPromise;
 
 	if (!userData?.user) {
 		redirect("/login?returnUrl=/dashboard/feedback/dev-plan-cancellation");
 	}
 
-	const eligibility = await fetchServerData<EligibilityResponse>(
-		"GET",
-		"/dev-plan-cancellation-feedback/eligibility",
-	);
+	const eligibility = await eligibilityPromise;
 
 	return (
 		<div className="min-h-screen bg-background py-12">

--- a/apps/code/src/app/dashboard/survey/page.tsx
+++ b/apps/code/src/app/dashboard/survey/page.tsx
@@ -13,19 +13,22 @@ export const metadata = {
 };
 
 export default async function SurveyPage() {
-	const userData = await fetchServerData<{ user: { id: string } } | null>(
+	const userDataPromise = fetchServerData<{ user: { id: string } } | null>(
 		"GET",
 		"/user/me",
 	);
+	const eligibilityPromise = fetchServerData<SurveyEligibility>(
+		"GET",
+		"/model-survey/eligibility",
+	);
+
+	const userData = await userDataPromise;
 
 	if (!userData?.user) {
 		redirect("/login?returnUrl=/dashboard/survey");
 	}
 
-	const eligibility = await fetchServerData<SurveyEligibility>(
-		"GET",
-		"/model-survey/eligibility",
-	);
+	const eligibility = await eligibilityPromise;
 
 	if (!eligibility || eligibility.topModels.length === 0) {
 		const year = eligibility?.year ?? new Date().getUTCFullYear();

--- a/apps/playground/src/app/audio/page.tsx
+++ b/apps/playground/src/app/audio/page.tsx
@@ -32,36 +32,31 @@ export default async function AudioPage({
 		cookieStore.get(AUDIO_MODEL_COOKIE)?.value,
 	);
 
-	const [models, providers] = await Promise.all([
-		fetchModels(),
-		fetchProviders(),
-	]);
-
-	// Ensure the dedicated Chat org exists, then list it so it can back the
-	// default billing context for the playground.
-	await fetchServerData("GET", "/playground/chat-org");
-	const initialOrganizationsData = await fetchServerData("GET", "/orgs", {
-		params: { query: { includeChat: "true" } },
-	});
-
-	let initialProjectsData: { projects: Project[] } | null = null;
-	if (orgId) {
-		try {
-			initialProjectsData = (await fetchServerData(
-				"GET",
-				"/orgs/{id}/projects",
-				{
-					params: {
-						path: {
-							id: orgId,
+	const [models, providers, initialOrganizationsData, orgIdProjectsData] =
+		await Promise.all([
+			fetchModels(),
+			fetchProviders(),
+			// Ensure the dedicated Chat org exists, then list it so it can back the
+			// default billing context for the playground.
+			fetchServerData("GET", "/playground/chat-org").then(() =>
+				fetchServerData("GET", "/orgs", {
+					params: { query: { includeChat: "true" } },
+				}),
+			),
+			orgId
+				? fetchServerData("GET", "/orgs/{id}/projects", {
+						params: {
+							path: {
+								id: orgId,
+							},
 						},
-					},
-				},
-			)) as { projects: Project[] };
-		} catch (error) {
-			console.warn("Failed to fetch projects for organization:", orgId, error);
-		}
-	}
+					})
+				: null,
+		]);
+
+	let initialProjectsData = (orgIdProjectsData ?? null) as {
+		projects: Project[];
+	} | null;
 
 	if (
 		projectId &&

--- a/apps/playground/src/app/canvas/page.tsx
+++ b/apps/playground/src/app/canvas/page.tsx
@@ -32,36 +32,31 @@ export default async function CanvasPage({
 		cookieStore.get(CANVAS_MODEL_COOKIE)?.value,
 	);
 
-	const [models, providers] = await Promise.all([
-		fetchModels(),
-		fetchProviders(),
-	]);
-
-	// Ensure the dedicated Chat org exists, then list it so it can back the
-	// default billing context for the playground.
-	await fetchServerData("GET", "/playground/chat-org");
-	const initialOrganizationsData = await fetchServerData("GET", "/orgs", {
-		params: { query: { includeChat: "true" } },
-	});
-
-	let initialProjectsData: { projects: Project[] } | null = null;
-	if (orgId) {
-		try {
-			initialProjectsData = (await fetchServerData(
-				"GET",
-				"/orgs/{id}/projects",
-				{
-					params: {
-						path: {
-							id: orgId,
+	const [models, providers, initialOrganizationsData, orgIdProjectsData] =
+		await Promise.all([
+			fetchModels(),
+			fetchProviders(),
+			// Ensure the dedicated Chat org exists, then list it so it can back the
+			// default billing context for the playground.
+			fetchServerData("GET", "/playground/chat-org").then(() =>
+				fetchServerData("GET", "/orgs", {
+					params: { query: { includeChat: "true" } },
+				}),
+			),
+			orgId
+				? fetchServerData("GET", "/orgs/{id}/projects", {
+						params: {
+							path: {
+								id: orgId,
+							},
 						},
-					},
-				},
-			)) as { projects: Project[] };
-		} catch (error) {
-			console.warn("Failed to fetch projects for organization:", orgId, error);
-		}
-	}
+					})
+				: null,
+		]);
+
+	let initialProjectsData = (orgIdProjectsData ?? null) as {
+		projects: Project[];
+	} | null;
 
 	const allOrganizations = (
 		initialOrganizationsData &&

--- a/apps/playground/src/app/image/page.tsx
+++ b/apps/playground/src/app/image/page.tsx
@@ -32,36 +32,31 @@ export default async function ImagePage({
 		cookieStore.get(IMAGE_MODEL_COOKIE)?.value,
 	);
 
-	const [models, providers] = await Promise.all([
-		fetchModels(),
-		fetchProviders(),
-	]);
-
-	// Ensure the dedicated Chat org exists, then list it so it can back the
-	// default billing context for the playground.
-	await fetchServerData("GET", "/playground/chat-org");
-	const initialOrganizationsData = await fetchServerData("GET", "/orgs", {
-		params: { query: { includeChat: "true" } },
-	});
-
-	let initialProjectsData: { projects: Project[] } | null = null;
-	if (orgId) {
-		try {
-			initialProjectsData = (await fetchServerData(
-				"GET",
-				"/orgs/{id}/projects",
-				{
-					params: {
-						path: {
-							id: orgId,
+	const [models, providers, initialOrganizationsData, orgIdProjectsData] =
+		await Promise.all([
+			fetchModels(),
+			fetchProviders(),
+			// Ensure the dedicated Chat org exists, then list it so it can back the
+			// default billing context for the playground.
+			fetchServerData("GET", "/playground/chat-org").then(() =>
+				fetchServerData("GET", "/orgs", {
+					params: { query: { includeChat: "true" } },
+				}),
+			),
+			orgId
+				? fetchServerData("GET", "/orgs/{id}/projects", {
+						params: {
+							path: {
+								id: orgId,
+							},
 						},
-					},
-				},
-			)) as { projects: Project[] };
-		} catch (error) {
-			console.warn("Failed to fetch projects for organization:", orgId, error);
-		}
-	}
+					})
+				: null,
+		]);
+
+	let initialProjectsData = (orgIdProjectsData ?? null) as {
+		projects: Project[];
+	} | null;
 
 	if (
 		projectId &&

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -65,6 +65,11 @@ export async function renderPlaygroundShell({
 		redirect(`/?${newParams.toString()}`);
 	}
 
+	// Start the model catalogue fetches immediately — they don't depend on any
+	// of the org/billing lookups below, so they resolve while those run.
+	const modelsPromise = fetchModels();
+	const providersPromise = fetchProviders();
+
 	const initialOrganizationsData = await fetchServerData("GET", "/orgs");
 	const allOrganizations = (
 		initialOrganizationsData &&
@@ -201,8 +206,8 @@ export async function renderPlaygroundShell({
 
 	const projects = (initialProjectsData?.projects ?? []) as Project[];
 	const [models, providers] = await Promise.all([
-		fetchModels(),
-		fetchProviders(),
+		modelsPromise,
+		providersPromise,
 	]);
 
 	let selectedProject: Project | null = null;

--- a/apps/playground/src/app/realtime/page.tsx
+++ b/apps/playground/src/app/realtime/page.tsx
@@ -31,12 +31,11 @@ export default async function RealtimePage({
 		cookieStore.get(REALTIME_MODEL_COOKIE)?.value,
 	);
 
-	const [models, providers] = await Promise.all([
+	const [models, providers, initialOrganizationsData] = await Promise.all([
 		fetchModels(),
 		fetchProviders(),
+		fetchServerData("GET", "/orgs"),
 	]);
-
-	const initialOrganizationsData = await fetchServerData("GET", "/orgs");
 
 	const allOrganizations = (
 		initialOrganizationsData &&

--- a/apps/playground/src/app/video/page.tsx
+++ b/apps/playground/src/app/video/page.tsx
@@ -32,36 +32,31 @@ export default async function VideoPage({
 		cookieStore.get(VIDEO_MODEL_COOKIE)?.value,
 	);
 
-	const [models, providers] = await Promise.all([
-		fetchModels(),
-		fetchProviders(),
-	]);
-
-	// Ensure the dedicated Chat org exists, then list it so it can back the
-	// default billing context for the playground.
-	await fetchServerData("GET", "/playground/chat-org");
-	const initialOrganizationsData = await fetchServerData("GET", "/orgs", {
-		params: { query: { includeChat: "true" } },
-	});
-
-	let initialProjectsData: { projects: Project[] } | null = null;
-	if (orgId) {
-		try {
-			initialProjectsData = (await fetchServerData(
-				"GET",
-				"/orgs/{id}/projects",
-				{
-					params: {
-						path: {
-							id: orgId,
+	const [models, providers, initialOrganizationsData, orgIdProjectsData] =
+		await Promise.all([
+			fetchModels(),
+			fetchProviders(),
+			// Ensure the dedicated Chat org exists, then list it so it can back the
+			// default billing context for the playground.
+			fetchServerData("GET", "/playground/chat-org").then(() =>
+				fetchServerData("GET", "/orgs", {
+					params: { query: { includeChat: "true" } },
+				}),
+			),
+			orgId
+				? fetchServerData("GET", "/orgs/{id}/projects", {
+						params: {
+							path: {
+								id: orgId,
+							},
 						},
-					},
-				},
-			)) as { projects: Project[] };
-		} catch (error) {
-			console.warn("Failed to fetch projects for organization:", orgId, error);
-		}
-	}
+					})
+				: null,
+		]);
+
+	let initialProjectsData = (orgIdProjectsData ?? null) as {
+		projects: Project[];
+	} | null;
 
 	if (
 		projectId &&

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
@@ -18,17 +18,6 @@ export default async function Dashboard({
 	}>;
 }) {
 	const { orgId, projectId } = await params;
-
-	// Project-scoped "developer" members don't get the project-wide dashboard —
-	// send them to their personal usage view.
-	const orgsData = await fetchServerData<{
-		organizations?: { id: string; role?: string }[];
-	}>("GET", "/orgs");
-	const role = orgsData?.organizations?.find((o) => o.id === orgId)?.role;
-	if (role === "developer") {
-		redirect(`/dashboard/${orgId}/${projectId}/me`);
-	}
-
 	const searchParamsData = searchParams ? await searchParams : {};
 
 	const today = new Date();
@@ -36,7 +25,11 @@ export default async function Dashboard({
 		searchParamsData?.from ?? format(subDays(today, 6), "yyyy-MM-dd");
 	const toParam = searchParamsData?.to ?? format(today, "yyyy-MM-dd");
 
-	const initialActivityData = await fetchServerData<ActivitT>(
+	const orgsDataPromise = fetchServerData<{
+		organizations?: { id: string; role?: string }[];
+	}>("GET", "/orgs");
+
+	const initialActivityDataPromise = fetchServerData<ActivitT>(
 		"GET",
 		"/activity",
 		{
@@ -49,6 +42,16 @@ export default async function Dashboard({
 			},
 		},
 	);
+
+	// Project-scoped "developer" members don't get the project-wide dashboard —
+	// send them to their personal usage view.
+	const orgsData = await orgsDataPromise;
+	const role = orgsData?.organizations?.find((o) => o.id === orgId)?.role;
+	if (role === "developer") {
+		redirect(`/dashboard/${orgId}/${projectId}/me`);
+	}
+
+	const initialActivityData = await initialActivityDataPromise;
 
 	return (
 		<DashboardClient initialActivityData={initialActivityData ?? undefined} />

--- a/apps/ui/src/app/dashboard/[orgId]/layout.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/layout.tsx
@@ -18,13 +18,28 @@ interface OrgLayoutProps {
 export default async function OrgLayout({ children, params }: OrgLayoutProps) {
 	const { orgId } = await params;
 
-	const initialUserData = await fetchServerData<
+	const initialUserDataPromise = fetchServerData<
 		{ user: User } | undefined | null
 	>("GET", "/user/me");
 
-	const initialOrganizationsData = await fetchServerData<{
+	const initialOrganizationsDataPromise = fetchServerData<{
 		organizations: Organization[];
 	}>("GET", "/orgs");
+
+	const initialProjectsDataPromise = orgId
+		? fetchServerData("GET", "/orgs/{id}/projects", {
+				params: {
+					path: {
+						id: orgId,
+					},
+				},
+			})
+		: null;
+
+	const [initialUserData, initialOrganizationsData] = await Promise.all([
+		initialUserDataPromise,
+		initialOrganizationsDataPromise,
+	]);
 
 	const orgs = initialOrganizationsData?.organizations ?? [];
 	const isAuthorizedForOrg = orgs.some((org) => org.id === orgId);
@@ -42,17 +57,7 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
 
 	if (orgId) {
 		try {
-			initialProjectsData = await fetchServerData(
-				"GET",
-				"/orgs/{id}/projects",
-				{
-					params: {
-						path: {
-							id: orgId,
-						},
-					},
-				},
-			);
+			initialProjectsData = await initialProjectsDataPromise;
 
 			// Get last used project for navigation fallback
 			if (

--- a/apps/ui/src/app/dashboard/page.tsx
+++ b/apps/ui/src/app/dashboard/page.tsx
@@ -6,18 +6,20 @@ import { fetchServerData } from "@/lib/server-api";
 import type { User } from "@/lib/types";
 
 export default async function DashboardPage() {
-	// Fetch user data server-side
-	const initialUserData = await fetchServerData<
+	// Fetch user and organization data server-side in parallel
+	const initialUserDataPromise = fetchServerData<
 		{ user: User } | undefined | null
 	>("GET", "/user/me");
+	const initialOrganizationsDataPromise = fetchServerData("GET", "/orgs");
+
+	const initialUserData = await initialUserDataPromise;
 
 	// Redirect to login if not authenticated
 	if (!initialUserData?.user) {
 		redirect("/login");
 	}
 
-	// Fetch organizations server-side
-	const initialOrganizationsData = await fetchServerData("GET", "/orgs");
+	const initialOrganizationsData = await initialOrganizationsDataPromise;
 
 	// Check if organizations data is null (API error)
 	if (!initialOrganizationsData) {


### PR DESCRIPTION
Weekly React/Next.js best-practices audit of the four Next.js apps (`apps/ui`, `apps/code`, `apps/playground`, `apps/docs`), using Vercel's [React best-practices guide](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-best-practices/AGENTS.md) as the rulebook. All fixes this week fall in the guide's highest-impact category, **Eliminating Waterfalls (CRITICAL)** — sequential `await`s of independent requests in server components. None of the changes alter rendering, routing, or user-visible behavior; they only change when independent requests start. All of `fetchServerData`, `fetchModels`, and `fetchProviders` catch internally and never reject, so eagerly started promises cannot produce unhandled rejections on early-return/redirect paths.

## Fixes

### Rule 1.5 — Promise.all() for Independent Operations

- **`apps/ui/src/app/dashboard/[orgId]/layout.tsx`** — `/user/me`, `/orgs`, and `/orgs/{id}/projects` were awaited one after another (3 sequential round trips to the API on every dashboard navigation). The three requests are independent, so they now start together; the projects result is consumed only after the org-authorization check, same as before.
- **`apps/playground/src/app/realtime/page.tsx`** — the `/orgs` fetch ran only after models + providers resolved; it now joins their existing `Promise.all`.

### Rule 1.4 — Prevent Waterfall Chains (start independent operations immediately)

- **`apps/ui/src/app/dashboard/page.tsx`** — `/orgs` waited for `/user/me` to finish even though it doesn't depend on it. Both now start immediately; the login redirect still happens before the orgs result is consumed.
- **`apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx`** — the `/activity` fetch (the page's main payload) waited for the `/orgs` role check. Both now start together; the developer-role redirect still occurs before activity data is used.
- **`apps/code/src/app/dashboard/survey/page.tsx`** and **`apps/code/src/app/dashboard/feedback/dev-plan-cancellation/page.tsx`** — the eligibility fetch waited for `/user/me`. Both start together now; unauthenticated users still get redirected before the eligibility result is consumed.
- **`apps/playground/src/app/playground-shell.tsx`** — `fetchModels()`/`fetchProviders()` (the model catalogue for the main chat page) started only after the entire org/billing chain (`/orgs` → `/chat-plans/status` → `/playground/chat-org` → projects) completed. The promises now start first and are awaited where they always were. The org/billing chain itself is left strictly sequential — its ordering is intentional (comments in the file: the funded-org redirect must run before the chat-org fetch so redirected users never get a Chat org provisioned).

### Rule 1.3 — Dependency-Based Parallelization

- **`apps/playground/src/app/{video,image,audio,canvas}/page.tsx`** (4 files, identical pattern) — the request chain was 4 sequential blocks: models+providers → `/playground/chat-org` → `/orgs` → `/orgs/{id}/projects`. Only one edge is a real dependency (`/orgs?includeChat=true` must run after the chat-org ensure call, per the in-code comment). That edge is kept as a `.then()` chain and everything else now runs in a single `Promise.all`, collapsing 4 awaits into the longest single chain. The removed `try/catch` around the projects fetch was dead code — `fetchServerData` never throws (it logs and returns `null` internally).

## Considered and deliberately skipped

- **`export const dynamic` declarations** — untouched everywhere; they are intentional and required for loading environment variables at runtime.
- **`apps/ui` dashboard layout's `await import("content-collections")`** (rule 2.5, statically analyzable imports) — the dynamic import is guarded by a try/catch because content collections may be unavailable during build; converting it to a top-level import could break builds, so left alone.
- **Playground share page double-fetch** (`generateMetadata` + page both fetch the share) — already deduplicated by Next.js request memoization; same for the `apps/code` public profile page (same URL + options within one render pass).
- **`lucide-react`/`date-fns`/`recharts` barrel imports** (rule 2.1) — already covered: these packages are in Next.js's default `optimizePackageImports` list (and `apps/playground` configures it explicitly).
- **Playground shell org/billing chain** — intentionally sequential (see above); only the independent catalogue fetches were hoisted.
- **localStorage reads in `useEffect`** (rules 4.4/6.5) — existing usages (sidebar state, dismissed banners) are already hydration-safe post-mount reads; no change warranted.
- **`apps/docs`** — pages are statically generated with `generateStaticParams`; the `getGithubLastEdit` call runs at build/revalidate time, not per-request. Nothing actionable found.

## Verification

- `pnpm build` — 17/17 tasks successful
- `pnpm format` — clean (no diffs beyond the fixes)
- Pre-commit lint-staged (eslint + prettier) passed on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFivAdY2xhHim6s1mWPR8G

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFivAdY2xhHim6s1mWPR8G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading times across dashboard, survey, feedback, audio, canvas, image, video, realtime, and playground pages by loading related data concurrently.
  * Reduced wait times when retrieving models, providers, organizations, projects, activities, and eligibility information.
* **Bug Fixes**
  * Project-loading failures are now surfaced consistently instead of being silently logged, improving error visibility and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->