### PR TITLE
chore(security): fix high-severity dep advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,19 +92,19 @@
 			"lodash-es@<4.18.0": "^4.18.1",
 			"picomatch@<2.3.2": "^2.3.2",
 			"picomatch@>=4 <4.0.4": "^4.0.4",
-			"fast-uri@<3.1.4": "^3.1.4",
+			"fast-uri@<3.1.5": "^3.1.5",
 			"fast-xml-builder@<1.1.7": "^1.1.7",
 			"uuid@<11.1.1": "^11.1.1",
 			"dompurify@<3.4.12": "^3.4.12",
 			"fast-xml-parser@<5.10.1": "^5.10.1",
 			"postcss@<8.5.18": "^8.5.18",
-			"ip-address@<10.1.1": "^10.1.1",
+			"ip-address@<10.3.1": "^10.3.1",
 			"qs@<6.15.2": "^6.15.2",
 			"yaml@<2.8.3": "^2.8.3",
 			"valibot@<1.4.2": "^1.4.2",
 			"body-parser@<1.20.6": "^1.20.6",
 			"body-parser@>=2 <2.3.0": "^2.3.0",
-			"brace-expansion@<5.0.8": "5.0.8",
+			"brace-expansion@<5.0.9": "5.0.9",
 			"mermaid@>=11 <11.15.0": "^11.15.0",
 			"js-yaml@<4.3.0": "^4.3.0",
 			"mdast-util-to-hast@>=13 <13.2.1": "^13.2.1",
@@ -131,7 +131,7 @@
 		},
 		"patchedDependencies": {
 			"gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch",
-			"brace-expansion@5.0.8": "patches/brace-expansion@5.0.8.patch"
+			"brace-expansion@5.0.9": "patches/brace-expansion@5.0.9.patch"
 		}
 	},
 	"dependencies": {

--- a/patches/brace-expansion@5.0.9.patch
+++ b/patches/brace-expansion@5.0.9.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/commonjs/index.d.ts b/dist/commonjs/index.d.ts
-index f3e2de9..af4e6e3 100644
+index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e59233f2208c 100644
 --- a/dist/commonjs/index.d.ts
 +++ b/dist/commonjs/index.d.ts
 @@ -5,4 +5,7 @@ export type BraceExpansionOptions = {
@@ -12,10 +12,10 @@ index f3e2de9..af4e6e3 100644
  //# sourceMappingURL=index.d.ts.map
 \ No newline at end of file
 diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
-index be9df86..0744f0b 100644
+index 869a6bee23807b9f01c18c99ab8e952b4b242f97..a696a289d3059e168b8a81d7ab6b09eaee0b5da5 100644
 --- a/dist/commonjs/index.js
 +++ b/dist/commonjs/index.js
-@@ -260,4 +260,16 @@ function expand_(str, max, maxLength, isTop) {
+@@ -286,4 +286,16 @@ function expand_(str, max, maxLength, isTop) {
      }
      return acc;
  }
@@ -34,7 +34,7 @@ index be9df86..0744f0b 100644
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/dist/esm/index.d.ts b/dist/esm/index.d.ts
-index f3e2de9..af4e6e3 100644
+index f3e2de9d87e1ce462517e49f35733bed8bdf85af..af4e6e3610c1833bbafa250a8218e59233f2208c 100644
 --- a/dist/esm/index.d.ts
 +++ b/dist/esm/index.d.ts
 @@ -5,4 +5,7 @@ export type BraceExpansionOptions = {
@@ -47,10 +47,10 @@ index f3e2de9..af4e6e3 100644
  //# sourceMappingURL=index.d.ts.map
 \ No newline at end of file
 diff --git a/dist/esm/index.js b/dist/esm/index.js
-index 6dc0392..633d61a 100644
+index fd68f57029207ac1bcafe7fb1c14ad5305b3ffa4..4cff3b524913fb920db6fe381032db32e8cd7575 100644
 --- a/dist/esm/index.js
 +++ b/dist/esm/index.js
-@@ -256,4 +256,7 @@ function expand_(str, max, maxLength, isTop) {
+@@ -282,4 +282,7 @@ function expand_(str, max, maxLength, isTop) {
      }
      return acc;
  }
@@ -58,4 +58,3 @@ index 6dc0392..633d61a 100644
 +// doing `import expand from 'brace-expansion'` keep working.
 +export default expand;
  //# sourceMappingURL=index.js.map
-\ No newline at end of file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,19 +24,19 @@ overrides:
   lodash-es@<4.18.0: ^4.18.1
   picomatch@<2.3.2: ^2.3.2
   picomatch@>=4 <4.0.4: ^4.0.4
-  fast-uri@<3.1.4: ^3.1.4
+  fast-uri@<3.1.5: ^3.1.5
   fast-xml-builder@<1.1.7: ^1.1.7
   uuid@<11.1.1: ^11.1.1
   dompurify@<3.4.12: ^3.4.12
   fast-xml-parser@<5.10.1: ^5.10.1
   postcss@<8.5.18: ^8.5.18
-  ip-address@<10.1.1: ^10.1.1
+  ip-address@<10.3.1: ^10.3.1
   qs@<6.15.2: ^6.15.2
   yaml@<2.8.3: ^2.8.3
   valibot@<1.4.2: ^1.4.2
   body-parser@<1.20.6: ^1.20.6
   body-parser@>=2 <2.3.0: ^2.3.0
-  brace-expansion@<5.0.8: 5.0.8
+  brace-expansion@<5.0.9: 5.0.9
   mermaid@>=11 <11.15.0: ^11.15.0
   js-yaml@<4.3.0: ^4.3.0
   mdast-util-to-hast@>=13 <13.2.1: ^13.2.1
@@ -57,9 +57,9 @@ overrides:
 packageExtensionsChecksum: sha256-7EyWhva5Lcamo6pe18OzfUc27A7xbWt39+G/ofluF9k=
 
 patchedDependencies:
-  brace-expansion@5.0.8:
-    hash: 3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98
-    path: patches/brace-expansion@5.0.8.patch
+  brace-expansion@5.0.9:
+    hash: 9a5906ff6abcb1e8562a798423ab1b25b8c014f867436e69ee2f3d78b5a39360
+    path: patches/brace-expansion@5.0.9.patch
   gray-matter@4.0.3:
     hash: 5e73cf5a4218f9a21d163ff21105495be3eea8c20af0f515db916ab0157fe5bc
     path: patches/gray-matter@4.0.3.patch
@@ -6756,8 +6756,8 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -8198,8 +8198,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -8997,8 +8997,8 @@ packages:
     resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -18140,14 +18140,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18560,7 +18560,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98):
+  brace-expansion@5.0.9(patch_hash=9a5906ff6abcb1e8562a798423ab1b25b8c014f867436e69ee2f3d78b5a39360):
     dependencies:
       balanced-match: 4.0.4
 
@@ -20174,7 +20174,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -20270,7 +20270,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -21207,7 +21207,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -22390,19 +22390,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
+      brace-expansion: 5.0.9(patch_hash=9a5906ff6abcb1e8562a798423ab1b25b8c014f867436e69ee2f3d78b5a39360)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
+      brace-expansion: 5.0.9(patch_hash=9a5906ff6abcb1e8562a798423ab1b25b8c014f867436e69ee2f3d78b5a39360)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
+      brace-expansion: 5.0.9(patch_hash=9a5906ff6abcb1e8562a798423ab1b25b8c014f867436e69ee2f3d78b5a39360)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=3dac86b614043eca2b402aa43952515e990242adc4be98ed894be852fe567c98)
+      brace-expansion: 5.0.9(patch_hash=9a5906ff6abcb1e8562a798423ab1b25b8c014f867436e69ee2f3d78b5a39360)
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Problem

`pnpm audit` (mirroring the GitHub Dependabot advisory feed) reports 3 high-severity advisories, all in transitive dependencies:

| Package | Installed | Advisory | Issue |
| --- | --- | --- | --- |
| `fast-uri` | 3.1.4 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | Host confusion via backslash authority introducer (CVE-2026-18446) |
| `ip-address` | 10.2.0 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) | Leading-zero octets decoded as decimal while resolvers decode octal |
| `brace-expansion` | 5.0.8 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 fix |

