### PR TITLE
feat(gateway): provider circuit breaker safety net

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -77,6 +77,11 @@ import {
 	resolvePreferredProvider,
 	setPreferredProvider,
 } from "@/lib/preferred-provider.js";
+import {
+	isProviderCircuitOpen,
+	openCircuitOnUpstreamFailure,
+	providerCapabilityContext,
+} from "@/lib/provider-circuit-breaker.js";
 import { getProviderMetricsForRouting } from "@/lib/provider-metrics-for-routing.js";
 import {
 	checkProviderRateLimit,
@@ -3214,13 +3219,37 @@ chat.openapi(completions, async (c) => {
 					anyPostComplianceCandidate = true;
 				}
 			}
-			// Filter by context size requirement, reasoning capability, and deprecation status
+			// Filter by context size requirement, reasoning capability, deprecation
+			// status, and open provider circuits.
 			const filteredOutForModel: Array<{
 				providerId: string;
 				reasons: string[];
 			}> = [];
+			const circuitChecks = await Promise.all(
+				complianceFilteredProviders.map(async (provider) => ({
+					provider,
+					open: await isProviderCircuitOpen(
+						project.organizationId,
+						provider.providerId,
+						modelDef.id,
+						provider.region,
+					),
+				})),
+			);
 			const suitableProviders = complianceFilteredProviders.filter(
 				(provider) => {
+					const circuitCheck = circuitChecks.find(
+						(c) =>
+							c.provider.providerId === provider.providerId &&
+							c.provider.region === provider.region,
+					);
+					if (circuitCheck?.open) {
+						recordFilteredProvider(filteredOutForModel, provider.providerId, [
+							"circuit open",
+						]);
+						return false;
+					}
+
 					// Skip deprecated provider mappings
 					if (provider.deprecatedAt && now > provider.deprecatedAt!) {
 						return false;
@@ -7612,6 +7641,19 @@ chat.openapi(completions, async (c) => {
 									usedInternalModel,
 								);
 							}
+							await openCircuitOnUpstreamFailure(
+								project.organizationId,
+								usedProvider,
+								usedInternalModel,
+								0,
+								usedRegion,
+								providerCapabilityContext(
+									modelInfo.providers,
+									usedProvider,
+									hasAssistantPrefill,
+									response_format?.type,
+								),
+							);
 
 							if (willRetrySameProvider && sameProviderRetryContext) {
 								routingAttempts.push(
@@ -7969,6 +8011,22 @@ chat.openapi(completions, async (c) => {
 							);
 						}
 
+						if (finishReason !== "content_filter") {
+							await openCircuitOnUpstreamFailure(
+								project.organizationId,
+								usedProvider,
+								usedInternalModel,
+								res.status,
+								usedRegion,
+								providerCapabilityContext(
+									modelInfo.providers,
+									usedProvider,
+									hasAssistantPrefill,
+									response_format?.type,
+								),
+							);
+						}
+
 						if (willRetrySameProvider && sameProviderRetryContext) {
 							routingAttempts.push(
 								buildRoutingAttempt(
@@ -8300,6 +8358,22 @@ chat.openapi(completions, async (c) => {
 								inferredStatusCode,
 								errorResponseText,
 								usedInternalModel,
+							);
+						}
+
+						if (errorType !== "content_filter") {
+							await openCircuitOnUpstreamFailure(
+								project.organizationId,
+								usedProvider,
+								usedInternalModel,
+								inferredStatusCode,
+								usedRegion,
+								providerCapabilityContext(
+									modelInfo.providers,
+									usedProvider,
+									hasAssistantPrefill,
+									response_format?.type,
+								),
 							);
 						}
 
@@ -11654,6 +11728,19 @@ chat.openapi(completions, async (c) => {
 					usedInternalModel,
 				);
 			}
+			await openCircuitOnUpstreamFailure(
+				project.organizationId,
+				usedProvider,
+				usedInternalModel,
+				0,
+				usedRegion,
+				providerCapabilityContext(
+					modelInfo.providers,
+					usedProvider,
+					hasAssistantPrefill,
+					response_format?.type,
+				),
+			);
 
 			if (willRetrySameProvider && sameProviderRetryContext) {
 				routingAttempts.push(
@@ -12152,6 +12239,22 @@ chat.openapi(completions, async (c) => {
 					res.status,
 					errorResponseText,
 					usedInternalModel,
+				);
+			}
+
+			if (finishReason !== "content_filter") {
+				await openCircuitOnUpstreamFailure(
+					project.organizationId,
+					usedProvider,
+					usedInternalModel,
+					res.status,
+					usedRegion,
+					providerCapabilityContext(
+						modelInfo.providers,
+						usedProvider,
+						hasAssistantPrefill,
+						response_format?.type,
+					),
 				);
 			}
 

--- a/apps/gateway/src/lib/provider-circuit-breaker.spec.ts
+++ b/apps/gateway/src/lib/provider-circuit-breaker.spec.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	isProviderCircuitOpen,
+	openCircuitOnUpstreamFailure,
+	openProviderCircuit,
+	providerCapabilityContext,
+} from "./provider-circuit-breaker.js";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+vi.mock("@llmgateway/cache", () => ({
+	redisClient: {
+		get: vi.fn(),
+		set: vi.fn(),
+	},
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+const mockCache = await import("@llmgateway/cache");
+const redis = mockCache.redisClient;
+
+describe("provider circuit breaker", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("reports a circuit closed when no entry exists", async () => {
+		vi.mocked(redis.get).mockResolvedValue(null);
+		await expect(
+			isProviderCircuitOpen("orgA", "runware", "deepseek-v4-flash", "x"),
+		).resolves.toBe(false);
+		expect(redis.get).toHaveBeenCalledWith(
+			"circuit:provider:orgA:runware:deepseek-v4-flash:x",
+		);
+	});
+
+	it("reports a circuit open when an entry exists", async () => {
+		vi.mocked(redis.get).mockResolvedValue("1");
+		await expect(
+			isProviderCircuitOpen("orgA", "runware", "deepseek-v4-flash"),
+		).resolves.toBe(true);
+	});
+
+	it("writes an open circuit with a TTL", async () => {
+		await openProviderCircuit("orgA", "runware", "deepseek-v4-flash", "us");
+		expect(redis.set).toHaveBeenCalledWith(
+			"circuit:provider:orgA:runware:deepseek-v4-flash:us",
+			"1",
+			"EX",
+			expect.any(Number),
+		);
+	});
+
+	it("does not trip on client errors (4xx)", async () => {
+		await openCircuitOnUpstreamFailure("orgA", "runware", "deepseek", 400);
+		expect(redis.set).not.toHaveBeenCalled();
+	});
+
+	it("trips on server errors but not rate limits", async () => {
+		await openCircuitOnUpstreamFailure("orgA", "runware", "deepseek", 503);
+		expect(redis.set).toHaveBeenCalled();
+		vi.clearAllMocks();
+		await openCircuitOnUpstreamFailure("orgA", "runware", "deepseek", 429);
+		expect(redis.set).not.toHaveBeenCalled();
+	});
+
+	it("trips on unknown status (network failure)", async () => {
+		await openCircuitOnUpstreamFailure(
+			"orgA",
+			"runware",
+			"deepseek",
+			undefined,
+		);
+		expect(redis.set).toHaveBeenCalled();
+	});
+
+	it("trips on a 400 when the mapping cannot serve the requested capability", async () => {
+		// Runware-style: `supportsAssistantPrefill: false` while the request
+		// ends on an assistant turn ("a conversation cannot end on an assistant turn").
+		await openCircuitOnUpstreamFailure(
+			"orgA",
+			"runware",
+			"deepseek-v4-pro",
+			400,
+			undefined,
+			{
+				supportsAssistantPrefill: false,
+				jsonOutput: false,
+				jsonOutputSchema: true,
+				hasAssistantPrefill: true,
+				responseFormatType: undefined,
+			},
+		);
+		expect(redis.set).toHaveBeenCalled();
+	});
+
+	it("does not trip on a 400 when the request did not use the unsupported capability", async () => {
+		await openCircuitOnUpstreamFailure(
+			"orgA",
+			"runware",
+			"deepseek-v4-pro",
+			400,
+			undefined,
+			{
+				supportsAssistantPrefill: false,
+				jsonOutput: false,
+				jsonOutputSchema: true,
+				hasAssistantPrefill: false,
+				responseFormatType: "text",
+			},
+		);
+		expect(redis.set).not.toHaveBeenCalled();
+	});
+
+	it("builds the capability context from the used provider mapping", () => {
+		const context = providerCapabilityContext(
+			[
+				{
+					providerId: "runware",
+					externalId: "deepseek-v4-flash",
+					supportsAssistantPrefill: false,
+					jsonOutput: false,
+					jsonOutputSchema: true,
+				},
+				{
+					providerId: "deepinfra",
+					externalId: "deepseek-v4-flash",
+					supportsAssistantPrefill: true,
+					jsonOutput: true,
+					jsonOutputSchema: true,
+				},
+			] as ProviderModelMapping[],
+			"runware",
+			true,
+			"text",
+		);
+		expect(context).toEqual({
+			supportsAssistantPrefill: false,
+			jsonOutput: false,
+			jsonOutputSchema: true,
+			hasAssistantPrefill: true,
+			responseFormatType: "text",
+		});
+	});
+});

--- a/apps/gateway/src/lib/provider-circuit-breaker.ts
+++ b/apps/gateway/src/lib/provider-circuit-breaker.ts
@@ -1,0 +1,155 @@
+import { redisClient } from "@llmgateway/cache";
+import { logger } from "@llmgateway/logger";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+const DEFAULT_OPEN_MS = 6 * 60 * 60 * 1000;
+
+function getOpenMs(): number {
+	const raw = process.env.PROVIDER_CIRCUIT_OPEN_MS;
+	if (!raw) {
+		return DEFAULT_OPEN_MS;
+	}
+	const v = parseInt(raw, 10);
+	return Number.isFinite(v) && v > 0 ? v : DEFAULT_OPEN_MS;
+}
+
+function circuitKey(
+	orgId: string,
+	providerId: string,
+	modelId: string,
+	region?: string,
+): string {
+	return `circuit:provider:${orgId}:${providerId}:${modelId}:${region ?? ""}`;
+}
+
+/**
+ * Whether the circuit is open for this (org, provider, model, region) tuple,
+ * i.e. the provider recently failed and should be skipped during routing.
+ * Returns false on any Redis error so the breaker never disrupts routing.
+ */
+export async function isProviderCircuitOpen(
+	orgId: string,
+	providerId: string,
+	modelId: string,
+	region?: string,
+): Promise<boolean> {
+	try {
+		const value = await redisClient.get(
+			circuitKey(orgId, providerId, modelId, region),
+		);
+		return value !== null;
+	} catch (error) {
+		logger.error(
+			"Error reading provider circuit breaker from Redis:",
+			error as Error,
+		);
+		return false;
+	}
+}
+
+/**
+ * Open the circuit for (org, provider, model, region) so routing skips this
+ * provider for the cooldown window. Failures are recorded against the concrete
+ * provider/region that was actually used.
+ */
+export async function openProviderCircuit(
+	orgId: string,
+	providerId: string,
+	modelId: string,
+	region?: string,
+): Promise<void> {
+	try {
+		await redisClient.set(
+			circuitKey(orgId, providerId, modelId, region),
+			"1",
+			"EX",
+			Math.ceil(getOpenMs() / 1000),
+		);
+	} catch (error) {
+		logger.error(
+			"Error opening provider circuit breaker in Redis:",
+			error as Error,
+		);
+	}
+}
+
+export interface ProviderCapabilityContext {
+	/**
+	 * Capabilities the provider mapping declares it does not support. When set
+	 * and the request actually exercised one of these, a 400 from the upstream is
+	 * treated as a provider flakiness signal (the provider is not a real match for
+	 * the workload) rather than a user mistake.
+	 */
+	supportsAssistantPrefill?: boolean;
+	jsonOutput?: boolean;
+	jsonOutputSchema?: boolean;
+	/**
+	 * Which capability (if any) this specific request used.
+	 */
+	hasAssistantPrefill?: boolean;
+	responseFormatType?: string;
+}
+
+/**
+ * Build the capability context for a single call site from the mapping that was
+ * actually used, so the 400-vs-flakiness classification sees the same
+ * capabilities the router validated against.
+ */
+export function providerCapabilityContext(
+	providers: readonly ProviderModelMapping[],
+	providerId: string,
+	hasAssistantPrefill: boolean,
+	responseFormatType: string | undefined,
+): ProviderCapabilityContext {
+	const mapping = providers.find((p) => p.providerId === providerId);
+	return {
+		supportsAssistantPrefill: mapping?.supportsAssistantPrefill,
+		jsonOutput: mapping?.jsonOutput,
+		jsonOutputSchema: mapping?.jsonOutputSchema,
+		hasAssistantPrefill,
+		responseFormatType,
+	};
+}
+
+/**
+ * Open the provider circuit from an upstream error only when the failure signals a
+ * real provider problem (server errors, unknown status, or a 400 that the mapping
+ * itself declares it cannot serve), not a generic client mistake. Arbitrary 4xx
+ * client errors and content-filter rejections are intentional and must not trip the
+ * breaker.
+ */
+export async function openCircuitOnUpstreamFailure(
+	orgId: string,
+	providerId: string,
+	modelId: string,
+	statusCode: number | undefined,
+	region?: string,
+	capabilities?: ProviderCapabilityContext,
+): Promise<void> {
+	if (statusCode === 400 && capabilities) {
+		const usedJson =
+			capabilities.responseFormatType === "json_object" ||
+			capabilities.responseFormatType === "json_schema";
+		const mappingCannotServeJson =
+			(usedJson && capabilities.jsonOutput !== true) ||
+			(capabilities.responseFormatType === "json_schema" &&
+				capabilities.jsonOutputSchema !== true);
+		const mappingCannotServePrefill =
+			capabilities.hasAssistantPrefill &&
+			capabilities.supportsAssistantPrefill === false;
+		if (mappingCannotServeJson || mappingCannotServePrefill) {
+			await openProviderCircuit(orgId, providerId, modelId, region);
+			return;
+		}
+		// A 400 the mapping does not declare it cannot serve is a client mistake.
+		return;
+	}
+	// Any other 4xx is a client mistake and must not trip the breaker.
+	if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+		return;
+	}
+	// Server errors (5xx), rate limits (429), and unknown/network failures (0,
+	// undefined) all signal a provider problem.
+	await openProviderCircuit(orgId, providerId, modelId, region);
+}


### PR DESCRIPTION
## Summary

Adds a Redis-backed **provider circuit breaker** that acts as a safety net **below** the gateway's static routing checks. When a provider genuinely fails (5xx, network errors), or a request that slipped past the capability checks gets 400'd by the upstream, the breaker records a fail-closed verdict in Redis and routing keeps skipping that `(org, provider, model, region)` tuple for a cooldown window (default 6h, configurable via `PROVIDER_CIRCUIT_OPEN_MS`).

Division of labor:

- **First line — static, at request time:** capability flags on the provider mappings (`supportsAssistantPrefill: false`, `jsonOutput: false`, …) make auto-routing skip the provider up front (`provider-filter-reasons.ts`), and `validateModelCapabilities` rejects pinned requests before the upstream is called. Known incompatibilities are prevented while they're described in the catalog.
- **Safety net — dynamic, Redis-backed:** the breaker re-validates the *outcome* and remembers failures the static checks can't see — 5xx/network flakiness, request shapes the capability checks don't detect (e.g. `auto`/`custom` requests that skip the pre-checks), or catalog drift (a flag that is wrong or missing). A cheap-but-unreliable provider can no longer keep winning on price request after request.

### Where this sits in the request flow

The capability checks run **above** (before) the money criteria, in this order:

1. `validateModelCapabilities` (model-level) — rejects the request with 400 if the model/pinned provider cannot serve the requested capabilities (JSON output, tools, vision, assistant prefill, …)
2. Provider-level filters — `getProviderFilterReasons` drops mappings like Runware (`supportsAssistantPrefill: false`) from the candidate set for the request shapes they can't serve, plus this PR's circuit filter
3. `getCheapestFromAvailableProviders` — only the *survivors* get scored by the weighted price/uptime/throughput formula

Because of that ordering, a **detected** capability mismatch never reaches pricing. But runtime failures (5xx, network errors) are invisible to every check above pricing — the provider is fully capable, it just fails at runtime, so the price-dominated score (weight `0.6`) reselects it on every new request. This circuit breaker is the only exclusion mechanism for those failures: it turns observed runtime failures into a fail-closed exclusion that pricing cannot override.

What the breaker defends against:

| Upstream behavior | Trips circuit? | Why |
|---|---|---|
| 5xx server error | Yes | Provider-side failure; routing again is likely to fail again |
| Network error / unknown status (0) | Yes | Fetch/connect failure; provider unreachable |
| 400 in tool-call loops — "a conversation cannot end on an assistant turn" (Runware's deepseek mappings declare `supportsAssistantPrefill: false`) | Yes | Safety net: the request reached the upstream despite the routing check (pinned/`auto`/`custom` path or undetected shape) — record it so routing avoids the provider for the cooldown |
| 400 "Missing required parameter: 'jsonSchema'" when `response_format` is used (Runware mappings declare `jsonOutput: false`) | Yes | Safety net: same as above — routing mismatch that slipped through |
| 429 rate limit | No | Transient quota exhaustion, not provider flakiness |
| Other 4xx client errors | No | User mistake, not a provider problem |
| Content-filter rejection | No | Intentional provider behavior |

The 400 rows are deliberately conservative: the static capability checks (first line) are the primary defense for Runware's known incompatibilities — this breaker only fires when a 400 still reaches the upstream, meaning the routing check was bypassed or the request shape went undetected.

Deliberately **not** defended (no error to trip on): the model-side tool-argument flake (dropped args, invented fields) still returns a valid 200, so there is no upstream failure signal — that is a model-quality issue, not a routing one. The gateway-side tool-ID mangling (`chatcmpl-tool-*` leaking to Anthropic clients) is fixed separately in #3389.

## Motivation

Auto (`standard`) routing ranks providers purely by a weighted score where `price` dominates (`0.6`). A cheap but flaky provider therefore keeps getting selected for every new request — there was no way to "remember" that it just failed and stop being served by it. DeepSeek direct through the gateway was far more reliable than the cheap alternative being picked. This adds a durable exclusion after observed failures.

## Changes

- **New** `apps/gateway/src/lib/provider-circuit-breaker.ts` — Redis-backed `isProviderCircuitOpen` / `openProviderCircuit` / `openCircuitOnUpstreamFailure`. The breaker only trips on **server errors (5xx) or network/unknown status (0)** — it deliberately does **not** trip on generic 4xx client errors, 429 rate limits, or content-filter rejections (those are user mistakes, quota, or intentional provider behavior, not flakiness). One exception: a 400 the model mapping itself declares it cannot serve (e.g. `supportsAssistantPrefill: false` while the request ends on an assistant turn) is a routing mismatch that slipped past the static checks, not a user mistake, and does trip the breaker.
- **Routing filter** — in the primary auto-selection path (`chat.ts`), providers whose circuit is open are dropped from the candidate set before the weighted `getCheapestFromAvailableProviders` scoring, and recorded in routing metadata with reason `"circuit open"`.
- **Trips** — wired at the upstream failure sites (streaming + non-streaming fetch/connect errors, HTTP status errors, and inferred streaming status errors), mirroring the existing `reportKeyError`/`reportTrackedKeyError` calls. The capability context for the 400 classification is built via the shared `providerCapabilityContext` helper.

## Tests

`apps/gateway/src/lib/provider-circuit-breaker.spec.ts` — 9 unit tests covering closed/open states, TTL write, 4xx/429 non-tripping, 5xx/network tripping, declared-incompatibility 400 tripping (Runware-style assistant-prefill case), and the capability-context helper.

## Notes / open questions

- Trip severity is intentionally conservative (only 5xx/network, plus declared-incompatibility 400s). If fleet-wide flakiness warrants more aggressive tripping (e.g. 429s), we can widen later.
- The breaker is scoped per `(org, provider, model, region)` so a provider failing on one model doesn't poison another model's routing.