### PR TITLE
feat: add quantization to Runware mappings

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -290,6 +290,7 @@ export const deepseekModels = [
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 384000,
+				quantization: "fp8",
 				streaming: true,
 				reasoning: true,
 				// Runware maps reasoning_effort onto its thinkingLevel setting and
@@ -454,6 +455,7 @@ export const deepseekModels = [
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 384000,
+				quantization: "fp8",
 				streaming: true,
 				reasoning: true,
 				// Runware maps reasoning_effort onto its thinkingLevel setting and

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2362,6 +2362,7 @@ export const googleModels = [
 				requestPrice: "0",
 				contextSize: 262144,
 				maxOutput: 65536,
+				quantization: "bf16",
 				streaming: true,
 				reasoning: true,
 				// Runware maps reasoning_effort onto its thinkingLevel setting and

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -422,6 +422,7 @@ export const moonshotModels = [
 				requestPrice: "0",
 				contextSize: 262144,
 				maxOutput: 131072,
+				quantization: "fp4",
 				streaming: true,
 				reasoning: true,
 				vision: true,

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -809,6 +809,7 @@ export const openaiModels = [
 				requestPrice: "0",
 				contextSize: 131072,
 				maxOutput: 32768,
+				quantization: "bf16",
 				streaming: true,
 				reasoning: true,
 				vision: false,

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -158,6 +158,7 @@ export const zaiModels = [
 				requestPrice: "0",
 				contextSize: 1024000,
 				maxOutput: 128000,
+				quantization: "fp4",
 				streaming: true,
 				reasoning: true,
 				vision: false,


### PR DESCRIPTION
## Problem

The six Runware provider mappings in the model catalogue had no `quantization` field, so the serving precision Runware documents for these deployments wasn't surfaced.

## Approach

Set `quantization` on each Runware mapping in `packages/models`:

| Model | Quantization |
|---|---|
| GLM-5.2 (`zai-glm-5-2`) | `fp4` (NVFP4) |
| Kimi K2.6 (`moonshotai-kimi-k2-6`) | `fp4` (NVFP4) |
| DeepSeek V4 Flash (`deepseek-v4-flash`) | `fp8` |
| DeepSeek V4 Pro (`deepseek-v4-pro`) | `fp8` |
| GPT OSS 120B (`openai-gpt-oss-120b`) | `bf16` |
| Gemma 4 31B IT (`google-gemma-4-31b`) | `bf16` |

NVFP4 is represented as `fp4`, matching the existing `Quantization` union and how other NVFP4-served mappings (e.g. Nebius GLM-5.2) are already recorded in the catalogue.

## Verification

- `pnpm format`
- `pnpm build` — all 17 tasks pass
- Models package specs pass (125 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQgw9ZZGqCQo1veSusnqH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQgw9ZZGqCQo1veSusnqH9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated quantization configurations for DeepSeek V4 Pro/Flash, Google Gemma 4, Moonshot Kimi K2.6, OpenAI GPT-OSS-120B, and ZAI GLM-5.2 models to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->