### PR TITLE
fix(runware): disable reasoning on dsv4 flash, only none is reliable

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -457,10 +457,10 @@ export const deepseekModels = [
 				maxOutput: 384000,
 				quantization: "fp8",
 				streaming: true,
-				reasoning: true,
-				// Runware maps reasoning_effort onto its thinkingLevel setting and
-				// 400s minimal/low/medium for this model.
-				reasoningEfforts: ["none", "high", "xhigh", "max"],
+				// Runware's vLLM proxy has a reasoning → tool_call transition bug
+				// (high leaks content, max drops ~half the handoffs). Only `none`
+				// is reliable (verified live, 2026-08-04).
+				reasoning: false,
 				vision: false,
 				tools: true,
 				// Runware rejects json_object for this model ("Missing required

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -461,6 +461,7 @@ export const deepseekModels = [
 				// (high leaks content, max drops ~half the handoffs). Only `none`
 				// is reliable (verified live, 2026-08-04).
 				reasoning: false,
+				stability: "unstable" as const, // see reasoning bug above
 				vision: false,
 				tools: true,
 				// Runware rejects json_object for this model ("Missing required


### PR DESCRIPTION
## Summary

Runware AI's vLLM proxy for `deepseek-v4-flash` has a reasoning → tool_call transition bug that leaks content into the tool-call stream. Live testing against `api.llmgateway.io` (2026-08-04):

| effort | stream + tools | result |
|--------|---------------|--------|
| `none` | yes | 10/10 clean, no reasoning, no leaks |
| `high` | yes | 7/10 tool_calls completed, but **3/10 leaked content** alongside tool_calls |
| `max` | yes | 33‑60% drop at transition — truncated args, `finish=stop`, or burnt tokens |

`none` is the only reliable effort. This PR sets `reasoning: false` on the Runware `deepseek-v4-flash` mapping so it is never selected for reasoning-capable requests. Non-reasoning requests continue to route normally.

## Routing impact

- `reasoning_effort=none` or omitted → Runware eligible (non-reasoning)
- `reasoning_effort=high/max/low/medium/xhigh` → Runware filtered out (`reasoning !== true`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for DeepSeek V4 Flash tool-call interactions by disabling unsupported reasoning modes.
  * Removed unavailable reasoning effort options from the model configuration.

* **Stability**
  * Marked DeepSeek V4 Flash as unstable while compatibility with reasoning-to-tool-call transitions is being improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->