### PR TITLE
feat: split BYOK vs credits in usage reporting

### DIFF
--- a/apps/api/src/lib/mode-split.ts
+++ b/apps/api/src/lib/mode-split.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+import { sql } from "@llmgateway/db";
+
+import type { AnyColumn } from "@llmgateway/db";
+
+/**
+ * Aggregated credits-vs-BYOK ("api-keys") split for any rollup table carrying
+ * the per-mode measure columns. The blended `cost`/`requestCount` columns on
+ * those tables include both modes; these fields let clients present a
+ * Total / Credits / BYOK view without extra queries.
+ */
+export function modeSplitFields(table: {
+	creditsRequestCount: AnyColumn;
+	apiKeysRequestCount: AnyColumn;
+	creditsCost: AnyColumn;
+	apiKeysCost: AnyColumn;
+}) {
+	return {
+		creditsRequestCount:
+			sql<number>`COALESCE(SUM(${table.creditsRequestCount}), 0)`.as(
+				"creditsRequestCount",
+			),
+		apiKeysRequestCount:
+			sql<number>`COALESCE(SUM(${table.apiKeysRequestCount}), 0)`.as(
+				"apiKeysRequestCount",
+			),
+		creditsCost: sql<number>`COALESCE(SUM(${table.creditsCost}), 0)`.as(
+			"creditsCost",
+		),
+		apiKeysCost: sql<number>`COALESCE(SUM(${table.apiKeysCost}), 0)`.as(
+			"apiKeysCost",
+		),
+	};
+}
+
+export const modeSplitSchema = {
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
+};
+
+export interface ModeSplitRow {
+	creditsRequestCount: number | string | null;
+	apiKeysRequestCount: number | string | null;
+	creditsCost: number | string | null;
+	apiKeysCost: number | string | null;
+}
+
+export function mapModeSplit(row: ModeSplitRow) {
+	return {
+		creditsRequestCount: Number(row.creditsRequestCount),
+		apiKeysRequestCount: Number(row.apiKeysRequestCount),
+		creditsCost: Number(row.creditsCost),
+		apiKeysCost: Number(row.apiKeysCost),
+	};
+}

