### PR TITLE
test(api): cover the 401 provider-key route message

### DIFF
--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -1,8 +1,9 @@
-import { expect, test, beforeEach, describe, afterEach } from "vitest";
+import { expect, test, beforeEach, describe, afterEach, vi } from "vitest";
 
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
+import { validateProviderKey } from "@llmgateway/actions";
 import {
 	redisClient,
 	SWR_PREFIX,
@@ -10,6 +11,17 @@ import {
 	waitForSwrMirrorWrites,
 } from "@llmgateway/cache";
 import { and, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
+
+import type * as ActionsModule from "@llmgateway/actions";
+
+// Validation is skipped in the test env, so the only way to exercise the
+// upstream-failure branches is to stand in for the validator. Delegates to the
+// real implementation unless a test overrides it, keeping every other case on
+// the normal path.
+vi.mock("@llmgateway/actions", async (importOriginal) => {
+	const actual = await importOriginal<typeof ActionsModule>();
+	return { ...actual, validateProviderKey: vi.fn(actual.validateProviderKey) };
+});
 
 describe("provider keys route", () => {
 	let token: string;
@@ -165,6 +177,74 @@ describe("provider keys route", () => {
 			}),
 		});
 		expect(res.status).toBe(400);
+	});
+
+	describe("POST /keys/provider upstream validation failures", () => {
+		// A provider can answer 401 for a key that is perfectly valid but not
+		// entitled to the validation model — AWS Bedrock does exactly this. The
+		// response must carry that reason instead of a generic "invalid key",
+		// which would send the user chasing the wrong problem.
+		test("surfaces the provider reason behind a 401", async () => {
+			const reason =
+				"openai.gpt-5.6-luna is not available for this account. You can explore other available models on Amazon Bedrock.";
+			vi.mocked(validateProviderKey).mockResolvedValueOnce({
+				valid: false,
+				statusCode: 401,
+				model: "gpt-5.6-luna",
+				error: reason,
+			});
+
+			const res = await app.request("/keys/provider", {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: JSON.stringify({
+					provider: "aws-mantle",
+					token: "ABSKtest",
+					organizationId: "test-org-id",
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.message).toContain(reason);
+			expect(json.message).toContain("aws-mantle");
+			expect(json.message).toContain("gpt-5.6-luna");
+			expect(json.message).toContain("status 401");
+			// The old generic wording is what this fix removes.
+			expect(json.message).not.toContain("Invalid API key");
+			// A 401 never resolves by waiting, so it must not advise retrying.
+			expect(json.message).not.toContain("try again later");
+
+			const stored = await db.query.providerKey.findFirst({
+				where: { provider: { eq: "aws-mantle" } },
+			});
+			expect(stored).toBeUndefined();
+		});
+
+		test("keeps the retryable wording for non-401 upstream errors", async () => {
+			vi.mocked(validateProviderKey).mockResolvedValueOnce({
+				valid: false,
+				statusCode: 429,
+				model: "gpt-4o-mini",
+				error: "Rate limit exceeded",
+			});
+
+			const res = await app.request("/keys/provider", {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: JSON.stringify({
+					provider: "inference.net",
+					token: "inference-test-token",
+					organizationId: "test-org-id",
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.message).toContain("Rate limit exceeded");
+			expect(json.message).toContain("status 429");
+			expect(json.message).toContain("try again later");
+		});
 	});
 
 	test("POST /keys/provider rejects stealth providers", async () => {


### PR DESCRIPTION
Follow-up to #3393, which merged before this landed.

That PR changed the message `POST /keys/provider` returns when a provider answers 401, and covered the actions layer with unit tests — but nothing asserted what the route itself returns, which is the layer the bug was reported at. This adds that.

## What it covers

Validation is skipped in the test env (`isTestEnv` → `skipValidation`), so the spec mocks `validateProviderKey` through `importOriginal`, delegating to the real implementation by default so the other 28 tests in the file stay on the normal path.

- **401** — the response carries the provider's reason, the provider, the model and `status 401`, and contains neither `Invalid API key` nor `try again later`.
- **429** — the retryable wording is unchanged, confirming the new branch didn't capture non-auth failures.

## Not vacuous

Reverting just the route branch fails the 401 test with:

```
AssertionError: expected 'Error from provider aws-mantle: opena…' not to contain 'try again later'
```

That assertion is the one doing the work: without the fix the message still contains the reason, provider, model and status — only the *advice* differs.

Because the route test mocks the validator, it bypasses the actions-layer change, so the two layers stay covered independently: `validate-provider-key.spec.ts` proves the 401 reason is returned at all, and these prove the route words it correctly. Neither alone catches a regression in the other.

Test-only; no source changes. 30 tests green in the spec, `pnpm format` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider key validation error handling.
  * Authentication failures now display the provider’s error details and status without misleading retry or invalid-key messaging.
  * Other upstream failures continue to provide retry guidance.
  * Invalid provider keys are not saved after unsuccessful validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->