### PR TITLE
fix(api): forward provider 401 reason to the client

### DIFF
--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -425,6 +425,16 @@ keysProvider.openapi(create, async (c) => {
 		const modelPart = validationResult.model
 			? ` using model ${validationResult.model}`
 			: "";
+		// A 401 is an auth or entitlement failure, so "try again later" is the
+		// wrong advice — the key will keep failing until it is replaced or the
+		// account is granted access. The provider's own message distinguishes the
+		// two (a bad token vs. a valid token without access to the model), so
+		// surface it rather than guessing.
+		if (validationResult.statusCode === 401) {
+			throw new HTTPException(400, {
+				message: `Provider ${provider} rejected the key${modelPart}${statusPart}. Make sure the key is correct and that your account has access to that model. Provider response: ${errorMessage}`,
+			});
+		}
 		throw new HTTPException(400, {
 			message: `Error from provider ${provider}: ${errorMessage}${statusPart}${modelPart}. Please try again later or contact support.`,
 		});

--- a/packages/actions/src/validate-provider-key.spec.ts
+++ b/packages/actions/src/validate-provider-key.spec.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { models } from "@llmgateway/models";
 
 import {
 	getValidationModel,
 	pickCheapestRecentModel,
+	validateProviderKey,
 } from "./validate-provider-key.js";
 
 describe("getValidationModel", () => {
@@ -83,5 +84,72 @@ describe("pickCheapestRecentModel", () => {
 			{ id: "old", price: 0.5, releasedAt: new Date("2023-01-01") },
 		]);
 		expect(picked?.id).toBe("new");
+	});
+});
+
+describe("validateProviderKey error reporting", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function mockUpstream(status: number, body: unknown) {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify(body), {
+				status,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	}
+
+	// A provider can answer 401 for a perfectly valid key that simply lacks
+	// entitlement to the validation model (AWS Bedrock does exactly this). The
+	// reason must reach the caller instead of being flattened into a generic
+	// "invalid API key", which sends users chasing the wrong problem.
+	it("forwards the upstream message on a 401", async () => {
+		const message =
+			"openai.gpt-5.6-luna is not available for this account. You can explore other available models on Amazon Bedrock.";
+		mockUpstream(401, { error: { message } });
+
+		const result = await validateProviderKey(
+			"aws-mantle",
+			"ABSKtest",
+			undefined,
+			false,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.statusCode).toBe(401);
+		expect(result.error).toBe(message);
+	});
+
+	it("still forwards the upstream message on non-401 failures", async () => {
+		mockUpstream(429, { error: { message: "Rate limit exceeded" } });
+
+		const result = await validateProviderKey(
+			"openai",
+			"sk-test",
+			undefined,
+			false,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.statusCode).toBe(429);
+		expect(result.error).toBe("Rate limit exceeded");
+	});
+
+	it("falls back to status text when the body carries no message", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("not json", { status: 401, statusText: "Unauthorized" }),
+		);
+
+		const result = await validateProviderKey(
+			"openai",
+			"sk-test",
+			undefined,
+			false,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe("401 Unauthorized");
 	});
 });

--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -327,14 +327,11 @@ export async function validateProviderKey(
 				error: errorMessage,
 			});
 
-			if (response.status === 401) {
-				return {
-					valid: false,
-					statusCode: response.status,
-					model: validationModel?.modelId,
-				};
-			}
-
+			// 401 used to drop the upstream text and fall back to a generic
+			// "invalid API key" message, which is wrong whenever the key is fine
+			// but lacks entitlement — AWS Bedrock answers 401 with "<model> is not
+			// available for this account", and Azure/Vertex behave similarly. The
+			// caller decides how to word it; always hand it the provider's reason.
 			return {
 				valid: false,
 				error: errorMessage,


### PR DESCRIPTION
## Problem

Adding a provider key that is **valid but not entitled to the validation model** reports the wrong cause. The API already knows exactly what went wrong and logs it:

```
WARN: Provider key validation returned error response
    provider: "aws-mantle"
    model: "gpt-5.6-luna"
    statusCode: 401
    error: "openai.gpt-5.6-luna is not available for this account. You can explore
            other available models on Amazon Bedrock. For additional access options,
            contact AWS Sales at https://aws.amazon.com/contact-us/sales-support/"
```

…and then tells the user:

> Invalid API key. Please make sure the key is correct.

So they go and re-check a key that was never the problem.

## Cause

`validateProviderKey` special-cased 401 and returned `{ valid: false, statusCode }` **without** the `error` field, unlike every other status:

```ts
if (response.status === 401) {
  return { valid: false, statusCode: response.status, model: validationModel?.modelId };
}
return { valid: false, error: errorMessage, statusCode: response.status, ... };
```

`keys-provider.ts` branches on `validationResult.error` for the detailed message and otherwise falls through to the generic `Invalid API key` line — so dropping the field is exactly what discards the reason. The special case dates back to the original implementation with no stated rationale.

## Fix

Return the upstream reason for 401 like any other status, and word that case for auth failures. "Please try again later or contact support" is wrong advice here — the key will keep failing until it is replaced or the account is granted access:

> Provider aws-mantle rejected the key using model gpt-5.6-luna (status 401). Make sure the key is correct and that your account has access to that model. Provider response: openai.gpt-5.6-luna is not available for this account. …

The provider's own text is what distinguishes a bad token from a valid-but-unentitled one, which is why it's surfaced rather than guessed at. The detail is placed last so it reads correctly regardless of how the upstream message is punctuated.

No UI change needed — the dialog's `onError` already renders the API's `message`.

## Notes

- `validateProviderKey` has exactly one caller (`keys-provider.ts`), so the blast radius is contained.
- The generic `if (!validationResult.valid)` branch is now unreachable from this caller but kept as a defensive fallback, since `error` is optional on `ProviderValidationResult`.
- The returned text originates from the provider and is shown only to the org member who submitted that key, so nothing crosses a trust boundary.
- Three unit tests cover it: a 401 forwards the message, non-401 failures still do, and a body with no parseable message falls back to `"401 Unauthorized"`.

`pnpm format` and `pnpm build` pass; `validate-provider-key.spec.ts` is green (9 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider-key validation errors by preserving and displaying relevant messages from upstream services.
  * Added a targeted error when a key is invalid or lacks access to the selected model.
  * Continued providing clear fallback guidance for other validation failures.
* **Tests**
  * Added coverage for unauthorized, rate-limited, and message-less provider responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->