--- a/apps/api/src/lib/user-usage-breakdown.ts
+++ b/apps/api/src/lib/user-usage-breakdown.ts
@@ -1,3 +1,4 @@
+import { mapModeSplit, modeSplitFields } from "@/lib/mode-split.js";
 import { bucketDate } from "@/utils/timezone.js";
 
 import {
@@ -23,6 +24,10 @@ export interface UserUsageRow {
 	outputTokens: number;
 	totalTokens: number;
 	cost: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 /**
@@ -78,6 +83,7 @@ export async function getUserUsageBreakdown(options: {
 					"totalTokens",
 				),
 			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
+			...modeSplitFields(apiKeyHourlyStats),
 		})
 		.from(apiKeyHourlyStats)
 		.innerJoin(tables.apiKey, eq(tables.apiKey.id, apiKeyHourlyStats.apiKeyId))
@@ -117,5 +123,6 @@ export async function getUserUsageBreakdown(options: {
 		outputTokens: Number(row.outputTokens),
 		totalTokens: Number(row.totalTokens),
 		cost: Number(row.cost),
+		...mapModeSplit(row),
 	}));
 }

--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -2338,4 +2338,147 @@ describe("activity endpoint", () => {
 			expect(res.status).toBe(403);
 		});
 	});
+
+	describe("credits vs BYOK mode split", () => {
+		beforeEach(async () => {
+			const now = new Date();
+			await db.insert(tables.log).values([
+				{
+					id: "mode-log-credits",
+					requestId: "mode-log-credits",
+					createdAt: now,
+					updatedAt: now,
+					organizationId: "test-org-id",
+					projectId: "test-project-id",
+					apiKeyId: "test-api-key-id",
+					duration: 100,
+					requestedModel: "mode-model",
+					requestedProvider: "openai",
+					usedModel: "mode-model",
+					usedProvider: "openai",
+					responseSize: 100,
+					promptTokens: "10",
+					completionTokens: "10",
+					totalTokens: "20",
+					messages: JSON.stringify([{ role: "user", content: "credits" }]),
+					mode: "hybrid",
+					usedMode: "credits",
+					cost: 1.5,
+					source: "test-agent",
+				},
+				{
+					id: "mode-log-byok",
+					requestId: "mode-log-byok",
+					createdAt: now,
+					updatedAt: now,
+					organizationId: "test-org-id",
+					projectId: "test-project-id",
+					apiKeyId: "test-api-key-id",
+					duration: 100,
+					requestedModel: "mode-model",
+					requestedProvider: "openai",
+					usedModel: "mode-model",
+					usedProvider: "openai",
+					responseSize: 100,
+					promptTokens: "10",
+					completionTokens: "10",
+					totalTokens: "20",
+					messages: JSON.stringify([{ role: "user", content: "byok" }]),
+					mode: "hybrid",
+					usedMode: "api-keys",
+					cost: 2.5,
+					source: "test-agent",
+				},
+			]);
+			await aggregateLogsForTesting();
+		});
+
+		test("splits day totals and model breakdown by usedMode", async () => {
+			const res = await app.request(
+				"/activity?days=7&projectId=test-project-id",
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			const day = data.activity.find(
+				(d: { creditsCost: number }) => d.creditsCost > 0,
+			);
+			expect(day).toBeDefined();
+			expect(day.creditsCost).toBeCloseTo(1.5, 5);
+			expect(day.apiKeysCost).toBeCloseTo(2.5, 5);
+			expect(day.creditsRequestCount).toBe(1);
+			// The two seeded api-keys logs from the outer beforeEach plus the BYOK
+			// log above.
+			expect(day.apiKeysRequestCount).toBe(3);
+			expect(day.cost).toBeCloseTo(4, 5);
+
+			const model = day.modelBreakdown.find(
+				(m: { id: string }) => m.id === "mode-model",
+			);
+			expect(model).toBeDefined();
+			expect(model.creditsCost).toBeCloseTo(1.5, 5);
+			expect(model.apiKeysCost).toBeCloseTo(2.5, 5);
+			expect(model.creditsRequestCount).toBe(1);
+			expect(model.apiKeysRequestCount).toBe(1);
+		});
+
+		test("splits the api key breakdown by usedMode", async () => {
+			const res = await app.request(
+				"/activity?days=7&projectId=test-project-id&groupBy=apiKey",
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			const entries = data.activity.flatMap(
+				(d: { apiKeyBreakdown: { id: string; creditsCost: number }[] }) =>
+					d.apiKeyBreakdown,
+			);
+			const entry = entries.find(
+				(e: { id: string; creditsCost: number }) =>
+					e.id === "test-api-key-id" && e.creditsCost > 0,
+			);
+			expect(entry).toBeDefined();
+			expect(entry.creditsCost).toBeCloseTo(1.5, 5);
+			expect(entry.apiKeysCost).toBeCloseTo(2.5, 5);
+			expect(entry.creditsRequestCount).toBe(1);
+			expect(entry.apiKeysRequestCount).toBe(3);
+		});
+
+		test("splits the source aggregation by usedMode", async () => {
+			// aggregateLogsForTesting does not cover the source rollup, so seed it
+			// directly like the other /activity/sources tests do.
+			await db.insert(tables.projectHourlySourceStats).values({
+				projectId: "test-project-id",
+				hourTimestamp: new Date(),
+				source: "test-agent",
+				requestCount: 2,
+				inputTokens: "20",
+				outputTokens: "20",
+				totalTokens: "40",
+				cost: 4,
+				creditsRequestCount: 1,
+				apiKeysRequestCount: 1,
+				creditsCost: 1.5,
+				apiKeysCost: 2.5,
+			});
+
+			const res = await app.request(
+				"/activity/sources?projectId=test-project-id",
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			const source = data.sources.find(
+				(s: { source: string }) => s.source === "test-agent",
+			);
+			expect(source).toBeDefined();
+			expect(source.creditsCost).toBeCloseTo(1.5, 5);
+			expect(source.apiKeysCost).toBeCloseTo(2.5, 5);
+			expect(source.creditsRequestCount).toBe(1);
+			expect(source.apiKeysRequestCount).toBe(1);
+		});
+	});
 });

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -3,6 +3,11 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { apiKeyScopeFilter } from "@/lib/api-key-scope-filter.js";
+import {
+	mapModeSplit,
+	modeSplitFields,
+	modeSplitSchema,
+} from "@/lib/mode-split.js";
 import { requireEnterpriseAdmin } from "@/lib/require-enterprise-admin.js";
 import { getUserUsageBreakdown } from "@/lib/user-usage-breakdown.js";
 import {
@@ -49,6 +54,7 @@ const modelUsageSchema = z.object({
 	outputTokens: z.number(),
 	totalTokens: z.number(),
 	cost: z.number(),
+	...modeSplitSchema,
 });
 
 // Define the response schema for api-key-specific usage
@@ -60,6 +66,7 @@ const apiKeyUsageSchema = z.object({
 	outputTokens: z.number(),
 	totalTokens: z.number(),
 	cost: z.number(),
+	...modeSplitSchema,
 });
 
 // Define the response schema for per-member usage. Requests are attributed to
@@ -73,6 +80,7 @@ const userUsageSchema = z.object({
 	outputTokens: z.number(),
 	totalTokens: z.number(),
 	cost: z.number(),
+	...modeSplitSchema,
 });
 
 // Define the response schema for daily activity
@@ -496,6 +504,7 @@ activity.openapi(getActivity, async (c) => {
 				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cost}), 0)`.as(
 					"cost",
 				),
+				...modeSplitFields(apiKeyHourlyModelStats),
 			})
 			.from(apiKeyHourlyModelStats)
 			.where(
@@ -531,6 +540,7 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens: Number(breakdown.outputTokens),
 				totalTokens: Number(breakdown.totalTokens),
 				cost: Number(breakdown.cost),
+				...mapModeSplit(breakdown),
 			});
 		}
 
@@ -569,6 +579,7 @@ activity.openapi(getActivity, async (c) => {
 					cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
 						"cost",
 					),
+					...modeSplitFields(apiKeyHourlyStats),
 				})
 				.from(apiKeyHourlyStats)
 				.leftJoin(apiKey, eq(apiKey.id, apiKeyHourlyStats.apiKeyId))
@@ -600,6 +611,7 @@ activity.openapi(getActivity, async (c) => {
 					outputTokens: Number(breakdown.outputTokens),
 					totalTokens: Number(breakdown.totalTokens),
 					cost: Number(breakdown.cost),
+					...mapModeSplit(breakdown),
 				});
 			}
 		}
@@ -854,6 +866,7 @@ activity.openapi(getActivity, async (c) => {
 				cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
 					"cost",
 				),
+				...modeSplitFields(projectHourlyModelStats),
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -880,6 +893,7 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens: Number(breakdown.outputTokens),
 				totalTokens: Number(breakdown.totalTokens),
 				cost: Number(breakdown.cost),
+				...mapModeSplit(breakdown),
 			});
 		}
 	}
@@ -918,6 +932,7 @@ activity.openapi(getActivity, async (c) => {
 				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
 					"cost",
 				),
+				...modeSplitFields(apiKeyHourlyStats),
 			})
 			.from(apiKeyHourlyStats)
 			.leftJoin(apiKey, eq(apiKey.id, apiKeyHourlyStats.apiKeyId))
@@ -944,6 +959,7 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens: Number(breakdown.outputTokens),
 				totalTokens: Number(breakdown.totalTokens),
 				cost: Number(breakdown.cost),
+				...mapModeSplit(breakdown),
 			});
 		}
 	}
@@ -974,6 +990,10 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens: breakdown.outputTokens,
 				totalTokens: breakdown.totalTokens,
 				cost: breakdown.cost,
+				creditsRequestCount: breakdown.creditsRequestCount,
+				apiKeysRequestCount: breakdown.apiKeysRequestCount,
+				creditsCost: breakdown.creditsCost,
+				apiKeysCost: breakdown.apiKeysCost,
 			});
 		}
 	}
@@ -1069,6 +1089,7 @@ const sourceUsageSchema = z.object({
 	outputTokens: z.number(),
 	totalTokens: z.number(),
 	cost: z.number(),
+	...modeSplitSchema,
 	lastUsedAt: z.string().nullable(),
 });
 
@@ -1183,6 +1204,7 @@ activity.openapi(getSourceActivity, async (c) => {
 			cost: sql<number>`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`.as(
 				"cost",
 			),
+			...modeSplitFields(projectHourlySourceStats),
 			lastUsedAt: sql<
 				string | null
 			>`to_char(MAX(${projectHourlySourceStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS')`.as(
@@ -1208,6 +1230,7 @@ activity.openapi(getSourceActivity, async (c) => {
 			outputTokens: Number(r.outputTokens),
 			totalTokens: Number(r.totalTokens),
 			cost: Number(r.cost),
+			...mapModeSplit(r),
 			lastUsedAt: r.lastUsedAt
 				? new Date(r.lastUsedAt + "Z").toISOString()
 				: null,

--- a/apps/api/src/routes/admin-metrics-mode-split.spec.ts
+++ b/apps/api/src/routes/admin-metrics-mode-split.spec.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import {
+	aggregateLogsForTesting,
+	createTestUser,
+	deleteAll,
+} from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const ORG_ID = "mode-split-org";
+const PROJECT_ID = "mode-split-project";
+const API_KEY_ID = "mode-split-key";
+const DEVPASS_ORG_ID = "mode-split-devpass-org";
+const DEVPASS_PROJECT_ID = "mode-split-devpass-project";
+const DEVPASS_KEY_ID = "mode-split-devpass-key";
+
+function makeLog(o: {
+	id: string;
+	projectId: string;
+	organizationId: string;
+	apiKeyId: string;
+	usedMode: "credits" | "api-keys";
+	cost: number;
+	dataStorageCost?: string;
+}) {
+	const now = new Date();
+	return {
+		id: o.id,
+		requestId: o.id,
+		createdAt: now,
+		updatedAt: now,
+		organizationId: o.organizationId,
+		projectId: o.projectId,
+		apiKeyId: o.apiKeyId,
+		duration: 100,
+		requestedModel: "gpt-4",
+		requestedProvider: "openai",
+		usedModel: "gpt-4",
+		usedProvider: "openai",
+		responseSize: 100,
+		promptTokens: "10",
+		completionTokens: "10",
+		totalTokens: "20",
+		messages: JSON.stringify([{ role: "user", content: "hi" }]),
+		mode: "hybrid" as const,
+		usedMode: o.usedMode,
+		cost: o.cost,
+		...(o.dataStorageCost ? { dataStorageCost: o.dataStorageCost } : {}),
+	};
+}
+
+describe("admin — credits vs BYOK mode split", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: ORG_ID,
+				name: "Mode Split Org",
+				billingEmail: "mode-split@example.com",
+			},
+			{
+				id: DEVPASS_ORG_ID,
+				name: "Mode Split DevPass Org",
+				billingEmail: "mode-split-devpass@example.com",
+				kind: "devpass",
+			},
+		]);
+
+		await db.insert(tables.transaction).values([
+			// $100 topped up on the PAYG org.
+			{
+				organizationId: ORG_ID,
+				type: "credit_topup",
+				amount: "105",
+				creditAmount: "100",
+				status: "completed",
+			},
+			// A plan transaction so the DevPass org's usage is excluded from the
+			// global credit-economy metrics.
+			{
+				organizationId: DEVPASS_ORG_ID,
+				type: "dev_plan_start",
+				amount: "20",
+				creditAmount: "40",
+				status: "completed",
+				stripeInvoiceId: "inv_mode_split_dev_1",
+			},
+		]);
+
+		await db.insert(tables.project).values([
+			{
+				id: PROJECT_ID,
+				name: "Mode Split Project",
+				organizationId: ORG_ID,
+			},
+			{
+				id: DEVPASS_PROJECT_ID,
+				name: "Mode Split DevPass Project",
+				organizationId: DEVPASS_ORG_ID,
+			},
+		]);
+
+		await db.insert(tables.apiKey).values([
+			{
+				id: API_KEY_ID,
+				token: "mode-split-token",
+				projectId: PROJECT_ID,
+				description: "Mode Split Key",
+				createdBy: "test-user-id",
+			},
+			{
+				id: DEVPASS_KEY_ID,
+				token: "mode-split-devpass-token",
+				projectId: DEVPASS_PROJECT_ID,
+				description: "Mode Split DevPass Key",
+				createdBy: "test-user-id",
+			},
+		]);
+
+		await db.insert(tables.log).values([
+			makeLog({
+				id: "mode-split-log-credits",
+				projectId: PROJECT_ID,
+				organizationId: ORG_ID,
+				apiKeyId: API_KEY_ID,
+				usedMode: "credits",
+				cost: 10,
+			}),
+			makeLog({
+				id: "mode-split-log-byok",
+				projectId: PROJECT_ID,
+				organizationId: ORG_ID,
+				apiKeyId: API_KEY_ID,
+				usedMode: "api-keys",
+				cost: 40,
+				dataStorageCost: "0.5",
+			}),
+			makeLog({
+				id: "mode-split-devpass-credits",
+				projectId: DEVPASS_PROJECT_ID,
+				organizationId: DEVPASS_ORG_ID,
+				apiKeyId: DEVPASS_KEY_ID,
+				usedMode: "credits",
+				cost: 3,
+			}),
+			makeLog({
+				id: "mode-split-devpass-byok",
+				projectId: DEVPASS_PROJECT_ID,
+				organizationId: DEVPASS_ORG_ID,
+				apiKeyId: DEVPASS_KEY_ID,
+				usedMode: "api-keys",
+				cost: 90,
+			}),
+		]);
+
+		await aggregateLogsForTesting();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("GET /admin/metrics splits spend and derives unusedCredits from debited spend", async () => {
+		const res = await app.request("/admin/metrics", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			totalSpent: number;
+			totalCreditsSpent: number;
+			totalApiKeysSpent: number;
+			unusedCredits: number;
+			overage: number;
+		};
+
+		// Blended stays blended; DevPass-org usage is excluded from all three.
+		expect(body.totalSpent).toBeCloseTo(50, 3);
+		expect(body.totalCreditsSpent).toBeCloseTo(10, 3);
+		expect(body.totalApiKeysSpent).toBeCloseTo(40, 3);
+		// Only debited spend counts against topped-up credits:
+		// 100 - (10 credits + 0.5 BYOK storage) = 89.5 — NOT 100 - 50.5.
+		expect(body.unusedCredits).toBeCloseTo(89.5, 3);
+		expect(body.overage).toBe(0);
+	});
+
+	test("GET /admin/organizations returns per-org spend splits", async () => {
+		const res = await app.request("/admin/organizations?limit=50", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			organizations: {
+				id: string;
+				totalSpent?: string;
+				totalCreditsSpent?: string;
+				totalApiKeysSpent?: string;
+			}[];
+		};
+
+		const org = body.organizations.find((o) => o.id === ORG_ID);
+		expect(org).toBeDefined();
+		expect(parseFloat(org!.totalSpent ?? "0")).toBeCloseTo(50, 3);
+		expect(parseFloat(org!.totalCreditsSpent ?? "0")).toBeCloseTo(10, 3);
+		expect(parseFloat(org!.totalApiKeysSpent ?? "0")).toBeCloseTo(40, 3);
+	});
+
+	test("GET /admin/organizations/{orgId} splits org metrics", async () => {
+		const res = await app.request(`/admin/organizations/${ORG_ID}?window=1d`, {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			totalCost: number;
+			creditsCost: number;
+			apiKeysCost: number;
+			creditsRequestCount: number;
+			apiKeysRequestCount: number;
+		};
+
+		expect(body.totalCost).toBeCloseTo(50, 3);
+		expect(body.creditsCost).toBeCloseTo(10, 3);
+		expect(body.apiKeysCost).toBeCloseTo(40, 3);
+		expect(body.creditsRequestCount).toBe(1);
+		expect(body.apiKeysRequestCount).toBe(1);
+	});
+
+	test("GET project metrics splits project totals", async () => {
+		const res = await app.request(
+			`/admin/organizations/${ORG_ID}/projects/${PROJECT_ID}/metrics?window=1d`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			totalCost: number;
+			creditsCost: number;
+			apiKeysCost: number;
+			creditsRequestCount: number;
+			apiKeysRequestCount: number;
+		};
+
+		expect(body.totalCost).toBeCloseTo(50, 3);
+		expect(body.creditsCost).toBeCloseTo(10, 3);
+		expect(body.apiKeysCost).toBeCloseTo(40, 3);
+		expect(body.creditsRequestCount).toBe(1);
+		expect(body.apiKeysRequestCount).toBe(1);
+	});
+
+	test("GET /admin/organizations/{orgId}/cost-by-model splits per-model rows", async () => {
+		const res = await app.request(
+			`/admin/organizations/${ORG_ID}/cost-by-model?window=1d`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			models: {
+				model: string;
+				cost: number;
+				creditsCost: number;
+				apiKeysCost: number;
+				creditsRequestCount: number;
+				apiKeysRequestCount: number;
+			}[];
+			totalCost: number;
+			totalCreditsCost: number;
+			totalApiKeysCost: number;
+		};
+
+		expect(body.totalCost).toBeCloseTo(50, 3);
+		expect(body.totalCreditsCost).toBeCloseTo(10, 3);
+		expect(body.totalApiKeysCost).toBeCloseTo(40, 3);
+
+		const gpt4 = body.models.find((m) => m.model === "gpt-4");
+		expect(gpt4).toBeDefined();
+		expect(gpt4!.creditsCost).toBeCloseTo(10, 3);
+		expect(gpt4!.apiKeysCost).toBeCloseTo(40, 3);
+		expect(gpt4!.creditsRequestCount).toBe(1);
+		expect(gpt4!.apiKeysRequestCount).toBe(1);
+	});
+
+	test("DevPass real provider cost excludes BYOK usage", async () => {
+		const res = await app.request(`/admin/devpass/${DEVPASS_ORG_ID}`, {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			subscriber: { allTimeCost: number };
+		};
+
+		// The $90 BYOK request is paid by the subscriber's own provider key, so
+		// it is not a cost LLM Gateway bears.
+		expect(body.subscriber.allTimeCost).toBeCloseTo(3, 3);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { deleteResendContact } from "@/auth/config.js";
 import { maskToken } from "@/lib/maskToken.js";
+import { modeSplitFields } from "@/lib/mode-split.js";
 import { parseReferralBonusPercent } from "@/lib/referral-bonus.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
@@ -283,6 +284,11 @@ const adminMetricsSchema = z.object({
 	totalOrganizations: z.number(),
 	totalToppedUp: z.number(),
 	totalSpent: z.number(),
+	// Credits-vs-BYOK split of totalSpent. totalSpent stays blended; BYOK
+	// ("api-keys") usage is provider list price paid by the customer's own key,
+	// not revenue-relevant spend.
+	totalCreditsSpent: z.number(),
+	totalApiKeysSpent: z.number(),
 	unusedCredits: z.number(),
 	overage: z.number(),
 	totalGiftedCredits: z.number(),
@@ -362,6 +368,8 @@ const organizationSchema = z.object({
 	credits: z.string(),
 	totalCreditsAllTime: z.string().optional(),
 	totalSpent: z.string().optional(),
+	totalCreditsSpent: z.string().optional(),
+	totalApiKeysSpent: z.string().optional(),
 	createdAt: z.string(),
 	status: z.string().nullable(),
 	referralBonusEnabled: z.boolean().optional(),
@@ -387,6 +395,10 @@ const orgMetricsSchema = z.object({
 	totalRequests: z.number(),
 	totalTokens: z.number(),
 	totalCost: z.number(),
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
 	inputTokens: z.number(),
 	inputCost: z.number(),
 	outputTokens: z.number(),
@@ -899,6 +911,20 @@ admin.openapi(getMetrics, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
 					"value",
 				),
+			creditsValue:
+				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
+					"creditsValue",
+				),
+			apiKeysValue:
+				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.apiKeysCost} AS NUMERIC)), 0)`.as(
+					"apiKeysValue",
+				),
+			// What the worker actually debits from credit balances: credits-mode
+			// rows at full cost plus BYOK rows' data-storage cost.
+			debitedValue:
+				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0) + COALESCE(SUM(CAST(${projectHourlyStats.apiKeysDataStorageCost} AS NUMERIC)), 0)`.as(
+					"debitedValue",
+				),
 		})
 		.from(projectHourlyStats)
 		.innerJoin(
@@ -927,6 +953,9 @@ admin.openapi(getMetrics, async (c) => {
 		);
 
 	const totalSpent = Number(spentRow?.value ?? 0);
+	const totalCreditsSpent = Number(spentRow?.creditsValue ?? 0);
+	const totalApiKeysSpent = Number(spentRow?.apiKeysValue ?? 0);
+	const totalDebitedSpend = Number(spentRow?.debitedValue ?? 0);
 
 	// Total processed (gross Stripe amounts from completed non-gift, non-plan transactions)
 	const [processedRow] = await db
@@ -1157,7 +1186,10 @@ admin.openapi(getMetrics, async (c) => {
 		grossChatPlansRevenue +
 		grossProSubscriptionsRevenue;
 
-	const rawBalance = totalToppedUp - totalSpent;
+	// Balance derivation must use debited spend, not blended cost: BYOK usage
+	// never drains purchased credits, so subtracting it would understate
+	// unusedCredits (and overstate overage) for orgs with BYOK traffic.
+	const rawBalance = totalToppedUp - totalDebitedSpend;
 	const unusedCredits = Math.max(0, rawBalance);
 	const overage = Math.max(0, -rawBalance);
 
@@ -1170,6 +1202,8 @@ admin.openapi(getMetrics, async (c) => {
 		totalOrganizations,
 		totalToppedUp,
 		totalSpent,
+		totalCreditsSpent,
+		totalApiKeysSpent,
 		unusedCredits,
 		overage,
 		totalGiftedCredits,
@@ -1703,6 +1737,10 @@ const globalStatsMetricsSchema = z.object({
 	inputCost: z.number(),
 	cachedInputCost: z.number(),
 	outputCost: z.number(),
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
 });
 
 const globalStatsTimeseriesPointSchema = globalStatsMetricsSchema
@@ -1729,6 +1767,10 @@ const globalStatsTimeseriesBreakdownPointSchema = z
 		requestCount: z.number(),
 		cost: z.number(),
 		totalTokens: z.number(),
+		creditsRequestCount: z.number(),
+		apiKeysRequestCount: z.number(),
+		creditsCost: z.number(),
+		apiKeysCost: z.number(),
 	})
 	.openapi({});
 
@@ -1877,6 +1919,22 @@ admin.openapi(getGlobalStats, async (c) => {
 			sql<number>`COALESCE(SUM(${sourceTable.outputCost}), 0)::float8`.as(
 				"outputCost",
 			),
+		creditsRequestCount:
+			sql<number>`COALESCE(SUM(${sourceTable.creditsRequestCount}), 0)::int`.as(
+				"creditsRequestCount",
+			),
+		apiKeysRequestCount:
+			sql<number>`COALESCE(SUM(${sourceTable.apiKeysRequestCount}), 0)::int`.as(
+				"apiKeysRequestCount",
+			),
+		creditsCost:
+			sql<number>`COALESCE(SUM(${sourceTable.creditsCost}), 0)::float8`.as(
+				"creditsCost",
+			),
+		apiKeysCost:
+			sql<number>`COALESCE(SUM(${sourceTable.apiKeysCost}), 0)::float8`.as(
+				"apiKeysCost",
+			),
 	};
 
 	const dateExpr =
@@ -1915,6 +1973,10 @@ admin.openapi(getGlobalStats, async (c) => {
 			inputCost: Number(row.inputCost),
 			cachedInputCost: Number(row.cachedInputCost),
 			outputCost: Number(row.outputCost),
+			creditsRequestCount: Number(row.creditsRequestCount),
+			apiKeysRequestCount: Number(row.apiKeysRequestCount),
+			creditsCost: Number(row.creditsCost),
+			apiKeysCost: Number(row.apiKeysCost),
 		});
 	}
 
@@ -1930,6 +1992,10 @@ admin.openapi(getGlobalStats, async (c) => {
 		inputCost: 0,
 		cachedInputCost: 0,
 		outputCost: 0,
+		creditsRequestCount: 0,
+		apiKeysRequestCount: 0,
+		creditsCost: 0,
+		apiKeysCost: 0,
 	};
 
 	const timeseries: z.infer<typeof globalStatsTimeseriesPointSchema>[] = [];
@@ -1949,6 +2015,10 @@ admin.openapi(getGlobalStats, async (c) => {
 			inputCost: 0,
 			cachedInputCost: 0,
 			outputCost: 0,
+			creditsRequestCount: 0,
+			apiKeysRequestCount: 0,
+			creditsCost: 0,
+			apiKeysCost: 0,
 		};
 		timeseries.push(point);
 		totals.requestCount += point.requestCount;
@@ -1962,6 +2032,10 @@ admin.openapi(getGlobalStats, async (c) => {
 		totals.inputCost += point.inputCost;
 		totals.cachedInputCost += point.cachedInputCost;
 		totals.outputCost += point.outputCost;
+		totals.creditsRequestCount += point.creditsRequestCount;
+		totals.apiKeysRequestCount += point.apiKeysRequestCount;
+		totals.creditsCost += point.creditsCost;
+		totals.apiKeysCost += point.apiKeysCost;
 	}
 
 	const breakdownRows =
@@ -2031,6 +2105,10 @@ admin.openapi(getGlobalStats, async (c) => {
 							inputCost: Number(row.inputCost),
 							cachedInputCost: Number(row.cachedInputCost),
 							outputCost: Number(row.outputCost),
+							creditsRequestCount: Number(row.creditsRequestCount),
+							apiKeysRequestCount: Number(row.apiKeysRequestCount),
+							creditsCost: Number(row.creditsCost),
+							apiKeysCost: Number(row.apiKeysCost),
 						};
 					});
 
@@ -2098,6 +2176,10 @@ admin.openapi(getGlobalStats, async (c) => {
 			existing.requestCount += Number(row.requestCount);
 			existing.cost += Number(row.cost);
 			existing.totalTokens += Number(row.totalTokens);
+			existing.creditsRequestCount += Number(row.creditsRequestCount);
+			existing.apiKeysRequestCount += Number(row.apiKeysRequestCount);
+			existing.creditsCost += Number(row.creditsCost);
+			existing.apiKeysCost += Number(row.apiKeysCost);
 		} else {
 			timeseriesBreakdownMap.set(mapKey, {
 				date: row.date,
@@ -2106,6 +2188,10 @@ admin.openapi(getGlobalStats, async (c) => {
 				requestCount: Number(row.requestCount),
 				cost: Number(row.cost),
 				totalTokens: Number(row.totalTokens),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
 			});
 		}
 	}
@@ -2148,6 +2234,10 @@ function aggregateModelRowsByCanonicalId(
 		inputCost: number;
 		cachedInputCost: number;
 		outputCost: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
 	}>,
 ): z.infer<typeof globalStatsBreakdownItemSchema>[] {
 	const aggregated = new Map<
@@ -2169,6 +2259,10 @@ function aggregateModelRowsByCanonicalId(
 			existing.inputCost += Number(row.inputCost);
 			existing.cachedInputCost += Number(row.cachedInputCost);
 			existing.outputCost += Number(row.outputCost);
+			existing.creditsRequestCount += Number(row.creditsRequestCount);
+			existing.apiKeysRequestCount += Number(row.apiKeysRequestCount);
+			existing.creditsCost += Number(row.creditsCost);
+			existing.apiKeysCost += Number(row.apiKeysCost);
 		} else {
 			aggregated.set(canonical, {
 				key: canonical,
@@ -2184,6 +2278,10 @@ function aggregateModelRowsByCanonicalId(
 				inputCost: Number(row.inputCost),
 				cachedInputCost: Number(row.cachedInputCost),
 				outputCost: Number(row.outputCost),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
 			});
 		}
 	}
@@ -2206,6 +2304,10 @@ function aggregateModelRowsByProvider(
 		inputCost: number;
 		cachedInputCost: number;
 		outputCost: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
 	}>,
 ): z.infer<typeof globalStatsBreakdownItemSchema>[] {
 	const aggregated = new Map<
@@ -2227,6 +2329,10 @@ function aggregateModelRowsByProvider(
 			existing.inputCost += Number(row.inputCost);
 			existing.cachedInputCost += Number(row.cachedInputCost);
 			existing.outputCost += Number(row.outputCost);
+			existing.creditsRequestCount += Number(row.creditsRequestCount);
+			existing.apiKeysRequestCount += Number(row.apiKeysRequestCount);
+			existing.creditsCost += Number(row.creditsCost);
+			existing.apiKeysCost += Number(row.apiKeysCost);
 		} else {
 			aggregated.set(provider, {
 				key: provider,
@@ -2242,6 +2348,10 @@ function aggregateModelRowsByProvider(
 				inputCost: Number(row.inputCost),
 				cachedInputCost: Number(row.cachedInputCost),
 				outputCost: Number(row.outputCost),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
 			});
 		}
 	}
@@ -2298,6 +2408,14 @@ admin.openapi(getOrganizations, async (c) => {
 				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
 					"total_spent",
 				),
+			creditsTotal:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
+					"credits_spent",
+				),
+			apiKeysTotal:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.apiKeysCost} AS NUMERIC)), 0)`.as(
+					"api_keys_spent",
+				),
 		})
 		.from(projectHourlyStats)
 		.innerJoin(
@@ -2352,6 +2470,14 @@ admin.openapi(getOrganizations, async (c) => {
 			totalSpent: sql<string>`COALESCE(${totalSpentSub.total}, '0')`.as(
 				"totalSpent",
 			),
+			totalCreditsSpent:
+				sql<string>`COALESCE(${totalSpentSub.creditsTotal}, '0')`.as(
+					"totalCreditsSpent",
+				),
+			totalApiKeysSpent:
+				sql<string>`COALESCE(${totalSpentSub.apiKeysTotal}, '0')`.as(
+					"totalApiKeysSpent",
+				),
 			ownerUserId: ownerSub.userId,
 			ownerName: ownerSub.userName,
 			ownerEmail: ownerSub.userEmail,
@@ -2382,6 +2508,8 @@ admin.openapi(getOrganizations, async (c) => {
 			credits: String(org.credits),
 			totalCreditsAllTime: String(org.totalCreditsAllTime ?? "0"),
 			totalSpent: String(org.totalSpent ?? "0"),
+			totalCreditsSpent: String(org.totalCreditsSpent ?? "0"),
+			totalApiKeysSpent: String(org.totalApiKeysSpent ?? "0"),
 			createdAt: org.createdAt.toISOString(),
 			status: org.status,
 			ownerUserId: org.ownerUserId ?? null,
@@ -2439,6 +2567,10 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 	let totalRequests = 0;
 	let totalTokens = 0;
 	let totalCost = 0;
+	let creditsRequestCount = 0;
+	let apiKeysRequestCount = 0;
+	let creditsCost = 0;
+	let apiKeysCost = 0;
 	let inputTokens = 0;
 	let inputCost = 0;
 	let outputTokens = 0;
@@ -2460,6 +2592,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 					sql<number>`COALESCE(SUM(${projectHourlyStats.requestCount}), 0)`.as(
 						"totalRequests",
 					),
+				...modeSplitFields(projectHourlyStats),
 				inputTokens:
 					sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.inputTokens} AS INTEGER)), 0)`.as(
 						"inputTokens",
@@ -2517,6 +2650,10 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 			totalRequests = Number(totals.totalRequests) || 0;
 			totalTokens = Number(totals.totalTokens) || 0;
 			totalCost = Number(totals.totalCost) || 0;
+			creditsRequestCount = Number(totals.creditsRequestCount) || 0;
+			apiKeysRequestCount = Number(totals.apiKeysRequestCount) || 0;
+			creditsCost = Number(totals.creditsCost) || 0;
+			apiKeysCost = Number(totals.apiKeysCost) || 0;
 			inputTokens = Number(totals.inputTokens) || 0;
 			inputCost = Number(totals.inputCost) || 0;
 			outputTokens = Number(totals.outputTokens) || 0;
@@ -2581,6 +2718,10 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 		totalRequests,
 		totalTokens,
 		totalCost,
+		creditsRequestCount,
+		apiKeysRequestCount,
+		creditsCost,
+		apiKeysCost,
 		inputTokens,
 		inputCost,
 		outputTokens,
@@ -2910,6 +3051,10 @@ const projectMetricsSchema = z.object({
 	totalRequests: z.number(),
 	totalTokens: z.number(),
 	totalCost: z.number(),
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
 	inputTokens: z.number(),
 	inputCost: z.number(),
 	outputTokens: z.number(),
@@ -2988,6 +3133,10 @@ admin.openapi(getProjectMetrics, async (c) => {
 	let totalRequests = 0;
 	let totalTokens = 0;
 	let totalCost = 0;
+	let creditsRequestCount = 0;
+	let apiKeysRequestCount = 0;
+	let creditsCost = 0;
+	let apiKeysCost = 0;
 	let inputTokens = 0;
 	let inputCost = 0;
 	let outputTokens = 0;
@@ -3007,6 +3156,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 				sql<number>`COALESCE(SUM(${projectHourlyStats.requestCount}), 0)`.as(
 					"totalRequests",
 				),
+			...modeSplitFields(projectHourlyStats),
 			inputTokens:
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.inputTokens} AS INTEGER)), 0)`.as(
 					"inputTokens",
@@ -3064,6 +3214,10 @@ admin.openapi(getProjectMetrics, async (c) => {
 		totalRequests = Number(totals.totalRequests) || 0;
 		totalTokens = Number(totals.totalTokens) || 0;
 		totalCost = Number(totals.totalCost) || 0;
+		creditsRequestCount = Number(totals.creditsRequestCount) || 0;
+		apiKeysRequestCount = Number(totals.apiKeysRequestCount) || 0;
+		creditsCost = Number(totals.creditsCost) || 0;
+		apiKeysCost = Number(totals.apiKeysCost) || 0;
 		inputTokens = Number(totals.inputTokens) || 0;
 		inputCost = Number(totals.inputCost) || 0;
 		outputTokens = Number(totals.outputTokens) || 0;
@@ -3122,6 +3276,10 @@ admin.openapi(getProjectMetrics, async (c) => {
 		totalRequests,
 		totalTokens,
 		totalCost,
+		creditsRequestCount,
+		apiKeysRequestCount,
+		creditsCost,
+		apiKeysCost,
 		inputTokens,
 		inputCost,
 		outputTokens,
@@ -8142,6 +8300,10 @@ const costByModelEntrySchema = z.object({
 	cost: z.number(),
 	requestCount: z.number(),
 	totalTokens: z.number(),
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
 });
 
 const costByModelResponseSchema = z.object({
@@ -8149,6 +8311,8 @@ const costByModelResponseSchema = z.object({
 	models: z.array(costByModelEntrySchema),
 	totalCost: z.number(),
 	totalRequests: z.number(),
+	totalCreditsCost: z.number(),
+	totalApiKeysCost: z.number(),
 });
 
 function getTokenWindowStartDate(window: string): Date {
@@ -8216,6 +8380,7 @@ admin.openapi(getGlobalCostByModel, async (c) => {
 				sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(projectHourlyModelStats),
 		})
 		.from(projectHourlyModelStats)
 		.where(
@@ -8235,6 +8400,14 @@ admin.openapi(getGlobalCostByModel, async (c) => {
 		(sum, r) => sum + Number(r.requestCount),
 		0,
 	);
+	const totalCreditsCost = rows.reduce(
+		(sum, r) => sum + Number(r.creditsCost),
+		0,
+	);
+	const totalApiKeysCost = rows.reduce(
+		(sum, r) => sum + Number(r.apiKeysCost),
+		0,
+	);
 
 	return c.json({
 		window,
@@ -8243,9 +8416,15 @@ admin.openapi(getGlobalCostByModel, async (c) => {
 			cost: Number(r.cost),
 			requestCount: Number(r.requestCount),
 			totalTokens: Number(r.totalTokens),
+			creditsRequestCount: Number(r.creditsRequestCount),
+			apiKeysRequestCount: Number(r.apiKeysRequestCount),
+			creditsCost: Number(r.creditsCost),
+			apiKeysCost: Number(r.apiKeysCost),
 		})),
 		totalCost,
 		totalRequests,
+		totalCreditsCost,
+		totalApiKeysCost,
 	});
 });
 
@@ -8301,6 +8480,8 @@ admin.openapi(getOrgCostByModel, async (c) => {
 			models: [],
 			totalCost: 0,
 			totalRequests: 0,
+			totalCreditsCost: 0,
+			totalApiKeysCost: 0,
 		});
 	}
 
@@ -8316,6 +8497,7 @@ admin.openapi(getOrgCostByModel, async (c) => {
 				sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(projectHourlyModelStats),
 		})
 		.from(projectHourlyModelStats)
 		.where(
@@ -8333,6 +8515,14 @@ admin.openapi(getOrgCostByModel, async (c) => {
 		(sum, r) => sum + Number(r.requestCount),
 		0,
 	);
+	const totalCreditsCost = rows.reduce(
+		(sum, r) => sum + Number(r.creditsCost),
+		0,
+	);
+	const totalApiKeysCost = rows.reduce(
+		(sum, r) => sum + Number(r.apiKeysCost),
+		0,
+	);
 
 	return c.json({
 		window,
@@ -8341,9 +8531,15 @@ admin.openapi(getOrgCostByModel, async (c) => {
 			cost: Number(r.cost),
 			requestCount: Number(r.requestCount),
 			totalTokens: Number(r.totalTokens),
+			creditsRequestCount: Number(r.creditsRequestCount),
+			apiKeysRequestCount: Number(r.apiKeysRequestCount),
+			creditsCost: Number(r.creditsCost),
+			apiKeysCost: Number(r.apiKeysCost),
 		})),
 		totalCost,
 		totalRequests,
+		totalCreditsCost,
+		totalApiKeysCost,
 	});
 });
 
@@ -8360,6 +8556,10 @@ const costByModelTimeseriesBucketSchema = z.object({
 	cost: z.number(),
 	requestCount: z.number(),
 	totalTokens: z.number(),
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
 });
 
 const costByModelTimeseriesPointSchema = z.object({
@@ -8647,6 +8847,7 @@ async function buildCostByModelTimeseries({
 				sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(projectHourlyModelStats),
 		})
 		.from(projectHourlyModelStats)
 		.where(
@@ -8668,6 +8869,10 @@ async function buildCostByModelTimeseries({
 				cost: Number(row.cost),
 				requestCount: Number(row.requestCount),
 				totalTokens: Number(row.totalTokens),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
 			})),
 		}),
 	};
@@ -8724,6 +8929,7 @@ async function buildCostBySourceTimeseries({
 				sql<number>`SUM(CAST(${projectHourlySourceStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(projectHourlySourceStats),
 		})
 		.from(projectHourlySourceStats)
 		.where(and(baseFilter, inArray(projectHourlySourceStats.source, topKeys)))
@@ -8740,6 +8946,10 @@ async function buildCostBySourceTimeseries({
 				cost: Number(row.cost),
 				requestCount: Number(row.requestCount),
 				totalTokens: Number(row.totalTokens),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
 			})),
 		}),
 	};
@@ -8756,11 +8966,26 @@ function assembleCostTimeseriesPoints({
 		cost: number;
 		requestCount: number;
 		totalTokens: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
 	}[];
 }): z.infer<typeof costByModelTimeseriesPointSchema>[] {
 	const bucketMap = new Map<
 		string,
-		Map<string, { cost: number; requestCount: number; totalTokens: number }>
+		Map<
+			string,
+			{
+				cost: number;
+				requestCount: number;
+				totalTokens: number;
+				creditsRequestCount: number;
+				apiKeysRequestCount: number;
+				creditsCost: number;
+				apiKeysCost: number;
+			}
+		>
 	>();
 
 	for (const row of rows) {
@@ -8769,10 +8994,18 @@ function assembleCostTimeseriesPoints({
 			cost: 0,
 			requestCount: 0,
 			totalTokens: 0,
+			creditsRequestCount: 0,
+			apiKeysRequestCount: 0,
+			creditsCost: 0,
+			apiKeysCost: 0,
 		};
 		existing.cost += row.cost;
 		existing.requestCount += row.requestCount;
 		existing.totalTokens += row.totalTokens;
+		existing.creditsRequestCount += row.creditsRequestCount;
+		existing.apiKeysRequestCount += row.apiKeysRequestCount;
+		existing.creditsCost += row.creditsCost;
+		existing.apiKeysCost += row.apiKeysCost;
 		entry.set(row.key, existing);
 		bucketMap.set(row.bucket, entry);
 	}
@@ -8785,6 +9018,10 @@ function assembleCostTimeseriesPoints({
 				cost: v.cost,
 				requestCount: v.requestCount,
 				totalTokens: v.totalTokens,
+				creditsRequestCount: v.creditsRequestCount,
+				apiKeysRequestCount: v.apiKeysRequestCount,
+				creditsCost: v.creditsCost,
+				apiKeysCost: v.apiKeysCost,
 			}),
 		),
 	}));
@@ -8801,6 +9038,10 @@ const projectModelProviderStatsEntrySchema = z.object({
 	cachedCount: z.number(),
 	cost: z.number(),
 	totalTokens: z.number(),
+	creditsRequestCount: z.number(),
+	apiKeysRequestCount: z.number(),
+	creditsCost: z.number(),
+	apiKeysCost: z.number(),
 	...tokenBreakdownShape,
 });
 
@@ -8928,6 +9169,7 @@ admin.openapi(getProjectModelProviderStats, async (c) => {
 			cachedCount: cachedCountExpr,
 			cost: costExpr,
 			totalTokens: totalTokensExpr,
+			...modeSplitFields(projectHourlyModelStats),
 			inputTokens:
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.inputTokens} AS NUMERIC)), 0)`.as(
 					"input_tokens",
@@ -8990,6 +9232,10 @@ admin.openapi(getProjectModelProviderStats, async (c) => {
 			cachedCount: Number(r.cachedCount),
 			cost: Number(r.cost),
 			totalTokens: Number(r.totalTokens),
+			creditsRequestCount: Number(r.creditsRequestCount),
+			apiKeysRequestCount: Number(r.apiKeysRequestCount),
+			creditsCost: Number(r.creditsCost),
+			apiKeysCost: Number(r.apiKeysCost),
 			...toTokenBreakdown(r),
 		})),
 		total: rows.length,
@@ -11791,12 +12037,14 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
 	);
 
-	// Subquery: real provider cost in current cycle, per org
+	// Subquery: real provider cost in current cycle, per org. Credits-mode cost
+	// only: BYOK ("api-keys") usage is paid by the customer's own provider key,
+	// so it is not a cost we bear and must not depress the margin.
 	const realCostSub = db
 		.select({
 			organizationId: tables.project.organizationId,
 			realCost:
-				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
 					"real_cost",
 				),
 		})
@@ -11883,7 +12131,8 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 	const allTimeCostSub = db
 		.select({
 			organizationId: tables.project.organizationId,
-			cost: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+			// Credits-mode cost only — BYOK usage is not a cost we bear.
+			cost: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
 				"all_time_cost",
 			),
 		})
@@ -12672,8 +12921,9 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	const costPerDay = await db
 		.select({
 			date: sql<string>`DATE(${projectHourlyStats.hourTimestamp})`.as("date"),
+			// Credits-mode cost only — BYOK usage is not a cost we bear.
 			total:
-				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
 					"total",
 				),
 		})
@@ -12984,7 +13234,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 	const [realCostRow] = org.devPlanBillingCycleStart
 		? await db
 				.select({
-					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`,
 				})
 				.from(projectHourlyStats)
 				.innerJoin(
@@ -13016,7 +13266,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 			: [...DEV_PLAN_TX_TYPES];
 	const [allTimeCostRow] = await db
 		.select({
-			total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+			total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`,
 		})
 		.from(projectHourlyStats)
 		.innerJoin(
@@ -13603,12 +13853,14 @@ admin.openapi(getChatPlansSubscribers, async (c) => {
 		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
 	);
 
-	// Subquery: real provider cost in current cycle, per org
+	// Subquery: real provider cost in current cycle, per org. Credits-mode cost
+	// only: BYOK ("api-keys") usage is paid by the customer's own provider key,
+	// so it is not a cost we bear and must not depress the margin.
 	const realCostSub = db
 		.select({
 			organizationId: tables.project.organizationId,
 			realCost:
-				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
 					"real_cost",
 				),
 		})
@@ -13684,7 +13936,8 @@ admin.openapi(getChatPlansSubscribers, async (c) => {
 	const allTimeCostSub = db
 		.select({
 			organizationId: tables.project.organizationId,
-			cost: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+			// Credits-mode cost only — BYOK usage is not a cost we bear.
+			cost: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
 				"all_time_cost",
 			),
 		})
@@ -14341,8 +14594,9 @@ admin.openapi(getChatPlansTimeseries, async (c) => {
 	const costPerDay = await db
 		.select({
 			date: sql<string>`DATE(${projectHourlyStats.hourTimestamp})`.as("date"),
+			// Credits-mode cost only — BYOK usage is not a cost we bear.
 			total:
-				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`.as(
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`.as(
 					"total",
 				),
 		})
@@ -14655,7 +14909,7 @@ admin.openapi(getChatPlansSubscriber, async (c) => {
 	const [realCostRow] = org.chatPlanBillingCycleStart
 		? await db
 				.select({
-					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+					total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`,
 				})
 				.from(projectHourlyStats)
 				.innerJoin(
@@ -14679,7 +14933,7 @@ admin.openapi(getChatPlansSubscriber, async (c) => {
 
 	const [allTimeCostRow] = await db
 		.select({
-			total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.cost} AS NUMERIC)), 0)`,
+			total: sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.creditsCost} AS NUMERIC)), 0)`,
 		})
 		.from(projectHourlyStats)
 		.innerJoin(

--- a/apps/api/src/routes/analytics.spec.ts
+++ b/apps/api/src/routes/analytics.spec.ts
@@ -181,7 +181,17 @@ describe("analytics endpoints", () => {
 		cost: number;
 		requestCount: number;
 		totalTokens: number;
-		breakdown: { key: string; label: string; cost: number }[];
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
+		breakdown: {
+			key: string;
+			label: string;
+			cost: number;
+			creditsCost: number;
+			apiKeysCost: number;
+		}[];
 	}
 
 	function activeRows(rows: ActivitySeriesRow[]): ActivitySeriesRow[] {
@@ -677,6 +687,122 @@ describe("analytics endpoints", () => {
 			const athensDay = activeRows((await athensRes.json()).activity)[0];
 			expect(athensDay.date).toBe(localDay(boundary, "Europe/Athens"));
 			expect(athensDay.date).not.toBe(utcDay.date);
+		});
+	});
+
+	describe("credits vs BYOK mode split", () => {
+		beforeEach(async () => {
+			// The base fixture is entirely usedMode=api-keys; add one credits-mode
+			// log for the owner so every endpoint has both modes to split.
+			await db.insert(tables.log).values({
+				id: "log-owner-credits",
+				requestId: "log-owner-credits",
+				createdAt: logTime,
+				updatedAt: logTime,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				apiKeyId: "key-owner",
+				duration: 100,
+				requestedModel: "gpt-4",
+				requestedProvider: "openai",
+				usedModel: "gpt-4",
+				usedProvider: "openai",
+				responseSize: 1000,
+				promptTokens: "10",
+				completionTokens: "20",
+				totalTokens: "30",
+				cost: 0.4,
+				messages: JSON.stringify([{ role: "user", content: "credits" }]),
+				mode: "hybrid",
+				usedMode: "credits",
+			});
+			await aggregateLogsForTesting();
+		});
+
+		test("GET /analytics/members splits per-member usage", async () => {
+			const res = await app.request(
+				`/analytics/members?organizationId=${ORG_ID}`,
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			const owner = data.members.find(
+				(m: { userId: string }) => m.userId === OWNER_ID,
+			);
+			expect(owner.cost).toBeCloseTo(0.7, 5);
+			expect(owner.creditsCost).toBeCloseTo(0.4, 5);
+			expect(owner.apiKeysCost).toBeCloseTo(0.3, 5);
+			expect(owner.creditsRequestCount).toBe(1);
+			expect(owner.apiKeysRequestCount).toBe(2);
+
+			const member = data.members.find(
+				(m: { userId: string }) => m.userId === MEMBER_ID,
+			);
+			expect(member.creditsCost).toBe(0);
+			expect(member.apiKeysCost).toBeCloseTo(0.05, 5);
+		});
+
+		test("GET /analytics/members/{userId} splits summary and breakdowns", async () => {
+			const res = await app.request(
+				`/analytics/members/${OWNER_ID}?organizationId=${ORG_ID}`,
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			expect(data.summary.creditsCost).toBeCloseTo(0.4, 5);
+			expect(data.summary.apiKeysCost).toBeCloseTo(0.3, 5);
+			expect(data.summary.creditsRequestCount).toBe(1);
+			expect(data.summary.apiKeysRequestCount).toBe(2);
+
+			const gpt4 = data.costByModel.find(
+				(m: { key: string }) => m.key === "gpt-4",
+			);
+			expect(gpt4.creditsCost).toBeCloseTo(0.4, 5);
+			expect(gpt4.apiKeysCost).toBeCloseTo(0.3, 5);
+		});
+
+		test("GET /analytics/activity splits totals and breakdown", async () => {
+			const res = await app.request(
+				`/analytics/activity?organizationId=${ORG_ID}`,
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			const day = activeRows(data.activity)[0];
+			expect(day.creditsCost).toBeCloseTo(0.4, 5);
+			expect(day.apiKeysCost).toBeCloseTo(0.35, 5);
+			expect(day.creditsRequestCount).toBe(1);
+			expect(day.apiKeysRequestCount).toBe(3);
+
+			const gpt4 = day.breakdown.find((b) => b.key === "gpt-4");
+			expect(gpt4).toBeDefined();
+			expect(gpt4!.creditsCost).toBeCloseTo(0.4, 5);
+			expect(gpt4!.apiKeysCost).toBeCloseTo(0.3, 5);
+		});
+
+		test("GET /analytics/me splits summary, activity and top models", async () => {
+			const res = await app.request(
+				`/analytics/me?organizationId=${ORG_ID}&projectId=${PROJECT_ID}`,
+				{ headers: { Cookie: token } },
+			);
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			expect(data.summary.creditsCost).toBeCloseTo(0.4, 5);
+			expect(data.summary.apiKeysCost).toBeCloseTo(0.3, 5);
+
+			const day = activeRows(data.activity)[0];
+			expect(day.creditsCost).toBeCloseTo(0.4, 5);
+			expect(day.apiKeysCost).toBeCloseTo(0.3, 5);
+
+			const gpt4 = data.topModels.find(
+				(m: { key: string }) => m.key === "gpt-4",
+			);
+			expect(gpt4.creditsCost).toBeCloseTo(0.4, 5);
+			expect(gpt4.apiKeysCost).toBeCloseTo(0.3, 5);
 		});
 	});
 });

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -2,6 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import {
+	mapModeSplit,
+	modeSplitFields,
+	modeSplitSchema,
+} from "@/lib/mode-split.js";
 import { requireEnterpriseAdmin } from "@/lib/require-enterprise-admin.js";
 import { getUserUsageBreakdown } from "@/lib/user-usage-breakdown.js";
 import { userHasProjectAccess } from "@/utils/authorization.js";
@@ -104,6 +109,7 @@ const memberUsageSchema = z.object({
 	totalTokens: z.number(),
 	requestCount: z.number(),
 	errorCount: z.number(),
+	...modeSplitSchema,
 });
 
 const getMembersUsage = createRoute({
@@ -161,6 +167,10 @@ analytics.openapi(getMembersUsage, async (c) => {
 				totalTokens: 0,
 				requestCount: 0,
 				errorCount: 0,
+				creditsRequestCount: 0,
+				apiKeysRequestCount: 0,
+				creditsCost: 0,
+				apiKeysCost: 0,
 			})),
 			plan: "enterprise",
 		});
@@ -198,6 +208,7 @@ analytics.openapi(getMembersUsage, async (c) => {
 			errorCount: sql<number>`SUM(${apiKeyHourlyStats.errorCount})`.as(
 				"error_count",
 			),
+			...modeSplitFields(apiKeyHourlyStats),
 		})
 		.from(apiKeyHourlyStats)
 		.where(
@@ -216,6 +227,10 @@ analytics.openapi(getMembersUsage, async (c) => {
 			totalTokens: number;
 			requestCount: number;
 			errorCount: number;
+			creditsRequestCount: number;
+			apiKeysRequestCount: number;
+			creditsCost: number;
+			apiKeysCost: number;
 		}
 	>();
 	for (const row of usageRows) {
@@ -228,11 +243,19 @@ analytics.openapi(getMembersUsage, async (c) => {
 			totalTokens: 0,
 			requestCount: 0,
 			errorCount: 0,
+			creditsRequestCount: 0,
+			apiKeysRequestCount: 0,
+			creditsCost: 0,
+			apiKeysCost: 0,
 		};
 		agg.cost += Number(row.cost ?? 0);
 		agg.totalTokens += Number(row.totalTokens ?? 0);
 		agg.requestCount += Number(row.requestCount ?? 0);
 		agg.errorCount += Number(row.errorCount ?? 0);
+		agg.creditsRequestCount += Number(row.creditsRequestCount ?? 0);
+		agg.apiKeysRequestCount += Number(row.apiKeysRequestCount ?? 0);
+		agg.creditsCost += Number(row.creditsCost ?? 0);
+		agg.apiKeysCost += Number(row.apiKeysCost ?? 0);
 		usageByCreator.set(creator, agg);
 	}
 
@@ -249,6 +272,10 @@ analytics.openapi(getMembersUsage, async (c) => {
 				totalTokens: agg?.totalTokens ?? 0,
 				requestCount: agg?.requestCount ?? 0,
 				errorCount: agg?.errorCount ?? 0,
+				creditsRequestCount: agg?.creditsRequestCount ?? 0,
+				apiKeysRequestCount: agg?.apiKeysRequestCount ?? 0,
+				creditsCost: agg?.creditsCost ?? 0,
+				apiKeysCost: agg?.apiKeysCost ?? 0,
 			};
 		})
 		.sort((a, b) => b.cost - a.cost);
@@ -261,6 +288,7 @@ const breakdownEntrySchema = z.object({
 	cost: z.number(),
 	requestCount: z.number(),
 	totalTokens: z.number(),
+	...modeSplitSchema,
 });
 
 const memberActivityModelSchema = z.object({
@@ -271,6 +299,7 @@ const memberActivityModelSchema = z.object({
 	outputTokens: z.number(),
 	totalTokens: z.number(),
 	cost: z.number(),
+	...modeSplitSchema,
 });
 
 const memberActivityRowSchema = z.object({
@@ -294,6 +323,7 @@ const memberDetailSchema = z.object({
 		errorCount: z.number(),
 		cacheCount: z.number(),
 		apiKeyCount: z.number(),
+		...modeSplitSchema,
 	}),
 	topModels: z.array(breakdownEntrySchema),
 	topProviders: z.array(breakdownEntrySchema),
@@ -382,6 +412,10 @@ analytics.openapi(getMemberDetail, async (c) => {
 		errorCount: 0,
 		cacheCount: 0,
 		apiKeyCount: 0,
+		creditsRequestCount: 0,
+		apiKeysRequestCount: 0,
+		creditsCost: 0,
+		apiKeysCost: 0,
 	};
 
 	if (projectIds.length === 0) {
@@ -444,6 +478,7 @@ analytics.openapi(getMemberDetail, async (c) => {
 				sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cacheCount}), 0)`.as(
 					"cache_count",
 				),
+			...modeSplitFields(apiKeyHourlyStats),
 		})
 		.from(apiKeyHourlyStats)
 		.where(
@@ -464,6 +499,10 @@ analytics.openapi(getMemberDetail, async (c) => {
 		errorCount: Number(summaryRow?.errorCount ?? 0),
 		cacheCount: Number(summaryRow?.cacheCount ?? 0),
 		apiKeyCount: keyIds.length,
+		creditsRequestCount: Number(summaryRow?.creditsRequestCount ?? 0),
+		apiKeysRequestCount: Number(summaryRow?.apiKeysRequestCount ?? 0),
+		creditsCost: Number(summaryRow?.creditsCost ?? 0),
+		apiKeysCost: Number(summaryRow?.apiKeysCost ?? 0),
 	};
 
 	const modelRows = await db
@@ -478,6 +517,7 @@ analytics.openapi(getMemberDetail, async (c) => {
 				sql<number>`SUM(CAST(${apiKeyHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(apiKeyHourlyModelStats),
 		})
 		.from(apiKeyHourlyModelStats)
 		.where(
@@ -499,22 +539,39 @@ analytics.openapi(getMemberDetail, async (c) => {
 			cost: Number(r.cost ?? 0),
 			requestCount: Number(r.requestCount ?? 0),
 			totalTokens: Number(r.totalTokens ?? 0),
+			...mapModeSplit(r),
 		}))
 		.slice(0, 20);
 
 	const providerMap = new Map<
 		string,
-		{ cost: number; requestCount: number; totalTokens: number }
+		{
+			cost: number;
+			requestCount: number;
+			totalTokens: number;
+			creditsRequestCount: number;
+			apiKeysRequestCount: number;
+			creditsCost: number;
+			apiKeysCost: number;
+		}
 	>();
 	for (const r of modelRows) {
 		const agg = providerMap.get(r.usedProvider) ?? {
 			cost: 0,
 			requestCount: 0,
 			totalTokens: 0,
+			creditsRequestCount: 0,
+			apiKeysRequestCount: 0,
+			creditsCost: 0,
+			apiKeysCost: 0,
 		};
 		agg.cost += Number(r.cost ?? 0);
 		agg.requestCount += Number(r.requestCount ?? 0);
 		agg.totalTokens += Number(r.totalTokens ?? 0);
+		agg.creditsRequestCount += Number(r.creditsRequestCount ?? 0);
+		agg.apiKeysRequestCount += Number(r.apiKeysRequestCount ?? 0);
+		agg.creditsCost += Number(r.creditsCost ?? 0);
+		agg.apiKeysCost += Number(r.apiKeysCost ?? 0);
 		providerMap.set(r.usedProvider, agg);
 	}
 	const topProviders = [...providerMap.entries()]
@@ -552,6 +609,7 @@ analytics.openapi(getMemberDetail, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(apiKeyHourlyModelStats),
 		})
 		.from(apiKeyHourlyModelStats)
 		.where(
@@ -581,6 +639,7 @@ analytics.openapi(getMemberDetail, async (c) => {
 			inputTokens: Number(row.inputTokens ?? 0),
 			outputTokens: Number(row.outputTokens ?? 0),
 			totalTokens: Number(row.totalTokens ?? 0),
+			...mapModeSplit(row),
 		});
 		breakdownByDate.set(date, list);
 	}
@@ -609,6 +668,7 @@ const selfUsageSchema = z.object({
 		requestCount: z.number(),
 		errorCount: z.number(),
 		apiKeyCount: z.number(),
+		...modeSplitSchema,
 	}),
 	activity: z.array(
 		z.object({
@@ -616,6 +676,7 @@ const selfUsageSchema = z.object({
 			cost: z.number(),
 			requestCount: z.number(),
 			totalTokens: z.number(),
+			...modeSplitSchema,
 		}),
 	),
 	topModels: z.array(breakdownEntrySchema),
@@ -684,12 +745,20 @@ analytics.openapi(getSelfUsage, async (c) => {
 		requestCount: 0,
 		errorCount: 0,
 		apiKeyCount: 0,
+		creditsRequestCount: 0,
+		apiKeysRequestCount: 0,
+		creditsCost: 0,
+		apiKeysCost: 0,
 	};
 	const emptyActivity = eachDay(fromStr, toStr).map((date) => ({
 		date,
 		cost: 0,
 		requestCount: 0,
 		totalTokens: 0,
+		creditsRequestCount: 0,
+		apiKeysRequestCount: 0,
+		creditsCost: 0,
+		apiKeysCost: 0,
 	}));
 
 	const myKeys = await db
@@ -734,6 +803,7 @@ analytics.openapi(getSelfUsage, async (c) => {
 				sql<number>`COALESCE(SUM(${apiKeyHourlyStats.errorCount}), 0)`.as(
 					"error_count",
 				),
+			...modeSplitFields(apiKeyHourlyStats),
 		})
 		.from(apiKeyHourlyStats)
 		.where(
@@ -752,6 +822,10 @@ analytics.openapi(getSelfUsage, async (c) => {
 		requestCount: Number(s?.requestCount ?? 0),
 		errorCount: Number(s?.errorCount ?? 0),
 		apiKeyCount: keyIds.length,
+		creditsRequestCount: Number(s?.creditsRequestCount ?? 0),
+		apiKeysRequestCount: Number(s?.apiKeysRequestCount ?? 0),
+		creditsCost: Number(s?.creditsCost ?? 0),
+		apiKeysCost: Number(s?.apiKeysCost ?? 0),
 	};
 
 	const activityRows = await db
@@ -768,6 +842,7 @@ analytics.openapi(getSelfUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(apiKeyHourlyStats),
 		})
 		.from(apiKeyHourlyStats)
 		.where(
@@ -789,6 +864,10 @@ analytics.openapi(getSelfUsage, async (c) => {
 			cost: Number(r?.cost ?? 0),
 			requestCount: Number(r?.requestCount ?? 0),
 			totalTokens: Number(r?.totalTokens ?? 0),
+			creditsRequestCount: Number(r?.creditsRequestCount ?? 0),
+			apiKeysRequestCount: Number(r?.apiKeysRequestCount ?? 0),
+			creditsCost: Number(r?.creditsCost ?? 0),
+			apiKeysCost: Number(r?.apiKeysCost ?? 0),
 		};
 	});
 
@@ -803,6 +882,7 @@ analytics.openapi(getSelfUsage, async (c) => {
 				sql<number>`SUM(CAST(${apiKeyHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(apiKeyHourlyModelStats),
 		})
 		.from(apiKeyHourlyModelStats)
 		.where(
@@ -819,6 +899,7 @@ analytics.openapi(getSelfUsage, async (c) => {
 		cost: Number(r.cost ?? 0),
 		requestCount: Number(r.requestCount ?? 0),
 		totalTokens: Number(r.totalTokens ?? 0),
+		...mapModeSplit(r),
 	}));
 
 	return c.json({ summary, activity, topModels });
@@ -873,6 +954,7 @@ const orgActivityBreakdownSchema = z.object({
 	cost: z.number(),
 	requestCount: z.number(),
 	totalTokens: z.number(),
+	...modeSplitSchema,
 });
 
 const orgActivityRowSchema = z.object({
@@ -880,6 +962,7 @@ const orgActivityRowSchema = z.object({
 	cost: z.number(),
 	requestCount: z.number(),
 	totalTokens: z.number(),
+	...modeSplitSchema,
 	breakdown: z.array(orgActivityBreakdownSchema),
 });
 
@@ -945,6 +1028,10 @@ analytics.openapi(getOrgActivity, async (c) => {
 				cost: 0,
 				requestCount: 0,
 				totalTokens: 0,
+				creditsRequestCount: 0,
+				apiKeysRequestCount: 0,
+				creditsCost: 0,
+				apiKeysCost: 0,
 				breakdown: [],
 			})),
 			groupBy,
@@ -969,6 +1056,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
+			...modeSplitFields(projectHourlyStats),
 		})
 		.from(projectHourlyStats)
 		.where(
@@ -990,6 +1078,10 @@ analytics.openapi(getOrgActivity, async (c) => {
 		cost: number;
 		requestCount: number;
 		totalTokens: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
 	}
 	const breakdownByDate = new Map<string, Map<string, BreakdownAgg>>();
 
@@ -997,9 +1089,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 		date: string,
 		key: string,
 		label: string,
-		cost: number,
-		requestCount: number,
-		totalTokens: number,
+		values: Omit<BreakdownAgg, "label">,
 	) => {
 		let dayMap = breakdownByDate.get(date);
 		if (!dayMap) {
@@ -1008,11 +1098,15 @@ analytics.openapi(getOrgActivity, async (c) => {
 		}
 		const existing = dayMap.get(key);
 		if (existing) {
-			existing.cost += cost;
-			existing.requestCount += requestCount;
-			existing.totalTokens += totalTokens;
+			existing.cost += values.cost;
+			existing.requestCount += values.requestCount;
+			existing.totalTokens += values.totalTokens;
+			existing.creditsRequestCount += values.creditsRequestCount;
+			existing.apiKeysRequestCount += values.apiKeysRequestCount;
+			existing.creditsCost += values.creditsCost;
+			existing.apiKeysCost += values.apiKeysCost;
 		} else {
-			dayMap.set(key, { label, cost, requestCount, totalTokens });
+			dayMap.set(key, { label, ...values });
 		}
 	};
 
@@ -1036,6 +1130,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"total_tokens",
 					),
+				...modeSplitFields(projectHourlyModelStats),
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -1053,14 +1148,12 @@ analytics.openapi(getOrgActivity, async (c) => {
 			const usedModel = row.usedModel || "unknown";
 			const key = canonicalModelId(usedModel);
 			const label = modelNameById.get(key) ?? key;
-			addBreakdown(
-				date,
-				key,
-				label,
-				Number(row.cost),
-				Number(row.requestCount),
-				Number(row.totalTokens),
-			);
+			addBreakdown(date, key, label, {
+				cost: Number(row.cost),
+				requestCount: Number(row.requestCount),
+				totalTokens: Number(row.totalTokens),
+				...mapModeSplit(row),
+			});
 		}
 	} else if (groupBy === "project") {
 		const projectNames = new Map(
@@ -1089,6 +1182,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"total_tokens",
 					),
+				...modeSplitFields(projectHourlyStats),
 			})
 			.from(projectHourlyStats)
 			.where(
@@ -1107,9 +1201,12 @@ analytics.openapi(getOrgActivity, async (c) => {
 				date,
 				row.projectId,
 				projectNames.get(row.projectId) ?? "Unknown project",
-				Number(row.cost),
-				Number(row.requestCount),
-				Number(row.totalTokens),
+				{
+					cost: Number(row.cost),
+					requestCount: Number(row.requestCount),
+					totalTokens: Number(row.totalTokens),
+					...mapModeSplit(row),
+				},
 			);
 		}
 	} else if (groupBy === "user") {
@@ -1121,14 +1218,15 @@ analytics.openapi(getOrgActivity, async (c) => {
 		});
 
 		for (const row of rows) {
-			addBreakdown(
-				row.date.slice(0, 10),
-				row.userId,
-				row.name,
-				row.cost,
-				row.requestCount,
-				row.totalTokens,
-			);
+			addBreakdown(row.date.slice(0, 10), row.userId, row.name, {
+				cost: row.cost,
+				requestCount: row.requestCount,
+				totalTokens: row.totalTokens,
+				creditsRequestCount: row.creditsRequestCount,
+				apiKeysRequestCount: row.apiKeysRequestCount,
+				creditsCost: row.creditsCost,
+				apiKeysCost: row.apiKeysCost,
+			});
 		}
 	} else {
 		const rows = await db
@@ -1149,6 +1247,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"total_tokens",
 					),
+				...modeSplitFields(apiKeyHourlyStats),
 			})
 			.from(apiKeyHourlyStats)
 			.leftJoin(tables.apiKey, eq(tables.apiKey.id, apiKeyHourlyStats.apiKeyId))
@@ -1167,14 +1266,12 @@ analytics.openapi(getOrgActivity, async (c) => {
 
 		for (const row of rows) {
 			const date = String(row.date).slice(0, 10);
-			addBreakdown(
-				date,
-				row.apiKeyId,
-				row.description ?? "Deleted key",
-				Number(row.cost),
-				Number(row.requestCount),
-				Number(row.totalTokens),
-			);
+			addBreakdown(date, row.apiKeyId, row.description ?? "Deleted key", {
+				cost: Number(row.cost),
+				requestCount: Number(row.requestCount),
+				totalTokens: Number(row.totalTokens),
+				...mapModeSplit(row),
+			});
 		}
 	}
 
@@ -1186,6 +1283,10 @@ analytics.openapi(getOrgActivity, async (c) => {
 			cost: Number(totals?.cost ?? 0),
 			requestCount: Number(totals?.requestCount ?? 0),
 			totalTokens: Number(totals?.totalTokens ?? 0),
+			creditsRequestCount: Number(totals?.creditsRequestCount ?? 0),
+			apiKeysRequestCount: Number(totals?.apiKeysRequestCount ?? 0),
+			creditsCost: Number(totals?.creditsCost ?? 0),
+			apiKeysCost: Number(totals?.apiKeysCost ?? 0),
 			breakdown: dayMap
 				? Array.from(dayMap.entries()).map(([key, v]) => ({
 						key,
@@ -1193,6 +1294,10 @@ analytics.openapi(getOrgActivity, async (c) => {
 						cost: v.cost,
 						requestCount: v.requestCount,
 						totalTokens: v.totalTokens,
+						creditsRequestCount: v.creditsRequestCount,
+						apiKeysRequestCount: v.apiKeysRequestCount,
+						creditsCost: v.creditsCost,
+						apiKeysCost: v.apiKeysCost,
 					}))
 				: [],
 		};

--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -250,6 +250,68 @@ describe("logs route", () => {
 			expect(json.pagination.limit).toBe(50);
 		});
 
+		test("should filter logs by usedMode", async () => {
+			await db.insert(tables.log).values({
+				id: "test-log-credits",
+				requestId: "test-log-credits",
+				organizationId: "test-org-id",
+				projectId: "test-project-id",
+				apiKeyId: "test-api-key-id",
+				duration: 100,
+				requestedModel: "gpt-4",
+				requestedProvider: "openai",
+				usedModel: "gpt-4",
+				usedProvider: "openai",
+				responseSize: 500,
+				promptTokens: "5",
+				completionTokens: "5",
+				totalTokens: "10",
+				messages: JSON.stringify([{ role: "user", content: "credits" }]),
+				mode: "hybrid",
+				usedMode: "credits",
+			});
+
+			const creditsRes = await app.request(
+				"/logs?" +
+					new URLSearchParams({
+						projectId: "test-project-id",
+						usedMode: "credits",
+					}),
+				{ headers: { Cookie: token } },
+			);
+			expect(creditsRes.status).toBe(200);
+			const creditsJson = await creditsRes.json();
+			expect(creditsJson.logs.length).toBe(1);
+			expect(creditsJson.logs[0].id).toBe("test-log-credits");
+			expect(creditsJson.logs[0].usedMode).toBe("credits");
+
+			const byokRes = await app.request(
+				"/logs?" +
+					new URLSearchParams({
+						projectId: "test-project-id",
+						usedMode: "api-keys",
+					}),
+				{ headers: { Cookie: token } },
+			);
+			expect(byokRes.status).toBe(200);
+			const byokJson = await byokRes.json();
+			expect(byokJson.logs.length).toBe(1);
+			expect(byokJson.logs[0].id).toBe("test-log-id-1");
+
+			// "all" behaves like no filter.
+			const allRes = await app.request(
+				"/logs?" +
+					new URLSearchParams({
+						projectId: "test-project-id",
+						usedMode: "all",
+					}),
+				{ headers: { Cookie: token } },
+			);
+			expect(allRes.status).toBe(200);
+			const allJson = await allRes.json();
+			expect(allJson.logs.length).toBe(2);
+		});
+
 		test("should filter by second projectId", async () => {
 			const params = new URLSearchParams({ projectId: "test-project-id-2" });
 			const res = await app.request("/logs?" + params, {

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -324,6 +324,11 @@ const querySchema = z.object({
 		description: "Filter logs by session ID",
 		example: "conversation-9f8e7d6c",
 	}),
+	usedMode: z.enum(["all", "credits", "api-keys"]).optional().openapi({
+		description:
+			"Filter logs by billing mode: credits (billed against the organization balance) or api-keys (BYOK provider keys, not billed)",
+		example: "credits",
+	}),
 });
 
 const get = createRoute({
@@ -401,6 +406,7 @@ logs.openapi(get, async (c) => {
 		customHeaderValue,
 		requestId,
 		sessionId,
+		usedMode,
 	} = {
 		...query,
 		apiKeyId: sanitize(query.apiKeyId),
@@ -418,6 +424,7 @@ logs.openapi(get, async (c) => {
 		customHeaderValue: sanitize(query.customHeaderValue),
 		requestId: sanitize(query.requestId),
 		sessionId: sanitize(query.sessionId),
+		usedMode: sanitize(query.usedMode) as "credits" | "api-keys" | undefined,
 	};
 
 	// Set default limit if not provided or enforce max limit
@@ -601,6 +608,11 @@ logs.openapi(get, async (c) => {
 		whereConditions.push(
 			eq(tables.log.unifiedFinishReason, unifiedFinishReason),
 		);
+	}
+
+	// Add billing mode filter
+	if (usedMode) {
+		whereConditions.push(eq(tables.log.usedMode, usedMode));
 	}
 
 	// Add apiKeyId filter

--- a/apps/api/src/routes/organization.spec.ts
+++ b/apps/api/src/routes/organization.spec.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { app } from "@/index.js";
-import { createTestUser, deleteAll } from "@/testing.js";
+import {
+	aggregateLogsForTesting,
+	createTestUser,
+	deleteAll,
+} from "@/testing.js";
 
-import { db, tables } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 import { randomInt } from "@llmgateway/shared/random";
 
 describe("organization route", () => {
@@ -215,5 +219,81 @@ describe("organization route", () => {
 				},
 			},
 		});
+	});
+
+	test("GET /orgs/{id}/credits-runway only counts spend that drains credits", async () => {
+		await db
+			.update(tables.organization)
+			.set({ credits: "77" })
+			.where(eq(tables.organization.id, "test-org-id"));
+
+		await db.insert(tables.project).values({
+			id: "runway-project-id",
+			name: "Runway Project",
+			organizationId: "test-org-id",
+		});
+		await db.insert(tables.apiKey).values({
+			id: "runway-api-key-id",
+			token: "runway-token",
+			projectId: "runway-project-id",
+			description: "Runway Key",
+			createdBy: "test-user-id",
+		});
+
+		const now = new Date();
+		const baseLog = {
+			createdAt: now,
+			updatedAt: now,
+			organizationId: "test-org-id",
+			projectId: "runway-project-id",
+			apiKeyId: "runway-api-key-id",
+			duration: 100,
+			requestedModel: "gpt-4",
+			requestedProvider: "openai",
+			usedModel: "gpt-4",
+			usedProvider: "openai",
+			responseSize: 100,
+			promptTokens: "10",
+			completionTokens: "10",
+			totalTokens: "20",
+			messages: JSON.stringify([{ role: "user", content: "hi" }]),
+			mode: "hybrid",
+		} as const;
+		await db.insert(tables.log).values([
+			{
+				...baseLog,
+				id: "runway-log-credits",
+				requestId: "runway-log-credits",
+				usedMode: "credits",
+				cost: 7,
+			},
+			{
+				// BYOK request: its provider cost never drains credits, only its
+				// data-storage cost does.
+				...baseLog,
+				id: "runway-log-byok",
+				requestId: "runway-log-byok",
+				usedMode: "api-keys",
+				cost: 700,
+				dataStorageCost: "0.7",
+			},
+		]);
+		await aggregateLogsForTesting();
+
+		const response = await app.request("/orgs/test-org-id/credits-runway", {
+			headers: { Cookie: token },
+		});
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			avgDailySpend7d: number;
+			runwayDays: number | null;
+			balance: number;
+		};
+
+		// (7 credits + 0.7 BYOK storage) / 7 days = 1.1 — NOT (7 + 700 + 0.7) / 7.
+		expect(body.avgDailySpend7d).toBeCloseTo(1.1, 2);
+		expect(body.balance).toBe(77);
+		// 77 / 1.1 = 70 days, capped to 31 ("30+").
+		expect(body.runwayDays).toBe(31);
 	});
 });

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -1478,9 +1478,13 @@ organization.openapi(getCreditsRunway, async (c) => {
 	// eslint-disable-next-line no-mixed-operators
 	const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
+	// Only count spend that actually drains the credit balance: the worker debits
+	// credits-mode rows at their full cost (billing_cost ?? cost, storage
+	// excluded) and BYOK ("api-keys") rows at their data-storage cost only, so
+	// blended `cost` would overstate the burn rate for BYOK-heavy orgs.
 	const result = await db
 		.select({
-			totalCost: sql<number>`COALESCE(SUM(${projectHourlyStats.cost}), 0)`,
+			totalCost: sql<number>`COALESCE(SUM(${projectHourlyStats.creditsCost}), 0) + COALESCE(SUM(${projectHourlyStats.apiKeysDataStorageCost}), 0)`,
 		})
 		.from(projectHourlyStats)
 		.innerJoin(

--- a/apps/ui/src/app/dashboard/[orgId]/org/analytics/org-analytics-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/analytics/org-analytics-client.tsx
@@ -12,6 +12,10 @@ import {
 import { currencyFormatter } from "@/components/analytics/chart-helpers";
 import { DimensionUsageCard } from "@/components/analytics/dimension-usage-card";
 import { DimensionUsageOverTimeCard } from "@/components/analytics/dimension-usage-over-time-card";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { useTeamMembers } from "@/hooks/useTeam";
 import { useUser } from "@/hooks/useUser";
@@ -32,6 +36,7 @@ import {
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageMode } from "@/lib/usage-mode";
 
 import type { DimensionRow } from "@/components/analytics/chart-helpers";
 import type { Route } from "next";
@@ -42,6 +47,10 @@ interface OrgActivityRow extends DimensionRow {
 	cost: number;
 	requestCount: number;
 	totalTokens: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 const GROUP_BY_OPTIONS: { value: GroupBy; label: string }[] = [
@@ -209,7 +218,11 @@ export function OrgAnalyticsClient() {
 		},
 	);
 
-	const rows = (data?.activity ?? []) as OrgActivityRow[];
+	const usageMode = useUsageMode();
+	const rows = ((data?.activity ?? []) as OrgActivityRow[]).map((row) => ({
+		...applyUsageMode(row, usageMode),
+		breakdown: row.breakdown.map((entry) => applyUsageMode(entry, usageMode)),
+	}));
 
 	const totals = rows.reduce(
 		(acc, row) => {
@@ -236,11 +249,14 @@ export function OrgAnalyticsClient() {
 						</p>
 					</div>
 					{isEnterprise && isAdmin && (
-						<AnalyticsDateRange
-							isEnterprise={isEnterprise}
-							buildUrl={buildOrgUrl}
-							path="org/analytics"
-						/>
+						<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+							<AnalyticsDateRange
+								isEnterprise={isEnterprise}
+								buildUrl={buildOrgUrl}
+								path="org/analytics"
+							/>
+							<UsageModeSelector />
+						</div>
 					)}
 				</div>
 

--- a/apps/ui/src/app/dashboard/[orgId]/org/team/[userId]/member-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/team/[userId]/member-detail-client.tsx
@@ -10,6 +10,10 @@ import { currencyFormatter } from "@/components/analytics/chart-helpers";
 import { CostByModelCard } from "@/components/analytics/cost-by-model-card";
 import { CostByModelOverTimeCard } from "@/components/analytics/cost-by-model-over-time-card";
 import { DateRangePicker } from "@/components/date-range-picker";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { useTeamMembers } from "@/hooks/useTeam";
 import { useUser } from "@/hooks/useUser";
@@ -31,8 +35,8 @@ import {
 } from "@/lib/components/table";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageMode, pickCost, pickRequests } from "@/lib/usage-mode";
 
-import type { ActivityRow } from "@/components/analytics/chart-helpers";
 import type { Route } from "next";
 
 function periodLabel(value: number, unit: string): string {
@@ -48,6 +52,7 @@ export function MemberDetailClient() {
 	const { buildOrgUrl, selectedOrganization } = useDashboardNavigation();
 	const api = useApi();
 	const { user } = useUser();
+	const usageMode = useUsageMode();
 	const { data: teamData } = useTeamMembers(organizationId);
 
 	const teamMember = teamData?.members.find(
@@ -100,23 +105,41 @@ export function MemberDetailClient() {
 	);
 
 	const summary = data?.summary;
+	// Errors are only tracked blended, so the rate always reflects all traffic.
 	const errorRate =
 		summary && summary.requestCount > 0
 			? (summary.errorCount / summary.requestCount) * 100
 			: 0;
 
-	const activity = (data?.activity ?? []) as ActivityRow[];
+	const activity = (data?.activity ?? []).map((row) => ({
+		...row,
+		modelBreakdown: row.modelBreakdown.map((entry) =>
+			applyUsageMode(entry, usageMode),
+		),
+	}));
+
+	const topModels = (data?.topModels ?? [])
+		.map((m) => applyUsageMode(m, usageMode))
+		.sort((a, b) => b.cost - a.cost);
+	const topProviders = (data?.topProviders ?? [])
+		.map((p) => applyUsageMode(p, usageMode))
+		.sort((a, b) => b.cost - a.cost);
 
 	const stats = [
 		{
 			label: "Total Cost",
-			value: currencyFormatter.format(summary?.cost ?? 0),
+			value: currencyFormatter.format(
+				summary ? pickCost(summary, usageMode) : 0,
+			),
 		},
 		{
 			label: "Total Tokens",
 			value: (summary?.totalTokens ?? 0).toLocaleString(),
 		},
-		{ label: "Requests", value: (summary?.requestCount ?? 0).toLocaleString() },
+		{
+			label: "Requests",
+			value: (summary ? pickRequests(summary, usageMode) : 0).toLocaleString(),
+		},
 		{ label: "Error Rate", value: `${errorRate.toFixed(1)}%` },
 		{ label: "API Keys", value: (summary?.apiKeyCount ?? 0).toLocaleString() },
 	];
@@ -124,12 +147,12 @@ export function MemberDetailClient() {
 	const mostUsed = [
 		{
 			label: "Most used model",
-			value: data?.topModels[0]?.key ?? "—",
+			value: topModels[0]?.key ?? "—",
 			icon: Sparkles,
 		},
 		{
 			label: "Most used provider",
-			value: data?.topProviders[0]?.key ?? "—",
+			value: topProviders[0]?.key ?? "—",
 			icon: Boxes,
 		},
 	];
@@ -170,10 +193,13 @@ export function MemberDetailClient() {
 						</div>
 					</div>
 					{showUsage && (
-						<DateRangePicker
-							buildUrl={buildOrgUrl}
-							path={`org/team/${userId}`}
-						/>
+						<div className="flex flex-wrap items-center gap-2">
+							<UsageModeSelector />
+							<DateRangePicker
+								buildUrl={buildOrgUrl}
+								path={`org/team/${userId}`}
+							/>
+						</div>
 					)}
 				</div>
 
@@ -360,7 +386,7 @@ export function MemberDetailClient() {
 										</TableRow>
 									</TableHeader>
 									<TableBody>
-										{(data?.topProviders.length ?? 0) === 0 ? (
+										{topProviders.length === 0 ? (
 											<TableRow>
 												<TableCell
 													colSpan={3}
@@ -370,7 +396,7 @@ export function MemberDetailClient() {
 												</TableCell>
 											</TableRow>
 										) : (
-											data?.topProviders.map((p) => (
+											topProviders.map((p) => (
 												<TableRow key={p.key}>
 													<TableCell className="font-medium">{p.key}</TableCell>
 													<TableCell className="text-right">

--- a/apps/ui/src/app/dashboard/[orgId]/org/team/team-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/team/team-client.tsx
@@ -19,6 +19,10 @@ import {
 	ProjectMultiSelect,
 	type OrgProject,
 } from "@/components/projects/project-multi-select";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import {
 	useTeamMembers,
@@ -83,6 +87,7 @@ import {
 import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageMode } from "@/lib/usage-mode";
 
 import { SSO_TEAM_DEFAULT_DEVELOPER_BUDGET } from "@llmgateway/shared";
 
@@ -695,6 +700,7 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 		useDashboardNavigation();
 	const api = useApi();
 	const { user } = useUser();
+	const usageMode = useUsageMode();
 
 	const { data, isLoading } = useTeamMembers(organizationId, initialData);
 	const addMemberMutation = useAddTeamMember(organizationId);
@@ -767,7 +773,10 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 	);
 
 	const usageByUserId = new Map(
-		(usageData?.members ?? []).map((member) => [member.userId, member]),
+		(usageData?.members ?? []).map((member) => [
+			member.userId,
+			applyUsageMode(member, usageMode),
+		]),
 	);
 
 	const usageColumnCount = 4;
@@ -890,7 +899,10 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 						</div>
 						<div className="flex items-center gap-2">
 							{showUsage && (
-								<DateRangePicker buildUrl={buildOrgUrl} path="org/team" />
+								<>
+									<UsageModeSelector />
+									<DateRangePicker buildUrl={buildOrgUrl} path="org/team" />
+								</>
 							)}
 							<Dialog
 								open={isAddDialogOpen}

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -16,6 +16,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { LogCard } from "@/components/dashboard/log-card";
 import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
+import {
 	TimeRangePicker,
 	type TimeRangeValue,
 } from "@/components/time-range-picker";
@@ -27,6 +31,7 @@ import {
 } from "@/lib/agent-time-ranges";
 import { useToast } from "@/lib/components/use-toast";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
+import { applyUsageMode } from "@/lib/usage-mode";
 
 import { buildAgentLogsCsv, CODING_AGENTS } from "@llmgateway/shared";
 import {
@@ -666,6 +671,7 @@ export function AgentsView({
 	const searchParams = useSearchParams();
 	const { buildUrl } = useDashboardNavigation();
 	const api = useApi();
+	const usageMode = useUsageMode();
 
 	const timeRange = parseAgentTimeRange(searchParams.get("timeRange"));
 
@@ -695,8 +701,11 @@ export function AgentsView({
 	);
 
 	const agentStats = useMemo(
-		() => computeAgentStats(data?.sources ?? []),
-		[data],
+		() =>
+			computeAgentStats(
+				(data?.sources ?? []).map((row) => applyUsageMode(row, usageMode)),
+			),
+		[data, usageMode],
 	);
 
 	const selectedStats = selectedAgentId
@@ -709,11 +718,14 @@ export function AgentsView({
 	return (
 		<div className="space-y-6">
 			<div className="flex flex-wrap items-center justify-between gap-4">
-				<TimeRangePicker
-					value={timeRange}
-					onChange={updateTimeRange}
-					allowedValues={AGENT_TIME_RANGES}
-				/>
+				<div className="flex flex-wrap items-center gap-3">
+					<TimeRangePicker
+						value={timeRange}
+						onChange={updateTimeRange}
+						allowedValues={AGENT_TIME_RANGES}
+					/>
+					<UsageModeSelector />
+				</div>
 				{!selectedStats && agentStats.length > 0 && (
 					<div className="flex items-center gap-3 text-sm text-muted-foreground">
 						<span>

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -211,6 +211,9 @@ export function RecentLogs({
 	const [apiKeyId, setApiKeyId] = useState<string | undefined>(
 		searchParams.get("apiKeyId") ?? undefined,
 	);
+	const [usedMode, setUsedMode] = useState<string | undefined>(
+		searchParams.get("usedMode") ?? undefined,
+	);
 
 	const api = useApi();
 	const deferredModelSearch = useDeferredValue(modelSearch);
@@ -332,6 +335,9 @@ export function RecentLogs({
 	if (apiKeyId && apiKeyId !== "all") {
 		queryParams.apiKeyId = apiKeyId;
 	}
+	if (usedMode && usedMode !== "all") {
+		queryParams.usedMode = usedMode;
+	}
 	if (projectId) {
 		queryParams.projectId = projectId;
 	}
@@ -345,7 +351,8 @@ export function RecentLogs({
 		customHeaderKey === (searchParams.get("customHeaderKey") ?? "") &&
 		customHeaderValue === (searchParams.get("customHeaderValue") ?? "") &&
 		sessionId === (searchParams.get("sessionId") ?? "") &&
-		apiKeyId === (searchParams.get("apiKeyId") ?? undefined);
+		apiKeyId === (searchParams.get("apiKeyId") ?? undefined) &&
+		usedMode === (searchParams.get("usedMode") ?? undefined);
 
 	const {
 		data,
@@ -469,6 +476,7 @@ export function RecentLogs({
 		provider,
 		model,
 		apiKeyId,
+		usedMode,
 		customHeaderKey.trim() || undefined,
 		customHeaderValue.trim() || undefined,
 		sessionId.trim() || undefined,
@@ -483,6 +491,7 @@ export function RecentLogs({
 		setProvider(undefined);
 		setModel(undefined);
 		setApiKeyId(undefined);
+		setUsedMode(undefined);
 		setCustomHeaderKey("");
 		setCustomHeaderValue("");
 		setSessionId("");
@@ -493,6 +502,7 @@ export function RecentLogs({
 			provider: undefined,
 			model: undefined,
 			apiKeyId: undefined,
+			usedMode: undefined,
 			customHeaderKey: undefined,
 			customHeaderValue: undefined,
 			sessionId: undefined,
@@ -667,6 +677,20 @@ export function RecentLogs({
 										{option.label}
 									</SelectItem>
 								))}
+							</SelectContent>
+						</Select>
+
+						<Select
+							onValueChange={handleFilterChange("usedMode", setUsedMode)}
+							value={usedMode ?? "all"}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Filter by billing" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All billing</SelectItem>
+								<SelectItem value="credits">Credits</SelectItem>
+								<SelectItem value="api-keys">BYOK</SelectItem>
 							</SelectContent>
 						</Select>
 

--- a/apps/ui/src/components/analytics/analytics-client.tsx
+++ b/apps/ui/src/components/analytics/analytics-client.tsx
@@ -10,9 +10,14 @@ import {
 } from "@/components/analytics/analytics-date-range";
 import { CostByModelCard } from "@/components/analytics/cost-by-model-card";
 import { CostByModelOverTimeCard } from "@/components/analytics/cost-by-model-over-time-card";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageModeToDaily } from "@/lib/usage-mode";
 
 import type { ActivityRow } from "@/components/analytics/chart-helpers";
 
@@ -67,7 +72,10 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 		},
 	);
 
-	const activity = (data?.activity ?? []) as ActivityRow[];
+	const usageMode = useUsageMode();
+	const activity: ActivityRow[] = (data?.activity ?? []).map((day) =>
+		applyUsageModeToDaily(day, usageMode),
+	);
 
 	return (
 		<div className="flex flex-col">
@@ -79,11 +87,14 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 							Cost and usage broken down by model for this project
 						</p>
 					</div>
-					<AnalyticsDateRange
-						isEnterprise={isEnterprise}
-						buildUrl={buildUrl}
-						path="analytics"
-					/>
+					<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+						<AnalyticsDateRange
+							isEnterprise={isEnterprise}
+							buildUrl={buildUrl}
+							path="analytics"
+						/>
+						<UsageModeSelector />
+					</div>
 				</div>
 
 				<CostByModelOverTimeCard activity={activity} loading={isLoading} />

--- a/apps/ui/src/components/analytics/chart-helpers.ts
+++ b/apps/ui/src/components/analytics/chart-helpers.ts
@@ -9,6 +9,10 @@ export interface ModelBreakdownEntry {
 	outputTokens: number;
 	totalTokens: number;
 	cost: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 export interface ActivityRow {
@@ -186,6 +190,10 @@ export interface DimensionEntry {
 	cost: number;
 	requestCount: number;
 	totalTokens: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 export interface DimensionRow {

--- a/apps/ui/src/components/api-keys/api-key-stats-client.tsx
+++ b/apps/ui/src/components/api-keys/api-key-stats-client.tsx
@@ -13,6 +13,10 @@ import {
 import { currencyFormatter } from "@/components/analytics/chart-helpers";
 import { CostByModelCard } from "@/components/analytics/cost-by-model-card";
 import { CostByModelOverTimeCard } from "@/components/analytics/cost-by-model-over-time-card";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import {
 	Card,
@@ -22,8 +26,8 @@ import {
 } from "@/lib/components/card";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageModeToDaily } from "@/lib/usage-mode";
 
-import type { ActivityRow } from "@/components/analytics/chart-helpers";
 import type { Route } from "next";
 
 interface ApiKeyStatsClientProps {
@@ -39,6 +43,7 @@ export function ApiKeyStatsClient({
 	const searchParams = useSearchParams();
 	const { buildUrl, selectedOrganization } = useDashboardNavigation();
 	const api = useApi();
+	const usageMode = useUsageMode();
 	const isEnterprise = selectedOrganization?.plan === "enterprise";
 
 	useEffect(() => {
@@ -92,11 +97,16 @@ export function ApiKeyStatsClient({
 		},
 	);
 
-	const activity = (data?.activity ?? []) as ActivityRow[];
+	const activity = useMemo(
+		() =>
+			(data?.activity ?? []).map((day) =>
+				applyUsageModeToDaily(day, usageMode),
+			),
+		[data, usageMode],
+	);
 
 	const summary = useMemo(() => {
-		const rows = data?.activity ?? [];
-		return rows.reduce(
+		return activity.reduce(
 			(acc, row) => {
 				acc.cost += row.cost;
 				acc.totalTokens += row.totalTokens;
@@ -106,11 +116,19 @@ export function ApiKeyStatsClient({
 			},
 			{ cost: 0, totalTokens: 0, requestCount: 0, errorCount: 0 },
 		);
-	}, [data]);
+	}, [activity]);
+
+	// Errors are only tracked blended, so the rate is computed against all
+	// traffic regardless of the selected usage mode.
+	const blendedRequestCount = useMemo(
+		() =>
+			(data?.activity ?? []).reduce((sum, row) => sum + row.requestCount, 0),
+		[data],
+	);
 
 	const errorRate =
-		summary.requestCount > 0
-			? (summary.errorCount / summary.requestCount) * 100
+		blendedRequestCount > 0
+			? (summary.errorCount / blendedRequestCount) * 100
 			: 0;
 
 	const stats = [
@@ -141,11 +159,14 @@ export function ApiKeyStatsClient({
 							{apiKey?.maskedToken ?? keyId}
 						</p>
 					</div>
-					<AnalyticsDateRange
-						isEnterprise={isEnterprise}
-						buildUrl={buildUrl}
-						path={`api-keys/${keyId}`}
-					/>
+					<div className="flex flex-wrap items-center gap-2">
+						<UsageModeSelector />
+						<AnalyticsDateRange
+							isEnterprise={isEnterprise}
+							buildUrl={buildUrl}
+							path={`api-keys/${keyId}`}
+						/>
+					</div>
 				</div>
 
 				<div className="grid grid-cols-2 gap-4 lg:grid-cols-4">

--- a/apps/ui/src/components/dashboard/activity-chart.tsx
+++ b/apps/ui/src/components/dashboard/activity-chart.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 
 import { getDateRangeFromParams } from "@/components/date-range-picker";
+import { useUsageMode } from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import {
 	Card,
@@ -31,6 +32,7 @@ import {
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageModeToDaily } from "@/lib/usage-mode";
 
 import type { TimeRangeValue } from "@/components/time-range-picker";
 import type { GroupBy } from "@/components/usage/group-by";
@@ -306,7 +308,11 @@ export function ActivityChart({
 		};
 	}, [timeRange, searchParams, selectedProject?.id, apiKeyId, groupBy]);
 
-	const { data, isLoading, error } = api.useQuery(
+	const {
+		data: rawData,
+		isLoading,
+		error,
+	} = api.useQuery(
 		"get",
 		"/activity",
 		{
@@ -318,6 +324,20 @@ export function ActivityChart({
 			enabled: !!selectedProject?.id,
 			initialData: timeRange ? undefined : initialData,
 		},
+	);
+
+	const usageMode = useUsageMode();
+	const data = useMemo(
+		() =>
+			rawData
+				? {
+						...rawData,
+						activity: rawData.activity.map((day) =>
+							applyUsageModeToDaily(day, usageMode),
+						),
+					}
+				: rawData,
+		[rawData, usageMode],
 	);
 
 	const periodLabel = useMemo(() => {

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -40,6 +40,10 @@ import {
 	getDateRangeFromParams,
 } from "@/components/date-range-picker";
 import { QuickStartSection } from "@/components/shared/quick-start-snippet";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import { Button } from "@/lib/components/button";
 import {
@@ -52,6 +56,7 @@ import {
 import { Skeleton } from "@/lib/components/skeleton";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageModeToDaily } from "@/lib/usage-mode";
 import { cn } from "@/lib/utils";
 
 import type { ActivitT } from "@/types/activity";
@@ -297,8 +302,16 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		router.push(`${buildUrl()}?${params.toString()}`);
 	};
 
-	const activityData = data?.activity ?? [];
-	const prevActivityData = prevData?.activity ?? [];
+	// Mode-normalized rows: cost/requestCount reflect the selected billing view
+	// (credits vs BYOK); token, error and cache measures stay blended.
+	const usageMode = useUsageMode();
+	const rawActivityData = data?.activity ?? [];
+	const activityData = rawActivityData.map((day) =>
+		applyUsageModeToDaily(day, usageMode),
+	);
+	const prevActivityData = (prevData?.activity ?? []).map((day) =>
+		applyUsageModeToDaily(day, usageMode),
+	);
 
 	const totalRequests =
 		activityData.reduce((sum, day) => sum + day.requestCount, 0) ?? 0;
@@ -310,6 +323,14 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 		}
 	}, [totalRequests]);
 	const totalCost = activityData.reduce((sum, day) => sum + day.cost, 0) ?? 0;
+	const totalCreditsCost = rawActivityData.reduce(
+		(sum, day) => sum + day.creditsCost,
+		0,
+	);
+	const totalApiKeysCost = rawActivityData.reduce(
+		(sum, day) => sum + day.apiKeysCost,
+		0,
+	);
 	const totalInputCost =
 		activityData.reduce((sum, day) => sum + day.inputCost, 0) ?? 0;
 	const totalOutputCost =
@@ -485,6 +506,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 
 				<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
 					<DateRangePicker buildUrl={buildUrl} />
+					<UsageModeSelector />
 					{rangeDays <= 366 && (
 						<p className="text-xs text-muted-foreground">
 							Trends compare to {format(prevFrom, "MMM d")} –{" "}
@@ -521,20 +543,32 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 							isLoading={isLoading}
 						/>
 						<MetricCard
-							label="Total Spend"
+							label={
+								usageMode === "credits"
+									? "Credits Spend"
+									: usageMode === "api-keys"
+										? "BYOK Usage"
+										: "Total Spend"
+							}
 							value={`$${totalCost.toFixed(2)}`}
 							subtitle={
-								totalRequests > 0
-									? `avg $${avgCostPerRequest.toFixed(4)} per request${
-											totalRequestCost > 0
-												? ` • $${totalRequestCost.toFixed(2)} requests`
-												: ""
-										}${
-											totalDataStorageCost > 0
-												? ` • $${totalDataStorageCost.toFixed(4)} storage`
-												: ""
-										}`
-									: `${format(from, "MMM d")} – ${format(to, "MMM d")}`
+								usageMode === "total" &&
+								totalCreditsCost > 0 &&
+								totalApiKeysCost > 0
+									? `$${totalCreditsCost.toFixed(2)} credits • $${totalApiKeysCost.toFixed(2)} BYOK (not billed)`
+									: usageMode === "api-keys" && totalCost > 0
+										? "Served by your provider keys — not billed to credits"
+										: totalRequests > 0
+											? `avg $${avgCostPerRequest.toFixed(4)} per request${
+													totalRequestCost > 0
+														? ` • $${totalRequestCost.toFixed(2)} requests`
+														: ""
+												}${
+													totalDataStorageCost > 0
+														? ` • $${totalDataStorageCost.toFixed(4)} storage`
+														: ""
+												}`
+											: `${format(from, "MMM d")} – ${format(to, "MMM d")}`
 							}
 							icon={<CircleDollarSign className="h-4 w-4" />}
 							accent="blue"

--- a/apps/ui/src/components/dashboard/developer-dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/developer-dashboard-client.tsx
@@ -18,6 +18,10 @@ import {
 	DateRangePicker,
 	getDateRangeFromParams,
 } from "@/components/date-range-picker";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
 import { MemberLimitsCard } from "@/components/team/member-limits-card";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import {
@@ -29,6 +33,7 @@ import {
 } from "@/lib/components/card";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageMode, pickCost, pickRequests } from "@/lib/usage-mode";
 
 function SummaryStat({
 	label,
@@ -99,18 +104,23 @@ export function DeveloperDashboardClient() {
 		{ enabled: !!organizationId && !!projectId, refetchOnWindowFocus: false },
 	);
 
+	const usageMode = useUsageMode();
 	const summary = data?.summary;
-	const activity = data?.activity ?? [];
+	const activity = (data?.activity ?? []).map((row) =>
+		applyUsageMode(row, usageMode),
+	);
 
 	const stats = [
 		{
 			label: "Total cost",
-			value: currencyFormatter.format(summary?.cost ?? 0),
+			value: currencyFormatter.format(
+				summary ? pickCost(summary, usageMode) : 0,
+			),
 			icon: Coins,
 		},
 		{
 			label: "Requests",
-			value: (summary?.requestCount ?? 0).toLocaleString(),
+			value: (summary ? pickRequests(summary, usageMode) : 0).toLocaleString(),
 			icon: Zap,
 		},
 		{
@@ -135,7 +145,10 @@ export function DeveloperDashboardClient() {
 							Your usage and API keys for this project
 						</p>
 					</div>
-					<DateRangePicker buildUrl={buildUrl} path="me" />
+					<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+						<DateRangePicker buildUrl={buildUrl} path="me" />
+						<UsageModeSelector />
+					</div>
 				</div>
 
 				<MemberLimitsCard organizationId={organizationId} />

--- a/apps/ui/src/components/enterprise/feature-showcase.tsx
+++ b/apps/ui/src/components/enterprise/feature-showcase.tsx
@@ -58,12 +58,18 @@ function buildMockRows(): DimensionRow[] {
 				const drift = i * 0.8;
 				const noise = Math.sin(drift + project.phase) * project.wave;
 				const cost = Math.max(2, (project.base + noise) * weekend);
+				const roundedCost = Math.round(cost * 100) / 100;
+				const requestCount = Math.round(cost * 420);
 				return {
 					key: project.key,
 					label: project.label,
-					cost: Math.round(cost * 100) / 100,
-					requestCount: Math.round(cost * 420),
+					cost: roundedCost,
+					requestCount,
 					totalTokens: Math.round(cost * 130_000),
+					creditsRequestCount: requestCount,
+					apiKeysRequestCount: 0,
+					creditsCost: roundedCost,
+					apiKeysCost: 0,
 				};
 			}),
 		});

--- a/apps/ui/src/components/shared/usage-mode-selector.tsx
+++ b/apps/ui/src/components/shared/usage-mode-selector.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+	parseUsageMode,
+	USAGE_MODE_OPTIONS,
+	type UsageMode,
+} from "@/lib/usage-mode";
+import { cn } from "@/lib/utils";
+
+/** Reads the current billing-mode view from the `mode` URL search param. */
+export function useUsageMode(): UsageMode {
+	const searchParams = useSearchParams();
+	return parseUsageMode(searchParams.get("mode"));
+}
+
+/**
+ * Segmented All / Credits / BYOK toggle for usage pages. Stores the selection
+ * in the `mode` URL search param so it survives navigation and can be shared.
+ */
+export function UsageModeSelector({ className }: { className?: string }) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const mode = parseUsageMode(searchParams.get("mode"));
+
+	const setMode = (next: UsageMode) => {
+		const params = new URLSearchParams(searchParams.toString());
+		if (next === "total") {
+			params.delete("mode");
+		} else {
+			params.set("mode", next);
+		}
+		const query = params.toString();
+		router.replace(query ? `${pathname}?${query}` : pathname, {
+			scroll: false,
+		});
+	};
+
+	return (
+		<div
+			className={cn(
+				"inline-flex items-center rounded-lg border border-border/60 bg-muted/40 p-0.5",
+				className,
+			)}
+		>
+			{USAGE_MODE_OPTIONS.map((option) => (
+				<button
+					key={option.value}
+					type="button"
+					onClick={() => setMode(option.value)}
+					title={
+						option.value === "api-keys"
+							? "Usage served by your own provider keys (not billed to credits)"
+							: option.value === "credits"
+								? "Usage billed against your credit balance"
+								: "All traffic"
+					}
+					className={cn(
+						"rounded-md px-3 py-1 text-xs font-medium transition-colors",
+						mode === option.value
+							? "bg-background text-foreground shadow-sm"
+							: "text-muted-foreground hover:text-foreground",
+					)}
+				>
+					{option.label}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/apps/ui/src/components/usage/cost-breakdown-chart.tsx
+++ b/apps/ui/src/components/usage/cost-breakdown-chart.tsx
@@ -6,6 +6,7 @@ import { useCallback, useMemo, useState } from "react";
 import { Label, Pie, PieChart } from "recharts";
 
 import { getDateRangeFromParams } from "@/components/date-range-picker";
+import { useUsageMode } from "@/components/shared/usage-mode-selector";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 import {
 	ChartContainer,
@@ -19,6 +20,7 @@ import {
 } from "@/lib/components/popover";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageModeToDaily } from "@/lib/usage-mode";
 
 import { providers } from "@llmgateway/models";
 
@@ -90,6 +92,7 @@ export function CostBreakdownChart({
 }: CostBreakdownChartProps) {
 	const searchParams = useSearchParams();
 	const { selectedProject } = useDashboardNavigation();
+	const usageMode = useUsageMode();
 
 	const { from, to } = getDateRangeFromParams(searchParams);
 	const fromStr = format(from, "yyyy-MM-dd");
@@ -118,73 +121,91 @@ export function CostBreakdownChart({
 		},
 	);
 
-	const { chartData, chartConfig, totalCost } = useMemo(() => {
-		if (!data || data.activity.length === 0) {
-			return { chartData: [], chartConfig: {} as ChartConfig, totalCost: 0 };
-		}
-
-		const modelCosts = new Map<string, { cost: number; provider: string }>();
-		let storageCost = 0;
-
-		for (const day of data.activity) {
-			for (const model of day.modelBreakdown) {
-				const existing = modelCosts.get(model.id);
-				if (existing) {
-					existing.cost += model.cost;
-				} else {
-					modelCosts.set(model.id, {
-						cost: model.cost,
-						provider: model.provider,
-					});
-				}
+	const { chartData, chartConfig, totalCost, creditsTotal, apiKeysTotal } =
+		useMemo(() => {
+			if (!data || data.activity.length === 0) {
+				return {
+					chartData: [],
+					chartConfig: {} as ChartConfig,
+					totalCost: 0,
+					creditsTotal: 0,
+					apiKeysTotal: 0,
+				};
 			}
-			storageCost += Number(day.dataStorageCost) || 0;
-		}
 
-		const sorted = Array.from(modelCosts.entries())
-			.map(([modelId, { cost, provider }]) => ({
-				model: modelId,
-				provider,
-				cost,
-			}))
-			.sort((a, b) => b.cost - a.cost);
+			const modelCosts = new Map<string, { cost: number; provider: string }>();
+			let storageCost = 0;
+			let creditsSum = 0;
+			let apiKeysSum = 0;
 
-		if (storageCost > 0) {
-			sorted.push({
-				model: "storage",
-				provider: "LLM Gateway",
-				cost: storageCost,
-			});
-		}
+			for (const rawDay of data.activity) {
+				creditsSum += rawDay.creditsCost;
+				apiKeysSum += rawDay.apiKeysCost;
+				const day = applyUsageModeToDaily(rawDay, usageMode);
+				for (const model of day.modelBreakdown) {
+					const existing = modelCosts.get(model.id);
+					if (existing) {
+						existing.cost += model.cost;
+					} else {
+						modelCosts.set(model.id, {
+							cost: model.cost,
+							provider: model.provider,
+						});
+					}
+				}
+				storageCost += Number(day.dataStorageCost) || 0;
+			}
 
-		const config: ChartConfig = {
-			cost: { label: "Cost" },
-		};
+			const sorted = Array.from(modelCosts.entries())
+				.map(([modelId, { cost, provider }]) => ({
+					model: modelId,
+					provider,
+					cost,
+				}))
+				.sort((a, b) => b.cost - a.cost);
 
-		const pieData = sorted.map((item, i) => {
-			const key = item.model.replace(/[^a-zA-Z0-9]/g, "_");
-			const color =
-				item.model === "storage"
-					? "#6366f1"
-					: getProviderColor(item.provider, i);
+			if (storageCost > 0) {
+				sorted.push({
+					model: "storage",
+					provider: "LLM Gateway",
+					cost: storageCost,
+				});
+			}
 
-			config[key] = {
-				label: item.model === "storage" ? "Storage" : item.model,
-				color,
+			const config: ChartConfig = {
+				cost: { label: "Cost" },
 			};
+
+			const pieData = sorted.map((item, i) => {
+				const key = item.model.replace(/[^a-zA-Z0-9]/g, "_");
+				const color =
+					item.model === "storage"
+						? "#6366f1"
+						: getProviderColor(item.provider, i);
+
+				config[key] = {
+					label: item.model === "storage" ? "Storage" : item.model,
+					color,
+				};
+
+				return {
+					model: key,
+					label: item.model === "storage" ? "Storage" : item.model,
+					cost: item.cost,
+					fill: `var(--color-${key})`,
+				};
+			});
+
+			const total = pieData.reduce((sum, item) => sum + item.cost, 0);
 
 			return {
-				model: key,
-				label: item.model === "storage" ? "Storage" : item.model,
-				cost: item.cost,
-				fill: `var(--color-${key})`,
+				chartData: pieData,
+				chartConfig: config,
+				totalCost: total,
+				creditsTotal: creditsSum,
+				apiKeysTotal: apiKeysSum,
 			};
-		});
-
-		const total = pieData.reduce((sum, item) => sum + item.cost, 0);
-
-		return { chartData: pieData, chartConfig: config, totalCost: total };
-	}, [data]);
+		}, [data, usageMode]);
 
 	const pieLabelContent = useCallback(
 		({ viewBox }: { viewBox?: ViewBox }) => {
@@ -388,6 +409,24 @@ export function CostBreakdownChart({
 						</Popover>
 					)}
 				</div>
+				{usageMode === "total" && creditsTotal > 0 && apiKeysTotal > 0 && (
+					<div className="flex flex-col gap-1.5 border-t pt-3 text-sm">
+						<div className="flex items-center justify-between gap-2">
+							<span className="text-muted-foreground">Credits (billed)</span>
+							<span className="font-medium tabular-nums">
+								{formatCompactCost(creditsTotal)}
+							</span>
+						</div>
+						<div className="flex items-center justify-between gap-2">
+							<span className="text-muted-foreground">
+								BYOK keys (not billed)
+							</span>
+							<span className="font-medium tabular-nums">
+								{formatCompactCost(apiKeysTotal)}
+							</span>
+						</div>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/ui/src/components/usage/model-usage-client.tsx
+++ b/apps/ui/src/components/usage/model-usage-client.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 import { ActivityChart } from "@/components/dashboard/activity-chart";
+import { UsageModeSelector } from "@/components/shared/usage-mode-selector";
 import {
 	TimeRangePicker,
 	type TimeRangeValue,
@@ -181,6 +182,7 @@ export function ModelUsageClient({ projectId }: ModelUsageClientProps) {
 							</SelectContent>
 						</Select>
 						<TimeRangePicker value={timeRange} onChange={updateTimeRange} />
+						<UsageModeSelector />
 					</div>
 				</div>
 				<div className="space-y-4">

--- a/apps/ui/src/components/usage/model-usage-table.tsx
+++ b/apps/ui/src/components/usage/model-usage-table.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 import { getDateRangeFromParams } from "@/components/date-range-picker";
+import { useUsageMode } from "@/components/shared/usage-mode-selector";
 import { Button } from "@/lib/components/button";
 import { Progress } from "@/lib/components/progress";
 import {
@@ -18,6 +19,7 @@ import {
 import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { applyUsageMode } from "@/lib/usage-mode";
 
 import type { ActivityModelUsage, ActivitT } from "@/types/activity";
 
@@ -39,6 +41,7 @@ export function ModelUsageTable({
 	const [sortColumn, setSortColumn] = useState<SortColumn>("totalTokens");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
 	const { selectedProject } = useDashboardState();
+	const usageMode = useUsageMode();
 
 	const { from, to } = getDateRangeFromParams(searchParams);
 	const fromStr = format(from, "yyyy-MM-dd");
@@ -131,7 +134,8 @@ export function ModelUsageTable({
 	const modelMap = new Map<string, ActivityModelUsage>();
 
 	data.activity.forEach((day) => {
-		day.modelBreakdown.forEach((model) => {
+		day.modelBreakdown.forEach((rawModel) => {
+			const model = applyUsageMode(rawModel, usageMode);
 			const key = `${model.provider}|${model.id}`;
 			if (modelMap.has(key)) {
 				const existing = modelMap.get(key)!;

--- a/apps/ui/src/components/usage/usage-chart.tsx
+++ b/apps/ui/src/components/usage/usage-chart.tsx
@@ -12,9 +12,11 @@ import {
 } from "recharts";
 
 import { getDateRangeFromParams } from "@/components/date-range-picker";
+import { useUsageMode } from "@/components/shared/usage-mode-selector";
 import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
+import { pickRequests } from "@/lib/usage-mode";
 
 import type { ActivitT } from "@/types/activity";
 import type { TooltipProps } from "recharts";
@@ -55,6 +57,7 @@ export function UsageChart({
 }: UsageChartProps) {
 	const searchParams = useSearchParams();
 	const { selectedProject } = useDashboardState();
+	const usageMode = useUsageMode();
 
 	const { from, to } = getDateRangeFromParams(searchParams);
 	const fromStr = format(from, "yyyy-MM-dd");
@@ -138,7 +141,7 @@ export function UsageChart({
 			return {
 				date,
 				formattedDate: format(parseISO(date), "MMM d"),
-				requests: dayData.requestCount,
+				requests: pickRequests(dayData, usageMode),
 			};
 		}
 		return {

--- a/apps/ui/src/components/usage/usage-client.tsx
+++ b/apps/ui/src/components/usage/usage-client.tsx
@@ -5,6 +5,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/shared/usage-mode-selector";
+import {
 	TimeRangePicker,
 	type TimeRangeValue,
 } from "@/components/time-range-picker";
@@ -35,6 +39,7 @@ import {
 	TabsTrigger,
 } from "@/lib/components/tabs";
 import { useApi } from "@/lib/fetch-client";
+import { USAGE_MODE_ALL_TRAFFIC_NOTE } from "@/lib/usage-mode";
 
 import type { ActivitT } from "@/types/activity";
 
@@ -67,6 +72,7 @@ export function UsageClient({
 	const searchParams = useSearchParams();
 	const { buildUrl } = useDashboardNavigation();
 	const api = useApi();
+	const usageMode = useUsageMode();
 
 	// Fetch API keys for the project
 	const { data: apiKeysData } = api.useQuery(
@@ -153,6 +159,7 @@ export function UsageClient({
 							</SelectContent>
 						</Select>
 						<TimeRangePicker value={timeRange} onChange={updateTimeRange} />
+						<UsageModeSelector />
 					</div>
 				</div>
 				<Tabs defaultValue="requests" className="space-y-4">
@@ -201,6 +208,7 @@ export function UsageClient({
 								<CardTitle>Error Rate</CardTitle>
 								<CardDescription>
 									API request error rate over time
+									{usageMode !== "total" && ` — ${USAGE_MODE_ALL_TRAFFIC_NOTE}`}
 								</CardDescription>
 							</CardHeader>
 							<CardContent className="h-[400px]">
@@ -218,6 +226,7 @@ export function UsageClient({
 								<CardTitle>Cache Rate</CardTitle>
 								<CardDescription>
 									API request cache rate over time
+									{usageMode !== "total" && ` — ${USAGE_MODE_ALL_TRAFFIC_NOTE}`}
 								</CardDescription>
 							</CardHeader>
 							<CardContent className="h-[400px]">

--- a/apps/ui/src/lib/usage-mode.ts
+++ b/apps/ui/src/lib/usage-mode.ts
@@ -1,0 +1,106 @@
+import type { DailyActivity } from "@/types/activity";
+
+/**
+ * Billing-mode view for usage reporting: "total" blends credits and BYOK
+ * ("api-keys") traffic, the other two narrow spend and request counts to the
+ * selected mode. Tokens, errors, cache and latency metrics are only tracked
+ * blended in the rollups, so they always reflect all traffic.
+ */
+export type UsageMode = "total" | "credits" | "api-keys";
+
+export const USAGE_MODE_OPTIONS: { value: UsageMode; label: string }[] = [
+	{ value: "total", label: "All" },
+	{ value: "credits", label: "Credits" },
+	{ value: "api-keys", label: "BYOK" },
+];
+
+export const USAGE_MODE_ALL_TRAFFIC_NOTE =
+	"Tokens, errors and cache metrics always include all traffic — per-mode history is only tracked for spend and request counts.";
+
+export function parseUsageMode(value: string | null | undefined): UsageMode {
+	return value === "credits" || value === "api-keys" ? value : "total";
+}
+
+export function usageModeLabel(mode: UsageMode): string {
+	return USAGE_MODE_OPTIONS.find((o) => o.value === mode)?.label ?? "All";
+}
+
+interface ModeSplitRow {
+	cost: number;
+	requestCount: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
+}
+
+export function pickCost(
+	row: Pick<ModeSplitRow, "cost" | "creditsCost" | "apiKeysCost">,
+	mode: UsageMode,
+): number {
+	if (mode === "credits") {
+		return row.creditsCost;
+	}
+	if (mode === "api-keys") {
+		return row.apiKeysCost;
+	}
+	return row.cost;
+}
+
+export function pickRequests(
+	row: Pick<
+		ModeSplitRow,
+		"requestCount" | "creditsRequestCount" | "apiKeysRequestCount"
+	>,
+	mode: UsageMode,
+): number {
+	if (mode === "credits") {
+		return row.creditsRequestCount;
+	}
+	if (mode === "api-keys") {
+		return row.apiKeysRequestCount;
+	}
+	return row.requestCount;
+}
+
+/**
+ * Returns a copy of the row with `cost` and `requestCount` replaced by the
+ * selected mode's split values, so downstream charts and reducers keep working
+ * unchanged. All other measures stay blended (see USAGE_MODE_ALL_TRAFFIC_NOTE).
+ */
+export function applyUsageMode<T extends ModeSplitRow>(
+	row: T,
+	mode: UsageMode,
+): T {
+	if (mode === "total") {
+		return row;
+	}
+	return {
+		...row,
+		cost: pickCost(row, mode),
+		requestCount: pickRequests(row, mode),
+	};
+}
+
+/**
+ * Mode-normalizes a /activity day row including its nested breakdowns and the
+ * per-mode data-storage cost.
+ */
+export function applyUsageModeToDaily(
+	day: DailyActivity,
+	mode: UsageMode,
+): DailyActivity {
+	if (mode === "total") {
+		return day;
+	}
+	return {
+		...applyUsageMode(day, mode),
+		dataStorageCost:
+			mode === "credits"
+				? day.creditsDataStorageCost
+				: day.apiKeysDataStorageCost,
+		modelBreakdown: day.modelBreakdown.map((m) => applyUsageMode(m, mode)),
+		apiKeyBreakdown: day.apiKeyBreakdown.map((k) => applyUsageMode(k, mode)),
+		userBreakdown: day.userBreakdown.map((u) => applyUsageMode(u, mode)),
+	};
+}

--- a/apps/ui/src/types/activity.ts
+++ b/apps/ui/src/types/activity.ts
@@ -8,6 +8,10 @@ export interface ActivityModelUsage {
 	outputTokens: number;
 	totalTokens: number;
 	cost: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 export interface ActivityApiKeyUsage {
@@ -18,6 +22,10 @@ export interface ActivityApiKeyUsage {
 	outputTokens: number;
 	totalTokens: number;
 	cost: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 export interface ActivityUserUsage {
@@ -28,6 +36,10 @@ export interface ActivityUserUsage {
 	outputTokens: number;
 	totalTokens: number;
 	cost: number;
+	creditsRequestCount: number;
+	apiKeysRequestCount: number;
+	creditsCost: number;
+	apiKeysCost: number;
 }
 
 export interface DailyActivity {

--- a/ee/admin/src/app/chat-plans/[orgId]/page.tsx
+++ b/ee/admin/src/app/chat-plans/[orgId]/page.tsx
@@ -265,7 +265,7 @@ export default async function ChatPlansDetailPage({
 				</div>
 				<div className="rounded-lg border border-border/60 bg-card p-4">
 					<div className="text-xs uppercase tracking-wide text-muted-foreground">
-						Real provider cost (cycle)
+						Real provider cost (cycle, credits-mode)
 					</div>
 					<div className="mt-2 text-2xl font-semibold tabular-nums">
 						{currencyFormatterPrecise.format(sub.realCost)}
@@ -316,7 +316,7 @@ export default async function ChatPlansDetailPage({
 					</div>
 					<div className="rounded-lg border border-border/60 bg-card p-4">
 						<div className="text-xs uppercase tracking-wide text-muted-foreground">
-							Real provider cost (all-time)
+							Real provider cost (all-time, credits-mode)
 						</div>
 						<div className="mt-2 text-2xl font-semibold tabular-nums">
 							{currencyFormatterPrecise.format(sub.allTimeCost)}

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -279,7 +279,7 @@ export default async function DevpassDetailPage({
 				</div>
 				<div className="rounded-lg border border-border/60 bg-card p-4">
 					<div className="text-xs uppercase tracking-wide text-muted-foreground">
-						Real provider cost (cycle)
+						Real provider cost (cycle, credits-mode)
 					</div>
 					<div className="mt-2 text-2xl font-semibold tabular-nums">
 						{currencyFormatterPrecise.format(sub.realCost)}
@@ -390,7 +390,7 @@ export default async function DevpassDetailPage({
 					</div>
 					<div className="rounded-lg border border-border/60 bg-card p-4">
 						<div className="text-xs uppercase tracking-wide text-muted-foreground">
-							Real provider cost (all-time)
+							Real provider cost (all-time, credits-mode)
 						</div>
 						<div className="mt-2 text-2xl font-semibold tabular-nums">
 							{currencyFormatterPrecise.format(sub.allTimeCost)}

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -464,7 +464,9 @@ export function GlobalStatsClient() {
 					value={totals ? currencyFormatter.format(totals.cost) : "—"}
 					subtitle={
 						totals
-							? `Input: ${currencyFormatter.format(totals.inputCost)} · Output: ${currencyFormatter.format(totals.outputCost)}`
+							? totals.apiKeysCost > 0
+								? `Credits: ${currencyFormatter.format(totals.creditsCost)} · BYOK: ${currencyFormatter.format(totals.apiKeysCost)}`
+								: `Input: ${currencyFormatter.format(totals.inputCost)} · Output: ${currencyFormatter.format(totals.outputCost)}`
 							: undefined
 					}
 					icon={<Coins className="h-4 w-4" />}

--- a/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
@@ -12,7 +12,12 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/usage-mode-selector";
 import { loadMetricsAction } from "@/lib/admin-organizations";
+import { pickCost, pickRequests } from "@/lib/usage-mode";
 import { cn } from "@/lib/utils";
 
 import type { OrganizationMetrics, TokenWindow } from "@/lib/types";
@@ -112,6 +117,7 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 	const pathname = usePathname();
 
 	const window = parseWindow(searchParams.get("window"));
+	const usageMode = useUsageMode();
 	const [metrics, setMetrics] = useState<OrganizationMetrics | null>(null);
 	const [loading, setLoading] = useState(true);
 
@@ -190,6 +196,8 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 					</p>
 				</div>
 				<div className="flex items-center gap-1">
+					<UsageModeSelector />
+					<div className="mx-1 h-5 w-px bg-border" />
 					<Button
 						variant={window === "1h" ? "default" : "outline"}
 						size="sm"
@@ -250,9 +258,28 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 			</div>
 			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 				<MetricCard
-					label="Total Requests"
-					value={formatCompactNumber(safeNumber(metrics.totalRequests))}
-					subtitle="All API requests in the selected time window"
+					label={
+						usageMode === "credits"
+							? "Credits Requests"
+							: usageMode === "api-keys"
+								? "BYOK Requests"
+								: "Total Requests"
+					}
+					value={formatCompactNumber(
+						pickRequests(
+							{
+								requestCount: safeNumber(metrics.totalRequests),
+								creditsRequestCount: safeNumber(metrics.creditsRequestCount),
+								apiKeysRequestCount: safeNumber(metrics.apiKeysRequestCount),
+							},
+							usageMode,
+						),
+					)}
+					subtitle={
+						usageMode === "total"
+							? `${formatCompactNumber(safeNumber(metrics.creditsRequestCount))} credits • ${formatCompactNumber(safeNumber(metrics.apiKeysRequestCount))} BYOK`
+							: "API requests in the selected time window"
+					}
 					icon={<Hash className="h-4 w-4" />}
 					accent="blue"
 				/>
@@ -264,9 +291,30 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 					accent="green"
 				/>
 				<MetricCard
-					label="Total Cost"
-					value={currencyFormatter.format(safeNumber(metrics.totalCost))}
-					subtitle="Sum of metered usage costs (USD)"
+					label={
+						usageMode === "credits"
+							? "Credits Cost"
+							: usageMode === "api-keys"
+								? "BYOK Cost"
+								: "Total Cost"
+					}
+					value={currencyFormatter.format(
+						pickCost(
+							{
+								cost: safeNumber(metrics.totalCost),
+								creditsCost: safeNumber(metrics.creditsCost),
+								apiKeysCost: safeNumber(metrics.apiKeysCost),
+							},
+							usageMode,
+						),
+					)}
+					subtitle={
+						usageMode === "total"
+							? `${currencyFormatter.format(safeNumber(metrics.creditsCost))} credits • ${currencyFormatter.format(safeNumber(metrics.apiKeysCost))} BYOK (not billed)`
+							: usageMode === "api-keys"
+								? "Served by the org's own provider keys — not billed"
+								: "Billed against the organization's credits"
+					}
 					icon={<CircleDollarSign className="h-4 w-4" />}
 					accent="purple"
 				/>

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
@@ -12,7 +12,12 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/usage-mode-selector";
 import { loadProjectMetricsAction } from "@/lib/admin-organizations";
+import { pickCost, pickRequests } from "@/lib/usage-mode";
 import { cn } from "@/lib/utils";
 
 import type { ProjectMetrics, TokenWindow } from "@/lib/types";
@@ -118,6 +123,7 @@ export function ProjectMetricsSection({
 	const pathname = usePathname();
 
 	const selectedWindow = parseWindow(searchParams.get("window"));
+	const usageMode = useUsageMode();
 	const [metrics, setMetrics] = useState<ProjectMetrics | null>(null);
 	const [loading, setLoading] = useState(true);
 
@@ -200,6 +206,8 @@ export function ProjectMetricsSection({
 					</p>
 				</div>
 				<div className="flex items-center gap-1">
+					<UsageModeSelector />
+					<div className="mx-1 h-5 w-px bg-border" />
 					{(["1h", "4h", "12h", "1d", "7d", "30d", "90d", "365d"] as const).map(
 						(w) => (
 							<Button
@@ -216,9 +224,28 @@ export function ProjectMetricsSection({
 			</div>
 			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 				<MetricCard
-					label="Total Requests"
-					value={formatCompactNumber(safeNumber(metrics.totalRequests))}
-					subtitle="All API requests in the selected time window"
+					label={
+						usageMode === "credits"
+							? "Credits Requests"
+							: usageMode === "api-keys"
+								? "BYOK Requests"
+								: "Total Requests"
+					}
+					value={formatCompactNumber(
+						pickRequests(
+							{
+								requestCount: safeNumber(metrics.totalRequests),
+								creditsRequestCount: safeNumber(metrics.creditsRequestCount),
+								apiKeysRequestCount: safeNumber(metrics.apiKeysRequestCount),
+							},
+							usageMode,
+						),
+					)}
+					subtitle={
+						usageMode === "total"
+							? `${formatCompactNumber(safeNumber(metrics.creditsRequestCount))} credits • ${formatCompactNumber(safeNumber(metrics.apiKeysRequestCount))} BYOK`
+							: "API requests in the selected time window"
+					}
 					icon={<Hash className="h-4 w-4" />}
 					accent="blue"
 				/>
@@ -230,9 +257,30 @@ export function ProjectMetricsSection({
 					accent="green"
 				/>
 				<MetricCard
-					label="Total Cost"
-					value={currencyFormatter.format(safeNumber(metrics.totalCost))}
-					subtitle="Sum of metered usage costs (USD)"
+					label={
+						usageMode === "credits"
+							? "Credits Cost"
+							: usageMode === "api-keys"
+								? "BYOK Cost"
+								: "Total Cost"
+					}
+					value={currencyFormatter.format(
+						pickCost(
+							{
+								cost: safeNumber(metrics.totalCost),
+								creditsCost: safeNumber(metrics.creditsCost),
+								apiKeysCost: safeNumber(metrics.apiKeysCost),
+							},
+							usageMode,
+						),
+					)}
+					subtitle={
+						usageMode === "total"
+							? `${currencyFormatter.format(safeNumber(metrics.creditsCost))} credits • ${currencyFormatter.format(safeNumber(metrics.apiKeysCost))} BYOK (not billed)`
+							: usageMode === "api-keys"
+								? "Served by the org's own provider keys — not billed"
+								: "Billed against the organization's credits"
+					}
 					icon={<CircleDollarSign className="h-4 w-4" />}
 					accent="purple"
 				/>

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -412,6 +412,18 @@ export default async function OrganizationsPage({
 										{currencyFormatter.format(
 											parseFloat(org.totalSpent ?? "0"),
 										)}
+										{parseFloat(org.totalApiKeysSpent ?? "0") > 0 && (
+											<p className="text-xs">
+												{currencyFormatter.format(
+													parseFloat(org.totalCreditsSpent ?? "0"),
+												)}{" "}
+												credits •{" "}
+												{currencyFormatter.format(
+													parseFloat(org.totalApiKeysSpent ?? "0"),
+												)}{" "}
+												BYOK
+											</p>
+										)}
 									</TableCell>
 									<TableCell className="text-muted-foreground">
 										{formatDate(org.createdAt)}

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -406,6 +406,14 @@ export default async function Page({
 									value: currencyFormatter.format(metrics.totalSpent),
 								},
 								{
+									label: "Spent (credits)",
+									value: currencyFormatter.format(metrics.totalCreditsSpent),
+								},
+								{
+									label: "Spent (BYOK, not billed)",
+									value: currencyFormatter.format(metrics.totalApiKeysSpent),
+								},
+								{
 									label: "Unused",
 									value: currencyFormatter.format(metrics.unusedCredits),
 								},

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -17,6 +17,10 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@/components/ui/chart";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/usage-mode-selector";
 import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
@@ -27,6 +31,10 @@ export interface CostByModelEntry {
 	cost: number;
 	requestCount: number;
 	totalTokens: number;
+	creditsRequestCount?: number;
+	apiKeysRequestCount?: number;
+	creditsCost?: number;
+	apiKeysCost?: number;
 }
 
 export interface CostByModelData {
@@ -34,6 +42,8 @@ export interface CostByModelData {
 	models: CostByModelEntry[];
 	totalCost: number;
 	totalRequests: number;
+	totalCreditsCost?: number;
+	totalApiKeysCost?: number;
 }
 
 type ActiveView = "cost" | "requests" | "tokens";
@@ -138,6 +148,32 @@ export function CostByModelChart({
 		void loadData();
 	}, [loadData]);
 
+	const usageMode = useUsageMode();
+	// Narrow cost/request figures to the selected billing mode; tokens are only
+	// tracked blended. Sorting is preserved from the API (by blended cost).
+	const displayModels =
+		usageMode === "total"
+			? (data?.models ?? [])
+			: (data?.models ?? []).map((m) => ({
+					...m,
+					cost:
+						(usageMode === "credits" ? m.creditsCost : m.apiKeysCost) ?? m.cost,
+					requestCount:
+						(usageMode === "credits"
+							? m.creditsRequestCount
+							: m.apiKeysRequestCount) ?? m.requestCount,
+				}));
+	const displayTotalCost =
+		usageMode === "total"
+			? (data?.totalCost ?? 0)
+			: ((usageMode === "credits"
+					? data?.totalCreditsCost
+					: data?.totalApiKeysCost) ?? 0);
+	const displayTotalRequests =
+		usageMode === "total"
+			? (data?.totalRequests ?? 0)
+			: displayModels.reduce((sum, m) => sum + m.requestCount, 0);
+
 	const config = viewConfigs[activeView];
 	const dataKey = Object.keys(config)[0];
 
@@ -157,15 +193,23 @@ export function CostByModelChart({
 						{data && (
 							<div className="mt-1 flex items-center gap-4 text-xs text-muted-foreground">
 								<span>
-									Total Cost:{" "}
+									{usageMode === "credits"
+										? "Credits Cost: "
+										: usageMode === "api-keys"
+											? "BYOK Cost: "
+											: "Total Cost: "}
 									<strong className="text-foreground">
-										{currencyFormatter.format(data.totalCost)}
+										{currencyFormatter.format(displayTotalCost)}
 									</strong>
 								</span>
 								<span>
-									Total Requests:{" "}
+									{usageMode === "credits"
+										? "Credits Requests: "
+										: usageMode === "api-keys"
+											? "BYOK Requests: "
+											: "Total Requests: "}
 									<strong className="text-foreground">
-										{data.totalRequests.toLocaleString()}
+										{displayTotalRequests.toLocaleString()}
 									</strong>
 								</span>
 							</div>
@@ -189,6 +233,7 @@ export function CostByModelChart({
 							</button>
 						))}
 					</div>
+					<UsageModeSelector />
 					{showModelView && (
 						<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
 							{modelViewOptions.map((opt) => {
@@ -215,7 +260,7 @@ export function CostByModelChart({
 					<div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
 						Loading...
 					</div>
-				) : !data || data.models.length === 0 ? (
+				) : !data || displayModels.length === 0 ? (
 					<div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
 						No data for this time window
 					</div>
@@ -224,11 +269,11 @@ export function CostByModelChart({
 						config={config}
 						className="aspect-auto w-full"
 						style={{
-							height: `${Math.max(300, data.models.length * 28)}px`,
+							height: `${Math.max(300, displayModels.length * 28)}px`,
 						}}
 					>
 						<BarChart
-							data={data.models}
+							data={displayModels}
 							layout="vertical"
 							margin={{ left: 8, right: 8, top: 20, bottom: 4 }}
 						>

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -16,6 +16,10 @@ import {
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@/components/ui/chart";
+import {
+	UsageModeSelector,
+	useUsageMode,
+} from "@/components/usage-mode-selector";
 import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
@@ -119,6 +123,8 @@ export function CostByModelTimeseriesChart({
 		void loadData();
 	}, [loadData]);
 
+	const usageMode = useUsageMode();
+
 	const { chartData, config, keyToModel } = useMemo(() => {
 		if (!data) {
 			return {
@@ -137,6 +143,18 @@ export function CostByModelTimeseriesChart({
 				color: seriesColors[index % seriesColors.length],
 			};
 		});
+		// Cost/request series respect the billing-mode view; tokens are only
+		// tracked blended.
+		const metricKey =
+			usageMode === "total" || activeMetric === "totalTokens"
+				? activeMetric
+				: activeMetric === "cost"
+					? usageMode === "credits"
+						? ("creditsCost" as const)
+						: ("apiKeysCost" as const)
+					: usageMode === "credits"
+						? ("creditsRequestCount" as const)
+						: ("apiKeysRequestCount" as const);
 		const rows = data.data.map((point) => {
 			const row: Record<string, number | string> = {
 				timestamp: point.timestamp,
@@ -146,12 +164,12 @@ export function CostByModelTimeseriesChart({
 			}
 			for (const entry of point.entries) {
 				const key = sanitizeKey(entry.model);
-				row[key] = Number(entry[activeMetric] ?? 0);
+				row[key] = Number(entry[metricKey] ?? 0);
 			}
 			return row;
 		});
 		return { chartData: rows, config: cfg, keyToModel: keyToModelLocal };
-	}, [data, activeMetric]);
+	}, [data, activeMetric, usageMode]);
 
 	const bucket = data?.bucket ?? "day";
 
@@ -193,6 +211,7 @@ export function CostByModelTimeseriesChart({
 						))}
 					</div>
 					<div className="flex flex-wrap items-center gap-2">
+						<UsageModeSelector />
 						{onGroupByChange && (
 							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
 								{groupByTabs.map((tab) => (

--- a/ee/admin/src/components/usage-mode-selector.tsx
+++ b/ee/admin/src/components/usage-mode-selector.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	parseUsageMode,
+	USAGE_MODE_OPTIONS,
+	type UsageMode,
+} from "@/lib/usage-mode";
+
+/** Reads the current billing-mode view from the `mode` URL search param. */
+export function useUsageMode(): UsageMode {
+	const searchParams = useSearchParams();
+	return parseUsageMode(searchParams.get("mode"));
+}
+
+/**
+ * All / Credits / BYOK toggle for admin usage views, persisted in the `mode`
+ * URL search param. Credits = billed against the org balance; BYOK = served by
+ * the org's own provider keys (not billed).
+ */
+export function UsageModeSelector() {
+	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
+	const mode = parseUsageMode(searchParams.get("mode"));
+
+	const setMode = useCallback(
+		(next: UsageMode) => {
+			const params = new URLSearchParams(searchParams.toString());
+			if (next === "total") {
+				params.delete("mode");
+			} else {
+				params.set("mode", next);
+			}
+			const query = params.toString();
+			router.push(query ? `${pathname}?${query}` : pathname);
+		},
+		[searchParams, router, pathname],
+	);
+
+	return (
+		<div className="flex items-center gap-1">
+			{USAGE_MODE_OPTIONS.map((option) => (
+				<Button
+					key={option.value}
+					variant={mode === option.value ? "default" : "outline"}
+					size="sm"
+					onClick={() => setMode(option.value)}
+				>
+					{option.label}
+				</Button>
+			))}
+		</div>
+	);
+}

--- a/ee/admin/src/lib/usage-mode.ts
+++ b/ee/admin/src/lib/usage-mode.ts
@@ -1,0 +1,41 @@
+export type UsageMode = "total" | "credits" | "api-keys";
+
+export const USAGE_MODE_OPTIONS: { value: UsageMode; label: string }[] = [
+	{ value: "total", label: "All" },
+	{ value: "credits", label: "Credits" },
+	{ value: "api-keys", label: "BYOK" },
+];
+
+export function parseUsageMode(value: string | null | undefined): UsageMode {
+	return value === "credits" || value === "api-keys" ? value : "total";
+}
+
+export function pickCost(
+	row: { cost: number; creditsCost: number; apiKeysCost: number },
+	mode: UsageMode,
+): number {
+	if (mode === "credits") {
+		return row.creditsCost;
+	}
+	if (mode === "api-keys") {
+		return row.apiKeysCost;
+	}
+	return row.cost;
+}
+
+export function pickRequests(
+	row: {
+		requestCount: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+	},
+	mode: UsageMode,
+): number {
+	if (mode === "credits") {
+		return row.creditsRequestCount;
+	}
+	if (mode === "api-keys") {
+		return row.apiKeysRequestCount;
+	}
+	return row.requestCount;
+}


### PR DESCRIPTION
## Problem

BYOK ("api-keys" mode) and credits usage were blended in every reported spend number, in both the user dashboard and the admin dashboard. Billing itself was correct — the worker only debits credits for `usedMode="credits"` rows (plus storage cost for BYOK rows) — but reporting showed the blended total everywhere, so neither users nor admins could tell billed credits spend apart from unbilled BYOK usage.

The data layer was already fully instrumented: `log.usedMode` records the billing mode per request, and every hourly rollup table has carried `creditsCost` / `apiKeysCost` / `creditsRequestCount` / `apiKeysRequestCount` **since the tables were created** (PR #1612), so the split is complete for all history and **no migration or backfill is needed**. The gaps were purely in the reporting endpoints and the UIs.

## Approach

**API (additive, backward compatible):** every aggregation endpoint now returns the four split fields next to each blended `cost`/`requestCount` — `/activity` nested breakdowns (model/apiKey/user) and `/activity/sources`, all four `/analytics/*` endpoints, and the admin metrics, org list, org/project metrics, cost-by-model, timeseries, model-provider-stats and global-stats endpoints. Existing blended fields keep their semantics. `/logs` gains a server-side `usedMode` filter.

**UI:** a shared **All / Credits / BYOK** segmented selector (persisted in the `mode` URL param) on every relevant page. Since the server returns all variants at once, switching is a pure client-side view toggle — no extra fetches. Rows are normalized once at the fetch boundary (`applyUsageMode` / `applyUsageModeToDaily`), so all downstream charts and reducers work unchanged. Wired in: dashboard, Usage & Metrics, model usage, project analytics, org analytics, team + member detail, developer "my usage", API key stats, agents/sources, and a "Billing" filter on the logs list. Same pattern in `ee/admin`: global metrics, org list, org/project metrics, cost-by-model tables + timeseries, global stats.

## Real bugs fixed along the way

1. **Credits runway** (`GET /orgs/{id}/credits-runway`) divided the balance by *blended* 7-day spend, understating runway for BYOK-heavy orgs. It now uses what the worker actually debits: `creditsCost + apiKeysDataStorageCost`.
2. **Admin `unusedCredits`/`overage`** subtracted blended spend from topped-up credits; now derived from debited spend only (the blended `totalSpent` field is unchanged, with `totalCreditsSpent`/`totalApiKeysSpent` added alongside).
3. **DevPass/Chat Plan margin** counted BYOK usage as "real provider cost" LLM Gateway paid, understating margin — those queries now count credits-mode cost only (own commit).

## Known limitations (deliberate)

- The rollups only split **cost, request counts, and storage cost** by mode. Tokens, errors, cache and latency were never mode-split and can't be reconstructed for history, so those metrics always show all traffic (labeled as such when a mode filter is active). Splitting them going forward would be a follow-up rollup-column addition.
- Member spend-limit enforcement (`team.ts` / gateway `api-key-usage-limits.ts`) still counts BYOK cost toward limits — changing that is a behavior decision left out of scope.
- The worker comment claims credits-mode storage cost is debited but no code path debits `creditsDataStorageCost` — billing question, untouched here, flagged as follow-up.

## Verification

- `pnpm build` — all 17 tasks pass.
- `pnpm test:unit` — 222 files, 3698 tests pass, including new coverage: mixed-mode seeds asserting the splits on `/activity` (day totals, model/apiKey/user/source breakdowns), all four `/analytics/*` endpoints, the credits-runway formula (`(7 + 0.7)/7 = 1.1`, explicitly not `707.7/7`), the `/logs?usedMode=` filter, and a new `admin-metrics-mode-split.spec.ts` (metrics split + debited-spend `unusedCredits`, org list/org/project splits, cost-by-model splits, DevPass margin excluding BYOK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added All, Credits, and BYOK usage views across dashboards, analytics, activity, and admin metrics.
  * Added billing-mode filtering for logs.
  * Usage charts, tables, cost breakdowns, and summaries now show mode-specific requests and costs.
  * Admin views distinguish credit spending from BYOK spending and clarify credit balance and margin calculations.
* **Bug Fixes**
  * Improved credits runway calculations by excluding BYOK provider costs while including applicable storage costs.
* **Tests**
  * Expanded coverage for mode-specific activity, analytics, metrics, filtering, and runway calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

### User dashboard — All view (split subtitle on Total Spend)
<img width="1440" alt="Dashboard with All/Credits/BYOK selector; Total Spend shows $1044.07 credits • $696.05 BYOK (not billed)" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/ui-dashboard-all.png" />

### User dashboard — BYOK view
<img width="1440" alt="Dashboard filtered to BYOK: card retitled BYOK Usage, requests narrowed to BYOK traffic" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/ui-dashboard-byok.png" />

### Usage & Metrics — Costs tab with Credits (billed) / BYOK (not billed) footer
<img width="1440" alt="Cost breakdown pie with Credits (billed) and BYOK keys (not billed) totals under the legend" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/ui-usage-costs.png" />

### Org analytics — selector in header
<img width="1440" alt="Organization analytics with All/Credits/BYOK selector next to the date range" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/ui-org-analytics.png" />

### Admin — global dashboard (Credit flow spent split, Cost by Model selector)
<img width="1440" alt="Admin dashboard Credit flow card showing Spent, Spent (credits), Spent (BYOK, not billed), Unused; Cost by Model card with mode selector" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/admin-dashboard.png" />

### Admin — org detail metrics, All view
<img width="1440" alt="Admin org metrics with mode selector; Total Requests and Total Cost cards show credits/BYOK split subtitles" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/admin-org-metrics.png" />

### Admin — org detail metrics, Credits view
<img width="1440" alt="Admin org metrics filtered to credits: Credits Requests and Credits Cost cards; Cost by Model totals narrowed" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/admin-org-metrics-credits.png" />

### Admin — organizations list (Total Spent split line)
<img width="1440" alt="Organizations table with credits • BYOK breakdown under each Total Spent value" src="https://raw.githubusercontent.com/theopenco/llmgateway/fabb4bc0e9df03b31fe234b6f4226d83a3c4cc6b/admin-org-list.png" />