There are no critical advisories.

## Approach

Following the repo's existing pattern, the range-keyed `pnpm.overrides` in the root `package.json` were bumped:

- `fast-uri@<3.1.4 → ^3.1.4` becomes `fast-uri@<3.1.5 → ^3.1.5` (resolves to 3.1.5)
- `ip-address@<10.1.1 → ^10.1.1` becomes `ip-address@<10.3.1 → ^10.3.1` (resolves to 10.4.0; also clears the two moderate ip-address advisories GHSA-4xrf-jv44-h6hh and GHSA-22jq-vg5j-6vgg)
- `brace-expansion@<5.0.8 → 5.0.8` becomes `brace-expansion@<5.0.9 → 5.0.9`

`brace-expansion` carries a local compat patch (re-exposing the callable pre-5.x CommonJS default export for consumers like `minimatch@3`). That patch was regenerated against 5.0.9 via `pnpm patch` / `pnpm patch-commit` (`patches/brace-expansion@5.0.9.patch`, replacing the 5.0.8 patch) and verified to apply: `require('brace-expansion')` is callable and expands correctly.

Remaining advisories are 4 moderates (3× `undici` via `@semantic-release/npm→@actions/core`, 1× `hono`), which are out of scope for this high/critical-only pass.

## Verification

- `pnpm audit` — 0 high / 0 critical remaining
- `pnpm format` — clean
- `pnpm build` — 17/17 tasks successful
- `pnpm test:unit` — 3712 passed, 3 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWLN7SQzvUHU4TWbKHMTBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWLN7SQzvUHU4TWbKHMTBU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for brace expansion imports across CommonJS and ESM environments.
  - Preserved existing expansion functionality while adding consistent default exports.
- **Chores**
  - Updated dependency version overrides and associated patch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->