### PR TITLE
ci: skip autofix for Dependabot pull requests

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,7 +9,7 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
 
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
 
     steps:
       - name: Autofix

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,7 +9,7 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
 
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:
       - name: Autofix


### PR DESCRIPTION
## Summary

Skip the autofix job when a pull request is opened by Dependabot. Dependabot does not receive the repository `GH_TOKEN` secret, so this job currently fails before formatting can run and leaves otherwise-valid dependency updates unstable.

The job remains enabled for same-repository human pull requests; build, tests, and quality checks are unchanged for Dependabot updates.

## Validation

- `actionlint .github/workflows/autofix.yml`
- `git diff --check`

Closes no issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated fixes to skip Dependabot-initiated pull requests.
  * Retained safeguards that restrict autofixes to pull requests from the current repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->