### PR TITLE
feat(gateway): add mapped view to /v1/models

### DIFF
--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -78,6 +78,41 @@ describe("Models API", () => {
 		expect(sonnet?.display_name).toBe("Claude Sonnet 5");
 	});
 
+	test("GET /v1/models?mapped=true returns one provider-prefixed entry per mapping", async () => {
+		const [mappedRes, rootRes] = await Promise.all([
+			app.request("/v1/models?mapped=true"),
+			app.request("/v1/models"),
+		]);
+		expect(mappedRes.status).toBe(200);
+		const mapped = await mappedRes.json();
+		const root = await rootRes.json();
+
+		expect(Array.isArray(mapped.data)).toBe(true);
+		// The mapped view expands multi-provider models, so it must be strictly
+		// larger than the aggregated catalogue.
+		expect(mapped.data.length).toBeGreaterThan(root.data.length);
+
+		// Ids are `provider/model-id`, unique, and each entry carries exactly the
+		// one mapping named by its prefix.
+		const ids = mapped.data.map((m: { id: string }) => m.id);
+		expect(new Set(ids).size).toBe(ids.length);
+		for (const model of mapped.data) {
+			expect(model.providers).toHaveLength(1);
+			expect(model.id).toBe(
+				`${model.providers[0].providerId}/${model.id.split("/").slice(1).join("/")}`,
+			);
+		}
+
+		// Entry-level pricing/context come from that specific mapping, not the
+		// cheapest mapping across providers.
+		const sonnet = mapped.data.find(
+			(m: { id: string }) => m.id === "anthropic/claude-sonnet-5",
+		);
+		expect(sonnet).toBeDefined();
+		expect(sonnet.display_name).toBe("Claude Sonnet 5 (Anthropic)");
+		expect(sonnet.pricing.prompt).toBe(sonnet.providers[0].pricing.prompt);
+	});
+
 	test("GET /v1/models exposes min_cacheable_tokens on provider mappings that define it", async () => {
 		const res = await app.request("/v1/models");
 		expect(res.status).toBe(200);

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -165,6 +165,14 @@ const listModels = createRoute({
 					"Only return models and provider mappings whose provider does not train on API data",
 				)
 				.openapi({ example: "false" }),
+			mapped: z
+				.string()
+				.optional()
+				.transform((val) => val === "true")
+				.describe(
+					"Return one entry per provider mapping with `provider/model-id` ids (the gateway's provider-pinned request format) instead of one aggregated entry per model. Each entry carries that specific mapping's pricing, context length, and capabilities.",
+				)
+				.openapi({ example: "false" }),
 		}),
 	},
 	responses: {
@@ -185,6 +193,7 @@ modelsApi.openapi(listModels, async (c) => {
 		const includeDeactivated = query.include_deactivated || false;
 		const excludeDeprecated = query.exclude_deprecated || false;
 		const noTraining = query.no_training || false;
+		const mapped = query.mapped || false;
 		const currentDate = new Date();
 
 		// Set of provider ids that do not train on API data
@@ -237,6 +246,105 @@ modelsApi.openapi(listModels, async (c) => {
 					}))
 					.filter((model) => model.providers.length > 0)
 			: deactivationFilteredModels;
+
+		// Mapped view: one entry per provider mapping, addressed the way the
+		// gateway accepts provider-pinned requests (`provider/model-id`). The
+		// deactivation/deprecation filters apply per mapping here — a mapping
+		// drops out on its own rather than only once the whole model flips.
+		if (mapped) {
+			const mappedData = filteredModels.flatMap((model: ModelDefinition) =>
+				model.providers
+					.filter((provider) => {
+						if (
+							!includeDeactivated &&
+							provider.deactivatedAt &&
+							currentDate > provider.deactivatedAt
+						) {
+							return false;
+						}
+						if (
+							excludeDeprecated &&
+							provider.deprecatedAt &&
+							currentDate > provider.deprecatedAt
+						) {
+							return false;
+						}
+						return true;
+					})
+					.map((provider: ProviderModelMapping) => {
+						const providerDef = providers.find(
+							(p) => p.id === provider.providerId,
+						);
+						const name = `${model.name ?? model.id} (${providerDef?.name ?? provider.providerId})`;
+
+						const inputModalities: (
+							"text" | "image" | "video" | "embedding" | "audio"
+						)[] = ["text"];
+						if (provider.vision) {
+							inputModalities.push("image");
+						}
+						if (provider.audio) {
+							inputModalities.push("audio");
+						}
+
+						const outputModalities: (
+							| "text"
+							| "image"
+							| "video"
+							| "embedding"
+							| "audio"
+							| "ocr"
+							| "transcription"
+							| "rerank"
+						)[] = model.output ?? ["text"];
+
+						return {
+							id: `${provider.providerId}/${model.id}`,
+							name,
+							display_name: name,
+							aliases: model.aliases?.map(
+								(alias) => `${provider.providerId}/${alias}`,
+							),
+							created: model.releasedAt
+								? Math.floor(model.releasedAt.getTime() / 1000)
+								: undefined,
+							description: `${model.id} served by ${provider.providerId}`,
+							family: model.family,
+							architecture: {
+								input_modalities: inputModalities,
+								output_modalities: outputModalities,
+								tokenizer: "GPT",
+							},
+							top_provider: {
+								is_moderated: true,
+							},
+							providers: [serializeProviderMapping(provider, model)],
+							pricing: {
+								...buildPricingFields(
+									hasPricing(provider) ? provider : undefined,
+								),
+								web_search: "0",
+								internal_reasoning: "0",
+							},
+							context_length: provider.contextSize,
+							max_output: provider.maxOutput,
+							per_request_limits: getPerRequestLimits(model),
+							supported_parameters: getSupportedParametersFromModel({
+								...model,
+								providers: [provider],
+							}),
+							json_output: provider.jsonOutput === true,
+							structured_outputs: provider.jsonOutputSchema === true,
+							free: model.free ?? false,
+							deprecated_at: provider.deprecatedAt?.toISOString(),
+							deactivated_at: provider.deactivatedAt?.toISOString(),
+							stability: provider.stability ?? model.stability,
+						};
+					}),
+			);
+
+			return c.json({ data: mappedData });
+		}
 
 		const modelData = filteredModels.map((model: ModelDefinition) => {
 			// Determine input modalities (if model supports images)
@@ -291,34 +399,9 @@ modelsApi.openapi(listModels, async (c) => {
 				top_provider: {
 					is_moderated: true,
 				},
-				providers: model.providers.map((provider: ProviderModelMapping) => {
-					// Find the provider definition to get cancellation support
-					const providerDef = providers.find(
-						(p) => p.id === provider.providerId,
-					);
-
-					return {
-						providerId: provider.providerId,
-						externalId: provider.externalId,
-						supportedVideoSizes: provider.supportedVideoSizes,
-						supportsVideoAudio: provider.supportsVideoAudio,
-						supportsVideoWithoutAudio: provider.supportsVideoWithoutAudio,
-						pricing: hasPricing(provider)
-							? buildPricingFields(provider)
-							: undefined,
-						streaming: provider.streaming,
-						vision: provider.vision ?? false,
-						realtime: provider.realtime === true ? true : undefined,
-						cancellation: providerDef?.cancellation ?? false,
-						tools: provider.tools ?? false,
-						parallelToolCalls: provider.parallelToolCalls ?? false,
-						reasoning: provider.reasoning ?? false,
-						reasoning_efforts: provider.reasoningEfforts,
-						min_cacheable_tokens: provider.minCacheableTokens,
-						max_output: provider.maxOutput,
-						stability: provider.stability ?? model.stability,
-					};
-				}),
+				providers: model.providers.map((provider: ProviderModelMapping) =>
+					serializeProviderMapping(provider, model),
+				),
 				pricing: {
 					...buildPricingFields(pricingProvider),
 					web_search: "0", // Not defined in model definitions yet
@@ -363,6 +446,36 @@ modelsApi.openapi(listModels, async (c) => {
 		throw new HTTPException(500, { message: "Internal server error" });
 	}
 });
+
+// Serialize a provider mapping into the public `providers` entry shape shared
+// by the aggregated and mapped views.
+function serializeProviderMapping(
+	provider: ProviderModelMapping,
+	model: ModelDefinition,
+) {
+	// Find the provider definition to get cancellation support
+	const providerDef = providers.find((p) => p.id === provider.providerId);
+
+	return {
+		providerId: provider.providerId,
+		externalId: provider.externalId,
+		supportedVideoSizes: provider.supportedVideoSizes,
+		supportsVideoAudio: provider.supportsVideoAudio,
+		supportsVideoWithoutAudio: provider.supportsVideoWithoutAudio,
+		pricing: hasPricing(provider) ? buildPricingFields(provider) : undefined,
+		streaming: provider.streaming,
+		vision: provider.vision ?? false,
+		realtime: provider.realtime === true ? true : undefined,
+		cancellation: providerDef?.cancellation ?? false,
+		tools: provider.tools ?? false,
+		parallelToolCalls: provider.parallelToolCalls ?? false,
+		reasoning: provider.reasoning ?? false,
+		reasoning_efforts: provider.reasoningEfforts,
+		min_cacheable_tokens: provider.minCacheableTokens,
+		max_output: provider.maxOutput,
+		stability: provider.stability ?? model.stability,
+	};
+}
 
 // Collapse the per-provider-mapping deprecation/deactivation dates into a single
 // model-level date. A model is only considered deprecated/deactivated once every


### PR DESCRIPTION
## Problem

We are splitting the opencode/models.dev catalogue into two providers: **DevPass (LLM Gateway)** keeps the aggregated root-model catalogue, while a new **LLM Gateway** provider lists provider-pinned models the way the gateway actually accepts them (`provider/model-id`). The `/v1/models` endpoint only exposed the aggregated view, so there was nothing for the second provider's sync to consume.

## Approach

Adds a `mapped=true` query param to `GET /v1/models`. The default response is unchanged. With `mapped=true` the endpoint returns one entry per provider mapping, in the **same response schema**:

- `id` is `provider/model-id` (e.g. `anthropic/claude-sonnet-5`), `name`/`display_name` become `Model (Provider)`, and aliases are prefixed the same way.
- Pricing, `context_length`, `max_output`, `json_output`/`structured_outputs`, modalities, and `supported_parameters` come from that specific mapping instead of the aggregate/cheapest-mapping values.
- `include_deactivated`/`exclude_deprecated` apply per mapping in this view — a dead mapping drops out on its own rather than only once the whole model flips; `deprecated_at`/`deactivated_at` are that mapping's own dates.
- The per-mapping serializer is shared between both views (`serializeProviderMapping`), so the shapes cannot drift.

Currently ~253 aggregated models expand to ~442 mapped entries, with no duplicate ids (guaranteed by the one-mapping-per-provider catalogue rule).

## Verification

- `pnpm build` passes.
- Added a spec asserting: mapped ids are unique and provider-prefixed, each entry carries exactly the one mapping named by its prefix, entry-level pricing equals that mapping's pricing, and the mapped list is strictly larger than the aggregated one. All 24 models-API tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pReWhniXJcDL9aiQHqoFQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mapped view for the models API, returning provider-specific model entries.
  * Mapped entries include provider-specific identifiers, display names, pricing, capabilities, limits, and lifecycle information.
  * Deactivation and deprecation filtering now applies independently to each provider mapping.
  * The existing aggregated models view remains available.

* **Tests**
  * Added integration coverage for mapped model results, uniqueness, provider mappings, pricing, and display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->